### PR TITLE
CalTopo NMEA mode

### DIFF
--- a/src/gps/NMEAWPL.cpp
+++ b/src/gps/NMEAWPL.cpp
@@ -18,10 +18,11 @@
  * -------------------------------------------
  */
 
-uint32_t printWPL(char *buf, size_t bufsz, const meshtastic_Position &pos, const char *name)
+uint32_t printWPL(char *buf, size_t bufsz, const meshtastic_Position &pos, const char *name, bool isCaltopoMode)
 {
     GeoCoord geoCoord(pos.latitude_i, pos.longitude_i, pos.altitude);
-    uint32_t len = snprintf(buf, bufsz, "$GNWPL,%02d%07.4f,%c,%03d%07.4f,%c,%s", geoCoord.getDMSLatDeg(),
+    char type = isCaltopoMode ? 'P' : 'N';
+    uint32_t len = snprintf(buf, bufsz, "$G%cWPL,%02d%07.4f,%c,%03d%07.4f,%c,%s", type, geoCoord.getDMSLatDeg(),
                             (abs(geoCoord.getLatitude()) - geoCoord.getDMSLatDeg() * 1e+7) * 6e-6, geoCoord.getDMSLatCP(),
                             geoCoord.getDMSLonDeg(), (abs(geoCoord.getLongitude()) - geoCoord.getDMSLonDeg() * 1e+7) * 6e-6,
                             geoCoord.getDMSLonCP(), name);

--- a/src/gps/NMEAWPL.h
+++ b/src/gps/NMEAWPL.h
@@ -3,5 +3,5 @@
 #include "main.h"
 #include <Arduino.h>
 
-uint32_t printWPL(char *buf, size_t bufsz, const meshtastic_Position &pos, const char *name);
+uint32_t printWPL(char *buf, size_t bufsz, const meshtastic_Position &pos, const char *name, bool isCaltopoMode = false);
 uint32_t printGGA(char *buf, size_t bufsz, const meshtastic_Position &pos);

--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -238,17 +238,16 @@ ProcessMessage SerialModuleRadio::handleReceived(const meshtastic_MeshPacket &mp
                 // Decode the Payload some more
                 meshtastic_Position scratch;
                 meshtastic_Position *decoded = NULL;
-                if (mp.which_payload_variant == meshtastic_MeshPacket_decoded_tag && mp.decoded.portnum == ourPortNum))
-                    {
-                        memset(&scratch, 0, sizeof(scratch));
-                        if (pb_decode_from_bytes(p.payload.bytes, p.payload.size, &meshtastic_Position_msg, &scratch)) {
-                            decoded = &scratch;
-                        }
-                        // send position packet as WPL to the serial port
-                        printWPL(outbuf, sizeof(outbuf), *decoded, nodeDB.getNode(getFrom(&mp))->user.long_name,
-                                 moduleConfig.serial.mode == meshtastic_ModuleConfig_SerialConfig_Serial_Mode_CALTOPO);
-                        Serial2.printf("%s", outbuf);
+                if (mp.which_payload_variant == meshtastic_MeshPacket_decoded_tag && mp.decoded.portnum == ourPortNum) {
+                    memset(&scratch, 0, sizeof(scratch));
+                    if (pb_decode_from_bytes(p.payload.bytes, p.payload.size, &meshtastic_Position_msg, &scratch)) {
+                        decoded = &scratch;
                     }
+                    // send position packet as WPL to the serial port
+                    printWPL(outbuf, sizeof(outbuf), *decoded, nodeDB.getNode(getFrom(&mp))->user.long_name,
+                             moduleConfig.serial.mode == meshtastic_ModuleConfig_SerialConfig_Serial_Mode_CALTOPO);
+                    Serial2.printf("%s", outbuf);
+                }
             }
         }
     }

--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -108,56 +108,7 @@ int32_t SerialModule::runOnce()
             // Interface with the serial peripheral from in here.
             LOG_INFO("Initializing serial peripheral interface\n");
 
