### PR TITLE
Fix for EnvironmentTelemetry Screen

### DIFF
--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -172,8 +172,8 @@ void EnvironmentTelemetryModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiSt
         return;
     }
 
-    // Display "From: ..." on its own
-    display->drawString(x, y, "From: " + String(lastSender) + "(" + String(agoSecs) + "s)");
+    // Display "Env. From: ..." on its own
+    display->drawString(x, y, "Env. From: " + String(lastSender) + "(" + String(agoSecs) + "s)");
 
     String last_temp = String(lastMeasurement.variant.environment_metrics.temperature, 0) + "°C";
     if (moduleConfig.telemetry.environment_display_fahrenheit) {
@@ -181,19 +181,27 @@ void EnvironmentTelemetryModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiSt
     }
 
     // Continue with the remaining details
-    display->drawString(x, y += fontHeight(FONT_SMALL), "Temp/Hum: " + last_temp + " / " + String(lastMeasurement.variant.environment_metrics.relative_humidity, 0) + "%");
+    display->drawString(x, y += fontHeight(FONT_SMALL),    
+                "Temp/Hum: " + last_temp + " / " + 
+                    String(lastMeasurement.variant.environment_metrics.relative_humidity, 0) + "%");
 
     if (lastMeasurement.variant.environment_metrics.barometric_pressure != 0) {
-        display->drawString(x, y += fontHeight(FONT_SMALL), "Press: " + String(lastMeasurement.variant.environment_metrics.barometric_pressure, 0) + "hPA");
+        display->drawString(x, y += fontHeight(FONT_SMALL), 
+                "Press: " + String(lastMeasurement.variant.environment_metrics.barometric_pressure, 0) + "hPA");
     }
 
     if (lastMeasurement.variant.environment_metrics.voltage != 0) {
-        display->drawString(x, y += fontHeight(FONT_SMALL), "Volt/Cur: " + String(lastMeasurement.variant.environment_metrics.voltage, 0) + "V / " + String(lastMeasurement.variant.environment_metrics.current, 0) + "mA");
+        display->drawString(x, y += fontHeight(FONT_SMALL), 
+                "Volt/Cur: " + String(lastMeasurement.variant.environment_metrics.voltage, 0) + "V / " + 
+                    String(lastMeasurement.variant.environment_metrics.current, 0) + "mA");
     }
-
     if (lastMeasurement.variant.environment_metrics.iaq != 0) {
-        display->drawString(x, y += fontHeight(FONT_SMALL), "IAQ: " + String(lastMeasurement.variant.environment_metrics.iaq));
+        display->drawString(x, y += fontHeight(FONT_SMALL), 
+                "IAQ: " + String(lastMeasurement.variant.environment_metrics.iaq));
     }
+    if (lastMeasurement.variant.environment_metrics.distance != 0)
+        display->drawString(x, y += fontHeight(FONT_SMALL),
+                "Water Level: " + String(lastMeasurement.variant.environment_metrics.distance, 0) + "mm");    
 }
 
 bool EnvironmentTelemetryModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_Telemetry *t)

--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -181,27 +181,26 @@ void EnvironmentTelemetryModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiSt
     }
 
     // Continue with the remaining details
-    display->drawString(x, y += fontHeight(FONT_SMALL),    
-                "Temp/Hum: " + last_temp + " / " + 
-                    String(lastMeasurement.variant.environment_metrics.relative_humidity, 0) + "%");
+    display->drawString(x, y += fontHeight(FONT_SMALL),
+                        "Temp/Hum: " + last_temp + " / " +
+                            String(lastMeasurement.variant.environment_metrics.relative_humidity, 0) + "%");
 
     if (lastMeasurement.variant.environment_metrics.barometric_pressure != 0) {
-        display->drawString(x, y += fontHeight(FONT_SMALL), 
-                "Press: " + String(lastMeasurement.variant.environment_metrics.barometric_pressure, 0) + "hPA");
+        display->drawString(x, y += fontHeight(FONT_SMALL),
+                            "Press: " + String(lastMeasurement.variant.environment_metrics.barometric_pressure, 0) + "hPA");
     }
 
     if (lastMeasurement.variant.environment_metrics.voltage != 0) {
-        display->drawString(x, y += fontHeight(FONT_SMALL), 
-                "Volt/Cur: " + String(lastMeasurement.variant.environment_metrics.voltage, 0) + "V / " + 
-                    String(lastMeasurement.variant.environment_metrics.current, 0) + "mA");
+        display->drawString(x, y += fontHeight(FONT_SMALL),
+                            "Volt/Cur: " + String(lastMeasurement.variant.environment_metrics.voltage, 0) + "V / " +
+                                String(lastMeasurement.variant.environment_metrics.current, 0) + "mA");
     }
     if (lastMeasurement.variant.environment_metrics.iaq != 0) {
-        display->drawString(x, y += fontHeight(FONT_SMALL), 
-                "IAQ: " + String(lastMeasurement.variant.environment_metrics.iaq));
+        display->drawString(x, y += fontHeight(FONT_SMALL), "IAQ: " + String(lastMeasurement.variant.environment_metrics.iaq));
     }
     if (lastMeasurement.variant.environment_metrics.distance != 0)
         display->drawString(x, y += fontHeight(FONT_SMALL),
-                "Water Level: " + String(lastMeasurement.variant.environment_metrics.distance, 0) + "mm");    
+                            "Water Level: " + String(lastMeasurement.variant.environment_metrics.distance, 0) + "mm");
 }
 
 bool EnvironmentTelemetryModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_Telemetry *t)

