### PR TITLE
Enable DeviceTelemetry on Portduino

### DIFF
--- a/arch/portduino/portduino.ini
+++ b/arch/portduino/portduino.ini
@@ -12,7 +12,9 @@ build_src_filter =
   -<mesh/http/>
   -<mesh/eth/>
   -<modules/esp32>
-  -<modules/Telemetry>
+  -<modules/Telemetry/EnvironmentTelemetry.cpp>
+  -<modules/Telemetry/AirQualityTelemetry.cpp>
+  -<modules/Telemetry/Sensor>
   +<../variants/portduino>
 lib_deps =
   ${env.lib_deps}

--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -103,7 +103,7 @@ size_t RedirectablePrint::log(const char *logLevel, const char *format, ...)
         }
         r += vprintf(format, arg);
 
-#if HAS_WIFI || HAS_ETHERNET
+#if (HAS_WIFI || HAS_ETHERNET) && !defined(ARCH_PORTDUINO)
         // if syslog is in use, collect the log messages and send them to syslog
         if (syslog.isEnabled()) {
             int ll = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -394,6 +394,19 @@ void setup()
 
     // radio init MUST BE AFTER service.init, so we have our radio config settings (from nodedb init)
 
+#if !HAS_RADIO && defined(ARCH_PORTDUINO)
+    if (!rIf) {
+        rIf = new SimRadio;
+        if (!rIf->init()) {
+            LOG_WARN("Failed to find simulated radio\n");
+            delete rIf;
+            rIf = NULL;
+        } else {
+            LOG_INFO("Using SIMULATED radio!\n");
+        }
+    }
+#endif
+
 #if defined(RF95_IRQ)
     if (!rIf) {
         rIf = new RF95Interface(RF95_NSS, RF95_IRQ, RF95_RESET, SPI);
@@ -455,19 +468,6 @@ void setup()
             rIf = NULL;
         } else {
             LOG_INFO("LLCC68 Radio init succeeded, using LLCC68 radio\n");
-        }
-    }
-#endif
-
-#ifdef ARCH_PORTDUINO
-    if (!rIf) {
-        rIf = new SimRadio;
-        if (!rIf->init()) {
-            LOG_WARN("Failed to find simulated radio\n");
-            delete rIf;
-            rIf = NULL;
-        } else {
-            LOG_INFO("Using SIMULATED radio!\n");
         }
     }
 #endif

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -132,7 +132,7 @@ void MeshService::reloadOwner(bool shouldSave)
  */
 void MeshService::handleToRadio(meshtastic_MeshPacket &p)
 {
-#ifdef ARCH_PORTDUINO
+#if defined(ARCH_PORTDUINO) && !HAS_RADIO
     // Simulates device is receiving a packet via the LoRa chip
     if (p.decoded.portnum == meshtastic_PortNum_SIMULATOR_APP) {
         // Simulator packet (=Compressed packet) is encapsulated in a MeshPacket, so need to unwrap first

--- a/src/mesh/MeshService.h
+++ b/src/mesh/MeshService.h
@@ -10,7 +10,7 @@
 #include "MeshTypes.h"
 #include "Observer.h"
 #include "PointerQueue.h"
-#ifdef ARCH_PORTDUINO
+#if defined(ARCH_PORTDUINO) && !HAS_RADIO
 #include "../platform/portduino/SimRadio.h"
 #endif
 

--- a/src/modules/Modules.cpp
+++ b/src/modules/Modules.cpp
@@ -17,8 +17,8 @@
 #include "modules/Telemetry/DeviceTelemetry.h"
 #endif
 #if HAS_SENSOR
-#include "modules/Telemetry/EnvironmentTelemetry.h"
 #include "modules/Telemetry/AirQualityTelemetry.h"
+#include "modules/Telemetry/EnvironmentTelemetry.h"
 #endif
 #ifdef ARCH_ESP32
 #include "modules/esp32/AudioModule.h"

--- a/src/modules/Modules.cpp
+++ b/src/modules/Modules.cpp
@@ -14,9 +14,11 @@
 #include "modules/TraceRouteModule.h"
 #include "modules/WaypointModule.h"
 #if HAS_TELEMETRY
-#include "modules/Telemetry/AirQualityTelemetry.h"
 #include "modules/Telemetry/DeviceTelemetry.h"
+#endif
+#if HAS_SENSOR
 #include "modules/Telemetry/EnvironmentTelemetry.h"
+#include "modules/Telemetry/AirQualityTelemetry.h"
 #endif
 #ifdef ARCH_ESP32
 #include "modules/esp32/AudioModule.h"
@@ -63,6 +65,8 @@ void setupModules()
 #endif
 #if HAS_TELEMETRY
         new DeviceTelemetryModule();
+#endif
+#if HAS_SENSOR
         new EnvironmentTelemetryModule();
         if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_PMSA003I] > 0) {
             new AirQualityTelemetryModule();

--- a/src/modules/Telemetry/AirQualityTelemetry.cpp
+++ b/src/modules/Telemetry/AirQualityTelemetry.cpp
@@ -10,7 +10,6 @@
 
 int32_t AirQualityTelemetryModule::runOnce()
 {
-#ifndef ARCH_PORTDUINO
     int32_t result = INT32_MAX;
     /*
         Uncomment the preferences below if you want to use the module
@@ -55,7 +54,6 @@ int32_t AirQualityTelemetryModule::runOnce()
         }
     }
     return sendToPhoneIntervalMs;
-#endif
 }
 
 bool AirQualityTelemetryModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_Telemetry *t)

--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -52,7 +52,6 @@ SHT31Sensor sht31Sensor;
 
 int32_t EnvironmentTelemetryModule::runOnce()
 {
-#ifndef ARCH_PORTDUINO
     int32_t result = INT32_MAX;
     /*
         Uncomment the preferences below if you want to use the module
@@ -115,7 +114,6 @@ int32_t EnvironmentTelemetryModule::runOnce()
         }
     }
     return sendToPhoneIntervalMs;
-#endif
 }
 
 bool EnvironmentTelemetryModule::wantUIFrame()

--- a/src/platform/esp32/architecture.h
+++ b/src/platform/esp32/architecture.h
@@ -27,6 +27,9 @@
 #ifndef HAS_TELEMETRY
 #define HAS_TELEMETRY 1
 #endif
+#ifndef HAS_SENSOR
+#define HAS_SENSOR 1
+#endif
 #ifndef HAS_RADIO
 #define HAS_RADIO 1
 #endif

--- a/src/platform/nrf52/architecture.h
+++ b/src/platform/nrf52/architecture.h
@@ -23,6 +23,9 @@
 #ifndef HAS_TELEMETRY
 #define HAS_TELEMETRY 1
 #endif
+#ifndef HAS_SENSOR
+#define HAS_SENSOR 1
+#endif
 #ifndef HAS_RADIO
 #define HAS_RADIO 1
 #endif

--- a/src/platform/portduino/SimRadio.h
+++ b/src/platform/portduino/SimRadio.h
@@ -3,10 +3,11 @@
 #include "MeshPacketQueue.h"
 #include "RadioInterface.h"
 #include "api/WiFiServerAPI.h"
+#include "concurrency/NotifiedWorkerThread.h"
 
 #include <RadioLib.h>
 
-class SimRadio : public RadioInterface
+class SimRadio : public RadioInterface, protected concurrency::NotifiedWorkerThread
 {
     enum PendingISR { ISR_NONE = 0, ISR_RX, ISR_TX, TRANSMIT_DELAY_COMPLETED };
 

--- a/src/platform/portduino/architecture.h
+++ b/src/platform/portduino/architecture.h
@@ -3,10 +3,6 @@
 #define ARCH_PORTDUINO
 
 //
-// defaults for NRF52 architecture
-//
-
-//
 // set HW_VENDOR
 //
 

--- a/src/platform/portduino/architecture.h
+++ b/src/platform/portduino/architecture.h
@@ -8,5 +8,12 @@
 
 #define HW_VENDOR meshtastic_HardwareModel_PORTDUINO
 
-#define HAS_RTC 1
+#ifndef HAS_WIFI
 #define HAS_WIFI 1
+#endif
+#ifndef HAS_RTC
+#define HAS_RTC 1
+#endif
+#ifndef HAS_TELEMETRY
+#define HAS_TELEMETRY 1
+#endif


### PR DESCRIPTION
I added a `HAS_SENSOR` flag to separate DeviceTelemetry from EnvironmentTelemetry such that we can enable it on Portduino. 

Furthermore, I had to put `SimRadio` in a separate thread such that I can use `notifyLater` when transmitting, to fix issues with the packetPool when it was using `ccToPhone` for DeviceTelemetry.

I also guarded the simulator stuff with `HAS_RADIO` such that we can distinguish between a Portduino target with radio and the simulator.

Then I found syslog causes Portduino to crash because it doesn't compile _mesh/http_, so I disabled that with an extra `!defined(ARCH_PORTDUINO)`.




