### PR TITLE
Potential fix for TX problem in RAK-4631 cores and other SX126X ant switch issues

### DIFF
--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -1,7 +1,7 @@
 #include "SX126xInterface.h"
-#include "mesh/NodeDB.h"
 #include "configuration.h"
 #include "error.h"
+#include "mesh/NodeDB.h"
 
 // Particular boards might define a different max power based on what their hardware can do
 #ifndef SX126X_MAX_POWER
@@ -19,8 +19,7 @@ SX126xInterface<T>::SX126xInterface(RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq,
 /// Initialise the Driver transport hardware and software.
 /// Make sure the Driver is properly configured before calling init().
 /// \return true if initialisation succeeded.
-template <typename T>
-bool SX126xInterface<T>::init()
+template <typename T> bool SX126xInterface<T>::init()
 {
 #ifdef SX126X_POWER_EN
     digitalWrite(SX126X_POWER_EN, HIGH);
@@ -77,20 +76,16 @@ bool SX126xInterface<T>::init()
 
 #if defined(SX126X_TXEN) && (SX126X_TXEN != RADIOLIB_NC)
     // lora.begin sets Dio2 as RF switch control, which is not true if we are manually controlling RX and TX
-    if (res == RADIOLIB_ERR_NONE)
-    {
+    if (res == RADIOLIB_ERR_NONE) {
         res = lora.setDio2AsRfSwitch(false);
         lora.setRfSwitchPins(SX126X_RXEN, SX126X_TXEN);
     }
 #endif
 
-    if (config.lora.sx126x_rx_boosted_gain)
-    {
+    if (config.lora.sx126x_rx_boosted_gain) {
         uint16_t result = lora.setRxBoostedGainMode(true);
         LOG_INFO("Set Rx Boosted Gain mode; result: %d\n", result);
-    }
-    else
-    {
+    } else {
         uint16_t result = lora.setRxBoostedGainMode(false);
         LOG_INFO("Set Rx Power Saving Gain mode; result: %d\n", result);
     }
@@ -128,8 +123,7 @@ bool SX126xInterface<T>::init()
     return res == RADIOLIB_ERR_NONE;
 }
 
-template <typename T>
-bool SX126xInterface<T>::reconfigure()
+template <typename T> bool SX126xInterface<T>::reconfigure()
 {
     RadioLibInterface::reconfigure();
 
@@ -178,14 +172,12 @@ bool SX126xInterface<T>::reconfigure()
     return RADIOLIB_ERR_NONE;
 }
 
-template <typename T>
-void INTERRUPT_ATTR SX126xInterface<T>::disableInterrupt()
+template <typename T> void INTERRUPT_ATTR SX126xInterface<T>::disableInterrupt()
 {
     lora.clearDio1Action();
 }
 
-template <typename T>
-void SX126xInterface<T>::setStandby()
+template <typename T> void SX126xInterface<T>::setStandby()
 {
     checkNotification(); // handle any pending interrupts before we force standby
 
@@ -211,8 +203,7 @@ void SX126xInterface<T>::setStandby()
 /**
  * Add SNR data to received messages
  */
-template <typename T>
-void SX126xInterface<T>::addReceiveMetadata(meshtastic_MeshPacket *mp)
+template <typename T> void SX126xInterface<T>::addReceiveMetadata(meshtastic_MeshPacket *mp)
 {
     // LOG_DEBUG("PacketStatus %x\n", lora.getPacketStatus());
     mp->rx_snr = lora.getSNR();
@@ -221,8 +212,7 @@ void SX126xInterface<T>::addReceiveMetadata(meshtastic_MeshPacket *mp)
 
 /** We override to turn on transmitter power as needed.
  */
-template <typename T>
-void SX126xInterface<T>::configHardwareForSend()
+template <typename T> void SX126xInterface<T>::configHardwareForSend()
 {
     // #if defined(SX126X_TXEN) && (SX126X_TXEN != RADIOLIB_NC) // we have RXEN/TXEN control - turn on TX power / off RX power
     //     digitalWrite(SX126X_TXEN, HIGH);
@@ -237,8 +227,7 @@ void SX126xInterface<T>::configHardwareForSend()
 // For power draw measurements, helpful to force radio to stay sleeping
 // #define SLEEP_ONLY
 
-template <typename T>
-void SX126xInterface<T>::startReceive()
+template <typename T> void SX126xInterface<T>::startReceive()
 {
 #ifdef SLEEP_ONLY
     sleep();
@@ -266,8 +255,7 @@ void SX126xInterface<T>::startReceive()
 }
 
 /** Could we send right now (i.e. either not actively receving or transmitting)? */
-template <typename T>
-bool SX126xInterface<T>::isChannelActive()
+template <typename T> bool SX126xInterface<T>::isChannelActive()
 {
     // check if we can detect a LoRa preamble on the current channel
     int16_t result;
@@ -283,8 +271,7 @@ bool SX126xInterface<T>::isChannelActive()
 }
 
 /** Could we send right now (i.e. either not actively receving or transmitting)? */
-template <typename T>
-bool SX126xInterface<T>::isActivelyReceiving()
+template <typename T> bool SX126xInterface<T>::isActivelyReceiving()
 {
     // The IRQ status will be cleared when we start our read operation.  Check if we've started a header, but haven't yet
     // received and handled the interrupt for reading the packet/handling errors.
@@ -301,8 +288,7 @@ bool SX126xInterface<T>::isActivelyReceiving()
     return hasPreamble;
 }
 
-template <typename T>
-bool SX126xInterface<T>::sleep()
+template <typename T> bool SX126xInterface<T>::sleep()
 {
     // Not keeping config is busted - next time nrf52 board boots lora sending fails  tcxo related? - see datasheet
     // \todo Display actual typename of the adapter, not just `SX126x`

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -19,7 +19,8 @@ SX126xInterface<T>::SX126xInterface(RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq,
 /// Initialise the Driver transport hardware and software.
 /// Make sure the Driver is properly configured before calling init().
 /// \return true if initialisation succeeded.
-template <typename T> bool SX126xInterface<T>::init()
+template <typename T>
+bool SX126xInterface<T>::init()
 {
 #ifdef SX126X_POWER_EN
     digitalWrite(SX126X_POWER_EN, HIGH);
@@ -67,11 +68,6 @@ template <typename T> bool SX126xInterface<T>::init()
     LOG_DEBUG("Current limit set to %f\n", currentLimit);
     LOG_DEBUG("Current limit set result %d\n", res);
 
-#if defined(SX126X_TXEN) && (SX126X_TXEN != RADIOLIB_NC)
-    // lora.begin sets Dio2 as RF switch control, which is not true if we are manually controlling RX and TX
-    if (res == RADIOLIB_ERR_NONE)
-        res = lora.setDio2AsRfSwitch(false);
-#endif
 #ifdef SX126X_E22
     // E22 Emulation explicitly requires DIO2 as RF switch, so set it to TRUE again for good measure. In case somebody defines
     // SX126X_TX for an E22 Module
@@ -79,13 +75,25 @@ template <typename T> bool SX126xInterface<T>::init()
         res = lora.setDio2AsRfSwitch(true);
 #endif
 
-if (config.lora.sx126x_rx_boosted_gain) {
-    uint16_t result = lora.setRxBoostedGainMode(true);
-    LOG_INFO("Set Rx Boosted Gain mode; result: %d\n", result);
-} else {
-    uint16_t result = lora.setRxBoostedGainMode(false);
-    LOG_INFO("Set Rx Power Saving Gain mode; result: %d\n", result);
-}
+#if defined(SX126X_TXEN) && (SX126X_TXEN != RADIOLIB_NC)
+    // lora.begin sets Dio2 as RF switch control, which is not true if we are manually controlling RX and TX
+    if (res == RADIOLIB_ERR_NONE)
+    {
+        res = lora.setDio2AsRfSwitch(false);
+        lora.setRfSwitchPins(SX126X_RXEN, SX126X_TXEN);
+    }
+#endif
+
+    if (config.lora.sx126x_rx_boosted_gain)
+    {
+        uint16_t result = lora.setRxBoostedGainMode(true);
+        LOG_INFO("Set Rx Boosted Gain mode; result: %d\n", result);
+    }
+    else
+    {
+        uint16_t result = lora.setRxBoostedGainMode(false);
+        LOG_INFO("Set Rx Power Saving Gain mode; result: %d\n", result);
+    }
 
 #if 0
     // Read/write a register we are not using (only used for FSK mode) to test SPI comms
@@ -120,7 +128,8 @@ if (config.lora.sx126x_rx_boosted_gain) {
     return res == RADIOLIB_ERR_NONE;
 }
 
-template <typename T> bool SX126xInterface<T>::reconfigure()
+template <typename T>
+bool SX126xInterface<T>::reconfigure()
 {
     RadioLibInterface::reconfigure();
 
@@ -169,12 +178,14 @@ template <typename T> bool SX126xInterface<T>::reconfigure()
     return RADIOLIB_ERR_NONE;
 }
 
-template <typename T> void INTERRUPT_ATTR SX126xInterface<T>::disableInterrupt()
+template <typename T>
+void INTERRUPT_ATTR SX126xInterface<T>::disableInterrupt()
 {
     lora.clearDio1Action();
 }
 
-template <typename T> void SX126xInterface<T>::setStandby()
+template <typename T>
+void SX126xInterface<T>::setStandby()
 {
     checkNotification(); // handle any pending interrupts before we force standby
 
@@ -185,12 +196,12 @@ template <typename T> void SX126xInterface<T>::setStandby()
 
     assert(err == RADIOLIB_ERR_NONE);
 
-#if defined(SX126X_RXEN) && (SX126X_RXEN != RADIOLIB_NC) // we have RXEN/TXEN control - turn off RX and TX power
-    digitalWrite(SX126X_RXEN, LOW);
-#endif
-#if defined(SX126X_TXEN) && (SX126X_TXEN != RADIOLIB_NC)
-    digitalWrite(SX126X_TXEN, LOW);
-#endif
+    // #if defined(SX126X_RXEN) && (SX126X_RXEN != RADIOLIB_NC) // we have RXEN/TXEN control - turn off RX and TX power
+    //     digitalWrite(SX126X_RXEN, LOW);
+    // #endif
+    // #if defined(SX126X_TXEN) && (SX126X_TXEN != RADIOLIB_NC)
+    //     digitalWrite(SX126X_TXEN, LOW);
+    // #endif
 
     isReceiving = false; // If we were receiving, not any more
     disableInterrupt();
@@ -200,7 +211,8 @@ template <typename T> void SX126xInterface<T>::setStandby()
 /**
  * Add SNR data to received messages
  */
-template <typename T> void SX126xInterface<T>::addReceiveMetadata(meshtastic_MeshPacket *mp)
+template <typename T>
+void SX126xInterface<T>::addReceiveMetadata(meshtastic_MeshPacket *mp)
 {
     // LOG_DEBUG("PacketStatus %x\n", lora.getPacketStatus());
     mp->rx_snr = lora.getSNR();
@@ -209,14 +221,15 @@ template <typename T> void SX126xInterface<T>::addReceiveMetadata(meshtastic_Mes
 
 /** We override to turn on transmitter power as needed.
  */
-template <typename T> void SX126xInterface<T>::configHardwareForSend()
+template <typename T>
+void SX126xInterface<T>::configHardwareForSend()
 {
-#if defined(SX126X_TXEN) && (SX126X_TXEN != RADIOLIB_NC) // we have RXEN/TXEN control - turn on TX power / off RX power
-    digitalWrite(SX126X_TXEN, HIGH);
-#endif
-#if defined(SX126X_RXEN) && (SX126X_RXEN != RADIOLIB_NC)
-    digitalWrite(SX126X_RXEN, LOW);
-#endif
+    // #if defined(SX126X_TXEN) && (SX126X_TXEN != RADIOLIB_NC) // we have RXEN/TXEN control - turn on TX power / off RX power
+    //     digitalWrite(SX126X_TXEN, HIGH);
+    // #endif
+    // #if defined(SX126X_RXEN) && (SX126X_RXEN != RADIOLIB_NC)
+    //     digitalWrite(SX126X_RXEN, LOW);
+    // #endif
 
     RadioLibInterface::configHardwareForSend();
 }
@@ -224,7 +237,8 @@ template <typename T> void SX126xInterface<T>::configHardwareForSend()
 // For power draw measurements, helpful to force radio to stay sleeping
 // #define SLEEP_ONLY
 
-template <typename T> void SX126xInterface<T>::startReceive()
+template <typename T>
+void SX126xInterface<T>::startReceive()
 {
 #ifdef SLEEP_ONLY
     sleep();
@@ -232,12 +246,12 @@ template <typename T> void SX126xInterface<T>::startReceive()
 
     setStandby();
 
-#if defined(SX126X_RXEN) && (SX126X_RXEN != RADIOLIB_NC) // we have RXEN/TXEN control - turn on RX power / off TX power
-    digitalWrite(SX126X_RXEN, HIGH);
-#endif
-#if defined(SX126X_TXEN) && (SX126X_TXEN != RADIOLIB_NC)
-    digitalWrite(SX126X_TXEN, LOW);
-#endif
+    // #if defined(SX126X_RXEN) && (SX126X_RXEN != RADIOLIB_NC) // we have RXEN/TXEN control - turn on RX power / off TX power
+    //     digitalWrite(SX126X_RXEN, HIGH);
+    // #endif
+    // #if defined(SX126X_TXEN) && (SX126X_TXEN != RADIOLIB_NC)
+    //     digitalWrite(SX126X_TXEN, LOW);
+    // #endif
 
     // int err = lora.startReceive();
     int err = lora.startReceiveDutyCycleAuto(); // We use a 32 bit preamble so this should save some power by letting radio sit in
@@ -252,7 +266,8 @@ template <typename T> void SX126xInterface<T>::startReceive()
 }
 
 /** Could we send right now (i.e. either not actively receving or transmitting)? */
-template <typename T> bool SX126xInterface<T>::isChannelActive()
+template <typename T>
+bool SX126xInterface<T>::isChannelActive()
 {
     // check if we can detect a LoRa preamble on the current channel
     int16_t result;
@@ -268,7 +283,8 @@ template <typename T> bool SX126xInterface<T>::isChannelActive()
 }
 
 /** Could we send right now (i.e. either not actively receving or transmitting)? */
-template <typename T> bool SX126xInterface<T>::isActivelyReceiving()
+template <typename T>
+bool SX126xInterface<T>::isActivelyReceiving()
 {
     // The IRQ status will be cleared when we start our read operation.  Check if we've started a header, but haven't yet
     // received and handled the interrupt for reading the packet/handling errors.
@@ -285,7 +301,8 @@ template <typename T> bool SX126xInterface<T>::isActivelyReceiving()
     return hasPreamble;
 }
 
-template <typename T> bool SX126xInterface<T>::sleep()
+template <typename T>
+bool SX126xInterface<T>::sleep()
 {
     // Not keeping config is busted - next time nrf52 board boots lora sending fails  tcxo related? - see datasheet
     // \todo Display actual typename of the adapter, not just `SX126x`

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -26,15 +26,6 @@ template <typename T> bool SX126xInterface<T>::init()
     pinMode(SX126X_POWER_EN, OUTPUT);
 #endif
 
-#if defined(SX126X_RXEN) && (SX126X_RXEN != RADIOLIB_NC) // set not rx or tx mode
-    digitalWrite(SX126X_RXEN, LOW);                      // Set low before becoming an output
-    pinMode(SX126X_RXEN, OUTPUT);
-#endif
-#if defined(SX126X_TXEN) && (SX126X_TXEN != RADIOLIB_NC)
-    digitalWrite(SX126X_TXEN, LOW);
-    pinMode(SX126X_TXEN, OUTPUT);
-#endif
-
 #ifndef SX126X_E22
     float tcxoVoltage = 0; // None - we use an XTAL
 #else
@@ -188,13 +179,6 @@ template <typename T> void SX126xInterface<T>::setStandby()
 
     assert(err == RADIOLIB_ERR_NONE);
 
-    // #if defined(SX126X_RXEN) && (SX126X_RXEN != RADIOLIB_NC) // we have RXEN/TXEN control - turn off RX and TX power
-    //     digitalWrite(SX126X_RXEN, LOW);
-    // #endif
-    // #if defined(SX126X_TXEN) && (SX126X_TXEN != RADIOLIB_NC)
-    //     digitalWrite(SX126X_TXEN, LOW);
-    // #endif
-
     isReceiving = false; // If we were receiving, not any more
     disableInterrupt();
     completeSending(); // If we were sending, not anymore
@@ -214,13 +198,6 @@ template <typename T> void SX126xInterface<T>::addReceiveMetadata(meshtastic_Mes
  */
 template <typename T> void SX126xInterface<T>::configHardwareForSend()
 {
-    // #if defined(SX126X_TXEN) && (SX126X_TXEN != RADIOLIB_NC) // we have RXEN/TXEN control - turn on TX power / off RX power
-    //     digitalWrite(SX126X_TXEN, HIGH);
-    // #endif
-    // #if defined(SX126X_RXEN) && (SX126X_RXEN != RADIOLIB_NC)
-    //     digitalWrite(SX126X_RXEN, LOW);
-    // #endif
-
     RadioLibInterface::configHardwareForSend();
 }
 
@@ -234,13 +211,6 @@ template <typename T> void SX126xInterface<T>::startReceive()
 #else
 
     setStandby();
-
-    // #if defined(SX126X_RXEN) && (SX126X_RXEN != RADIOLIB_NC) // we have RXEN/TXEN control - turn on RX power / off TX power
-    //     digitalWrite(SX126X_RXEN, HIGH);
-    // #endif
-    // #if defined(SX126X_TXEN) && (SX126X_TXEN != RADIOLIB_NC)
-    //     digitalWrite(SX126X_TXEN, LOW);
-    // #endif
 
     // int err = lora.startReceive();
     int err = lora.startReceiveDutyCycleAuto(); // We use a 32 bit preamble so this should save some power by letting radio sit in

--- a/variants/diy/v1/variant.h
+++ b/variants/diy/v1/variant.h
@@ -44,6 +44,9 @@
 #define RF95_RXEN 14
 #define RF95_TXEN 13
 
+// Set lora.tx_power to 13 for Hydra or other E22 900M30S target due to PA
+#define SX126X_MAX_POWER 22
+
 #ifdef EBYTE_E22
 // Internally the TTGO module hooks the SX126x-DIO2 in to control the TX/RX switch
 // (which is the default for the sx1262interface code)

--- a/variants/rak4631/variant.h
+++ b/variants/rak4631/variant.h
@@ -206,6 +206,7 @@ SO GPIO 39/TXEN MAY NOT BE DEFINED FOR SUCCESSFUL OPERATION OF THE SX1262 - TG
 #define SX126X_RESET (38)
 // #define SX126X_TXEN (39)
 // #define SX126X_RXEN (37)
+#define SX126X_POWER_EN (37)
 #define SX126X_E22 // DIO2 controlls an antenna switch and the TCXO voltage is controlled by DIO3
 
 // enables 3.3V periphery like GPS or IO Module

--- a/variants/rak4631_epaper/variant.h
+++ b/variants/rak4631_epaper/variant.h
@@ -136,7 +136,7 @@ static const uint8_t SCK = PIN_SPI_SCK;
 
 // Controls power for the eink display - Board power is enabled either by VBUS from USB or the CPU asserting PWR_ON
 // FIXME - I think this is actually just the board power enable - it enables power to the CPU also
-//#define PIN_EINK_PWR_ON (-1)
+// #define PIN_EINK_PWR_ON (-1)
 
 #define USE_EINK
 
@@ -181,8 +181,9 @@ static const uint8_t SCK = PIN_SPI_SCK;
 #define SX126X_DIO1 (47)
 #define SX126X_BUSY (46)
 #define SX126X_RESET (38)
-#define SX126X_TXEN (39)
-#define SX126X_RXEN (37)
+// #define SX126X_TXEN (39)
+// #define SX126X_RXEN (37)
+#define SX126X_POWER_EN (37)
 #define SX126X_E22 // DIO2 controlls an antenna switch and the TCXO voltage is controlled by DIO3
 
 // enables 3.3V periphery like GPS or IO Module


### PR DESCRIPTION
It appears RX_EN pin needs to be powered, to be used as the antenna switch properly.