### PR TITLE
RP2040: Use Pico SDK USB stack instead of TinyUSB

### DIFF
--- a/variants/rak11310/platformio.ini
+++ b/variants/rak11310/platformio.ini
@@ -8,7 +8,6 @@ build_flags = ${rp2040_base.build_flags}
   -DPRIVATE_HW
   -Ivariants/rak11310
   -DDEBUG_RP2040_PORT=Serial
-  -DUSE_TINYUSB
   -L "${platformio.libdeps_dir}/${this.__env__}/BSEC2 Software Library/src/cortex-m0plus"
 lib_deps =
   ${rp2040_base.lib_deps}

--- a/variants/rak11310/variant.h
+++ b/variants/rak11310/variant.h
@@ -51,5 +51,3 @@
 #define SX126X_POWER_EN 25
 #define SX126X_E22 // DIO2 controlls an antenna switch and the TCXO voltage is controlled by DIO3
 #endif
-
-#include <Adafruit_TinyUSB.h>

--- a/variants/rpipico/platformio.ini
+++ b/variants/rpipico/platformio.ini
@@ -8,7 +8,6 @@ build_flags = ${rp2040_base.build_flags}
   -DPRIVATE_HW
   -Ivariants/rpipico
   -DDEBUG_RP2040_PORT=Serial
-  -DUSE_TINYUSB
   -DHW_SPI1_DEVICE
   -L "${platformio.libdeps_dir}/${this.__env__}/BSEC2 Software Library/src/cortex-m0plus"
 lib_deps =

--- a/variants/rpipico/variant.h
+++ b/variants/rpipico/variant.h
@@ -52,5 +52,3 @@
 #define SX126X_RESET LORA_RESET
 #define SX126X_E22
 #endif
-
-#include <Adafruit_TinyUSB.h>

--- a/variants/rpipicow/platformio.ini
+++ b/variants/rpipicow/platformio.ini
@@ -9,7 +9,6 @@ build_flags = ${rp2040_base.build_flags}
   -DPRIVATE_HW
   -Ivariants/rpipicow
   -DDEBUG_RP2040_PORT=Serial
-  -DUSE_TINYUSB
   -DHW_SPI1_DEVICE
   -L "${platformio.libdeps_dir}/${this.__env__}/BSEC2 Software Library/src/cortex-m0plus"
 lib_deps =

--- a/variants/rpipicow/variant.h
+++ b/variants/rpipicow/variant.h
@@ -50,5 +50,3 @@
 #define SX126X_RESET LORA_RESET
 #define SX126X_E22
 #endif
-
-#include <Adafruit_TinyUSB.h>


### PR DESCRIPTION
Partially fixes #2521. I can't get it to freeze anymore, but serial output still stops after a while.
