### PR TITLE
Include esp32c3 ble ota

### DIFF
--- a/.github/workflows/build_esp32_c3.yml
+++ b/.github/workflows/build_esp32_c3.yml
@@ -7,6 +7,8 @@ on:
         required: true
         type: string
 
+permissions: read-all
+
 jobs:
   build-esp32-c3:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_esp32_c3.yml
+++ b/.github/workflows/build_esp32_c3.yml
@@ -1,4 +1,4 @@
-name: Build ESP32
+name: Build ESP32-C3
 
 on:
   workflow_call:
@@ -8,7 +8,7 @@ on:
         type: string
 
 jobs:
-  build-esp32:
+  build-esp32-c3:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -28,7 +28,6 @@ jobs:
         run: |
           tar -xf build.tar -C data/static
           rm build.tar
-
       - name: Remove debug flags for release
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
@@ -36,7 +35,6 @@ jobs:
           sed -i '/DDEBUG_HEAP/d' ./arch/esp32/esp32s2.ini
           sed -i '/DDEBUG_HEAP/d' ./arch/esp32/esp32s3.ini
           sed -i '/DDEBUG_HEAP/d' ./arch/esp32/esp32c3.ini
-
       - name: Build ESP32
         run: bin/build-esp32.sh ${{ inputs.board }}
 
@@ -44,8 +42,8 @@ jobs:
         uses: dsaltares/fetch-gh-release-asset@a40c8b4a0471f9ab81bdf73a010f74cc51476ad4
         with:
           repo: meshtastic/firmware-ota
-          file: firmware.bin
-          target: release/bleota.bin
+          file: firmware-c3.bin
+          target: release/bleota-c3.bin
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get release version string

--- a/.github/workflows/build_esp32_s3.yml
+++ b/.github/workflows/build_esp32_s3.yml
@@ -34,6 +34,7 @@ jobs:
           sed -i '/DDEBUG_HEAP/d' ./arch/esp32/esp32.ini
           sed -i '/DDEBUG_HEAP/d' ./arch/esp32/esp32s2.ini
           sed -i '/DDEBUG_HEAP/d' ./arch/esp32/esp32s3.ini
+          sed -i '/DDEBUG_HEAP/d' ./arch/esp32/esp32c3.ini
       - name: Build ESP32
         run: bin/build-esp32.sh ${{ inputs.board }}
 

--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -67,7 +67,6 @@ jobs:
           - board: tlora-v2-1-1_6-tcxo
           - board: tlora-v2-1-1_8
           - board: tbeam
-          - board: heltec-ht62-esp32c3-sx1262
           - board: heltec-v2_0
           - board: heltec-v2_1
           - board: tbeam0_7
@@ -102,6 +101,16 @@ jobs:
           - board: picomputer-s3
           - board: station-g2
     uses: ./.github/workflows/build_esp32_s3.yml
+    with:
+      board: ${{ matrix.board }}
+
+  build-esp32-c3:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - board: heltec-ht62-esp32c3-sx1262
+    uses: ./.github/workflows/build_esp32_c3.yml
     with:
       board: ${{ matrix.board }}
 
