### PR TITLE
Generalise SPI pin names

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -628,24 +628,24 @@ void setup()
     initSPI();
 #ifdef ARCH_RP2040
 #ifdef HW_SPI1_DEVICE
-    SPI1.setSCK(RF95_SCK);
-    SPI1.setTX(RF95_MOSI);
-    SPI1.setRX(RF95_MISO);
-    pinMode(RF95_NSS, OUTPUT);
-    digitalWrite(RF95_NSS, HIGH);
+    SPI1.setSCK(LORA_SCK);
+    SPI1.setTX(LORA_MOSI);
+    SPI1.setRX(LORA_MISO);
+    pinMode(LORA_NSS, OUTPUT);
+    digitalWrite(LORA_NSS, HIGH);
     SPI1.begin(false);
 #else                      // HW_SPI1_DEVICE
-    SPI.setSCK(RF95_SCK);
-    SPI.setTX(RF95_MOSI);
-    SPI.setRX(RF95_MISO);
+    SPI.setSCK(LORA_SCK);
+    SPI.setTX(LORA_MOSI);
+    SPI.setRX(LORA_MISO);
     SPI.begin(false);
 #endif                     // HW_SPI1_DEVICE
 #elif !defined(ARCH_ESP32) // ARCH_RP2040
     SPI.begin();
 #else
     // ESP32
-    SPI.begin(RF95_SCK, RF95_MISO, RF95_MOSI, RF95_NSS);
-    LOG_WARN("SPI.begin(SCK=%d, MISO=%d, MOSI=%d, NSS=%d)\n", RF95_SCK, RF95_MISO, RF95_MOSI, RF95_NSS);
+    SPI.begin(LORA_SCK, LORA_MISO, LORA_MOSI, LORA_NSS);
+    LOG_WARN("SPI.begin(SCK=%d, MISO=%d, MOSI=%d, NSS=%d)\n", LORA_SCK, LORA_MISO, LORA_MOSI, LORA_NSS);
     SPI.setFrequency(4000000);
 #endif
 
@@ -755,7 +755,7 @@ void setup()
 
 #if defined(RF95_IRQ)
     if (!rIf) {
-        rIf = new RF95Interface(RadioLibHAL, RF95_NSS, RF95_IRQ, RF95_RESET, RF95_DIO1);
+        rIf = new RF95Interface(RadioLibHAL, LORA_NSS, RF95_IRQ, RF95_RESET, RF95_DIO1);
         if (!rIf->init()) {
             LOG_WARN("Failed to find RF95 radio\n");
             delete rIf;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -631,8 +631,8 @@ void setup()
     SPI1.setSCK(LORA_SCK);
     SPI1.setTX(LORA_MOSI);
     SPI1.setRX(LORA_MISO);
-    pinMode(LORA_NSS, OUTPUT);
-    digitalWrite(LORA_NSS, HIGH);
+    pinMode(LORA_CS, OUTPUT);
+    digitalWrite(LORA_CS, HIGH);
     SPI1.begin(false);
 #else                      // HW_SPI1_DEVICE
     SPI.setSCK(LORA_SCK);
@@ -644,8 +644,8 @@ void setup()
     SPI.begin();
 #else
     // ESP32
-    SPI.begin(LORA_SCK, LORA_MISO, LORA_MOSI, LORA_NSS);
-    LOG_WARN("SPI.begin(SCK=%d, MISO=%d, MOSI=%d, NSS=%d)\n", LORA_SCK, LORA_MISO, LORA_MOSI, LORA_NSS);
+    SPI.begin(LORA_SCK, LORA_MISO, LORA_MOSI, LORA_CS);
+    LOG_WARN("SPI.begin(SCK=%d, MISO=%d, MOSI=%d, NSS=%d)\n", LORA_SCK, LORA_MISO, LORA_MOSI, LORA_CS);
     SPI.setFrequency(4000000);
 #endif
 
@@ -755,7 +755,7 @@ void setup()
 
 #if defined(RF95_IRQ)
     if (!rIf) {
-        rIf = new RF95Interface(RadioLibHAL, LORA_NSS, RF95_IRQ, RF95_RESET, RF95_DIO1);
+        rIf = new RF95Interface(RadioLibHAL, LORA_CS, RF95_IRQ, RF95_RESET, RF95_DIO1);
         if (!rIf->init()) {
             LOG_WARN("Failed to find RF95 radio\n");
             delete rIf;

--- a/src/platform/esp32/architecture.h
+++ b/src/platform/esp32/architecture.h
@@ -132,7 +132,7 @@
 #define LORA_SCK 5
 #define LORA_MISO 19
 #define LORA_MOSI 27
-#define LORA_NSS 18
+#define LORA_CS 18
 #endif
 
 #define SERIAL0_RX_GPIO 3 // Always GPIO3 on ESP32

--- a/src/platform/esp32/architecture.h
+++ b/src/platform/esp32/architecture.h
@@ -128,11 +128,11 @@
 // -----------------------------------------------------------------------------
 
 // NRF52 boards will define this in variant.h
-#ifndef RF95_SCK
-#define RF95_SCK 5
-#define RF95_MISO 19
-#define RF95_MOSI 27
-#define RF95_NSS 18
+#ifndef LORA_SCK
+#define LORA_SCK 5
+#define LORA_MISO 19
+#define LORA_MOSI 27
+#define LORA_NSS 18
 #endif
 
 #define SERIAL0_RX_GPIO 3 // Always GPIO3 on ESP32

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -192,6 +192,6 @@ void portduinoSetup()
         gpioBind(new SimGPIOPin(LORA_DIO1, "fakeLoraIrq"));
     }
     // gpioBind((new SimGPIOPin(LORA_RESET, "LORA_RESET")));
-    // gpioBind((new SimGPIOPin(LORA_NSS, "LORA_NSS"))->setSilent());
+    // gpioBind((new SimGPIOPin(LORA_CS, "LORA_CS"))->setSilent());
 #endif
 }

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -192,6 +192,6 @@ void portduinoSetup()
         gpioBind(new SimGPIOPin(LORA_DIO1, "fakeLoraIrq"));
     }
     // gpioBind((new SimGPIOPin(LORA_RESET, "LORA_RESET")));
-    // gpioBind((new SimGPIOPin(RF95_NSS, "RF95_NSS"))->setSilent());
+    // gpioBind((new SimGPIOPin(LORA_NSS, "LORA_NSS"))->setSilent());
 #endif
 }

--- a/variants/ai-c3/variant.h
+++ b/variants/ai-c3/variant.h
@@ -7,10 +7,10 @@
 #define LED_PIN 30   // RGB LED
 
 #define USE_RF95
-#define RF95_SCK 4
-#define RF95_MISO 5
-#define RF95_MOSI 6
-#define RF95_NSS 7
+#define LORA_SCK 4
+#define LORA_MISO 5
+#define LORA_MOSI 6
+#define LORA_NSS 7
 
 #define LORA_DIO0 10
 #define LORA_DIO1 3
@@ -19,7 +19,7 @@
 // WaveShare Core1262-868M
 // https://www.waveshare.com/wiki/Core1262-868M
 #define USE_SX1262
-#define SX126X_CS RF95_NSS
+#define SX126X_CS LORA_NSS
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY 10
 #define SX126X_RESET LORA_RESET

--- a/variants/ai-c3/variant.h
+++ b/variants/ai-c3/variant.h
@@ -10,7 +10,7 @@
 #define LORA_SCK 4
 #define LORA_MISO 5
 #define LORA_MOSI 6
-#define LORA_NSS 7
+#define LORA_CS 7
 
 #define LORA_DIO0 10
 #define LORA_DIO1 3
@@ -19,7 +19,7 @@
 // WaveShare Core1262-868M
 // https://www.waveshare.com/wiki/Core1262-868M
 #define USE_SX1262
-#define SX126X_CS LORA_NSS
+#define SX126X_CS LORA_CS
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY 10
 #define SX126X_RESET LORA_RESET

