### PR TITLE
Wait for I2C power to stabilize on Heltec VME213; tidy variant folder

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -308,6 +308,13 @@ void setup()
     digitalWrite(RESET_OLED, 1);
 #endif
 
+#ifdef PERIPHERAL_WARMUP_MS
+    // Some peripherals may require additional time to stabilize after power is connected
+    // e.g. I2C on Heltec Vision Master
+    LOG_INFO("Waiting for peripherals to stabilize\n");
+    delay(PERIPHERAL_WARMUP_MS);
+#endif
+
 #ifdef BUTTON_PIN
 #ifdef ARCH_ESP32
 

--- a/variants/heltec_vision_master_e213/pins_arduino.h
+++ b/variants/heltec_vision_master_e213/pins_arduino.h
@@ -3,8 +3,8 @@
 
 #include <stdint.h>
 
-static const uint8_t LED_BUILTIN = 35;
-#define BUILTIN_LED LED_BUILTIN // backward compatibility
+static const uint8_t LED_BUILTIN = -1; // Board has no built-in LED, despite what schematic shows
+#define BUILTIN_LED LED_BUILTIN        // backward compatibility
 #define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t TX = 43;
@@ -56,6 +56,6 @@ static const uint8_t T14 = 14;
 
 static const uint8_t RST_LoRa = 12;
 static const uint8_t BUSY_LoRa = 13;
-static const uint8_t DIO0 = 14;
+static const uint8_t DIO1 = 14;
 
 #endif /* Pins_Arduino_h */

--- a/variants/heltec_vision_master_e213/variant.h
+++ b/variants/heltec_vision_master_e213/variant.h
@@ -1,14 +1,11 @@
-// #define LED_PIN 18
+#define BUTTON_PIN 0
 
-// Enable bus for external periherals
+// I2C
 #define I2C_SDA SDA
 #define I2C_SCL SCL
 
+// Display (E-Ink)
 #define USE_EINK
-
-/*
- * eink display pins
- */
 #define PIN_EINK_CS 5
 #define PIN_EINK_BUSY 1
 #define PIN_EINK_DC 2
@@ -16,33 +13,29 @@
 #define PIN_EINK_SCLK 4
 #define PIN_EINK_MOSI 6
 
-/*
- * SPI interfaces
- */
+// SPI
 #define SPI_INTERFACES_COUNT 2
+#define PIN_SPI_MISO 10 // MISO
+#define PIN_SPI_MOSI 11 // MOSI
+#define PIN_SPI_SCK 9   // SCK
 
-#define PIN_SPI_MISO 10 // MISO      P0.17
-#define PIN_SPI_MOSI 11 // MOSI      P0.15
-#define PIN_SPI_SCK 9   // SCK       P0.13
-
-#define VEXT_ENABLE 18 // powers the oled display and the lora antenna boost
-#define VEXT_ON_VALUE 1
-#define BUTTON_PIN 0
-
+// Power
+#define VEXT_ENABLE 18 // Powers the E-Ink display
+#define VEXT_ON_VALUE HIGH
 #define ADC_CTRL 46
 #define ADC_CTRL_ENABLED HIGH
 #define BATTERY_PIN 7
 #define ADC_CHANNEL ADC1_GPIO7_CHANNEL
-#define ADC_MULTIPLIER 4.9 * 1.03        // Voltage divider is roughly 1:1
-#define ADC_ATTENUATION ADC_ATTEN_DB_2_5 // Voltage divider output is quite high
+#define ADC_MULTIPLIER 4.9 * 1.03
+#define ADC_ATTENUATION ADC_ATTEN_DB_2_5
 
+// LoRa
 #define USE_SX1262
 
 #define LORA_DIO0 -1 // a No connect on the SX1262 module
 #define LORA_RESET 12
 #define LORA_DIO1 14 // SX1262 IRQ
 #define LORA_DIO2 13 // SX1262 BUSY
-#define LORA_DIO3    // Not connected on PCB, but internally on the TTGO SX1262, if DIO3 is high the TXCO is enabled
 
 #define LORA_SCK 9
 #define LORA_MISO 11

--- a/variants/heltec_vision_master_e213/variant.h
+++ b/variants/heltec_vision_master_e213/variant.h
@@ -20,7 +20,8 @@
 #define PIN_SPI_SCK 9   // SCK
 
 // Power
-#define VEXT_ENABLE 18 // Powers the E-Ink display
+#define VEXT_ENABLE 18            // Powers the E-Ink display, and the 3.3V supply to the I2C QuickLink connector
+#define PERIPHERAL_WARMUP_MS 1000 // Make sure I2C QuickLink has stable power before continuing
 #define VEXT_ON_VALUE HIGH
 #define ADC_CTRL 46
 #define ADC_CTRL_ENABLED HIGH


### PR DESCRIPTION
Heltec Vision Master 213 has a QuickLink-type I2C connector
![image](https://github.com/user-attachments/assets/1e4c3648-0f4e-4fcd-98fb-2beae611622f)

The 3.3V pin of connector is fed from `Ve_3V3` [(schematic)](https://resource.heltec.cn/download/HT-VME213/HT-VME213%20Schematic%20Diagram.pdf). This supply is not enabled until partway through [setup()](https://github.com/meshtastic/firmware/blob/f25644e8cfb30f64a4aa9cb2eeff67eeca94c6eb/src/main.cpp#L278-L280), followed soon after by I2C device scan.

This causes issues with CardKB detection, and may also impact other I2C devices. This PR adds a one second delay for Heltec Vision Master E213 after enabling peripheral power.

@HarukiToreda found in testing that a 500ms delay was insufficient.

___

Note: PR also tidies the variant.h, in line with #4226. It may be helpful to review this PR's two commits separately.