### PR TITLE
replace arch with uname -m for arch linux

### DIFF
--- a/bin/build-native.sh
+++ b/bin/build-native.sh
@@ -15,6 +15,6 @@ rm -r $OUTDIR/* || true
 # Important to pull latest version of libs into all device flavors, otherwise some devices might be stale
 platformio pkg update
 pio run --environment native
-cp .pio/build/native/program "$OUTDIR/meshtasticd_linux_$(arch)"
+cp .pio/build/native/program "$OUTDIR/meshtasticd_linux_$(uname -m)"
 cp bin/device-install.* $OUTDIR
 cp bin/device-update.* $OUTDIR

--- a/bin/native-install.sh
+++ b/bin/native-install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-cp "release/meshtasticd_linux_$(arch)" /usr/sbin/meshtasticd
+cp "release/meshtasticd_linux_$(uname -m)" /usr/sbin/meshtasticd
 mkdir /etc/meshtasticd
 if [[ -f "/etc/meshtasticd/config.yaml" ]]; then
 	cp bin/config-dist.yaml /etc/meshtasticd/config-upgrade.yaml


### PR DESCRIPTION
From the manpage:
> arch - print machine hardware name (same as uname -m)

Arch Linux does not have the `arch` alias, only `uname`, so use `uname` to fix this issue:
> ```
> ./bin/build-native.sh: line 18: arch: command not found
> ```
