### PR TITLE
Generalize SWD debugging stuff so it works on all nrf52 targets.

### DIFF
--- a/arch/nrf52/nrf52840.ini
+++ b/arch/nrf52/nrf52840.ini
@@ -7,3 +7,72 @@ lib_deps =
   ${nrf52_base.lib_deps}
   ${environmental_base.lib_deps}
   https://github.com/Kongduino/Adafruit_nRFCrypto.git#e31a8825ea3300b163a0a3c1ddd5de34e10e1371
+
+; Common NRF52 debugging settings follow.  See the Meshtastic developer docs for how to connect SWD debugging probes to your board.
+
+; We want the initial breakpoint at setup() instead of main().  Also we want to enable semihosting at that point so instead of
+debug_init_break = tbreak setup
+; we just turn off the platformio tbreak and do it in .gdbinit (where we have more flexibility for scripting)
+; also we use a permanent breakpoint so it gets reused each time we restart the debugging session?
+; debug_init_break = tbreak main
+
+; Note: add "monitor arm semihosting_redirect tcp 4444 all" if you want the stdout from the device to go to that port number instead
+; (for use by meshtastic command line)
+;  monitor arm semihosting disable
+;  monitor debug_level 3
+;
+; IMPORTANT: fileio must be disabled before using port 5555 - openocd ver 0.12 has a bug where if enabled it never properly parses the special :tt name
+; for stdio access.
+;   monitor arm semihosting_redirect tcp 5555 stdio
+
+; Also note: it is _impossible_ to do non blocking reads on the semihost console port (an oversight when ARM specified the semihost API).
+; So we'll neve be able to general purpose bi-directional communication with the device over semihosting.
+debug_extra_cmds =
+  echo Running .gdbinit script
+  ;monitor arm semihosting enable
+  ;monitor arm semihosting_fileio enable
+  ;monitor arm semihosting_redirect disable
+  commands 1
+  ; echo Breakpoint at setup() has semihosting console, connect to it with "telnet localhost 5555"
+  ; set wantSemihost = 1
+  set useSoftDevice = 0
+  end
+
+  ; Only reprogram the board if the code has changed
+debug_load_mode = modified
+;debug_load_mode = manual
+; We default to the stlink adapter because it is very cheap and works well, though others (such as jlink) are also supported.
+;debug_tool = jlink
+debug_tool = stlink
+debug_speed = 4000
+;debug_tool = custom
+; debug_server =
+;  openocd
+;  -f
+;  /usr/local/share/openocd/scripts/interface/stlink.cfg
+;  -f
+;  /usr/local/share/openocd/scripts/target/nrf52.cfg
+; $PLATFORMIO_CORE_DIR/packages/tool-openocd/openocd/scripts/interface/cmsis-dap.cfg
+
+; Allows programming and debug via the RAK NanoDAP as the default debugger tool for the RAK4631 (it is only $10!)
+; programming time is about the same as the bootloader version.
+; For information on this see the meshtastic developers documentation for "Development on the NRF52"
+; We manually pass in the elf file so that pyocd can reverse engineer FreeRTOS data (running threads, etc...)
+;debug_server =
+;  pyocd
+;  gdbserver
+;  -j
+;  ${platformio.workspace_dir}/..
+;  -t
+;  nrf52840
+;  --semihosting
+;  --elf
+;  ${platformio.build_dir}/${this.__env__}/firmware.elf
+
+; If you want to debug the semihosting support you can turn on extra logging in pyocd with
+;   -L
+;   pyocd.debug.semihost.trace=debug
+
+; The following is not needed because it automatically tries do this
+;debug_server_ready_pattern = -.*GDB server started on port \d+.*
+;debug_port = localhost:3333

--- a/bin/wio_tracker_bootloader_update.bin
+++ b/bin/wio_tracker_bootloader_update.bin
@@ -1,0 +1,30 @@
+# tips from mark on how to replace the (broken) bootloader on the red wio_tracker_1110 boards.
+
+~/.platformio/penv/bin/adafruit-nrfutil --verbose dfu serial --package wio_tracker_1110_bootloader-0.9.1_s140_7.3.0.zip -p /dev/ttyACM1 -b 115200 --singlebank --touch 1200
+
+exit
+
+# Output should look like
+
+Upgrading target on /dev/ttyACM1 with DFU package /home/kevinh/development/meshtastic/WioWM1110/wio_tracker_1110_bootloader-0.9.1_s140_7.3.0.zip. Flow control is disabled, Single bank, Touch 1200
+Touched serial port /dev/ttyACM1
+Opened serial port /dev/ttyACM1
+Starting DFU upgrade of type 3, SoftDevice size: 152728, bootloader size: 39000, application size: 0
+Sending DFU start packet
+Sending DFU init packet
+Sending firmware file
+########################################
+########################################
+########################################
+########################################
+########################################
+########################################
+########################################
+########################################
+########################################
+###############
+Activating new firmware
+
+DFU upgrade took 20.242434978485107s
+Device programmed.
+

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -17,9 +17,6 @@ lib_deps =
   https://github.com/RAKWireless/RAK13800-W5100S.git#1.0.2
   rakwireless/RAKwireless NCP5623 RGB LED library@^1.0.2
   https://github.com/meshtastic/RAK12034-BMX160.git#4821355fb10390ba8557dc43ca29a023bcfbb9d9
