### PR TITLE
Run tzset() and localtime() in getTZOffset() to ensure proper timezone offset

### DIFF
--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -222,14 +222,11 @@ bool perhapsSetRTC(RTCQuality q, struct tm &t)
  */
 int32_t getTZOffset()
 {
-    tzset();
-    time_t now;
+    time_t now = getTime(false);
     struct tm *gmt;
-    struct tm *local;
-    now = time(NULL);
     gmt = gmtime(&now);
-    local = localtime(&now);
-    return (int32_t)difftime(mktime(local), mktime(gmt));
+    gmt->tm_isdst = -1;
+    return (int32_t)difftime(now, mktime(gmt));
 }
 
 /**

--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -222,12 +222,14 @@ bool perhapsSetRTC(RTCQuality q, struct tm &t)
  */
 int32_t getTZOffset()
 {
+    tzset();
     time_t now;
     struct tm *gmt;
+    struct tm *local;
     now = time(NULL);
     gmt = gmtime(&now);
-    gmt->tm_isdst = -1;
-    return (int32_t)difftime(now, mktime(gmt));
+    local = localtime(&now);
+    return (int32_t)difftime(mktime(local), mktime(gmt));
 }
 
 /**


### PR DESCRIPTION
Fixes #3812 
My guess is that we run tzset before we have a valid date, so the DST element can't happen. This moves that to every time we attempt to calculate the offset, as well as moving to localtime() to make sure we get the proper timezone offset.