### PR TITLE
Fix: don't enable the CDC interface already at boot

### DIFF
--- a/boards/tbeam-s3-core.json
+++ b/boards/tbeam-s3-core.json
@@ -7,7 +7,6 @@
     "extra_flags": [
       "-DBOARD_HAS_PSRAM",
       "-DLILYGO_TBEAM_S3_CORE",
-      "-DARDUINO_USB_CDC_ON_BOOT=1",
       "-DARDUINO_USB_MODE=1",
       "-DARDUINO_RUNNING_CORE=1",
       "-DARDUINO_EVENT_RUNNING_CORE=1"


### PR DESCRIPTION
This should fix #3650 by not enabling USB CDC already at boot.

Also see #3597 

