### PR TITLE
Don't let MQTT ACKs cancel LoRa transmission if it's still in the Tx queue

### DIFF
--- a/src/mesh/ReliableRouter.cpp
+++ b/src/mesh/ReliableRouter.cpp
@@ -168,10 +168,14 @@ bool ReliableRouter::stopRetransmission(GlobalPacketId key)
         auto p = old->packet;
         auto numErased = pending.erase(key);
         assert(numErased == 1);
-        // remove the 'original' (identified by originator and packet->id) from the txqueue and free it
-        cancelSending(getFrom(p), p->id);
-        // now free the pooled copy for retransmission too
-        packetPool.release(p);
+        /* Only when we already transmitted a packet via LoRa, we will cancel the packet in the Tx queue
+          to avoid canceling a transmission if it was ACKed super fast via MQTT */
+        if (old->numRetransmissions < NUM_RETRANSMISSIONS - 1) {
+            // remove the 'original' (identified by originator and packet->id) from the txqueue and free it
+            cancelSending(getFrom(p), p->id);
+            // now free the pooled copy for retransmission too
+            packetPool.release(p);
+        }
         return true;
     } else
         return false;


### PR DESCRIPTION
A user on Discord reported that packets were still not sent out via LoRa if MQTT uplink was enabled.
Looks like if you have a fast internet connection (or local MQTT server), a packet may be ACKed via MQTT during the small delay we add before transmitting via LoRa. To avoid canceling this packet (removing it from the LoRa Tx queue), I now check if we have less than `NUM_RETRANSMISSIONS - 1` left, which is the original setting: 
https://github.com/meshtastic/firmware/blob/54e52ae05fb495e07a4b1706d2ad73dc674d0d01/src/mesh/ReliableRouter.cpp#L144 
Meaning we've not yet decremented it due to a failed transmission.