### PR TITLE
T-Deck/T-Watch: enhancements/fixes

### DIFF
--- a/boards/t-deck.json
+++ b/boards/t-deck.json
@@ -1,7 +1,8 @@
 {
   "build": {
     "arduino": {
-      "ldscript": "esp32s3_out.ld"
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_opi"
     },
     "core": "esp32",
     "extra_flags": [
@@ -13,7 +14,7 @@
     ],
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "flash_mode": "dio",
+    "flash_mode": "qio",
     "hwids": [["0x303A", "0x1001"]],
     "mcu": "esp32s3",
     "variant": "t-deck"

--- a/boards/t-watch-s3.json
+++ b/boards/t-watch-s3.json
@@ -1,7 +1,8 @@
 {
   "build": {
     "arduino": {
-      "ldscript": "esp32s3_out.ld"
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_opi"
     },
     "core": "esp32",
     "extra_flags": [
@@ -14,7 +15,7 @@
     ],
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "flash_mode": "dio",
+    "flash_mode": "qio",
     "hwids": [["0x303A", "0x1001"]],
     "mcu": "esp32s3",
     "variant": "t-watch-s3"
@@ -31,8 +32,9 @@
     "maximum_size": 8388608,
     "require_upload_port": true,
     "use_1200bps_touch": true,
-    "wait_for_upload_port": true
+    "wait_for_upload_port": true,
+    "speed": 921600
   },
-  "url": "http://www.lilygo.cn/",
+  "url": "https://www.lilygo.cc/en-pl/products/t-watch-s3",
   "vendor": "LilyGo"
 }

--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -189,7 +189,7 @@ static void powerEnter()
         screen->setOn(true);
         setBluetoothEnable(true);
 #ifdef KB_POWERON
-    digitalWrite(KB_POWERON, HIGH);
+        digitalWrite(KB_POWERON, HIGH);
 #endif
         // within enter() the function getState() returns the state we came from
         if (strcmp(powerFSM.getState()->name, "BOOT") != 0 && strcmp(powerFSM.getState()->name, "POWER") != 0 &&

--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -158,6 +158,9 @@ static void darkEnter()
 {
     setBluetoothEnable(true);
     screen->setOn(false);
+#ifdef KB_POWERON
+    digitalWrite(KB_POWERON, LOW);
+#endif
 }
 
 static void serialEnter()
@@ -185,6 +188,9 @@ static void powerEnter()
     } else {
         screen->setOn(true);
         setBluetoothEnable(true);
+#ifdef KB_POWERON
+    digitalWrite(KB_POWERON, HIGH);
+#endif
         // within enter() the function getState() returns the state we came from
         if (strcmp(powerFSM.getState()->name, "BOOT") != 0 && strcmp(powerFSM.getState()->name, "POWER") != 0 &&
             strcmp(powerFSM.getState()->name, "DARK") != 0) {
@@ -215,6 +221,9 @@ static void onEnter()
     LOG_DEBUG("Enter state: ON\n");
     screen->setOn(true);
     setBluetoothEnable(true);
+#ifdef KB_POWERON
+    digitalWrite(KB_POWERON, HIGH);
+#endif
 }
 
 static void onIdle()

--- a/variants/t-deck/platformio.ini
+++ b/variants/t-deck/platformio.ini
@@ -11,4 +11,4 @@ build_flags = ${esp32_base.build_flags}
   -Ivariants/t-deck
 
 lib_deps = ${esp32s3_base.lib_deps}
-	lovyan03/LovyanGFX@^1.1.8
+	lovyan03/LovyanGFX@^1.1.9

--- a/variants/t-deck/variant.h
+++ b/variants/t-deck/variant.h
@@ -27,8 +27,8 @@
 #define BUTTON_PIN 0
 // #define BUTTON_NEED_PULLUP
 
-#undef GPS_RX_PIN
-#undef GPS_TX_PIN
+#define GPS_RX_PIN 44
+#define GPS_TX_PIN 43
 
 // Have SPI interface SD card slot
 #define HAS_SDCARD 1
@@ -41,7 +41,7 @@
 #define BATTERY_PIN 4 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
 // ratio of voltage divider = 2.0 (RD2=100k, RD3=100k)
 #define ADC_MULTIPLIER 2.11 // 2.0 + 10% for correction of display undervoltage.
-#define ADC_CHANNEL ADC1_GPIO1_CHANNEL
+#define ADC_CHANNEL ADC1_GPIO4_CHANNEL
 
 // keyboard
 #define I2C_SDA 18 // I2C pins for this board

--- a/variants/t-watch-s3/platformio.ini
+++ b/variants/t-watch-s3/platformio.ini
@@ -3,8 +3,6 @@
 extends = esp32s3_base
 board = t-watch-s3
 upload_protocol = esptool
-upload_speed = 115200
-#upload_port = /dev/tty.usbmodem3485188D636C1
 
 build_flags = ${esp32_base.build_flags} 
   -DT_WATCH_S3
@@ -12,6 +10,6 @@ build_flags = ${esp32_base.build_flags}
   -DPCF8563_RTC=0x51
 
 lib_deps = ${esp32s3_base.lib_deps}
-	lovyan03/LovyanGFX@^1.1.8
+	lovyan03/LovyanGFX@^1.1.9
   lewisxhe/PCF8563_Library@1.0.1
   adafruit/Adafruit DRV2605 Library@^1.2.2


### PR DESCRIPTION
This PR fixes a few issues for T-Deck:

- PSRAM is now correctly detected (also for T-Watch S3):
```
DEBUG | ??:??:?? 3 Total heap: 269872
DEBUG | ??:??:?? 3 Free heap: 227360
DEBUG | ??:??:?? 3 Total PSRAM: 8386295
DEBUG | ??:??:?? 3 Free PSRAM: 8386295
```

- GPS default pins set to 43/44 (matching external connector)
```
DEBUG | ??:??:?? 4 WANT GPS=1
DEBUG | ??:??:?? 4 Using GPIO44 for GPS RX
DEBUG | ??:??:?? 4 Using GPIO43 for GPS TX
DEBUG | ??:??:?? 4 Probing for GPS at 9600 
INFO  | ??:??:?? 5 Found a UBlox Module using baudrate 9600
DEBUG | ??:??:?? 5 Module Info : 
DEBUG | ??:??:?? 5 Soft version: 7.03 (45969)
DEBUG | ??:??:?? 5 Hard version: 00040007
DEBUG | ??:??:?? 5 Extensions:0
WARN  | ??:??:?? 6 Unable to save GNSS module configuration.
DEBUG | ??:??:?? 6 GxGSA NOT available
```

- Power down keyboard during dark screen (saves 20mA)
- tryfix: battery voltage readout (could not test though, my T-Deck has HW issues)
- bump LovyanGFX version
