### PR TITLE
Publish fixed position updates and consider changes in only altitude as an updated point

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1467,7 +1467,7 @@ bool GPS::lookForLocation()
 #endif // GPS_EXTRAVERBOSE
 
     // Is this a new point or are we re-reading the previous one?
-    if (!reader.location.isUpdated())
+    if (!reader.location.isUpdated() && !reader.altitude.isUpdated())
         return false;
 
     // check if a complete GPS solution set is available for reading

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -23,6 +23,10 @@
 #include "mqtt/MQTT.h"
 #endif
 
+#if !MESHTASTIC_EXCLUDE_GPS
+#include "GPS.h"
+#endif
+
 AdminModule *adminModule;
 bool hasOpenEditTransaction;
 
@@ -217,6 +221,10 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
             nodeDB->setLocalPosition(r->set_fixed_position);
             config.position.fixed_position = true;
             saveChanges(SEGMENT_DEVICESTATE | SEGMENT_CONFIG, false);
+#if !MESHTASTIC_EXCLUDE_GPS
+            if (gps != nullptr)
+                gps->enable();
+#endif
         }
         break;
     }


### PR DESCRIPTION
Enabled GPS thread when fixed position is updated, to let the GPS thread run once and publish the new fixed position.

Also consider changes in only altitude as an updated point, so that running Python `meshtastic` with `--setlat --setlong --setalt` but only changes to altitude will still publish to the mesh.