-            uint32_t baud = 0;
-
-            if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_DEFAULT) {
-                baud = 38400;
-
-            } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_110) {
-                baud = 110;
-
-            } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_300) {
-                baud = 300;
-
-            } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_600) {
-                baud = 600;
-
-            } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_1200) {
-                baud = 1200;
-
-            } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_2400) {
-                baud = 2400;
-
-            } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_4800) {
-                baud = 4800;
-
-            } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_9600) {
-                baud = 9600;
-
-            } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_19200) {
-                baud = 19200;
-
-            } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_38400) {
-                baud = 38400;
-
-            } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_57600) {
-                baud = 57600;
-
-            } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_115200) {
-                baud = 115200;
-
-            } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_230400) {
-                baud = 230400;
-
-            } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_460800) {
-                baud = 460800;
-
-            } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_576000) {
-                baud = 576000;
-
-            } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_921600) {
-                baud = 921600;
-            }
+            uint32_t baud = getBaudRate();
 
 #ifdef ARCH_ESP32
             Serial2.setRxBufferSize(RX_BUFFER);
@@ -186,16 +137,21 @@ int32_t SerialModule::runOnce()
             if (moduleConfig.serial.mode == meshtastic_ModuleConfig_SerialConfig_Serial_Mode_PROTO) {
                 emitRebooted();
             }
-
         } else {
 
             if (moduleConfig.serial.mode == meshtastic_ModuleConfig_SerialConfig_Serial_Mode_PROTO) {
                 return runOncePart();
-            } else if (moduleConfig.serial.mode == meshtastic_ModuleConfig_SerialConfig_Serial_Mode_NMEA) {
+            } else if (moduleConfig.serial.mode == meshtastic_ModuleConfig_SerialConfig_Serial_Mode_NMEA ||
+                       moduleConfig.serial.mode == meshtastic_ModuleConfig_SerialConfig_Serial_Mode_CALTOPO) {
                 // in NMEA mode send out GGA every 2 seconds, Don't read from Port
                 if (millis() - lastNmeaTime > 2000) {
                     lastNmeaTime = millis();
-                    printGGA(outbuf, sizeof(outbuf), nodeDB.getNode(myNodeInfo.my_node_num)->position);
+                    if (moduleConfig.serial.mode == meshtastic_ModuleConfig_SerialConfig_Serial_Mode_CALTOPO) {
+                        printWPL(outbuf, sizeof(outbuf), nodeDB.getNode(myNodeInfo.my_node_num)->position,
+                                 nodeDB.getNode(myNodeInfo.my_node_num)->user.long_name, true);
+                    } else {
+                        printGGA(outbuf, sizeof(outbuf), nodeDB.getNode(myNodeInfo.my_node_num)->position);
+                    }
                     Serial2.printf("%s", outbuf);
                 }
             } else {
@@ -266,7 +222,6 @@ ProcessMessage SerialModuleRadio::handleReceived(const meshtastic_MeshPacket &mp
                     Serial2.printf("%s", p.payload.bytes);
                 }
             }
-
         } else {
 
             if (moduleConfig.serial.mode == meshtastic_ModuleConfig_SerialConfig_Serial_Mode_DEFAULT ||
@@ -282,18 +237,58 @@ ProcessMessage SerialModuleRadio::handleReceived(const meshtastic_MeshPacket &mp
                 // Decode the Payload some more
                 meshtastic_Position scratch;
                 meshtastic_Position *decoded = NULL;
-                if (mp.which_payload_variant == meshtastic_MeshPacket_decoded_tag && mp.decoded.portnum == ourPortNum) {
+                if (mp.which_payload_variant == meshtastic_MeshPacket_decoded_tag &&
+                    (mp.decoded.portnum == ourPortNum || mp.decoded.portnum == meshtastic_PortNum_POSITION_APP)) {
                     memset(&scratch, 0, sizeof(scratch));
                     if (pb_decode_from_bytes(p.payload.bytes, p.payload.size, &meshtastic_Position_msg, &scratch)) {
                         decoded = &scratch;
                     }
                     // send position packet as WPL to the serial port
-                    printWPL(outbuf, sizeof(outbuf), *decoded, nodeDB.getNode(getFrom(&mp))->user.long_name);
+                    printWPL(outbuf, sizeof(outbuf), *decoded, nodeDB.getNode(getFrom(&mp))->user.long_name,
+                             moduleConfig.serial.mode == meshtastic_ModuleConfig_SerialConfig_Serial_Mode_CALTOPO);
                     Serial2.printf("%s", outbuf);
                 }
             }
         }
     }
     return ProcessMessage::CONTINUE; // Let others look at this message also if they want
+}
+
+uint32_t SerialModule::getBaudRate()
+{
+    if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_DEFAULT) {
+        return 38400;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_110) {
+        return 110;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_300) {
+        return 300;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_600) {
+        return 600;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_1200) {
+        return 1200;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_2400) {
+        return 2400;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_4800) {
+        return 4800;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_9600) {
+        return 9600;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_19200) {
+        return 19200;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_38400) {
+        return 38400;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_57600) {
+        return 57600;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_115200) {
+        return 115200;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_230400) {
+        return 230400;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_460800) {
+        return 460800;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_576000) {
+        return 576000;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_921600) {
+        return 921600;
+    }
+    return 38400;
 }
 #endif

