### PR TITLE
Add Heltec Wireless Paper to main_matrix.yml

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -85,6 +85,7 @@ jobs:
           - board: heltec-v3
           - board: heltec-wsl-v3
           - board: heltec-wireless-tracker
+          - board: heltec-wireless-paper
           - board: tbeam-s3-core
           - board: tlora-t3s3-v1
     uses: ./.github/workflows/build_esp32_s3.yml


### PR DESCRIPTION
This PR adds the Heltec Wireless Paper to the S3 section of the build file. No firmware file was built with latest release as expected. 