### PR TITLE
Don't allow arbitrary channel name for boundChannel

### DIFF
--- a/src/mesh/MeshModule.cpp
+++ b/src/mesh/MeshModule.cpp
@@ -109,10 +109,7 @@ void MeshModule::callPlugins(const MeshPacket &mp, RxSource src)
             /// Also: if a packet comes in on the local PC interface, we don't check for bound channels, because it is TRUSTED and it needs to
             /// to be able to fetch the initial admin packets without yet knowing any channels.
 
-            bool rxChannelOk = !pi.boundChannel || (mp.from == 0) ||
-                !ch ||
-                strlen(ch->settings.name) > 0 ||
-                (strcasecmp(ch->settings.name, pi.boundChannel) == 0);
+            bool rxChannelOk = !pi.boundChannel || (mp.from == 0) || (strcasecmp(ch->settings.name, pi.boundChannel) == 0);
 
             if (!rxChannelOk) {
                 // no one should have already replied!


### PR DESCRIPTION
I could send an admin packet over the primary channel after I set a different name to that channel. 

This basically reverts [this commit](https://github.com/meshtastic/firmware/commit/c8aec324f527ec2367c091657f442a613bec3d50#diff-2c96c0d7355013e87dff13cd11e84479bff756bb1a4a2391780b563f6aa4293aR115). It was used as a workaround for getting the ExternalNotification module to work, but that should still work if setting the channel name to 'gpio' or if this checking is disabled after PR #1882 is merged. 
