### PR TITLE
Native: fail-safes for simulated node without config file

### DIFF
--- a/src/input/LinuxInput.cpp
+++ b/src/input/LinuxInput.cpp
@@ -24,7 +24,8 @@ LinuxInput::LinuxInput(const char *name) : concurrency::OSThread(name)
 
 void LinuxInput::deInit()
 {
-    close(fd);
+    if (fd >= 0)
+        close(fd);
 }
 
 int32_t LinuxInput::runOnce()

--- a/src/input/LinuxInput.h
+++ b/src/input/LinuxInput.h
@@ -38,7 +38,7 @@ class LinuxInput : public Observable<const InputEvent *>, public concurrency::OS
     int queue_progress = 0;
 
     struct epoll_event events[MAX_EVENTS];
-    int fd;
+    int fd = -1;
     int ret;
     uint8_t report[8];
     int epollfd;

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -106,6 +106,8 @@ void portduinoSetup()
         }
     } else {
         std::cout << "No 'config.yaml' found, running simulated." << std::endl;
+        settingsMap[maxnodes] = 200;               // Default to 200 nodes
+        settingsMap[logoutputlevel] = level_debug; // Default to debug
         // Set the random seed equal to TCPPort to have a different seed per instance
         randomSeed(TCPPort);
         return;


### PR DESCRIPTION
When trying to run multiple simulated nodes without config file on my Ubuntu system, I experienced two crashes. The first one was because `settingsMap[maxnodes]` was not defined. Second one was because LinuxInput was closing file descriptor 0 when rebooting and after boot `psock` in WiFiServer got assigned to 0, which lead to an assert.

I also set the default log level to debug.