### PR TITLE
Fix xiao_ble variant build error due to undefined BATTERY_SENSE_RESOLUTION_BITS

### DIFF
--- a/variants/xiao_ble/variant.h
+++ b/variants/xiao_ble/variant.h
@@ -181,6 +181,7 @@ static const uint8_t SCL = PIN_WIRE_SCL;
 #define BAT_READ                                                                                                                 \
     14 // P0_14 = 14  Reads battery voltage from divider on signal board. (PIN_VBAT is reading voltage divider on XIAO and is
        // program pin 32 / or P0.31)
+#define BATTERY_SENSE_RESOLUTION_BITS 10
 #define CHARGE_LED 23 // P0_17 = 17  D23   YELLOW CHARGE LED
 #define HICHG 22      // P0_13 = 13  D22   Charge-select pin for Lipo for 100 mA instead of default 50mA charge
 


### PR DESCRIPTION
Define BATTERY_SENSE_RESOLUTION_BITS based on [amoroz's snippet on the Meshtastic forum](https://meshtastic.discourse.group/t/new-1w-diy-variant-xiao-nrf52840-ebyte-e22-900m30s/7904/10).

Fixes following build error:

```
src/Power.cpp: In member function 'virtual uint16_t AnalogBatteryLevel::getBattVoltage()':
src/Power.cpp:224:79: error: 'BATTERY_SENSE_RESOLUTION_BITS' was not declared in this scope
             scaled = operativeAdcMultiplier * ((1000 * AREF_VOLTAGE) / pow(2, BATTERY_SENSE_RESOLUTION_BITS)) * raw;
```