### PR TITLE
Add wio-sdk-wm1110 to build.

### DIFF
--- a/variants/wio-sdk-wm1110/platformio.ini
+++ b/variants/wio-sdk-wm1110/platformio.ini
@@ -6,7 +6,6 @@ board = wio-sdk-wm1110
 # Remove adafruit USB serial from the build (it is incompatible with using the ch340 serial chip on this board)
 build_unflags = ${nrf52840_base:build_unflags} -DUSBCON -DUSE_TINYUSB
 
-board_level = extra
 ; platform = https://github.com/maxgerhardt/platform-nordicnrf52#cac6fcf943a41accd2aeb4f3659ae297a73f422e
 build_flags = ${nrf52840_base.build_flags} -Ivariants/wio-sdk-wm1110 -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52 -DWIO_WM1110
   -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"


### PR DESCRIPTION
The wio-sdk-wm1110 is distinct from the wio-tracker-wm1110, with different platformio build options and pin config.

This change adds the wio-sdk-wm1110 to the CI matrix so firmware is built as part of release.