### PR TITLE
Add Heltec Capsule Sensor V3 to the Meshtastic source code

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -33,6 +33,7 @@ default_envs = tbeam
 ;default_envs = wio-e5
 ;default_envs = radiomaster_900_bandit_nano
 ;default_envs = radiomaster_900_bandit_micro
+;default_envs = heltec_capsule_sensor_v3
 
 extra_configs =
   arch/*/*.ini

--- a/src/ButtonThread.cpp
+++ b/src/ButtonThread.cpp
@@ -41,7 +41,11 @@ ButtonThread::ButtonThread() : OSThread("Button")
     }
 #elif defined(BUTTON_PIN)
     int pin = config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN; // Resolved button pin
+#if defined(HELTEC_CAPSULE_SENSOR_V3)
+    this->userButton = OneButton(pin, false, false);
+#else
     this->userButton = OneButton(pin, true, true);
+#endif
     LOG_DEBUG("Using GPIO%02d for button\n", pin);
 #endif
 

--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -335,13 +335,20 @@ class AnalogBatteryLevel : public HasBatteryLevel
     virtual bool isVbusIn() override
     {
 #ifdef EXT_PWR_DETECT
-        // if external powered that pin will be pulled up
-        if (digitalRead(EXT_PWR_DETECT) == HIGH) {
-            return true;
-        }
-        // if it's not HIGH - check the battery
+    #ifdef HELTEC_CAPSULE_SENSOR_V3
+            // if external powered that pin will be pulled down
+            if (digitalRead(EXT_PWR_DETECT) == LOW) {
+                return true;
+            }
+            // if it's not LOW - check the battery
+    #else
+                // if external powered that pin will be pulled up
+            if (digitalRead(EXT_PWR_DETECT) == HIGH) {
+                return true;
+            }
+            // if it's not HIGH - check the battery
+    #endif
 #endif
-
         return getBattVoltage() > chargingVolt;
     }
 
@@ -421,7 +428,11 @@ Power::Power() : OSThread("Power")
 bool Power::analogInit()
 {
 #ifdef EXT_PWR_DETECT
-    pinMode(EXT_PWR_DETECT, INPUT);
+    #ifdef HELTEC_CAPSULE_SENSOR_V3
+        pinMode(EXT_PWR_DETECT, INPUT_PULLUP);
+    #else
+        pinMode(EXT_PWR_DETECT, INPUT);
+    #endif
 #endif
 #ifdef EXT_CHRG_DETECT
     pinMode(EXT_CHRG_DETECT, ext_chrg_detect_mode);

--- a/src/platform/esp32/architecture.h
+++ b/src/platform/esp32/architecture.h
@@ -147,6 +147,8 @@
 #define HW_VENDOR meshtastic_HardwareModel_WIPHONE
 #elif defined(RADIOMASTER_900_BANDIT_NANO)
 #define HW_VENDOR meshtastic_HardwareModel_RADIOMASTER_900_BANDIT_NANO
+#elif defined(HELTEC_CAPSULE_SENSOR_V3)
+#define HW_VENDOR meshtastic_HardwareModel_HELTEC_CAPSULE_SENSOR_V3
 #endif
 
 // -----------------------------------------------------------------------------

--- a/variants/heltec_capsule_sensor_v3/platformio.ini
+++ b/variants/heltec_capsule_sensor_v3/platformio.ini
@@ -1,0 +1,11 @@
+[env:heltec_capsule_sensor_v3]
+extends = esp32s3_base
+board = heltec_wifi_lora_32_V3
+board_check = true
+
+build_flags = 
+  ${esp32s3_base.build_flags} -I variants/heltec_capsule_sensor_v3
+  -D HELTEC_CAPSULE_SENSOR_V3
+  -D GPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
+  ;-D DEBUG_DISABLED ; uncomment this line to disable DEBUG output
+

--- a/variants/heltec_capsule_sensor_v3/variant.h
+++ b/variants/heltec_capsule_sensor_v3/variant.h
@@ -1,0 +1,42 @@
+#define LED_PIN 33
+#define LED_PIN2 34 
+#define EXT_PWR_DETECT 35
+
+#define BUTTON_PIN 18
+
+#define BATTERY_PIN 7 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
+#define ADC_CHANNEL ADC1_GPIO7_CHANNEL
+#define ADC_ATTENUATION ADC_ATTEN_DB_2_5 // lower dB for high resistance voltage divider
+#define ADC_MULTIPLIER (4.9 * 1.045)
+#define ADC_CTRL 36 // active HIGH, powers the voltage divider. Only on 1.1
+#define ADC_CTRL_ENABLED HIGH
+
+#undef GPS_RX_PIN
+#undef GPS_TX_PIN
+#define GPS_RX_PIN 5
+#define GPS_TX_PIN 4
+#define PIN_GPS_RESET 3
+#define GPS_RESET_MODE LOW
+#define PIN_GPS_PPS 1
+#define PIN_GPS_EN 21
+#define GPS_EN_ACTIVE HIGH
+
+#define USE_SX1262
+#define LORA_DIO0 -1 // a No connect on the SX1262 module
+#define LORA_RESET 12
+#define LORA_DIO1 14 // SX1262 IRQ
+#define LORA_DIO2 13 // SX1262 BUSY
+#define LORA_DIO3    // Not connected on PCB, but internally on the TTGO SX1262, if DIO3 is high the TXCO is enabled
+
+#define LORA_SCK 9
+#define LORA_MISO 11
+#define LORA_MOSI 10
+#define LORA_CS 8
+
+#define SX126X_CS LORA_CS
+#define SX126X_DIO1 LORA_DIO1
+#define SX126X_BUSY LORA_DIO2
+#define SX126X_RESET LORA_RESET
+
+#define SX126X_DIO2_AS_RF_SWITCH
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8


### PR DESCRIPTION
This commit includes the following functions for Capsule Sensor V3:
- Add Heltec Capsule Sensor V3 hardware definition,
- Button status read.
- Battery level read,
- Charging status detection.

The following functions are tested before submission:
- The whole project compile, build, and firmware update,
- Bluetooth connect to an Android/IOS phone,
- GPS read;
- LoRa transmission and reception,
- Mesh network communication.

Going to do in the next PR:
- Various sensor drives and running on Capsule Sensor V3;
- Sensor data read, monitor, and transmit.