### PR TITLE
Cover two ACK/NAK edge cases for admin packets

### DIFF
--- a/src/mesh/MeshModule.cpp
+++ b/src/mesh/MeshModule.cpp
@@ -115,11 +115,11 @@ void MeshModule::callPlugins(const MeshPacket &mp, RxSource src)
                 // no one should have already replied!
                 assert(!currentReply);
 
-                if (mp.decoded.want_response) {
-                    printPacket("packet on wrong channel, returning error", &mp);
-                    currentReply = pi.allocErrorResponse(Routing_Error_NOT_AUTHORIZED, &mp);
+                if (mp.decoded.want_response || (isDecoded && mp.want_ack)) {
+                      printPacket("Packet on wrong channel, returning error", &mp);
+                      currentReply = pi.allocErrorResponse(Routing_Error_NOT_AUTHORIZED, &mp);
                 } else
-                    printPacket("packet on wrong channel, but can't respond", &mp);
+                    printPacket("Packet on wrong channel, but it didn't require a response or ACK", &mp);
             } else {
 
                 ProcessMessage handled = pi.handleReceived(mp);
@@ -156,12 +156,12 @@ void MeshModule::callPlugins(const MeshPacket &mp, RxSource src)
         pi.currentRequest = NULL;
     }
 
-    if (mp.decoded.want_response && toUs) {
+    if ((mp.decoded.want_response || mp.want_ack) && toUs) {
         if (currentReply) {
             printPacket("Sending response", currentReply);
             service.sendToMesh(currentReply);
             currentReply = NULL;
-        } else if(mp.from != ourNodeNum) {
+        } else if(mp.decoded.want_response && mp.from != ourNodeNum) {
             // Note: if the message started with the local node we don't want to send a no response reply
 
             // No one wanted to reply to this requst, tell the requster that happened

--- a/src/mesh/ReliableRouter.cpp
+++ b/src/mesh/ReliableRouter.cpp
@@ -96,7 +96,11 @@ void ReliableRouter::sniffReceived(const MeshPacket *p, const Routing *c)
             if (MeshModule::currentReply)
                 DEBUG_MSG("Some other module has replied to this message, no need for a 2nd ack\n");
             else
-                sendAckNak(Routing_Error_NONE, getFrom(p), p->id, p->channel);
+                if (p->which_payload_variant == MeshPacket_decoded_tag)
+                    sendAckNak(Routing_Error_NONE, getFrom(p), p->id, p->channel);
+                else
+                    // Send a 'NO_CHANNEL' error on the primary channel if want_ack packet destined for us cannot be decoded
+                    sendAckNak(Routing_Error_NO_CHANNEL, getFrom(p), p->id, channels.getPrimaryIndex());
         }
 
         // We consider an ack to be either a !routing packet with a request ID or a routing packet with !error


### PR DESCRIPTION
This covers two edge cases I found when testing with admin packets to remote nodes via the CLI. 

The first commit ensures that a NAK with "NOT_AUTHORIZED" error is also sent when the receiving node doesn't have an admin channel and want_response is not set, but want_ack is. Otherwise, the Admin Module will just ignore the packet, while the Routing Module happily sends an ACK because indeed it received the packet. 

The second commit makes sure that a NAK with "NO_CHANNEL" error is sent on the primary channel in case two admin channels do not have the same PSK. Otherwise actually an assert fails if want_ack is set, because it is trying to send an ACK while it cannot decrypt the packet.