### PR TITLE
Minimized build fixes

### DIFF
--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -108,8 +108,10 @@ static void onNetworkConnected()
     }
 
     // FIXME this is kinda yucky, instead we should just have an observable for 'wifireconnected'
+#ifndef MESHTASTIC_EXCLUDE_MQTT
     if (mqtt)
         mqtt->reconnect();
+#endif
 }
 
 static int32_t reconnectWiFi()

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -26,6 +26,11 @@
 #if !MESHTASTIC_EXCLUDE_GPS
 #include "GPS.h"
 #endif
+
+#if MESHTASTIC_EXCLUDE_GPS
+#include "modules/PositionModule.h"
+#endif
+
 #if !defined(ARCH_PORTDUINO) && !defined(ARCH_STM32WL) && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
 #include "AccelerometerThread.h"
 #endif

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -756,7 +756,9 @@ void AdminModule::handleGetDeviceConnectionStatus(const meshtastic_MeshPacket &r
     if (conn.wifi.status.is_connected) {
         conn.wifi.rssi = WiFi.RSSI();
         conn.wifi.status.ip_address = WiFi.localIP();
+#ifndef MESHTASTIC_EXCLUDE_MQTT
         conn.wifi.status.is_mqtt_connected = mqtt && mqtt->isConnectedDirectly();
+#endif
         conn.wifi.status.is_syslog_connected = false; // FIXME wire this up
     }
 #endif

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -396,6 +396,7 @@ bool MQTT::wantsLink() const
 
 int32_t MQTT::runOnce()
 {
+#ifdef HAS_NETWORKING
     if (!moduleConfig.mqtt.enabled || !(moduleConfig.mqtt.map_reporting_enabled || channels.anyMqttEnabled()))
         return disable();
 
@@ -408,7 +409,7 @@ int32_t MQTT::runOnce()
         publishQueuedMessages();
         return 200;
     }
-#ifdef HAS_NETWORKING
+
     else if (!pubSub.loop()) {
         if (!wantConnection)
             return 5000; // If we don't want connection now, check again in 5 secs

--- a/src/platform/esp32/main-esp32.cpp
+++ b/src/platform/esp32/main-esp32.cpp
@@ -24,121 +24,126 @@
 #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !MESHTASTIC_EXCLUDE_BLUETOOTH
 void setBluetoothEnable(bool enable)
 {
+#ifndef MESHTASTIC_EXCLUDE_WIFI
     if (!isWifiAvailable() && config.bluetooth.enabled == true) {
-        if (!nimbleBluetooth) {
-            nimbleBluetooth = new NimbleBluetooth();
+#endif
+#ifdef MESHTASTIC_EXCLUDE_WIFI
+        if (config.bluetooth.enabled == true) {
+#endif
+            if (!nimbleBluetooth) {
+                nimbleBluetooth = new NimbleBluetooth();
+            }
+            if (enable && !nimbleBluetooth->isActive()) {
+                nimbleBluetooth->setup();
+            }
+            // For ESP32, no way to recover from bluetooth shutdown without reboot
+            // BLE advertising automatically stops when MCU enters light-sleep(?)
+            // For deep-sleep, shutdown hardware with nimbleBluetooth->deinit(). Requires reboot to reverse
         }
-        if (enable && !nimbleBluetooth->isActive()) {
-            nimbleBluetooth->setup();
-        }
-        // For ESP32, no way to recover from bluetooth shutdown without reboot
-        // BLE advertising automatically stops when MCU enters light-sleep(?)
-        // For deep-sleep, shutdown hardware with nimbleBluetooth->deinit(). Requires reboot to reverse
     }
-}
 #else
 void setBluetoothEnable(bool enable) {}
 void updateBatteryLevel(uint8_t level) {}
 #endif
 
-void getMacAddr(uint8_t *dmac)
-{
-    assert(esp_efuse_mac_get_default(dmac) == ESP_OK);
-}
+    void getMacAddr(uint8_t * dmac)
+    {
+        assert(esp_efuse_mac_get_default(dmac) == ESP_OK);
+    }
 
 #ifdef HAS_32768HZ
 #define CALIBRATE_ONE(cali_clk) calibrate_one(cali_clk, #cali_clk)
 
-static uint32_t calibrate_one(rtc_cal_sel_t cal_clk, const char *name)
-{
-    const uint32_t cal_count = 1000;
-    // const float factor = (1 << 19) * 1000.0f; unused var?
-    uint32_t cali_val;
-    for (int i = 0; i < 5; ++i) {
-        cali_val = rtc_clk_cal(cal_clk, cal_count);
+    static uint32_t calibrate_one(rtc_cal_sel_t cal_clk, const char *name)
+    {
+        const uint32_t cal_count = 1000;
+        // const float factor = (1 << 19) * 1000.0f; unused var?
+        uint32_t cali_val;
+        for (int i = 0; i < 5; ++i) {
+            cali_val = rtc_clk_cal(cal_clk, cal_count);
+        }
+        return cali_val;
     }
-    return cali_val;
-}
 
-void enableSlowCLK()
-{
-    rtc_clk_32k_enable(true);
+    void enableSlowCLK()
+    {
+        rtc_clk_32k_enable(true);
 
-    CALIBRATE_ONE(RTC_CAL_RTC_MUX);
-    uint32_t cal_32k = CALIBRATE_ONE(RTC_CAL_32K_XTAL);
+        CALIBRATE_ONE(RTC_CAL_RTC_MUX);
+        uint32_t cal_32k = CALIBRATE_ONE(RTC_CAL_32K_XTAL);
 
-    if (cal_32k == 0) {
-        LOG_DEBUG("32K XTAL OSC has not started up\n");
-    } else {
-        rtc_clk_slow_freq_set(RTC_SLOW_FREQ_32K_XTAL);
-        LOG_DEBUG("Switching RTC Source to 32.768Khz succeeded, using 32K XTAL\n");
+        if (cal_32k == 0) {
+            LOG_DEBUG("32K XTAL OSC has not started up\n");
+        } else {
+            rtc_clk_slow_freq_set(RTC_SLOW_FREQ_32K_XTAL);
+            LOG_DEBUG("Switching RTC Source to 32.768Khz succeeded, using 32K XTAL\n");
+            CALIBRATE_ONE(RTC_CAL_RTC_MUX);
+            CALIBRATE_ONE(RTC_CAL_32K_XTAL);
+        }
         CALIBRATE_ONE(RTC_CAL_RTC_MUX);
         CALIBRATE_ONE(RTC_CAL_32K_XTAL);
+        if (rtc_clk_slow_freq_get() != RTC_SLOW_FREQ_32K_XTAL) {
+            LOG_WARN("Failed to switch 32K XTAL RTC source to 32.768Khz !!! \n");
+            return;
+        }
     }
-    CALIBRATE_ONE(RTC_CAL_RTC_MUX);
-    CALIBRATE_ONE(RTC_CAL_32K_XTAL);
-    if (rtc_clk_slow_freq_get() != RTC_SLOW_FREQ_32K_XTAL) {
-        LOG_WARN("Failed to switch 32K XTAL RTC source to 32.768Khz !!! \n");
-        return;
-    }
-}
 #endif
 
-void esp32Setup()
-{
-    uint32_t seed = esp_random();
-    LOG_DEBUG("Setting random seed %u\n", seed);
+    void esp32Setup()
+    {
+        uint32_t seed = esp_random();
+        LOG_DEBUG("Setting random seed %u\n", seed);
 
-    LOG_DEBUG("Total heap: %d\n", ESP.getHeapSize());
-    LOG_DEBUG("Free heap: %d\n", ESP.getFreeHeap());
-    LOG_DEBUG("Total PSRAM: %d\n", ESP.getPsramSize());
-    LOG_DEBUG("Free PSRAM: %d\n", ESP.getFreePsram());
+        LOG_DEBUG("Total heap: %d\n", ESP.getHeapSize());
+        LOG_DEBUG("Free heap: %d\n", ESP.getFreeHeap());
+        LOG_DEBUG("Total PSRAM: %d\n", ESP.getPsramSize());
+        LOG_DEBUG("Free PSRAM: %d\n", ESP.getFreePsram());
 
-    nvs_stats_t nvs_stats;
-    auto res = nvs_get_stats(NULL, &nvs_stats);
-    assert(res == ESP_OK);
-    LOG_DEBUG("NVS: UsedEntries %d, FreeEntries %d, AllEntries %d, NameSpaces %d\n", nvs_stats.used_entries,
-              nvs_stats.free_entries, nvs_stats.total_entries, nvs_stats.namespace_count);
+        nvs_stats_t nvs_stats;
+        auto res = nvs_get_stats(NULL, &nvs_stats);
+        assert(res == ESP_OK);
+        LOG_DEBUG("NVS: UsedEntries %d, FreeEntries %d, AllEntries %d, NameSpaces %d\n", nvs_stats.used_entries,
+                  nvs_stats.free_entries, nvs_stats.total_entries, nvs_stats.namespace_count);
 
-    LOG_DEBUG("Setup Preferences in Flash Storage\n");
+        LOG_DEBUG("Setup Preferences in Flash Storage\n");
 
-    // Create object to store our persistent data
-    Preferences preferences;
-    preferences.begin("meshtastic", false);
+        // Create object to store our persistent data
+        Preferences preferences;
+        preferences.begin("meshtastic", false);
 
-    uint32_t rebootCounter = preferences.getUInt("rebootCounter", 0);
-    rebootCounter++;
-    preferences.putUInt("rebootCounter", rebootCounter);
-    preferences.end();
-    LOG_DEBUG("Number of Device Reboots: %d\n", rebootCounter);
+        uint32_t rebootCounter = preferences.getUInt("rebootCounter", 0);
+        rebootCounter++;
+        preferences.putUInt("rebootCounter", rebootCounter);
+        preferences.end();
+        LOG_DEBUG("Number of Device Reboots: %d\n", rebootCounter);
 #if !MESHTASTIC_EXCLUDE_BLUETOOTH
-    String BLEOTA = BleOta::getOtaAppVersion();
-    if (BLEOTA.isEmpty()) {
-        LOG_DEBUG("No OTA firmware available\n");
-    } else {
-        LOG_DEBUG("OTA firmware version %s\n", BLEOTA.c_str());
-    }
+        String BLEOTA = BleOta::getOtaAppVersion();
+        if (BLEOTA.isEmpty()) {
+            LOG_DEBUG("No OTA firmware available\n");
+        } else {
+            LOG_DEBUG("OTA firmware version %s\n", BLEOTA.c_str());
+        }
 #else
     LOG_DEBUG("No OTA firmware available\n");
 #endif
 
-    // enableModemSleep();
+        // enableModemSleep();
 
 // Since we are turning on watchdogs rather late in the release schedule, we really don't want to catch any
 // false positives.  The wait-to-sleep timeout for shutting down radios is 30 secs, so pick 45 for now.
 // #define APP_WATCHDOG_SECS 45
 #define APP_WATCHDOG_SECS 90
 
-    res = esp_task_wdt_init(APP_WATCHDOG_SECS, true);
-    assert(res == ESP_OK);
+        res = esp_task_wdt_init(APP_WATCHDOG_SECS, true);
+        assert(res == ESP_OK);
 
-    res = esp_task_wdt_add(NULL);
-    assert(res == ESP_OK);
+        res = esp_task_wdt_add(NULL);
+        assert(res == ESP_OK);
 
 #ifdef HAS_32768HZ
-    enableSlowCLK();
+        enableSlowCLK();
 #endif
-}
+    }
 
 #if 0
 // Turn off for now
@@ -160,76 +165,76 @@ uint32_t axpDebugRead()
 Periodic axpDebugOutput(axpDebugRead);
 #endif
 
-/// loop code specific to ESP32 targets
-void esp32Loop()
-{
-    esp_task_wdt_reset(); // service our app level watchdog
+    /// loop code specific to ESP32 targets
+    void esp32Loop()
+    {
+        esp_task_wdt_reset(); // service our app level watchdog
 
-    // for debug printing
-    // radio.radioIf.canSleep();
-}
+        // for debug printing
+        // radio.radioIf.canSleep();
+    }
 
-void cpuDeepSleep(uint32_t msecToWake)
-{
-    /*
-    Some ESP32 IOs have internal pullups or pulldowns, which are enabled by default.
-    If an external circuit drives this pin in deep sleep mode, current consumption may
-    increase due to current flowing through these pullups and pulldowns.
+    void cpuDeepSleep(uint32_t msecToWake)
+    {
+        /*
+        Some ESP32 IOs have internal pullups or pulldowns, which are enabled by default.
+        If an external circuit drives this pin in deep sleep mode, current consumption may
+        increase due to current flowing through these pullups and pulldowns.
 
-    To isolate a pin, preventing extra current draw, call rtc_gpio_isolate() function.
-    For example, on ESP32-WROVER module, GPIO12 is pulled up externally.
-    GPIO12 also has an internal pulldown in the ESP32 chip. This means that in deep sleep,
-    some current will flow through these external and internal resistors, increasing deep
-    sleep current above the minimal possible value.
+        To isolate a pin, preventing extra current draw, call rtc_gpio_isolate() function.
+        For example, on ESP32-WROVER module, GPIO12 is pulled up externally.
+        GPIO12 also has an internal pulldown in the ESP32 chip. This means that in deep sleep,
+        some current will flow through these external and internal resistors, increasing deep
+        sleep current above the minimal possible value.
 
-    Note: we don't isolate pins that are used for the LORA, LED, i2c, or ST7735 Display for the Chatter2, spi or the wake
-    button(s), maybe we should not include any other GPIOs...
-    */
+        Note: we don't isolate pins that are used for the LORA, LED, i2c, or ST7735 Display for the Chatter2, spi or the wake
+        button(s), maybe we should not include any other GPIOs...
+        */
 #if SOC_RTCIO_HOLD_SUPPORTED
-    static const uint8_t rtcGpios[] = {/* 0, */ 2,
-    /* 4, */
+        static const uint8_t rtcGpios[] = {/* 0, */ 2,
+        /* 4, */
 #ifndef USE_JTAG
-                                       13,
-    /* 14, */ /* 15, */
+                                           13,
+        /* 14, */ /* 15, */
 #endif
-                                       /* 25, */ /* 26, */ /* 27, */
-                                       /* 32, */ /* 33, */ 34, 35,
-                                       /* 36, */ 37
-                                       /* 38, 39 */};
+                                           /* 25, */ /* 26, */ /* 27, */
+                                           /* 32, */ /* 33, */ 34, 35,
+                                           /* 36, */ 37
+                                           /* 38, 39 */};
 
-    for (int i = 0; i < sizeof(rtcGpios); i++)
-        rtc_gpio_isolate((gpio_num_t)rtcGpios[i]);
+        for (int i = 0; i < sizeof(rtcGpios); i++)
+            rtc_gpio_isolate((gpio_num_t)rtcGpios[i]);
 #endif
 
-        // FIXME, disable internal rtc pullups/pulldowns on the non isolated pins. for inputs that we aren't using
-        // to detect wake and in normal operation the external part drives them hard.
+            // FIXME, disable internal rtc pullups/pulldowns on the non isolated pins. for inputs that we aren't using
+            // to detect wake and in normal operation the external part drives them hard.
 #ifdef BUTTON_PIN
-        // Only GPIOs which are have RTC functionality can be used in this bit map: 0,2,4,12-15,25-27,32-39.
+            // Only GPIOs which are have RTC functionality can be used in this bit map: 0,2,4,12-15,25-27,32-39.
 #if SOC_RTCIO_HOLD_SUPPORTED
-    uint64_t gpioMask = (1ULL << (config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN));
+        uint64_t gpioMask = (1ULL << (config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN));
 #endif
 
 #ifdef BUTTON_NEED_PULLUP
-    gpio_pullup_en((gpio_num_t)BUTTON_PIN);
+        gpio_pullup_en((gpio_num_t)BUTTON_PIN);
 #endif
 
-    // Not needed because both of the current boards have external pullups
-    // FIXME change polarity in hw so we can wake on ANY_HIGH instead - that would allow us to use all three buttons (instead of
-    // just the first) gpio_pullup_en((gpio_num_t)BUTTON_PIN);
+        // Not needed because both of the current boards have external pullups
+        // FIXME change polarity in hw so we can wake on ANY_HIGH instead - that would allow us to use all three buttons (instead
+        // of just the first) gpio_pullup_en((gpio_num_t)BUTTON_PIN);
 
 #if SOC_PM_SUPPORT_EXT_WAKEUP
 #ifdef CONFIG_IDF_TARGET_ESP32
-    // ESP_EXT1_WAKEUP_ALL_LOW has been deprecated since esp-idf v5.4 for any other target.
-    esp_sleep_enable_ext1_wakeup(gpioMask, ESP_EXT1_WAKEUP_ALL_LOW);
+        // ESP_EXT1_WAKEUP_ALL_LOW has been deprecated since esp-idf v5.4 for any other target.
+        esp_sleep_enable_ext1_wakeup(gpioMask, ESP_EXT1_WAKEUP_ALL_LOW);
 #else
-    esp_sleep_enable_ext1_wakeup(gpioMask, ESP_EXT1_WAKEUP_ANY_LOW);
+        esp_sleep_enable_ext1_wakeup(gpioMask, ESP_EXT1_WAKEUP_ANY_LOW);
 #endif
 #endif
 #endif
 
-    // We want RTC peripherals to stay on
-    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
+        // We want RTC peripherals to stay on
+        esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
 
-    esp_sleep_enable_timer_wakeup(msecToWake * 1000ULL); // call expects usecs
-    esp_deep_sleep_start();                              // TBD mA sleep current (battery)
-}
+        esp_sleep_enable_timer_wakeup(msecToWake * 1000ULL); // call expects usecs
+        esp_deep_sleep_start();                              // TBD mA sleep current (battery)
+    }

--- a/src/platform/esp32/main-esp32.cpp
+++ b/src/platform/esp32/main-esp32.cpp
@@ -25,11 +25,12 @@
 void setBluetoothEnable(bool enable)
 {
 #ifndef MESHTASTIC_EXCLUDE_WIFI
-    if (!isWifiAvailable() && config.bluetooth.enabled == true) {
+    if (!isWifiAvailable() && config.bluetooth.enabled == true)
 #endif
 #ifdef MESHTASTIC_EXCLUDE_WIFI
-        if (config.bluetooth.enabled == true) {
+        if (config.bluetooth.enabled == true)
 #endif
+        {
             if (!nimbleBluetooth) {
                 nimbleBluetooth = new NimbleBluetooth();
             }
@@ -40,110 +41,110 @@ void setBluetoothEnable(bool enable)
             // BLE advertising automatically stops when MCU enters light-sleep(?)
             // For deep-sleep, shutdown hardware with nimbleBluetooth->deinit(). Requires reboot to reverse
         }
-    }
+}
 #else
 void setBluetoothEnable(bool enable) {}
 void updateBatteryLevel(uint8_t level) {}
 #endif
 
-    void getMacAddr(uint8_t * dmac)
-    {
-        assert(esp_efuse_mac_get_default(dmac) == ESP_OK);
-    }
+void getMacAddr(uint8_t *dmac)
+{
+    assert(esp_efuse_mac_get_default(dmac) == ESP_OK);
+}
 
 #ifdef HAS_32768HZ
 #define CALIBRATE_ONE(cali_clk) calibrate_one(cali_clk, #cali_clk)
 
-    static uint32_t calibrate_one(rtc_cal_sel_t cal_clk, const char *name)
-    {
-        const uint32_t cal_count = 1000;
-        // const float factor = (1 << 19) * 1000.0f; unused var?
-        uint32_t cali_val;
-        for (int i = 0; i < 5; ++i) {
-            cali_val = rtc_clk_cal(cal_clk, cal_count);
-        }
-        return cali_val;
+static uint32_t calibrate_one(rtc_cal_sel_t cal_clk, const char *name)
+{
+    const uint32_t cal_count = 1000;
+    // const float factor = (1 << 19) * 1000.0f; unused var?
+    uint32_t cali_val;
+    for (int i = 0; i < 5; ++i) {
+        cali_val = rtc_clk_cal(cal_clk, cal_count);
     }
+    return cali_val;
+}
 
-    void enableSlowCLK()
-    {
-        rtc_clk_32k_enable(true);
+void enableSlowCLK()
+{
+    rtc_clk_32k_enable(true);
 
-        CALIBRATE_ONE(RTC_CAL_RTC_MUX);
-        uint32_t cal_32k = CALIBRATE_ONE(RTC_CAL_32K_XTAL);
+    CALIBRATE_ONE(RTC_CAL_RTC_MUX);
+    uint32_t cal_32k = CALIBRATE_ONE(RTC_CAL_32K_XTAL);
 
-        if (cal_32k == 0) {
-            LOG_DEBUG("32K XTAL OSC has not started up\n");
-        } else {
-            rtc_clk_slow_freq_set(RTC_SLOW_FREQ_32K_XTAL);
-            LOG_DEBUG("Switching RTC Source to 32.768Khz succeeded, using 32K XTAL\n");
-            CALIBRATE_ONE(RTC_CAL_RTC_MUX);
-            CALIBRATE_ONE(RTC_CAL_32K_XTAL);
-        }
+    if (cal_32k == 0) {
+        LOG_DEBUG("32K XTAL OSC has not started up\n");
+    } else {
+        rtc_clk_slow_freq_set(RTC_SLOW_FREQ_32K_XTAL);
+        LOG_DEBUG("Switching RTC Source to 32.768Khz succeeded, using 32K XTAL\n");
         CALIBRATE_ONE(RTC_CAL_RTC_MUX);
         CALIBRATE_ONE(RTC_CAL_32K_XTAL);
-        if (rtc_clk_slow_freq_get() != RTC_SLOW_FREQ_32K_XTAL) {
-            LOG_WARN("Failed to switch 32K XTAL RTC source to 32.768Khz !!! \n");
-            return;
-        }
     }
+    CALIBRATE_ONE(RTC_CAL_RTC_MUX);
+    CALIBRATE_ONE(RTC_CAL_32K_XTAL);
+    if (rtc_clk_slow_freq_get() != RTC_SLOW_FREQ_32K_XTAL) {
+        LOG_WARN("Failed to switch 32K XTAL RTC source to 32.768Khz !!! \n");
+        return;
+    }
+}
 #endif
 
-    void esp32Setup()
-    {
-        uint32_t seed = esp_random();
-        LOG_DEBUG("Setting random seed %u\n", seed);
+void esp32Setup()
+{
+    uint32_t seed = esp_random();
+    LOG_DEBUG("Setting random seed %u\n", seed);
 
-        LOG_DEBUG("Total heap: %d\n", ESP.getHeapSize());
-        LOG_DEBUG("Free heap: %d\n", ESP.getFreeHeap());
-        LOG_DEBUG("Total PSRAM: %d\n", ESP.getPsramSize());
-        LOG_DEBUG("Free PSRAM: %d\n", ESP.getFreePsram());
+    LOG_DEBUG("Total heap: %d\n", ESP.getHeapSize());
+    LOG_DEBUG("Free heap: %d\n", ESP.getFreeHeap());
+    LOG_DEBUG("Total PSRAM: %d\n", ESP.getPsramSize());
+    LOG_DEBUG("Free PSRAM: %d\n", ESP.getFreePsram());
 
-        nvs_stats_t nvs_stats;
-        auto res = nvs_get_stats(NULL, &nvs_stats);
-        assert(res == ESP_OK);
-        LOG_DEBUG("NVS: UsedEntries %d, FreeEntries %d, AllEntries %d, NameSpaces %d\n", nvs_stats.used_entries,
-                  nvs_stats.free_entries, nvs_stats.total_entries, nvs_stats.namespace_count);
+    nvs_stats_t nvs_stats;
+    auto res = nvs_get_stats(NULL, &nvs_stats);
+    assert(res == ESP_OK);
+    LOG_DEBUG("NVS: UsedEntries %d, FreeEntries %d, AllEntries %d, NameSpaces %d\n", nvs_stats.used_entries,
+              nvs_stats.free_entries, nvs_stats.total_entries, nvs_stats.namespace_count);
 
-        LOG_DEBUG("Setup Preferences in Flash Storage\n");
+    LOG_DEBUG("Setup Preferences in Flash Storage\n");
 
-        // Create object to store our persistent data
-        Preferences preferences;
-        preferences.begin("meshtastic", false);
+    // Create object to store our persistent data
+    Preferences preferences;
+    preferences.begin("meshtastic", false);
 
-        uint32_t rebootCounter = preferences.getUInt("rebootCounter", 0);
-        rebootCounter++;
-        preferences.putUInt("rebootCounter", rebootCounter);
-        preferences.end();
-        LOG_DEBUG("Number of Device Reboots: %d\n", rebootCounter);
+    uint32_t rebootCounter = preferences.getUInt("rebootCounter", 0);
+    rebootCounter++;
+    preferences.putUInt("rebootCounter", rebootCounter);
+    preferences.end();
+    LOG_DEBUG("Number of Device Reboots: %d\n", rebootCounter);
 #if !MESHTASTIC_EXCLUDE_BLUETOOTH
-        String BLEOTA = BleOta::getOtaAppVersion();
-        if (BLEOTA.isEmpty()) {
-            LOG_DEBUG("No OTA firmware available\n");
-        } else {
-            LOG_DEBUG("OTA firmware version %s\n", BLEOTA.c_str());
-        }
+    String BLEOTA = BleOta::getOtaAppVersion();
+    if (BLEOTA.isEmpty()) {
+        LOG_DEBUG("No OTA firmware available\n");
+    } else {
+        LOG_DEBUG("OTA firmware version %s\n", BLEOTA.c_str());
+    }
 #else
     LOG_DEBUG("No OTA firmware available\n");
 #endif
 
-        // enableModemSleep();
+    // enableModemSleep();
 
 // Since we are turning on watchdogs rather late in the release schedule, we really don't want to catch any
 // false positives.  The wait-to-sleep timeout for shutting down radios is 30 secs, so pick 45 for now.
 // #define APP_WATCHDOG_SECS 45
 #define APP_WATCHDOG_SECS 90
 
-        res = esp_task_wdt_init(APP_WATCHDOG_SECS, true);
-        assert(res == ESP_OK);
+    res = esp_task_wdt_init(APP_WATCHDOG_SECS, true);
+    assert(res == ESP_OK);
 
-        res = esp_task_wdt_add(NULL);
-        assert(res == ESP_OK);
+    res = esp_task_wdt_add(NULL);
+    assert(res == ESP_OK);
 
 #ifdef HAS_32768HZ
-        enableSlowCLK();
+    enableSlowCLK();
 #endif
-    }
+}
 
 #if 0
 // Turn off for now
@@ -165,76 +166,76 @@ uint32_t axpDebugRead()
 Periodic axpDebugOutput(axpDebugRead);
 #endif
 
-    /// loop code specific to ESP32 targets
-    void esp32Loop()
-    {
-        esp_task_wdt_reset(); // service our app level watchdog
+/// loop code specific to ESP32 targets
+void esp32Loop()
+{
+    esp_task_wdt_reset(); // service our app level watchdog
 
-        // for debug printing
-        // radio.radioIf.canSleep();
-    }
+    // for debug printing
+    // radio.radioIf.canSleep();
+}
 
-    void cpuDeepSleep(uint32_t msecToWake)
-    {
-        /*
-        Some ESP32 IOs have internal pullups or pulldowns, which are enabled by default.
-        If an external circuit drives this pin in deep sleep mode, current consumption may
-        increase due to current flowing through these pullups and pulldowns.
+void cpuDeepSleep(uint32_t msecToWake)
+{
+    /*
+    Some ESP32 IOs have internal pullups or pulldowns, which are enabled by default.
+    If an external circuit drives this pin in deep sleep mode, current consumption may
+    increase due to current flowing through these pullups and pulldowns.
 
-        To isolate a pin, preventing extra current draw, call rtc_gpio_isolate() function.
-        For example, on ESP32-WROVER module, GPIO12 is pulled up externally.
-        GPIO12 also has an internal pulldown in the ESP32 chip. This means that in deep sleep,
-        some current will flow through these external and internal resistors, increasing deep
-        sleep current above the minimal possible value.
+    To isolate a pin, preventing extra current draw, call rtc_gpio_isolate() function.
+    For example, on ESP32-WROVER module, GPIO12 is pulled up externally.
+    GPIO12 also has an internal pulldown in the ESP32 chip. This means that in deep sleep,
+    some current will flow through these external and internal resistors, increasing deep
+    sleep current above the minimal possible value.
 
-        Note: we don't isolate pins that are used for the LORA, LED, i2c, or ST7735 Display for the Chatter2, spi or the wake
-        button(s), maybe we should not include any other GPIOs...
-        */
+    Note: we don't isolate pins that are used for the LORA, LED, i2c, or ST7735 Display for the Chatter2, spi or the wake
+    button(s), maybe we should not include any other GPIOs...
+    */
 #if SOC_RTCIO_HOLD_SUPPORTED
-        static const uint8_t rtcGpios[] = {/* 0, */ 2,
-        /* 4, */
+    static const uint8_t rtcGpios[] = {/* 0, */ 2,
+    /* 4, */
 #ifndef USE_JTAG
-                                           13,
-        /* 14, */ /* 15, */
+                                       13,
+    /* 14, */ /* 15, */
 #endif
-                                           /* 25, */ /* 26, */ /* 27, */
-                                           /* 32, */ /* 33, */ 34, 35,
-                                           /* 36, */ 37
-                                           /* 38, 39 */};
+                                       /* 25, */ /* 26, */ /* 27, */
+                                       /* 32, */ /* 33, */ 34, 35,
+                                       /* 36, */ 37
+                                       /* 38, 39 */};
 
-        for (int i = 0; i < sizeof(rtcGpios); i++)
-            rtc_gpio_isolate((gpio_num_t)rtcGpios[i]);
+    for (int i = 0; i < sizeof(rtcGpios); i++)
+        rtc_gpio_isolate((gpio_num_t)rtcGpios[i]);
 #endif
 
-            // FIXME, disable internal rtc pullups/pulldowns on the non isolated pins. for inputs that we aren't using
-            // to detect wake and in normal operation the external part drives them hard.
+        // FIXME, disable internal rtc pullups/pulldowns on the non isolated pins. for inputs that we aren't using
+        // to detect wake and in normal operation the external part drives them hard.
 #ifdef BUTTON_PIN
-            // Only GPIOs which are have RTC functionality can be used in this bit map: 0,2,4,12-15,25-27,32-39.
+        // Only GPIOs which are have RTC functionality can be used in this bit map: 0,2,4,12-15,25-27,32-39.
 #if SOC_RTCIO_HOLD_SUPPORTED
-        uint64_t gpioMask = (1ULL << (config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN));
+    uint64_t gpioMask = (1ULL << (config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN));
 #endif
 
 #ifdef BUTTON_NEED_PULLUP
-        gpio_pullup_en((gpio_num_t)BUTTON_PIN);
+    gpio_pullup_en((gpio_num_t)BUTTON_PIN);
 #endif
 
-        // Not needed because both of the current boards have external pullups
-        // FIXME change polarity in hw so we can wake on ANY_HIGH instead - that would allow us to use all three buttons (instead
-        // of just the first) gpio_pullup_en((gpio_num_t)BUTTON_PIN);
+    // Not needed because both of the current boards have external pullups
+    // FIXME change polarity in hw so we can wake on ANY_HIGH instead - that would allow us to use all three buttons (instead
+    // of just the first) gpio_pullup_en((gpio_num_t)BUTTON_PIN);
 
 #if SOC_PM_SUPPORT_EXT_WAKEUP
 #ifdef CONFIG_IDF_TARGET_ESP32
-        // ESP_EXT1_WAKEUP_ALL_LOW has been deprecated since esp-idf v5.4 for any other target.
-        esp_sleep_enable_ext1_wakeup(gpioMask, ESP_EXT1_WAKEUP_ALL_LOW);
+    // ESP_EXT1_WAKEUP_ALL_LOW has been deprecated since esp-idf v5.4 for any other target.
+    esp_sleep_enable_ext1_wakeup(gpioMask, ESP_EXT1_WAKEUP_ALL_LOW);
 #else
-        esp_sleep_enable_ext1_wakeup(gpioMask, ESP_EXT1_WAKEUP_ANY_LOW);
+    esp_sleep_enable_ext1_wakeup(gpioMask, ESP_EXT1_WAKEUP_ANY_LOW);
 #endif
 #endif
 #endif
 
-        // We want RTC peripherals to stay on
-        esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
+    // We want RTC peripherals to stay on
+    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
 
-        esp_sleep_enable_timer_wakeup(msecToWake * 1000ULL); // call expects usecs
-        esp_deep_sleep_start();                              // TBD mA sleep current (battery)
-    }
+    esp_sleep_enable_timer_wakeup(msecToWake * 1000ULL); // call expects usecs
+    esp_deep_sleep_start();                              // TBD mA sleep current (battery)
+}


### PR DESCRIPTION
Was working through configuration.h on the Minimized Builds options and was running into a couple of issues, so fixed up some minor changes to allow it to build correctly.

Made a minor changes to AdminModule.cpp to include modules/PositionModule.h when MESHTASTIC_EXCLUDE_GPS is defined.
Made a minor change to WiFiAPClient.cpp to not attempt to reconnect MQTT if MESHTASTIC_EXCLUDE_MQTT is defined.
Made a minor change to AdminModule.cpp to not attempt to check if MQTT is connected if MESHTASTIC_EXCUDE_MQTT is defined
In MQTT.cpp moved #ifdef HAS_NETWORKING further up the function to catch when EXCLUDE_MESHTASTIC_WIFI is defined.
In main-esp32.cpp created a ifndef and ifdef statement to have the right IF statement when EXCLUDE_MESHTASTIC_WIFI is defined.

No fixes for MESHTASTIC_EXCLUDE_MODULES as there are many to go through.

No issue to link, just cleaning up build issues for minimized builds.