### PR TITLE
Typo fix in logs - mhz - MHz

### DIFF
--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -521,7 +521,7 @@ void RadioInterface::applyModemConfig()
     LOG_INFO("Radio freq=%.3f, config.lora.frequency_offset=%.3f\n", freq, loraConfig.frequency_offset);
     LOG_INFO("Set radio: region=%s, name=%s, config=%u, ch=%d, power=%d\n", myRegion->name, channelName, loraConfig.modem_preset,
              channel_num, power);
-    LOG_INFO("Radio myRegion->freqStart -> myRegion->freqEnd: %f -> %f (%f mhz)\n", myRegion->freqStart, myRegion->freqEnd,
+    LOG_INFO("Radio myRegion->freqStart -> myRegion->freqEnd: %f -> %f (%f MHz)\n", myRegion->freqStart, myRegion->freqEnd,
              myRegion->freqEnd - myRegion->freqStart);
     LOG_INFO("Radio myRegion->numChannels: %d x %.3fkHz\n", numChannels, bw);
     LOG_INFO("Radio channel_num: %d\n", channel_num + 1);

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -62,14 +62,14 @@ void setCPUFast(bool on)
         /*
          *
          * There's a newly introduced bug in the espressif framework where WiFi is
-         *   unstable when the frequency is less than 240mhz.
+         *   unstable when the frequency is less than 240MHz.
          *
          *   This mostly impacts WiFi AP mode but we'll bump the frequency for
          *     all WiFi use cases.
          * (Added: Dec 23, 2021 by Jm Casler)
          */
 #ifndef CONFIG_IDF_TARGET_ESP32C3
-        LOG_DEBUG("Setting CPU to 240mhz because WiFi is in use.\n");
+        LOG_DEBUG("Setting CPU to 240MHz because WiFi is in use.\n");
         setCpuFrequencyMhz(240);
 #endif
         return;


### PR DESCRIPTION
As reported by karamo, a few different places in our logs had incorrect capitalization of MHz.

fixes meshtastic/firmware#4126