### PR TITLE
Fix: return failure when PhoneAPI times out

### DIFF
--- a/src/Observer.h
+++ b/src/Observer.h
@@ -10,12 +10,12 @@ template <class T> class Observable;
  */
 template <class T> class Observer
 {
-    std::list<Observable<T> *> observed;
+    std::list<Observable<T> *> observables;
 
   public:
     virtual ~Observer();
 
-    /// Stop watching the obserable
+    /// Stop watching the observable
     void unobserve(Observable<T> *o);
 
     /// Start watching a specified observable
@@ -86,21 +86,21 @@ template <class T> class Observable
 
 template <class T> Observer<T>::~Observer()
 {
-    for (typename std::list<Observable<T> *>::const_iterator iterator = observed.begin(); iterator != observed.end();
+    for (typename std::list<Observable<T> *>::const_iterator iterator = observables.begin(); iterator != observables.end();
          ++iterator) {
         (*iterator)->removeObserver(this);
     }
-    observed.clear();
+    observables.clear();
 }
 
 template <class T> void Observer<T>::unobserve(Observable<T> *o)
 {
     o->removeObserver(this);
-    observed.remove(o);
+    observables.remove(o);
 }
 
 template <class T> void Observer<T>::observe(Observable<T> *o)
 {
-    observed.push_back(o);
+    observables.push_back(o);
     o->addObserver(this);
 }

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -108,8 +108,9 @@ void MeshService::loop()
             (void)sendQueueStatusToPhone(qs, 0, 0);
     }
     if (oldFromNum != fromNum) { // We don't want to generate extra notifies for multiple new packets
-        fromNumChanged.notifyObservers(fromNum);
-        oldFromNum = fromNum;
+        int result = fromNumChanged.notifyObservers(fromNum);
+        if (result == 0) // If any observer returns non-zero, we will try again
+            oldFromNum = fromNum;
     }
 }
 

--- a/src/mesh/PhoneAPI.h
+++ b/src/mesh/PhoneAPI.h
@@ -108,8 +108,8 @@ class PhoneAPI
     /// Hookable to find out when connection changes
     virtual void onConnectionChanged(bool connected) {}
 
-    /// If we haven't heard from the other side in a while then say not connected
-    void checkConnectionTimeout();
+    /// If we haven't heard from the other side in a while then say not connected. Returns true if timeout occurred
+    bool checkConnectionTimeout();
 
     /// Check the current underlying physical link to see if the client is currently connected
     virtual bool checkIsConnected() = 0;

--- a/variants/rak11310/platformio.ini
+++ b/variants/rak11310/platformio.ini
@@ -11,3 +11,5 @@ build_flags = ${rp2040_base.build_flags}
   -L "${platformio.libdeps_dir}/${this.__env__}/BSEC2 Software Library/src/cortex-m0plus"
 lib_deps =
   ${rp2040_base.lib_deps}
+debug_build_flags = ${rp2040_base.build_flags}
+debug_tool = cmsis-dap ; for e.g. Picotool

--- a/variants/rpipico/platformio.ini
+++ b/variants/rpipico/platformio.ini
@@ -12,3 +12,5 @@ build_flags = ${rp2040_base.build_flags}
   -L "${platformio.libdeps_dir}/${this.__env__}/BSEC2 Software Library/src/cortex-m0plus"
 lib_deps =
   ${rp2040_base.lib_deps}
+debug_build_flags = ${rp2040_base.build_flags}
+debug_tool = cmsis-dap ; for e.g. Picotool

--- a/variants/rpipicow/platformio.ini
+++ b/variants/rpipicow/platformio.ini
@@ -15,3 +15,5 @@ build_src_filter = ${rp2040_base.build_src_filter} +<mesh/wifi/>
 lib_deps =
   ${rp2040_base.lib_deps}
   ${networking_base.lib_deps}
+debug_build_flags = ${rp2040_base.build_flags}
+debug_tool = cmsis-dap ; for e.g. Picotool


### PR DESCRIPTION
Fixes #3132. 

In `notifyObservers()`, we loop through all the observers. Then the PhoneAPI’s `onNotifiy()` got called, which then got closed in `checkConnectionTimeout()`. Upon closing, it removed itself from the list of observers of `fromNumChanged`, where we were looping through. So the iterator got invalidated and that caused a memory corruption and a hardfault on the RP2040.
Now the PhoneAPI returns a failure when this happens, such that the loop through the observers exits.

Also renamed `observed` to `observables` because it's a list of `Observable`. 
Also added debug configurations for the RP2040.

