### PR TITLE
Pause BLE logging during want_config flow

### DIFF
--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -169,7 +169,7 @@ size_t RedirectablePrint::log(const char *logLevel, const char *format, ...)
 
         isContinuationMessage = !hasNewline;
 
-        if (config.bluetooth.device_logging_enabled) {
+        if (config.bluetooth.device_logging_enabled && !pauseBluetoothLogging) {
             bool isBleConnected = false;
 #ifdef ARCH_ESP32
             isBleConnected = nimbleBluetooth && nimbleBluetooth->isActive() && nimbleBluetooth->isConnected();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -154,6 +154,7 @@ bool isVibrating = false;
 bool eink_found = true;
 
 uint32_t serialSinceMsec;
+bool pauseBluetoothLogging = false;
 
 bool pmu_found;
 

--- a/src/main.h
+++ b/src/main.h
@@ -85,6 +85,8 @@ extern uint32_t serialSinceMsec;
 // This will suppress the current delay and instead try to run ASAP.
 extern bool runASAP;
 
+extern bool pauseBluetoothLogging;
+
 void nrf52Setup(), esp32Setup(), nrf52Loop(), esp32Loop(), rp2040Setup(), clearBonds(), enterDfuMode();
 
 meshtastic_DeviceMetadata getDeviceMetadata();

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -46,6 +46,7 @@ void PhoneAPI::handleStartConfig()
 
     // even if we were already connected - restart our state machine
     state = STATE_SEND_MY_INFO;
+    pauseBluetoothLogging = true;
 
     LOG_INFO("Starting API client config\n");
     nodeInfoForPhone.num = 0; // Don't keep returning old nodeinfos
@@ -352,9 +353,11 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
         fromRadioScratch.config_complete_id = config_nonce;
         config_nonce = 0;
         state = STATE_SEND_PACKETS;
+        pauseBluetoothLogging = false;
         break;
 
     case STATE_SEND_PACKETS:
+        pauseBluetoothLogging = false;
         // Do we have a message from the mesh or packet from the local device?
         LOG_INFO("getFromRadio=STATE_SEND_PACKETS\n");
         if (queueStatusPacketForPhone) {
@@ -398,6 +401,7 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
 
 void PhoneAPI::handleDisconnect()
 {
+    pauseBluetoothLogging = false;
     LOG_INFO("PhoneAPI disconnect\n");
 }
 

--- a/src/mesh/PhoneAPI.h
+++ b/src/mesh/PhoneAPI.h
@@ -98,8 +98,6 @@ class PhoneAPI
 
     bool isConnected() { return state != STATE_SEND_NOTHING; }
 
-    void setInitialState() { state = STATE_SEND_MY_INFO; }
-
   protected:
     /// Our fromradio packet while it is being assembled
     meshtastic_FromRadio fromRadioScratch = {};


### PR DESCRIPTION
Logging during a want_config flow slows down the initial bluetooth connection to the apps and really does not add appreciable value.