### PR TITLE
Add support for the rak10701 board, no touch

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -26,6 +26,7 @@
 ;default_envs = meshtastic-dr-dev
 ;default_envs = m5stack-coreink
 ;default_envs = rak4631
+;default_envs = rak10701
 default_envs = wio-e5
 
 extra_configs =

--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -390,7 +390,7 @@ class Screen : public concurrency::OSThread
     SH1106Wire dispdev;
 #elif defined(USE_SSD1306)
     SSD1306Wire dispdev;
-#elif defined(ST7735_CS) || defined(ILI9341_DRIVER) || defined(ST7789_CS)
+#elif defined(ST7735_CS) || defined(ILI9341_DRIVER) || defined(ST7789_CS) || defined(RAK14014)
     TFTDisplay dispdev;
 #elif defined(USE_EINK)
     EInkDisplay dispdev;

--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -105,6 +105,10 @@ class LGFX : public lgfx::LGFX_Device
 
 static LGFX tft;
 
+#elif defined(RAK14014)
+#include <TFT_eSPI.h>
+TFT_eSPI tft = TFT_eSPI();
+
 #elif defined(ST7789_CS)
 #include <LovyanGFX.hpp> // Graphics and font library for ST7735 driver chip
 
@@ -327,7 +331,7 @@ static TFT_eSPI tft = TFT_eSPI(); // Invoke library, pins defined in User_Setup.
 
 #endif
 
-#if defined(ST7735_CS) || defined(ST7789_CS) || defined(ILI9341_DRIVER)
+#if defined(ST7735_CS) || defined(ST7789_CS) || defined(ILI9341_DRIVER) || defined(RAK14014)
 #include "SPILock.h"
 #include "TFTDisplay.h"
 #include <SPI.h>
@@ -393,7 +397,9 @@ void TFTDisplay::sendCommand(uint8_t com)
 #ifdef VTFT_CTRL
         digitalWrite(VTFT_CTRL, LOW);
 #endif
-#ifndef M5STACK
+
+#ifdef RAK14014
+#elif !defined(M5STACK)
         tft.setBrightness(128);
 #endif
         break;
@@ -419,7 +425,8 @@ void TFTDisplay::sendCommand(uint8_t com)
 #ifdef VTFT_CTRL
         digitalWrite(VTFT_CTRL, HIGH);
 #endif
-#ifndef M5STACK
+#ifdef RAK14014
+#elif !defined(M5STACK)
         tft.setBrightness(0);
 #endif
         break;
@@ -441,7 +448,8 @@ void TFTDisplay::flipScreenVertically()
 
 bool TFTDisplay::hasTouch(void)
 {
-#ifndef M5STACK
+#ifdef RAK14014
+#elif !defined(M5STACK)
     return tft.touch() != nullptr;
 #else
     return false;
@@ -450,7 +458,8 @@ bool TFTDisplay::hasTouch(void)
 
 bool TFTDisplay::getTouch(int16_t *x, int16_t *y)
 {
-#ifndef M5STACK
+#ifdef RAK14014
+#elif !defined(M5STACK)
     return tft.getTouch(x, y);
 #else
     return false;
@@ -471,6 +480,9 @@ bool TFTDisplay::connect()
 #ifdef TFT_BL
     digitalWrite(TFT_BL, TFT_BACKLIGHT_ON);
     pinMode(TFT_BL, OUTPUT);
+    // pinMode(PIN_3V3_EN, OUTPUT);
+    // digitalWrite(PIN_3V3_EN, HIGH);
+    LOG_INFO("Power to TFT Backlight\n");
 #endif
 
 #ifdef ST7735_BACKLIGHT_EN_V03
@@ -484,16 +496,21 @@ bool TFTDisplay::connect()
 #endif
 
     tft.init();
+
 #if defined(M5STACK)
     tft.setRotation(0);
+#elif defined(RAK14014)
+    tft.setRotation(1);
+    tft.setSwapBytes(true);
+    tft.fillScreen(TFT_BLACK);
 #elif defined(T_DECK) || defined(PICOMPUTER_S3)
     tft.setRotation(1); // T-Deck has the TFT in landscape
 #elif defined(T_WATCH_S3)
     tft.setRotation(2); // T-Watch S3 left-handed orientation
 #else
     tft.setRotation(3); // Orient horizontal and wide underneath the silkscreen name label
-#endif
     tft.fillScreen(TFT_BLACK);
+#endif
     return true;
 }
 

--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -502,15 +502,16 @@ bool TFTDisplay::connect()
 #elif defined(RAK14014)
     tft.setRotation(1);
     tft.setSwapBytes(true);
-    tft.fillScreen(TFT_BLACK);
+//    tft.fillScreen(TFT_BLACK);
 #elif defined(T_DECK) || defined(PICOMPUTER_S3)
     tft.setRotation(1); // T-Deck has the TFT in landscape
 #elif defined(T_WATCH_S3)
     tft.setRotation(2); // T-Watch S3 left-handed orientation
 #else
     tft.setRotation(3); // Orient horizontal and wide underneath the silkscreen name label
-    tft.fillScreen(TFT_BLACK);
 #endif
+    tft.fillScreen(TFT_BLACK);
+
     return true;
 }
 

