### PR TITLE
try-fix: max nodes crash during boot

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -790,8 +790,7 @@ meshtastic_NodeInfoLite *NodeDB::getOrCreateMeshNode(NodeNum n)
 
     if (!lite) {
         if ((*numMeshNodes >= MAX_NUM_NODES) || (memGet.getFreeHeap() < meshtastic_NodeInfoLite_size * 3)) {
-            if (screen)
-                screen->print("warning: node_db_lite full! erasing oldest entry\n");
+            screen->print("warning: node_db_lite full! erasing oldest entry\n");
             // look for oldest node and erase it
             uint32_t oldest = UINT32_MAX;
             int oldestIndex = -1;

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -790,7 +790,8 @@ meshtastic_NodeInfoLite *NodeDB::getOrCreateMeshNode(NodeNum n)
 
     if (!lite) {
         if ((*numMeshNodes >= MAX_NUM_NODES) || (memGet.getFreeHeap() < meshtastic_NodeInfoLite_size * 3)) {
-            screen->print("warning: node_db_lite full! erasing oldest entry\n");
+            if (screen)
+                screen->print("warning: node_db_lite full! erasing oldest entry\n");
             // look for oldest node and erase it
             uint32_t oldest = UINT32_MAX;
             int oldestIndex = -1;


### PR DESCRIPTION
looks like screen nullptr access in getOrCreateMeshNode() when MAX_NUM_NODES is exceeded:

```
INFO  | ??:??:?? 0 Initializing NodeDB
INFO  | ??:??:?? 0 Loading /prefs/db.proto
INFO  | ??:??:?? 0 Loaded saved devicestate version 22
INFO  | ??:??:?? 0 Loading /prefs/config.proto
INFO  | ??:??:?? 0 Loaded saved config version 22
[   633][E][vfs_api.cpp:105] open(): /littlefs/prefs/module.proto does not exist, no permits for creation
INFO  | ??:??:?? 0 No /prefs/module.proto preferences found
INFO  | ??:??:?? 0 Installing default ModuleConfig
INFO  | ??:??:?? 0 Loading /prefs/channels.proto
INFO  | ??:??:?? 0 Loaded saved channelFile version 22
[   660][E][vfs_api.cpp:105] open(): /littlefs/oem/oem.proto does not exist, no permits for creation
INFO  | ??:??:?? 0 No /oem/oem.proto preferences found
Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.

Core  1 register dump:
PC      : 0x400d4b5f  PS      : 0x00060e30  A0      : 0x800d4c97  A1      : 0x3ffd8860  
A2      : 0x00000000  A3      : 0x3ffd8898  A4      : 0x3ffc62c4  A5      : 0x3ffcaec4  
A6      : 0x3ffbc1c8  A7      : 0x00000000  A8      : 0x80092df4  A9      : 0x3ffd8850  
A10     : 0x3ffd96e4  A11     : 0x3f4051f0  A12     : 0x00000032  A13     : 0x3ffd8780  
A14     : 0x00000003  A15     : 0x00060023  SAR     : 0x0000001b  EXCCAUSE: 0x0000001c  
EXCVADDR: 0x000000f4  LBEG    : 0x400920ec  LEND    : 0x40092102  LCOUNT  : 0x00000000  


Backtrace: 0x400d4b5c:0x3ffd8860 0x400d4c94:0x3ffd8890 0x400e33b0:0x3ffd88c0 0x400e3e15:0x3ffd88e0 0x400e0e99:0x3ffd8920 0x401358d6:0x3ffd89b0


0x400d4b5c: graphics::Screen::enqueueCmd(graphics::Screen::ScreenCmd const&) at /home/runner/work/firmware/firmware/src/graphics/Screen.h:339
0x400d4c94: graphics::Screen::print(char const) at /home/runner/work/firmware/firmware/src/graphics/Screen.h:215
0x400e33b0: NodeDB::getOrCreateMeshNode(unsigned int) at /home/runner/work/firmware/firmware/src/mesh/NodeDB.cpp:793
0x400e33b0: NodeDB::getOrCreateMeshNode(unsigned int) at /home/runner/work/firmware/firmware/src/mesh/NodeDB.cpp:787
0x400e3e15: NodeDB::init() at /home/runner/work/firmware/firmware/src/mesh/NodeDB.cpp:339
0x400e0e99: setup() at /home/runner/work/firmware/firmware/src/main.cpp:484
0x401358d6: loopTask(void) at /home/runner/.platformio/packages/framework-arduinoespressif32/cores/esp32/main.cpp:42
```