### PR TITLE
Temp fix for S3 bluetooth

### DIFF
--- a/arch/esp32/esp32.ini
+++ b/arch/esp32/esp32.ini
@@ -1,7 +1,7 @@
 ; Common settings for ESP targes, mixin with extends = esp32_base
 [esp32_base]
 extends = arduino_base
-platform = platformio/espressif32@^6.4.0
+platform = platformio/espressif32@6.3.2
 
 build_src_filter = 
   ${arduino_base.build_src_filter} -<platform/nrf52/> -<platform/stm32wl> -<platform/rp2040> -<mesh/eth/>

--- a/arch/esp32/esp32.ini
+++ b/arch/esp32/esp32.ini
@@ -1,7 +1,7 @@
 ; Common settings for ESP targes, mixin with extends = esp32_base
 [esp32_base]
 extends = arduino_base
-platform = platformio/espressif32@6.3.2
+platform = platformio/espressif32@6.3.2 # This is a temporary fix to the S3-based devices bluetooth issues until we can determine what within ESP-IDF changed and can develop a suitable patch. 
 
 build_src_filter = 
   ${arduino_base.build_src_filter} -<platform/nrf52/> -<platform/stm32wl> -<platform/rp2040> -<mesh/eth/>


### PR DESCRIPTION
Need to roll back espressif to v6.3.2 to avoid the issues in #2793