### PR TITLE
Add Heltec Wireless Paper V1.0 to the build matrix

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -93,7 +93,8 @@ jobs:
           - board: heltec-wsl-v3
           - board: heltec-wireless-tracker
           - board: heltec-wireless-tracker-V1-0
-          - board: heltec-wireless-paper
+          - board: heltec-wireless-paper-v1_0
+          - board: heltec-wireless-paper #v1.1
           - board: tbeam-s3-core
           - board: tlora-t3s3-v1
           - board: t-watch-s3


### PR DESCRIPTION
A bit out of my depth.
Accompanies https://github.com/meshtastic/api/pull/20