### PR TITLE
Add ability to turn off heartbeat LED blinking

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -179,7 +179,8 @@ const char *getDeviceName()
 
 static int32_t ledBlinker()
 {
-    // Still set up the blinking (heartbeat) interval but skip code path below, so LED will blink if config.device.led_heartbeat_disabled is changed
+    // Still set up the blinking (heartbeat) interval but skip code path below, so LED will blink if
+    // config.device.led_heartbeat_disabled is changed
     if (config.device.led_heartbeat_disabled)
         return 1000;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -179,6 +179,10 @@ const char *getDeviceName()
 
 static int32_t ledBlinker()
 {
+    // Still set up the blinker interval but skip code path below, so LED will blink if config.device.status_led_off is changed
+    if (config.device.status_led_off)
+        return 1000;
+
     static bool ledOn;
     ledOn ^= 1;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -179,8 +179,8 @@ const char *getDeviceName()
 
 static int32_t ledBlinker()
 {
-    // Still set up the blinker interval but skip code path below, so LED will blink if config.device.status_led_off is changed
-    if (config.device.status_led_off)
+    // Still set up the blinking (heartbeat) interval but skip code path below, so LED will blink if config.device.led_heartbeat_disabled is changed
+    if (config.device.led_heartbeat_disabled)
         return 1000;
 
     static bool ledOn;


### PR DESCRIPTION
Fixes #3635 and depends on [protobufs PR #485](https://github.com/meshtastic/protobufs/pull/485).


This only affects the GPIO-controllable LED and may be desirable behavior for Meshtastic users who sleep in the vicinity of their node and are annoyed by the blinking LED, especially for boards that indicate charging when USB power is connected, resulting in a 1 second LED illumination cycle.

Most boards however, have a non-GPIO controlled power LED (i.e. hardwired to VBUS/VCC/etc.) that can only be turned off by desoldering or otherwise removing that LED. This can't be addressed by firmware changes.

Implemented as inhibiting rather than `status_led` because having `status_led = true` by default will cause status LED to get disabled for users upgrading from previous firmware due to `installDefaultConfig` not being run.