### PR TITLE
fix MQTT crash

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -131,7 +131,10 @@ void MQTT::onReceive(char *topic, byte *payload, size_t length)
         }
         delete json_value;
     } else {
-        if (!pb_decode_from_bytes(payload, length, &meshtastic_ServiceEnvelope_msg, &e)) {
+        if (length == 0) {
+            LOG_WARN("Empty MQTT payload received, topic %s!\n", topic);
+            return;
+        } else if (!pb_decode_from_bytes(payload, length, &meshtastic_ServiceEnvelope_msg, &e)) {
             LOG_ERROR("Invalid MQTT service envelope, topic %s, len %u!\n", topic, length);
             return;
         } else {


### PR DESCRIPTION
This is a fix for a potential crash when receiving an empty MQTT payload:

```
INFO  | 16:13:10 21243 [Router] Should encrypt MQTT?: 1
INFO  | 16:13:10 21243 [mqtt] Received MQTT topic msh/EU_868/2/c/LongFast/!a3fb6054, len=75
INFO  | 16:13:14 21247 [mqtt] Received MQTT topic msh/EU_868/2/c/LongFast/!a3fb6054, len=101
INFO  | 16:13:14 21247 [Router] Received nodeinfo from=0x767161ec, id=0x3a9cc231, portnum=4, payloadlen=34
INFO  | 16:13:14 21247 [Router] Received routing from=0x767161ec, id=0x3a9cc231, portnum=4, payloadlen=34
INFO  | 16:13:14 21247 [Router] Rebroadcasting received floodmsg to neighbors
INFO  | 16:13:14 21247 [Router] Should encrypt MQTT?: 1
INFO  | 16:13:14 21247 [mqtt] Received MQTT topic msh/EU_868/2/c/LongFast/!e0f79900, len=103

Program received signal SIGSEGV, Segmentation fault.
#0  0x00007ffff7a9ddab in __strcmp_avx2 () from /usr/lib64/libc.so.6
#1  0x00000000004df6e9 in MQTT::onReceive (this=0x30401b0, topic=0x3041003 "msh/EU_868/2/c/LongFast/!e2e38870", payload=0x3041025 "", length=0) at src/mqtt/MQTT.cpp:138
#2  0x00000000004de0ca in MQTT::mqttCallback (topic=0x3041003 "msh/EU_868/2/c/LongFast/!e2e38870", payload=0x3041025 "", length=0) at src/mqtt/MQTT.cpp:33
#3  0x0000000000520c70 in PubSubClient::loop (this=0x3040238) at .pio/libdeps/native/PubSubClient/src/PubSubClient.cpp:416
#4  0x00000000004e0e09 in MQTT::runOnce (this=0x30401b0) at src/mqtt/MQTT.cpp:403
#5  0x0000000000471259 in concurrency::OSThread::run (this=0x30401b0) at src/concurrency/OSThread.cpp:85
#6  0x0000000000519748 in ThreadController::runOrDelay (this=0x3014820 <concurrency::mainController>) at .pio/libdeps/native/Thread/ThreadController.cpp:59
#7  0x000000000049a926 in loop () at src/main.cpp:973
#8  0x0000000000530e01 in main (argc=1, argv=0x7fffffffcd78) at /home/manuel/.platformio/packages/framework-portduino/cores/portduino/main.cpp:198
```