### PR TITLE
MQTT JSON downlink fixes

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -67,7 +67,9 @@ void MQTT::onReceive(char *topic, byte *payload, size_t length)
                         // construct protobuf data packet using TEXT_MESSAGE, send it to the mesh
                         meshtastic_MeshPacket *p = router->allocForSending();
                         p->decoded.portnum = meshtastic_PortNum_TEXT_MESSAGE_APP;
-                        p->channel = sendChannel.index;
+                        if (json.find("channel") != json.end() && json["channel"]->IsNumber() &&
+                            (json["channel"]->AsNumber() < channels.getNumChannels()))
+                            p->channel = json["channel"]->AsNumber();
                         if (json.find("to") != json.end() && json["to"]->IsNumber())
                             p->to = json["to"]->AsNumber();
                         if (jsonPayloadStr.length() <= sizeof(p->decoded.payload.bytes)) {
@@ -95,7 +97,9 @@ void MQTT::onReceive(char *topic, byte *payload, size_t length)
                         // construct protobuf data packet using POSITION, send it to the mesh
                         meshtastic_MeshPacket *p = router->allocForSending();
                         p->decoded.portnum = meshtastic_PortNum_POSITION_APP;
-                        p->channel = sendChannel.index;
+                        if (json.find("channel") != json.end() && json["channel"]->IsNumber() &&
+                            (json["channel"]->AsNumber() < channels.getNumChannels()))
+                            p->channel = json["channel"]->AsNumber();
                         if (json.find("to") != json.end() && json["to"]->IsNumber())
                             p->to = json["to"]->AsNumber();
                         p->decoded.payload.size =

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -52,11 +52,8 @@ void MQTT::onReceive(char *topic, byte *payload, size_t length)
             JSONObject json;
             json = json_value->AsObject();
 
-            // parse the channel name from the topic string
-            char *ptr = strtok(topic, "/");
-            for (int i = 0; i < 3; i++) {
-                ptr = strtok(NULL, "/");
-            }
+            // parse the channel name from the topic string by looking at the last occurrence of "/"
+            char *ptr = strrchr(topic, '/');
             meshtastic_Channel sendChannel = channels.getByName(ptr);
             // We allow downlink JSON packets only on a channel named "mqtt"
             if (strncasecmp(channels.getGlobalId(sendChannel.index), Channels::mqttChannel, strlen(Channels::mqttChannel)) == 0 &&

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -52,8 +52,10 @@ void MQTT::onReceive(char *topic, byte *payload, size_t length)
             JSONObject json;
             json = json_value->AsObject();
 
-            // parse the channel name from the topic string by looking at the last occurrence of "/"
-            char *ptr = strrchr(topic, '/');
+            // parse the channel name from the topic string by looking for "json/"
+            const char *jsonSlash = "json/";
+            char *ptr = strstr(topic, jsonSlash) + sizeof(jsonSlash) + 1; // set pointer to after "json/"
+            ptr = strtok(ptr, "/") ? strtok(ptr, "/") : ptr; // if another "/" was added, parse string up to that character
             meshtastic_Channel sendChannel = channels.getByName(ptr);
             // We allow downlink JSON packets only on a channel named "mqtt"
             if (strncasecmp(channels.getGlobalId(sendChannel.index), Channels::mqttChannel, strlen(Channels::mqttChannel)) == 0 &&


### PR DESCRIPTION
- Fixes #3168 by looking for the last occurrence of "/" in the topic, instead of the third.
- Allow specifying channel index to send on via LoRa in new JSON field "channel" while still requiring the message to be published to a channel called "mqtt".

