### PR TITLE
(ESP32) Fix bluetooth after light-sleep; de-init for deep-sleep

### DIFF
--- a/src/nimble/NimbleBluetooth.cpp
+++ b/src/nimble/NimbleBluetooth.cpp
@@ -106,20 +106,26 @@ static NimbleBluetoothFromRadioCallback *fromRadioCallbacks;
 
 void NimbleBluetooth::shutdown()
 {
+    // No measurable power saving for ESP32 during light-sleep(?)
+#ifndef ARCH_ESP32
     // Shutdown bluetooth for minimum power draw
     LOG_INFO("Disable bluetooth\n");
-    // Bluefruit.Advertising.stop();
     NimBLEAdvertising *pAdvertising = NimBLEDevice::getAdvertising();
     pAdvertising->reset();
     pAdvertising->stop();
+#endif
 }
 
-// Extra power-saving on some devices
+// Proper shutdown for ESP32. Needs reboot to reverse.
 void NimbleBluetooth::deinit()
 {
+#ifdef ARCH_ESP32
+    LOG_INFO("Disable bluetooth until reboot\n");
     NimBLEDevice::deinit();
+#endif
 }
 
+// Has initial setup been completed
 bool NimbleBluetooth::isActive()
 {
     return bleServer;

--- a/src/platform/esp32/main-esp32.cpp
+++ b/src/platform/esp32/main-esp32.cpp
@@ -30,9 +30,10 @@ void setBluetoothEnable(bool enable)
         }
         if (enable && !nimbleBluetooth->isActive()) {
             nimbleBluetooth->setup();
-        } else if (!enable) {
-            nimbleBluetooth->shutdown();
         }
+        // For ESP32, no way to recover from bluetooth shutdown without reboot
+        // BLE advertising automatically stops when MCU enters light-sleep(?)
+        // For deep-sleep, shutdown hardware with nimbleBluetooth->deinit(). Requires reboot to reverse
     }
 }
 #else

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -207,8 +207,8 @@ void doDeepSleep(uint32_t msecToWake, bool skipPreflight = false)
     // esp_wifi_stop();
     waitEnterSleep(skipPreflight);
 
-#ifdef NIMBLE_DEINIT_FOR_DEEPSLEEP
-    // Extra power saving on some devices
+#ifdef ARCH_ESP32
+    // Full shutdown of bluetooth hardware
     nimbleBluetooth->deinit();
 #endif
 

--- a/variants/heltec_wireless_paper/variant.h
+++ b/variants/heltec_wireless_paper/variant.h
@@ -55,6 +55,3 @@
 
 #define SX126X_DIO2_AS_RF_SWITCH
 #define SX126X_DIO3_TCXO_VOLTAGE 1.8
-
-// Power management
-#define NIMBLE_DEINIT_FOR_DEEPSLEEP // Required to reach manufacturers claim of 18uA

--- a/variants/heltec_wireless_paper_v1/variant.h
+++ b/variants/heltec_wireless_paper_v1/variant.h
@@ -55,6 +55,3 @@
 
 #define SX126X_DIO2_AS_RF_SWITCH
 #define SX126X_DIO3_TCXO_VOLTAGE 1.8
-
-// Power management
-#define NIMBLE_DEINIT_FOR_DEEPSLEEP // Required to reach manufacturers claim of 18uA


### PR DESCRIPTION
Currently:
* When ESP32 devices enter light-sleep (power saving), BLE advertising is reset and disabled.
* If phone remains connected during light-sleep, it is possible to use BLE when the node wakes.
* If phone loses BLE connection during light-sleep, it is not possible to reconnect to the node.
* This does not appear to be an intentional behavior, and this "locked out" state does not appear to give any power savings.

Pull Request:
* When ESP32 device prepares to enter light-sleep, no calls to NimBLE to stop advertising.
* During light-sleep, advertising stops automatically, even without explicit calls to NimBLE. Power consumption measured same as with current code.
* After waking from light-sleep, BLE regains full normal function.
* NimBLE de-init enabled for ESP32 devices entering deep-sleep. Modest reduction in deep-sleep current. Device resumes normal BLE function after exiting deep-sleep.