### PR TITLE
Add #define USE_SSD1306 to avoid automatic detection causing pixel sh…

### DIFF
--- a/variants/heltec_v3/variant.h
+++ b/variants/heltec_v3/variant.h
@@ -1,5 +1,7 @@
 #define LED_PIN LED
 
+#define USE_SSD1306 // Heltec_v3 has a SSD1306 display
+
 #define RESET_OLED RST_OLED
 #define I2C_SDA SDA_OLED // I2C pins for this board
 #define I2C_SCL SCL_OLED


### PR DESCRIPTION
Add #define USE_SSD1306 to avoid automatic detection causing pixel shift. Testing on Heltec V3 hardware has been completed.
![截圖 2024-07-30 晚上11 26 36](https://github.com/user-attachments/assets/8ac1f9ec-baf7-4207-b338-4c27ab51ea19)
![截圖 2024-07-30 晚上11 26 43](https://github.com/user-attachments/assets/9be6e056-95e1-4141-b333-fd457bb944ed)
