### PR TITLE
Nano G1 Explorer

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,8 +2,9 @@
     // See http://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-        "ms-vscode.cpptools",
-        "platformio.platformio-ide",
-        "trunk.io"
+        "platformio.platformio-ide"
     ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,9 +2,8 @@
     // See http://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-        "platformio.platformio-ide"
+        "ms-vscode.cpptools",
+        "platformio.platformio-ide",
+        "trunk.io"
     ],
-    "unwantedRecommendations": [
-        "ms-vscode.cpptools-extension-pack"
-    ]
 }

--- a/src/platform/esp32/architecture.h
+++ b/src/platform/esp32/architecture.h
@@ -95,6 +95,8 @@
 #define HW_VENDOR meshtastic_HardwareModel_TLORA_T3_S3
 #elif defined(BETAFPV_2400_TX)
 #define HW_VENDOR meshtastic_HardwareModel_BETAFPV_2400_TX
+#elif defined(NANO_G1_EXPLORER)
+#define HW_VENDOR meshtastic_HardwareModel_NANO_G1_EXPLORER
 #endif
 
 //

--- a/variants/nano-g1-explorer/platformio.ini
+++ b/variants/nano-g1-explorer/platformio.ini
@@ -1,0 +1,8 @@
+; The 1.0 release of the nano-g1-explorer board 
+[env:nano-g1-explorer]
+extends = esp32_base
+board = ttgo-t-beam
+lib_deps =
+  ${esp32_base.lib_deps}
+build_flags = 
+  ${esp32_base.build_flags} -D NANO_G1_EXPLORER  -I variants/nano-g1-explorer

--- a/variants/nano-g1-explorer/variant.h
+++ b/variants/nano-g1-explorer/variant.h
@@ -1,0 +1,37 @@
+// #define BUTTON_NEED_PULLUP // if set we need to turn on the internal CPU pullup during sleep
+
+#define I2C_SDA 21
+#define I2C_SCL 22
+
+#define BUTTON_PIN 36 // The user button (information button) GPIO on the Nano G1 explorer
+//#define BUTTON_PIN_ALT 13 // Alternate GPIO for an external button if needed. Does anyone use this? It is not documented
+// anywhere.
+#define EXT_NOTIFY_OUT 13 // Default pin to use for Ext Notify Module.
+
+// common pinout for their SX1262 vs RF95 modules - both can be enabled and we will probe at runtime for RF95 and if
+// not found then probe for SX1262
+#define USE_RF95
+#define USE_SX1262
+
+#define LORA_DIO0 26 // a No connect on the SX1262 module
+#define LORA_RESET 23
+#define LORA_DIO1 33 // SX1262 IRQ
+#define LORA_DIO2 32 // SX1262 BUSY
+#define LORA_DIO3    // Not connected on PCB
+
+#ifdef USE_SX1262
+#define SX126X_CS RF95_NSS // FIXME - we really should define LORA_CS instead
+#define SX126X_DIO1 LORA_DIO1
+#define SX126X_BUSY LORA_DIO2
+#define SX126X_RESET LORA_RESET
+#define SX126X_E22 // Not really an E22
+// Internally the module hooks the SX1262-DIO2 in to control the TX/RX switch (which is the default for the sx1262interface
+// code)
+#endif
+
+#define BATTERY_PIN 35           // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
+#define BATTERY_SENSE_SAMPLES 15 // Set the number of samples, It has an effect of increasing sensitivity.
+#define ADC_MULTIPLIER 2
+
+//#define USE_SH1107    // Finally we will use SH1107 128x64 resolution driver, because SH1106 will shift the screen by 2 lines.
+#define USE_SH1106


### PR DESCRIPTION
Known Issues: 
1. Finally we will use SH1107 128x64 resolution driver, because SH1106 will shift the screen by 2 lines.

The Nano G1 Explorer features a new internal wideband Lora antenna, which supports frequencies from 815 Mhz to 940 Mhz. The wideband antenna, combined with an optimized wideband Lora RF frontend circuit, enables the Nano G1 Explorer to work with the majority of regions' LoRa frequency bands around the world without the need for antenna changes. The design of the device also takes into account the potential effect of the human body on its antenna performance, ensuring optimal RF performance even when carried in a pocket.