### PR TITLE
[breaking] fix EU433 LoRa definitions

### DIFF
--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -32,9 +32,10 @@ const RegionInfo regions[] = {
     RDEF(US, 902.0f, 928.0f, 100, 0, 30, true, false, false),
 
     /*
-        https://lora-alliance.org/wp-content/uploads/2020/11/lorawan_regional_parameters_v1.0.3reva_0.pdf
-     */
-    RDEF(EU_433, 433.0f, 434.0f, 10, 0, 12, true, false, false),
+        EN300220 ETSI V3.2.1 [Table B.1, Item H, p. 21]
+        https://www.etsi.org/deliver/etsi_en/300200_300299/30022002/03.02.01_60/en_30022002v030201p.pdf
+    */
+    RDEF(EU_433, 433.05f, 434.79f, 10, 0, 10, true, false, false),
 
     /*
        https://www.thethingsnetwork.org/docs/lorawan/duty-cycle/


### PR DESCRIPTION
[EN300220 ETSI V3.2.1 [Table B.1, Item H, p. 21]](https://www.etsi.org/deliver/etsi_en/300200_300299/30022002/03.02.01_60/en_30022002v030201p.pdf)

<img width="1001" alt="EN300220 ETSI V3 2 1  Table B 1, Item H, p  21" src="https://github.com/meshtastic/firmware/assets/48680741/6a914498-5af4-48d4-9eae-b34832e47bc4">
