### PR TITLE
Check if packet is not released before CC to phone

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -257,7 +257,7 @@ void MeshService::sendToMesh(meshtastic_MeshPacket *p, RxSource src, bool ccToPh
         LOG_DEBUG("Can't send status to phone");
     }
 
-    if (ccToPhone) {
+    if (res == ERRNO_OK && ccToPhone) { // Check if p is not released in case it couldn't be sent
         sendToPhone(packetPool.allocCopy(*p));
     }
 }


### PR DESCRIPTION
Fixes #3782.

`RadioLibInterface::send()` will release the packet if it couldn't be sent (e.g. when region is `UNSET`). This caused a crash on the RP2040 when it afterwards tried to send this packet to the phone.
