### PR TITLE
RemoteHardwareModule.cpp: Fix digitalReads() pinModes(mask, INPUT_PULLUP)

### DIFF
--- a/src/modules/RemoteHardwareModule.cpp
+++ b/src/modules/RemoteHardwareModule.cpp
@@ -29,10 +29,7 @@ static uint64_t digitalReads(uint64_t mask)
 {
     uint64_t res = 0;
 
-    // The Arduino docs show to run pinMode(). But, when testing, found it is best not to.
-    // If the line below is uncommented, read will flip the pin to the default of the second
-    // argument in pinModes(), which will make the read turn the PIN "on".
-    // pinModes(mask, INPUT_PULLUP);
+    pinModes(mask, INPUT_PULLUP);
 
     for (uint64_t i = 0; i < NUM_GPIOS; i++) {
         uint64_t m = 1ULL << i;


### PR DESCRIPTION
https://github.com/meshtastic/firmware/blob/973b30fc0be1960d412b031359bd8a839ed91ee2/src/modules/RemoteHardwareModule.cpp#L32-L35

This comment describes an unfortunate misunderstanding caused by incorrect mask calculation from #2454