### PR TITLE
Fix various typos

### DIFF
--- a/src/AccelerometerThread.h
+++ b/src/AccelerometerThread.h
@@ -43,7 +43,7 @@ class AccelerometerThread : public concurrency::OSThread
         } else if (accleremoter_type == ScanI2C::DeviceType::LIS3DH && lis.begin(accelerometer_found.address)) {
             LOG_DEBUG("LIS3DH initializing\n");
             lis.setRange(LIS3DH_RANGE_2_G);
-            // Adjust threshhold, higher numbers are less sensitive
+            // Adjust threshold, higher numbers are less sensitive
             lis.setClick(config.device.double_tap_as_button_press ? 2 : 1, ACCELEROMETER_CLICK_THRESHOLD);
         }
     }

--- a/src/ButtonThread.h
+++ b/src/ButtonThread.h
@@ -98,7 +98,7 @@ class ButtonThread : public concurrency::OSThread
         userButtonTouch.tick();
         canSleep &= userButtonTouch.isIdle();
 #endif
-        // if (!canSleep) LOG_DEBUG("Supressing sleep!\n");
+        // if (!canSleep) LOG_DEBUG("Suppressing sleep!\n");
         // else LOG_DEBUG("sleep ok\n");
 
         return 5;

--- a/src/OSTimer.cpp
+++ b/src/OSTimer.cpp
@@ -5,7 +5,7 @@
  * Schedule a callback to run.  The callback must _not_ block, though it is called from regular thread level (not ISR)
  *
  * NOTE! xTimerPend... seems to ignore the time passed in on ESP32 and on NRF52
- * The reason this didn't work is bcause xTimerPednFunctCall really isn't a timer function at all - it just means run the callback
+ * The reason this didn't work is because xTimerPednFunctCall really isn't a timer function at all - it just means run the callback
  * from the timer thread the next time you have spare cycles.
  *
  * @return true if successful, false if the timer fifo is too full.

--- a/src/OSTimer.cpp
+++ b/src/OSTimer.cpp
@@ -5,7 +5,8 @@
  * Schedule a callback to run.  The callback must _not_ block, though it is called from regular thread level (not ISR)
  *
  * NOTE! xTimerPend... seems to ignore the time passed in on ESP32 and on NRF52
- * The reason this didn't work is because xTimerPednFunctCall really isn't a timer function at all - it just means run the callback
+ * The reason this didn't work is because xTimerPednFunctCall really isn't a timer function at all - it just means run the
+callback
  * from the timer thread the next time you have spare cycles.
  *
  * @return true if successful, false if the timer fifo is too full.

--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -50,7 +50,7 @@ XPowersLibInterface *PMU = NULL;
 #else
 
 // Copy of the base class defined in axp20x.h.
-// I'd rather not inlude axp20x.h as it brings Wire dependency.
+// I'd rather not include axp20x.h as it brings Wire dependency.
 class HasBatteryLevel
 {
   public:
@@ -712,7 +712,7 @@ bool Power::axpChipInit()
             PMU->setPowerChannelVoltage(XPOWERS_ALDO1, 3300);
             PMU->enablePowerOutput(XPOWERS_ALDO1);
 
-            // sdcard power channle
+            // sdcard power channel
             PMU->setPowerChannelVoltage(XPOWERS_BLDO1, 3300);
             PMU->enablePowerOutput(XPOWERS_BLDO1);
 

--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -352,5 +352,5 @@ void PowerFSM_setup()
                                       "mesh timeout");
 #endif
 
-    powerFSM.run_machine(); // run one interation of the state machine, so we run our on enter tasks for the initial DARK state
+    powerFSM.run_machine(); // run one iteration of the state machine, so we run our on enter tasks for the initial DARK state
 }

--- a/src/airtime.h
+++ b/src/airtime.h
@@ -17,9 +17,9 @@
 
   Example analytics:
 
-  TX_LOG + RX_LOG = Total air time for a perticular meshtastic channel.
+  TX_LOG + RX_LOG = Total air time for a particular meshtastic channel.
 
-  TX_LOG + RX_LOG = Total air time for a perticular meshtastic channel, including
+  TX_LOG + RX_LOG = Total air time for a particular meshtastic channel, including
                     other lora radios.
 
   RX_ALL_LOG - RX_LOG = Other lora radios on our frequency channel.

--- a/src/concurrency/InterruptableDelay.h
+++ b/src/concurrency/InterruptableDelay.h
@@ -18,7 +18,7 @@ namespace concurrency
  *
  * Useful for they top level loop() delay call to keep the CPU powered down until our next scheduled event or some external event.
  *
- * This is implmented for FreeRTOS but should be easy to port to other operating systems.
+ * This is implemented for FreeRTOS but should be easy to port to other operating systems.
  */
 class InterruptableDelay
 {

--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -129,12 +129,12 @@ int GPS::getAck(uint8_t *buffer, uint16_t size, uint8_t requestedClass, uint8_t 
                 }
                 break;
             case 4:
-                // Payload lenght lsb
+                // Payload length lsb
                 needRead = c;
                 ubxFrameCounter++;
                 break;
             case 5:
-                // Payload lenght msb
+                // Payload length msb
                 needRead |= (c << 8);
                 ubxFrameCounter++;
                 break;
@@ -147,7 +147,7 @@ int GPS::getAck(uint8_t *buffer, uint16_t size, uint8_t requestedClass, uint8_t 
                 if (_serial_gps->readBytes(buffer, needRead) != needRead) {
                     ubxFrameCounter = 0;
                 } else {
-                    // return payload lenght
+                    // return payload length
                     return needRead;
                 }
                 break;
@@ -254,7 +254,7 @@ bool GPS::setupGPS()
                 return true;
             }
 
-            // Enable interference resistance, because we are using LoRa, WiFi and Bluetoot on same board,
+            // Enable interference resistance, because we are using LoRa, WiFi and Bluetooth on same board,
             // and we need to reduce interference from them
             byte _message_JAM[16] = {
                 0xB5, 0x62, // UBX protocol sync characters
@@ -670,7 +670,7 @@ void GPS::setAwake(bool on)
     }
 }
 
