### PR TITLE
Get apollo3 building again

### DIFF
--- a/arch/apollo3/apollo3.ini
+++ b/arch/apollo3/apollo3.ini
@@ -8,6 +8,7 @@ build_flags =
   -Isrc/platform/apollo3 -g
   -I"${platformio.packages_dir}/framework-arduinoapollo3/libraries/SPI/src"
   -DRADIOLIB_EEPROM_UNSUPPORTED
+  -DMESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
 build_src_filter = 
   ${arduino_base.build_src_filter}
   -<platform/nrf52>

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -585,7 +585,7 @@ LoadFileResult NodeDB::loadProto(const char *filename, size_t protoSize, size_t 
     }
 #else
     LOG_ERROR("ERROR: Filesystem not implemented\n");
-    state = LoadFileState::NO_FILESYSTEM;
+    state = LoadFileResult::NO_FILESYSTEM;
 #endif
     return state;
 }


### PR DESCRIPTION
Small fixes to get apollo3/RAK11720 building after the last few merges from master. 

Added MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR flag since Adafruit_LIS3DH doesn't seem to be available for this build target.