### PR TITLE
Check AQ_SET_PIN instead of EINK dependency

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -342,7 +342,7 @@ void setup()
     pinMode(PIN_3V3_EN, OUTPUT);
     digitalWrite(PIN_3V3_EN, HIGH);
 #endif
-#ifndef USE_EINK
+#ifdef AQ_SET_PIN
     // RAK-12039 set pin for Air quality sensor
     pinMode(AQ_SET_PIN, OUTPUT);
     digitalWrite(AQ_SET_PIN, HIGH);

--- a/src/platform/nrf52/main-nrf52.cpp
+++ b/src/platform/nrf52/main-nrf52.cpp
@@ -177,7 +177,7 @@ void cpuDeepSleep(uint32_t msecToWake)
 #ifdef PIN_3V3_EN
     digitalWrite(PIN_3V3_EN, LOW);
 #endif
-#ifndef USE_EINK
+#ifdef AQ_SET_PIN
     // RAK-12039 set pin for Air quality sensor
     digitalWrite(AQ_SET_PIN, LOW);
 #endif


### PR DESCRIPTION
We should really check if the `AQ_SET_PIN` is defined here instead of depending on some other configuration element that has nothing directly to do with it. Checked against current RAK4630 based configs and should not break anything.