### PR TITLE
Revert "Bump actions to node 20 (#3461)"

### DIFF
--- a/.github/actions/setup-base/action.yml
+++ b/.github/actions/setup-base/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
       with:
         submodules: "recursive"
         ref: ${{github.event.pull_request.head.ref}}
@@ -30,12 +30,12 @@ runs:
         sudo apt-get install -y libyaml-cpp-dev
 
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v4
       with:
         python-version: 3.x
 
     - name: Cache python libs
-      uses: actions/cache@v4
+      uses: actions/cache@v3
       id: cache-pip # needed in if test
       with:
         path: ~/.cache/pip

--- a/.github/workflows/build_esp32.yml
+++ b/.github/workflows/build_esp32.yml
@@ -11,7 +11,7 @@ jobs:
   build-esp32:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Build base
         id: base
         uses: ./.github/actions/setup-base
@@ -54,7 +54,7 @@ jobs:
         id: version
 
       - name: Store binaries as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: firmware-${{ inputs.board }}-${{ steps.version.outputs.version }}.zip
           path: |

--- a/.github/workflows/build_esp32_c3.yml
+++ b/.github/workflows/build_esp32_c3.yml
@@ -13,7 +13,7 @@ jobs:
   build-esp32-c3:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Build base
         id: base
         uses: ./.github/actions/setup-base
@@ -54,7 +54,7 @@ jobs:
         id: version
 
       - name: Store binaries as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: firmware-${{ inputs.board }}-${{ steps.version.outputs.version }}.zip
           path: |

--- a/.github/workflows/build_esp32_s3.yml
+++ b/.github/workflows/build_esp32_s3.yml
@@ -11,7 +11,7 @@ jobs:
   build-esp32-s3:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Build base
         id: base
         uses: ./.github/actions/setup-base
@@ -52,7 +52,7 @@ jobs:
         id: version
 
       - name: Store binaries as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: firmware-${{ inputs.board }}-${{ steps.version.outputs.version }}.zip
           path: |

--- a/.github/workflows/build_nrf52.yml
+++ b/.github/workflows/build_nrf52.yml
@@ -11,7 +11,7 @@ jobs:
   build-nrf52:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Build base
         id: base
         uses: ./.github/actions/setup-base
@@ -24,7 +24,7 @@ jobs:
         id: version
 
       - name: Store binaries as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: firmware-${{ inputs.board }}-${{ steps.version.outputs.version }}.zip
           path: |

--- a/.github/workflows/build_raspbian.yml
+++ b/.github/workflows/build_raspbian.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [self-hosted, linux, ARM64]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           submodules: recursive
           ref: ${{github.event.pull_request.head.ref}}
@@ -37,7 +37,7 @@ jobs:
         id: version
 
       - name: Store binaries as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: firmware-raspbian-${{ steps.version.outputs.version }}.zip
           path: |

--- a/.github/workflows/build_rpi2040.yml
+++ b/.github/workflows/build_rpi2040.yml
@@ -11,7 +11,7 @@ jobs:
   build-rpi2040:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Build base
         id: base
         uses: ./.github/actions/setup-base
@@ -24,7 +24,7 @@ jobs:
         id: version
 
       - name: Store binaries as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: firmware-${{ inputs.board }}-${{ steps.version.outputs.version }}.zip
           path: |

--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -42,7 +42,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Build base
         id: base
         uses: ./.github/actions/setup-base
@@ -157,7 +157,7 @@ jobs:
   build-native:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Build base
         id: base
         uses: ./.github/actions/setup-base
@@ -180,7 +180,7 @@ jobs:
         id: version
 
       - name: Store binaries as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: firmware-native-${{ steps.version.outputs.version }}.zip
           path: |
@@ -221,7 +221,7 @@ jobs:
     needs: [check]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
@@ -244,7 +244,7 @@ jobs:
       ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
@@ -264,7 +264,7 @@ jobs:
         run: mv -b -t ./ ./*tbeam-2*/littlefs*.bin ./*tbeam-2*/bleota.bin ./*tbeam-s3*/bleota-s3.bin ./*esp32c3*/bleota-c3.bin ./**/firmware*.bin ./*t-echo*/Meshtastic_nRF52_factory_erase_v2.uf2 ./**/firmware-*.uf2 ./**/firmware-*-ota.zip ./**/*.elf ./*native*/*device-*.sh ./*native*/*device-*.bat ./firmware-raspbian-*/release/meshtasticd_linux_aarch64 ./firmware-raspbian-*/bin/config-dist.yaml
 
       - name: Repackage in single firmware zip
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: firmware-${{ steps.version.outputs.version }}
           path: |
@@ -295,7 +295,7 @@ jobs:
         run: zip -j -9 -r ./firmware-${{ steps.version.outputs.version }}.zip ./output
 
       - name: Repackage in single elfs zip
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: debug-elfs-${{ steps.version.outputs.version }}.zip
           path: ./*.elf
@@ -319,10 +319,10 @@ jobs:
     needs: [gather-artifacts, after-checks]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Trunk Check
         uses: trunk-io/trunk-action@782e83f803ca6e369f035d64c6ba2768174ba61b

--- a/.github/workflows/package_raspbian.yml
+++ b/.github/workflows/package_raspbian.yml
@@ -17,7 +17,7 @@ jobs:
     needs: build-raspbian
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           submodules: recursive
           ref: ${{github.event.pull_request.head.ref}}
@@ -66,7 +66,7 @@ jobs:
           depends: libyaml-cpp0.7, openssl
           desc: Native Linux Meshtastic binary.
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           name: artifact-deb
           path: |

--- a/.github/workflows/sec_sast_flawfinder.yml
+++ b/.github/workflows/sec_sast_flawfinder.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       # step 1
       - name: clone application source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       # step 2
       - name: flawfinder_scan
@@ -27,7 +27,7 @@ jobs:
 
       # step 3
       - name: save report as pipeline artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: flawfinder_report.sarif
           path: flawfinder_report.sarif

--- a/.github/workflows/sec_sast_semgrep_cron.yml
+++ b/.github/workflows/sec_sast_semgrep_cron.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # step 1
       - name: clone application source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       # step 2
       - name: full scan
@@ -29,7 +29,7 @@ jobs:
 
       # step 3
       - name: save report as pipeline artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: report.sarif
           path: report.sarif

--- a/.github/workflows/sec_sast_semgrep_pull.yml
+++ b/.github/workflows/sec_sast_semgrep_pull.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       # step 1
       - name: clone application source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/trunk-check.yml
+++ b/.github/workflows/trunk-check.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1

--- a/.github/workflows/update_protobufs.yml
+++ b/.github/workflows/update_protobufs.yml
@@ -7,7 +7,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           submodules: true
 


### PR DESCRIPTION
This reverts commit defeb8e52bab51eff5ab990119a0976f43730482.

As per https://github.com/actions/upload-artifact/issues/478 the new version of upload-artifact includes a breaking change.