### PR TITLE
fix: T-Echo auto-detection (vscode)

### DIFF
--- a/boards/t-echo.json
+++ b/boards/t-echo.json
@@ -7,7 +7,10 @@
     "cpu": "cortex-m4",
     "extra_flags": "-DARDUINO_NRF52840_TTGO_EINK -DNRF52840_XXAA",
     "f_cpu": "64000000L",
-    "hwids": [["0x239A", "0x4405"]],
+    "hwids": [
+      ["0x239A", "0x4405"],
+      ["0x239A", "0x002A"]
+    ],
     "usb_product": "TTGO_eink",
     "mcu": "nrf52840",
     "variant": "t-echo",


### PR DESCRIPTION
This is a minor dev environment fix to allow T-Echo serial port auto-detection in vscode. Currently when uploading the firmware and no port is selected a weird error message appears.

```
$ lsusb | grep Echo
Bus 005 Device 070: ID 239a:002a Adafruit T-Echo v1
```

