### PR TITLE
Portduino only: don't continue to try rebooting

### DIFF
--- a/src/shutdown.h
+++ b/src/shutdown.h
@@ -13,7 +13,8 @@ void powerCommandsCheck()
 #elif defined(ARCH_NRF52)
         NVIC_SystemReset();
 #else
-        DEBUG_MSG("FIXME implement reboot for this platform");
+        rebootAtMsec = -1; 
+        DEBUG_MSG("FIXME implement reboot for this platform. Skipping for now.\n");
 #endif
     }
 


### PR DESCRIPTION
This prevents the Linux application from trying to reboot while it can't.
