### PR TITLE
Fix t-echo gps failure

### DIFF
--- a/variants/t-echo/variant.h
+++ b/variants/t-echo/variant.h
@@ -131,7 +131,7 @@ External serial flash WP25R1635FZUIL0
 // Note DIO2 is attached internally to the module to an analog switch for TX/RX switching
 #define SX1262_DIO3                                                                                                              \
     (0 + 21) // This is used as an *output* from the sx1262 and connected internally to power the tcxo, do not drive from the main
-             // CPU?
+// CPU?
 #define SX126X_BUSY (0 + 17)
 #define SX126X_RESET (0 + 25)
 // Not really an E22 but TTGO seems to be trying to clone that
@@ -177,13 +177,13 @@ External serial flash WP25R1635FZUIL0
 #define PIN_GPS_STANDBY (32 + 2) // An output to wake GPS, low means allow sleep, high means force wake
 // Seems to be missing on this new board
 // #define PIN_GPS_PPS (32 + 4)  // Pulse per second input from the GPS
-#define PIN_GPS_TX (32 + 9) // This is for bits going TOWARDS the CPU
-#define PIN_GPS_RX (32 + 8) // This is for bits going TOWARDS the GPS
+#define GPS_TX_PIN (32 + 9) // This is for bits going TOWARDS the CPU
+#define GPS_RX_PIN (32 + 8) // This is for bits going TOWARDS the GPS
 
 #define GPS_THREAD_INTERVAL 50
 
-#define PIN_SERIAL1_RX PIN_GPS_TX
-#define PIN_SERIAL1_TX PIN_GPS_RX
+#define PIN_SERIAL1_RX GPS_TX_PIN
+#define PIN_SERIAL1_TX GPS_RX_PIN
 
 // PCF8563 RTC Module
 #define PCF8563_RTC 0x51


### PR DESCRIPTION
When I changed the T-echo factory default firmware to 2.3.7 or 2.3.6, I encountered the problem of GPS being unable to locate. I had to find the problem in the source code. I don’t know why. PIN_GPS_TX has been renamed to GPS_RX_PIN, but The pin names in t-echo have not been changed, so the default compiled firmware will not have GPS functionality.