### PR TITLE
Set default position precision of MQTT map report to 14

### DIFF
--- a/src/mqtt/MQTT.h
+++ b/src/mqtt/MQTT.h
@@ -90,8 +90,8 @@ class MQTT : private concurrency::OSThread
 
     // For map reporting (only applies when enabled)
     uint32_t last_report_to_map = 0;
-    uint32_t map_position_precision = 32;         // default to full precision
-    uint32_t map_publish_interval_secs = 60 * 15; // default to 15 minutes
+    uint32_t map_position_precision = 14;         // defaults to max. offset of ~1459m
+    uint32_t map_publish_interval_secs = 60 * 15; // defaults to 15 minutes
 
     /** return true if we have a channel that wants uplink/downlink or map reporting is enabled
      */


### PR DESCRIPTION
Although map reporting is disabled by default, maybe better to not use full precision by default. 
As per a suggestion of @garthvh.
