### PR TITLE
Use LORA_DIO1 as RadioLib GPIO for SX127x chips

### DIFF
--- a/src/RF95Configuration.h
+++ b/src/RF95Configuration.h
@@ -2,6 +2,6 @@
 #ifdef USE_RF95
 #define RF95_RESET LORA_RESET
 #define RF95_IRQ LORA_DIO0  // on SX1262 version this is a no connect DIO0
-#define RF95_DIO1 LORA_DIO1 // Note: not really used for RF95
+#define RF95_DIO1 LORA_DIO1 // Note: not really used for RF95, but used for pure SX127x
 #define RF95_DIO2 LORA_DIO2 // Note: not really used for RF95
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -409,7 +409,7 @@ void setup()
 
 #if defined(RF95_IRQ)
     if (!rIf) {
-        rIf = new RF95Interface(RF95_NSS, RF95_IRQ, RF95_RESET, SPI);
+        rIf = new RF95Interface(RF95_NSS, RF95_IRQ, RF95_RESET, RF95_DIO1, SPI);
         if (!rIf->init()) {
             LOG_WARN("Failed to find RF95 radio\n");
             delete rIf;

--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -11,8 +11,9 @@
 
 #define POWER_DEFAULT 17 // How much power to use if the user hasn't set a power level
 
-RF95Interface::RF95Interface(RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst, SPIClass &spi)
-    : RadioLibInterface(cs, irq, rst, RADIOLIB_NC, spi)
+RF95Interface::RF95Interface(RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst, RADIOLIB_PIN_TYPE busy,
+                             SPIClass &spi)
+    : RadioLibInterface(cs, irq, rst, busy, spi)
 {
     // FIXME - we assume devices never get destroyed
 }

--- a/src/mesh/RF95Interface.h
+++ b/src/mesh/RF95Interface.h
@@ -12,7 +12,7 @@ class RF95Interface : public RadioLibInterface
     RadioLibRF95 *lora = NULL; // Either a RFM95 or RFM96 depending on what was stuffed on this board
 
   public:
-    RF95Interface(RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst, SPIClass &spi);
+    RF95Interface(RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst, RADIOLIB_PIN_TYPE busy, SPIClass &spi);
 
     // TODO: Verify that this irq flag works with RFM95 / SX1276 radios the way it used to
     bool isIRQPending() override { return lora->getIRQFlags() & RADIOLIB_SX127X_MASK_IRQ_FLAG_VALID_HEADER; }

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -389,8 +389,6 @@ void RadioLibInterface::startSend(meshtastic_MeshPacket *txp)
         LOG_WARN("startSend is dropping tx packet because we are disabled\n");
         packetPool.release(txp);
     } else {
-        setStandby(); // Cancel any already in process receives
-
         configHardwareForSend(); // must be after setStandby
 
         size_t numbytes = beginSending(txp);

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -219,7 +219,8 @@ void RadioLibInterface::onNotify(uint32_t notification)
             } else {
                 if (isChannelActive()) { // check if there is currently a LoRa packet on the channel
                     // LOG_DEBUG("Channel is active: set random delay\n");
-                    setTransmitDelay(); // reset random delay
+                    startReceive(); // try receiving this packet, afterwards we'll be trying to transmit again
+                    break;
                 } else {
                     // Send any outgoing packets we have ready
                     meshtastic_MeshPacket *txp = txQueue.dequeue();

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -218,9 +218,9 @@ void RadioLibInterface::onNotify(uint32_t notification)
                 setTransmitDelay(); // currently Rx/Tx-ing: reset random delay
             } else {
                 if (isChannelActive()) { // check if there is currently a LoRa packet on the channel
-                    // LOG_DEBUG("Channel is active: set random delay\n");
+                    // LOG_DEBUG("Channel is active, try receiving first.\n");
                     startReceive(); // try receiving this packet, afterwards we'll be trying to transmit again
-                    break;
+                    setTransmitDelay();
                 } else {
                     // Send any outgoing packets we have ready
                     meshtastic_MeshPacket *txp = txQueue.dequeue();

--- a/variants/heltec_v1/variant.h
+++ b/variants/heltec_v1/variant.h
@@ -20,8 +20,8 @@
 #ifndef USE_JTAG
 #define LORA_RESET 14
 #endif
-#define LORA_DIO1 35 // Not really used
-#define LORA_DIO2 34 // Not really used
+#define LORA_DIO1 33 // https://www.thethingsnetwork.org/forum/t/big-esp32-sx127x-topic-part-3/18436
+#define LORA_DIO2 32 // Not really used
 
 // ratio of voltage divider = 3.20 (R1=100k, R2=220k)
 #define ADC_MULTIPLIER 3.2

--- a/variants/heltec_v1/variant.h
+++ b/variants/heltec_v1/variant.h
@@ -20,7 +20,7 @@
 #ifndef USE_JTAG
 #define LORA_RESET 14
 #endif
-#define LORA_DIO1 33 // https://www.thethingsnetwork.org/forum/t/big-esp32-sx127x-topic-part-3/18436
+#define LORA_DIO1 RADIOLIB_NC
 #define LORA_DIO2 32 // Not really used
 
 // ratio of voltage divider = 3.20 (R1=100k, R2=220k)

--- a/variants/heltec_v2.1/variant.h
+++ b/variants/heltec_v2.1/variant.h
@@ -24,7 +24,7 @@
 #ifndef USE_JTAG
 #define LORA_RESET 14
 #endif
-#define LORA_DIO1 35 // Not really used
+#define LORA_DIO1 35 // https://www.thethingsnetwork.org/forum/t/big-esp32-sx127x-topic-part-3/18436
 #define LORA_DIO2 34 // Not really used
 
 #define ADC_MULTIPLIER 3.8

--- a/variants/heltec_v2/variant.h
+++ b/variants/heltec_v2/variant.h
@@ -21,7 +21,7 @@
 #ifndef USE_JTAG
 #define LORA_RESET 14
 #endif
-#define LORA_DIO1 35 // Not really used
+#define LORA_DIO1 35 // https://www.thethingsnetwork.org/forum/t/big-esp32-sx127x-topic-part-3/18436
 #define LORA_DIO2 34 // Not really used
 
 // ratio of voltage divider = 3.20 (R12=100k, R10=220k)

--- a/variants/tbeam_v07/variant.h
+++ b/variants/tbeam_v07/variant.h
@@ -10,7 +10,7 @@
 #define USE_RF95
 #define LORA_DIO0 26 // a No connect on the SX1262 module
 #define LORA_RESET 23
-#define LORA_DIO1 33 // Not really used
+#define LORA_DIO1 33
 #define LORA_DIO2 32 // Not really used
 
 // This board has different GPS pins than all other boards

--- a/variants/tlora_v1/variant.h
+++ b/variants/tlora_v1/variant.h
@@ -15,5 +15,5 @@
 #define USE_RF95
 #define LORA_DIO0 26 // a No connect on the SX1262 module
 #define LORA_RESET 14
-#define LORA_DIO1 35 // Not really used
-#define LORA_DIO2 34 // Not really used
+#define LORA_DIO1 33 // Must be manually wired: https://www.thethingsnetwork.org/forum/t/big-esp32-sx127x-topic-part-3/18436
+#define LORA_DIO2 32 // Not really used

--- a/variants/tlora_v1_3/variant.h
+++ b/variants/tlora_v1_3/variant.h
@@ -18,5 +18,5 @@
 #define USE_RF95
 #define LORA_DIO0 26 // a No connect on the SX1262 module
 #define LORA_RESET 14
-#define LORA_DIO1 35 // Not really used
-#define LORA_DIO2 34 // Not really used
+#define LORA_DIO1 33 // Prob. must be manually wired: https://www.thethingsnetwork.org/forum/t/big-esp32-sx127x-topic-part-3/18436
+#define LORA_DIO2 32 // Not really used

--- a/variants/tlora_v2/variant.h
+++ b/variants/tlora_v2/variant.h
@@ -18,5 +18,5 @@
 #define USE_RF95
 #define LORA_DIO0 26 // a No connect on the SX1262 module
 #define LORA_RESET 14
-#define LORA_DIO1 35 // Not really used
-#define LORA_DIO2 34 // Not really used
+#define LORA_DIO1 33 // Must be manually wired: https://www.thethingsnetwork.org/forum/t/big-esp32-sx127x-topic-part-3/18436
+#define LORA_DIO2 32 // Not really used

--- a/variants/tlora_v2_1_16/variant.h
+++ b/variants/tlora_v2_1_16/variant.h
@@ -18,3 +18,5 @@
 #define USE_RF95
 #define LORA_DIO0 26 // a No connect on the SX1262 module
 #define LORA_RESET 23
+#define LORA_DIO1 33 // https://www.thethingsnetwork.org/forum/t/big-esp32-sx127x-topic-part-3/18436
+#define LORA_DIO2 32 // Not really used


### PR DESCRIPTION
This will set the LORA_DIO1 pin as the GPIO for RadioLib when using the RF95Interface, which we also use for boards with pure SX127x chip. The function `startChannelScan` relies on it, so otherwise channel activity detection doesn’t work. I confirmed it to be working after this with two T-Beams (using a long preamble) when trying to send at the same time by looking at the waterfall with an SDR.

For boards with real RF95, this pin is not connected. Unfortunately I also [found](https://www.thethingsnetwork.org/forum/t/big-esp32-sx127x-topic-part-3/18436) that for some TTGO LoRa32 boards this pin has to be wired manually. 

Please check the new pin configurations. Since the only devices with a SX127x I have are T-Beams, I didn’t test other hardware. For the Heltec v1 I set the LORA_DIO1 as RADIOLIB_NC as otherwise it would overlap with GPS_TX_PIN.

This should really increase the reliability of messaging. Unfortunately it looks like channel activity detection also doesn’t work with SX126x. This might be related to `startReceive` (as opposed to `startReceiveDutyCycleAuto`) not working either.
