### PR TITLE
Screen changes from time deltas to timestamps after 15 minutes

### DIFF
--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -348,12 +348,18 @@ void PowerFSM_setup()
 
     powerFSM.add_transition(&stateDARK, &stateDARK, EVENT_CONTACT_FROM_PHONE, NULL, "Contact from phone");
 
-    powerFSM.add_timed_transition(&stateON, &stateDARK,
-                                  Default::getConfiguredOrDefaultMs(config.display.screen_on_secs, default_screen_on_secs), NULL,
-                                  "Screen-on timeout");
-    powerFSM.add_timed_transition(&statePOWER, &stateDARK,
-                                  Default::getConfiguredOrDefaultMs(config.display.screen_on_secs, default_screen_on_secs), NULL,
-                                  "Screen-on timeout");
+#ifdef USE_EINK
+    // Allow E-Ink devices to suppress the screensaver, if screen timeout set to 0
+    if (config.display.screen_on_secs > 0)
+#endif
+    {
+        powerFSM.add_timed_transition(&stateON, &stateDARK,
+                                      Default::getConfiguredOrDefaultMs(config.display.screen_on_secs, default_screen_on_secs),
+                                      NULL, "Screen-on timeout");
+        powerFSM.add_timed_transition(&statePOWER, &stateDARK,
+                                      Default::getConfiguredOrDefaultMs(config.display.screen_on_secs, default_screen_on_secs),
+                                      NULL, "Screen-on timeout");
+    }
 
 // We never enter light-sleep or NB states on NRF52 (because the CPU uses so little power normally)
 #ifdef ARCH_ESP32

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -524,15 +524,21 @@ static void drawTextMessageFrame(OLEDDisplay *display, OLEDDisplayUiState *state
     // If bold, draw twice, shifting right by one pixel
     for (uint8_t xOff = 0; xOff <= (config.display.heading_bold ? 1 : 0); xOff++) {
         // Show a timestamp if received today, but longer than 15 minutes ago
-        if (useTimestamp && minutes >= 15 && (daysAgo == 0 || hours < 2)) {
+        if (useTimestamp && minutes >= 15 && daysAgo == 0) {
             display->drawStringf(xOff + x, 0 + y, tempBuf, "At %02hu:%02hu from %s", timestampHours, timestampMinutes,
                                  (node && node->has_user) ? node->user.short_name : "???");
-            continue;
+        }
+        // Timestamp yesterday (if display is wide enough)
+        else if (useTimestamp && daysAgo == 1 && display->width() >= 200) {
+            display->drawStringf(xOff + x, 0 + y, tempBuf, "Yesterday %02hu:%02hu from %s", timestampHours, timestampMinutes,
+                                 (node && node->has_user) ? node->user.short_name : "???");
         }
         // Otherwise, show a time delta
-        display->drawStringf(xOff + x, 0 + y, tempBuf, "%s ago from %s",
-                             screen->drawTimeDelta(days, hours, minutes, seconds).c_str(),
-                             (node && node->has_user) ? node->user.short_name : "???");
+        else {
+            display->drawStringf(xOff + x, 0 + y, tempBuf, "%s ago from %s",
+                                 screen->drawTimeDelta(days, hours, minutes, seconds).c_str(),
+                                 (node && node->has_user) ? node->user.short_name : "???");
+        }
     }
 
     display->setColor(WHITE);

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1550,6 +1550,15 @@ void Screen::setFrames()
     LOG_DEBUG("showing standard frames\n");
     showingNormalScreen = true;
 
+#ifdef USE_EINK
+    // If user has disabled the screensaver, warn them after boot
+    static bool warnedScreensaverDisabled = false;
+    if (config.display.screen_on_secs == 0 && !warnedScreensaverDisabled) {
+        screen->print("Screensaver disabled\n");
+        warnedScreensaverDisabled = true;
+    }
+#endif
+
     moduleFrames = MeshModule::GetMeshModulesWithUIFrames();
     LOG_DEBUG("Showing %d module frames\n", moduleFrames.size());
 #ifdef DEBUG_PORT

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -526,7 +526,7 @@ static void drawTextMessageFrame(OLEDDisplay *display, OLEDDisplayUiState *state
 #endif
 
     // If bold, draw twice, shifting right by one pixel
-    for (uint8_t xOff = 0; xOff <= config.display.heading_bold ? 1 : 0; xOff++) {
+    for (uint8_t xOff = 0; xOff <= (config.display.heading_bold ? 1 : 0); xOff++) {
 #ifdef USE_EINK
         // Show an "absolute" timestamp if received today, but longer than 15 minutes ago
         if (useTimestamp && minutes >= 15 && (daysAgo == 0 || hours < 2)) {

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -440,8 +440,8 @@ bool deltaToTimestamp(uint32_t secondsAgo, uint8_t *hours, uint8_t *minutes, int
         return validCached;
     }
 
-    // Abort: if time seems invalid.. (> 12 months ago, probably seen before RTC set)
-    if (secondsAgo > SEC_PER_DAY * 30UL * 12) {
+    // Abort: if time seems invalid.. (> 6 months ago, probably seen before RTC set)
+    if (secondsAgo > SEC_PER_DAY * 30UL * 6) {
         validCached = false;
         return validCached;
     }
@@ -977,7 +977,7 @@ static void drawNodeInfo(OLEDDisplay *display, OLEDDisplayUiState *state, int16_
         snprintf(lastStr, sizeof(lastStr), "Last seen: %02u:%02u", (unsigned int)timestampHours, (unsigned int)timestampMinutes);
     else if (useTimestamp && daysAgo == 1) // Yesterday
         snprintf(lastStr, sizeof(lastStr), "Seen yesterday");
-    else if (useTimestamp && daysAgo < 183) // Last six months
+    else if (useTimestamp && daysAgo > 1) // Last six months (capped by deltaToTimestamp method)
         snprintf(lastStr, sizeof(lastStr), "%li days ago", (long)daysAgo);
     // -- if using time delta instead --
     else if (agoSecs < 120 * 60) // last 2 hrs

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -427,34 +427,34 @@ bool deltaToTimestamp(uint32_t secondsAgo, uint8_t *hours, uint8_t *minutes, int
     static uint8_t hoursCached = 0, minutesCached = 0;
     static uint32_t daysAgoCached = 0;
     static uint32_t secondsAgoCached = 0;
-    static bool valid = false;
+    static bool validCached = false;
 
     // Abort: if timezone not set
     if (strlen(config.device.tzdef) == 0) {
-        valid = false;
-        return valid;
+        validCached = false;
+        return validCached;
     }
 
     // Abort: if invalid pointers passed
     if (hours == nullptr || minutes == nullptr || daysAgo == nullptr) {
-        valid = false;
-        return valid;
+        validCached = false;
+        return validCached;
     }
 
     // Abort: if time seems invalid.. (> 12 months ago, probably seen before RTC set)
     if (secondsAgo > SEC_PER_DAY * 30UL * 12) {
-        valid = false;
-        return valid;
+        validCached = false;
+        return validCached;
     }
 
     // If repeated request, don't bother recalculating
     if (secondsAgo - secondsAgoCached < 60 && secondsAgoCached != 0) {
-        if (valid) {
+        if (validCached) {
             *hours = hoursCached;
             *minutes = minutesCached;
             *daysAgo = daysAgoCached;
         }
-        return valid;
+        return validCached;
     }
 
     // Get local time
@@ -462,8 +462,8 @@ bool deltaToTimestamp(uint32_t secondsAgo, uint8_t *hours, uint8_t *minutes, int
 
     // Abort: if RTC not set
     if (!secondsRTC) {
-        valid = false;
-        return valid;
+        validCached = false;
+        return validCached;
     }
 
     // Get absolute time when last seen
@@ -486,8 +486,8 @@ bool deltaToTimestamp(uint32_t secondsAgo, uint8_t *hours, uint8_t *minutes, int
     minutesCached = *minutes;
     secondsAgoCached = secondsAgo;
 
-    valid = true;
-    return valid;
+    validCached = true;
+    return validCached;
 }
 #endif
 

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -981,11 +981,11 @@ static void drawNodeInfo(OLEDDisplay *display, OLEDDisplayUiState *state, int16_
     else if (useTimestamp && agoSecs < 15 * SECONDS_IN_MINUTE) // Last 15 minutes
         snprintf(lastStr, sizeof(lastStr), "%u minutes ago", agoSecs / SECONDS_IN_MINUTE);
     else if (useTimestamp && daysAgo == 0) // Today
-        snprintf(lastStr, sizeof(lastStr), "Last seen: %02hu:%02hu", timestampHours, timestampMinutes);
+        snprintf(lastStr, sizeof(lastStr), "Last seen: %02u:%02u", (unsigned int)timestampHours, (unsigned int)timestampMinutes);
     else if (useTimestamp && daysAgo == 1) // Yesterday
         snprintf(lastStr, sizeof(lastStr), "Seen yesterday");
     else if (useTimestamp && daysAgo < 183) // Last six months
-        snprintf(lastStr, sizeof(lastStr), "%li days ago", daysAgo);
+        snprintf(lastStr, sizeof(lastStr), "%li days ago", (long)daysAgo);
 #endif
     else if (agoSecs < 120 * 60) // last 2 hrs
         snprintf(lastStr, sizeof(lastStr), "%u minutes ago", agoSecs / 60);


### PR DESCRIPTION
Changes the time deltas to timestamps in some situations, ~~for E-Ink displays.~~ **extended to all displays**

Conditions:
  * Timezone must be set
  * Timestamp must be at least 15 minutes in the past. Until this point, time delta is displayed

Impact:
  * E-Ink UI is more static, fewer refreshes: avoids refreshing every minute to update time-deltas
  * If configured correctly (if timezone set), much higher screen-timeout values are suitable (longer before screensaver appears)

___

Allows users to disable the E-Ink screensaver, by setting screen timeout to zero.
If disabled, a cautionary message is printed to the on-screen log buffer at startup.