### PR TITLE
Add PSRAM on Lilygo T3 S3

### DIFF
--- a/boards/tlora-t3s3-v1.json
+++ b/boards/tlora-t3s3-v1.json
@@ -9,7 +9,8 @@
       "-DARDUINO_USB_CDC_ON_BOOT=1",
       "-DARDUINO_USB_MODE=0",
       "-DARDUINO_RUNNING_CORE=1",
-      "-DARDUINO_EVENT_RUNNING_CORE=1"
+      "-DARDUINO_EVENT_RUNNING_CORE=1",
+      "-DBOARD_HAS_PSRAM"
     ],
     "f_cpu": "240000000L",
     "f_flash": "80000000L",


### PR DESCRIPTION
# Add PSRAM on Lilygo T3 S3

Not much of a change, this just adds a missing compile flag that enables PSRAM on these boards. I've tested it, and there's some PSRAM:

```
[21:25:38.294] Connected
@INFO  | ??:??:?? 1 

//\ E S H T /\ S T / C

INFO  | ??:??:?? 1 Booted, wake cause 0 (boot count 1), reset_reason=reset
DEBUG | ??:??:?? 1 Filesystem files (16384/1048576 Bytes):
DEBUG | ??:??:?? 1  /prefs/channels.proto (53 Bytes)
DEBUG | ??:??:?? 1  /prefs/config.proto (92 Bytes)
DEBUG | ??:??:?? 1  /prefs/db.proto (143 Bytes)
DEBUG | ??:??:?? 1 Using analog input 1 for battery level
DEBUG | ??:??:?? 1 I2C device found at address 0x3c
DEBUG | ??:??:?? 1 0x4 subtype probed in 2 tries 
INFO  | ??:??:?? 1 ssd1306 display found
INFO  | ??:??:?? 1 1 I2C devices found
DEBUG | ??:??:?? 1 SD_MMC Card Type: SDHC
DEBUG | ??:??:?? 1 SD Card Size: 14910MB
DEBUG | ??:??:?? 1 Total space: 14905 MB
DEBUG | ??:??:?? 1 Used space: 0 MB
INFO  | ??:??:?? 1 Meshtastic hwvendor=16, swver=2.0.24.4a0dfb54
DEBUG | ??:??:?? 1 Setting random seed 1702144770
DEBUG | ??:??:?? 1 Total heap: 281168
DEBUG | ??:??:?? 1 Free heap: 239420
DEBUG | ??:??:?? 1 Total PSRAM: 2094691
DEBUG | ??:??:?? 1 Free PSRAM: 2067755
```