### PR TITLE
DIY external power pin

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -165,11 +165,11 @@ class AnalogBatteryLevel : public HasBatteryLevel
     virtual bool isVbusIn() override
     {
 #ifdef EXT_PWR_DETECT
-    // if external powered that pin will be pulled up
-    if (digitalRead(EXT_PWR_DETECT) == HIGH) {
-        return true;
-    }
-    // if it's not HIGH - check the battery
+        // if external powered that pin will be pulled up
+        if (digitalRead(EXT_PWR_DETECT) == HIGH) {
+            return true;
+        }
+        // if it's not HIGH - check the battery
 #endif
 
         return getBattVoltage() > chargingVolt;

--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -160,8 +160,18 @@ class AnalogBatteryLevel : public HasBatteryLevel
 
     /// If we see a battery voltage higher than physics allows - assume charger is pumping
     /// in power
+    /// On some boards we don't have the power management chip (like AXPxxxx)
+    /// so we use EXT_PWR_DETECT GPIO pin to detect external power source
     virtual bool isVbusIn() override
     {
+#ifdef EXT_PWR_DETECT
+    // if external powered that pin will be pulled up
+    if (digitalRead(EXT_PWR_DETECT) == HIGH) {
+        return true;
+    }
+    // if it's not HIGH - check the battery
+#endif
+
         return getBattVoltage() > chargingVolt;
     }
 

--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -218,6 +218,10 @@ Power::Power() : OSThread("Power")
 
 bool Power::analogInit()
 {
+#ifdef EXT_PWR_DETECT
+    pinMode(EXT_PWR_DETECT, INPUT);
+#endif
+
 #ifdef BATTERY_PIN
     LOG_DEBUG("Using analog input %d for battery level\n", BATTERY_PIN);
 

--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -27,8 +27,8 @@ static bool isPowered()
 
         2) If we detect USB power from the power management chip, we must be getting power externally.
 
-        3) On some boards we don't have the power management chip (like AXPxxxx) so we use EXT_PWR_DETECT GPIO pin to detect external power source
-            (see `isVbusIn()` in `Power.cpp`)
+        3) On some boards we don't have the power management chip (like AXPxxxx) so we use EXT_PWR_DETECT GPIO pin to detect
+       external power source (see `isVbusIn()` in `Power.cpp`)
     */
     return !isPowerSavingMode && powerStatus && (!powerStatus->getHasBattery() || powerStatus->getHasUSB());
 }

--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -26,6 +26,9 @@ static bool isPowered()
         1) If we're powered up and there's no battery, we must be getting power externally. (because we'd be dead otherwise)
 
         2) If we detect USB power from the power management chip, we must be getting power externally.
+
+        3) On some boards we don't have the power management chip (like AXPxxxx) so we use EXT_PWR_DETECT GPIO pin to detect external power source
+            (see `isVbusIn()` in `Power.cpp`)
     */
     return !isPowerSavingMode && powerStatus && (!powerStatus->getHasBattery() || powerStatus->getHasUSB());
 }

--- a/variants/diy/v1/variant.h
+++ b/variants/diy/v1/variant.h
@@ -12,6 +12,7 @@
 #define BUTTON_PIN 39       // The middle button GPIO on the T-Beam
 #define BATTERY_PIN 35      // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
 #define ADC_MULTIPLIER 1.85 // (R1 = 470k, R2 = 680k)
+#define EXT_PWR_DETECT 4    // Pin to detect connected external power source for LILYGO® TTGO T-Energy T18 and other DIY boards
 #define EXT_NOTIFY_OUT 12   // Overridden default pin to use for Ext Notify Module (#975).
 #define LED_PIN 2           // add status LED (compatible with core-pcb and DIY targets)
 


### PR DESCRIPTION

This fixes various issues such as unexpected node sleep, WiFi disconnection.

On some boards (DIY boards with ESP32 DevKit and LILYGO® TTGO T-Energy T18) we don't have a power management chip (like AXPxxxx) so we use GPIO pin `EXT_PWR_DETECT` to detect the external power supply.

To detect an external power supply, we need to pull up the `EXT_PWR_DETECT` pin on the board.