### PR TITLE
Fix the charging parmas error of tbeam-s3core and change the default USB mode

### DIFF
--- a/boards/tbeam-s3-core.json
+++ b/boards/tbeam-s3-core.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "arduino":{
+    "arduino": {
       "ldscript": "esp32s3_out.ld"
     },
     "core": "esp32",
@@ -8,9 +8,7 @@
       "-DBOARD_HAS_PSRAM",
       "-DLILYGO_TBEAM_S3_CORE",
       "-DARDUINO_USB_CDC_ON_BOOT=1",
-      "-DARDUINO_USB_DFU_ON_BOOT=1",
-      "-DARDUINO_USB_MSC_ON_BOOT=1",
-      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_MODE=0",
       "-DARDUINO_RUNNING_CORE=1",
       "-DARDUINO_EVENT_RUNNING_CORE=1"
     ],

--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -455,6 +455,9 @@ bool Power::axpChipInit()
         // Set constant current charging current
         PMU->setChargerConstantCurr(XPOWERS_AXP192_CHG_CUR_450MA);
 
+        //Set up the charging voltage
+        PMU->setChargeTargetVoltage(XPOWERS_AXP192_CHG_VOL_4V2);
+
     } else if (PMU->getChipModel() == XPOWERS_AXP2101) {
 
         // t-beam s3 core 
@@ -507,6 +510,8 @@ bool Power::axpChipInit()
         //Set the constant current charging current of AXP2101, temporarily use 500mA by default
         PMU->setChargerConstantCurr(XPOWERS_AXP2101_CHG_CUR_500MA);
 
+        //Set up the charging voltage
+        PMU->setChargeTargetVoltage(XPOWERS_AXP2101_CHG_VOL_4V2);
     }
     
 
@@ -560,9 +565,6 @@ bool Power::axpChipInit()
     DEBUG_MSG("=======================================================================\n");
 
 
-    //Set up the charging voltage, AXP2101/AXP192 4.2V gear is the same
-    // XPOWERS_AXP192_CHG_VOL_4V2 = XPOWERS_AXP2101_CHG_VOL_4V2
-    PMU->setChargeTargetVoltage(XPOWERS_AXP192_CHG_VOL_4V2);
 
     // Set PMU shutdown voltage at 2.6V to maximize battery utilization
     PMU->setSysPowerDownVoltage(2600);


### PR DESCRIPTION
1. Use the default USB mode. It will be blocked before opening Serial. Change to TinyUSB mode
2. The wrong cut-off voltage parameters AXP192 and AXP2101 are different