### PR TITLE
Color fix platformio

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -77,6 +77,7 @@ build_flags = -Wno-missing-field-initializers
   -DMESHTASTIC_EXCLUDE_DROPZONE=1
 
 monitor_speed = 115200
+monitor_filters = direct
 
 lib_deps =
   jgromes/RadioLib@~6.6.0


### PR DESCRIPTION
As https://github.com/meshtastic/firmware/pull/4199 introduced nice colors these should be shown by default in the platformio serial monitor.

This PR enables it globally:
![image](https://github.com/meshtastic/firmware/assets/71137295/4a7e60dd-f6d9-46fc-9418-1ca8bfb75238)

