### PR TITLE
Implement software GNSS shutoff

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -32,6 +32,17 @@ static bool didSerialInit;
 struct uBloxGnssModelInfo info;
 uint8_t uBloxProtocolVersion;
 
+byte _message_PMREQ[] = {
+    0xB5, 0x62, // UBX protocol sync characters
+    0x02, 0x41, // Message class and ID (UBX-RXM-PMREQ)
+    0x08, 0x00, // Length of payload (6 bytes)
+    0x00, 0x00, // 4 bytes duration of request task
+    0x00, 0x00, // (milliseconds)
+    0x02, 0x00, // Task flag bitfield
+    0x00, 0x00, // byte index 1 = sleep mode
+    0x00, 0x00  // Placeholder for checksum, will be calculated next
+};
+
 void GPS::UBXChecksum(byte *message, size_t length)
 {
     uint8_t CK_A = 0, CK_B = 0;
@@ -250,8 +261,8 @@ bool GPS::setupGPS()
             config.position.tx_gpio = GPS_TX_PIN;
 #endif
 
-// #define BAUD_RATE 115200
-//  ESP32 has a special set of parameters vs other arduino ports
+//  #define BAUD_RATE 115200
+//   ESP32 has a special set of parameters vs other arduino ports
 #if defined(ARCH_ESP32)
         if (config.position.rx_gpio) {
             LOG_DEBUG("Using GPIO%d for GPS RX\n", config.position.rx_gpio);

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -68,6 +68,8 @@ class GPS : private concurrency::OSThread
 
     virtual ~GPS();
 
+    uint8_t _message_PMREQ[16];
+    friend void doGPSpowersave(bool on);
     /** We will notify this observable anytime GPS state has changed meaningfully */
     Observable<const meshtastic::GPSStatus *> newStatus;
 

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -61,14 +61,13 @@ class GPS : private concurrency::OSThread
   public:
     /** If !NULL we will use this serial port to construct our GPS */
     static HardwareSerial *_serial_gps;
-
+    static const uint8_t _message_PMREQ[8];
     meshtastic_Position p = meshtastic_Position_init_default;
 
     GPS() : concurrency::OSThread("GPS") {}
 
     virtual ~GPS();
 
-    uint8_t _message_PMREQ[16];
     friend void doGPSpowersave(bool on);
     /** We will notify this observable anytime GPS state has changed meaningfully */
     Observable<const meshtastic::GPSStatus *> newStatus;
@@ -102,6 +101,7 @@ class GPS : private concurrency::OSThread
 
     // Empty the input buffer as quickly as possible
     void clearBuffer();
+    uint8_t makeUBXPacket(uint8_t class_id, uint8_t msg_id, uint8_t payload_size, const uint8_t *msg);
 
   protected:
     /// Do gps chipset specific init, return true for success
@@ -143,6 +143,8 @@ class GPS : private concurrency::OSThread
 
     void setNumSatellites(uint8_t n);
 
+    uint8_t UBXscratch[250];
+
   private:
     /// Prepare the GPS for the cpu entering deep or light sleep, expect to be gone for at least 100s of msecs
     /// always returns 0 to indicate okay to sleep
@@ -154,8 +156,6 @@ class GPS : private concurrency::OSThread
 
     // Calculate checksum
     void UBXChecksum(uint8_t *message, size_t length);
-
-    uint8_t makeUBXCFG(uint8_t class_id, uint8_t msg_id, uint16_t msglen, const uint8_t *msg);
 
     /**
      * Switch the GPS into a mode where we are actively looking for a lock, or alternatively switch GPS into a low power mode

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -153,7 +153,9 @@ class GPS : private concurrency::OSThread
     int prepareDeepSleep(void *unused);
 
     // Calculate checksum
-    void UBXChecksum(byte *message, size_t length);
+    void UBXChecksum(uint8_t *message, size_t length);
+
+    uint8_t makeUBXCFG(uint8_t class_id, uint8_t msg_id, uint16_t msglen, const uint8_t *msg);
 
     /**
      * Switch the GPS into a mode where we are actively looking for a lock, or alternatively switch GPS into a low power mode

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -204,19 +204,19 @@ void doGPSpowersave(bool on)
         notifyGPSSleep.notifyObservers(NULL);
     }
 #endif
+#if !(defined(HAS_PMU) || defined(PIN_GPS_EN) || defined(PIN_GPS_WAKE))
     if (!on) {
+        uint8_t msglen;
         notifyGPSSleep.notifyObservers(NULL);
-        gps->UBXChecksum(gps->_message_PMREQ, sizeof(gps->_message_PMREQ));
-        gps->_serial_gps->write(gps->_message_PMREQ, sizeof(gps->_message_PMREQ));
-        if (!gps->getACK(0x02, 0x41, 500)) {
-            LOG_WARN("No response for RXM-PMREQ\n");
-        } else {
-            LOG_WARN("PMREQ received successfully\n");
+        msglen = gps->makeUBXPacket(0x02, 0x41, 0x08, gps->_message_PMREQ);
+        for (int i = 0; i < msglen; i++) {
+            gps->_serial_gps->write(gps->UBXscratch, msglen);
         }
     } else {
         gps->forceWake(1);
         gps->_serial_gps->write(0xFF);
     }
+#endif
 }
 
 void doDeepSleep(uint32_t msecToWake)

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -204,6 +204,19 @@ void doGPSpowersave(bool on)
         notifyGPSSleep.notifyObservers(NULL);
     }
 #endif
+    if (!on) {
+        notifyGPSSleep.notifyObservers(NULL);
+        gps->UBXChecksum(gps->_message_PMREQ, sizeof(gps->_message_PMREQ));
+        gps->_serial_gps->write(gps->_message_PMREQ, sizeof(gps->_message_PMREQ));
+        if (!gps->getACK(0x02, 0x41, 500)) {
+            LOG_WARN("No response for RXM-PMREQ\n");
+        } else {
+            LOG_WARN("PMREQ received successfully\n");
+        }
+    } else {
+        gps->forceWake(1);
+        gps->_serial_gps->write(0xFF);
+    }
 }
 
 void doDeepSleep(uint32_t msecToWake)


### PR DESCRIPTION
This should allow anyone without dedicated gpio to put their Ublox GNSS receivers to sleep.
Either using triple user button press or simply setting position.gps_enable to zero.

We can also start constructing packets for use elsewhere in the code base. Previously all ublox messages were defined and sent within functions.