### PR TITLE
Fix flakey phone api transition from file manifest to complete

### DIFF
--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -358,6 +358,7 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
             state = STATE_SEND_COMPLETE_ID;
             config_state = 0;
             filesManifest.clear();
+            sendConfigComplete();
         } else {
             fromRadioScratch.which_payload_variant = meshtastic_FromRadio_fileInfo_tag;
             fromRadioScratch.fileInfo = filesManifest.at(config_state);
@@ -368,12 +369,7 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
     }
 
     case STATE_SEND_COMPLETE_ID:
-        LOG_INFO("getFromRadio=STATE_SEND_COMPLETE_ID\n");
-        fromRadioScratch.which_payload_variant = meshtastic_FromRadio_config_complete_id_tag;
-        fromRadioScratch.config_complete_id = config_nonce;
-        config_nonce = 0;
-        state = STATE_SEND_PACKETS;
-        pauseBluetoothLogging = false;
+        sendConfigComplete();
         break;
 
     case STATE_SEND_PACKETS:
@@ -417,6 +413,16 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
 
     LOG_DEBUG("no FromRadio packet available\n");
     return 0;
+}
+
+void PhoneAPI::sendConfigComplete()
+{
+    LOG_INFO("getFromRadio=STATE_SEND_COMPLETE_ID\n");
+    fromRadioScratch.which_payload_variant = meshtastic_FromRadio_config_complete_id_tag;
+    fromRadioScratch.config_complete_id = config_nonce;
+    config_nonce = 0;
+    state = STATE_SEND_PACKETS;
+    pauseBluetoothLogging = false;
 }
 
 void PhoneAPI::handleDisconnect()

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -355,9 +355,9 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
         LOG_INFO("getFromRadio=STATE_SEND_FILEMANIFEST\n");
         // last element
         if (config_state == filesManifest.size()) { // also handles an empty filesManifest
-            state = STATE_SEND_COMPLETE_ID;
             config_state = 0;
             filesManifest.clear();
+            // Skip to complete packet
             sendConfigComplete();
         } else {
             fromRadioScratch.which_payload_variant = meshtastic_FromRadio_fileInfo_tag;

--- a/src/mesh/PhoneAPI.h
+++ b/src/mesh/PhoneAPI.h
@@ -104,6 +104,8 @@ class PhoneAPI
      */
     size_t getFromRadio(uint8_t *buf);
 
+    void sendConfigComplete();
+
     /**
      * Return true if we have data available to send to the phone
      */


### PR DESCRIPTION
At the end of the files vector, go straight to sending the config complete packet.