### PR TITLE
Revert "Fix TBeam Supreme woes (and upgrade platform)"

### DIFF
--- a/boards/tbeam-s3-core.json
+++ b/boards/tbeam-s3-core.json
@@ -7,7 +7,6 @@
     "extra_flags": [
       "-DBOARD_HAS_PSRAM",
       "-DLILYGO_TBEAM_S3_CORE",
-      "-DARDUINO_USB_CDC_ON_BOOT=1",
       "-DARDUINO_USB_MODE=1",
       "-DARDUINO_RUNNING_CORE=1",
       "-DARDUINO_EVENT_RUNNING_CORE=1"

--- a/variants/tbeam-s3-core/pins_arduino.h
+++ b/variants/tbeam-s3-core/pins_arduino.h
@@ -6,6 +6,14 @@
 #define USB_VID 0x303a
 #define USB_PID 0x1001
 
+#define EXTERNAL_NUM_INTERRUPTS 46
+#define NUM_DIGITAL_PINS 48
+#define NUM_ANALOG_INPUTS 20
+
+#define analogInputToDigitalPin(p) (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
+#define digitalPinToInterrupt(p) (((p) < 48) ? (p) : -1)
+#define digitalPinHasPWM(p) (p < 46)
+
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
 

--- a/variants/tbeam-s3-core/platformio.ini
+++ b/variants/tbeam-s3-core/platformio.ini
@@ -4,8 +4,6 @@ extends = esp32s3_base
 board = tbeam-s3-core
 board_check = true
 
-platform = platformio/espressif32@6.7.0
-
 lib_deps =
   ${esp32s3_base.lib_deps}
   lewisxhe/PCF8563_Library@1.0.1


### PR DESCRIPTION
Reverting due to issue with new BLE pairing auth