### PR TITLE
UBX-RXM-PMREQ soft-off implemented

### DIFF
--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -62,6 +62,8 @@ class GPS : private concurrency::OSThread
     /** If !NULL we will use this serial port to construct our GPS */
     static HardwareSerial *_serial_gps;
 
+    static const uint8_t _message_PMREQ[8];
+
     meshtastic_Position p = meshtastic_Position_init_default;
 
     GPS() : concurrency::OSThread("GPS") {}
@@ -100,6 +102,9 @@ class GPS : private concurrency::OSThread
 
     // Empty the input buffer as quickly as possible
     void clearBuffer();
+
+    // Create a ublox packet for editing in memory
+    uint8_t makeUBXPacket(uint8_t class_id, uint8_t msg_id, uint8_t payload_size, const uint8_t *msg);
 
   protected:
     /// Do gps chipset specific init, return true for success
@@ -141,6 +146,9 @@ class GPS : private concurrency::OSThread
 
     void setNumSatellites(uint8_t n);
 
+    // scratch space for creating ublox packets
+    uint8_t UBXscratch[250];
+
   private:
     /// Prepare the GPS for the cpu entering deep or light sleep, expect to be gone for at least 100s of msecs
     /// always returns 0 to indicate okay to sleep
@@ -151,7 +159,7 @@ class GPS : private concurrency::OSThread
     int prepareDeepSleep(void *unused);
 
     // Calculate checksum
-    void UBXChecksum(byte *message, size_t length);
+    void UBXChecksum(uint8_t *message, size_t length);
 
     /**
      * Switch the GPS into a mode where we are actively looking for a lock, or alternatively switch GPS into a low power mode

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -204,6 +204,19 @@ void doGPSpowersave(bool on)
         notifyGPSSleep.notifyObservers(NULL);
     }
 #endif
+#if !(defined(HAS_PMU) || defined(PIN_GPS_EN) || defined(PIN_GPS_WAKE))
+    if (!on) {
+        uint8_t msglen;
+        notifyGPSSleep.notifyObservers(NULL);
+        msglen = gps->makeUBXPacket(0x02, 0x41, 0x08, gps->_message_PMREQ);
+        for (int i = 0; i < msglen; i++) {
+            gps->_serial_gps->write(gps->UBXscratch, msglen);
+        }
+    } else {
+        gps->forceWake(1);
+        gps->_serial_gps->write(0xFF);
+    }
+#endif
 }
 
 void doDeepSleep(uint32_t msecToWake)


### PR DESCRIPTION
Rather than be mad at git for my misuse of its rebase function, I just made a new branch and copied my simple changes.
Enjoy all!

Original PR:
This should allow anyone without dedicated gpio to put their Ublox GNSS receivers to sleep.
Either using triple user button press or simply setting position.gps_enable to zero.

We can also start constructing packets for use elsewhere in the code base. Previously all ublox messages were defined and sent within functions.
