### PR TITLE
fix for unPhone hangs during boot without sd card present

### DIFF
--- a/variants/unphone/variant.h
+++ b/variants/unphone/variant.h
@@ -48,7 +48,7 @@
 #undef GPS_RX_PIN
 #undef GPS_TX_PIN
 
-#define HAS_SDCARD 0 // causes hang if defined
+// #define HAS_SDCARD 1 // causes hang if defined
 #define SDCARD_CS 43
 
 #define LED_PIN 13 // the red part of the RGB LED

--- a/variants/unphone/variant.h
+++ b/variants/unphone/variant.h
@@ -48,7 +48,7 @@
 #undef GPS_RX_PIN
 #undef GPS_TX_PIN
 
-#define HAS_SDCARD 1
+#define HAS_SDCARD 0 // causes hang if defined
 #define SDCARD_CS 43
 
 #define LED_PIN 13 // the red part of the RGB LED


### PR DESCRIPTION
Hello

I've just noticed that somehow in latest version the stub of sd card support is interfering with boot.

This only occurs if a sd card is not present, hence why I missed it earlier.

For the time being please accept this PR to comment out HAS_SDCARD.

When the feature is more developed we can reverse this change.