### PR TITLE
Add initial support for BETAFPV ELRS Micro TX Module 2.4G with ESP32 CPU

### DIFF
--- a/src/mesh/SX128xInterface.cpp
+++ b/src/mesh/SX128xInterface.cpp
@@ -25,7 +25,12 @@ bool SX128xInterface<T>::init()
     digitalWrite(SX128X_POWER_EN, HIGH);
     pinMode(SX128X_POWER_EN, OUTPUT);
 #endif
-
+  
+#ifdef RF95_FAN_EN
+    pinMode(RF95_FAN_EN, OUTPUT);
+    digitalWrite(RF95_FAN_EN, 1);
+#endif
+  
 #if defined(SX128X_RXEN) && (SX128X_RXEN != RADIOLIB_NC) // set not rx or tx mode
     digitalWrite(SX128X_RXEN, LOW); // Set low before becoming an output
     pinMode(SX128X_RXEN, OUTPUT);

--- a/variants/betafpv_2400_tx_micro/platformio.ini
+++ b/variants/betafpv_2400_tx_micro/platformio.ini
@@ -4,11 +4,9 @@ board = esp32doit-devkit-v1
 build_flags =
   ${esp32_base.build_flags}
   -D DIY_V1
-  ;-D EBYTE_E22
-  ;-D OLED_RU
-	-D VTABLES_IN_FLASH=1
-	-D CONFIG_DISABLE_HAL_LOCKS=1
-	-O2
+  -D VTABLES_IN_FLASH=1
+  -D CONFIG_DISABLE_HAL_LOCKS=1
+  -O2
   -I variants/betafpv_2400_tx_micro
 board_build.f_cpu = 240000000L
 upload_protocol = esptool

--- a/variants/betafpv_2400_tx_micro/platformio.ini
+++ b/variants/betafpv_2400_tx_micro/platformio.ini
@@ -1,0 +1,19 @@
+[env:betafpv_2400_tx_micro]
+extends = esp32_base
+board = esp32doit-devkit-v1
+build_flags =
+  ${esp32_base.build_flags}
+  -D DIY_V1
+  ;-D EBYTE_E22
+  ;-D OLED_RU
+	-D VTABLES_IN_FLASH=1
+	-D CONFIG_DISABLE_HAL_LOCKS=1
+	-O2
+  -I variants/betafpv_2400_tx_micro
+board_build.f_cpu = 240000000L
+upload_protocol = esptool
+upload_port = /dev/ttyUSB0
+upload_speed = 460800
+lib_deps =
+  ${esp32_base.lib_deps}
+  makuna/NeoPixelBus@^2.7.1

--- a/variants/betafpv_2400_tx_micro/platformio.ini
+++ b/variants/betafpv_2400_tx_micro/platformio.ini
@@ -3,7 +3,7 @@ extends = esp32_base
 board = esp32doit-devkit-v1
 build_flags =
   ${esp32_base.build_flags}
-  -D DIY_V1
+  -D BETAFPV_2400_TX
   -D VTABLES_IN_FLASH=1
   -D CONFIG_DISABLE_HAL_LOCKS=1
   -O2

--- a/variants/betafpv_2400_tx_micro/variant.h
+++ b/variants/betafpv_2400_tx_micro/variant.h
@@ -1,0 +1,37 @@
+#include <NeoPixelBus.h>
+
+// For OLED LCD
+#define I2C_SDA         22
+#define I2C_SCL         32
+
+//#undef I2C_SDA
+//#undef I2C_SCL
+//#define HAS_SCREEN 0
+
+// NO GPS
+#undef GPS_RX_PIN
+#undef GPS_TX_PIN
+
+#define RF95_SCK        18
+#define RF95_MISO       19
+#define RF95_MOSI       23
+#define RF95_NSS        5
+#define RF95_FAN_EN     17
+
+#define LED_PIN         16     // This is a LED_WS2812 not a standard LED
+
+#define BUTTON_PIN      25
+#define BUTTON_NEED_PULLUP
+
+#undef EXT_NOTIFY_OUT
+
+// SX128X 2.4 Ghz LoRa module
+#define USE_SX1280
+#define LORA_RESET      14
+#define SX128X_CS       5
+#define SX128X_DIO1     4
+#define SX128X_BUSY     21 
+#define SX128X_TXEN     26
+#define SX128X_RXEN     27
+#define SX128X_RESET LORA_RESET
+#define SX128X_MAX_POWER 13

--- a/variants/betafpv_2400_tx_micro/variant.h
+++ b/variants/betafpv_2400_tx_micro/variant.h
@@ -1,3 +1,4 @@
+//https://betafpv.com/products/elrs-micro-tx-module
 #include <NeoPixelBus.h>
 
 // 0.96" OLED

--- a/variants/betafpv_2400_tx_micro/variant.h
+++ b/variants/betafpv_2400_tx_micro/variant.h
@@ -1,12 +1,8 @@
 #include <NeoPixelBus.h>
 
-// For OLED LCD
+// 0.96" OLED
 #define I2C_SDA         22
 #define I2C_SCL         32
-
-//#undef I2C_SDA
-//#undef I2C_SCL
-//#define HAS_SCREEN 0
 
 // NO GPS
 #undef GPS_RX_PIN


### PR DESCRIPTION
https://meshtastic.discourse.group/t/add-wip-support-for-betafpv-elrs-micro-tx-module-2-4g-500-1000-mw-with-esp32-cpu/7023