### PR TITLE
Avoid assert on receiving undecryptable packet

### DIFF
--- a/src/mesh/MeshModule.cpp
+++ b/src/mesh/MeshModule.cpp
@@ -53,8 +53,7 @@ meshtastic_MeshPacket *MeshModule::allocAckNak(meshtastic_Routing_Error err, Nod
     p->hop_limit = routingModule->getHopLimitForResponse(hopStart, hopLimit); // Flood ACK back to original sender
     p->to = to;
     p->decoded.request_id = idFrom;
-    // If the original packet couldn't be decoded, use the primary channel
-    p->channel = p->which_payload_variant == meshtastic_MeshPacket_decoded_tag ? chIndex : channels.getPrimaryIndex();
+    p->channel = chIndex;
     if (err != meshtastic_Routing_Error_NONE)
         LOG_ERROR("Alloc an err=%d,to=0x%x,idFrom=0x%x,id=0x%x\n", err, to, idFrom, p->id);
 
@@ -63,7 +62,10 @@ meshtastic_MeshPacket *MeshModule::allocAckNak(meshtastic_Routing_Error err, Nod
 
 meshtastic_MeshPacket *MeshModule::allocErrorResponse(meshtastic_Routing_Error err, const meshtastic_MeshPacket *p)
 {
-    auto r = allocAckNak(err, getFrom(p), p->id, p->channel);
+    // If the original packet couldn't be decoded, use the primary channel
+    uint8_t channelIndex =
+        p->which_payload_variant == meshtastic_MeshPacket_decoded_tag ? p->channel : channels.getPrimaryIndex();
+    auto r = allocAckNak(err, getFrom(p), p->id, channelIndex);
 
     setReplyTo(r, *p);
 

--- a/src/mesh/MeshModule.cpp
+++ b/src/mesh/MeshModule.cpp
@@ -53,7 +53,8 @@ meshtastic_MeshPacket *MeshModule::allocAckNak(meshtastic_Routing_Error err, Nod
     p->hop_limit = routingModule->getHopLimitForResponse(hopStart, hopLimit); // Flood ACK back to original sender
     p->to = to;
     p->decoded.request_id = idFrom;
-    p->channel = chIndex;
+    // If the original packet couldn't be decoded, use the primary channel
+    p->channel = p->which_payload_variant == meshtastic_MeshPacket_decoded_tag ? chIndex : channels.getPrimaryIndex();
     if (err != meshtastic_Routing_Error_NONE)
         LOG_ERROR("Alloc an err=%d,to=0x%x,idFrom=0x%x,id=0x%x\n", err, to, idFrom, p->id);
 

--- a/src/mesh/MeshModule.cpp
+++ b/src/mesh/MeshModule.cpp
@@ -115,13 +115,13 @@ void MeshModule::callModules(meshtastic_MeshPacket &mp, RxSource src)
             /// Also: if a packet comes in on the local PC interface, we don't check for bound channels, because it is TRUSTED and
             /// it needs to to be able to fetch the initial admin packets without yet knowing any channels.
 
-            bool rxChannelOk = !pi.boundChannel || (mp.from == 0) || (strcasecmp(ch->settings.name, pi.boundChannel) == 0);
+            bool rxChannelOk = !pi.boundChannel || (mp.from == 0) || (ch && strcasecmp(ch->settings.name, pi.boundChannel) == 0);
 
             if (!rxChannelOk) {
                 // no one should have already replied!
                 assert(!currentReply);
 
-                if (mp.decoded.want_response) {
+                if (isDecoded && mp.decoded.want_response) {
                     printPacket("packet on wrong channel, returning error", &mp);
                     currentReply = pi.allocErrorResponse(meshtastic_Routing_Error_NOT_AUTHORIZED, &mp);
                 } else
@@ -139,7 +139,8 @@ void MeshModule::callModules(meshtastic_MeshPacket &mp, RxSource src)
                 // because currently when the phone sends things, it sends things using the local node ID as the from address.  A
                 // better solution (FIXME) would be to let phones have their own distinct addresses and we 'route' to them like
                 // any other node.
-                if (mp.decoded.want_response && toUs && (getFrom(&mp) != ourNodeNum || mp.to == ourNodeNum) && !currentReply) {
+                if (isDecoded && mp.decoded.want_response && toUs && (getFrom(&mp) != ourNodeNum || mp.to == ourNodeNum) &&
+                    !currentReply) {
                     pi.sendResponse(mp);
                     ignoreRequest = ignoreRequest || pi.ignoreRequest; // If at least one module asks it, we may ignore a request
                     LOG_INFO("Asked module '%s' to send a response\n", pi.name);
@@ -164,7 +165,7 @@ void MeshModule::callModules(meshtastic_MeshPacket &mp, RxSource src)
         pi.currentRequest = NULL;
     }
 
-    if (mp.decoded.want_response && toUs) {
+    if (isDecoded && mp.decoded.want_response && toUs) {
         if (currentReply) {
             printPacket("Sending response", currentReply);
             service.sendToMesh(currentReply);
@@ -184,7 +185,7 @@ void MeshModule::callModules(meshtastic_MeshPacket &mp, RxSource src)
         }
     }
 
-    if (!moduleFound) {
+    if (!moduleFound && isDecoded) {
         LOG_DEBUG("No modules interested in portnum=%d, src=%s\n", mp.decoded.portnum,
                   (src == RX_SRC_LOCAL) ? "LOCAL" : "REMOTE");
     }


### PR DESCRIPTION
Fixes #3959.

It actually was an assert, as I captured it also on an ESP32: 

```assert failed: CryptoKey Channels::getKey(ChannelIndex) Channels.cpp:108 (ch.has_settings)```

Problem was that it tried to send a NAK when decrypting failed. In that case, the channel index is still the hash, so it couldn’t get the channel settings when trying to encrypt the NAK. So now we’ll send the NAK on its primary channel in that case. It’s the best we can do, in the hope the other side understands that.

However, it tried to send the NAK because it thought `mp.decoded.want_response` was set and no module responded, but `decoded` is not valid if it’s not decrypted, so I also added additional checks for that.
