### PR TITLE
Account for AO7801/3401 mosfet

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -300,6 +300,10 @@ bool Power::analogInit()
     } else {
         LOG_INFO("ADCmod: ADC characterization based on default reference voltage\n");
     }
+#if defined(HELTEC_V3) || defined(HELTEC_WSL_V3)
+    pinMode(37, OUTPUT); // needed for P channel mosfet to work
+    digitalWrite(37, LOW);
+#endif
 #endif // ARCH_ESP32
 
 #ifdef ARCH_NRF52


### PR DESCRIPTION
The Heltec v3, Wireless Stick v3, and Wireless Stick Lite v3 all have some version of this P channel mosfet tied to GPIO37.

This pull request makes sure that when we init the ADC code, the pin is not in high impedance and is LOW.