### PR TITLE
This change to the I2C Scan is to distinguish QMI8658 and BQ24295 

### DIFF
--- a/src/detect/ScanI2C.h
+++ b/src/detect/ScanI2C.h
@@ -38,6 +38,7 @@ class ScanI2C
         MPU6050,
         LIS3DH,
         BMA423,
+        BQ24295,
 #ifdef HAS_NCP5623
         NCP5623,
 #endif

--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -293,7 +293,18 @@ void ScanI2CTwoWire::scanPort(I2CPort port)
                 SCAN_SIMPLE_CASE(LPS22HB_ADDR, LPS22HB, "LPS22HB sensor found\n")
 
                 SCAN_SIMPLE_CASE(QMC6310_ADDR, QMC6310, "QMC6310 Highrate 3-Axis magnetic sensor found\n")
-                SCAN_SIMPLE_CASE(QMI8658_ADDR, QMI8658, "QMI8658 Highrate 6-Axis inertial measurement sensor found\n")
+
+            case QMI8658_ADDR:
+                registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x0A), 1); // get ID
+                if (registerValue == 0xC0) {
+                    type = BQ24295;
+                    LOG_INFO("BQ24295 PMU found\n");
+                } else {
+                    type = QMI8658;
+                    LOG_INFO("QMI8658 Highrate 6-Axis inertial measurement sensor found\n");
+                }
+                break;
+
                 SCAN_SIMPLE_CASE(QMC5883L_ADDR, QMC5883L, "QMC5883L Highrate 3-Axis magnetic sensor found\n")
 
                 SCAN_SIMPLE_CASE(PMSA0031_ADDR, PMSA0031, "PMSA0031 air quality sensor found\n")


### PR DESCRIPTION
Both these devices share the same I2C address (0x6B) the QMI8658 IMU and BQ24295 PMU.

I've got a BQ24295 to test and it seems to work but I am unable to test with a QMI8658. I don't imagine reading from register 0xA would cause any problems, but if would be really good if someone is able to verify this, also to check that the contents of it don't accidently match the version ID from the BQ24295!!

Fingers crossed I got the trunking formatted correctly this time...