### PR TITLE
Don't save Neighbors to flash when receiving

### DIFF
--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -114,9 +114,10 @@ size_t NeighborInfoModule::cleanUpNeighbors()
         (*numNeighbors)--;
     }
 
-    // Save the neighbor list if we removed any neighbors
-    if (indices_to_remove.size() > 0) {
+    // Save the neighbor list if we removed any neighbors or neighbors were already updated upon receiving a packet
+    if (indices_to_remove.size() > 0 || shouldSave) {
         saveProtoForModule();
+        shouldSave = false;
     }
 
     return *numNeighbors;
@@ -210,7 +211,6 @@ meshtastic_Neighbor *NeighborInfoModule::getOrCreateNeighbor(NodeNum originalSen
             // Only if this is the original sender, the broadcast interval corresponds to it
             if (originalSender == n && node_broadcast_interval_secs != 0)
                 nbr->node_broadcast_interval_secs = node_broadcast_interval_secs;
-            saveProtoForModule(); // Save the updated neighbor
             return nbr;
         }
     }
@@ -228,7 +228,7 @@ meshtastic_Neighbor *NeighborInfoModule::getOrCreateNeighbor(NodeNum originalSen
         new_nbr->node_broadcast_interval_secs = node_broadcast_interval_secs;
     else // Assume the same broadcast interval as us for the neighbor if we don't know it
         new_nbr->node_broadcast_interval_secs = moduleConfig.neighbor_info.update_interval;
-    saveProtoForModule(); // Save the new neighbor
+    shouldSave = true; // Save the new neighbor upon next cleanup
     return new_nbr;
 }
 

--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -117,7 +117,6 @@ size_t NeighborInfoModule::cleanUpNeighbors()
     // Save the neighbor list if we removed any neighbors or neighbors were already updated upon receiving a packet
     if (indices_to_remove.size() > 0 || shouldSave) {
         saveProtoForModule();
-        shouldSave = false;
     }
 
     return *numNeighbors;
@@ -255,6 +254,8 @@ bool NeighborInfoModule::saveProtoForModule()
 #endif
 
     okay &= nodeDB->saveProto(neighborInfoConfigFile, meshtastic_NeighborInfo_size, &meshtastic_NeighborInfo_msg, &neighborState);
+    if (okay)
+        shouldSave = false;
 
     return okay;
 }

--- a/src/modules/NeighborInfoModule.h
+++ b/src/modules/NeighborInfoModule.h
@@ -20,6 +20,9 @@ class NeighborInfoModule : public ProtobufModule<meshtastic_NeighborInfo>, priva
 
     bool saveProtoForModule();
 
+  private:
+    bool shouldSave = false; // Whether we should save the neighbor info to flash
+
   protected:
     // Note: this holds our local info.
     meshtastic_NeighborInfo neighborState;


### PR DESCRIPTION
Now that with 2.3 neighbors can also be detected for packets other than NeighborInfo, it may lead to excessive writing to flash, causing issues like #3516 and it may wear out the flash rather quickly.
Now it will not write to flash when receiving a packet, but only before it broadcasts its own NeighborInfo and there is a new neighbor, or there is one removed.