### PR TITLE
Fix heap leak mentioned in #2358

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -82,7 +82,7 @@ int MeshService::handleFromRadio(const meshtastic_MeshPacket *mp)
     }
 
     printPacket("Forwarding to phone", mp);
-    sendToPhone((meshtastic_MeshPacket *)mp);
+    sendToPhone(packetPool.allocCopy(*mp));
 
     return 0;
 }

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -231,7 +231,7 @@ void MeshService::sendToMesh(meshtastic_MeshPacket *p, RxSource src, bool ccToPh
     }
 
     if (ccToPhone) {
-        sendToPhone(p);
+        sendToPhone(packetPool.allocCopy(*p));
     }
 }
 
@@ -262,9 +262,8 @@ void MeshService::sendToPhone(meshtastic_MeshPacket *p)
             releaseToPool(d);
     }
 
-    meshtastic_MeshPacket *copied = packetPool.allocCopy(*p);
-    perhapsDecode(copied);
-    assert(toPhoneQueue.enqueue(copied, 0));
+    perhapsDecode(p);
+    assert(toPhoneQueue.enqueue(p, 0));
     fromNum++;
 }
 


### PR DESCRIPTION
This is a fix for #2358. 

In MeshService::sendToPhone() a copy of a meshPacket is created. This copy is sent into the phoneQueue where it eventually gets deleted when fetched by the phone. The original packet is only released when it is sent over the mesh, which will not happen if DeviceTelemetryModule enters the upper branch in method EnvironmentTelemetrieModule::sendTelemetry():

```
    lastMeasurementPacket = packetPool.allocCopy(*p); // first copy
    if (phoneOnly) {
        LOG_INFO("Sending packet to phone\n");
        service.sendToPhone(p);                       // another copy
    } else {
        LOG_INFO("Sending packet to mesh\n");
        service.sendToMesh(p, RX_SRC_LOCAL, true);
    }
```
The fix avoids the copying in sendToPhone(). The copying is better done in sendToMesh(), just before invoking sendToPhone():

```
    if (ccToPhone) {
        sendToPhone(packetPool.allocCopy(*p));
    }

```

Note: the relevant code in AirQualityTelemetryModule looks exactly the same as in EnvironmentTelemetryModule, so there should be no issue. However, I was not able to test it due to lack of such equipment.