@@ -226,6 +235,7 @@ jobs:
       [
         build-esp32,
         build-esp32-s3,
+        build-esp32-c3,
         build-nrf52,
         build-raspbian,
         build-native,
@@ -251,7 +261,7 @@ jobs:
         id: version
 
       - name: Move files up
-        run: mv -b -t ./ ./*tbeam-2*/littlefs*.bin ./*tbeam-2*/bleota.bin ./*tbeam-s3*/bleota-s3.bin ./**/firmware*.bin ./*t-echo*/Meshtastic_nRF52_factory_erase_v2.uf2 ./**/firmware-*.uf2 ./**/firmware-*-ota.zip ./**/*.elf ./*native*/*device-*.sh ./*native*/*device-*.bat ./firmware-raspbian-*/release/meshtasticd_linux_aarch64 ./firmware-raspbian-*/bin/config-dist.yaml
+        run: mv -b -t ./ ./*tbeam-2*/littlefs*.bin ./*tbeam-2*/bleota.bin ./*tbeam-s3*/bleota-s3.bin ./*esp32c3*/bleota-c3.bin ./**/firmware*.bin ./*t-echo*/Meshtastic_nRF52_factory_erase_v2.uf2 ./**/firmware-*.uf2 ./**/firmware-*-ota.zip ./**/*.elf ./*native*/*device-*.sh ./*native*/*device-*.bat ./firmware-raspbian-*/release/meshtasticd_linux_aarch64 ./firmware-raspbian-*/bin/config-dist.yaml
 
       - name: Repackage in single firmware zip
         uses: actions/upload-artifact@v3

--- a/bin/device-install.bat
+++ b/bin/device-install.bat
@@ -31,9 +31,13 @@ IF EXIST %FILENAME% IF x%FILENAME:update=%==x%FILENAME% (
 	%PYTHON% -m esptool --baud 115200 erase_flash
 	%PYTHON% -m esptool --baud 115200 write_flash 0x00 %FILENAME%
     
-    @REM Account for S3 board's different OTA partition
+    @REM Account for S3 and C3 board's different OTA partition
     IF x%FILENAME:s3=%==x%FILENAME% IF x%FILENAME:v3=%==x%FILENAME% IF x%FILENAME:t-deck=%==x%FILENAME% IF x%FILENAME:wireless-paper=%==x%FILENAME% IF x%FILENAME:wireless-tracker=%==x%FILENAME% (
-        %PYTHON% -m esptool --baud 115200 write_flash 0x260000 bleota.bin
+        IF x%FILENAME:esp32c3=%==x%FILENAME% (
+            %PYTHON% -m esptool --baud 115200 write_flash 0x260000 bleota.bin
+        ) else (
+            %PYTHON% -m esptool --baud 115200 write_flash 0x260000 bleota-c3.bin
+        )
 	) else (
         %PYTHON% -m esptool --baud 115200 write_flash 0x260000 bleota-s3.bin
     )

--- a/bin/device-install.sh
+++ b/bin/device-install.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 
-PYTHON=${PYTHON:-$(which python3 python|head -n 1)}
+PYTHON=${PYTHON:-$(which python3 python | head -n 1)}
 
 set -e
 
 # Usage info
 show_help() {
-cat << EOF
+	cat <<EOF
 Usage: $(basename $0) [-h] [-p ESPTOOL_PORT] [-P PYTHON] [-f FILENAME|FILENAME]
 Flash image file to device, but first erasing and writing system information"
 
@@ -18,37 +18,39 @@ Flash image file to device, but first erasing and writing system information"
 EOF
 }
 
-
 while getopts ":hp:P:f:" opt; do
-    case "${opt}" in
-        h)
-            show_help
-            exit 0
-            ;;
-        p)  export ESPTOOL_PORT=${OPTARG}
-	    ;;
-        P)  PYTHON=${OPTARG}
-            ;;
-        f)  FILENAME=${OPTARG}
-            ;;
-        *)
- 	    echo "Invalid flag."
-            show_help >&2
-            exit 1
-            ;;
-    esac
+	case "${opt}" in
+	h)
+		show_help
+		exit 0
+		;;
+	p)
+		export ESPTOOL_PORT=${OPTARG}
+		;;
+	P)
+		PYTHON=${OPTARG}
+		;;
+	f)
+		FILENAME=${OPTARG}
+		;;
+	*)
+		echo "Invalid flag."
+		show_help >&2
+		exit 1
+		;;
+	esac
 done
-shift "$((OPTIND-1))"
+shift "$((OPTIND - 1))"
 
 [ -z "$FILENAME" -a -n "$1" ] && {
-    FILENAME=$1
-    shift
+	FILENAME=$1
+	shift
 }
 
 if [ -f "${FILENAME}" ] && [ ! -z "${FILENAME##*"update"*}" ]; then
 	echo "Trying to flash ${FILENAME}, but first erasing and writing system information"
