### PR TITLE
always send range tests with zero hops

### DIFF
--- a/src/modules/RangeTestModule.cpp
+++ b/src/modules/RangeTestModule.cpp
@@ -113,7 +113,7 @@ void RangeTestModuleRadio::sendPayload(NodeNum dest, bool wantReplies)
     meshtastic_MeshPacket *p = allocDataPacket();
     p->to = dest;
     p->decoded.want_response = wantReplies;
-
+    p->hop_limit = 0;
     p->want_ack = true;
 
     packetSequence++;


### PR DESCRIPTION
range testing is typically measured point-to-point (sender --> receiver), adding hops can result in inaccurate data and unnecessarily extend packet air time.