### PR TITLE
Heltec ESP32-C3 HT-CT62 support

### DIFF
--- a/variants/heltec_esp32c3/pins_arduino.h
+++ b/variants/heltec_esp32c3/pins_arduino.h
@@ -1,0 +1,32 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define EXTERNAL_NUM_INTERRUPTS 22
+#define NUM_DIGITAL_PINS 22
+#define NUM_ANALOG_INPUTS 6
+
+#define analogInputToDigitalPin(p) (((p) < NUM_ANALOG_INPUTS) ? (esp32_adc2gpio[(p)]) : -1)
+#define digitalPinToInterrupt(p) (((p) < NUM_DIGITAL_PINS) ? (p) : -1)
+#define digitalPinHasPWM(p) (p < EXTERNAL_NUM_INTERRUPTS)
+
+static const uint8_t TX = 21;
+static const uint8_t RX = 20;
+
+static const uint8_t SDA = 1;
+static const uint8_t SCL = 0;
+
+static const uint8_t SS = 8;
+static const uint8_t MOSI = 7;
+static const uint8_t MISO = 6;
+static const uint8_t SCK = 10;
+
+static const uint8_t A0 = 0;
+static const uint8_t A1 = 1;
+static const uint8_t A2 = 2;
+static const uint8_t A3 = 3;
+static const uint8_t A4 = 4;
+static const uint8_t A5 = 5;
+
+#endif /* Pins_Arduino_h */

--- a/variants/heltec_esp32c3/platformio.ini
+++ b/variants/heltec_esp32c3/platformio.ini
@@ -4,7 +4,8 @@ board = esp32-c3-devkitm-1
 board_level = extra
 build_flags = 
   ${esp32_base.build_flags}
-  -D HELTEC_HT62
+  -D PRIVATE_HW
+  ;-D HELTEC_HT62
   -I variants/heltec_esp32c3
 monitor_speed = 115200
 upload_protocol = esptool

--- a/variants/heltec_esp32c3/platformio.ini
+++ b/variants/heltec_esp32c3/platformio.ini
@@ -1,0 +1,12 @@
+[env:heltec-esp32c3-sx1262]
+extends = esp32c3_base
+board = esp32-c3-devkitm-1
+board_level = extra
+build_flags = 
+  ${esp32_base.build_flags}
+  -D PRIVATE_HW
+  -I variants/heltec_esp32c3
+monitor_speed = 115200
+upload_protocol = esptool
+upload_port = /dev/ttyUSB0
+upload_speed = 921600

--- a/variants/heltec_esp32c3/platformio.ini
+++ b/variants/heltec_esp32c3/platformio.ini
@@ -4,8 +4,7 @@ board = esp32-c3-devkitm-1
 board_level = extra
 build_flags = 
   ${esp32_base.build_flags}
-  -D PRIVATE_HW
-  ;-D HELTEC_HT62
+  -D HELTEC_HT62
   -I variants/heltec_esp32c3
 monitor_speed = 115200
 upload_protocol = esptool

--- a/variants/heltec_esp32c3/platformio.ini
+++ b/variants/heltec_esp32c3/platformio.ini
@@ -1,10 +1,10 @@
-[env:heltec-esp32c3-sx1262]
+[env:heltec-ht62-esp32c3-sx1262]
 extends = esp32c3_base
 board = esp32-c3-devkitm-1
 board_level = extra
 build_flags = 
   ${esp32_base.build_flags}
-  -D PRIVATE_HW
+  -D HELTEC_HT62
   -I variants/heltec_esp32c3
 monitor_speed = 115200
 upload_protocol = esptool

--- a/variants/heltec_esp32c3/variant.h
+++ b/variants/heltec_esp32c3/variant.h
@@ -1,5 +1,5 @@
-//#define I2C_SDA 1
-//#define I2C_SCL 0
+#define I2C_SDA 1
+#define I2C_SCL 0
 
 #define BUTTON_PIN 9
 #define BUTTON_NEED_PULLUP
@@ -34,13 +34,3 @@
 #define SX126X_BUSY LORA_BUSY
 #define SX126X_RESET LORA_RESET
 #define SX126X_E22
-
-// Not yet tested
-//#define USE_EINK
-//#define PIN_EINK_EN   -1  // N/C
-//#define PIN_EINK_CS   9   // EPD_CS
-//#define PIN_EINK_BUSY 18  // EPD_BUSY
-//#define PIN_EINK_DC   19  // EPD_D/C
-//#define PIN_EINK_RES  -1  // Connected but not needed
-//#define PIN_EINK_SCLK 4   // EPD_SCLK
-//#define PIN_EINK_MOSI 6   // EPD_MOSI

--- a/variants/heltec_esp32c3/variant.h
+++ b/variants/heltec_esp32c3/variant.h
@@ -1,0 +1,46 @@
+//#define I2C_SDA 1
+//#define I2C_SCL 0
+
+#define BUTTON_PIN 9
+#define BUTTON_NEED_PULLUP
+
+// LED flashes brighter
+// https://resource.heltec.cn/download/HT-CT62/HT-CT62_Reference_Design.pdf
+#define LED_PIN 18 // LED
+#define LED_INVERTED 1
+
+#define HAS_SCREEN 0
+#define HAS_GPS 0
+#undef GPS_RX_PIN
+#undef GPS_TX_PIN
+
+#undef RF95_SCK
+#undef RF95_MISO
+#undef RF95_MOSI
+#undef RF95_NSS
+
+#define USE_SX1262
+#define RF95_SCK 10
+#define RF95_MISO 6
+#define RF95_MOSI 7
+#define RF95_NSS 8
+#define LORA_DIO0 RADIOLIB_NC
+#define LORA_RESET 5
+#define LORA_DIO1 3
+#define LORA_DIO2 RADIOLIB_NC
+#define LORA_BUSY 4
+#define SX126X_CS RF95_NSS
+#define SX126X_DIO1 LORA_DIO1
+#define SX126X_BUSY LORA_BUSY
+#define SX126X_RESET LORA_RESET
+#define SX126X_E22
+
+// Not yet tested
+//#define USE_EINK
+//#define PIN_EINK_EN   -1  // N/C
+//#define PIN_EINK_CS   9   // EPD_CS
+//#define PIN_EINK_BUSY 18  // EPD_BUSY
+//#define PIN_EINK_DC   19  // EPD_D/C
+//#define PIN_EINK_RES  -1  // Connected but not needed
+//#define PIN_EINK_SCLK 4   // EPD_SCLK
+//#define PIN_EINK_MOSI 6   // EPD_MOSI


### PR DESCRIPTION
https://github.com/meshtastic/firmware/issues/2740

Product Link
https://heltec.org/project/ht-ct62/

Description
Pinout for the Module
https://resource.heltec.cn/download/HT-CT62/HT-CT62.png

Heltec provides a ready to use backplate for the HT-C62
https://heltec.org/product/esp-dev-backplane/