### PR TITLE
Periodic reporting of device information to a map via MQTT

### DIFF
--- a/src/mesh/Channels.cpp
+++ b/src/mesh/Channels.cpp
@@ -257,8 +257,8 @@ const char *Channels::getName(size_t chIndex)
 
 bool Channels::hasDefaultChannel()
 {
-    // If we don't use a preset or we override the frequency, we don't have a default channel
-    if (!config.lora.use_preset || config.lora.override_frequency)
+    // If we don't use a preset or the default frequency slot, or we override the frequency, we don't have a default channel
+    if (!config.lora.use_preset || !RadioInterface::uses_default_frequency_slot || config.lora.override_frequency)
         return false;
     // Check if any of the channels are using the default name and PSK
     for (size_t i = 0; i < getNumChannels(); i++) {
@@ -266,8 +266,8 @@ bool Channels::hasDefaultChannel()
         if (ch.settings.psk.size == 1 && ch.settings.psk.bytes[0] == 1) {
             const char *name = getName(i);
             const char *presetName = DisplayFormatters::getModemPresetDisplayName(config.lora.modem_preset, false);
-            // Check if the name is the default derived from the modem preset and we use the default frequency slot
-            if (strcmp(name, presetName) == 0 && RadioInterface::uses_default_frequency_slot)
+            // Check if the name is the default derived from the modem preset
+            if (strcmp(name, presetName) == 0)
                 return true;
         }
     }

--- a/src/mesh/Channels.cpp
+++ b/src/mesh/Channels.cpp
@@ -2,6 +2,7 @@
 #include "CryptoEngine.h"
 #include "DisplayFormatters.h"
 #include "NodeDB.h"
+#include "RadioInterface.h"
 #include "configuration.h"
 
 #include <assert.h>
@@ -252,6 +253,25 @@ const char *Channels::getName(size_t chIndex)
     }
 
     return channelName;
+}
+
+bool Channels::hasDefaultChannel()
+{
+    // If we don't use a preset or we override the frequency, we don't have a default channel
+    if (!config.lora.use_preset || config.lora.override_frequency)
+        return false;
+    // Check if any of the channels are using the default name and PSK
+    for (size_t i = 0; i < getNumChannels(); i++) {
+        const auto &ch = getByIndex(i);
+        if (ch.settings.psk.size == 1 && ch.settings.psk.bytes[0] == 1) {
+            const char *name = getName(i);
+            const char *presetName = DisplayFormatters::getModemPresetDisplayName(config.lora.modem_preset, false);
+            // Check if the name is the default derived from the modem preset and we use the default frequency slot
+            if (strcmp(name, presetName) == 0 && RadioInterface::uses_default_frequency_slot)
+                return true;
+        }
+    }
+    return false;
 }
 
 /**

--- a/src/mesh/Channels.h
+++ b/src/mesh/Channels.h
@@ -102,6 +102,9 @@ class Channels
      */
     int16_t setActiveByIndex(ChannelIndex channelIndex);
 
+    // Returns true if we can be reached via a channel with the default settings given a region and modem preset
+    bool hasDefaultChannel();
+
   private:
     /** Given a channel index, change to use the crypto key specified by that index
      *

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -744,14 +744,17 @@ uint32_t sinceReceived(const meshtastic_MeshPacket *p)
 
 #define NUM_ONLINE_SECS (60 * 60 * 2) // 2 hrs to consider someone offline
 
-size_t NodeDB::getNumOnlineMeshNodes()
+size_t NodeDB::getNumOnlineMeshNodes(bool localOnly)
 {
     size_t numseen = 0;
 
     // FIXME this implementation is kinda expensive
-    for (int i = 0; i < *numMeshNodes; i++)
+    for (int i = 0; i < *numMeshNodes; i++) {
+        if (localOnly && meshNodes[i].via_mqtt)
+            continue;
         if (sinceLastSeen(&meshNodes[i]) < NUM_ONLINE_SECS)
             numseen++;
+    }
 
     return numseen;
 }

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -108,8 +108,10 @@ class NodeDB
     // get channel channel index we heard a nodeNum on, defaults to 0 if not found
     uint8_t getMeshNodeChannel(NodeNum n);
 
-    /// Return the number of nodes we've heard from recently (within the last 2 hrs?)
-    size_t getNumOnlineMeshNodes();
+    /* Return the number of nodes we've heard from recently (within the last 2 hrs?)
+     * @param localOnly if true, ignore nodes heard via MQTT
+     */
+    size_t getNumOnlineMeshNodes(bool localOnly = false);
 
     void initConfigIntervals(), initModuleConfigIntervals(), resetNodes(), removeNodeByNum(uint nodeNum);
 

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -1,5 +1,6 @@
 #include "RadioInterface.h"
 #include "Channels.h"
