### PR TITLE
Enable T-Echo touch button by default

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -347,6 +347,9 @@ void NodeDB::installDefaultModuleConfig()
     moduleConfig.external_notification.output_ms = 100;
     moduleConfig.external_notification.active = true;
 #endif
+#ifdef TTGO_T_ECHO
+    config.display.wake_on_tap_or_motion = true; // Enable touch button for screen-on / refresh
+#endif
     moduleConfig.has_canned_message = true;
 
     strncpy(moduleConfig.mqtt.address, default_mqtt_address, sizeof(moduleConfig.mqtt.address));


### PR DESCRIPTION
By default, enable a behavior that some T-Echo have come to expect (refresh / screen wake on touch).
Touch functionality may optionally be disabling by clearing "wake on tap or motion" setting.

> Andrew VA7EKA
> — 
> Yesterday at 4:57 AM
> OK yeah cuz I touched the button on top of the T-Echo and it does nothing, which previously it would cause a refresh of the screen

> todd-herbert
> — 
> Yesterday at 5:08 AM
> Ah yeah you have to set "wake on tap or motion"