### PR TITLE
Tdeck_better_fonts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ release/
 /compile_commands.json
 src/mesh/raspihttp/certificate.pem
 src/mesh/raspihttp/private_key.pem
+src/desktop.ini
+.vscode/extensions.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,8 +2,9 @@
     // See http://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-		"ms-vscode.cpptools",
-        "platformio.platformio-ide",
-        "trunk.io"
+        "platformio.platformio-ide"
     ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
 }

--- a/src/graphics/ScreenFonts.h
+++ b/src/graphics/ScreenFonts.h
@@ -11,7 +11,11 @@
 #if (defined(USE_EINK) || defined(ILI9341_DRIVER) || defined(ST7735_CS) || defined(ST7789_CS) || defined(HX8357_CS)) &&          \
     !defined(DISPLAY_FORCE_SMALL_FONTS)
 // The screen is bigger so use bigger fonts
+#ifdef T_DECK
+#define FONT_SMALL ArialMT_Plain_24  // Height: 19
+#else
 #define FONT_SMALL ArialMT_Plain_16  // Height: 19
+#endif
 #define FONT_MEDIUM ArialMT_Plain_24 // Height: 28
 #define FONT_LARGE ArialMT_Plain_24  // Height: 28
 #else
@@ -30,6 +34,10 @@
 
 #define _fontHeight(font) ((font)[1] + 1) // height is position 1
 
+#ifdef T_DECK
+#define FONT_HEIGHT_SMALL _fontHeight(FONT_LARGE)
+#else
 #define FONT_HEIGHT_SMALL _fontHeight(FONT_SMALL)
+#endif
 #define FONT_HEIGHT_MEDIUM _fontHeight(FONT_MEDIUM)
 #define FONT_HEIGHT_LARGE _fontHeight(FONT_LARGE)

--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -15,7 +15,11 @@ extern SX1509 gpioExtender;
 #endif
 
 #ifndef TFT_MESH
+#ifdef T_DECK
+#define TFT_MESH COLOR565(0xFF, 0xFF, 0xFF)
+#else
 #define TFT_MESH COLOR565(0x67, 0xEA, 0x94)
+#endif
 #endif
 
 #if defined(ST7735S)

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -987,7 +987,11 @@ void CannedMessageModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *st
             uint16_t charsLeft =
                 meshtastic_Constants_DATA_PAYLOAD_LEN - this->freetext.length() - (moduleConfig.canned_message.send_bell ? 1 : 0);
             snprintf(buffer, sizeof(buffer), "%d left", charsLeft);
-            display->drawString(x + display->getWidth() - display->getStringWidth(buffer), y + 0, buffer);
+#ifdef T_DECK
+            display->drawString(x + display->getWidth() - display->getStringWidth(buffer), y + 180, buffer);
+#else
+						display->drawString(x + display->getWidth() - display->getStringWidth(buffer), y + 0, buffer);
+#endif
         }
         display->setColor(WHITE);
         display->drawStringMaxWidth(


### PR DESCRIPTION
Increased font size on T-Deck, changed font color from green to white, moved "x chars left" to bottom of screen when typing to fit better. Needs testing - haven't tested every possible screen/frame