### PR TITLE
Remove redundant checks for power of 0

### DIFF
--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -37,9 +37,6 @@ bool RF95Interface::init()
 {
     RadioLibInterface::init();
 
-    if (power == 0)
-        power = POWER_DEFAULT;
-
     if (power > MAX_POWER) // This chip has lower power limits than some
         power = MAX_POWER;
 

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -446,9 +446,11 @@ void RadioInterface::applyModemConfig()
 
     if ((power == 0) || ((power > myRegion->powerLimit) && !devicestate.owner.is_licensed))
         power = myRegion->powerLimit;
-
+    
     if (power == 0)
-        power = 17; // Default to default power if we don't have a valid power
+        power = 17; // Default to this power level if we don't have a valid regional power limit (powerLimit of myRegion defaults
+                    // to 0, currently no region has an actual power limit of 0 [dBm] so we can assume regions which have this
+                    // variable set to 0 don't have a valid power limit)
 
     // Set final tx_power back onto config
     loraConfig.tx_power = (int8_t)power; // cppcheck-suppress assignmentAddressToInteger

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -446,7 +446,7 @@ void RadioInterface::applyModemConfig()
 
     if ((power == 0) || ((power > myRegion->powerLimit) && !devicestate.owner.is_licensed))
         power = myRegion->powerLimit;
-    
+
     if (power == 0)
         power = 17; // Default to this power level if we don't have a valid regional power limit (powerLimit of myRegion defaults
                     // to 0, currently no region has an actual power limit of 0 [dBm] so we can assume regions which have this

--- a/src/mesh/STM32WLE5JCInterface.cpp
+++ b/src/mesh/STM32WLE5JCInterface.cpp
@@ -20,9 +20,6 @@ bool STM32WLE5JCInterface::init()
 
     lora.setRfSwitchTable(rfswitch_pins, rfswitch_table);
 
-    if (power == 0)
-        power = STM32WLx_MAX_POWER;
-
     if (power > STM32WLx_MAX_POWER) // This chip has lower power limits than some
         power = STM32WLx_MAX_POWER;
 

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -43,6 +43,7 @@ template <typename T> bool SX126xInterface<T>::init()
     bool useRegulatorLDO = false; // Seems to depend on the connection to pin 9/DCC_SW - if an inductor DCDC?
 
     RadioLibInterface::init();
+
     if (power > SX126X_MAX_POWER) // Clamp power to maximum defined level
         power = SX126X_MAX_POWER;
 

--- a/src/mesh/SX128xInterface.cpp
+++ b/src/mesh/SX128xInterface.cpp
@@ -42,10 +42,7 @@ template <typename T> bool SX128xInterface<T>::init()
 
     RadioLibInterface::init();
 
-    if (power == 0)
-        power = SX128X_MAX_POWER;
-
-    if (power > SX128X_MAX_POWER) // This chip has lower power limits than some
+    if (power > SX128X_MAX_POWER) // Note: this chip has lower power limits than some
         power = SX128X_MAX_POWER;
 
     limitPower();

--- a/src/mesh/SX128xInterface.cpp
+++ b/src/mesh/SX128xInterface.cpp
@@ -42,7 +42,7 @@ template <typename T> bool SX128xInterface<T>::init()
 
     RadioLibInterface::init();
 
-    if (power > SX128X_MAX_POWER) // Note: this chip has lower power limits than some
+    if (power > SX128X_MAX_POWER) // This chip has lower power limits than some
         power = SX128X_MAX_POWER;
 
     limitPower();


### PR DESCRIPTION
The power cannot be 0 once the execution results in whichever radio module interface initialised RadioInterface through RadioLibInterface, as the code below is executed (comment clarified)
```cpp
    if ((power == 0) || ((power > myRegion->powerLimit) && !devicestate.owner.is_licensed))
        power = myRegion->powerLimit;
    
    if (power == 0)
        power = 17; // Default to this power level if we don't have a valid regional power limit (powerLimit of myRegion defaults
                    // to 0, currently no region has an actual power limit of 0 [dBm] so we can assume regions which have this
                    // variable set to 0 don't have a valid power limit)
```
Therefore, it is unecessary to then check again if power is 0 in each radio module's interface. This behaviour was found as the changes in #2813 which removed this check had no effect (the intention was to avoid accidentally setting 0 dBm to max power, but this should have not been done as this was intended behaviour as the default value sent in protobufs is empty (0) to reduce the message size, as in most cases you will be transmitting at the maximum allowed power), it didn't cause SX126x devices to transmit at 0 dBm, but continues behaving as before.