### PR TITLE
Fixes reset loop with new espressif32 platform on tlora-v2

### DIFF
--- a/variants/tlora_v2/variant.h
+++ b/variants/tlora_v2/variant.h
@@ -8,8 +8,6 @@
 #define I2C_SDA 21 // I2C pins for this board
 #define I2C_SCL 22
 
-#define RESET_OLED 16 // If defined, this pin will be used to reset the display controller
-
 #define VEXT_ENABLE 21 // active low, powers the oled display and the lora antenna boost
 #define LED_PIN 25     // If defined we will blink this LED
 #define BUTTON_PIN                                                                                                               \


### PR DESCRIPTION
 Sending a pulse to the OLED_RESET Pin 16 results in a reset loop using recent version of the espressif32 platform. 