### PR TITLE
update node db lite log message

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -903,8 +903,8 @@ meshtastic_NodeInfoLite *NodeDB::getOrCreateMeshNode(NodeNum n)
     if (!lite) {
         if ((*numMeshNodes >= MAX_NUM_NODES) || (memGet.getFreeHeap() < meshtastic_NodeInfoLite_size * 3)) {
             if (screen)
-                screen->print("warning: node_db_lite full! erasing oldest entry\n");
-            LOG_INFO("warning: node_db_lite full! erasing oldest entry\n");
+                screen->print("Warn: node database full!\nErasing oldest entry\n");
+            LOG_INFO("Warn: node database full!\nErasing oldest entry\n");
             // look for oldest node and erase it
             uint32_t oldest = UINT32_MAX;
             int oldestIndex = -1;


### PR DESCRIPTION
Replaces the `warning: node_db_lite full! erasing oldest entry\n`  with `Warn: node database full!\nErasing oldest entry\n` per the request from @GUVWAF here https://github.com/meshtastic/firmware/pull/3272#issuecomment-1962302749