--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -151,48 +151,49 @@ uint32_t GetTimeSinceMeshPacket(const meshtastic_MeshPacket *mp)
 void EnvironmentTelemetryModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y)
 {
     display->setTextAlignment(TEXT_ALIGN_LEFT);
-    display->setFont(FONT_MEDIUM);
-    display->drawString(x, y, "Environment");
+    display->setFont(FONT_SMALL);
+
     if (lastMeasurementPacket == nullptr) {
-        display->setFont(FONT_SMALL);
-        display->drawString(x, y += fontHeight(FONT_MEDIUM), "No measurement");
+        // If there's no valid packet, display "Environment"
+        display->drawString(x, y, "Environment");
+        display->drawString(x, y += fontHeight(FONT_SMALL), "No measurement");
         return;
     }
 
+    // Decode the last measurement packet
     meshtastic_Telemetry lastMeasurement;
-
     uint32_t agoSecs = GetTimeSinceMeshPacket(lastMeasurementPacket);
     const char *lastSender = getSenderShortName(*lastMeasurementPacket);
 
     auto &p = lastMeasurementPacket->decoded;
     if (!pb_decode_from_bytes(p.payload.bytes, p.payload.size, &meshtastic_Telemetry_msg, &lastMeasurement)) {
-        display->setFont(FONT_SMALL);
-        display->drawString(x, y += fontHeight(FONT_MEDIUM), "Measurement Error");
+        display->drawString(x, y, "Measurement Error");
         LOG_ERROR("Unable to decode last packet");
         return;
     }
 
-    display->setFont(FONT_SMALL);
+    // Display "From: ..." on its own
+    display->drawString(x, y, "From: " + String(lastSender) + "(" + String(agoSecs) + "s)");
+
     String last_temp = String(lastMeasurement.variant.environment_metrics.temperature, 0) + "°C";
     if (moduleConfig.telemetry.environment_display_fahrenheit) {
         last_temp = String(CelsiusToFahrenheit(lastMeasurement.variant.environment_metrics.temperature), 0) + "°F";
     }
-    display->drawString(x, y += fontHeight(FONT_MEDIUM) - 2, "From: " + String(lastSender) + "(" + String(agoSecs) + "s)");
-    display->drawString(x, y += fontHeight(FONT_SMALL) - 2,
-                        "Temp/Hum: " + last_temp + " / " +
-                            String(lastMeasurement.variant.environment_metrics.relative_humidity, 0) + "%");
-    if (lastMeasurement.variant.environment_metrics.barometric_pressure != 0)
-        display->drawString(x, y += fontHeight(FONT_SMALL),
-                            "Press: " + String(lastMeasurement.variant.environment_metrics.barometric_pressure, 0) + "hPA");
-    if (lastMeasurement.variant.environment_metrics.voltage != 0)
-        display->drawString(x, y += fontHeight(FONT_SMALL),
-                            "Volt/Cur: " + String(lastMeasurement.variant.environment_metrics.voltage, 0) + "V / " +
-                                String(lastMeasurement.variant.environment_metrics.current, 0) + "mA");
-    if (lastMeasurement.variant.environment_metrics.iaq != 0)
+
+    // Continue with the remaining details
+    display->drawString(x, y += fontHeight(FONT_SMALL), "Temp/Hum: " + last_temp + " / " + String(lastMeasurement.variant.environment_metrics.relative_humidity, 0) + "%");
+
+    if (lastMeasurement.variant.environment_metrics.barometric_pressure != 0) {
+        display->drawString(x, y += fontHeight(FONT_SMALL), "Press: " + String(lastMeasurement.variant.environment_metrics.barometric_pressure, 0) + "hPA");
+    }
+
+    if (lastMeasurement.variant.environment_metrics.voltage != 0) {
+        display->drawString(x, y += fontHeight(FONT_SMALL), "Volt/Cur: " + String(lastMeasurement.variant.environment_metrics.voltage, 0) + "V / " + String(lastMeasurement.variant.environment_metrics.current, 0) + "mA");
+    }
+
+    if (lastMeasurement.variant.environment_metrics.iaq != 0) {
         display->drawString(x, y += fontHeight(FONT_SMALL), "IAQ: " + String(lastMeasurement.variant.environment_metrics.iaq));
-    if (lastMeasurement.variant.environment_metrics.distance != 0)
-        display->drawString(x, y += fontHeight(FONT_SMALL),
-                            "Water Level: " + String(lastMeasurement.variant.environment_metrics.distance, 0) + "mm");
+    }
 }
 
 bool EnvironmentTelemetryModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_Telemetry *t)


### PR DESCRIPTION
Fixing issue for issues #3751 for telemetry screen. Made it so that all information fits in the screen properly

![Before](https://github.com/meshtastic/firmware/assets/116696711/15313cf7-91e1-40d8-bdc6-034a8b858dc0)
![After](https://github.com/meshtastic/firmware/assets/116696711/9ec8c6d3-6326-4d9d-949e-a05fa1c4f6ad)
