### PR TITLE
Drop packets if `toPhoneQueue` is full, unless it's text/RangeTest

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -267,14 +267,22 @@ void MeshService::sendNetworkPing(NodeNum dest, bool wantReplies)
 
 void MeshService::sendToPhone(meshtastic_MeshPacket *p)
 {
+    perhapsDecode(p);
+
     if (toPhoneQueue.numFree() == 0) {
-        LOG_WARN("ToPhone queue is full, discarding oldest\n");
-        meshtastic_MeshPacket *d = toPhoneQueue.dequeuePtr(0);
-        if (d)
-            releaseToPool(d);
+        if (p->decoded.portnum == meshtastic_PortNum_TEXT_MESSAGE_APP ||
+            p->decoded.portnum == meshtastic_PortNum_RANGE_TEST_APP) {
+            LOG_WARN("ToPhone queue is full, discarding oldest\n");
+            meshtastic_MeshPacket *d = toPhoneQueue.dequeuePtr(0);
+            if (d)
+                releaseToPool(d);
+        } else {
+            LOG_WARN("ToPhone queue is full, dropping packet.\n");
+            releaseToPool(p);
+            return;
+        }
     }
 
-    perhapsDecode(p);
     assert(toPhoneQueue.enqueue(p, 0));
     fromNum++;
 }


### PR DESCRIPTION
If the queue for packets to be sent to a client (`toPhoneQueue`) is full, drop the new packet, unless it's a text message or RangeTest. This way, text messages will not be overwritten by other types of packets (telemetry, position, etc.). 

I think this is the best solution until we get rid of the FreeRTOS queues (which [seemed to be the idea](https://github.com/meshtastic/firmware/commit/49b4ed2a89db5a7676bfbffe5d2dafd6281c95ee#diff-69f63c99952e36262405135b56d296b17d3d2098d531bae41f106fceec917972R38) when ArduinoThread was introduced), since we cannot easily reorder/selectively drop packets in such a queue.

