### PR TITLE
Updates for esp32s2 builds

### DIFF
--- a/arch/esp32/esp32s2.ini
+++ b/arch/esp32/esp32s2.ini
@@ -2,14 +2,17 @@
 extends = esp32_base
 
 build_src_filter = 
-  ${esp32_base.build_src_filter} -<nimble/> -<mesh/raspihttp>
+ ${esp32_base.build_src_filter} - <libpax/> -<nimble/> -<mesh/raspihttp>
 
 monitor_speed = 115200
 
 build_flags =
   ${esp32_base.build_flags} 
   -DHAS_BLUETOOTH=0
+  -DMESHTASTIC_EXCLUDE_PAXCOUNTER
+  -DMESHTASTIC_EXCLUDE_BLUETOOTH
   
 lib_ignore = 
   ${esp32_base.lib_ignore} 
   NimBLE-Arduino
+  libpax

--- a/src/modules/esp32/PaxcounterModule.cpp
+++ b/src/modules/esp32/PaxcounterModule.cpp
@@ -1,5 +1,5 @@
 #include "configuration.h"
-#if defined(ARCH_ESP32)
+#if defined(ARCH_ESP32) && !MESHTASTIC_EXCLUDE_PAXCOUNTER
 #include "Default.h"
 #include "MeshService.h"
 #include "PaxcounterModule.h"

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -211,7 +211,7 @@ void doDeepSleep(uint32_t msecToWake, bool skipPreflight = false)
     // esp_wifi_stop();
     waitEnterSleep(skipPreflight);
 
-#ifdef ARCH_ESP32
+#if defined(ARCH_ESP32) && !MESHTASTIC_EXCLUDE_BLUETOOTH
     // Full shutdown of bluetooth hardware
     if (nimbleBluetooth)
         nimbleBluetooth->deinit();


### PR DESCRIPTION
Minor update to allow builds for `esp32s2` modules to succeed. The esp32s2 doesn't have Bluetooth so exclude various Bluetooth related components to allow for a successful build if the target platform is an `esp32s2`.
