### PR TITLE
SX126x/8x: Add HEADER_VALID IRQ flag for actively receiving check

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -67,7 +67,7 @@ lib_deps =
   nanopb/Nanopb@^0.4.6
   erriez/ErriezCRC32@^1.0.1
 ;  jgromes/RadioLib@^5.5.1
-  https://github.com/jgromes/RadioLib.git#1afa947030c5637f71f6563bc22aa75032e53a57
+  https://github.com/jgromes/RadioLib.git#ed4fc84a70f59e61cce98543da381b77a47fad18
 
 ; Used for the code analysis in PIO Home / Inspect
 check_tool = cppcheck

--- a/platformio.ini
+++ b/platformio.ini
@@ -66,8 +66,7 @@ lib_deps =
   https://github.com/meshtastic/ArduinoThread.git#72921ac222eed6f526ba1682023cee290d9aa1b3
   nanopb/Nanopb@^0.4.6
   erriez/ErriezCRC32@^1.0.1
-;  jgromes/RadioLib@^5.5.1
-  https://github.com/jgromes/RadioLib.git#ed4fc84a70f59e61cce98543da381b77a47fad18
+  jgromes/RadioLib@^5.7.0
 
 ; Used for the code analysis in PIO Home / Inspect
 check_tool = cppcheck

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -225,7 +225,7 @@ template <typename T> void SX126xInterface<T>::startReceive()
 #endif
 }
 
-/** Could we send right now (i.e. either not actively receving or transmitting)? */
+/** Is the channel currently active? */
 template <typename T> bool SX126xInterface<T>::isChannelActive()
 {
     // check if we can detect a LoRa preamble on the current channel
@@ -246,8 +246,6 @@ template <typename T> bool SX126xInterface<T>::isActivelyReceiving()
 {
     // The IRQ status will be cleared when we start our read operation.  Check if we've started a header, but haven't yet
     // received and handled the interrupt for reading the packet/handling errors.
-    // FIXME: it would be better to check for preamble, but we currently have our ISR not set to fire for packets that
-    // never even get a valid header, so we don't want preamble to get set and stay set due to noise on the network.
 
     uint16_t irq = lora.getIrqStatus();
     bool headerValid = (irq & RADIOLIB_SX126X_IRQ_HEADER_VALID);

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -212,9 +212,10 @@ template <typename T> void SX126xInterface<T>::startReceive()
 
     setStandby();
 
-    // int err = lora.startReceive();
-    int err = lora.startReceiveDutyCycleAuto(); // We use a 32 bit preamble so this should save some power by letting radio sit in
-                                                // standby mostly.
+    // We use a 16 bit preamble so this should save some power by letting radio sit in standby mostly.
+    // Furthermore, we need the HEADER_VALID IRQ flag to detect whether we are actively receiving
+    int err =
+        lora.startReceiveDutyCycleAuto(preambleLength, 8, RADIOLIB_SX126X_IRQ_RX_DEFAULT | RADIOLIB_SX126X_IRQ_HEADER_VALID);
     assert(err == RADIOLIB_ERR_NONE);
 
     isReceiving = true;
@@ -249,13 +250,10 @@ template <typename T> bool SX126xInterface<T>::isActivelyReceiving()
     // never even get a valid header, so we don't want preamble to get set and stay set due to noise on the network.
 
     uint16_t irq = lora.getIrqStatus();
-    bool hasPreamble = (irq & RADIOLIB_SX126X_IRQ_HEADER_VALID);
+    bool headerValid = (irq & RADIOLIB_SX126X_IRQ_HEADER_VALID);
 
-    // this is not correct - often always true - need to add an extra conditional
-    // size_t bytesPending = lora.getPacketLength();
-
-    // if (hasPreamble) LOG_DEBUG("rx hasPreamble\n");
-    return hasPreamble;
+    // if (headerValid) LOG_DEBUG("rx headerValid\n");
+    return headerValid;
 }
 
 template <typename T> bool SX126xInterface<T>::sleep()

--- a/src/mesh/SX128xInterface.cpp
+++ b/src/mesh/SX128xInterface.cpp
@@ -216,7 +216,7 @@ template <typename T> void SX128xInterface<T>::startReceive()
 #endif
 }
 
-/** Could we send right now (i.e. either not actively receving or transmitting)? */
+/** Is the channel currently active? */
 template <typename T> bool SX128xInterface<T>::isChannelActive()
 {
     // check if we can detect a LoRa preamble on the current channel

--- a/src/mesh/SX128xInterface.cpp
+++ b/src/mesh/SX128xInterface.cpp
@@ -203,7 +203,9 @@ template <typename T> void SX128xInterface<T>::startReceive()
     digitalWrite(SX128X_TXEN, LOW);
 #endif
 
-    int err = lora.startReceive();
+    // We use the HEADER_VALID IRQ flag to detect whether we are actively receiving
+    int err =
+        lora.startReceive(RADIOLIB_SX128X_RX_TIMEOUT_INF, RADIOLIB_SX128X_IRQ_RX_DEFAULT | RADIOLIB_SX128X_IRQ_HEADER_VALID);
 
     assert(err == RADIOLIB_ERR_NONE);
 
@@ -234,8 +236,8 @@ template <typename T> bool SX128xInterface<T>::isChannelActive()
 template <typename T> bool SX128xInterface<T>::isActivelyReceiving()
 {
     uint16_t irq = lora.getIrqStatus();
-    bool hasPreamble = (irq & RADIOLIB_SX128X_IRQ_HEADER_VALID);
-    return hasPreamble;
+    bool hasHeader = (irq & RADIOLIB_SX128X_IRQ_HEADER_VALID);
+    return hasHeader;
 }
 
 template <typename T> bool SX128xInterface<T>::sleep()


### PR DESCRIPTION
Fixes #2307.

This updates the RadioLib dependency to the latest release which includes user-configurable IRQ flags for SX126x and SX128x radios. Now the `isActivelyReceiving()` function actually works, which gives way better reliability.