### PR TITLE
fix repeater crash during screen setup

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1058,7 +1058,8 @@ void Screen::setup()
     nodeStatusObserver.observe(&nodeStatus->onNewStatus);
     if (textMessageModule)
         textMessageObserver.observe(textMessageModule);
-    inputObserver.observe(inputBroker);
+    if (inputBroker)
+        inputObserver.observe(inputBroker);
 
     // Modules can notify screen about refresh
     MeshModule::observeUIEvents(&uiFrameEventObserver);


### PR DESCRIPTION
fixed null-pointer exception (inputbroker)

2.1.23 exception trace:
```
0x40230a8c: std::__detail::_List_node_base::_M_hook(std::__detail::_List_node_base*) at /builds/idf/crosstool-NG/.build/xtensa-esp32-elf/src/gcc/libstdc++-v3/src/c++98/list.cc:129
0x400e2b60: void std::__cxx11::list*, std::allocator*> >::_M_insert* const&>(std::_List_iterator*>, Observer<_InputEvent const*>* const&) at /home/runner/.platformio/packages/toolchain-xtensa-esp32/xtensa-esp32-elf/include/c++/8.4.0/bits/stl_list.h:1904
0x400e2b60: std::__cxx11::list*, std::allocator*> >::push_back(Observer<_InputEvent const*>* const&) at /home/runner/.platformio/packages/toolchain-xtensa-esp32/xtensa-esp32-elf/include/c++/8.4.0/bits/stl_list.h:1220
0x400e2b60: Observable<_InputEvent const*>::addObserver(Observer<_InputEvent const*>*) at /home/runner/work/firmware/firmware/src/Observer.h:82
0x400e2b60: Observer<_InputEvent const*>::observe(Observable<_InputEvent const*>*) at /home/runner/work/firmware/firmware/src/Observer.h:105
0x400e2b60: graphics::Screen::setup() at /home/runner/work/firmware/firmware/src/graphics/Screen.cpp:1061
0x400e4f1e: setup() at /home/runner/work/firmware/firmware/src/main.cpp:583
0x40141106: loopTask(void*) at /home/runner/.platformio/packages/framework-arduinoespressif32/cores/esp32/main.cpp:42
```