### PR TITLE
(E-Ink) Fix issue drawing module frames

### DIFF
--- a/src/graphics/EInkDynamicDisplay.cpp
+++ b/src/graphics/EInkDynamicDisplay.cpp
@@ -534,6 +534,10 @@ void EInkDynamicDisplay::checkBusyAsyncRefresh()
 
         return;
     }
+
+    // Async refresh appears to have stopped, but wasn't caught by onNotify()
+    else
+        pollAsyncRefresh(); // Check (and terminate) the async refresh manually
 }
 
 // Hold control while an async refresh runs


### PR DESCRIPTION
Addresses an issue where frames which take longer to render (such as module frames) could freeze the display by attempting a new update while an async refresh is already in progress.

*Collaboration with joec2511 (Meshtastic Discord server)*
