### PR TITLE
Adjust refresh for Heltec Wireless Paper V1.1

### DIFF
--- a/src/graphics/EInkDynamicDisplay.h
+++ b/src/graphics/EInkDynamicDisplay.h
@@ -109,6 +109,7 @@ class EInkDynamicDisplay : public EInkDisplay, protected concurrency::NotifiedWo
     refreshTypes currentConfig = FULL; // Which refresh type is GxEPD2 currently configured for
 
     // Optional - track ghosting, pixel by pixel
+    // May 2024: no longer used by any display. Kept for possible future use.
 #ifdef EINK_LIMIT_GHOSTING_PX
     void countGhostPixels();        // Count any pixels which have moved from black to white since last full-refresh
     void checkExcessiveGhosting();  // Check if ghosting exceeds defined limit

--- a/variants/heltec_wireless_paper/platformio.ini
+++ b/variants/heltec_wireless_paper/platformio.ini
@@ -12,12 +12,12 @@ build_flags =
   -D EINK_LIMIT_FASTREFRESH=10          ; How many consecutive fast-refreshes are permitted
   -D EINK_LIMIT_RATE_BACKGROUND_SEC=30  ; Minimum interval between BACKGROUND updates
   -D EINK_LIMIT_RATE_RESPONSIVE_SEC=1   ; Minimum interval between RESPONSIVE updates
-  -D EINK_LIMIT_GHOSTING_PX=2000        ; (Optional) How much image ghosting is tolerated
+;   -D EINK_LIMIT_GHOSTING_PX=2000      ; (Optional) How much image ghosting is tolerated
   -D EINK_BACKGROUND_USES_FAST          ; (Optional) Use FAST refresh for both BACKGROUND and RESPONSIVE, until a limit is reached.
   -D EINK_HASQUIRK_GHOSTING             ; Display model is identified as "prone to ghosting"
   -D EINK_HASQUIRK_WEAKFASTREFRESH      ; Pixels set with fast-refresh are easy to clear, disrupted by sunlight
 lib_deps =
   ${esp32s3_base.lib_deps}
-  https://github.com/meshtastic/GxEPD2#55f618961db45a23eff0233546430f1e5a80f63a
+  https://github.com/meshtastic/GxEPD2#b202ebfec6a4821e098cf7a625ba0f6f2400292d
   lewisxhe/PCF8563_Library@^1.0.1
 upload_speed = 115200


### PR DESCRIPTION
Adjusted fast-refresh operation: higher contrast, less ghosting. With less prominent ghosting, "ghost pixel tracking" has now been disabled for this display, which will mean fewer full refreshes are triggered. 