### PR TITLE
refactor: LED colors and ext. notification convention

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -246,10 +246,9 @@ void NodeDB::installDefaultModuleConfig()
     moduleConfig.has_store_forward = true;
     moduleConfig.has_telemetry = true;
     moduleConfig.has_external_notification = true;
-#if defined(RAK4630) || defined(RAK11310)
-    // Default to RAK led pin 2 (blue)
+#if defined(RAK4630) || defined(RAK11310) || defined(TTGO_T_ECHO) // TODO #if defined(LED_BLUE) && (LED_BLUE > 0) ?
     moduleConfig.external_notification.enabled = true;
-    moduleConfig.external_notification.output = PIN_LED2;
+    moduleConfig.external_notification.output = LED_BLUE;
     moduleConfig.external_notification.active = true;
     moduleConfig.external_notification.alert_message = true;
     moduleConfig.external_notification.output_ms = 1000;

--- a/variants/t-echo/variant.h
+++ b/variants/t-echo/variant.h
@@ -54,8 +54,7 @@ extern "C" {
 #define LED_BUILTIN LED_GREEN
 #define LED_CONN LED_BLUE
 
-#define LED_STATE_ON 0 // State when LED is lit
-#define LED_INVERTED 1
+#define LED_STATE_ON 1 // State when LED is lit
 
 /*
  * Buttons

--- a/variants/t-echo/variant.h
+++ b/variants/t-echo/variant.h
@@ -43,16 +43,16 @@ extern "C" {
 #define NUM_ANALOG_OUTPUTS (0)
 
 // LEDs
-#define PIN_LED1 (0 + 14) // blue (confirmed on boards marked v1.0, date 2021-6-28)
-#define PIN_LED2 (32 + 1) // green
+#define PIN_LED1 (32 + 1) // green (confirmed on boards marked v1.0, date 2021-6-28)
+#define PIN_LED2 (0 + 14) // blue
 #define PIN_LED3 (32 + 3) // red
 
 #define LED_RED PIN_LED3
-#define LED_BLUE PIN_LED1
-#define LED_GREEN PIN_LED2
+#define LED_BLUE PIN_LED2
+#define LED_GREEN PIN_LED1
 
-#define LED_BUILTIN LED_BLUE
-#define LED_CONN PIN_GREEN
+#define LED_BUILTIN LED_GREEN
+#define LED_CONN LED_BLUE
 
 #define LED_STATE_ON 0 // State when LED is lit
 #define LED_INVERTED 1


### PR DESCRIPTION
- change T-Echo heartbeat to `LED_GREEN`
- use default `LED_BLUE` with External Notifications