### PR TITLE
Fix: Revert changes on wakeup

### DIFF
--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -93,18 +93,23 @@ static void lsIdle()
                 powerFSM.trigger(EVENT_SERIAL_CONNECTED);
                 break;
 
-            case ESP_SLEEP_WAKEUP_GPIO:
-                // GPIO of BUTTON_PIN (if available) triggered the wakeup
-                powerFSM.trigger(EVENT_PRESS);
-                break;
-
             default:
-                // We woke for some other reason (device interrupt)
+                // We woke for some other reason (button press, device interrupt)
                 // uint64_t status = esp_sleep_get_ext1_wakeup_status();
                 LOG_INFO("wakeCause2 %d\n", wakeCause2);
-                // Let the NB state handle the IRQ (and that state will handle stuff like IRQs etc)
-                // we lie and say "wake timer" because the interrupt will be handled by the regular IRQ code
-                powerFSM.trigger(EVENT_WAKE_TIMER);
+
+#ifdef BUTTON_PIN
+                bool pressed = !digitalRead(BUTTON_PIN);
+#else
+                bool pressed = false;
+#endif
+                if (pressed) { // If we woke because of press, instead generate a PRESS event.
+                    powerFSM.trigger(EVENT_PRESS);
+                } else {
+                    // Otherwise let the NB state handle the IRQ (and that state will handle stuff like IRQs etc)
+                    // we lie and say "wake timer" because the interrupt will be handled by the regular IRQ code
+                    powerFSM.trigger(EVENT_WAKE_TIMER);
+                }
                 break;
             }
         } else {


### PR DESCRIPTION
I need to revert a change done in #2403. 

The current effect is that during light sleep in mode ROUTER every packet that arrives triggers the screen on. 
The previous code was correctly handling this situation, so need to revert to that code.

This issue happens now (after all my previous tests were ok) because now the device correctly wakes up on LORA_DIO1 IRQ, which it didn't do before and the screen on didn't happen. I missed that one.
