### PR TITLE
Notify client to empty `toPhoneQueue` if it's full

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -299,6 +299,7 @@ void MeshService::sendToPhone(meshtastic_MeshPacket *p)
         } else {
             LOG_WARN("ToPhone queue is full, dropping packet.\n");
             releaseToPool(p);
+            fromNum++; // Make sure to notify observers in case they are reconnected so they can get the packets
             return;
         }
     }


### PR DESCRIPTION
If the `toPhoneQueue` is full, a client didn't get the packets when reconnecting, because it wouldn't be notified unless there's a new `toPhoneQueueStatusQueue`/`toPhoneMqttProxyQueue` packet which increments `fromNum`. To notify them, let's also increment `fromNum` when the `toPhoneQueue` is full.
