### PR TITLE
Send and request NodeInfo when hearing new node

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -75,9 +75,13 @@ int MeshService::handleFromRadio(const meshtastic_MeshPacket *mp)
 {
     powerFSM.trigger(EVENT_PACKET_FOR_PHONE); // Possibly keep the node from sleeping
 
-    printPacket("Forwarding to phone", mp);
     nodeDB.updateFrom(*mp); // update our DB state based off sniffing every RX packet from the radio
+    if (!nodeDB.getNode(mp->from)->has_user) {
+        LOG_INFO("Heard a node we don't know, sending NodeInfo and asking for a response.\n");
+        nodeInfoModule->sendOurNodeInfo(mp->from, true);
+    }
 
+    printPacket("Forwarding to phone", mp);
     sendToPhone((meshtastic_MeshPacket *)mp);
 
     return 0;

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -170,6 +170,7 @@ void NodeDB::installDefaultConfig()
     config.lora.hop_limit = HOP_RELIABLE;
     config.position.gps_enabled = true;
     config.position.position_broadcast_smart_enabled = true;
+    config.device.node_info_broadcast_secs = 3 * 60 * 60;
     config.device.serial_enabled = true;
     resetRadioConfig();
     strncpy(config.network.ntp_server, "0.pool.ntp.org", 32);

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -194,7 +194,7 @@ extern NodeDB nodeDB;
 
 #define default_gps_attempt_time IF_ROUTER(5 * 60, 15 * 60)
 #define default_gps_update_interval IF_ROUTER(ONE_DAY, 2 * 60)
-#define default_broadcast_interval_secs IF_ROUTER(ONE_DAY / 2, 15 * 60)
+#define default_broadcast_interval_secs IF_ROUTER(ONE_DAY / 2, 3 * 60 * 60)
 #define default_wait_bluetooth_secs IF_ROUTER(1, 60)
 #define default_mesh_sds_timeout_secs IF_ROUTER(NODE_DELAY_FOREVER, 2 * 60 * 60)
 #define default_sds_secs IF_ROUTER(ONE_DAY, UINT32_MAX) // Default to forever super deep sleep

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -194,7 +194,7 @@ extern NodeDB nodeDB;
 
 #define default_gps_attempt_time IF_ROUTER(5 * 60, 15 * 60)
 #define default_gps_update_interval IF_ROUTER(ONE_DAY, 2 * 60)
-#define default_broadcast_interval_secs IF_ROUTER(ONE_DAY / 2, 3 * 60 * 60)
+#define default_broadcast_interval_secs IF_ROUTER(ONE_DAY / 2, 15 * 60)
 #define default_wait_bluetooth_secs IF_ROUTER(1, 60)
 #define default_mesh_sds_timeout_secs IF_ROUTER(NODE_DELAY_FOREVER, 2 * 60 * 60)
 #define default_sds_secs IF_ROUTER(ONE_DAY, UINT32_MAX) // Default to forever super deep sleep

--- a/src/modules/Telemetry/DeviceTelemetry.h
+++ b/src/modules/Telemetry/DeviceTelemetry.h
@@ -12,7 +12,7 @@ class DeviceTelemetryModule : private concurrency::OSThread, public ProtobufModu
         : concurrency::OSThread("DeviceTelemetryModule"),
           ProtobufModule("DeviceTelemetry", meshtastic_PortNum_TELEMETRY_APP, &meshtastic_Telemetry_msg)
     {
-        setIntervalFromNow(10 * 1000);
+        setIntervalFromNow(45 * 1000); // Wait until NodeInfo is sent
     }
     virtual bool wantUIFrame() { return false; }
 


### PR DESCRIPTION
When we get a packet with a NodeID whom we don't know the user, we send our NodeInfo and ask for a response. This way the NodeDB gets updated directly and not just when the next NodeInfo broadcast occurs. Using this, we can also increase the default NodeInfo broadcast to 3 hours.

I also delayed the initial DeviceTelemetry packet to 45 seconds after booting, such that it is sent after the first NodeInfo packet.
