### PR TITLE
Correct unused variable warning and typo around GNSS_MODEL_UNKNOWN

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -212,9 +212,6 @@ bool GPS::setupGPS()
             _serial_gps->write("$PCAS11,3*1E\r\n");
             delay(250);
         } else if (gnssModel == GNSS_MODEL_UBLOX) {
-
-            uint8_t CK_A = 0, CK_B = 0; // checksum bytes
-
             // Configure GNSS system to GPS+SBAS+GLONASS (Module may restart after this command)
             // We need set it because by default it is GPS only, and we want to use GLONASS too
             // Also we need SBAS for better accuracy and extra features

--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -749,7 +749,7 @@ GnssModel_t GPS::probe()
     // Check that the returned response class and message ID are correct
     if (!getAck(buffer, 256, 0x06, 0x08)) {
         LOG_WARN("Failed to find UBlox & MTK GNSS Module\n");
-        return GNSS_MODEL_UNKONW;
+        return GNSS_MODEL_UNKNOWN;
     }
 
     //  Get Ublox gnss module hardware and software info

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -14,7 +14,7 @@ struct uBloxGnssModelInfo {
 typedef enum {
     GNSS_MODEL_MTK,
     GNSS_MODEL_UBLOX,
-    GNSS_MODEL_UNKONW,
+    GNSS_MODEL_UNKNOWN,
 } GnssModel_t;
 
 // Generate a string representation of DOP
@@ -175,7 +175,7 @@ class GPS : private concurrency::OSThread
     uint8_t fixeddelayCtr = 0;
 
   protected:
-    GnssModel_t gnssModel = GNSS_MODEL_UNKONW;
+    GnssModel_t gnssModel = GNSS_MODEL_UNKNOWN;
 };
 
 // Creates an instance of the GPS class.


### PR DESCRIPTION
Removed unused checksum variables that were causing compilation warnings.

Fixed GNSS_MODEL_UNKONW -> GNSS_MODEL_UNKNOWN
