### PR TITLE
Fix t-beam-s3-core display not working 

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -606,7 +606,7 @@ bool Power::axpChipInit()
     } else if (PMU->getChipModel() == XPOWERS_AXP2101) {
 
         /*The alternative version of T-Beam 1.1 differs from T-Beam V1.1 in that it uses an AXP2101 power chip*/
-        if (HW_VENDOR == meshtastic_HardwareModel_TBEAM){
+        if (HW_VENDOR == meshtastic_HardwareModel_TBEAM) {
             // Unuse power channel
             PMU->disablePowerOutput(XPOWERS_DCDC2);
             PMU->disablePowerOutput(XPOWERS_DCDC3);
@@ -636,7 +636,7 @@ bool Power::axpChipInit()
             PMU->setPowerChannelVoltage(XPOWERS_ALDO3, 3300);
             PMU->enablePowerOutput(XPOWERS_ALDO3);
 
-        }else if(HW_VENDOR == meshtastic_HardwareModel_LILYGO_TBEAM_S3_CORE){
+        } else if (HW_VENDOR == meshtastic_HardwareModel_LILYGO_TBEAM_S3_CORE) {
             // t-beam s3 core
             /**
              * gnss module power channel

--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -606,82 +606,81 @@ bool Power::axpChipInit()
     } else if (PMU->getChipModel() == XPOWERS_AXP2101) {
 
         /*The alternative version of T-Beam 1.1 differs from T-Beam V1.1 in that it uses an AXP2101 power chip*/
-#if (HW_VENDOR == meshtastic_HardwareModel_TBEAM)
-        // Unuse power channel
-        PMU->disablePowerOutput(XPOWERS_DCDC2);
-        PMU->disablePowerOutput(XPOWERS_DCDC3);
-        PMU->disablePowerOutput(XPOWERS_DCDC4);
-        PMU->disablePowerOutput(XPOWERS_DCDC5);
-        PMU->disablePowerOutput(XPOWERS_ALDO1);
-        PMU->disablePowerOutput(XPOWERS_ALDO4);
-        PMU->disablePowerOutput(XPOWERS_BLDO1);
-        PMU->disablePowerOutput(XPOWERS_BLDO2);
-        PMU->disablePowerOutput(XPOWERS_DLDO1);
-        PMU->disablePowerOutput(XPOWERS_DLDO2);
+        if (HW_VENDOR == meshtastic_HardwareModel_TBEAM){
+            // Unuse power channel
+            PMU->disablePowerOutput(XPOWERS_DCDC2);
+            PMU->disablePowerOutput(XPOWERS_DCDC3);
+            PMU->disablePowerOutput(XPOWERS_DCDC4);
+            PMU->disablePowerOutput(XPOWERS_DCDC5);
+            PMU->disablePowerOutput(XPOWERS_ALDO1);
+            PMU->disablePowerOutput(XPOWERS_ALDO4);
+            PMU->disablePowerOutput(XPOWERS_BLDO1);
+            PMU->disablePowerOutput(XPOWERS_BLDO2);
+            PMU->disablePowerOutput(XPOWERS_DLDO1);
+            PMU->disablePowerOutput(XPOWERS_DLDO2);
 
-        // GNSS RTC PowerVDD 3300mV
-        PMU->setPowerChannelVoltage(XPOWERS_VBACKUP, 3300);
-        PMU->enablePowerOutput(XPOWERS_VBACKUP);
+            // GNSS RTC PowerVDD 3300mV
+            PMU->setPowerChannelVoltage(XPOWERS_VBACKUP, 3300);
+            PMU->enablePowerOutput(XPOWERS_VBACKUP);
 
-        // ESP32 VDD 3300mV
-        //  ! No need to set, automatically open , Don't close it
-        //  PMU->setPowerChannelVoltage(XPOWERS_DCDC1, 3300);
-        //  PMU->setProtectedChannel(XPOWERS_DCDC1);
+            // ESP32 VDD 3300mV
+            //  ! No need to set, automatically open , Don't close it
+            //  PMU->setPowerChannelVoltage(XPOWERS_DCDC1, 3300);
+            //  PMU->setProtectedChannel(XPOWERS_DCDC1);
 
-        // LoRa VDD 3300mV
-        PMU->setPowerChannelVoltage(XPOWERS_ALDO2, 3300);
-        PMU->enablePowerOutput(XPOWERS_ALDO2);
+            // LoRa VDD 3300mV
+            PMU->setPowerChannelVoltage(XPOWERS_ALDO2, 3300);
+            PMU->enablePowerOutput(XPOWERS_ALDO2);
 
-        // GNSS VDD 3300mV
-        PMU->setPowerChannelVoltage(XPOWERS_ALDO3, 3300);
-        PMU->enablePowerOutput(XPOWERS_ALDO3);
+            // GNSS VDD 3300mV
+            PMU->setPowerChannelVoltage(XPOWERS_ALDO3, 3300);
+            PMU->enablePowerOutput(XPOWERS_ALDO3);
 
-#elif (HW_VENDOR == meshtastic_HardwareModel_LILYGO_TBEAM_S3_CORE)
-        // t-beam s3 core
-        /**
-         * gnss module power channel
-         * The default ALDO4 is off, you need to turn on the GNSS power first, otherwise it will be invalid during
-         * initialization
-         */
-        PMU->setPowerChannelVoltage(XPOWERS_ALDO4, 3300);
-        PMU->enablePowerOutput(XPOWERS_ALDO4);
+        }else if(HW_VENDOR == meshtastic_HardwareModel_LILYGO_TBEAM_S3_CORE){
+            // t-beam s3 core
+            /**
+             * gnss module power channel
+             * The default ALDO4 is off, you need to turn on the GNSS power first, otherwise it will be invalid during
+             * initialization
+             */
+            PMU->setPowerChannelVoltage(XPOWERS_ALDO4, 3300);
+            PMU->enablePowerOutput(XPOWERS_ALDO4);
 
-        // lora radio power channel
-        PMU->setPowerChannelVoltage(XPOWERS_ALDO3, 3300);
-        PMU->enablePowerOutput(XPOWERS_ALDO3);
+            // lora radio power channel
+            PMU->setPowerChannelVoltage(XPOWERS_ALDO3, 3300);
+            PMU->enablePowerOutput(XPOWERS_ALDO3);
 
-        // m.2 interface
-        PMU->setPowerChannelVoltage(XPOWERS_DCDC3, 3300);
-        PMU->enablePowerOutput(XPOWERS_DCDC3);
+            // m.2 interface
+            PMU->setPowerChannelVoltage(XPOWERS_DCDC3, 3300);
+            PMU->enablePowerOutput(XPOWERS_DCDC3);
 
-        /**
-         * ALDO2 cannot be turned off.
-         * It is a necessary condition for sensor communication.
-         * It must be turned on to properly access the sensor and screen
-         * It is also responsible for the power supply of PCF8563
-         */
-        PMU->setPowerChannelVoltage(XPOWERS_ALDO2, 3300);
-        PMU->enablePowerOutput(XPOWERS_ALDO2);
+            /**
+             * ALDO2 cannot be turned off.
+             * It is a necessary condition for sensor communication.
+             * It must be turned on to properly access the sensor and screen
+             * It is also responsible for the power supply of PCF8563
+             */
+            PMU->setPowerChannelVoltage(XPOWERS_ALDO2, 3300);
+            PMU->enablePowerOutput(XPOWERS_ALDO2);
 
-        // 6-axis , magnetometer ,bme280 , oled screen power channel
-        PMU->setPowerChannelVoltage(XPOWERS_ALDO1, 3300);
-        PMU->enablePowerOutput(XPOWERS_ALDO1);
+            // 6-axis , magnetometer ,bme280 , oled screen power channel
+            PMU->setPowerChannelVoltage(XPOWERS_ALDO1, 3300);
+            PMU->enablePowerOutput(XPOWERS_ALDO1);
 
-        // sdcard power channle
-        PMU->setPowerChannelVoltage(XPOWERS_BLDO1, 3300);
-        PMU->enablePowerOutput(XPOWERS_BLDO1);
+            // sdcard power channle
+            PMU->setPowerChannelVoltage(XPOWERS_BLDO1, 3300);
+            PMU->enablePowerOutput(XPOWERS_BLDO1);
 
-        // PMU->setPowerChannelVoltage(XPOWERS_DCDC4, 3300);
-        // PMU->enablePowerOutput(XPOWERS_DCDC4);
+            // PMU->setPowerChannelVoltage(XPOWERS_DCDC4, 3300);
+            // PMU->enablePowerOutput(XPOWERS_DCDC4);
 
-        // not use channel
-        PMU->disablePowerOutput(XPOWERS_DCDC2); // not elicited
-        PMU->disablePowerOutput(XPOWERS_DCDC5); // not elicited
-        PMU->disablePowerOutput(XPOWERS_DLDO1); // Invalid power channel, it does not exist
-        PMU->disablePowerOutput(XPOWERS_DLDO2); // Invalid power channel, it does not exist
-        PMU->disablePowerOutput(XPOWERS_VBACKUP);
-
-#endif
+            // not use channel
+            PMU->disablePowerOutput(XPOWERS_DCDC2); // not elicited
+            PMU->disablePowerOutput(XPOWERS_DCDC5); // not elicited
+            PMU->disablePowerOutput(XPOWERS_DLDO1); // Invalid power channel, it does not exist
+            PMU->disablePowerOutput(XPOWERS_DLDO2); // Invalid power channel, it does not exist
+            PMU->disablePowerOutput(XPOWERS_VBACKUP);
+        }
 
         // disable all axp chip interrupt
         PMU->disableIRQ(XPOWERS_AXP2101_ALL_IRQ);

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -103,13 +103,13 @@ void setGPSPower(bool on)
     if (pmu_found && PMU) {
         uint8_t model = PMU->getChipModel();
         if (model == XPOWERS_AXP2101) {
-#if (HW_VENDOR == meshtastic_HardwareModel_TBEAM)
-            // t-beam v1.2 GNSS power channel
-            on ? PMU->enablePowerOutput(XPOWERS_ALDO3) : PMU->disablePowerOutput(XPOWERS_ALDO3);
-#elif (HW_VENDOR == meshtastic_HardwareModel_LILYGO_TBEAM_S3_CORE)
-            // t-beam-s3-core GNSS  power channel
-            on ? PMU->enablePowerOutput(XPOWERS_ALDO4) : PMU->disablePowerOutput(XPOWERS_ALDO4);
-#endif
+            if (HW_VENDOR == meshtastic_HardwareModel_TBEAM){
+                // t-beam v1.2 GNSS power channel
+                on ? PMU->enablePowerOutput(XPOWERS_ALDO3) : PMU->disablePowerOutput(XPOWERS_ALDO3);
+            }else if(HW_VENDOR == meshtastic_HardwareModel_LILYGO_TBEAM_S3_CORE){
+                // t-beam-s3-core GNSS  power channel
+                on ? PMU->enablePowerOutput(XPOWERS_ALDO4) : PMU->disablePowerOutput(XPOWERS_ALDO4);
+            }
         } else if (model == XPOWERS_AXP192) {
             // t-beam v1.1 GNSS  power channel
             on ? PMU->enablePowerOutput(XPOWERS_LDO3) : PMU->disablePowerOutput(XPOWERS_LDO3);
@@ -252,12 +252,12 @@ void doDeepSleep(uint32_t msecToWake)
 
         uint8_t model = PMU->getChipModel();
         if (model == XPOWERS_AXP2101) {
-#if (HW_VENDOR == meshtastic_HardwareModel_TBEAM)
-            // t-beam v1.2 radio power channel
-            PMU->disablePowerOutput(XPOWERS_ALDO2); // lora radio power channel
-#elif (HW_VENDOR == meshtastic_HardwareModel_LILYGO_TBEAM_S3_CORE)
-            PMU->disablePowerOutput(XPOWERS_ALDO3); // lora radio power channel
-#endif
+            if (HW_VENDOR == meshtastic_HardwareModel_TBEAM){
+                // t-beam v1.2 radio power channel
+                PMU->disablePowerOutput(XPOWERS_ALDO2); // lora radio power channel
+            }else if(HW_VENDOR == meshtastic_HardwareModel_LILYGO_TBEAM_S3_CORE){
+                PMU->disablePowerOutput(XPOWERS_ALDO3); // lora radio power channel
+            }
         } else if (model == XPOWERS_AXP192) {
             // t-beam v1.1 radio power channel
             PMU->disablePowerOutput(XPOWERS_LDO2); // lora radio power channel

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -103,10 +103,10 @@ void setGPSPower(bool on)
     if (pmu_found && PMU) {
         uint8_t model = PMU->getChipModel();
         if (model == XPOWERS_AXP2101) {
-            if (HW_VENDOR == meshtastic_HardwareModel_TBEAM){
+            if (HW_VENDOR == meshtastic_HardwareModel_TBEAM) {
                 // t-beam v1.2 GNSS power channel
                 on ? PMU->enablePowerOutput(XPOWERS_ALDO3) : PMU->disablePowerOutput(XPOWERS_ALDO3);
-            }else if(HW_VENDOR == meshtastic_HardwareModel_LILYGO_TBEAM_S3_CORE){
+            } else if (HW_VENDOR == meshtastic_HardwareModel_LILYGO_TBEAM_S3_CORE) {
                 // t-beam-s3-core GNSS  power channel
                 on ? PMU->enablePowerOutput(XPOWERS_ALDO4) : PMU->disablePowerOutput(XPOWERS_ALDO4);
             }
@@ -252,10 +252,10 @@ void doDeepSleep(uint32_t msecToWake)
 
         uint8_t model = PMU->getChipModel();
         if (model == XPOWERS_AXP2101) {
-            if (HW_VENDOR == meshtastic_HardwareModel_TBEAM){
+            if (HW_VENDOR == meshtastic_HardwareModel_TBEAM) {
                 // t-beam v1.2 radio power channel
                 PMU->disablePowerOutput(XPOWERS_ALDO2); // lora radio power channel
-            }else if(HW_VENDOR == meshtastic_HardwareModel_LILYGO_TBEAM_S3_CORE){
+            } else if (HW_VENDOR == meshtastic_HardwareModel_LILYGO_TBEAM_S3_CORE) {
                 PMU->disablePowerOutput(XPOWERS_ALDO3); // lora radio power channel
             }
         } else if (model == XPOWERS_AXP192) {


### PR DESCRIPTION
See https://github.com/meshtastic/firmware/issues/2519

https://meshtastic.discourse.group/t/new-lilygo-t-beam-supreme-product/7474
The conditional macro cannot recognize the enumeration variable, change it to a conditional statement to determine the hardware manufacturer model.

When the OLED power is not turned on, scanning the I2C port will cause the application to be stuck, because the I2C bus is not normal. It cannot scan to the device correctly.