### PR TITLE
Add REGULATORY_GAIN configuration to remain within regulatory ERP limit

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -75,11 +75,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 // -----------------------------------------------------------------------------
-// Regulatory overrides for producing regional builds
+// Regulatory overrides
 // -----------------------------------------------------------------------------
 
-// Define if region should override user saved region
-// #define LORA_REGIONCODE meshtastic_Config_LoRaConfig_RegionCode_SG_923
+// Override user saved region, for producing region-locked builds
+// #define REGULATORY_LORA_REGIONCODE meshtastic_Config_LoRaConfig_RegionCode_SG_923
 
 // -----------------------------------------------------------------------------
 // Feature toggles

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -81,6 +81,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // Override user saved region, for producing region-locked builds
 // #define REGULATORY_LORA_REGIONCODE meshtastic_Config_LoRaConfig_RegionCode_SG_923
 
+// Total system gain in dBm to subtract from Tx power to remain within regulatory ERP limit for non-licensed operators
+// This value should be set in variant.h and is PA gain + antenna gain (if system ships with an antenna)
+#ifndef REGULATORY_GAIN
+#define REGULATORY_GAIN 0
+#endif
+
 // -----------------------------------------------------------------------------
 // Feature toggles
 // -----------------------------------------------------------------------------

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -83,8 +83,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // Total system gain in dBm to subtract from Tx power to remain within regulatory ERP limit for non-licensed operators
 // This value should be set in variant.h and is PA gain + antenna gain (if system ships with an antenna)
-#ifndef REGULATORY_GAIN
-#define REGULATORY_GAIN 0
+#ifndef REGULATORY_GAIN_LORA
+#define REGULATORY_GAIN_LORA 0
 #endif
 
 // -----------------------------------------------------------------------------

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -154,8 +154,8 @@ static uint8_t bytes[MAX_RHPACKETLEN];
 void initRegion()
 {
     const RegionInfo *r = regions;
-#ifdef LORA_REGIONCODE
-    for (; r->code != meshtastic_Config_LoRaConfig_RegionCode_UNSET && r->code != LORA_REGIONCODE; r++)
+#ifdef REGULATORY_LORA_REGIONCODE
+    for (; r->code != meshtastic_Config_LoRaConfig_RegionCode_UNSET && r->code != REGULATORY_LORA_REGIONCODE; r++)
         ;
     LOG_INFO("Wanted region %d, regulatory override to %s\n", config.lora.region, r->name);
 #else

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -478,8 +478,8 @@ void RadioInterface::applyModemConfig()
 
     power = loraConfig.tx_power;
 
-    if ((power == 0) || ((power + REGULATORY_GAIN > myRegion->powerLimit) && !devicestate.owner.is_licensed))
-        power = myRegion->powerLimit - REGULATORY_GAIN;
+    if ((power == 0) || ((power + REGULATORY_GAIN_LORA > myRegion->powerLimit) && !devicestate.owner.is_licensed))
+        power = myRegion->powerLimit - REGULATORY_GAIN_LORA;
 
     if (power == 0)
         power = 17; // Default to this power level if we don't have a valid regional power limit (powerLimit of myRegion defaults

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -478,8 +478,8 @@ void RadioInterface::applyModemConfig()
 
     power = loraConfig.tx_power;
 
-    if ((power == 0) || ((power > myRegion->powerLimit) && !devicestate.owner.is_licensed))
-        power = myRegion->powerLimit;
+    if ((power == 0) || ((power + REGULATORY_GAIN > myRegion->powerLimit) && !devicestate.owner.is_licensed))
+        power = myRegion->powerLimit - REGULATORY_GAIN;
 
     if (power == 0)
         power = 17; // Default to this power level if we don't have a valid regional power limit (powerLimit of myRegion defaults

--- a/variants/xiao_ble/platformio.ini
+++ b/variants/xiao_ble/platformio.ini
@@ -3,7 +3,7 @@
 extends = nrf52840_base
 board = xiao_ble_sense
 board_level = extra
-build_flags = ${nrf52840_base.build_flags} -Ivariants/xiao_ble -Dxiao_ble -D EBYTE_E22
+build_flags = ${nrf52840_base.build_flags} -Ivariants/xiao_ble -Dxiao_ble -DEBYTE_E22 -DEBYTE_E22_900M30S
   -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/xiao_ble>
 lib_deps = 

--- a/variants/xiao_ble/variant.h
+++ b/variants/xiao_ble/variant.h
@@ -144,12 +144,12 @@ static const uint8_t SCK = PIN_SPI_SCK;
 #define SX126X_DIO3_TCXO_VOLTAGE 1.8
 #ifdef EBYTE_E22_900M30S
 // 10dB PA gain and 30dB rated output; based on PA output table from Ebyte Robin <sales06@ebyte.com>
-#define REGULATORY_GAIN 10
+#define REGULATORY_GAIN_LORA 10
 #define SX126X_MAX_POWER 20
 #endif
 #ifdef EBYTE_E22_900M33S
 // 25dB PA gain and 33dB rated output; based on TX Power Curve from E22-900M33S_UserManual_EN_v1.0.pdf
-#define REGULATORY_GAIN 25
+#define REGULATORY_GAIN_LORA 25
 #define SX126X_MAX_POWER 8
 #endif
 #endif

--- a/variants/xiao_ble/variant.h
+++ b/variants/xiao_ble/variant.h
@@ -147,6 +147,11 @@ static const uint8_t SCK = PIN_SPI_SCK;
 #define REGULATORY_GAIN 10
 #define SX126X_MAX_POWER 20
 #endif
+#ifdef EBYTE_E22_900M33S
+// 25dB PA gain and 33dB rated output; based on TX Power Curve from E22-900M33S_UserManual_EN_v1.0.pdf
+#define REGULATORY_GAIN 25
+#define SX126X_MAX_POWER 8
+#endif
 #endif
 
 /*

--- a/variants/xiao_ble/variant.h
+++ b/variants/xiao_ble/variant.h
@@ -142,6 +142,11 @@ static const uint8_t SCK = PIN_SPI_SCK;
 // (which is the default for the sx1262interface code)
 #define SX126X_DIO2_AS_RF_SWITCH
 #define SX126X_DIO3_TCXO_VOLTAGE 1.8
+#ifdef EBYTE_E22_900M30S
+// 10dB PA gain and 30dB rated output; based on PA output table from Ebyte Robin <sales06@ebyte.com>
+#define REGULATORY_GAIN 10
+#define SX126X_MAX_POWER 20
+#endif
 #endif
 
 /*


### PR DESCRIPTION
REGULATORY_GAIN_LORA is the total LoRa gain in dBm to subtract from the configured Tx power, to remain within regulatory ERP limit for non-licensed operators.

This value should be set at build-time in variant.h and is PA gain + antenna gain (if the Meshtastic device is built with a fixed antenna, e.g. PCB trace antenna or non-removable whip).

This is similar to antenna_gain/NL80211_ATTR_WIPHY_ANTENNA_GAIN/NL80211_ATTR_REG_RULE_POWER_MAX_ANT_GAIN setting in Linux Regulatory/OpenWrt/mac80211/nl80211/iw.

The final transmit power is (myRegion->powerLimit - REGULATORY_GAIN) or the user's configured loraConfig.tx_power, whichever is lower.

This is implemented in DIY XIAO BLE EBYTE E22-900M30S variant as an example.