### PR TITLE
Station G2

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,8 +2,9 @@
     // See http://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-        "ms-vscode.cpptools",
-        "platformio.platformio-ide",
-        "trunk.io"
+        "platformio.platformio-ide"
     ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,9 +2,8 @@
     // See http://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-        "platformio.platformio-ide"
+        "ms-vscode.cpptools",
+        "platformio.platformio-ide",
+        "trunk.io"
     ],
-    "unwantedRecommendations": [
-        "ms-vscode.cpptools-extension-pack"
-    ]
 }

--- a/boards/station-g2.json
+++ b/boards/station-g2.json
@@ -1,0 +1,41 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_opi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_USB_MODE=0",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=0"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [["0x303A", "0x1001"]],
+    "mcu": "esp32s3",
+    "variant": "station-g2"
+  },
+  "connectivity": ["wifi", "bluetooth", "lora"],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": ["esp-builtin"],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": ["arduino", "espidf"],
+  "name": "BQ Station G2",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://wiki.uniteng.com/en/meshtastic/station-g2",
+  "vendor": "BQ Consulting"
+}

--- a/src/platform/esp32/architecture.h
+++ b/src/platform/esp32/architecture.h
@@ -133,6 +133,8 @@
 #define HW_VENDOR meshtastic_HardwareModel_HELTEC_HT62
 #elif defined(CHATTER_2)
 #define HW_VENDOR meshtastic_HardwareModel_CHATTER_2
+#elif defined(STATION_G2)
+#define HW_VENDOR meshtastic_HardwareModel_STATION_G2
 #endif
 
 // -----------------------------------------------------------------------------

--- a/variants/station-g2/pins_arduino.h
+++ b/variants/station-g2/pins_arduino.h
@@ -1,0 +1,29 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define USB_VID 0x303a
+#define USB_PID 0x1001
+
+#define EXTERNAL_NUM_INTERRUPTS 46
+#define NUM_DIGITAL_PINS 48
+#define NUM_ANALOG_INPUTS 20
+
+#define analogInputToDigitalPin(p) (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
+#define digitalPinToInterrupt(p) (((p) <= 48) ? (p) : -1)
+#define digitalPinHasPWM(p) (p < 46)
+
+// GPIO48 Reference: https://github.com/espressif/arduino-esp32/pull/8600
+
+// The default Wire will be mapped to Screen and Sensors
+static const uint8_t SDA = 5;
+static const uint8_t SCL = 6;
+
+// Default SPI will be mapped to Radio
+static const uint8_t MISO = 14;
+static const uint8_t SCK = 12;
+static const uint8_t MOSI = 13;
+static const uint8_t SS = 11;
+
+#endif /* Pins_Arduino_h */

--- a/variants/station-g2/platformio.ini
+++ b/variants/station-g2/platformio.ini
@@ -1,0 +1,15 @@
+[env:station-g2]
+extends = esp32s3_base
+board = station-g2
+board_build.mcu = esp32s3
+upload_protocol = esptool
+;upload_port = /dev/ttyACM0
+upload_speed = 921600
+lib_deps =
+  ${esp32s3_base.lib_deps}
+build_unflags = -DARDUINO_USB_MODE=1
+build_flags = 
+  ${esp32s3_base.build_flags} -D STATION_G2 -I variants/station-g2
+  -DBOARD_HAS_PSRAM 
+  -DSTATION_G2
+  -DARDUINO_USB_MODE=0

--- a/variants/station-g2/variant.h
+++ b/variants/station-g2/variant.h
@@ -35,7 +35,8 @@ Board Information: https://wiki.uniteng.com/en/meshtastic/station-g2
 #define SX126X_DIO2_AS_RF_SWITCH
 #define SX126X_DIO3_TCXO_VOLTAGE 1.8
 
-// Ensure the PA does not exceed the saturation output power. More Info:https://wiki.uniteng.com/en/meshtastic/station-g2#summary-for-lora-power-amplifier-conduction-test
+// Ensure the PA does not exceed the saturation output power. More
+// Info:https://wiki.uniteng.com/en/meshtastic/station-g2#summary-for-lora-power-amplifier-conduction-test
 #define SX126X_MAX_POWER 19
 #endif
 

