### PR TITLE
Check if packet is decrypted when converting to JSON

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -516,34 +516,34 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
     JSONObject msgPayload;
     JSONObject jsonObj;
 
-    switch (mp->decoded.portnum) {
-    case meshtastic_PortNum_TEXT_MESSAGE_APP: {
-        msgType = "text";
-        // convert bytes to string
-        LOG_DEBUG("got text message of size %u\n", mp->decoded.payload.size);
-        char payloadStr[(mp->decoded.payload.size) + 1];
-        memcpy(payloadStr, mp->decoded.payload.bytes, mp->decoded.payload.size);
-        payloadStr[mp->decoded.payload.size] = 0; // null terminated string
-        // check if this is a JSON payload
-        JSONValue *json_value = JSON::Parse(payloadStr);
-        if (json_value != NULL) {
-            LOG_INFO("text message payload is of type json\n");
-            // if it is, then we can just use the json object
-            jsonObj["payload"] = json_value;
-        } else {
-            // if it isn't, then we need to create a json object
-            // with the string as the value
-            LOG_INFO("text message payload is of type plaintext\n");
-            msgPayload["text"] = new JSONValue(payloadStr);
-            jsonObj["payload"] = new JSONValue(msgPayload);
+    if (mp->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
+        switch (mp->decoded.portnum) {
+        case meshtastic_PortNum_TEXT_MESSAGE_APP: {
+            msgType = "text";
+            // convert bytes to string
+            LOG_DEBUG("got text message of size %u\n", mp->decoded.payload.size);
+            char payloadStr[(mp->decoded.payload.size) + 1];
+            memcpy(payloadStr, mp->decoded.payload.bytes, mp->decoded.payload.size);
+            payloadStr[mp->decoded.payload.size] = 0; // null terminated string
+            // check if this is a JSON payload
+            JSONValue *json_value = JSON::Parse(payloadStr);
+            if (json_value != NULL) {
+                LOG_INFO("text message payload is of type json\n");
+                // if it is, then we can just use the json object
+                jsonObj["payload"] = json_value;
+            } else {
+                // if it isn't, then we need to create a json object
+                // with the string as the value
+                LOG_INFO("text message payload is of type plaintext\n");
+                msgPayload["text"] = new JSONValue(payloadStr);
+                jsonObj["payload"] = new JSONValue(msgPayload);
+            }
+            break;
         }
-        break;
-    }
-    case meshtastic_PortNum_TELEMETRY_APP: {
-        msgType = "telemetry";
-        meshtastic_Telemetry scratch;
-        meshtastic_Telemetry *decoded = NULL;
-        if (mp->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
+        case meshtastic_PortNum_TELEMETRY_APP: {
+            msgType = "telemetry";
+            meshtastic_Telemetry scratch;
+            meshtastic_Telemetry *decoded = NULL;
             memset(&scratch, 0, sizeof(scratch));
             if (pb_decode_from_bytes(mp->decoded.payload.bytes, mp->decoded.payload.size, &meshtastic_Telemetry_msg, &scratch)) {
                 decoded = &scratch;
@@ -564,14 +564,12 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
             } else {
                 LOG_ERROR("Error decoding protobuf for telemetry message!\n");
             }
-        };
-        break;
-    }
-    case meshtastic_PortNum_NODEINFO_APP: {
-        msgType = "nodeinfo";
-        meshtastic_User scratch;
-        meshtastic_User *decoded = NULL;
-        if (mp->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
+            break;
+        }
+        case meshtastic_PortNum_NODEINFO_APP: {
+            msgType = "nodeinfo";
+            meshtastic_User scratch;
+            meshtastic_User *decoded = NULL;
             memset(&scratch, 0, sizeof(scratch));
             if (pb_decode_from_bytes(mp->decoded.payload.bytes, mp->decoded.payload.size, &meshtastic_User_msg, &scratch)) {
                 decoded = &scratch;
@@ -583,14 +581,12 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
             } else {
                 LOG_ERROR("Error decoding protobuf for nodeinfo message!\n");
             }
-        };
-        break;
-    }
-    case meshtastic_PortNum_POSITION_APP: {
-        msgType = "position";
-        meshtastic_Position scratch;
-        meshtastic_Position *decoded = NULL;
-        if (mp->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
+            break;
+        }
+        case meshtastic_PortNum_POSITION_APP: {
+            msgType = "position";
+            meshtastic_Position scratch;
+            meshtastic_Position *decoded = NULL;
             memset(&scratch, 0, sizeof(scratch));
             if (pb_decode_from_bytes(mp->decoded.payload.bytes, mp->decoded.payload.size, &meshtastic_Position_msg, &scratch)) {
                 decoded = &scratch;
@@ -627,15 +623,12 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
             } else {
                 LOG_ERROR("Error decoding protobuf for position message!\n");
             }
-        };
-        break;
-    }
-
-    case meshtastic_PortNum_WAYPOINT_APP: {
-        msgType = "position";
-        meshtastic_Waypoint scratch;
-        meshtastic_Waypoint *decoded = NULL;
-        if (mp->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
+            break;
+        }
+        case meshtastic_PortNum_WAYPOINT_APP: {
+            msgType = "position";
+            meshtastic_Waypoint scratch;
+            meshtastic_Waypoint *decoded = NULL;
             memset(&scratch, 0, sizeof(scratch));
             if (pb_decode_from_bytes(mp->decoded.payload.bytes, mp->decoded.payload.size, &meshtastic_Waypoint_msg, &scratch)) {
                 decoded = &scratch;
@@ -650,14 +643,12 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
             } else {
                 LOG_ERROR("Error decoding protobuf for position message!\n");
             }
-        };
-        break;
-    }
-    case meshtastic_PortNum_NEIGHBORINFO_APP: {
-        msgType = "neighborinfo";
-        meshtastic_NeighborInfo scratch;
-        meshtastic_NeighborInfo *decoded = NULL;
-        if (mp->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
+            break;
+        }
+        case meshtastic_PortNum_NEIGHBORINFO_APP: {
+            msgType = "neighborinfo";
+            meshtastic_NeighborInfo scratch;
+            meshtastic_NeighborInfo *decoded = NULL;
             memset(&scratch, 0, sizeof(scratch));
             if (pb_decode_from_bytes(mp->decoded.payload.bytes, mp->decoded.payload.size, &meshtastic_NeighborInfo_msg,
                                      &scratch)) {
@@ -678,12 +669,14 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
             } else {
                 LOG_ERROR("Error decoding protobuf for neighborinfo message!\n");
             }
-        };
-        break;
-    }
-    // add more packet types here if needed
-    default:
-        break;
+            break;
+        }
+        // add more packet types here if needed
+        default:
+            break;
+        }
+    } else {
+        LOG_WARN("Couldn't convert encrypted payload of MeshPacket to JSON\n");
     }
 
     jsonObj["id"] = new JSONValue((uint)mp->id);


### PR DESCRIPTION
A device could crash when JSON and encryption are enabled for MQTT, because it was using the portnum (which is part of the decrypted payload) before checking the tag. 
Removed unnecessary checks for the tag afterwards.