### PR TITLE
fix: device PMU shutdown (part 2)

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -500,12 +500,7 @@ void Power::shutdown()
 {
     LOG_INFO("Shutting down\n");
 
-#ifdef HAS_PMU
-    if (pmu_found == true) {
-        PMU->setChargingLedMode(XPOWERS_CHG_LED_OFF);
-        PMU->shutdown();
-    }
-#elif defined(ARCH_NRF52) || defined(ARCH_ESP32)
+#if defined(ARCH_NRF52) || defined(ARCH_ESP32)
 #ifdef PIN_LED1
     ledOff(PIN_LED1);
 #endif

--- a/src/nimble/NimbleBluetooth.cpp
+++ b/src/nimble/NimbleBluetooth.cpp
@@ -113,8 +113,8 @@ void NimbleBluetooth::shutdown()
     pAdvertising->reset();
     pAdvertising->stop();
 
-#if defined(HELTEC_WIRELESS_PAPER) || defined(HELTEC_WIRELESS_PAPER_V1_0)
-    // Saving of ~1mA
+#if defined(ARCH_ESP32)
+    // Saving of ~1mA for esp32-s3 and 0.1mA for esp32
     // Probably applicable to other ESP32 boards - unverified
     NimBLEDevice::deinit();
 #endif

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -249,9 +249,11 @@ void doDeepSleep(uint32_t msecToWake, bool skipPreflight = false)
     if (shouldLoraWake(msecToWake)) {
         enableLoraInterrupt();
     }
+#ifdef BUTTON_PIN
     // Avoid leakage through button pin
     pinMode(BUTTON_PIN, INPUT);
     gpio_hold_en((gpio_num_t)BUTTON_PIN);
+#endif
 
     // LoRa CS (RADIO_NSS) needs to stay HIGH, even during deep sleep
     pinMode(LORA_CS, OUTPUT);


### PR DESCRIPTION
The shutdown for devices with PMU (tbeam, T-Watch) seems broken. E.g. a shutdown tbeam still consumes around 10mA and since #3162 the screen even stays on (showing "Shutdown...") when shutdown.

This PR fixes Power::shutdown() and redirects the PMU shutdown into the deep sleep branch to switch off all uneccesary peripherals before the pmu shutdown. 

The tbeam v1.1 deep sleep power consumption (when using the Lilygo 1.3" display) dropped from 10mA to 1mA.