--- a/variants/betafpv_2400_tx_micro/variant.h
+++ b/variants/betafpv_2400_tx_micro/variant.h
@@ -9,10 +9,10 @@
 #undef GPS_RX_PIN
 #undef GPS_TX_PIN
 
-#define RF95_SCK 18
-#define RF95_MISO 19
-#define RF95_MOSI 23
-#define RF95_NSS 5
+#define LORA_SCK 18
+#define LORA_MISO 19
+#define LORA_MOSI 23
+#define LORA_NSS 5
 #define RF95_FAN_EN 17
 
 #define LED_PIN 16 // This is a LED_WS2812 not a standard LED

--- a/variants/betafpv_2400_tx_micro/variant.h
+++ b/variants/betafpv_2400_tx_micro/variant.h
@@ -12,7 +12,7 @@
 #define LORA_SCK 18
 #define LORA_MISO 19
 #define LORA_MOSI 23
-#define LORA_NSS 5
+#define LORA_CS 5
 #define RF95_FAN_EN 17
 
 #define LED_PIN 16 // This is a LED_WS2812 not a standard LED

--- a/variants/betafpv_900_tx_nano/variant.h
+++ b/variants/betafpv_900_tx_nano/variant.h
@@ -12,7 +12,7 @@
 #define LORA_SCK 18
 #define LORA_MISO 19
 #define LORA_MOSI 23
-#define LORA_NSS 5
+#define LORA_CS 5
 
 #define LORA_DIO0 4
 #define LORA_RESET 14

--- a/variants/betafpv_900_tx_nano/variant.h
+++ b/variants/betafpv_900_tx_nano/variant.h
@@ -9,10 +9,10 @@
 
 #define USE_RF95
 
-#define RF95_SCK 18
-#define RF95_MISO 19
-#define RF95_MOSI 23
-#define RF95_NSS 5
+#define LORA_SCK 18
+#define LORA_MISO 19
+#define LORA_MOSI 23
+#define LORA_NSS 5
 
 #define LORA_DIO0 4
 #define LORA_RESET 14

--- a/variants/bpi_picow_esp32_s3/variant.h
+++ b/variants/bpi_picow_esp32_s3/variant.h
@@ -25,7 +25,7 @@
 #undef LORA_SCK
 #undef LORA_MISO
 #undef LORA_MOSI
-#undef LORA_NSS
+#undef LORA_CS
 
 // WaveShare Core1262-868M OK
 // https://www.waveshare.com/wiki/Core1262-868M
@@ -35,11 +35,11 @@
 #define LORA_MISO 39
 #define LORA_SCK 21
 #define LORA_MOSI 38
-#define LORA_NSS 17
+#define LORA_CS 17
 #define LORA_RESET 42
 #define LORA_DIO1 5
 #define LORA_BUSY 47
-#define SX126X_CS LORA_NSS
+#define SX126X_CS LORA_CS
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_BUSY
 #define SX126X_RESET LORA_RESET
@@ -52,11 +52,11 @@
 #define LORA_MISO 1
 #define LORA_SCK 3
 #define LORA_MOSI 4
-#define LORA_NSS 2
+#define LORA_CS 2
 #define LORA_RESET 17
 #define LORA_DIO1 12
 #define LORA_BUSY 47
-#define SX128X_CS LORA_NSS
+#define SX128X_CS LORA_CS
 #define SX128X_DIO1 LORA_DIO1
 #define SX128X_BUSY LORA_BUSY
 #define SX128X_RESET LORA_RESET

--- a/variants/bpi_picow_esp32_s3/variant.h
+++ b/variants/bpi_picow_esp32_s3/variant.h
@@ -22,24 +22,24 @@
 
 // #define USE_RF95   // RFM95/SX127x
 
-#undef RF95_SCK
-#undef RF95_MISO
-#undef RF95_MOSI
-#undef RF95_NSS
+#undef LORA_SCK
+#undef LORA_MISO
+#undef LORA_MOSI
+#undef LORA_NSS
 
 // WaveShare Core1262-868M OK
 // https://www.waveshare.com/wiki/Core1262-868M
 #define USE_SX1262
 
 #ifdef USE_SX1262
-#define RF95_MISO 39
-#define RF95_SCK 21
-#define RF95_MOSI 38
-#define RF95_NSS 17
+#define LORA_MISO 39
+#define LORA_SCK 21
+#define LORA_MOSI 38
+#define LORA_NSS 17
 #define LORA_RESET 42
 #define LORA_DIO1 5
 #define LORA_BUSY 47
-#define SX126X_CS RF95_NSS
+#define SX126X_CS LORA_NSS
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_BUSY
 #define SX126X_RESET LORA_RESET
@@ -49,14 +49,14 @@
 
 // #define USE_SX1280
 #ifdef USE_SX1280
-#define RF95_MISO 1
-#define RF95_SCK 3
-#define RF95_MOSI 4
-#define RF95_NSS 2
+#define LORA_MISO 1
+#define LORA_SCK 3
+#define LORA_MOSI 4
+#define LORA_NSS 2
 #define LORA_RESET 17
 #define LORA_DIO1 12
 #define LORA_BUSY 47
-#define SX128X_CS RF95_NSS
+#define SX128X_CS LORA_NSS
 #define SX128X_DIO1 LORA_DIO1
 #define SX128X_BUSY LORA_BUSY
 #define SX128X_RESET LORA_RESET

--- a/variants/diy/dr-dev/variant.h
+++ b/variants/diy/dr-dev/variant.h
@@ -22,12 +22,12 @@
 // In receiving, set RXEN as high communication level, TXEN is lowlevel;
 // Before powering off, set TXEN、RXEN as low level.
 
-#undef RF95_SCK
-#define RF95_SCK 18
-#undef RF95_MISO
-#define RF95_MISO 19
-#undef RF95_MOSI
-#define RF95_MOSI 23
+#undef LORA_SCK
+#define LORA_SCK 18
+#undef LORA_MISO
+#define LORA_MISO 19
+#undef LORA_MOSI
+#define LORA_MOSI 23
 
 // PINS FOR THE 900M22S
 
@@ -38,8 +38,8 @@
 // E22_TXEN_CONNECTED_TO_DIO2 wasn't defined, so RXEN wasn't controlled. Commented it out to maintain behavior, but shouldn't be.
 // Need to comment out defining SX126X_RXEN as LORA_RXEN too
 // #define LORA_RXEN 17 // Input - RF switch RX control, connecting external MCU IO, valid in high level
-#undef RF95_NSS
-#define RF95_NSS 16
+#undef LORA_NSS
+#define LORA_NSS 16
 #define SX126X_BUSY 22
 #define SX126X_CS 16
 
@@ -49,8 +49,8 @@
 #define LORA_DIO2 35 // BUSY for SX1262/SX1268
 #define LORA_TXEN NOT_A_PIN // Input - RF switch TX control, connecting external MCU IO or DIO2, valid in high level
 #define LORA_RXEN 21  // Input - RF switch RX control, connecting external MCU IO, valid in high level
-#undef RF95_NSS
-#define RF95_NSS 33
+#undef LORA_NSS
+#define LORA_NSS 33
 #define SX126X_BUSY 35
 #define SX126X_CS 33
 */

--- a/variants/diy/dr-dev/variant.h
+++ b/variants/diy/dr-dev/variant.h
@@ -38,8 +38,8 @@
 // E22_TXEN_CONNECTED_TO_DIO2 wasn't defined, so RXEN wasn't controlled. Commented it out to maintain behavior, but shouldn't be.
 // Need to comment out defining SX126X_RXEN as LORA_RXEN too
 // #define LORA_RXEN 17 // Input - RF switch RX control, connecting external MCU IO, valid in high level
-#undef LORA_NSS
-#define LORA_NSS 16
+#undef LORA_CS
+#define LORA_CS 16
 #define SX126X_BUSY 22
 #define SX126X_CS 16
 
