### PR TITLE
Prevent spontaneous screen-on while charging

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -555,14 +555,24 @@ void Power::readPowerStatus()
 #ifdef NRF_APM // Section of code detects USB power on the RAK4631 and updates the power states.  Takes 20 seconds or so to detect
                // changes.
 
+        static nrfx_power_usb_state_t prev_nrf_usb_state = (nrfx_power_usb_state_t)-1; // -1 so that state detected at boot
         nrfx_power_usb_state_t nrf_usb_state = nrfx_power_usbstatus_get();
 
-        if (nrf_usb_state == NRFX_POWER_USB_STATE_DISCONNECTED) {
-            powerFSM.trigger(EVENT_POWER_DISCONNECTED);
-            NRF_USB = OptFalse;
-        } else {
-            powerFSM.trigger(EVENT_POWER_CONNECTED);
-            NRF_USB = OptTrue;
+        // If state changed
+        if (nrf_usb_state != prev_nrf_usb_state) {
+            // If changed to DISCONNECTED
+            if (nrf_usb_state == NRFX_POWER_USB_STATE_DISCONNECTED) {
+                powerFSM.trigger(EVENT_POWER_DISCONNECTED);
+                NRF_USB = OptFalse;
+            }
+            // If changed to CONNECTED / READY
+            else {
+                powerFSM.trigger(EVENT_POWER_CONNECTED);
+                NRF_USB = OptTrue;
+            }
+
+            // Cache the current state
+            prev_nrf_usb_state = nrf_usb_state;
         }
 #endif
         // Notify any status instances that are observing us


### PR DESCRIPTION
Raised as an issue on the [discord server](https://discord.com/channels/867578229534359593/871553024030556250/1241939522330034227)
Also mentioned in a [reddit post](https://www.reddit.com/r/meshtastic/comments/1bi8n70/screen_keeps_waking_only_while_charging/)

Addresses an issue where devices which use `nrfx_power_usbstatus_get()` enter `statePower` every 30 seconds, while connected to USB.