### PR TITLE
Enable compiling with gccnoneeabi 12.3.1 for nRF52 targets, additional small fixes

### DIFF
--- a/arch/nrf52/nrf52.ini
+++ b/arch/nrf52/nrf52.ini
@@ -3,7 +3,7 @@
 platform = platformio/nordicnrf52@^10.4.0
 extends = arduino_base
 
-build_type = debug ; I'm debugging with ICE a lot now
+build_type = release
 build_flags = 
   ${arduino_base.build_flags}
   -DSERIAL_BUFFER_SIZE=1024

--- a/src/SerialConsole.cpp
+++ b/src/SerialConsole.cpp
@@ -2,6 +2,7 @@
 #include "NodeDB.h"
 #include "PowerFSM.h"
 #include "configuration.h"
+#include "time.h"
 
 #ifdef RP2040_SLOW_CLOCK
 #define Port Serial2

--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -452,7 +452,7 @@ bool GPS::setup()
             // Set the NEMA output messages
             // Ask for only RMC and GGA
             uint8_t fields[] = {CAS_NEMA_RMC, CAS_NEMA_GGA};
-            for (uint i = 0; i < sizeof(fields); i++) {
+            for (unsigned int i = 0; i < sizeof(fields); i++) {
                 // Construct a CAS-CFG-MSG packet
                 uint8_t cas_cfg_msg_packet[] = {0x4e, fields[i], 0x01, 0x00};
                 msglen = makeCASPacket(0x06, 0x01, sizeof(cas_cfg_msg_packet), cas_cfg_msg_packet);
@@ -1584,7 +1584,7 @@ bool GPS::hasFlow()
 
 bool GPS::whileIdle()
 {
-    uint charsInBuf = 0;
+    unsigned int charsInBuf = 0;
     bool isValid = false;
     if (!isAwake) {
         clearBuffer();

--- a/src/input/TouchScreenBase.h
+++ b/src/input/TouchScreenBase.h
@@ -3,6 +3,7 @@
 #include "InputBroker.h"
 #include "concurrency/OSThread.h"
 #include "mesh/NodeDB.h"
+#include "time.h"
 
 typedef struct _TouchEvent {
     const char *source;

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -449,7 +449,7 @@ void NodeDB::resetNodes()
         neighborInfoModule->resetNeighbors();
 }
 
-void NodeDB::removeNodeByNum(uint nodeNum)
+void NodeDB::removeNodeByNum(NodeNum nodeNum)
 {
     int newPos = 0, removed = 0;
     for (int i = 0; i < numMeshNodes; i++) {

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -124,7 +124,7 @@ class NodeDB
      */
     size_t getNumOnlineMeshNodes(bool localOnly = false);
 
-    void initConfigIntervals(), initModuleConfigIntervals(), resetNodes(), removeNodeByNum(uint nodeNum);
+    void initConfigIntervals(), initModuleConfigIntervals(), resetNodes(), removeNodeByNum(NodeNum nodeNum);
 
     bool factoryReset();
 

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -495,7 +495,7 @@ void RadioInterface::applyModemConfig()
     // If user has manually specified a channel num, then use that, otherwise generate one by hashing the name
     const char *channelName = channels.getName(channels.getPrimaryIndex());
     // channel_num is actually (channel_num - 1), since modulus (%) returns values from 0 to (numChannels - 1)
-    uint channel_num = (loraConfig.channel_num ? loraConfig.channel_num - 1 : hash(channelName)) % numChannels;
+    uint32_t channel_num = (loraConfig.channel_num ? loraConfig.channel_num - 1 : hash(channelName)) % numChannels;
 
     // Check if we use the default frequency slot
     RadioInterface::uses_default_frequency_slot =

--- a/src/mqtt/JSONValue.cpp
+++ b/src/mqtt/JSONValue.cpp
@@ -368,9 +368,9 @@ JSONValue::JSONValue(int m_integer_value)
  *
  * @access public
  *
- * @param uint m_integer_value The number to use as the value
+ * @param unsigned int m_integer_value The number to use as the value
  */
-JSONValue::JSONValue(uint m_integer_value)
+JSONValue::JSONValue(unsigned int m_integer_value)
 {
     type = JSONType_Number;
     number_value = (double)m_integer_value;

--- a/src/mqtt/JSONValue.h
+++ b/src/mqtt/JSONValue.h
@@ -45,7 +45,7 @@ class JSONValue
     JSONValue(bool m_bool_value);
     JSONValue(double m_number_value);
     JSONValue(int m_integer_value);
-    JSONValue(uint m_integer_value);
+    JSONValue(unsigned int m_integer_value);
     JSONValue(const JSONArray &m_array_value);
     JSONValue(const JSONObject &m_object_value);
     JSONValue(const JSONValue &m_source);

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -659,11 +659,11 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
             if (pb_decode_from_bytes(mp->decoded.payload.bytes, mp->decoded.payload.size, &meshtastic_Telemetry_msg, &scratch)) {
                 decoded = &scratch;
                 if (decoded->which_variant == meshtastic_Telemetry_device_metrics_tag) {
-                    msgPayload["battery_level"] = new JSONValue((uint)decoded->variant.device_metrics.battery_level);
+                    msgPayload["battery_level"] = new JSONValue((unsigned int)decoded->variant.device_metrics.battery_level);
                     msgPayload["voltage"] = new JSONValue(decoded->variant.device_metrics.voltage);
                     msgPayload["channel_utilization"] = new JSONValue(decoded->variant.device_metrics.channel_utilization);
                     msgPayload["air_util_tx"] = new JSONValue(decoded->variant.device_metrics.air_util_tx);
-                    msgPayload["uptime_seconds"] = new JSONValue((uint)decoded->variant.device_metrics.uptime_seconds);
+                    msgPayload["uptime_seconds"] = new JSONValue((unsigned int)decoded->variant.device_metrics.uptime_seconds);
                 } else if (decoded->which_variant == meshtastic_Telemetry_environment_metrics_tag) {
                     msgPayload["temperature"] = new JSONValue(decoded->variant.environment_metrics.temperature);
                     msgPayload["relative_humidity"] = new JSONValue(decoded->variant.environment_metrics.relative_humidity);
@@ -710,10 +710,10 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
             if (pb_decode_from_bytes(mp->decoded.payload.bytes, mp->decoded.payload.size, &meshtastic_Position_msg, &scratch)) {
                 decoded = &scratch;
                 if ((int)decoded->time) {
-                    msgPayload["time"] = new JSONValue((uint)decoded->time);
+                    msgPayload["time"] = new JSONValue((unsigned int)decoded->time);
                 }
                 if ((int)decoded->timestamp) {
-                    msgPayload["timestamp"] = new JSONValue((uint)decoded->timestamp);
+                    msgPayload["timestamp"] = new JSONValue((unsigned int)decoded->timestamp);
                 }
                 msgPayload["latitude_i"] = new JSONValue((int)decoded->latitude_i);
                 msgPayload["longitude_i"] = new JSONValue((int)decoded->longitude_i);
@@ -721,13 +721,13 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
                     msgPayload["altitude"] = new JSONValue((int)decoded->altitude);
                 }
                 if ((int)decoded->ground_speed) {
-                    msgPayload["ground_speed"] = new JSONValue((uint)decoded->ground_speed);
+                    msgPayload["ground_speed"] = new JSONValue((unsigned int)decoded->ground_speed);
                 }
                 if (int(decoded->ground_track)) {
-                    msgPayload["ground_track"] = new JSONValue((uint)decoded->ground_track);
+                    msgPayload["ground_track"] = new JSONValue((unsigned int)decoded->ground_track);
                 }
                 if (int(decoded->sats_in_view)) {
-                    msgPayload["sats_in_view"] = new JSONValue((uint)decoded->sats_in_view);
+                    msgPayload["sats_in_view"] = new JSONValue((unsigned int)decoded->sats_in_view);
                 }
                 if ((int)decoded->PDOP) {
                     msgPayload["PDOP"] = new JSONValue((int)decoded->PDOP);
@@ -754,11 +754,11 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
             memset(&scratch, 0, sizeof(scratch));
             if (pb_decode_from_bytes(mp->decoded.payload.bytes, mp->decoded.payload.size, &meshtastic_Waypoint_msg, &scratch)) {
                 decoded = &scratch;
-                msgPayload["id"] = new JSONValue((uint)decoded->id);
+                msgPayload["id"] = new JSONValue((unsigned int)decoded->id);
                 msgPayload["name"] = new JSONValue(decoded->name);
                 msgPayload["description"] = new JSONValue(decoded->description);
-                msgPayload["expire"] = new JSONValue((uint)decoded->expire);
-                msgPayload["locked_to"] = new JSONValue((uint)decoded->locked_to);
+                msgPayload["expire"] = new JSONValue((unsigned int)decoded->expire);
+                msgPayload["locked_to"] = new JSONValue((unsigned int)decoded->locked_to);
                 msgPayload["latitude_i"] = new JSONValue((int)decoded->latitude_i);
                 msgPayload["longitude_i"] = new JSONValue((int)decoded->longitude_i);
                 jsonObj["payload"] = new JSONValue(msgPayload);
@@ -775,14 +775,14 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
             if (pb_decode_from_bytes(mp->decoded.payload.bytes, mp->decoded.payload.size, &meshtastic_NeighborInfo_msg,
                                      &scratch)) {
                 decoded = &scratch;
-                msgPayload["node_id"] = new JSONValue((uint)decoded->node_id);
-                msgPayload["node_broadcast_interval_secs"] = new JSONValue((uint)decoded->node_broadcast_interval_secs);
-                msgPayload["last_sent_by_id"] = new JSONValue((uint)decoded->last_sent_by_id);
+                msgPayload["node_id"] = new JSONValue((unsigned int)decoded->node_id);
+                msgPayload["node_broadcast_interval_secs"] = new JSONValue((unsigned int)decoded->node_broadcast_interval_secs);
+                msgPayload["last_sent_by_id"] = new JSONValue((unsigned int)decoded->last_sent_by_id);
                 msgPayload["neighbors_count"] = new JSONValue(decoded->neighbors_count);
                 JSONArray neighbors;
                 for (uint8_t i = 0; i < decoded->neighbors_count; i++) {
                     JSONObject neighborObj;
-                    neighborObj["node_id"] = new JSONValue((uint)decoded->neighbors[i].node_id);
+                    neighborObj["node_id"] = new JSONValue((unsigned int)decoded->neighbors[i].node_id);
                     neighborObj["snr"] = new JSONValue((int)decoded->neighbors[i].snr);
                     neighbors.push_back(new JSONValue(neighborObj));
                 }
@@ -843,9 +843,9 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
             memset(&scratch, 0, sizeof(scratch));
             if (pb_decode_from_bytes(mp->decoded.payload.bytes, mp->decoded.payload.size, &meshtastic_Paxcount_msg, &scratch)) {
                 decoded = &scratch;
-                msgPayload["wifi_count"] = new JSONValue((uint)decoded->wifi);
-                msgPayload["ble_count"] = new JSONValue((uint)decoded->ble);
-                msgPayload["uptime"] = new JSONValue((uint)decoded->uptime);
+                msgPayload["wifi_count"] = new JSONValue((unsigned int)decoded->wifi);
+                msgPayload["ble_count"] = new JSONValue((unsigned int)decoded->ble);
+                msgPayload["uptime"] = new JSONValue((unsigned int)decoded->uptime);
                 jsonObj["payload"] = new JSONValue(msgPayload);
             } else {
                 LOG_ERROR("Error decoding protobuf for Paxcount message!\n");
@@ -862,12 +862,12 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
                 decoded = &scratch;
                 if (decoded->type == meshtastic_HardwareMessage_Type_GPIOS_CHANGED) {
                     msgType = "gpios_changed";
-                    msgPayload["gpio_value"] = new JSONValue((uint)decoded->gpio_value);
+                    msgPayload["gpio_value"] = new JSONValue((unsigned int)decoded->gpio_value);
                     jsonObj["payload"] = new JSONValue(msgPayload);
                 } else if (decoded->type == meshtastic_HardwareMessage_Type_READ_GPIOS_REPLY) {
                     msgType = "gpios_read_reply";
-                    msgPayload["gpio_value"] = new JSONValue((uint)decoded->gpio_value);
-                    msgPayload["gpio_mask"] = new JSONValue((uint)decoded->gpio_mask);
+                    msgPayload["gpio_value"] = new JSONValue((unsigned int)decoded->gpio_value);
+                    msgPayload["gpio_mask"] = new JSONValue((unsigned int)decoded->gpio_mask);
                     jsonObj["payload"] = new JSONValue(msgPayload);
                 }
             } else {
@@ -883,11 +883,11 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
         LOG_WARN("Couldn't convert encrypted payload of MeshPacket to JSON\n");
     }
 
-    jsonObj["id"] = new JSONValue((uint)mp->id);
-    jsonObj["timestamp"] = new JSONValue((uint)mp->rx_time);
-    jsonObj["to"] = new JSONValue((uint)mp->to);
-    jsonObj["from"] = new JSONValue((uint)mp->from);
-    jsonObj["channel"] = new JSONValue((uint)mp->channel);
+    jsonObj["id"] = new JSONValue((unsigned int)mp->id);
+    jsonObj["timestamp"] = new JSONValue((unsigned int)mp->rx_time);
+    jsonObj["to"] = new JSONValue((unsigned int)mp->to);
+    jsonObj["from"] = new JSONValue((unsigned int)mp->from);
+    jsonObj["channel"] = new JSONValue((unsigned int)mp->channel);
     jsonObj["type"] = new JSONValue(msgType.c_str());
     jsonObj["sender"] = new JSONValue(owner.id);
     if (mp->rx_rssi != 0)
@@ -895,7 +895,7 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
     if (mp->rx_snr != 0)
         jsonObj["snr"] = new JSONValue((float)mp->rx_snr);
     if (mp->hop_start != 0 && mp->hop_limit <= mp->hop_start)
-        jsonObj["hops_away"] = new JSONValue((uint)(mp->hop_start - mp->hop_limit));
+        jsonObj["hops_away"] = new JSONValue((unsigned int)(mp->hop_start - mp->hop_limit));
 
     // serialize and write it to the stream
     JSONValue *value = new JSONValue(jsonObj);

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -287,7 +287,7 @@ void NRF52Bluetooth::setup()
     LOG_INFO("Advertising\n");
 }
 
-void NRF52Bluetooth::resumeAdverising()
+void NRF52Bluetooth::resumeAdvertising()
 {
     Bluefruit.Advertising.restartOnDisconnect(true);
     Bluefruit.Advertising.setInterval(32, 244); // in unit of 0.625 ms

--- a/src/platform/nrf52/NRF52Bluetooth.h
+++ b/src/platform/nrf52/NRF52Bluetooth.h
@@ -8,7 +8,7 @@ class NRF52Bluetooth : BluetoothApi
   public:
     void setup();
     void shutdown();
-    void resumeAdverising();
+    void resumeAdvertising();
     void clearBonds();
     bool isConnected();
     int getRssi();

--- a/src/platform/nrf52/main-nrf52.cpp
+++ b/src/platform/nrf52/main-nrf52.cpp
@@ -80,7 +80,7 @@ void setBluetoothEnable(bool enable)
                 // We delay brownout init until after BLE because BLE starts soft device
                 initBrownout();
             } else {
-                nrf52Bluetooth->resumeAdverising();
+                nrf52Bluetooth->resumeAdvertising();
             }
         }
     } else {


### PR DESCRIPTION
When compiling with gccnoneeabi 12.3.1 (on windows) one runs into the problem that there are some definitions using the type "uint", which is not a standard type. Resulting in a failed compiler run.

Also there are two instances of a missing time.h (error: time_t not declared).

The meshtastic type of nodeNum is "NodeNum", so it should be used instead of uint.

channel_num is defined as uint, but should rather be uint32_t (type of hash() and num_channels)

Typo "Adverising" fixed in nrf/bluetooth