### PR TITLE
Reduce blink interval to 30s in power saving mode, to save power

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -140,6 +140,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // -----------------------------------------------------------------------------
 // LED
 // -----------------------------------------------------------------------------
+#define LED_BLINK_TIME 1
+#define LED_BLINK_INTERVAL 1000
+#define LED_BLINK_INTERVAL_POWERSAVE 30000
+#define LED_BLINK_INTERVAL_CHARGING 1000
 #define NCP5623_ADDR 0x38
 
 // -----------------------------------------------------------------------------

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -184,8 +184,14 @@ static int32_t ledBlinker()
 
     setLed(ledOn);
 
-    // have a very sparse duty cycle of LED being on, unless charging, then blink 0.5Hz square wave rate to indicate that
-    return powerStatus->getIsCharging() ? 1000 : (ledOn ? 1 : 1000);
+    // Blink steadily to indicate charging, otherwise blink sparsely
+    if (powerStatus->getIsCharging()) {
+        return LED_BLINK_INTERVAL_CHARGING;
+    } else if (ledOn) {
+        return LED_BLINK_TIME;
+    } else {
+        return (config.power.is_power_saving ? LED_BLINK_INTERVAL_POWERSAVE : LED_BLINK_INTERVAL) - LED_BLINK_TIME;
+    }
 }
 
 uint32_t timeLastPowered = 0;


### PR DESCRIPTION
Picked 30 seconds as it felt like the limits of patience for anyone to stare at their node, while having significantly lower LED power consumption than at 1 second.

Refactored slightly and moved duration definitions to configuration.h.