### PR TITLE
fix/enhance: allow telemetry sensors connected to second I2C port

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -281,9 +281,10 @@ class AnalogBatteryLevel : public HasBatteryLevel
 #if defined(HAS_TELEMETRY) && !defined(ARCH_PORTDUINO)
     uint16_t getINAVoltage()
     {
-        if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_INA219] == config.power.device_battery_ina_address) {
+        if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_INA219].first == config.power.device_battery_ina_address) {
             return ina219Sensor.getBusVoltageMv();
-        } else if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_INA260] == config.power.device_battery_ina_address) {
+        } else if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_INA260].first ==
+                   config.power.device_battery_ina_address) {
             return ina260Sensor.getBusVoltageMv();
         }
         return 0;
@@ -294,11 +295,12 @@ class AnalogBatteryLevel : public HasBatteryLevel
         if (!config.power.device_battery_ina_address) {
             return false;
         }
-        if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_INA219] == config.power.device_battery_ina_address) {
+        if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_INA219].first == config.power.device_battery_ina_address) {
             if (!ina219Sensor.isInitialized())
                 return ina219Sensor.runOnce() > 0;
             return ina219Sensor.isRunning();
-        } else if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_INA260] == config.power.device_battery_ina_address) {
+        } else if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_INA260].first ==
+                   config.power.device_battery_ina_address) {
             if (!ina260Sensor.isInitialized())
                 return ina260Sensor.runOnce() > 0;
             return ina260Sensor.isRunning();

--- a/src/detect/ScanI2CTwoWire.h
+++ b/src/detect/ScanI2CTwoWire.h
@@ -18,6 +18,8 @@ class ScanI2CTwoWire : public ScanI2C
 
     ScanI2C::FoundDevice find(ScanI2C::DeviceType) const override;
 
+    TwoWire *fetchI2CBus(ScanI2C::DeviceAddress) const;
+
     bool exists(ScanI2C::DeviceType) const override;
 
     size_t countDevices() const override;
@@ -51,6 +53,4 @@ class ScanI2CTwoWire : public ScanI2C
     uint16_t getRegisterValue(const RegisterLocation &, ResponseWidth) const;
 
     DeviceType probeOLED(ScanI2C::DeviceAddress) const;
-
-    TwoWire *fetchI2CBus(ScanI2C::DeviceAddress) const;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,7 @@
 #include "target_specific.h"
 #include <Wire.h>
 #include <memory>
+#include <utility>
 // #include <driver/rtc_io.h>
 
 #include "mesh/eth/ethClient.h"
@@ -122,9 +123,8 @@ uint32_t serialSinceMsec;
 
 bool pmu_found;
 
-// Array map of sensor types (as array index) and i2c address as value we'll find in the i2c scan
-uint8_t nodeTelemetrySensorsMap[_meshtastic_TelemetrySensorType_MAX + 1] = {
-    0}; // one is enough, missing elements will be initialized to 0 anyway.
+// Array map of sensor types with i2c address and wire as we'll find in the i2c scan
+std::pair<uint8_t, TwoWire *> nodeTelemetrySensorsMap[_meshtastic_TelemetrySensorType_MAX + 1] = {};
 
 Router *router = NULL; // Users of router don't care what sort of subclass implements that API
 
@@ -491,7 +491,8 @@ void setup()
     {                                                                                                                            \
         auto found = i2cScanner->find(SCANNER_T);                                                                                \
         if (found.type != ScanI2C::DeviceType::NONE) {                                                                           \
-            nodeTelemetrySensorsMap[PB_T] = found.address.address;                                                               \
+            nodeTelemetrySensorsMap[PB_T].first = found.address.address;                                                         \
+            nodeTelemetrySensorsMap[PB_T].second = i2cScanner->fetchI2CBus(found.address);                                       \
             LOG_DEBUG("found i2c sensor %s\n", STRING(PB_T));                                                                    \
         }                                                                                                                        \
     }

--- a/src/modules/Modules.cpp
+++ b/src/modules/Modules.cpp
@@ -88,7 +88,7 @@ void setupModules()
 #endif
 #if HAS_SENSOR
         new EnvironmentTelemetryModule();
-        if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_PMSA003I] > 0) {
+        if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_PMSA003I].first > 0) {
             new AirQualityTelemetryModule();
         }
 #endif

