### PR TITLE
Set NRF cpu brownout at 2.4V instead of running down to the limit

### DIFF
--- a/src/platform/nrf52/main-nrf52.cpp
+++ b/src/platform/nrf52/main-nrf52.cpp
@@ -51,7 +51,7 @@ void getMacAddr(uint8_t *dmac)
 
 static void initBrownout()
 {
-    auto vccthresh = POWER_POFCON_THRESHOLD_V17;
+    auto vccthresh = POWER_POFCON_THRESHOLD_V24;
 
     auto err_code = sd_power_pof_enable(POWER_POFCON_POF_Enabled);
     assert(err_code == NRF_SUCCESS);


### PR DESCRIPTION
Closes #2936 hopefully.
@pdxlocations can you try to repro with the build assets from this change on a RAK?