### PR TITLE
correct xiao_ble build preventing sx1262 init

### DIFF
--- a/variants/xiao_ble/platformio.ini
+++ b/variants/xiao_ble/platformio.ini
@@ -3,7 +3,7 @@
 extends = nrf52840_base
 board = xiao_ble_sense
 board_level = extra
-build_flags = ${nrf52840_base.build_flags} -Ivariants/xiao_ble -Ivariants/xiao_ble/softdevice -Ivariants/xiao_ble/softdevice/nrf52 -D EBYTE_E22 -DEBYTE_E22_900M30S -DPRIVATE_HW
+build_flags = ${nrf52840_base.build_flags} -Ivariants/xiao_ble -Ivariants/xiao_ble/softdevice -Ivariants/xiao_ble/softdevice/nrf52 -DEBYTE_E22 -DEBYTE_E22_900M30S -DPRIVATE_HW
   -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
 board_build.ldscript = variants/xiao_ble/nrf52840_s140_v7.ld
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/xiao_ble>


### PR DESCRIPTION
A small fix to correct a build issue for xiao_ble that prevented the SX1262 init.
