### PR TITLE
Fix #3641: Always set MAC when picking new NodeNum

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -527,8 +527,8 @@ void NodeDB::installDefaultDeviceState()
 void NodeDB::pickNewNodeNum()
 {
     NodeNum nodeNum = myNodeInfo.my_node_num;
+    getMacAddr(ourMacAddr); // Make sure ourMacAddr is set
     if (nodeNum == 0) {
-        getMacAddr(ourMacAddr); // Make sure ourMacAddr is set
         // Pick an initial nodenum based on the macaddr
         nodeNum = (ourMacAddr[2] << 24) | (ourMacAddr[3] << 16) | (ourMacAddr[4] << 8) | ourMacAddr[5];
     }


### PR DESCRIPTION
Fixes #3641. Apparently the factory reset command first sets the long/short name based on the MAC address but it might be that `getMacAddr()` was never called. Since our NodeNum is only erased afterwards, it is not yet 0, so this part wouldn't be executed.
