### PR TITLE
NodeInfo fixes for other roles

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -76,7 +76,7 @@ int MeshService::handleFromRadio(const meshtastic_MeshPacket *mp)
     powerFSM.trigger(EVENT_PACKET_FOR_PHONE); // Possibly keep the node from sleeping
 
     nodeDB.updateFrom(*mp); // update our DB state based off sniffing every RX packet from the radio
-    if (!nodeDB.getNode(mp->from)->has_user) {
+    if (!nodeDB.getNode(mp->from)->has_user && nodeInfoModule) {
         LOG_INFO("Heard a node we don't know, sending NodeInfo and asking for a response.\n");
         nodeInfoModule->sendOurNodeInfo(mp->from, true);
     }

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -170,7 +170,8 @@ void NodeDB::installDefaultConfig()
     config.lora.hop_limit = HOP_RELIABLE;
     config.position.gps_enabled = true;
     config.position.position_broadcast_smart_enabled = true;
-    config.device.node_info_broadcast_secs = 3 * 60 * 60;
+    if (config.device.role != meshtastic_Config_DeviceConfig_Role_ROUTER)
+        config.device.node_info_broadcast_secs = 3 * 60 * 60;
     config.device.serial_enabled = true;
     resetRadioConfig();
     strncpy(config.network.ntp_server, "0.pool.ntp.org", 32);


### PR DESCRIPTION
With this, the new default NodeInfo broadcast interval will not be set for a Router. 

Also, I added a check whether the NodeInfoModule exists before triggering a NodeInfo packet, otherwise a repeater doesn't know what to do.
