### PR TITLE
Don't send potentially bogus timestamps with fixed location

### DIFF
--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -211,11 +211,11 @@ meshtastic_MeshPacket *PositionModule::allocReply()
     // Strip out any time information before sending packets to other nodes - to keep the wire size small (and because other
     // nodes shouldn't trust it anyways) Note: we allow a device with a local GPS to include the time, so that gpsless
     // devices can get time.
-    if (getRTCQuality() < RTCQualityDevice) {
+    if (getRTCQuality() < RTCQualityGPS) {
         LOG_INFO("Stripping time %u from position send\n", p.time);
         p.time = 0;
     } else {
-        p.time = getValidTime(RTCQualityDevice);
+        p.time = getValidTime(RTCQualityGPS);
         LOG_INFO("Providing time to mesh %u\n", p.time);
     }
 


### PR DESCRIPTION
I'm seeing a situation where a "rogue" node thinks it has a valid timestamp, but doesn't. It's using fixed position, so the wrong timestamp is overwriting a time provided by another node that actually has a GPS.