### PR TITLE
Workaround to disable bluetooth on NRF52

### DIFF
--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -215,6 +215,19 @@ void NRF52Bluetooth::shutdown()
     Bluefruit.Advertising.stop();
 }
 
+void NRF52Bluetooth::startDisabled()
+{
+    LOG_DEBUG("Initializing NRF52 Bluetooth, then disabling. (workaround)\n");
+
+    // Setup Bluetooth
+    nrf52Bluetooth = new NRF52Bluetooth();
+    nrf52Bluetooth->setup();
+
+    // Shutdown bluetooth for minimum power draw
+    Bluefruit.Advertising.stop();
+    Bluefruit.setTxPower(0); // Minimum power
+}
+
 bool NRF52Bluetooth::isConnected()
 {
     return Bluefruit.connected(connectionHandle);

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -217,7 +217,7 @@ void NRF52Bluetooth::shutdown()
 
 void NRF52Bluetooth::startDisabled()
 {
-    LOG_DEBUG("Initializing NRF52 Bluetooth, then disabling. (workaround)\n");
+    LOG_DEBUG("Initializing NRF52 Bluetooth, then disabling. (Workaround)\n");
 
     // Setup Bluetooth
     nrf52Bluetooth = new NRF52Bluetooth();

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -220,7 +220,6 @@ void NRF52Bluetooth::startDisabled()
     LOG_DEBUG("Initializing NRF52 Bluetooth, then disabling. (Workaround)\n");
 
     // Setup Bluetooth
-    nrf52Bluetooth = new NRF52Bluetooth();
     nrf52Bluetooth->setup();
 
     // Shutdown bluetooth for minimum power draw

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -217,14 +217,14 @@ void NRF52Bluetooth::shutdown()
 
 void NRF52Bluetooth::startDisabled()
 {
-    LOG_DEBUG("Initializing NRF52 Bluetooth, then disabling. (Workaround)\n");
-
     // Setup Bluetooth
     nrf52Bluetooth->setup();
 
     // Shutdown bluetooth for minimum power draw
     Bluefruit.Advertising.stop();
     Bluefruit.setTxPower(-40); // Minimum power
+
+    LOG_INFO("Disabling NRF52 Bluetooth. (Workaround: tx power min, advertising stopped)\n");
 }
 
 bool NRF52Bluetooth::isConnected()

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -225,7 +225,7 @@ void NRF52Bluetooth::startDisabled()
 
     // Shutdown bluetooth for minimum power draw
     Bluefruit.Advertising.stop();
-    Bluefruit.setTxPower(0); // Minimum power
+    Bluefruit.setTxPower(-40); // Minimum power
 }
 
 bool NRF52Bluetooth::isConnected()

--- a/src/platform/nrf52/NRF52Bluetooth.h
+++ b/src/platform/nrf52/NRF52Bluetooth.h
@@ -8,6 +8,7 @@ class NRF52Bluetooth : BluetoothApi
   public:
     void setup();
     void shutdown();
+    void startDisabled();
     void resumeAdvertising();
     void clearBonds();
     bool isConnected();

--- a/src/platform/nrf52/main-nrf52.cpp
+++ b/src/platform/nrf52/main-nrf52.cpp
@@ -81,6 +81,7 @@ void setBluetoothEnable(bool enable)
     if (!config.bluetooth.enabled) {
         static bool initialized = false;
         if (!initialized) {
+            nrf52Bluetooth = new NRF52Bluetooth();
             nrf52Bluetooth->startDisabled();
             initBrownout();
             initialized = true;

--- a/src/platform/nrf52/main-nrf52.cpp
+++ b/src/platform/nrf52/main-nrf52.cpp
@@ -68,7 +68,18 @@ static const bool useSoftDevice = true; // Set to false for easier debugging
 #if !MESHTASTIC_EXCLUDE_BLUETOOTH
 void setBluetoothEnable(bool enable)
 {
-    if (enable && config.bluetooth.enabled) {
+    // Workaround: if bluetooth disabled, init then disable advertising & reduce power
+    if (!config.bluetooth.enabled) {
+        static bool initialized = false;
+        if (!initialized) {
+            nrf52Bluetooth->startDisabled();
+            initBrownout();
+            initialized = true;
+        }
+        return;
+    }
+
+    if (enable) {
         if (!useSoftDevice) {
             LOG_INFO("DISABLING NRF52 BLUETOOTH WHILE DEBUGGING\n");
         } else {
@@ -90,6 +101,7 @@ void setBluetoothEnable(bool enable)
     }
 }
 #else
+#warning NRF52 "Bluetooth disable" workaround does not apply to builds with MESHTASTIC_EXCLUDE_BLUETOOTH
 void setBluetoothEnable(bool enable) {}
 #endif
 /**


### PR DESCRIPTION
Not a fix, but a workaround for #2885. 
Implements a suggestion discussed on the Meshtastic Discord server:

If `config.bluetooth.enabled` is false, Bluefruit is setup as normal, then advertising is stopped, and the tx power is reduced to minimum. This means that the SoftDevice, and the brown-out-detection, are enabled as usual.

With this workaround, and Bluetooth disabled:
* the device does not show in scans
* it is not possible to connect to the device using Bluetooth

This workaround seems to avoid the issue of #2885, and RadioLib -706 errors (discussed in #NRF52 on Discord). I have not experienced any lock-ups or crashes during testing, even with uptime > 3 days. It would be good to get more test time on this before rolling out.

I don't have equipment to measure the power consumption over time, but crude current measurement with a digital multimeter suggests that the workaround is similar to running with Bluetooth completely uninitialized. The workaround is *at most* a few perfect more efficient than running normally, with Bluetooth at idle.