### PR TITLE
T-Deck fix: revert KB_POWERON changes

### DIFF
--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -154,9 +154,6 @@ static void darkEnter()
 {
     setBluetoothEnable(true);
     screen->setOn(false);
-#ifdef KB_POWERON
-    digitalWrite(KB_POWERON, LOW);
-#endif
 }
 
 static void serialEnter()
@@ -184,9 +181,6 @@ static void powerEnter()
     } else {
         screen->setOn(true);
         setBluetoothEnable(true);
-#ifdef KB_POWERON
-        digitalWrite(KB_POWERON, HIGH);
-#endif
         // within enter() the function getState() returns the state we came from
         if (strcmp(powerFSM.getState()->name, "BOOT") != 0 && strcmp(powerFSM.getState()->name, "POWER") != 0 &&
             strcmp(powerFSM.getState()->name, "DARK") != 0) {
@@ -217,9 +211,6 @@ static void onEnter()
     LOG_DEBUG("Enter state: ON\n");
     screen->setOn(true);
     setBluetoothEnable(true);
-#ifdef KB_POWERON
-    digitalWrite(KB_POWERON, HIGH);
-#endif
 }
 
 static void onIdle()


### PR DESCRIPTION
The change in #2786 to disable the T-Deck's keyboard during screen blanking to save 20mAh power seems to have a negative side effect on the LoRa TX interrupt which leads to a reboot when sending mesh packets after the screen blanking.
This PR reverts the change in PowerFSM.cpp.

```
INFO  | ??:??:?? 201 [Screen] From Radio onread
INFO  | ??:??:?? 201 [Screen] getFromRadio=STATE_SEND_PACKETS
DEBUG | ??:??:?? 201 [Screen] encoding toPhone packet to phone variant=11, 12 bytes
INFO  | ??:??:?? 201 [Screen] From Radio onread
WARN  | ??:??:?? 201 [RadioIf] Can not send yet, busyTx
ERROR | ??:??:?? 201 [RadioIf] Hardware Failure! busyTx for more than 60s
ERROR | ??:??:?? 201 [RadioIf] NOTE! Recording critical error 8 at src/mesh/RadioLibInterface.cpp:88
INFO  | ??:??:?? 201 Rebooting

[20:46:07.013] Disconnected
[20:46:08.014] Warning: Could not open tty device (Permission denied)
[20:46:08.014] Waiting for tty device..
[20:46:09.016] Connected
��@INFO  | ??:??:?? 2 

//\ E S H T /\ S T / C
```
