### PR TITLE
tryfix #2228 as suggested by @mverch67

### DIFF
--- a/src/mesh/ReliableRouter.cpp
+++ b/src/mesh/ReliableRouter.cpp
@@ -148,7 +148,10 @@ bool ReliableRouter::stopRetransmission(GlobalPacketId key)
     if (old) {
         auto numErased = pending.erase(key);
         assert(numErased == 1);
+        // remove the 'original' (identified by originator and packet->id) from the txqueue and free it
         cancelSending(getFrom(old->packet), old->packet->id);
+        // now free the pooled copy for retransmission too. tryfix for #2228
+        packetPool.release(old->packet);
         return true;
     } else
         return false;

--- a/src/mesh/ReliableRouter.cpp
+++ b/src/mesh/ReliableRouter.cpp
@@ -151,7 +151,8 @@ bool ReliableRouter::stopRetransmission(GlobalPacketId key)
         // remove the 'original' (identified by originator and packet->id) from the txqueue and free it
         cancelSending(getFrom(old->packet), old->packet->id);
         // now free the pooled copy for retransmission too. tryfix for #2228
-        packetPool.release(old->packet);
+        if (old->packet)
+            packetPool.release(old->packet);
         return true;
     } else
         return false;


### PR DESCRIPTION
the ID is the same since it's essentially a copy - not sure the cancelSending always gets the right copy since it aborts after the first match. Maybe the correct way to do this is loop there till all references of the packetID in the pool are found and eliminated
