### PR TITLE
add optional define DEBUG_MUTE

### DIFF
--- a/src/DebugConfiguration.h
+++ b/src/DebugConfiguration.h
@@ -36,7 +36,7 @@
 #define LOG_CRIT(...) SEGGER_RTT_printf(0, __VA_ARGS__)
 #define LOG_TRACE(...) SEGGER_RTT_printf(0, __VA_ARGS__)
 #else
-#ifdef DEBUG_PORT
+#if defined(DEBUG_PORT) && !defined(DEBUG_MUTE)
 #define LOG_DEBUG(...) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_DEBUG, __VA_ARGS__)
 #define LOG_INFO(...) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_INFO, __VA_ARGS__)
 #define LOG_WARN(...) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_WARN, __VA_ARGS__)


### PR DESCRIPTION
This shaves roughly 60k from firmware builds by not including the Logging Ressource strings. Define in variant.h or architecture.h

Stats from T-ECHO compiles:
```
Before:
Flash: [========  ]  81.5% (used 664700 bytes from 815104 bytes)
After:
Flash: [=======   ]  74.5% (used 606924 bytes from 815104 bytes)
```
