### PR TITLE
Accel mpu6050 on tbeam

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # Meshtastic Firmware
 
-![GitHub release downloads](https://img.shields.io/github/downloads/meshtastic/firmware/total)
-[![CI](https://img.shields.io/github/actions/workflow/status/meshtastic/firmware/main_matrix.yml?branch=master&label=actions&logo=github&color=yellow)](https://github.com/meshtastic/firmware/actions/workflows/ci.yml)
-[![CLA assistant](https://cla-assistant.io/readme/badge/meshtastic/firmware)](https://cla-assistant.io/meshtastic/firmware)
-[![Fiscal Contributors](https://opencollective.com/meshtastic/tiers/badge.svg?label=Fiscal%20Contributors&color=deeppink)](https://opencollective.com/meshtastic/)
-[![Vercel](https://img.shields.io/static/v1?label=Powered%20by&message=Vercel&style=flat&logo=vercel&color=000000)](https://vercel.com?utm_source=meshtastic&utm_campaign=oss)
-
 ## Overview
 
 This repository contains the device firmware for the Meshtastic project.
@@ -13,6 +7,4 @@ This repository contains the device firmware for the Meshtastic project.
 **[Building Instructions](https://meshtastic.org/docs/development/firmware/build)**
 **[Flashing Instructions](https://meshtastic.org/docs/getting-started/flashing-firmware/)**
 
-## Stats
 
-![Alt](https://repobeats.axiom.co/api/embed/a92f097d9197ae853e780ec53d7d126e545629ab.svg "Repobeats analytics image")

--- a/variants/tbeam/variant.h
+++ b/variants/tbeam/variant.h
@@ -3,6 +3,9 @@
 #define I2C_SDA 21
 #define I2C_SCL 22
 
+#define I2C_SDA1 13
+#define I2C_SCL1 14
+
 #define BUTTON_PIN 38 // The middle button GPIO on the T-Beam
 //#define BUTTON_PIN_ALT 13 // Alternate GPIO for an external button if needed. Does anyone use this? It is not documented
 // anywhere.


### PR DESCRIPTION
To activate Accelerometer thread, please set either of two settings: config.display.wake_on_tap_or_motion or config.device.double_tap_as_button_press. This is a temporary workaround to ensure the accelerometer thread does not shutdown.
The MPU6050 has to be connected to pins: 14--SCL 13--SDA, +5 and GND respectively. The Wire1 (I2C_1) interface is being remapped to these pins, and the accelerometer thread is hardcoded to use only the Wire1 (instead of Wire) I2C in this PR.

The accelerometer thread reports the accel/rotation/temperature data from the MPU6050 like:

```
INFO  | ??:??:?? 284 [AccelerometerThread] Acceleration: x -0.6800 y -2.9281 z 10.3238, Rotation: yaw 0.0049 pitch 0.0205 roll -0.0453, Temperature: 28.62
```
in console (USB UART)

Known issues: for yet an unknown reason the image on LCD display is a bit corrupted -- a narrow strip of noise on the left side; investigation pending.