### PR TITLE
Align glibc with Debian builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN wget https://raw.githubusercontent.com/platformio/platformio-core-installer/
 	source ~/.platformio/penv/bin/activate && \
 	./bin/build-native.sh
 
-FROM frolvlad/alpine-glibc
+FROM frolvlad/alpine-glibc:glibc-2.31
 
 RUN apk --update add --no-cache g++ shadow && \
 	groupadd -g 1000 mesh && useradd -ml -u 1000 -g 1000 mesh


### PR DESCRIPTION
glibc on [Debian bullseye is on 2.31](https://packages.debian.org/source/bullseye/glibc). This causes segfaults if we use a newer one that might be incompatible in the Alpine image.