### PR TITLE
fix crash during reset nodedb

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -444,9 +444,9 @@ void NodeDB::installDefaultChannels()
 
 void NodeDB::resetNodes()
 {
+    clearLocalPosition();
     numMeshNodes = 1;
     std::fill(devicestate.node_db_lite.begin() + 1, devicestate.node_db_lite.end(), meshtastic_NodeInfoLite());
-    clearLocalPosition();
     saveDeviceStateToDisk();
     if (neighborInfoModule && moduleConfig.neighbor_info.enabled)
         neighborInfoModule->resetNeighbors();


### PR DESCRIPTION
This PR fixes a crash during reset NodeDB (dereferencing null pointer).

The order of statements in `resetNodes()` is wrong. First, `numMeshNodes` is set to 1, but after that (in `clearLocalPosition()`) the nodeId is searched in the meshDB, which cannot be found anymore, because meshDB is set to one element already.

Note: normally this may not happens, as the own node is at position 0 (the only one element which is found). But when running MQTT with hundreds of nodes the own node seems not at position 0 anymore -> crash.

Another question is: who wrote code that reorders the own node away from position 0? Should not be necessary at all, right?