### PR TITLE
Make SPI frequency configurable on Native

### DIFF
--- a/bin/config-dist.yaml
+++ b/bin/config-dist.yaml
@@ -152,3 +152,4 @@ Webserver:
 
 General:
   MaxNodes: 200
+  MaxMessageQueue: 100

--- a/bin/config-dist.yaml
+++ b/bin/config-dist.yaml
@@ -54,6 +54,8 @@ Lora:
 
 #  ch341_quirk: true # Uncomment this to use the chunked SPI transfer that seems to fix the ch341
 
+#  spiSpeed: 2000000
+
 ### Set gpio chip to use in /dev/. Defaults to 0.
 ### Notably the Raspberry Pi 5 puts the GPIO header on gpiochip4
 #  gpiochip: 4
@@ -111,6 +113,9 @@ Display:
 #  Height: 320
 #  Rotate: true
 
+### You can also specify the spi device for the display to use
+# spidev: spidev0.0
+
 Touchscreen:
 ### Note, at least for now, the touchscreen must have a CS pin defined, even if you let Linux manage the CS switching.
 
@@ -126,9 +131,13 @@ Touchscreen:
 #  CS: 7
 #  IRQ: 17
 
-### Configure device for direct keyboard input
+### You can also specify the spi device for the touchscreen to use
+# spidev: spidev0.0
+
 
 Input:
+### Configure device for direct keyboard input
+
 #  KeyboardDevice: /dev/input/by-id/usb-_Raspberry_Pi_Internal_Keyboard-event-kbd
 
 ###

