### PR TITLE
Portduino: Catch the keyboard power button and initiate poweroff

### DIFF
--- a/src/input/LinuxInput.cpp
+++ b/src/input/LinuxInput.cpp
@@ -155,6 +155,9 @@ int32_t LinuxInput::runOnce()
                     case KEY_ENTER: // Enter
                         e.inputEvent = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_SELECT;
                         break;
+                    case KEY_POWER:
+                        system("poweroff");
+                        break;
                     default: // all other keys
                         if (keymap[code]) {
                             e.inputEvent = ANYKEY;


### PR DESCRIPTION
When running on the Pi400, and using the built-in keyboard inputs, there's no clean way to power off the unit without SSH or an external keyboard. This is the first step in fixing that. The Pi generates a bower button event when releasing the FN key and the f10 key after held together for more than 2 seconds.

