### PR TITLE
Fix power enable pin used for e-Ink

### DIFF
--- a/variants/rak4631/variant.h
+++ b/variants/rak4631/variant.h
@@ -127,7 +127,7 @@ static const uint8_t SCK = PIN_SPI_SCK;
  * eink display pins
  */
 
-#define PIN_EINK_EN (0 + 2) // (0 + 2) Note: this is really just backlight power
+#define PIN_EINK_EN (32 + 2) // (0 + 2) Note: this is really just backlight power
 #define PIN_EINK_CS (0 + 26)
 #define PIN_EINK_BUSY (0 + 4)
 #define PIN_EINK_DC (0 + 17)

--- a/variants/rak4631_epaper/variant.h
+++ b/variants/rak4631_epaper/variant.h
@@ -127,7 +127,7 @@ static const uint8_t SCK = PIN_SPI_SCK;
  * eink display pins
  */
 
-#define PIN_EINK_EN (0 + 2) // (0 + 2) Note: this is really just backlight power
+#define PIN_EINK_EN (32 + 2) // (0 + 2) Note: this is really just backlight power
 #define PIN_EINK_CS (0 + 26)
 #define PIN_EINK_BUSY (0 + 4)
 #define PIN_EINK_DC (0 + 17)


### PR DESCRIPTION
Fix for correct power enable pin on RAK nRF52 boards which is P1.02 (32 + 2)

