### PR TITLE
Permanently Enable Canned Messages on T-Deck and Picomputer

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -147,6 +147,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define GPS_THREAD_INTERVAL 100
 #endif
 
+// convert 24-bit color to 16-bit (56K)
+#define COLOR565(r, g, b) (((r & 0xF8) << 8) | ((g & 0xFC) << 3) | ((b & 0xF8) >> 3))
+
 /* Step #1: offer chance for variant-specific defines */
 #include "variant.h"
 

--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -4,9 +4,9 @@
 #define TFT_BACKLIGHT_ON HIGH
 #endif
 
-// convert 24-bit color to 16-bit (56K)
-#define COLOR565(r, g, b) (((r & 0xF8) << 8) | ((g & 0xFC) << 3) | ((b & 0xF8) >> 3))
+#ifndef TFT_MESH
 #define TFT_MESH COLOR565(0x67, 0xEA, 0x94)
+#endif
 
 #if defined(ST7735S)
 #include <LovyanGFX.hpp> // Graphics and font library for ST7735 driver chip

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -63,10 +63,10 @@ CannedMessageModule *cannedMessageModule;
 CannedMessageModule::CannedMessageModule()
     : SinglePortModule("canned", meshtastic_PortNum_TEXT_MESSAGE_APP), concurrency::OSThread("CannedMessageModule")
 {
-    if (moduleConfig.canned_message.enabled) {
+    if (moduleConfig.canned_message.enabled || CANNED_MESSAGE_MODULE_ENABLE) {
         this->loadProtoForModule();
         if ((this->splitConfiguredMessages() <= 0) && (cardkb_found.address != CARDKB_ADDR) &&
-            (cardkb_found.address != TDECK_KB_ADDR) && !INPUTBROKER_MATRIX_TYPE) {
+            (cardkb_found.address != TDECK_KB_ADDR) && !INPUTBROKER_MATRIX_TYPE && !CANNED_MESSAGE_MODULE_ENABLE) {
             LOG_INFO("CannedMessageModule: No messages are configured. Module is disabled\n");
             this->runState = CANNED_MESSAGE_RUN_STATE_DISABLED;
             disable();
@@ -237,8 +237,8 @@ void CannedMessageModule::sendText(NodeNum dest, const char *message, bool wantR
 
 int32_t CannedMessageModule::runOnce()
 {
-    if ((!moduleConfig.canned_message.enabled) || (this->runState == CANNED_MESSAGE_RUN_STATE_DISABLED) ||
-        (this->runState == CANNED_MESSAGE_RUN_STATE_INACTIVE)) {
+    if (((!moduleConfig.canned_message.enabled) && !CANNED_MESSAGE_MODULE_ENABLE) ||
+        (this->runState == CANNED_MESSAGE_RUN_STATE_DISABLED) || (this->runState == CANNED_MESSAGE_RUN_STATE_INACTIVE)) {
         return INT32_MAX;
     }
     // LOG_DEBUG("Check status\n");
@@ -454,7 +454,7 @@ const char *CannedMessageModule::getNodeName(NodeNum node)
 
 bool CannedMessageModule::shouldDraw()
 {
-    if (!moduleConfig.canned_message.enabled) {
+    if (!moduleConfig.canned_message.enabled && !CANNED_MESSAGE_MODULE_ENABLE) {
         return false;
     }
     return (currentMessageIndex != -1) || (this->runState != CANNED_MESSAGE_RUN_STATE_INACTIVE);

--- a/src/modules/CannedMessageModule.h
+++ b/src/modules/CannedMessageModule.h
@@ -20,6 +20,10 @@ enum cannedMessageModuleRunState {
  */
 #define CANNED_MESSAGE_MODULE_MESSAGES_SIZE 800
 
+#ifndef CANNED_MESSAGE_MODULE_ENABLE
+#define CANNED_MESSAGE_MODULE_ENABLE 0
+#endif
+
 class CannedMessageModule : public SinglePortModule, public Observable<const UIFrameEvent *>, private concurrency::OSThread
 {
     CallbackObserver<CannedMessageModule, const InputEvent *> inputObserver =

--- a/variants/picomputer-s3/variant.h
+++ b/variants/picomputer-s3/variant.h
@@ -43,6 +43,11 @@
 #define SCREEN_ROTATE
 #define SCREEN_TRANSITION_FRAMERATE 5
 
+// Picomputer gets a white on black display
+#define TFT_MESH COLOR565(0xFF, 0xFF, 0xFF)
+
+#define CANNED_MESSAGE_MODULE_ENABLE 1
+
 #define INPUTBROKER_MATRIX_TYPE 1
 
 #define KEYS_COLS                                                                                                                \

--- a/variants/t-deck/variant.h
+++ b/variants/t-deck/variant.h
@@ -49,6 +49,7 @@
 #define KB_POWERON 10                  // must be set to HIGH
 #define KB_SLAVE_ADDRESS TDECK_KB_ADDR // 0x55
 #define KB_BL_PIN 46                   // not used for now
+#define CANNED_MESSAGE_MODULE_ENABLE 1
 
 // trackball
 #define HAS_TRACKBALL 1


### PR DESCRIPTION
picomputer has a really dark TFT; switch color to white for better UX.