### PR TITLE
Convert protobuf values that are unsigned properly to uint in JSON

### DIFF
--- a/src/mqtt/JSONValue.cpp
+++ b/src/mqtt/JSONValue.cpp
@@ -364,6 +364,19 @@ JSONValue::JSONValue(int m_integer_value)
 }
 
 /**
+ * Basic constructor for creating a JSON Value of type Number
+ *
+ * @access public
+ *
+ * @param uint m_integer_value The number to use as the value
+ */
+JSONValue::JSONValue(uint m_integer_value)
+{
+    type = JSONType_Number;
+    number_value = (double)m_integer_value;
+}
+
+/**
  * Basic constructor for creating a JSON Value of type Array
  *
  * @access public

--- a/src/mqtt/JSONValue.h
+++ b/src/mqtt/JSONValue.h
@@ -45,6 +45,7 @@ class JSONValue
     JSONValue(bool m_bool_value);
     JSONValue(double m_number_value);
     JSONValue(int m_integer_value);
+    JSONValue(uint m_integer_value);
     JSONValue(const JSONArray &m_array_value);
     JSONValue(const JSONObject &m_object_value);
     JSONValue(const JSONValue &m_source);

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -541,7 +541,7 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
             if (pb_decode_from_bytes(mp->decoded.payload.bytes, mp->decoded.payload.size, &meshtastic_Telemetry_msg, &scratch)) {
                 decoded = &scratch;
                 if (decoded->which_variant == meshtastic_Telemetry_device_metrics_tag) {
-                    msgPayload["battery_level"] = new JSONValue((int)decoded->variant.device_metrics.battery_level);
+                    msgPayload["battery_level"] = new JSONValue((uint)decoded->variant.device_metrics.battery_level);
                     msgPayload["voltage"] = new JSONValue(decoded->variant.device_metrics.voltage);
                     msgPayload["channel_utilization"] = new JSONValue(decoded->variant.device_metrics.channel_utilization);
                     msgPayload["air_util_tx"] = new JSONValue(decoded->variant.device_metrics.air_util_tx);
@@ -588,10 +588,10 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
             if (pb_decode_from_bytes(mp->decoded.payload.bytes, mp->decoded.payload.size, &meshtastic_Position_msg, &scratch)) {
                 decoded = &scratch;
                 if ((int)decoded->time) {
-                    msgPayload["time"] = new JSONValue((int)decoded->time);
+                    msgPayload["time"] = new JSONValue((uint)decoded->time);
                 }
                 if ((int)decoded->timestamp) {
-                    msgPayload["timestamp"] = new JSONValue((int)decoded->timestamp);
+                    msgPayload["timestamp"] = new JSONValue((uint)decoded->timestamp);
                 }
                 msgPayload["latitude_i"] = new JSONValue((int)decoded->latitude_i);
                 msgPayload["longitude_i"] = new JSONValue((int)decoded->longitude_i);
@@ -599,13 +599,13 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
                     msgPayload["altitude"] = new JSONValue((int)decoded->altitude);
                 }
                 if ((int)decoded->ground_speed) {
-                    msgPayload["ground_speed"] = new JSONValue((int)decoded->ground_speed);
+                    msgPayload["ground_speed"] = new JSONValue((uint)decoded->ground_speed);
                 }
                 if (int(decoded->ground_track)) {
-                    msgPayload["ground_track"] = new JSONValue((int)decoded->ground_track);
+                    msgPayload["ground_track"] = new JSONValue((uint)decoded->ground_track);
                 }
                 if (int(decoded->sats_in_view)) {
-                    msgPayload["sats_in_view"] = new JSONValue((int)decoded->sats_in_view);
+                    msgPayload["sats_in_view"] = new JSONValue((uint)decoded->sats_in_view);
                 }
                 jsonObj["payload"] = new JSONValue(msgPayload);
             } else {
@@ -623,11 +623,11 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
             memset(&scratch, 0, sizeof(scratch));
             if (pb_decode_from_bytes(mp->decoded.payload.bytes, mp->decoded.payload.size, &meshtastic_Waypoint_msg, &scratch)) {
                 decoded = &scratch;
-                msgPayload["id"] = new JSONValue((int)decoded->id);
+                msgPayload["id"] = new JSONValue((uint)decoded->id);
                 msgPayload["name"] = new JSONValue(decoded->name);
                 msgPayload["description"] = new JSONValue(decoded->description);
-                msgPayload["expire"] = new JSONValue((int)decoded->expire);
-                msgPayload["locked_to"] = new JSONValue((int)decoded->locked_to);
+                msgPayload["expire"] = new JSONValue((uint)decoded->expire);
+                msgPayload["locked_to"] = new JSONValue((uint)decoded->locked_to);
                 msgPayload["latitude_i"] = new JSONValue((int)decoded->latitude_i);
                 msgPayload["longitude_i"] = new JSONValue((int)decoded->longitude_i);
                 jsonObj["payload"] = new JSONValue(msgPayload);
@@ -646,8 +646,8 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
             if (pb_decode_from_bytes(mp->decoded.payload.bytes, mp->decoded.payload.size, &meshtastic_NeighborInfo_msg,
                                      &scratch)) {
                 decoded = &scratch;
-                msgPayload["node_id"] = new JSONValue((int)decoded->node_id);
-                msgPayload["neighbors_count"] = new JSONValue((int)decoded->neighbors_count);
+                msgPayload["node_id"] = new JSONValue((uint)decoded->node_id);
+                msgPayload["neighbors_count"] = new JSONValue(decoded->neighbors_count);
                 msgPayload["neighbors"] = new JSONValue(decoded->neighbors);
             } else {
                 LOG_ERROR("Error decoding protobuf for neighborinfo message!\n");
@@ -660,11 +660,11 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
         break;
     }
 
-    jsonObj["id"] = new JSONValue((int)mp->id);
-    jsonObj["timestamp"] = new JSONValue((int)mp->rx_time);
-    jsonObj["to"] = new JSONValue((int)mp->to);
-    jsonObj["from"] = new JSONValue((int)mp->from);
-    jsonObj["channel"] = new JSONValue((int)mp->channel);
+    jsonObj["id"] = new JSONValue((uint)mp->id);
+    jsonObj["timestamp"] = new JSONValue((uint)mp->rx_time);
+    jsonObj["to"] = new JSONValue((uint)mp->to);
+    jsonObj["from"] = new JSONValue((uint)mp->from);
+    jsonObj["channel"] = new JSONValue((uint)mp->channel);
     jsonObj["type"] = new JSONValue(msgType.c_str());
     jsonObj["sender"] = new JSONValue(owner.id);
 


### PR DESCRIPTION
Note: this PR is going to the 2.2-working-changes branch. Needs to be in the release notes of 2.2, as it will break set-ups relying on this JSON value.

Should fix #2565. 

Untested yet with an actual MQTT set-up.
