### PR TITLE
automatically propose to setup virtualenv if platformio is having issues in native build

### DIFF
--- a/bin/build-native.py
+++ b/bin/build-native.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+
+from readprops import readProps
+
+
+def run(*command, check=True):
+    subprocess.run(command, check=check)
+
+
+def bash(command: str, /, *, check=True):
+    run("bash", "-c", command, check=check)
+
+
+verObj = readProps("version.properties")
+
+version = verObj["long"]
+short_version = verObj["short"]
+
+outdir = "release"
+
+bash(f'rm -f "{outdir}/firmware*"')
+bash(f'mkdir -p "{outdir}/"')
+bash(f'rm -r "{outdir}"/*', check=False)
+
+pathPrefix = ""
+try:
+    run("platformio", "pkg", "update", "--environment", "native")
+except Exception as e:
+    if sys.prefix != sys.base_prefix:
+        raise e  # we are in a venv
+    if not (sys.stdin and sys.stdin.isatty()):
+        raise e  # no point asking the user
+    a = ""
+    while a.lower() not in ["y", "n", "yes", "no"]:
+        a = input(
+            "platformio had issues and you are not using a virtual environment\n"
+            "would you like to setup virtualenv and retry with platformio from pip ? (y/n): "
+        )
+    if a.lower() not in ["y", "yes"]:
+        raise e
+    run("python3", "-m", "virtualenv", "venv")
+    run("venv/bin/pip", "install", "platformio")
+    pathPrefix = "venv/bin/"
+    run(pathPrefix + "platformio", "pkg", "update", "--environment", "native")
+
+run(pathPrefix + "pio", "run", "--environment", "native")
+bash(f"cp .pio/build/native/program {outdir}/meshtasticd_linux_$(uname -m)")
+bash(f"cp bin/device-install.* {outdir}/")
+bash(f"cp bin/device-update.* {outdir}/")

--- a/bin/build-native.sh
+++ b/bin/build-native.sh
@@ -1,20 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-set -e
-
-VERSION=$(bin/buildinfo.py long)
-SHORT_VERSION=$(bin/buildinfo.py short)
-
-OUTDIR=release/
-
-rm -f $OUTDIR/firmware*
-
-mkdir -p $OUTDIR/
-rm -r $OUTDIR/* || true
-
-# Important to pull latest version of libs into all device flavors, otherwise some devices might be stale
-platformio pkg update --environment native
-pio run --environment native
-cp .pio/build/native/program "$OUTDIR/meshtasticd_linux_$(uname -m)"
-cp bin/device-install.* $OUTDIR
-cp bin/device-update.* $OUTDIR
+"./$(dirname "$0")/build-native.py" "$@"


### PR DESCRIPTION
I'm not sure it's quite the right thing to do, it tooks me a dozen minutes to find which version of platformio would work when trying to build on ubuntu jammy.