### PR TITLE
fix #if HAS_TELEMETRY when set to 0

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -184,7 +184,7 @@ class AnalogBatteryLevel : public HasBatteryLevel
     virtual uint16_t getBattVoltage() override
     {
 
-#if defined(HAS_TELEMETRY) && !defined(ARCH_PORTDUINO) && !defined(HAS_PMU)
+#if HAS_TELEMETRY && !defined(ARCH_PORTDUINO) && !defined(HAS_PMU)
         if (hasINA()) {
             LOG_DEBUG("Using INA on I2C addr 0x%x for device battery voltage\n", config.power.device_battery_ina_address);
             return getINAVoltage();
@@ -360,7 +360,7 @@ class AnalogBatteryLevel : public HasBatteryLevel
     float last_read_value = (OCV[NUM_OCV_POINTS - 1] * NUM_CELLS);
     uint32_t last_read_time_ms = 0;
 
-#if defined(HAS_TELEMETRY) && !defined(ARCH_PORTDUINO)
+#if HAS_TELEMETRY && !defined(ARCH_PORTDUINO)
     uint16_t getINAVoltage()
     {
         if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_INA219].first == config.power.device_battery_ina_address) {


### PR DESCRIPTION
This fixes a small issue when HAS_TELEMETRY is set to 0, eg as done in [configuration.h](https://github.com/meshtastic/firmware/blob/master/src/configuration.h#L211) 

I've had a look over most other #defines that are set to 0 and they seem all checked by #if, not #ifdef

Small contribution towards #3632 