### PR TITLE
Temporary band-aid to address mesh [un]reliability after queue "fix"

### DIFF
--- a/src/mesh/FloodingRouter.cpp
+++ b/src/mesh/FloodingRouter.cpp
@@ -21,7 +21,12 @@ bool FloodingRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
 {
     if (wasSeenRecently(p)) { // Note: this will also add a recent packet record
         printPacket("Ignoring incoming msg, because we've already seen it", p);
-        Router::cancelSending(p->from, p->id); // cancel rebroadcast of this message *if* there was already one
+        if (config.device.role != meshtastic_Config_DeviceConfig_Role_ROUTER &&
+            config.device.role != meshtastic_Config_DeviceConfig_Role_ROUTER_CLIENT &&
+            config.device.role != meshtastic_Config_DeviceConfig_Role_REPEATER) {
+            // cancel rebroadcast of this message *if* there was already one, unless we're a router/repeater!
+            Router::cancelSending(p->from, p->id);
+        }
         return true;
     }
 


### PR DESCRIPTION
This lets routers/repeaters rebroadcast a packet that is in queue even if another node has already rebroadcasted, ensuring that a router/repeater in a good location does not get its chance to transmit taken away by another node in a worse location.

Positive things: much better mesh reliability in cases when there are two or more routers in range of each other and one of them is at a strategic location (linking two groups of nodes together, etc).

Negative things: possibly more collisions, unless router/repeater nodes are positioned well and not all clumped together.

Am I doin' it right?