### PR TITLE
Configure pin modes of selected pins before attempting to write to them in Remote Hardware module

### DIFF
--- a/src/modules/RemoteHardwareModule.cpp
+++ b/src/modules/RemoteHardwareModule.cpp
@@ -60,13 +60,13 @@ bool RemoteHardwareModule::handleReceivedProtobuf(const meshtastic_MeshPacket &r
             // Print notification to LCD screen
             screen->print("Write GPIOs\n");
 
+            pinModes(p.gpio_mask, OUTPUT);
             for (uint8_t i = 0; i < NUM_GPIOS; i++) {
                 uint64_t mask = 1ULL << i;
                 if (p.gpio_mask & mask) {
                     digitalWrite(i, (p.gpio_value & mask) ? 1 : 0);
                 }
             }
-            pinModes(p.gpio_mask, OUTPUT);
 
             break;
         }


### PR DESCRIPTION
This is a small change to properly configure the correct pin mode before attempting to write to the specified pins in the mask in the Remote Hardware module. This change fixes Remote Hardware writes on RP2040-based devices.

Previously, the pin modes were set after the writes had taken place, and it seems like the Arduino core for ESP32 implicitly set the target pin to `OUTPUT` automagically before writing if it wasn't set prior. This does not appear to be the case with the `arduino-pico` core so writes to a misconfigured pin would just silently fail.