### PR TITLE
Change preambleLength to 8 symbols to reduce airtime

### DIFF
--- a/src/mesh/RadioInterface.h
+++ b/src/mesh/RadioInterface.h
@@ -65,7 +65,7 @@ class RadioInterface
       - Tx/Rx turnaround time (maximum of SX126x and SX127x);
       - MAC processing time (measured on T-beam) */
     uint32_t slotTimeMsec = 8.5 * pow(2, sf)/bw + 0.2 + 0.4 + 7;
-    uint16_t preambleLength = 32; // 8 is default, but we use longer to increase the amount of sleep time when receiving
+    uint16_t preambleLength = 8; // 8 is default
     const uint32_t PROCESSING_TIME_MSEC = 4500;  // time to construct, process and construct a packet again (empirically determined)
     const uint8_t CWmin = 2;  // minimum CWsize
     const uint8_t CWmax = 8;  // maximum CWsize 


### PR DESCRIPTION
This changes the preamble length from 32 to 8 symbols, which is the same as is used in LoRaWAN. I saw in the source that it was set to 32 in order to let the device sleep longer, but since the LoRa chip itself doesn’t sleep, this does not make sense to me. 

It does reduce the time on air quite significantly, namely more than 20% when sending 10 bytes (from 854ms to 657ms on Long Fast). It think we should test it a bit, because it may have an influence on the performance of Channel Activity Detection, but I don’t think it is significant. RadioLib sets the CAD duration for SX126x to 8 symbols and for SX127x, it is only around 2 symbols. 

I did some initial testing and messaging works for me. It seems even not to be a breaking change as I also received messages from my solar node on 1.3.x.
