### PR TITLE
Update Heltec HT-C62 variant based on HT-DEV-ESP board

### DIFF
--- a/variants/heltec_esp32c3/variant.h
+++ b/variants/heltec_esp32c3/variant.h
@@ -1,23 +1,15 @@
-#define I2C_SDA 1
-#define I2C_SCL 0
-
 #define BUTTON_PIN 9
-#define BUTTON_NEED_PULLUP
 
-// LED flashes brighter
+// LED pin on HT-DEV-ESP_V2 and HT-DEV-ESP_V3
 // https://resource.heltec.cn/download/HT-CT62/HT-CT62_Reference_Design.pdf
-#define LED_PIN 18 // LED
-#define LED_INVERTED 1
+// https://resource.heltec.cn/download/HT-DEV-ESP/HT-DEV-ESP_V3_Sch.pdf
+#define LED_PIN 2 // LED
+#define LED_INVERTED 0
 
-#define HAS_SCREEN 1
+#define HAS_SCREEN 0
 #define HAS_GPS 0
 #undef GPS_RX_PIN
 #undef GPS_TX_PIN
-
-#undef LORA_SCK
-#undef LORA_MISO
-#undef LORA_MOSI
-#undef LORA_CS
 
 #define USE_SX1262
 #define LORA_SCK 10


### PR DESCRIPTION
* I2C is not defined in the reference schematic nor HT-DEV-ESP board, remove definition accordingly
* There is no screen in the the reference schematic nor HT-DEV-ESP board, change definition accordingly
* BUTTON_PIN has a 10 kOhm pullup resistor on HT-DEV-ESP, turning off redundant internal pullup should save some power
* LED is connected to GPIO2 on HT-DEV-ESP and is not inverted, update definition accordingly
* Remove redundant undef lines for LoRa pins

Above changes were built and flashed to my [HT-DEV-ESP_V2 board purchased from Heltec's Taobao store](https://item.taobao.com/item.htm?id=521590063077).