### PR TITLE
Fix that Dockerfile would not run with podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ ENV TZ=Etc/UTC
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
 # Install build deps
 USER root
 
@@ -24,10 +22,10 @@ USER mesh
 
 WORKDIR /tmp/firmware
 RUN python3 -m venv /tmp/firmware 
-RUN bash -c "source bin/activate; pip3 install --no-cache-dir -U platformio==6.1.15"
+RUN bash -o pipefail -c "source bin/activate; pip3 install --no-cache-dir -U platformio==6.1.15"
 # trunk-ignore(terrascan/AC_DOCKER_00024): We would actually like these files to be owned by mesh tyvm
 COPY --chown=mesh:mesh . /tmp/firmware
-RUN bash -c "source ./bin/activate && bash ./bin/build-native.sh"
+RUN bash -o pipefail -c "source ./bin/activate && bash ./bin/build-native.sh"
 RUN cp "/tmp/firmware/release/meshtasticd_linux_$(uname -m)" "/tmp/firmware/release/meshtasticd"
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,10 @@ USER mesh
 
 WORKDIR /tmp/firmware
 RUN python3 -m venv /tmp/firmware 
-RUN source ./bin/activate && pip3 install --no-cache-dir -U platformio==6.1.14
+RUN bash -c "source bin/activate; pip3 install --no-cache-dir -U platformio==6.1.15"
 # trunk-ignore(terrascan/AC_DOCKER_00024): We would actually like these files to be owned by mesh tyvm
 COPY --chown=mesh:mesh . /tmp/firmware
-RUN source ./bin/activate && chmod +x /tmp/firmware/bin/build-native.sh && ./bin/build-native.sh
+RUN bash -c "source ./bin/activate && bash ./bin/build-native.sh"
 RUN cp "/tmp/firmware/release/meshtasticd_linux_$(uname -m)" "/tmp/firmware/release/meshtasticd"
 
 


### PR DESCRIPTION
The Dockerfile would not work with Podman, the problematic lines were the ones containing the `source` keyword. It had to be slightly rewritten.

The `SHELL` command was also problematic with podman and, additionally, is not OCI compliant: https://github.com/containers/podman/issues/8477

While I was at it I bumped platformio from PyPi to a newer patch level.

This PR provides identical functionality, but fixes issues with podman and OCI-compliance.
