### PR TITLE
Fix missing includes for wio-sdk-wm1110 SoftDevice 7.3.0 update

### DIFF
--- a/variants/wio-sdk-wm1110/platformio.ini
+++ b/variants/wio-sdk-wm1110/platformio.ini
@@ -8,7 +8,7 @@ build_unflags = ${nrf52840_base:build_unflags} -DUSBCON -DUSE_TINYUSB
 
 board_level = extra
 ; platform = https://github.com/maxgerhardt/platform-nordicnrf52#cac6fcf943a41accd2aeb4f3659ae297a73f422e
-build_flags = ${nrf52840_base.build_flags} -Ivariants/wio-sdk-wm1110 -DWIO_WM1110
+build_flags = ${nrf52840_base.build_flags} -Ivariants/wio-sdk-wm1110 -Ivariants/wio-sdk-wm1110/softdevice -Ivariants/wio-sdk-wm1110/softdevice/nrf52 -DWIO_WM1110
   -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
 board_build.ldscript = variants/wio-sdk-wm1110/nrf52840_s140_v7.ld


### PR DESCRIPTION
The build ci failing, due to missing includes
https://github.com/meshtastic/firmware/pull/4248