### PR TITLE
feat: implement StoreAndForward `lastRequest` map handling

### DIFF
--- a/src/modules/esp32/StoreForwardModule.cpp
+++ b/src/modules/esp32/StoreForwardModule.cpp
@@ -100,7 +100,8 @@ void StoreForwardModule::populatePSRAM()
  */
 void StoreForwardModule::historySend(uint32_t msAgo, uint32_t to, uint32_t last_request_index)
 {
-    uint32_t queueSize = storeForwardModule->historyQueueCreate(msAgo, to, &last_request_index);
+    uint32_t lastIndex = last_request_index ? last_request_index : lastRequest[to];
+    uint32_t queueSize = storeForwardModule->historyQueueCreate(msAgo, to, &lastIndex);
 
     if (queueSize) {
         LOG_INFO("*** S&F - Sending %u message(s)\n", queueSize);
@@ -114,7 +115,8 @@ void StoreForwardModule::historySend(uint32_t msAgo, uint32_t to, uint32_t last_
     sf.which_variant = meshtastic_StoreAndForward_history_tag;
     sf.variant.history.history_messages = queueSize;
     sf.variant.history.window = msAgo;
-    sf.variant.history.last_request = last_request_index;
+    sf.variant.history.last_request = lastIndex;
+    lastRequest[to] = lastIndex;
     storeForwardModule->sendMessage(to, sf);
 }
 

--- a/src/modules/esp32/StoreForwardModule.h
+++ b/src/modules/esp32/StoreForwardModule.h
@@ -7,6 +7,7 @@
 #include "configuration.h"
 #include <Arduino.h>
 #include <functional>
+#include <unordered_map>
 
 struct PacketHistoryStruct {
     uint32_t time;
@@ -35,6 +36,9 @@ class StoreForwardModule : private concurrency::OSThread, public ProtobufModule<
 
     bool is_client = false;
     bool is_server = false;
+
+    // Unordered_map stores the last request for each nodeNum (`to` field)
+    std::unordered_map<int16_t, int16_t> lastRequest;
 
   public:
     StoreForwardModule();


### PR DESCRIPTION
simplified Store and Forward server side handling of each client node's 'last_request' using an unordered_map to store the last request for each nodeNum (`to` field).