### PR TITLE
Added one minute throttling to NodeDB save to disk

### DIFF
--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -2,6 +2,7 @@
 #include <NodeDB.h>
 #include <cstdint>
 #define ONE_DAY 24 * 60 * 60
+#define ONE_MINUTE_MS 60 * 1000
 
 #define default_gps_update_interval IF_ROUTER(ONE_DAY, 2 * 60)
 #define default_broadcast_interval_secs IF_ROUTER(ONE_DAY / 2, 15 * 60)

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -813,6 +813,7 @@ size_t NodeDB::getNumOnlineMeshNodes(bool localOnly)
 }
 
 #include "MeshModule.h"
+#include "Throttle.h"
 
 /** Update position info for this node based on received position data
  */
@@ -907,8 +908,10 @@ bool NodeDB::updateUser(uint32_t nodeId, const meshtastic_User &p, uint8_t chann
         powerFSM.trigger(EVENT_NODEDB_UPDATED);
         notifyObservers(true); // Force an update whether or not our node counts have changed
 
-        // We just changed something important about the user, store our DB
-        saveToDisk(SEGMENT_DEVICESTATE);
+        // We just changed something about the user, store our DB
+        Throttle::execute(
+            &lastNodeDbSave, ONE_MINUTE_MS, []() { nodeDB->saveToDisk(SEGMENT_DEVICESTATE); },
+            []() { LOG_DEBUG("Deferring NodeDB saveToDisk for now, since we saved less than a minute ago\n"); });
     }
 
     return changed;

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -160,6 +160,7 @@ class NodeDB
     }
 
   private:
+    uint32_t lastNodeDbSave = 0; // when we last saved our db to flash
     /// Find a node in our DB, create an empty NodeInfoLite if missing
     meshtastic_NodeInfoLite *getOrCreateMeshNode(NodeNum n);
 

--- a/src/mesh/Throttle.cpp
+++ b/src/mesh/Throttle.cpp
@@ -1,0 +1,27 @@
+#include "Throttle.h"
+#include <Arduino.h>
+
+/// @brief Execute a function throttled to a minimum interval
+/// @param lastExecutionMs Pointer to the last execution time in milliseconds
+/// @param minumumIntervalMs Minimum execution interval in milliseconds
+/// @param throttleFunc Function to execute if the execution is not deferred
+/// @param onDefer Default to NULL, execute the function if the execution is deferred
+/// @return true if the function was executed, false if it was deferred
+bool Throttle::execute(uint32_t *lastExecutionMs, uint32_t minumumIntervalMs, void (*throttleFunc)(void), void (*onDefer)(void))
+{
+    if (lastExecutionMs == 0) {
+        *lastExecutionMs = millis();
+        throttleFunc();
+        return true;
+    }
+    uint32_t now = millis();
+
+    if ((now - *lastExecutionMs) >= minumumIntervalMs) {
+        throttleFunc();
+        *lastExecutionMs = now;
+        return true;
+    } else if (onDefer != NULL) {
+        onDefer();
+    }
+    return false;
+}

--- a/src/mesh/Throttle.cpp
+++ b/src/mesh/Throttle.cpp
@@ -9,7 +9,7 @@
 /// @return true if the function was executed, false if it was deferred
 bool Throttle::execute(uint32_t *lastExecutionMs, uint32_t minumumIntervalMs, void (*throttleFunc)(void), void (*onDefer)(void))
 {
-    if (lastExecutionMs == 0) {
+    if (*lastExecutionMs == 0) {
         *lastExecutionMs = millis();
         throttleFunc();
         return true;

--- a/src/mesh/Throttle.h
+++ b/src/mesh/Throttle.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <cstddef>
+#include <cstdint>
+
+class Throttle
+{
+  public:
+    static bool execute(uint32_t *lastExecutionMs, uint32_t minumumIntervalMs, void (*func)(void), void (*onDefer)(void) = NULL);
+};


### PR DESCRIPTION
This is to prevent the hammering of the file system on large meshes (public mqtt included). I ran a test earlier on the msh/US root and experienced 13 nodedb saves to disk within about a one minute period. It is likely responsible for some of the issues with nodes "loosing settings". 

I have plans for a more uses of the generic throttle methods. A follow up PR to refactor smart position will utilize it.