### PR TITLE
Fix uBlox M10 GPS doesn't sleep if device is switched off

### DIFF
--- a/src/gps/ubx.h
+++ b/src/gps/ubx.h
@@ -319,6 +319,7 @@ const uint8_t GPS::_message_SAVE[] = {
 // As the M10 has no flash, the best we can do to preserve the config is to set it in RAM and BBR.
 // BBR will survive a restart, and power off for a while, but modules with small backup
 // batteries or super caps will not retain the config for a long power off time.
+// for all configurations using sleep / low power modes, V_BCKP needs to be hooked to permanent power for fast aquisition after sleep
 
 // VALSET Commands for M10
 // Please refer to the M10 Protocol Specification:
@@ -327,40 +328,44 @@ const uint8_t GPS::_message_SAVE[] = {
 // and:
 // https://content.u-blox.com/sites/default/files/u-blox-M10-ROM-5.10_ReleaseNotes_UBX-22001426.pdf
 // for interesting insights.
+//
+// Integration manual:
+// https://content.u-blox.com/sites/default/files/documents/SAM-M10Q_IntegrationManual_UBX-22020019.pdf
+// has details on low-power modes
+
 /*
 CFG-PM2 has been replaced by many CFG-PM commands
-OPERATEMODE E1 2 (0 | 1 | 2)
-POSUPDATEPERIOD U4 1000ms for M10 must be >= 5s try 5
-ACQPERIOD U4 10 seems ok for M10 def ok
-GRIDOFFSET U4 0 seems ok for M10 def ok
-ONTIME U2 1 will try 1
-MINACQTIME U1 0 will try 0 def ok
-MAXACQTIME U1 stick with default of 0 def ok
-DONOTENTEROFF L 1 stay at 1
-WAITTIMEFIX  L 1 stay with 1
-UPDATEEPH L 1 changed to 1 for gps rework default is 1
-EXTINTWAKE L 0 no ext ints
-EXTINTBACKUP L 0 no ext ints
-EXTINTINACTIVE L 0 no ext ints
-EXTINTACTIVITY U4 0 no ext ints
-LIMITPEAKCURRENT L 1 stay with 1
-*/
-// CFG-PMS has been removed
+CFG-PMS has been removed
+
+CFG-PM-OPERATEMODE E1 (0 | 1 | 2) -> 1 (PSMOO), because sporadic position updates are required instead of continous tracking <10s (PSMCT)
+CFG-PM-POSUPDATEPERIOD U4 -> 0ms, no self-timed wakup because receiver power mode is controlled via "software standby mode" by legacy UBX-RXM-PMREQ request
+CFG-PM-ACQPERIOD U4 -> 0ms, because receiver power mode is controlled via "software standby mode" by legacy UBX-RXM-PMREQ request
+CFG-PM-ONTIME U4 -> 0ms, optional I guess
+CFG-PM-EXTINTBACKUP L -> 1, force receiver into BACKUP mode when EXTINT (should be connected to GPS_EN_PIN) pin is "low"
+
+This is required because the receiver never enters low power mode if microcontroller is in deep-sleep.
+Maybe the changing UART_RX levels trigger a wakeup but even with UBX-RXM-PMREQ[12] = 0x00 (all external wakeup sources disabled) the receivcer remains 
+in aquisition state -> potentially a bug
+
+Workaround: Control the EXTINT pin by the GPS_EN_PIN signal
+
+As mentioned in the M10 operational issues down below, power save won't allow the use of BDS B1C.
+CFG-SIGNAL-BDS_B1C_ENA L -> 0
 
 // Ram layer config message:
-// b5 62 06 8a 26 00 00 01 00 00 01 00 d0 20 02 02 00 d0 40 05 00 00 00 05 00 d0 30 01 00 08 00 d0 10 01 09 00 d0 10 01 10 00 d0
-// 10 01 8b de
+// 01 01 00 00 01 00 D0 20 01 02 00 D0 40 00 00 00 00 03 00 D0 40 00 00 00 00 05 00 D0 30 00 00 0D 00 D0 10 01
 
 // BBR layer config message:
-// b5 62 06 8a 26 00 00 02 00 00 01 00 d0 20 02 02 00 d0 40 05 00 00 00 05 00 d0 30 01 00 08 00 d0 10 01 09 00 d0 10 01 10 00 d0
-// 10 01 8c 03
-
-const uint8_t GPS::_message_VALSET_PM_RAM[] = {0x00, 0x01, 0x00, 0x00, 0x01, 0x00, 0xd0, 0x20, 0x02, 0x02, 0x00, 0xd0, 0x40,
-                                               0x05, 0x00, 0x00, 0x00, 0x05, 0x00, 0xd0, 0x30, 0x01, 0x00, 0x08, 0x00, 0xd0,
-                                               0x10, 0x01, 0x09, 0x00, 0xd0, 0x10, 0x01, 0x10, 0x00, 0xd0, 0x10, 0x01};
-const uint8_t GPS::_message_VALSET_PM_BBR[] = {0x00, 0x02, 0x00, 0x00, 0x01, 0x00, 0xd0, 0x20, 0x02, 0x02, 0x00, 0xd0, 0x40,
-                                               0x05, 0x00, 0x00, 0x00, 0x05, 0x00, 0xd0, 0x30, 0x01, 0x00, 0x08, 0x00, 0xd0,
-                                               0x10, 0x01, 0x09, 0x00, 0xd0, 0x10, 0x01, 0x10, 0x00, 0xd0, 0x10, 0x01};
+// 01 02 00 00 01 00 D0 20 01 02 00 D0 40 00 00 00 00 03 00 D0 40 00 00 00 00 05 00 D0 30 00 00 0D 00 D0 10 01
+*/
+const uint8_t GPS::_message_VALSET_PM_RAM[] = {0x01, 0x01, 0x00, 0x00, 0x0F, 0x00, 0x31, 0x10, 0x00, 0x01, 0x00, 0xD0, 0x20,
+                                               0x01, 0x02, 0x00, 0xD0, 0x40, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0xD0, 0x40, 
+                                               0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0xD0, 0x30, 0x00, 0x00, 0x0D, 0x00, 0xD0, 
+                                               0x10, 0x01};
+const uint8_t GPS::_message_VALSET_PM_BBR[] = {0x01, 0x02, 0x00, 0x00, 0x0F, 0x00, 0x31, 0x10, 0x00, 0x01, 0x00, 0xD0, 0x20,
+                                               0x01, 0x02, 0x00, 0xD0, 0x40, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0xD0, 0x40, 
+                                               0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0xD0, 0x30, 0x00, 0x00, 0x0D, 0x00, 0xD0, 
+                                               0x10, 0x01};
 
 /*
 CFG-ITFM replaced by 5 valset messages which can be combined into one for RAM and one for BBR


### PR DESCRIPTION
This PR fixes #4061 

The ublox GPS modules power state is controlled by legacy `UBX-RXM-PMREQ` commands. A defined sleep time and/or a wakeup source (in this case UART_RX activity) is defined in the sleep request message (_message_PMREQ_10 in ubx.h). For an unknown reason, the receiver wakes up/stays awake if the meshtastic device is switched off, even if sleep time is set to 0 (wakeup only by external events).

To fix this issue, the existing signal `PIN_GPS_EN` is used to control to the **EXTINT** pin of the receiver. (PIN_GPS_EN pin needs to be defined in the boards variant.h)

This requires only the modification of the M10 specific **CFG-PM** register.

The important modifications are:

1. CFG-PM-OPERATEMODE set to PSMOO, to enable external control through pin
2. CFG-PM-EXTINTBACKUP set to true, to enable backup mode (deep sleep) if EXTPIN is low.

Further explanation is commented in the code **ubx.h**

The normal operation is not influenced by the register change.
All other parameters of CFG-PM were ineffective anyways because the receivers power state was controlled by legacy `UBX-RXM-PMREQ` commands. Further documentation regarding the power modes can be found in the [SAM M10Q Integration manual](https://content.u-blox.com/sites/default/files/documents/SAM-M10Q_IntegrationManual_UBX-22020019.pdf)

The configuration stream was generated with the [UBlox u-center2 utility](https://www.u-blox.com/en/u-center-2)
