### PR TITLE
Add trunk githooks to the repo

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -47,7 +47,7 @@ runtimes:
 actions:
   disabled:
     - trunk-announce
-    - trunk-check-pre-push
-    - trunk-fmt-pre-commit
   enabled:
+    - trunk-fmt-pre-commit
+    - trunk-check-pre-push
     - trunk-upgrade-available


### PR DESCRIPTION
Hello from Trunk!

We noticed a few comments recently on your discord mentioning not having run trunk fmt before pushing the change.

Usually the command is done in the vscode extension, and in git hooks (fmt on commit, check on push).
However the git hooks are explicitly disabled in your trunk config.

Just wanted to start a discussion about why it was turned off, if it wasn't really intentional.

Anyways, feel free to close this PR if it's not something you want.

![image](https://github.com/meshtastic/firmware/assets/131031962/d1d4ab9e-2c2a-4ace-801b-33d1f5b57f6e)