--- a/variants/rak10701/platformio.ini
+++ b/variants/rak10701/platformio.ini
@@ -1,0 +1,18 @@
+; The very slick RAK wireless RAK10701 Field Tester device.  Note you will have to flash to Arduino bootloader to use this firmware.  Be aware touch is not currently working.
+[env:rak10701]
+extends = nrf52840_base
+board = wiscore_rak4631
+build_flags = ${nrf52840_base.build_flags} -Ivariants/rak10701 -D RAK_4631
+  -L "${platformio.libdeps_dir}/${this.__env__}/BSEC2 Software Library/src/cortex-m4/fpv4-sp-d16-hard"
+  -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
+build_src_filter = ${nrf52_base.build_src_filter} +<../variants/rak4631> +<mesh/eth/> +<mesh/api/> +<mqtt/>
+lib_deps = 
+  ${nrf52840_base.lib_deps}
+  ${networking_base.lib_deps}
+  melopero/Melopero RV3028@^1.1.0
+  https://github.com/RAKWireless/RAK13800-W5100S.git#1.0.2
+  rakwireless/RAKwireless NCP5623 RGB LED library@^1.0.2
+  bodmer/TFT_eSPI
+debug_tool = jlink
+; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
+;upload_protocol = jlink

--- a/variants/rak10701/platformio.ini
+++ b/variants/rak10701/platformio.ini
@@ -5,7 +5,7 @@ board = wiscore_rak4631
 build_flags = ${nrf52840_base.build_flags} -Ivariants/rak10701 -D RAK_4631
   -L "${platformio.libdeps_dir}/${this.__env__}/BSEC2 Software Library/src/cortex-m4/fpv4-sp-d16-hard"
   -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
-build_src_filter = ${nrf52_base.build_src_filter} +<../variants/rak4631> +<mesh/eth/> +<mesh/api/> +<mqtt/>
+build_src_filter = ${nrf52_base.build_src_filter} +<../variants/rak10701> +<mesh/eth/> +<mesh/api/> +<mqtt/>
 lib_deps = 
   ${nrf52840_base.lib_deps}
   ${networking_base.lib_deps}

--- a/variants/rak10701/variant.cpp
+++ b/variants/rak10701/variant.cpp
@@ -1,0 +1,41 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  Copyright (c) 2018, Adafruit Industries (adafruit.com)
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "variant.h"
+#include "nrf.h"
+#include "wiring_constants.h"
+#include "wiring_digital.h"
+
+const uint32_t g_ADigitalPinMap[] = {
+    // P0
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+
+    // P1
+    32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47};
+
+void initVariant()
+{
+    // LED1 & LED2
+    pinMode(PIN_LED1, OUTPUT);
+    ledOff(PIN_LED1);
+
+    pinMode(PIN_LED2, OUTPUT);
+    ledOff(PIN_LED2);
+}

