### PR TITLE
Add necessary libs to Dockerfile for native build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install build deps
 USER root
 RUN apt-get update && \
-	apt-get -y install wget python3 g++ zip python3-venv git vim ca-certificates
+	apt-get -y install wget python3 g++ zip python3-venv git vim ca-certificates libgpiod-dev libyaml-cpp-dev libbluetooth-dev
 
 # create a non-priveleged user & group
 RUN groupadd -g 1000 mesh && useradd -ml -u 1000 -g 1000 mesh

--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -99,10 +99,17 @@ size_t RedirectablePrint::log(const char *logLevel, const char *format, ...)
                 int hour = hms / SEC_PER_HOUR;
                 int min = (hms % SEC_PER_HOUR) / SEC_PER_MIN;
                 int sec = (hms % SEC_PER_HOUR) % SEC_PER_MIN; // or hms % SEC_PER_MIN
-
+#ifdef ARCH_PORTDUINO
                 r += ::printf("%s | %02d:%02d:%02d %u ", logLevel, hour, min, sec, millis() / 1000);
+#else
+                r += printf("%s | %02d:%02d:%02d %u ", logLevel, hour, min, sec, millis() / 1000);
+#endif
             } else
+#ifdef ARCH_PORTDUINO
                 r += ::printf("%s | ??:??:?? %u ", logLevel, millis() / 1000);
+#else
+                r += printf("%s | ??:??:?? %u ", logLevel, millis() / 1000);
+#endif
 
             auto thread = concurrency::OSThread::currentThread;
             if (thread) {


### PR DESCRIPTION
CI is failing because the Dockerfile didn't have the new libraries to build Portduino. 

Also changed using `::printf` only for Portduino.