### PR TITLE
Fix init resolution for all architectures

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -389,11 +389,9 @@ bool Power::analogInit()
 #else
     analogReference(AR_INTERNAL); // 3.6V
 #endif
-    analogReadResolution(BATTERY_SENSE_RESOLUTION_BITS); // Default of 12 is not very linear. Recommended to use 10 or 11
-                                                         // depending on needed resolution.
-
 #endif // ARCH_NRF52
-
+    analogReadResolution(BATTERY_SENSE_RESOLUTION_BITS);
+  
     batteryLevel = &analogLevel;
     return true;
 #else

--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -391,7 +391,7 @@ bool Power::analogInit()
 #endif
 #endif // ARCH_NRF52
     analogReadResolution(BATTERY_SENSE_RESOLUTION_BITS);
-  
+
     batteryLevel = &analogLevel;
     return true;
 #else


### PR DESCRIPTION
RP2040 was initializing to 10bit adc resolution b/c of the analogReadResolution call being cordoned off by a preprocessor ifdef.
Now fixed, hopefully for all archs