### PR TITLE
Fix build when HAS_NETWORKING is false on nrf52

### DIFF
--- a/src/mesh/eth/ethClient.cpp
+++ b/src/mesh/eth/ethClient.cpp
@@ -12,6 +12,8 @@
 #include <RAK13800_W5100S.h>
 #include <SPI.h>
 
+#if HAS_NETWORKING
+
 #ifndef DISABLE_NTP
 #include <NTPClient.h>
 
@@ -183,3 +185,5 @@ bool isEthernetAvailable()
         return true;
     }
 }
+
+#endif


### PR DESCRIPTION
(tested on a rak4631 by setting HAS_ETHERNET false when shrinking image)

