### PR TITLE
Threshold based smart position broadcasts

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -165,7 +165,7 @@ void NodeDB::installDefaultConfig()
     config.lora.hop_limit = HOP_RELIABLE;
     config.position.gps_enabled = true;
     config.position.position_broadcast_smart_enabled = true;
-    config.position.broadcast_smart_minimum_distance = 50;
+    config.position.broadcast_smart_minimum_distance = 100;
     config.position.broadcast_smart_minimum_interval_secs = 30;
     if (config.device.role != meshtastic_Config_DeviceConfig_Role_ROUTER)
         config.device.node_info_broadcast_secs = 3 * 60 * 60;

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -75,13 +75,11 @@ bool NodeDB::resetRadioConfig(bool factory_reset)
 
     radioGeneration++;
 
-    if (factory_reset)
-    {
+    if (factory_reset) {
         didFactoryReset = factoryReset();
     }
 
-    if (channelFile.channels_count != MAX_NUM_CHANNELS)
-    {
+    if (channelFile.channels_count != MAX_NUM_CHANNELS) {
         LOG_INFO("Setting default channel and radio preferences!\n");
 
         channels.initDefaults();
@@ -91,8 +89,7 @@ bool NodeDB::resetRadioConfig(bool factory_reset)
 
     // temp hack for quicker testing
     // devicestate.no_save = true;
-    if (devicestate.no_save)
-    {
+    if (devicestate.no_save) {
         LOG_DEBUG("***** DEVELOPMENT MODE - DO NOT RELEASE *****\n");
 
         // Sleep quite frequently to stress test the BLE comms, broadcast position every 6 mins
@@ -110,8 +107,7 @@ bool NodeDB::resetRadioConfig(bool factory_reset)
     // Update the global myRegion
     initRegion();
 
-    if (didFactoryReset)
-    {
+    if (didFactoryReset) {
         LOG_INFO("Rebooting due to factory reset");
         screen->startRebootScreen();
         rebootAtMsec = millis() + (5 * 1000);
@@ -169,8 +165,8 @@ void NodeDB::installDefaultConfig()
     config.lora.hop_limit = HOP_RELIABLE;
     config.position.gps_enabled = true;
     config.position.position_broadcast_smart_enabled = true;
-    config.position.broadcast_smart_minumum_distance = 50;
-    config.position.broadcast_smart_minumum_interval_secs = 30;
+    config.position.broadcast_smart_minimum_distance = 50;
+    config.position.broadcast_smart_minimum_interval_secs = 30;
     if (config.device.role != meshtastic_Config_DeviceConfig_Role_ROUTER)
         config.device.node_info_broadcast_secs = 3 * 60 * 60;
     config.device.serial_enabled = true;
@@ -231,21 +227,14 @@ void NodeDB::installDefaultModuleConfig()
 
 void NodeDB::installRoleDefaults(meshtastic_Config_DeviceConfig_Role role)
 {
-    if (role == meshtastic_Config_DeviceConfig_Role_ROUTER)
-    {
+    if (role == meshtastic_Config_DeviceConfig_Role_ROUTER) {
         initConfigIntervals();
         initModuleConfigIntervals();
-    }
-    else if (role == meshtastic_Config_DeviceConfig_Role_REPEATER)
-    {
+    } else if (role == meshtastic_Config_DeviceConfig_Role_REPEATER) {
         config.display.screen_on_secs = 1;
-    }
-    else if (role == meshtastic_Config_DeviceConfig_Role_TRACKER)
-    {
+    } else if (role == meshtastic_Config_DeviceConfig_Role_TRACKER) {
         config.position.gps_update_interval = 30;
-    }
-    else if (role == meshtastic_Config_DeviceConfig_Role_SENSOR)
-    {
+    } else if (role == meshtastic_Config_DeviceConfig_Role_SENSOR) {
         moduleConfig.telemetry.environment_measurement_enabled = true;
         moduleConfig.telemetry.environment_update_interval = 300;
     }
@@ -381,8 +370,7 @@ void NodeDB::pickNewNodeNum()
         r = NUM_RESERVED; // don't pick a reserved node number
 
     meshtastic_NodeInfo *found;
-    while ((found = getNode(r)) && memcmp(found->user.macaddr, owner.macaddr, sizeof(owner.macaddr)))
-    {
+    while ((found = getNode(r)) && memcmp(found->user.macaddr, owner.macaddr, sizeof(owner.macaddr))) {
         NodeNum n = random(NUM_RESERVED, NODENUM_BROADCAST); // try a new random choice
         LOG_DEBUG("NOTE! Our desired nodenum 0x%x is in use, so trying for 0x%x\n", r, n);
         r = n;
@@ -406,27 +394,21 @@ bool NodeDB::loadProto(const char *filename, size_t protoSize, size_t objSize, c
 
     auto f = FSCom.open(filename, FILE_O_READ);
 
-    if (f)
-    {
+    if (f) {
         LOG_INFO("Loading %s\n", filename);
         pb_istream_t stream = {&readcb, &f, protoSize};
 
         // LOG_DEBUG("Preload channel name=%s\n", channelSettings.name);
 
         memset(dest_struct, 0, objSize);
-        if (!pb_decode(&stream, fields, dest_struct))
-        {
+        if (!pb_decode(&stream, fields, dest_struct)) {
             LOG_ERROR("Error: can't decode protobuf %s\n", PB_GET_ERROR(&stream));
-        }
-        else
-        {
+        } else {
             okay = true;
         }
 
         f.close();
-    }
-    else
-    {
+    } else {
         LOG_INFO("No %s preferences found\n", filename);
     }
 #else
@@ -439,73 +421,49 @@ void NodeDB::loadFromDisk()
 {
     // static DeviceState scratch; We no longer read into a tempbuf because this structure is 15KB of valuable RAM
     if (!loadProto(prefFileName, meshtastic_DeviceState_size, sizeof(meshtastic_DeviceState), &meshtastic_DeviceState_msg,
-                   &devicestate))
-    {
+                   &devicestate)) {
         installDefaultDeviceState(); // Our in RAM copy might now be corrupt
-    }
-    else
-    {
-        if (devicestate.version < DEVICESTATE_MIN_VER)
-        {
+    } else {
+        if (devicestate.version < DEVICESTATE_MIN_VER) {
             LOG_WARN("Devicestate %d is old, discarding\n", devicestate.version);
             factoryReset();
-        }
-        else
-        {
+        } else {
             LOG_INFO("Loaded saved devicestate version %d\n", devicestate.version);
         }
     }
 
     if (!loadProto(configFileName, meshtastic_LocalConfig_size, sizeof(meshtastic_LocalConfig), &meshtastic_LocalConfig_msg,
-                   &config))
-    {
+                   &config)) {
         installDefaultConfig(); // Our in RAM copy might now be corrupt
-    }
-    else
-    {
-        if (config.version < DEVICESTATE_MIN_VER)
-        {
+    } else {
+        if (config.version < DEVICESTATE_MIN_VER) {
             LOG_WARN("config %d is old, discarding\n", config.version);
             installDefaultConfig();
-        }
-        else
-        {
+        } else {
             LOG_INFO("Loaded saved config version %d\n", config.version);
         }
     }
 
     if (!loadProto(moduleConfigFileName, meshtastic_LocalModuleConfig_size, sizeof(meshtastic_LocalModuleConfig),
-                   &meshtastic_LocalModuleConfig_msg, &moduleConfig))
-    {
+                   &meshtastic_LocalModuleConfig_msg, &moduleConfig)) {
         installDefaultModuleConfig(); // Our in RAM copy might now be corrupt
-    }
-    else
-    {
-        if (moduleConfig.version < DEVICESTATE_MIN_VER)
-        {
+    } else {
+        if (moduleConfig.version < DEVICESTATE_MIN_VER) {
             LOG_WARN("moduleConfig %d is old, discarding\n", moduleConfig.version);
             installDefaultModuleConfig();
-        }
-        else
-        {
+        } else {
             LOG_INFO("Loaded saved moduleConfig version %d\n", moduleConfig.version);
         }
     }
 
     if (!loadProto(channelFileName, meshtastic_ChannelFile_size, sizeof(meshtastic_ChannelFile), &meshtastic_ChannelFile_msg,
-                   &channelFile))
-    {
+                   &channelFile)) {
         installDefaultChannels(); // Our in RAM copy might now be corrupt
-    }
-    else
-    {
-        if (channelFile.version < DEVICESTATE_MIN_VER)
-        {
+    } else {
+        if (channelFile.version < DEVICESTATE_MIN_VER) {
             LOG_WARN("channelFile %d is old, discarding\n", channelFile.version);
             installDefaultChannels();
-        }
-        else
-        {
+        } else {
             LOG_INFO("Loaded saved channelFile version %d\n", channelFile.version);
         }
     }
@@ -523,17 +481,13 @@ bool NodeDB::saveProto(const char *filename, size_t protoSize, const pb_msgdesc_
     String filenameTmp = filename;
     filenameTmp += ".tmp";
     auto f = FSCom.open(filenameTmp.c_str(), FILE_O_WRITE);
-    if (f)
-    {
+    if (f) {
         LOG_INFO("Saving %s\n", filename);
         pb_ostream_t stream = {&writecb, &f, protoSize};
 
-        if (!pb_encode(&stream, fields, dest_struct))
-        {
+        if (!pb_encode(&stream, fields, dest_struct)) {
             LOG_ERROR("Error: can't encode protobuf %s\n", PB_GET_ERROR(&stream));
-        }
-        else
-        {
+        } else {
             okay = true;
         }
         f.close();
@@ -543,15 +497,12 @@ bool NodeDB::saveProto(const char *filename, size_t protoSize, const pb_msgdesc_
             LOG_WARN("Can't remove old pref file\n");
         if (!renameFile(filenameTmp.c_str(), filename))
             LOG_ERROR("Error: can't rename new pref file\n");
-    }
-    else
-    {
+    } else {
         LOG_ERROR("Can't write prefs\n");
 #ifdef ARCH_NRF52
         static uint8_t failedCounter = 0;
         failedCounter++;
-        if (failedCounter >= 2)
-        {
+        if (failedCounter >= 2) {
             FSCom.format();
             // After formatting, the device needs to be restarted
             nodeDB.resetRadioConfig(true);
@@ -566,8 +517,7 @@ bool NodeDB::saveProto(const char *filename, size_t protoSize, const pb_msgdesc_
 
 void NodeDB::saveChannelsToDisk()
 {
-    if (!devicestate.no_save)
-    {
+    if (!devicestate.no_save) {
 #ifdef FSCom
         FSCom.mkdir("/prefs");
 #endif
@@ -577,8 +527,7 @@ void NodeDB::saveChannelsToDisk()
 
 void NodeDB::saveDeviceStateToDisk()
 {
-    if (!devicestate.no_save)
-    {
+    if (!devicestate.no_save) {
 #ifdef FSCom
         FSCom.mkdir("/prefs");
 #endif
@@ -588,18 +537,15 @@ void NodeDB::saveDeviceStateToDisk()
 
 void NodeDB::saveToDisk(int saveWhat)
 {
-    if (!devicestate.no_save)
-    {
+    if (!devicestate.no_save) {
 #ifdef FSCom
         FSCom.mkdir("/prefs");
 #endif
-        if (saveWhat & SEGMENT_DEVICESTATE)
-        {
+        if (saveWhat & SEGMENT_DEVICESTATE) {
             saveDeviceStateToDisk();
         }
 
-        if (saveWhat & SEGMENT_CONFIG)
-        {
+        if (saveWhat & SEGMENT_CONFIG) {
             config.has_device = true;
             config.has_display = true;
             config.has_lora = true;
@@ -610,8 +556,7 @@ void NodeDB::saveToDisk(int saveWhat)
             saveProto(configFileName, meshtastic_LocalConfig_size, &meshtastic_LocalConfig_msg, &config);
         }
 
-        if (saveWhat & SEGMENT_MODULECONFIG)
-        {
+        if (saveWhat & SEGMENT_MODULECONFIG) {
             moduleConfig.has_canned_message = true;
             moduleConfig.has_external_notification = true;
             moduleConfig.has_mqtt = true;
@@ -622,13 +567,10 @@ void NodeDB::saveToDisk(int saveWhat)
             saveProto(moduleConfigFileName, meshtastic_LocalModuleConfig_size, &meshtastic_LocalModuleConfig_msg, &moduleConfig);
         }
 
-        if (saveWhat & SEGMENT_CHANNELS)
-        {
+        if (saveWhat & SEGMENT_CHANNELS) {
             saveChannelsToDisk();
         }
-    }
-    else
-    {
+    } else {
         LOG_DEBUG("***** DEVELOPMENT MODE - DO NOT RELEASE - not saving to flash *****\n");
     }
 }
@@ -685,27 +627,21 @@ size_t NodeDB::getNumOnlineNodes()
 void NodeDB::updatePosition(uint32_t nodeId, const meshtastic_Position &p, RxSource src)
 {
     meshtastic_NodeInfo *info = getOrCreateNode(nodeId);
-    if (!info)
-    {
+    if (!info) {
         return;
     }
 
-    if (src == RX_SRC_LOCAL)
-    {
+    if (src == RX_SRC_LOCAL) {
         // Local packet, fully authoritative
         LOG_INFO("updatePosition LOCAL pos@%x, time=%u, latI=%d, lonI=%d, alt=%d\n", p.timestamp, p.time, p.latitude_i,
                  p.longitude_i, p.altitude);
         info->position = p;
-    }
-    else if ((p.time > 0) && !p.latitude_i && !p.longitude_i && !p.timestamp && !p.location_source)
-    {
+    } else if ((p.time > 0) && !p.latitude_i && !p.longitude_i && !p.timestamp && !p.location_source) {
         // FIXME SPECIAL TIME SETTING PACKET FROM EUD TO RADIO
         // (stop-gap fix for issue #900)
         LOG_DEBUG("updatePosition SPECIAL time setting time=%u\n", p.time);
         info->position.time = p.time;
-    }
-    else
-    {
+    } else {
         // Be careful to only update fields that have been set by the REMOTE sender
         // A lot of position reports don't have time populated.  In that case, be careful to not blow away the time we
         // recorded based on the packet rxTime
@@ -735,18 +671,14 @@ void NodeDB::updateTelemetry(uint32_t nodeId, const meshtastic_Telemetry &t, RxS
 {
     meshtastic_NodeInfo *info = getOrCreateNode(nodeId);
     // Environment metrics should never go to NodeDb but we'll safegaurd anyway
-    if (!info || t.which_variant != meshtastic_Telemetry_device_metrics_tag)
-    {
+    if (!info || t.which_variant != meshtastic_Telemetry_device_metrics_tag) {
         return;
     }
 
-    if (src == RX_SRC_LOCAL)
-    {
+    if (src == RX_SRC_LOCAL) {
         // Local packet, fully authoritative
         LOG_DEBUG("updateTelemetry LOCAL\n");
-    }
-    else
-    {
+    } else {
         LOG_DEBUG("updateTelemetry REMOTE node=0x%x \n", nodeId);
     }
     info->device_metrics = t.variant.device_metrics;
@@ -760,8 +692,7 @@ void NodeDB::updateTelemetry(uint32_t nodeId, const meshtastic_Telemetry &t, RxS
 void NodeDB::updateUser(uint32_t nodeId, const meshtastic_User &p)
 {
     meshtastic_NodeInfo *info = getOrCreateNode(nodeId);
-    if (!info)
-    {
+    if (!info) {
         return;
     }
 
@@ -774,8 +705,7 @@ void NodeDB::updateUser(uint32_t nodeId, const meshtastic_User &p)
     LOG_DEBUG("updating changed=%d user %s/%s/%s\n", changed, info->user.id, info->user.long_name, info->user.short_name);
     info->has_user = true;
 
-    if (changed)
-    {
+    if (changed) {
         updateGUIforNode = info;
         powerFSM.trigger(EVENT_NODEDB_UPDATED);
         notifyObservers(true); // Force an update whether or not our node counts have changed
@@ -790,13 +720,11 @@ void NodeDB::updateUser(uint32_t nodeId, const meshtastic_User &p)
 /// we updateGUI and updateGUIforNode if we think our this change is big enough for a redraw
 void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
 {
-    if (mp.which_payload_variant == meshtastic_MeshPacket_decoded_tag && mp.from)
-    {
+    if (mp.which_payload_variant == meshtastic_MeshPacket_decoded_tag && mp.from) {
         LOG_DEBUG("Update DB node 0x%x, rx_time=%u\n", mp.from, mp.rx_time);
 
         meshtastic_NodeInfo *info = getOrCreateNode(getFrom(&mp));
-        if (!info)
-        {
+        if (!info) {
             return;
         }
 
@@ -824,25 +752,20 @@ meshtastic_NodeInfo *NodeDB::getOrCreateNode(NodeNum n)
 {
     meshtastic_NodeInfo *info = getNode(n);
 
-    if (!info)
-    {
-        if (*numNodes >= MAX_NUM_NODES)
-        {
+    if (!info) {
+        if (*numNodes >= MAX_NUM_NODES) {
             screen->print("warning: node_db full! erasing oldest entry\n");
             // look for oldest node and erase it
             uint32_t oldest = UINT32_MAX;
             int oldestIndex = -1;
-            for (int i = 0; i < *numNodes; i++)
-            {
-                if (nodes[i].last_heard < oldest)
-                {
+            for (int i = 0; i < *numNodes; i++) {
+                if (nodes[i].last_heard < oldest) {
                     oldest = nodes[i].last_heard;
                     oldestIndex = i;
                 }
             }
             // Shove the remaining nodes down the chain
-            for (int i = oldestIndex; i < *numNodes - 1; i++)
-            {
+            for (int i = oldestIndex; i < *numNodes - 1; i++) {
                 nodes[i] = nodes[i + 1];
             }
             (*numNodes)--;

--- a/src/mesh/generated/meshtastic/config.pb.h
+++ b/src/mesh/generated/meshtastic/config.pb.h
@@ -263,9 +263,9 @@ typedef struct _meshtastic_Config_PositionConfig {
     /* (Re)define GPS_TX_PIN for your board. */
     uint32_t tx_gpio;
     /* The minimum distance in meters traveled (since the last send) before we can send a position to the mesh if position_broadcast_smart_enabled */
-    uint32_t broadcast_smart_minumum_distance;
+    uint32_t broadcast_smart_minimum_distance;
     /* The minumum number of seconds (since the last send) before we can send a position to the mesh if position_broadcast_smart_enabled */
-    uint32_t broadcast_smart_minumum_interval_secs;
+    uint32_t broadcast_smart_minimum_interval_secs;
 } meshtastic_Config_PositionConfig;
 
 /* Power Config\
@@ -562,8 +562,8 @@ extern "C" {
 #define meshtastic_Config_PositionConfig_position_flags_tag 7
 #define meshtastic_Config_PositionConfig_rx_gpio_tag 8
 #define meshtastic_Config_PositionConfig_tx_gpio_tag 9
-#define meshtastic_Config_PositionConfig_broadcast_smart_minumum_distance_tag 10
-#define meshtastic_Config_PositionConfig_broadcast_smart_minumum_interval_secs_tag 11
+#define meshtastic_Config_PositionConfig_broadcast_smart_minimum_distance_tag 10
+#define meshtastic_Config_PositionConfig_broadcast_smart_minimum_interval_secs_tag 11
 #define meshtastic_Config_PowerConfig_is_power_saving_tag 1
 #define meshtastic_Config_PowerConfig_on_battery_shutdown_after_secs_tag 2
 #define meshtastic_Config_PowerConfig_adc_multiplier_override_tag 3
@@ -660,8 +660,8 @@ X(a, STATIC,   SINGULAR, UINT32,   gps_attempt_time,   6) \
 X(a, STATIC,   SINGULAR, UINT32,   position_flags,    7) \
 X(a, STATIC,   SINGULAR, UINT32,   rx_gpio,           8) \
 X(a, STATIC,   SINGULAR, UINT32,   tx_gpio,           9) \
-X(a, STATIC,   SINGULAR, UINT32,   broadcast_smart_minumum_distance,  10) \
-X(a, STATIC,   SINGULAR, UINT32,   broadcast_smart_minumum_interval_secs,  11)
+X(a, STATIC,   SINGULAR, UINT32,   broadcast_smart_minimum_distance,  10) \
+X(a, STATIC,   SINGULAR, UINT32,   broadcast_smart_minimum_interval_secs,  11)
 #define meshtastic_Config_PositionConfig_CALLBACK NULL
 #define meshtastic_Config_PositionConfig_DEFAULT NULL
 

--- a/src/mesh/generated/meshtastic/config.pb.h
+++ b/src/mesh/generated/meshtastic/config.pb.h
@@ -262,6 +262,10 @@ typedef struct _meshtastic_Config_PositionConfig {
     uint32_t rx_gpio;
     /* (Re)define GPS_TX_PIN for your board. */
     uint32_t tx_gpio;
+    /* The minimum distance in meters traveled (since the last send) before we can send a position to the mesh if position_broadcast_smart_enabled */
+    uint32_t broadcast_smart_minumum_distance;
+    /* The minumum number of seconds (since the last send) before we can send a position to the mesh if position_broadcast_smart_enabled */
+    uint32_t broadcast_smart_minumum_interval_secs;
 } meshtastic_Config_PositionConfig;
 
 /* Power Config\
@@ -524,7 +528,7 @@ extern "C" {
 /* Initializer values for message structs */
 #define meshtastic_Config_init_default           {0, {meshtastic_Config_DeviceConfig_init_default}}
 #define meshtastic_Config_DeviceConfig_init_default {_meshtastic_Config_DeviceConfig_Role_MIN, 0, 0, 0, 0, _meshtastic_Config_DeviceConfig_RebroadcastMode_MIN, 0}
-#define meshtastic_Config_PositionConfig_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0}
+#define meshtastic_Config_PositionConfig_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_Config_PowerConfig_init_default {0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_Config_NetworkConfig_init_default {0, "", "", "", 0, _meshtastic_Config_NetworkConfig_AddressMode_MIN, false, meshtastic_Config_NetworkConfig_IpV4Config_init_default, ""}
 #define meshtastic_Config_NetworkConfig_IpV4Config_init_default {0, 0, 0, 0}
@@ -533,7 +537,7 @@ extern "C" {
 #define meshtastic_Config_BluetoothConfig_init_default {0, _meshtastic_Config_BluetoothConfig_PairingMode_MIN, 0}
 #define meshtastic_Config_init_zero              {0, {meshtastic_Config_DeviceConfig_init_zero}}
 #define meshtastic_Config_DeviceConfig_init_zero {_meshtastic_Config_DeviceConfig_Role_MIN, 0, 0, 0, 0, _meshtastic_Config_DeviceConfig_RebroadcastMode_MIN, 0}
-#define meshtastic_Config_PositionConfig_init_zero {0, 0, 0, 0, 0, 0, 0, 0, 0}
+#define meshtastic_Config_PositionConfig_init_zero {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_Config_PowerConfig_init_zero  {0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_Config_NetworkConfig_init_zero {0, "", "", "", 0, _meshtastic_Config_NetworkConfig_AddressMode_MIN, false, meshtastic_Config_NetworkConfig_IpV4Config_init_zero, ""}
 #define meshtastic_Config_NetworkConfig_IpV4Config_init_zero {0, 0, 0, 0}
@@ -558,6 +562,8 @@ extern "C" {
 #define meshtastic_Config_PositionConfig_position_flags_tag 7
 #define meshtastic_Config_PositionConfig_rx_gpio_tag 8
 #define meshtastic_Config_PositionConfig_tx_gpio_tag 9
+#define meshtastic_Config_PositionConfig_broadcast_smart_minumum_distance_tag 10
+#define meshtastic_Config_PositionConfig_broadcast_smart_minumum_interval_secs_tag 11
 #define meshtastic_Config_PowerConfig_is_power_saving_tag 1
 #define meshtastic_Config_PowerConfig_on_battery_shutdown_after_secs_tag 2
 #define meshtastic_Config_PowerConfig_adc_multiplier_override_tag 3
@@ -653,7 +659,9 @@ X(a, STATIC,   SINGULAR, UINT32,   gps_update_interval,   5) \
 X(a, STATIC,   SINGULAR, UINT32,   gps_attempt_time,   6) \
 X(a, STATIC,   SINGULAR, UINT32,   position_flags,    7) \
 X(a, STATIC,   SINGULAR, UINT32,   rx_gpio,           8) \
-X(a, STATIC,   SINGULAR, UINT32,   tx_gpio,           9)
+X(a, STATIC,   SINGULAR, UINT32,   tx_gpio,           9) \
+X(a, STATIC,   SINGULAR, UINT32,   broadcast_smart_minumum_distance,  10) \
+X(a, STATIC,   SINGULAR, UINT32,   broadcast_smart_minumum_interval_secs,  11)
 #define meshtastic_Config_PositionConfig_CALLBACK NULL
 #define meshtastic_Config_PositionConfig_DEFAULT NULL
 
@@ -758,7 +766,7 @@ extern const pb_msgdesc_t meshtastic_Config_BluetoothConfig_msg;
 #define meshtastic_Config_LoRaConfig_size        77
 #define meshtastic_Config_NetworkConfig_IpV4Config_size 20
 #define meshtastic_Config_NetworkConfig_size     195
-#define meshtastic_Config_PositionConfig_size    42
+#define meshtastic_Config_PositionConfig_size    54
 #define meshtastic_Config_PowerConfig_size       43
 #define meshtastic_Config_size                   198
 

--- a/src/mesh/generated/meshtastic/deviceonly.pb.h
+++ b/src/mesh/generated/meshtastic/deviceonly.pb.h
@@ -188,7 +188,7 @@ extern const pb_msgdesc_t meshtastic_OEMStore_msg;
 /* Maximum encoded size of messages (where known) */
 #define meshtastic_ChannelFile_size              638
 #define meshtastic_DeviceState_size              22040
-#define meshtastic_OEMStore_size                 3008
+#define meshtastic_OEMStore_size                 3020
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/mesh/generated/meshtastic/localonly.pb.h
+++ b/src/mesh/generated/meshtastic/localonly.pb.h
@@ -156,7 +156,7 @@ extern const pb_msgdesc_t meshtastic_LocalModuleConfig_msg;
 #define meshtastic_LocalModuleConfig_fields &meshtastic_LocalModuleConfig_msg
 
 /* Maximum encoded size of messages (where known) */
-#define meshtastic_LocalConfig_size              442
+#define meshtastic_LocalConfig_size              454
 #define meshtastic_LocalModuleConfig_size        420
 
 #ifdef __cplusplus

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -171,9 +171,8 @@ int32_t PositionModule::runOnce()
 
             if (node2->has_position && (node2->position.latitude_i != 0 || node2->position.longitude_i != 0)) {
                 // The minimum distance to travel before we are able to send a new position packet.
-                const uint32_t distanceTravelThreshold = config.position.broadcast_smart_minimum_distance > 0
-                                                             ? config.position.broadcast_smart_minimum_interval_secs
-                                                             : 50;
+                const uint32_t distanceTravelThreshold =
+                    config.position.broadcast_smart_minimum_distance > 0 ? config.position.broadcast_smart_minimum_distance : 50;
 
                 // The minimum time (in seconds) that would pass before we are able to send a new position packet.
                 const uint32_t minimumTimeThreshold =

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -187,9 +187,9 @@ int32_t PositionModule::runOnce()
                     bool requestReplies = currentGeneration != radioGeneration;
                     currentGeneration = radioGeneration;
 
-                    LOG_INFO("Sending smart pos@%x:6 to mesh (distanceTraveled=%d, distanceMin=%d, timeElapsed=%d, "
-                             "minTimeInterval=%d)\n",
-                             node2->position.timestamp, distanceTraveledSinceLastSend, distanceTravelThreshold, msSinceLastSend,
+                    LOG_INFO("Sending smart pos@%x:6 to mesh (distanceTraveled=%f, minDistanceThreshold=%i, timeElapsed=%i, "
+                             "minTimeInterval=%i)\n",
+                             node2->position.timestamp, abs(distanceTraveledSinceLastSend), distanceTravelThreshold, msSinceLastSend,
                              minimumTimeThreshold);
                     sendOurPosition(NODENUM_BROADCAST, requestReplies);
 

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -26,8 +26,7 @@ bool PositionModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
 
     // FIXME this can in fact happen with packets sent from EUD (src=RX_SRC_USER)
     // to set fixed location, EUD-GPS location or just the time (see also issue #900)
-    if (nodeDB.getNodeNum() == getFrom(&mp))
-    {
+    if (nodeDB.getNodeNum() == getFrom(&mp)) {
         LOG_DEBUG("Incoming update from MYSELF\n");
         // LOG_DEBUG("Ignored an incoming update from MYSELF\n");
         // return false;
@@ -40,8 +39,7 @@ bool PositionModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
              p.sats_in_view ? "SIV " : "", p.fix_quality ? "FXQ " : "", p.fix_type ? "FXT " : "", p.timestamp ? "PTS " : "",
              p.time ? "TIME " : "");
 
-    if (p.time)
-    {
+    if (p.time) {
         struct timeval tv;
         uint32_t secs = p.time;
 
@@ -75,8 +73,7 @@ meshtastic_MeshPacket *PositionModule::allocReply()
     p.longitude_i = node->position.longitude_i;
     p.time = node->position.time;
 
-    if (pos_flags & meshtastic_Config_PositionConfig_PositionFlags_ALTITUDE)
-    {
+    if (pos_flags & meshtastic_Config_PositionConfig_PositionFlags_ALTITUDE) {
         if (pos_flags & meshtastic_Config_PositionConfig_PositionFlags_ALTITUDE_MSL)
             p.altitude = node->position.altitude;
         else
@@ -86,14 +83,11 @@ meshtastic_MeshPacket *PositionModule::allocReply()
             p.altitude_geoidal_separation = node->position.altitude_geoidal_separation;
     }
 
-    if (pos_flags & meshtastic_Config_PositionConfig_PositionFlags_DOP)
-    {
-        if (pos_flags & meshtastic_Config_PositionConfig_PositionFlags_HVDOP)
-        {
+    if (pos_flags & meshtastic_Config_PositionConfig_PositionFlags_DOP) {
+        if (pos_flags & meshtastic_Config_PositionConfig_PositionFlags_HVDOP) {
             p.HDOP = node->position.HDOP;
             p.VDOP = node->position.VDOP;
-        }
-        else
+        } else
             p.PDOP = node->position.PDOP;
     }
 
@@ -115,12 +109,10 @@ meshtastic_MeshPacket *PositionModule::allocReply()
     // Strip out any time information before sending packets to other nodes - to keep the wire size small (and because other
     // nodes shouldn't trust it anyways) Note: we allow a device with a local GPS to include the time, so that gpsless
     // devices can get time.
-    if (getRTCQuality() < RTCQualityDevice)
-    {
+    if (getRTCQuality() < RTCQualityDevice) {
         LOG_INFO("Stripping time %u from position send\n", p.time);
         p.time = 0;
-    }
-    else
+    } else
         LOG_INFO("Providing time to mesh %u\n", p.time);
 
     LOG_INFO("Position reply: time=%i, latI=%i, lonI=-%i\n", p.time, p.latitude_i, p.longitude_i);
@@ -155,13 +147,10 @@ int32_t PositionModule::runOnce()
     uint32_t intervalMs = getConfiguredOrDefaultMs(config.position.position_broadcast_secs, default_broadcast_interval_secs);
     uint32_t msSinceLastSend = now - lastGpsSend;
 
-    if (lastGpsSend == 0 || msSinceLastSend >= intervalMs)
-    {
+    if (lastGpsSend == 0 || msSinceLastSend >= intervalMs) {
         // Only send packets if the channel is less than 40% utilized.
-        if (airTime->isTxAllowedChannelUtil())
-        {
-            if (node->has_position && (node->position.latitude_i != 0 || node->position.longitude_i != 0))
-            {
+        if (airTime->isTxAllowedChannelUtil()) {
+            if (node->has_position && (node->position.latitude_i != 0 || node->position.longitude_i != 0)) {
                 lastGpsSend = now;
 
                 lastGpsLatitude = node->position.latitude_i;
@@ -175,36 +164,33 @@ int32_t PositionModule::runOnce()
                 sendOurPosition(NODENUM_BROADCAST, requestReplies);
             }
         }
-    }
-    else if (config.position.position_broadcast_smart_enabled)
-    {
+    } else if (config.position.position_broadcast_smart_enabled) {
         // Only send packets if the channel is less than 25% utilized or we're a tracker.
-        if (airTime->isTxAllowedChannelUtil(config.device.role != meshtastic_Config_DeviceConfig_Role_TRACKER))
-        {
+        if (airTime->isTxAllowedChannelUtil(config.device.role != meshtastic_Config_DeviceConfig_Role_TRACKER)) {
             meshtastic_NodeInfo *node2 = service.refreshMyNodeInfo(); // should guarantee there is now a position
 
-            if (node2->has_position && (node2->position.latitude_i != 0 || node2->position.longitude_i != 0))
-            {
+            if (node2->has_position && (node2->position.latitude_i != 0 || node2->position.longitude_i != 0)) {
                 // The minimum distance to travel before we are able to send a new position packet.
-                const uint32_t distanceTravelThreshold = config.position.broadcast_smart_minumum_distance > 0 ? config.position.broadcast_smart_minumum_interval_secs : 50;
+                const uint32_t distanceTravelThreshold = config.position.broadcast_smart_minimum_distance > 0
+                                                             ? config.position.broadcast_smart_minimum_interval_secs
+                                                             : 50;
 
                 // The minimum time (in seconds) that would pass before we are able to send a new position packet.
-                const uint32_t minimumTimeThreshold = getConfiguredOrDefaultMs(config.position.broadcast_smart_minumum_interval_secs, 30);
+                const uint32_t minimumTimeThreshold =
+                    getConfiguredOrDefaultMs(config.position.broadcast_smart_minimum_interval_secs, 30);
 
                 // Determine the distance in meters between two points on the globe
-                float distanceTraveledSinceLastSend = GeoCoord::latLongToMeter(lastGpsLatitude * 1e-7, lastGpsLongitude * 1e-7,
-                                                                               node->position.latitude_i * 1e-7, node->position.longitude_i * 1e-7);
+                float distanceTraveledSinceLastSend =
+                    GeoCoord::latLongToMeter(lastGpsLatitude * 1e-7, lastGpsLongitude * 1e-7, node->position.latitude_i * 1e-7,
+                                             node->position.longitude_i * 1e-7);
 
-                if ((abs(distanceTraveledSinceLastSend) >= distanceTravelThreshold) && msSinceLastSend >= minimumTimeThreshold)
-                {
+                if ((abs(distanceTraveledSinceLastSend) >= distanceTravelThreshold) && msSinceLastSend >= minimumTimeThreshold) {
                     bool requestReplies = currentGeneration != radioGeneration;
                     currentGeneration = radioGeneration;
 
-                    LOG_INFO("Sending smart pos@%x:6 to mesh (distanceTraveled=%d, distanceMin=%d, timeElapsed=%d, minTimeInterval=%d)\n",
-                             node2->position.timestamp,
-                             distanceTraveledSinceLastSend,
-                             distanceTravelThreshold,
-                             msSinceLastSend,
+                    LOG_INFO("Sending smart pos@%x:6 to mesh (distanceTraveled=%d, distanceMin=%d, timeElapsed=%d, "
+                             "minTimeInterval=%d)\n",
+                             node2->position.timestamp, distanceTraveledSinceLastSend, distanceTravelThreshold, msSinceLastSend,
                              minimumTimeThreshold);
                     sendOurPosition(NODENUM_BROADCAST, requestReplies);
 

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -187,8 +187,8 @@ int32_t PositionModule::runOnce()
                     bool requestReplies = currentGeneration != radioGeneration;
                     currentGeneration = radioGeneration;
 
-                    LOG_INFO("Sending smart pos@%x:6 to mesh (distanceTraveled=%f, minDistanceThreshold=%i, timeElapsed=%i, "
-                             "minTimeInterval=%i)\n",
+                    LOG_INFO("Sending smart pos@%x:6 to mesh (distanceTraveled=%fm, minDistanceThreshold=%im, timeElapsed=%ims, "
+                             "minTimeInterval=%ims)\n",
                              node2->position.timestamp, abs(distanceTraveledSinceLastSend), distanceTravelThreshold,
                              msSinceLastSend, minimumTimeThreshold);
                     sendOurPosition(NODENUM_BROADCAST, requestReplies);

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -189,8 +189,8 @@ int32_t PositionModule::runOnce()
 
                     LOG_INFO("Sending smart pos@%x:6 to mesh (distanceTraveled=%f, minDistanceThreshold=%i, timeElapsed=%i, "
                              "minTimeInterval=%i)\n",
-                             node2->position.timestamp, abs(distanceTraveledSinceLastSend), distanceTravelThreshold, msSinceLastSend,
-                             minimumTimeThreshold);
+                             node2->position.timestamp, abs(distanceTraveledSinceLastSend), distanceTravelThreshold,
+                             msSinceLastSend, minimumTimeThreshold);
                     sendOurPosition(NODENUM_BROADCAST, requestReplies);
 
                     // Set the current coords as our last ones, after we've compared distance with current and decided to send

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -172,7 +172,7 @@ int32_t PositionModule::runOnce()
             if (node2->has_position && (node2->position.latitude_i != 0 || node2->position.longitude_i != 0)) {
                 // The minimum distance to travel before we are able to send a new position packet.
                 const uint32_t distanceTravelThreshold =
-                    config.position.broadcast_smart_minimum_distance > 0 ? config.position.broadcast_smart_minimum_distance : 50;
+                    config.position.broadcast_smart_minimum_distance > 0 ? config.position.broadcast_smart_minimum_distance : 100;
 
                 // The minimum time (in seconds) that would pass before we are able to send a new position packet.
                 const uint32_t minimumTimeThreshold =


### PR DESCRIPTION
Under the new protobufs, smart broadcast positioning will honor two position config properties:

**Broadcast_smart_minimum_distance** (default of 100) is the minimum distance traveled in meters before we consider sending our position.

**Broadcast_smart_minimum_interval_secs** (default of 30) is the minimum seconds after the last sent position before we consider sending our position again.

**Position_broadcast_secs** is still honored as the interval for regular broadcasting of positions, so users likely want this to be a longer interval to avoid wasted packets while a node is static.

Tracker role changes:

- We no longer turn off smart position broadcast by default when this role is set
- We no longer abide by the 25% polite channel utilization while the device remains in a Tracker role