### PR TITLE
Increase button responsiveness

### DIFF
--- a/src/ButtonThread.cpp
+++ b/src/ButtonThread.cpp
@@ -214,6 +214,7 @@ int32_t ButtonThread::runOnce()
         btnEvent = BUTTON_EVENT_NONE;
     }
 
+    runASAP = false;
     return 50;
 }
 
@@ -234,6 +235,7 @@ void ButtonThread::attachButtonInterrupts()
             BaseType_t higherWake = 0;
             mainDelay.interruptFromISR(&higherWake);
             ButtonThread::userButton.tick();
+            runASAP = true;
         },
         CHANGE);
 #endif
@@ -280,6 +282,7 @@ void ButtonThread::wakeOnIrq(int irq, int mode)
         [] {
             BaseType_t higherWake = 0;
             mainDelay.interruptFromISR(&higherWake);
+            runASAP = true;
         },
         FALLING);
 }


### PR DESCRIPTION
Sets `runAsap = true` from the user button ISR.

Would this change break anything else? Tested on Heltec Wireless Paper and T-Echo with no issues, but would be very helpful to test on a few more devices, as an issue here could break a key feature for a lot of people..