### PR TITLE
Elimate non-text output for Portduino

### DIFF
--- a/src/SerialConsole.cpp
+++ b/src/SerialConsole.cpp
@@ -51,7 +51,9 @@ SerialConsole::SerialConsole() : StreamAPI(&Port), RedirectablePrint(&Port), con
         }
     }
 #endif
+#if !ARCH_PORTDUINO
     emitRebooted();
+#endif
 }
 
 int32_t SerialConsole::runOnce()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -344,7 +344,7 @@ void setup()
     Wire.begin(I2C_SDA, I2C_SCL);
 #elif defined(ARCH_PORTDUINO)
     if (settingsStrings[i2cdev] != "") {
-        LOG_INFO("Using %s as I2C device.\n", settingsStrings[i2cdev]);
+        LOG_INFO("Using %s as I2C device.\n", settingsStrings[i2cdev].c_str());
         Wire.begin(settingsStrings[i2cdev].c_str());
     } else {
         LOG_INFO("No I2C device configured, skipping.\n");


### PR DESCRIPTION
In a couple places, we were sending binary data to the console, which can cause journald to act oddly. This cleans those up for the native target.