### PR TITLE
Fix GPS toggle on Heltec v3

### DIFF
--- a/variants/heltec_v3/variant.h
+++ b/variants/heltec_v3/variant.h
@@ -18,6 +18,8 @@
 #define ADC_ATTENUATION ADC_ATTEN_DB_2_5 // lower dB for high resistance voltage divider
 #define ADC_MULTIPLIER 4.9
 
+#define PIN_GPS_EN 46 // GPS power enable pin
+
 #define USE_SX1262
 
 #define LORA_DIO0 -1 // a No connect on the SX1262 module


### PR DESCRIPTION
The definition of PIN_GPS_EN was missing from the heltec_v3 variant.
Originally, I thought it was removed for some reason, and perhaps was it indeed? But while testing this change, it seems like I have encountered no malfunctioning with the GPS.
If I am missing some important detail, I'd be happy to hear some news about it.