### PR TITLE
Split warning into two messages, so we know which one is the case.

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -548,7 +548,10 @@ void MQTT::perhapsReportToMap()
     } else {
         if (map_position_precision == 0 || (localPosition.latitude_i == 0 && localPosition.longitude_i == 0)) {
             last_report_to_map = millis();
-            LOG_WARN("MQTT Map reporting is enabled, but precision is 0 or no position available.\n");
+            if (map_position_precision == 0)
+                LOG_WARN("MQTT Map reporting is enabled, but precision is 0\n");
+            if (localPosition.latitude_i == 0 && localPosition.longitude_i == 0)
+                LOG_WARN("MQTT Map reporting is enabled, but no position available.\n");
             return;
         }
 


### PR DESCRIPTION
I always wonder which is the case when I see this log entry, so split it into separate pieces.