-debug_tool = jlink
-
-
 
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
 ; Note: as of 6/2013 the serial/bootloader based programming takes approximately 30 seconds
@@ -53,68 +50,3 @@ upload_protocol = stlink
 ; eventually use platformio/tool-pyocd@^2.3600.0 instad
 ;upload_protocol = custom
 ;upload_command = pyocd flash -t nrf52840 $UPLOADERFLAGS $SOURCE
-
-; We want the initial breakpoint at setup() instead of main().  Also we want to enable semihosting at that point so instead of
-; debug_init_break = tbreak setup
-; we just turn off the platformio tbreak and do it in .gdbinit (where we have more flexibility for scripting)
-; also we use a permanent breakpoint so it gets reused each time we restart the debugging session?
-debug_init_break = tbreak setup
-
-; Note: add "monitor arm semihosting_redirect tcp 4444 all" if you want the stdout from the device to go to that port number instead
-; (for use by meshtastic command line)
-;  monitor arm semihosting disable
-;  monitor debug_level 3
-;
-; IMPORTANT: fileio must be disabled before using port 5555 - openocd ver 0.12 has a bug where if enabled it never properly parses the special :tt name
-; for stdio access.
-;   monitor arm semihosting_redirect tcp 5555 stdio
-
-; Also note: it is _impossible_ to do non blocking reads on the semihost console port (an oversight when ARM specified the semihost API).
-; So we'll neve be able to general purpose bi-directional communication with the device over semihosting.
-debug_extra_cmds =
-  echo Running .gdbinit script
-  monitor arm semihosting enable
-  monitor arm semihosting_fileio enable
-  monitor arm semihosting_redirect disable
-  commands 1
-  echo Breakpoint at setup() has semihosting console, connect to it with "telnet localhost 5555"
-  set wantSemihost = true
-  set useSoftDevice = false
-  end
-
-
-; Only reprogram the board if the code has changed
-debug_load_mode = modified
-;debug_load_mode = manual
-debug_tool = stlink
-;debug_tool = custom
-; debug_server =
-;  openocd
-;  -f
-;  /usr/local/share/openocd/scripts/interface/stlink.cfg
-;  -f
-;  /usr/local/share/openocd/scripts/target/nrf52.cfg
-; $PLATFORMIO_CORE_DIR/packages/tool-openocd/openocd/scripts/interface/cmsis-dap.cfg
-
-; Allows programming and debug via the RAK NanoDAP as the default debugger tool for the RAK4631 (it is only $10!)
-; programming time is about the same as the bootloader version.
-; For information on this see the meshtastic developers documentation for "Development on the NRF52"
-; We manually pass in the elf file so that pyocd can reverse engineer FreeRTOS data (running threads, etc...)
-;debug_server =
-;  pyocd
-;  gdbserver
-;  -j
-;  ${platformio.workspace_dir}/..
-;  -t
-;  nrf52840
-;  --semihosting
-;  --elf
-;  ${platformio.build_dir}/${this.__env__}/firmware.elf
-
-; If you want to debug the semihosting support you can turn on extra logging in pyocd with
-;   -L
-;   pyocd.debug.semihost.trace=debug
-
-; The following is not needed because it automatically tries do this
-;debug_server_ready_pattern = -.*GDB server started on port \d+.*
-;debug_port = localhost:3333

--- a/variants/wio-tracker-wm1110/platformio.ini
+++ b/variants/wio-tracker-wm1110/platformio.ini
@@ -9,6 +9,5 @@ board_build.ldscript = src/platform/nrf52/nrf52840_s140_v7.ld
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/wio-tracker-wm1110>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-debug_tool = jlink
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
 ;upload_protocol = jlink


### PR DESCRIPTION
* Move the SWD debugging support I added to rak4631 up into the shared nrf52 platform.ini file - this allows SWD debugging on all of our targets.  I defaulted to using "stlink" USB debugging dongles instead of "jlink" because stlinks are much cheaper and just as fast.  This shouldn't change behavior for anyone who was already doing debugging because most of the nrf52 projects have been manually slamming in jlink instead.

* Add a small script in bin for installing bootloaders on wio tracker boards (per @markbirss wisdom) mostly as documentation for other advanced developers.
