### PR TITLE
Add custom esp32 libs to save some iram space

### DIFF
--- a/bin/platformio-custom.py
+++ b/bin/platformio-custom.py
@@ -7,6 +7,7 @@ from readprops import readProps
 
 Import("env")
 platform = env.PioPlatform()
+board = env.GetProjectOption("board")
 
 
 def esp32_create_combined_bin(source, target, env):
@@ -77,6 +78,9 @@ if platform.name == "espressif32":
     else:
         # For newer ESP32 targets, using newlib nano works better.
         env.Append(LINKFLAGS=["--specs=nano.specs", "-u", "_printf_float"])
+    if board == "ttgo-t-beam":
+        print("patching esp32 libs")
+        env.Execute("tar -xvf bin/arduino-esp32-libs-release_*tar.gz -C ~/.platformio/packages/framework-arduinoespressif32/")
 
 Import("projenv")
 


### PR DESCRIPTION
This adds the results from a build of https://github.com/espressif/esp32-arduino-lib-builder v4.4 with the extra sdkconfig options of:

```
CONFIG_FREERTOS_PLACE_FUNCTIONS_INTO_FLASH=y
CONFIG_ESP_SYSTEM_ESP32_SRAM1_REGION_AS_IRAM=y
CONFIG_FREERTOS_PLACE_SNAPSHOT_FUNS_INTO_FLASH=y
CONFIG_RINGBUF_PLACE_FUNCTIONS_INTO_FLASH=y
CONFIG_ESP_WIFI_IRAM_OPT=n
CONFIG_ESP32_WIFI_RX_IRAM_OPT=n
CONFIG_SPIRAM_CACHE_LIBCHAR_IN_IRAM=n
CONFIG_SPIRAM_CACHE_LIBSTR_IN_IRAM=n
CONFIG_HAL_DEFAULT_ASSERTION_LEVEL=0
CONFIG_SPIRAM_CACHE_LIBMISC_IN_IRAM=n
CONFIG_SPIRAM_CACHE_LIBTIME_IN_IRAM=n
```

Which reduces iram usage from 
``Used static IRAM:  130970 bytes (    102 remain, 99.9% used)`` to ``Used static IRAM:  113762 bytes (  17310 remain, 86.8% used)``

This pr turns it on for just the tbeam target, since that's all I've tested it on.