--- a/src/modules/Telemetry/Sensor/BME280Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/BME280Sensor.cpp
@@ -13,7 +13,7 @@ int32_t BME280Sensor::runOnce()
     if (!hasSensor()) {
         return DEFAULT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS;
     }
-    status = bme280.begin(nodeTelemetrySensorsMap[sensorType]);
+    status = bme280.begin(nodeTelemetrySensorsMap[sensorType].first, nodeTelemetrySensorsMap[sensorType].second);
 
     bme280.setSampling(Adafruit_BME280::MODE_FORCED,
                        Adafruit_BME280::SAMPLING_X1, // Temp. oversampling

--- a/src/modules/Telemetry/Sensor/BME280Sensor.h
+++ b/src/modules/Telemetry/Sensor/BME280Sensor.h
@@ -2,7 +2,7 @@
 #include "TelemetrySensor.h"
 #include <Adafruit_BME280.h>
 
-class BME280Sensor : virtual public TelemetrySensor
+class BME280Sensor : public TelemetrySensor
 {
   private:
     Adafruit_BME280 bme280;

--- a/src/modules/Telemetry/Sensor/BME680Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/BME680Sensor.cpp
@@ -20,7 +20,7 @@ int32_t BME680Sensor::runOnce()
     if (!hasSensor()) {
         return DEFAULT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS;
     }
-    if (!bme680.begin(nodeTelemetrySensorsMap[sensorType], Wire))
+    if (!bme680.begin(nodeTelemetrySensorsMap[sensorType].first, *nodeTelemetrySensorsMap[sensorType].second))
         checkStatus("begin");
 
     if (bme680.status == BSEC_OK) {

--- a/src/modules/Telemetry/Sensor/BME680Sensor.h
+++ b/src/modules/Telemetry/Sensor/BME680Sensor.h
@@ -6,7 +6,7 @@
 
 #include "bme680_iaq_33v_3s_4d/bsec_iaq.h"
 
-class BME680Sensor : virtual public TelemetrySensor
+class BME680Sensor : public TelemetrySensor
 {
   private:
     Bsec2 bme680;

--- a/src/modules/Telemetry/Sensor/BMP280Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/BMP280Sensor.cpp
@@ -13,7 +13,8 @@ int32_t BMP280Sensor::runOnce()
     if (!hasSensor()) {
         return DEFAULT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS;
     }
-    status = bmp280.begin(nodeTelemetrySensorsMap[sensorType]);
+    bmp280 = Adafruit_BMP280(nodeTelemetrySensorsMap[sensorType].second);
+    status = bmp280.begin(nodeTelemetrySensorsMap[sensorType].first);
 
     bmp280.setSampling(Adafruit_BMP280::MODE_FORCED,
                        Adafruit_BMP280::SAMPLING_X1, // Temp. oversampling

--- a/src/modules/Telemetry/Sensor/BMP280Sensor.h
+++ b/src/modules/Telemetry/Sensor/BMP280Sensor.h
@@ -2,7 +2,7 @@
 #include "TelemetrySensor.h"
 #include <Adafruit_BMP280.h>
 
-class BMP280Sensor : virtual public TelemetrySensor
+class BMP280Sensor : public TelemetrySensor
 {
   private:
     Adafruit_BMP280 bmp280;

--- a/src/modules/Telemetry/Sensor/INA219Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/INA219Sensor.cpp
@@ -13,8 +13,8 @@ int32_t INA219Sensor::runOnce()
         return DEFAULT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS;
     }
     if (!ina219.success()) {
-        ina219 = Adafruit_INA219(nodeTelemetrySensorsMap[sensorType]);
-        status = ina219.begin();
+        ina219 = Adafruit_INA219(nodeTelemetrySensorsMap[sensorType].first);
+        status = ina219.begin(nodeTelemetrySensorsMap[sensorType].second);
     } else {
         status = ina219.success();
     }

--- a/src/modules/Telemetry/Sensor/INA219Sensor.h
+++ b/src/modules/Telemetry/Sensor/INA219Sensor.h
@@ -3,7 +3,7 @@
 #include "VoltageSensor.h"
 #include <Adafruit_INA219.h>
 
-class INA219Sensor : virtual public TelemetrySensor, VoltageSensor
+class INA219Sensor : public TelemetrySensor, VoltageSensor
 {
   private:
     Adafruit_INA219 ina219;

--- a/src/modules/Telemetry/Sensor/INA260Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/INA260Sensor.cpp
@@ -14,7 +14,7 @@ int32_t INA260Sensor::runOnce()
     }
 
     if (!status) {
-        status = ina260.begin(nodeTelemetrySensorsMap[sensorType]);
+        status = ina260.begin(nodeTelemetrySensorsMap[sensorType].first, nodeTelemetrySensorsMap[sensorType].second);
     }
     return initI2CSensor();
 }

--- a/src/modules/Telemetry/Sensor/INA260Sensor.h
+++ b/src/modules/Telemetry/Sensor/INA260Sensor.h
@@ -3,7 +3,7 @@
 #include "VoltageSensor.h"
 #include <Adafruit_INA260.h>
 
-class INA260Sensor : virtual public TelemetrySensor, VoltageSensor
+class INA260Sensor : public TelemetrySensor, VoltageSensor
 {
   private:
     Adafruit_INA260 ina260 = Adafruit_INA260();

--- a/src/modules/Telemetry/Sensor/LPS22HBSensor.cpp
+++ b/src/modules/Telemetry/Sensor/LPS22HBSensor.cpp
@@ -13,7 +13,7 @@ int32_t LPS22HBSensor::runOnce()
     if (!hasSensor()) {
         return DEFAULT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS;
     }
-    status = lps22hb.begin_I2C(nodeTelemetrySensorsMap[sensorType]);
+    status = lps22hb.begin_I2C(nodeTelemetrySensorsMap[sensorType].first, nodeTelemetrySensorsMap[sensorType].second);
     return initI2CSensor();
 }
 

--- a/src/modules/Telemetry/Sensor/LPS22HBSensor.h
+++ b/src/modules/Telemetry/Sensor/LPS22HBSensor.h
@@ -3,7 +3,7 @@
 #include <Adafruit_LPS2X.h>
 #include <Adafruit_Sensor.h>
 
-class LPS22HBSensor : virtual public TelemetrySensor
+class LPS22HBSensor : public TelemetrySensor
 {
   private:
     Adafruit_LPS22 lps22hb;

--- a/src/modules/Telemetry/Sensor/MCP9808Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/MCP9808Sensor.cpp
@@ -12,7 +12,7 @@ int32_t MCP9808Sensor::runOnce()
     if (!hasSensor()) {
         return DEFAULT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS;
     }
-    status = mcp9808.begin(nodeTelemetrySensorsMap[sensorType]);
+    status = mcp9808.begin(nodeTelemetrySensorsMap[sensorType].first, nodeTelemetrySensorsMap[sensorType].second);
     return initI2CSensor();
 }
 

--- a/src/modules/Telemetry/Sensor/MCP9808Sensor.h
+++ b/src/modules/Telemetry/Sensor/MCP9808Sensor.h
@@ -2,7 +2,7 @@
 #include "TelemetrySensor.h"
 #include <Adafruit_MCP9808.h>
 
-class MCP9808Sensor : virtual public TelemetrySensor
+class MCP9808Sensor : public TelemetrySensor
 {
   private:
     Adafruit_MCP9808 mcp9808;

--- a/src/modules/Telemetry/Sensor/SHT31Sensor.h
+++ b/src/modules/Telemetry/Sensor/SHT31Sensor.h
@@ -2,7 +2,7 @@
 #include "TelemetrySensor.h"
 #include <Adafruit_SHT31.h>
 
-class SHT31Sensor : virtual public TelemetrySensor
+class SHT31Sensor : public TelemetrySensor
 {
   private:
     Adafruit_SHT31 sht31 = Adafruit_SHT31();

--- a/src/modules/Telemetry/Sensor/SHTC3Sensor.h
+++ b/src/modules/Telemetry/Sensor/SHTC3Sensor.h
@@ -2,7 +2,7 @@
 #include "TelemetrySensor.h"
 #include <Adafruit_SHTC3.h>
 
-class SHTC3Sensor : virtual public TelemetrySensor
+class SHTC3Sensor : public TelemetrySensor
 {
   private:
     Adafruit_SHTC3 shtc3 = Adafruit_SHTC3();

--- a/src/modules/Telemetry/Sensor/TelemetrySensor.h
+++ b/src/modules/Telemetry/Sensor/TelemetrySensor.h
@@ -1,9 +1,12 @@
 #pragma once
 #include "../mesh/generated/meshtastic/telemetry.pb.h"
 #include "NodeDB.h"
+#include <utility>
+
+class TwoWire;
 
 #define DEFAULT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS 1000
-extern uint8_t nodeTelemetrySensorsMap[_meshtastic_TelemetrySensorType_MAX + 1];
+extern std::pair<uint8_t, TwoWire *> nodeTelemetrySensorsMap[_meshtastic_TelemetrySensorType_MAX + 1];
 
 class TelemetrySensor
 {
@@ -16,7 +19,7 @@ class TelemetrySensor
     }
 
     const char *sensorName;
-    meshtastic_TelemetrySensorType sensorType;
+    meshtastic_TelemetrySensorType sensorType = meshtastic_TelemetrySensorType_SENSOR_UNSET;
     unsigned status;
     bool initialized = false;
 
@@ -24,9 +27,9 @@ class TelemetrySensor
     {
         if (!status) {
             LOG_WARN("Could not connect to detected %s sensor.\n Removing from nodeTelemetrySensorsMap.\n", sensorName);
-            nodeTelemetrySensorsMap[sensorType] = 0;
+            nodeTelemetrySensorsMap[sensorType].first = 0;
         } else {
-            LOG_INFO("Opened %s sensor on default i2c bus\n", sensorName);
+            LOG_INFO("Opened %s sensor on i2c bus\n", sensorName);
             setup();
         }
         initialized = true;
@@ -35,7 +38,7 @@ class TelemetrySensor
     virtual void setup();
 
   public:
-    bool hasSensor() { return sensorType < sizeof(nodeTelemetrySensorsMap) && nodeTelemetrySensorsMap[sensorType] > 0; }
+    bool hasSensor() { return nodeTelemetrySensorsMap[sensorType].first > 0; }
 
     virtual int32_t runOnce() = 0;
     virtual bool isInitialized() { return initialized; }


### PR DESCRIPTION
When connecting a telemetry sensor to the I2C port 1 the sensor is detected during the I2C scan but cannot be used. Only sensors connected to I2C port 0 are functional.

```
INFO  | ??:??:?? 15 [EnvironmentTelemetryModule] Environment Telemetry: Initializing
INFO  | ??:??:?? 15 [EnvironmentTelemetryModule] Init sensor: BMP280
WARN  | ??:??:?? 15 [EnvironmentTelemetryModule] Could not connect to detected BMP280 sensor.
```

The telemetry sensor classes use only the global variable "Wire" even the sensor was detected on "Wire1".

This PR fixes this behavior by passing the wire pointer to the sensor class using an enhanced version of the nodeTelemetrySensorsMap. 

```
INFO  | ??:??:?? 14 [EnvironmentTelemetryModule] Environment Telemetry: Initializing
INFO  | ??:??:?? 14 [EnvironmentTelemetryModule] Init sensor: BMP280
INFO  | ??:??:?? 14 [EnvironmentTelemetryModule] Opened BMP280 sensor on i2c bus
DEBUG | ??:??:?? 15 [EnvironmentTelemetryModule] BMP280Sensor::getMetrics
INFO  | ??:??:?? 15 [EnvironmentTelemetryModule] (Sending): barometric_pressure=949.862549, current=0.000000, gas_resistance=0.000000, relative_humidity=0.000000, temperature=23.020000, voltage=0.000000
```
