### PR TITLE
Re issue: #2496 Populate the position log entries from PositionModule with data fields

### DIFF
--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -34,11 +34,12 @@ bool PositionModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
     }
 
     // Log packet size and data fields
-    LOG_INFO("POSITION node=%08x l=%d latI=%d lonI=%d msl=%d hae=%d geo=%d pdop=%d hdop=%d vdop=%d siv=%d fxq=%d fxt=%d pts=%d time=%d\n", getFrom(&mp), mp.decoded.payload.size,
-             p.latitude_i, p.longitude_i, p.altitude, p.altitude_hae,
-             p.altitude_geoidal_separation, p.PDOP, p.HDOP, p.VDOP,
-             p.sats_in_view, p.fix_quality, p.fix_type, p.timestamp,p.time);
-             
+    LOG_INFO("POSITION node=%08x l=%d latI=%d lonI=%d msl=%d hae=%d geo=%d pdop=%d hdop=%d vdop=%d siv=%d fxq=%d fxt=%d pts=%d "
+             "time=%d\n",
+             getFrom(&mp), mp.decoded.payload.size, p.latitude_i, p.longitude_i, p.altitude, p.altitude_hae,
+             p.altitude_geoidal_separation, p.PDOP, p.HDOP, p.VDOP, p.sats_in_view, p.fix_quality, p.fix_type, p.timestamp,
+             p.time);
+
     if (p.time) {
         struct timeval tv;
         uint32_t secs = p.time;

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -33,13 +33,12 @@ bool PositionModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
         // return false;
     }
 
-    // Log packet size and list of fields
-    LOG_INFO("POSITION node=%08x l=%d %s%s%s%s%s%s%s%s%s%s%s%s%s\n", getFrom(&mp), mp.decoded.payload.size,
-             p.latitude_i ? "LAT " : "", p.longitude_i ? "LON " : "", p.altitude ? "MSL " : "", p.altitude_hae ? "HAE " : "",
-             p.altitude_geoidal_separation ? "GEO " : "", p.PDOP ? "PDOP " : "", p.HDOP ? "HDOP " : "", p.VDOP ? "VDOP " : "",
-             p.sats_in_view ? "SIV " : "", p.fix_quality ? "FXQ " : "", p.fix_type ? "FXT " : "", p.timestamp ? "PTS " : "",
-             p.time ? "TIME " : "");
-
+    // Log packet size and data fields
+    LOG_INFO("POSITION node=%08x l=%d latI=%d lonI=%d msl=%d hae=%d geo=%d pdop=%d hdop=%d vdop=%d siv=%d fxq=%d fxt=%d pts=%d time=%d\n", getFrom(&mp), mp.decoded.payload.size,
+             p.latitude_i, p.longitude_i, p.altitude, p.altitude_hae,
+             p.altitude_geoidal_separation, p.PDOP, p.HDOP, p.VDOP,
+             p.sats_in_view, p.fix_quality, p.fix_type, p.timestamp,p.time);
+             
     if (p.time) {
         struct timeval tv;
         uint32_t secs = p.time;


### PR DESCRIPTION
include position datafields in log entries. If the there is no data in the packet it displays as 0 in the log. eg:
`INFO  | ??:??:?? 25 [Router] POSITION node=25d62b24 l=17 latI=208759619 lonI=-1565037628 msl=113 hae=0 geo=0 pdop=0 hdop=0 vdop=0 siv=0 fxq=0 fxt=0 pts=0 time=1695811433`

regarding issue  #2496
