### PR TITLE
Added LilyGo T3 V1.6.1 TCXO  Version Support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,6 +15,7 @@ default_envs = tbeam
 ;default_envs = tlora_v1_3
 ;default_envs = tlora-v2
 ;default_envs = tlora-v2-1-1_6
+; default_envs = tlora-v1-6-1-tcxo
 ;default_envs = tlora-t3s3-v1
 ;default_envs = lora-relay-v1 # nrf board
 ;default_envs = t-echo

--- a/src/mesh/RadioLibRF95.cpp
+++ b/src/mesh/RadioLibRF95.cpp
@@ -25,8 +25,9 @@ int16_t RadioLibRF95::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_
     RADIOLIB_ASSERT(state);
 
 #ifdef RF95_TCXO
-    state = _mod->SPIsetRegValue(RADIOLIB_SX127X_REG_TCXO, 0x10 | _mod->SPIgetRegValue(RADIOLIB_SX127X_REG_TCXO));
-    RADIOLIB_ASSERT(state);
+    // There is no variant to use this, comment it out
+    // state = _mod->SPIsetRegValue(RADIOLIB_SX127X_REG_TCXO, 0x10 | _mod->SPIgetRegValue(RADIOLIB_SX127X_REG_TCXO));
+    // RADIOLIB_ASSERT(state);
 #endif
 
     // configure publicly accessible settings

--- a/src/platform/esp32/architecture.h
+++ b/src/platform/esp32/architecture.h
@@ -127,6 +127,8 @@
 #define HW_VENDOR meshtastic_HardwareModel_HELTEC_HT62
 #elif defined(CHATTER_2)
 #define HW_VENDOR meshtastic_HardwareModel_CHATTER_2
+#elif defined(TLORA_V1_6_1_TCXO)
+#define HW_VENDOR meshtastic_HardwareModel_TLORA_V1_6_1_TCXO
 #endif
 
 // -----------------------------------------------------------------------------

--- a/variants/tlora_v1_6_1_tcxo/platformio.ini
+++ b/variants/tlora_v1_6_1_tcxo/platformio.ini
@@ -1,0 +1,6 @@
+[env:tlora-v1-6-1-tcxo]
+extends = esp32_base
+board = ttgo-lora32-v21
+build_flags = 
+  ${esp32_base.build_flags} -D TLORA_V1_6_1_TCXO -I variants/tlora_v1_6_1_tcxo
+  -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.

--- a/variants/tlora_v1_6_1_tcxo/variant.h
+++ b/variants/tlora_v1_6_1_tcxo/variant.h
@@ -1,0 +1,21 @@
+#define BATTERY_PIN 35
+#define ADC_CHANNEL ADC1_GPIO35_CHANNEL
+#define BATTERY_SENSE_SAMPLES 30
+
+// ratio of voltage divider = 2.0 (R42=100k, R43=100k)
+#define ADC_MULTIPLIER 2
+
+#define I2C_SDA 21 // I2C pins for this board
+#define I2C_SCL 22
+
+#define LED_PIN 25    // If defined we will blink this LED
+#define BUTTON_PIN 12 // If defined, this will be used for user button presses,
+
+#define BUTTON_NEED_PULLUP
+
+#define USE_RF95
+#define LORA_DIO0 26
+#define LORA_RESET 23
+#define LORA_DIO1 RADIOLIB_NC // No connect on the SX1276 module
+#define LORA_DIO2 32
+#define RF95_TCXO 33            //TCXO Enable


### PR DESCRIPTION
The LilyGo T3 V1.6.1 TCXO version is different from the normal version and the original variant cannot be used.
https://www.lilygo.cc/products/lora3?variant=43365007425717

protobufs PR:

https://github.com/meshtastic/protobufs/pull/426