### PR TITLE
fix rak4631_epaper PIN_EINK_EN

### DIFF
--- a/variants/rak4631/variant.h
+++ b/variants/rak4631/variant.h
@@ -126,7 +126,6 @@ static const uint8_t SCK = PIN_SPI_SCK;
  * eink display pins
  */
 
-#define PIN_EINK_EN (32 + 2) // (0 + 2) Note: this is really just backlight power
 #define PIN_EINK_CS (0 + 26)
 #define PIN_EINK_BUSY (0 + 4)
 #define PIN_EINK_DC (0 + 17)

--- a/variants/rak4631_epaper/variant.h
+++ b/variants/rak4631_epaper/variant.h
@@ -126,7 +126,7 @@ static const uint8_t SCK = PIN_SPI_SCK;
  * eink display pins
  */
 
-#define PIN_EINK_EN (32 + 2) // (0 + 2) Note: this is really just backlight power
+#define PIN_EINK_EN (0 + 2) // (0 + 2) Note: this is really just backlight power
 #define PIN_EINK_CS (0 + 26)
 #define PIN_EINK_BUSY (0 + 4)
 #define PIN_EINK_DC (0 + 17)

--- a/variants/rak4631_epaper/variant.h
+++ b/variants/rak4631_epaper/variant.h
@@ -126,7 +126,6 @@ static const uint8_t SCK = PIN_SPI_SCK;
  * eink display pins
  */
 
-#define PIN_EINK_EN (0 + 2) // (0 + 2) Note: this is really just backlight power
 #define PIN_EINK_CS (0 + 26)
 #define PIN_EINK_BUSY (0 + 4)
 #define PIN_EINK_DC (0 + 17)


### PR DESCRIPTION
`firmware-rak4631_eink` works again on stock RAK4631 + RAK14000 combo reverting 2.0.8 `PIN_EINK_EN` change back to (0 + 2). tested and confirmed by @feh123

fixes #2101 #2241