### PR TITLE
Make LogRecord protobuf serial logging over Phone API opt-in instead

### DIFF
--- a/src/SerialConsole.cpp
+++ b/src/SerialConsole.cpp
@@ -96,7 +96,7 @@ bool SerialConsole::handleToRadio(const uint8_t *buf, size_t len)
 
 void SerialConsole::log_to_serial(const char *logLevel, const char *format, va_list arg)
 {
-    if (usingProtobufs && config.device.logrecord_serial_enabled) {
+    if (usingProtobufs && config.device.debug_log_enabled) {
         meshtastic_LogRecord_Level ll = meshtastic_LogRecord_Level_UNSET; // default to unset
         switch (logLevel[0]) {
         case 'D':

--- a/src/SerialConsole.cpp
+++ b/src/SerialConsole.cpp
@@ -96,7 +96,7 @@ bool SerialConsole::handleToRadio(const uint8_t *buf, size_t len)
 
 void SerialConsole::log_to_serial(const char *logLevel, const char *format, va_list arg)
 {
-    if (usingProtobufs) {
+    if (usingProtobufs && config.device.logrecord_serial_enabled) {
         meshtastic_LogRecord_Level ll = meshtastic_LogRecord_Level_UNSET; // default to unset
         switch (logLevel[0]) {
         case 'D':


### PR DESCRIPTION
This seems to be causing congestion in the API connection in python for some users, so we'll make it opt-in