### PR TITLE
GPS: short update intervals, lock-time prediction

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -783,7 +783,9 @@ void GPS::setGPSPower(bool on, bool standbyOnly, uint32_t sleepTime)
     // Record the current powerState
     if (on)
         powerState = GPS_ACTIVE;
-    else if (sleepTime <= GPS_IDLE_THRESHOLD_SECONDS * 1000UL && sleepTime > 0) // Note: sleepTime==0 if from GPS::disable()
+    else if (!enabled) // User has disabled with triple press
+        powerState = GPS_OFF;
+    else if (sleepTime <= GPS_IDLE_THRESHOLD_SECONDS * 1000UL)
         powerState = GPS_IDLE;
     else if (standbyOnly)
         powerState = GPS_STANDBY;
@@ -1664,6 +1666,10 @@ bool GPS::whileIdle()
 }
 void GPS::enable()
 {
+    // Clear the old lock-time prediction
+    GPSCycles = 0;
+    averageLockTime = 0;
+
     enabled = true;
     setInterval(GPS_THREAD_INTERVAL);
     setAwake(true);

--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -785,7 +785,7 @@ void GPS::setGPSPower(bool on, bool standbyOnly, uint32_t sleepTime)
         powerState = GPS_ACTIVE;
     else if (!enabled) // User has disabled with triple press
         powerState = GPS_OFF;
-    else if (sleepTime <= GPS_IDLE_THRESHOLD_SECONDS * 1000UL)
+    else if (sleepTime <= GPS_IDLE_THRESHOLD_SECONDS * 1000UL && sleepTime > 0) // sleepTime=0 indicates indefinite GPS poweroff
         powerState = GPS_IDLE;
     else if (standbyOnly)
         powerState = GPS_STANDBY;
@@ -940,7 +940,8 @@ void GPS::setAwake(bool wantAwake)
 
         // How long to wait before attempting next GPS update
         // Aims to hit position.gps_update_interval by using the lock-time prediction
-        uint32_t compensatedSleepTime = (getSleepTime() > predictedLockTime) ? (getSleepTime() - predictedLockTime) : 0;
+        // Sleep for at least 1 second, so we don't ask GPS hardware to sleep indefinitely with a "0 second PMREQ"
+        uint32_t compensatedSleepTime = (getSleepTime() > predictedLockTime) ? (getSleepTime() - predictedLockTime) : 1;
 
         // If long interval between updates: power off between updates
         if (compensatedSleepTime > GPS_STANDBY_THRESHOLD_MINUTES * MS_IN_MINUTE) {
@@ -1129,11 +1130,10 @@ void GPS::clearBuffer()
 /// Prepare the GPS for the cpu entering deep or light sleep, expect to be gone for at least 100s of msecs
 int GPS::prepareDeepSleep(void *unused)
 {
-    LOG_INFO("GPS deep sleep!\n");
-
-    // Manually enter GPSPowerState::OFF, so we can ensure a PMREQ with duration 0 has been sent
-    setGPSPower(false, false, 0);
-
+    /*
+     * GPS power was previously set here.
+     * Now removed, as the same call is already made directly in doDeepSleep.
+     */
     return 0;
 }
 

--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -30,8 +30,8 @@
 
 // How many seconds of sleep make it worthwhile for the GPS to use powered-on standby
 // Shorter than this, and we'll just wait instead
-#ifndef GPS_RESTING_THRESHOLD_SECONDS
-#define GPS_RESTING_THRESHOLD_SECONDS 10
+#ifndef GPS_IDLE_THRESHOLD_SECONDS
+#define GPS_IDLE_THRESHOLD_SECONDS 10
 #endif
 
 #if defined(NRF52840_XXAA) || defined(NRF52833_XXAA) || defined(ARCH_ESP32) || defined(ARCH_PORTDUINO)
@@ -783,8 +783,8 @@ void GPS::setGPSPower(bool on, bool standbyOnly, uint32_t sleepTime)
     // Record the current powerState
     if (on)
         powerState = GPS_ACTIVE;
-    else if (sleepTime <= GPS_RESTING_THRESHOLD_SECONDS * 1000UL && sleepTime > 0) // Note: sleepTime==0 if from GPS::disable()
-        powerState = GPS_RESTING;
+    else if (sleepTime <= GPS_IDLE_THRESHOLD_SECONDS * 1000UL && sleepTime > 0) // Note: sleepTime==0 if from GPS::disable()
+        powerState = GPS_IDLE;
     else if (standbyOnly)
         powerState = GPS_STANDBY;
     else
@@ -793,7 +793,7 @@ void GPS::setGPSPower(bool on, bool standbyOnly, uint32_t sleepTime)
     LOG_DEBUG("GPS::powerState=%d\n", powerState);
 
     // If the next update is due *really soon*, don't actually power off or enter standby. Just wait it out.
-    if (!on && powerState == GPS_RESTING)
+    if (!on && powerState == GPS_IDLE)
         return;
 
     if (on) {
@@ -892,7 +892,7 @@ void GPS::setConnected()
 void GPS::setAwake(bool wantAwake)
 {
 
-    // If user has disabled GPS, make sure it is off, not just in standby or "resting"
+    // If user has disabled GPS, make sure it is off, not just in standby or idle
     if (!wantAwake && !enabled && powerState != GPS_OFF) {
         setGPSPower(false, false, 0);
         return;

--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1131,7 +1131,8 @@ int GPS::prepareDeepSleep(void *unused)
 {
     LOG_INFO("GPS deep sleep!\n");
 
-    setAwake(false);
+    // Manually enter GPSPowerState::OFF, so we can ensure a PMREQ with duration 0 has been sent
+    setGPSPower(false, false, 0);
 
     return 0;
 }

--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1131,8 +1131,7 @@ int GPS::prepareDeepSleep(void *unused)
 {
     LOG_INFO("GPS deep sleep!\n");
 
-    // Manually enter GPSPowerState::OFF, so we can ensure a PMREQ with duration 0 has been sent
-    setGPSPower(false, false, 0);
+    setAwake(false);
 
     return 0;
 }

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -42,7 +42,7 @@ enum GPSPowerState : uint8_t {
     GPS_OFF = 0,     // Physically powered off
     GPS_ACTIVE = 1,  // Awake and want a position
     GPS_STANDBY = 2, // Physically powered on, but soft-sleeping
-    GPS_RESTING = 3, // Awake, but not wanting another position yet
+    GPS_IDLE = 3,    // Awake, but not wanting another position yet
 };
 
 // Generate a string representation of DOP

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -39,9 +39,10 @@ typedef enum {
 } GPS_RESPONSE;
 
 enum GPSPowerState : uint8_t {
-    GPS_OFF = 0,
-    GPS_AWAKE = 1,
-    GPS_STANDBY = 2,
+    GPS_OFF = 0,     // Physically powered off
+    GPS_ACTIVE = 1,  // Awake and want a position
+    GPS_STANDBY = 2, // Physically powered on, but soft-sleeping
+    GPS_RESTING = 3, // Awake, but not wanting another position yet
 };
 
 // Generate a string representation of DOP
@@ -93,7 +94,7 @@ class GPS : private concurrency::OSThread
     bool GPSInitFinished = false; // Init thread finished?
     bool GPSInitStarted = false;  // Init thread finished?
 
-    GPSPowerState powerState = GPS_OFF; // GPS_AWAKE if we want a location right now
+    GPSPowerState powerState = GPS_OFF; // GPS_ACTIVE if we want a location right now
 
     uint8_t numSatellites = 0;
 

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -73,7 +73,7 @@ class GPS : private concurrency::OSThread
     uint32_t rx_gpio = 0;
     uint32_t tx_gpio = 0;
     uint32_t en_gpio = 0;
-    int32_t averageLockTime = 0;
+    int32_t predictedLockTime = 0;
     uint32_t GPSCycles = 0;
 
     int speedSelect = 0;


### PR DESCRIPTION
Addresses #4067 

Currently, a `position.gps_update_interval` of 10 seconds or less is not correctly handled.
This PR refactors the `GPSPowerState` enum to mark this case, and prevent back-to-back position updates occurring.

Pretty sure this fixes it, but please do double-check my work, so we don't have round-two of this issue..