### PR TITLE
Add M5Paper support

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -77,6 +77,7 @@ jobs:
           - board: station-g1
           - board: m5stack-core
           - board: m5stack-coreink
+          - board: m5stack-m5paper
           - board: nano-g1-explorer
           - board: chatter2
     uses: ./.github/workflows/build_esp32.yml

--- a/boards/m5stack-m5paper.json
+++ b/boards/m5stack-m5paper.json
@@ -1,0 +1,33 @@
+{
+    "build": {
+      "arduino": {
+        "ldscript": "esp32_out.ld",
+        "partitions": "default_16MB.csv"
+      },
+      "core": "esp32",
+      "extra_flags": [
+        "-DARDUINO_M5Stack_M5Paper",
+        "-DBOARD_HAS_PSRAM",
+        "-mfix-esp32-psram-cache-issue",
+        "-mfix-esp32-psram-cache-strategy=memw"
+      ],
+      "f_cpu": "240000000L",
+      "f_flash": "80000000L",
+      "flash_mode": "qio",
+      "mcu": "esp32",
+      "variant": "m5stack_m5paper"
+    },
+    "connectivity": ["wifi", "bluetooth"],
+    "frameworks": ["arduino", "espidf"],
+    "name": " M5Stack M5Paper (16 MB FLASH, 8 MB PSRAM)",
+    "upload": {
+      "flash_size": "16MB",
+      "maximum_ram_size": 327680,
+      "maximum_size": 16777216,
+      "require_upload_port": true,
+      "speed": 460800
+    },
+    "url": "https://docs.m5stack.com/en/core/m5paper",
+    "vendor": "M5Stack"
+  }
+  

