### PR TITLE
Tracker role wakeup and sleep cycle when power.is_power_saving true

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -414,7 +414,7 @@ void Power::shutdown()
 #ifdef PIN_LED3
     ledOff(PIN_LED2);
 #endif
-    doDeepSleep(DELAY_FOREVER);
+    doDeepSleep(DELAY_FOREVER, false);
 #endif
 }
 

--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -45,7 +45,7 @@ static void sdsEnter()
 {
     LOG_DEBUG("Enter state: SDS\n");
     // FIXME - make sure GPS and LORA radio are off first - because we want close to zero current draw
-    doDeepSleep(getConfiguredOrDefaultMs(config.power.sds_secs));
+    doDeepSleep(getConfiguredOrDefaultMs(config.power.sds_secs), false);
 }
 
 extern Power *power;

--- a/src/concurrency/OSThread.h
+++ b/src/concurrency/OSThread.h
@@ -67,6 +67,7 @@ class OSThread : public Thread
      * Returns desired period for next invocation (or RUN_SAME for no change)
      */
     virtual int32_t runOnce() = 0;
+    bool sleepOnNextExecution = false;
 
     // Do not override this
     virtual void run();

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -166,7 +166,7 @@ meshtastic_QueueStatus RadioLibInterface::getQueueStatus()
 bool RadioLibInterface::canSleep()
 {
     bool res = txQueue.empty();
-    if (!res) { // only print debug messages if we are vetoing sleep
+    if (res != true) { // only print debug messages if we are vetoing sleep
         LOG_DEBUG("radio wait to sleep, txEmpty=%d\n", res);
     }
     return res;

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -166,7 +166,7 @@ meshtastic_QueueStatus RadioLibInterface::getQueueStatus()
 bool RadioLibInterface::canSleep()
 {
     bool res = txQueue.empty();
-    if (res != true) { // only print debug messages if we are vetoing sleep
+    if (!res) { // only print debug messages if we are vetoing sleep
         LOG_DEBUG("radio wait to sleep, txEmpty=%d\n", res);
     }
     return res;

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -165,8 +165,9 @@ void PositionModule::sendOurPosition(NodeNum dest, bool wantReplies, uint8_t cha
 #ifdef ARCH_ESP32
     if (config.device.role == meshtastic_Config_DeviceConfig_Role_TRACKER && config.power.is_power_saving) {
         uint32_t nightyNightMs = getConfiguredOrDefaultMs(config.position.position_broadcast_secs);
-        doDeepSleep(nightyNightMs);
         LOG_DEBUG("Sleeping for %ims, then awaking to send position again.\n", nightyNightMs);
+
+        doDeepSleep(nightyNightMs, true);
     }
 #endif
 }

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -3,7 +3,6 @@
 #include "MeshService.h"
 #include "NodeDB.h"
 #include "RTC.h"
-#include "RadioLibInterface.h"
 #include "Router.h"
 #include "TypeConversions.h"
 #include "airtime.h"

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -190,12 +190,7 @@ int32_t PositionModule::runOnce()
         sleepOnNextExecution = false;
         uint32_t nightyNightMs = getConfiguredOrDefaultMs(config.position.position_broadcast_secs);
         LOG_DEBUG("Sleeping for %ims, then awaking to send position again.\n", nightyNightMs);
-        // if (HW_VENDOR == meshtastic_HardwareModel_TBEAM) {
-        //     doLightSleep(nightyNightMs);
-        // }
-        // else {
         doDeepSleep(nightyNightMs, false);
-        // }
     }
 
     meshtastic_NodeInfoLite *node = nodeDB.getMeshNode(nodeDB.getNodeNum());

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -3,6 +3,7 @@
 #include "MeshService.h"
 #include "NodeDB.h"
 #include "RTC.h"
+#include "RadioLibInterface.h"
 #include "Router.h"
 #include "TypeConversions.h"
 #include "airtime.h"
@@ -180,25 +181,8 @@ void PositionModule::sendOurPosition(NodeNum dest, bool wantReplies, uint8_t cha
     if (config.device.role == meshtastic_Config_DeviceConfig_Role_TRACKER && config.power.is_power_saving) {
         uint32_t nightyNightMs = getConfiguredOrDefaultMs(config.position.position_broadcast_secs);
         LOG_DEBUG("Sleeping for %ims, then awaking to send position again.\n", nightyNightMs);
-#ifdef ARCH_ESP32
+#if defined(ARCH_ESP32) || defined(ARCH_NRF52)
         doDeepSleep(nightyNightMs, true);
-#elif defined(ARCH_NRF52)
-        setBluetoothEnable(false);
-        gps->disable();
-#ifdef PIN_3V3_EN
-        digitalWrite(PIN_3V3_EN, LOW);
-#endif
-        clearPosition();
-        sd_power_mode_set(NRF_POWER_MODE_LOWPWR);
-        delay(nightyNightMs);
-#ifdef PIN_3V3_EN
-        digitalWrite(PIN_3V3_EN, HIGH);
-#endif
-        gps->enable();
-        if (config.bluetooth.enabled)
-            setBluetoothEnable(true);
-        // Default power mode
-        sd_power_mode_set(NRF_POWER_MODE_CONSTLAT);
 #endif
     }
 }

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -165,7 +165,7 @@ void PositionModule::sendOurPosition(NodeNum dest, bool wantReplies, uint8_t cha
     }
 
     p->to = dest;
-    p->decoded.want_response = wantReplies;
+    p->decoded.want_response = config.device.role == meshtastic_Config_DeviceConfig_Role_TRACKER ? false : wantReplies;
     if (config.device.role == meshtastic_Config_DeviceConfig_Role_TRACKER)
         p->priority = meshtastic_MeshPacket_Priority_RELIABLE;
     else

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -198,7 +198,7 @@ int32_t PositionModule::runOnce()
 
     if (lastGpsSend == 0 || msSinceLastSend >= intervalMs) {
         // Only send packets if the channel is less than 40% utilized.
-        if (airTime->isTxAllowedChannelUtil()) {
+        if (airTime->isTxAllowedChannelUtil(config.device.role != meshtastic_Config_DeviceConfig_Role_TRACKER)) {
             if (hasValidPosition(node)) {
                 lastGpsSend = now;
 

--- a/src/modules/PositionModule.h
+++ b/src/modules/PositionModule.h
@@ -49,6 +49,9 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
 
   private:
     struct SmartPosition getDistanceTraveledSinceLastSend(meshtastic_PositionLite currentPosition);
+
+    /** Only used in power saving trackers for now */
+    void clearPosition();
 };
 
 struct SmartPosition {

--- a/src/platform/esp32/main-esp32.cpp
+++ b/src/platform/esp32/main-esp32.cpp
@@ -201,7 +201,7 @@ void cpuDeepSleep(uint32_t msecToWake)
 
 #ifdef BUTTON_PIN
 
-#if SOC_PM_SUPPORT_EXT_WAKEUP
+#if SOC_PM_SUPPORT_EXT_WAKEUP && !defined(HELTEC_WIRELESS_TRACKER)
     esp_sleep_enable_ext0_wakeup((gpio_num_t)(1ULL << (config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN)), LOW);
 #endif
 

--- a/src/platform/esp32/main-esp32.cpp
+++ b/src/platform/esp32/main-esp32.cpp
@@ -200,22 +200,15 @@ void cpuDeepSleep(uint32_t msecToWake)
     esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
 
 #ifdef BUTTON_PIN
-    // Only GPIOs which are have RTC functionality can be used in this bit map: 0,2,4,12-15,25-27,32-39.
-#if SOC_RTCIO_HOLD_SUPPORTED
-    uint64_t gpioMask = (1ULL << config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN);
+
+#if SOC_PM_SUPPORT_EXT_WAKEUP
+    esp_sleep_enable_ext0_wakeup((gpio_num_t)(1ULL << (config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN)), LOW);
 #endif
 
 #ifdef BUTTON_NEED_PULLUP
     gpio_pullup_en((gpio_num_t)BUTTON_PIN);
 #endif
 
-    // Not needed because both of the current boards have external pullups
-    // FIXME change polarity in hw so we can wake on ANY_HIGH instead - that would allow us to use all three buttons (instead of
-    // just the first) gpio_pullup_en((gpio_num_t)BUTTON_PIN);
-
-#if SOC_PM_SUPPORT_EXT_WAKEUP
-    esp_sleep_enable_ext1_wakeup(gpioMask, ESP_EXT1_WAKEUP_ALL_LOW);
-#endif
 #endif
 
     esp_sleep_enable_timer_wakeup(msecToWake * 1000ULL); // call expects usecs

--- a/src/platform/nrf52/main-nrf52.cpp
+++ b/src/platform/nrf52/main-nrf52.cpp
@@ -184,10 +184,16 @@ void cpuDeepSleep(uint32_t msecToWake)
     // FIXME, use non-init RAM per
     // https://devzone.nordicsemi.com/f/nordic-q-a/48919/ram-retention-settings-with-softdevice-enabled
 
-    auto ok = sd_power_system_off();
-    if (ok != NRF_SUCCESS) {
-        LOG_ERROR("FIXME: Ignoring soft device (EasyDMA pending?) and forcing system-off!\n");
-        NRF_POWER->SYSTEMOFF = 1;
+    if (config.device.role == meshtastic_Config_DeviceConfig_Role_TRACKER && config.power.is_power_saving == true) {
+        sd_power_mode_set(NRF_POWER_MODE_LOWPWR);
+        delay(msecToWake);
+        NVIC_SystemReset();
+    } else {
+        auto ok = sd_power_system_off();
+        if (ok != NRF_SUCCESS) {
+            LOG_ERROR("FIXME: Ignoring soft device (EasyDMA pending?) and forcing system-off!\n");
+            NRF_POWER->SYSTEMOFF = 1;
+        }
     }
 
     // The following code should not be run, because we are off

--- a/src/sleep.h
+++ b/src/sleep.h
@@ -4,7 +4,7 @@
 #include "Observer.h"
 #include "configuration.h"
 
-void doDeepSleep(uint32_t msecToWake), cpuDeepSleep(uint32_t msecToWake);
+void doDeepSleep(uint32_t msecToWake, bool skipPreflight), cpuDeepSleep(uint32_t msecToWake);
 
 #ifdef ARCH_ESP32
 #include "esp_sleep.h"


### PR DESCRIPTION
Current flow if device is Tracker role and power.is_power_saving is enabled is as follows:

1. Remove delayed startup for PositionModule so that we start the thread immediately

2. Clear last node->position.lat / lon to zero, so that we don't just immediately broadcast the last (stale) position

3. Upon valid position and successful send (which should happen as soon as we get a fix), go to sleep for position_broadcast_secs.

4. Wake up and start the process over again.