-/** Get how long we should stay looking for each aquisition in msecs
+/** Get how long we should stay looking for each acquisition in msecs
  */
 uint32_t GPS::getWakeTime() const
 {

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -149,7 +149,7 @@ class GPS : private concurrency::OSThread
      */
     void setAwake(bool on);
 
-    /** Get how long we should stay looking for each aquisition
+    /** Get how long we should stay looking for each acquisition
      */
     uint32_t getWakeTime() const;
 

--- a/src/gps/GeoCoord.cpp
+++ b/src/gps/GeoCoord.cpp
@@ -12,7 +12,7 @@ GeoCoord::GeoCoord(int32_t lat, int32_t lon, int32_t alt) : _latitude(lat), _lon
 
 GeoCoord::GeoCoord(float lat, float lon, int32_t alt) : _altitude(alt)
 {
-    // Change decimial reprsentation to int32_t. I.e., 12.345 becomes 123450000
+    // Change decimial representation to int32_t. I.e., 12.345 becomes 123450000
     _latitude = int32_t(lat * 1e+7);
     _longitude = int32_t(lon * 1e+7);
     GeoCoord::setCoords();
@@ -20,7 +20,7 @@ GeoCoord::GeoCoord(float lat, float lon, int32_t alt) : _altitude(alt)
 
 GeoCoord::GeoCoord(double lat, double lon, int32_t alt) : _altitude(alt)
 {
-    // Change decimial reprsentation to int32_t. I.e., 12.345 becomes 123450000
+    // Change decimial representation to int32_t. I.e., 12.345 becomes 123450000
     _latitude = int32_t(lat * 1e+7);
     _longitude = int32_t(lon * 1e+7);
     GeoCoord::setCoords();
@@ -41,7 +41,7 @@ void GeoCoord::setCoords()
 
 void GeoCoord::updateCoords(int32_t lat, int32_t lon, int32_t alt)
 {
-    // If marked dirty or new coordiantes
+    // If marked dirty or new coordinates
     if (_dirty || _latitude != lat || _longitude != lon || _altitude != alt) {
         _dirty = true;
         _latitude = lat;
@@ -55,7 +55,7 @@ void GeoCoord::updateCoords(const double lat, const double lon, const int32_t al
 {
     int32_t iLat = lat * 1e+7;
     int32_t iLon = lon * 1e+7;
-    // If marked dirty or new coordiantes
+    // If marked dirty or new coordinates
     if (_dirty || _latitude != iLat || _longitude != iLon || _altitude != alt) {
         _dirty = true;
         _latitude = iLat;
@@ -69,7 +69,7 @@ void GeoCoord::updateCoords(const float lat, const float lon, const int32_t alt)
 {
     int32_t iLat = lat * 1e+7;
     int32_t iLon = lon * 1e+7;
-    // If marked dirty or new coordiantes
+    // If marked dirty or new coordinates
     if (_dirty || _latitude != iLat || _longitude != iLon || _altitude != alt) {
         _dirty = true;
         _latitude = iLat;
@@ -217,7 +217,7 @@ void GeoCoord::latLongToOSGR(const double lat, const double lon, OSGR &osgr)
     double eta2 = v / rho - 1;
     double mA = (1 + n + (5 / 4) * n * n + (5 / 4) * n * n * n) * (phi - phi0);
     double mB = (3 * n + 3 * n * n + (21 / 8) * n * n * n) * sin(phi - phi0) * cos(phi + phi0);
-    // loss of precision in mC & mD due to floating point rounding can cause innaccuracy of northing by a few meters
+    // loss of precision in mC & mD due to floating point rounding can cause inaccuracy of northing by a few meters
     double mC = (15 / 8 * n * n + 15 / 8 * n * n * n) * sin(2 * (phi - phi0)) * cos(2 * (phi + phi0));
     double mD = (35 / 24) * n * n * n * sin(3 * (phi - phi0)) * cos(3 * (phi + phi0));
     double m = b * f0 * (mA - mB + mC - mD);

--- a/src/gps/GeoCoord.h
+++ b/src/gps/GeoCoord.h
@@ -65,7 +65,7 @@ struct MGRS {
     uint32_t northing;
 };
 
-// A struct to hold the data for a OSGR coordiante
+// A struct to hold the data for a OSGR coordinate
 struct OSGR {
     char e100k;
     char n100k;

--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -19,7 +19,7 @@ static uint64_t zeroOffsetSecs; // GPS based time in secs since 1970 - only upda
 
 void readFromRTC()
 {
-    struct timeval tv; /* btw settimeofday() is helpfull here too*/
+    struct timeval tv; /* btw settimeofday() is helpful here too*/
 #ifdef RV3028_RTC
     if (rtc_found.address == RV3028_RTC) {
         uint32_t now = millis();

--- a/src/graphics/EInkDisplay2.cpp
+++ b/src/graphics/EInkDisplay2.cpp
@@ -109,7 +109,7 @@ bool EInkDisplay::forceDisplay(uint32_t msecLimit)
         for (uint32_t y = 0; y < displayHeight; y++) {
             for (uint32_t x = 0; x < displayWidth; x++) {
 
-                // get src pixel in the page based ordering the OLED lib uses FIXME, super inefficent
+                // get src pixel in the page based ordering the OLED lib uses FIXME, super inefficient
                 auto b = buffer[x + (y / 8) * displayWidth];
                 auto isset = b & (1 << (y & 7));
                 adafruitDisplay->drawPixel(x, y, isset ? COLORED : UNCOLORED);

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -360,7 +360,7 @@ static void drawCriticalFaultFrame(OLEDDisplay *display, OLEDDisplayUiState *sta
     display->drawString(0 + x, FONT_HEIGHT_MEDIUM + y, "For help, please visit \nmeshtastic.org");
 }
 
-// Ignore messages orginating from phone (from the current node 0x0) unless range test or store and forward module are enabled
+// Ignore messages originating from phone (from the current node 0x0) unless range test or store and forward module are enabled
 static bool shouldDrawMessage(const meshtastic_MeshPacket *packet)
 {
     return packet->from != 0 && !moduleConfig.range_test.enabled && !moduleConfig.store_forward.enabled;
@@ -442,7 +442,7 @@ static void drawWaypointFrame(OLEDDisplay *display, OLEDDisplayUiState *state, i
     }
 }
 
-/// Draw a series of fields in a column, wrapping to multiple colums if needed
+/// Draw a series of fields in a column, wrapping to multiple columns if needed
 static void drawColumns(OLEDDisplay *display, int16_t x, int16_t y, const char **fields)
 {
     // The coordinates define the left starting point of the text
@@ -1789,7 +1789,7 @@ void DebugInfo::drawFrameSettings(OLEDDisplay *display, OLEDDisplayUiState *stat
     heartbeat = !heartbeat;
 #endif
 }
-// adjust Brightness cycle trough 1 to 254 as long as attachDuringLongPress is true
+// adjust Brightness cycle through 1 to 254 as long as attachDuringLongPress is true
 void Screen::adjustBrightness()
 {
     if (!useDisplay)

--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -26,7 +26,7 @@ void TFTDisplay::display(void)
 
     for (y = 0; y < displayHeight; y++) {
         for (x = 0; x < displayWidth; x++) {
-            // get src pixel in the page based ordering the OLED lib uses FIXME, super inefficent
+            // get src pixel in the page based ordering the OLED lib uses FIXME, super inefficient
             auto isset = buffer[x + (y / 8) * displayWidth] & (1 << (y & 7));
             auto dblbuf_isset = buffer_back[x + (y / 8) * displayWidth] & (1 << (y & 7));
             if (isset != dblbuf_isset) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -169,7 +169,7 @@ SPISettings spiSettings(4000000, MSBFIRST, SPI_MODE0);
 RadioInterface *rIf = NULL;
 
 /**
- * Some platforms (nrf52) might provide an alterate version that supresses calling delay from sleep.
+ * Some platforms (nrf52) might provide an alterate version that suppresses calling delay from sleep.
  */
 __attribute__((weak, noinline)) bool loopCanSleep()
 {
@@ -700,7 +700,7 @@ uint32_t rebootAtMsec;   // If not zero we will reboot at this time (used to reb
 uint32_t shutdownAtMsec; // If not zero we will shutdown at this time (used to shutdown from python or mobile client)
 
 // If a thread does something that might need for it to be rescheduled ASAP it can set this flag
-// This will supress the current delay and instead try to run ASAP.
+// This will suppress the current delay and instead try to run ASAP.
 bool runASAP;
 
 extern meshtastic_DeviceMetadata getDeviceMetadata()

--- a/src/main.h
+++ b/src/main.h
@@ -59,7 +59,7 @@ extern uint32_t shutdownAtMsec;
 extern uint32_t serialSinceMsec;
 
 // If a thread does something that might need for it to be rescheduled ASAP it can set this flag
-// This will supress the current delay and instead try to run ASAP.
+// This will suppress the current delay and instead try to run ASAP.
 extern bool runASAP;
 
 void nrf52Setup(), esp32Setup(), nrf52Loop(), esp32Loop(), clearBonds();

--- a/src/mesh/Channels.h
+++ b/src/mesh/Channels.h
@@ -20,7 +20,7 @@ class Channels
     /// The index of the primary channel
     ChannelIndex primaryIndex = 0;
 
-    /** The channel index that was requested for sending/receving.  Note: if this channel is a secondary
+    /** The channel index that was requested for sending/receiving.  Note: if this channel is a secondary
     channel and does not have a PSK, we will use the PSK from the primary channel.  If this channel is disabled
     no sending or receiving will be allowed */
     ChannelIndex activeChannelIndex = 0;

--- a/src/mesh/FloodingRouter.h
+++ b/src/mesh/FloodingRouter.h
@@ -48,7 +48,7 @@ class FloodingRouter : public Router, protected PacketHistory
     /**
      * Should this incoming filter be dropped?
      *
-     * Called immedately on receiption, before any further processing.
+     * Called immediately on reception, before any further processing.
      * @return true to abandon the packet
      */
     virtual bool shouldFilterReceived(const meshtastic_MeshPacket *p) override;

--- a/src/mesh/MeshModule.cpp
+++ b/src/mesh/MeshModule.cpp
@@ -18,7 +18,7 @@ meshtastic_MeshPacket *MeshModule::currentReply;
 
 MeshModule::MeshModule(const char *_name) : name(_name)
 {
-    // Can't trust static initalizer order, so we check each time
+    // Can't trust static initializer order, so we check each time
     if (!modules)
         modules = new std::vector<MeshModule *>();
 
@@ -39,7 +39,7 @@ meshtastic_MeshPacket *MeshModule::allocAckNak(meshtastic_Routing_Error err, Nod
     c.error_reason = err;
     c.which_variant = meshtastic_Routing_error_reason_tag;
 
-    // Now that we have moded sendAckNak up one level into the class heirarchy we can no longer assume we are a RoutingPlugin
+    // Now that we have moded sendAckNak up one level into the class hierarchy we can no longer assume we are a RoutingPlugin
     // So we manually call pb_encode_to_bytes and specify routing port number
     // auto p = allocDataProtobuf(c);
     meshtastic_MeshPacket *p = router->allocForSending();
@@ -169,7 +169,7 @@ void MeshModule::callPlugins(const meshtastic_MeshPacket &mp, RxSource src)
             // Note: if the message started with the local node or a module asked to ignore the request, we don't want to send a
             // no response reply
 
-            // No one wanted to reply to this requst, tell the requster that happened
+            // No one wanted to reply to this request, tell the requster that happened
             LOG_DEBUG("No one responded, send a nak\n");
 
             // SECURITY NOTE! I considered sending back a different error code if we didn't find the psk (i.e. !isDecoded)

--- a/src/mesh/MeshModule.h
+++ b/src/mesh/MeshModule.h
@@ -47,7 +47,7 @@ typedef struct _UIFrameEvent {
  * A key concept for this is that your module should use a particular "portnum" for each message type you want to receive
  * and handle.
  *
- * Interally we use modules to implement the core meshtastic text messaging and gps position sharing features.  You
+ * Internally we use modules to implement the core meshtastic text messaging and gps position sharing features.  You
  * can use these classes as examples for how to write your own custom module.  See here: (FIXME)
  */
 class MeshModule

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -34,7 +34,7 @@ arbitrating to select a node number and keeping the current nodedb.
 
 /* Broadcast when a newly powered mesh node wants to find a node num it can use
 
-The algoritm is as follows:
+The algorithm is as follows:
 * when a node starts up, it broadcasts their user and the normal flow is for all other nodes to reply with their User as well (so
 the new node can build its node db)
 * If a node ever receives a User (not just the first broadcast) message where the sender node number equals our node number, that

--- a/src/mesh/MeshService.h
+++ b/src/mesh/MeshService.h
@@ -120,7 +120,7 @@ class MeshService
 
   private:
     /// Called when our gps position has changed - updates nodedb and sends Location message out into the mesh
-    /// returns 0 to allow futher processing
+    /// returns 0 to allow further processing
     int onGPSChanged(const meshtastic::GPSStatus *arg);
 
     /// Handle a packet that just arrived from the radio.  This method does _ReliableRouternot_ free the provided packet.  If it

--- a/src/mesh/MeshTypes.h
+++ b/src/mesh/MeshTypes.h
@@ -13,7 +13,7 @@ typedef uint32_t PacketId; // A packet sequence number
 #define ERRNO_OK 0
 #define ERRNO_NO_INTERFACES 33
 #define ERRNO_UNKNOWN 32  // pick something that doesn't conflict with RH_ROUTER_ERROR_UNABLE_TO_DELIVER
-#define ERRNO_DISABLED 34 // the itnerface is disabled
+#define ERRNO_DISABLED 34 // the interface is disabled
 
 /*
  * Source of a received message

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -138,7 +138,7 @@ bool NodeDB::factoryReset()
     // third, write everything to disk
     saveToDisk();
 #ifdef ARCH_ESP32
-    // This will erase what's in NVS including ssl keys, persistant variables and ble pairing
+    // This will erase what's in NVS including ssl keys, persistent variables and ble pairing
     nvs_flash_erase();
 #endif
 #ifdef ARCH_NRF52
@@ -911,7 +911,7 @@ void recordCriticalError(meshtastic_CriticalErrorCode code, uint32_t address, co
     error_code = code;
     error_address = address;
 
-    // Currently portuino is mostly used for simulation.  Make sue the user notices something really bad happend
+    // Currently portuino is mostly used for simulation.  Make sure the user notices something really bad happened
 #ifdef ARCH_PORTDUINO
     LOG_ERROR("A critical failure occurred, portduino is exiting...");
     exit(2);

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -56,7 +56,7 @@ class NodeDB
     meshtastic_NodeInfoLite *updateGUIforNode = NULL; // if currently showing this node, we think you should update the GUI
     Observable<const meshtastic::NodeStatus *> newStatus;
 
-    /// don't do mesh based algoritm for node id assignment (initially)
+    /// don't do mesh based algorithm for node id assignment (initially)
     /// instead just store in flash - possibly even in the initial alpha release do this hack
     NodeDB();
 

--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -192,7 +192,7 @@ bool RF95Interface::isChannelActive()
     return false;
 }
 
-/** Could we send right now (i.e. either not actively receving or transmitting)? */
+/** Could we send right now (i.e. either not actively receiving or transmitting)? */
 bool RF95Interface::isActivelyReceiving()
 {
     return lora->isReceiving();
@@ -201,7 +201,7 @@ bool RF95Interface::isActivelyReceiving()
 bool RF95Interface::sleep()
 {
     // put chipset into sleep mode
-    setStandby(); // First cancel any active receving/sending
+    setStandby(); // First cancel any active receiving/sending
     lora->sleep();
 
     return true;

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -308,7 +308,7 @@ bool RadioInterface::init()
     preflightSleepObserver.observe(&preflightSleep);
     notifyDeepSleepObserver.observe(&notifyDeepSleep);
 
-    // we now expect interfaces to operate in promiscous mode
+    // we now expect interfaces to operate in promiscuous mode
     // radioIf.setThisAddress(nodeDB.getNodeNum()); // Note: we must do this here, because the nodenum isn't inited at constructor
     // time.
 

--- a/src/mesh/RadioInterface.h
+++ b/src/mesh/RadioInterface.h
@@ -15,7 +15,7 @@
 
 /**
  * This structure has to exactly match the wire layout when sent over the radio link.  Used to keep compatibility
- * wtih the old radiohead implementation.
+ * with the old radiohead implementation.
  */
 typedef struct {
     NodeNum to, from; // can be 1 byte or four bytes
@@ -75,7 +75,7 @@ class RadioInterface
     uint32_t lastTxStart = 0L;
 
     /**
-     * A temporary buffer used for sending/receving packets, sized to hold the biggest buffer we might need
+     * A temporary buffer used for sending/receiving packets, sized to hold the biggest buffer we might need
      * */
     uint8_t radiobuf[MAX_RHPACKETLEN];
 
@@ -198,7 +198,7 @@ class RadioInterface
     virtual void saveFreq(float savedFreq);
 
     /**
-     * Save the chanel we selected for later reuse.
+     * Save the channel we selected for later reuse.
      */
     virtual void saveChannelNum(uint32_t savedChannelNum);
 
@@ -206,7 +206,7 @@ class RadioInterface
     /**
      * Convert our modemConfig enum into wf, sf, etc...
      *
-     * These paramaters will be pull from the channelSettings global
+     * These parameters will be pull from the channelSettings global
      */
     void applyModemConfig();
 

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -68,7 +68,7 @@ void INTERRUPT_ATTR RadioLibInterface::isrTxLevel0()
  */
 RadioLibInterface *RadioLibInterface::instance;
 
-/** Could we send right now (i.e. either not actively receving or transmitting)? */
+/** Could we send right now (i.e. either not actively receiving or transmitting)? */
 bool RadioLibInterface::canSendImmediately()
 {
     // We wait _if_ we are partially though receiving a packet (rather than just merely waiting for one).

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -399,7 +399,7 @@ meshtastic_Routing_Error perhapsEncode(meshtastic_MeshPacket *p)
             if (compressed_len >= p->decoded.payload.size) {
 
                 LOG_DEBUG("Not using compressing message.\n");
-                // Set the uncompressed payload varient anyway. Shouldn't hurt?
+                // Set the uncompressed payload variant anyway. Shouldn't hurt?
                 // p->decoded.which_payloadVariant = Data_payload_tag;
 
                 // Otherwise we use the compressor

--- a/src/mesh/Router.h
+++ b/src/mesh/Router.h
@@ -90,7 +90,7 @@ class Router : protected concurrency::OSThread
      *
      * FIXME, move this into the new RoutingModule and do the filtering there using the regular module logic
      *
-     * Called immedately on receiption, before any further processing.
+     * Called immediately on reception, before any further processing.
      * @return true to abandon the packet
      */
     virtual bool shouldFilterReceived(const meshtastic_MeshPacket *p) { return false; }

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -249,7 +249,7 @@ template <typename T> bool SX126xInterface<T>::isChannelActive()
     return false;
 }
 
-/** Could we send right now (i.e. either not actively receving or transmitting)? */
+/** Could we send right now (i.e. either not actively receiving or transmitting)? */
 template <typename T> bool SX126xInterface<T>::isActivelyReceiving()
 {
     // The IRQ status will be cleared when we start our read operation.  Check if we've started a header, but haven't yet

--- a/src/mesh/SX128xInterface.cpp
+++ b/src/mesh/SX128xInterface.cpp
@@ -242,7 +242,7 @@ template <typename T> bool SX128xInterface<T>::isChannelActive()
     return false;
 }
 
-/** Could we send right now (i.e. either not actively receving or transmitting)? */
+/** Could we send right now (i.e. either not actively receiving or transmitting)? */
 template <typename T> bool SX128xInterface<T>::isActivelyReceiving()
 {
     uint16_t irq = lora.getIrqStatus();

--- a/src/mesh/SinglePortModule.h
+++ b/src/mesh/SinglePortModule.h
@@ -3,7 +3,7 @@
 #include "Router.h"
 
 /**
- * Most modules are only interested in sending/receving one particular portnum.  This baseclass simplifies that common
+ * Most modules are only interested in sending/receiving one particular portnum.  This baseclass simplifies that common
  * case.
  */
 class SinglePortModule : public MeshModule

--- a/src/mesh/compression/unishox2.c
+++ b/src/mesh/compression/unishox2.c
@@ -57,7 +57,7 @@ uint8_t usx_code_94[94];
 uint8_t usx_vcodes[] = {0x00, 0x40, 0x60, 0x80, 0x90, 0xA0, 0xB0, 0xC0, 0xD0, 0xD8, 0xE0, 0xE4, 0xE8, 0xEC,
                         0xEE, 0xF0, 0xF2, 0xF4, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF};
 
-/// Length of each veritical code
+/// Length of each vertical code
 uint8_t usx_vcode_lens[] = {2, 3, 3, 4, 4, 4, 4, 4, 5, 5, 6, 6, 6, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8};
 
 /// Vertical Codes and Set number for frequent sequences in sets USX_SYM and USX_NUM. First 3 bits indicate set (USX_SYM/USX_NUM)
@@ -188,7 +188,7 @@ int append_switch_code(char *out, int olen, int ol, uint8_t state)
     return ol;
 }
 
-/// Appends given horizontal and veritical code bits to out
+/// Appends given horizontal and vertical code bits to out
 int append_code(char *out, int olen, int ol, uint8_t code, uint8_t *state, const uint8_t usx_hcodes[],
                 const uint8_t usx_hcode_lens[])
 {
@@ -888,7 +888,7 @@ int read8bitCode(const char *in, int len, int bit_no)
     return code;
 }
 
-/// The list of veritical codes is split into 5 sections. Used by readVCodeIdx()
+/// The list of vertical codes is split into 5 sections. Used by readVCodeIdx()
 #define SECTION_COUNT 5
 /// Used by readVCodeIdx() for finding the section under which the code read using read8bitCode() falls
 uint8_t usx_vsections[] = {0x7F, 0xBF, 0xDF, 0xEF, 0xFF};
@@ -915,7 +915,7 @@ uint8_t usx_vcode_lookup[36] = {(1 << 5) + 0,  (1 << 5) + 0,  (2 << 5) + 1,  (2 
 /// compared to using a 256 uint8_t buffer to decode the next 8 bits read by read8bitCode() \n
 /// by splitting the list of vertical codes. \n
 /// Decoder is designed for using less memory, not speed. \n
-/// Returns the veritical code index or 99 if match could not be found. \n
+/// Returns the vertical code index or 99 if match could not be found. \n
 /// Also updates bit_no_p with how many ever bits used by the vertical code.
 int readVCodeIdx(const char *in, int len, int *bit_no_p)
 {

--- a/src/mesh/compression/unishox2.h
+++ b/src/mesh/compression/unishox2.h
@@ -198,8 +198,8 @@
         2, 2, 2, 2, 0                                                                                                            \
     }
 
-/// Default frequently occurring sequences. When composition of text is know beforehand, the other sequences in this section can be
-/// used to achieve more compression.
+/// Default frequently occurring sequences. When composition of text is know beforehand, the other sequences in this section can
+/// be used to achieve more compression.
 #define USX_FREQ_SEQ_DFLT                                                                                                        \
     (const char *[])                                                                                                             \
     {                                                                                                                            \

--- a/src/mesh/compression/unishox2.h
+++ b/src/mesh/compression/unishox2.h
@@ -198,45 +198,45 @@
         2, 2, 2, 2, 0                                                                                                            \
     }
 
-/// Default frequently occuring sequences. When composition of text is know beforehand, the other sequences in this section can be
+/// Default frequently occurring sequences. When composition of text is know beforehand, the other sequences in this section can be
 /// used to achieve more compression.
 #define USX_FREQ_SEQ_DFLT                                                                                                        \
     (const char *[])                                                                                                             \
     {                                                                                                                            \
         "\": \"", "\": ", "</", "=\"", "\":\"", "://"                                                                            \
     }
-/// Frequently occuring sequences in text content
+/// Frequently occurring sequences in text content
 #define USX_FREQ_SEQ_TXT                                                                                                         \
     (const char *[])                                                                                                             \
     {                                                                                                                            \
         " the ", " and ", "tion", " with", "ing", "ment"                                                                         \
     }
-/// Frequently occuring sequences in URL content
+/// Frequently occurring sequences in URL content
 #define USX_FREQ_SEQ_URL                                                                                                         \
     (const char *[])                                                                                                             \
     {                                                                                                                            \
         "https://", "www.", ".com", "http://", ".org", ".net"                                                                    \
     }
-/// Frequently occuring sequences in JSON content
+/// Frequently occurring sequences in JSON content
 #define USX_FREQ_SEQ_JSON                                                                                                        \
     (const char *[])                                                                                                             \
     {                                                                                                                            \
         "\": \"", "\": ", "\",", "}}}", "\":\"", "}}"                                                                            \
     }
-/// Frequently occuring sequences in HTML content
+/// Frequently occurring sequences in HTML content
 #define USX_FREQ_SEQ_HTML                                                                                                        \
     (const char *[])                                                                                                             \
     {                                                                                                                            \
         "</", "=\"", "div", "href", "class", "<p>"                                                                               \
     }
-/// Frequently occuring sequences in XML content
+/// Frequently occurring sequences in XML content
 #define USX_FREQ_SEQ_XML                                                                                                         \
     (const char *[])                                                                                                             \
     {                                                                                                                            \
         "</", "=\"", "\">", "<?xml version=\"1.0\"", "xmlns:", "://"                                                             \
     }
 
-/// Commonly occuring templates (ISO Date/Time, ISO Date, US Phone number, ISO Time, Unused)
+/// Commonly occurring templates (ISO Date/Time, ISO Date, US Phone number, ISO Time, Unused)
 #define USX_TEMPLATES                                                                                                            \
     (const char *[])                                                                                                             \
     {                                                                                                                            \
@@ -333,8 +333,8 @@ extern int unishox2_decompress_simple(const char *in, int len, char *out);
  * @param[in] olen           length of 'out' buffer in bytes. Can be omitted if sufficient buffer is provided
  * @param[in] usx_hcodes     Horizontal codes (array of bytes). See macro section for samples.
  * @param[in] usx_hcode_lens Length of each element in usx_hcodes array
- * @param[in] usx_freq_seq   Frequently occuring sequences. See USX_FREQ_SEQ_* macros for samples
- * @param[in] usx_templates  Templates of frequently occuring patterns. See USX_TEMPLATES macro.
+ * @param[in] usx_freq_seq   Frequently occurring sequences. See USX_FREQ_SEQ_* macros for samples
+ * @param[in] usx_templates  Templates of frequently occurring patterns. See USX_TEMPLATES macro.
  */
 extern int unishox2_compress(const char *in, int len, UNISHOX_API_OUT_AND_LEN(char *out, int olen),
                              const unsigned char usx_hcodes[], const unsigned char usx_hcode_lens[], const char *usx_freq_seq[],
@@ -352,8 +352,8 @@ extern int unishox2_compress(const char *in, int len, UNISHOX_API_OUT_AND_LEN(ch
  * @param[in] olen           length of 'out' buffer in bytes. Can be omitted if sufficient buffer is provided
  * @param[in] usx_hcodes     Horizontal codes (array of bytes). See macro section for samples.
  * @param[in] usx_hcode_lens Length of each element in usx_hcodes array
- * @param[in] usx_freq_seq   Frequently occuring sequences. See USX_FREQ_SEQ_* macros for samples
- * @param[in] usx_templates  Templates of frequently occuring patterns. See USX_TEMPLATES macro.
+ * @param[in] usx_freq_seq   Frequently occurring sequences. See USX_FREQ_SEQ_* macros for samples
+ * @param[in] usx_templates  Templates of frequently occurring patterns. See USX_TEMPLATES macro.
  */
 extern int unishox2_decompress(const char *in, int len, UNISHOX_API_OUT_AND_LEN(char *out, int olen),
                                const unsigned char usx_hcodes[], const unsigned char usx_hcode_lens[], const char *usx_freq_seq[],
@@ -373,7 +373,7 @@ extern int unishox2_compress_lines(const char *in, int len, UNISHOX_API_OUT_AND_
                                    const char *usx_freq_seq[], const char *usx_templates[], struct us_lnk_lst *prev_lines);
 /**
  * More Comprehensive API for de-compressing array of strings \n
- * This function is not be used in conjuction with unishox2_compress_lines()
+ * This function is not be used in conjunction with unishox2_compress_lines()
  *
  * See unishox2_decompress() function for parameter definitions. \n
  * Typically an array is compressed using unishox2_compress_lines() and \n

--- a/src/mesh/generated/meshtastic/channel.pb.h
+++ b/src/mesh/generated/meshtastic/channel.pb.h
@@ -81,7 +81,7 @@ typedef struct _meshtastic_ChannelSettings {
  a table of well known IDs.
  (see Well Known Channels FIXME) */
     uint32_t id;
-    /* If true, messages on the mesh will be sent to the *public* internet by any gateway ndoe */
+    /* If true, messages on the mesh will be sent to the *public* internet by any gateway node */
     bool uplink_enabled;
     /* If true, messages seen on the internet will be forwarded to the local mesh. */
     bool downlink_enabled;

--- a/src/mesh/generated/meshtastic/config.pb.h
+++ b/src/mesh/generated/meshtastic/config.pb.h
@@ -215,7 +215,7 @@ typedef enum _meshtastic_Config_BluetoothConfig_PairingMode {
 typedef struct _meshtastic_Config_DeviceConfig {
     /* Sets the role of node */
     meshtastic_Config_DeviceConfig_Role role;
-    /* Disabling this will disable the SerialConsole by not initilizing the StreamAPI */
+    /* Disabling this will disable the SerialConsole by not initializing the StreamAPI */
     bool serial_enabled;
     /* By default we turn off logging as soon as an API client connects (to keep shared serial link quiet).
  Set this to true to leave the debug log outputting even when API is active. */
@@ -269,7 +269,7 @@ typedef struct _meshtastic_Config_PositionConfig {
     uint32_t tx_gpio;
     /* The minimum distance in meters traveled (since the last send) before we can send a position to the mesh if position_broadcast_smart_enabled */
     uint32_t broadcast_smart_minimum_distance;
-    /* The minumum number of seconds (since the last send) before we can send a position to the mesh if position_broadcast_smart_enabled */
+    /* The minimum number of seconds (since the last send) before we can send a position to the mesh if position_broadcast_smart_enabled */
     uint32_t broadcast_smart_minimum_interval_secs;
 } meshtastic_Config_PositionConfig;
 
@@ -363,7 +363,7 @@ typedef struct _meshtastic_Config_DisplayConfig {
     bool compass_north_top;
     /* Flip screen vertically, for cases that mount the screen upside down */
     bool flip_screen;
-    /* Perferred display units */
+    /* Preferred display units */
     meshtastic_Config_DisplayConfig_DisplayUnits units;
     /* Override auto-detect in screen */
     meshtastic_Config_DisplayConfig_OledType oled;

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -147,7 +147,7 @@ typedef enum _meshtastic_CriticalErrorCode {
     /* Radio transmit hardware failure. We sent data to the radio chip, but it didn't
  reply with an interrupt. */
     meshtastic_CriticalErrorCode_TRANSMIT_FAILED = 8,
-    /* We detected that the main CPU voltage dropped below the minumum acceptable value */
+    /* We detected that the main CPU voltage dropped below the minimum acceptable value */
     meshtastic_CriticalErrorCode_BROWNOUT = 9,
     /* Selftest of SX1262 radio chip failed */
     meshtastic_CriticalErrorCode_SX1262_FAILURE = 10,
@@ -371,7 +371,7 @@ typedef struct _meshtastic_Position {
  0 through 3 - for future use */
 typedef struct _meshtastic_User {
     /* A globally unique ID string for this user.
- In the case of Signal that would mean +16504442323, for the default macaddr derived id it would be !<8 hexidecimal bytes>.
+ In the case of Signal that would mean +16504442323, for the default macaddr derived id it would be !<8 hexadecimal bytes>.
  Note: app developers are encouraged to also use the following standard
  node IDs "^all" (for broadcast), "^local" (for the locally connected node) */
     char id[16];
@@ -418,7 +418,7 @@ typedef struct _meshtastic_Routing {
 
 typedef PB_BYTES_ARRAY_T(237) meshtastic_Data_payload_t;
 /* (Formerly called SubPacket)
- The payload portion fo a packet, this is the actual bytes that are sent
+ The payload portion for a packet, this is the actual bytes that are sent
  inside a radio packet (because from/to are broken out by the comms library) */
 typedef struct _meshtastic_Data {
     /* Formerly named typ and of type Type */
@@ -552,7 +552,7 @@ typedef struct _meshtastic_MeshPacket {
     /* The priority of this message for sending.
  See MeshPacket.Priority description for more details. */
     meshtastic_MeshPacket_Priority priority;
-    /* rssi of received packet. Only sent to phone for dispay purposes. */
+    /* rssi of received packet. Only sent to phone for display purposes. */
     int32_t rx_rssi;
     /* Describe if this message is delayed */
     meshtastic_MeshPacket_Delayed delayed;

--- a/src/mesh/generated/meshtastic/portnums.pb.h
+++ b/src/mesh/generated/meshtastic/portnums.pb.h
@@ -17,7 +17,7 @@
  PortNums should be assigned in the following range:
  0-63   Core Meshtastic use, do not use for third party apps
  64-127 Registered 3rd party apps, send in a pull request that adds a new entry to portnums.proto to  register your application
- 256-511 Use one of these portnums for your private applications that you don't want to register publically
+ 256-511 Use one of these portnums for your private applications that you don't want to register publicly
  All other values are reserved.
  Note: This was formerly a Type enum named 'typ' with the same id #
  We have change to this 'portnum' based scheme for specifying app handlers for particular payloads.

--- a/src/mesh/http/ContentHandler.cpp
+++ b/src/mesh/http/ContentHandler.cpp
@@ -165,7 +165,7 @@ void handleAPIv1FromRadio(HTTPRequest *req, HTTPResponse *res)
 
     if (params->getQueryParameter("all", valueAll)) {
 
-        // If all is ture, return all the buffers we have available
+        // If all is true, return all the buffers we have available
         //   to us at this point in time.
         if (valueAll == "true") {
             while (len) {
@@ -179,7 +179,7 @@ void handleAPIv1FromRadio(HTTPRequest *req, HTTPResponse *res)
             res->write(txBuf, len);
         }
 
-        // the param "all" was not spcified. Return just one protobuf
+        // the param "all" was not specified. Return just one protobuf
     } else {
         len = webAPI.getFromRadio(txBuf);
         res->write(txBuf, len);
@@ -460,7 +460,7 @@ void handleFormUpload(HTTPRequest *req, HTTPResponse *res)
     HTTPBodyParser *parser;
     std::string contentType = req->getHeader("Content-Type");
 
-    // The content type may have additional properties after a semicolon, for exampel:
+    // The content type may have additional properties after a semicolon, for example:
     // Content-Type: text/html;charset=utf-8
     // Content-Type: multipart/form-data;boundary=------s0m3w31rdch4r4c73rs
     // As we're interested only in the actual mime _type_, we strip everything after the

--- a/src/mesh/http/WebServer.cpp
+++ b/src/mesh/http/WebServer.cpp
@@ -15,7 +15,7 @@
 #include "esp_task_wdt.h"
 #endif
 
-// Persistant Data Storage
+// Persistent Data Storage
 #include <Preferences.h>
 Preferences prefs;
 

--- a/src/mesh/mesh-pb-constants.cpp
+++ b/src/mesh/mesh-pb-constants.cpp
@@ -14,7 +14,7 @@ size_t pb_encode_to_bytes(uint8_t *destbuf, size_t destbufsize, const pb_msgdesc
     if (!pb_encode(&stream, fields, src_struct)) {
         LOG_ERROR("Panic: can't encode protobuf reason='%s'\n", PB_GET_ERROR(&stream));
         assert(
-            0); // If this asser fails it probably means you made a field too large for the max limits specified in mesh.options
+            0); // If this assert fails it probably means you made a field too large for the max limits specified in mesh.options
     } else {
         return stream.bytes_written;
     }

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -4,7 +4,7 @@
 #include "FSCommon.h"
 #include "MeshService.h"
 #include "NodeDB.h"
-#include "PowerFSM.h" // neede for button bypass
+#include "PowerFSM.h" // needed for button bypass
 #include "detect/ScanI2C.h"
 #include "mesh/generated/meshtastic/cannedmessages.pb.h"
 

--- a/src/modules/RangeTestModule.cpp
+++ b/src/modules/RangeTestModule.cpp
@@ -54,7 +54,7 @@ int32_t RangeTestModule::runOnce()
             if (moduleConfig.range_test.sender) {
                 LOG_INFO("Initializing Range Test Module -- Sender\n");
                 started = millis(); // make a note of when we started
-                return (5000);      // Sending first message 5 seconds after initilization.
+                return (5000);      // Sending first message 5 seconds after initialization.
             } else {
                 LOG_INFO("Initializing Range Test Module -- Receiver\n");
                 return disable();
@@ -147,8 +147,8 @@ ProcessMessage RangeTestModuleRadio::handleReceived(const meshtastic_MeshPacket 
             LOG_DEBUG("mp.from          %d\n", mp.from);
             LOG_DEBUG("mp.rx_snr        %f\n", mp.rx_snr);
             LOG_DEBUG("mp.hop_limit     %d\n", mp.hop_limit);
-            // LOG_DEBUG("mp.decoded.position.latitude_i     %d\n", mp.decoded.position.latitude_i); // Depricated
-            // LOG_DEBUG("mp.decoded.position.longitude_i    %d\n", mp.decoded.position.longitude_i); // Depricated
+            // LOG_DEBUG("mp.decoded.position.latitude_i     %d\n", mp.decoded.position.latitude_i); // Deprecated
+            // LOG_DEBUG("mp.decoded.position.longitude_i    %d\n", mp.decoded.position.longitude_i); // Deprecated
             LOG_DEBUG("---- Node Information of Received Packet (mp.from):\n");
             LOG_DEBUG("n->user.long_name         %s\n", n->user.long_name);
             LOG_DEBUG("n->user.short_name        %s\n", n->user.short_name);
@@ -186,8 +186,8 @@ bool RangeTestModuleRadio::appendFile(const meshtastic_MeshPacket &mp)
         LOG_DEBUG("mp.from          %d\n", mp.from);
         LOG_DEBUG("mp.rx_snr        %f\n", mp.rx_snr);
         LOG_DEBUG("mp.hop_limit     %d\n", mp.hop_limit);
-        // LOG_DEBUG("mp.decoded.position.latitude_i     %d\n", mp.decoded.position.latitude_i);  // Depricated
-        // LOG_DEBUG("mp.decoded.position.longitude_i    %d\n", mp.decoded.position.longitude_i); // Depricated
+        // LOG_DEBUG("mp.decoded.position.latitude_i     %d\n", mp.decoded.position.latitude_i);  // Deprecated
+        // LOG_DEBUG("mp.decoded.position.longitude_i    %d\n", mp.decoded.position.longitude_i); // Deprecated
         LOG_DEBUG("---- Node Information of Received Packet (mp.from):\n");
         LOG_DEBUG("n->user.long_name         %s\n", n->user.long_name);
         LOG_DEBUG("n->user.short_name        %s\n", n->user.short_name);

--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -33,11 +33,11 @@
            to your device.
 
     TODO (in this order):
-        * Define a verbose RX mode to report on mesh and packet infomration.
+        * Define a verbose RX mode to report on mesh and packet information.
             - This won't happen any time soon.
 
     KNOWN PROBLEMS
-        * Until the module is initilized by the startup sequence, the TX pin is in a floating
+        * Until the module is initialized by the startup sequence, the TX pin is in a floating
           state. Device connected to that pin may see this as "noise".
         * Will not work on Linux device targets.
 

--- a/src/modules/esp32/StoreForwardModule.cpp
+++ b/src/modules/esp32/StoreForwardModule.cpp
@@ -62,7 +62,7 @@ void StoreForwardModule::populatePSRAM()
         https://learn.upesy.com/en/programmation/psram.html#psram-tab
     */
 
-    LOG_DEBUG("*** Before PSRAM initilization: heap %d/%d PSRAM %d/%d\n", memGet.getFreeHeap(), memGet.getHeapSize(),
+    LOG_DEBUG("*** Before PSRAM initialization: heap %d/%d PSRAM %d/%d\n", memGet.getFreeHeap(), memGet.getHeapSize(),
               memGet.getFreePsram(), memGet.getPsramSize());
 
     this->packetHistoryTXQueue =
@@ -77,7 +77,7 @@ void StoreForwardModule::populatePSRAM()
 
     this->packetHistory = static_cast<PacketHistoryStruct *>(ps_calloc(numberOfPackets, sizeof(PacketHistoryStruct)));
 
-    LOG_DEBUG("*** After PSRAM initilization: heap %d/%d PSRAM %d/%d\n", memGet.getFreeHeap(), memGet.getHeapSize(),
+    LOG_DEBUG("*** After PSRAM initialization: heap %d/%d PSRAM %d/%d\n", memGet.getFreeHeap(), memGet.getHeapSize(),
               memGet.getFreePsram(), memGet.getPsramSize());
     LOG_DEBUG("*** numberOfPackets for packetHistory - %u\n", numberOfPackets);
 }

--- a/src/mqtt/JSONValue.cpp
+++ b/src/mqtt/JSONValue.cpp
@@ -282,7 +282,7 @@ JSONValue *JSONValue::Parse(const char **data)
         return NULL;
     }
 
-    // Ran out of possibilites, it's bad!
+    // Ran out of possibilities, it's bad!
     else {
         return NULL;
     }

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -290,7 +290,7 @@ void MQTT::reconnect()
         pubSub.setServer(serverAddr, serverPort);
         pubSub.setBufferSize(512);
 
-        LOG_INFO("Attempting to connnect directly to MQTT server %s, port: %d, username: %s, password: %s\n", serverAddr,
+        LOG_INFO("Attempting to connect directly to MQTT server %s, port: %d, username: %s, password: %s\n", serverAddr,
                  serverPort, mqttUsername, mqttPassword);
 
         auto myStatus = (statusTopic + owner.id);

--- a/src/mqtt/MQTT.h
+++ b/src/mqtt/MQTT.h
@@ -53,7 +53,7 @@ class MQTT : private concurrency::OSThread
      * @param chIndex the index of the channel for this message
      *
      * Note: for messages we are forwarding on the mesh that we can't find the channel for (because we don't have the keys), we
-     * can not forward those messages to the cloud - becuase no way to find a global channel ID.
+     * can not forward those messages to the cloud - because no way to find a global channel ID.
      */
     void onSend(const meshtastic_MeshPacket &mp, ChannelIndex chIndex);
 

--- a/src/platform/esp32/CallbackCharacteristic.h
+++ b/src/platform/esp32/CallbackCharacteristic.h
@@ -3,7 +3,7 @@
 #include "PowerFSM.h" // FIXME - someday I want to make this OTA thing a separate lb at at that point it can't touch this
 
 /**
- * A characterstic with a set of overridable callbacks
+ * A characteristic with a set of overridable callbacks
  */
 class CallbackCharacteristic : public BLECharacteristic, public BLECharacteristicCallbacks
 {

--- a/src/platform/esp32/main-esp32.cpp
+++ b/src/platform/esp32/main-esp32.cpp
@@ -99,7 +99,7 @@ void esp32Setup()
 
     LOG_DEBUG("Setup Preferences in Flash Storage\n");
 
-    // Create object to store our persistant data
+    // Create object to store our persistent data
     Preferences preferences;
     preferences.begin("meshtastic", false);
 

--- a/src/platform/nrf52/JLINK_MONITOR_ISR_SES.S
+++ b/src/platform/nrf52/JLINK_MONITOR_ISR_SES.S
@@ -136,7 +136,7 @@ Purpose : Implementation of debug monitor for J-Link monitor mode
 *    This handler is also responsible for handling commands that are sent by the debugger.
 *
 *  Notes 
-*    This is actually the ISR for the debug inerrupt (exception no. 12)
+*    This is actually the ISR for the debug interrupt (exception no. 12)
 */ 
         .thumb_func
 

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -17,7 +17,7 @@ static BLEBas blebas; // BAS (Battery Service) helper class instance
 static BLEDfu bledfu; // DFU software update helper service
 
 // This scratch buffer is used for various bluetooth reads/writes - but it is safe because only one bt operation can be in
-// proccess at once
+// process at once
 // static uint8_t trBytes[_max(_max(_max(_max(ToRadio_size, RadioConfig_size), User_size), MyNodeInfo_size), FromRadio_size)];
 static uint8_t fromRadioBytes[meshtastic_FromRadio_size];
 static uint8_t toRadioBytes[meshtastic_ToRadio_size];

--- a/src/platform/portduino/SimRadio.cpp
+++ b/src/platform/portduino/SimRadio.cpp
@@ -92,7 +92,7 @@ void SimRadio::completeSending()
     }
 }
 
-/** Could we send right now (i.e. either not actively receving or transmitting)? */
+/** Could we send right now (i.e. either not actively receiving or transmitting)? */
 bool SimRadio::canSendImmediately()
 {
     // We wait _if_ we are partially though receiving a packet (rather than just merely waiting for one).

--- a/src/platform/stm32wl/InternalFileSystem.cpp
+++ b/src/platform/stm32wl/InternalFileSystem.cpp
@@ -49,7 +49,7 @@ static int _internal_flash_read(const struct lfs_config *c, lfs_block_t block, l
 }
 
 // Program a region in a block. The block must have previously
-// been erased. Negative error codes are propogated to the user.
+// been erased. Negative error codes are propagated to the user.
 // May return LFS_ERR_CORRUPT if the block should be considered bad.
 static int _internal_flash_prog(const struct lfs_config *c, lfs_block_t block, lfs_off_t off, const void *buffer, lfs_size_t size)
 {
@@ -67,7 +67,7 @@ static int _internal_flash_prog(const struct lfs_config *c, lfs_block_t block, l
 
 // Erase a block. A block must be erased before being programmed.
 // The state of an erased block is undefined. Negative error codes
-// are propogated to the user.
+// are propagated to the user.
 // May return LFS_ERR_CORRUPT if the block should be considered bad.
 static int _internal_flash_erase(const struct lfs_config *c, lfs_block_t block)
 {
@@ -84,7 +84,7 @@ static int _internal_flash_erase(const struct lfs_config *c, lfs_block_t block)
 }
 
 // Sync the state of the underlying block device. Negative error codes
-// are propogated to the user.
+// are propagated to the user.
 static int _internal_flash_sync(const struct lfs_config *c)
 {
     // we don't use a ram cache, this is a noop

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -250,7 +250,7 @@ void doDeepSleep(uint32_t msecToWake)
         //
         // No need to turn this off if the power draw in sleep mode really is just 0.2uA and turning it off would
         // leave floating input for the IRQ line
-        // If we want to leave the radio receving in would be 11.5mA current draw, but most of the time it is just waiting
+        // If we want to leave the radio receiving in would be 11.5mA current draw, but most of the time it is just waiting
         // in its sequencer (true?) so the average power draw should be much lower even if we were listinging for packets
         // all the time.
 


### PR DESCRIPTION
Found via `codespell -q 3 -L acount,clen,dout`