### PR TITLE
Fix SHT41 support

### DIFF
--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -314,7 +314,7 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
 
             case SHT31_4x_ADDR:
                 registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x89), 2);
-                if (registerValue == 0x11a2) {
+                if (registerValue == 0x11a2 || registerValue == 0x11da) {
                     type = SHT4X;
                     LOG_INFO("SHT4X sensor found\n");
                 } else if (getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x7E), 2) == 0x5449) {

--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -285,6 +285,10 @@ bool EnvironmentTelemetryModule::getEnvironmentTelemetry(meshtastic_Telemetry *m
         valid = valid && sht31Sensor.getMetrics(m);
         hasSensor = true;
     }
+    if (sht4xSensor.hasSensor()) {
+        valid = valid && sht4xSensor.getMetrics(m);
+        hasSensor = true;
+    }
     if (lps22hbSensor.hasSensor()) {
         valid = valid && lps22hbSensor.getMetrics(m);
         hasSensor = true;


### PR DESCRIPTION
On the Seeed Wio-WM1110 Dev Kit board, the SHT41 chip was being incorrectly detected as SHT31.

This patch adds the necessary serial number for the SHT41 chip to be correctly detected.

Further, code to actually read the SHT41 sensor was missing. This patch also adds that.

fixes meshtastic/firmware#4221
