### PR TITLE
Fixed<t-beam-s3-core>display model is SH1106

### DIFF
--- a/variants/tbeam-s3-core/variant.h
+++ b/variants/tbeam-s3-core/variant.h
@@ -66,3 +66,4 @@
 //has 32768 Hz crystal
 #define HAS_32768HZ
 
+#define USE_SH1106


### PR DESCRIPTION
This topic has already explained the situation

https://github.com/meshtastic/firmware/pull/2062