### PR TITLE
resolve heltec-wireless-tracker serial issue

### DIFF
--- a/boards/heltec_wireless_tracker.json
+++ b/boards/heltec_wireless_tracker.json
@@ -1,0 +1,38 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default_8MB.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DHELTEC_WIRELESS_TRACKER",
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_USB_MODE=0",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [["0x303A", "0x1001"]],
+    "mcu": "esp32s3",
+    "variant": "heltec_wireless_tracker"
+  },
+  "connectivity": ["wifi", "bluetooth", "lora"],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": ["arduino", "espidf"],
+  "name": "Heltec Wireless Tracker",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "wait_for_upload_port": true,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://heltec.org/project/wireless-tracker/",
+  "vendor": "Heltec"
+}

--- a/variants/heltec_wireless_tracker/pins_arduino.h
+++ b/variants/heltec_wireless_tracker/pins_arduino.h
@@ -1,0 +1,80 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include "soc/soc_caps.h"
+#include <stdint.h>
+
+#define WIFI_LoRa_32_V3 true
+#define DISPLAY_HEIGHT 64
+#define DISPLAY_WIDTH 128
+
+#define USB_VID 0x303a
+#define USB_PID 0x1001
+
+#define EXTERNAL_NUM_INTERRUPTS 46
+#define NUM_DIGITAL_PINS 48
+#define NUM_ANALOG_INPUTS 20
+
+static const uint8_t LED_BUILTIN = 18;
+#define BUILTIN_LED LED_BUILTIN // backward compatibility
+#define LED_BUILTIN LED_BUILTIN
+
+#define analogInputToDigitalPin(p) (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
+#define digitalPinToInterrupt(p) (((p) < 48) ? (p) : -1)
+#define digitalPinHasPWM(p) (p < 46)
+
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+static const uint8_t SDA = 41;
+static const uint8_t SCL = 42;
+
+static const uint8_t SS = 8;
+static const uint8_t MOSI = 10;
+static const uint8_t MISO = 11;
+static const uint8_t SCK = 9;
+
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+static const uint8_t A7 = 8;
+static const uint8_t A8 = 9;
+static const uint8_t A9 = 10;
+static const uint8_t A10 = 11;
+static const uint8_t A11 = 12;
+static const uint8_t A12 = 13;
+static const uint8_t A13 = 14;
+static const uint8_t A14 = 15;
+static const uint8_t A15 = 16;
+static const uint8_t A16 = 17;
+static const uint8_t A17 = 18;
+static const uint8_t A18 = 19;
+static const uint8_t A19 = 20;
+
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+static const uint8_t T8 = 8;
+static const uint8_t T9 = 9;
+static const uint8_t T10 = 10;
+static const uint8_t T11 = 11;
+static const uint8_t T12 = 12;
+static const uint8_t T13 = 13;
+static const uint8_t T14 = 14;
+
+static const uint8_t Vext = 36;
+static const uint8_t LED = 18;
+
+static const uint8_t RST_LoRa = 12;
+static const uint8_t BUSY_LoRa = 13;
+static const uint8_t DIO0 = 14;
+
+#endif /* Pins_Arduino_h */

--- a/variants/heltec_wireless_tracker/platformio.ini
+++ b/variants/heltec_wireless_tracker/platformio.ini
@@ -1,11 +1,10 @@
 [env:heltec-wireless-tracker]
 extends = esp32s3_base
-board = heltec_wifi_lora_32_V3
+board = heltec_wireless_tracker
 upload_protocol = esp-builtin
 
 build_flags = 
-  ${esp32s3_base.build_flags} -D HELTEC_WIRELESS_TRACKER -I variants/heltec_wireless_tracker
-   -DARDUINO_USB_CDC_ON_BOOT=1
+  ${esp32s3_base.build_flags} -I variants/heltec_wireless_tracker
 
 lib_deps =
   ${esp32s3_base.lib_deps}


### PR DESCRIPTION
heltec-wireless-tracker is not (yet) natively supported by platformio, so previously we used the very similar board definition  of _heltec_wifi_lora_32_V3_.
However this leads to USB serial problems, because its board definition has a hard-coded `-DARDUINO_USB_MODE=1` defined.

This PR solves this issue by using an explicit board definition in heltec-wireless-board.json which corrects the unwanted serial (mis-)behavior.