### PR TITLE
Optimize the shutdown current of RAK10701 to around 25uA

### DIFF
--- a/src/platform/nrf52/main-nrf52.cpp
+++ b/src/platform/nrf52/main-nrf52.cpp
@@ -234,6 +234,18 @@ void cpuDeepSleep(uint32_t msecToWake)
     // RAK-12039 set pin for Air quality sensor
     digitalWrite(AQ_SET_PIN, LOW);
 #endif
+#ifdef RAK14014
+    // GPIO restores input status, otherwise there will be leakage current
+    nrf_gpio_cfg_default(TFT_BL);
+    nrf_gpio_cfg_default(TFT_DC);
+    nrf_gpio_cfg_default(TFT_CS);
+    nrf_gpio_cfg_default(TFT_SCLK);
+    nrf_gpio_cfg_default(TFT_MOSI);
+    nrf_gpio_cfg_default(TFT_MISO);
+    nrf_gpio_cfg_default(SCREEN_TOUCH_INT);
+    nrf_gpio_cfg_default(WB_I2C1_SCL);
+    nrf_gpio_cfg_default(WB_I2C1_SDA);
+#endif
 #endif
     // Sleepy trackers or sensors can low power "sleep"
     // Don't enter this if we're sleeping portMAX_DELAY, since that's a shutdown event


### PR DESCRIPTION
Optimize the shutdown current of RAK10701 to around 25uA
