### PR TITLE
Fix the infinite restart caused by unformatted t-echo fs file system

### DIFF
--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -212,8 +212,23 @@ void fsInit()
         LOG_ERROR("Filesystem mount Failed.\n");
         // assert(0); This auto-formats the partition, so no need to fail here.
     }
-#ifdef ARCH_ESP32
+#if   defined(ARCH_ESP32)
     LOG_DEBUG("Filesystem files (%d/%d Bytes):\n", FSCom.usedBytes(), FSCom.totalBytes());
+#elif defined(ARCH_NRF52)
+    /*
+    * nRF52840 has a certain chance of automatic formatting failure.
+    * Try to create a file after initializing the file system. If the creation fails,
+    * it means that the file system is not working properly. Please format it manually again.
+    * */
+    Adafruit_LittleFS_Namespace::File file(FSCom);
+    const char *filename = "/meshtastic.txt";
+    if (! file.open(filename, FILE_O_WRITE) ) {
+        LOG_DEBUG("Format ....");
+        FSCom.format();
+        FSCom.begin();
+    } else {
+        file.close();
+    }
 #else
     LOG_DEBUG("Filesystem files:\n");
 #endif

--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -212,17 +212,17 @@ void fsInit()
         LOG_ERROR("Filesystem mount Failed.\n");
         // assert(0); This auto-formats the partition, so no need to fail here.
     }
-#if   defined(ARCH_ESP32)
+#if defined(ARCH_ESP32)
     LOG_DEBUG("Filesystem files (%d/%d Bytes):\n", FSCom.usedBytes(), FSCom.totalBytes());
 #elif defined(ARCH_NRF52)
     /*
-    * nRF52840 has a certain chance of automatic formatting failure.
-    * Try to create a file after initializing the file system. If the creation fails,
-    * it means that the file system is not working properly. Please format it manually again.
-    * */
+     * nRF52840 has a certain chance of automatic formatting failure.
+     * Try to create a file after initializing the file system. If the creation fails,
+     * it means that the file system is not working properly. Please format it manually again.
+     * */
     Adafruit_LittleFS_Namespace::File file(FSCom);
     const char *filename = "/meshtastic.txt";
-    if (! file.open(filename, FILE_O_WRITE) ) {
+    if (!file.open(filename, FILE_O_WRITE)) {
         LOG_DEBUG("Format ....");
         FSCom.format();
         FSCom.begin();


### PR DESCRIPTION
In the actual production environment, it was found that some t-echo did not start as expected. After debugging, it was found that they all died while reading file system files, triggering system assertions and causing infinite restarts. The following is the exception log.
```
//\ E S H T /\ S T / C

DEBUG | ??:??:?? 3 Filesystem files:
DEBUG | ??:??:?? 3  db.proto (1966 Bytes)
DEBUG | ??:??:?? 3 Using analog input 4 for battery level
INFO  | ??:??:?? 3 Scanning for i2c devices...
DEBUG | ??:??:?? 3 Scanning for i2c devices on port 1
DEBUG | ??:??:?? 4 I2C device found at address 0x51
INFO  | ??:??:?? 4 PCF8563 RTC found
DEBUG | ??:??:?? 4 I2C device found at address 0x77
DEBUG | ??:??:?? 4 Wire.available() = 1
INFO  | ??:??:?? 4 BME-280 sensor found at address 0x77
INFO  | ??:??:?? 4 2 I2C devices found
DEBUG | ??:??:?? 4 acc_info = 0
DEBUG | ??:??:?? 4 found i2c sensor meshtastic_TelemetrySensorType_BME280
INFO  | ??:??:?? 4 Meshtastic hwvendor=7, swver=2.3.8.102a20d2
DEBUG | ??:??:?? 4 Reset reason: 0x0
DEBUG | ??:??:?? 4 Setting random seed 2134818540
INFO  | ??:??:?? 4 Initializing NodeDB
INFO  | ??:??:?? 4 Loading /prefs/db.proto
ERROR | ??:??:?? 4 assert failed C:\Users\Lewis\.platformio\packages\framework-arduinoadafruitnrf52\libraries\Ad
```

The solution is to try to create a file after initializing the file system and test whether the file is created normally. If not, manually format the internal file system again. After adding it, the device starts as expected and works normally.

By the way, this bug has existed for a long time. The last exception was fixed in https://github.com/meshtastic/firmware/pull/1987. This time it may be a better way to make a judgment before initialization. Because the application layer is constantly changing
