### PR TITLE
Fixed ESP32 ADC resolution bug introduced by #3184

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -390,7 +390,10 @@ bool Power::analogInit()
     analogReference(AR_INTERNAL); // 3.6V
 #endif
 #endif // ARCH_NRF52
+
+#ifndef ARCH_ESP32
     analogReadResolution(BATTERY_SENSE_RESOLUTION_BITS);
+#endif
 
     batteryLevel = &analogLevel;
     return true;


### PR DESCRIPTION
Fixed ESP32 ADC resolution bug introduced by #3184 as esp32 analog resolution is already set some line of code before to 12 bit default, this break things on ESP32 (every time on non S3 and random on S3).