### PR TITLE
Cosmetics: rename remaining plugins → modules and less errors

### DIFF
--- a/src/mesh/MeshModule.cpp
+++ b/src/mesh/MeshModule.cpp
@@ -12,7 +12,7 @@ const meshtastic_MeshPacket *MeshModule::currentRequest;
 
 /**
  * If any of the current chain of modules has already sent a reply, it will be here.  This is useful to allow
- * the RoutingPlugin to avoid sending redundant acks
+ * the RoutingModule to avoid sending redundant acks
  */
 meshtastic_MeshPacket *MeshModule::currentReply;
 
@@ -40,7 +40,7 @@ meshtastic_MeshPacket *MeshModule::allocAckNak(meshtastic_Routing_Error err, Nod
     c.error_reason = err;
     c.which_variant = meshtastic_Routing_error_reason_tag;
 
-    // Now that we have moded sendAckNak up one level into the class hierarchy we can no longer assume we are a RoutingPlugin
+    // Now that we have moded sendAckNak up one level into the class hierarchy we can no longer assume we are a RoutingModule
     // So we manually call pb_encode_to_bytes and specify routing port number
     // auto p = allocDataProtobuf(c);
     meshtastic_MeshPacket *p = router->allocForSending();
@@ -54,7 +54,8 @@ meshtastic_MeshPacket *MeshModule::allocAckNak(meshtastic_Routing_Error err, Nod
     p->to = to;
     p->decoded.request_id = idFrom;
     p->channel = chIndex;
-    LOG_ERROR("Alloc an err=%d,to=0x%x,idFrom=0x%x,id=0x%x\n", err, to, idFrom, p->id);
+    if (err != meshtastic_Routing_Error_NONE)
+        LOG_ERROR("Alloc an err=%d,to=0x%x,idFrom=0x%x,id=0x%x\n", err, to, idFrom, p->id);
 
     return p;
 }
@@ -68,7 +69,7 @@ meshtastic_MeshPacket *MeshModule::allocErrorResponse(meshtastic_Routing_Error e
     return r;
 }
 
-void MeshModule::callPlugins(meshtastic_MeshPacket &mp, RxSource src)
+void MeshModule::callModules(meshtastic_MeshPacket &mp, RxSource src)
 {
     // LOG_DEBUG("In call modules\n");
     bool moduleFound = false;
@@ -258,7 +259,7 @@ void MeshModule::observeUIEvents(Observer<const UIFrameEvent *> *observer)
     }
 }
 
-AdminMessageHandleResult MeshModule::handleAdminMessageForAllPlugins(const meshtastic_MeshPacket &mp,
+AdminMessageHandleResult MeshModule::handleAdminMessageForAllModules(const meshtastic_MeshPacket &mp,
                                                                      meshtastic_AdminMessage *request,
                                                                      meshtastic_AdminMessage *response)
 {

--- a/src/mesh/MeshModule.h
+++ b/src/mesh/MeshModule.h
@@ -64,11 +64,11 @@ class MeshModule
 
     /** For use only by MeshService
      */
-    static void callPlugins(meshtastic_MeshPacket &mp, RxSource src = RX_SRC_RADIO);
+    static void callModules(meshtastic_MeshPacket &mp, RxSource src = RX_SRC_RADIO);
 
     static std::vector<MeshModule *> GetMeshModulesWithUIFrames();
     static void observeUIEvents(Observer<const UIFrameEvent *> *observer);
-    static AdminMessageHandleResult handleAdminMessageForAllPlugins(const meshtastic_MeshPacket &mp,
+    static AdminMessageHandleResult handleAdminMessageForAllModules(const meshtastic_MeshPacket &mp,
                                                                     meshtastic_AdminMessage *request,
                                                                     meshtastic_AdminMessage *response);
 #if HAS_SCREEN

--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -215,7 +215,7 @@ bool RF95Interface::isChannelActive()
         // LOG_DEBUG("Channel is busy!\n");
         return true;
     }
-    if (result != RADIOLIB_ERR_WRONG_MODEM)
+    if (result != RADIOLIB_CHANNEL_FREE)
         LOG_ERROR("Radiolib error %d when attempting RF95 isChannelActive!\n", result);
     assert(result != RADIOLIB_ERR_WRONG_MODEM);
 

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -479,7 +479,7 @@ void Router::handleReceived(meshtastic_MeshPacket *p, RxSource src)
 
     // call modules here
     if (!skipHandle)
-        MeshModule::callPlugins(*p, src);
+        MeshModule::callModules(*p, src);
 }
 
 void Router::perhapsHandleReceived(meshtastic_MeshPacket *p)

--- a/src/mesh/SX128xInterface.cpp
+++ b/src/mesh/SX128xInterface.cpp
@@ -280,7 +280,7 @@ template <typename T> bool SX128xInterface<T>::isChannelActive()
     result = lora.scanChannel();
     if (result == RADIOLIB_LORA_DETECTED)
         return true;
-    if (result != RADIOLIB_ERR_WRONG_MODEM)
+    if (result != RADIOLIB_CHANNEL_FREE)
         LOG_ERROR("Radiolib error %d when attempting SX128X scanChannel!\n", result);
     assert(result != RADIOLIB_ERR_WRONG_MODEM);
 

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -256,7 +256,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
 
     default:
         meshtastic_AdminMessage res = meshtastic_AdminMessage_init_default;
-        AdminMessageHandleResult handleResult = MeshModule::handleAdminMessageForAllPlugins(mp, r, &res);
+        AdminMessageHandleResult handleResult = MeshModule::handleAdminMessageForAllModules(mp, r, &res);
 
         if (handleResult == AdminMessageHandleResult::HANDLED_WITH_RESPONSE) {
             myReply = allocDataProtobuf(res);


### PR DESCRIPTION
- Found some remaining references to "Plugin", which I renamed to "Modules". 
- An implicit ACK is not an error, so let's not print that (it will print "generating implicit ack" before that).
- Also for SX128x and SX127x, `CHANNEL_FREE` result is not an error.
