### PR TITLE
Add timeout to ublox PMREQ command

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -903,7 +903,7 @@ GPS *GPS::createGps()
     LOG_DEBUG("Using " NMEA_MSG_GXGSA " for 3DFIX and PDOP\n");
 #endif
 
-    new_gps->setGPSPower(true, false);
+    new_gps->setGPSPower(true, false, 0);
 
 #ifdef PIN_GPS_RESET
     digitalWrite(PIN_GPS_RESET, GPS_RESET_MODE); // assert for 10ms

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -94,7 +94,7 @@ class GPS : private concurrency::OSThread
     /** If !NULL we will use this serial port to construct our GPS */
     static HardwareSerial *_serial_gps;
 
-    static const uint8_t _message_PMREQ[];
+    static uint8_t _message_PMREQ[];
     static const uint8_t _message_CFG_RXM_PSM[];
     static const uint8_t _message_CFG_RXM_ECO[];
     static const uint8_t _message_CFG_PM2[];
@@ -132,7 +132,7 @@ class GPS : private concurrency::OSThread
     // Disable the thread
     int32_t disable() override;
 
-    void setGPSPower(bool on, bool standbyOnly);
+    void setGPSPower(bool on, bool standbyOnly, uint32_t sleepTime);
 
     /// Returns true if we have acquired GPS lock.
     virtual bool hasLock();

--- a/src/gps/ubx.h
+++ b/src/gps/ubx.h
@@ -1,4 +1,4 @@
-const uint8_t GPS::_message_PMREQ[] PROGMEM = {
+uint8_t GPS::_message_PMREQ[] PROGMEM = {
     0x00, 0x00, // 4 bytes duration of request task
     0x00, 0x00, // (milliseconds)
     0x02, 0x00, // Task flag bitfield

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -173,7 +173,7 @@ void doDeepSleep(uint32_t msecToWake)
     nodeDB.saveToDisk();
 
     // Kill GPS power completely (even if previously we just had it in sleep mode)
-    gps->setGPSPower(false, false);
+    gps->setGPSPower(false, false, 0);
 
     setLed(false);
 


### PR DESCRIPTION
Some U-blox GPS chips don't seem to properly wake up from the PMREQ command on receiving data on the serial port. That command does allow specifying a timeout, so calculate and do so, to work around that issue.