### PR TITLE
add custom mqtt topic version letter /2/X

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -189,10 +189,10 @@ MQTT::MQTT() : concurrency::OSThread("mqtt"), mqttQueue(MAX_MQTT_QUEUE)
 
             // Check if the length is greater than 0 and if the second to last character is '+'
             if (length > 0 && moduleConfig.mqtt.root[length - 2] == '+') {
-                
+
                 char custom_char = moduleConfig.mqtt.root[length - 1];
 
-                moduleConfig.mqtt.root[length-2] = '\0'; // remove +X for the rest
+                moduleConfig.mqtt.root[length - 2] = '\0'; // remove +X for the rest
                 // replace the sub-version leter with the custom char
                 cryptTopic[3] = custom_char;
             }

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -183,6 +183,19 @@ MQTT::MQTT() : concurrency::OSThread("mqtt"), mqttQueue(MAX_MQTT_QUEUE)
         mqtt = this;
 
         if (*moduleConfig.mqtt.root) {
+            // hack to allow for custom mqtt topic versioning (2/c or 2/d or 2/e or whatever) triggered by
+            // having a trailing +X (eg. +c, +d, +e whatever)
+            size_t length = strlen(moduleConfig.mqtt.root); // Find the length of the string
+
+            // Check if the length is greater than 0 and if the second to last character is '+'
+            if (length > 0 && moduleConfig.mqtt.root[length - 2] == '+') {
+                
+                char custom_char = moduleConfig.mqtt.root[length - 1];
+
+                moduleConfig.mqtt.root[length-2] = '\0'; // remove +X for the rest
+                // replace the sub-version leter with the custom char
+                cryptTopic[3] = custom_char;
+            }
             statusTopic = moduleConfig.mqtt.root + statusTopic;
             cryptTopic = moduleConfig.mqtt.root + cryptTopic;
             jsonTopic = moduleConfig.mqtt.root + jsonTopic;


### PR DESCRIPTION
I've had some issues with old nodes running mqtt /2/c/ not interoperating with new nodes on /2/e/ and I wanted a way to switch between the two without recompiling/flashing.
trigger it with secret hand shake in root topic field.
msh+c will use 2/c instead of 2/e

using '+' is good because its not a valid publish topic as '+' is a wildcard in mqtt topic format

I realize this may not be appropriate for the official firmware but though I'd see if it might be useful as a secret option for those in need.