### PR TITLE
Fixed XPT2046 syntax and using unPhone library to clean up support

### DIFF
--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -564,8 +564,10 @@ void TFTDisplay::sendCommand(uint8_t com)
 #elif defined(ST7735_BL_V05)
         pinMode(ST7735_BL_V05, OUTPUT);
         digitalWrite(ST7735_BL_V05, TFT_BACKLIGHT_ON);
-#endif
-#if defined(TFT_BL) && defined(TFT_BACKLIGHT_ON)
+#elif !defined(RAK14014) && !defined(M5STACK) && !defined(UNPHONE)
+        tft->wakeup();
+        tft->powerSaveOff();
+#elif defined(TFT_BL) && defined(TFT_BACKLIGHT_ON)
         digitalWrite(TFT_BL, TFT_BACKLIGHT_ON);
 #endif
 
@@ -595,10 +597,13 @@ void TFTDisplay::sendCommand(uint8_t com)
 #elif defined(ST7735_BL_V05)
         pinMode(ST7735_BL_V05, OUTPUT);
         digitalWrite(ST7735_BL_V05, !TFT_BACKLIGHT_ON);
-#endif
-#if defined(TFT_BL) && defined(TFT_BACKLIGHT_ON)
+#elif !defined(RAK14014) && !defined(M5STACK) && !defined(UNPHONE)
+        tft->sleep();
+        tft->powerSaveOn();
+#elif defined(TFT_BL) && defined(TFT_BACKLIGHT_ON)
         digitalWrite(TFT_BL, !TFT_BACKLIGHT_ON);
 #endif
+
 #ifdef VTFT_CTRL_V03
         digitalWrite(VTFT_CTRL_V03, HIGH);
 #endif

--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -411,8 +411,7 @@ class LGFX : public lgfx::LGFX_Device
     lgfx::Panel_HX8357D _panel_instance;
     lgfx::Bus_SPI _bus_instance;
 #if defined(USE_XPT2046)
-    lgfx::ITouch *_touch_instance;
-// lgfx::Touch_XPT2046 _touch_instance;
+    lgfx::Touch_XPT2046 _touch_instance;
 #endif
 
   public:
@@ -466,8 +465,7 @@ class LGFX : public lgfx::LGFX_Device
 #if defined(USE_XPT2046)
         {
             // Configure settings for touch control.
-            _touch_instance = new lgfx::Touch_XPT2046;
-            auto touch_cfg = _touch_instance->config();
+            auto touch_cfg = _touch_instance.config();
 
             touch_cfg.pin_cs = TOUCH_CS;
             touch_cfg.x_min = 0;
@@ -478,8 +476,8 @@ class LGFX : public lgfx::LGFX_Device
             touch_cfg.bus_shared = true;
             touch_cfg.offset_rotation = 1;
 
-            _touch_instance->config(touch_cfg);
-            //_panel_instance->setTouch(_touch_instance);
+            _touch_instance.config(touch_cfg);
+            _panel_instance.setTouch(&_touch_instance);
         }
 #endif
         setPanel(&_panel_instance);
@@ -495,6 +493,11 @@ static LGFX *tft = nullptr;
 #include "SPILock.h"
 #include "TFTDisplay.h"
 #include <SPI.h>
