### PR TITLE
Enable GPS capabilities on heltec V3

### DIFF
--- a/variants/heltec_v3/variant.h
+++ b/variants/heltec_v3/variant.h
@@ -1,7 +1,5 @@
 #define LED_PIN LED
 
-#define HAS_GPS 0
-
 #define RESET_OLED RST_OLED
 #define I2C_SDA SDA_OLED // I2C pins for this board
 #define I2C_SCL SCL_OLED


### PR DESCRIPTION
The heltec V3 variant had HAS_GPS set to disable GPS capabilities.  I've tested with this enabled and using GPIO 2 and 3 via config params.