### PR TITLE
Add support for Heltec HRI-485-2

### DIFF
--- a/variants/heltec_hri485_2/platformio.ini
+++ b/variants/heltec_hri485_2/platformio.ini
@@ -1,0 +1,7 @@
+[env:heltec-hri485-2]
+;build_type = debug ; to make it possible to step through our jtag debugger
+extends = esp32_base
+board = heltec_wifi_lora_32
+board_level = extra
+build_flags =
+  ${esp32_base.build_flags} -D PRIVATE_HW -I variants/heltec_hri485_2

--- a/variants/heltec_hri485_2/variant.h
+++ b/variants/heltec_hri485_2/variant.h
@@ -3,17 +3,17 @@
 
 #define HAS_ETHERNET 1
 
-#define ETH_TYPE                        ETH_PHY_RTL8201
-#define ETH_ADDR                        0
-#define ETH_CLK_MODE                    ETH_CLOCK_GPIO16_OUT
-#define ETH_RESET_PIN                   -1
-#define ETH_MDC_PIN                     23
-#define ETH_POWER_PIN                   12
-#define ETH_MDIO_PIN                    18
-#define SD_MISO_PIN                     34
-#define SD_MOSI_PIN                     13
-#define SD_SCLK_PIN                     14
-#define SD_CS_PIN                       5
+#define ETH_TYPE ETH_PHY_RTL8201
+#define ETH_ADDR 0
+#define ETH_CLK_MODE ETH_CLOCK_GPIO16_OUT
+#define ETH_RESET_PIN -1
+#define ETH_MDC_PIN 23
+#define ETH_POWER_PIN 12
+#define ETH_MDIO_PIN 18
+#define SD_MISO_PIN 34
+#define SD_MOSI_PIN 13
+#define SD_SCLK_PIN 14
+#define SD_CS_PIN 5
 
 #define USE_SX1262
 

--- a/variants/heltec_hri485_2/variant.h
+++ b/variants/heltec_hri485_2/variant.h
@@ -1,0 +1,37 @@
+#define LED_PIN 2     // If defined we will blink this LED
+#define BUTTON_PIN 32 // If defined, this will be used for user button presses
+
+#define HAS_ETHERNET 1
+
+#define ETH_TYPE                        ETH_PHY_RTL8201
+#define ETH_ADDR                        0
+#define ETH_CLK_MODE                    ETH_CLOCK_GPIO16_OUT
+#define ETH_RESET_PIN                   -1
+#define ETH_MDC_PIN                     23
+#define ETH_POWER_PIN                   12
+#define ETH_MDIO_PIN                    18
+#define SD_MISO_PIN                     34
+#define SD_MOSI_PIN                     13
+#define SD_SCLK_PIN                     14
+#define SD_CS_PIN                       5
+
+#define USE_SX1262
+
+#define LORA_DIO0 -1 // a No connect on the SX1262 module
+#define LORA_RESET 12
+#define LORA_DIO1 14 // SX1262 IRQ
+#define LORA_DIO2 13 // SX1262 BUSY
+#define LORA_DIO3    // Not connected on PCB, but internally on the TTGO SX1262, if DIO3 is high the TXCO is enabled
+
+#define LORA_SCK 9
+#define LORA_MISO 11
+#define LORA_MOSI 10
+#define LORA_CS 8
+
+#define SX126X_CS LORA_CS
+#define SX126X_DIO1 LORA_DIO1
+#define SX126X_BUSY LORA_DIO2
+#define SX126X_RESET LORA_RESET
+
+#define SX126X_DIO2_AS_RF_SWITCH
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8


### PR DESCRIPTION
The Heltec HRI-485-2 is a LoRa to Ethernet gateway with wide-range DC power input, packaged in a DIN rail case. Includes slots for SIM card and LTE modem.

![IMG_3270](https://github.com/meshtastic/firmware/assets/106662/3e05dbf3-e7b0-4f7a-bb52-e6f17c7eddc4)

MCU: ESP32 D0WDQ6
LoRa radio: SX1262
Ethernet PHYceiver: Realtek RTL8201F 
Extra flash: GigaDevice GD25Q64C (64 Mbit)
RS-485 transceiver (not populated)

![IMG_3273](https://github.com/meshtastic/firmware/assets/106662/2eedc3fe-ca9b-405b-aaf5-d3fe2edc3d1a)

![IMG_3275](https://github.com/meshtastic/firmware/assets/106662/68009c24-bb93-48bc-80ea-6dfdb84717e5)

![IMG_3272](https://github.com/meshtastic/firmware/assets/106662/b620de2d-4932-44f3-a408-43693ff6a0df)

![IMG_3278](https://github.com/meshtastic/firmware/assets/106662/0e03f334-d593-4e83-83e0-ced0c55283a2)

(4 layer board)

I'm not sure how to activate the RTL8201. It seems, Ethernet is tied more or less to a specific platform:

```
src/DebugConfiguration.h:113:10: fatal error: RAK13800_W5100S.h: No such file or directory
```

After removing the includes:

```
src/mqtt/MQTT.h:17:10: fatal error: EthernetClient.h: No such file or directory
```

If I'm not mistaken it should be enough to include `ETH.h` as part of the ESP32 Arduino library.

Related to #2107. I did not reverse engineer the board fully yet, but apparently Eth and LoRa are connected in parallel.

Thoughts?