### PR TITLE
Fix Light-sleep for ESP32

### DIFF
--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -102,23 +102,18 @@ static void lsIdle()
                 powerFSM.trigger(EVENT_SERIAL_CONNECTED);
                 break;
 
+            case ESP_SLEEP_WAKEUP_GPIO:
+                // GPIO wakeup is now used for all ESP32 devices during light sleep
+                powerFSM.trigger(EVENT_PRESS);
+                break;
+
             default:
-                // We woke for some other reason (button press, device interrupt)
-                // uint64_t status = esp_sleep_get_ext1_wakeup_status();
+                // We woke for some other reason (device interrupt?)
                 LOG_INFO("wakeCause2 %d\n", wakeCause2);
 
-#ifdef BUTTON_PIN
-                bool pressed = !digitalRead(config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN);
-#else
-                bool pressed = false;
-#endif
-                if (pressed) { // If we woke because of press, instead generate a PRESS event.
-                    powerFSM.trigger(EVENT_PRESS);
-                } else {
-                    // Otherwise let the NB state handle the IRQ (and that state will handle stuff like IRQs etc)
-                    // we lie and say "wake timer" because the interrupt will be handled by the regular IRQ code
-                    powerFSM.trigger(EVENT_WAKE_TIMER);
-                }
+                // Let the NB state handle the IRQ (and that state will handle stuff like IRQs etc)
+                // we lie and say "wake timer" because the interrupt will be handled by the regular IRQ code
+                powerFSM.trigger(EVENT_WAKE_TIMER);
                 break;
             }
         } else {

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -312,13 +312,10 @@ esp_sleep_wakeup_cause_t doLightSleep(uint64_t sleepMsec) // FIXME, use a more r
     // assert(esp_sleep_enable_uart_wakeup(0) == ESP_OK);
 #endif
 #ifdef BUTTON_PIN
-#if SOC_PM_SUPPORT_EXT_WAKEUP
-    esp_sleep_enable_ext0_wakeup((gpio_num_t)(config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN),
-                                 LOW); // when user presses, this button goes low
-#else
+    // The enableLoraInterrupt() method is using ext0_wakeup, so we are forced to use GPIO wakeup
+    gpio_num_t pin = (gpio_num_t)(config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN);
+    gpio_wakeup_enable(pin, GPIO_INTR_LOW_LEVEL);
     esp_sleep_enable_gpio_wakeup();
-    gpio_wakeup_enable((gpio_num_t)BUTTON_PIN, GPIO_INTR_LOW_LEVEL);
-#endif
 #endif
     enableLoraInterrupt();
 #ifdef PMU_IRQ

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -314,6 +314,7 @@ esp_sleep_wakeup_cause_t doLightSleep(uint64_t sleepMsec) // FIXME, use a more r
 #ifdef BUTTON_PIN
     // The enableLoraInterrupt() method is using ext0_wakeup, so we are forced to use GPIO wakeup
     gpio_num_t pin = (gpio_num_t)(config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN);
+    gpio_intr_disable(pin);
     gpio_wakeup_enable(pin, GPIO_INTR_LOW_LEVEL);
     esp_sleep_enable_gpio_wakeup();
 #endif
@@ -338,6 +339,10 @@ esp_sleep_wakeup_cause_t doLightSleep(uint64_t sleepMsec) // FIXME, use a more r
         LOG_DEBUG("esp_light_sleep_start result %d\n", res);
     }
     assert(res == ESP_OK);
+
+    gpio_wakeup_disable(pin);
+    // Would have thought that need gpio_intr_enable() here, but nope..
+    // Works fine without it; crashes with it.
 
     esp_sleep_wakeup_cause_t cause = esp_sleep_get_wakeup_cause();
 #ifdef BUTTON_PIN

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -340,9 +340,11 @@ esp_sleep_wakeup_cause_t doLightSleep(uint64_t sleepMsec) // FIXME, use a more r
     }
     assert(res == ESP_OK);
 
+#ifdef BUTTON_PIN
     gpio_wakeup_disable(pin);
     // Would have thought that need gpio_intr_enable() here, but nope..
     // Works fine without it; crashes with it.
+#endif
 
     esp_sleep_wakeup_cause_t cause = esp_sleep_get_wakeup_cause();
 #ifdef BUTTON_PIN


### PR DESCRIPTION
Hopefully addresses https://github.com/meshtastic/firmware/issues/3512

Main culprit seems to have been the addition of [`enableLoRaInterrupt()`](https://github.com/meshtastic/firmware/blame/a4c22321fca6fc8da7bab157c3812055603512ba/src/sleep.cpp#L323), which is competing with the hardware button for use of the EXT0 wake source. Using GPIO wake for the button works around this issue.

Secondary issues with ISRs on wake, and PRESS event detection have also been addressed (kludged).

Tested with Heltec Wireless Paper, however this does currently require a hotfix for https://github.com/meshtastic/firmware/issues/3517 to first be applied. Will be separately address soon. Briefly tested with T-Echo. All seems to be running fine, at least at first glance.

I would expect this bug to affect all ESP32 devices(?). It would be good to have the fix independently tested, if anyone has the time / energy to spare.
