### PR TITLE
remove has screen = 0 from wsl variant

### DIFF
--- a/variants/heltec_wsl_v3/variant.h
+++ b/variants/heltec_wsl_v3/variant.h
@@ -3,8 +3,6 @@
 
 #define LED_PIN LED
 
-#define HAS_SCREEN 0
-
 #define VEXT_ENABLE Vext // active low, powers the oled display and the lora antenna boost
 #define BUTTON_PIN 0
 


### PR DESCRIPTION
That way if people want to use screens with the WSL v3, they can easily add one without needing to custom compile the firmware. 