### PR TITLE
Fix typo in tbeam-s3-core hwids address

### DIFF
--- a/boards/tbeam-s3-core.json
+++ b/boards/tbeam-s3-core.json
@@ -15,7 +15,7 @@
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "dio",
-    "hwids": [["0X303A", "0x1001"]],
+    "hwids": [["0x303A", "0x1001"]],
     "mcu": "esp32s3",
     "variant": "tbeam-s3-core"
   },


### PR DESCRIPTION
It will fix the upload new firmware issue on the board.