### PR TITLE
RAK14001 LED - Turn on to 50% at boot

### DIFF
--- a/src/graphics/RAKled.h
+++ b/src/graphics/RAKled.h
@@ -1,0 +1,7 @@
+#include "main.h"
+
+#ifdef RAK4630
+#include <NCP5623.h>
+extern NCP5623 rgb;
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,8 +19,8 @@
 #include "detect/ScanI2CTwoWire.h"
 #include "detect/axpDebug.h"
 #include "detect/einkScan.h"
-#include "graphics/Screen.h"
 #include "graphics/RAKled.h"
+#include "graphics/Screen.h"
 #include "main.h"
 #include "mesh/generated/meshtastic/config.pb.h"
 #include "modules/Modules.h"
@@ -360,15 +360,15 @@ void setup()
 
     // Only one supported RGB LED currently
     rgb_found = i2cScanner->find(ScanI2C::DeviceType::NCP5623);
-    
-    // Start the RGB LED at 50%
-    #ifdef RAK4630
+
+// Start the RGB LED at 50%
+#ifdef RAK4630
     if (rgb_found.type == ScanI2C::NCP5623) {
         rgb.begin();
         rgb.setCurrent(10);
         rgb.setColor(128, 128, 128);
     }
-    #endif
+#endif
 
 #if !defined(ARCH_PORTDUINO) && !defined(ARCH_STM32WL)
     auto acc_info = i2cScanner->firstAccelerometer();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #include "detect/axpDebug.h"
 #include "detect/einkScan.h"
 #include "graphics/Screen.h"
+#include "graphics/RAKled.h"
 #include "main.h"
 #include "mesh/generated/meshtastic/config.pb.h"
 #include "modules/Modules.h"
@@ -359,6 +360,15 @@ void setup()
 
     // Only one supported RGB LED currently
     rgb_found = i2cScanner->find(ScanI2C::DeviceType::NCP5623);
+    
+    // Start the RGB LED at 50%
+    #ifdef RAK4630
+    if (rgb_found.type == ScanI2C::NCP5623) {
+        rgb.begin();
+        rgb.setCurrent(10);
+        rgb.setColor(128, 128, 128);
+    }
+    #endif
 
 #if !defined(ARCH_PORTDUINO) && !defined(ARCH_STM32WL)
     auto acc_info = i2cScanner->firstAccelerometer();

--- a/src/modules/ExternalNotificationModule.cpp
+++ b/src/modules/ExternalNotificationModule.cpp
@@ -11,7 +11,7 @@
 #include "main.h"
 
 #ifdef RAK4630
-#include <NCP5623.h>
+#include <graphics/RAKled.h>
 NCP5623 rgb;
 
 uint8_t red = 0;


### PR DESCRIPTION
Enables the RAK14001 to turn on to a static 50% white upon boot, and creates a central location (RAKled.h) for defining "rgb". 

I could use help in one aspect of this - I don't know C++ fundamentals, so I suspect the organization of code between this and the ExternalNotificationModule could be better organized. I'm not 100% sure if I used best practices, but I tried moving the declaration of "rgb" into the RAKled.h file to give it a more centralized location rather than the Module's file.

In the future, I would like to add the ability to control the LED levels/colors/cycles via the CLI and apps.