### PR TITLE
Make sure we dont use a multicast MAC for ethernet

### DIFF
--- a/src/mesh/eth/ethClient.cpp
+++ b/src/mesh/eth/ethClient.cpp
@@ -94,6 +94,7 @@ bool initEthernet()
         //        createSSLCert();
 
         getMacAddr(mac); // FIXME use the BLE MAC for now...
+	mac[0] &= 0xfe; // Make sure this is not a multicast MAC
 
         if (config.network.address_mode == Config_NetworkConfig_AddressMode_DHCP) {
             LOG_INFO("starting Ethernet DHCP\n");


### PR DESCRIPTION
Clear the multicast bit in the ethernet address. This upsets some DHCP servers which will not issue IPs for multicast addresses (they're not suppose to).