### PR TITLE
Reverse directions for swiping left and right on touchscreen

### DIFF
--- a/src/input/TouchScreenImpl1.cpp
+++ b/src/input/TouchScreenImpl1.cpp
@@ -51,11 +51,11 @@ void TouchScreenImpl1::onEvent(const TouchEvent &event)
     e.source = event.source;
     switch (event.touchEvent) {
     case TOUCH_ACTION_LEFT: {
-        e.inputEvent = static_cast<char>(meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_RIGHT);
+        e.inputEvent = static_cast<char>(meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_LEFT);
         break;
     }
     case TOUCH_ACTION_RIGHT: {
-        e.inputEvent = static_cast<char>(meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_LEFT);
+        e.inputEvent = static_cast<char>(meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_RIGHT);
         break;
     }
     case TOUCH_ACTION_UP: {


### PR DESCRIPTION
Reverse the directions for swiping left and right on touch screen. This fix makes it correct on T-deck. 