### PR TITLE
Fix crash on shutdown, if Bluetooth not enabled

### DIFF
--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -209,7 +209,8 @@ void doDeepSleep(uint32_t msecToWake, bool skipPreflight = false)
 
 #ifdef ARCH_ESP32
     // Full shutdown of bluetooth hardware
-    nimbleBluetooth->deinit();
+    if (nimbleBluetooth)
+        nimbleBluetooth->deinit();
 #endif
 
 #ifdef ARCH_ESP32


### PR DESCRIPTION
Collaboration with: \_burr\_ (Meshtastic Discord server)

Fix an crash caused by attempting to shutdown hardware which was never initialized.