### PR TITLE
Addition of RAK 14001 functionality - On at Boot

### DIFF
--- a/src/graphics/RAKled.h
+++ b/src/graphics/RAKled.h
@@ -1,0 +1,7 @@
+#include "main.h"
+
+#ifdef RAK4630
+#include <NCP5623.h>
+extern NCP5623 rgb;
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #include "detect/axpDebug.h"
 #include "detect/einkScan.h"
 #include "graphics/Screen.h"
+#include "graphics/RAKled.h"
 #include "main.h"
 #include "mesh/generated/meshtastic/config.pb.h"
 #include "modules/Modules.h"
@@ -359,6 +360,15 @@ void setup()
 
     // Only one supported RGB LED currently
     rgb_found = i2cScanner->find(ScanI2C::DeviceType::NCP5623);
+    
+    // Start the RGB LED at 50%
+    #ifdef RAK4630
+    if (rgb_found.type == ScanI2C::NCP5623) {
+        rgb.begin();
+        rgb.setCurrent(10);
+        rgb.setColor(128, 128, 128);
+    }
+    #endif
 
 #if !defined(ARCH_PORTDUINO) && !defined(ARCH_STM32WL)
     auto acc_info = i2cScanner->firstAccelerometer();

--- a/src/modules/ExternalNotificationModule.cpp
+++ b/src/modules/ExternalNotificationModule.cpp
@@ -11,7 +11,7 @@
 #include "main.h"
 
 #ifdef RAK4630
-#include <NCP5623.h>
+#include <graphics/RAKled.h>
 NCP5623 rgb;
 
 uint8_t red = 0;


### PR DESCRIPTION
Intention of this PR is to allow the RAK 14001 to turn on at boot, and stay on. I envision future code changes will allow control of the LED through the CLI or apps, but wanted to get the LED working from the start.

I did have some trouble figuring out how to coordinate with the existing code in the External Notification Module, since I lack most of the fundamentals for C++.

I did successfully build and upload this to a RAK 4630 and is it is working on my device.