@@ -49,8 +49,8 @@
 #define LORA_DIO2 35 // BUSY for SX1262/SX1268
 #define LORA_TXEN NOT_A_PIN // Input - RF switch TX control, connecting external MCU IO or DIO2, valid in high level
 #define LORA_RXEN 21  // Input - RF switch RX control, connecting external MCU IO, valid in high level
-#undef LORA_NSS
-#define LORA_NSS 33
+#undef LORA_CS
+#define LORA_CS 33
 #define SX126X_BUSY 35
 #define SX126X_CS 33
 */

--- a/variants/diy/hydra/variant.h
+++ b/variants/diy/hydra/variant.h
@@ -33,8 +33,8 @@
 #define SX126X_TXEN 13 // Schematic connects EBYTE module's TXEN pin to MCU
 #define SX126X_RXEN 14 // Schematic connects EBYTE module's RXEN pin to MCU
 
-#define RF95_NSS SX126X_CS    // Compatibility with variant file configuration structure
-#define RF95_SCK SX126X_SCK   // Compatibility with variant file configuration structure
-#define RF95_MOSI SX126X_MOSI // Compatibility with variant file configuration structure
-#define RF95_MISO SX126X_MISO // Compatibility with variant file configuration structure
+#define LORA_NSS SX126X_CS    // Compatibility with variant file configuration structure
+#define LORA_SCK SX126X_SCK   // Compatibility with variant file configuration structure
+#define LORA_MOSI SX126X_MOSI // Compatibility with variant file configuration structure
+#define LORA_MISO SX126X_MISO // Compatibility with variant file configuration structure
 #define LORA_DIO1 SX126X_DIO1 // Compatibility with variant file configuration structure

--- a/variants/diy/hydra/variant.h
+++ b/variants/diy/hydra/variant.h
@@ -33,7 +33,7 @@
 #define SX126X_TXEN 13 // Schematic connects EBYTE module's TXEN pin to MCU
 #define SX126X_RXEN 14 // Schematic connects EBYTE module's RXEN pin to MCU
 
-#define LORA_NSS SX126X_CS    // Compatibility with variant file configuration structure
+#define LORA_CS SX126X_CS    // Compatibility with variant file configuration structure
 #define LORA_SCK SX126X_SCK   // Compatibility with variant file configuration structure
 #define LORA_MOSI SX126X_MOSI // Compatibility with variant file configuration structure
 #define LORA_MISO SX126X_MISO // Compatibility with variant file configuration structure

--- a/variants/diy/hydra/variant.h
+++ b/variants/diy/hydra/variant.h
@@ -33,7 +33,7 @@
 #define SX126X_TXEN 13 // Schematic connects EBYTE module's TXEN pin to MCU
 #define SX126X_RXEN 14 // Schematic connects EBYTE module's RXEN pin to MCU
 
-#define LORA_CS SX126X_CS    // Compatibility with variant file configuration structure
+#define LORA_CS SX126X_CS     // Compatibility with variant file configuration structure
 #define LORA_SCK SX126X_SCK   // Compatibility with variant file configuration structure
 #define LORA_MOSI SX126X_MOSI // Compatibility with variant file configuration structure
 #define LORA_MISO SX126X_MISO // Compatibility with variant file configuration structure

--- a/variants/diy/v1/variant.h
+++ b/variants/diy/v1/variant.h
@@ -23,10 +23,10 @@
 #define LORA_DIO2 32  // BUSY for SX1262/SX1268
 #define LORA_DIO3     // Not connected on PCB, but internally on the TTGO SX1262/SX1268, if DIO3 is high the TXCO is enabled
 
-#define RF95_SCK 5
-#define RF95_MISO 19
-#define RF95_MOSI 27
-#define RF95_NSS 18
+#define LORA_SCK 5
+#define LORA_MISO 19
+#define LORA_MOSI 27
+#define LORA_NSS 18
 
 // supported modules list
 #define USE_RF95 // RFM95/SX127x

--- a/variants/diy/v1/variant.h
+++ b/variants/diy/v1/variant.h
@@ -26,7 +26,7 @@
 #define LORA_SCK 5
 #define LORA_MISO 19
 #define LORA_MOSI 27
-#define LORA_NSS 18
+#define LORA_CS 18
 
 // supported modules list
 #define USE_RF95 // RFM95/SX127x

--- a/variants/diy/v1_1/variant.h
+++ b/variants/diy/v1_1/variant.h
@@ -22,14 +22,14 @@
 #define LORA_RXEN 14 // Input - RF switch RX control, connecting external MCU IO, valid in high level
 #define LORA_TXEN 13 // Input - RF switch TX control, connecting external MCU IO or DIO2, valid in high level
 
-#undef RF95_SCK
-#define RF95_SCK 18
-#undef RF95_MISO
-#define RF95_MISO 19
-#undef RF95_MOSI
-#define RF95_MOSI 23
-#undef RF95_NSS
-#define RF95_NSS 5
+#undef LORA_SCK
+#define LORA_SCK 18
+#undef LORA_MISO
+#define LORA_MISO 19
+#undef LORA_MOSI
+#define LORA_MOSI 23
+#undef LORA_NSS
+#define LORA_NSS 5
 
 // RX/TX for RFM95/SX127x
 #define RF95_RXEN LORA_RXEN

--- a/variants/diy/v1_1/variant.h
+++ b/variants/diy/v1_1/variant.h
@@ -28,8 +28,8 @@
 #define LORA_MISO 19
 #undef LORA_MOSI
 #define LORA_MOSI 23
-#undef LORA_NSS
-#define LORA_NSS 5
+#undef LORA_CS
+#define LORA_CS 5
 
 // RX/TX for RFM95/SX127x
 #define RF95_RXEN LORA_RXEN

