### PR TITLE
Routers / Repeaters deep sleep default w/ LoRA interrupts

### DIFF
--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -357,10 +357,10 @@ void PowerFSM_setup()
     // Don't add power saving transitions if we are a power saving tracker or sensor. Sleep will be initiatiated through the
     // modules
     if ((isRouter || config.power.is_power_saving) && !isTrackerOrSensor) {
-        powerFSM.add_timed_transition(&stateNB, &stateLS,
+        powerFSM.add_timed_transition(&stateNB, &stateSDS,
                                       getConfiguredOrDefaultMs(config.power.min_wake_secs, default_min_wake_secs), NULL,
                                       "Min wake timeout");
-        powerFSM.add_timed_transition(&stateDARK, &stateLS,
+        powerFSM.add_timed_transition(&stateDARK, &stateSDS,
                                       getConfiguredOrDefaultMs(config.power.wait_bluetooth_secs, default_wait_bluetooth_secs),
                                       NULL, "Bluetooth timeout");
     }

--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -245,6 +245,7 @@ Fsm powerFSM(&stateBOOT);
 void PowerFSM_setup()
 {
     bool isRouter = (config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER ? 1 : 0);
+    bool isInfrastructureRole = isRouter || config.device.role == meshtastic_Config_DeviceConfig_Role_REPEATER;
     bool isTrackerOrSensor = config.device.role == meshtastic_Config_DeviceConfig_Role_TRACKER ||
                              config.device.role == meshtastic_Config_DeviceConfig_Role_TAK_TRACKER ||
                              config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR;
@@ -357,10 +358,10 @@ void PowerFSM_setup()
     // Don't add power saving transitions if we are a power saving tracker or sensor. Sleep will be initiatiated through the
     // modules
     if ((isRouter || config.power.is_power_saving) && !isTrackerOrSensor) {
-        powerFSM.add_timed_transition(&stateNB, &stateSDS,
+        powerFSM.add_timed_transition(&stateNB, isInfrastructureRole ? &stateSDS : &stateLS,
                                       getConfiguredOrDefaultMs(config.power.min_wake_secs, default_min_wake_secs), NULL,
                                       "Min wake timeout");
-        powerFSM.add_timed_transition(&stateDARK, &stateSDS,
+        powerFSM.add_timed_transition(&stateDARK, isInfrastructureRole ? &stateSDS : &stateLS,
                                       getConfiguredOrDefaultMs(config.power.wait_bluetooth_secs, default_wait_bluetooth_secs),
                                       NULL, "Bluetooth timeout");
     }

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -373,8 +373,12 @@ void enableLoraInterrupt()
 {
 #if SOC_PM_SUPPORT_EXT_WAKEUP && defined(LORA_DIO1) && (LORA_DIO1 != RADIOLIB_NC)
     rtc_gpio_pulldown_en((gpio_num_t)LORA_DIO1);
+#if defined(LORA_RESET) && (LORA_RESET != RADIOLIB_NC)
     rtc_gpio_pullup_en((gpio_num_t)LORA_RESET);
+#endif
+#if defined(LORA_CS) && (LORA_CS != RADIOLIB_NC)
     rtc_gpio_pullup_en((gpio_num_t)LORA_CS);
+#endif
     // Setup deep sleep with wakeup by external source
     esp_sleep_enable_ext0_wakeup((gpio_num_t)LORA_DIO1, RISING);
 #elif defined(LORA_DIO1) && (LORA_DIO1 != RADIOLIB_NC)

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -187,7 +187,7 @@ void doDeepSleep(uint32_t msecToWake, bool skipPreflight = false)
     // esp_wifi_stop();
     waitEnterSleep(skipPreflight);
 #ifdef ARCH_ESP32
-    if (canLoraWake(msecToWake)) {
+    if (shouldLoraWake(msecToWake)) {
         notifySleep.notifyObservers(NULL);
     } else {
         notifyDeepSleep.notifyObservers(NULL);
@@ -249,7 +249,7 @@ void doDeepSleep(uint32_t msecToWake, bool skipPreflight = false)
 #endif
 
 #ifdef ARCH_ESP32
-    if (canLoraWake(msecToWake)) {
+    if (shouldLoraWake(msecToWake)) {
         enableLoraInterrupt();
     }
 #endif
@@ -368,7 +368,7 @@ void enableModemSleep()
     LOG_DEBUG("Sleep request result %x\n", rv);
 }
 
-bool canLoraWake(uint32_t msecToWake)
+bool shouldLoraWake(uint32_t msecToWake)
 {
     return msecToWake < portMAX_DELAY && (config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER ||
                                           config.device.role == meshtastic_Config_DeviceConfig_Role_REPEATER);

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -186,11 +186,15 @@ void doDeepSleep(uint32_t msecToWake, bool skipPreflight = false)
     // not using wifi yet, but once we are this is needed to shutoff the radio hw
     // esp_wifi_stop();
     waitEnterSleep(skipPreflight);
+#ifdef ARCH_ESP32
     if (canLoraWake(msecToWake)) {
         notifySleep.notifyObservers(NULL);
     } else {
         notifyDeepSleep.notifyObservers(NULL);
     }
+#else
+    notifyDeepSleep.notifyObservers(NULL);
+#endif
 
     screen->doDeepSleep(); // datasheet says this will draw only 10ua
 
@@ -244,10 +248,11 @@ void doDeepSleep(uint32_t msecToWake, bool skipPreflight = false)
     }
 #endif
 
+#ifdef ARCH_ESP32
     if (canLoraWake(msecToWake)) {
         enableLoraInterrupt();
     }
-
+#endif
     cpuDeepSleep(msecToWake);
 }
 

--- a/src/sleep.h
+++ b/src/sleep.h
@@ -45,3 +45,4 @@ extern Observable<void *> notifyDeepSleep;
 extern Observable<void *> notifyGPSSleep;
 void enableModemSleep();
 void enableLoraInterrupt();
+bool canLoraWake(uint32_t msecToWake);

--- a/src/sleep.h
+++ b/src/sleep.h
@@ -44,3 +44,4 @@ extern Observable<void *> notifyDeepSleep;
 /// Called to tell GPS thread to enter deep sleep independently of LoRa/MCU sleep, prior to full poweroff. Must return 0
 extern Observable<void *> notifyGPSSleep;
 void enableModemSleep();
+void enableLoraInterrupt();

--- a/src/sleep.h
+++ b/src/sleep.h
@@ -44,5 +44,7 @@ extern Observable<void *> notifyDeepSleep;
 /// Called to tell GPS thread to enter deep sleep independently of LoRa/MCU sleep, prior to full poweroff. Must return 0
 extern Observable<void *> notifyGPSSleep;
 void enableModemSleep();
+#ifdef ARCH_ESP32
 void enableLoraInterrupt();
 bool canLoraWake(uint32_t msecToWake);
+#endif

--- a/src/sleep.h
+++ b/src/sleep.h
@@ -46,5 +46,5 @@ extern Observable<void *> notifyGPSSleep;
 void enableModemSleep();
 #ifdef ARCH_ESP32
 void enableLoraInterrupt();
-bool canLoraWake(uint32_t msecToWake);
+bool shouldLoraWake(uint32_t msecToWake);
 #endif


### PR DESCRIPTION
This switches Router / Repeater role low power state transition to deep sleep but with some modifications to keep the LoRA module running and ensure that LoRA DIO1 pin interrupts are only added for the state machine transition and not shutdown commands or other contexts. 
For @tropho23 