### PR TITLE
Add final debug call for Portduino reboot

### DIFF
--- a/src/shutdown.h
+++ b/src/shutdown.h
@@ -28,6 +28,7 @@ void powerCommandsCheck()
         Serial1.end();
         if (screen)
             delete screen;
+        LOG_DEBUG("final reboot!\n");
         reboot();
 #else
         rebootAtMsec = -1;


### PR DESCRIPTION
We sometimes see segfaults on reboot, but can never catch them in GDB. Adding an extra debug call to help troubleshoot.