### PR TITLE
heltec-ht62-esp32c3-sx1262: Assign GPIO18 and GPIO19 to I2C

### DIFF
--- a/variants/heltec_esp32c3/pins_arduino.h
+++ b/variants/heltec_esp32c3/pins_arduino.h
@@ -2,23 +2,20 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include <variant.h>
 
-static const uint8_t TX = 21;
-static const uint8_t RX = 20;
+// Serial
+static const uint8_t TX = UART_TX;
+static const uint8_t RX = UART_RX;
 
-static const uint8_t SDA = 1;
-static const uint8_t SCL = 0;
+// Default SPI will be mapped to Radio
+static const uint8_t SS = LORA_CS;
+static const uint8_t SCK = LORA_SCK;
+static const uint8_t MOSI = LORA_MOSI;
+static const uint8_t MISO = LORA_MISO;
 
-static const uint8_t SS = 8;
-static const uint8_t MOSI = 7;
-static const uint8_t MISO = 6;
-static const uint8_t SCK = 10;
-
-static const uint8_t A0 = 0;
-static const uint8_t A1 = 1;
-static const uint8_t A2 = 2;
-static const uint8_t A3 = 3;
-static const uint8_t A4 = 4;
-static const uint8_t A5 = 5;
+// Wire
+static const uint8_t SCL = I2C_SCL;
+static const uint8_t SDA = I2C_SDA;
 
 #endif /* Pins_Arduino_h */

--- a/variants/heltec_esp32c3/variant.h
+++ b/variants/heltec_esp32c3/variant.h
@@ -1,16 +1,52 @@
-#define BUTTON_PIN 9
+/*
+ * Heltec HT-CT62, Heltec HT-DEV-ESP V2 and Heltec HT-DEV-ESP V3
+ *
+ * Heltec HT-CT62 Schematic: https://resource.heltec.cn/download/HT-CT62/HT-CT62_Schematic_Diagram.pdf
+ * Heltec HT-CT62 Reference Design: https://resource.heltec.cn/download/HT-CT62/HT-CT62_Reference_Design.pdf
+ * Note: Reference design is just an application note, but no actual product exists
+ *
+ * Heltec HT-DEV-ESP V3 Schematic: https://resource.heltec.cn/download/HT-DEV-ESP/HT-DEV-ESP_V2_Sch.pdf
+ * Heltec HT-DEV-ESP V3 Schematic: https://resource.heltec.cn/download/HT-DEV-ESP/HT-DEV-ESP_V3_Sch.pdf
+ * Note: Heltec sells HT-DEV-ESP boards
+ *
+ * Note: GPIO0 and GPIO1 are connected to 32kHz crystal on HT-DEV-ESP boards and in reference design
+ *
+ */
 
-// LED pin on HT-DEV-ESP_V2 and HT-DEV-ESP_V3
-// https://resource.heltec.cn/download/HT-CT62/HT-CT62_Reference_Design.pdf
-// https://resource.heltec.cn/download/HT-DEV-ESP/HT-DEV-ESP_V3_Sch.pdf
-#define LED_PIN 2 // LED
-#define LED_INVERTED 0
-
-#define HAS_SCREEN 0
+// Module does not have enough free pins for a UART GPS
 #define HAS_GPS 0
 #undef GPS_RX_PIN
 #undef GPS_TX_PIN
 
+// USER_SW (HT-DEV-ESP V2/V3)
+#define BUTTON_PIN 9
+
+/*
+ * LED (HT-DEV-ESP_V2/V3)
+ * HT-CT62 reference schematic connects the LED to GPIO18 but HT-DEV-ESP schematic connects the LED to GPIO2
+ */
+#define LED_PIN 2
+#define LED_INVERTED 0
+
+/*
+ * I2C
+ * Not defined on schematics, but these are the only free GPIO exposed on the castellated pads.
+ * There are pin mux conflicts: GPIO18 = USB_DN and GPIO19 = USB_DP. Since the HT-DEV-ESP provides a CP2102, re-use these ports
+ * for I2C instead since it's more useful (attaching peripherals vs. connecting to a host PC). Boards which use the native ESP32
+ * USB will require a separate variant (refer to Heltec HRU-3601 variant for example). Perhaps a "heltec_esp32c3_usb" variant
+ * would make things easier?
+ */
+#define I2C_SCL 18
+#define I2C_SDA 19
+
+// Since we have I2C, probe for screens
+#define HAS_SCREEN 1
+
+// U0TXD, U0RXD to CP2102 (HT-DEV-ESP_V2/V3)
+#define UART_TX 21
+#define UART_RX 20
+
+// SX1262 (HT-CT62)
 #define USE_SX1262
 #define LORA_SCK 10
 #define LORA_MISO 6


### PR DESCRIPTION
I2C is not defined on schematics, but these are the only free GPIO exposed on the castellated pads.

There are pin mux conflicts: GPIO18 = USB_DN and GPIO19 = USB_DP.

Since the HT-DEV-ESP provides a CP2102, re-use these ports for I2C instead since it's more useful (attaching peripherals vs. connecting to a host PC). Boards which use the native ESP32 USB will require a separate variant (refer to Heltec HRU-3601 variant for example).

Perhaps a "heltec_esp32c3_usb" variant would make things easier?

Took the opportunity to clean up the variant's header files too.

Relevant forum post/discussion in [Heltec HT-CT62 support - Meshtastic’s future?#14](https://meshtastic.discourse.group/t/heltec-ht-ct62-support-meshtastics-future/11391/14).