### PR TITLE
1.2-legacy version pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 
 This branch is End-of-Life.
 
-Requires platformio =< 6.0.0
-Recommended to add core_dir = .platformio to your cloned platformio.ini and use python-virtualenv to keep newer platformio versions/platform packages separate.
+Requires platformio = 6.0.0
+
+Recommended to add "core_dir = .platformio" to your cloned platformio.ini and use python-virtualenv for compiling this branch. This will keep your system platformio and platform_packages separate.
 
 # Old readme below #
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,16 @@
 [![Continuous Integration](https://github.com/meshtastic/Meshtastic-device/actions/workflows/main.yml/badge.svg)](https://github.com/meshtastic/Meshtastic-device/actions/workflows/main.yml)
 ![GitHub all releases](https://img.shields.io/github/downloads/meshtastic/meshtastic-device/total)
 
+This branch is End-of-Life.
+
+Requires platformio =< 6.0.0
+Recommended to add core_dir = .platformio to your cloned platformio.ini and use python-virtualenv to keep newer platformio versions/platform packages separate.
+
+# Old readme below #
+
 ## This repository contains the device firmware used in the [Meshtastic](https://meshtastic.org) project.
 
-Update Instructions
+Update Instructions (docs have versioned up, may no longer apply)
 
 [For ESP32 devices click here](https://meshtastic.org/docs/getting-started/flashing-esp32)
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -139,9 +139,9 @@ build_flags =
 lib_deps =
   ${arduino_base.lib_deps}
   ${environmental.lib_deps}
-  https://github.com/meshtastic/esp32_https_server.git
+  https://github.com/lewisxhe/esp32_https_server.git#6900520645c0e974eefcc699b659fa481a36b870
   h2zero/NimBLE-Arduino@1.3.6
-  tobozo/ESP32-targz@^1.1.4
+  https://github.com/tobozo/ESP32-targz#1.1.4
   arduino-libraries/NTPClient#531eff39d9fbc831f3d03f706a161739203fbe2a
 
 # Hmm - this doesn't work yet

--- a/variants/diy/dr-dev/variant.h
+++ b/variants/diy/dr-dev/variant.h
@@ -1,6 +1,6 @@
 // For OLED LCD
-#define I2C_SDA 21
-#define I2C_SCL 22
+#define I2C_SDA 4
+#define I2C_SCL 5
 
 // GPS
 #undef GPS_RX_PIN
@@ -19,7 +19,7 @@
 // In transmitting, set TXEN as high communication level，RXEN pin is low level;
 // In receiving, set RXEN as high communication level, TXEN is lowlevel;
 // Before powering off, set TXEN、RXEN as low level.
-#define LORA_RXEN 17  // Input - RF switch RX control, connecting external MCU IO, valid in high level
+#define LORA_RXEN 21  // Input - RF switch RX control, connecting external MCU IO, valid in high level
 #define LORA_TXEN -1 // Input - RF switch TX control, connecting external MCU IO or DIO2, valid in high level
 /*  --PINS FOR THE 900M22S
 #undef RF95_SCK


### PR DESCRIPTION
While trying to get debug output from my Ebyte board, I had to do some manipulations to make 1.2 compile as certain lib_deps versioned up for the new platformio versions.

The git commits I changed these to were the ones that produced a working firmware, after creating a python venv with platformio == 6.0.0 installed. I also changed the core_dir to silence complaints about last used version > 6.0

It seems to make all the esp32 targets happy for the CI workflow.