--- a/variants/station-g2/variant.h
+++ b/variants/station-g2/variant.h
@@ -1,0 +1,52 @@
+/*
+Board Information: https://wiki.uniteng.com/en/meshtastic/station-g2
+*/
+
+// Station G2 may not have GPS installed, but it has a GROVE GPS Socket for Optional GPS Module
+#define GPS_RX_PIN 7
+#define GPS_TX_PIN 15
+
+// Station G2 has 1.3 inch OLED Screen
+#define USE_SH1107_128_64
+
+#define I2C_SDA 5 // I2C pins for this board
+#define I2C_SCL 6
+
+#define BUTTON_PIN 38 // This is the Program Button
+#define BUTTON_NEED_PULLUP
+
+#define USE_SX1262
+
+#define LORA_MISO 14
+#define LORA_SCK 12
+#define LORA_MOSI 13
+#define LORA_CS 11
+
+#define LORA_RESET 21
+#define LORA_DIO1 48
+
+#ifdef USE_SX1262
+#define SX126X_CS LORA_CS // FIXME - we really should define LORA_CS instead
+#define SX126X_DIO1 LORA_DIO1
+#define SX126X_BUSY 47
+#define SX126X_RESET LORA_RESET
+
+//  DIO2 controlls an antenna switch and the TCXO voltage is controlled by DIO3
+#define SX126X_DIO2_AS_RF_SWITCH
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8
+
+#define SX126X_MAX_POWER                                                                                                         \
+    19 // Ensure the PA does not exceed the saturation output power. More
+       // Info:https://wiki.uniteng.com/en/meshtastic/station-g2#summary-for-lora-power-amplifier-conduction-test
+#endif
+
+#define BATTERY_PIN 4 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
+#define ADC_CHANNEL ADC1_GPIO4_CHANNEL
+#define ADC_MULTIPLIER 4
+#define BATTERY_SENSE_SAMPLES 15 // Set the number of samples, It has an effect of increasing sensitivity.
+#define BAT_FULLVOLT 8400
+#define BAT_EMPTYVOLT 5000
+#define BAT_CHARGINGVOLT 8400
+#define BAT_NOBATVOLT 4460
+#define CELL_TYPE_LION // same curve for liion/lipo
+#define NUM_CELLS 2

--- a/variants/station-g2/variant.h
+++ b/variants/station-g2/variant.h
@@ -35,9 +35,8 @@ Board Information: https://wiki.uniteng.com/en/meshtastic/station-g2
 #define SX126X_DIO2_AS_RF_SWITCH
 #define SX126X_DIO3_TCXO_VOLTAGE 1.8
 
-#define SX126X_MAX_POWER                                                                                                         \
-    19 // Ensure the PA does not exceed the saturation output power. More
-       // Info:https://wiki.uniteng.com/en/meshtastic/station-g2#summary-for-lora-power-amplifier-conduction-test
+// Ensure the PA does not exceed the saturation output power. More Info:https://wiki.uniteng.com/en/meshtastic/station-g2#summary-for-lora-power-amplifier-conduction-test
+#define SX126X_MAX_POWER 19
 #endif
 
 #define BATTERY_PIN 4 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage


### PR DESCRIPTION
<html><body>
<!--StartFragment--><h3 dir="auto">SOC</h3>
<p dir="auto">ESP32</p>
<h3 dir="auto">Lora IC</h3>
<p dir="auto">SX1262</p>
<h3 dir="auto">Product Link</h3>
<p dir="auto"><a href="https://wiki.uniteng.com/en/meshtastic/station-g2" rel="nofollow">https://wiki.uniteng.com/en/meshtastic/station-g2</a></p>
<h3 dir="auto">Description</h3>

<p dir="auto">Meshtastic
 Mesh Device Station G2 is an upgraded design of Station G1, using the 
