### PR TITLE
Add missing hops in traceroute as "unknown" nodes

### DIFF
--- a/src/modules/TraceRouteModule.h
+++ b/src/modules/TraceRouteModule.h
@@ -19,6 +19,9 @@ class TraceRouteModule : public ProtobufModule<meshtastic_RouteDiscovery>
     void alterReceivedProtobuf(meshtastic_MeshPacket &p, meshtastic_RouteDiscovery *r) override;
 
   private:
+    // Call to add unknown hops (e.g. when a node couldn't decrypt it) to the route based on hopStart and current hopLimit
+    void insertUnknownHops(meshtastic_MeshPacket &p, meshtastic_RouteDiscovery *r);
+
     // Call to add your ID to the route array of a RouteDiscovery message
     void appendMyID(meshtastic_RouteDiscovery *r);
 


### PR DESCRIPTION
Implements #3942. 
Using `hopStart` and `hopLimit`, missing hops in a traceroute (e.g. when a node cannot decrypt it) can be detected. In this case, the node receiving it afterwards adds dummy node numbers (`0xFFFFFF`) to the route, which will be shown as “Unknown Username” in the apps.

It shows as follows in the logs: 
```
INFO  | ??:??:?? 13 [Router] Route traced:
INFO  | ??:??:?? 13 [Router] 0x75a2bca4 --> 0xffffffff --> 0xfa6c5f90
```
