### PR TITLE
Fix time=0 bug for fixed_position nodes

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -338,10 +338,8 @@ int MeshService::onGPSChanged(const meshtastic::GPSStatus *newStatus)
         pos = ConvertToPosition(node->position);
     }
 
-    // Finally add a fresh timestamp and battery level reading
-    // I KNOW this is redundant with refreshLocalMeshNode() above, but these are
-    //   inexpensive nonblocking calls and can be refactored in due course
-    pos.time = getValidTime(RTCQualityGPS);
+    // Add a fresh timestamp
+    pos.time = getValidTime(RTCQualityFromNet);
 
     // In debug logs, identify position by @timestamp:stage (stage 4 = nodeDB)
     LOG_DEBUG("onGPSChanged() pos@%x, time=%u, lat=%d, lon=%d, alt=%d\n", pos.timestamp, pos.time, pos.latitude_i,


### PR DESCRIPTION
Should fix bug reported by @b8b8 and @cmh in Discord, wherein fixed position nodes send out problematic time=0 with position packets