### PR TITLE
Pico W: Handle Wi-Fi reconnects and update core

### DIFF
--- a/arch/rp2040/rp2040.ini
+++ b/arch/rp2040/rp2040.ini
@@ -2,7 +2,7 @@
 [rp2040_base]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git#612de5399d68b359053f1307ed223d400aea975c
 extends = arduino_base
-platform_packages = framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#d2461a14ad5aa920e44508d236c2f459e3befbf8
+platform_packages = framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#3.6.2
 
 board_build.core = earlephilhower
 board_build.filesystem_size = 0.5m

--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -152,7 +152,7 @@ bool perhapsSetRTC(RTCQuality q, const struct timeval *tv)
 #endif
 
         // nrf52 doesn't have a readable RTC (yet - software not written)
-#ifdef HAS_RTC
+#if HAS_RTC
         readFromRTC();
 #endif
 

--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -151,6 +151,11 @@ static int32_t reconnectWiFi()
 #endif
 
     if (config.network.wifi_enabled && !WiFi.isConnected()) {
+#ifdef ARCH_RP2040 // (ESP32 handles this in WiFiEvent)
+        /* If APStartupComplete, but we're not connected, try again.
+           Shouldn't try again before APStartupComplete. */
+        needReconnect = APStartupComplete;
+#endif
         return 1000; // check once per second
     } else {
 #ifdef ARCH_RP2040


### PR DESCRIPTION
- Handles reconnects when you got disconnected from the AP.
- Updates `arduino-core` to the latest version with more Wi-Fi + FreeRTOS fixes.
- Change one `#ifdef` to `#if` for RTC, since it will be defined, but set to 0 if not used. Now the Pico W keeps the time when connected via Wi-Fi. 