### PR TITLE
RPi Pico screen, CannedMessageModule (CardKB) and reboot support

### DIFF
--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -123,8 +123,8 @@ int CannedMessageModule::splitConfiguredMessages()
 int CannedMessageModule::handleInputEvent(const InputEvent *event)
 {
     if ((strlen(moduleConfig.canned_message.allow_input_source) > 0) &&
-        (strcmp(moduleConfig.canned_message.allow_input_source, event->source) != 0) &&
-        (strcmp(moduleConfig.canned_message.allow_input_source, "_any") != 0)) {
+        (strcasecmp(moduleConfig.canned_message.allow_input_source, event->source) != 0) &&
+        (strcasecmp(moduleConfig.canned_message.allow_input_source, "_any") != 0)) {
         // Event source is not accepted.
         // Event only accepted if source matches the configured one, or
         //   the configured one is "_any" (or if there is no configured

--- a/src/platform/rp2040/architecture.h
+++ b/src/platform/rp2040/architecture.h
@@ -2,8 +2,17 @@
 
 #define ARCH_RP2040
 
+#ifndef HAS_BUTTON
+#define HAS_BUTTON 1
+#endif
 #ifndef HAS_TELEMETRY
 #define HAS_TELEMETRY 1
+#endif
+#ifndef HAS_SCREEN
+#define HAS_SCREEN 1
+#endif
+#ifndef HAS_WIRE
+#define HAS_WIRE 1
 #endif
 #ifndef HAS_SENSOR
 #define HAS_SENSOR 1

--- a/src/shutdown.h
+++ b/src/shutdown.h
@@ -12,6 +12,8 @@ void powerCommandsCheck()
         ESP.restart();
 #elif defined(ARCH_NRF52)
         NVIC_SystemReset();
+#elif defined(ARCH_RP2040)
+        rp2040.reboot();
 #else
         rebootAtMsec = -1;
         LOG_WARN("FIXME implement reboot for this platform. Skipping for now.\n");

--- a/variants/rpipico/variant.h
+++ b/variants/rpipico/variant.h
@@ -15,11 +15,11 @@
 #define USE_SH1106 1
 #undef GPS_SERIAL_NUM
 
-// #define I2C_SDA 6
-// #define I2C_SCL 7
+// default I2C pins:
+// SDA = 4
+// SCL = 5
 
 #define BUTTON_PIN 17
-#define EXT_NOTIFY_OUT 4
 
 #define LED_PIN PIN_LED
 

--- a/variants/rpipicow/variant.h
+++ b/variants/rpipicow/variant.h
@@ -15,11 +15,11 @@
 #define USE_SH1106 1
 #undef GPS_SERIAL_NUM
 
-// #define I2C_SDA 6
-// #define I2C_SCL 7
+// default I2C pins:
+// SDA = 4
+// SCL = 5
 
 #define BUTTON_PIN 17
-#define EXT_NOTIFY_OUT 4
 
 #define BATTERY_PIN 26
 // ratio of voltage divider = 3.0 (R17=200k, R18=100k)


### PR DESCRIPTION
This adds support for the Pico to use an I2C screen on pins 4 (SDA) and 5 (SCL), as well as e.g. a CardKB for usage with the CannedMessageModule. I made the input_source for the CannedMessageModule case insensitive as it took me a while to figure out why it wasn't working (the documentation had the wrong case).

For now I removed the `EXT_NOTIFY_OUT` pin, as it conflicts with I2C and the module is not yet supported.

Also implements rebooting.