### PR TITLE
Make serial port on wio-sdk-wm1110 board work

### DIFF
--- a/boards/wio-sdk-wm1110.json
+++ b/boards/wio-sdk-wm1110.json
@@ -7,13 +7,6 @@
     "cpu": "cortex-m4",
     "extra_flags": "-DARDUINO_WIO_WM1110 -DNRF52840_XXAA",
     "f_cpu": "64000000L",
-    "hwids": [
-      ["0x239A", "0x8029"],
-      ["0x239A", "0x0029"],
-      ["0x239A", "0x002A"],
-      ["0x239A", "0x802A"]
-    ],
-    "usb_product": "WIO-BOOT",
     "mcu": "nrf52840",
     "variant": "Seeed_WIO_WM1110",
     "bsp": {

--- a/extra_scripts/README.md
+++ b/extra_scripts/README.md
@@ -1,0 +1,3 @@
+# extra_scripts
+
+This directory contains special [scripts](https://docs.platformio.org/en/latest/scripting/index.html) that are used to modify the platformio environment in rare cases.

--- a/extra_scripts/disable_adafruit_usb.py
+++ b/extra_scripts/disable_adafruit_usb.py
@@ -1,3 +1,6 @@
+# trunk-ignore-all(flake8/F821)
+# trunk-ignore-all(ruff/F821)
+
 Import("env")
 
 # NOTE: This is not currently used, but can serve as an example on how to write extra_scripts

--- a/extra_scripts/disable_adafruit_usb.py
+++ b/extra_scripts/disable_adafruit_usb.py
@@ -1,0 +1,17 @@
+Import("env")
+
+# NOTE: This is not currently used, but can serve as an example on how to write extra_scripts
+
+print("Current CLI targets", COMMAND_LINE_TARGETS)
+print("Current Build targets", BUILD_TARGETS)
+print("CPP defs", env.get("CPPDEFINES"))
+
+# Adafruit.py in the platformio build tree is a bit naive and always enables their USB stack for building.  We don't want this.
+# So come in after that python script has run and disable it.  This hack avoids us having to fork that big project and send in a PR
+# which might not be accepted. -@geeksville
+
+env["CPPDEFINES"].remove("USBCON")
+env["CPPDEFINES"].remove("USE_TINYUSB")
+
+# Custom actions when building program/firmware
+# env.AddPreAction("buildprog", callback...)

--- a/variants/wio-sdk-wm1110/platformio.ini
+++ b/variants/wio-sdk-wm1110/platformio.ini
@@ -2,6 +2,10 @@
 [env:wio-sdk-wm1110]
 extends = nrf52840_base
 board = wio-sdk-wm1110
+
+# Remove adafruit USB serial from the build (it is incompatible with using the ch340 serial chip on this board)
+build_unflags = ${nrf52840_base:build_unflags} -DUSBCON -DUSE_TINYUSB
+
 board_level = extra
 ; platform = https://github.com/maxgerhardt/platform-nordicnrf52#cac6fcf943a41accd2aeb4f3659ae297a73f422e
 build_flags = ${nrf52840_base.build_flags} -Ivariants/wio-sdk-wm1110 -DWIO_WM1110

--- a/variants/wio-sdk-wm1110/variant.h
+++ b/variants/wio-sdk-wm1110/variant.h
@@ -31,6 +31,13 @@
 
 #include "WVariant.h"
 
+#ifdef USE_TINYUSB
+#error TinyUSB must be disabled by platformio before using this variant
+#endif
+
+// We use the hardware serial port for the serial console
+#define Serial Serial1
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus


### PR DESCRIPTION
By disabling the (inaccessible) adafruit USB
