### PR TITLE
Ci improv

### DIFF
--- a/.github/workflows/build_raspbian.yml
+++ b/.github/workflows/build_raspbian.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Install libbluetooth
         shell: bash
         run: |
+          apt-get update -y
           apt-get install -y libbluetooth-dev libgpiod-dev libyaml-cpp-dev openssl libssl-dev libulfius-dev liborcania-dev
 
       - name: Checkout code

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -414,6 +414,7 @@ int32_t MQTT::runOnce()
         if (!wantConnection)
             return 5000; // If we don't want connection now, check again in 5 secs
         else {
+            LOG_DEBUG("Reconnecting MQTT because the PubSub loop returned false\n");
             reconnect();
             // If we succeeded, empty the queue one by one and start reading rapidly, else try again in 30 seconds (TCP
             // connections are EXPENSIVE so try rarely)

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -414,7 +414,7 @@ int32_t MQTT::runOnce()
         if (!wantConnection)
             return 5000; // If we don't want connection now, check again in 5 secs
         else {
-            LOG_DEBUG("Reconnecting MQTT because the PubSub loop returned false\n");
+            LOG_DEBUG("Reconnecting MQTT because the PubSub loop returned false:%d \n", pubSub.state());
             reconnect();
             // If we succeeded, empty the queue one by one and start reading rapidly, else try again in 30 seconds (TCP
             // connections are EXPENSIVE so try rarely)


### PR DESCRIPTION
Raspbian build aarch64 fails because the origin image does not have its apt repository updated before checking out libbluetooth packages.  This pull updates the apt repository before attempting to check out the bluetooth packages.