### PR TITLE
PA FAN Disable

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -973,9 +973,9 @@ void setup()
     mqttInit();
 #endif
 
+#ifdef RF95_FAN_EN
     // Ability to disable FAN if PIN has been set with RF95_FAN_EN.
     // Make sure LoRa has been started before disabling FAN.
-#ifdef RF95_FAN_EN
     if (config.lora.pa_fan_disabled)
         digitalWrite(RF95_FAN_EN, LOW ^ 0);
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -973,6 +973,13 @@ void setup()
     mqttInit();
 #endif
 
+    // Ability to disable FAN if PIN has been set with RF95_FAN_EN.
+    // Make sure LoRa has been started before disabling FAN.
+#ifdef RF95_FAN_EN
+    if (config.lora.pa_fan_disabled)
+        digitalWrite(RF95_FAN_EN, LOW ^ 0);
+#endif
+
 #ifndef ARCH_PORTDUINO
 
     // Initialize Wifi

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -466,6 +466,15 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c)
             config.lora.sx126x_rx_boosted_gain == c.payload_variant.lora.sx126x_rx_boosted_gain) {
             requiresReboot = false;
         }
+
+#ifdef RF95_FAN_EN
+        // Turn PA off if disabled by config
+        if (c.payload_variant.lora.pa_fan_disabled) {
+            digitalWrite(RF95_FAN_EN, LOW ^ 0);
+        } else {
+            digitalWrite(RF95_FAN_EN, HIGH ^ 0);
+        }
+#endif
         config.lora = c.payload_variant.lora;
         // If we're setting region for the first time, init the region
         if (isRegionUnset && config.lora.region > meshtastic_Config_LoRaConfig_RegionCode_UNSET) {


### PR DESCRIPTION
Ability to disable PA FAN if RF95_FAN_EN is set, doesn't require reboot.