### PR TITLE
fix: nodenum 4

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -81,13 +81,11 @@ bool NodeDB::resetRadioConfig(bool factory_reset)
 
     radioGeneration++;
 
-    if (factory_reset)
-    {
+    if (factory_reset) {
         didFactoryReset = factoryReset();
     }
 
-    if (channelFile.channels_count != MAX_NUM_CHANNELS)
-    {
+    if (channelFile.channels_count != MAX_NUM_CHANNELS) {
         LOG_INFO("Setting default channel and radio preferences!\n");
 
         channels.initDefaults();
@@ -97,8 +95,7 @@ bool NodeDB::resetRadioConfig(bool factory_reset)
 
     // temp hack for quicker testing
     // devicestate.no_save = true;
-    if (devicestate.no_save)
-    {
+    if (devicestate.no_save) {
         LOG_DEBUG("***** DEVELOPMENT MODE - DO NOT RELEASE *****\n");
 
         // Sleep quite frequently to stress test the BLE comms, broadcast position every 6 mins
@@ -115,8 +112,7 @@ bool NodeDB::resetRadioConfig(bool factory_reset)
     // Update the global myRegion
     initRegion();
 
-    if (didFactoryReset)
-    {
+    if (didFactoryReset) {
         LOG_INFO("Rebooting due to factory reset");
         screen->startRebootScreen();
         rebootAtMsec = millis() + (5 * 1000);
@@ -271,21 +267,14 @@ void NodeDB::installDefaultModuleConfig()
 
 void NodeDB::installRoleDefaults(meshtastic_Config_DeviceConfig_Role role)
 {
-    if (role == meshtastic_Config_DeviceConfig_Role_ROUTER)
-    {
+    if (role == meshtastic_Config_DeviceConfig_Role_ROUTER) {
         initConfigIntervals();
         initModuleConfigIntervals();
-    }
-    else if (role == meshtastic_Config_DeviceConfig_Role_REPEATER)
-    {
+    } else if (role == meshtastic_Config_DeviceConfig_Role_REPEATER) {
         config.display.screen_on_secs = 1;
-    }
-    else if (role == meshtastic_Config_DeviceConfig_Role_TRACKER)
-    {
+    } else if (role == meshtastic_Config_DeviceConfig_Role_TRACKER) {
         config.position.gps_update_interval = 30;
-    }
-    else if (role == meshtastic_Config_DeviceConfig_Role_SENSOR)
-    {
+    } else if (role == meshtastic_Config_DeviceConfig_Role_SENSOR) {
         moduleConfig.telemetry.environment_measurement_enabled = true;
         moduleConfig.telemetry.environment_update_interval = 300;
     }
@@ -318,8 +307,7 @@ void NodeDB::resetNodes()
 void NodeDB::cleanupMeshDB()
 {
     int newPos = 0, removed = 0;
-    for (int i = 0; i < *numMeshNodes; i++)
-    {
+    for (int i = 0; i < *numMeshNodes; i++) {
         if (meshNodes[i].has_user)
             meshNodes[newPos++] = meshNodes[i];
         else
@@ -398,8 +386,7 @@ void NodeDB::init()
     if (channelFileCRC != crc32Buffer(&channelFile, sizeof(channelFile)))
         saveWhat |= SEGMENT_CHANNELS;
 
-    if (!devicestate.node_remote_hardware_pins)
-    {
+    if (!devicestate.node_remote_hardware_pins) {
         meshtastic_NodeRemoteHardwarePin empty[12] = {meshtastic_RemoteHardwarePin_init_default};
         memcpy(devicestate.node_remote_hardware_pins, empty, sizeof(empty));
     }
@@ -422,8 +409,7 @@ void NodeDB::pickNewNodeNum()
 
     meshtastic_NodeInfoLite *found;
     while ((nodeNum == NODENUM_BROADCAST || nodeNum < NUM_RESERVED) ||
-           ((found = getMeshNode(nodeNum)) && memcmp(found->user.macaddr, owner.macaddr, sizeof(owner.macaddr)) != 0))
-    {
+           ((found = getMeshNode(nodeNum)) && memcmp(found->user.macaddr, owner.macaddr, sizeof(owner.macaddr)) != 0)) {
         NodeNum candidate = random(NUM_RESERVED, LONG_MAX); // try a new random choice
         LOG_WARN("NOTE! Our desired nodenum 0x%x is invalid or in use, so trying for 0x%x\n", nodeNum, candidate);
         nodeNum = candidate;
@@ -447,27 +433,21 @@ bool NodeDB::loadProto(const char *filename, size_t protoSize, size_t objSize, c
 
     auto f = FSCom.open(filename, FILE_O_READ);
 
-    if (f)
-    {
+    if (f) {
         LOG_INFO("Loading %s\n", filename);
         pb_istream_t stream = {&readcb, &f, protoSize};
 
         // LOG_DEBUG("Preload channel name=%s\n", channelSettings.name);
 
         memset(dest_struct, 0, objSize);
-        if (!pb_decode(&stream, fields, dest_struct))
-        {
+        if (!pb_decode(&stream, fields, dest_struct)) {
             LOG_ERROR("Error: can't decode protobuf %s\n", PB_GET_ERROR(&stream));
-        }
-        else
-        {
+        } else {
             okay = true;
         }
 
         f.close();
-    }
-    else
-    {
+    } else {
         LOG_INFO("No %s preferences found\n", filename);
     }
 #else
@@ -480,79 +460,54 @@ void NodeDB::loadFromDisk()
 {
     // static DeviceState scratch; We no longer read into a tempbuf because this structure is 15KB of valuable RAM
     if (!loadProto(prefFileName, meshtastic_DeviceState_size, sizeof(meshtastic_DeviceState), &meshtastic_DeviceState_msg,
-                   &devicestate))
-    {
+                   &devicestate)) {
         installDefaultDeviceState(); // Our in RAM copy might now be corrupt
-    }
-    else
-    {
-        if (devicestate.version < DEVICESTATE_MIN_VER)
-        {
+    } else {
+        if (devicestate.version < DEVICESTATE_MIN_VER) {
             LOG_WARN("Devicestate %d is old, discarding\n", devicestate.version);
             factoryReset();
-        }
-        else
-        {
+        } else {
             LOG_INFO("Loaded saved devicestate version %d\n", devicestate.version);
         }
     }
 
     if (!loadProto(configFileName, meshtastic_LocalConfig_size, sizeof(meshtastic_LocalConfig), &meshtastic_LocalConfig_msg,
-                   &config))
-    {
+                   &config)) {
         installDefaultConfig(); // Our in RAM copy might now be corrupt
-    }
-    else
-    {
-        if (config.version < DEVICESTATE_MIN_VER)
-        {
+    } else {
+        if (config.version < DEVICESTATE_MIN_VER) {
             LOG_WARN("config %d is old, discarding\n", config.version);
             installDefaultConfig();
-        }
-        else
-        {
+        } else {
             LOG_INFO("Loaded saved config version %d\n", config.version);
         }
     }
 
     if (!loadProto(moduleConfigFileName, meshtastic_LocalModuleConfig_size, sizeof(meshtastic_LocalModuleConfig),
-                   &meshtastic_LocalModuleConfig_msg, &moduleConfig))
-    {
+                   &meshtastic_LocalModuleConfig_msg, &moduleConfig)) {
         installDefaultModuleConfig(); // Our in RAM copy might now be corrupt
-    }
-    else
-    {
-        if (moduleConfig.version < DEVICESTATE_MIN_VER)
-        {
+    } else {
+        if (moduleConfig.version < DEVICESTATE_MIN_VER) {
             LOG_WARN("moduleConfig %d is old, discarding\n", moduleConfig.version);
             installDefaultModuleConfig();
-        }
-        else
-        {
+        } else {
             LOG_INFO("Loaded saved moduleConfig version %d\n", moduleConfig.version);
         }
     }
 
     if (!loadProto(channelFileName, meshtastic_ChannelFile_size, sizeof(meshtastic_ChannelFile), &meshtastic_ChannelFile_msg,
-                   &channelFile))
-    {
+                   &channelFile)) {
         installDefaultChannels(); // Our in RAM copy might now be corrupt
-    }
-    else
-    {
-        if (channelFile.version < DEVICESTATE_MIN_VER)
-        {
+    } else {
+        if (channelFile.version < DEVICESTATE_MIN_VER) {
             LOG_WARN("channelFile %d is old, discarding\n", channelFile.version);
             installDefaultChannels();
-        }
-        else
-        {
+        } else {
             LOG_INFO("Loaded saved channelFile version %d\n", channelFile.version);
         }
     }
 
-    if (loadProto(oemConfigFile, meshtastic_OEMStore_size, sizeof(meshtastic_OEMStore), &meshtastic_OEMStore_msg, &oemStore))
-    {
+    if (loadProto(oemConfigFile, meshtastic_OEMStore_size, sizeof(meshtastic_OEMStore), &meshtastic_OEMStore_msg, &oemStore)) {
         LOG_INFO("Loaded OEMStore\n");
     }
 }
@@ -566,40 +521,31 @@ bool NodeDB::saveProto(const char *filename, size_t protoSize, const pb_msgdesc_
     String filenameTmp = filename;
     filenameTmp += ".tmp";
     auto f = FSCom.open(filenameTmp.c_str(), FILE_O_WRITE);
-    if (f)
-    {
+    if (f) {
         LOG_INFO("Saving %s\n", filename);
         pb_ostream_t stream = {&writecb, &f, protoSize};
 
-        if (!pb_encode(&stream, fields, dest_struct))
-        {
+        if (!pb_encode(&stream, fields, dest_struct)) {
             LOG_ERROR("Error: can't encode protobuf %s\n", PB_GET_ERROR(&stream));
-        }
-        else
-        {
+        } else {
             okay = true;
         }
         f.flush();
         f.close();
 
         // brief window of risk here ;-)
-        if (FSCom.exists(filename) && !FSCom.remove(filename))
-        {
+        if (FSCom.exists(filename) && !FSCom.remove(filename)) {
             LOG_WARN("Can't remove old pref file\n");
         }
-        if (!renameFile(filenameTmp.c_str(), filename))
-        {
+        if (!renameFile(filenameTmp.c_str(), filename)) {
             LOG_ERROR("Error: can't rename new pref file\n");
         }
-    }
-    else
-    {
+    } else {
         LOG_ERROR("Can't write prefs\n");
 #ifdef ARCH_NRF52
         static uint8_t failedCounter = 0;
         failedCounter++;
-        if (failedCounter >= 2)
-        {
+        if (failedCounter >= 2) {
             FSCom.format();
             // After formatting, the device needs to be restarted
             nodeDB.resetRadioConfig(true);
@@ -614,8 +560,7 @@ bool NodeDB::saveProto(const char *filename, size_t protoSize, const pb_msgdesc_
 
 void NodeDB::saveChannelsToDisk()
 {
-    if (!devicestate.no_save)
-    {
+    if (!devicestate.no_save) {
 #ifdef FSCom
         FSCom.mkdir("/prefs");
 #endif
@@ -625,8 +570,7 @@ void NodeDB::saveChannelsToDisk()
 
 void NodeDB::saveDeviceStateToDisk()
 {
-    if (!devicestate.no_save)
-    {
+    if (!devicestate.no_save) {
 #ifdef FSCom
         FSCom.mkdir("/prefs");
 #endif
@@ -636,18 +580,15 @@ void NodeDB::saveDeviceStateToDisk()
 
 void NodeDB::saveToDisk(int saveWhat)
 {
-    if (!devicestate.no_save)
-    {
+    if (!devicestate.no_save) {
 #ifdef FSCom
         FSCom.mkdir("/prefs");
 #endif
-        if (saveWhat & SEGMENT_DEVICESTATE)
-        {
+        if (saveWhat & SEGMENT_DEVICESTATE) {
             saveDeviceStateToDisk();
         }
 
-        if (saveWhat & SEGMENT_CONFIG)
-        {
+        if (saveWhat & SEGMENT_CONFIG) {
             config.has_device = true;
             config.has_display = true;
             config.has_lora = true;
@@ -658,8 +599,7 @@ void NodeDB::saveToDisk(int saveWhat)
             saveProto(configFileName, meshtastic_LocalConfig_size, &meshtastic_LocalConfig_msg, &config);
         }
 
-        if (saveWhat & SEGMENT_MODULECONFIG)
-        {
+        if (saveWhat & SEGMENT_MODULECONFIG) {
             moduleConfig.has_canned_message = true;
             moduleConfig.has_external_notification = true;
             moduleConfig.has_mqtt = true;
@@ -670,13 +610,10 @@ void NodeDB::saveToDisk(int saveWhat)
             saveProto(moduleConfigFileName, meshtastic_LocalModuleConfig_size, &meshtastic_LocalModuleConfig_msg, &moduleConfig);
         }
 
-        if (saveWhat & SEGMENT_CHANNELS)
-        {
+        if (saveWhat & SEGMENT_CHANNELS) {
             saveChannelsToDisk();
         }
-    }
-    else
-    {
+    } else {
         LOG_DEBUG("***** DEVELOPMENT MODE - DO NOT RELEASE - not saving to flash *****\n");
     }
 }
@@ -733,29 +670,23 @@ size_t NodeDB::getNumOnlineMeshNodes()
 void NodeDB::updatePosition(uint32_t nodeId, const meshtastic_Position &p, RxSource src)
 {
     meshtastic_NodeInfoLite *info = getOrCreateMeshNode(nodeId);
-    if (!info)
-    {
+    if (!info) {
         return;
     }
 
-    if (src == RX_SRC_LOCAL)
-    {
+    if (src == RX_SRC_LOCAL) {
         // Local packet, fully authoritative
         LOG_INFO("updatePosition LOCAL pos@%x, time=%u, latI=%d, lonI=%d, alt=%d\n", p.timestamp, p.time, p.latitude_i,
                  p.longitude_i, p.altitude);
 
         info->position = ConvertToPositionLite(p);
         localPosition = p;
-    }
-    else if ((p.time > 0) && !p.latitude_i && !p.longitude_i && !p.timestamp && !p.location_source)
-    {
+    } else if ((p.time > 0) && !p.latitude_i && !p.longitude_i && !p.timestamp && !p.location_source) {
         // FIXME SPECIAL TIME SETTING PACKET FROM EUD TO RADIO
         // (stop-gap fix for issue #900)
         LOG_DEBUG("updatePosition SPECIAL time setting time=%u\n", p.time);
         info->position.time = p.time;
-    }
-    else
-    {
+    } else {
         // Be careful to only update fields that have been set by the REMOTE sender
         // A lot of position reports don't have time populated.  In that case, be careful to not blow away the time we
         // recorded based on the packet rxTime
@@ -785,18 +716,14 @@ void NodeDB::updateTelemetry(uint32_t nodeId, const meshtastic_Telemetry &t, RxS
 {
     meshtastic_NodeInfoLite *info = getOrCreateMeshNode(nodeId);
     // Environment metrics should never go to NodeDb but we'll safegaurd anyway
-    if (!info || t.which_variant != meshtastic_Telemetry_device_metrics_tag)
-    {
+    if (!info || t.which_variant != meshtastic_Telemetry_device_metrics_tag) {
         return;
     }
 
-    if (src == RX_SRC_LOCAL)
-    {
+    if (src == RX_SRC_LOCAL) {
         // Local packet, fully authoritative
         LOG_DEBUG("updateTelemetry LOCAL\n");
-    }
-    else
-    {
+    } else {
         LOG_DEBUG("updateTelemetry REMOTE node=0x%x \n", nodeId);
     }
     info->device_metrics = t.variant.device_metrics;
@@ -810,8 +737,7 @@ void NodeDB::updateTelemetry(uint32_t nodeId, const meshtastic_Telemetry &t, RxS
 bool NodeDB::updateUser(uint32_t nodeId, const meshtastic_User &p)
 {
     meshtastic_NodeInfoLite *info = getOrCreateMeshNode(nodeId);
-    if (!info)
-    {
+    if (!info) {
         return false;
     }
 
@@ -824,8 +750,7 @@ bool NodeDB::updateUser(uint32_t nodeId, const meshtastic_User &p)
     LOG_DEBUG("updating changed=%d user %s/%s/%s\n", changed, info->user.id, info->user.long_name, info->user.short_name);
     info->has_user = true;
 
-    if (changed)
-    {
+    if (changed) {
         updateGUIforNode = info;
         powerFSM.trigger(EVENT_NODEDB_UPDATED);
         notifyObservers(true); // Force an update whether or not our node counts have changed
@@ -841,13 +766,11 @@ bool NodeDB::updateUser(uint32_t nodeId, const meshtastic_User &p)
 /// we updateGUI and updateGUIforNode if we think our this change is big enough for a redraw
 void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
 {
-    if (mp.which_payload_variant == meshtastic_MeshPacket_decoded_tag && mp.from)
-    {
+    if (mp.which_payload_variant == meshtastic_MeshPacket_decoded_tag && mp.from) {
         LOG_DEBUG("Update DB node 0x%x, rx_time=%u, channel=%d\n", mp.from, mp.rx_time, mp.channel);
 
         meshtastic_NodeInfoLite *info = getOrCreateMeshNode(getFrom(&mp));
-        if (!info)
-        {
+        if (!info) {
             return;
         }
 
@@ -857,8 +780,7 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
         if (mp.rx_snr)
             info->snr = mp.rx_snr; // keep the most recent SNR we received for this node.
 
-        if (mp.decoded.portnum == meshtastic_PortNum_NODEINFO_APP)
-        {
+        if (mp.decoded.portnum == meshtastic_PortNum_NODEINFO_APP) {
             info->channel = mp.channel;
         }
     }
@@ -867,8 +789,7 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
 uint8_t NodeDB::getMeshNodeChannel(NodeNum n)
 {
     const meshtastic_NodeInfoLite *info = getMeshNode(n);
-    if (!info)
-    {
+    if (!info) {
         return 0; // defaults to PRIMARY
     }
     return info->channel;
@@ -890,26 +811,21 @@ meshtastic_NodeInfoLite *NodeDB::getOrCreateMeshNode(NodeNum n)
 {
     meshtastic_NodeInfoLite *lite = getMeshNode(n);
 
-    if (!lite)
-    {
-        if ((*numMeshNodes >= MAX_NUM_NODES) || (memGet.getFreeHeap() < meshtastic_NodeInfoLite_size * 3))
-        {
+    if (!lite) {
+        if ((*numMeshNodes >= MAX_NUM_NODES) || (memGet.getFreeHeap() < meshtastic_NodeInfoLite_size * 3)) {
             if (screen)
                 screen->print("warning: node_db_lite full! erasing oldest entry\n");
             // look for oldest node and erase it
             uint32_t oldest = UINT32_MAX;
             int oldestIndex = -1;
-            for (int i = 0; i < *numMeshNodes; i++)
-            {
-                if (meshNodes[i].last_heard < oldest)
-                {
+            for (int i = 0; i < *numMeshNodes; i++) {
+                if (meshNodes[i].last_heard < oldest) {
                     oldest = meshNodes[i].last_heard;
                     oldestIndex = i;
                 }
             }
             // Shove the remaining nodes down the chain
-            for (int i = oldestIndex; i < *numMeshNodes - 1; i++)
-            {
+            for (int i = oldestIndex; i < *numMeshNodes - 1; i++) {
                 meshNodes[i] = meshNodes[i + 1];
             }
             (*numMeshNodes)--;
@@ -931,12 +847,9 @@ void recordCriticalError(meshtastic_CriticalErrorCode code, uint32_t address, co
     // Print error to screen and serial port
     String lcd = String("Critical error ") + code + "!\n";
     screen->print(lcd.c_str());
-    if (filename)
-    {
+    if (filename) {
         LOG_ERROR("NOTE! Recording critical error %d at %s:%lu\n", code, filename, address);
-    }
-    else
-    {
+    } else {
         LOG_ERROR("NOTE! Recording critical error %d, address=0x%lx\n", code, address);
     }
 

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -81,11 +81,13 @@ bool NodeDB::resetRadioConfig(bool factory_reset)
 
     radioGeneration++;
 
-    if (factory_reset) {
+    if (factory_reset)
+    {
         didFactoryReset = factoryReset();
     }
 
-    if (channelFile.channels_count != MAX_NUM_CHANNELS) {
+    if (channelFile.channels_count != MAX_NUM_CHANNELS)
+    {
         LOG_INFO("Setting default channel and radio preferences!\n");
 
         channels.initDefaults();
@@ -95,7 +97,8 @@ bool NodeDB::resetRadioConfig(bool factory_reset)
 
     // temp hack for quicker testing
     // devicestate.no_save = true;
-    if (devicestate.no_save) {
+    if (devicestate.no_save)
+    {
         LOG_DEBUG("***** DEVELOPMENT MODE - DO NOT RELEASE *****\n");
 
         // Sleep quite frequently to stress test the BLE comms, broadcast position every 6 mins
@@ -112,7 +115,8 @@ bool NodeDB::resetRadioConfig(bool factory_reset)
     // Update the global myRegion
     initRegion();
 
-    if (didFactoryReset) {
+    if (didFactoryReset)
+    {
         LOG_INFO("Rebooting due to factory reset");
         screen->startRebootScreen();
         rebootAtMsec = millis() + (5 * 1000);
@@ -267,14 +271,21 @@ void NodeDB::installDefaultModuleConfig()
 
 void NodeDB::installRoleDefaults(meshtastic_Config_DeviceConfig_Role role)
 {
-    if (role == meshtastic_Config_DeviceConfig_Role_ROUTER) {
+    if (role == meshtastic_Config_DeviceConfig_Role_ROUTER)
+    {
         initConfigIntervals();
         initModuleConfigIntervals();
-    } else if (role == meshtastic_Config_DeviceConfig_Role_REPEATER) {
+    }
+    else if (role == meshtastic_Config_DeviceConfig_Role_REPEATER)
+    {
         config.display.screen_on_secs = 1;
-    } else if (role == meshtastic_Config_DeviceConfig_Role_TRACKER) {
+    }
+    else if (role == meshtastic_Config_DeviceConfig_Role_TRACKER)
+    {
         config.position.gps_update_interval = 30;
-    } else if (role == meshtastic_Config_DeviceConfig_Role_SENSOR) {
+    }
+    else if (role == meshtastic_Config_DeviceConfig_Role_SENSOR)
+    {
         moduleConfig.telemetry.environment_measurement_enabled = true;
         moduleConfig.telemetry.environment_update_interval = 300;
     }
@@ -313,7 +324,9 @@ void NodeDB::installDefaultDeviceState()
 
     // init our devicestate with valid flags so protobuf writing/reading will work
     devicestate.has_my_node = true;
+    devicestate.my_node.my_node_num = 0;
     devicestate.has_owner = true;
+    devicestate.owner = {};
     devicestate.node_db_lite_count = 0;
     devicestate.version = DEVICESTATE_CUR_VER;
     devicestate.receive_queue_count = 0; // Not yet implemented FIXME
@@ -372,7 +385,8 @@ void NodeDB::init()
     if (channelFileCRC != crc32Buffer(&channelFile, sizeof(channelFile)))
         saveWhat |= SEGMENT_CHANNELS;
 
-    if (!devicestate.node_remote_hardware_pins) {
+    if (!devicestate.node_remote_hardware_pins)
+    {
         meshtastic_NodeRemoteHardwarePin empty[12] = {meshtastic_RemoteHardwarePin_init_default};
         memcpy(devicestate.node_remote_hardware_pins, empty, sizeof(empty));
     }
@@ -388,25 +402,22 @@ void NodeDB::init()
  */
 void NodeDB::pickNewNodeNum()
 {
-    NodeNum r = myNodeInfo.my_node_num;
-
     getMacAddr(ourMacAddr); // Make sure ourMacAddr is set
 
     // Pick an initial nodenum based on the macaddr
-    r = (ourMacAddr[2] << 24) | (ourMacAddr[3] << 16) | (ourMacAddr[4] << 8) | ourMacAddr[5];
-
-    if (r == NODENUM_BROADCAST || r < NUM_RESERVED)
-        r = NUM_RESERVED; // don't pick a reserved node number
+    NodeNum n = (ourMacAddr[2] << 24) | (ourMacAddr[3] << 16) | (ourMacAddr[4] << 8) | ourMacAddr[5];
 
     meshtastic_NodeInfoLite *found;
-    while ((found = getMeshNode(r)) && memcmp(found->user.macaddr, owner.macaddr, sizeof(owner.macaddr))) {
-        // FIXME: input for random() is int, so NODENUM_BROADCAST becomes -1
-        NodeNum n = random(NUM_RESERVED, NODENUM_BROADCAST); // try a new random choice
-        LOG_WARN("NOTE! Our desired nodenum 0x%x is in use, so trying for 0x%x\n", r, n);
-        r = n;
+    while ((n == NODENUM_BROADCAST || n < NUM_RESERVED) ||
+           ((found = getMeshNode(n)) && memcmp(found->user.macaddr, owner.macaddr, sizeof(owner.macaddr) == 0)))
+    {
+        NodeNum r = random(NUM_RESERVED, LONG_MAX); // try a new random choice
+        LOG_WARN("NOTE! Our desired nodenum 0x%x is invalid or in use, so trying for 0x%x\n", n, r);
+        n = r;
     }
 
-    myNodeInfo.my_node_num = r;
+    LOG_DEBUG("pickNewNodeNum: 0x%08x\n", n);
+    myNodeInfo.my_node_num = n;
 }
 
 static const char *prefFileName = "/prefs/db.proto";
@@ -424,21 +435,27 @@ bool NodeDB::loadProto(const char *filename, size_t protoSize, size_t objSize, c
 
     auto f = FSCom.open(filename, FILE_O_READ);
 
-    if (f) {
+    if (f)
+    {
         LOG_INFO("Loading %s\n", filename);
         pb_istream_t stream = {&readcb, &f, protoSize};
 
         // LOG_DEBUG("Preload channel name=%s\n", channelSettings.name);
 
         memset(dest_struct, 0, objSize);
-        if (!pb_decode(&stream, fields, dest_struct)) {
+        if (!pb_decode(&stream, fields, dest_struct))
+        {
             LOG_ERROR("Error: can't decode protobuf %s\n", PB_GET_ERROR(&stream));
-        } else {
+        }
+        else
+        {
             okay = true;
         }
 
         f.close();
-    } else {
+    }
+    else
+    {
         LOG_INFO("No %s preferences found\n", filename);
     }
 #else
@@ -451,54 +468,79 @@ void NodeDB::loadFromDisk()
 {
     // static DeviceState scratch; We no longer read into a tempbuf because this structure is 15KB of valuable RAM
     if (!loadProto(prefFileName, meshtastic_DeviceState_size, sizeof(meshtastic_DeviceState), &meshtastic_DeviceState_msg,
-                   &devicestate)) {
+                   &devicestate))
+    {
         installDefaultDeviceState(); // Our in RAM copy might now be corrupt
-    } else {
-        if (devicestate.version < DEVICESTATE_MIN_VER) {
+    }
+    else
+    {
+        if (devicestate.version < DEVICESTATE_MIN_VER)
+        {
             LOG_WARN("Devicestate %d is old, discarding\n", devicestate.version);
             factoryReset();
-        } else {
+        }
+        else
+        {
             LOG_INFO("Loaded saved devicestate version %d\n", devicestate.version);
         }
     }
 
     if (!loadProto(configFileName, meshtastic_LocalConfig_size, sizeof(meshtastic_LocalConfig), &meshtastic_LocalConfig_msg,
-                   &config)) {
+                   &config))
+    {
         installDefaultConfig(); // Our in RAM copy might now be corrupt
-    } else {
-        if (config.version < DEVICESTATE_MIN_VER) {
+    }
+    else
+    {
+        if (config.version < DEVICESTATE_MIN_VER)
+        {
             LOG_WARN("config %d is old, discarding\n", config.version);
             installDefaultConfig();
-        } else {
+        }
+        else
+        {
             LOG_INFO("Loaded saved config version %d\n", config.version);
         }
     }
 
     if (!loadProto(moduleConfigFileName, meshtastic_LocalModuleConfig_size, sizeof(meshtastic_LocalModuleConfig),
-                   &meshtastic_LocalModuleConfig_msg, &moduleConfig)) {
+                   &meshtastic_LocalModuleConfig_msg, &moduleConfig))
+    {
         installDefaultModuleConfig(); // Our in RAM copy might now be corrupt
-    } else {
-        if (moduleConfig.version < DEVICESTATE_MIN_VER) {
+    }
+    else
+    {
+        if (moduleConfig.version < DEVICESTATE_MIN_VER)
+        {
             LOG_WARN("moduleConfig %d is old, discarding\n", moduleConfig.version);
             installDefaultModuleConfig();
-        } else {
+        }
+        else
+        {
             LOG_INFO("Loaded saved moduleConfig version %d\n", moduleConfig.version);
         }
     }
 
     if (!loadProto(channelFileName, meshtastic_ChannelFile_size, sizeof(meshtastic_ChannelFile), &meshtastic_ChannelFile_msg,
-                   &channelFile)) {
+                   &channelFile))
+    {
         installDefaultChannels(); // Our in RAM copy might now be corrupt
-    } else {
-        if (channelFile.version < DEVICESTATE_MIN_VER) {
+    }
+    else
+    {
+        if (channelFile.version < DEVICESTATE_MIN_VER)
+        {
             LOG_WARN("channelFile %d is old, discarding\n", channelFile.version);
             installDefaultChannels();
-        } else {
+        }
+        else
+        {
             LOG_INFO("Loaded saved channelFile version %d\n", channelFile.version);
         }
     }
 
-    if (loadProto(oemConfigFile, meshtastic_OEMStore_size, sizeof(meshtastic_OEMStore), &meshtastic_OEMStore_msg, &oemStore)) {
+    if (loadProto(oemConfigFile, meshtastic_OEMStore_size, sizeof(meshtastic_OEMStore), &meshtastic_OEMStore_msg, &oemStore))
+    {
         LOG_INFO("Loaded OEMStore\n");
     }
 }
@@ -512,31 +554,40 @@ bool NodeDB::saveProto(const char *filename, size_t protoSize, const pb_msgdesc_
     String filenameTmp = filename;
     filenameTmp += ".tmp";
     auto f = FSCom.open(filenameTmp.c_str(), FILE_O_WRITE);
-    if (f) {
+    if (f)
+    {
         LOG_INFO("Saving %s\n", filename);
         pb_ostream_t stream = {&writecb, &f, protoSize};
 
-        if (!pb_encode(&stream, fields, dest_struct)) {
+        if (!pb_encode(&stream, fields, dest_struct))
+        {
             LOG_ERROR("Error: can't encode protobuf %s\n", PB_GET_ERROR(&stream));
-        } else {
+        }
+        else
+        {
             okay = true;
         }
         f.flush();
         f.close();
 
         // brief window of risk here ;-)
-        if (FSCom.exists(filename) && !FSCom.remove(filename)) {
+        if (FSCom.exists(filename) && !FSCom.remove(filename))
+        {
             LOG_WARN("Can't remove old pref file\n");
         }
-        if (!renameFile(filenameTmp.c_str(), filename)) {
+        if (!renameFile(filenameTmp.c_str(), filename))
+        {
             LOG_ERROR("Error: can't rename new pref file\n");
         }
-    } else {
+    }
+    else
+    {
         LOG_ERROR("Can't write prefs\n");
 #ifdef ARCH_NRF52
         static uint8_t failedCounter = 0;
         failedCounter++;
-        if (failedCounter >= 2) {
+        if (failedCounter >= 2)
+        {
             FSCom.format();
             // After formatting, the device needs to be restarted
             nodeDB.resetRadioConfig(true);
@@ -551,7 +602,8 @@ bool NodeDB::saveProto(const char *filename, size_t protoSize, const pb_msgdesc_
 
 void NodeDB::saveChannelsToDisk()
 {
-    if (!devicestate.no_save) {
+    if (!devicestate.no_save)
+    {
 #ifdef FSCom
         FSCom.mkdir("/prefs");
 #endif
@@ -561,7 +613,8 @@ void NodeDB::saveChannelsToDisk()
 
 void NodeDB::saveDeviceStateToDisk()
 {
-    if (!devicestate.no_save) {
+    if (!devicestate.no_save)
+    {
 #ifdef FSCom
         FSCom.mkdir("/prefs");
 #endif
@@ -571,15 +624,18 @@ void NodeDB::saveDeviceStateToDisk()
 
 void NodeDB::saveToDisk(int saveWhat)
 {
-    if (!devicestate.no_save) {
+    if (!devicestate.no_save)
+    {
 #ifdef FSCom
         FSCom.mkdir("/prefs");
 #endif
-        if (saveWhat & SEGMENT_DEVICESTATE) {
+        if (saveWhat & SEGMENT_DEVICESTATE)
+        {
             saveDeviceStateToDisk();
         }
 
-        if (saveWhat & SEGMENT_CONFIG) {
+        if (saveWhat & SEGMENT_CONFIG)
+        {
             config.has_device = true;
             config.has_display = true;
             config.has_lora = true;
@@ -590,7 +646,8 @@ void NodeDB::saveToDisk(int saveWhat)
             saveProto(configFileName, meshtastic_LocalConfig_size, &meshtastic_LocalConfig_msg, &config);
         }
 
-        if (saveWhat & SEGMENT_MODULECONFIG) {
+        if (saveWhat & SEGMENT_MODULECONFIG)
+        {
             moduleConfig.has_canned_message = true;
             moduleConfig.has_external_notification = true;
             moduleConfig.has_mqtt = true;
@@ -601,10 +658,13 @@ void NodeDB::saveToDisk(int saveWhat)
             saveProto(moduleConfigFileName, meshtastic_LocalModuleConfig_size, &meshtastic_LocalModuleConfig_msg, &moduleConfig);
         }
 
-        if (saveWhat & SEGMENT_CHANNELS) {
+        if (saveWhat & SEGMENT_CHANNELS)
+        {
             saveChannelsToDisk();
         }
-    } else {
+    }
+    else
+    {
         LOG_DEBUG("***** DEVELOPMENT MODE - DO NOT RELEASE - not saving to flash *****\n");
     }
 }
@@ -661,23 +721,29 @@ size_t NodeDB::getNumOnlineMeshNodes()
 void NodeDB::updatePosition(uint32_t nodeId, const meshtastic_Position &p, RxSource src)
 {
     meshtastic_NodeInfoLite *info = getOrCreateMeshNode(nodeId);
-    if (!info) {
+    if (!info)
+    {
         return;
     }
 
-    if (src == RX_SRC_LOCAL) {
+    if (src == RX_SRC_LOCAL)
+    {
         // Local packet, fully authoritative
         LOG_INFO("updatePosition LOCAL pos@%x, time=%u, latI=%d, lonI=%d, alt=%d\n", p.timestamp, p.time, p.latitude_i,
                  p.longitude_i, p.altitude);
 
         info->position = ConvertToPositionLite(p);
         localPosition = p;
-    } else if ((p.time > 0) && !p.latitude_i && !p.longitude_i && !p.timestamp && !p.location_source) {
+    }
+    else if ((p.time > 0) && !p.latitude_i && !p.longitude_i && !p.timestamp && !p.location_source)
+    {
         // FIXME SPECIAL TIME SETTING PACKET FROM EUD TO RADIO
         // (stop-gap fix for issue #900)
         LOG_DEBUG("updatePosition SPECIAL time setting time=%u\n", p.time);
         info->position.time = p.time;
-    } else {
+    }
+    else
+    {
         // Be careful to only update fields that have been set by the REMOTE sender
         // A lot of position reports don't have time populated.  In that case, be careful to not blow away the time we
         // recorded based on the packet rxTime
@@ -707,14 +773,18 @@ void NodeDB::updateTelemetry(uint32_t nodeId, const meshtastic_Telemetry &t, RxS
 {
     meshtastic_NodeInfoLite *info = getOrCreateMeshNode(nodeId);
     // Environment metrics should never go to NodeDb but we'll safegaurd anyway
-    if (!info || t.which_variant != meshtastic_Telemetry_device_metrics_tag) {
+    if (!info || t.which_variant != meshtastic_Telemetry_device_metrics_tag)
+    {
         return;
     }
 
-    if (src == RX_SRC_LOCAL) {
+    if (src == RX_SRC_LOCAL)
+    {
         // Local packet, fully authoritative
         LOG_DEBUG("updateTelemetry LOCAL\n");
-    } else {
+    }
+    else
+    {
         LOG_DEBUG("updateTelemetry REMOTE node=0x%x \n", nodeId);
     }
     info->device_metrics = t.variant.device_metrics;
@@ -728,7 +798,8 @@ void NodeDB::updateTelemetry(uint32_t nodeId, const meshtastic_Telemetry &t, RxS
 bool NodeDB::updateUser(uint32_t nodeId, const meshtastic_User &p)
 {
     meshtastic_NodeInfoLite *info = getOrCreateMeshNode(nodeId);
-    if (!info) {
+    if (!info)
+    {
         return false;
     }
 
@@ -741,7 +812,8 @@ bool NodeDB::updateUser(uint32_t nodeId, const meshtastic_User &p)
     LOG_DEBUG("updating changed=%d user %s/%s/%s\n", changed, info->user.id, info->user.long_name, info->user.short_name);
     info->has_user = true;
 
-    if (changed) {
+    if (changed)
+    {
         updateGUIforNode = info;
         powerFSM.trigger(EVENT_NODEDB_UPDATED);
         notifyObservers(true); // Force an update whether or not our node counts have changed
@@ -757,11 +829,13 @@ bool NodeDB::updateUser(uint32_t nodeId, const meshtastic_User &p)
 /// we updateGUI and updateGUIforNode if we think our this change is big enough for a redraw
 void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
 {
-    if (mp.which_payload_variant == meshtastic_MeshPacket_decoded_tag && mp.from) {
+    if (mp.which_payload_variant == meshtastic_MeshPacket_decoded_tag && mp.from)
+    {
         LOG_DEBUG("Update DB node 0x%x, rx_time=%u, channel=%d\n", mp.from, mp.rx_time, mp.channel);
 
         meshtastic_NodeInfoLite *info = getOrCreateMeshNode(getFrom(&mp));
-        if (!info) {
+        if (!info)
+        {
             return;
         }
 
@@ -771,7 +845,8 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
         if (mp.rx_snr)
             info->snr = mp.rx_snr; // keep the most recent SNR we received for this node.
 
-        if (mp.decoded.portnum == meshtastic_PortNum_NODEINFO_APP) {
+        if (mp.decoded.portnum == meshtastic_PortNum_NODEINFO_APP)
+        {
             info->channel = mp.channel;
         }
     }
@@ -780,7 +855,8 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
 uint8_t NodeDB::getMeshNodeChannel(NodeNum n)
 {
     const meshtastic_NodeInfoLite *info = getMeshNode(n);
-    if (!info) {
+    if (!info)
+    {
         return 0; // defaults to PRIMARY
     }
     return info->channel;
@@ -802,21 +878,26 @@ meshtastic_NodeInfoLite *NodeDB::getOrCreateMeshNode(NodeNum n)
 {
     meshtastic_NodeInfoLite *lite = getMeshNode(n);
 
-    if (!lite) {
-        if ((*numMeshNodes >= MAX_NUM_NODES) || (memGet.getFreeHeap() < meshtastic_NodeInfoLite_size * 3)) {
+    if (!lite)
+    {
+        if ((*numMeshNodes >= MAX_NUM_NODES) || (memGet.getFreeHeap() < meshtastic_NodeInfoLite_size * 3))
+        {
             if (screen)
                 screen->print("warning: node_db_lite full! erasing oldest entry\n");
             // look for oldest node and erase it
             uint32_t oldest = UINT32_MAX;
             int oldestIndex = -1;
-            for (int i = 0; i < *numMeshNodes; i++) {
-                if (meshNodes[i].last_heard < oldest) {
+            for (int i = 0; i < *numMeshNodes; i++)
+            {
+                if (meshNodes[i].last_heard < oldest)
+                {
                     oldest = meshNodes[i].last_heard;
                     oldestIndex = i;
                 }
             }
             // Shove the remaining nodes down the chain
-            for (int i = oldestIndex; i < *numMeshNodes - 1; i++) {
+            for (int i = oldestIndex; i < *numMeshNodes - 1; i++)
+            {
                 meshNodes[i] = meshNodes[i + 1];
             }
             (*numMeshNodes)--;
@@ -838,9 +919,12 @@ void recordCriticalError(meshtastic_CriticalErrorCode code, uint32_t address, co
     // Print error to screen and serial port
     String lcd = String("Critical error ") + code + "!\n";
     screen->print(lcd.c_str());
-    if (filename) {
+    if (filename)
+    {
         LOG_ERROR("NOTE! Recording critical error %d at %s:%lu\n", code, filename, address);
-    } else {
+    }
+    else
+    {
         LOG_ERROR("NOTE! Recording critical error %d, address=0x%lx\n", code, address);
     }
 

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -81,11 +81,13 @@ bool NodeDB::resetRadioConfig(bool factory_reset)
 
     radioGeneration++;
 
-    if (factory_reset) {
+    if (factory_reset)
+    {
         didFactoryReset = factoryReset();
     }
 
-    if (channelFile.channels_count != MAX_NUM_CHANNELS) {
+    if (channelFile.channels_count != MAX_NUM_CHANNELS)
+    {
         LOG_INFO("Setting default channel and radio preferences!\n");
 
         channels.initDefaults();
@@ -95,7 +97,8 @@ bool NodeDB::resetRadioConfig(bool factory_reset)
 
     // temp hack for quicker testing
     // devicestate.no_save = true;
-    if (devicestate.no_save) {
+    if (devicestate.no_save)
+    {
         LOG_DEBUG("***** DEVELOPMENT MODE - DO NOT RELEASE *****\n");
 
         // Sleep quite frequently to stress test the BLE comms, broadcast position every 6 mins
@@ -112,7 +115,8 @@ bool NodeDB::resetRadioConfig(bool factory_reset)
     // Update the global myRegion
     initRegion();
 
-    if (didFactoryReset) {
+    if (didFactoryReset)
+    {
         LOG_INFO("Rebooting due to factory reset");
         screen->startRebootScreen();
         rebootAtMsec = millis() + (5 * 1000);
@@ -267,14 +271,21 @@ void NodeDB::installDefaultModuleConfig()
 
 void NodeDB::installRoleDefaults(meshtastic_Config_DeviceConfig_Role role)
 {
-    if (role == meshtastic_Config_DeviceConfig_Role_ROUTER) {
+    if (role == meshtastic_Config_DeviceConfig_Role_ROUTER)
+    {
         initConfigIntervals();
         initModuleConfigIntervals();
-    } else if (role == meshtastic_Config_DeviceConfig_Role_REPEATER) {
+    }
+    else if (role == meshtastic_Config_DeviceConfig_Role_REPEATER)
+    {
         config.display.screen_on_secs = 1;
-    } else if (role == meshtastic_Config_DeviceConfig_Role_TRACKER) {
+    }
+    else if (role == meshtastic_Config_DeviceConfig_Role_TRACKER)
+    {
         config.position.gps_update_interval = 30;
-    } else if (role == meshtastic_Config_DeviceConfig_Role_SENSOR) {
+    }
+    else if (role == meshtastic_Config_DeviceConfig_Role_SENSOR)
+    {
         moduleConfig.telemetry.environment_measurement_enabled = true;
         moduleConfig.telemetry.environment_update_interval = 300;
     }
@@ -304,6 +315,20 @@ void NodeDB::resetNodes()
         neighborInfoModule->resetNeighbors();
 }
 
+void NodeDB::cleanupMeshDB()
+{
+    int newPos = 0, removed = 0;
+    for (int i = 0; i < *numMeshNodes; i++)
+    {
+        if (meshNodes[i].has_user)
+            meshNodes[newPos++] = meshNodes[i];
+        else
+            removed++;
+    }
+    *numMeshNodes -= removed;
+    LOG_DEBUG("cleanupMeshDB purged %d entries\n", removed);
+}
+
 void NodeDB::installDefaultDeviceState()
 {
     LOG_INFO("Installing default DeviceState\n");
@@ -313,9 +338,7 @@ void NodeDB::installDefaultDeviceState()
 
     // init our devicestate with valid flags so protobuf writing/reading will work
     devicestate.has_my_node = true;
-    devicestate.my_node.my_node_num = 0;
     devicestate.has_owner = true;
-    devicestate.owner = {};
     devicestate.node_db_lite_count = 0;
     devicestate.version = DEVICESTATE_CUR_VER;
     devicestate.receive_queue_count = 0; // Not yet implemented FIXME
@@ -335,6 +358,7 @@ void NodeDB::init()
 {
     LOG_INFO("Initializing NodeDB\n");
     loadFromDisk();
+    cleanupMeshDB();
 
     uint32_t devicestateCRC = crc32Buffer(&devicestate, sizeof(devicestate));
     uint32_t configCRC = crc32Buffer(&config, sizeof(config));
@@ -374,7 +398,8 @@ void NodeDB::init()
     if (channelFileCRC != crc32Buffer(&channelFile, sizeof(channelFile)))
         saveWhat |= SEGMENT_CHANNELS;
 
-    if (!devicestate.node_remote_hardware_pins) {
+    if (!devicestate.node_remote_hardware_pins)
+    {
         meshtastic_NodeRemoteHardwarePin empty[12] = {meshtastic_RemoteHardwarePin_init_default};
         memcpy(devicestate.node_remote_hardware_pins, empty, sizeof(empty));
     }
@@ -397,13 +422,13 @@ void NodeDB::pickNewNodeNum()
 
     meshtastic_NodeInfoLite *found;
     while ((nodeNum == NODENUM_BROADCAST || nodeNum < NUM_RESERVED) ||
-           ((found = getMeshNode(nodeNum)) && memcmp(found->user.macaddr, owner.macaddr, sizeof(owner.macaddr)) != 0)) {
+           ((found = getMeshNode(nodeNum)) && memcmp(found->user.macaddr, owner.macaddr, sizeof(owner.macaddr)) != 0))
+    {
         NodeNum candidate = random(NUM_RESERVED, LONG_MAX); // try a new random choice
         LOG_WARN("NOTE! Our desired nodenum 0x%x is invalid or in use, so trying for 0x%x\n", nodeNum, candidate);
         nodeNum = candidate;
     }
 
-    LOG_DEBUG("pickNewNodeNum: 0x%08x\n", nodeNum);
     myNodeInfo.my_node_num = nodeNum;
 }
 
@@ -422,21 +447,27 @@ bool NodeDB::loadProto(const char *filename, size_t protoSize, size_t objSize, c
 
     auto f = FSCom.open(filename, FILE_O_READ);
 
-    if (f) {
+    if (f)
+    {
         LOG_INFO("Loading %s\n", filename);
         pb_istream_t stream = {&readcb, &f, protoSize};
 
         // LOG_DEBUG("Preload channel name=%s\n", channelSettings.name);
 
         memset(dest_struct, 0, objSize);
-        if (!pb_decode(&stream, fields, dest_struct)) {
+        if (!pb_decode(&stream, fields, dest_struct))
+        {
             LOG_ERROR("Error: can't decode protobuf %s\n", PB_GET_ERROR(&stream));
-        } else {
+        }
+        else
+        {
             okay = true;
         }
 
         f.close();
-    } else {
+    }
+    else
+    {
         LOG_INFO("No %s preferences found\n", filename);
     }
 #else
@@ -449,54 +480,79 @@ void NodeDB::loadFromDisk()
 {
     // static DeviceState scratch; We no longer read into a tempbuf because this structure is 15KB of valuable RAM
     if (!loadProto(prefFileName, meshtastic_DeviceState_size, sizeof(meshtastic_DeviceState), &meshtastic_DeviceState_msg,
-                   &devicestate)) {
+                   &devicestate))
+    {
         installDefaultDeviceState(); // Our in RAM copy might now be corrupt
-    } else {
-        if (devicestate.version < DEVICESTATE_MIN_VER) {
+    }
+    else
+    {
+        if (devicestate.version < DEVICESTATE_MIN_VER)
+        {
             LOG_WARN("Devicestate %d is old, discarding\n", devicestate.version);
             factoryReset();
-        } else {
+        }
+        else
+        {
             LOG_INFO("Loaded saved devicestate version %d\n", devicestate.version);
         }
     }
 
     if (!loadProto(configFileName, meshtastic_LocalConfig_size, sizeof(meshtastic_LocalConfig), &meshtastic_LocalConfig_msg,
-                   &config)) {
+                   &config))
+    {
         installDefaultConfig(); // Our in RAM copy might now be corrupt
-    } else {
-        if (config.version < DEVICESTATE_MIN_VER) {
+    }
+    else
+    {
+        if (config.version < DEVICESTATE_MIN_VER)
+        {
             LOG_WARN("config %d is old, discarding\n", config.version);
             installDefaultConfig();
-        } else {
+        }
+        else
+        {
             LOG_INFO("Loaded saved config version %d\n", config.version);
         }
     }
 
     if (!loadProto(moduleConfigFileName, meshtastic_LocalModuleConfig_size, sizeof(meshtastic_LocalModuleConfig),
-                   &meshtastic_LocalModuleConfig_msg, &moduleConfig)) {
+                   &meshtastic_LocalModuleConfig_msg, &moduleConfig))
+    {
         installDefaultModuleConfig(); // Our in RAM copy might now be corrupt
-    } else {
-        if (moduleConfig.version < DEVICESTATE_MIN_VER) {
+    }
+    else
+    {
+        if (moduleConfig.version < DEVICESTATE_MIN_VER)
+        {
             LOG_WARN("moduleConfig %d is old, discarding\n", moduleConfig.version);
             installDefaultModuleConfig();
-        } else {
+        }
+        else
+        {
             LOG_INFO("Loaded saved moduleConfig version %d\n", moduleConfig.version);
         }
     }
 
     if (!loadProto(channelFileName, meshtastic_ChannelFile_size, sizeof(meshtastic_ChannelFile), &meshtastic_ChannelFile_msg,
-                   &channelFile)) {
+                   &channelFile))
+    {
         installDefaultChannels(); // Our in RAM copy might now be corrupt
-    } else {
-        if (channelFile.version < DEVICESTATE_MIN_VER) {
+    }
+    else
+    {
+        if (channelFile.version < DEVICESTATE_MIN_VER)
+        {
             LOG_WARN("channelFile %d is old, discarding\n", channelFile.version);
             installDefaultChannels();
-        } else {
+        }
+        else
+        {
             LOG_INFO("Loaded saved channelFile version %d\n", channelFile.version);
         }
     }
 
-    if (loadProto(oemConfigFile, meshtastic_OEMStore_size, sizeof(meshtastic_OEMStore), &meshtastic_OEMStore_msg, &oemStore)) {
+    if (loadProto(oemConfigFile, meshtastic_OEMStore_size, sizeof(meshtastic_OEMStore), &meshtastic_OEMStore_msg, &oemStore))
+    {
         LOG_INFO("Loaded OEMStore\n");
     }
 }
@@ -510,31 +566,40 @@ bool NodeDB::saveProto(const char *filename, size_t protoSize, const pb_msgdesc_
     String filenameTmp = filename;
     filenameTmp += ".tmp";
     auto f = FSCom.open(filenameTmp.c_str(), FILE_O_WRITE);
-    if (f) {
+    if (f)
+    {
         LOG_INFO("Saving %s\n", filename);
         pb_ostream_t stream = {&writecb, &f, protoSize};
 
-        if (!pb_encode(&stream, fields, dest_struct)) {
+        if (!pb_encode(&stream, fields, dest_struct))
+        {
             LOG_ERROR("Error: can't encode protobuf %s\n", PB_GET_ERROR(&stream));
-        } else {
+        }
+        else
+        {
             okay = true;
         }
         f.flush();
         f.close();
 
         // brief window of risk here ;-)
-        if (FSCom.exists(filename) && !FSCom.remove(filename)) {
+        if (FSCom.exists(filename) && !FSCom.remove(filename))
+        {
             LOG_WARN("Can't remove old pref file\n");
         }
-        if (!renameFile(filenameTmp.c_str(), filename)) {
+        if (!renameFile(filenameTmp.c_str(), filename))
+        {
             LOG_ERROR("Error: can't rename new pref file\n");
         }
-    } else {
+    }
+    else
+    {
         LOG_ERROR("Can't write prefs\n");
 #ifdef ARCH_NRF52
         static uint8_t failedCounter = 0;
         failedCounter++;
-        if (failedCounter >= 2) {
+        if (failedCounter >= 2)
+        {
             FSCom.format();
             // After formatting, the device needs to be restarted
             nodeDB.resetRadioConfig(true);
@@ -549,7 +614,8 @@ bool NodeDB::saveProto(const char *filename, size_t protoSize, const pb_msgdesc_
 
 void NodeDB::saveChannelsToDisk()
 {
-    if (!devicestate.no_save) {
+    if (!devicestate.no_save)
+    {
 #ifdef FSCom
         FSCom.mkdir("/prefs");
 #endif
@@ -559,7 +625,8 @@ void NodeDB::saveChannelsToDisk()
 
 void NodeDB::saveDeviceStateToDisk()
 {
-    if (!devicestate.no_save) {
+    if (!devicestate.no_save)
+    {
 #ifdef FSCom
         FSCom.mkdir("/prefs");
 #endif
@@ -569,15 +636,18 @@ void NodeDB::saveDeviceStateToDisk()
 
 void NodeDB::saveToDisk(int saveWhat)
 {
-    if (!devicestate.no_save) {
+    if (!devicestate.no_save)
+    {
 #ifdef FSCom
         FSCom.mkdir("/prefs");
 #endif
-        if (saveWhat & SEGMENT_DEVICESTATE) {
+        if (saveWhat & SEGMENT_DEVICESTATE)
+        {
             saveDeviceStateToDisk();
         }
 
-        if (saveWhat & SEGMENT_CONFIG) {
+        if (saveWhat & SEGMENT_CONFIG)
+        {
             config.has_device = true;
             config.has_display = true;
             config.has_lora = true;
@@ -588,7 +658,8 @@ void NodeDB::saveToDisk(int saveWhat)
             saveProto(configFileName, meshtastic_LocalConfig_size, &meshtastic_LocalConfig_msg, &config);
         }
 
-        if (saveWhat & SEGMENT_MODULECONFIG) {
+        if (saveWhat & SEGMENT_MODULECONFIG)
+        {
             moduleConfig.has_canned_message = true;
             moduleConfig.has_external_notification = true;
             moduleConfig.has_mqtt = true;
@@ -599,10 +670,13 @@ void NodeDB::saveToDisk(int saveWhat)
             saveProto(moduleConfigFileName, meshtastic_LocalModuleConfig_size, &meshtastic_LocalModuleConfig_msg, &moduleConfig);
         }
 
-        if (saveWhat & SEGMENT_CHANNELS) {
+        if (saveWhat & SEGMENT_CHANNELS)
+        {
             saveChannelsToDisk();
         }
-    } else {
+    }
+    else
+    {
         LOG_DEBUG("***** DEVELOPMENT MODE - DO NOT RELEASE - not saving to flash *****\n");
     }
 }
@@ -659,23 +733,29 @@ size_t NodeDB::getNumOnlineMeshNodes()
 void NodeDB::updatePosition(uint32_t nodeId, const meshtastic_Position &p, RxSource src)
 {
     meshtastic_NodeInfoLite *info = getOrCreateMeshNode(nodeId);
-    if (!info) {
+    if (!info)
+    {
         return;
     }
 
-    if (src == RX_SRC_LOCAL) {
+    if (src == RX_SRC_LOCAL)
+    {
         // Local packet, fully authoritative
         LOG_INFO("updatePosition LOCAL pos@%x, time=%u, latI=%d, lonI=%d, alt=%d\n", p.timestamp, p.time, p.latitude_i,
                  p.longitude_i, p.altitude);
 
         info->position = ConvertToPositionLite(p);
         localPosition = p;
-    } else if ((p.time > 0) && !p.latitude_i && !p.longitude_i && !p.timestamp && !p.location_source) {
+    }
+    else if ((p.time > 0) && !p.latitude_i && !p.longitude_i && !p.timestamp && !p.location_source)
+    {
         // FIXME SPECIAL TIME SETTING PACKET FROM EUD TO RADIO
         // (stop-gap fix for issue #900)
         LOG_DEBUG("updatePosition SPECIAL time setting time=%u\n", p.time);
         info->position.time = p.time;
-    } else {
+    }
+    else
+    {
         // Be careful to only update fields that have been set by the REMOTE sender
         // A lot of position reports don't have time populated.  In that case, be careful to not blow away the time we
         // recorded based on the packet rxTime
@@ -705,14 +785,18 @@ void NodeDB::updateTelemetry(uint32_t nodeId, const meshtastic_Telemetry &t, RxS
 {
     meshtastic_NodeInfoLite *info = getOrCreateMeshNode(nodeId);
     // Environment metrics should never go to NodeDb but we'll safegaurd anyway
-    if (!info || t.which_variant != meshtastic_Telemetry_device_metrics_tag) {
+    if (!info || t.which_variant != meshtastic_Telemetry_device_metrics_tag)
+    {
         return;
     }
 
-    if (src == RX_SRC_LOCAL) {
+    if (src == RX_SRC_LOCAL)
+    {
         // Local packet, fully authoritative
         LOG_DEBUG("updateTelemetry LOCAL\n");
-    } else {
+    }
+    else
+    {
         LOG_DEBUG("updateTelemetry REMOTE node=0x%x \n", nodeId);
     }
     info->device_metrics = t.variant.device_metrics;
@@ -726,7 +810,8 @@ void NodeDB::updateTelemetry(uint32_t nodeId, const meshtastic_Telemetry &t, RxS
 bool NodeDB::updateUser(uint32_t nodeId, const meshtastic_User &p)
 {
     meshtastic_NodeInfoLite *info = getOrCreateMeshNode(nodeId);
-    if (!info) {
+    if (!info)
+    {
         return false;
     }
 
@@ -739,7 +824,8 @@ bool NodeDB::updateUser(uint32_t nodeId, const meshtastic_User &p)
     LOG_DEBUG("updating changed=%d user %s/%s/%s\n", changed, info->user.id, info->user.long_name, info->user.short_name);
     info->has_user = true;
 
-    if (changed) {
+    if (changed)
+    {
         updateGUIforNode = info;
         powerFSM.trigger(EVENT_NODEDB_UPDATED);
         notifyObservers(true); // Force an update whether or not our node counts have changed
@@ -755,11 +841,13 @@ bool NodeDB::updateUser(uint32_t nodeId, const meshtastic_User &p)
 /// we updateGUI and updateGUIforNode if we think our this change is big enough for a redraw
 void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
 {
-    if (mp.which_payload_variant == meshtastic_MeshPacket_decoded_tag && mp.from) {
+    if (mp.which_payload_variant == meshtastic_MeshPacket_decoded_tag && mp.from)
+    {
         LOG_DEBUG("Update DB node 0x%x, rx_time=%u, channel=%d\n", mp.from, mp.rx_time, mp.channel);
 
         meshtastic_NodeInfoLite *info = getOrCreateMeshNode(getFrom(&mp));
-        if (!info) {
+        if (!info)
+        {
             return;
         }
 
@@ -769,7 +857,8 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
         if (mp.rx_snr)
             info->snr = mp.rx_snr; // keep the most recent SNR we received for this node.
 
-        if (mp.decoded.portnum == meshtastic_PortNum_NODEINFO_APP) {
+        if (mp.decoded.portnum == meshtastic_PortNum_NODEINFO_APP)
+        {
             info->channel = mp.channel;
         }
     }
@@ -778,7 +867,8 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
 uint8_t NodeDB::getMeshNodeChannel(NodeNum n)
 {
     const meshtastic_NodeInfoLite *info = getMeshNode(n);
-    if (!info) {
+    if (!info)
+    {
         return 0; // defaults to PRIMARY
     }
     return info->channel;
@@ -800,21 +890,26 @@ meshtastic_NodeInfoLite *NodeDB::getOrCreateMeshNode(NodeNum n)
 {
     meshtastic_NodeInfoLite *lite = getMeshNode(n);
 
-    if (!lite) {
-        if ((*numMeshNodes >= MAX_NUM_NODES) || (memGet.getFreeHeap() < meshtastic_NodeInfoLite_size * 3)) {
+    if (!lite)
+    {
+        if ((*numMeshNodes >= MAX_NUM_NODES) || (memGet.getFreeHeap() < meshtastic_NodeInfoLite_size * 3))
+        {
             if (screen)
                 screen->print("warning: node_db_lite full! erasing oldest entry\n");
             // look for oldest node and erase it
             uint32_t oldest = UINT32_MAX;
             int oldestIndex = -1;
-            for (int i = 0; i < *numMeshNodes; i++) {
-                if (meshNodes[i].last_heard < oldest) {
+            for (int i = 0; i < *numMeshNodes; i++)
+            {
+                if (meshNodes[i].last_heard < oldest)
+                {
                     oldest = meshNodes[i].last_heard;
                     oldestIndex = i;
                 }
             }
             // Shove the remaining nodes down the chain
-            for (int i = oldestIndex; i < *numMeshNodes - 1; i++) {
+            for (int i = oldestIndex; i < *numMeshNodes - 1; i++)
+            {
                 meshNodes[i] = meshNodes[i + 1];
             }
             (*numMeshNodes)--;
@@ -836,9 +931,12 @@ void recordCriticalError(meshtastic_CriticalErrorCode code, uint32_t address, co
     // Print error to screen and serial port
     String lcd = String("Critical error ") + code + "!\n";
     screen->print(lcd.c_str());
-    if (filename) {
+    if (filename)
+    {
         LOG_ERROR("NOTE! Recording critical error %d at %s:%lu\n", code, filename, address);
-    } else {
+    }
+    else
+    {
         LOG_ERROR("NOTE! Recording critical error %d, address=0x%lx\n", code, address);
     }
 

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -393,18 +393,18 @@ void NodeDB::pickNewNodeNum()
     getMacAddr(ourMacAddr); // Make sure ourMacAddr is set
 
     // Pick an initial nodenum based on the macaddr
-    NodeNum n = (ourMacAddr[2] << 24) | (ourMacAddr[3] << 16) | (ourMacAddr[4] << 8) | ourMacAddr[5];
+    NodeNum nodeNum = (ourMacAddr[2] << 24) | (ourMacAddr[3] << 16) | (ourMacAddr[4] << 8) | ourMacAddr[5];
 
     meshtastic_NodeInfoLite *found;
-    while ((n == NODENUM_BROADCAST || n < NUM_RESERVED) ||
-           ((found = getMeshNode(n)) && memcmp(found->user.macaddr, owner.macaddr, sizeof(owner.macaddr) == 0))) {
-        NodeNum r = random(NUM_RESERVED, LONG_MAX); // try a new random choice
-        LOG_WARN("NOTE! Our desired nodenum 0x%x is invalid or in use, so trying for 0x%x\n", n, r);
-        n = r;
+    while ((nodeNum == NODENUM_BROADCAST || nodeNum < NUM_RESERVED) ||
+           ((found = getMeshNode(nodeNum)) && memcmp(found->user.macaddr, owner.macaddr, sizeof(owner.macaddr)) != 0)) {
+        NodeNum candidate = random(NUM_RESERVED, LONG_MAX); // try a new random choice
+        LOG_WARN("NOTE! Our desired nodenum 0x%x is invalid or in use, so trying for 0x%x\n", nodeNum, candidate);
+        nodeNum = candidate;
     }
 
-    LOG_DEBUG("pickNewNodeNum: 0x%08x\n", n);
-    myNodeInfo.my_node_num = n;
+    LOG_DEBUG("pickNewNodeNum: 0x%08x\n", nodeNum);
+    myNodeInfo.my_node_num = nodeNum;
 }
 
 static const char *prefFileName = "/prefs/db.proto";

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -146,6 +146,9 @@ class NodeDB
     /// read our db from flash
     void loadFromDisk();
 
+    /// purge db entries without user info
+    void cleanupMeshDB();
+
     /// Reinit device state from scratch (not loading from disk)
     void installDefaultDeviceState(), installDefaultChannels(), installDefaultConfig(), installDefaultModuleConfig();
 };


### PR DESCRIPTION
fix for #2754.

Root cause:
When receiving the admin message to reset the NodeDB an empty db is saved and then waited for 7s for reboot. If in the meantime a new node msg was received then it is saved in db.proto (before the reboot), however the own mac address is 0 in this list (as the own node was already removed). This will lead to the discrepancy on next reboot. 

This fix does the following: when the node starts and loads the db.proto then the meshnode array is checked for entries with has_user==false and removes these as they are the problematic ones (and not shown at the client anyway). 
