### PR TITLE
Add spiTransfer function to Native to support Linux-managed CS

### DIFF
--- a/arch/portduino/portduino.ini
+++ b/arch/portduino/portduino.ini
@@ -1,6 +1,6 @@
 ; The Portduino based sim environment on top of any host OS, all hardware will be simulated
 [portduino_base]
-platform = https://github.com/meshtastic/platform-native.git#1b8a32c60ab7495026033858d53c737f7d1cb34a
+platform = https://github.com/meshtastic/platform-native.git#117acc5e7fcc2047e9ba1dc11789daea26fc36d2
 framework = arduino
 
 build_src_filter = 

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -23,7 +23,7 @@ void LockingArduinoHal::spiEndTransaction()
     ArduinoHal::spiEndTransaction();
 }
 #if ARCH_PORTDUINO
-void LockingArduinoHal::spiTransfer(uint8_t* out, size_t len, uint8_t* in)
+void LockingArduinoHal::spiTransfer(uint8_t *out, size_t len, uint8_t *in)
 {
     spi->transfer(out, in, len);
 }

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -22,6 +22,12 @@ void LockingArduinoHal::spiEndTransaction()
 
     ArduinoHal::spiEndTransaction();
 }
+#if ARCH_PORTDUINO
+void LockingArduinoHal::spiTransfer(uint8_t* out, size_t len, uint8_t* in)
+{
+    spi->transfer(out, in, len);
+}
+#endif
 
 RadioLibInterface::RadioLibInterface(LockingArduinoHal *hal, RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst,
                                      RADIOLIB_PIN_TYPE busy, PhysicalLayer *_iface)

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -25,6 +25,9 @@ class LockingArduinoHal : public ArduinoHal
 
     void spiBeginTransaction() override;
     void spiEndTransaction() override;
+    #if ARCH_PORTDUINO
+    void spiTransfer(uint8_t* out, size_t len, uint8_t* in) override;
+    #endif
 };
 
 #if defined(USE_STM32WLx)

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -25,9 +25,9 @@ class LockingArduinoHal : public ArduinoHal
 
     void spiBeginTransaction() override;
     void spiEndTransaction() override;
-    #if ARCH_PORTDUINO
-    void spiTransfer(uint8_t* out, size_t len, uint8_t* in) override;
-    #endif
+#if ARCH_PORTDUINO
+    void spiTransfer(uint8_t *out, size_t len, uint8_t *in) override;
+#endif
 };
 
 #if defined(USE_STM32WLx)

--- a/variants/portduino/variant.h
+++ b/variants/portduino/variant.h
@@ -2,3 +2,4 @@
 #define CANNED_MESSAGE_MODULE_ENABLE 1
 #define HAS_GPS 1
 #define MAX_NUM_NODES settingsMap[maxnodes]
+#define RADIOLIB_GODMODE 1


### PR DESCRIPTION
This allows radios using GPIO 7 or 8 on the Pi to use the OS management of the CS pin. Should make the setup one step easier.