### PR TITLE
Fix T-Beam S3 USB CLI #3736

### DIFF
--- a/boards/tbeam-s3-core.json
+++ b/boards/tbeam-s3-core.json
@@ -7,6 +7,7 @@
     "extra_flags": [
       "-DBOARD_HAS_PSRAM",
       "-DLILYGO_TBEAM_S3_CORE",
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
       "-DARDUINO_USB_MODE=1",
       "-DARDUINO_RUNNING_CORE=1",
       "-DARDUINO_EVENT_RUNNING_CORE=1"

--- a/variants/tbeam-s3-core/platformio.ini
+++ b/variants/tbeam-s3-core/platformio.ini
@@ -3,6 +3,8 @@
 extends = esp32s3_base
 board = tbeam-s3-core
 
+platform_packages = framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.15
+
 lib_deps =
   ${esp32s3_base.lib_deps}
   lewisxhe/PCF8563_Library@1.0.1


### PR DESCRIPTION
Fix for #3736 

It seems that we do need ARDUINO_USB_CDC_ON_BOOT=1 after all in order for the CLI to work with the ESP32-S3. Otherwise I cannot get the S3 to read from USB Serial.

Issue https://github.com/meshtastic/firmware/issues/3650 that can cause the S3 to block on boot when no Serial is connected (and is triggered by ARDUINO_USB_CDC_ON_BOOT=1 in combination with ARDUINO_USB_MODE=1) has recently been fixed in [arduino-esp32 @ 2.0.15](https://github.com/espressif/arduino-esp32/releases/tag/2.0.15) . I've confirmed that using platform_packages = framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.15