### PR TITLE
[WiP] Ethernet: will try DHCP twice, and fallback to 192.168.192.168

### DIFF
--- a/src/mesh/eth/ethClient.cpp
+++ b/src/mesh/eth/ethClient.cpp
@@ -127,8 +127,11 @@ bool initEthernet()
         mac[0] &= 0xfe;  // Make sure this is not a multicast MAC
 
         if (config.network.address_mode == meshtastic_Config_NetworkConfig_AddressMode_DHCP) {
-            LOG_INFO("Starting Ethernet DHCP\n");
+            LOG_INFO("Starting DHCP client\n");
+            LOG_INFO("MAC: %02x:%02x:%02x:%02x:%02x:%02x\n", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+
             Ethernet.begin(mac);
+            LOG_INFO("Started\n");
             // DHCP failed, switch to static IP
             if (Ethernet.localIP() == IPAddress(0, 0, 0, 0)) {
                 LOG_INFO("DHCP failed, switching to factory IP (192.168.192.168)\n");
@@ -178,6 +181,12 @@ bool initEthernet()
                      Ethernet.gatewayIP()[3]);
             LOG_INFO("DNS Server IP %u.%u.%u.%u\n", Ethernet.dnsServerIP()[0], Ethernet.dnsServerIP()[1],
                      Ethernet.dnsServerIP()[2], Ethernet.dnsServerIP()[3]);
+            LOG_INFO("Link Status: %s\n", Ethernet.linkStatus() == LinkON ? "LinkON" : "LinkOFF");
+            LOG_INFO("LAN Hardware: %s\n", Ethernet.hardwareStatus() == EthernetNoHardware ? "EthernetNoHardware"
+                                           : Ethernet.hardwareStatus() == EthernetW5100    ? "EthernetW5100"
+                                           : Ethernet.hardwareStatus() == EthernetW5200    ? "EthernetW5200"
+                                           : Ethernet.hardwareStatus() == EthernetW5500    ? "EthernetW5500"
+                                                                                           : "Unknown");
         }
 
         ethEvent = new Periodic("ethConnect", reconnectETH);

--- a/src/mesh/eth/ethClient.cpp
+++ b/src/mesh/eth/ethClient.cpp
@@ -128,7 +128,24 @@ bool initEthernet()
 
         if (config.network.address_mode == meshtastic_Config_NetworkConfig_AddressMode_DHCP) {
             LOG_INFO("starting Ethernet DHCP\n");
-            status = Ethernet.begin(mac);
+
+            for (int i = 0; i < 2; i++) { // try DHCP 2 times
+                status = Ethernet.begin(mac);
+                if (status != 0)
+                    break;   // break the loop if DHCP is successful
+                delay(3000); // delay before next attempt
+            }
+
+            // DHCP failed twice, switch to static IP
+            if (status == 0) {
+                LOG_INFO("DHCP failed twice, switching to factory IP (192.168.192.168)\n");
+                IPAddress ip(192, 168, 192, 168);    // Static IP
+                IPAddress dns(1, 1, 1, 1);           // DNS
+                IPAddress gateway(192, 168, 192, 1); // Gateway
+                IPAddress subnet(255, 255, 255, 0);  // Subnet mask
+                Ethernet.begin(mac, ip, dns, gateway, subnet);
+                status = 1;
+            }
         } else if (config.network.address_mode == meshtastic_Config_NetworkConfig_AddressMode_STATIC) {
             LOG_INFO("starting Ethernet Static\n");
 

--- a/src/mesh/eth/ethClient.cpp
+++ b/src/mesh/eth/ethClient.cpp
@@ -127,36 +127,34 @@ bool initEthernet()
         mac[0] &= 0xfe;  // Make sure this is not a multicast MAC
 
         if (config.network.address_mode == meshtastic_Config_NetworkConfig_AddressMode_DHCP) {
-            LOG_INFO("starting Ethernet DHCP\n");
-
-            for (int i = 0; i < 2; i++) { // try DHCP 2 times
-                status = Ethernet.begin(mac);
-                if (status != 0)
-                    break;   // break the loop if DHCP is successful
-                delay(3000); // delay before next attempt
-            }
-
-            // DHCP failed twice, switch to static IP
+            LOG_INFO("Starting Ethernet DHCP\n");
+            status = Ethernet.begin(mac);
+            // DHCP failed, switch to static IP
             if (status == 0) {
-                LOG_INFO("DHCP failed twice, switching to factory IP (192.168.192.168)\n");
+                LOG_INFO("DHCP failed, switching to factory IP (192.168.192.168)\n");
                 IPAddress ip(192, 168, 192, 168);    // Static IP
                 IPAddress dns(1, 1, 1, 1);           // DNS
                 IPAddress gateway(192, 168, 192, 1); // Gateway
                 IPAddress subnet(255, 255, 255, 0);  // Subnet mask
-                Ethernet.begin(mac, ip, dns, gateway, subnet);
-                status = 1;
+                if (Ethernet.begin(mac, ip, dns, gateway, subnet) == 1) {
+                    status = 1;
+                } else {
+                    LOG_ERROR("Failed to assign factory IP address\n");
+                }
             }
         } else if (config.network.address_mode == meshtastic_Config_NetworkConfig_AddressMode_STATIC) {
-            LOG_INFO("starting Ethernet Static\n");
+            LOG_INFO("Starting Ethernet IP\n");
 
             IPAddress ip = IPAddress(bigToLittleEndian(config.network.ipv4_config.ip));
             IPAddress dns = IPAddress(bigToLittleEndian(config.network.ipv4_config.dns));
             IPAddress gateway = IPAddress(bigToLittleEndian(config.network.ipv4_config.gateway));
             IPAddress subnet = IPAddress(bigToLittleEndian(config.network.ipv4_config.subnet));
 
-            Ethernet.begin(mac, ip, dns, gateway, subnet);
-
-            status = 1;
+            if (Ethernet.begin(mac, ip, dns, gateway, subnet) == 1) {
+                status = 1;
+            } else {
+                LOG_ERROR("Failed to assign static IP address\n");
+            }
         } else {
             LOG_INFO("Ethernet Disabled\n");
             return false;

--- a/src/mesh/eth/ethClient.cpp
+++ b/src/mesh/eth/ethClient.cpp
@@ -128,19 +128,19 @@ bool initEthernet()
 
         if (config.network.address_mode == meshtastic_Config_NetworkConfig_AddressMode_DHCP) {
             LOG_INFO("Starting Ethernet DHCP\n");
-            status = Ethernet.begin(mac);
+            Ethernet.begin(mac);
             // DHCP failed, switch to static IP
-            if (status == 0) {
+            if (Ethernet.localIP() == IPAddress(0, 0, 0, 0)) {
                 LOG_INFO("DHCP failed, switching to factory IP (192.168.192.168)\n");
                 IPAddress ip(192, 168, 192, 168);    // Static IP
                 IPAddress dns(1, 1, 1, 1);           // DNS
                 IPAddress gateway(192, 168, 192, 1); // Gateway
                 IPAddress subnet(255, 255, 255, 0);  // Subnet mask
-                if (Ethernet.begin(mac, ip, dns, gateway, subnet) == 1) {
-                    status = 1;
-                } else {
-                    LOG_ERROR("Failed to assign factory IP address\n");
-                }
+                Ethernet.begin(mac, ip, dns, gateway, subnet);
+                status = 1;
+            } else {
+                LOG_INFO("DHCP Success\n");
+                status = 1;
             }
         } else if (config.network.address_mode == meshtastic_Config_NetworkConfig_AddressMode_STATIC) {
             LOG_INFO("Starting Ethernet IP\n");
@@ -150,11 +150,9 @@ bool initEthernet()
             IPAddress gateway = IPAddress(bigToLittleEndian(config.network.ipv4_config.gateway));
             IPAddress subnet = IPAddress(bigToLittleEndian(config.network.ipv4_config.subnet));
 
-            if (Ethernet.begin(mac, ip, dns, gateway, subnet) == 1) {
-                status = 1;
-            } else {
-                LOG_ERROR("Failed to assign static IP address\n");
-            }
+            Ethernet.begin(mac, ip, dns, gateway, subnet);
+            status = 1;
+
         } else {
             LOG_INFO("Ethernet Disabled\n");
             return false;


### PR DESCRIPTION
By my experience as a network engineer I suggest this must work something like this:
1) Will try to obtain an address via DHCP, repeat this action 2 times
2) If we fail to obtain an address via DHCP, fallback to set IP settings to well-known IP settings, something like 192.168.192.168/24, DNS=1.1.1.1, and GW 192.168.192.1.
