### PR TITLE
Force a compile time failur if FromRadio or ToRadio get larger than

### DIFF
--- a/src/mesh/PhoneAPI.h
+++ b/src/mesh/PhoneAPI.h
@@ -8,6 +8,14 @@
 
 // Make sure that we never let our packets grow too large for one BLE packet
 #define MAX_TO_FROM_RADIO_SIZE 512
+
+#if meshtastic_FromRadio_size > MAX_TO_FROM_RADIO_SIZE
+#error "meshtastic_FromRadio_size is too large for our BLE packets"
+#endif
+#if meshtastic_ToRadio_size > MAX_TO_FROM_RADIO_SIZE
+#error "meshtastic_ToRadio_size is too large for our BLE packets"
+#endif
+
 #define SPECIAL_NONCE 69420
 
 /**


### PR DESCRIPTION
a BLE packet size. We are actually very close to this threshold so important to make sure we don't accidentally pass it.