-	"$PYTHON" -m esptool  erase_flash
-	"$PYTHON" -m esptool  write_flash 0x00 ${FILENAME}
+	"$PYTHON" -m esptool erase_flash
+	"$PYTHON" -m esptool write_flash 0x00 ${FILENAME}
 	# Account for S3 board's different OTA partition
 	if [ ! -z "${FILENAME##*"s3"*}" ] && [ ! -z "${FILENAME##*"-v3"*}" ] && [ ! -z "${FILENAME##*"t-deck"*}" ] && [ ! -z "${FILENAME##*"wireless-paper"*}" ] && [ ! -z "${FILENAME##*"wireless-tracker"*}" ]; then
 		if [ ! -z "${FILENAME##*"esp32c3"*}" ]; then
@@ -57,9 +59,9 @@ if [ -f "${FILENAME}" ] && [ ! -z "${FILENAME##*"update"*}" ]; then
 			"$PYTHON" -m esptool write_flash 0x260000 bleota-c3.bin
 		fi
 	else
-	    "$PYTHON" -m esptool  write_flash 0x260000 bleota-s3.bin
+		"$PYTHON" -m esptool write_flash 0x260000 bleota-s3.bin
 	fi
-	"$PYTHON" -m esptool  write_flash 0x300000 littlefs-*.bin
+	"$PYTHON" -m esptool write_flash 0x300000 littlefs-*.bin
 
 else
 	show_help

--- a/bin/device-install.sh
+++ b/bin/device-install.sh
@@ -51,7 +51,11 @@ if [ -f "${FILENAME}" ] && [ ! -z "${FILENAME##*"update"*}" ]; then
 	"$PYTHON" -m esptool  write_flash 0x00 ${FILENAME}
 	# Account for S3 board's different OTA partition
 	if [ ! -z "${FILENAME##*"s3"*}" ] && [ ! -z "${FILENAME##*"-v3"*}" ] && [ ! -z "${FILENAME##*"t-deck"*}" ] && [ ! -z "${FILENAME##*"wireless-paper"*}" ] && [ ! -z "${FILENAME##*"wireless-tracker"*}" ]; then
-		"$PYTHON" -m esptool  write_flash 0x260000 bleota.bin
+		if [ ! -z "${FILENAME##*"esp32c3"*}" ]; then
+			"$PYTHON" -m esptool write_flash 0x260000 bleota.bin
+		else
+			"$PYTHON" -m esptool write_flash 0x260000 bleota-c3.bin
+		fi
 	else
 	    "$PYTHON" -m esptool  write_flash 0x260000 bleota-s3.bin
 	fi

--- a/bin/device-install.sh
+++ b/bin/device-install.sh
@@ -47,13 +47,13 @@ shift "$((OPTIND - 1))"
 	shift
 }
 
-if [ -f "${FILENAME}" ] && [ ! -z "${FILENAME##*"update"*}" ]; then
+if [ -f "${FILENAME}" ] && [ -n "${FILENAME##*"update"*}" ]; then
 	echo "Trying to flash ${FILENAME}, but first erasing and writing system information"
 	"$PYTHON" -m esptool erase_flash
 	"$PYTHON" -m esptool write_flash 0x00 ${FILENAME}
 	# Account for S3 board's different OTA partition
-	if [ ! -z "${FILENAME##*"s3"*}" ] && [ ! -z "${FILENAME##*"-v3"*}" ] && [ ! -z "${FILENAME##*"t-deck"*}" ] && [ ! -z "${FILENAME##*"wireless-paper"*}" ] && [ ! -z "${FILENAME##*"wireless-tracker"*}" ]; then
-		if [ ! -z "${FILENAME##*"esp32c3"*}" ]; then
+	if [ -n "${FILENAME##*"s3"*}" ] && [ -n "${FILENAME##*"-v3"*}" ] && [ -n "${FILENAME##*"t-deck"*}" ] && [ -n "${FILENAME##*"wireless-paper"*}" ] && [ -n "${FILENAME##*"wireless-tracker"*}" ]; then
+		if [ -n "${FILENAME##*"esp32c3"*}" ]; then
 			"$PYTHON" -m esptool write_flash 0x260000 bleota.bin
 		else
 			"$PYTHON" -m esptool write_flash 0x260000 bleota-c3.bin


### PR DESCRIPTION
**Issue**

