### PR TITLE
Allow button press if CannedMessage `updown1` or `rotary1` are not enabled

### DIFF
--- a/src/ButtonThread.h
+++ b/src/ButtonThread.h
@@ -138,6 +138,7 @@ class ButtonThread : public concurrency::OSThread
 #ifdef BUTTON_PIN
         if (((config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN) !=
              moduleConfig.canned_message.inputbroker_pin_press) ||
+            !(moduleConfig.canned_message.updown1_enabled || moduleConfig.canned_message.rotary1_enabled) ||
             !moduleConfig.canned_message.enabled) {
             powerFSM.trigger(EVENT_PRESS);
         }


### PR DESCRIPTION
`BUTTON_PIN` may be 0 (e.g. on LoRa T3S3), which is equal to `inputbroker_pin_press` by default. `inputbroker_pin_press` is only used when either `updown1` or `rotary1` is enabled.

Should fix #3061.