--- a/variants/feather_diy/variant.h
+++ b/variants/feather_diy/variant.h
@@ -84,7 +84,7 @@ extern "C" {
 #define LORA_SCK SCK
 #define LORA_MISO MI
 #define LORA_MOSI MO
-#define LORA_NSS SS
+#define LORA_CS SS
 
 // enables 3.3V periphery like GPS or IO Module
 #define PIN_3V3_EN (-1)
@@ -95,7 +95,7 @@ extern "C" {
 #define USE_SX1262
 
 // common pinouts for SX126X modules
-#define SX126X_CS LORA_NSS // NSS for SX126X
+#define SX126X_CS LORA_CS // NSS for SX126X
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/feather_diy/variant.h
+++ b/variants/feather_diy/variant.h
@@ -81,10 +81,10 @@ extern "C" {
 #define LORA_DIO2 (0 + 8)   // P0.08 12  // BUSY for SX1262/SX1268
 #define LORA_DIO3           // Not connected on PCB, but internally on the TTGO SX1262/SX1268, if DIO3 is high the TXCO is enabled
 
-#define RF95_SCK SCK
-#define RF95_MISO MI
-#define RF95_MOSI MO
-#define RF95_NSS SS
+#define LORA_SCK SCK
+#define LORA_MISO MI
+#define LORA_MOSI MO
+#define LORA_NSS SS
 
 // enables 3.3V periphery like GPS or IO Module
 #define PIN_3V3_EN (-1)
@@ -95,7 +95,7 @@ extern "C" {
 #define USE_SX1262
 
 // common pinouts for SX126X modules
-#define SX126X_CS RF95_NSS // NSS for SX126X
+#define SX126X_CS LORA_NSS // NSS for SX126X
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/heltec_esp32c3/variant.h
+++ b/variants/heltec_esp32c3/variant.h
@@ -14,22 +14,22 @@
 #undef GPS_RX_PIN
 #undef GPS_TX_PIN
 
-#undef RF95_SCK
-#undef RF95_MISO
-#undef RF95_MOSI
-#undef RF95_NSS
+#undef LORA_SCK
+#undef LORA_MISO
+#undef LORA_MOSI
+#undef LORA_NSS
 
 #define USE_SX1262
-#define RF95_SCK 10
-#define RF95_MISO 6
-#define RF95_MOSI 7
-#define RF95_NSS 8
+#define LORA_SCK 10
+#define LORA_MISO 6
+#define LORA_MOSI 7
+#define LORA_NSS 8
 #define LORA_DIO0 RADIOLIB_NC
 #define LORA_RESET 5
 #define LORA_DIO1 3
 #define LORA_DIO2 RADIOLIB_NC
 #define LORA_BUSY 4
-#define SX126X_CS RF95_NSS
+#define SX126X_CS LORA_NSS
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_BUSY
 #define SX126X_RESET LORA_RESET

--- a/variants/heltec_esp32c3/variant.h
+++ b/variants/heltec_esp32c3/variant.h
@@ -17,19 +17,19 @@
 #undef LORA_SCK
 #undef LORA_MISO
 #undef LORA_MOSI
-#undef LORA_NSS
+#undef LORA_CS
 
 #define USE_SX1262
 #define LORA_SCK 10
 #define LORA_MISO 6
 #define LORA_MOSI 7
-#define LORA_NSS 8
+#define LORA_CS 8
 #define LORA_DIO0 RADIOLIB_NC
 #define LORA_RESET 5
 #define LORA_DIO1 3
 #define LORA_DIO2 RADIOLIB_NC
 #define LORA_BUSY 4
-#define SX126X_CS LORA_NSS
+#define SX126X_CS LORA_CS
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_BUSY
 #define SX126X_RESET LORA_RESET

--- a/variants/heltec_v3/variant.h
+++ b/variants/heltec_v3/variant.h
@@ -27,9 +27,9 @@
 #define LORA_SCK 9
 #define LORA_MISO 11
 #define LORA_MOSI 10
-#define LORA_NSS 8
+#define LORA_CS 8
 
-#define SX126X_CS LORA_NSS
+#define SX126X_CS LORA_CS
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/heltec_v3/variant.h
+++ b/variants/heltec_v3/variant.h
@@ -24,12 +24,12 @@
 #define LORA_DIO2 13 // SX1262 BUSY
 #define LORA_DIO3    // Not connected on PCB, but internally on the TTGO SX1262, if DIO3 is high the TXCO is enabled
 
-#define RF95_SCK 9
-#define RF95_MISO 11
-#define RF95_MOSI 10
-#define RF95_NSS 8
+#define LORA_SCK 9
+#define LORA_MISO 11
+#define LORA_MOSI 10
+#define LORA_NSS 8
 
-#define SX126X_CS RF95_NSS
+#define SX126X_CS LORA_NSS
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/heltec_wireless_paper/variant.h
+++ b/variants/heltec_wireless_paper/variant.h
@@ -34,9 +34,9 @@
 #define LORA_SCK 9
 #define LORA_MISO 11
 #define LORA_MOSI 10
-#define LORA_NSS 8
+#define LORA_CS 8
 
-#define SX126X_CS LORA_NSS
+#define SX126X_CS LORA_CS
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/heltec_wireless_paper/variant.h
+++ b/variants/heltec_wireless_paper/variant.h
@@ -31,12 +31,12 @@
 #define LORA_DIO2 13 // SX1262 BUSY
 #define LORA_DIO3    // Not connected on PCB, but internally on the TTGO SX1262, if DIO3 is high the TXCO is enabled
 
-#define RF95_SCK 9
-#define RF95_MISO 11
-#define RF95_MOSI 10
-#define RF95_NSS 8
+#define LORA_SCK 9
+#define LORA_MISO 11
+#define LORA_MOSI 10
+#define LORA_NSS 8
 
-#define SX126X_CS RF95_NSS
+#define SX126X_CS LORA_NSS
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/heltec_wireless_tracker/variant.h
+++ b/variants/heltec_wireless_tracker/variant.h
@@ -61,9 +61,9 @@
 #define LORA_SCK 9
 #define LORA_MISO 11
 #define LORA_MOSI 10
-#define LORA_NSS 8
+#define LORA_CS 8
 
-#define SX126X_CS LORA_NSS
+#define SX126X_CS LORA_CS
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/heltec_wireless_tracker/variant.h
+++ b/variants/heltec_wireless_tracker/variant.h
@@ -58,12 +58,12 @@
 #define LORA_DIO2 13 // SX1262 BUSY
 #define LORA_DIO3    // Not connected on PCB, but internally on the TTGO SX1262, if DIO3 is high the TXCO is enabled
 
-#define RF95_SCK 9
-#define RF95_MISO 11
-#define RF95_MOSI 10
-#define RF95_NSS 8
+#define LORA_SCK 9
+#define LORA_MISO 11
+#define LORA_MOSI 10
+#define LORA_NSS 8
 
-#define SX126X_CS RF95_NSS
+#define SX126X_CS LORA_NSS
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/heltec_wsl_v3/variant.h
+++ b/variants/heltec_wsl_v3/variant.h
@@ -24,9 +24,9 @@
 #define LORA_SCK 9
 #define LORA_MISO 11
 #define LORA_MOSI 10
-#define LORA_NSS 8
+#define LORA_CS 8
 
-#define SX126X_CS LORA_NSS
+#define SX126X_CS LORA_CS
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/heltec_wsl_v3/variant.h
+++ b/variants/heltec_wsl_v3/variant.h
@@ -21,12 +21,12 @@
 #define LORA_DIO2 13 // SX1262 BUSY
 #define LORA_DIO3    // Not connected on PCB, but internally on the TTGO SX1262, if DIO3 is high the TXCO is enabled
 
-#define RF95_SCK 9
-#define RF95_MISO 11
-#define RF95_MOSI 10
-#define RF95_NSS 8
+#define LORA_SCK 9
+#define LORA_MISO 11
+#define LORA_MOSI 10
+#define LORA_NSS 8
 
-#define SX126X_CS RF95_NSS
+#define SX126X_CS LORA_NSS
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/m5stack-stamp-c3/variant.h
+++ b/variants/m5stack-stamp-c3/variant.h
@@ -9,18 +9,18 @@
 #undef GPS_RX_PIN
 #undef GPS_TX_PIN
 
-#undef RF95_SCK
-#undef RF95_MISO
-#undef RF95_MOSI
-#undef RF95_NSS
+#undef LORA_SCK
+#undef LORA_MISO
+#undef LORA_MOSI
+#undef LORA_NSS
 
 // Adafruit RFM95W OK
 // https://www.adafruit.com/product/3072
 #define USE_RF95
-#define RF95_SCK 4
-#define RF95_MISO 5
-#define RF95_MOSI 6
-#define RF95_NSS 7
+#define LORA_SCK 4
+#define LORA_MISO 5
+#define LORA_MOSI 6
+#define LORA_NSS 7
 #define LORA_DIO0 10
 #define LORA_RESET 8
 #define LORA_DIO1 RADIOLIB_NC
@@ -29,16 +29,16 @@
 // WaveShare Core1262-868M OK
 // https://www.waveshare.com/wiki/Core1262-868M
 // #define USE_SX1262
-// #define RF95_SCK 4
-// #define RF95_MISO 5
-// #define RF95_MOSI 6
-// #define RF95_NSS 7
+// #define LORA_SCK 4
+// #define LORA_MISO 5
+// #define LORA_MOSI 6
+// #define LORA_NSS 7
 // #define LORA_DIO0 RADIOLIB_NC
 // #define LORA_RESET 8
 // #define LORA_DIO1 10
 // #define LORA_DIO2 RADIOLIB_NC
 // #define LORA_BUSY 18
-// #define SX126X_CS RF95_NSS
+// #define SX126X_CS LORA_NSS
 // #define SX126X_DIO1 LORA_DIO1
 // #define SX126X_BUSY LORA_BUSY
 // #define SX126X_RESET LORA_RESET
@@ -47,16 +47,16 @@
 
 // SX128X 2.4 Ghz LoRa module Not OK - RadioLib issue ? still to confirm
 // #define USE_SX1280
-// #define RF95_SCK 4
-// #define RF95_MISO 5
-// #define RF95_MOSI 6
-// #define RF95_NSS 7
+// #define LORA_SCK 4
+// #define LORA_MISO 5
+// #define LORA_MOSI 6
+// #define LORA_NSS 7
 // #define LORA_DIO0 -1
 // #define LORA_DIO1 10
 // #define LORA_DIO2 21
 // #define LORA_RESET 8
 // #define LORA_BUSY 1
-// #define SX128X_CS RF95_NSS
+// #define SX128X_CS LORA_NSS
 // #define SX128X_DIO1 LORA_DIO1
 // #define SX128X_BUSY LORA_BUSY
 // #define SX128X_RESET LORA_RESET

--- a/variants/m5stack-stamp-c3/variant.h
+++ b/variants/m5stack-stamp-c3/variant.h
@@ -12,7 +12,7 @@
 #undef LORA_SCK
 #undef LORA_MISO
 #undef LORA_MOSI
-#undef LORA_NSS
+#undef LORA_CS
 
 // Adafruit RFM95W OK
 // https://www.adafruit.com/product/3072
@@ -20,7 +20,7 @@
 #define LORA_SCK 4
 #define LORA_MISO 5
 #define LORA_MOSI 6
-#define LORA_NSS 7
+#define LORA_CS 7
 #define LORA_DIO0 10
 #define LORA_RESET 8
 #define LORA_DIO1 RADIOLIB_NC
@@ -32,13 +32,13 @@
 // #define LORA_SCK 4
 // #define LORA_MISO 5
 // #define LORA_MOSI 6
-// #define LORA_NSS 7
+// #define LORA_CS 7
 // #define LORA_DIO0 RADIOLIB_NC
 // #define LORA_RESET 8
 // #define LORA_DIO1 10
 // #define LORA_DIO2 RADIOLIB_NC
 // #define LORA_BUSY 18
-// #define SX126X_CS LORA_NSS
+// #define SX126X_CS LORA_CS
 // #define SX126X_DIO1 LORA_DIO1
 // #define SX126X_BUSY LORA_BUSY
 // #define SX126X_RESET LORA_RESET
@@ -50,13 +50,13 @@
 // #define LORA_SCK 4
 // #define LORA_MISO 5
 // #define LORA_MOSI 6
-// #define LORA_NSS 7
+// #define LORA_CS 7
 // #define LORA_DIO0 -1
 // #define LORA_DIO1 10
 // #define LORA_DIO2 21
 // #define LORA_RESET 8
 // #define LORA_BUSY 1
-// #define SX128X_CS LORA_NSS
+// #define SX128X_CS LORA_CS
 // #define SX128X_DIO1 LORA_DIO1
 // #define SX128X_BUSY LORA_BUSY
 // #define SX128X_RESET LORA_RESET

--- a/variants/m5stack_core/variant.h
+++ b/variants/m5stack_core/variant.h
@@ -15,12 +15,12 @@
 #undef LORA_SCK
 #undef LORA_MISO
 #undef LORA_MOSI
-#undef LORA_NSS
+#undef LORA_CS
 
 #define LORA_SCK 18
 #define LORA_MISO 19
 #define LORA_MOSI 23
-#define LORA_NSS 5
+#define LORA_CS 5
 
 #define USE_RF95
 #define LORA_DIO0 36 // a No connect on the SX1262 module

--- a/variants/m5stack_core/variant.h
+++ b/variants/m5stack_core/variant.h
@@ -12,15 +12,15 @@
 
 #define PIN_BUZZER 25
 
-#undef RF95_SCK
-#undef RF95_MISO
-#undef RF95_MOSI
-#undef RF95_NSS
+#undef LORA_SCK
+#undef LORA_MISO
+#undef LORA_MOSI
+#undef LORA_NSS
 
-#define RF95_SCK 18
-#define RF95_MISO 19
-#define RF95_MOSI 23
-#define RF95_NSS 5
+#define LORA_SCK 18
+#define LORA_MISO 19
+#define LORA_MOSI 23
+#define LORA_NSS 5
 
 #define USE_RF95
 #define LORA_DIO0 36 // a No connect on the SX1262 module

--- a/variants/m5stack_coreink/variant.h
+++ b/variants/m5stack_coreink/variant.h
@@ -34,18 +34,18 @@
 // BUZZER
 #define PIN_BUZZER 2
 
-#undef RF95_SCK
-#undef RF95_MISO
-#undef RF95_MOSI
-#undef RF95_NSS
+#undef LORA_SCK
+#undef LORA_MISO
+#undef LORA_MOSI
+#undef LORA_NSS
 #define USE_RF95
 // #define USE_SX1280
 
 #ifdef USE_RF95
-#define RF95_SCK 18
-#define RF95_MISO 34
-#define RF95_MOSI 23
-#define RF95_NSS 14
+#define LORA_SCK 18
+#define LORA_MISO 34
+#define LORA_MOSI 23
+#define LORA_NSS 14
 #define LORA_DIO0 25
 #define LORA_RESET 26
 #define LORA_DIO1 RADIOLIB_NC
@@ -53,14 +53,14 @@
 #endif
 
 #ifdef USE_SX1280
-#define RF95_SCK 18
-#define RF95_MISO 34
-#define RF95_MOSI 23
-#define RF95_NSS 14
+#define LORA_SCK 18
+#define LORA_MISO 34
+#define LORA_MOSI 23
+#define LORA_NSS 14
 #define LORA_RESET 26
 #define LORA_DIO1 25
 #define LORA_DIO2 13
-#define SX128X_CS RF95_NSS
+#define SX128X_CS LORA_NSS
 #define SX128X_DIO1 LORA_DIO1
 #define SX128X_BUSY LORA_DIO2
 #define SX128X_RESET LORA_RESET

--- a/variants/m5stack_coreink/variant.h
+++ b/variants/m5stack_coreink/variant.h
@@ -37,7 +37,7 @@
 #undef LORA_SCK
 #undef LORA_MISO
 #undef LORA_MOSI
-#undef LORA_NSS
+#undef LORA_CS
 #define USE_RF95
 // #define USE_SX1280
 
@@ -45,7 +45,7 @@
 #define LORA_SCK 18
 #define LORA_MISO 34
 #define LORA_MOSI 23
-#define LORA_NSS 14
+#define LORA_CS 14
 #define LORA_DIO0 25
 #define LORA_RESET 26
 #define LORA_DIO1 RADIOLIB_NC
@@ -56,11 +56,11 @@
 #define LORA_SCK 18
 #define LORA_MISO 34
 #define LORA_MOSI 23
-#define LORA_NSS 14
+#define LORA_CS 14
 #define LORA_RESET 26
 #define LORA_DIO1 25
 #define LORA_DIO2 13
-#define SX128X_CS LORA_NSS
+#define SX128X_CS LORA_CS
 #define SX128X_DIO1 LORA_DIO1
 #define SX128X_BUSY LORA_DIO2
 #define SX128X_RESET LORA_RESET

--- a/variants/my_esp32s3_diy_eink/variant.h
+++ b/variants/my_esp32s3_diy_eink/variant.h
@@ -20,16 +20,16 @@
 // #define USE_SX1262
 #define USE_SX1280
 
-#define RF95_MISO 3
-#define RF95_SCK 5
-#define RF95_MOSI 6
-#define RF95_NSS 7
+#define LORA_MISO 3
+#define LORA_SCK 5
+#define LORA_MOSI 6
+#define LORA_NSS 7
 
 #define LORA_RESET 8
 #define LORA_DIO1 16
 
 #ifdef USE_SX1262
-#define SX126X_CS RF95_NSS // FIXME - we really should define LORA_CS instead
+#define SX126X_CS LORA_NSS // FIXME - we really should define LORA_CS instead
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY 15
 #define SX126X_RESET LORA_RESET
@@ -38,7 +38,7 @@
 #endif
 
 #ifdef USE_SX1280
-#define SX128X_CS RF95_NSS
+#define SX128X_CS LORA_NSS
 #define SX128X_DIO1 LORA_DIO1
 #define SX128X_BUSY 15
 #define SX128X_RESET LORA_RESET

--- a/variants/my_esp32s3_diy_eink/variant.h
+++ b/variants/my_esp32s3_diy_eink/variant.h
@@ -23,13 +23,13 @@
 #define LORA_MISO 3
 #define LORA_SCK 5
 #define LORA_MOSI 6
-#define LORA_NSS 7
+#define LORA_CS 7
 
 #define LORA_RESET 8
 #define LORA_DIO1 16
 
 #ifdef USE_SX1262
-#define SX126X_CS LORA_NSS // FIXME - we really should define LORA_CS instead
+#define SX126X_CS LORA_CS // FIXME - we really should define LORA_CS instead
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY 15
 #define SX126X_RESET LORA_RESET
@@ -38,7 +38,7 @@
 #endif
 
 #ifdef USE_SX1280
-#define SX128X_CS LORA_NSS
+#define SX128X_CS LORA_CS
 #define SX128X_DIO1 LORA_DIO1
 #define SX128X_BUSY 15
 #define SX128X_RESET LORA_RESET

--- a/variants/my_esp32s3_diy_oled/variant.h
+++ b/variants/my_esp32s3_diy_oled/variant.h
@@ -20,16 +20,16 @@
 // #define USE_SX1262
 #define USE_SX1280
 
-#define RF95_MISO 3
-#define RF95_SCK 5
-#define RF95_MOSI 6
-#define RF95_NSS 7
+#define LORA_MISO 3
+#define LORA_SCK 5
+#define LORA_MOSI 6
+#define LORA_NSS 7
 
 #define LORA_RESET 8
 #define LORA_DIO1 16
 
 #ifdef USE_SX1262
-#define SX126X_CS RF95_NSS // FIXME - we really should define LORA_CS instead
+#define SX126X_CS LORA_NSS // FIXME - we really should define LORA_CS instead
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY 15
 #define SX126X_RESET LORA_RESET
@@ -38,7 +38,7 @@
 #endif
 
 #ifdef USE_SX1280
-#define SX128X_CS RF95_NSS
+#define SX128X_CS LORA_NSS
 #define SX128X_DIO1 LORA_DIO1
 #define SX128X_BUSY 15
 #define SX128X_RESET LORA_RESET

--- a/variants/my_esp32s3_diy_oled/variant.h
+++ b/variants/my_esp32s3_diy_oled/variant.h
@@ -23,13 +23,13 @@
 #define LORA_MISO 3
 #define LORA_SCK 5
 #define LORA_MOSI 6
-#define LORA_NSS 7
+#define LORA_CS 7
 
 #define LORA_RESET 8
 #define LORA_DIO1 16
 
 #ifdef USE_SX1262
-#define SX126X_CS LORA_NSS // FIXME - we really should define LORA_CS instead
+#define SX126X_CS LORA_CS // FIXME - we really should define LORA_CS instead
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY 15
 #define SX126X_RESET LORA_RESET
@@ -38,7 +38,7 @@
 #endif
 
 #ifdef USE_SX1280
-#define SX128X_CS LORA_NSS
+#define SX128X_CS LORA_CS
 #define SX128X_DIO1 LORA_DIO1
 #define SX128X_BUSY 15
 #define SX128X_RESET LORA_RESET

--- a/variants/nano-g1-explorer/variant.h
+++ b/variants/nano-g1-explorer/variant.h
@@ -23,7 +23,7 @@
 #define LORA_DIO3    // Not connected on PCB
 
 #ifdef USE_SX1262
-#define SX126X_CS RF95_NSS // FIXME - we really should define LORA_CS instead
+#define SX126X_CS LORA_NSS // FIXME - we really should define LORA_CS instead
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/nano-g1-explorer/variant.h
+++ b/variants/nano-g1-explorer/variant.h
@@ -23,7 +23,7 @@
 #define LORA_DIO3    // Not connected on PCB
 
 #ifdef USE_SX1262
-#define SX126X_CS LORA_NSS // FIXME - we really should define LORA_CS instead
+#define SX126X_CS LORA_CS // FIXME - we really should define LORA_CS instead
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/nano-g1/variant.h
+++ b/variants/nano-g1/variant.h
@@ -23,7 +23,7 @@
 #define LORA_DIO3    // Not connected on PCB
 
 #ifdef USE_SX1262
-#define SX126X_CS RF95_NSS // FIXME - we really should define LORA_CS instead
+#define SX126X_CS LORA_NSS // FIXME - we really should define LORA_CS instead
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/nano-g1/variant.h
+++ b/variants/nano-g1/variant.h
@@ -23,7 +23,7 @@
 #define LORA_DIO3    // Not connected on PCB
 
 #ifdef USE_SX1262
-#define SX126X_CS LORA_NSS // FIXME - we really should define LORA_CS instead
+#define SX126X_CS LORA_CS // FIXME - we really should define LORA_CS instead
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/picomputer-s3/variant.h
+++ b/variants/picomputer-s3/variant.h
@@ -18,7 +18,7 @@
 #define LORA_SCK SCK   // 21
 #define LORA_MISO MISO // 39
 #define LORA_MOSI MOSI // 38
-#define LORA_CS SS    // 40
+#define LORA_CS SS     // 40
 #define LORA_RESET RADIOLIB_NC
 
 // per SX1276_Receive_Interrupt/utilities.h

--- a/variants/picomputer-s3/variant.h
+++ b/variants/picomputer-s3/variant.h
@@ -15,10 +15,10 @@
 
 #define USE_RF95 // RFM95/SX127x
 
-#define RF95_SCK SCK   // 21
-#define RF95_MISO MISO // 39
-#define RF95_MOSI MOSI // 38
-#define RF95_NSS SS    // 40
+#define LORA_SCK SCK   // 21
+#define LORA_MISO MISO // 39
+#define LORA_MOSI MOSI // 38
+#define LORA_NSS SS    // 40
 #define LORA_RESET RADIOLIB_NC
 
 // per SX1276_Receive_Interrupt/utilities.h

--- a/variants/picomputer-s3/variant.h
+++ b/variants/picomputer-s3/variant.h
@@ -18,7 +18,7 @@
 #define LORA_SCK SCK   // 21
 #define LORA_MISO MISO // 39
 #define LORA_MOSI MOSI // 38
-#define LORA_NSS SS    // 40
+#define LORA_CS SS    // 40
 #define LORA_RESET RADIOLIB_NC
 
 // per SX1276_Receive_Interrupt/utilities.h

--- a/variants/portduino/variant.h
+++ b/variants/portduino/variant.h
@@ -12,7 +12,7 @@
 #define LORA_SCK 5
 #define LORA_MISO 19
 #define LORA_MOSI 27
-#define LORA_NSS RADIOLIB_NC // the ch341f spi controller does CS for us
+#define LORA_CS RADIOLIB_NC // the ch341f spi controller does CS for us
 
 #define LORA_DIO0 26 // a No connect on the SX1262 module
 #define LORA_RESET 14

--- a/variants/portduino/variant.h
+++ b/variants/portduino/variant.h
@@ -9,10 +9,10 @@
 #define USE_SX1262
 
 // Fake SPI device selections
-#define RF95_SCK 5
-#define RF95_MISO 19
-#define RF95_MOSI 27
-#define RF95_NSS RADIOLIB_NC // the ch341f spi controller does CS for us
+#define LORA_SCK 5
+#define LORA_MISO 19
+#define LORA_MOSI 27
+#define LORA_NSS RADIOLIB_NC // the ch341f spi controller does CS for us
 
 #define LORA_DIO0 26 // a No connect on the SX1262 module
 #define LORA_RESET 14

--- a/variants/rak11200/variant.h
+++ b/variants/rak11200/variant.h
@@ -66,14 +66,14 @@ static const uint8_t SCK = 33;
 #define LORA_DIO3                                                                                                                \
     RADIOLIB_NC // Not connected on PCB, but internally on the TTGO SX1262/SX1268, if DIO3 is high the TXCO is enabled
 
-#undef RF95_SCK
-#define RF95_SCK SCK
-#undef RF95_MISO
-#define RF95_MISO MISO
-#undef RF95_MOSI
-#define RF95_MOSI MOSI
-#undef RF95_NSS
-#define RF95_NSS SS
+#undef LORA_SCK
+#define LORA_SCK SCK
+#undef LORA_MISO
+#define LORA_MISO MISO
+#undef LORA_MOSI
+#define LORA_MOSI MOSI
+#undef LORA_NSS
+#define LORA_NSS SS
 
 #define USE_SX1262
 #define SX126X_CS SS // NSS for SX126X

--- a/variants/rak11200/variant.h
+++ b/variants/rak11200/variant.h
@@ -72,8 +72,8 @@ static const uint8_t SCK = 33;
 #define LORA_MISO MISO
 #undef LORA_MOSI
 #define LORA_MOSI MOSI
-#undef LORA_NSS
-#define LORA_NSS SS
+#undef LORA_CS
+#define LORA_CS SS
 
 #define USE_SX1262
 #define SX126X_CS SS // NSS for SX126X

--- a/variants/rak11310/variant.h
+++ b/variants/rak11310/variant.h
@@ -22,14 +22,14 @@
 #undef LORA_SCK
 #undef LORA_MISO
 #undef LORA_MOSI
-#undef LORA_NSS
+#undef LORA_CS
 
 // RAK BSP somehow uses SPI1 instead of SPI0
 #define HW_SPI1_DEVICE
 #define LORA_SCK PIN_SPI0_SCK
 #define LORA_MOSI PIN_SPI0_MOSI
 #define LORA_MISO PIN_SPI0_MISO
-#define LORA_NSS PIN_SPI0_SS
+#define LORA_CS PIN_SPI0_SS
 
 #define LORA_DIO0 RADIOLIB_NC
 #define LORA_RESET 14
@@ -38,7 +38,7 @@
 #define LORA_DIO3 RADIOLIB_NC
 
 #ifdef USE_SX1262
-#define SX126X_CS LORA_NSS
+#define SX126X_CS LORA_CS
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/rak11310/variant.h
+++ b/variants/rak11310/variant.h
@@ -19,17 +19,17 @@
 
 #define USE_SX1262
 
-#undef RF95_SCK
-#undef RF95_MISO
-#undef RF95_MOSI
-#undef RF95_NSS
+#undef LORA_SCK
+#undef LORA_MISO
+#undef LORA_MOSI
+#undef LORA_NSS
 
 // RAK BSP somehow uses SPI1 instead of SPI0
 #define HW_SPI1_DEVICE
-#define RF95_SCK PIN_SPI0_SCK
-#define RF95_MOSI PIN_SPI0_MOSI
-#define RF95_MISO PIN_SPI0_MISO
-#define RF95_NSS PIN_SPI0_SS
+#define LORA_SCK PIN_SPI0_SCK
+#define LORA_MOSI PIN_SPI0_MOSI
+#define LORA_MISO PIN_SPI0_MISO
+#define LORA_NSS PIN_SPI0_SS
 
 #define LORA_DIO0 RADIOLIB_NC
 #define LORA_RESET 14
@@ -38,7 +38,7 @@
 #define LORA_DIO3 RADIOLIB_NC
 
 #ifdef USE_SX1262
-#define SX126X_CS RF95_NSS
+#define SX126X_CS LORA_NSS
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/rpipico/variant.h
+++ b/variants/rpipico/variant.h
@@ -28,12 +28,12 @@
 #undef LORA_SCK
 #undef LORA_MISO
 #undef LORA_MOSI
-#undef LORA_NSS
+#undef LORA_CS
 
 #define LORA_SCK 10
 #define LORA_MISO 12
 #define LORA_MOSI 11
-#define LORA_NSS 3
+#define LORA_CS 3
 
 #define LORA_DIO0 RADIOLIB_NC
 #define LORA_RESET 15
@@ -42,7 +42,7 @@
 #define LORA_DIO3 RADIOLIB_NC
 
 #ifdef USE_SX1262
-#define SX126X_CS LORA_NSS
+#define SX126X_CS LORA_CS
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/rpipico/variant.h
+++ b/variants/rpipico/variant.h
@@ -25,15 +25,15 @@
 
 #define USE_SX1262
 
-#undef RF95_SCK
-#undef RF95_MISO
-#undef RF95_MOSI
-#undef RF95_NSS
+#undef LORA_SCK
+#undef LORA_MISO
+#undef LORA_MOSI
+#undef LORA_NSS
 
-#define RF95_SCK 10
-#define RF95_MISO 12
-#define RF95_MOSI 11
-#define RF95_NSS 3
+#define LORA_SCK 10
+#define LORA_MISO 12
+#define LORA_MOSI 11
+#define LORA_NSS 3
 
 #define LORA_DIO0 RADIOLIB_NC
 #define LORA_RESET 15
@@ -42,7 +42,7 @@
 #define LORA_DIO3 RADIOLIB_NC
 
 #ifdef USE_SX1262
-#define SX126X_CS RF95_NSS
+#define SX126X_CS LORA_NSS
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/rpipicow/variant.h
+++ b/variants/rpipicow/variant.h
@@ -23,15 +23,15 @@
 
 #define USE_SX1262
 
-#undef RF95_SCK
-#undef RF95_MISO
-#undef RF95_MOSI
-#undef RF95_NSS
+#undef LORA_SCK
+#undef LORA_MISO
+#undef LORA_MOSI
+#undef LORA_NSS
 
-#define RF95_SCK 10
-#define RF95_MISO 12
-#define RF95_MOSI 11
-#define RF95_NSS 3
+#define LORA_SCK 10
+#define LORA_MISO 12
+#define LORA_MOSI 11
+#define LORA_NSS 3
 
 #define LORA_DIO0 RADIOLIB_NC
 #define LORA_RESET 15
@@ -40,7 +40,7 @@
 #define LORA_DIO3 RADIOLIB_NC
 
 #ifdef USE_SX1262
-#define SX126X_CS RF95_NSS
+#define SX126X_CS LORA_NSS
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/rpipicow/variant.h
+++ b/variants/rpipicow/variant.h
@@ -26,12 +26,12 @@
 #undef LORA_SCK
 #undef LORA_MISO
 #undef LORA_MOSI
-#undef LORA_NSS
+#undef LORA_CS
 
 #define LORA_SCK 10
 #define LORA_MISO 12
 #define LORA_MOSI 11
-#define LORA_NSS 3
+#define LORA_CS 3
 
 #define LORA_DIO0 RADIOLIB_NC
 #define LORA_RESET 15
@@ -40,7 +40,7 @@
 #define LORA_DIO3 RADIOLIB_NC
 
 #ifdef USE_SX1262
-#define SX126X_CS LORA_NSS
+#define SX126X_CS LORA_CS
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/station-g1/variant.h
+++ b/variants/station-g1/variant.h
@@ -23,7 +23,7 @@
 #define LORA_DIO3    // Not connected on PCB
 
 #ifdef USE_SX1262
-#define SX126X_CS RF95_NSS // FIXME - we really should define LORA_CS instead
+#define SX126X_CS LORA_NSS // FIXME - we really should define LORA_CS instead
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/station-g1/variant.h
+++ b/variants/station-g1/variant.h
@@ -23,7 +23,7 @@
 #define LORA_DIO3    // Not connected on PCB
 
 #ifdef USE_SX1262
-#define SX126X_CS LORA_NSS // FIXME - we really should define LORA_CS instead
+#define SX126X_CS LORA_CS // FIXME - we really should define LORA_CS instead
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/t-deck/variant.h
+++ b/variants/t-deck/variant.h
@@ -72,7 +72,7 @@
 #define LORA_SCK 40
 #define LORA_MISO 38
 #define LORA_MOSI 41
-#define LORA_NSS 9
+#define LORA_CS 9
 
 #define LORA_DIO0 -1 // a No connect on the SX1262 module
 #define LORA_RESET 17
@@ -80,7 +80,7 @@
 #define LORA_DIO2 13 // SX1262 BUSY
 #define LORA_DIO3    // Not connected on PCB, but internally on the TTGO SX1262, if DIO3 is high the TXCO is enabled
 
-#define SX126X_CS LORA_NSS // FIXME - we really should define LORA_CS instead
+#define SX126X_CS LORA_CS // FIXME - we really should define LORA_CS instead
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/t-deck/variant.h
+++ b/variants/t-deck/variant.h
@@ -69,10 +69,10 @@
 #define USE_SX1262
 #define USE_SX1268
 
-#define RF95_SCK 40
-#define RF95_MISO 38
-#define RF95_MOSI 41
-#define RF95_NSS 9
+#define LORA_SCK 40
+#define LORA_MISO 38
+#define LORA_MOSI 41
+#define LORA_NSS 9
 
 #define LORA_DIO0 -1 // a No connect on the SX1262 module
 #define LORA_RESET 17
@@ -80,7 +80,7 @@
 #define LORA_DIO2 13 // SX1262 BUSY
 #define LORA_DIO3    // Not connected on PCB, but internally on the TTGO SX1262, if DIO3 is high the TXCO is enabled
 
-#define SX126X_CS RF95_NSS // FIXME - we really should define LORA_CS instead
+#define SX126X_CS LORA_NSS // FIXME - we really should define LORA_CS instead
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/t-watch-s3/variant.h
+++ b/variants/t-watch-s3/variant.h
@@ -48,10 +48,10 @@
 #define USE_SX1262
 #define USE_SX1268
 
-#define RF95_SCK 3
-#define RF95_MISO 4
-#define RF95_MOSI 1
-#define RF95_NSS 5
+#define LORA_SCK 3
+#define LORA_MISO 4
+#define LORA_MOSI 1
+#define LORA_NSS 5
 
 #define LORA_DIO0 -1 // a No connect on the SX1262 module
 #define LORA_RESET 8
@@ -59,7 +59,7 @@
 #define LORA_DIO2 7 // SX1262 BUSY
 #define LORA_DIO3   // Not connected on PCB, but internally on the TTGO SX1262, if DIO3 is high the TXCO is enabled
 
-#define SX126X_CS RF95_NSS // FIXME - we really should define LORA_CS instead
+#define SX126X_CS LORA_NSS // FIXME - we really should define LORA_CS instead
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/t-watch-s3/variant.h
+++ b/variants/t-watch-s3/variant.h
@@ -51,7 +51,7 @@
 #define LORA_SCK 3
 #define LORA_MISO 4
 #define LORA_MOSI 1
-#define LORA_NSS 5
+#define LORA_CS 5
 
 #define LORA_DIO0 -1 // a No connect on the SX1262 module
 #define LORA_RESET 8
@@ -59,7 +59,7 @@
 #define LORA_DIO2 7 // SX1262 BUSY
 #define LORA_DIO3   // Not connected on PCB, but internally on the TTGO SX1262, if DIO3 is high the TXCO is enabled
 
-#define SX126X_CS LORA_NSS // FIXME - we really should define LORA_CS instead
+#define SX126X_CS LORA_CS // FIXME - we really should define LORA_CS instead
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/tbeam-s3-core/variant.h
+++ b/variants/tbeam-s3-core/variant.h
@@ -47,10 +47,10 @@
 #define PMU_USE_WIRE1
 #define RTC_USE_WIRE1
 
-#define RF95_SCK 12
-#define RF95_MISO 13
-#define RF95_MOSI 11
-#define RF95_NSS 10
+#define LORA_SCK 12
+#define LORA_MISO 13
+#define LORA_MOSI 11
+#define LORA_NSS 10
 
 #define GPS_RX_PIN 9
 #define GPS_TX_PIN 8

--- a/variants/tbeam-s3-core/variant.h
+++ b/variants/tbeam-s3-core/variant.h
@@ -50,7 +50,7 @@
 #define LORA_SCK 12
 #define LORA_MISO 13
 #define LORA_MOSI 11
-#define LORA_NSS 10
+#define LORA_CS 10
 
 #define GPS_RX_PIN 9
 #define GPS_TX_PIN 8

--- a/variants/tbeam/variant.h
+++ b/variants/tbeam/variant.h
@@ -24,7 +24,7 @@
 #define LORA_DIO3    // Not connected on PCB, but internally on the TTGO SX1262, if DIO3 is high the TXCO is enabled
 
 #ifdef USE_SX1262
-#define SX126X_CS RF95_NSS // FIXME - we really should define LORA_CS instead
+#define SX126X_CS LORA_NSS // FIXME - we really should define LORA_CS instead
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/tbeam/variant.h
+++ b/variants/tbeam/variant.h
@@ -24,7 +24,7 @@
 #define LORA_DIO3    // Not connected on PCB, but internally on the TTGO SX1262, if DIO3 is high the TXCO is enabled
 
 #ifdef USE_SX1262
-#define SX126X_CS LORA_NSS // FIXME - we really should define LORA_CS instead
+#define SX126X_CS LORA_CS // FIXME - we really should define LORA_CS instead
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET

--- a/variants/tlora_t3s3_v1/variant.h
+++ b/variants/tlora_t3s3_v1/variant.h
@@ -25,10 +25,10 @@
 #define USE_SX1262
 #define USE_SX1280
 
-#define RF95_SCK 5
-#define RF95_MISO 3
-#define RF95_MOSI 6
-#define RF95_NSS 7
+#define LORA_SCK 5
+#define LORA_MISO 3
+#define LORA_MOSI 6
+#define LORA_NSS 7
 #define LORA_RESET 8
 
 // per SX1276_Receive_Interrupt/utilities.h
@@ -40,7 +40,7 @@
 
 // per SX1262_Receive_Interrupt/utilities.h
 #ifdef USE_SX1262
-#define SX126X_CS RF95_NSS
+#define SX126X_CS LORA_NSS
 #define SX126X_DIO1 33
 #define SX126X_BUSY 34
 #define SX126X_RESET LORA_RESET
@@ -50,7 +50,7 @@
 
 // per SX128x_Receive_Interrupt/utilities.h
 #ifdef USE_SX1280
-#define SX128X_CS RF95_NSS
+#define SX128X_CS LORA_NSS
 #define SX128X_DIO1 9
 #define SX128X_DIO2 33
 #define SX128X_DIO3 34

--- a/variants/tlora_t3s3_v1/variant.h
+++ b/variants/tlora_t3s3_v1/variant.h
@@ -28,7 +28,7 @@
 #define LORA_SCK 5
 #define LORA_MISO 3
 #define LORA_MOSI 6
-#define LORA_NSS 7
+#define LORA_CS 7
 #define LORA_RESET 8
 
 // per SX1276_Receive_Interrupt/utilities.h
@@ -40,7 +40,7 @@
 
 // per SX1262_Receive_Interrupt/utilities.h
 #ifdef USE_SX1262
-#define SX126X_CS LORA_NSS
+#define SX126X_CS LORA_CS
 #define SX126X_DIO1 33
 #define SX126X_BUSY 34
 #define SX126X_RESET LORA_RESET
@@ -50,7 +50,7 @@
 
 // per SX128x_Receive_Interrupt/utilities.h
 #ifdef USE_SX1280
-#define SX128X_CS LORA_NSS
+#define SX128X_CS LORA_CS
 #define SX128X_DIO1 9
 #define SX128X_DIO2 33
 #define SX128X_DIO3 34


### PR DESCRIPTION
Removes legacy `RF95_` naming scheme for pins used by **all** (and only all) LoRa ICs, changes them to generic `LORA_`.
Replacements done using VS Code find-and-replace.
The SPI bus used by the LoRa IC can support other devices (they need their own NSS pin) (such as a display) but its best to use another SPI bus for other devices, so that the LoRa IC always has a bus available ASAP to communicate with the MCU, instead of waiting communication between the MCU and another device to finish.