### PR TITLE
Fix: two button presses sometimes required to wake screen

### DIFF
--- a/src/ButtonThread.cpp
+++ b/src/ButtonThread.cpp
@@ -232,10 +232,10 @@ void ButtonThread::attachButtonInterrupts()
     attachInterrupt(
         config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN,
         []() {
-            BaseType_t higherWake = 0;
-            mainDelay.interruptFromISR(&higherWake);
             ButtonThread::userButton.tick();
             runASAP = true;
+            BaseType_t higherWake = 0;
+            mainDelay.interruptFromISR(&higherWake);
         },
         CHANGE);
 #endif


### PR DESCRIPTION
On some devices, after a long period of inactivity, the first press of the user button does not reliably wake the screen. A second button press is often required. This PR hopefully corrects (or at least reduces) this issue. 

Tested working on T-Beam v1.2