latest ESP32 S3 MCU. As an RF research project, Station G2 also brings 
key updates in RF. The primary RF design goal of Station G2 is to 
improve the Lora receiving sensitivity by about 4dB based on <a href="https://wiki.uniteng.com/en/meshtastic/station-g2#ultra-low-noise-figure-lna-for-lora" rel="nofollow">a dedicated Ultra-Low Noise Figure LNA</a>. And to increase the transmit power and improve Signal to Noise ratio of short data packets by designing the <a href="https://wiki.uniteng.com/en/meshtastic/station-g2#fast-transient-dc-dc-for-lora-power-amplifier" rel="nofollow">Fast-Transient DC-DC for 35dBm Lora PA</a>.</p> <p dir="auto">For Lora Power Amplifier, <a href="https://wiki.uniteng.com/en/meshtastic/station-g2#lora-power-amplifier" rel="nofollow">the
 1 dB Compression Point (P1dB) is 35 dBm (3.16 W), and the maximum RF 
output power is 36.5 dBm (4.46 W) for US915 and 37 dBm (5 W) for EU868.</a></p> <p dir="auto">Station
 G2 has a rugged SMA antenna socket and rich external IO interfaces. It 
can be powered by either 15VDC USB Type C PD protocol or <a href="https://wiki.uniteng.com/en/meshtastic/station-g2#external-power-supply" rel="nofollow">9VDC-19VDC External Power Supply</a>. These features make Station G2 ideally suited as a Fixed-Location Base Station or Vehicle-Mounted Base Station.</p> <h4 id="user-content-features-comparison-of-station-g2-and-station-g1" dir="auto"> Features Comparison of Station G2 and Station G1</h4> 

Editions | Station G2 | Station G1
-- | -- | --
Core Research Areas | Ultra-Low Noise Figure LNA for LoRaFast-Transient DC-DC for LoRa PA | Modern Cost-Effective RF Power Amplifier RF Components/Materials Measurement and Modeling
Product Status | ACTIVE | OBSOLETE
Current Hardware Version | 18 Jan 2024 | 20 Sep 2022
Initial Release Date | 18 Jan 2024 | 12 Jun 2022
Lora RF Max Output Power | Up to 35 dBm (P1dB Point) | Up to 35 dBm (Maximum RF Output Power)
Frequency Reference for Lora | 32MHz TCXO (+-1.5 ppm) | 32MHz XTAL (+-10 ppm)
Lora Ultra-Low Noise Figure LNA | Typical Gain: 18.5 dB, Typical Noise Figure: 1.8 dB | -
Fast-Transient DC-DC for LoRa PA | Transient Response Time < 18us, Maximum Transient Voltage  Deviation < 275mV, Phase Margin > 66.73 Degrees, Ripple < 30mV,  Test Condition: 0A-3A@7.5VDC Dynamic Test, Input Voltage 15VDC | -
LoRa Transceiver | SX1262 | SX1262
Lora Operation Frequency | US915MHz / EU868MHz | US915MHz / EU868MHz
MCU | ESP32 S3 (Flash: 16MB, PSRAM: 8MB) | ESP32 (Flash: 4MB, PSRAM: -)
WIFI | YES | YES
Bluetooth | v5.0 | v4.2
Satellite Navigation | Optional (1x GROVE GPS Socket) | Optional
USB Connector | Type C (PD Protocol) | Type C (PD Protocol)
Screen | 1.3 Inch OLED Screen | 1.3 Inch OLED Screen
Battery | - | Optional 12V Battery Docker
Power Input Socket | 15VDC USB Type C PD protocol, 1x5P Pitch=1.5mm Socket (9VDC-19VDC External Power Supply) | USB Type C, 1x2P Pitch=2.5mm Socket
LoRa Antenna | SMA Socket | SMA Socket
Accessories | 1x GROVE GPS Socket, 1x GROVE I2C Socket, 1x SparkFun QWIIC I2C Socket and 1x IO Extension Socket | 1x IO Extension Socket
Typical Scenarios | Fixed-Location Base Stations and Vehicle-Mounted Base Stations | Fixed-Location Base Stations and Vehicle-Mounted Base Stations

