### PR TITLE
Sanity check for sending NodeInfo

### DIFF
--- a/src/mesh/MeshModule.h
+++ b/src/mesh/MeshModule.h
@@ -94,6 +94,9 @@ class MeshModule
      * flag */
     bool encryptedOk = false;
 
+    /* We allow modules to ignore a request without sending an error if they have a specific reason for it. */
+    bool ignoreRequest = false;
+
     /** If a bound channel name is set, we will only accept received packets that come in on that channel.
      * A special exception (FIXME, not sure if this is a good idea) - packets that arrive on the local interface
      * are allowed on any channel (this lets the local user do anything).

--- a/src/modules/NodeInfoModule.h
+++ b/src/modules/NodeInfoModule.h
@@ -35,6 +35,9 @@ class NodeInfoModule : public ProtobufModule<meshtastic_User>, private concurren
 
     /** Does our periodic broadcast */
     virtual int32_t runOnce() override;
+
+  private:
+    uint32_t lastSentToMesh = 0; // Last time we sent our NodeInfo to the mesh
 };
 
 extern NodeInfoModule *nodeInfoModule;


### PR DESCRIPTION
This adds a "sanity check" before sending your NodeInfo, to make sure you don’t send it again if you’ve sent it less than one minute ago. This may happen when someone requests it, e.g. after a node boots. The original NodeInfo might still be underway to some of the nodes, e.g., if it needs to go across multiple hops or due to queuing since it has background priority. 

For this, I had to allow a module to ignore a request without sending an error.

At least in the interactive simulator it avoids the big storm of NodeInfo messages at the beginning, while still every node received the NodeInfo of every other node. Here I simulated 5 nodes starting up at the exact same locations. First without sanity check:
![image](https://user-images.githubusercontent.com/78759985/219120879-d873e391-8660-453a-af51-f9273290afe4.png)
With sanity check (note the y-scale):
![image](https://user-images.githubusercontent.com/78759985/219120960-77bf857c-9c56-4712-9af7-a1f6c570f1f6.png)

In reality this will not occur frequently, but a sanity check won't hurt. If a node somehow missed the NodeInfo, it will ask for it the next time it receives a message from a node it doesn't know.
