### PR TITLE
E-Ink "Dynamic Partial"

### DIFF
--- a/src/graphics/EInkDisplay2.h
+++ b/src/graphics/EInkDisplay2.h
@@ -54,4 +54,68 @@ class EInkDisplay : public OLEDDisplay
 
     // Connect to the display
     virtual bool connect() override;
+
+#if defined(USE_EINK_DYNAMIC_PARTIAL)
+    // Full, partial, or skip: balance urgency with display health
+
+    // Use partial refresh if EITHER:
+    // * highPriority() was set
+    // * a highPriority() update was previously skipped, for rate-limiting - (EINK_HIGHPRIORITY_LIMIT_SECONDS)
+
+    // Use full refresh if EITHER:
+    // * lowPriority() was set
+    // * too many partial updates in a row: protect display - (EINK_PARTIAL_REPEAT_LIMIT)
+    // * no recent updates, and last update was partial: redraw for image quality (EINK_LOWPRIORITY_LIMIT_SECONDS)
+
+    // Rate limit if:
+    // * lowPriority() - (EINK_LOWPRIORITY_LIMIT_SECONDS)
+    // * highPriority(), if multiple partials have run back-to-back - (EINK_HIGHPRIORITY_LIMIT_SECONDS)
+
+    // Skip update entirely if ALL criteria met:
+    // * new image matches old image
+    // * lowPriority()
+    // * not redrawing for image quality
+    // * not refreshing for display health
+
+    // ------------------------------------
+
+    // To implement for your E-Ink display:
+    // * edit configForPartialRefresh()
+    // * edit configForFullRefresh()
+    // * add macros to variant.h, and adjust to taste:
+
+    /*
+        #define USE_EINK_DYNAMIC_PARTIAL
+        #define EINK_LOWPRIORITY_LIMIT_SECONDS 30
+        #define EINK_HIGHPRIORITY_LIMIT_SECONDS 1
+        #define EINK_PARTIAL_REPEAT_LIMIT 5
+    */
+
+  public:
+    void highPriority(); // Suggest partial refresh
+    void lowPriority();  // Suggest full refresh
+
+  protected:
+    void configForPartialRefresh(); // Display specific code to select partial refresh mode
+    void configForFullRefresh();    // Display specific code to return to full refresh mode
+    bool newImageMatchesOld();      // Is the new update actually different to the last image?
+    bool determineRefreshMode();    // Called immediately before data written to display - choose refresh mode, or abort update
+
+    bool isHighPriority = true;            // Does the method calling update believe that this is urgent?
+    bool needsFull = false;                // Is a full refresh forced? (display health)
+    bool missedHighPriorityUpdate = false; // Was a high priority update skipped for rate-limiting?
+    uint16_t partialRefreshCount = 0;      // How many partials have occurred since last full refresh?
+    uint32_t lastUpdateMsec = 0;           // When did the last update occur?
+    uint32_t prevImageHash = 0;            // Used to check if update will change screen image (skippable or not)
+
+    // Set in variant.h
+    const uint32_t lowPriorityLimitMsec = (uint32_t)1000 * EINK_LOWPRIORITY_LIMIT_SECONDS;   // Max rate for partial refreshes
+    const uint32_t highPriorityLimitMsec = (uint32_t)1000 * EINK_HIGHPRIORITY_LIMIT_SECONDS; // Max rate for full refreshes
+    const uint32_t partialRefreshLimit = EINK_PARTIAL_REPEAT_LIMIT; // Max consecutive partials, before full is triggered
+
+#else // !USE_EINK_DYNAMIC_PARTIAL
+    // Tolerate calls to these methods anywhere, just to be safe
+    void highPriority() {}
+    void lowPriority() {}
+#endif
 };

--- a/variants/heltec_wireless_paper_v1/variant.h
+++ b/variants/heltec_wireless_paper_v1/variant.h
@@ -5,6 +5,14 @@
 #define I2C_SCL SCL
 
 #define USE_EINK
