### PR TITLE
Detect USB power on Heltec boards

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -330,6 +330,20 @@ class AnalogBatteryLevel : public HasBatteryLevel
             return true;
         }
         // if it's not HIGH - check the battery
+#elif defined(EXT_POWER_DETECT_CP2102)
+        bool rxHeldHigh = false;
+
+        // Check (several times) to see if UART RX is held HIGH
+        // CP2102 is powered by VCC_5V. If unpowered, pin is LOW
+        for (uint8_t i; i < 3; i++) {
+            if (digitalRead(RX) == HIGH) {
+                rxHeldHigh = true;
+                break;
+            }
+            delay(10);
+        }
+
+        return rxHeldHigh;
 #endif
 
         return getBattVoltage() > chargingVolt;

--- a/variants/heltec_v3/variant.h
+++ b/variants/heltec_v3/variant.h
@@ -1,5 +1,8 @@
 #define LED_PIN LED
 
+// Power Management
+#define EXT_POWER_DETECT_CP2102
+
 #define RESET_OLED RST_OLED
 #define I2C_SDA SDA_OLED // I2C pins for this board
 #define I2C_SCL SCL_OLED

--- a/variants/heltec_wireless_paper/variant.h
+++ b/variants/heltec_wireless_paper/variant.h
@@ -1,5 +1,8 @@
 #define LED_PIN 18
 
+// Power Management
+#define EXT_POWER_DETECT_CP2102
+
 // Enable bus for external periherals
 #define I2C_SDA SDA
 #define I2C_SCL SCL

--- a/variants/heltec_wireless_paper_v1/variant.h
+++ b/variants/heltec_wireless_paper_v1/variant.h
@@ -1,5 +1,8 @@
 #define LED_PIN 18
 
+// Power Management
+#define EXT_POWER_DETECT_CP2102
+
 // Enable bus for external periherals
 #define I2C_SDA SDA
 #define I2C_SCL SCL

--- a/variants/heltec_wsl_v3/variant.h
+++ b/variants/heltec_wsl_v3/variant.h
@@ -3,6 +3,9 @@
 
 #define LED_PIN LED
 
+// Power Management
+#define EXT_POWER_DETECT_CP2102
+
 #define HAS_SCREEN 0
 
 #define VEXT_ENABLE Vext // active low, powers the oled display and the lora antenna boost


### PR DESCRIPTION
Implements a novel method for detecting USB power, on some Heltec devices which currently lack the ability.

These boards use a CP2102 USB to UART bridge. This IC is powered with `VCC_5V`, which is only supplied by USB. When USB is connected, and CP2102 is powered, it holds its TX pin HIGH (3.3V), as expected for UART. When USB is disconnected, and CP2102 is unpowered, its TX pin consistently reads LOW.

When `isVbusIn()` runs, it takes three digital readings of the MCU's UART RX pin, spaced 10ms apart. This is at attempt to avoid false negatives, in case CP2012 *is* powered, but MCU's RX pin is LOW due to a transmission in progress.

These readings do not seem to disrupt UART transmission, but if anyone has specific knowledge of this area and has concerns, please do comment.

Tested with Heltec Wireless Paper.
After reviewing the schematics, I am assuming that this technique is applicable to (and suggesting implementing for) the following variants:
* Heltec Wireless Paper
* Heltec V3
* Heltec Wireless Stick Lite V3