### PR TITLE
code reduction

### DIFF
--- a/src/xmodem.cpp
+++ b/src/xmodem.cpp
@@ -54,11 +54,7 @@ unsigned short XModemAdapter::crc16_ccitt(const pb_byte_t *buffer, int length)
 
 int XModemAdapter::check(const pb_byte_t *buf, int sz, unsigned short tcrc)
 {
-    unsigned short crc = crc16_ccitt(buf, sz);
-    if (crc == tcrc)
-        return 1;
-    else
-        return 0;
+    return crc16_ccitt(buf, sz) == tcrc;
 }
 
 void XModemAdapter::sendControl(meshtastic_XModem_Control c)


### PR DESCRIPTION
Small tweak that reduces the number of lines of code in XModemAdapter::check to 1. It should be functionally the same.