### PR TITLE
fix rotary encoder

### DIFF
--- a/src/input/RotaryEncoderInterruptBase.cpp
+++ b/src/input/RotaryEncoderInterruptBase.cpp
@@ -104,7 +104,6 @@ RotaryEncoderInterruptBaseStateType RotaryEncoderInterruptBase::intHandler(bool 
             newState = ROTARY_EVENT_OCCURRED;
             if ((this->action != ROTARY_ACTION_PRESSED) && (this->action != action)) {
                 this->action = action;
-                LOG_DEBUG("Rotary action\n");
             }
         }
     } else if (!actualPinRaising && (otherPinLevel == HIGH)) {


### PR DESCRIPTION
spotted a DEBUG_LOG within the rotary encoder interrupt handler code, which causes crashes and lags and which is root cause for #3238
