### PR TITLE
bin: remove unused import in buildinfo.py

### DIFF
--- a/bin/buildinfo.py
+++ b/bin/buildinfo.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
-import configparser
 import sys
+
 from readprops import readProps
 
-
-verObj = readProps('version.properties')
+verObj = readProps("version.properties")
 propName = sys.argv[1]
 print(f"{verObj[propName]}")


### PR DESCRIPTION
This was originally added in b1c30f06509459e5afc5291de067b1946ae4ddd5 and it now do nothing since 361556a6a7913104c513c8f8029efe090267bb9f because it now use readprops.