### PR TITLE
fix typo in build-nrf52.sh

### DIFF
--- a/bin/build-nrf52.sh
+++ b/bin/build-nrf52.sh
@@ -33,7 +33,7 @@ SRCHEX=.pio/build/$1/firmware.hex
 # if WM1110 target, merge hex with softdevice 7.3.0
 if (echo $1 | grep -q "wio-sdk-wm1110"); then
 	echo "Merging with softdevice"
-    sudo chmod+x ./bin/mergehex
+    sudo chmod +x ./bin/mergehex
 	bin/mergehex -m bin/s140_nrf52_7.3.0_softdevice.hex $SRCHEX -o .pio/build/$1/merged_fimware.hex
 	SRCHEX=.pio/build/$1/merged_fimware.hex
 fi


### PR DESCRIPTION
chmod is the command, '+x' is the argument.