### PR TITLE
Fix button interrupt after light sleep

### DIFF
--- a/src/ButtonThread.cpp
+++ b/src/ButtonThread.cpp
@@ -221,7 +221,6 @@ void ButtonThread::attachButtonInterrupts()
     attachInterrupt(
         config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN,
         []() {
-            LOG_DEBUG("Interrupt: user button\n");
             BaseType_t higherWake = 0;
             mainDelay.interruptFromISR(&higherWake);
             ButtonThread::userButton.tick();

--- a/src/ButtonThread.cpp
+++ b/src/ButtonThread.cpp
@@ -23,9 +23,12 @@
 
 using namespace concurrency;
 
-ButtonThread *buttonThread;         // Declared extern in header
-OneButton ButtonThread::userButton; // Get reference to static member
+ButtonThread *buttonThread; // Declared extern in header
 volatile ButtonThread::ButtonEventType ButtonThread::btnEvent = ButtonThread::BUTTON_EVENT_NONE;
+
+#if defined(BUTTON_PIN) || defined(ARCH_PORTDUINO)
+OneButton ButtonThread::userButton; // Get reference to static member
+#endif
 
 ButtonThread::ButtonThread() : OSThread("Button")
 {
@@ -44,6 +47,8 @@ ButtonThread::ButtonThread() : OSThread("Button")
     // Some platforms (nrf52) have a SENSE variant which allows wake from sleep - override what OneButton did
     pinMode(pin, INPUT_PULLUP_SENSE);
 #endif
+
+#if defined(BUTTON_PIN) || defined(ARCH_PORTDUINO)
     userButton.attachClick(userButtonPressed);
     userButton.setClickMs(250);
     userButton.setPressMs(c_longPressTime);
@@ -53,6 +58,7 @@ ButtonThread::ButtonThread() : OSThread("Button")
 #ifndef T_DECK // T-Deck immediately wakes up after shutdown, so disable this function
     userButton.attachLongPressStart(userButtonPressedLongStart);
     userButton.attachLongPressStop(userButtonPressedLongStop);
+#endif
 #endif
 
 #ifdef BUTTON_PIN_ALT

--- a/src/ButtonThread.cpp
+++ b/src/ButtonThread.cpp
@@ -23,6 +23,7 @@
 
 using namespace concurrency;
 
+ButtonThread *buttonThread;         // Declared extern in header
 volatile ButtonThread::ButtonEventType ButtonThread::btnEvent = ButtonThread::BUTTON_EVENT_NONE;
 
 ButtonThread::ButtonThread() : OSThread("Button")

--- a/src/ButtonThread.cpp
+++ b/src/ButtonThread.cpp
@@ -32,13 +32,15 @@ OneButton ButtonThread::userButton; // Get reference to static member
 
 ButtonThread::ButtonThread() : OSThread("Button")
 {
+#if defined(BUTTON_PIN) || defined(ARCH_PORTDUINO)
+    int pin = config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN; // Resolved button pin
+
 #if defined(ARCH_PORTDUINO)
     if (settingsMap.count(user) != 0 && settingsMap[user] != RADIOLIB_NC) {
         this->userButton = OneButton(settingsMap[user], true, true);
         LOG_DEBUG("Using GPIO%02d for button\n", settingsMap[user]);
     }
 #elif defined(BUTTON_PIN)
-    int pin = config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN;
     this->userButton = OneButton(pin, true, true);
     LOG_DEBUG("Using GPIO%02d for button\n", pin);
 #endif
@@ -83,6 +85,7 @@ ButtonThread::ButtonThread() : OSThread("Button")
 #endif
 
     attachButtonInterrupts();
+#endif
 }
 
 int32_t ButtonThread::runOnce()

--- a/src/ButtonThread.cpp
+++ b/src/ButtonThread.cpp
@@ -33,7 +33,6 @@ OneButton ButtonThread::userButton; // Get reference to static member
 ButtonThread::ButtonThread() : OSThread("Button")
 {
 #if defined(BUTTON_PIN) || defined(ARCH_PORTDUINO)
-    int pin = config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN; // Resolved button pin
 
 #if defined(ARCH_PORTDUINO)
     if (settingsMap.count(user) != 0 && settingsMap[user] != RADIOLIB_NC) {
@@ -41,6 +40,7 @@ ButtonThread::ButtonThread() : OSThread("Button")
         LOG_DEBUG("Using GPIO%02d for button\n", settingsMap[user]);
     }
 #elif defined(BUTTON_PIN)
+    int pin = config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN; // Resolved button pin
     this->userButton = OneButton(pin, true, true);
     LOG_DEBUG("Using GPIO%02d for button\n", pin);
 #endif

--- a/src/ButtonThread.h
+++ b/src/ButtonThread.h
@@ -27,7 +27,7 @@ class ButtonThread : public concurrency::OSThread
     void storeClickCount();
 
   private:
-#ifdef BUTTON_PIN
+#if defined(BUTTON_PIN) || defined(ARCH_PORTDUINO)
     static OneButton userButton; // Static - accessed from an interrupt
 #endif
 #ifdef BUTTON_PIN_ALT
@@ -35,9 +35,6 @@ class ButtonThread : public concurrency::OSThread
 #endif
 #ifdef BUTTON_PIN_TOUCH
     OneButton userButtonTouch;
-#endif
-#if defined(ARCH_PORTDUINO)
-    OneButton userButton;
 #endif
 
     // set during IRQ

--- a/src/ButtonThread.h
+++ b/src/ButtonThread.h
@@ -22,11 +22,13 @@ class ButtonThread : public concurrency::OSThread
 
     ButtonThread();
     int32_t runOnce() override;
+    void attachButtonInterrupts();
+    void detachButtonInterrupts();
     void storeClickCount();
 
   private:
 #ifdef BUTTON_PIN
-    OneButton userButton;
+    static OneButton userButton; // Static - accessed from an interrupt
 #endif
 #ifdef BUTTON_PIN_ALT
     OneButton userButtonAlt;

--- a/src/ButtonThread.h
+++ b/src/ButtonThread.h
@@ -54,3 +54,5 @@ class ButtonThread : public concurrency::OSThread
     static void userButtonPressedLongStop();
     static void touchPressedLongStart() { btnEvent = BUTTON_EVENT_TOUCH_LONG_PRESSED; }
 };
+
+extern ButtonThread *buttonThread;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -188,9 +188,6 @@ uint32_t timeLastPowered = 0;
 
 static Periodic *ledPeriodic;
 static OSThread *powerFSMthread;
-#if HAS_BUTTON || defined(ARCH_PORTDUINO)
-static OSThread *buttonThread;
-#endif
 static OSThread *accelerometerThread;
 static OSThread *ambientLightingThread;
 SPISettings spiSettings(4000000, MSBFIRST, SPI_MODE0);

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -4,6 +4,7 @@
 #include "GPS.h"
 #endif
 
+#include "ButtonThread.h"
 #include "MeshRadio.h"
 #include "MeshService.h"
 #include "NodeDB.h"
@@ -337,7 +338,10 @@ esp_sleep_wakeup_cause_t doLightSleep(uint64_t sleepMsec) // FIXME, use a more r
 #ifdef BUTTON_PIN
     // The enableLoraInterrupt() method is using ext0_wakeup, so we are forced to use GPIO wakeup
     gpio_num_t pin = (gpio_num_t)(config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN);
-    gpio_intr_disable(pin);
+
+    // Have to *fully* detach the normal button-interrupts first
+    buttonThread->detachButtonInterrupts();
+
     gpio_wakeup_enable(pin, GPIO_INTR_LOW_LEVEL);
     esp_sleep_enable_gpio_wakeup();
 #endif
@@ -364,9 +368,9 @@ esp_sleep_wakeup_cause_t doLightSleep(uint64_t sleepMsec) // FIXME, use a more r
     assert(res == ESP_OK);
 
 #ifdef BUTTON_PIN
+    // Disable wake-on-button interrupt. Re-attach normal button-interrupts
     gpio_wakeup_disable(pin);
-    // Would have thought that need gpio_intr_enable() here, but nope..
-    // Works fine without it; crashes with it.
+    buttonThread->attachButtonInterrupts();
 #endif
 
     esp_sleep_wakeup_cause_t cause = esp_sleep_get_wakeup_cause();


### PR DESCRIPTION
In collaboration with @mverch67 

Addresses issues created by https://github.com/meshtastic/firmware/pull/3521: user-button interrupt causes crash after `gpio_wakeup_enable` is used in [sleep.cpp](https://github.com/meshtastic/firmware/blob/fcab20fb3bb0d32ab0630c83d7750bebca1e91b9/src/sleep.cpp#L341)