### PR TITLE
Ensure data directory ownership is with mesh user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ USER mesh
 WORKDIR /home/mesh
 COPY --from=builder /tmp/firmware/release/meshtasticd /home/mesh/
 
+RUN mkdir data
 VOLUME /home/mesh/data
 
 CMD [ "sh",  "-cx", "./meshtasticd -d /home/mesh/data --hwid=${HWID:-$RANDOM}" ]


### PR DESCRIPTION
Without this the default owner of the volume mount is root. In which case the mesh user won't be able to write to it and fail.