+#include "DisplayFormatters.h"
 #include "MeshRadio.h"
 #include "MeshService.h"
 #include "NodeDB.h"
@@ -143,6 +144,7 @@ const RegionInfo regions[] = {
 };
 
 const RegionInfo *myRegion;
+bool RadioInterface::uses_default_frequency_slot = true;
 
 static uint8_t bytes[MAX_RHPACKETLEN];
 
@@ -485,6 +487,10 @@ void RadioInterface::applyModemConfig()
     const char *channelName = channels.getName(channels.getPrimaryIndex());
     // channel_num is actually (channel_num - 1), since modulus (%) returns values from 0 to (numChannels - 1)
     int channel_num = (loraConfig.channel_num ? loraConfig.channel_num - 1 : hash(channelName)) % numChannels;
+
+    // Check if we use the default frequency slot
+    RadioInterface::uses_default_frequency_slot =
+        channel_num == hash(DisplayFormatters::getModemPresetDisplayName(config.lora.modem_preset, false)) % numChannels;
 
     // Old frequency selection formula
     // float freq = myRegion->freqStart + ((((myRegion->freqEnd - myRegion->freqStart) / numChannels) / 2) * channel_num);

--- a/src/mesh/RadioInterface.h
+++ b/src/mesh/RadioInterface.h
@@ -175,6 +175,9 @@ class RadioInterface
     /// Some boards (1st gen Pinetab Lora module) have broken IRQ wires, so we need to poll via i2c registers
     virtual bool isIRQPending() { return false; }
 
+    // Whether we use the default frequency slot given our LoRa config (region and modem preset)
+    static bool uses_default_frequency_slot;
+
   protected:
     int8_t power = 17; // Set by applyModemConfig()
 

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -77,8 +77,7 @@ void MQTT::onReceive(char *topic, byte *payload, size_t length)
                         if (jsonPayloadStr.length() <= sizeof(p->decoded.payload.bytes)) {
                             memcpy(p->decoded.payload.bytes, jsonPayloadStr.c_str(), jsonPayloadStr.length());
                             p->decoded.payload.size = jsonPayloadStr.length();
-                            meshtastic_MeshPacket *packet = packetPool.allocCopy(*p);
-                            service.sendToMesh(packet, RX_SRC_LOCAL);
+                            service.sendToMesh(p, RX_SRC_LOCAL);
                         } else {
                             LOG_WARN("Received MQTT json payload too long, dropping\n");
                         }
@@ -190,6 +189,11 @@ MQTT::MQTT() : concurrency::OSThread("mqtt"), mqttQueue(MAX_MQTT_QUEUE)
             statusTopic = "msh" + statusTopic;
             cryptTopic = "msh" + cryptTopic;
             jsonTopic = "msh" + jsonTopic;
+        }
+
+        if (moduleConfig.mqtt.map_reporting_enabled && moduleConfig.mqtt.has_map_report_settings) {
+            map_position_precision = moduleConfig.mqtt.map_report_settings.position_precision;
+            map_publish_interval_secs = moduleConfig.mqtt.map_report_settings.publish_interval_secs;
         }
 
 #ifdef HAS_NETWORKING
