### PR TITLE
try-fix: tbeam router goes sporadically into DS

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -365,27 +365,24 @@ void Power::readPowerStatus()
 
 #endif
 
-// If we have a battery at all and it is less than 10% full, force deep sleep if we have more than 3 low readings in a row
-// Supect fluctuating voltage on the RAK4631 to force it to deep sleep even if battery is at 85% after only a few days
-#ifdef ARCH_NRF52
+        // If we have a battery at all and it is less than 10% full, force deep sleep if we have more than 10 low readings in a row
         if (powerStatus2.getHasBattery() && !powerStatus2.getHasUSB()) {
             if (batteryLevel->getBattVoltage() < MIN_BAT_MILLIVOLTS) {
                 low_voltage_counter++;
-                LOG_DEBUG("Warning RAK4631 Low voltage counter: %d/10\n", low_voltage_counter);
+                LOG_DEBUG("Low voltage counter: %d/10\n", low_voltage_counter);
                 if (low_voltage_counter > 10) {
+#ifdef ARCH_NRF52
                     // We can't trigger deep sleep on NRF52, it's freezing the board
-                    // powerFSM.trigger(EVENT_LOW_BATTERY);
                     LOG_DEBUG("Low voltage detected, but not triggering deep sleep\n");
+#else
+                    LOG_INFO("Low voltage detected, triggering deep sleep\n");
+                    powerFSM.trigger(EVENT_LOW_BATTERY);
+#endif
                 }
             } else {
                 low_voltage_counter = 0;
             }
         }
-#else
-        // If we have a battery at all and it is less than 10% full, force deep sleep
-        if (powerStatus2.getHasBattery() && !powerStatus2.getHasUSB() && batteryLevel->getBattVoltage() < MIN_BAT_MILLIVOLTS)
-            powerFSM.trigger(EVENT_LOW_BATTERY);
-#endif
     } else {
         // No power sensing on this board - tell everyone else we have no idea what is happening
         const PowerStatus powerStatus3 = PowerStatus(OptUnknown, OptUnknown, OptUnknown, -1, -1);
@@ -539,7 +536,6 @@ bool Power::axpChipInit()
 
         // Set up the charging voltage
         PMU->setChargeTargetVoltage(XPOWERS_AXP192_CHG_VOL_4V2);
-
     } else if (PMU->getChipModel() == XPOWERS_AXP2101) {
 
         /*The alternative version of T-Beam 1.1 differs from T-Beam V1.1 in that it uses an AXP2101 power chip*/

--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -365,7 +365,8 @@ void Power::readPowerStatus()
 
 #endif
 
-        // If we have a battery at all and it is less than 10% full, force deep sleep if we have more than 10 low readings in a row
+        // If we have a battery at all and it is less than 10% full, force deep sleep if we have more than 10 low readings in a
+        // row
         if (powerStatus2.getHasBattery() && !powerStatus2.getHasUSB()) {
             if (batteryLevel->getBattVoltage() < MIN_BAT_MILLIVOLTS) {
                 low_voltage_counter++;


### PR DESCRIPTION
It has been observed that a node which is configured with device.role ROUTER is sometimes dead after a while. 

It is suspected that the dead node is in deep sleep which normally happens only when the battery percentage falls below 10%. However it may happen also in case the battery readings deliver a wrong too low (or zero) value. For NRF52 the code requires ten subsequent measurements below the 10% threshold. For ESP32 only one(!) measurement below the threshold causes immediately a transition into deep sleep:

```
Power.cpp
// If we have a battery at all and it is less than 10% full, force deep sleep if we have more than 3 low readings in a row
// Supect fluctuating voltage on the RAK4631 to force it to deep sleep even if battery is at 85% after only a few days
#ifdef ARCH_NRF52
        if (powerStatus2.getHasBattery() && !powerStatus2.getHasUSB()) {
            if (batteryLevel->getBattVoltage() < MIN_BAT_MILLIVOLTS) {
                low_voltage_counter++;
                LOG_DEBUG("Warning RAK4631 Low voltage counter: %d/10\n", low_voltage_counter);
                if (low_voltage_counter > 10) {
                    // We can't trigger deep sleep on NRF52, it's freezing the board
                    // powerFSM.trigger(EVENT_LOW_BATTERY);
                    LOG_DEBUG("Low voltage detected, but not triggering deep sleep\n");
                }
            } else {
                low_voltage_counter = 0;
            }
        }
#else
        // If we have a battery at all and it is less than 10% full, force deep sleep
        if (powerStatus2.getHasBattery() && !powerStatus2.getHasUSB() && batteryLevel->getBattVoltage() < MIN_BAT_MILLIVOLTS)
            powerFSM.trigger(EVENT_LOW_BATTERY);
#endif
```
 
This try-fix adopts the algorithm for battery low detection also for other platforms (ESP32). Hopefully, this will make the TBeam router mode usable.
