### PR TITLE
Remove LED_INVERTED, see below for why ;-)

### DIFF
--- a/src/DebugConfiguration.h
+++ b/src/DebugConfiguration.h
@@ -3,8 +3,8 @@
 #include "configuration.h"
 
 // DEBUG LED
-#ifndef LED_INVERTED
-#define LED_INVERTED 0 // define as 1 if LED is active low (on)
+#ifndef LED_STATE_ON
+#define LED_STATE_ON 1
 #endif
 
 // -----------------------------------------------------------------------------

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -583,7 +583,7 @@ void setup()
 
 #ifdef LED_PIN
     pinMode(LED_PIN, OUTPUT);
-    digitalWrite(LED_PIN, 1 ^ LED_INVERTED); // turn on for now
+    digitalWrite(LED_PIN, LED_STATE_ON); // turn on for now
 #endif
 
     // Hello
@@ -728,7 +728,7 @@ void setup()
 #ifdef LED_PIN
     // Turn LED off after boot, if heartbeat by config
     if (config.device.led_heartbeat_disabled)
-        digitalWrite(LED_PIN, LOW ^ LED_INVERTED);
+        digitalWrite(LED_PIN, HIGH ^ LED_STATE_ON);
 #endif
 
 // Do this after service.init (because that clears error_code)

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -372,7 +372,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c)
 #ifdef LED_PIN
         // Turn LED off if heartbeat by config
         if (c.payload_variant.device.led_heartbeat_disabled) {
-            digitalWrite(LED_PIN, LOW ^ LED_INVERTED);
+            digitalWrite(LED_PIN, HIGH ^ LED_STATE_ON);
         }
 #endif
         if (config.device.button_gpio == c.payload_variant.device.button_gpio &&

--- a/src/platform/nrf52/architecture.h
+++ b/src/platform/nrf52/architecture.h
@@ -75,16 +75,16 @@
 #ifdef ARDUINO_NRF52840_PCA10056
 
 // This board uses 0 to be mean LED on
-#undef LED_INVERTED
-#define LED_INVERTED 1
+#undef LED_STATE_ON
+#define LED_STATE_ON 0 // State when LED is lit
 
 #endif
 
 #ifdef _SEEED_XIAO_NRF52840_SENSE_H_
 
 // This board uses 0 to be mean LED on
-#undef LED_INVERTED
-#define LED_INVERTED 1
+#undef LED_STATE_ON
+#define LED_STATE_ON 0 // State when LED is lit
 
 #endif
 

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -90,7 +90,7 @@ void setLed(bool ledOn)
 
 #ifdef LED_PIN
     // toggle the led so we can get some rough sense of how often loop is pausing
-    digitalWrite(LED_PIN, ledOn ^ LED_INVERTED);
+    digitalWrite(LED_PIN, ledOn ^ LED_STATE_ON ^ HIGH);
 #endif
 
 #ifdef HAS_PMU

--- a/variants/EBYTE_ESP32-S3/variant.h
+++ b/variants/EBYTE_ESP32-S3/variant.h
@@ -101,7 +101,7 @@
 
 // Status
 #define LED_PIN 1
-#define LED_INVERTED 0
+#define LED_STATE_ON 1 // State when LED is lit
 // External notification
 // FIXME: Check if EXT_NOTIFY_OUT actualy has any effect and removes the need for setting the external notication pin in the
 // app/preferences

--- a/variants/canaryone/variant.h
+++ b/variants/canaryone/variant.h
@@ -56,7 +56,6 @@ extern "C" {
 #define LED_CONN PIN_LED3
 
 #define LED_STATE_ON 0 // State when LED is lit
-#define LED_INVERTED 1
 
 /*
  * Buttons

--- a/variants/heltec_esp32c3/variant.h
+++ b/variants/heltec_esp32c3/variant.h
@@ -3,8 +3,8 @@
 // LED pin on HT-DEV-ESP_V2 and HT-DEV-ESP_V3
 // https://resource.heltec.cn/download/HT-CT62/HT-CT62_Reference_Design.pdf
 // https://resource.heltec.cn/download/HT-DEV-ESP/HT-DEV-ESP_V3_Sch.pdf
-#define LED_PIN 2 // LED
-#define LED_INVERTED 0
+#define LED_PIN 2      // LED
+#define LED_STATE_ON 1 // State when LED is lit
 
 #define HAS_SCREEN 0
 #define HAS_GPS 0

--- a/variants/heltec_mesh_node_t114/variant.h
+++ b/variants/heltec_mesh_node_t114/variant.h
@@ -80,7 +80,6 @@ extern "C" {
 #define LED_CONN PIN_GREEN
 
 #define LED_STATE_ON 0 // State when LED is lit
-#define LED_INVERTED 1
 
 /*
  * Buttons

--- a/variants/m5stack_coreink/variant.h
+++ b/variants/m5stack_coreink/variant.h
@@ -10,7 +10,7 @@
 // #define GPS_TX_PIN 32 (now used by SX1262 BUSY as GPS works with just RX)
 
 // Green LED
-#define LED_INVERTED 0
+#define LED_STATE_ON 1 // State when LED is lit
 #define LED_PIN 10
 
 #include "pcf8563.h"

--- a/variants/nano-g2-ultra/variant.h
+++ b/variants/nano-g2-ultra/variant.h
@@ -54,7 +54,6 @@ extern "C" {
 #define LED_CONN PIN_GREEN
 
 #define LED_STATE_ON 0 // State when LED is lit
-// #define LED_INVERTED 1
 
 /*
  * Buttons

--- a/variants/t-echo/variant.h
+++ b/variants/t-echo/variant.h
@@ -56,7 +56,6 @@ extern "C" {
 #define LED_CONN PIN_GREEN
 
 #define LED_STATE_ON 0 // State when LED is lit
-#define LED_INVERTED 1
 
 /*
  * Buttons

--- a/variants/tbeam-s3-core/variant.h
+++ b/variants/tbeam-s3-core/variant.h
@@ -11,7 +11,7 @@
 //  anywhere.
 //  #define EXT_NOTIFY_OUT 13 // Default pin to use for Ext Notify Module.
 
-#define LED_INVERTED 1
+#define LED_STATE_ON 0 // State when LED is lit
 
 // TTGO uses a common pinout for their SX1262 vs RF95 modules - both can be enabled and we will probe at runtime for RF95 and if
 // not found then probe for SX1262

--- a/variants/tbeam/variant.h
+++ b/variants/tbeam/variant.h
@@ -8,8 +8,8 @@
 //  anywhere.
 #define EXT_NOTIFY_OUT 13 // Default pin to use for Ext Notify Module.
 
-#define LED_INVERTED 1
-#define LED_PIN 4 // Newer tbeams (1.1) have an extra led on GPIO4
+#define LED_STATE_ON 0 // State when LED is lit
+#define LED_PIN 4      // Newer tbeams (1.1) have an extra led on GPIO4
 
 // TTGO uses a common pinout for their SX1262 vs RF95 modules - both can be enabled and we will probe at runtime for RF95 and if
 // not found then probe for SX1262

--- a/variants/unphone/variant.h
+++ b/variants/unphone/variant.h
@@ -51,8 +51,8 @@
 // #define HAS_SDCARD 1 // causes hang if defined
 #define SDCARD_CS 43
 
-#define LED_PIN 13 // the red part of the RGB LED
-#define LED_INVERTED 1
+#define LED_PIN 13     // the red part of the RGB LED
+#define LED_STATE_ON 0 // State when LED is lit
 
 #define BUTTON_PIN 21      // Button 3 - square - top button in landscape mode
 #define BUTTON_NEED_PULLUP // we do need a helping hand up


### PR DESCRIPTION
While working on #4378 I noticed a funny problem: the blinking system LED was on during deep-sleep.  Initially I thought it was some weird sleep hw config thing but it turns out it was easier but more pervasive.

We had two different preprocessor symbols which both meant approximately the same thing LED_INVERTED and LED_STATE_ON (though their polarity was opposite). Some variant files were setting one, others were setting the other, and others were setting both. heh.

In the case of the board I was testing (seeed tracker wio 1100) it was only setting one and the default behavior for the other (for all boards) was incorrect.  So I did a grep and it seems like LED_STATE_ON was used more often, so I kept that one and removed LED_INVERTED everywhere.

