### PR TITLE
Track actual GPIO values, not just the enum values

### DIFF
--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -75,7 +75,7 @@ void portduinoSetup()
 {
     printf("Setting up Meshtastic on Portduino...\n");
     int max_GPIO = 0;
-    int GPIO_lines[] = {cs,
+    configNames GPIO_lines[] = {cs,
                         irq,
                         busy,
                         reset,
@@ -281,9 +281,9 @@ void portduinoSetup()
         exit(EXIT_FAILURE);
     }
 
-    for (int i : GPIO_lines) {
-        if (i > max_GPIO)
-            max_GPIO = i;
+    for (configNames i : GPIO_lines) {
+        if (settingsMap[i] > max_GPIO)
+            max_GPIO = settingsMap[i];
     }
 
     gpioInit(max_GPIO + 1); // Done here so we can inform Portduino how many GPIOs we need.

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -76,19 +76,19 @@ void portduinoSetup()
     printf("Setting up Meshtastic on Portduino...\n");
     int max_GPIO = 0;
     configNames GPIO_lines[] = {cs,
-                        irq,
-                        busy,
-                        reset,
-                        txen,
-                        rxen,
-                        displayDC,
-                        displayCS,
-                        displayBacklight,
-                        displayBacklightPWMChannel,
-                        displayReset,
-                        touchscreenCS,
-                        touchscreenIRQ,
-                        user};
+                                irq,
+                                busy,
+                                reset,
+                                txen,
+                                rxen,
+                                displayDC,
+                                displayCS,
+                                displayBacklight,
+                                displayBacklightPWMChannel,
+                                displayReset,
+                                touchscreenCS,
+                                touchscreenIRQ,
+                                user};
 
     std::string gpioChipName = "gpiochip";
     settingsStrings[i2cdev] = "";


### PR DESCRIPTION
Silly mistake in the logic that finds the highest GPIO number in use.