### PR TITLE
Triple-press not disabling GPS

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -774,18 +774,15 @@ GPS::~GPS()
 
 void GPS::setGPSPower(bool on, bool standbyOnly, uint32_t sleepTime)
 {
-    // Record the current state
-    LOG_INFO("Setting GPS powerState=");
-    if (on) {
+    // Record the current powerState
+    if (on)
         powerState = GPS_AWAKE;
-        LOG_INFO("AWAKE\n");
-    } else if (!on && standbyOnly) {
+    else if (!on && standbyOnly)
         powerState = GPS_STANDBY;
-        LOG_INFO("STANDBY\n");
-    } else {
+    else
         powerState = GPS_OFF;
-        LOG_INFO("OFF\n");
-    }
+
+    LOG_DEBUG("GPS::powerState=%d\n", powerState);
 
     if (on) {
         clearBuffer(); // drop any old data waiting in the buffer before re-enabling

--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -777,13 +777,13 @@ void GPS::setGPSPower(bool on, bool standbyOnly, uint32_t sleepTime)
     // Record the current state
     LOG_INFO("Setting GPS powerState=");
     if (on) {
-        powerState = AWAKE;
+        powerState = GPS_AWAKE;
         LOG_INFO("AWAKE\n");
     } else if (!on && standbyOnly) {
-        powerState = STANDBY;
+        powerState = GPS_STANDBY;
         LOG_INFO("STANDBY\n");
     } else {
-        powerState = OFF;
+        powerState = GPS_OFF;
         LOG_INFO("OFF\n");
     }
 
@@ -884,13 +884,13 @@ void GPS::setAwake(bool wantAwake)
 {
 
     // If user has disabled GPS, make sure it is off, not just in standby
-    if (!wantAwake && !enabled && powerState != OFF) {
+    if (!wantAwake && !enabled && powerState != GPS_OFF) {
         setGPSPower(false, false, 0);
         return;
     }
 
     // If GPS power state needs to change
-    if ((wantAwake && powerState != AWAKE) || (!wantAwake && powerState == AWAKE)) {
+    if ((wantAwake && powerState != GPS_AWAKE) || (!wantAwake && powerState == GPS_AWAKE)) {
         LOG_DEBUG("WANT GPS=%d\n", wantAwake);
 
         // Calculate how long it takes to get a GPS lock
@@ -1036,14 +1036,14 @@ int32_t GPS::runOnce()
     uint32_t timeAsleep = now - lastSleepStartMsec;
 
     auto sleepTime = getSleepTime();
-    if (powerState != AWAKE && (sleepTime != UINT32_MAX) &&
+    if (powerState != GPS_AWAKE && (sleepTime != UINT32_MAX) &&
         ((timeAsleep > sleepTime) || (isInPowersave && timeAsleep > (sleepTime - averageLockTime)))) {
         // We now want to be awake - so wake up the GPS
         setAwake(true);
     }
 
     // While we are awake
-    if (powerState == AWAKE) {
+    if (powerState == GPS_AWAKE) {
         // LOG_DEBUG("looking for location\n");
         // If we've already set time from the GPS, no need to ask the GPS
         bool gotTime = (getRTCQuality() >= RTCQualityGPS);
@@ -1089,7 +1089,7 @@ int32_t GPS::runOnce()
 
     // 9600bps is approx 1 byte per msec, so considering our buffer size we never need to wake more often than 200ms
     // if not awake we can run super infrquently (once every 5 secs?) to see if we need to wake.
-    return (powerState == AWAKE) ? GPS_THREAD_INTERVAL : 5000;
+    return (powerState == GPS_AWAKE) ? GPS_THREAD_INTERVAL : 5000;
 }
 
 // clear the GPS rx buffer as quickly as possible
@@ -1620,9 +1620,9 @@ bool GPS::whileIdle()
 {
     unsigned int charsInBuf = 0;
     bool isValid = false;
-    if (powerState != AWAKE) {
+    if (powerState != GPS_AWAKE) {
         clearBuffer();
-        return (powerState == AWAKE);
+        return (powerState == GPS_AWAKE);
     }
 #ifdef SERIAL_BUFFER_SIZE
     if (_serial_gps->available() >= SERIAL_BUFFER_SIZE - 1) {

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -39,9 +39,9 @@ typedef enum {
 } GPS_RESPONSE;
 
 enum GPSPowerState : uint8_t {
-    GPS_OFF,
-    GPS_STANDBY,
-    GPS_AWAKE,
+    GPS_OFF = 0,
+    GPS_AWAKE = 1,
+    GPS_STANDBY = 2,
 };
 
 // Generate a string representation of DOP

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -39,9 +39,9 @@ typedef enum {
 } GPS_RESPONSE;
 
 enum GPSPowerState : uint8_t {
-    OFF,
-    STANDBY,
-    AWAKE,
+    GPS_OFF,
+    GPS_STANDBY,
+    GPS_AWAKE,
 };
 
 // Generate a string representation of DOP
@@ -93,7 +93,7 @@ class GPS : private concurrency::OSThread
     bool GPSInitFinished = false; // Init thread finished?
     bool GPSInitStarted = false;  // Init thread finished?
 
-    GPSPowerState powerState = OFF; // AWAKE if we want a location right now
+    GPSPowerState powerState = GPS_OFF; // GPS_AWAKE if we want a location right now
 
     uint8_t numSatellites = 0;
 

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -38,6 +38,12 @@ typedef enum {
     GNSS_RESPONSE_OK,
 } GPS_RESPONSE;
 
+enum GPSPowerState : uint8_t {
+    OFF,
+    STANDBY,
+    AWAKE,
+};
+
 // Generate a string representation of DOP
 const char *getDOPString(uint32_t dop);
 
@@ -78,8 +84,6 @@ class GPS : private concurrency::OSThread
      */
     bool hasValidLocation = false; // default to false, until we complete our first read
 
-    bool isAwake = false; // true if we want a location right now
-
     bool isInPowersave = false;
 
     bool shouldPublish = false; // If we've changed GPS state, this will force a publish the next loop()
@@ -88,6 +92,8 @@ class GPS : private concurrency::OSThread
 
     bool GPSInitFinished = false; // Init thread finished?
     bool GPSInitStarted = false;  // Init thread finished?
+
+    GPSPowerState powerState = OFF; // AWAKE if we want a location right now
 
     uint8_t numSatellites = 0;
 


### PR DESCRIPTION
Fixes an issue where triple-pressing the user button may not change the output at `PIN_GPS_EN`

Replaces a boolean, which didn't differentiate between "off" and "standby", with an enum.