### PR TITLE
feature-mqtt: add hop_start and hop_limit to MQTT uplink

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -903,7 +903,6 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
     if (mp->hop_start != 0 && mp->hop_limit <= mp->hop_start)
         jsonObj["hops_away"] = new JSONValue((unsigned int)(mp->hop_start - mp->hop_limit));
     jsonObj["hop_start"] = new JSONValue((unsigned int)(mp->hop_start));
-    jsonObj["hop_limit"] = new JSONValue((unsigned int)(mp->hop_limit));
     
     // serialize and write it to the stream
     JSONValue *value = new JSONValue(jsonObj);

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -902,7 +902,9 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
         jsonObj["snr"] = new JSONValue((float)mp->rx_snr);
     if (mp->hop_start != 0 && mp->hop_limit <= mp->hop_start)
         jsonObj["hops_away"] = new JSONValue((unsigned int)(mp->hop_start - mp->hop_limit));
-
+    jsonObj["hop_start"] = new JSONValue((unsigned int)(mp->hop_start));
+    jsonObj["hop_limit"] = new JSONValue((unsigned int)(mp->hop_limit));
+    
     // serialize and write it to the stream
     JSONValue *value = new JSONValue(jsonObj);
     std::string jsonStr = value->Stringify();

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -900,9 +900,10 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
         jsonObj["rssi"] = new JSONValue((int)mp->rx_rssi);
     if (mp->rx_snr != 0)
         jsonObj["snr"] = new JSONValue((float)mp->rx_snr);
-    if (mp->hop_start != 0 && mp->hop_limit <= mp->hop_start)
+    if (mp->hop_start != 0 && mp->hop_limit <= mp->hop_start) {
         jsonObj["hops_away"] = new JSONValue((unsigned int)(mp->hop_start - mp->hop_limit));
-    jsonObj["hop_start"] = new JSONValue((unsigned int)(mp->hop_start));
+        jsonObj["hop_start"] = new JSONValue((unsigned int)(mp->hop_start));
+    }
     
     // serialize and write it to the stream
     JSONValue *value = new JSONValue(jsonObj);

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -904,7 +904,7 @@ std::string MQTT::meshPacketToJson(meshtastic_MeshPacket *mp)
         jsonObj["hops_away"] = new JSONValue((unsigned int)(mp->hop_start - mp->hop_limit));
         jsonObj["hop_start"] = new JSONValue((unsigned int)(mp->hop_start));
     }
-    
+
     // serialize and write it to the stream
     JSONValue *value = new JSONValue(jsonObj);
     std::string jsonStr = value->Stringify();


### PR DESCRIPTION
This PR adds "hop_start" and "hop_limit" to the MQTT JSON uplink message. 
This is useful in network management, helping to identify stations with larger-than-recommended hop-limits and lets network managers guide them to better choices.

References:  https://github.com/meshtastic/firmware/issues/4087