### PR TITLE
Set PIN_3V3_EN to HIGH (nrf52_promicro_diy variants)

### DIFF
--- a/variants/diy/nrf52_promicro_diy_tcxo/variant.cpp
+++ b/variants/diy/nrf52_promicro_diy_tcxo/variant.cpp
@@ -29,3 +29,10 @@ const uint32_t g_ADigitalPinMap[] = {
 
     // P1
     32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47};
+
+void initVariant()
+{
+     // 3V3 Power Rail
+    pinMode(PIN_3V3_EN, OUTPUT);
+    digitalWrite(PIN_3V3_EN, HIGH);
+}

--- a/variants/diy/nrf52_promicro_diy_xtal/variant.cpp
+++ b/variants/diy/nrf52_promicro_diy_xtal/variant.cpp
@@ -29,3 +29,10 @@ const uint32_t g_ADigitalPinMap[] = {
 
     // P1
     32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47};
+
+void initVariant()
+{
+     // 3V3 Power Rail
+    pinMode(PIN_3V3_EN, OUTPUT);
+    digitalWrite(PIN_3V3_EN, HIGH);
+}


### PR DESCRIPTION
Added missed 3v3 pin initialisation for nrf52_promicro_diy variants.
This NRF52 board has vcc pin, which usually powers lora module and sensors.

Old promicro versions has incorrect resistor, so in any PIN_3V3_EN state LDO has enough voltage on EN pin (active state) and custom boards.
New boards has correct resistor value, so PIN_3V3_EN state able to activate/inactivate LDO and it need to be enabled in variant.cpp.

