### PR TITLE
t-watch-fix: Fully insulate T-Watch free text updates from other hardware platforms

### DIFF
--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -75,9 +75,11 @@ int CannedMessageModule::splitConfiguredMessages()
 
     String messages = cannedMessageModuleConfig.messages;
 
+#ifdef T_WATCH_S3
     String separator = messages.length() ? "|" : "";
 
     messages = "[---- Free Text ----]" + separator + messages;
+#endif
 
     // collect all the message parts
     strncpy(this->messageStore, messages.c_str(), sizeof(this->messageStore));
@@ -141,6 +143,8 @@ int CannedMessageModule::handleInputEvent(const InputEvent *event)
         }
     }
     if (event->inputEvent == static_cast<char>(meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_SELECT)) {
+
+#ifdef T_WATCH_S3
         if (this->currentMessageIndex == 0) {
             this->runState = CANNED_MESSAGE_RUN_STATE_FREETEXT;
 
@@ -150,6 +154,7 @@ int CannedMessageModule::handleInputEvent(const InputEvent *event)
 
             return 0;
         }
+#endif
 
         // when inactive, call the onebutton shortpress instead. Activate Module only on up/down
         if ((this->runState == CANNED_MESSAGE_RUN_STATE_INACTIVE) || (this->runState == CANNED_MESSAGE_RUN_STATE_DISABLED)) {


### PR DESCRIPTION
Addendum to my previous PR – my intention had been to fully separate the new T-Watch functionality from other platforms, but I missed these two spots.

If a user were to select the '[---- Free Text ----]' option on a device with a non-touch screen and no text entry input, I am not sure what behavior would result. Their device would be in free text mode, with (potentially?) no way to exit short of a reboot. I'm unable to test locally since the T-Watch is the only device I own that has a screen, so wanted to push this up out of an abundance of caution.