+
+// Settings for Dynamic Partial mode
+// Change between partial and full refresh config, or skip update, balancing urgency and display health.
+#define USE_EINK_DYNAMIC_PARTIAL
+#define EINK_LOWPRIORITY_LIMIT_SECONDS 30
+#define EINK_HIGHPRIORITY_LIMIT_SECONDS 1
+#define EINK_PARTIAL_REPEAT_LIMIT 5
+
 /*
  * eink display pins
  */


### PR DESCRIPTION
> The other issue to include in discussion is the need for a full update to be includes after so many partial updates - e-ink displays are not meant to be partially updates for ever.

https://github.com/meshtastic/firmware/issues/3075#issuecomment-1885420501

## What it is
Selects between full refresh, partial refresh, and skipped updates, balancing urgency and display health. Non-intrusive, disabled by default. Implementable for individual boards.

## How to implement it
### For individual boards
#### 1. Configure in `variant.h`
```cpp
#define USE_EINK
#define USE_EINK_DYNAMIC_PARTIAL
#define EINK_LOWPRIORITY_LIMIT_SECONDS 30
#define EINK_HIGHPRIORITY_LIMIT_SECONDS 1
#define EINK_PARTIAL_REPEAT_LIMIT 5
```
  * `EINK_LOWPRIORITY_LIMIT_SECONDS`: interval between "low priority" updates
  * `EINK_HIGHPRIORITY_LIMIT_SECONDS`: min. interval between "high priority" updates
  * `EINK_PARTIAL_REPEAT_LIMIT`: max. consecutive partial refreshes, before a full refresh is forced

#### 2. Adjust `configForPartialRefresh()` and `configForFullRefresh()`, if necessary 

These methods are used internally to execute any code required to switch the display between partial and full refresh configurations. The *should* work out-of-the-box, but any "display specific" code can go here.

### In GFX code

Graphics code should suggest that an update is either "high priority" or "low priority". This is considered by the *Dynamic Partial* code, when determining whether to use partial or full refresh.
* `EInkDisplay::highPriority()` - subsequent updates are important: show ASAP
* `EInkDisplay::lowPriority()` - no rush with these ones

For the EInkDisplay class as it currently exists,  **this pull request has already implemented the required changes.**
This is hooked into the existing update `display()` and `forceDisplay()` methods:
* updates called via `display()` are considered *low priority* - receives one per `loop()` (?)
* updates called via `forceDisplay()` are considered *high priority*

## What does it change?

The main *selection* process is handled by this block, in `EInkDisplay::forceDisplay()`
```cpp
#if defined(USE_EINK_DYNAMIC_PARTIAL)
    // Decide if update is partial or full
    bool continueUpdate = determineRefreshMode();
    if (!continueUpdate)
        return false; // Abort forceDisplay()
#else
```

For the most part, the changes are additions, selected by the preprocessor. One exception is the minor refactoring of the "rate-limiting" code in `forceDisplay()`:
https://github.com/meshtastic/firmware/blob/1085b54069e426b592f7d458548de6e485f72c8b/src/graphics/EInkDisplay2.cpp#L131

Structure has changed from:
```cpp
if (condition_met)
  doStuff();
```

to:
```cpp
if (!condition_met)
  return;

doStuff();
```

## What will I notice?
Probably, nothing. This pull request only enables *Dynamic Partial* mode for `HELTEC_WIRELESS_PAPER_V1_0`. Ideally, there should be no impact on other boards.

The hope is that devs will test *Dynamic Partial* mode on their own hardware, and if the result is good, implement it for the relevant boards; even if only as an interim measure, pending a rewrite of the EInkDisplay class I had seen [mentioned in passing](https://github.com/meshtastic/firmware/issues/3075#issuecomment-1902231040).

## How is the refresh mode selected?
I will admit, the logic is slightly convoluted. I do believe though that the resulting behavior feels intuitive.

A rough outline:

![flowchart of dynamic partial modes' selection logic](https://github.com/meshtastic/firmware/assets/24772776/32224866-5045-488b-96ed-8b5979c4d351)
