### PR TITLE
Add TAK Tracker role behavior

### DIFF
--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -246,6 +246,7 @@ void PowerFSM_setup()
 {
     bool isRouter = (config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER ? 1 : 0);
     bool isTrackerOrSensor = config.device.role == meshtastic_Config_DeviceConfig_Role_TRACKER ||
+                             config.device.role == meshtastic_Config_DeviceConfig_Role_TAK_TRACKER ||
                              config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR;
     bool hasPower = isPowered();
 

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -325,6 +325,17 @@ void NodeDB::installRoleDefaults(meshtastic_Config_DeviceConfig_Role role)
             (meshtastic_Config_PositionConfig_PositionFlags_ALTITUDE | meshtastic_Config_PositionConfig_PositionFlags_SPEED |
              meshtastic_Config_PositionConfig_PositionFlags_HEADING | meshtastic_Config_PositionConfig_PositionFlags_DOP);
         moduleConfig.telemetry.device_update_interval = ONE_DAY;
+    } else if (role == meshtastic_Config_DeviceConfig_Role_TAK_TRACKER) {
+        config.device.node_info_broadcast_secs = ONE_DAY;
+        config.position.position_broadcast_smart_enabled = true;
+        config.position.position_broadcast_secs = 3 * 60; // Every 3 minutes
+        config.position.broadcast_smart_minimum_distance = 20;
+        config.position.broadcast_smart_minimum_interval_secs = 15;
+        // Remove Altitude MSL from flags since CoTs use HAE (height above ellipsoid)
+        config.position.position_flags =
+            (meshtastic_Config_PositionConfig_PositionFlags_ALTITUDE | meshtastic_Config_PositionConfig_PositionFlags_SPEED |
+             meshtastic_Config_PositionConfig_PositionFlags_HEADING | meshtastic_Config_PositionConfig_PositionFlags_DOP);
+        moduleConfig.telemetry.device_update_interval = ONE_DAY;
     } else if (role == meshtastic_Config_DeviceConfig_Role_CLIENT_HIDDEN) {
         config.device.rebroadcast_mode = meshtastic_Config_DeviceConfig_RebroadcastMode_LOCAL_ONLY;
         config.device.node_info_broadcast_secs = UINT32_MAX;

--- a/src/mesh/generated/meshtastic/config.pb.h
+++ b/src/mesh/generated/meshtastic/config.pb.h
@@ -38,7 +38,7 @@ typedef enum _meshtastic_Config_DeviceConfig_Role {
    When used in conjunction with power.is_power_saving = true, nodes will wake up, 
    send environment telemetry, and then sleep for telemetry.environment_update_interval seconds. */
     meshtastic_Config_DeviceConfig_Role_SENSOR = 6,
-    /* Description: Optimized for ATAK system communication, reduces routine broadcasts.
+    /* Description: Optimized for ATAK system communication and reduces routine broadcasts.
  Technical Details: Used for nodes dedicated for connection to an ATAK EUD.
     Turns off many of the routine broadcasts to favor CoT packet stream
     from the Meshtastic ATAK plugin -> IMeshService -> Node */
@@ -53,7 +53,12 @@ typedef enum _meshtastic_Config_DeviceConfig_Role {
  Technical Details: Used to automatically send a text message to the mesh 
     with the current position of the device on a frequent interval:
     "I'm lost! Position: lat / long" */
-    meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND = 9
+    meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND = 9,
+    /* Description: Enables automatic TAK PLI broadcasts and reduces routine broadcasts.
+ Technical Details: Turns off many of the routine broadcasts to favor ATAK CoT packet stream
+    and automatic TAK PLI (position location information) broadcasts.
+    Uses position module configuration to determine TAK PLI broadcast interval. */
+    meshtastic_Config_DeviceConfig_Role_TAK_TRACKER = 10
 } meshtastic_Config_DeviceConfig_Role;
 
 /* Defines the device's behavior for how messages are rebroadcast */
@@ -511,8 +516,8 @@ extern "C" {
 
 /* Helper constants for enums */
 #define _meshtastic_Config_DeviceConfig_Role_MIN meshtastic_Config_DeviceConfig_Role_CLIENT
-#define _meshtastic_Config_DeviceConfig_Role_MAX meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND
-#define _meshtastic_Config_DeviceConfig_Role_ARRAYSIZE ((meshtastic_Config_DeviceConfig_Role)(meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND+1))
+#define _meshtastic_Config_DeviceConfig_Role_MAX meshtastic_Config_DeviceConfig_Role_TAK_TRACKER
+#define _meshtastic_Config_DeviceConfig_Role_ARRAYSIZE ((meshtastic_Config_DeviceConfig_Role)(meshtastic_Config_DeviceConfig_Role_TAK_TRACKER+1))
 
 #define _meshtastic_Config_DeviceConfig_RebroadcastMode_MIN meshtastic_Config_DeviceConfig_RebroadcastMode_ALL
 #define _meshtastic_Config_DeviceConfig_RebroadcastMode_MAX meshtastic_Config_DeviceConfig_RebroadcastMode_KNOWN_ONLY

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -172,6 +172,7 @@ meshtastic_MeshPacket *PositionModule::allocReply()
 
 meshtastic_MeshPacket *PositionModule::allocAtakPli()
 {
+    LOG_INFO("Sending TAK PLI packet\n");
     meshtastic_MeshPacket *mp = allocDataPacket();
     mp->decoded.portnum = meshtastic_PortNum_ATAK_PLUGIN;
 

--- a/src/modules/PositionModule.h
+++ b/src/modules/PositionModule.h
@@ -49,6 +49,7 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
 
   private:
     struct SmartPosition getDistanceTraveledSinceLastSend(meshtastic_PositionLite currentPosition);
+    meshtastic_MeshPacket *allocAtakPli();
 
     /** Only used in power saving trackers for now */
     void clearPosition();

--- a/src/platform/nrf52/main-nrf52.cpp
+++ b/src/platform/nrf52/main-nrf52.cpp
@@ -185,6 +185,7 @@ void cpuDeepSleep(uint32_t msecToWake)
     // Don't enter this if we're sleeping portMAX_DELAY, since that's a shutdown event
     if (msecToWake != portMAX_DELAY &&
         (config.device.role == meshtastic_Config_DeviceConfig_Role_TRACKER ||
+         config.device.role == meshtastic_Config_DeviceConfig_Role_TAK_TRACKER ||
          config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR) &&
         config.power.is_power_saving == true) {
         sd_power_mode_set(NRF_POWER_MODE_LOWPWR);


### PR DESCRIPTION
This role enables the standalone sending of TAK PLI Packets for the in new protocol used by the ATAK Plugin. 