### PR TITLE
Fix build to not use incorrect OneButton version

### DIFF
--- a/arch/stm32/stm32.ini
+++ b/arch/stm32/stm32.ini
@@ -32,5 +32,5 @@ lib_deps =
   https://github.com/caveman99/Crypto.git#f61ae26a53f7a2d0ba5511625b8bf8eff3a35d5e
 
 lib_ignore =
-  mathertel/OneButton
+  mathertel/OneButton@^~2.5.0
   Wire

--- a/arch/stm32/stm32.ini
+++ b/arch/stm32/stm32.ini
@@ -32,5 +32,5 @@ lib_deps =
   https://github.com/caveman99/Crypto.git#f61ae26a53f7a2d0ba5511625b8bf8eff3a35d5e
 
 lib_ignore =
-  mathertel/OneButton@^~2.6.1
+  https://github.com/mathertel/OneButton@~2.6.1
   Wire

--- a/arch/stm32/stm32.ini
+++ b/arch/stm32/stm32.ini
@@ -32,5 +32,5 @@ lib_deps =
   https://github.com/caveman99/Crypto.git#f61ae26a53f7a2d0ba5511625b8bf8eff3a35d5e
 
 lib_ignore =
-  mathertel/OneButton@^~2.5.0
+  mathertel/OneButton@^~2.6.1
   Wire

--- a/platformio.ini
+++ b/platformio.ini
@@ -86,7 +86,7 @@ monitor_filters = direct
 lib_deps =
   jgromes/RadioLib@~6.6.0
   https://github.com/meshtastic/esp8266-oled-ssd1306.git#e16cee124fe26490cb14880c679321ad8ac89c95 ; ESP8266_SSD1306
-  mathertel/OneButton@^2.5.0 ; OneButton library for non-blocking button debounce
+  mathertel/OneButton@~2.5.0 ; OneButton library for non-blocking button debounce
   https://github.com/meshtastic/arduino-fsm.git#7db3702bf0cfe97b783d6c72595e3f38e0b19159
   https://github.com/meshtastic/TinyGPSPlus.git#71a82db35f3b973440044c476d4bcdc673b104f4
   https://github.com/meshtastic/ArduinoThread.git#1ae8778c85d0a2a729f989e0b1e7d7c4dc84eef0

--- a/platformio.ini
+++ b/platformio.ini
@@ -86,7 +86,7 @@ monitor_filters = direct
 lib_deps =
   jgromes/RadioLib@~6.6.0
   https://github.com/meshtastic/esp8266-oled-ssd1306.git#e16cee124fe26490cb14880c679321ad8ac89c95 ; ESP8266_SSD1306
-  mathertel/OneButton@~2.5.0 ; OneButton library for non-blocking button debounce
+  mathertel/OneButton@~2.6.1 ; OneButton library for non-blocking button debounce
   https://github.com/meshtastic/arduino-fsm.git#7db3702bf0cfe97b783d6c72595e3f38e0b19159
   https://github.com/meshtastic/TinyGPSPlus.git#71a82db35f3b973440044c476d4bcdc673b104f4
   https://github.com/meshtastic/ArduinoThread.git#1ae8778c85d0a2a729f989e0b1e7d7c4dc84eef0

--- a/platformio.ini
+++ b/platformio.ini
@@ -86,7 +86,7 @@ monitor_filters = direct
 lib_deps =
   jgromes/RadioLib@~6.6.0
   https://github.com/meshtastic/esp8266-oled-ssd1306.git#e16cee124fe26490cb14880c679321ad8ac89c95 ; ESP8266_SSD1306
-  mathertel/OneButton@~2.6.1 ; OneButton library for non-blocking button debounce
+  https://github.com/mathertel/OneButton@~2.6.1 ; OneButton library for non-blocking button debounce
   https://github.com/meshtastic/arduino-fsm.git#7db3702bf0cfe97b783d6c72595e3f38e0b19159
   https://github.com/meshtastic/TinyGPSPlus.git#71a82db35f3b973440044c476d4bcdc673b104f4
   https://github.com/meshtastic/ArduinoThread.git#1ae8778c85d0a2a729f989e0b1e7d7c4dc84eef0


### PR DESCRIPTION
OneButton pushed out a new update today that has a different API rather than just use whichever new version they push, stay on 2.5.x until someone sees a need to update.  Fixes build for wm1100 tracker.


