### PR TITLE
Disable holds / isolations on RTC IO pads after deep sleep

### DIFF
--- a/src/graphics/EInkDisplay2.cpp
+++ b/src/graphics/EInkDisplay2.cpp
@@ -151,31 +151,12 @@ bool EInkDisplay::connect()
 
 #elif defined(HELTEC_WIRELESS_PAPER_V1_0) || defined(HELTEC_WIRELESS_PAPER)
     {
-        // Is this a normal boot, or a wake from deep sleep?
-        esp_sleep_wakeup_cause_t wakeReason = esp_sleep_get_wakeup_cause();
-
-        // If waking from sleep, need to reverse rtc_gpio_isolate(), called in cpuDeepSleep()
-        // Otherwise, SPI won't work
-        if (wakeReason != ESP_SLEEP_WAKEUP_UNDEFINED) {
-            // HSPI + other display pins
-            rtc_gpio_hold_dis((gpio_num_t)PIN_EINK_SCLK);
-            rtc_gpio_hold_dis((gpio_num_t)PIN_EINK_DC);
-            rtc_gpio_hold_dis((gpio_num_t)PIN_EINK_RES);
-            rtc_gpio_hold_dis((gpio_num_t)PIN_EINK_BUSY);
-            rtc_gpio_hold_dis((gpio_num_t)PIN_EINK_CS);
-            rtc_gpio_hold_dis((gpio_num_t)PIN_EINK_MOSI);
-        }
-
         // Start HSPI
         hspi = new SPIClass(HSPI);
         hspi->begin(PIN_EINK_SCLK, -1, PIN_EINK_MOSI, PIN_EINK_CS); // SCLK, MISO, MOSI, SS
 
-        // Enable VExt (ACTIVE LOW)
-        // Unsure if called elsewhere first?
-        delay(100);
-        pinMode(Vext, OUTPUT);
-        digitalWrite(Vext, LOW);
-        delay(100);
+        // VExt already enabled in setup()
+        // RTC GPIO hold disabled in setup()
 
         // Create GxEPD2 objects
         auto lowLevel = new EINK_DISPLAY_MODEL(PIN_EINK_CS, PIN_EINK_DC, PIN_EINK_RES, PIN_EINK_BUSY, *hspi);

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -147,6 +147,16 @@ void initDeepSleep()
 
     LOG_INFO("Booted, wake cause %d (boot count %d), reset_reason=%s\n", wakeCause, bootCount, reason);
 #endif
+
+    // If waking from sleep, release any and all RTC GPIOs
+    if (wakeCause != ESP_SLEEP_WAKEUP_UNDEFINED) {
+        LOG_DEBUG("Disabling any holds on RTC IO pads\n");
+        for (uint8_t i = 0; i <= 45; i++) {
+            if (rtc_gpio_is_valid_gpio((gpio_num_t)i))
+                rtc_gpio_hold_dis((gpio_num_t)i);
+        }
+    }
+
 #endif
 }
 


### PR DESCRIPTION
> Anonymoushindeiru
 — 
Yesterday at 9:20 PM
I found a bug: after waking from manual sleep/poweroff on a nano G1 explorer, buzzer no longer works

___

On ESP32, on wake from deep sleep, releases RTC IO pads which were held or isolated to minimize current leakage, freeing them to resume their normal function.