### PR TITLE
Add neighbor IDs to MQTT JSON 

### DIFF
--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -277,7 +277,7 @@ meshtastic_Neighbor *NeighborInfoModule::getOrCreateNeighbor(NodeNum originalSen
     }
     // otherwise, allocate one and assign data to it
     // TODO: max memory for the database should take neighbors into account, but currently doesn't
-    if (*numNeighbors < MAX_NUM_NODES) {
+    if (*numNeighbors < MAX_NUM_NEIGHBORS) {
         (*numNeighbors)++;
     }
     meshtastic_Neighbor *new_nbr = &neighbors[((*numNeighbors) - 1)];

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -659,12 +659,11 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
                 msgPayload["node_broadcast_interval_secs"] = new JSONValue((uint)decoded->node_broadcast_interval_secs);
                 msgPayload["last_sent_by_id"] = new JSONValue((uint)decoded->last_sent_by_id);
                 msgPayload["neighbors_count"] = new JSONValue(decoded->neighbors_count);
-                const char baseString[] = "neighborID_";
-                char resultString[14];
+                std::vector<JSONValue *> neighbor_ids;
                 for (uint8_t i = 0; i < decoded->neighbors_count; i++) {
-                    sprintf(resultString, "%s%d", baseString, i);
-                    msgPayload[resultString] = new JSONValue((uint)decoded->neighbors[i].node_id);
+                    neighbor_ids.push_back(new JSONValue((uint)decoded->neighbors[i].node_id));
                 }
+                msgPayload["neighbor_ids"] = new JSONValue(neighbor_ids);
                 jsonObj["payload"] = new JSONValue(msgPayload);
             } else {
                 LOG_ERROR("Error decoding protobuf for neighborinfo message!\n");

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -659,11 +659,14 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
                 msgPayload["node_broadcast_interval_secs"] = new JSONValue((uint)decoded->node_broadcast_interval_secs);
                 msgPayload["last_sent_by_id"] = new JSONValue((uint)decoded->last_sent_by_id);
                 msgPayload["neighbors_count"] = new JSONValue(decoded->neighbors_count);
-                std::vector<JSONValue *> neighbor_ids;
+                JSONArray neighbors;
                 for (uint8_t i = 0; i < decoded->neighbors_count; i++) {
-                    neighbor_ids.push_back(new JSONValue((uint)decoded->neighbors[i].node_id));
+                    JSONObject neighborObj;
+                    neighborObj["node_id"] = new JSONValue((uint)decoded->neighbors[i].node_id);
+                    neighborObj["snr"] = new JSONValue((int)decoded->neighbors[i].snr);
+                    neighbors.push_back(new JSONValue(neighborObj));
                 }
-                msgPayload["neighbor_ids"] = new JSONValue(neighbor_ids);
+                msgPayload["neighbors"] = new JSONValue(neighbors);
                 jsonObj["payload"] = new JSONValue(msgPayload);
             } else {
                 LOG_ERROR("Error decoding protobuf for neighborinfo message!\n");

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -656,8 +656,16 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
                                      &scratch)) {
                 decoded = &scratch;
                 msgPayload["node_id"] = new JSONValue((uint)decoded->node_id);
+                msgPayload["node_broadcast_interval_secs"] = new JSONValue((uint)decoded->node_broadcast_interval_secs);
+                msgPayload["last_sent_by_id"] = new JSONValue((uint)decoded->last_sent_by_id);
                 msgPayload["neighbors_count"] = new JSONValue(decoded->neighbors_count);
-                msgPayload["neighbors"] = new JSONValue(decoded->neighbors);
+                const char baseString[] = "neighborID_";
+                char resultString[14];
+                for (uint8_t i = 0; i < decoded->neighbors_count; i++) {
+                    sprintf(resultString, "%s%d", baseString, i);
+                    msgPayload[resultString] = new JSONValue((uint)decoded->neighbors[i].node_id);
+                }
+                jsonObj["payload"] = new JSONValue(msgPayload);
             } else {
                 LOG_ERROR("Error decoding protobuf for neighborinfo message!\n");
             }


### PR DESCRIPTION
Fixes #2755. 

I also put the limit of the number of neighbors saved to the maximum that the neighbor state can hold (instead of the maximum number of nodes it was before).