### PR TITLE
No more power-state messages printed to screen (?)

### DIFF
--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -185,10 +185,12 @@ static void powerEnter()
         screen->setOn(true);
         setBluetoothEnable(true);
         // within enter() the function getState() returns the state we came from
-        if (strcmp(powerFSM.getState()->name, "BOOT") != 0 && strcmp(powerFSM.getState()->name, "POWER") != 0 &&
+
+        // Mothballed: print change of power-state to device screen
+        /* if (strcmp(powerFSM.getState()->name, "BOOT") != 0 && strcmp(powerFSM.getState()->name, "POWER") != 0 &&
             strcmp(powerFSM.getState()->name, "DARK") != 0) {
             screen->print("Powered...\n");
-        }
+        }*/
     }
 }
 
@@ -205,8 +207,10 @@ static void powerExit()
 {
     screen->setOn(true);
     setBluetoothEnable(true);
-    if (!isPowered())
-        screen->print("Unpowered...\n");
+
+    // Mothballed: print change of power-state to device screen
+    /*if (!isPowered())
+        screen->print("Unpowered...\n");*/
 }
 
 static void onEnter()


### PR DESCRIPTION
Suggestion: remove code which prints "Powered.." and "Unpowered.." to device screens.

This pull-request is submitted as "very much open for discussion".

Several days ago, on the discord server, there was a small discussion about the usefulness of these message. The shared opinion was that they may not be particularly useful to users, and that they have a tendency to appear at somewhat arbitrary times.

If anyone has an attachment to this feature, or feels that they have an important use, it would be good to hear from you!