--- a/src/ButtonThread.cpp
+++ b/src/ButtonThread.cpp
@@ -144,8 +144,8 @@ int32_t ButtonThread::runOnce()
 
         case BUTTON_EVENT_DOUBLE_PRESSED: {
             LOG_BUTTON("Double press!\n");
-            service.refreshLocalMeshNode();
-            auto sentPosition = service.trySendPosition(NODENUM_BROADCAST, true);
+            service->refreshLocalMeshNode();
+            auto sentPosition = service->trySendPosition(NODENUM_BROADCAST, true);
             if (screen) {
                 if (sentPosition)
                     screen->print("Sent ad-hoc position\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -208,11 +208,7 @@ uint32_t timeLastPowered = 0;
 static Periodic *ledPeriodic;
 static OSThread *powerFSMthread;
 static OSThread *ambientLightingThread;
-#if ARCH_PORTDUINO
-SPISettings spiSettings(settingsMap[spiSpeed], MSBFIRST, SPI_MODE0);
-#else
-SPISettings spiSettings(4000000, MSBFIRST, SPI_MODE0);
-#endif
+
 RadioInterface *rIf = NULL;
 
 /**
@@ -234,6 +230,12 @@ void printInfo()
 void setup()
 {
     concurrency::hasBeenSetup = true;
+#if ARCH_PORTDUINO
+    SPISettings spiSettings(settingsMap[spiSpeed], MSBFIRST, SPI_MODE0);
+#else
+    SPISettings spiSettings(4000000, MSBFIRST, SPI_MODE0);
+#endif
+
     meshtastic_Config_DisplayConfig_OledType screen_model =
         meshtastic_Config_DisplayConfig_OledType::meshtastic_Config_DisplayConfig_OledType_OLED_AUTO;
     OLEDDISPLAY_GEOMETRY screen_geometry = GEOMETRY_128_64;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -208,8 +208,11 @@ uint32_t timeLastPowered = 0;
 static Periodic *ledPeriodic;
 static OSThread *powerFSMthread;
 static OSThread *ambientLightingThread;
+#if ARCH_PORTDUINO
+SPISettings spiSettings(settingsMap[spiSpeed], MSBFIRST, SPI_MODE0);
+#else
 SPISettings spiSettings(4000000, MSBFIRST, SPI_MODE0);
-
+#endif
 RadioInterface *rIf = NULL;
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -719,8 +719,8 @@ void setup()
     LOG_DEBUG("Starting audio thread\n");
     audioThread = new AudioThread();
 #endif
-
-    service.init();
+    service = new MeshService();
+    service->init();
 
     // Now that the mesh service is created, create any modules
     setupModules();
@@ -1085,7 +1085,7 @@ void loop()
     // TODO: This should go into a thread handled by FreeRTOS.
     // handleWebResponse();
 
-    service.loop();
+    service->loop();
 
     long delayMsec = mainController.runOrDelay();
 

--- a/src/mesh/MeshModule.cpp
+++ b/src/mesh/MeshModule.cpp
@@ -170,7 +170,7 @@ void MeshModule::callModules(meshtastic_MeshPacket &mp, RxSource src)
     if (isDecoded && mp.decoded.want_response && toUs) {
         if (currentReply) {
             printPacket("Sending response", currentReply);
-            service.sendToMesh(currentReply);
+            service->sendToMesh(currentReply);
             currentReply = NULL;
         } else if (mp.from != ourNodeNum && !ignoreRequest) {
             // Note: if the message started with the local node or a module asked to ignore the request, we don't want to send a

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -57,7 +57,7 @@ nodenum (filtering against whatever it knows about the nodedb) and rebroadcast t
 FIXME in the initial proof of concept we just skip the entire want/deny flow and just hand pick node numbers at first.
 */
 
-MeshService service;
+MeshService *service;
 
 static MemoryDynamic<meshtastic_MqttClientProxyMessage> staticMqttClientProxyMessagePool;
 

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -23,6 +23,10 @@
 #include "nimble/NimbleBluetooth.h"
 #endif
 
+#if ARCH_PORTDUINO
+#include "PortduinoGlue.h"
+#endif
+
 /*
 receivedPacketQueue - this is a queue of messages we've received from the mesh, which we are keeping to deliver to the phone.
 It is implemented with a FreeRTos queue (wrapped with a little RTQueue class) of pointers to MeshPacket protobufs (which were

--- a/src/mesh/MeshService.h
+++ b/src/mesh/MeshService.h
@@ -150,4 +150,4 @@ class MeshService
     friend class RoutingModule;
 };
 
-extern MeshService service;
+extern MeshService *service;

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -41,7 +41,7 @@ void PhoneAPI::handleStartConfig()
     // Must be before setting state (because state is how we know !connected)
     if (!isConnected()) {
         onConnectionChanged(true);
-        observe(&service.fromNumChanged);
+        observe(&service->fromNumChanged);
 #ifdef FSCom
         observe(&xModem.packetReady);
 #endif
@@ -63,7 +63,7 @@ void PhoneAPI::close()
     if (state != STATE_SEND_NOTHING) {
         state = STATE_SEND_NOTHING;
 
-        unobserve(&service.fromNumChanged);
+        unobserve(&service->fromNumChanged);
 #ifdef FSCom
         unobserve(&xModem.packetReady);
 #endif
@@ -186,7 +186,7 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
         fromRadioScratch.my_info = myNodeInfo;
         state = STATE_SEND_OWN_NODEINFO;
 
-        service.refreshLocalMeshNode(); // Update my NodeInfo because the client will be asking for it soon.
+        service->refreshLocalMeshNode(); // Update my NodeInfo because the client will be asking for it soon.
         break;
 
     case STATE_SEND_OWN_NODEINFO: {
@@ -443,7 +443,7 @@ void PhoneAPI::handleDisconnect()
 void PhoneAPI::releasePhonePacket()
 {
     if (packetForPhone) {
-        service.releaseToPool(packetForPhone); // we just copied the bytes, so don't need this buffer anymore
+        service->releaseToPool(packetForPhone); // we just copied the bytes, so don't need this buffer anymore
         packetForPhone = NULL;
     }
 }
@@ -451,7 +451,7 @@ void PhoneAPI::releasePhonePacket()
 void PhoneAPI::releaseQueueStatusPhonePacket()
 {
     if (queueStatusPacketForPhone) {
-        service.releaseQueueStatusToPool(queueStatusPacketForPhone);
+        service->releaseQueueStatusToPool(queueStatusPacketForPhone);
         queueStatusPacketForPhone = NULL;
     }
 }
@@ -459,7 +459,7 @@ void PhoneAPI::releaseQueueStatusPhonePacket()
 void PhoneAPI::releaseMqttClientProxyPhonePacket()
 {
     if (mqttClientProxyMessageForPhone) {
-        service.releaseMqttClientProxyMessageToPool(mqttClientProxyMessageForPhone);
+        service->releaseMqttClientProxyMessageToPool(mqttClientProxyMessageForPhone);
         mqttClientProxyMessageForPhone = NULL;
     }
 }
@@ -495,9 +495,9 @@ bool PhoneAPI::available()
         return true; // Always say we have something, because we might need to advance our state machine
     case STATE_SEND_PACKETS: {
         if (!queueStatusPacketForPhone)
-            queueStatusPacketForPhone = service.getQueueStatusForPhone();
+            queueStatusPacketForPhone = service->getQueueStatusForPhone();
         if (!mqttClientProxyMessageForPhone)
-            mqttClientProxyMessageForPhone = service.getMqttClientProxyMessageForPhone();
+            mqttClientProxyMessageForPhone = service->getMqttClientProxyMessageForPhone();
         bool hasPacket = !!queueStatusPacketForPhone || !!mqttClientProxyMessageForPhone;
         if (hasPacket)
             return true;
@@ -520,7 +520,7 @@ bool PhoneAPI::available()
 #endif
 
         if (!packetForPhone)
-            packetForPhone = service.getForPhone();
+            packetForPhone = service->getForPhone();
         hasPacket = !!packetForPhone;
         // LOG_DEBUG("available hasPacket=%d\n", hasPacket);
         return hasPacket;
@@ -538,7 +538,7 @@ bool PhoneAPI::available()
 bool PhoneAPI::handleToRadioPacket(meshtastic_MeshPacket &p)
 {
     printPacket("PACKET FROM PHONE", &p);
-    service.handleToRadio(p);
+    service->handleToRadio(p);
 
     return true;
 }

--- a/src/mesh/ProtobufModule.h
+++ b/src/mesh/ProtobufModule.h
@@ -38,7 +38,7 @@ template <class T> class ProtobufModule : protected SinglePortModule
     /**
      * Return a mesh packet which has been preinited with a particular protobuf data payload and port number.
      * You can then send this packet (after customizing any of the payload fields you might need) with
-     * service.sendToMesh()
+     * service->sendToMesh()
      */
     meshtastic_MeshPacket *allocDataProtobuf(const T &payload)
     {

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -334,7 +334,7 @@ bool RadioInterface::init()
 {
     LOG_INFO("Starting meshradio init...\n");
 
-    configChangedObserver.observe(&service.configChanged);
+    configChangedObserver.observe(&service->configChanged);
     preflightSleepObserver.observe(&preflightSleep);
     notifyDeepSleepObserver.observe(&notifyDeepSleep);
 

--- a/src/mesh/SinglePortModule.h
+++ b/src/mesh/SinglePortModule.h
@@ -26,7 +26,7 @@ class SinglePortModule : public MeshModule
     /**
      * Return a mesh packet which has been preinited as a data packet with a particular port number.
      * You can then send this packet (after customizing any of the payload fields you might need) with
-     * service.sendToMesh()
+     * service->sendToMesh()
      */
     meshtastic_MeshPacket *allocDataPacket()
     {

--- a/src/mesh/mesh-pb-constants.h
+++ b/src/mesh/mesh-pb-constants.h
@@ -14,7 +14,9 @@
 /// max number of packets which can be waiting for delivery to android - note, this value comes from mesh.options protobuf
 // FIXME - max_count is actually 32 but we save/load this as one long string of preencoded MeshPacket bytes - not a big array in
 // RAM #define MAX_RX_TOPHONE (member_size(DeviceState, receive_queue) / member_size(DeviceState, receive_queue[0]))
+#ifndef MAX_RX_TOPHONE
 #define MAX_RX_TOPHONE 32
+#endif
 
 /// max number of nodes allowed in the mesh
 #ifndef MAX_NUM_NODES

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -348,7 +348,7 @@ void AdminModule::handleSetOwner(const meshtastic_User &o)
     }
 
     if (changed) { // If nothing really changed, don't broadcast on the network or write to flash
-        service.reloadOwner(!hasOpenEditTransaction);
+        service->reloadOwner(!hasOpenEditTransaction);
         saveChanges(SEGMENT_DEVICESTATE);
     }
 }
@@ -848,7 +848,7 @@ void AdminModule::saveChanges(int saveWhat, bool shouldReboot)
 {
     if (!hasOpenEditTransaction) {
         LOG_INFO("Saving changes to disk\n");
-        service.reloadConfig(saveWhat); // Calls saveToDisk among other things
+        service->reloadConfig(saveWhat); // Calls saveToDisk among other things
     } else {
         LOG_INFO("Delaying save of changes to disk until the open transaction is committed\n");
     }
@@ -879,7 +879,7 @@ void AdminModule::handleSetHamMode(const meshtastic_HamParameters &p)
     channels.setChannel(primaryChannel);
     channels.onConfigChanged();
 
-    service.reloadOwner(false);
+    service->reloadOwner(false);
     saveChanges(SEGMENT_CONFIG | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS);
 }
 

--- a/src/modules/AtakPluginModule.cpp
+++ b/src/modules/AtakPluginModule.cpp
@@ -188,7 +188,7 @@ void AtakPluginModule::alterReceivedProtobuf(meshtastic_MeshPacket &mp, meshtast
             pb_encode_to_bytes(decompressedCopy->decoded.payload.bytes, sizeof(decompressedCopy->decoded.payload),
                                meshtastic_TAKPacket_fields, &uncompressed);
 
-        service.sendToPhone(decompressedCopy);
+        service->sendToPhone(decompressedCopy);
     }
     return;
 }

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -264,8 +264,8 @@ int CannedMessageModule::handleInputEvent(const InputEvent *event)
 #endif
             break;
         case 0xaf: // fn+space send network ping like double press does
-            service.refreshLocalMeshNode();
-            if (service.trySendPosition(NODENUM_BROADCAST, true)) {
+            service->refreshLocalMeshNode();
+            if (service->trySendPosition(NODENUM_BROADCAST, true)) {
                 showTemporaryMessage("Position \nUpdate Sent");
             } else {
                 showTemporaryMessage("Node Info \nUpdate Sent");
@@ -388,7 +388,7 @@ void CannedMessageModule::sendText(NodeNum dest, ChannelIndex channel, const cha
 
     LOG_INFO("Sending message id=%d, dest=%x, msg=%.*s\n", p->id, p->to, p->decoded.payload.size, p->decoded.payload.bytes);
 
-    service.sendToMesh(
+    service->sendToMesh(
         p, RX_SRC_LOCAL,
         true); // send to mesh, cc to phone. Even if there's no phone connected, this stores the message to match ACKs
 }
@@ -1048,7 +1048,7 @@ ProcessMessage CannedMessageModule::handleReceived(const meshtastic_MeshPacket &
             e.action = UIFrameEvent::Action::REGENERATE_FRAMESET; // We want to change the list of frames shown on-screen
             requestFocus(); // Tell Screen::setFrames that our module's frame should be shown, even if not "first" in the frameset
             this->runState = CANNED_MESSAGE_RUN_STATE_ACK_NACK_RECEIVED;
-            this->incoming = service.getNodenumFromRequestId(mp.decoded.request_id);
+            this->incoming = service->getNodenumFromRequestId(mp.decoded.request_id);
             meshtastic_Routing decoded = meshtastic_Routing_init_default;
             pb_decode_from_bytes(mp.decoded.payload.bytes, mp.decoded.payload.size, meshtastic_Routing_fields, &decoded);
             this->ack = decoded.error_reason == meshtastic_Routing_Error_NONE;

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -82,7 +82,7 @@ void DetectionSensorModule::sendDetectionMessage()
     }
     LOG_INFO("Sending message id=%d, dest=%x, msg=%.*s\n", p->id, p->to, p->decoded.payload.size, p->decoded.payload.bytes);
     lastSentToMesh = millis();
-    service.sendToMesh(p);
+    service->sendToMesh(p);
     delete[] message;
 }
 
@@ -97,7 +97,7 @@ void DetectionSensorModule::sendCurrentStateMessage()
     memcpy(p->decoded.payload.bytes, message, p->decoded.payload.size);
     LOG_INFO("Sending message id=%d, dest=%x, msg=%.*s\n", p->id, p->to, p->decoded.payload.size, p->decoded.payload.bytes);
     lastSentToMesh = millis();
-    service.sendToMesh(p);
+    service->sendToMesh(p);
     delete[] message;
 }
 

--- a/src/modules/DropzoneModule.cpp
+++ b/src/modules/DropzoneModule.cpp
@@ -1,7 +1,7 @@
 #if !MESHTASTIC_EXCLUDE_DROPZONE
 
 #include "DropzoneModule.h"
-#include "MeshService.h"
+#include "Meshservice->h"
 #include "configuration.h"
 #include "gps/GeoCoord.h"
 #include "gps/RTC.h"
@@ -20,7 +20,7 @@ int32_t DropzoneModule::runOnce()
 {
     // Send on a 5 second delay from receiving the matching request
     if (startSendConditions != 0 && (startSendConditions + 5000U) < millis()) {
-        service.sendToMesh(sendConditions(), RX_SRC_LOCAL);
+        service->sendToMesh(sendConditions(), RX_SRC_LOCAL);
         startSendConditions = 0;
     }
     // Run every second to check if we need to send conditions

--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -108,7 +108,7 @@ void NeighborInfoModule::sendNeighborInfo(NodeNum dest, bool wantReplies)
     p->to = dest;
     p->decoded.want_response = wantReplies;
     printNeighborInfo("SENDING", &neighborInfo);
-    service.sendToMesh(p, RX_SRC_LOCAL, true);
+    service->sendToMesh(p, RX_SRC_LOCAL, true);
 }
 
 /*

--- a/src/modules/NodeInfoModule.cpp
+++ b/src/modules/NodeInfoModule.cpp
@@ -26,7 +26,7 @@ bool NodeInfoModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
 
     // if user has changed while packet was not for us, inform phone
     if (hasChanged && !wasBroadcast && mp.to != nodeDB->getNodeNum())
-        service.sendToPhone(packetPool.allocCopy(mp));
+        service->sendToPhone(packetPool.allocCopy(mp));
 
     // LOG_DEBUG("did handleReceived\n");
     return false; // Let others look at this message also if they want
@@ -36,7 +36,7 @@ void NodeInfoModule::sendOurNodeInfo(NodeNum dest, bool wantReplies, uint8_t cha
 {
     // cancel any not yet sent (now stale) position packets
     if (prevPacketId) // if we wrap around to zero, we'll simply fail to cancel in that rare case (no big deal)
-        service.cancelSending(prevPacketId);
+        service->cancelSending(prevPacketId);
 
     meshtastic_MeshPacket *p = allocReply();
     if (p) { // Check whether we didn't ignore it
@@ -52,7 +52,7 @@ void NodeInfoModule::sendOurNodeInfo(NodeNum dest, bool wantReplies, uint8_t cha
 
         prevPacketId = p->id;
 
-        service.sendToMesh(p);
+        service->sendToMesh(p);
     }
 }
 

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -141,7 +141,7 @@ meshtastic_MeshPacket *PositionModule::allocReply()
         return nullptr;
     }
 
-    meshtastic_NodeInfoLite *node = service.refreshLocalMeshNode(); // should guarantee there is now a position
+    meshtastic_NodeInfoLite *node = service->refreshLocalMeshNode(); // should guarantee there is now a position
     assert(node->has_position);
 
     // configuration of POSITION packet
@@ -280,7 +280,7 @@ void PositionModule::sendOurPosition(NodeNum dest, bool wantReplies, uint8_t cha
 {
     // cancel any not yet sent (now stale) position packets
     if (prevPacketId) // if we wrap around to zero, we'll simply fail to cancel in that rare case (no big deal)
-        service.cancelSending(prevPacketId);
+        service->cancelSending(prevPacketId);
 
     // Set's the class precision value for this particular packet
     if (channels.getByIndex(channel).settings.has_module_settings) {
@@ -309,7 +309,7 @@ void PositionModule::sendOurPosition(NodeNum dest, bool wantReplies, uint8_t cha
     if (channel > 0)
         p->channel = channel;
 
-    service.sendToMesh(p, RX_SRC_LOCAL, true);
+    service->sendToMesh(p, RX_SRC_LOCAL, true);
 
     if ((config.device.role == meshtastic_Config_DeviceConfig_Role_TRACKER ||
          config.device.role == meshtastic_Config_DeviceConfig_Role_TAK_TRACKER) &&
@@ -359,7 +359,7 @@ int32_t PositionModule::runOnce()
             }
         }
     } else if (config.position.position_broadcast_smart_enabled) {
-        const meshtastic_NodeInfoLite *node2 = service.refreshLocalMeshNode(); // should guarantee there is now a position
+        const meshtastic_NodeInfoLite *node2 = service->refreshLocalMeshNode(); // should guarantee there is now a position
 
         if (hasValidPosition(node2)) {
             // The minimum time (in seconds) that would pass before we are able to send a new position packet.
@@ -398,7 +398,7 @@ void PositionModule::sendLostAndFoundText()
     p->decoded.payload.size = strlen(message);
     memcpy(p->decoded.payload.bytes, message, p->decoded.payload.size);
 
-    service.sendToMesh(p, RX_SRC_LOCAL, true);
+    service->sendToMesh(p, RX_SRC_LOCAL, true);
     delete[] message;
 }
 
@@ -437,7 +437,7 @@ struct SmartPosition PositionModule::getDistanceTraveledSinceLastSend(meshtastic
 void PositionModule::handleNewPosition()
 {
     meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(nodeDB->getNodeNum());
-    const meshtastic_NodeInfoLite *node2 = service.refreshLocalMeshNode(); // should guarantee there is now a position
+    const meshtastic_NodeInfoLite *node2 = service->refreshLocalMeshNode(); // should guarantee there is now a position
     // We limit our GPS broadcasts to a max rate
     if (hasValidPosition(node2)) {
         auto smartPosition = getDistanceTraveledSinceLastSend(node->position);

--- a/src/modules/RangeTestModule.cpp
+++ b/src/modules/RangeTestModule.cpp
@@ -120,7 +120,7 @@ void RangeTestModuleRadio::sendPayload(NodeNum dest, bool wantReplies)
     p->decoded.payload.size = strlen(heartbeatString); // You must specify how many bytes are in the reply
     memcpy(p->decoded.payload.bytes, heartbeatString, p->decoded.payload.size);
 
-    service.sendToMesh(p);
+    service->sendToMesh(p);
 
     // TODO: Handle this better. We want to keep the phone awake otherwise it stops sending.
     powerFSM.trigger(EVENT_CONTACT_FROM_PHONE);

--- a/src/modules/RemoteHardwareModule.cpp
+++ b/src/modules/RemoteHardwareModule.cpp
@@ -131,7 +131,7 @@ int32_t RemoteHardwareModule::runOnce()
                 r.type = meshtastic_HardwareMessage_Type_GPIOS_CHANGED;
                 r.gpio_value = curVal;
                 meshtastic_MeshPacket *p = allocDataProtobuf(r);
-                service.sendToMesh(p);
+                service->sendToMesh(p);
             }
         }
     } else {

--- a/src/modules/RoutingModule.cpp
+++ b/src/modules/RoutingModule.cpp
@@ -17,7 +17,7 @@ bool RoutingModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mesh
     // Note: we are careful not to send back packets that started with the phone back to the phone
     if ((mp.to == NODENUM_BROADCAST || mp.to == nodeDB->getNodeNum()) && (mp.from != 0)) {
         printPacket("Delivering rx packet", &mp);
-        service.handleFromRadio(&mp);
+        service->handleFromRadio(&mp);
     }
 
     return false; // Let others look at this message also if they want

--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -236,7 +236,7 @@ void SerialModule::sendTelemetry(meshtastic_Telemetry m)
     p->to = NODENUM_BROADCAST;
     p->decoded.want_response = false;
     p->priority = meshtastic_MeshPacket_Priority_RELIABLE;
-    service.sendToMesh(p, RX_SRC_LOCAL, true);
+    service->sendToMesh(p, RX_SRC_LOCAL, true);
 }
 
 /**
@@ -272,7 +272,7 @@ void SerialModuleRadio::sendPayload(NodeNum dest, bool wantReplies)
     p->decoded.payload.size = serialPayloadSize; // You must specify how many bytes are in the reply
     memcpy(p->decoded.payload.bytes, serialBytes, p->decoded.payload.size);
 
-    service.sendToMesh(p);
+    service->sendToMesh(p);
 }
 
 /**

--- a/src/modules/Telemetry/AirQualityTelemetry.cpp
+++ b/src/modules/Telemetry/AirQualityTelemetry.cpp
@@ -54,7 +54,7 @@ int32_t AirQualityTelemetryModule::runOnce()
             airTime->isTxAllowedAirUtil()) {
             sendTelemetry();
             lastSentToMesh = now;
-        } else if (service.isToPhoneQueueEmpty()) {
+        } else if (service->isToPhoneQueueEmpty()) {
             // Just send to phone when it's not our time to send to mesh yet
             // Only send while queue is empty (phone assumed connected)
             sendTelemetry(NODENUM_BROADCAST, true);
@@ -162,10 +162,10 @@ bool AirQualityTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
         lastMeasurementPacket = packetPool.allocCopy(*p);
         if (phoneOnly) {
             LOG_INFO("Sending packet to phone\n");
-            service.sendToPhone(p);
+            service->sendToPhone(p);
         } else {
             LOG_INFO("Sending packet to mesh\n");
-            service.sendToMesh(p, RX_SRC_LOCAL, true);
+            service->sendToMesh(p, RX_SRC_LOCAL, true);
         }
         return true;
     }

--- a/src/modules/Telemetry/DeviceTelemetry.cpp
+++ b/src/modules/Telemetry/DeviceTelemetry.cpp
@@ -25,7 +25,7 @@ int32_t DeviceTelemetryModule::runOnce()
         config.device.role != meshtastic_Config_DeviceConfig_Role_CLIENT_HIDDEN) {
         sendTelemetry();
         lastSentToMesh = uptimeLastMs;
-    } else if (service.isToPhoneQueueEmpty()) {
+    } else if (service->isToPhoneQueueEmpty()) {
         // Just send to phone when it's not our time to send to mesh yet
         // Only send while queue is empty (phone assumed connected)
         sendTelemetry(NODENUM_BROADCAST, true);
@@ -113,10 +113,10 @@ bool DeviceTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
     nodeDB->updateTelemetry(nodeDB->getNodeNum(), telemetry, RX_SRC_LOCAL);
     if (phoneOnly) {
         LOG_INFO("Sending packet to phone\n");
-        service.sendToPhone(p);
+        service->sendToPhone(p);
     } else {
         LOG_INFO("Sending packet to mesh\n");
-        service.sendToMesh(p, RX_SRC_LOCAL, true);
+        service->sendToMesh(p, RX_SRC_LOCAL, true);
     }
     return true;
 }

--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -161,7 +161,7 @@ int32_t EnvironmentTelemetryModule::runOnce()
             sendTelemetry();
             lastSentToMesh = now;
         } else if (((lastSentToPhone == 0) || ((now - lastSentToPhone) >= sendToPhoneIntervalMs)) &&
-                   (service.isToPhoneQueueEmpty())) {
+                   (service->isToPhoneQueueEmpty())) {
             // Just send to phone when it's not our time to send to mesh yet
             // Only send while queue is empty (phone assumed connected)
             sendTelemetry(NODENUM_BROADCAST, true);
@@ -449,10 +449,10 @@ bool EnvironmentTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
         lastMeasurementPacket = packetPool.allocCopy(*p);
         if (phoneOnly) {
             LOG_INFO("Sending packet to phone\n");
-            service.sendToPhone(p);
+            service->sendToPhone(p);
         } else {
             LOG_INFO("Sending packet to mesh\n");
-            service.sendToMesh(p, RX_SRC_LOCAL, true);
+            service->sendToMesh(p, RX_SRC_LOCAL, true);
 
             if (config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR && config.power.is_power_saving) {
                 LOG_DEBUG("Starting next execution in 5 seconds and then going to sleep.\n");

--- a/src/modules/Telemetry/PowerTelemetry.cpp
+++ b/src/modules/Telemetry/PowerTelemetry.cpp
@@ -78,7 +78,7 @@ int32_t PowerTelemetryModule::runOnce()
             sendTelemetry();
             lastSentToMesh = now;
         } else if (((lastSentToPhone == 0) || ((now - lastSentToPhone) >= sendToPhoneIntervalMs)) &&
-                   (service.isToPhoneQueueEmpty())) {
+                   (service->isToPhoneQueueEmpty())) {
             // Just send to phone when it's not our time to send to mesh yet
             // Only send while queue is empty (phone assumed connected)
             sendTelemetry(NODENUM_BROADCAST, true);
@@ -244,10 +244,10 @@ bool PowerTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
         lastMeasurementPacket = packetPool.allocCopy(*p);
         if (phoneOnly) {
             LOG_INFO("Sending packet to phone\n");
-            service.sendToPhone(p);
+            service->sendToPhone(p);
         } else {
             LOG_INFO("Sending packet to mesh\n");
-            service.sendToMesh(p, RX_SRC_LOCAL, true);
+            service->sendToMesh(p, RX_SRC_LOCAL, true);
 
             if (config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR && config.power.is_power_saving) {
                 LOG_DEBUG("Starting next execution in 5 seconds and then going to sleep.\n");

--- a/src/modules/esp32/AudioModule.cpp
+++ b/src/modules/esp32/AudioModule.cpp
@@ -266,7 +266,7 @@ void AudioModule::sendPayload(NodeNum dest, bool wantReplies)
     p->decoded.payload.size = tx_encode_frame_index;
     memcpy(p->decoded.payload.bytes, tx_encode_frame, p->decoded.payload.size);
 
-    service.sendToMesh(p);
+    service->sendToMesh(p);
 }
 
 ProcessMessage AudioModule::handleReceived(const meshtastic_MeshPacket &mp)

--- a/src/modules/esp32/PaxcounterModule.cpp
+++ b/src/modules/esp32/PaxcounterModule.cpp
@@ -52,7 +52,7 @@ bool PaxcounterModule::sendInfo(NodeNum dest)
     p->decoded.want_response = false;
     p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
 
-    service.sendToMesh(p, RX_SRC_LOCAL, true);
+    service->sendToMesh(p, RX_SRC_LOCAL, true);
 
     paxcounterModule->reportedDataSent = true;
 

--- a/src/modules/esp32/StoreForwardModule.cpp
+++ b/src/modules/esp32/StoreForwardModule.cpp
@@ -211,7 +211,7 @@ bool StoreForwardModule::sendPayload(NodeNum dest, uint32_t last_time)
     meshtastic_MeshPacket *p = preparePayload(dest, last_time);
     if (p) {
         LOG_INFO("*** Sending S&F Payload\n");
-        service.sendToMesh(p);
+        service->sendToMesh(p);
         this->requestCount++;
         return true;
     }
@@ -293,7 +293,7 @@ void StoreForwardModule::sendMessage(NodeNum dest, const meshtastic_StoreAndForw
     p->want_ack = false;
     p->decoded.want_response = false;
 
-    service.sendToMesh(p);
+    service->sendToMesh(p);
 }
 
 /**
@@ -336,7 +336,7 @@ void StoreForwardModule::sendErrorTextMessage(NodeNum dest, bool want_response)
     if (want_response) {
         ignoreRequest = true; // This text message counts as response.
     }
-    service.sendToMesh(pr);
+    service->sendToMesh(pr);
 }
 
 /**

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -83,7 +83,7 @@ void MQTT::onReceive(char *topic, byte *payload, size_t length)
                         if (jsonPayloadStr.length() <= sizeof(p->decoded.payload.bytes)) {
                             memcpy(p->decoded.payload.bytes, jsonPayloadStr.c_str(), jsonPayloadStr.length());
                             p->decoded.payload.size = jsonPayloadStr.length();
-                            service.sendToMesh(p, RX_SRC_LOCAL);
+                            service->sendToMesh(p, RX_SRC_LOCAL);
                         } else {
                             LOG_WARN("Received MQTT json payload too long, dropping\n");
                         }
@@ -114,7 +114,7 @@ void MQTT::onReceive(char *topic, byte *payload, size_t length)
                         p->decoded.payload.size =
                             pb_encode_to_bytes(p->decoded.payload.bytes, sizeof(p->decoded.payload.bytes),
                                                &meshtastic_Position_msg, &pos); // make the Data protobuf from position
-                        service.sendToMesh(p, RX_SRC_LOCAL);
+                        service->sendToMesh(p, RX_SRC_LOCAL);
                     } else {
                         LOG_DEBUG("JSON Ignoring downlink message with unsupported type.\n");
                     }
@@ -245,7 +245,7 @@ bool MQTT::publish(const char *topic, const char *payload, bool retained)
         strcpy(msg->topic, topic);
         strcpy(msg->payload_variant.text, payload);
         msg->retained = retained;
-        service.sendMqttMessageToClientProxy(msg);
+        service->sendMqttMessageToClientProxy(msg);
         return true;
     }
 #if HAS_NETWORKING
@@ -265,7 +265,7 @@ bool MQTT::publish(const char *topic, const uint8_t *payload, size_t length, boo
         msg->payload_variant.data.size = length;
         memcpy(msg->payload_variant.data.bytes, payload, length);
         msg->retained = retained;
-        service.sendMqttMessageToClientProxy(msg);
+        service->sendMqttMessageToClientProxy(msg);
         return true;
     }
 #if HAS_NETWORKING

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -149,7 +149,7 @@ void onToRadioWrite(uint16_t conn_hdl, BLECharacteristic *chr, uint8_t *data, ui
 void setupMeshService(void)
 {
     bluetoothPhoneAPI = new BluetoothPhoneAPI();
-    meshBleservice->begin();
+    meshBleService.begin();
     // Note: You must call .begin() on the BLEService before calling .begin() on
     // any characteristic(s) within that service definition.. Calling .begin() on
     // a BLECharacteristic will cause it to be added to the last BLEService that
@@ -242,10 +242,10 @@ void NRF52Bluetooth::setup()
         Bluefruit.Security.setPairPasskeyCallback(NRF52Bluetooth::onPairingPasskey);
         Bluefruit.Security.setPairCompleteCallback(NRF52Bluetooth::onPairingCompleted);
         Bluefruit.Security.setSecuredCallback(NRF52Bluetooth::onConnectionSecured);
-        meshBleservice->setPermission(SECMODE_ENC_WITH_MITM, SECMODE_ENC_WITH_MITM);
+        meshBleService.setPermission(SECMODE_ENC_WITH_MITM, SECMODE_ENC_WITH_MITM);
     } else {
         Bluefruit.Security.setIOCaps(false, false, false);
-        meshBleservice->setPermission(SECMODE_OPEN, SECMODE_OPEN);
+        meshBleService.setPermission(SECMODE_OPEN, SECMODE_OPEN);
     }
     // Set the advertised device name (keep it short!)
     Bluefruit.setName(getDeviceName());

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -149,7 +149,7 @@ void onToRadioWrite(uint16_t conn_hdl, BLECharacteristic *chr, uint8_t *data, ui
 void setupMeshService(void)
 {
     bluetoothPhoneAPI = new BluetoothPhoneAPI();
-    meshBleService.begin();
+    meshBleservice->begin();
     // Note: You must call .begin() on the BLEService before calling .begin() on
     // any characteristic(s) within that service definition.. Calling .begin() on
     // a BLECharacteristic will cause it to be added to the last BLEService that
@@ -242,10 +242,10 @@ void NRF52Bluetooth::setup()
         Bluefruit.Security.setPairPasskeyCallback(NRF52Bluetooth::onPairingPasskey);
         Bluefruit.Security.setPairCompleteCallback(NRF52Bluetooth::onPairingCompleted);
         Bluefruit.Security.setSecuredCallback(NRF52Bluetooth::onConnectionSecured);
-        meshBleService.setPermission(SECMODE_ENC_WITH_MITM, SECMODE_ENC_WITH_MITM);
+        meshBleservice->setPermission(SECMODE_ENC_WITH_MITM, SECMODE_ENC_WITH_MITM);
     } else {
         Bluefruit.Security.setIOCaps(false, false, false);
-        meshBleService.setPermission(SECMODE_OPEN, SECMODE_OPEN);
+        meshBleservice->setPermission(SECMODE_OPEN, SECMODE_OPEN);
     }
     // Set the advertised device name (keep it short!)
     Bluefruit.setName(getDeviceName());

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -97,6 +97,7 @@ void portduinoSetup()
     settingsStrings[webserverrootpath] = "";
     settingsStrings[spidev] = "";
     settingsStrings[displayspidev] = "";
+    settingsMap[spiSpeed] = 2000000;
 
     YAML::Node yamlConfig;
 
@@ -173,6 +174,7 @@ void portduinoSetup()
             settingsMap[rxen] = yamlConfig["Lora"]["RXen"].as<int>(RADIOLIB_NC);
             settingsMap[gpiochip] = yamlConfig["Lora"]["gpiochip"].as<int>(0);
             settingsMap[ch341Quirk] = yamlConfig["Lora"]["ch341_quirk"].as<bool>(false);
+            settingsMap[spiSpeed] = yamlConfig["Lora"]["spiSpeed"].as<int>(2000000);
             gpioChipName += std::to_string(settingsMap[gpiochip]);
 
             settingsStrings[spidev] = "/dev/" + yamlConfig["Lora"]["spidev"].as<std::string>("spidev0.0");

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -282,6 +282,7 @@ void portduinoSetup()
         }
 
         settingsMap[maxnodes] = (yamlConfig["General"]["MaxNodes"]).as<int>(200);
+        settingsMap[maxtophone] = (yamlConfig["General"]["MaxMessageQueue"]).as<int>(100);
 
     } catch (YAML::Exception &e) {
         std::cout << "*** Exception " << e.what() << std::endl;

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -52,6 +52,7 @@ enum configNames {
     webserver,
     webserverport,
     webserverrootpath,
+    maxtophone,
     maxnodes
 };
 enum { no_screen, x11, st7789, st7735, st7735s, st7796, ili9341, ili9488, hx8357d };

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -19,6 +19,7 @@ enum configNames {
     user,
     gpiochip,
     spidev,
+    spiSpeed,
     i2cdev,
     has_gps,
     touchscreenModule,

--- a/src/platform/portduino/SimRadio.cpp
+++ b/src/platform/portduino/SimRadio.cpp
@@ -199,8 +199,8 @@ void SimRadio::startSend(meshtastic_MeshPacket *txp)
         pb_encode_to_bytes(p->decoded.payload.bytes, sizeof(p->decoded.payload.bytes), &meshtastic_Compressed_msg, &c);
     p->decoded.portnum = meshtastic_PortNum_SIMULATOR_APP;
 
-    service.sendQueueStatusToPhone(router->getQueueStatus(), 0, p->id);
-    service.sendToPhone(p); // Sending back to simulator
+    service->sendQueueStatusToPhone(router->getQueueStatus(), 0, p->id);
+    service->sendToPhone(p); // Sending back to simulator
 }
 
 void SimRadio::startReceive(meshtastic_MeshPacket *p)

--- a/variants/heltec_mesh_node_t114/variant.h
+++ b/variants/heltec_mesh_node_t114/variant.h
@@ -126,8 +126,8 @@ No longer populated on PCB
 #define LORA_CS (0 + 24)
 #define SX126X_DIO1 (0 + 20)
 // Note DIO2 is attached internally to the module to an analog switch for TX/RX switching
-// #define SX1262_DIO3 \
-//    (0 + 21) // This is used as an *output* from the sx1262 and connected internally to power the tcxo, do not drive from the
+// #define SX1262_DIO3 (0 + 21)
+// This is used as an *output* from the sx1262 and connected internally to power the tcxo, do not drive from the
 //    main
 // CPU?
 #define SX126X_BUSY (0 + 17)

--- a/variants/portduino/variant.h
+++ b/variants/portduino/variant.h
@@ -1,5 +1,6 @@
 #define HAS_SCREEN 1
 #define CANNED_MESSAGE_MODULE_ENABLE 1
 #define HAS_GPS 1
+#define MAX_RX_TOPHONE settingsMap[maxtophone]
 #define MAX_NUM_NODES settingsMap[maxnodes]
 #define RADIOLIB_GODMODE 1


### PR DESCRIPTION
At times setting SPI to 4Mhz can cause CRC errors, aka -7 errors in Radiolib. This sets the default to 2Mhz for LoRa communication, and makes it configurable.