### PR TITLE
Changed a RADIOMASTER_900_BANDIT_NANO to DISPLAY_FLIP_SCREEN

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -303,7 +303,7 @@ void NodeDB::installDefaultConfig()
          meshtastic_Config_PositionConfig_PositionFlags_SPEED | meshtastic_Config_PositionConfig_PositionFlags_HEADING |
          meshtastic_Config_PositionConfig_PositionFlags_DOP | meshtastic_Config_PositionConfig_PositionFlags_SATINVIEW);
 
-#ifdef RADIOMASTER_900_BANDIT_NANO
+#ifdef DISPLAY_FLIP_SCREEN
     config.display.flip_screen = true;
 #endif
 #ifdef T_WATCH_S3

--- a/variants/radiomaster_900_bandit_nano/variant.h
+++ b/variants/radiomaster_900_bandit_nano/variant.h
@@ -50,7 +50,7 @@
 #define BUTTON_PIN 39
 #define BUTTON_NEED_PULLUP
 
-#define SCREEN_ROTATE
+#define DISPLAY_FLIP_SCREEN
 
 /*
   No External notification.


### PR DESCRIPTION
- Changed a RADIOMASTER_900_BANDIT_NANO to DISPLAY_FLIP_SCREEN that is responsible for flipping the OLED screen for better compatible with other devices.
- Remove a un-used SCREEN_ROTATE and added DISPLAY_FLIP_SCREEN for RadioMaster 900 Nano/Micro