### PR TITLE
Fix: Sporadig crashes and reboot

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,8 +2,9 @@
     // See http://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-        "ms-vscode.cpptools",
-        "platformio.platformio-ide",
-        "trunk.io"
+        "platformio.platformio-ide"
     ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,9 +2,8 @@
     // See http://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-        "platformio.platformio-ide"
+        "ms-vscode.cpptools",
+        "platformio.platformio-ide",
+        "trunk.io"
     ],
-    "unwantedRecommendations": [
-        "ms-vscode.cpptools-extension-pack"
-    ]
 }

--- a/src/mesh/ReliableRouter.cpp
+++ b/src/mesh/ReliableRouter.cpp
@@ -164,13 +164,13 @@ bool ReliableRouter::stopRetransmission(GlobalPacketId key)
 {
     auto old = findPendingPacket(key);
     if (old) {
-        auto p = old->packet;
         auto numErased = pending.erase(key);
         assert(numErased == 1);
         // remove the 'original' (identified by originator and packet->id) from the txqueue and free it
-        cancelSending(getFrom(p), p->id);
-        // now free the pooled copy for retransmission too
-        packetPool.release(p);
+        cancelSending(getFrom(old->packet), old->packet->id);
+        // now free the pooled copy for retransmission too. tryfix for #2228
+        if (old->packet)
+            packetPool.release(old->packet);
         return true;
     } else
         return false;

--- a/src/mesh/ReliableRouter.cpp
+++ b/src/mesh/ReliableRouter.cpp
@@ -164,13 +164,13 @@ bool ReliableRouter::stopRetransmission(GlobalPacketId key)
 {
     auto old = findPendingPacket(key);
     if (old) {
+        auto p = old->packet;
         auto numErased = pending.erase(key);
         assert(numErased == 1);
         // remove the 'original' (identified by originator and packet->id) from the txqueue and free it
-        cancelSending(getFrom(old->packet), old->packet->id);
-        // now free the pooled copy for retransmission too. tryfix for #2228
-        if (old->packet)
-            packetPool.release(old->packet);
+        cancelSending(getFrom(p), p->id);
+        // now free the pooled copy for retransmission too
+        packetPool.release(p);
         return true;
     } else
         return false;


### PR DESCRIPTION
This is a fix for [Bug]: Sporadig crashes with reboot #2365.

After some investigations it is clear that the cause is a dangling pointer which is used after being erased from a hashmap:


```
bool ReliableRouter::stopRetransmission(GlobalPacketId key)
{
    auto old = findPendingPacket(key);          // returns PendingPacket pointer 
    if (old) {
        auto numErased = pending.erase(key);    // PendingPacket is deleted from hashmap
        assert(numErased == 1);
        cancelSending(getFrom(old->packet), old->packet->id);  // old is now a dangling pointer!
        if (old->packet)
            packetPool.release(old->packet);
        return true;
    } else
        return false;
}
```

The fix will save the MeshPacket pointer within the PendingPacket envelope before deletion.