### PR TITLE
Set encryptedOk to false for local_only rebroadcast

### DIFF
--- a/src/mesh/FloodingRouter.cpp
+++ b/src/mesh/FloodingRouter.cpp
@@ -59,11 +59,6 @@ void FloodingRouter::sniffReceived(const meshtastic_MeshPacket *p, const meshtas
             LOG_DEBUG("Ignoring a simple (0 id) broadcast\n");
         }
     }
-
-    if (config.device.rebroadcast_mode == meshtastic_Config_DeviceConfig_RebroadcastMode_LOCAL_ONLY) {
-        LOG_DEBUG("Cancelling rebroadcast of message from node on a foreign mesh, due to local only rebroadcast mode\n");
-        Router::cancelSending(p->to, p->decoded.request_id);
-    }
     // handle the packet as normal
     Router::sniffReceived(p, c);
 }

--- a/src/modules/RoutingModule.cpp
+++ b/src/modules/RoutingModule.cpp
@@ -14,7 +14,8 @@ bool RoutingModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mesh
 
     // FIXME - move this to a non promsicious PhoneAPI module?
     // Note: we are careful not to send back packets that started with the phone back to the phone
-    if ((mp.to == NODENUM_BROADCAST || mp.to == nodeDB.getNodeNum()) && (mp.from != 0)) {
+    if ((mp.to == NODENUM_BROADCAST || mp.to == nodeDB.getNodeNum()) && (mp.from != 0))
+    {
         printPacket("Delivering rx packet", &mp);
         service.handleFromRadio(&mp);
     }
@@ -29,7 +30,8 @@ meshtastic_MeshPacket *RoutingModule::allocReply()
     assert(currentRequest);
 
     // We only consider making replies if the request was a legit routing packet (not just something we were sniffing)
-    if (currentRequest->decoded.portnum == meshtastic_PortNum_ROUTING_APP) {
+    if (currentRequest->decoded.portnum == meshtastic_PortNum_ROUTING_APP)
+    {
         assert(0); // 1.2 refactoring fixme, Not sure if anything needs this yet?
         // return allocDataProtobuf(u);
     }
@@ -46,5 +48,5 @@ void RoutingModule::sendAckNak(meshtastic_Routing_Error err, NodeNum to, PacketI
 RoutingModule::RoutingModule() : ProtobufModule("routing", meshtastic_PortNum_ROUTING_APP, &meshtastic_Routing_msg)
 {
     isPromiscuous = true;
-    encryptedOk = true;
+    encryptedOk = config.device.rebroadcast_mode != meshtastic_Config_DeviceConfig_RebroadcastMode_LOCAL_ONLY;
 }

--- a/src/modules/RoutingModule.cpp
+++ b/src/modules/RoutingModule.cpp
@@ -14,8 +14,7 @@ bool RoutingModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mesh
 
     // FIXME - move this to a non promsicious PhoneAPI module?
     // Note: we are careful not to send back packets that started with the phone back to the phone
-    if ((mp.to == NODENUM_BROADCAST || mp.to == nodeDB.getNodeNum()) && (mp.from != 0))
-    {
+    if ((mp.to == NODENUM_BROADCAST || mp.to == nodeDB.getNodeNum()) && (mp.from != 0)) {
         printPacket("Delivering rx packet", &mp);
         service.handleFromRadio(&mp);
     }
@@ -30,8 +29,7 @@ meshtastic_MeshPacket *RoutingModule::allocReply()
     assert(currentRequest);
 
     // We only consider making replies if the request was a legit routing packet (not just something we were sniffing)
-    if (currentRequest->decoded.portnum == meshtastic_PortNum_ROUTING_APP)
-    {
+    if (currentRequest->decoded.portnum == meshtastic_PortNum_ROUTING_APP) {
         assert(0); // 1.2 refactoring fixme, Not sure if anything needs this yet?
         // return allocDataProtobuf(u);
     }


### PR DESCRIPTION
Fixed incorrect assumptions about cancelling rebroadcasts of foreign channel packets