### PR TITLE
DRAFT: Add hardware watchdog for the RP2040 platform

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,8 +2,9 @@
     // See http://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-		"ms-vscode.cpptools",
-        "platformio.platformio-ide",
-        "trunk.io"
+        "platformio.platformio-ide"
     ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,9 +2,8 @@
     // See http://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-        "platformio.platformio-ide"
+		"ms-vscode.cpptools",
+        "platformio.platformio-ide",
+        "trunk.io"
     ],
-    "unwantedRecommendations": [
-        "ms-vscode.cpptools-extension-pack"
-    ]
 }

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -63,6 +63,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "platform/portduino/PortduinoGlue.h"
 #endif
 
+#ifdef ARCH_RP2040
+#include "platform/rp2040/rp2040Watchdog.h"
+#endif
+
 using namespace meshtastic; /** @todo remove */
 
 namespace graphics
@@ -251,6 +255,10 @@ static void drawSSLScreen(OLEDDisplay *display, OLEDDisplayUiState *state, int16
     yield();
     esp_task_wdt_reset();
 #endif
+#ifdef ARCH_RP2040
+    yield();
+    rp2040Watchdog->reset();
+#endif
 
     display->setFont(FONT_SMALL);
     if ((millis() / 1000) % 2) {
@@ -282,6 +290,10 @@ static void drawWelcomeScreen(OLEDDisplay *display, OLEDDisplayUiState *state, i
 #ifdef ARCH_ESP32
     yield();
     esp_task_wdt_reset();
+#endif
+#ifdef ARCH_RP2040
+    yield();
+    rp2040Watchdog->reset();
 #endif
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1072,6 +1072,9 @@ void loop()
 #ifdef ARCH_NRF52
     nrf52Loop();
 #endif
+#ifdef ARCH_RP2040
+    rp2040Loop();
+#endif
     powerCommandsCheck();
 
     // For debugging

--- a/src/main.h
+++ b/src/main.h
@@ -81,7 +81,7 @@ extern bool runASAP;
 
 extern bool pauseBluetoothLogging;
 
-void nrf52Setup(), esp32Setup(), nrf52Loop(), esp32Loop(), rp2040Setup(), clearBonds(), enterDfuMode();
+void nrf52Setup(), esp32Setup(), nrf52Loop(), esp32Loop(), rp2040Setup(), rp2040Loop(), clearBonds(), enterDfuMode();
 
 meshtastic_DeviceMetadata getDeviceMetadata();
 

--- a/src/mesh/http/ContentHandler.cpp
+++ b/src/mesh/http/ContentHandler.cpp
@@ -21,6 +21,10 @@
 #include "esp_task_wdt.h"
 #endif
 
+#ifdef ARCH_RP2040
+#include "platform/rp2040/rp2040Watchdog.h"
+#endif
+
 /*
   Including the esp32_https_server library will trigger a compile time error. I've
   tracked it down to a reoccurrance of this bug:
@@ -532,7 +536,13 @@ void handleFormUpload(HTTPRequest *req, HTTPResponse *res)
         // With endOfField you can check whether the end of field has been reached or if there's
         // still data pending. With multipart bodies, you cannot know the field size in advance.
         while (!parser->endOfField()) {
+#ifdef ARCH_ESP32
             esp_task_wdt_reset();
+#endif
+#ifdef ARCH_RP2040
+            // Todo: Added here to be prepared when we add the rp2040 webserver
+            rp2040Watchdog->reset();
+#endif
 
             byte buf[512];
             size_t readLength = parser->read(buf, 512);

--- a/src/mesh/http/WebServer.cpp
+++ b/src/mesh/http/WebServer.cpp
@@ -15,6 +15,9 @@
 #ifdef ARCH_ESP32
 #include "esp_task_wdt.h"
 #endif
+#ifdef ARCH_RP2040
+#include "platform/rp2040/rp2040Watchdog.h"
+#endif
 
 // Persistent Data Storage
 #include <Preferences.h>
@@ -145,8 +148,13 @@ void createSSLCert()
                 if (runLoop) {
                     LOG_DEBUG(".");
 
+#ifdef ARCH_ESP32
                     yield();
+#endif
+#ifdef ARCH_RP2040
+                    // Todo: Added here to be prepared when we add the rp2040 webserver
                     esp_task_wdt_reset();
+#endif
 #if HAS_SCREEN
                     if (millis() / 1000 >= 3) {
                         screen->setSSLFrames();

--- a/src/platform/rp2040/main-rp2040.cpp
+++ b/src/platform/rp2040/main-rp2040.cpp
@@ -10,6 +10,49 @@ void setBluetoothEnable(bool enable)
     // not needed
 }
 
+// loop code specific to RP2040 targets
+void rp2040Loop()
+{
+    // Watchdog can not be enabled on startup since some initializtion wich takes place
+    // after, especially the wifi initialization, takes a long time and and may exceed
+    // the maximum delay of the hardare watchdog. So we start the watchdog after having
+    // called the loop a few times since the first calls to loop() is still interupted
+    // by long running, blocking calls.
+    //
+    // This leaves a small window where the device can get stuck
+    // in the boot phase, and never be rebooted, but it's a heck
+    // better than having no watchdog at all ;)
+    //
+    // Check if the watchdog is enabled, and if not, then start it
+    static bool watchdog_is_enabled = false;
+    static int watchdog_enable_delay = 3;
+    static uint32_t last_reset_ms = to_ms_since_boot(get_absolute_time());
+    static int watchdog_reset_cnt = 0;
+    if (!watchdog_is_enabled) {
+        if (watchdog_enable_delay > 0) {
+            watchdog_enable_delay--;
+            LOG_INFO("rp2040Loop(): Delaying enable of the rp2040 hardware watchdog: %d retries left\n", watchdog_enable_delay);
+        } else {
+            // Enable the hardware watchdog, 8 seconds delay before reboot if not reset
+            LOG_INFO("rp2040Loop(): Enabling rp2040 hardware watchdog\n");
+            watchdog_enable(0x7fffff, true);
+            watchdog_is_enabled = true;
+        }
+    } else {
+        // Reset watchdog periodically, after aprox. 3 seconds.
+        // This leaves plenty of time to perform long running radio operations before the
+        // hardware delay of 8 seconds runs out.
+        // Note: The uint32_t gives us aprox. 49 days of uptime before it rolls over, hence
+        //       the need for checking if 'now' is before last reset also.
+        uint32_t now_ms = to_ms_since_boot(get_absolute_time());
+        if (now_ms - last_reset_ms > 3000 || now_ms < last_reset_ms) {
+            LOG_TRACE("rp2040Loop(): watchdog reset at %ld seconds after boot (or wrap)\n", now_ms / 1000);
+            watchdog_update();
+            last_reset_ms = now_ms;
+        }
+    }
+}
+
 void cpuDeepSleep(uint32_t msecs)
 {
     // not needed
@@ -59,6 +102,11 @@ void rp2040Setup()
     LOG_INFO("clk_adc  = %dkHz\n", f_clk_adc);
     LOG_INFO("clk_rtc  = %dkHz\n", f_clk_rtc);
 #endif
+
+    // We have to delay the watchdog initialization since some parts
+    // of the initialization can take longer than the maximum delay
+    // of the hardware watchdog allows.
+    LOG_DEBUG("rp2040Setup(): watchdog initialization delayed\n");
 }
 
 void enterDfuMode()

--- a/src/platform/rp2040/rp2040Watchdog.cpp
+++ b/src/platform/rp2040/rp2040Watchdog.cpp
@@ -1,0 +1,3 @@
+#include "rp2040Watchdog.h"
+
+Rp2040Watchdog *rp2040Watchdog;

--- a/src/platform/rp2040/rp2040Watchdog.h
+++ b/src/platform/rp2040/rp2040Watchdog.h
@@ -1,0 +1,77 @@
+#pragma once
+#include "configuration.h"
+
+class Rp2040Watchdog : public concurrency::OSThread
+{
+  public:
+    explicit Rp2040Watchdog() : OSThread("Rp2040Watchdog")
+    {
+        LOG_TRACE("Rp2040Watchdog::Rp2040Watchdog(): Initializing\n");
+        watchdogIsRunning = false;
+        statusOutputCount = 0;
+
+        // Todo: We need a port of the 'Preferences' type to rp2040 so that
+        //       we can keep track of reboots
+    }
+
+    void reset() { lastResetTick = to_ms_since_boot(get_absolute_time()); }
+
+  protected:
+    int32_t runOnce() override
+    {
+        // If we are long enough into boot/initialization, start the hardware watchdog,
+        // otherwise check if timer is below timeout and update the watchdog.
+        uint32_t currentTick = to_ms_since_boot(get_absolute_time());
+        if (!watchdogIsRunning) {
+
+            LOG_TRACE("Rp2040Watchdog->runOnce(): watchdog not running (uptime = %u seconds)\n", currentTick / 1000);
+
+            if (currentTick > 30 * 1000) { // 30 seconds into boot
+                LOG_INFO("Rp2040Watchdog->runOnce(): starting watchdog (currentTick = %u seconds)\n", currentTick / 1000);
+                watchdog_enable(0x7fffff, true);
+                watchdogIsRunning = true;
+                lastResetTick = currentTick;
+            }
+        } else {
+            uint32_t timeout = currentTick - lastResetTick;
+
+            if (currentTick < lastTick) {
+                rollover++;
+            }
+            uint64_t uptime = (rollover * 0xFFFFFFFF) + currentTick;
+            lastTick = currentTick;
+
+            // Dump trace output aprox. each minute, just to allow some sort of feeling with the watchdog
+            // (We do not handle 49 days rollover, that's not important, we just want to know if
+            // the device has been up for days, and not with hours between restarts)
+            if (statusOutputCount++ > 14) {
+                LOG_TRACE("Rp2040Watchdog->runOnce(): watchdog running (timeout = %u seconds, uptime = %lu minutes)\n", timeout,
+                          uptime / (60 * 1000));
+                statusOutputCount = 0;
+            }
+
+            if (timeout < 90 * 1000) { // 90 seconds, same as esp32 watchdog
+                watchdog_update();
+            } else {
+                LOG_ERROR("Rp2040Watchdog->runOnce(): watchdog time since last update has exceeded timeout (timeout = %u "
+                          "seconds, uptime = %lu minutes)\n",
+                          timeout, uptime / (60 * 1000));
+                LOG_ERROR("Rp2040Watchdog->runOnce(): WAITING FOR REBOOT\n");
+            }
+        }
+
+        // Time until this thread runs again
+        return 4 * 1000; // 4 seconds
+    }
+
+  private:
+    uint32_t lastResetTick;
+    uint32_t lastTick;
+    uint32_t rollover;
+
+    bool watchdogIsRunning;
+
+    int statusOutputCount;
+};
+
+extern Rp2040Watchdog *rp2040Watchdog;


### PR DESCRIPTION
The watchdog must be enabled late in the boot stage since the rp2040's watchdog only allow for 8 seconds delay before resetting, and some of the initialization calls after the call to rp2040Setup() and even after the first call to rp2040Loop() blocks execution long enough to exceed this delay.

Due to this architectural problem, we still have a potential freeze on the rp2040 if it hangs during boot and initialization, but practical experience seems to indicate that in most cases, a freeze happens long into the running state (often days), so unless one builds a node to be deployed deep into the wilderness, we accept this risk.

There is not any likely solution to the short delay counter in the hardware watchdog since this is based on hardware registers.
