### PR TITLE
Fix local time-zones for some regions

### DIFF
--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -223,7 +223,7 @@ int32_t getTZOffset()
     now = time(NULL);
     gmt = gmtime(&now);
     gmt->tm_isdst = -1;
-    return (int16_t)difftime(now, mktime(gmt));
+    return (int32_t)difftime(now, mktime(gmt));
 }
 
 /**


### PR DESCRIPTION
Fixes an issue with time-zones which differ from UTC by more than 9 hours.
In these cases, the "difference in seconds" from UTC is too large for `uint16_t`.