### PR TITLE
E-Ink: change inaccurate terminology

### DIFF
--- a/variants/heltec_wireless_paper_v1/variant.h
+++ b/variants/heltec_wireless_paper_v1/variant.h
@@ -6,12 +6,12 @@
 
 #define USE_EINK
 
-// Settings for Dynamic Partial mode
-// Change between partial and full refresh config, or skip update, balancing urgency and display health.
-#define USE_EINK_DYNAMIC_PARTIAL
+// Settings for Dynamic Refresh mode
+// Change between full-refresh, fast-refresh, or update-skipping, to balance urgency and display health.
+#define USE_EINK_DYNAMIC_REFRESH
 #define EINK_LOWPRIORITY_LIMIT_SECONDS 30
 #define EINK_HIGHPRIORITY_LIMIT_SECONDS 1
-#define EINK_PARTIAL_REPEAT_LIMIT 5
+#define EINK_FASTREFRESH_REPEAT_LIMIT 5
 
 /*
  * eink display pins


### PR DESCRIPTION
Relates to Issue https://github.com/meshtastic/firmware/issues/3261

Following a discussion @markbirss on discord, many uses of the term "partial refresh" have been changed to "fast refresh".
Please don't hesitate to suggest any different phrasing you would prefer anywhere.