The current `bleota.bin` and `bleota-s3.bin` firmwares can be used on esp32 and esp32s3 respectively, however cannot be flashed to esp32c3 devices. A esp32c3 compatible version of the ota firmware was added and merged here https://github.com/meshtastic/firmware-ota/pull/3.

**Proposed Solution**

Update the workflows to:

1. Split out building esp32c3 firmwares as is done with the esp32 and esp32s3 firmwares into separate stages
2. Pull in the https://github.com/meshtastic/firmware-ota/releases/download/latest/firmware-c3.bin binary for esp32c3 builds and rename to `bleota-c3.bin`
3. Update the `device-install.sh` and `device-install.bat` scripts to select the `bleout-c3.bin` firmware file as is done for the the esp32 and esp32s3 variants

**Testing**

1. The esp32c3 variant of the ota firmware was confirmed to work on a custom esp32c3 board and build here: https://github.com/meshtastic/firmware-ota/pull/3
2. As far as possible the actions were tested there: https://github.com/titan098/firmware/actions/runs/8190305545

`device-install.sh` script flashing the `bleola-c3.bin` firmware:

```
$ ./device-install.sh  -p /dev/ttyACM0 -f firmware-heltec-ht62-esp32c3-sx1262-2.2.25.c6ced245.bin
Trying to flash firmware-heltec-ht62-esp32c3-sx1262-2.2.25.c6ced245.bin, but first erasing and writing system information
esptool.py v4.7.0
Serial port /dev/ttyACM0
Connecting...
Detecting chip type... ESP32-C3
Chip is ESP32-C3 (QFN32) (revision v0.4)
Features: WiFi, BLE, Embedded Flash 4MB (XMC)
Crystal is 40MHz
MAC: 48:31:b7:3e:85:7c
Uploading stub...
Running stub...
Stub running...
Erasing flash (this may take a while)...
Chip erase completed successfully in 15.9s
Hard resetting via RTS pin...
esptool.py v4.7.0
Serial port /dev/ttyACM0
Connecting...
Detecting chip type... ESP32-C3
Chip is ESP32-C3 (QFN32) (revision v0.4)
Features: WiFi, BLE, Embedded Flash 4MB (XMC)
Crystal is 40MHz
MAC: 48:31:b7:3e:85:7c
Uploading stub...
Running stub...
Stub running...
Configuring flash size...
Flash will be erased from 0x00000000 to 0x00203fff...
Compressed 2110560 bytes to 1149529...
Wrote 2110560 bytes (1149529 compressed) at 0x00000000 in 17.8 seconds (effective 949.7 kbit/s)...
Hash of data verified.

Leaving...
Hard resetting via RTS pin...
esptool.py v4.7.0
Serial port /dev/ttyACM0
Connecting...
Detecting chip type... ESP32-C3
Chip is ESP32-C3 (QFN32) (revision v0.4)
Features: WiFi, BLE, Embedded Flash 4MB (XMC)
Crystal is 40MHz
MAC: 48:31:b7:3e:85:7c
Uploading stub...
Running stub...
Stub running...
Configuring flash size...
Flash will be erased from 0x00260000 to 0x002e4fff...
Compressed 542832 bytes to 315183...
Wrote 542832 bytes (315183 compressed) at 0x00260000 in 4.7 seconds (effective 914.8 kbit/s)...
Hash of data verified.

Leaving...
Hard resetting via RTS pin...
esptool.py v4.7.0
Serial port /dev/ttyACM0
Connecting...
Detecting chip type... ESP32-C3
Chip is ESP32-C3 (QFN32) (revision v0.4)
Features: WiFi, BLE, Embedded Flash 4MB (XMC)
Crystal is 40MHz
MAC: 48:31:b7:3e:85:7c
Uploading stub...
Running stub...
Stub running...
Configuring flash size...
Flash will be erased from 0x00300000 to 0x003fffff...
Compressed 1048576 bytes to 1368...
Wrote 1048576 bytes (1368 compressed) at 0x00300000 in 5.8 seconds (effective 1436.0 kbit/s)...
Hash of data verified.

Leaving...
Hard resetting via RTS pin...
```