### PR TITLE
remove residual code for `mesh_sds_timeout_secs`

### DIFF
--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -374,10 +374,6 @@ void PowerFSM_setup()
                                       getConfiguredOrDefaultMs(config.power.wait_bluetooth_secs, default_wait_bluetooth_secs),
                                       NULL, "Bluetooth timeout");
     }
-
-    if (config.power.sds_secs != UINT32_MAX)
-        powerFSM.add_timed_transition(lowPowerState, &stateSDS, getConfiguredOrDefaultMs(config.power.sds_secs), NULL,
-                                      "mesh timeout");
 #endif
 
     powerFSM.run_machine(); // run one iteration of the state machine, so we run our on enter tasks for the initial DARK state


### PR DESCRIPTION
```
    if (config.power.sds_secs != UINT32_MAX)
        powerFSM.add_timed_transition(lowPowerState, &stateSDS, getConfiguredOrDefaultMs(config.power.sds_secs), NULL,
                                      "mesh timeout");
```
was originally:

https://github.com/meshtastic/firmware/blob/948146114589cb45aeee154f684f10e8c6551e03/src/PowerFSM.cpp#L358-L359

