### PR TITLE
Only allow phone to set time for fixed positions

### DIFF
--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -133,8 +133,13 @@ class NodeDB
     meshtastic_NodeInfoLite *getMeshNode(NodeNum n);
     size_t getNumMeshNodes() { return *numMeshNodes; }
 
-    void setLocalPosition(meshtastic_Position position)
+    void setLocalPosition(meshtastic_Position position, bool timeOnly = false)
     {
+        if (timeOnly) {
+            LOG_DEBUG("Setting local position time only: time=%i\n", position.time);
+            localPosition.time = position.time;
+            return;
+        }
         LOG_DEBUG("Setting local position: latitude=%i, longitude=%i, time=%i\n", position.latitude_i, position.longitude_i,
                   position.time);
         localPosition = position;

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -59,9 +59,15 @@ bool PositionModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
     // to set fixed location, EUD-GPS location or just the time (see also issue #900)
     bool isLocal = false;
     if (nodeDB.getNodeNum() == getFrom(&mp)) {
-        LOG_DEBUG("Incoming update from MYSELF\n");
         isLocal = true;
-        nodeDB.setLocalPosition(p);
+        if (config.position.fixed_position) {
+            LOG_DEBUG("Ignore incoming position update from myself except for time, because position.fixed_position is true\n");
+            nodeDB.setLocalPosition(p, true);
+            return false;
+        } else {
+            LOG_DEBUG("Incoming update from MYSELF\n");
+            nodeDB.setLocalPosition(p);
+        }
     }
 
     // Log packet size and data fields


### PR DESCRIPTION
Fixed position functionality appears to have been well safeguarded in the GPS classes but not in the position module itself and was taking any position packet from the phone and applying it locally. This PR should resolve that and only allow the phone to modify the time, which is desirable.

**Before fix:**
```
INFO  | 20:35:30 98 [Router] Received position from=0x0, id=0x45736e49, portnum=3, payloadlen=25
DEBUG | 20:35:30 98 [Router] Incoming update from MYSELF
DEBUG | 20:35:30 98 [Router] Setting local position: latitude=3XXXXXXXXX, longitude=-9XXXXXXXXX, time=1710362131
INFO  | 20:35:30 98 [Router] POSITION node=fa8165a4 l=25 latI=3XXXXXXXXX lonI=-9XXXXXXXXX msl=107 hae=0 geo=0 pdop=0 hdop=0 vdop=0 siv=10 fxq=0 fxt=0 pts=1710362131 time=1710362131
INFO  | 20:35:30 98 [Router] From Radio onread
INFO  | 20:35:30 98 [Router] updatePosition REMOTE node=0xfa8165a4 time=1710362131, latI=3XXXXXXXXX, lonI=-9XXXXXXXXX
INFO  | 20:35:30 98 [Router] getFromRadio=STATE_SEND_PACKETS

```

**After fix:**
```
INFO  | ??:??:?? 11 [Router] Received position from=0x0, id=0x4d5e2909, portnum=3, payloadlen=25
DEBUG | ??:??:?? 11 [Router] Ignore incoming position update from myself except for time, because position.fixed_position is true
DEBUG | ??:??:?? 11 [Router] Setting local position time only: time=1710362463
DEBUG | ??:??:?? 11 [Router] Module 'position' considered
INFO  | ??:??:?? 11 [Router] From Radio onread
DEBUG | ??:??:?? 11 [Router] Module 'routing' wantsPacket=1
INFO  | ??:??:?? 11 [Router] Received routing from=0x0, id=0x4d5e2909, portnum=3, payloadlen=25
INFO  | ??:??:?? 11 [Router] getFromRadio=STATE_SEND_PACKETS
```
