### PR TITLE
Fix static ip assignment on wifi for rp2040

### DIFF
--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -225,10 +225,16 @@ bool initWifi()
 
             WiFi.mode(WIFI_STA);
             WiFi.setHostname(ourHost);
+
             if (config.network.address_mode == meshtastic_Config_NetworkConfig_AddressMode_STATIC &&
                 config.network.ipv4_config.ip != 0) {
+#ifndef ARCH_RP2040
                 WiFi.config(config.network.ipv4_config.ip, config.network.ipv4_config.gateway, config.network.ipv4_config.subnet,
                             config.network.ipv4_config.dns);
+#else
+                WiFi.config(config.network.ipv4_config.ip, config.network.ipv4_config.dns, config.network.ipv4_config.gateway,
+                            config.network.ipv4_config.subnet);
+#endif
             }
 #ifndef ARCH_RP2040
             WiFi.onEvent(WiFiEvent);


### PR DESCRIPTION
by rearranging the arguments to config(...) to match the expected input order. The lwip library makes an internal reorder or the arguments depending on the netmask to work with both ESP and Arduino platforms.

The input order was incorrect when running on an rp2040 device.
