### PR TITLE
StoreForward: Remove assert when receiving unhandled case

### DIFF
--- a/src/modules/esp32/StoreForwardModule.cpp
+++ b/src/modules/esp32/StoreForwardModule.cpp
@@ -506,7 +506,7 @@ bool StoreForwardModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp,
         break;
 
     default:
-        assert(0); // unexpected state
+        break; // no need to do anything
     }
     return true; // There's no need for others to look at this message.
 }


### PR DESCRIPTION
Someone reported a crash when requesting history from a Store and Forward router. I believe this could cause that when it also has StoreForward enabled, that because the router is sending `meshtastic_StoreAndForward_RequestResponse_ROUTER_TEXT_DIRECT` or `ROUTER_TEXT_BROADCAST`, which is not in the switch case.
