### PR TITLE
Fix memory leak when there's no display

### DIFF
--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -360,7 +360,7 @@ class Screen : public concurrency::OSThread
     bool enqueueCmd(const ScreenCmd &cmd)
     {
         if (!useDisplay)
-            return true; // claim success if our display is not in use
+            return false; // not enqueued if our display is not in use
         else {
             bool success = cmdQueue.enqueue(cmd, 0);
             enabled = true; // handle ASAP (we are the registered reader for cmdQueue, but might have been disabled)


### PR DESCRIPTION
The string does never get freed when useDisplay is false.
https://github.com/meshtastic/firmware/blob/2233507667c6030cc86d9e66a3746b2ed828d8ba/src/graphics/Screen.h#L228-L231