### PR TITLE
Add setuptools to CI/CD basic setup

### DIFF
--- a/.github/actions/setup-base/action.yml
+++ b/.github/actions/setup-base/action.yml
@@ -15,7 +15,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get -y update --fix-missing
-        sudo apt-get install -y cppcheck libbluetooth-dev libgpiod-dev libyaml-cpp-dev
+        sudo apt-get install -y cppcheck libbluetooth-dev libgpiod-dev libyaml-cpp-dev python3-setuptools
 
     - name: Setup Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
Build was failing due to missing setuptools.
