### PR TITLE
refactor: simplify MQTT defaults

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -254,6 +254,8 @@ void NodeDB::installDefaultModuleConfig()
     strncpy(moduleConfig.mqtt.address, default_mqtt_address, sizeof(moduleConfig.mqtt.address));
     strncpy(moduleConfig.mqtt.username, default_mqtt_username, sizeof(moduleConfig.mqtt.username));
     strncpy(moduleConfig.mqtt.password, default_mqtt_password, sizeof(moduleConfig.mqtt.password));
+    strncpy(moduleConfig.mqtt.root, default_mqtt_root, sizeof(moduleConfig.mqtt.root));
+    moduleConfig.mqtt.encryption_enabled = true;
 
     moduleConfig.has_neighbor_info = true;
     moduleConfig.neighbor_info.enabled = false;

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -204,6 +204,7 @@ extern NodeDB nodeDB;
 #define default_mqtt_address "mqtt.meshtastic.org"
 #define default_mqtt_username "meshdev"
 #define default_mqtt_password "large4cats"
+#define default_mqtt_root "msh"
 
 inline uint32_t getConfiguredOrDefaultMs(uint32_t configuredInterval)
 {

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -249,29 +249,12 @@ ErrorCode Router::send(meshtastic_MeshPacket *p)
     if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
         ChannelIndex chIndex = p->channel; // keep as a local because we are about to change it
 
-        bool shouldActuallyEncrypt = true;
-
         if (moduleConfig.mqtt.enabled) {
-            // check if we should send decrypted packets to mqtt
 
-            // truth table:
-            /* mqtt_server  mqtt_encryption_enabled should_encrypt
-             *    not set                        0              1
-             *    not set                        1              1
-             *        set                        0              0
-             *        set                        1              1
-             *
-             * => so we only decrypt mqtt if they have a custom mqtt server AND mqtt_encryption_enabled is FALSE
-             */
-
-            if (*moduleConfig.mqtt.address && !moduleConfig.mqtt.encryption_enabled) {
-                shouldActuallyEncrypt = false;
-            }
-
-            LOG_INFO("Should encrypt MQTT?: %d\n", shouldActuallyEncrypt);
+            LOG_INFO("Should encrypt MQTT?: %d\n", moduleConfig.mqtt.encryption_enabled);
 
             // the packet is currently in a decrypted state.  send it now if they want decrypted packets
-            if (mqtt && !shouldActuallyEncrypt)
+            if (mqtt && !moduleConfig.mqtt.encryption_enabled)
                 mqtt->onSend(*p, chIndex);
         }
 
@@ -284,7 +267,7 @@ ErrorCode Router::send(meshtastic_MeshPacket *p)
         if (moduleConfig.mqtt.enabled) {
             // the packet is now encrypted.
             // check if we should send encrypted packets to mqtt
-            if (mqtt && shouldActuallyEncrypt)
+            if (mqtt && moduleConfig.mqtt.encryption_enabled)
                 mqtt->onSend(*p, chIndex);
         }
     }


### PR DESCRIPTION
- removes residual `shouldActuallyEncrypt` code (`address` default is not empty in 2.0)
- promotes `encryption_enabled` as default
- adds default topic `root` "msh" (for convention)