### PR TITLE
Actually set the rand() seed for Portduino

### DIFF
--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -7,6 +7,7 @@
 
 #include <Utility.h>
 #include <assert.h>
+#include <time.h>
 
 #include "PortduinoGlue.h"
 #include "linux/gpio/LinuxGPIOPin.h"
@@ -133,6 +134,9 @@ void portduinoSetup()
         randomSeed(TCPPort);
         return;
     }
+
+    // Rather important to set this, if not running simulated.
+    randomSeed(time(NULL));
 
     try {
         if (yamlConfig["Logging"]) {


### PR DESCRIPTION
Turns out we weren't actually seeding random on Portduino. In the future I'd like to do a true randomness implementation when not seeded, but this fixes the immediate problem for now.