### PR TITLE
Fix T-LoRa V2.1-1.6 with TCXO init

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -226,6 +226,11 @@ void setup()
     digitalWrite(PIN_POWER_EN1, INPUT);
 #endif
 
+#if defined(LORA_TCXO_GPIO)
+    pinMode(LORA_TCXO_GPIO, OUTPUT);
+    digitalWrite(LORA_TCXO_GPIO, HIGH);
+#endif
+
 #if defined(VEXT_ENABLE_V03)
     pinMode(VEXT_ENABLE_V03, OUTPUT);
     pinMode(ST7735_BL_V03, OUTPUT);


### PR DESCRIPTION
As reported [here](https://meshtastic.discourse.group/t/lilygo-2-1-1-6-tcxo-doesnt-work-anymore-on-2-2-24-firmware/10950), the T-LoRa V2.1-1.6 variant with TCXO fails to initialize. Seems the pin write got accidentally removed in #3213.