### PR TITLE
Add missing defaulting for HAS_SENSOR to configuration.h

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -188,6 +188,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef HAS_TELEMETRY
 #define HAS_TELEMETRY 0
 #endif
+#ifndef HAS_SENSOR
+#define HAS_SENSOR 0
+#endif
 #ifndef HAS_RADIO
 #define HAS_RADIO 0
 #endif


### PR DESCRIPTION
Add missing `HAS_SENSOR` defaulting. The value is used twice in `/src/modules/Modules.cpp` ([source](https://github.com/search?q=repo%3Ameshtastic%2Ffirmware%20HAS_SENSOR&type=code))