### PR TITLE
Promicro_diy variants: RF95 SX1268 support

### DIFF
--- a/variants/diy/nrf52_promicro_diy_tcxo/variant.h
+++ b/variants/diy/nrf52_promicro_diy_tcxo/variant.h
@@ -115,6 +115,8 @@ NRF52 PRO MICRO PIN ASSIGNMENT
 // LORA MODULES
 #define USE_LLCC68
 #define USE_SX1262
+#define USE_RF95
+#define USE_SX1268
 
 // LORA CONFIG
 #define SX126X_CS (32 + 13)      // P1.13 FIXME - we really should define LORA_CS instead

--- a/variants/diy/nrf52_promicro_diy_xtal/variant.h
+++ b/variants/diy/nrf52_promicro_diy_xtal/variant.h
@@ -114,6 +114,8 @@ NRF52 PRO MICRO PIN ASSIGNMENT
 // LORA MODULES
 #define USE_LLCC68
 #define USE_SX1262
+#define USE_RF95
+#define USE_SX1268
 
 // LORA CONFIG
 #define SX126X_CS (32 + 13)      // P1.13 FIXME - we really should define LORA_CS instead


### PR DESCRIPTION
Added RF95 and SX1268 support, mostly for ebyte 400M22S/400M30S modems.