### PR TITLE
Fix BLE logging on nrf52

### DIFF
--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -206,7 +206,7 @@ void RedirectablePrint::log_to_ble(const char *logLevel, const char *format, va_
 #ifdef ARCH_ESP32
             nimbleBluetooth->sendLog(buffer, size);
 #elif defined(ARCH_NRF52)
-            nrf52Bluetooth->sendLog(reinterpret_cast<const char *>(buffer));
+            nrf52Bluetooth->sendLog(buffer, size);
 #endif
             delete[] message;
             delete[] buffer;

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -339,12 +339,12 @@ void NRF52Bluetooth::onPairingCompleted(uint16_t conn_handle, uint8_t auth_statu
     screen->endAlert();
 }
 
-void NRF52Bluetooth::sendLog(const char *logMessage)
+void NRF52Bluetooth::sendLog(const uint8_t *logMessage, size_t length)
 {
-    if (!isConnected() || strlen(logMessage) > 512)
+    if (!isConnected() || length > 512)
         return;
     if (logRadio.indicateEnabled())
-        logRadio.indicate(logMessage);
+        logRadio.indicate(logMessage, (uint16_t)length);
     else
-        logRadio.notify(logMessage);
+        logRadio.notify(logMessage, (uint16_t)length);
 }

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -74,11 +74,16 @@ void onCccd(uint16_t conn_hdl, BLECharacteristic *chr, uint16_t cccd_value)
     LOG_INFO("CCCD Updated: %u\n", cccd_value);
     // Check the characteristic this CCCD update is associated with in case
     // this handler is used for multiple CCCD records.
+
+    // According to the GATT spec: cccd value = 0x0001 means notifications are enabled
+    // and cccd value = 0x0002 means indications are enabled
+
     if (chr->uuid == fromNum.uuid || chr->uuid == logRadio.uuid) {
-        if (chr->notifyEnabled(conn_hdl)) {
-            LOG_INFO("fromNum 'Notify' enabled\n");
+        auto result = cccd_value == 2 ? chr->indicateEnabled(conn_hdl) : chr->notifyEnabled(conn_hdl);
+        if (result) {
+            LOG_INFO("Notify/Indicate enabled\n");
         } else {
-            LOG_INFO("fromNum 'Notify' disabled\n");
+            LOG_INFO("Notify/Indicate disabled\n");
         }
     }
 }
@@ -176,7 +181,7 @@ void setupMeshService(void)
     toRadio.setWriteCallback(onToRadioWrite, false);
     toRadio.begin();
 
-    logRadio.setProperties(CHR_PROPS_NOTIFY | CHR_PROPS_READ);
+    logRadio.setProperties(CHR_PROPS_INDICATE | CHR_PROPS_NOTIFY | CHR_PROPS_READ);
     logRadio.setPermission(secMode, SECMODE_NO_ACCESS);
     logRadio.setMaxLen(512);
     logRadio.setCccdWriteCallback(onCccd);
@@ -338,5 +343,8 @@ void NRF52Bluetooth::sendLog(const char *logMessage)
 {
     if (!isConnected() || strlen(logMessage) > 512)
         return;
-    logRadio.notify(logMessage);
+    if (logRadio.indicateEnabled())
+        logRadio.indicate(logMessage);
+    else
+        logRadio.notify(logMessage);
 }

--- a/src/platform/nrf52/NRF52Bluetooth.h
+++ b/src/platform/nrf52/NRF52Bluetooth.h
@@ -13,7 +13,7 @@ class NRF52Bluetooth : BluetoothApi
     void clearBonds();
     bool isConnected();
     int getRssi();
-    void sendLog(const char *logMessage);
+    void sendLog(const uint8_t *logMessage, size_t length);
 
   private:
     static void onConnectionSecured(uint16_t conn_handle);


### PR DESCRIPTION
Two changes - the first one is not required (though it will be useful in the future, because I'm about to add an option to the python client to use BLE indicate instead of notify - for lossless log message transmission).  But the second one is an oops I missed in the review of the LogRecord changes.  See the commit for a description.