### PR TITLE
Fix error when compiling with "#define MESHTASTIC_EXCLUDE_SCREEN 1"

### DIFF
--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -295,6 +295,7 @@ bool NRF52Bluetooth::onPairingPasskey(uint16_t conn_handle, uint8_t const passke
 {
     LOG_INFO("BLE pairing process started with passkey %.3s %.3s\n", passkey, passkey + 3);
     powerFSM.trigger(EVENT_BLUETOOTH_PAIR);
+    #if !MESHTASTIC_EXCLUDE_SCREEN
     screen->startAlert([](OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y) -> void {
         char btPIN[16] = "888888";
         snprintf(btPIN, sizeof(btPIN), "%06u", configuredPasskey);
@@ -320,6 +321,7 @@ bool NRF52Bluetooth::onPairingPasskey(uint16_t conn_handle, uint8_t const passke
         y_offset = display->height() == 64 ? y_offset + FONT_HEIGHT_LARGE - 6 : y_offset + FONT_HEIGHT_LARGE + 5;
         display->drawString(x_offset + x, y_offset + y, deviceName);
     });
+    #endif // !MESHTASTIC_EXCLUDE_SCREEN
     if (match_request) {
         uint32_t start_time = millis();
         while (millis() < start_time + 30000) {


### PR DESCRIPTION
Fix compile error when excluding screen (#define MESHTASTIC_EXCLUDE_SCREEN 1) on target nrf52

NRF52Bluetooth::onPairingPasskey() tries to create and write to OLEDDisplay *display, which is not defined when excluding the screen code.
