### PR TITLE
Add t-echo to the operation after the flash operation fails

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -481,7 +481,7 @@ bool saveProto(const char *filename, size_t protoSize, size_t objSize, const pb_
         if(failedCounter >= 2){
             FSCom.format();
             //After formatting, the device needs to be restarted
-            nodeDB.resetRadioConfig();
+            nodeDB.resetRadioConfig(true);
         }
 #endif
     }

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -475,6 +475,15 @@ bool saveProto(const char *filename, size_t protoSize, size_t objSize, const pb_
             DEBUG_MSG("Error: can't rename new pref file\n");
     } else {
         DEBUG_MSG("Can't write prefs\n");
+#ifdef ARCH_NRF52
+        static uint8_t failedCounter = 0;
+        failedCounter++;
+        if(failedCounter >= 2){
+            FSCom.format();
+            //After formatting, the device needs to be restarted
+            nodeDB.resetRadioConfig();
+        }
+#endif
     }
 #else
     DEBUG_MSG("ERROR: Filesystem not implemented\n");


### PR DESCRIPTION
At present, it is only found on NRF52840 that this is a bug that has existed for a period of time. I found this problem a few months ago. Today, I again applied my t-echo to Meshtastic, and still found that the problem still exists. Here are my solutions

Although `FSCom.begin()` returns true. In some cases, the file cannot be opened. I try to open the file in `FSCom` After `begin()`, test the reading and writing of the file. Although the existence and writing of the file can be judged, when you call saveProto, you still respond to **Can't write prefs**,
At present, my method is that when the firmware is written for the first time, meshtastic will call saveProto twice to save the default configuration settings. If both writes fail, format should be called to format the flash memory


