### PR TITLE
Prioritize lowest channel for each remote node in NodeDB

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -844,7 +844,7 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
         if (mp.rx_snr)
             info->snr = mp.rx_snr; // keep the most recent SNR we received for this node.
 
-        if (mp.decoded.portnum == meshtastic_PortNum_NODEINFO_APP) {
+        if (mp.decoded.portnum == meshtastic_PortNum_NODEINFO_APP && mp.channel < info->channel) {
             info->channel = mp.channel;
         }
     }


### PR DESCRIPTION
- Simple implementation that would close #3086 
- Every time we update NodeDB with info from a remote node's packet, we only update the channel if it is "closer" to our primary channel 0. This results in not downgrading remote nodes away from the primary channel in certain situations.