### PR TITLE
Disable deep sleep for nRF  and force shutdown for RAK463x on discharged battery

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -295,6 +295,7 @@ void Power::readPowerStatus()
                     // We can't trigger deep sleep on NRF52, it's freezing the board
                     //powerFSM.trigger(EVENT_LOW_BATTERY);
                     DEBUG_MSG("Low voltage detected, but not triggering deep sleep\n");
+                }
             } else {
                 low_voltage_counter = 0;
             }

--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -568,8 +568,12 @@ bool Power::axpChipInit()
     }
     DEBUG_MSG("=======================================================================\n");
 
-// Disable shutdown for non ESP32 boards
-#ifdef ARCH_ESP32
+// We can safely ignore this approach for most (or all) boards because MCU turned off
+// earlier than battery discharged to 2.6V.
+//
+// Unfortanly for now we can't use this killswitch for RAK4630-based boards because they have a bug with
+// battery voltage measurement. Probably it sometimes drops to low values.
+#ifndef RAK4630
     // Set PMU shutdown voltage at 2.6V to maximize battery utilization
     PMU->setSysPowerDownVoltage(2600);
 #endif

--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -292,7 +292,9 @@ void Power::readPowerStatus()
                 low_voltage_counter++;
                 DEBUG_MSG("Warning RAK4631 Low voltage counter: %d/10\n", low_voltage_counter);
                 if (low_voltage_counter > 10)
-                    powerFSM.trigger(EVENT_LOW_BATTERY);
+                    // We can't trigger deep sleep on NRF52, it's freezing the board
+                    //powerFSM.trigger(EVENT_LOW_BATTERY);
+                    DEBUG_MSG("Low voltage detected, but not triggering deep sleep\n")
             } else {
                 low_voltage_counter = 0;
             }

--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -568,11 +568,11 @@ bool Power::axpChipInit()
     }
     DEBUG_MSG("=======================================================================\n");
 
-
-
+// Disable shutdown for non ESP32 boards
+#ifdef ARCH_ESP32
     // Set PMU shutdown voltage at 2.6V to maximize battery utilization
     PMU->setSysPowerDownVoltage(2600);
-
+#endif
 
 
 #ifdef PMU_IRQ

--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -291,10 +291,10 @@ void Power::readPowerStatus()
             if (batteryLevel->getBattVoltage() < MIN_BAT_MILLIVOLTS) {
                 low_voltage_counter++;
                 DEBUG_MSG("Warning RAK4631 Low voltage counter: %d/10\n", low_voltage_counter);
-                if (low_voltage_counter > 10)
+                if (low_voltage_counter > 10) {
                     // We can't trigger deep sleep on NRF52, it's freezing the board
                     //powerFSM.trigger(EVENT_LOW_BATTERY);
-                    DEBUG_MSG("Low voltage detected, but not triggering deep sleep\n")
+                    DEBUG_MSG("Low voltage detected, but not triggering deep sleep\n");
             } else {
                 low_voltage_counter = 0;
             }


### PR DESCRIPTION
Fix for https://github.com/meshtastic/firmware/issues/2022