### PR TITLE
Cleanup trunk linter disables

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,24 +1,24 @@
 version: 0.1
 cli:
-  version: 1.17.0
+  version: 1.17.1
 plugins:
   sources:
     - id: trunk
-      ref: v1.2.5
+      ref: v1.2.6
       uri: https://github.com/trunk-io/plugins
 lint:
   enabled:
     - bandit@1.7.5
-    - checkov@2.5.0
+    - checkov@3.0.16
     - terrascan@1.18.3
-    - trivy@0.45.1
-    - trufflehog@3.59.0
+    - trivy@0.46.1
+    - trufflehog@3.62.1
     - taplo@0.8.1
-    - ruff@0.0.292
+    - ruff@0.1.3
     - yamllint@1.32.0
     - isort@5.12.0
     - markdownlint@0.37.0
-    - oxipng@8.0.0
+    - oxipng@9.0.0
     - svgo@3.0.2
     - actionlint@1.6.26
     - flake8@6.1.0
@@ -30,15 +30,6 @@ lint:
     - gitleaks@8.18.0
     - clang-format@16.0.3
     - prettier@3.0.3
-  disabled:
-    - taplo@0.8.1
-    - shellcheck@0.9.0
-    - shfmt@3.6.0
-    - oxipng@8.0.0
-    - actionlint@1.6.22
-    - markdownlint@0.37.0
-    - hadolint@2.12.0
-    - svgo@3.0.2
 runtimes:
   enabled:
     - python@3.10.8


### PR DESCRIPTION
Hello from Trunk!

We noticed that this repo's trunk.yaml has several linters marked as disabled. We expect items in the `disabled` list to be versionless (`shfmt`, not `shfmt@foo`), so this is actually a no-op as-is. I've removed these extraneous disables and upgraded Trunk.

If any of these are actually intended to be disabled, let me know and I'll add them back in. In a future version of Trunk, we'll be adding config validation to catch this case automatically!