### PR TITLE
Add support for Heltec HRU-3601

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -242,7 +242,7 @@ void setup()
     initDeepSleep();
 
     // power on peripherals
-#if defined(TTGO_T_ECHO) && defined(PIN_POWER_EN)
+#if defined(PIN_POWER_EN)
     pinMode(PIN_POWER_EN, OUTPUT);
     digitalWrite(PIN_POWER_EN, HIGH);
     // digitalWrite(PIN_POWER_EN1, INPUT);

--- a/src/platform/esp32/architecture.h
+++ b/src/platform/esp32/architecture.h
@@ -101,6 +101,8 @@
 #define HW_VENDOR meshtastic_HardwareModel_STATION_G1
 #elif defined(DR_DEV)
 #define HW_VENDOR meshtastic_HardwareModel_DR_DEV
+#elif defined(HELTEC_HRU_3601)
+#define HW_VENDOR meshtastic_HardwareModel_HELTEC_HRU_3601
 #elif defined(HELTEC_V3)
 #define HW_VENDOR meshtastic_HardwareModel_HELTEC_V3
 #elif defined(HELTEC_WSL_V3)

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -231,11 +231,9 @@ void doDeepSleep(uint32_t msecToWake, bool skipPreflight = false)
 
     nodeDB->saveToDisk();
 
-#ifdef TTGO_T_ECHO
 #ifdef PIN_POWER_EN
     pinMode(PIN_POWER_EN, INPUT); // power off peripherals
     // pinMode(PIN_POWER_EN1, INPUT_PULLDOWN);
-#endif
 #endif
 #if HAS_GPS
     // Kill GPS power completely (even if previously we just had it in sleep mode)

--- a/variants/heltec_hru_3601/pins_arduino.h
+++ b/variants/heltec_hru_3601/pins_arduino.h
@@ -1,0 +1,25 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include <variant.h>
+
+static const uint8_t TX = UART_TX;
+static const uint8_t RX = UART_RX;
+
+static const uint8_t SDA = I2C_SDA;
+static const uint8_t SCL = I2C_SCL;
+
+static const uint8_t SS = 8;
+static const uint8_t MOSI = 7;
+static const uint8_t MISO = 6;
+static const uint8_t SCK = 10;
+
+static const uint8_t A0 = 0;
+static const uint8_t A1 = 1;
+static const uint8_t A2 = 2;
+static const uint8_t A3 = 3;
+static const uint8_t A4 = 4;
+static const uint8_t A5 = 5;
+
+#endif /* Pins_Arduino_h */

--- a/variants/heltec_hru_3601/platformio.ini
+++ b/variants/heltec_hru_3601/platformio.ini
@@ -1,0 +1,9 @@
+[env:heltec-hru-3601]
+extends = esp32c3_base
+board = adafruit_qtpy_esp32c3
+build_flags =
+  ${esp32_base.build_flags}
+  -D HELTEC_HRU_3601
+  -I variants/heltec_hru_3601
+lib_deps = ${esp32c3_base.lib_deps}
+  adafruit/Adafruit NeoPixel @ ^1.12.0

--- a/variants/heltec_hru_3601/variant.h
+++ b/variants/heltec_hru_3601/variant.h
@@ -1,0 +1,40 @@
+#define BUTTON_PIN 9
+
+#define HAS_SCREEN 0
+#define HAS_GPS 0
+#undef GPS_RX_PIN
+#undef GPS_TX_PIN
+
+#define USE_SX1262
+#define LORA_SCK 10
+#define LORA_MISO 6
+#define LORA_MOSI 7
+#define LORA_CS 8
+#define LORA_DIO0 RADIOLIB_NC
+#define LORA_RESET 5
+#define LORA_DIO1 3
+#define LORA_DIO2 RADIOLIB_NC
+#define LORA_BUSY 4
+#define SX126X_CS LORA_CS
+#define SX126X_DIO1 LORA_DIO1
+#define SX126X_BUSY LORA_BUSY
+#define SX126X_RESET LORA_RESET
+#define SX126X_DIO2_AS_RF_SWITCH
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8
+
+// Vext_Ctrl pin controls 3.3V LDO (U2) which provides power to I2C peripheral
+#define PIN_POWER_EN 1
+
+// Board has I2C connected to UART0 pins, and no other hardware serial port
+#define UART_TX -1
+#define UART_RX -1
+
+// Board has I2C connected to U0RXD and U0TXD
+#define I2C_SDA 21
+#define I2C_SCL 20
+
+// Board has RGB LED on GPIO2
+#define HAS_NEOPIXEL                         // Enable the use of neopixels
+#define NEOPIXEL_COUNT 1                     // How many neopixels are connected
+#define NEOPIXEL_DATA 2                      // gpio pin used to send data to the neopixels
+#define NEOPIXEL_TYPE (NEO_GRB + NEO_KHZ800) // type of neopixels in use


### PR DESCRIPTION
Board is very similar to the Heltec HT-C62 based boards (Heltec HT62 variant) but due to wiring of SK6812 Neopixel LED to GPIO2 it becomes incompatible due to the regular HT-C62 dev board using a simple LED on the same GPIO. Depends on [protobufs#521](https://github.com/meshtastic/protobufs/pull/521).

Works:

* SK6812 Neopixel on GPIO2
* [GXCAS GXHTV3](https://www.lcsc.com/product-detail/Temperature-Sensors_GXCAS-GXHTV3C_C5441730.html) (SHTC3 compatible)

Not working:

* SX1262 initialization after deep sleep (seems like an issue out of scope of the PR)

Won't fix:

* Battery reading - Board has no voltage divider on VBAT (board has a 1.25mm pitch "JST" style connector and a TP4054 charge IC)
* Main thread LED - Board has no LED on simple GPIO

Board schematic: [HRU3601.pdf](https://github.com/user-attachments/files/15874850/HRU3601.pdf)