### PR TITLE
Reduce deep-sleep current for Heltec Wireless Paper

### DIFF
--- a/src/nimble/NimbleBluetooth.cpp
+++ b/src/nimble/NimbleBluetooth.cpp
@@ -112,6 +112,12 @@ void NimbleBluetooth::shutdown()
     NimBLEAdvertising *pAdvertising = NimBLEDevice::getAdvertising();
     pAdvertising->reset();
     pAdvertising->stop();
+
+#if defined(HELTEC_WIRELESS_PAPER) || defined(HELTEC_WIRELESS_PAPER_V1_0)
+    // Saving of ~1mA
+    // Probably applicable to other ESP32 boards - unverified
+    NimBLEDevice::deinit();
+#endif
 }
 
 bool NimbleBluetooth::isActive()

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -277,6 +277,17 @@ void doDeepSleep(uint32_t msecToWake, bool skipPreflight = false)
     if (shouldLoraWake(msecToWake)) {
         enableLoraInterrupt();
     }
+
+#if defined(HELTEC_WIRELESS_PAPER) || defined(HELTEC_WIRELESS_PAPER_V1_0) // Applicable to most ESP32 boards?
+    // Avoid leakage through button pin
+    pinMode(0, INPUT);
+    rtc_gpio_hold_en((gpio_num_t)0);
+
+    // LoRa CS (RADIO_NSS) needs to stay HIGH, even during deep sleep
+    pinMode(LORA_CS, OUTPUT);
+    digitalWrite(LORA_CS, HIGH);
+    rtc_gpio_hold_en((gpio_num_t)LORA_CS);
+#endif
 #endif
     cpuDeepSleep(msecToWake);
 }

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -280,8 +280,8 @@ void doDeepSleep(uint32_t msecToWake, bool skipPreflight = false)
 
 #if defined(HELTEC_WIRELESS_PAPER) || defined(HELTEC_WIRELESS_PAPER_V1_0) // Applicable to most ESP32 boards?
     // Avoid leakage through button pin
-    pinMode(0, INPUT);
-    rtc_gpio_hold_en((gpio_num_t)0);
+    pinMode(BUTTON_PIN, INPUT);
+    rtc_gpio_hold_en((gpio_num_t)BUTTON_PIN);
 
     // LoRa CS (RADIO_NSS) needs to stay HIGH, even during deep sleep
     pinMode(LORA_CS, OUTPUT);


### PR DESCRIPTION
Addresses https://github.com/meshtastic/firmware/issues/3523

At present, deep-sleep current is 2.2mA @ 3.8V.
Changes lower the current draw to 18µA @ 3.8V.

These modifications are likely to be applicable to a number of ESP32 devices, but I don't have the hardware to test this.