### PR TITLE
Ignore MQTT by default and then don't transmit downlink over LoRa

### DIFF
--- a/src/mesh/FloodingRouter.cpp
+++ b/src/mesh/FloodingRouter.cpp
@@ -43,7 +43,8 @@ void FloodingRouter::sniffReceived(const meshtastic_MeshPacket *p, const meshtas
     }
     if ((p->to != getNodeNum()) && (p->hop_limit > 0) && (getFrom(p) != getNodeNum())) {
         if (p->id != 0) {
-            if (config.device.role != meshtastic_Config_DeviceConfig_Role_CLIENT_MUTE) {
+            if (config.device.role != meshtastic_Config_DeviceConfig_Role_CLIENT_MUTE &&
+                !(p->via_mqtt && config.lora.ignore_mqtt)) {
                 meshtastic_MeshPacket *tosend = packetPool.allocCopy(*p); // keep a copy because we will be sending it
 
                 tosend->hop_limit--; // bump down the hop count
@@ -53,7 +54,7 @@ void FloodingRouter::sniffReceived(const meshtastic_MeshPacket *p, const meshtas
                 // We are careful not to call our hooked version of send() - because we don't want to check this again
                 Router::send(tosend);
             } else {
-                LOG_DEBUG("Not rebroadcasting. Role = Role_ClientMute\n");
+                LOG_DEBUG("Not rebroadcasting. Role = Role_ClientMute or packet came via MQTT with ignore MQTT set\n");
             }
         } else {
             LOG_DEBUG("Ignoring a simple (0 id) broadcast\n");

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -92,7 +92,7 @@ int MeshService::handleFromRadio(const meshtastic_MeshPacket *mp)
             "Received telemetry response. Skip sending our NodeInfo because this potentially a Repeater which will ignore our "
             "request for its NodeInfo.\n");
     } else if (mp->which_payload_variant == meshtastic_MeshPacket_decoded_tag && !nodeDB->getMeshNode(mp->from)->has_user &&
-               nodeInfoModule) {
+               nodeInfoModule && !(mp->via_mqtt && config.lora.ignore_mqtt)) {
         LOG_INFO("Heard a node on channel %d we don't know, sending NodeInfo and asking for a response.\n", mp->channel);
         nodeInfoModule->sendOurNodeInfo(mp->from, true, mp->channel);
     }

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -243,7 +243,7 @@ void NodeDB::installDefaultConfig()
     config.lora.region = meshtastic_Config_LoRaConfig_RegionCode_UNSET;
     config.lora.modem_preset = meshtastic_Config_LoRaConfig_ModemPreset_LONG_FAST;
     config.lora.hop_limit = HOP_RELIABLE;
-    config.lora.ignore_mqtt = false;
+    config.lora.ignore_mqtt = true;
 #ifdef PIN_GPS_EN
     config.position.gps_en_gpio = PIN_GPS_EN;
 #endif

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -452,9 +452,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c)
         if (isRegionUnset && config.lora.region > meshtastic_Config_LoRaConfig_RegionCode_UNSET) {
             config.lora.tx_enabled = true;
             initRegion();
-            if (myRegion->dutyCycle < 100) {
-                config.lora.ignore_mqtt = true; // Ignore MQTT by default if region has a duty cycle limit
-            }
+            config.lora.ignore_mqtt = true; // Ignore MQTT by default
             if (strcmp(moduleConfig.mqtt.root, default_mqtt_root) == 0) {
                 sprintf(moduleConfig.mqtt.root, "%s/%s", default_mqtt_root, myRegion->name);
                 changes = SEGMENT_CONFIG | SEGMENT_MODULECONFIG;


### PR DESCRIPTION
This implements what has been discussed up till now in https://github.com/meshtastic/rfcs/pull/9 and thus needs to be approved first.
The "ignore MQTT" LoRa setting will be enabled by default and this now also means if you have MQTT downlink enabled, it doesn't transmit these packets over LoRa. MQTT-only will work as before and if you also want your mesh to receive the downlinks, you have to explicitly disable "ignore MQTT".

Tested both that MQTT downlink works and also ignoring MQTT works as before.