### PR TITLE
User experience improvement - app battery icon

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,8 +2,9 @@
     // See http://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-        "ms-vscode.cpptools",
-        "platformio.platformio-ide",
-        "trunk.io"
+        "platformio.platformio-ide"
     ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
 }

--- a/src/PowerStatus.h
+++ b/src/PowerStatus.h
@@ -59,9 +59,18 @@ class PowerStatus : public Status
     int getBatteryVoltageMv() const { return batteryVoltageMv; }
 
     /**
-     * Note: 0% battery means 'unknown/this board doesn't have a battery installed'
+     * Note: for boards with battery pin, 0% battery means 'unknown/this board doesn't have a battery installed'
      */
+#ifdef BATTERY_PIN
     uint8_t getBatteryChargePercent() const { return getHasBattery() ? batteryChargePercent : 0; }
+#endif
+
+    /**
+     * Note: for boards without battery pin, 101% battery means 'the board is using external power'
+     */
+#ifndef BATTERY_PIN
+    uint8_t getBatteryChargePercent() const { return getHasBattery() ? batteryChargePercent : 101; }
+#endif
 
     bool matches(const PowerStatus *newStatus) const
     {

--- a/src/PowerStatus.h
+++ b/src/PowerStatus.h
@@ -59,16 +59,16 @@ class PowerStatus : public Status
     int getBatteryVoltageMv() const { return batteryVoltageMv; }
 
     /**
-     * Note: for boards with battery pin, 0% battery means 'unknown/this board doesn't have a battery installed'
+     * Note: for boards with battery pin or PMU, 0% battery means 'unknown/this board doesn't have a battery installed'
      */
-#ifdef BATTERY_PIN
+#if defined(HAS_PMU) || defined(BATTERY_PIN)
     uint8_t getBatteryChargePercent() const { return getHasBattery() ? batteryChargePercent : 0; }
 #endif
 
     /**
-     * Note: for boards without battery pin, 101% battery means 'the board is using external power'
+     * Note: for boards without battery pin and PMU, 101% battery means 'the board is using external power'
      */
-#ifndef BATTERY_PIN
+#if !defined(HAS_PMU) && !defined(BATTERY_PIN)
     uint8_t getBatteryChargePercent() const { return getHasBattery() ? batteryChargePercent : 101; }
 #endif
 

--- a/variants/station-g2/variant.h
+++ b/variants/station-g2/variant.h
@@ -40,6 +40,7 @@ Board Information: https://wiki.uniteng.com/en/meshtastic/station-g2
 #define SX126X_MAX_POWER 19
 #endif
 
+/*
 #define BATTERY_PIN 4 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
 #define ADC_CHANNEL ADC1_GPIO4_CHANNEL
 #define ADC_MULTIPLIER 4
@@ -50,3 +51,4 @@ Board Information: https://wiki.uniteng.com/en/meshtastic/station-g2
 #define BAT_NOBATVOLT 4460
 #define CELL_TYPE_LION // same curve for liion/lipo
 #define NUM_CELLS 2
+*/


### PR DESCRIPTION
For Station G2 or any board that does not have the BATTERY_PIN function defined, the current firmware can accurately determine that the board does not have a battery installed.

However, the current firmware will send batteryChargePercent = 0 to the APP for boards without battery, and the APP will display a battery empty icon. Users hope that boards without BATTERY_PIN will display a plug icon in the APP.

Ps. This is a PR about user experience and does not involve any bug fixes. 