### PR TITLE
Only update neighbors when module is enabled

### DIFF
--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -99,7 +99,6 @@ NeighborInfoModule::NeighborInfoModule()
         setIntervalFromNow(35 * 1000);
     } else {
         LOG_DEBUG("NeighborInfoModule is disabled\n");
-        neighborState = meshtastic_NeighborInfo_init_zero;
         disable();
     }
 }

--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -203,8 +203,10 @@ Pass it to an upper client; do not persist this data on the mesh
 */
 bool NeighborInfoModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_NeighborInfo *np)
 {
-    printNeighborInfo("RECEIVED", np);
-    updateNeighbors(mp, np);
+    if (enabled) {
+        printNeighborInfo("RECEIVED", np);
+        updateNeighbors(mp, np);
+    }
     // Allow others to handle this packet
     return false;
 }


### PR DESCRIPTION
If the NeighborInfoModule is not enabled, we shouldn't do any bookkeeping upon receiving a packet as we don't do anything with it and we also don't clean-up any neighbors, thus only consuming processing power/writes to flash (and it even caused a bug before #2767). It will still update the `last_sent_by_id` when passing through it in the FloodingRouter.