### PR TITLE
Remove status topic

### DIFF
--- a/src/mesh/MeshTypes.h
+++ b/src/mesh/MeshTypes.h
@@ -10,6 +10,8 @@ typedef uint32_t NodeNum;
 typedef uint32_t PacketId; // A packet sequence number
 
 #define NODENUM_BROADCAST UINT32_MAX
+#define NODENUM_BROADCAST_NO_LORA                                                                                                \
+    1 // Reserved to only deliver packets over high speed (non-lora) transports, such as MQTT or BLE mesh (not yet implemented)
 #define ERRNO_OK 0
 #define ERRNO_NO_INTERFACES 33
 #define ERRNO_UNKNOWN 32  // pick something that doesn't conflict with RH_ROUTER_ERROR_UNABLE_TO_DELIVER

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -188,12 +188,10 @@ MQTT::MQTT() : concurrency::OSThread("mqtt"), mqttQueue(MAX_MQTT_QUEUE)
         mqtt = this;
 
         if (*moduleConfig.mqtt.root) {
-            statusTopic = moduleConfig.mqtt.root + statusTopic;
             cryptTopic = moduleConfig.mqtt.root + cryptTopic;
             jsonTopic = moduleConfig.mqtt.root + jsonTopic;
             mapTopic = moduleConfig.mqtt.root + mapTopic;
         } else {
-            statusTopic = "msh" + statusTopic;
             cryptTopic = "msh" + cryptTopic;
             jsonTopic = "msh" + jsonTopic;
             mapTopic = "msh" + mapTopic;
@@ -216,7 +214,7 @@ MQTT::MQTT() : concurrency::OSThread("mqtt"), mqttQueue(MAX_MQTT_QUEUE)
             enabled = true;
             runASAP = true;
             reconnectCount = 0;
-            publishStatus();
+            publishNodeInfo();
         }
         // preflightSleepObserver.observe(&preflightSleep);
     } else {
@@ -281,7 +279,7 @@ void MQTT::reconnect()
             runASAP = true;
             reconnectCount = 0;
 
-            publishStatus();
+            publishNodeInfo();
             return; // Don't try to connect directly to the server
         }
 #if HAS_NETWORKING
@@ -330,15 +328,14 @@ void MQTT::reconnect()
         LOG_INFO("Attempting to connect directly to MQTT server %s, port: %d, username: %s, password: %s\n", serverAddr,
                  serverPort, mqttUsername, mqttPassword);
 
-        auto myStatus = (statusTopic + owner.id);
-        bool connected = pubSub.connect(owner.id, mqttUsername, mqttPassword, myStatus.c_str(), 1, true, "offline");
+        bool connected = pubSub.connect(owner.id, mqttUsername, mqttPassword);
         if (connected) {
             LOG_INFO("MQTT connected\n");
             enabled = true; // Start running background process again
             runASAP = true;
             reconnectCount = 0;
 
-            publishStatus();
+            publishNodeInfo();
             sendSubscriptions();
         } else {
 #if HAS_WIFI && !defined(ARCH_PORTDUINO)
@@ -437,14 +434,10 @@ int32_t MQTT::runOnce()
     return 30000;
 }
 
-/// FIXME, include more information in the status text
-void MQTT::publishStatus()
+void MQTT::publishNodeInfo()
 {
-    auto myStatus = (statusTopic + owner.id);
-    bool ok = publish(myStatus.c_str(), "online", true);
-    LOG_INFO("published online=%d\n", ok);
+    // TODO: NodeInfo broadcast over MQTT only (NODENUM_BROADCAST_NO_LORA)
 }
-
 void MQTT::publishQueuedMessages()
 {
     if (!mqttQueue.isEmpty()) {

--- a/src/mqtt/MQTT.h
+++ b/src/mqtt/MQTT.h
@@ -81,10 +81,9 @@ class MQTT : private concurrency::OSThread
     virtual int32_t runOnce() override;
 
   private:
-    std::string statusTopic = "/2/stat/"; // For "online"/"offline" message
-    std::string cryptTopic = "/2/e/";     // msh/2/e/CHANNELID/NODEID
-    std::string jsonTopic = "/2/json/";   // msh/2/json/CHANNELID/NODEID
-    std::string mapTopic = "/2/map/";     // For protobuf-encoded MapReport messages
+    std::string cryptTopic = "/2/e/";   // msh/2/e/CHANNELID/NODEID
+    std::string jsonTopic = "/2/json/"; // msh/2/json/CHANNELID/NODEID
+    std::string mapTopic = "/2/map/";   // For protobuf-encoded MapReport messages
 
     // For map reporting (only applies when enabled)
     const uint32_t default_map_position_precision = 14;         // defaults to max. offset of ~1459m
@@ -110,8 +109,9 @@ class MQTT : private concurrency::OSThread
     /// Called when a new publish arrives from the MQTT server
     std::string meshPacketToJson(meshtastic_MeshPacket *mp);
 
-    void publishStatus();
     void publishQueuedMessages();
+
+    void publishNodeInfo();
 
     // Check if we should report unencrypted information about our node for consumption by a map
     void perhapsReportToMap();


### PR DESCRIPTION
I think it's time to say goodbye to our old friend mister stat topic. It didn't provide much value and we've moved pretty much entirely away from it now with client proxy and the new MQTT broker.

As a consolation prize, I'm working on an MQTT-only (and other high bandwidth options in the future) messaging support and I think we can do something like send our nodeinfo on initial connection in lieu of the stat topic and this will provide more useful discovery of nodes long-term anyway.