### PR TITLE
Add better support for the Adafruit PiTFT 2.8 for Native

### DIFF
--- a/arch/portduino/portduino.ini
+++ b/arch/portduino/portduino.ini
@@ -1,6 +1,6 @@
 ; The Portduino based sim environment on top of any host OS, all hardware will be simulated
 [portduino_base]
-platform = https://github.com/meshtastic/platform-native.git#6fb39b6f94ece9c042141edb4afb91aca94dcaab
+platform = https://github.com/meshtastic/platform-native.git#659e49346aa33008b150dfb206b1817ddabc7132
 framework = arduino
 
 build_src_filter = 

--- a/bin/config-dist.yaml
+++ b/bin/config-dist.yaml
@@ -96,15 +96,18 @@ Display:
 #  Panel: ILI9341
 #  CS: 8
 #  DC: 25
-#  Backlight: 2
-#  Width: 320
-#  Height: 240
+#  Width: 240
+#  Height: 320
+#  Rotate: true
 
 Touchscreen:
 ### Note, at least for now, the touchscreen must have a CS pin defined, even if you let Linux manage the CS switching.
 
-#  Module: STMPE610
+#  Module: STMPE610 # Option 1 for Adafruit PiTFT 2.8
 #  CS: 7
+#  IRQ: 24
+
+#  Module: FT5x06 # Option 2 for Adafruit PiTFT 2.8
 #  IRQ: 24
 
 #  Module: XPT2046 # Waveshare 2.8inch

--- a/bin/config-dist.yaml
+++ b/bin/config-dist.yaml
@@ -109,6 +109,7 @@ Touchscreen:
 
 #  Module: FT5x06 # Option 2 for Adafruit PiTFT 2.8
 #  IRQ: 24
+#  I2CAddr: 0x38
 
 #  Module: XPT2046 # Waveshare 2.8inch
 #  CS: 7

--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -396,8 +396,8 @@ class LGFX : public lgfx::LGFX_Device
             touch_cfg.pin_int = settingsMap[touchscreenIRQ];
             touch_cfg.bus_shared = true;
             touch_cfg.offset_rotation = 1;
-            if (settingsMap[touchscreenModule] == ft5x06) {
-                touch_cfg.i2c_addr = 0x38;
+            if (settingsMap[touchscreenI2CAddr] != -1) {
+                touch_cfg.i2c_addr = settingsMap[touchscreenI2CAddr];
             }
 
             _touch_instance->config(touch_cfg);

--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -383,6 +383,8 @@ class LGFX : public lgfx::LGFX_Device
                 _touch_instance = new lgfx::Touch_XPT2046;
             } else if (settingsMap[touchscreenModule] == stmpe610) {
                 _touch_instance = new lgfx::Touch_STMPE610;
+            } else if (settingsMap[touchscreenModule] == ft5x06) {
+                _touch_instance = new lgfx::Touch_FT5x06;
             }
             auto touch_cfg = _touch_instance->config();
 
@@ -394,6 +396,9 @@ class LGFX : public lgfx::LGFX_Device
             touch_cfg.pin_int = settingsMap[touchscreenIRQ];
             touch_cfg.bus_shared = true;
             touch_cfg.offset_rotation = 1;
+            if (settingsMap[touchscreenModule] == ft5x06) {
+                touch_cfg.i2c_addr = 0x38;
+            }
 
             _touch_instance->config(touch_cfg);
             _panel_instance->setTouch(_touch_instance);

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -221,6 +221,7 @@ void portduinoSetup()
             settingsMap[touchscreenIRQ] = yamlConfig["Touchscreen"]["IRQ"].as<int>(-1);
             settingsMap[touchscreenBusFrequency] = yamlConfig["Touchscreen"]["BusFrequency"].as<int>(1000000);
             settingsMap[touchscreenRotate] = yamlConfig["Touchscreen"]["Rotate"].as<int>(-1);
+            settingsMap[touchscreenI2CAddr] = yamlConfig["Touchscreen"]["I2CAddr"].as<int>(-1);
             if (yamlConfig["Touchscreen"]["spidev"]) {
                 settingsStrings[touchscreenspidev] = "/dev/" + yamlConfig["Touchscreen"]["spidev"].as<std::string>("");
             }

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -21,6 +21,7 @@ enum configNames {
     touchscreenModule,
     touchscreenCS,
     touchscreenIRQ,
+    touchscreenI2CAddr,
     touchscreenBusFrequency,
     touchscreenRotate,
     touchscreenspidev,


### PR DESCRIPTION
This touchscreen can optionally use an I2C chip for touch events, which caused me quite the headache. Getting support required changes to LovyanGFX, (https://github.com/lovyan03/LovyanGFX/pull/557) and Portduino (https://github.com/meshtastic/framework-portduino/pull/21)