### PR TITLE
Automatically generate .uf2 files anytime we generate a .hex file for nrf52

### DIFF
--- a/bin/platformio-custom.py
+++ b/bin/platformio-custom.py
@@ -78,6 +78,11 @@ if platform.name == "espressif32":
         # For newer ESP32 targets, using newlib nano works better.
         env.Append(LINKFLAGS=["--specs=nano.specs", "-u", "_printf_float"])
 
+if platform.name == "nordicnrf52":
+    env.AddPostAction("$BUILD_DIR/${PROGNAME}.hex",
+                      env.VerboseAction(f"python ./bin/uf2conv.py $BUILD_DIR/firmware.hex -c -f 0xADA52840 -o $BUILD_DIR/firmware.uf2",
+                                        "Generating UF2 file"))
+
 Import("projenv")
 
 prefsLoc = projenv["PROJECT_DIR"] + "/version.properties"
@@ -90,13 +95,4 @@ projenv.Append(
         "-DAPP_VERSION=" + verObj["long"],
         "-DAPP_VERSION_SHORT=" + verObj["short"],
     ]
-)
-
-# Add a custom p.io project task to run the UF2 conversion script.
-env.AddCustomTarget(
-    name="Convert Hex to UF2",
-    dependencies=None,
-    actions=["PYTHON .\\bin\\uf2conv.py $BUILD_DIR\$env\\firmware.hex -c -f 0xADA52840 -o $BUILD_DIR\$env\\firmware.uf2"],
-    title="Convert hex to uf2",
-    description="Runs the python script to convert an already-built .hex file into .uf2 for copying to a device"
 )


### PR DESCRIPTION
* Automatically generate .uf2 files (which are often used by nrf52 bootloaders for installing app loads) anytime we generate a new hex file.  This tool takes very little time to run and it is handy for development

* Remove an old custom target I had tried to add to autogen uf2 files (that never worked)

Build output now looks like:

```
$ pio run --environment tracker-t1000-e
Processing tracker-t1000-e (board: tracker-t1000-e; platform: platformio/nordicnrf52@^10.5.0; framework: arduino) ...
...
Generating UF2 file
Converting to uf2, output size: 1395200, start address: 0x27000 Wrote 1395200 bytes to /home/kevinh/development/meshtastic/firmware/.pio/build/tracker-t1000-e/firmware.uf2 
Building .pio/build/tracker-t1000-e/firmware.zip
Zip created at .pio/build/tracker-t1000-e/firmware.zip 
...
```