### PR TITLE
Allow RTC to auto-fix in case of noisy neighbour with delayed clock.

### DIFF
--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -113,6 +113,11 @@ bool perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpdate)
         // Every 12 hrs we will slam in a new GPS or Phone GPS / NTP time, to correct for local RTC clock drift
         shouldSet = true;
         LOG_DEBUG("Reapplying external time to correct clock drift %ld secs\n", tv->tv_sec);
+    } else if (q == currentQuality && tv->tv_sec > (zeroOffsetSecs + 3 * 24 * 60 * 60)) {
+        // Sometimes nodes have RTC issues and broadcast time in the past. Jump clock forward if our time is "older" than 3 days.
+        shouldSet = true;
+        LOG_INFO("External time is more than 3 days in the future. Setting RTC to %ld. A neighbour likely has a broken clock.\n", tv->tv_sec);
+        LOG_DEBUG("new_time=%ld, old_time=%ld, diff=%ld\n", tv->tv_sec, zeroOffsetSecs, (tv->tv_sec - zeroOffsetSecs));
     } else {
         shouldSet = false;
         LOG_DEBUG("Current RTC quality: %s. Ignoring time of RTC quality of %s\n", RtcName(currentQuality), RtcName(q));


### PR DESCRIPTION
### Problem

There's a node misconfigured in my area, it's broadcasting every 10 seconds a position packet with timestamp set to two weeks in the past.

Notice time of `1720219611` two weeks ago.
```
INFO  | ??:??:?? 6 [Router] Received position from=0xb01eb761, id=0x6adafb99, portnum=3, payloadlen=17
DEBUG | ??:??:?? 6 [Router] POSITION node=b01eb761 l=17 lat=454006399 lon=-756663217 msl=66 hae=0 geo=0 pdop=0 hdop=0 vdop=0 siv=0 fxq=0 fxt=0 pts=0 time=1720219611
DEBUG | ??:??:?? 6 [Router] Upgrading time to quality Net
DEBUG | 18:46:51 6 [Router] Read RTC time as 1720219611
INFO  | 18:46:51 6 [Router] updatePosition REMOTE node=0xb01eb761 time=1720219611 lat=454006399 lon=-756663217
DEBUG | 18:46:51 7 [Router] Node status update: 38 online, 40 total
```

### Proposed fix
If a new position packet comes from the net, which is at least 3 days ahead of our current time, we'll jump-forward to that new time.

```
DEBUG | 18:47:48 64 [Router] POSITION node=7f1e7692 l=30 lat=454098944 lon=-757268480 msl=69 hae=0 geo=0 pdop=112 hdop=0 vdop=0 siv=16 fxq=0 fxt=0 pts=1722156207 time=1722165205
INFO  | 18:47:48 64 [Router] Reapplying external time to correct clock drift 1722165205 secs. A neighbour likely has a broken clock.
DEBUG | 18:47:48 64 [Router] tv_sec=1722165205, now=1720219611, diff=0
DEBUG | 07:13:25 64 [Router] Read RTC time as 1722165205
INFO  | 07:13:25 64 [Router] updatePosition REMOTE node=0x7f1e7692 time=1722165205 lat=454098944 lon=-757268480
DEBUG | 07:13:25 64 [Router] Node status update: 0 online, 40 total
```