### PR TITLE
Remap backlight toggle and touch button

### DIFF
--- a/src/ButtonThread.cpp
+++ b/src/ButtonThread.cpp
@@ -249,7 +249,9 @@ void ButtonThread::userButtonMultiPressed(void *callerThread)
 // Non-static method, runs during callback. Grabs info while still valid
 void ButtonThread::handleMultiPress()
 {
+#ifdef BUTTON_PIN
     multipressClickCount = userButton.getNumberClicks();
+#endif
 }
 
 void ButtonThread::userButtonPressedLongStart()

--- a/src/ButtonThread.cpp
+++ b/src/ButtonThread.cpp
@@ -180,8 +180,14 @@ int32_t ButtonThread::runOnce()
         }
         case BUTTON_EVENT_TOUCH_PRESSED: {
             LOG_BUTTON("Touch press!\n");
-            if (screen)
+            if (screen) {
+                // Wake if asleep
+                if (powerFSM.getState() == &stateDARK)
+                    powerFSM.trigger(EVENT_PRESS);
+
+                // Update display (legacy behaviour)
                 screen->forceDisplay();
+            }
             break;
         }
         default:

--- a/src/ButtonThread.cpp
+++ b/src/ButtonThread.cpp
@@ -197,7 +197,7 @@ int32_t ButtonThread::runOnce()
 #ifdef BUTTON_PIN_TOUCH
         case BUTTON_EVENT_TOUCH_LONG_PRESSED: {
             LOG_BUTTON("Touch press!\n");
-
+            if (config.display.wake_on_tap_or_motion) {
                 if (screen) {
                     // Wake if asleep
                     if (powerFSM.getState() == &stateDARK)
@@ -206,6 +206,7 @@ int32_t ButtonThread::runOnce()
                     // Update display (legacy behaviour)
                     screen->forceDisplay();
                 }
+            }
             break;
         }
 #endif // BUTTON_PIN_TOUCH

--- a/src/ButtonThread.cpp
+++ b/src/ButtonThread.cpp
@@ -240,14 +240,14 @@ void ButtonThread::userButtonMultiPressed(void *callerThread)
 {
     // Grab click count from non-static button, while the info is still valid
     ButtonThread *thread = (ButtonThread *)callerThread;
-    thread->handleMultiPress();
+    thread->storeClickCount();
 
     // Then handle later, in the usual way
     btnEvent = BUTTON_EVENT_MULTI_PRESSED;
 }
 
 // Non-static method, runs during callback. Grabs info while still valid
-void ButtonThread::handleMultiPress()
+void ButtonThread::storeClickCount()
 {
 #ifdef BUTTON_PIN
     multipressClickCount = userButton.getNumberClicks();

--- a/src/ButtonThread.cpp
+++ b/src/ButtonThread.cpp
@@ -191,6 +191,8 @@ int32_t ButtonThread::runOnce()
             power->shutdown();
             break;
         }
+
+#ifdef BUTTON_PIN_TOUCH
         case BUTTON_EVENT_TOUCH_LONG_PRESSED: {
             LOG_BUTTON("Touch press!\n");
             touchModifier = true;
@@ -209,6 +211,8 @@ int32_t ButtonThread::runOnce()
             touchModifier = false;
             break;
         }
+#endif // BUTTON_PIN_TOUCH
+
         default:
             break;
         }

--- a/src/ButtonThread.cpp
+++ b/src/ButtonThread.cpp
@@ -143,8 +143,10 @@ int32_t ButtonThread::runOnce()
 #endif
             service.refreshLocalMeshNode();
             service.sendNetworkPing(NODENUM_BROADCAST, true);
-            if (screen)
+            if (screen) {
                 screen->print("Sent ad-hoc ping\n");
+                screen->forceDisplay(true); // Force a new UI frame, then force an EInk update
+            }
             break;
         }
 #if HAS_GPS
@@ -153,7 +155,7 @@ int32_t ButtonThread::runOnce()
             if (!config.device.disable_triple_click && (gps != nullptr)) {
                 gps->toggleGpsMode();
                 if (screen)
-                    screen->forceDisplay();
+                    screen->forceDisplay(true); // Force a new UI frame, then force an EInk update
             }
             break;
         }

--- a/src/ButtonThread.cpp
+++ b/src/ButtonThread.cpp
@@ -48,7 +48,7 @@ ButtonThread::ButtonThread() : OSThread("Button")
     userButton.setPressMs(c_longPressTime);
     userButton.setDebounceMs(1);
     userButton.attachDoubleClick(userButtonDoublePressed);
-    userButton.attachMultiClick(userButtonMultiPressed);
+    userButton.attachMultiClick(userButtonMultiPressed, this); // Reference to instance: get click count from non-static OneButton
 #ifndef T_DECK // T-Deck immediately wakes up after shutdown, so disable this function
     userButton.attachLongPressStart(userButtonPressedLongStart);
     userButton.attachLongPressStop(userButtonPressedLongStop);
