### PR TITLE
Poll the CardKB More Aggressively

### DIFF
--- a/src/input/kbI2cBase.h
+++ b/src/input/kbI2cBase.h
@@ -16,4 +16,6 @@ class KbI2cBase : public Observable<const InputEvent *>, public concurrency::OST
     const char *_originName;
 
     TwoWire *i2cBus = 0;
+
+    char readKeystroke() const;
 };


### PR DESCRIPTION
Currently, keystrokes are requested one at a time, once per `#runOnce` of the `KbI2CBase` instance invocation. This will update the polling logic to request up to 4 keystrokes every time a keystroke is returned instead of just one, potentially draining any pending characters in buffered devices to allow for more responsive input.
