### PR TITLE
Fix immediate wake from deep-sleep for some devices

### DIFF
--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -264,7 +264,11 @@ void doDeepSleep(uint32_t msecToWake, bool skipPreflight = false)
 #ifdef BUTTON_PIN
     // Avoid leakage through button pin
     if (GPIO_IS_VALID_OUTPUT_GPIO(BUTTON_PIN)) {
+#ifdef BUTTON_NEED_PULLUP
+        pinMode(BUTTON_PIN, INPUT_PULLUP);
+#else
         pinMode(BUTTON_PIN, INPUT);
+#endif
         gpio_hold_en((gpio_num_t)BUTTON_PIN);
     }
 #endif


### PR DESCRIPTION
Collaboration with @roha-github
Addresses https://github.com/meshtastic/firmware/issues/3875

Fixes an issue where ESP32 boards needing an internal pull-up immediately wake from deep-sleep.
This particular PR doesn't clean up the old BUTTON_PIN definitions, as [suggested](https://github.com/meshtastic/firmware/issues/3875#issuecomment-2108166352) by @caveman99 

 
