### PR TITLE
Wireless Paper: Fix BLE after Lightsleep

### DIFF
--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -17,6 +17,7 @@
 #include "sleep.h"
 #include "target_specific.h"
 
+// How long between LED blinks during light-sleep
 #ifndef SLEEP_TIME
 #define SLEEP_TIME 30
 #endif
@@ -84,19 +85,27 @@ static void lsIdle()
     if (secsSlept < config.power.ls_secs) {
         // If some other service would stall sleep, don't let sleep happen yet
         if (doPreflightSleep()) {
+
+#ifdef LS_NO_BLINK
+            // Sleep now for the full duration
+            uint32_t sleepTime = config.power.ls_secs;
+#else
             // Briefly come out of sleep long enough to blink the led once every few seconds
             uint32_t sleepTime = SLEEP_TIME;
-
+#endif
             setLed(false); // Never leave led on while in light sleep
             esp_sleep_source_t wakeCause2 = doLightSleep(sleepTime * 1000LL);
 
             switch (wakeCause2) {
             case ESP_SLEEP_WAKEUP_TIMER:
-                // Normal case: timer expired, we should just go back to sleep ASAP
 
+#ifndef LS_NO_BLINK
+                // Normal case: timer expired, we should just go back to sleep ASAP
                 setLed(true);                   // briefly turn on led
                 wakeCause2 = doLightSleep(100); // leave led on for 1ms
-
+#else
+                // If LS_NO_BLINK, no action here. Mark complete (secsSlept), and handle next time lsIdle() is called
+#endif
                 secsSlept += sleepTime;
                 // LOG_INFO("sleeping, flash led!\n");
                 break;

--- a/src/nimble/NimbleBluetooth.cpp
+++ b/src/nimble/NimbleBluetooth.cpp
@@ -112,12 +112,12 @@ void NimbleBluetooth::shutdown()
     NimBLEAdvertising *pAdvertising = NimBLEDevice::getAdvertising();
     pAdvertising->reset();
     pAdvertising->stop();
+}
 
-#if defined(HELTEC_WIRELESS_PAPER) || defined(HELTEC_WIRELESS_PAPER_V1_0)
-    // Saving of ~1mA
-    // Probably applicable to other ESP32 boards - unverified
+// Extra power-saving on some devices
+void NimbleBluetooth::deinit()
+{
     NimBLEDevice::deinit();
-#endif
 }
 
 bool NimbleBluetooth::isActive()

--- a/src/nimble/NimbleBluetooth.h
+++ b/src/nimble/NimbleBluetooth.h
@@ -6,6 +6,7 @@ class NimbleBluetooth : BluetoothApi
   public:
     void setup();
     void shutdown();
+    void deinit();
     void clearBonds();
     bool isActive();
     bool isConnected();

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -206,6 +206,12 @@ void doDeepSleep(uint32_t msecToWake, bool skipPreflight = false)
     // not using wifi yet, but once we are this is needed to shutoff the radio hw
     // esp_wifi_stop();
     waitEnterSleep(skipPreflight);
+
+#ifdef NIMBLE_DEINIT_FOR_DEEPSLEEP
+    // Extra power saving on some devices
+    nimbleBluetooth->deinit();
+#endif
+
 #ifdef ARCH_ESP32
     if (shouldLoraWake(msecToWake)) {
         notifySleep.notifyObservers(NULL);

--- a/variants/heltec_wireless_paper/variant.h
+++ b/variants/heltec_wireless_paper/variant.h
@@ -55,3 +55,6 @@
 
 #define SX126X_DIO2_AS_RF_SWITCH
 #define SX126X_DIO3_TCXO_VOLTAGE 1.8
+
+// Power management
+#define NIMBLE_DEINIT_FOR_DEEPSLEEP // Required to reach manufacturers claim of 18uA

--- a/variants/heltec_wireless_paper/variant.h
+++ b/variants/heltec_wireless_paper/variant.h
@@ -58,3 +58,4 @@
 
 // Power management
 #define NIMBLE_DEINIT_FOR_DEEPSLEEP // Required to reach manufacturers claim of 18uA
+#define LS_NO_BLINK                 // Prevent LED blink during light-sleep. BLE hardware has slow current ramp-down; too wasteful

--- a/variants/heltec_wireless_paper_v1/variant.h
+++ b/variants/heltec_wireless_paper_v1/variant.h
@@ -55,3 +55,6 @@
 
 #define SX126X_DIO2_AS_RF_SWITCH
 #define SX126X_DIO3_TCXO_VOLTAGE 1.8
+
+// Power management
+#define NIMBLE_DEINIT_FOR_DEEPSLEEP // Required to reach manufacturers claim of 18uA

--- a/variants/heltec_wireless_paper_v1/variant.h
+++ b/variants/heltec_wireless_paper_v1/variant.h
@@ -58,3 +58,4 @@
 
 // Power management
 #define NIMBLE_DEINIT_FOR_DEEPSLEEP // Required to reach manufacturers claim of 18uA
+#define LS_NO_BLINK                 // Prevent LED blink during light-sleep. BLE hardware has slow current ramp-down; too wasteful


### PR DESCRIPTION
1. **Refactor NimBLE deinit**
  `NimBLEDevice::deinit()` is used with Wireless Paper to achieve low current during deep-sleep (1mA -> 18µA).
  Previously called for both deep-sleep and light-sleep. Unable to re-init BLE after light-sleep. Bluetooth broken.
  
    Changes implemented:
    * `NimBLEDevice::deinit()` called only for deep-sleep.
    * "De-init during deep-sleep" behavior now set with macro in variant.h: `NIMBLE_DEINIT_FOR_DEEPSLEEP`. Currently enabled only for Wireless Paper.

    Result: 
    *  BLE working after light-sleep
    *  Light-sleep current increased

2. **LED Blink disabled during light-sleep** (Wireless Paper only)
  Without `NimBLEDevice::deinit()`, Wireless Paper BLE hardware has a prolonged run-down. After ~30 seconds, current stabilizes at ~13mA (compared to immediate 12mA with deinit).
  Previously, light-sleep would wake every 30 seconds to blink the LED. This caused Wireless Paper to spend significant time in inefficient "run-down" phase.

    **Mean current during a light-sleep period of a given duration.**
    ![lightsleep mean current](https://github.com/meshtastic/firmware/assets/24772776/496892b3-19e7-4231-8ca5-47a90e9f59db)
    *A singe 180s sleep consumes 25% less power than  6 x 30s sleeps.*

    Changes:
    * Wireless Paper will not wake to blink LED during light-sleep.
    * New "no blink" behavior enabled with macro in variant.h: `LS_NO_BLINK`

    Result:
    * Moderate reduction in light-sleep power consumption.
