### PR TITLE
RP2040: Add SerialModule support 

### DIFF
--- a/src/modules/Modules.cpp
+++ b/src/modules/Modules.cpp
@@ -31,7 +31,7 @@
 #if defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040)
 #include "modules/ExternalNotificationModule.h"
 #include "modules/RangeTestModule.h"
-#if (defined(ARCH_ESP32) || defined(ARCH_NRF52)) && !defined(CONFIG_IDF_TARGET_ESP32S2)
+#if (defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040)) && !defined(CONFIG_IDF_TARGET_ESP32S2)
 #include "modules/SerialModule.h"
 #endif
 #endif
@@ -92,7 +92,8 @@ void setupModules()
             new AirQualityTelemetryModule();
         }
 #endif
-#if (defined(ARCH_ESP32) || defined(ARCH_NRF52)) && !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+#if (defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040)) && !defined(CONFIG_IDF_TARGET_ESP32S2) &&               \
+    !defined(CONFIG_IDF_TARGET_ESP32C3)
         new SerialModule();
 #endif
 #ifdef ARCH_ESP32

--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -47,7 +47,7 @@
 #if (defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040)) && !defined(CONFIG_IDF_TARGET_ESP32S2) &&               \
     !defined(CONFIG_IDF_TARGET_ESP32C3)
 
-#define RX_BUFFER 128
+#define RX_BUFFER 256
 #define TIMEOUT 250
 #define BAUD 38400
 #define ACK 1

--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -188,7 +188,7 @@ int32_t SerialModule::runOnce()
                     }
                 }
             }
-#if !defined(TTGO_T_ECHO) && !defined(ARCH_RP2040)
+#if !defined(TTGO_T_ECHO)
             else {
                 while (Serial2.available()) {
                     serialPayloadSize = Serial2.readBytes(serialBytes, meshtastic_Constants_DATA_PAYLOAD_LEN);

--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -44,7 +44,8 @@
 
 */
 
-#if (defined(ARCH_ESP32) || defined(ARCH_NRF52)) && !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+#if (defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040)) && !defined(CONFIG_IDF_TARGET_ESP32S2) &&               \
+    !defined(CONFIG_IDF_TARGET_ESP32C3)
 
 #define RX_BUFFER 128
 #define TIMEOUT 250
@@ -141,7 +142,12 @@ int32_t SerialModule::runOnce()
             }
 #elif !defined(TTGO_T_ECHO)
             if (moduleConfig.serial.rxd && moduleConfig.serial.txd) {
+#ifdef ARCH_RP2040
+                Serial2.setFIFOSize(RX_BUFFER);
+                Serial2.setPinout(moduleConfig.serial.txd, moduleConfig.serial.rxd);
+#else
                 Serial2.setPins(moduleConfig.serial.rxd, moduleConfig.serial.txd);
+#endif
                 Serial2.begin(baud, SERIAL_8N1);
                 Serial2.setTimeout(moduleConfig.serial.timeout > 0 ? moduleConfig.serial.timeout : TIMEOUT);
             } else {
@@ -182,7 +188,7 @@ int32_t SerialModule::runOnce()
                     }
                 }
             }
-#ifndef TTGO_T_ECHO
+#if !defined(TTGO_T_ECHO) && !defined(ARCH_RP2040)
             else {
                 while (Serial2.available()) {
                     serialPayloadSize = Serial2.readBytes(serialBytes, meshtastic_Constants_DATA_PAYLOAD_LEN);

--- a/src/modules/SerialModule.h
+++ b/src/modules/SerialModule.h
@@ -8,7 +8,8 @@
 #include <Arduino.h>
 #include <functional>
 
-#if (defined(ARCH_ESP32) || defined(ARCH_NRF52)) && !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+#if (defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040)) && !defined(CONFIG_IDF_TARGET_ESP32S2) &&               \
+    !defined(CONFIG_IDF_TARGET_ESP32C3)
 
 class SerialModule : public StreamAPI, private concurrency::OSThread
 {

--- a/variants/rpipico/variant.h
+++ b/variants/rpipico/variant.h
@@ -17,6 +17,10 @@
 // SDA = 4
 // SCL = 5
 
+// Recommended pins for SerialModule:
+// txd = 8
+// rxd = 9
+
 #define EXT_NOTIFY_OUT 22
 #define BUTTON_PIN 17
 

--- a/variants/rpipicow/variant.h
+++ b/variants/rpipicow/variant.h
@@ -17,6 +17,10 @@
 // SDA = 4
 // SCL = 5
 
+// Recommended pins for SerialModule:
+// txd = 8
+// rxd = 9
+
 #define EXT_NOTIFY_OUT 22
 #define BUTTON_PIN 17
 


### PR DESCRIPTION
Fixes #2825. Tested with `serial.txd 8` and `serial.rxd 9`. 

Had to increase the `RX_BUFFER` to 256, otherwise long packets would occasionally fail. I saw that for ESP32 it even [throws an error]( https://github.com/espressif/arduino-esp32/blob/master/cores/esp32/HardwareSerial.cpp#L580.) if you have it set to 128 or lower.
