### PR TITLE
Always turn on TCXO for SX126X chips

### DIFF
--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -26,7 +26,9 @@ template <typename T> bool SX126xInterface<T>::init()
     pinMode(SX126X_POWER_EN, OUTPUT);
 #endif
     // Always power on the TCXO on SX126X devices, since all of them have a TCXO onboard
-    // which needs to be activated by setting DIO3 to high. Reference: https://github.com/Xinyuan-LilyGO/LilyGo-LoRa-Series/blob/master/schematic/T-SX1262.pdf
+    // which needs to be activated by setting DIO3 to high. Reference:
+    // https://github.com/Xinyuan-LilyGO/LilyGo-LoRa-Series/blob/master/schematic/T-SX1262.pdf
+
     // Use DIO3 to power tcxo per https://github.com/jgromes/RadioLib/issues/12#issuecomment-520695575
     float tcxoVoltage = 1.8;
 

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -25,13 +25,11 @@ template <typename T> bool SX126xInterface<T>::init()
     digitalWrite(SX126X_POWER_EN, HIGH);
     pinMode(SX126X_POWER_EN, OUTPUT);
 #endif
-
-#ifndef SX126X_E22
-    float tcxoVoltage = 0; // None - we use an XTAL
-#else
+    // Always power on the TCXO on SX126X devices, since all of them have a TCXO onboard
+    // which needs to be activated by setting DIO3 to high. Reference: https://github.com/Xinyuan-LilyGO/LilyGo-LoRa-Series/blob/master/schematic/T-SX1262.pdf
     // Use DIO3 to power tcxo per https://github.com/jgromes/RadioLib/issues/12#issuecomment-520695575
     float tcxoVoltage = 1.8;
-#endif
+
     bool useRegulatorLDO = false; // Seems to depend on the connection to pin 9/DCC_SW - if an inductor DCDC?
 
     RadioLibInterface::init();


### PR DESCRIPTION
Always power on the TCXO on SX126X devices, since all of them have a TCXO onboard which needs to be activated by setting DIO3 to high. Reference: https://github.com/Xinyuan-LilyGO/LilyGo-LoRa-Series/blob/master/schematic/T-SX1262.pdf. We don't need to have an "if" check here.

