### PR TITLE
fix for MESHTASTIC_EXCLUDE_INPUTBROKER

### DIFF
--- a/src/input/InputBroker.cpp
+++ b/src/input/InputBroker.cpp
@@ -1,7 +1,7 @@
 #include "InputBroker.h"
 #include "PowerFSM.h" // needed for event trigger
 
-InputBroker *inputBroker;
+InputBroker *inputBroker = nullptr;
 
 InputBroker::InputBroker(){};
 

--- a/src/input/cardKbI2cImpl.cpp
+++ b/src/input/cardKbI2cImpl.cpp
@@ -1,5 +1,6 @@
 #include "cardKbI2cImpl.h"
 #include "InputBroker.h"
+#include "main.h"
 
 CardKbI2cImpl *cardKbI2cImpl;
 

--- a/src/input/cardKbI2cImpl.h
+++ b/src/input/cardKbI2cImpl.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "kbI2cBase.h"
-#include "main.h"
 
 /**
  * @brief The idea behind this class to have static methods for the event handlers.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,13 +41,14 @@
 #endif
 #if !MESHTASTIC_EXCLUDE_BLUETOOTH
 #include "nimble/NimbleBluetooth.h"
-NimbleBluetooth *nimbleBluetooth;
+NimbleBluetooth *nimbleBluetooth = nullptr;
 #endif
 #endif
 
 #ifdef ARCH_NRF52
 #include "NRF52Bluetooth.h"
-NRF52Bluetooth *nrf52Bluetooth;
+NRF52Bluetooth *nrf52Bluetooth = nullptr;
+;
 #endif
 
 #if HAS_WIFI
@@ -94,23 +95,26 @@ NRF52Bluetooth *nrf52Bluetooth;
 #include "ButtonThread.h"
 #endif
 
+#include "AmbientLightingThread.h"
 #include "PowerFSMThread.h"
 
 #if !defined(ARCH_PORTDUINO) && !defined(ARCH_STM32WL) && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
 #include "AccelerometerThread.h"
-#include "AmbientLightingThread.h"
-AccelerometerThread *accelerometerThread;
+AccelerometerThread *accelerometerThread = nullptr;
+;
 #endif
 
 #ifdef HAS_I2S
 #include "AudioThread.h"
-AudioThread *audioThread;
+AudioThread *audioThread = nullptr;
+;
 #endif
 
 using namespace concurrency;
 
 // We always create a screen object, but we only init it if we find the hardware
-graphics::Screen *screen;
+graphics::Screen *screen = nullptr;
+;
 
 // Global power status
 meshtastic::PowerStatus *powerStatus = new meshtastic::PowerStatus();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -101,7 +101,6 @@ NRF52Bluetooth *nrf52Bluetooth = nullptr;
 #if !defined(ARCH_PORTDUINO) && !defined(ARCH_STM32WL) && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
 #include "AccelerometerThread.h"
 AccelerometerThread *accelerometerThread = nullptr;
-;
 #endif
 
 #ifdef HAS_I2S

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,14 +106,12 @@ AccelerometerThread *accelerometerThread = nullptr;
 #ifdef HAS_I2S
 #include "AudioThread.h"
 AudioThread *audioThread = nullptr;
-;
 #endif
 
 using namespace concurrency;
 
 // We always create a screen object, but we only init it if we find the hardware
 graphics::Screen *screen = nullptr;
-;
 
 // Global power status
 meshtastic::PowerStatus *powerStatus = new meshtastic::PowerStatus();

--- a/src/modules/Modules.cpp
+++ b/src/modules/Modules.cpp
@@ -42,6 +42,7 @@
 #include "modules/Telemetry/DeviceTelemetry.h"
 #endif
 #if HAS_SENSOR && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
+#include "main.h"
 #include "modules/Telemetry/AirQualityTelemetry.h"
 #include "modules/Telemetry/EnvironmentTelemetry.h"
 #endif

--- a/src/modules/Telemetry/Sensor/OPT3001Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/OPT3001Sensor.cpp
@@ -1,7 +1,10 @@
-#include "OPT3001Sensor.h"
-#include "../mesh/generated/meshtastic/telemetry.pb.h"
-#include "TelemetrySensor.h"
 #include "configuration.h"
+
+#if !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
+
+#include "../mesh/generated/meshtastic/telemetry.pb.h"
+#include "OPT3001Sensor.h"
+#include "TelemetrySensor.h"
 #include <ClosedCube_OPT3001.h>
 
 OPT3001Sensor::OPT3001Sensor() : TelemetrySensor(meshtastic_TelemetrySensorType_OPT3001, "OPT3001") {}
@@ -42,3 +45,5 @@ bool OPT3001Sensor::getMetrics(meshtastic_Telemetry *measurement)
 
     return true;
 }
+
+#endif

--- a/src/modules/Telemetry/Sensor/OPT3001Sensor.h
+++ b/src/modules/Telemetry/Sensor/OPT3001Sensor.h
@@ -1,3 +1,8 @@
+#pragma once
+#include "configuration.h"
+
+#if !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
+
 #include "../mesh/generated/meshtastic/telemetry.pb.h"
 #include "TelemetrySensor.h"
 #include <ClosedCube_OPT3001.h>
@@ -15,3 +20,5 @@ class OPT3001Sensor : public TelemetrySensor
     virtual int32_t runOnce() override;
     virtual bool getMetrics(meshtastic_Telemetry *measurement) override;
 };
+
+#endif


### PR DESCRIPTION
There were compile issues due to newly added telemetry sensor modules when using the exclude macros.

This PR adds the missing defines and makes it compile clean again.
