### PR TITLE
Fix for Pi Pico hang

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -252,7 +252,7 @@ bool GPS::setup()
 {
     int msglen = 0;
 
-    if (_serial_gps && !didSerialInit) {
+    if (!didSerialInit) {
 #if !defined(GPS_UC6580)
         if (tx_gpio) {
             LOG_DEBUG("Probing for GPS at %d \n", serialSpeeds[speedSelect]);
@@ -548,6 +548,8 @@ void GPS::publishUpdate()
 int32_t GPS::runOnce()
 {
     if (!GPSInitFinished) {
+        if (!_serial_gps)
+            return disable();
         if (!setup())
             return 2000; // Setup failed, re-run in two seconds
 

--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -852,7 +852,7 @@ GPS *GPS::createGps()
     if (!_tx_gpio)
         _tx_gpio = GPS_TX_PIN;
 #endif
-    if (!_rx_gpio) // Configured to have no GPS at all
+    if (!_rx_gpio || !_serial_gps) // Configured to have no GPS at all
         return nullptr;
 
     GPS *new_gps = new GPS;


### PR DESCRIPTION
The pico startup code was leaving _serial_gps set to null, but then failing to properly catch that state and short-circuit GPS probing. Fix by disabling the GPS thread when null.