### PR TITLE
variants\tbeam\variant.h: Use LORA_CS instead of RF95_NSS

### DIFF
--- a/variants/tbeam/variant.h
+++ b/variants/tbeam/variant.h
@@ -12,7 +12,7 @@
 
 // TTGO uses a common pinout for their SX1262 vs RF95 modules - both can be enabled and we will probe at runtime for RF95 and if
 // not found then probe for SX1262
-#define USE_RF95
+#define USE_RF95 // RFM95/SX127x
 #define USE_SX1262
 #define USE_SX1268
 

--- a/variants/tbeam/variant.h
+++ b/variants/tbeam/variant.h
@@ -21,9 +21,10 @@
 #define LORA_DIO1 33 // SX1262 IRQ
 #define LORA_DIO2 32 // SX1262 BUSY
 #define LORA_DIO3    // Not connected on PCB, but internally on the TTGO SX1262, if DIO3 is high the TXCO is enabled
+#define LORA_CS 18
 
 #ifdef USE_SX1262
-#define SX126X_CS RF95_NSS // FIXME - we really should define LORA_CS instead
+#define SX126X_CS LORA_CS
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET


### PR DESCRIPTION
Tested Ok with module LILYGO Model:T-BEAM-V1.1