### PR TITLE
Fix compression (#2806)

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -359,6 +359,7 @@ bool perhapsDecode(meshtastic_MeshPacket *p)
                     // LOG_DEBUG("\n\n**\n\nDecompressed length - %d \n", decompressed_len);
 
                     memcpy(p->decoded.payload.bytes, decompressed_out, decompressed_len);
+                    p->decoded.payload.size = decompressed_len;
 
                     // Switch the port from PortNum_TEXT_MESSAGE_COMPRESSED_APP to PortNum_TEXT_MESSAGE_APP
                     p->decoded.portnum = meshtastic_PortNum_TEXT_MESSAGE_APP;


### PR DESCRIPTION
Fixes #2806.

The packet was encoded to protobufs before the `decoded` part was modified, so in protobufs encoding, still the old payload and portnum was used. Furthermore, while decompressing (which actually didn't happen because the portnum was not `TEXT_MESSAGE_COMPRESSED_APP`), the payload size wasn't modified.

Not sure if this has ever worked before, since there were no real changes in this part of the code since it was implemented.