### PR TITLE
fix native compilation for linux PCs

### DIFF
--- a/arch/portduino/portduino.ini
+++ b/arch/portduino/portduino.ini
@@ -1,6 +1,6 @@
 ; The Portduino based sim environment on top of any host OS, all hardware will be simulated
 [portduino_base]
-platform = https://github.com/meshtastic/platform-native.git#9881bf3721d610cccacf5ae8e3a07839cce75d63
+platform = https://github.com/meshtastic/platform-native.git#f5ec3c031b0fcd89c0523de9e43eef3a92d59292
 framework = arduino
 
 build_src_filter = 

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -283,7 +283,7 @@ void portduinoSetup()
     }
 
     for (configNames i : GPIO_lines) {
-        if (settingsMap[i] > max_GPIO)
+        if (settingsMap.count(i) && settingsMap[i] > max_GPIO)
             max_GPIO = settingsMap[i];
     }
 
@@ -342,6 +342,7 @@ void portduinoSetup()
         if (settingsMap[touchscreenIRQ] > 0)
             initGPIOPin(settingsMap[touchscreenIRQ], gpioChipName);
     }
+
     if (settingsStrings[spidev] != "") {
         SPI.begin(settingsStrings[spidev].c_str());
     }
@@ -350,6 +351,7 @@ void portduinoSetup()
 
 int initGPIOPin(int pinNum, const std::string gpioChipName)
 {
+#ifdef PORTDUINO_LINUX_HARDWARE
     std::string gpio_name = "GPIO" + std::to_string(pinNum);
     try {
         GPIOPin *csPin;
@@ -362,4 +364,7 @@ int initGPIOPin(int pinNum, const std::string gpioChipName)
         std::cout << "Warning, cannot claim pin " << gpio_name << (p ? p.__cxa_exception_type()->name() : "null") << std::endl;
         return ERRNO_DISABLED;
     }
+#else
+    return ERRNO_OK;
+#endif
 }


### PR DESCRIPTION
- fix compiler guard PORTDUINO_LINUX_HARDWARE
- fix logic for GPIO_lines search max loop

It looks like the native target is running only on machines that have SPI and GPIO (e.g. raspberry), otherwise it will crash with a message that spidev0.0 cannot be opened. It's not simulating SpiChip anymore.


Note: this PR relies on https://github.com/meshtastic/framework-portduino/pull/27 and needs pull in the corresponding platform-native.