### PR TITLE
Always assign NodeNum based on MAC address

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -299,6 +299,7 @@ void NodeDB::installDefaultDeviceState()
     snprintf(owner.short_name, sizeof(owner.short_name), "%02x%02x", ourMacAddr[4], ourMacAddr[5]);
 
     snprintf(owner.id, sizeof(owner.id), "!%08x", getNodeNum()); // Default node ID now based on nodenum
+    memcpy(owner.macaddr, ourMacAddr, sizeof(owner.macaddr));
 }
 
 void NodeDB::init()

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -377,17 +377,17 @@ void NodeDB::pickNewNodeNum()
 {
     NodeNum r = myNodeInfo.my_node_num;
 
-    // If we don't have a nodenum at app - pick an initial nodenum based on the macaddr
-    if (r == 0)
-        r = (ourMacAddr[2] << 24) | (ourMacAddr[3] << 16) | (ourMacAddr[4] << 8) | ourMacAddr[5];
+    // Pick an initial nodenum based on the macaddr
+    r = (ourMacAddr[2] << 24) | (ourMacAddr[3] << 16) | (ourMacAddr[4] << 8) | ourMacAddr[5];
 
     if (r == NODENUM_BROADCAST || r < NUM_RESERVED)
         r = NUM_RESERVED; // don't pick a reserved node number
 
     meshtastic_NodeInfoLite *found;
     while ((found = getMeshNode(r)) && memcmp(found->user.macaddr, owner.macaddr, sizeof(owner.macaddr))) {
+        // FIXME: input for random() is int, so NODENUM_BROADCAST becomes -1
         NodeNum n = random(NUM_RESERVED, NODENUM_BROADCAST); // try a new random choice
-        LOG_DEBUG("NOTE! Our desired nodenum 0x%x is in use, so trying for 0x%x\n", r, n);
+        LOG_WARN("NOTE! Our desired nodenum 0x%x is in use, so trying for 0x%x\n", r, n);
         r = n;
     }
 


### PR DESCRIPTION
This is step one of trying to fix the infinite loop that happens occasionally. Clients cannot set `my_node_num`, so this will not break anything.

If it doesn't happen anymore using this, we can fix the call to the random function, but I would rather leave it there now such that it is easier to see if it goes wrong. Otherwise, the device will assign a new NodeNum to itself and other devices will think there is a new node.

