### PR TITLE
Fixed bug making t-deck reboot when muted

### DIFF
--- a/src/modules/ExternalNotificationModule.cpp
+++ b/src/modules/ExternalNotificationModule.cpp
@@ -244,7 +244,8 @@ void ExternalNotificationModule::stopNow()
 {
     rtttl::stop();
 #ifdef HAS_I2S
-    audioThread->stop();
+    if (audioThread->isPlaying())
+        audioThread->stop();
 #endif
     nagCycleCutoff = 1; // small value
     isNagging = false;


### PR DESCRIPTION
T-deck was rebooting when the notifications were set to mute. This only happend if you set mute before you recieved a message since the device was powered.
