### PR TITLE
Don't use "wake on tap or motion" for T-Echo touch button

### DIFF
--- a/src/ButtonThread.cpp
+++ b/src/ButtonThread.cpp
@@ -196,15 +196,13 @@ int32_t ButtonThread::runOnce()
 #ifdef BUTTON_PIN_TOUCH
         case BUTTON_EVENT_TOUCH_LONG_PRESSED: {
             LOG_BUTTON("Touch press!\n");
-            if (config.display.wake_on_tap_or_motion) {
-                if (screen) {
-                    // Wake if asleep
-                    if (powerFSM.getState() == &stateDARK)
-                        powerFSM.trigger(EVENT_PRESS);
+            if (screen) {
+                // Wake if asleep
+                if (powerFSM.getState() == &stateDARK)
+                    powerFSM.trigger(EVENT_PRESS);
 
-                    // Update display (legacy behaviour)
-                    screen->forceDisplay();
-                }
+                // Update display (legacy behaviour)
+                screen->forceDisplay();
             }
             break;
         }

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -353,9 +353,6 @@ void NodeDB::installDefaultModuleConfig()
     moduleConfig.external_notification.output_ms = 100;
     moduleConfig.external_notification.active = true;
 #endif
-#ifdef TTGO_T_ECHO
-    config.display.wake_on_tap_or_motion = true; // Enable touch button for screen-on / refresh
-#endif
     moduleConfig.has_canned_message = true;
 
     strncpy(moduleConfig.mqtt.address, default_mqtt_address, sizeof(moduleConfig.mqtt.address));


### PR DESCRIPTION
Back in 2022, @caveman99 mentioned an issue where transmitting would trigger a long-press of the touch button.
The "wake on tap or motion" setting was used recently as a "bail-out" option for any users experiencing this issue.
I am not aware of any reports of this issue recently, so it seems safe to enable the touch button for all T-Echo devices, removing the association with the "wake on tap or motion" setting.

There is currently a mystery issue, where this setting does not always persist. Removing the use of this setting with the T-Echo avoids the issue for now.