### PR TITLE
T-Echo screen and button performance

### DIFF
--- a/src/ButtonThread.cpp
+++ b/src/ButtonThread.cpp
@@ -52,8 +52,8 @@ ButtonThread::ButtonThread() : OSThread("Button")
 
 #if defined(BUTTON_PIN) || defined(ARCH_PORTDUINO)
     userButton.attachClick(userButtonPressed);
-    userButton.setClickMs(250);
-    userButton.setPressMs(c_longPressTime);
+    userButton.setClickMs(BUTTON_CLICK_MS);
+    userButton.setPressMs(BUTTON_LONGPRESS_MS);
     userButton.setDebounceMs(1);
     userButton.attachDoubleClick(userButtonDoublePressed);
     userButton.attachMultiClick(userButtonMultiPressed, this); // Reference to instance: get click count from non-static OneButton
@@ -70,8 +70,8 @@ ButtonThread::ButtonThread() : OSThread("Button")
     pinMode(BUTTON_PIN_ALT, INPUT_PULLUP_SENSE);
 #endif
     userButtonAlt.attachClick(userButtonPressed);
-    userButtonAlt.setClickMs(250);
-    userButtonAlt.setPressMs(c_longPressTime);
+    userButtonAlt.setClickMs(BUTTON_CLICK_MS);
+    userButtonAlt.setPressMs(BUTTON_LONGPRESS_MS);
     userButtonAlt.setDebounceMs(1);
     userButtonAlt.attachDoubleClick(userButtonDoublePressed);
     userButtonAlt.attachLongPressStart(userButtonPressedLongStart);
@@ -80,7 +80,7 @@ ButtonThread::ButtonThread() : OSThread("Button")
 
 #ifdef BUTTON_PIN_TOUCH
     userButtonTouch = OneButton(BUTTON_PIN_TOUCH, true, true);
-    userButtonTouch.setPressMs(400);
+    userButtonTouch.setPressMs(BUTTON_TOUCH_MS);
     userButtonTouch.attachLongPressStart(touchPressedLongStart); // Better handling with longpress than click?
 #endif
 

--- a/src/ButtonThread.h
+++ b/src/ButtonThread.h
@@ -4,11 +4,22 @@
 #include "concurrency/OSThread.h"
 #include "configuration.h"
 
+#ifndef BUTTON_CLICK_MS
+#define BUTTON_CLICK_MS 250
+#endif
+
+#ifndef BUTTON_LONGPRESS_MS
+#define BUTTON_LONGPRESS_MS 5000
+#endif
+
+#ifndef BUTTON_TOUCH_MS
+#define BUTTON_TOCH_MS 400
+#endif
+
 class ButtonThread : public concurrency::OSThread
 {
   public:
-    static const uint32_t c_longPressTime = 5000; // shutdown after 5s
-    static const uint32_t c_holdOffTime = 30000;  // hold off 30s after boot
+    static const uint32_t c_holdOffTime = 30000; // hold off 30s after boot
 
     enum ButtonEventType {
         BUTTON_EVENT_NONE,

--- a/variants/t-echo/platformio.ini
+++ b/variants/t-echo/platformio.ini
@@ -15,7 +15,7 @@ build_flags = ${nrf52840_base.build_flags} -Ivariants/t-echo
   -DEINK_LIMIT_FASTREFRESH=20          ; How many consecutive fast-refreshes are permitted
   -DEINK_LIMIT_RATE_BACKGROUND_SEC=30  ; Minimum interval between BACKGROUND updates
   -DEINK_LIMIT_RATE_RESPONSIVE_SEC=1   ; Minimum interval between RESPONSIVE updates
-  -DEINK_LIMIT_GHOSTING_PX=2000        ; (Optional) How much image ghosting is tolerated
+;   -DEINK_LIMIT_GHOSTING_PX=2000        ; (Optional) How much image ghosting is tolerated
   -DEINK_BACKGROUND_USES_FAST          ; (Optional) Use FAST refresh for both BACKGROUND and RESPONSIVE, until a limit is reached.
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/t-echo>
 lib_deps = 

--- a/variants/t-echo/variant.h
+++ b/variants/t-echo/variant.h
@@ -65,6 +65,9 @@ extern "C" {
 #define PIN_BUTTON2 (0 + 18)      // 0.18 is labeled on the board as RESET but we configure it in the bootloader as a regular GPIO
 #define PIN_BUTTON_TOUCH (0 + 11) // 0.11 is the soft touch button on T-Echo
 
+#define BUTTON_CLICK_MS 400
+#define BUTTON_TOUCH_MS 200
+
 /*
  * Analog pins
  */


### PR DESCRIPTION
Two small tweaks which I believe improve the T-Echo UX. Changes affect only the T-Echo.

### Disable ghost-pixel tracking
"Ghost pixels" referring to the after-image left by setting black pixels to white with a fast refresh.
These artifacts are fairly faint for this model of display, and there doesn't seem to be much benefit in tracking / actively avoiding them with the T-Echo. Disabling this results in fewer full-refreshes; a smoother experience.

### Increase the "click ms" value
This value determines how long a button waits to register a double-press, before accepting the current input as a single click. This PR increases the value from 250ms to 400ms. I don't believe this is perceptible when single-pressing, as the display refresh operation is fairly slow.

The benefit is that the double, triple, and quad presses are easier to execute.

To enable this change, the PR allows for variant-specific "click ms" values. If not specified, the current values are used as a default.  