--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -71,6 +71,7 @@ SerialModuleRadio::SerialModuleRadio() : MeshModule("SerialModuleRadio")
         ourPortNum = meshtastic_PortNum_TEXT_MESSAGE_APP;
         break;
     case meshtastic_ModuleConfig_SerialConfig_Serial_Mode_NMEA:
+    case meshtastic_ModuleConfig_SerialConfig_Serial_Mode_CALTOPO:
         ourPortNum = meshtastic_PortNum_POSITION_APP;
         break;
     default:
@@ -237,17 +238,17 @@ ProcessMessage SerialModuleRadio::handleReceived(const meshtastic_MeshPacket &mp
                 // Decode the Payload some more
                 meshtastic_Position scratch;
                 meshtastic_Position *decoded = NULL;
-                if (mp.which_payload_variant == meshtastic_MeshPacket_decoded_tag &&
-                    (mp.decoded.portnum == ourPortNum || mp.decoded.portnum == meshtastic_PortNum_POSITION_APP)) {
-                    memset(&scratch, 0, sizeof(scratch));
-                    if (pb_decode_from_bytes(p.payload.bytes, p.payload.size, &meshtastic_Position_msg, &scratch)) {
-                        decoded = &scratch;
+                if (mp.which_payload_variant == meshtastic_MeshPacket_decoded_tag && mp.decoded.portnum == ourPortNum))
+                    {
+                        memset(&scratch, 0, sizeof(scratch));
+                        if (pb_decode_from_bytes(p.payload.bytes, p.payload.size, &meshtastic_Position_msg, &scratch)) {
+                            decoded = &scratch;
+                        }
+                        // send position packet as WPL to the serial port
+                        printWPL(outbuf, sizeof(outbuf), *decoded, nodeDB.getNode(getFrom(&mp))->user.long_name,
+                                 moduleConfig.serial.mode == meshtastic_ModuleConfig_SerialConfig_Serial_Mode_CALTOPO);
+                        Serial2.printf("%s", outbuf);
                     }
-                    // send position packet as WPL to the serial port
-                    printWPL(outbuf, sizeof(outbuf), *decoded, nodeDB.getNode(getFrom(&mp))->user.long_name,
-                             moduleConfig.serial.mode == meshtastic_ModuleConfig_SerialConfig_Serial_Mode_CALTOPO);
-                    Serial2.printf("%s", outbuf);
-                }
             }
         }
     }

--- a/src/modules/SerialModule.h
+++ b/src/modules/SerialModule.h
@@ -25,6 +25,9 @@ class SerialModule : public StreamAPI, private concurrency::OSThread
 
     /// Check the current underlying physical link to see if the client is currently connected
     virtual bool checkIsConnected() override;
+
+  private:
+    uint32_t getBaudRate();
 };
 
 extern SerialModule *serialModule;


### PR DESCRIPTION
This mode uses the GPS prefix instead of GLONASS prefix and prints positions as WPLs even for the connected node