### PR TITLE
fix: UpDown CARDKB button press

### DIFF
--- a/src/input/UpDownInterruptBase.cpp
+++ b/src/input/UpDownInterruptBase.cpp
@@ -1,7 +1,7 @@
 #include "UpDownInterruptBase.h"
 #include "configuration.h"
 
-UpDownInterruptBase::UpDownInterruptBase(const char *name)
+UpDownInterruptBase::UpDownInterruptBase(const char *name) : concurrency::OSThread(name)
 {
     this->_originName = name;
 }
@@ -24,31 +24,48 @@ void UpDownInterruptBase::init(uint8_t pinDown, uint8_t pinUp, uint8_t pinPress,
     attachInterrupt(this->_pinUp, onIntUp, RISING);
 
     LOG_DEBUG("Up/down/press GPIO initialized (%d, %d, %d)\n", this->_pinUp, this->_pinDown, pinPress);
+
+    this->setInterval(100);
+}
+
+int32_t UpDownInterruptBase::runOnce()
+{
+    InputEvent e;
+    e.inputEvent = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_NONE;
+
+    if (this->action == UPDOWN_ACTION_PRESSED) {
+        LOG_DEBUG("GPIO event Press\n");
+        e.inputEvent = this->_eventPressed;
+    } else if (this->action == UPDOWN_ACTION_UP) {
+        LOG_DEBUG("GPIO event Up\n");
+        e.inputEvent = this->_eventUp;
+    } else if (this->action == UPDOWN_ACTION_DOWN) {
+        LOG_DEBUG("GPIO event Down\n");
+        e.inputEvent = this->_eventDown;
+    }
+
+    if (e.inputEvent != meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_NONE) {
+        e.source = this->_originName;
+        e.kbchar = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_NONE;
+        this->notifyObservers(&e);
+    }
+
+    this->action = UPDOWN_ACTION_NONE;
+
+    return 100;
 }
 
 void UpDownInterruptBase::intPressHandler()
 {
-    InputEvent e;
-    e.source = this->_originName;
-    LOG_DEBUG("GPIO event Press\n");
-    e.inputEvent = this->_eventPressed;
-    this->notifyObservers(&e);
+    this->action = UPDOWN_ACTION_PRESSED;
 }
 
 void UpDownInterruptBase::intDownHandler()
 {
-    InputEvent e;
-    e.source = this->_originName;
-    LOG_DEBUG("GPIO event Down\n");
-    e.inputEvent = this->_eventDown;
-    this->notifyObservers(&e);
+    this->action = UPDOWN_ACTION_DOWN;
 }
 
 void UpDownInterruptBase::intUpHandler()
 {
-    InputEvent e;
-    e.source = this->_originName;
-    LOG_DEBUG("GPIO event Up\n");
-    e.inputEvent = this->_eventUp;
-    this->notifyObservers(&e);
+    this->action = UPDOWN_ACTION_UP;
 }

--- a/src/input/UpDownInterruptBase.h
+++ b/src/input/UpDownInterruptBase.h
@@ -3,7 +3,7 @@
 #include "InputBroker.h"
 #include "mesh/NodeDB.h"
 
-class UpDownInterruptBase : public Observable<const InputEvent *>
+class UpDownInterruptBase : public Observable<const InputEvent *>, public concurrency::OSThread
 {
   public:
     explicit UpDownInterruptBase(const char *name);
@@ -12,6 +12,13 @@ class UpDownInterruptBase : public Observable<const InputEvent *>
     void intPressHandler();
     void intDownHandler();
     void intUpHandler();
+
+    int32_t runOnce() override;
+
+  protected:
+    enum UpDownInterruptBaseActionType { UPDOWN_ACTION_NONE, UPDOWN_ACTION_PRESSED, UPDOWN_ACTION_UP, UPDOWN_ACTION_DOWN };
+
+    volatile UpDownInterruptBaseActionType action = UPDOWN_ACTION_NONE;
 
   private:
     uint8_t _pinDown = 0;


### PR DESCRIPTION
fixes #3602

Note: this fix requires another OSThread, watch out if MAX_THREADS (default=32) is large enough for all devices.