### PR TITLE
Check if packet is decrypted before searching node in DB

### DIFF
--- a/src/mesh/FloodingRouter.cpp
+++ b/src/mesh/FloodingRouter.cpp
@@ -44,7 +44,8 @@ void FloodingRouter::sniffReceived(const meshtastic_MeshPacket *p, const meshtas
                 tosend->hop_limit--; // bump down the hop count
 
                 // If it is a traceRoute request, update the route that it went via me
-                if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag && traceRouteModule->wantPacket(p)) {
+                if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag && traceRouteModule &&
+                    traceRouteModule->wantPacket(p)) {
                     traceRouteModule->updateRoute(tosend);
                 }
 

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -76,7 +76,7 @@ int MeshService::handleFromRadio(const meshtastic_MeshPacket *mp)
     powerFSM.trigger(EVENT_PACKET_FOR_PHONE); // Possibly keep the node from sleeping
 
     nodeDB.updateFrom(*mp); // update our DB state based off sniffing every RX packet from the radio
-    if (!nodeDB.getNode(mp->from)->has_user && nodeInfoModule) {
+    if (mp->which_payload_variant == meshtastic_MeshPacket_decoded_tag && !nodeDB.getNode(mp->from)->has_user && nodeInfoModule) {
         LOG_INFO("Heard a node we don't know, sending NodeInfo and asking for a response.\n");
         nodeInfoModule->sendOurNodeInfo(mp->from, true);
     }


### PR DESCRIPTION
Fixes #2318. Only happened when you got a message you could decrypt and from a node you did not yet have in the nodeDB.

Also added a check for the TraceRouteModule, in case it will not be enabled it for some role in the future.
