### PR TITLE
Add the UF2 conversion script to the p.io task menu

### DIFF
--- a/bin/platformio-custom.py
+++ b/bin/platformio-custom.py
@@ -96,7 +96,7 @@ projenv.Append(
 env.AddCustomTarget(
     name="Convert Hex to UF2",
     dependencies=None,
-    actions=["PYTHON .\\bin\\uf2conv.py $BUILD_DIR\$env\\firmware.hex -c -o $BUILD_DIR\$env\\firmware.uf2"],
+    actions=["PYTHON .\\bin\\uf2conv.py $BUILD_DIR\$env\\firmware.hex -c -f 0xADA52840 -o $BUILD_DIR\$env\\firmware.uf2"],
     title="Convert hex to uf2",
     description="Runs the python script to convert an already-built .hex file into .uf2 for copying to a device"
 )

--- a/bin/platformio-custom.py
+++ b/bin/platformio-custom.py
@@ -91,3 +91,12 @@ projenv.Append(
         "-DAPP_VERSION_SHORT=" + verObj["short"],
     ]
 )
+
+# Add a custom p.io project task to run the UF2 conversion script.
+env.AddCustomTarget(
+    name="Convert Hex to UF2",
+    dependencies=None,
+    actions=["PYTHON .\\bin\\uf2conv.py $BUILD_DIR\$env\\firmware.hex -c -o $BUILD_DIR\$env\\firmware.uf2"],
+    title="Convert hex to uf2",
+    description="Runs the python script to convert an already-built .hex file into .uf2 for copying to a device"
+)


### PR DESCRIPTION
Update platformio-custom.py to include the UF2 conversion script as a project task. Saves you dropping into the command line every time.

Tested on Windows only...

![image](https://github.com/user-attachments/assets/d5a228bf-d22c-4b77-81ad-fc2d7957ef02)
