### PR TITLE
Only set NodeNum based on MAC if it's still zero

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -517,11 +517,12 @@ void NodeDB::installDefaultDeviceState()
  */
 void NodeDB::pickNewNodeNum()
 {
-
-    getMacAddr(ourMacAddr); // Make sure ourMacAddr is set
-
-    // Pick an initial nodenum based on the macaddr
-    NodeNum nodeNum = (ourMacAddr[2] << 24) | (ourMacAddr[3] << 16) | (ourMacAddr[4] << 8) | ourMacAddr[5];
+    NodeNum nodeNum = myNodeInfo.my_node_num;
+    if (nodeNum == 0) {
+        getMacAddr(ourMacAddr); // Make sure ourMacAddr is set
+        // Pick an initial nodenum based on the macaddr
+        NodeNum nodeNum = (ourMacAddr[2] << 24) | (ourMacAddr[3] << 16) | (ourMacAddr[4] << 8) | ourMacAddr[5];
+    }
 
     meshtastic_NodeInfoLite *found;
     while ((nodeNum == NODENUM_BROADCAST || nodeNum < NUM_RESERVED) ||

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -521,7 +521,7 @@ void NodeDB::pickNewNodeNum()
     if (nodeNum == 0) {
         getMacAddr(ourMacAddr); // Make sure ourMacAddr is set
         // Pick an initial nodenum based on the macaddr
-        NodeNum nodeNum = (ourMacAddr[2] << 24) | (ourMacAddr[3] << 16) | (ourMacAddr[4] << 8) | ourMacAddr[5];
+        nodeNum = (ourMacAddr[2] << 24) | (ourMacAddr[3] << 16) | (ourMacAddr[4] << 8) | ourMacAddr[5];
     }
 
     meshtastic_NodeInfoLite *found;


### PR DESCRIPTION
Seems there is a batch of RAK4631 going around that have (nearly) the same MAC address, causing nodes to choose a random new NodeNum when it detects another in its DB. However, it's currently doing this at every reboot: https://meshtastic.discourse.group/t/android-app-duplicate-nodes/11806 

This reverts this piece of code to the original behaviour before it was removed in a failed attempt (#2567) to fix the "nodeNum = 4" issue.