--- a/boards/m5stack-m5paper.json
+++ b/boards/m5stack-m5paper.json
@@ -1,33 +1,32 @@
 {
-    "build": {
-      "arduino": {
-        "ldscript": "esp32_out.ld",
-        "partitions": "default_16MB.csv"
-      },
-      "core": "esp32",
-      "extra_flags": [
-        "-DARDUINO_M5Stack_M5Paper",
-        "-DBOARD_HAS_PSRAM",
-        "-mfix-esp32-psram-cache-issue",
-        "-mfix-esp32-psram-cache-strategy=memw"
-      ],
-      "f_cpu": "240000000L",
-      "f_flash": "80000000L",
-      "flash_mode": "qio",
-      "mcu": "esp32",
-      "variant": "m5stack_m5paper"
+  "build": {
+    "arduino": {
+      "ldscript": "esp32_out.ld",
+      "partitions": "default_16MB.csv"
     },
-    "connectivity": ["wifi", "bluetooth"],
-    "frameworks": ["arduino", "espidf"],
-    "name": " M5Stack M5Paper (16 MB FLASH, 8 MB PSRAM)",
-    "upload": {
-      "flash_size": "16MB",
-      "maximum_ram_size": 327680,
-      "maximum_size": 16777216,
-      "require_upload_port": true,
-      "speed": 460800
-    },
-    "url": "https://docs.m5stack.com/en/core/m5paper",
-    "vendor": "M5Stack"
-  }
-  
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_M5Stack_M5Paper",
+      "-DBOARD_HAS_PSRAM",
+      "-mfix-esp32-psram-cache-issue",
+      "-mfix-esp32-psram-cache-strategy=memw"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "mcu": "esp32",
+    "variant": "m5stack_m5paper"
+  },
+  "connectivity": ["wifi", "bluetooth"],
+  "frameworks": ["arduino", "espidf"],
+  "name": " M5Stack M5Paper (16 MB FLASH, 8 MB PSRAM)",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://docs.m5stack.com/en/core/m5paper",
+  "vendor": "M5Stack"
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -31,6 +31,7 @@ default_envs = tbeam
 ;default_envs = rak4631
 ;default_envs = rak10701
 ;default_envs = wio-e5
+;default_envs = m5stack-m5paper
 
 extra_configs =
   arch/*/*.ini

--- a/src/graphics/EInkDisplay2.cpp
+++ b/src/graphics/EInkDisplay2.cpp
@@ -180,6 +180,12 @@ bool EInkDisplay::connect()
     adafruitDisplay->init(115200, true, 40, false, SPI, SPISettings(4000000, MSBFIRST, SPI_MODE0));
     adafruitDisplay->setRotation(0);
     adafruitDisplay->setPartialWindow(0, 0, EINK_WIDTH, EINK_HEIGHT);
+#elif defined(M5_PAPER)
+    auto lowLevel = new EINK_DISPLAY_MODEL(PIN_EINK_CS, PIN_EINK_DC, PIN_EINK_RES, PIN_EINK_BUSY);
+    adafruitDisplay = new GxEPD2_BW<EINK_DISPLAY_MODEL, EINK_DISPLAY_MODEL::HEIGHT>(*lowLevel);
+    adafruitDisplay->init(115200, true, 40, false, SPI, SPISettings(10000000, MSBFIRST, SPI_MODE0));
+    adafruitDisplay->setRotation(3);
+    adafruitDisplay->setPartialWindow(0, 0, EINK_WIDTH, EINK_HEIGHT);
 #elif defined(my) || defined(ESP32_S3_PICO)
     {
         auto lowLevel = new EINK_DISPLAY_MODEL(PIN_EINK_CS, PIN_EINK_DC, PIN_EINK_RES, PIN_EINK_BUSY);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -245,6 +245,17 @@ void setup()
     // digitalWrite(PIN_POWER_EN1, INPUT);
 #endif
 
+#if defined(M5_PAPER)
+    pinMode(M5EPD_MAIN_PWR_PIN, OUTPUT);
+    pinMode(M5EPD_EXT_PWR_EN_PIN, OUTPUT);
+    pinMode(M5EPD_EPD_PWR_EN_PIN, OUTPUT);
+
+    digitalWrite(M5EPD_MAIN_PWR_PIN, HIGH);
+    delay(100);
+    digitalWrite(M5EPD_EXT_PWR_EN_PIN, 1);
+    digitalWrite(M5EPD_EPD_PWR_EN_PIN, 1);
+#endif
+
 #if defined(LORA_TCXO_GPIO)
     pinMode(LORA_TCXO_GPIO, OUTPUT);
     digitalWrite(LORA_TCXO_GPIO, HIGH);

--- a/variants/m5stack_m5paper/pins_arduino.h
+++ b/variants/m5stack_m5paper/pins_arduino.h
@@ -25,7 +25,6 @@ static const uint8_t MOSI = 12;
 static const uint8_t MISO = 13;
 static const uint8_t SCK = 14;
 
-
 static const uint8_t G0 = 0;
 static const uint8_t G1 = 1;
 static const uint8_t G2 = 2;
@@ -52,7 +51,6 @@ static const uint8_t G36 = 36;
 static const uint8_t G37 = 37;
 static const uint8_t G38 = 38;
 static const uint8_t G39 = 39;
-
 
 static const uint8_t DAC1 = 25;
 static const uint8_t DAC2 = 26;

--- a/variants/m5stack_m5paper/pins_arduino.h
+++ b/variants/m5stack_m5paper/pins_arduino.h
@@ -1,0 +1,63 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define EXTERNAL_NUM_INTERRUPTS 16
+#define NUM_DIGITAL_PINS 40
+#define NUM_ANALOG_INPUTS 16
+
+#define analogInputToDigitalPin(p) (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
+#define digitalPinToInterrupt(p) (((p) < 40) ? (p) : -1)
+#define digitalPinHasPWM(p) (p < 34)
+
+static const uint8_t TX = 1;
+static const uint8_t RX = 3;
+
+static const uint8_t TXD2 = 17;
+static const uint8_t RXD2 = 16;
+
+static const uint8_t SDA = 21;
+static const uint8_t SCL = 22;
+
+static const uint8_t SS = 4;
+static const uint8_t MOSI = 12;
+static const uint8_t MISO = 13;
+static const uint8_t SCK = 14;
+
+
+static const uint8_t G0 = 0;
+static const uint8_t G1 = 1;
+static const uint8_t G2 = 2;
+static const uint8_t G3 = 3;
+static const uint8_t G5 = 5;
+
+static const uint8_t G12 = 12;
+static const uint8_t G13 = 13;
+static const uint8_t G15 = 15;
+static const uint8_t G16 = 16;
+static const uint8_t G17 = 17;
+static const uint8_t G18 = 18;
+static const uint8_t G19 = 19;
+
+static const uint8_t G21 = 21;
+static const uint8_t G22 = 22;
+static const uint8_t G23 = 23;
+static const uint8_t G25 = 25;
+static const uint8_t G26 = 26;
+
+static const uint8_t G34 = 34;
+static const uint8_t G35 = 35;
+static const uint8_t G36 = 36;
+static const uint8_t G37 = 37;
+static const uint8_t G38 = 38;
+static const uint8_t G39 = 39;
+
+
+static const uint8_t DAC1 = 25;
+static const uint8_t DAC2 = 26;
+
+static const uint8_t ADC1 = 35;
+static const uint8_t ADC2 = 12;
+
+#endif /* Pins_Arduino_h */

--- a/variants/m5stack_m5paper/platformio.ini
+++ b/variants/m5stack_m5paper/platformio.ini
@@ -1,0 +1,33 @@
+[env:m5stack-m5paper]
+extends = esp32_base
+board = m5stack-m5paper
+board_level = extra
+build_src_filter = 
+  ${esp32_base.build_src_filter}
+build_flags = 
+  ${esp32_base.build_flags} -I variants/m5stack_m5paper
+  ;-D RADIOLIB_VERBOSE
+  -Ofast
+  -D__MCUXPRESSO
+  -DEINK_DISPLAY_MODEL=GxEPD2_m5paper
+  -DEINK_WIDTH=540
+  -DEINK_HEIGHT=960
+  -DUSER_SETUP_LOADED
+  -DM5_PAPER
+  -DM5STACK
+  -DUSE_EINK_DYNAMICDISPLAY            ; Enable Dynamic EInk
+  -DEINK_LIMIT_FASTREFRESH=20          ; How many consecutive fast-refreshes are permitted
+  -DEINK_LIMIT_RATE_BACKGROUND_SEC=30  ; Minimum interval between BACKGROUND updates
+  -DEINK_LIMIT_RATE_RESPONSIVE_SEC=1   ; Minimum interval between RESPONSIVE updates
+  -DEINK_LIMIT_GHOSTING_PX=2000        ; (Optional) How much image ghosting is tolerated
+  -DEINK_BACKGROUND_USES_FAST          ; (Optional) Use FAST refresh for both BACKGROUND and RESPONSIVE, until a limit is reached.
+lib_deps = 
+  ${esp32_base.lib_deps}
+  https://github.com/fonix232/GxEPD2.git#m5paper
+  https://github.com/lewisxhe/PCF8563_Library.git@^1.0.1
+lib_ignore =
+  m5stack-m5paper
+monitor_filters = esp32_exception_decoder
+board_build.f_cpu = 240000000L
+upload_protocol = esptool
+upload_port = /dev/ttyACM0

--- a/variants/m5stack_m5paper/variant.h
+++ b/variants/m5stack_m5paper/variant.h
@@ -1,9 +1,9 @@
 #include "pcf8563.h"
 
-//#define LED_PIN -1
+// #define LED_PIN -1
 
-#define I2C_SDA 21 
-#define I2C_SCL 22 
+#define I2C_SDA 21
+#define I2C_SCL 22
 
 // PCF8563 RTC Module
 #define HAS_RTC 1
@@ -24,12 +24,12 @@
 #define ADC_MULTIPLIER 2
 #define DEFAULT_VREF 3600
 
-//Wheel
-// Down 37
-// Push 38
-// Up 39
+// Wheel
+//  Down 37
+//  Push 38
+//  Up 39
 
-//#define BUTTON_NEED_PULLUP
+// #define BUTTON_NEED_PULLUP
 #define BUTTON_PIN 38
 
 // #undef RF95_SCK
@@ -40,10 +40,10 @@
 
 // #define RF95_SCK  18 //13
 // #define RF95_MISO 34 //26
-// #define RF95_MOSI 23 //25 
-// #define RF95_NSS 14 
-// #define LORA_DIO0 25 
-// #define LORA_RESET 26 
+// #define RF95_MOSI 23 //25
+// #define RF95_NSS 14
+// #define LORA_DIO0 25
+// #define LORA_RESET 26
 // #define LORA_DIO1 RADIOLIB_NC
 // #define LORA_DIO2 RADIOLIB_NC
 
@@ -62,16 +62,16 @@
 #define HAS_EINK 1
 #define USE_EINK
 
-#define PIN_EINK_MOSI  SPI_MOSI          // EPD_MOSI
-#define PIN_EINK_MISO  SPI_MISO          // EPD_MISO
-#define PIN_EINK_SCLK  SPI_SCK          // EPD_SCLK
-#define PIN_EINK_CS    15          // EPD_CS
-#define PIN_EINK_BUSY  27          // EPD_BUSY
+#define PIN_EINK_MOSI SPI_MOSI // EPD_MOSI
+#define PIN_EINK_MISO SPI_MISO // EPD_MISO
+#define PIN_EINK_SCLK SPI_SCK  // EPD_SCLK
+#define PIN_EINK_CS 15         // EPD_CS
+#define PIN_EINK_BUSY 27       // EPD_BUSY
 
-#define PIN_EINK_EN    -1
-#define PIN_EINK_DC    -1          // EPD_D/C
-#define PIN_EINK_RES   -1          // EPD RES
+#define PIN_EINK_EN -1
+#define PIN_EINK_DC -1  // EPD_D/C
+#define PIN_EINK_RES -1 // EPD RES
 
-#define M5EPD_MAIN_PWR_PIN   2
+#define M5EPD_MAIN_PWR_PIN 2
 #define M5EPD_EXT_PWR_EN_PIN 5
 #define M5EPD_EPD_PWR_EN_PIN 23

--- a/variants/m5stack_m5paper/variant.h
+++ b/variants/m5stack_m5paper/variant.h
@@ -1,0 +1,77 @@
+#include "pcf8563.h"
+
+//#define LED_PIN -1
+
+#define I2C_SDA 21 
+#define I2C_SCL 22 
+
+// PCF8563 RTC Module
+#define HAS_RTC 1
+#define PCF8563_RTC 0x51
+
+#define HAS_TEMP_SENSOR 1
+#define SHT3x_ADDR 0x44
+
+// #define HAS_TOUCHSCREEN 1
+// #define SCREEN_TOUCH_INT 36
+// #define TOUCH_I2C_PORT 0
+// #define TOUCH_SLAVE_ADDRESS 0x5D // GT911
+
+#define BATTERY_PIN 35
+#define ADC_CHANNEL ADC1_GPIO35_CHANNEL
+#define ADC_ATTENUATION ADC_ATTEN_DB_11
+#define ADC_WIDTH ADC_WIDTH_BIT_12
+#define ADC_MULTIPLIER 2
+#define DEFAULT_VREF 3600
+
+//Wheel
+// Down 37
+// Push 38
+// Up 39
+
+//#define BUTTON_NEED_PULLUP
+#define BUTTON_PIN 38
+
+// #undef RF95_SCK
+// #undef RF95_MISO
+// #undef RF95_MOSI
+// #undef RF95_NSS
+// #define USE_RF95
+
+// #define RF95_SCK  18 //13
+// #define RF95_MISO 34 //26
+// #define RF95_MOSI 23 //25 
+// #define RF95_NSS 14 
+// #define LORA_DIO0 25 
+// #define LORA_RESET 26 
+// #define LORA_DIO1 RADIOLIB_NC
+// #define LORA_DIO2 RADIOLIB_NC
+
+#define NO_GPS
+// This board has no GPS but there's an UART connector
+// #define GPS_RX_PIN 19
+// #define GPS_TX_PIN 18
+
+#define HAS_SDCARD 1
+#define SPI_MOSI (12)
+#define SPI_SCK (14)
+#define SPI_MISO (13)
+#define SPI_CS (4)
+#define SDCARD_CS SPI_CS
+
+#define HAS_EINK 1
+#define USE_EINK
+
+#define PIN_EINK_MOSI  SPI_MOSI          // EPD_MOSI
+#define PIN_EINK_MISO  SPI_MISO          // EPD_MISO
+#define PIN_EINK_SCLK  SPI_SCK          // EPD_SCLK
+#define PIN_EINK_CS    15          // EPD_CS
+#define PIN_EINK_BUSY  27          // EPD_BUSY
+
+#define PIN_EINK_EN    -1
+#define PIN_EINK_DC    -1          // EPD_D/C
+#define PIN_EINK_RES   -1          // EPD RES
+
+#define M5EPD_MAIN_PWR_PIN   2
+#define M5EPD_EXT_PWR_EN_PIN 5
+#define M5EPD_EPD_PWR_EN_PIN 23


### PR DESCRIPTION
## New device: M5Paper

I've had a few of these lying around for a long time, and given the form factor, I thought they'd be perfect for Meshtastic.

Sadly, the official M5Stack LoRaWAN Unit, which uses the ASR6501 radio over UART, can't be supported, so I'm a bit stuck on what kind of LoRa radio to attach to this.

Nonetheless I thought it would be nice to get some initial reviews on the parts I did finish.

## Notes

1. This will obviously not boot as-is due to the hard requirement for a LoRa radio. To work this around, any reviewer will need to [change this line](https://github.com/meshtastic/firmware/blob/master/src/main.cpp#L921) and replace it with a non-critical log (e.g. `LOG_DEBUG("LoRa Radio not found!\n");`). I've [started a thread on the forum](https://meshtastic.discourse.group/t/best-way-to-add-lora-to-the-m5paper/12084) to hunt for a module that could be used.
2. I still haven't gotten the touch screen to work, as the appropriate bits of code are in the TFTDisplay class. I'd like to propose moving all commonly shared display bits to a separate `BaseDisplay` class that both TFTDisplay and EInkDisplay can inherit from, thereby working around this limitation - but that is way out of scope for this PR and needs proper planning.
3. For now, both LORA and GPS definitions are commented out - I will be enabling these once I have a solid approach to them.
4. The display is barely readable, as there's no scaling for physical size in the current GUI framework. This, as well as handling of a partial window (the M5Paper's display runs to the edges, and since Meshtastic draws to the very edge of the screen, this makes some parts hard to read, even at appropriate scaling), would be needed for _proper_ support of the M5Paper.
5. Currently, this is using my fork of GxEPD2 as ZinggMJ refuses to merge any PRs or include any display they don't own. As such, I will be keeping that tag up to date (though I doubt any further changes will be needed as the display works just fine).
6. There's a weird `invalid pin` error during initial boot:
  ```
INFO  | 17:38:13 1 External Notification Module Disabled
INFO  | 17:38:13 1 Doing EInk init
[  1737][E][esp32-hal-gpio.c:102] __pinMode(): Invalid pin selected
E (1732) gpio: gpio_set_level(226): GPIO output gpio_n_IT8951SetVCOM : 430955
set VCOM = -2.30
GetIT8951SystemInfo : 6001
Panel(W,H) = (960, 540)
  ```
which I can't place. It interrupts, and gets interrupted, by the EINK init sequence, so the logs are a bit garbled, making it hard to debug. Any advice regarding this would be appreciated!
