### PR TITLE
Update OLED ref

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -80,7 +80,7 @@ monitor_speed = 115200
 
 lib_deps =
   jgromes/RadioLib@~6.6.0
-  https://github.com/meshtastic/esp8266-oled-ssd1306.git#69ba98fa30e67b12d4577b121f210f3eb7049d6b ; ESP8266_SSD1306
+  https://github.com/meshtastic/esp8266-oled-ssd1306.git#dcacac5d2c7942376bc17f7079cced6a73cb659f ; ESP8266_SSD1306
   mathertel/OneButton@^2.5.0 ; OneButton library for non-blocking button debounce
   https://github.com/meshtastic/arduino-fsm.git#7db3702bf0cfe97b783d6c72595e3f38e0b19159
   https://github.com/meshtastic/TinyGPSPlus.git#71a82db35f3b973440044c476d4bcdc673b104f4


### PR DESCRIPTION
Reverts upstream changes to the library (temporarily), to restore the on-screen debug info frame.