### PR TITLE
#3172 Fixes possible position leak when location is disabled

### DIFF
--- a/src/GPSStatus.h
+++ b/src/GPSStatus.h
@@ -57,8 +57,10 @@ class GPSStatus : public Status
 #endif
             meshtastic_NodeInfoLite *node = nodeDB.getMeshNode(nodeDB.getNodeNum());
             return node->position.latitude_i;
-        } else {
+        } else if (config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED) {
             return p.latitude_i;
+        } else {
+            return 0;
         }
     }
 
@@ -70,8 +72,10 @@ class GPSStatus : public Status
 #endif
             meshtastic_NodeInfoLite *node = nodeDB.getMeshNode(nodeDB.getNodeNum());
             return node->position.longitude_i;
-        } else {
+        } else if (config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED) {
             return p.longitude_i;
+        } else {
+            return 0;
         }
     }
 
@@ -83,25 +87,18 @@ class GPSStatus : public Status
 #endif
             meshtastic_NodeInfoLite *node = nodeDB.getMeshNode(nodeDB.getNodeNum());
             return node->position.altitude;
-        } else {
+        } else if (config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED) {
             return p.altitude;
+        } else {
+            return 0;
         }
     }
 
-    uint32_t getDOP() const
-    {
-        return p.PDOP;
-    }
+    uint32_t getDOP() const { return p.PDOP; }
 
-    uint32_t getHeading() const
-    {
-        return p.ground_track;
-    }
+    uint32_t getHeading() const { return p.ground_track; }
 
-    uint32_t getNumSatellites() const
-    {
-        return p.sats_in_view;
-    }
+    uint32_t getNumSatellites() const { return p.sats_in_view; }
 
     bool matches(const GPSStatus *newStatus) const
     {

--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1301,6 +1301,7 @@ bool GPS::whileIdle()
     }
     return isValid;
 }
+
 void GPS::enable()
 {
     enabled = true;
@@ -1313,7 +1314,10 @@ int32_t GPS::disable()
     enabled = false;
     setInterval(INT32_MAX);
     setAwake(false);
-
+    // reset position data if location is disabled and not fixed
+    if (config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_DISABLED && !config.position.fixed_position) {
+        positionModule->clearLastPosition();
+    }
     return INT32_MAX;
 }
 

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -27,6 +27,18 @@ PositionModule::PositionModule()
     }
 }
 
+void PositionModule::clearLastPosition()
+{
+    LOG_DEBUG("Clearing last position saved\n");
+    meshtastic_NodeInfoLite *node = nodeDB.getMeshNode(nodeDB.getNodeNum());
+    node->position.latitude_i = 0;
+    node->position.longitude_i = 0;
+    node->position.altitude = 0;
+    node->position.time = 0;
+    lastGpsLatitude = 0;
+    lastGpsLongitude = 0;
+}
+
 void PositionModule::clearPosition()
 {
     LOG_DEBUG("Clearing position on startup for sleepy tracker (ー。ー) zzz\n");

--- a/src/modules/PositionModule.h
+++ b/src/modules/PositionModule.h
@@ -33,6 +33,8 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
 
     void handleNewPosition();
 
+    void clearLastPosition();
+
   protected:
     /** Called to handle a particular incoming message
 


### PR DESCRIPTION
Related to #3172 fixes location leaks when location is disabled and we don't want our position to be given.
basically we send our position only if the location is enabled, and if it get disabled we reset the local data to avoid any unwanted data sharing.