### PR TITLE
Make lora radio reset reliable on wio-tracker-1100 and lower lr11x0 power consumption in sleep

### DIFF
--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -285,17 +285,15 @@ template <typename T> bool LR11x0Interface<T>::isActivelyReceiving()
 
 template <typename T> bool LR11x0Interface<T>::sleep()
 {
-    // Not keeping config is busted - next time nrf52 board boots lora sending fails  tcxo related? - see datasheet
     // \todo Display actual typename of the adapter, not just `LR11x0`
-    LOG_DEBUG("LR11x0 entering sleep mode (FIXME, don't keep config)\n");
+    LOG_DEBUG("LR11x0 entering sleep mode\n");
     setStandby(); // Stop any pending operations
 
     // turn off TCXO if it was powered
-    // FIXME - this isn't correct
-    // lora.setTCXO(0);
+    lora.setTCXO(0);
 
     // put chipset into sleep mode (we've already disabled interrupts by now)
-    bool keepConfig = true;
+    bool keepConfig = false;
     lora.sleep(keepConfig, 0); // Note: we do not keep the config, full reinit will be needed
 
 #ifdef LR11X0_POWER_EN

--- a/variants/wio-tracker-wm1110/variant.h
+++ b/variants/wio-tracker-wm1110/variant.h
@@ -79,9 +79,9 @@ extern "C" {
 #define PIN_SPI_SCK (32 + 13)  // P1.13 45
 #define PIN_SPI_NSS (32 + 12)  // P1.12 44
 
-#define LORA_RESET (0 + 18) // P0.18 18 // RST
-#define LORA_DIO1 (0 + 2)   // P0.02 2 // IRQ
-#define LORA_DIO2 (32 + 11) // P1.11 43 // BUSY
+#define LORA_RESET (32 + 10) // P1.10 10 // RST
+#define LORA_DIO1 (0 + 2)    // P0.02 2 // IRQ
+#define LORA_DIO2 (32 + 11)  // P1.11 43 // BUSY
 #define LORA_SCK PIN_SPI_SCK
 #define LORA_MISO PIN_SPI_MISO
 #define LORA_MOSI PIN_SPI_MOSI


### PR DESCRIPTION
Two related changes:

* Fix wio-tracker-1110 lora radio reset GPIO assignment 
This fixes flaky lora radio init on this board.  Prior to this change while debugging I would often see the lr11x0 fail to init.

* No need to keep lr11x0 radio config during sleep anymore, also stop TCXO

I think the problem (at least on the board I'm using for power testing
a wio tracker 1110) was that actually the RESET GPIO was not correct for
the radio.  This led to the radio not being properly reinited after exiting
sleep mode.

Now that the GPIO is fixed I can enter deep sleep (fully shutting down
radio) and then later when the CPU resets, it can successfully init the
radio and send packets.

After this seeming success, I also turned off the TCXO during sleep and that
worked as well.
