### PR TITLE
Change default Coding Rate to 4/5 for <=LongFast

### DIFF
--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -384,27 +384,27 @@ void RadioInterface::applyModemConfig()
         switch (loraConfig.modem_preset) {
         case meshtastic_Config_LoRaConfig_ModemPreset_SHORT_FAST:
             bw = (myRegion->wideLora) ? 812.5 : 250;
-            cr = 8;
+            cr = 5;
             sf = 7;
             break;
         case meshtastic_Config_LoRaConfig_ModemPreset_SHORT_SLOW:
             bw = (myRegion->wideLora) ? 812.5 : 250;
-            cr = 8;
+            cr = 5;
             sf = 8;
             break;
         case meshtastic_Config_LoRaConfig_ModemPreset_MEDIUM_FAST:
             bw = (myRegion->wideLora) ? 812.5 : 250;
-            cr = 8;
+            cr = 5;
             sf = 9;
             break;
         case meshtastic_Config_LoRaConfig_ModemPreset_MEDIUM_SLOW:
             bw = (myRegion->wideLora) ? 812.5 : 250;
-            cr = 8;
+            cr = 5;
             sf = 10;
             break;
         default: // Config_LoRaConfig_ModemPreset_LONG_FAST is default. Gracefully use this is preset is something illegal.
             bw = (myRegion->wideLora) ? 812.5 : 250;
-            cr = 8;
+            cr = 5;
             sf = 11;
             break;
         case meshtastic_Config_LoRaConfig_ModemPreset_LONG_MODERATE:

--- a/src/mesh/RadioInterface.h
+++ b/src/mesh/RadioInterface.h
@@ -56,7 +56,7 @@ class RadioInterface
 
     float bw = 125;
     uint8_t sf = 9;
-    uint8_t cr = 7;
+    uint8_t cr = 5;
     /** Slottime is the minimum time to wait, consisting of:
       - CAD duration (maximum of SX126x and SX127x);
       - roundtrip air propagation time (assuming max. 30km between nodes);


### PR DESCRIPTION
Increases throughput by about 1.5x at the cost of a little bit of sensitivity (according to "_Experimental Evaluation of the Packet Reception Performance of LoRa_" by Guo, Q. et al. it's less than 1 dB). LoRaWAN is also using only 4/5 (see [RP002-1.0.1](https://lora-alliance.org/wp-content/uploads/2020/11/rp_2-1.0.1.pdf) Section 3.1.2). 
This is non-breaking as the CR is sent in the LoRa header. I tested that two devices with CR of 4/5 and 4/8 can talk to each other.
