### PR TITLE
Fix Neighborinfo crash

### DIFF
--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -99,6 +99,7 @@ NeighborInfoModule::NeighborInfoModule()
         setIntervalFromNow(35 * 1000);
     } else {
         LOG_DEBUG("NeighborInfoModule is disabled\n");
+        neighborState = meshtastic_NeighborInfo_init_zero;
         disable();
     }
 }


### PR DESCRIPTION
neighbors object wasn't initialized when module disabled, this initializes it to a safe, empty object.