### PR TITLE
SimRadio: send queue status to phone

### DIFF
--- a/src/mesh/MeshService.h
+++ b/src/mesh/MeshService.h
@@ -129,6 +129,8 @@ class MeshService
 
     bool isToPhoneQueueEmpty();
 
+    ErrorCode sendQueueStatusToPhone(const meshtastic_QueueStatus &qs, ErrorCode res, uint32_t mesh_packet_id);
+
   private:
     /// Called when our gps position has changed - updates nodedb and sends Location message out into the mesh
     /// returns 0 to allow further processing
@@ -138,8 +140,6 @@ class MeshService
     /// needs to keep the packet around it makes a copy
     int handleFromRadio(const meshtastic_MeshPacket *p);
     friend class RoutingModule;
-
-    ErrorCode sendQueueStatusToPhone(const meshtastic_QueueStatus &qs, ErrorCode res, uint32_t mesh_packet_id);
 };
 
 extern MeshService service;

--- a/src/platform/portduino/SimRadio.cpp
+++ b/src/platform/portduino/SimRadio.cpp
@@ -198,6 +198,8 @@ void SimRadio::startSend(meshtastic_MeshPacket *txp)
     p->decoded.payload.size =
         pb_encode_to_bytes(p->decoded.payload.bytes, sizeof(p->decoded.payload.bytes), &meshtastic_Compressed_msg, &c);
     p->decoded.portnum = meshtastic_PortNum_SIMULATOR_APP;
+
+    service.sendQueueStatusToPhone(router->getQueueStatus(), 0, p->id);
     service.sendToPhone(p); // Sending back to simulator
 }
 


### PR DESCRIPTION
This only affects `SimRadio`. The Python API got stuck, because it was not getting `QueueStatus` updates and it decrements the number of free elements on its own.