@@ -147,17 +147,34 @@ int32_t ButtonThread::runOnce()
             }
             break;
         }
-#if HAS_GPS
+
         case BUTTON_EVENT_MULTI_PRESSED: {
-            LOG_BUTTON("Multi press!\n");
-            if (!config.device.disable_triple_click && (gps != nullptr)) {
-                gps->toggleGpsMode();
-                if (screen)
-                    screen->forceDisplay(true); // Force a new UI frame, then force an EInk update
-            }
-            break;
-        }
+            LOG_BUTTON("Mulitipress! %hux\n", multipressClickCount);
+            switch (multipressClickCount) {
+#if HAS_GPS
+            // 3 clicks: toggle GPS
+            case 3:
+                if (!config.device.disable_triple_click && (gps != nullptr)) {
+                    gps->toggleGpsMode();
+                    if (screen)
+                        screen->forceDisplay(true); // Force a new UI frame, then force an EInk update
+                }
+                break;
 #endif
+#if defined(USE_EINK) && defined(PIN_EINK_EN) // i.e. T-Echo
+            // 4 clicks: toggle backlight
+            case 4:
+                digitalWrite(PIN_EINK_EN, digitalRead(PIN_EINK_EN) == LOW);
+                break;
+#endif
+            // No valid multipress action
+            default:
+                break;
+            } // end switch: click count
+
+            break;
+        } // end multipress event
+
         case BUTTON_EVENT_LONG_PRESSED: {
             LOG_BUTTON("Long press!\n");
             powerFSM.trigger(EVENT_PRESS);
@@ -215,6 +232,23 @@ void ButtonThread::wakeOnIrq(int irq, int mode)
             mainDelay.interruptFromISR(&higherWake);
         },
         FALLING);
+}
+
+// Static callback
+void ButtonThread::userButtonMultiPressed(void *callerThread)
+{
+    // Grab click count from non-static button, while the info is still valid
+    ButtonThread *thread = (ButtonThread *)callerThread;
+    thread->handleMultiPress();
+
+    // Then handle later, in the usual way
+    btnEvent = BUTTON_EVENT_MULTI_PRESSED;
+}
+
+// Non-static method, runs during callback. Grabs info while still valid
+void ButtonThread::handleMultiPress()
+{
+    multipressClickCount = userButton.getNumberClicks();
 }
 
 void ButtonThread::userButtonPressedLongStart()

--- a/src/ButtonThread.h
+++ b/src/ButtonThread.h
@@ -22,6 +22,7 @@ class ButtonThread : public concurrency::OSThread
 
     ButtonThread();
     int32_t runOnce() override;
+    void handleMultiPress();
 
   private:
 #ifdef BUTTON_PIN
@@ -40,12 +41,15 @@ class ButtonThread : public concurrency::OSThread
     // set during IRQ
     static volatile ButtonEventType btnEvent;
 
+    // Store click count during callback, for later use
+    volatile int multipressClickCount;
+
     static void wakeOnIrq(int irq, int mode);
 
     // IRQ callbacks
     static void userButtonPressed() { btnEvent = BUTTON_EVENT_PRESSED; }
     static void userButtonDoublePressed() { btnEvent = BUTTON_EVENT_DOUBLE_PRESSED; }
-    static void userButtonMultiPressed() { btnEvent = BUTTON_EVENT_MULTI_PRESSED; }
+    static void userButtonMultiPressed(void *callerThread); // Retrieve click count from non-static Onebutton while still valid
     static void userButtonPressedLongStart();
     static void userButtonPressedLongStop();
     static void touchPressedLongStart() { btnEvent = BUTTON_EVENT_TOUCH_LONG_PRESSED; }

--- a/src/ButtonThread.h
+++ b/src/ButtonThread.h
@@ -17,7 +17,8 @@ class ButtonThread : public concurrency::OSThread
         BUTTON_EVENT_MULTI_PRESSED,
         BUTTON_EVENT_LONG_PRESSED,
         BUTTON_EVENT_LONG_RELEASED,
-        BUTTON_EVENT_TOUCH_PRESSED
+        BUTTON_EVENT_TOUCH_LONG_PRESSED,
+        BUTTON_EVENT_TOUCH_LONG_RELEASED,
     };
 
     ButtonThread();
@@ -32,6 +33,7 @@ class ButtonThread : public concurrency::OSThread
 #endif
 #ifdef BUTTON_PIN_TOUCH
     OneButton userButtonTouch;
+    bool touchModifier = false;
 #endif
 #if defined(ARCH_PORTDUINO)
     OneButton userButton;
@@ -43,7 +45,8 @@ class ButtonThread : public concurrency::OSThread
     static void wakeOnIrq(int irq, int mode);
 
     // IRQ callbacks
