### PR TITLE
Updated raspbian CI to update apt repository ahead of libbluetooth.

### DIFF
--- a/.github/workflows/build_raspbian.yml
+++ b/.github/workflows/build_raspbian.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Install libbluetooth
         shell: bash
         run: |
+          apt-get update -y
           apt-get install -y libbluetooth-dev libgpiod-dev libyaml-cpp-dev openssl libssl-dev libulfius-dev liborcania-dev
 
       - name: Checkout code


### PR DESCRIPTION
It was noticed that the raspbian CI build was failing because apt-get attempts to fetch URL's from debian that do not exist (404).  This is a sure sign that the apt repository has not been updated in the image.

This update resolves that issue by updating the apt repository prior to fetching libbluetooth.
