### PR TITLE
adjust adc for rak11310 devices

### DIFF
--- a/variants/rak11310/variant.h
+++ b/variants/rak11310/variant.h
@@ -14,7 +14,7 @@
 #define BATTERY_PIN 26
 #define BATTERY_SENSE_RESOLUTION_BITS ADC_RESOLUTION
 // ratio of voltage divider = 3.0 (R17=200k, R18=100k)
-#define ADC_MULTIPLIER 3.1 // 3.0 + a bit for being optimistic
+#define ADC_MULTIPLIER 1.84
 
 #define DETECTION_SENSOR_EN 28
 


### PR DESCRIPTION
Adjusts ADC on RAK11310 devices, fixes #3687 

The default of 3.1 reports over 7v.
