### PR TITLE
Turn off vscode cmake prompt - we don't use cmake on meshtastic

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
   "editor.defaultFormatter": "trunk.io",
   "trunk.enableWindows": true,
   "files.insertFinalNewline": false,
-  "files.trimFinalNewlines": false
+  "files.trimFinalNewlines": false,
+  "cmake.configureOnOpen": false
 }


### PR DESCRIPTION
If dev has cmake extension installed in vscode it warns about this project.  Add a flag to stop such spam.  Should be no-effect for anyone without that extension.
