### PR TITLE
Restrict MQTT JSON downlink messages

### DIFF
--- a/src/mesh/Channels.cpp
+++ b/src/mesh/Channels.cpp
@@ -15,6 +15,7 @@ Channels channels;
 const char *Channels::adminChannel = "admin";
 const char *Channels::gpioChannel = "gpio";
 const char *Channels::serialChannel = "serial";
+const char *Channels::mqttChannel = "mqtt";
 
 uint8_t xorHash(const uint8_t *p, size_t len)
 {

--- a/src/mesh/Channels.h
+++ b/src/mesh/Channels.h
@@ -32,7 +32,7 @@ class Channels
     Channels() {}
 
     /// Well known channel names
-    static const char *adminChannel, *gpioChannel, *serialChannel;
+    static const char *adminChannel, *gpioChannel, *serialChannel, *mqttChannel;
 
     const meshtastic_ChannelSettings &getPrimary() { return getByIndex(getPrimaryIndex()).settings; }
 

--- a/src/mqtt/MQTT.h
+++ b/src/mqtt/MQTT.h
@@ -5,6 +5,7 @@
 #include "concurrency/OSThread.h"
 #include "mesh/Channels.h"
 #include "mesh/generated/meshtastic/mqtt.pb.h"
+#include "mqtt/JSON.h"
 #if HAS_WIFI
 #include <WiFiClient.h>
 #define HAS_NETWORKING 1
@@ -99,6 +100,9 @@ class MQTT : private concurrency::OSThread
 
     void publishStatus();
     void publishQueuedMessages();
+
+    // returns true if this is a valid JSON envelope which we accept on downlink
+    bool isValidJsonEnvelope(JSONObject &json);
 
     /// Return 0 if sleep is okay, veto sleep if we are connected to pubsub server
     // int preflightSleepCb(void *unused = NULL) { return pubSub.connected() ? 1 : 0; }


### PR DESCRIPTION
Currently anyone on an MQTT server can format a JSON message to instruct **all** nodes with JSON enabled to send out a text or position packet as coming from that node. 
With these changes, this is only allowed when the channel is called "mqtt", and the "from" field should be set to the node number of the transmitter (such that only one node transmits).

Also prevented a crash when you didn't specify "altitude" or "time" on a "sendposition" packet.

Furthermore, you can now specify a destination by setting the "to" field to the node number of the receiver.

**TODO**: documentation needs to reflect these new requirements.
