### PR TITLE
Remove sending network ping to displayed node on interval

### DIFF
--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -194,17 +194,6 @@ static void onEnter()
     LOG_INFO("Enter state: ON\n");
     screen->setOn(true);
     setBluetoothEnable(true);
-
-    static uint32_t lastPingMs;
-
-    uint32_t now = millis();
-
-    if ((now - lastPingMs) >
-        30 * 1000) { // if more than a minute since our last press, ask node we are looking at to update their state
-        if (displayedNodeNum)
-            service.sendNetworkPing(displayedNodeNum, true); // Refresh the currently displayed node
-        lastPingMs = now;
-    }
 }
 
 static void onIdle()

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -348,8 +348,6 @@ static void drawFrameFirmware(OLEDDisplay *display, OLEDDisplayUiState *state, i
 /// Draw the last text message we received
 static void drawCriticalFaultFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y)
 {
-    displayedNodeNum = 0; // Not currently showing a node pane
-
     display->setTextAlignment(TEXT_ALIGN_LEFT);
     display->setFont(FONT_MEDIUM);
 
@@ -370,8 +368,6 @@ static bool shouldDrawMessage(const meshtastic_MeshPacket *packet)
 /// Draw the last text message we received
 static void drawTextMessageFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y)
 {
-    displayedNodeNum = 0; // Not currently showing a node pane
-
     // the max length of this buffer is much longer than we can possibly print
     static char tempBuf[237];
 
@@ -773,7 +769,6 @@ static void drawNodeInfo(OLEDDisplay *display, OLEDDisplayUiState *state, int16_
             nodeIndex = (nodeIndex + 1) % nodeDB.getNumNodes();
             n = nodeDB.getNodeByIndex(nodeIndex);
         }
-        displayedNodeNum = n->num;
     }
 
     meshtastic_NodeInfo *node = nodeDB.getNodeByIndex(nodeIndex);
@@ -1393,8 +1388,6 @@ void Screen::setFastFramerate()
 
 void DebugInfo::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y)
 {
-    displayedNodeNum = 0; // Not currently showing a node pane
-
     display->setFont(FONT_SMALL);
 
     // The coordinates define the left starting point of the text
@@ -1501,8 +1494,6 @@ void DebugInfo::drawFrameWiFi(OLEDDisplay *display, OLEDDisplayUiState *state, i
 {
 #if HAS_WIFI
     const char *wifiName = config.network.wifi_ssid;
-
-    displayedNodeNum = 0; // Not currently showing a node pane
 
     display->setFont(FONT_SMALL);
 
@@ -1634,8 +1625,6 @@ void DebugInfo::drawFrameWiFi(OLEDDisplay *display, OLEDDisplayUiState *state, i
 
 void DebugInfo::drawFrameSettings(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y)
 {
-    displayedNodeNum = 0; // Not currently showing a node pane
-
     display->setFont(FONT_SMALL);
 
     // The coordinates define the left starting point of the text

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -58,12 +58,6 @@ meshtastic_User &owner = devicestate.owner;
 
 static uint8_t ourMacAddr[6];
 
-/**
- * The node number the user is currently looking at
- * 0 if none
- */
-NodeNum displayedNodeNum;
-
 NodeDB::NodeDB() : nodes(devicestate.node_db), numNodes(&devicestate.node_db_count) {}
 
 /**

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -153,12 +153,6 @@ class NodeDB
     void installDefaultDeviceState(), installDefaultChannels(), installDefaultConfig(), installDefaultModuleConfig();
 };
 
-/**
- * The node number the user is currently looking at
- * 0 if none
- */
-extern NodeNum displayedNodeNum;
-
 extern NodeDB nodeDB;
 
 /*

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -446,8 +446,6 @@ int CannedMessageModule::getPrevIndex()
 
 void CannedMessageModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y)
 {
-    displayedNodeNum = 0; // Not currently showing a node pane
-
     char buffer[50];
 
     if (cannedMessageModule->runState == CANNED_MESSAGE_RUN_STATE_SENDING_ACTIVE) {

--- a/src/modules/esp32/AudioModule.cpp
+++ b/src/modules/esp32/AudioModule.cpp
@@ -153,8 +153,6 @@ AudioModule::AudioModule() : SinglePortModule("AudioModule", meshtastic_PortNum_
 
 void AudioModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y)
 {
-    displayedNodeNum = 0; // Not currently showing a node pane
-
     char buffer[50];
 
     display->setTextAlignment(TEXT_ALIGN_LEFT);


### PR DESCRIPTION
Fixes #2360.
This removes sending a network ping on an interval to the node that is currently displayed on a screen. This feature silently overrules the position broadcast setting, or sends its NodeInfo over and over again, which seems unnecessary. It will also create a lot of packets when you set the screen to carousel.
The ‘last seen’ time already gets updated with any other packet received from the node. Besides, this feature is not documented, so I don’t think anyone will miss it.