### PR TITLE
Add MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR exclusion to RCWL9620

### DIFF
--- a/src/modules/Telemetry/Sensor/RCWL9620Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/RCWL9620Sensor.cpp
@@ -1,7 +1,10 @@
+#include "configuration.h"
+
+#if !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
+
 #include "RCWL9620Sensor.h"
 #include "../mesh/generated/meshtastic/telemetry.pb.h"
 #include "TelemetrySensor.h"
-#include "configuration.h"
 
 RCWL9620Sensor::RCWL9620Sensor() : TelemetrySensor(meshtastic_TelemetrySensorType_RCWL9620, "RCWL9620") {}
 
@@ -58,3 +61,5 @@ float RCWL9620Sensor::getDistance()
         return Distance;
     }
 }
+
+#endif

--- a/src/modules/Telemetry/Sensor/RCWL9620Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/RCWL9620Sensor.cpp
@@ -2,8 +2,8 @@
 
 #if !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
 
-#include "RCWL9620Sensor.h"
 #include "../mesh/generated/meshtastic/telemetry.pb.h"
+#include "RCWL9620Sensor.h"
 #include "TelemetrySensor.h"
 
 RCWL9620Sensor::RCWL9620Sensor() : TelemetrySensor(meshtastic_TelemetrySensorType_RCWL9620, "RCWL9620") {}

--- a/src/modules/Telemetry/Sensor/RCWL9620Sensor.h
+++ b/src/modules/Telemetry/Sensor/RCWL9620Sensor.h
@@ -1,3 +1,7 @@
+#include "configuration.h"
+
+#if !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
+
 #include "../mesh/generated/meshtastic/telemetry.pb.h"
 #include "TelemetrySensor.h"
 #include <Wire.h>
@@ -21,3 +25,5 @@ class RCWL9620Sensor : public TelemetrySensor
     virtual int32_t runOnce() override;
     virtual bool getMetrics(meshtastic_Telemetry *measurement) override;
 };
+
+#endif


### PR DESCRIPTION
Fix errors when #MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR is set
