### PR TITLE
Fix LED pinout for T-Echo board marked v1.0, date 2021-6-28

### DIFF
--- a/variants/t-echo/variant.h
+++ b/variants/t-echo/variant.h
@@ -43,9 +43,9 @@ extern "C" {
 #define NUM_ANALOG_OUTPUTS (0)
 
 // LEDs
-#define PIN_LED1 (0 + 14) // 13 red (confirmed on 1.0 board)
-#define PIN_LED2 (0 + 15) // 14 blue
-#define PIN_LED3 (0 + 13) // 15 green
+#define PIN_LED1 (0 + 14) // blue (confirmed on boards marked v1.0, date 2021-6-28)
+#define PIN_LED2 (32 + 1) // green
+#define PIN_LED3 (32 + 3) // red
 
 #define LED_RED PIN_LED3
 #define LED_BLUE PIN_LED1


### PR DESCRIPTION
Fixes the multi-color LED pinout for T-Echo boards marked v1.0 with date 2021-6-28. The change also reflects the T-Echo schematic dated 2021-6-23.
Green and red LED are not used in code so far but at least the code fits the actual hardware.