### PR TITLE
Remove unused define in NRF52 architecture

### DIFF
--- a/src/platform/nrf52/architecture.h
+++ b/src/platform/nrf52/architecture.h
@@ -88,10 +88,6 @@
 
 #endif
 
-#ifndef TTGO_T_ECHO
-#define GPS_UBLOX
-#endif
-
 #define LED_PIN PIN_LED1 // LED1 on nrf52840-DK
 
 #ifdef PIN_BUTTON1


### PR DESCRIPTION
The NRF52 architecture defaulted to setting GPS_UBLOX. However, GPS_UBLOX is not used anywhere in the code.

Remove these lines.
