### PR TITLE
Try-fix: Remove logging of actual payload strings (and compressed) for TAK packets 

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -311,7 +311,10 @@ bool perhapsDecode(meshtastic_MeshPacket *p)
         if (channels.decryptForHash(chIndex, p->channel)) {
             // Try to decrypt the packet if we can
             size_t rawSize = p->encrypted.size;
-            assert(rawSize <= sizeof(bytes));
+            if (rawSize > sizeof(bytes)) {
+                LOG_ERROR("Packet too large to attempt decription! (rawSize=%d > 256)\n", rawSize);
+                return false;
+            }
             memcpy(bytes, p->encrypted.bytes,
                    rawSize); // we have to copy into a scratch buffer, because these bytes are a union with the decoded protobuf
             crypto->decrypt(p->from, p->id, rawSize, bytes);

--- a/src/modules/AtakPluginModule.cpp
+++ b/src/modules/AtakPluginModule.cpp
@@ -64,40 +64,33 @@ void AtakPluginModule::alterReceivedProtobuf(meshtastic_MeshPacket &mp, meshtast
 {
     // From Phone (EUD)
     if (mp.from == 0) {
-        LOG_DEBUG("Received uncompressed TAK payload from phone with %d bytes\n", mp.decoded.payload.size);
+        LOG_DEBUG("Received uncompressed TAK payload from phone: %d bytes\n", mp.decoded.payload.size);
         // Compress for LoRA transport
         auto compressed = cloneTAKPacketData(t);
         compressed.is_compressed = true;
         if (t->has_contact) {
             auto length = unishox2_compress_simple(t->contact.callsign, strlen(t->contact.callsign), compressed.contact.callsign);
-            LOG_DEBUG("Uncompressed callsign '%s' - %d bytes\n", t->contact.callsign, strlen(t->contact.callsign));
-            LOG_DEBUG("Compressed callsign '%s' - %d bytes\n", t->contact.callsign, length);
+            LOG_DEBUG("Compressed callsign: %d bytes\n", length);
 
             length = unishox2_compress_simple(t->contact.device_callsign, strlen(t->contact.device_callsign),
                                               compressed.contact.device_callsign);
-            LOG_DEBUG("Uncompressed device_callsign '%s' - %d bytes\n", t->contact.device_callsign,
-                      strlen(t->contact.device_callsign));
-            LOG_DEBUG("Compressed device_callsign '%s' - %d bytes\n", compressed.contact.device_callsign, length);
+            LOG_DEBUG("Compressed device_callsign: %d bytes\n", length);
         }
         if (t->which_payload_variant == meshtastic_TAKPacket_chat_tag) {
             auto length = unishox2_compress_simple(t->payload_variant.chat.message, strlen(t->payload_variant.chat.message),
                                                    compressed.payload_variant.chat.message);
-            LOG_DEBUG("Uncompressed chat message '%s' - %d bytes\n", t->payload_variant.chat.message,
-                      strlen(t->payload_variant.chat.message));
-            LOG_DEBUG("Compressed chat message '%s' - %d bytes\n", compressed.payload_variant.chat.message, length);
+            LOG_DEBUG("Compressed chat message: %d bytes\n", length);
 
             if (t->payload_variant.chat.has_to) {
                 compressed.payload_variant.chat.has_to = true;
                 length = unishox2_compress_simple(t->payload_variant.chat.to, strlen(t->payload_variant.chat.to),
                                                   compressed.payload_variant.chat.to);
-                LOG_DEBUG("Uncompressed chat to '%s' - %d bytes\n", t->payload_variant.chat.to,
-                          strlen(t->payload_variant.chat.to));
-                LOG_DEBUG("Compressed chat to '%s' - %d bytes\n", compressed.payload_variant.chat.to, length);
+                LOG_DEBUG("Compressed chat to: %d bytes\n", length);
             }
         }
         mp.decoded.payload.size = pb_encode_to_bytes(mp.decoded.payload.bytes, sizeof(mp.decoded.payload.bytes),
                                                      meshtastic_TAKPacket_fields, &compressed);
-        LOG_DEBUG("Final payload size of %d bytes\n", mp.decoded.payload.size);
+        LOG_DEBUG("Final payload: %d bytes\n", mp.decoded.payload.size);
     } else {
         if (!t->is_compressed) {
             // Not compressed. Something is wrong
@@ -113,27 +106,23 @@ void AtakPluginModule::alterReceivedProtobuf(meshtastic_MeshPacket &mp, meshtast
             auto length =
                 unishox2_decompress_simple(t->contact.callsign, strlen(t->contact.callsign), uncompressed.contact.callsign);
 
-            LOG_DEBUG("Compressed callsign: %d bytes\n", strlen(t->contact.callsign));
-            LOG_DEBUG("Decompressed callsign: '%s' @ %d bytes\n", uncompressed.contact.callsign, length);
+            LOG_DEBUG("Decompressed callsign: %d bytes\n", length);
 
             length = unishox2_decompress_simple(t->contact.device_callsign, strlen(t->contact.device_callsign),
                                                 uncompressed.contact.device_callsign);
 
-            LOG_DEBUG("Compressed device_callsign: %d bytes\n", strlen(t->contact.device_callsign));
-            LOG_DEBUG("Decompressed device_callsign: '%s' @ %d bytes\n", uncompressed.contact.device_callsign, length);
+            LOG_DEBUG("Decompressed device_callsign: %d bytes\n", length);
         }
         if (uncompressed.which_payload_variant == meshtastic_TAKPacket_chat_tag) {
             auto length = unishox2_decompress_simple(t->payload_variant.chat.message, strlen(t->payload_variant.chat.message),
                                                      uncompressed.payload_variant.chat.message);
-            LOG_DEBUG("Compressed chat message: %d bytes\n", strlen(t->payload_variant.chat.message));
-            LOG_DEBUG("Decompressed chat message: '%s' @ %d bytes\n", uncompressed.payload_variant.chat.message, length);
+            LOG_DEBUG("Decompressed chat message: %d bytes\n", length);
 
             if (t->payload_variant.chat.has_to) {
                 uncompressed.payload_variant.chat.has_to = true;
                 length = unishox2_decompress_simple(t->payload_variant.chat.to, strlen(t->payload_variant.chat.to),
                                                     uncompressed.payload_variant.chat.to);
-                LOG_DEBUG("Compressed chat to: %d bytes\n", strlen(t->payload_variant.chat.to));
-                LOG_DEBUG("Decompressed chat to: '%s' @ %d bytes\n", uncompressed.payload_variant.chat.to, length);
+                LOG_DEBUG("Decompressed chat to: %d bytes\n", length);
             }
         }
         decompressedCopy->decoded.payload.size =


### PR DESCRIPTION
Closes #3725
