### PR TITLE
Added more clear RTC handling and quality logging

### DIFF
--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -104,13 +104,15 @@ bool perhapsSetRTC(RTCQuality q, const struct timeval *tv)
     bool shouldSet;
     if (q > currentQuality) {
         shouldSet = true;
-        LOG_DEBUG("Upgrading time to quality %d\n", q);
+        LOG_DEBUG("Upgrading time to quality %s\n", RtcName(q));
     } else if (q == RTCQualityGPS && (now - lastSetMsec) > (12 * 60 * 60 * 1000UL)) {
         // Every 12 hrs we will slam in a new GPS time, to correct for local RTC clock drift
         shouldSet = true;
         LOG_DEBUG("Reapplying external time to correct clock drift %ld secs\n", tv->tv_sec);
-    } else
+    } else {
         shouldSet = false;
+        LOG_DEBUG("Current RTC quality: %s. Ignoring time of RTC quality of %s\n", RtcName(currentQuality), RtcName(q));
+    }
 
     if (shouldSet) {
         currentQuality = q;
@@ -159,6 +161,24 @@ bool perhapsSetRTC(RTCQuality q, const struct timeval *tv)
         return true;
     } else {
         return false;
+    }
+}
+
+const char *RtcName(RTCQuality quality)
+{
+    switch (quality) {
+    case RTCQualityNone:
+        return "None";
+    case RTCQualityDevice:
+        return "Device";
+    case RTCQualityFromNet:
+        return "Net";
+    case RTCQualityNTP:
+        return "NTP";
+    case RTCQualityGPS:
+        return "GPS";
+    default:
+        return "Unknown";
     }
 }
 

--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -105,8 +105,8 @@ bool perhapsSetRTC(RTCQuality q, const struct timeval *tv)
     if (q > currentQuality) {
         shouldSet = true;
         LOG_DEBUG("Upgrading time to quality %s\n", RtcName(q));
-    } else if (q == RTCQualityGPS && (now - lastSetMsec) > (12 * 60 * 60 * 1000UL)) {
-        // Every 12 hrs we will slam in a new GPS time, to correct for local RTC clock drift
+    } else if (q >= RTCQualityNTP && (now - lastSetMsec) > (12 * 60 * 60 * 1000UL)) {
+        // Every 12 hrs we will slam in a new GPS or Phone GPS / NTP time, to correct for local RTC clock drift
         shouldSet = true;
         LOG_DEBUG("Reapplying external time to correct clock drift %ld secs\n", tv->tv_sec);
     } else {

--- a/src/gps/RTC.h
+++ b/src/gps/RTC.h
@@ -28,6 +28,9 @@ RTCQuality getRTCQuality();
 bool perhapsSetRTC(RTCQuality q, const struct timeval *tv);
 bool perhapsSetRTC(RTCQuality q, struct tm &t);
 
+/// Return a string name for the quality
+const char *RtcName(RTCQuality quality);
+
 /// Return time since 1970 in secs.  While quality is RTCQualityNone we will be returning time based at zero
 uint32_t getTime(bool local = false);
 

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -150,12 +150,13 @@ class NodeDB
     void setLocalPosition(meshtastic_Position position, bool timeOnly = false)
     {
         if (timeOnly) {
-            LOG_DEBUG("Setting local position time only: time=%i\n", position.time);
+            LOG_DEBUG("Setting local position time only: time=%i timestamp=%i\n", position.time, position.timestamp);
             localPosition.time = position.time;
+            localPosition.timestamp = position.timestamp > 0 ? position.timestamp : position.time;
             return;
         }
-        LOG_DEBUG("Setting local position: latitude=%i, longitude=%i, time=%i\n", position.latitude_i, position.longitude_i,
-                  position.time);
+        LOG_DEBUG("Setting local position: latitude=%i, longitude=%i, time=%i, timeestamp=%i\n", position.latitude_i,
+                  position.longitude_i, position.time, position.timestamp);
         localPosition = position;
     }
 

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -71,14 +71,8 @@ bool PositionModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
               p.time);
 
     if (p.time && channels.getByIndex(mp.channel).role == meshtastic_Channel_Role_PRIMARY) {
-        struct timeval tv;
-        uint32_t secs = p.time;
-
-        tv.tv_sec = secs;
-        tv.tv_usec = 0;
-
         // Set from phone RTC Quality to RTCQualityNTP since it should be approximately so
-        perhapsSetRTC(isLocal ? RTCQualityNTP : RTCQualityFromNet, &tv);
+        trySetRtc(p, isLocal);
     }
 
     nodeDB->updatePosition(getFrom(&mp), p);
@@ -91,6 +85,16 @@ bool PositionModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
     }
 
     return false; // Let others look at this message also if they want
+}
+
+void PositionModule::trySetRtc(meshtastic_Position p, bool isLocal)
+{
+    struct timeval tv;
+    uint32_t secs = p.time;
+
+    tv.tv_sec = secs;
+    tv.tv_usec = 0;
+    perhapsSetRTC(isLocal ? RTCQualityNTP : RTCQualityFromNet, &tv);
 }
 
 meshtastic_MeshPacket *PositionModule::allocReply()

--- a/src/modules/PositionModule.h
+++ b/src/modules/PositionModule.h
@@ -52,6 +52,7 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
   private:
     struct SmartPosition getDistanceTraveledSinceLastSend(meshtastic_PositionLite currentPosition);
     meshtastic_MeshPacket *allocAtakPli();
+    void trySetRtc(meshtastic_Position p, bool isLocal);
     uint32_t precision;
     void sendLostAndFoundText();
 


### PR DESCRIPTION
We now "refresh" NTP quality time which should keep drift from becoming an issue in GPSless devices connected to phones