### PR TITLE
Turn GPS off on RAK and maybe others

### DIFF
--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -29,7 +29,8 @@ Observable<void *> preflightSleep;
 
 /// Called to tell observers we are now entering sleep and you should prepare.  Must return 0
 /// notifySleep will be called for light or deep sleep, notifyDeepSleep is only called for deep sleep
-/// notifyGPSSleep will be called when config.position.gps_enabled is set to 0 or from buttonthread when GPS_POWER_TOGGLE is enabled.
+/// notifyGPSSleep will be called when config.position.gps_enabled is set to 0 or from buttonthread when GPS_POWER_TOGGLE is
+/// enabled.
 Observable<void *> notifySleep, notifyDeepSleep;
 Observable<void *> notifyGPSSleep;
 
@@ -93,14 +94,14 @@ void setGPSPower(bool on)
     LOG_INFO("Setting GPS power=%d\n", on);
 
 #ifdef HAS_PMU
-    if (pmu_found && PMU){
+    if (pmu_found && PMU) {
         uint8_t model = PMU->getChipModel();
-        if(model == XPOWERS_AXP2101){
+        if (model == XPOWERS_AXP2101) {
             // t-beam-s3-core GNSS  power channel
             on ? PMU->enablePowerOutput(XPOWERS_ALDO4) : PMU->disablePowerOutput(XPOWERS_ALDO4);
-        }else if(model == XPOWERS_AXP192){
+        } else if (model == XPOWERS_AXP192) {
             // t-beam GNSS  power channel
-            on ? PMU->enablePowerOutput(XPOWERS_LDO3)  : PMU->disablePowerOutput(XPOWERS_LDO3);         
+            on ? PMU->enablePowerOutput(XPOWERS_LDO3) : PMU->disablePowerOutput(XPOWERS_LDO3);
         }
     }
 #endif
@@ -163,7 +164,7 @@ static void waitEnterSleep()
     }
 
     // Code that still needs to be moved into notifyObservers
-    console->flush();            // send all our characters before we stop cpu clock
+    console->flush();          // send all our characters before we stop cpu clock
     setBluetoothEnable(false); // has to be off before calling light sleep
 
     notifySleep.notifyObservers(NULL);
@@ -171,45 +172,36 @@ static void waitEnterSleep()
 
 void doGPSpowersave(bool on)
 {
-    #ifdef HAS_PMU
-    if (on)
-    {
+#ifdef HAS_PMU
+    if (on) {
         LOG_INFO("Turning GPS back on\n");
         gps->forceWake(1);
         setGPSPower(1);
-    }
-    else
-    {
+    } else {
         LOG_INFO("Turning off GPS chip\n");
         notifyGPSSleep.notifyObservers(NULL);
         setGPSPower(0);
     }
-    #endif
-    #ifdef PIN_GPS_WAKE
-    if (on)
-    {
+#endif
+#ifdef PIN_GPS_WAKE
+    if (on) {
         LOG_INFO("Waking GPS");
         gps->forceWake(1);
-    }
-    else
-    {
+    } else {
         LOG_INFO("GPS entering sleep");
         notifyGPSSleep.notifyObservers(NULL);
     }
-    #endif
-    #ifdef PIN_GPS_EN
-    if (on)
-    {
+#endif
+#ifdef PIN_GPS_EN
+    if (on) {
         LOG_INFO("Turning GPS/3.3v rail on");
         digitalWrite(PIN_GPS_EN, 1);
-    }
-    else
-    {
+    } else {
         LOG_INFO("Turning GPS/3.3v rail off");
         notifyGPSSleep.notifyObservers(NULL);
-        digitalWrite(PIN_GPS_EN,0);
+        digitalWrite(PIN_GPS_EN, 0);
     }
-    #endif
+#endif
 }
 
 void doDeepSleep(uint64_t msecToWake)
@@ -252,10 +244,10 @@ void doDeepSleep(uint64_t msecToWake)
         // all the time.
 
         uint8_t model = PMU->getChipModel();
-        if(model == XPOWERS_AXP2101){
+        if (model == XPOWERS_AXP2101) {
             PMU->disablePowerOutput(XPOWERS_ALDO3); // lora radio power channel
-        }else if(model == XPOWERS_AXP192){
-            PMU->disablePowerOutput(XPOWERS_LDO2);  // lora radio power channel
+        } else if (model == XPOWERS_AXP192) {
+            PMU->disablePowerOutput(XPOWERS_LDO2); // lora radio power channel
         }
     }
 #endif
@@ -341,7 +333,6 @@ esp_sleep_wakeup_cause_t doLightSleep(uint64_t sleepMsec) // FIXME, use a more r
 void enableModemSleep()
 {
     static esp_pm_config_esp32_t esp32_config; // filled with zeros because bss
-
 
 #if CONFIG_IDF_TARGET_ESP32S3
     esp32_config.max_freq_mhz = CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ;

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -192,7 +192,7 @@ void doGPSpowersave(bool on)
         notifyGPSSleep.notifyObservers(NULL);
     }
 #endif
-#ifdef PIN_GPS_EN
+#if defined PIN_GPS_EN && (PIN_GPS_EN > -1)
     if (on) {
         LOG_INFO("Turning GPS/3.3v rail on");
         digitalWrite(PIN_GPS_EN, 1);

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -206,6 +206,7 @@ void doGPSpowersave(bool on)
     else
     {
         LOG_INFO("Turning GPS/3.3v rail off");
+        notifyGPSSleep.notifyObservers(NULL);
         digitalWrite(PIN_GPS_EN,0);
     }
     #endif

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -197,6 +197,18 @@ void doGPSpowersave(bool on)
         notifyGPSSleep.notifyObservers(NULL);
     }
     #endif
+    #ifdef PIN_GPS_EN
+    if (on)
+    {
+        LOG_INFO("Turning GPS/3.3v rail on");
+        digitalWrite(PIN_GPS_EN, 1);
+    }
+    else
+    {
+        LOG_INFO("Turning GPS/3.3v rail off");
+        digitalWrite(PIN_GPS_EN,0);
+    }
+    #endif
 }
 
 void doDeepSleep(uint64_t msecToWake)


### PR DESCRIPTION
Fixes #2155 
Should do what it says on the tin, cleanly shut down the GPS thread/unit (plus everything else on the 3v3 bus, in the case of RAK4361)

Don't have one to test, but setting position_enable=0 ought to work.