### PR TITLE
Add Malaysia Region

### DIFF
--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -108,20 +108,24 @@ const RegionInfo regions[] = {
     RDEF(UA_868, 868.0f, 868.6f, 1, 0, 14, true, false, false),
 
     /*
+        Malaysia
         433 - 435 MHz at 100mW, no restrictions.
-        919 - 923 Mhz at 500mW, no restrictions.
-        923 - 924 MHz at 500mW with 1% duty cycle OR frequency hopping. 
-        Frequency hopping is used for 919 - 923 MHz. 
         https://www.mcmc.gov.my/skmmgovmy/media/General/pdf/Short-Range-Devices-Specification.pdf
     */
     RDEF(MY_433, 433.0f, 435.0f, 100, 0, 20, true, false, false),
 
+    /*
+        Malaysia
+        919 - 923 Mhz at 500mW, no restrictions.
+        923 - 924 MHz at 500mW with 1% duty cycle OR frequency hopping.
+        Frequency hopping is used for 919 - 923 MHz.
+        https://www.mcmc.gov.my/skmmgovmy/media/General/pdf/Short-Range-Devices-Specification.pdf
+    */
     RDEF(MY_919, 919.0f, 924.0f, 100, 0, 27, true, true, false),
 
     /*
        2.4 GHZ WLAN Band equivalent. Only for SX128x chips.
     */
-
     RDEF(LORA_24, 2400.0f, 2483.5f, 100, 0, 10, true, false, true),
 
     /*

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -108,6 +108,17 @@ const RegionInfo regions[] = {
     RDEF(UA_868, 868.0f, 868.6f, 1, 0, 14, true, false, false),
 
     /*
+        433 - 435 MHz at 100mW, no restrictions.
+        919 - 923 Mhz at 500mW, no restrictions.
+        923 - 924 MHz at 500mW with 1% duty cycle OR frequency hopping. 
+        Frequency hopping is used for 919 - 923 MHz. 
+        https://www.mcmc.gov.my/skmmgovmy/media/General/pdf/Short-Range-Devices-Specification.pdf
+    */
+    RDEF(MY_433, 433.0f, 435.0f, 100, 0, 20, true, false, false),
+
+    RDEF(MY_919, 919.0f, 924.0f, 100, 0, 27, true, true, false),
+
+    /*
        2.4 GHZ WLAN Band equivalent. Only for SX128x chips.
     */
 

--- a/src/mesh/generated/meshtastic/config.pb.h
+++ b/src/mesh/generated/meshtastic/config.pb.h
@@ -201,7 +201,12 @@ typedef enum _meshtastic_Config_LoRaConfig_RegionCode {
     /* Ukraine 433mhz */
     meshtastic_Config_LoRaConfig_RegionCode_UA_433 = 14,
     /* Ukraine 868mhz */
-    meshtastic_Config_LoRaConfig_RegionCode_UA_868 = 15
+    meshtastic_Config_LoRaConfig_RegionCode_UA_868 = 15,
+    /* Malaysia 433mhz */
+    meshtastic_Config_LoRaConfig_RegionCode_MY_433 = 16,
+    /* Malaysia 919mhz */
+    meshtastic_Config_LoRaConfig_RegionCode_MY_919 = 17
+
 } meshtastic_Config_LoRaConfig_RegionCode;
 
 /* Standard predefined channel settings


### PR DESCRIPTION
Add frequencies for 433MHz and 919MHz with specific power limits and limitations.


433 - 435 MHz at 100mW, no restrictions.

919 - 923 Mhz at 500mW, no restrictions.
923 - 924 MHz at 500mW with 1% duty cycle OR frequency hopping. 
Frequency hopping is used for 919 - 923 MHz. 

Reference: 
https://www.mcmc.gov.my/skmmgovmy/media/General/pdf/Short-Range-Devices-Specification.pdf

<img width="584" alt="Screenshot 2024-01-04 225034" src="https://github.com/meshtastic/firmware/assets/8511047/adf060ae-87de-4b2a-a726-8b734f114eda">
<img width="601" alt="Screenshot 2024-01-04 225029" src="https://github.com/meshtastic/firmware/assets/8511047/e6a7c318-46f5-4d4c-95c4-ef52930c7387">