-    static void touchPressed() { btnEvent = BUTTON_EVENT_TOUCH_PRESSED; }
+    static void touchPressedLongStart() { btnEvent = BUTTON_EVENT_TOUCH_LONG_PRESSED; }
+    static void touchPressedLongStop() { btnEvent = BUTTON_EVENT_TOUCH_LONG_RELEASED; }
     static void userButtonPressed() { btnEvent = BUTTON_EVENT_PRESSED; }
     static void userButtonDoublePressed() { btnEvent = BUTTON_EVENT_DOUBLE_PRESSED; }
     static void userButtonMultiPressed() { btnEvent = BUTTON_EVENT_MULTI_PRESSED; }

--- a/src/ButtonThread.h
+++ b/src/ButtonThread.h
@@ -18,7 +18,6 @@ class ButtonThread : public concurrency::OSThread
         BUTTON_EVENT_LONG_PRESSED,
         BUTTON_EVENT_LONG_RELEASED,
         BUTTON_EVENT_TOUCH_LONG_PRESSED,
-        BUTTON_EVENT_TOUCH_LONG_RELEASED,
     };
 
     ButtonThread();
@@ -33,7 +32,6 @@ class ButtonThread : public concurrency::OSThread
 #endif
 #ifdef BUTTON_PIN_TOUCH
     OneButton userButtonTouch;
-    bool touchModifier = false;
 #endif
 #if defined(ARCH_PORTDUINO)
     OneButton userButton;
@@ -45,11 +43,10 @@ class ButtonThread : public concurrency::OSThread
     static void wakeOnIrq(int irq, int mode);
 
     // IRQ callbacks
-    static void touchPressedLongStart() { btnEvent = BUTTON_EVENT_TOUCH_LONG_PRESSED; }
-    static void touchPressedLongStop() { btnEvent = BUTTON_EVENT_TOUCH_LONG_RELEASED; }
     static void userButtonPressed() { btnEvent = BUTTON_EVENT_PRESSED; }
     static void userButtonDoublePressed() { btnEvent = BUTTON_EVENT_DOUBLE_PRESSED; }
     static void userButtonMultiPressed() { btnEvent = BUTTON_EVENT_MULTI_PRESSED; }
     static void userButtonPressedLongStart();
     static void userButtonPressedLongStop();
+    static void touchPressedLongStart() { btnEvent = BUTTON_EVENT_TOUCH_LONG_PRESSED; }
 };

--- a/src/ButtonThread.h
+++ b/src/ButtonThread.h
@@ -42,7 +42,7 @@ class ButtonThread : public concurrency::OSThread
     static volatile ButtonEventType btnEvent;
 
     // Store click count during callback, for later use
-    volatile int multipressClickCount;
+    volatile int multipressClickCount = 0;
 
     static void wakeOnIrq(int irq, int mode);
 

--- a/src/ButtonThread.h
+++ b/src/ButtonThread.h
@@ -22,7 +22,7 @@ class ButtonThread : public concurrency::OSThread
 
     ButtonThread();
     int32_t runOnce() override;
-    void handleMultiPress();
+    void storeClickCount();
 
   private:
 #ifdef BUTTON_PIN

--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -20,7 +20,7 @@ class Screen
     void setOn(bool) {}
     void print(const char *) {}
     void doDeepSleep() {}
-    void forceDisplay() {}
+    void forceDisplay(bool forceUiUpdate = false) {}
     void startBluetoothPinScreen(uint32_t pin) {}
     void stopBluetoothPinScreen() {}
     void startRebootScreen() {}
@@ -318,7 +318,7 @@ class Screen : public concurrency::OSThread
     int handleInputEvent(const InputEvent *arg);
 
     /// Used to force (super slow) eink displays to draw critical frames
-    void forceDisplay();
+    void forceDisplay(bool forceUiUpdate = false);
 
     /// Draws our SSL cert screen during boot (called from WebServer)
     void setSSLFrames();


### PR DESCRIPTION
Addresses https://github.com/meshtastic/firmware/issues/3533

* Ensure E-Ink display updates after "adhoc ping" or "toggle GPS"

* Touch button wakes screen, disables screensaver (Includes TFT / OLED. Should narrow scope?)

* Re-map buttons for T-Echo
  &nbsp; | <nobr>Send Adhoc Ping</nobr> | <nobr>Toggle Backlight</nobr> | <nobr>Exit `stateDARK`</nobr> | <nobr>Force display update</nobr>
  ---|---|---|---|---
  Previous | Double Press (*user button*) | Double Press (*user button*) | -- | Press (*touch button*)
  New | Double Press (*user button*) | Hold (*touch button*) <br /> + Double Press (*user button*) | Press (*touch button*) | Press (*touch button*)

  Intent is to separate "adhoc ping" and "toggle backlight" behaviors.

___

I vaguely remember reading a comment that T-Echo touch has a hardware issue, where LoRa TX consistently triggers the touch button. I did not observe any cases of this during testing, but if would be good to hear from anyone who has more information.