### PR TITLE
Bump portduino to pick up improvements to reboot()

### DIFF
--- a/arch/portduino/portduino.ini
+++ b/arch/portduino/portduino.ini
@@ -1,6 +1,6 @@
 ; The Portduino based sim environment on top of any host OS, all hardware will be simulated
 [portduino_base]
-platform = https://github.com/meshtastic/platform-native.git#f5ec3c031b0fcd89c0523de9e43eef3a92d59292
+platform = https://github.com/meshtastic/platform-native.git#ad8112adf82ce1f5b917092cf32be07a077801a0
 framework = arduino
 
 build_src_filter = 


### PR DESCRIPTION
Two fixes here. One is to properly catch errors when calling execv() in the reboot() function, to prevent a crash. The other is to skip the --erase flag when calling a reboot, to prevent continual erase on reboot.