--- a/variants/rak10701/variant.h
+++ b/variants/rak10701/variant.h
@@ -1,0 +1,329 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  Copyright (c) 2018, Adafruit Industries (adafruit.com)
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _VARIANT_RAK4630_
+#define _VARIANT_RAK4630_
+
+#define RAK4630
+
+/** Master clock frequency */
+#define VARIANT_MCK (64000000ul)
+
+#define USE_LFXO // Board uses 32khz crystal for LF
+// define USE_LFRC    // Board uses RC for LF
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+// Number of pins defined in PinDescription array
+#define PINS_COUNT (48)
+#define NUM_DIGITAL_PINS (48)
+#define NUM_ANALOG_INPUTS (6)
+#define NUM_ANALOG_OUTPUTS (0)
+
+// LEDs
+#define PIN_LED1 (35)
+#define PIN_LED2 (36)
+
+#define LED_BUILTIN PIN_LED1
+#define LED_CONN PIN_LED2
+
+#define LED_GREEN PIN_LED1
+#define LED_BLUE PIN_LED2
+
+#define LED_STATE_ON 1 // State when LED is litted
+
+/*
+ * Buttons
+ */
+
+#define PIN_BUTTON1 9 // Pin for button on E-ink button module or IO expansion such as the RAK14014 or RAK14015 TFT modules
+#define BUTTON_NEED_PULLUP
+#define PIN_BUTTON2 12
+#define PIN_BUTTON3 24
+#define PIN_BUTTON4 25
+
+/*
+ * Analog pins
+ */
+#define PIN_A0 (5)
+#define PIN_A1 (31)
+#define PIN_A2 (28)
+#define PIN_A3 (29)
+#define PIN_A4 (30)
+#define PIN_A5 (31)
+#define PIN_A6 (0xff)
+#define PIN_A7 (0xff)
+
+static const uint8_t A0 = PIN_A0;
+static const uint8_t A1 = PIN_A1;
+static const uint8_t A2 = PIN_A2;
+static const uint8_t A3 = PIN_A3;
+static const uint8_t A4 = PIN_A4;
+static const uint8_t A5 = PIN_A5;
+static const uint8_t A6 = PIN_A6;
+static const uint8_t A7 = PIN_A7;
+#define ADC_RESOLUTION 14
+
+// Other pins
+#define PIN_AREF (2)
+#define PIN_NFC1 (9)
+#define PIN_NFC2 (10)
+
+static const uint8_t AREF = PIN_AREF;
+
+/*
+ * Serial interfaces
+ */
+#define PIN_SERIAL1_RX (15)
+#define PIN_SERIAL1_TX (16)
+
+// Connected to Jlink CDC
+#define PIN_SERIAL2_RX (8)
+#define PIN_SERIAL2_TX (6)
+
+/*
+ * SPI Interfaces
+ */
+#define SPI_INTERFACES_COUNT 2
+
+#define PIN_SPI_MISO (45)
+#define PIN_SPI_MOSI (44)
+#define PIN_SPI_SCK (43)
+
+#define PIN_SPI1_MISO (29) // (0 + 29)
+#define PIN_SPI1_MOSI (30) // (0 + 30)
+#define PIN_SPI1_SCK (3)   // (0 + 3)
+
+static const uint8_t SS = 42;
+static const uint8_t MOSI = PIN_SPI_MOSI;
+static const uint8_t MISO = PIN_SPI_MISO;
+static const uint8_t SCK = PIN_SPI_SCK;
+
+/*
+ * eink display pins
+ */
+
+#define PIN_EINK_CS (0 + 26)
+#define PIN_EINK_BUSY (0 + 4)
+#define PIN_EINK_DC (0 + 17)
+#define PIN_EINK_RES (-1)
+#define PIN_EINK_SCLK (0 + 3)
+#define PIN_EINK_MOSI (0 + 30) // also called SDI
+
+// Controls power for the eink display - Board power is enabled either by VBUS from USB or the CPU asserting PWR_ON
+// FIXME - I think this is actually just the board power enable - it enables power to the CPU also
+// #define PIN_EINK_PWR_ON (-1)
+
+// #define USE_EINK
+
+// RAKRGB
+#define HAS_NCP5623
+
+/*
+ * Wire Interfaces
+ */
+#define WIRE_INTERFACES_COUNT 1
+
+#define PIN_WIRE_SDA (13)
+#define PIN_WIRE_SCL (14)
+
+// QSPI Pins
+#define PIN_QSPI_SCK 3
+#define PIN_QSPI_CS 26
+#define PIN_QSPI_IO0 30
+#define PIN_QSPI_IO1 29
+#define PIN_QSPI_IO2 28
+#define PIN_QSPI_IO3 2
+
+// On-board QSPI Flash
+#define EXTERNAL_FLASH_DEVICES IS25LP080D
+#define EXTERNAL_FLASH_USE_QSPI
+
+/* @note RAK5005-O GPIO mapping to RAK4631 GPIO ports
+   RAK5005-O <->  nRF52840
+   IO1       <->  P0.17 (Arduino GPIO number 17)
+   IO2       <->  P1.02 (Arduino GPIO number 34)
+   IO3       <->  P0.21 (Arduino GPIO number 21)
+   IO4       <->  P0.04 (Arduino GPIO number 4)
+   IO5       <->  P0.09 (Arduino GPIO number 9)
+   IO6       <->  P0.10 (Arduino GPIO number 10)
+   IO7       <->  P0.28 (Arduino GPIO number 28)
+   SW1       <->  P0.01 (Arduino GPIO number 1)
+   A0        <->  P0.04/AIN2 (Arduino Analog A2
+   A1        <->  P0.31/AIN7 (Arduino Analog A7
+   SPI_CS    <->  P0.26 (Arduino GPIO number 26)
+ */
+
+// No reason not to have the RAK Wireless pin defs here too.  This allows code from example RAK sketches to run without
+// modification.
+
+static const uint8_t WB_IO1 = 17;      // SLOT_A SLOT_B
+static const uint8_t WB_IO2 = 34;      // SLOT_A SLOT_B
+static const uint8_t WB_IO3 = 21;      // SLOT_C
+static const uint8_t WB_IO4 = 4;       // SLOT_C
+static const uint8_t WB_IO5 = 9;       // SLOT_D
+static const uint8_t WB_IO6 = 10;      // SLOT_D
+static const uint8_t WB_SW1 = 33;      // IO_SLOT
+static const uint8_t WB_A0 = 5;        // IO_SLOT
+static const uint8_t WB_A1 = 31;       // IO_SLOT
+static const uint8_t WB_I2C1_SDA = 13; // SENSOR_SLOT IO_SLOT
+static const uint8_t WB_I2C1_SCL = 14; // SENSOR_SLOT IO_SLOT
+static const uint8_t WB_I2C2_SDA = 24; // IO_SLOT
+static const uint8_t WB_I2C2_SCL = 25; // IO_SLOT
+static const uint8_t WB_SPI_CS = 26;   // IO_SLOT
+static const uint8_t WB_SPI_CLK = 3;   // IO_SLOT
+static const uint8_t WB_SPI_MISO = 29; // IO_SLOT
+static const uint8_t WB_SPI_MOSI = 30; // IO_SLOT
+
+// RAK4630 LoRa module
+
+/* Setup of the SX1262 LoRa module ( https://docs.rakwireless.com/Product-Categories/WisBlock/RAK4631/Datasheet/ )
+
+P1.10 	NSS 	SPI NSS (Arduino GPIO number 42)
+P1.11 	SCK 	SPI CLK (Arduino GPIO number 43)
+P1.12 	MOSI 	SPI MOSI (Arduino GPIO number 44)
+P1.13 	MISO 	SPI MISO (Arduino GPIO number 45)
+P1.14 	BUSY 	BUSY signal (Arduino GPIO number 46)
+P1.15 	DIO1 	DIO1 event interrupt (Arduino GPIO number 47)
+P1.06 	NRESET 	NRESET manual reset of the SX1262 (Arduino GPIO number 38)
+
+Important for successful SX1262 initialization:
+
+* Setup DIO2 to control the antenna switch
+* Setup DIO3 to control the TCXO power supply
+* Setup the SX1262 to use it's DCDC regulator and not the LDO
+* RAK4630 schematics show GPIO P1.07 connected to the antenna switch, but it should not be initialized, as DIO2 will do the
+control of the antenna switch
+
+SO GPIO 39/TXEN MAY NOT BE DEFINED FOR SUCCESSFUL OPERATION OF THE SX1262 - TG
+
+*/
+
+#define USE_SX1262
+#define SX126X_CS (42)
+#define SX126X_DIO1 (47)
+#define SX126X_BUSY (46)
+#define SX126X_RESET (38)
+// #define SX126X_TXEN (39)
+// #define SX126X_RXEN (37)
+#define SX126X_POWER_EN (37)
+// DIO2 controlls an antenna switch and the TCXO voltage is controlled by DIO3
+#define SX126X_DIO2_AS_RF_SWITCH
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8
+
+// enables 3.3V periphery like GPS or IO Module
+#define PIN_3V3_EN (34)
+
+// RAK1910 GPS module
+// If using the wisblock GPS module and pluged into Port A on WisBlock base
+// IO1 is hooked to PPS (pin 12 on header) = gpio 17
+// IO2 is hooked to GPS RESET = gpio 34, but it can not be used to this because IO2 is ALSO used to control 3V3_S power (1 is on).
+// Therefore must be 1 to keep peripherals powered
+// Power is on the controllable 3V3_S rail
+// #define PIN_GPS_RESET (34)
+#define PIN_GPS_EN PIN_3V3_EN
+#define PIN_GPS_PPS (17) // Pulse per second input from the GPS
+
+#define GPS_RX_PIN PIN_SERIAL1_RX
+#define GPS_TX_PIN PIN_SERIAL1_TX
+
+// Define pin to enable GPS toggle (set GPIO to LOW) via user button triple press
+
+// RAK12002 RTC Module
+#define RV3028_RTC (uint8_t)0b1010010
+
+// RAK18001 Buzzer in Slot C
+// #define PIN_BUZZER 21 // IO3 is PWM2
+// NEW: set this via protobuf instead!
+
+// Battery
+// The battery sense is hooked to pin A0 (5)
+#define BATTERY_PIN PIN_A0
+// and has 12 bit resolution
+#define BATTERY_SENSE_RESOLUTION_BITS 12
+#define BATTERY_SENSE_RESOLUTION 4096.0
+// Definition of milliVolt per LSB => 3.0V ADC range and 12-bit ADC resolution = 3000mV/4096
+#define VBAT_MV_PER_LSB (0.73242188F)
+// Voltage divider value => 1.5M + 1M voltage divider on VBAT = (1.5M / (1M + 1.5M))
+#define VBAT_DIVIDER (0.4F)
+// Compensation factor for the VBAT divider
+#define VBAT_DIVIDER_COMP (1.73)
+// Fixed calculation of milliVolt from compensation value
+#define REAL_VBAT_MV_PER_LSB (VBAT_DIVIDER_COMP * VBAT_MV_PER_LSB)
+#undef AREF_VOLTAGE
+#define AREF_VOLTAGE 3.0
+#define VBAT_AR_INTERNAL AR_INTERNAL_3_0
+#define ADC_MULTIPLIER VBAT_DIVIDER_COMP // REAL_VBAT_MV_PER_LSB
+#define VBAT_RAW_TO_SCALED(x) (REAL_VBAT_MV_PER_LSB * x)
+
+#define HAS_RTC 1
+
+#define HAS_ETHERNET 1
+
+#define RAK_4631 1
+
+#define PIN_ETHERNET_RESET 21
+#define PIN_ETHERNET_SS PIN_EINK_CS
+#define ETH_SPI_PORT SPI1
+#define AQ_SET_PIN 10
+
+#ifdef __cplusplus
+}
+#endif
+
+#define RAK14014 // Tell it we have a RAK14014
+#define USER_SETUP_LOADED 1
+#define DISABLE_ALL_LIBRARY_WARNINGS 1
+#define ST7789_DRIVER 1
+#define TFT_WIDTH 240
+#define TFT_HEIGHT 320
+#define TFT_MISO WB_SPI_MISO
+#define TFT_MOSI WB_SPI_MOSI
+#define TFT_SCLK WB_SPI_CLK
+#define TFT_CS WB_SPI_CS
+#define TFT_DC WB_IO4
+#define TFT_RST -1
+#define TFT_BL WB_IO3
+#define LOAD_GLCD 1
+#define LOAD_GFXFF 1
+#define TFT_RGB_ORDER 0
+#define SPI_FREQUENCY 50000000
+#define TFT_SPI_PORT SPI1
+#define ST7789_CS WB_SPI_CS // Adds compatibility with the rest of the checking for a ST7789 TFT.
+
+#define SCREEN_ROTATE
+#define SCREEN_TRANSITION_FRAMERATE 5
+
+#define HAS_TOUCHSCREEN 0
+#define SCREEN_TOUCH_INT 10 // From tp.h on the tracker open source code.
+#define TOUCH_I2C_PORT 0
+#define TOUCH_SLAVE_ADDRESS 0x5D // GT911
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#endif


### PR DESCRIPTION
Add support for the RAK10701 Field Tester device.  You must flash from the RUI3 firmware to Arduino before use.  

The TFT and the button on the side work, but the touch screen will require more work as its not the same libs as the ESP32 TFT/touch devices.  