### PR TITLE
Fix External Notification Cutoff on nRF52

### DIFF
--- a/src/modules/Modules.cpp
+++ b/src/modules/Modules.cpp
@@ -75,7 +75,7 @@ void setupModules()
 
     new RangeTestModule();
 #elif defined(ARCH_NRF52)
-    new ExternalNotificationModule();
+    externalNotificationModule = new ExternalNotificationModule();
 #endif
 
     // NOTE! This module must be added LAST because it likes to check for replies from other modules and avoid sending extra acks


### PR DESCRIPTION
After an extensive debug session with Thropho i officially declare i hate macro guards. I was wondering why 'nagCycleCutoff' was returning '1923' instead of '4294967295' on nRF52 while working on ESP32 - gotta instantiate the class too ... 