@@ -365,27 +369,30 @@ void MQTT::sendSubscriptions()
 
 bool MQTT::wantsLink() const
 {
-    bool hasChannel = false;
+    bool hasChannelorMapReport = false;
 
     if (moduleConfig.mqtt.enabled) {
-        // No need for link if no channel needed it
-        size_t numChan = channels.getNumChannels();
-        for (size_t i = 0; i < numChan; i++) {
-            const auto &ch = channels.getByIndex(i);
-            if (ch.settings.uplink_enabled || ch.settings.downlink_enabled) {
-                hasChannel = true;
-                break;
+        hasChannelorMapReport = moduleConfig.mqtt.map_reporting_enabled;
+        if (!hasChannelorMapReport) {
+            // No need for link if no channel needed it
+            size_t numChan = channels.getNumChannels();
+            for (size_t i = 0; i < numChan; i++) {
+                const auto &ch = channels.getByIndex(i);
+                if (ch.settings.uplink_enabled || ch.settings.downlink_enabled) {
+                    hasChannelorMapReport = true;
+                    break;
+                }
             }
         }
     }
-    if (hasChannel && moduleConfig.mqtt.proxy_to_client_enabled)
+    if (hasChannelorMapReport && moduleConfig.mqtt.proxy_to_client_enabled)
         return true;
 
 #if HAS_WIFI
-    return hasChannel && WiFi.isConnected();
+    return hasChannelorMapReport && WiFi.isConnected();
 #endif
 #if HAS_ETHERNET
-    return hasChannel && Ethernet.linkStatus() == LinkON;
+    return hasChannelorMapReport && Ethernet.linkStatus() == LinkON;
 #endif
     return false;
 }
@@ -396,6 +403,8 @@ int32_t MQTT::runOnce()
         return disable();
 
     bool wantConnection = wantsLink();
+
+    perhapsReportToMap();
 
     // If connected poll rapidly, otherwise only occasionally check for a wifi connection change and ability to contact server
     if (moduleConfig.mqtt.proxy_to_client_enabled) {
@@ -533,6 +542,78 @@ void MQTT::onSend(const meshtastic_MeshPacket &mp, const meshtastic_MeshPacket &
             assert(mqttQueue.enqueue(copied, 0));
         }
         mqttPool.release(env);
+    }
+}
+
+void MQTT::perhapsReportToMap()
+{
+    if (!moduleConfig.mqtt.map_reporting_enabled || !(moduleConfig.mqtt.proxy_to_client_enabled || isConnectedDirectly()))
+        return;
+
+    if (map_position_precision == 0 || (localPosition.latitude_i == 0 && localPosition.longitude_i == 0)) {
+        LOG_WARN("MQTT Map reporting is enabled, but precision is 0 or no position available.\n");
+        return;
+    }
+
+    if (millis() - last_report_to_map < map_publish_interval_secs * 1000) {
+        return;
+    } else {
+        // Allocate ServiceEnvelope and fill it
+        meshtastic_ServiceEnvelope *se = mqttPool.allocZeroed();
+        se->channel_id = (char *)channels.getGlobalId(channels.getPrimaryIndex()); // Use primary channel as the channel_id
+        se->gateway_id = owner.id;
+
+        // Allocate MeshPacket and fill it
+        meshtastic_MeshPacket *mp = packetPool.allocZeroed();
+        mp->which_payload_variant = meshtastic_MeshPacket_decoded_tag;
+        mp->from = nodeDB.getNodeNum();
+        mp->to = NODENUM_BROADCAST;
+        mp->decoded.portnum = meshtastic_PortNum_MAP_REPORT_APP;
+
+        // Fill MapReport message
+        meshtastic_MapReport mapReport = meshtastic_MapReport_init_default;
+        memcpy(mapReport.long_name, owner.long_name, sizeof(owner.long_name));
+        memcpy(mapReport.short_name, owner.short_name, sizeof(owner.short_name));
+        mapReport.role = config.device.role;
+        mapReport.hw_model = owner.hw_model;
+        strncpy(mapReport.firmware_version, optstr(APP_VERSION), sizeof(mapReport.firmware_version));
+        mapReport.region = config.lora.region;
+        mapReport.modem_preset = config.lora.modem_preset;
+        mapReport.has_default_channel = channels.hasDefaultChannel();
+
+        // Set position with precision (same as in PositionModule)
+        if (map_position_precision < 32 && map_position_precision > 0) {
+            mapReport.latitude_i = localPosition.latitude_i & (UINT32_MAX << (32 - map_position_precision));
+            mapReport.longitude_i = localPosition.longitude_i & (UINT32_MAX << (32 - map_position_precision));
+            mapReport.latitude_i += (1 << (31 - map_position_precision));
+            mapReport.longitude_i += (1 << (31 - map_position_precision));
+        } else {
+            mapReport.latitude_i = localPosition.latitude_i;
+            mapReport.longitude_i = localPosition.longitude_i;
+        }
+        mapReport.altitude = localPosition.altitude;
+        mapReport.position_precision = map_position_precision;
+
+        mapReport.num_online_local_nodes = nodeDB.getNumOnlineMeshNodes(true);
+
+        // Encode MapReport message and set it to MeshPacket in ServiceEnvelope
+        mp->decoded.payload.size = pb_encode_to_bytes(mp->decoded.payload.bytes, sizeof(mp->decoded.payload.bytes),
+                                                      &meshtastic_MapReport_msg, &mapReport);
+        se->packet = mp;
+
+        // FIXME - this size calculation is super sloppy, but it will go away once we dynamically alloc meshpackets
+        static uint8_t bytes[meshtastic_MeshPacket_size + 64];
+        size_t numBytes = pb_encode_to_bytes(bytes, sizeof(bytes), &meshtastic_ServiceEnvelope_msg, se);
+
+        LOG_INFO("MQTT Publish map report to %s\n", statusTopic.c_str());
+        publish(statusTopic.c_str(), bytes, numBytes, false);
+
+        // Release the allocated memory for ServiceEnvelope and MeshPacket
+        mqttPool.release(se);
+        packetPool.release(mp);
+
+        // Update the last report time
+        last_report_to_map = millis();
     }
 }
 

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -185,10 +185,12 @@ MQTT::MQTT() : concurrency::OSThread("mqtt"), mqttQueue(MAX_MQTT_QUEUE)
             statusTopic = moduleConfig.mqtt.root + statusTopic;
             cryptTopic = moduleConfig.mqtt.root + cryptTopic;
             jsonTopic = moduleConfig.mqtt.root + jsonTopic;
+            mapTopic = moduleConfig.mqtt.root + jsonTopic;
         } else {
             statusTopic = "msh" + statusTopic;
             cryptTopic = "msh" + cryptTopic;
             jsonTopic = "msh" + jsonTopic;
+            mapTopic = "msh" + mapTopic;
         }
 
         if (moduleConfig.mqtt.map_reporting_enabled && moduleConfig.mqtt.has_map_report_settings) {
@@ -605,8 +607,8 @@ void MQTT::perhapsReportToMap()
         static uint8_t bytes[meshtastic_MeshPacket_size + 64];
         size_t numBytes = pb_encode_to_bytes(bytes, sizeof(bytes), &meshtastic_ServiceEnvelope_msg, se);
 
-        LOG_INFO("MQTT Publish map report to %s\n", statusTopic.c_str());
-        publish(statusTopic.c_str(), bytes, numBytes, false);
+        LOG_INFO("MQTT Publish map report to %s\n", mapTopic.c_str());
+        publish(mapTopic.c_str(), bytes, numBytes, false);
 
         // Release the allocated memory for ServiceEnvelope and MeshPacket
         mqttPool.release(se);

--- a/src/mqtt/MQTT.h
+++ b/src/mqtt/MQTT.h
@@ -79,10 +79,16 @@ class MQTT : private concurrency::OSThread
     virtual int32_t runOnce() override;
 
   private:
-    std::string statusTopic = "/2/stat/";
-    std::string cryptTopic = "/2/c/";   // msh/2/c/CHANNELID/NODEID
-    std::string jsonTopic = "/2/json/"; // msh/2/json/CHANNELID/NODEID
-    /** return true if we have a channel that wants uplink/downlink
+    std::string statusTopic = "/2/stat/"; // For "online"/"offline" message and MapReport
+    std::string cryptTopic = "/2/c/";     // msh/2/c/CHANNELID/NODEID
+    std::string jsonTopic = "/2/json/";   // msh/2/json/CHANNELID/NODEID
+
+    // For map reporting (only applies when enabled)
+    uint32_t last_report_to_map = 0;
+    uint32_t map_position_precision = 32;         // default to full precision
+    uint32_t map_publish_interval_secs = 60 * 15; // default to 15 minutes
+
+    /** return true if we have a channel that wants uplink/downlink or map reporting is enabled
      */
     bool wantsLink() const;
 
@@ -101,6 +107,9 @@ class MQTT : private concurrency::OSThread
 
     void publishStatus();
     void publishQueuedMessages();
+
+    // Check if we should report unencrypted information about our node for consumption by a map
+    void perhapsReportToMap();
 
     // returns true if this is a valid JSON envelope which we accept on downlink
     bool isValidJsonEnvelope(JSONObject &json);

--- a/src/mqtt/MQTT.h
+++ b/src/mqtt/MQTT.h
@@ -79,9 +79,10 @@ class MQTT : private concurrency::OSThread
     virtual int32_t runOnce() override;
 
   private:
-    std::string statusTopic = "/2/stat/"; // For "online"/"offline" message and MapReport
+    std::string statusTopic = "/2/stat/"; // For "online"/"offline" message
     std::string cryptTopic = "/2/e/";     // msh/2/e/CHANNELID/NODEID
     std::string jsonTopic = "/2/json/";   // msh/2/json/CHANNELID/NODEID
+    std::string mapTopic = "/2/map/";     // For protobuf-encoded MapReport messages
 
     // For map reporting (only applies when enabled)
     uint32_t last_report_to_map = 0;


### PR DESCRIPTION
This adds an easy way to periodically report all kinds of information about the device (long/short name, position with precision, firmware version, LoRa settings, number of local online nodes, etc.) to a map via MQTT only, regardless of any channel and is thus unencrypted. It will be published to a new `/2/map/` topic as a protobuf in a `ServiceEnvelope` with `MeshPacket` portnum `MAP_REPORT_APP` and can be decoded using the new `MapReport` message. 
If map reporting is enabled, the publish interval (default is 15 min.) and position precision (default is full precision) can be configured.

Implements #3336.