### PR TITLE
Update T-Deck variant.h to remove HAS_GPS

### DIFF
--- a/variants/t-deck/variant.h
+++ b/variants/t-deck/variant.h
@@ -27,7 +27,6 @@
 #define BUTTON_PIN 0
 // #define BUTTON_NEED_PULLUP
 
-#define HAS_GPS 0
 #undef GPS_RX_PIN
 #undef GPS_TX_PIN
 


### PR DESCRIPTION
This removes the HAS_GPS 0 definition from the variant.h file so users can add gps without needing to build custom firmware. 

