### PR TITLE
Fix exclude macros

### DIFF
--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -173,6 +173,7 @@ void RedirectablePrint::log_to_syslog(const char *logLevel, const char *format, 
 
 void RedirectablePrint::log_to_ble(const char *logLevel, const char *format, va_list arg)
 {
+#if !MESHTASTIC_EXCLUDE_BLUETOOTH
     if (config.bluetooth.device_logging_enabled && !pauseBluetoothLogging) {
         bool isBleConnected = false;
 #ifdef ARCH_ESP32
@@ -211,6 +212,11 @@ void RedirectablePrint::log_to_ble(const char *logLevel, const char *format, va_
             delete[] buffer;
         }
     }
+#else
+    (void)logLevel;
+    (void)format;
+    (void)arg;
+#endif
 }
 
 meshtastic_LogRecord_Level RedirectablePrint::getLogLevel(const char *logLevel)

--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -22,6 +22,10 @@ class Screen
     void doDeepSleep() {}
     void forceDisplay(bool forceUiUpdate = false) {}
     void startFirmwareUpdateScreen() {}
+    void increaseBrightness() {}
+    void decreaseBrightness() {}
+    void setFunctionSymbal(std::string) {}
+    void removeFunctionSymbal(std::string) {}
     void startAlert(const char *) {}
     void endAlert() {}
 };

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -269,7 +269,7 @@ bool MeshService::trySendPosition(NodeNum dest, bool wantReplies)
     assert(node);
 
     if (hasValidPosition(node)) {
-#if HAS_GPS
+#if HAS_GPS && !MESHTASTIC_EXCLUDE_GPS
         if (positionModule) {
             LOG_INFO("Sending position ping to 0x%x, wantReplies=%d, channel=%d\n", dest, wantReplies, node->channel);
             positionModule->sendOurPosition(dest, wantReplies, node->channel);

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -232,9 +232,9 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
 #if !MESHTASTIC_EXCLUDE_GPS
             if (gps != nullptr)
                 gps->enable();
-#endif
             // Send our new fixed position to the mesh for good measure
             positionModule->sendOurPosition();
+#endif
         }
         break;
     }


### PR DESCRIPTION
#3469 and  #3337 introduced macros to exclude modules or to minimize the build.

In the meantime some of these macros are broken and lead to compiler/linker errors when in use.

This PR fixes these compiler/linker errors.
