### PR TITLE
Update variant.h heltec v3 adc multiplier to match actual readings

### DIFF
--- a/variants/heltec_v3/variant.h
+++ b/variants/heltec_v3/variant.h
@@ -14,7 +14,7 @@
 #define BATTERY_PIN 1 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
 #define ADC_CHANNEL ADC1_GPIO1_CHANNEL
 #define ADC_ATTENUATION ADC_ATTEN_DB_2_5 // lower dB for high resistance voltage divider
-#define ADC_MULTIPLIER 4.9
+#define ADC_MULTIPLIER 5.05
 
 #define USE_SX1262
 


### PR DESCRIPTION
As per message adc multiplier 5.05 results in correct battery readings for heltec v3