+
+#ifdef UNPHONE
+#include "unPhone.h"
+extern unPhone unphone;
+#endif
 
 TFTDisplay::TFTDisplay(uint8_t address, int sda, int scl, OLEDDISPLAY_GEOMETRY geometry, HW_I2C i2cBus)
 {
@@ -561,10 +564,8 @@ void TFTDisplay::sendCommand(uint8_t com)
 #elif defined(ST7735_BL_V05)
         pinMode(ST7735_BL_V05, OUTPUT);
         digitalWrite(ST7735_BL_V05, TFT_BACKLIGHT_ON);
-#elif !defined(RAK14014) && !defined(M5STACK) && !defined(UNPHONE)
-        tft->wakeup();
-        tft->powerSaveOff();
-#elif defined(TFT_BL) && defined(TFT_BACKLIGHT_ON)
+#endif
+#if defined(TFT_BL) && defined(TFT_BACKLIGHT_ON)
         digitalWrite(TFT_BL, TFT_BACKLIGHT_ON);
 #endif
 
@@ -576,11 +577,7 @@ void TFTDisplay::sendCommand(uint8_t com)
         digitalWrite(VTFT_CTRL, LOW);
 #endif
 #ifdef UNPHONE
-        Wire.beginTransmission(0x26);
-        Wire.write(0x02);
-        Wire.write(0x04); // Backlight on
-        Wire.write(0x22); // G&B LEDs off
-        Wire.endTransmission();
+        unphone.backlight(true); // using unPhone library
 #endif
 #ifdef RAK14014
 #elif !defined(M5STACK)
@@ -598,13 +595,10 @@ void TFTDisplay::sendCommand(uint8_t com)
 #elif defined(ST7735_BL_V05)
         pinMode(ST7735_BL_V05, OUTPUT);
         digitalWrite(ST7735_BL_V05, !TFT_BACKLIGHT_ON);
-#elif !defined(RAK14014) && !defined(M5STACK) && !defined(UNPHONE)
-        tft->sleep();
-        tft->powerSaveOn();
-#elif defined(TFT_BL) && defined(TFT_BACKLIGHT_ON)
+#endif
+#if defined(TFT_BL) && defined(TFT_BACKLIGHT_ON)
         digitalWrite(TFT_BL, !TFT_BACKLIGHT_ON);
 #endif
-
 #ifdef VTFT_CTRL_V03
         digitalWrite(VTFT_CTRL_V03, HIGH);
 #endif
@@ -612,11 +606,7 @@ void TFTDisplay::sendCommand(uint8_t com)
         digitalWrite(VTFT_CTRL, HIGH);
 #endif
 #ifdef UNPHONE
-        Wire.beginTransmission(0x26);
-        Wire.write(0x02);
-        Wire.write(0x00); // Backlight off
-        Wire.write(0x22); // G&B LEDs off
-        Wire.endTransmission();
+        unphone.backlight(false); // using unPhone library
 #endif
 #ifdef RAK14014
 #elif !defined(M5STACK)
@@ -690,11 +680,7 @@ bool TFTDisplay::connect()
     digitalWrite(ST7735_BL_V05, TFT_BACKLIGHT_ON);
 #endif
 #ifdef UNPHONE
-    Wire.beginTransmission(0x26);
-    Wire.write(0x02);
-    Wire.write(0x04); // Backlight on
-    Wire.write(0x22); // G&B LEDs off
-    Wire.endTransmission();
+    unphone.backlight(true); // using unPhone library
     LOG_INFO("Power to TFT Backlight\n");
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -590,20 +590,6 @@ void setup()
     if (config.display.oled != meshtastic_Config_DisplayConfig_OledType_OLED_AUTO)
         screen_model = config.display.oled;
 
-#ifdef UNPHONE
-    // initialise IO expander with pinmodes
-    Wire.beginTransmission(0x26);
-    Wire.write(0x06);
-    Wire.write(0x7A);
-    Wire.write(0xDD);
-    Wire.endTransmission();
-    Wire.beginTransmission(0x26);
-    Wire.write(0x02);
-    Wire.write(0x04); // Backlight on
-    Wire.write(0x22); // G&B LEDs off
-    Wire.endTransmission();
-#endif
-
 #if defined(USE_SH1107)
     screen_model = meshtastic_Config_DisplayConfig_OledType_OLED_SH1107; // set dimension of 128x128
     display_geometry = GEOMETRY_128_128;

--- a/variants/unphone/platformio.ini
+++ b/variants/unphone/platformio.ini
@@ -1,5 +1,7 @@
+; platformio.ini for unphone meshtastic
+
 [env:unphone]
-;build_type = debug ; to make it possible to step through our jtag debugger 
+
 extends = esp32s3_base
 board_level = extra
 board = unphone9
@@ -14,6 +16,15 @@ build_flags = ${esp32_base.build_flags}
   -D UNPHONE
   -I variants/unphone
   -D ARDUINO_USB_MODE=0
+  -D UNPHONE_ACCEL=0
+  -D UNPHONE_TOUCHS=0
+  -D UNPHONE_SDCARD=0
+  -D UNPHONE_UI0=0
+  -D UNPHONE_LORA=0
+  -D UNPHONE_FACTORY_MODE=0
+
+build_src_filter = ${esp32_base.build_src_filter} +<../variants/unphone>
 
 lib_deps = ${esp32s3_base.lib_deps}
-  lovyan03/LovyanGFX@^1.1.8
+  lovyan03/LovyanGFX                                   @ ^1.1.8
+  https://gitlab.com/hamishcunningham/unphonelibrary#meshtastic   @ ^9.0.0

--- a/variants/unphone/variant.cpp
+++ b/variants/unphone/variant.cpp
@@ -1,0 +1,20 @@
+// meshtastic/firmware/variants/unphone/variant.cpp
+
+#include "unPhone.h"
+unPhone unphone = unPhone("meshtastic_unphone");
+
+void initVariant()
+{
+    unphone.begin(); // initialise hardware etc.
+    unphone.store(unphone.buildTime);
+    unphone.printWakeupReason(); // what woke us up? (stored, not printed :|)
+    unphone.checkPowerSwitch();  // if power switch is off, shutdown
+    unphone.backlight(false);    // setup backlight and make sure its off
+
+    for (int i = 0; i < 3; i++) { // buzz a bit
+        unphone.vibe(true);
+        delay(150);
+        unphone.vibe(false);
+        delay(150);
+    }
+}

--- a/variants/unphone/variant.h
+++ b/variants/unphone/variant.h
@@ -1,3 +1,7 @@
+// meshtastic/firmware/variants/unphone/variant.h
+
+#pragma once
+
 #define SPI_SCK 39
 #define SPI_MOSI 40
 #define SPI_MISO 41
@@ -28,7 +32,7 @@
 #define TFT_WIDTH 320
 #define TFT_OFFSET_X 0
 #define TFT_OFFSET_Y 0
-#define TFT_OFFSET_ROTATION 6 // the unPhone's screen is wired unusually, 0 is typical value here
+#define TFT_OFFSET_ROTATION 6 // unPhone's screen wired unusually, 0 typical
 #define TFT_INVERT false
 #define SCREEN_ROTATE true
 #define SCREEN_TRANSITION_FRAMERATE 5
@@ -37,7 +41,10 @@
 #define USE_XPT2046 1
 #define TOUCH_CS 38
 
-#define HAS_GPS 0 // the unphone doesn't have a gps module
+#define HAS_GPS                                                                                                                  \
+    0 // the unphone doesn't have a gps module by default (though
+      // GPS featherwing -- https://www.adafruit.com/product/3133
+      // -- can be added)
 #undef GPS_RX_PIN
 #undef GPS_TX_PIN
 
@@ -49,6 +56,7 @@
 
 #define BUTTON_PIN 21      // Button 3 - square - top button in landscape mode
 #define BUTTON_NEED_PULLUP // we do need a helping hand up
+#define BUTTON_PIN_ALT 45  // Button 1 - triangle - bottom button in landscape mode
 
 #define I2C_SDA 3 // I2C pins for this board
 #define I2C_SCL 4
@@ -58,6 +66,6 @@
 // ratio of voltage divider = 3.20 (R1=100k, R2=220k)
 // #define ADC_MULTIPLIER 3.2
 
-// #define BATTERY_PIN 13 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
+// #define BATTERY_PIN 13 // battery V measurement pin; vbat divider is here
 // #define ADC_CHANNEL ADC2_GPIO13_CHANNEL
 // #define BAT_MEASURE_ADC_UNIT 2


### PR DESCRIPTION
This PR just tidies up support for the unPhone by using its [library](https://gitlab.com/hamishcunningham/unphonelibrary)

Also fixes incomplete syntax for the touchscreen driver invocation for XPT2046 when attached to a HX8357.