### PR TITLE
Change SHT4X sensors library from Sensirion to Adafruit

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -133,4 +133,4 @@ lib_deps =
   https://github.com/lewisxhe/SensorLib#27fd0f721e20cd09e1f81383f0ba58a54fe84a17
   adafruit/Adafruit LSM6DS@^4.7.2
   mprograms/QMC5883LCompass@^1.2.0
-  https://github.com/Sensirion/arduino-i2c-sht4x#1.1.0
+  https://github.com/adafruit/Adafruit_SHT4X#1.0.4

--- a/src/modules/Telemetry/Sensor/SHT4XSensor.h
+++ b/src/modules/Telemetry/Sensor/SHT4XSensor.h
@@ -4,12 +4,12 @@
 
 #include "../mesh/generated/meshtastic/telemetry.pb.h"
 #include "TelemetrySensor.h"
-#include <SensirionI2cSht4x.h>
+#include <Adafruit_SHT4x.h>
 
 class SHT4XSensor : public TelemetrySensor
 {
   private:
-    SensirionI2cSht4x sht4x;
+    Adafruit_SHT4x sht4x = Adafruit_SHT4x();
 
   protected:
     virtual void setup() override;


### PR DESCRIPTION
As requested #3845, changing the library from Sensirion to Adafruit for SHT4X sensors.