### PR TITLE
Enable SX126X RX Boosted gain by default

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -166,7 +166,7 @@ void NodeDB::installDefaultConfig()
     config.has_bluetooth = true;
     config.device.rebroadcast_mode = meshtastic_Config_DeviceConfig_RebroadcastMode_ALL;
 
-    config.lora.sx126x_rx_boosted_gain = false;
+    config.lora.sx126x_rx_boosted_gain = true;
     config.lora.tx_enabled =
         true; // FIXME: maybe false in the future, and setting region to enable it. (unset region forces it off)
     config.lora.override_duty_cycle = false;


### PR DESCRIPTION
Fixes #2662 
Since non-SX126X devices ignore the setting, it's fine to just enable it by default globally.