### PR TITLE
Remove call to randomSeed()

### DIFF
--- a/src/platform/esp32/main-esp32.cpp
+++ b/src/platform/esp32/main-esp32.cpp
@@ -85,7 +85,6 @@ void esp32Setup()
 {
     uint32_t seed = esp_random();
     LOG_DEBUG("Setting random seed %u\n", seed);
-    randomSeed(seed); // ESP docs say this is fairly random
 
     LOG_DEBUG("Total heap: %d\n", ESP.getHeapSize());
     LOG_DEBUG("Free heap: %d\n", ESP.getFreeHeap());


### PR DESCRIPTION
This function causes the new arduino-esp32 core to revert to the pseudorandom behavior specified in Arduino. 
Calls to random() automatically use esp_random() if randomSeed or useRealRandomGenerator(false) aren't called. Tentative fix for #2357