### PR TITLE
Set unused header bytes to zero for future use

### DIFF
--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -564,6 +564,8 @@ size_t RadioInterface::beginSending(meshtastic_MeshPacket *p)
     h->to = p->to;
     h->id = p->id;
     h->channel = p->channel;
+    h->next_hop = 0;   // *** For future use ***
+    h->relay_node = 0; // *** For future use ***
     if (p->hop_limit > HOP_MAX) {
         LOG_WARN("hop limit %d is too high, setting to %d\n", p->hop_limit, HOP_RELIABLE);
         p->hop_limit = HOP_RELIABLE;

--- a/src/mesh/RadioInterface.h
+++ b/src/mesh/RadioInterface.h
@@ -34,6 +34,12 @@ typedef struct {
 
     /** The channel hash - used as a hint for the decoder to limit which channels we consider */
     uint8_t channel;
+
+    // ***For future use*** Last byte of the NodeNum of the next-hop for this packet
+    uint8_t next_hop;
+
+    // ***For future use*** Last byte of the NodeNum of the node that will relay/relayed this packet
+    uint8_t relay_node;
 } PacketHeader;
 
 /**


### PR DESCRIPTION
Currently the `PacketHeader` is 16 bytes, but only 14 are used. The remaining two can take any value depending on what is in that memory location. To ensure a smooth transition for when those two bytes will be used in the future (e.g. PR #2856), force them to 0 now.