### PR TITLE
Add Minewsemi LR1110+nRF52840-ME25LS01 [both 4.2inch e-ink and non e-ink varaint]

### DIFF
--- a/boards/me25ls01-4y10td.json
+++ b/boards/me25ls01-4y10td.json
@@ -1,0 +1,58 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "nrf52840_s140_v7.ld"
+    },
+    "core": "nRF5",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DARDUINO_WIO_WM1110 -DNRF52840_XXAA",
+    "f_cpu": "64000000L",
+    "hwids": [
+      ["0x239A", "0x8029"],
+      ["0x239A", "0x0029"],
+      ["0x239A", "0x002A"],
+      ["0x239A", "0x802A"]
+    ],
+    "usb_product": "ME25LS01-BOOT",
+    "mcu": "nrf52840",
+    "variant": "MINEWSEMI_ME25LS01",
+    "bsp": {
+      "name": "adafruit"
+    },
+    "softdevice": {
+      "sd_flags": "-DS140",
+      "sd_name": "s140",
+      "sd_version": "7.3.0",
+      "sd_fwid": "0x0123"
+    },
+    "bootloader": {
+      "settings_addr": "0xFF000"
+    }
+  },
+  "connectivity": ["bluetooth"],
+  "debug": {
+    "jlink_device": "nRF52840_xxAA",
+    "svd_path": "nrf52840.svd"
+  },
+  "frameworks": ["arduino"],
+  "name": "Minesemi ME25LS01",
+  "upload": {
+    "maximum_ram_size": 248832,
+    "maximum_size": 815104,
+    "speed": 115200,
+    "protocol": "nrfutil",
+    "protocols": [
+      "jlink",
+      "nrfjprog",
+      "nrfutil",
+      "stlink",
+      "cmsis-dap",
+      "blackmagic"
+    ],
+    "use_1200bps_touch": true,
+    "require_upload_port": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://en.minewsemi.com/lora-module/lr1110-nrf52840-me25LS01l",
+  "vendor": "Minesemi"
+}

--- a/src/graphics/EInkDisplay2.cpp
+++ b/src/graphics/EInkDisplay2.cpp
@@ -174,13 +174,13 @@ bool EInkDisplay::connect()
         adafruitDisplay->init();
         adafruitDisplay->setRotation(3);
     }
-#elif defined(PCA10059)
+#elif defined(PCA10059) || defined(ME25LS01)
     {
         auto lowLevel = new EINK_DISPLAY_MODEL(PIN_EINK_CS, PIN_EINK_DC, PIN_EINK_RES, PIN_EINK_BUSY);
         adafruitDisplay = new GxEPD2_BW<EINK_DISPLAY_MODEL, EINK_DISPLAY_MODEL::HEIGHT>(*lowLevel);
-        adafruitDisplay->init(115200, true, 10, false, SPI1, SPISettings(4000000, MSBFIRST, SPI_MODE0));
-        adafruitDisplay->setRotation(3);
-        adafruitDisplay->setPartialWindow(0, 0, displayWidth, displayHeight);
+        adafruitDisplay->init(115200, true, 40, false, SPI1, SPISettings(4000000, MSBFIRST, SPI_MODE0));
+        adafruitDisplay->setRotation(0);
+        adafruitDisplay->setPartialWindow(0, 0, EINK_WIDTH, EINK_HEIGHT);
     }
 #elif defined(M5_COREINK)
     auto lowLevel = new EINK_DISPLAY_MODEL(PIN_EINK_CS, PIN_EINK_DC, PIN_EINK_RES, PIN_EINK_BUSY);

--- a/variants/ME25LS01-4Y10TD/platformio.ini
+++ b/variants/ME25LS01-4Y10TD/platformio.ini
@@ -1,9 +1,9 @@
 [env:ME25LS01-4Y10TD]
 extends = nrf52840_base
 board = me25ls01-4y10td
-; board_level = extra
+board_level = extra
 ; platform = https://github.com/maxgerhardt/platform-nordicnrf52#cac6fcf943a41accd2aeb4f3659ae297a73f422e
-build_flags = ${nrf52840_base.build_flags} -Ivariants/ME25LS01-4Y10TD -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52 -DME25LS01_4Y10TD -DRADIOLIB_GODMODE
+build_flags = ${nrf52840_base.build_flags} -Ivariants/ME25LS01-4Y10TD -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52 -DME25LS01_4Y10TD ;-DRADIOLIB_GODMODE
   -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
 board_build.ldscript = src/platform/nrf52/nrf52840_s140_v7.ld

--- a/variants/ME25LS01-4Y10TD/platformio.ini
+++ b/variants/ME25LS01-4Y10TD/platformio.ini
@@ -1,0 +1,16 @@
+[env:ME25LS01-4Y10TD]
+extends = nrf52840_base
+board = me25ls01-4y10td
+; board_level = extra
+; platform = https://github.com/maxgerhardt/platform-nordicnrf52#cac6fcf943a41accd2aeb4f3659ae297a73f422e
+build_flags = ${nrf52840_base.build_flags} -Ivariants/ME25LS01-4Y10TD -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52 -DME25LS01_4Y10TD -DRADIOLIB_GODMODE
+  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
+  -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
+board_build.ldscript = src/platform/nrf52/nrf52840_s140_v7.ld
+build_src_filter = ${nrf52_base.build_src_filter} +<../variants/ME25LS01-4Y10TD>
+lib_deps = 
+  ${nrf52840_base.lib_deps}
+debug_tool = jlink
+; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
+upload_protocol = nrfutil
+upload_port = /dev/ttyACM1

--- a/variants/ME25LS01-4Y10TD/platformio.ini
+++ b/variants/ME25LS01-4Y10TD/platformio.ini
@@ -10,7 +10,6 @@ board_build.ldscript = src/platform/nrf52/nrf52840_s140_v7.ld
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/ME25LS01-4Y10TD>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-debug_tool = jlink
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
 upload_protocol = nrfutil
 upload_port = /dev/ttyACM1

--- a/variants/ME25LS01-4Y10TD/variant.cpp
+++ b/variants/ME25LS01-4Y10TD/variant.cpp
@@ -1,0 +1,40 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  Copyright (c) 2018, Adafruit Industries (adafruit.com)
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "variant.h"
+#include "nrf.h"
+#include "wiring_constants.h"
+#include "wiring_digital.h"
+
+const uint32_t g_ADigitalPinMap[] = {
+    // P0
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+
+    // P1
+    32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47};
+
+void initVariant()
+{
+    pinMode(LED_PIN, OUTPUT);
+    digitalWrite(LED_PIN, LOW);
+
+    pinMode(PIN_3V3_EN, OUTPUT);
+    digitalWrite(PIN_3V3_EN, HIGH);
+}

--- a/variants/ME25LS01-4Y10TD/variant.h
+++ b/variants/ME25LS01-4Y10TD/variant.h
@@ -1,0 +1,139 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  Copyright (c) 2018, Adafruit Industries (adafruit.com)
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _VARIANT_ME25LS01_4Y10TD_
+#define _VARIANT_ME25LS01_4Y10TD_
+
+#define ME25LS01
+
+/** Master clock frequency */
+#define VARIANT_MCK (64000000ul)
+
+#define USE_LFXO // Board uses 32khz crystal for LF
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+// Number of pins defined in PinDescription array
+#define PINS_COUNT (48)
+#define NUM_DIGITAL_PINS (48)
+#define NUM_ANALOG_INPUTS (6)
+#define NUM_ANALOG_OUTPUTS (0)
+
+// Use the native nrf52 usb power detection
+#define NRF_APM
+
+#define PIN_3V3_EN (32 + 5) //-1
+#define PIN_3V3_ACC_EN -1
+
+#define PIN_LED1 (32 + 7) // P1.07 Blue D2
+
+#define LED_PIN PIN_LED1
+#define LED_BUILTIN -1
+
+#define LED_BLUE -1
+#define LED_STATE_ON 1 // State when LED is lit
+
+#define BUTTON_PIN (0 + 27) // P0.27 K3
+#define BUTTON_NEED_PULLUP
+
+#define HAS_WIRE 1
+
+#define WIRE_INTERFACES_COUNT 1
+
+#define PIN_WIRE_SDA (0 + 15) // P0.15
+#define PIN_WIRE_SCL (0 + 17) // P0.17
+
+/*
+ * Serial interfaces
+ */
+#define PIN_SERIAL1_RX (0 + 14) // P0.14
+#define PIN_SERIAL1_TX (0 + 13) // P0.13
+
+#define PIN_SERIAL2_RX (0 + 17) // P0.17
+#define PIN_SERIAL2_TX (0 + 16) // P0.16
+
+#define SPI_INTERFACES_COUNT 1
+
+#define PIN_SPI_MISO (0 + 29) // P0.20 // MISO
+#define PIN_SPI_MOSI (0 + 2)  // P0.02 // MOSI
+#define PIN_SPI_SCK (32 + 15) // P1.15 // SCK
+#define PIN_SPI_NSS (32 + 13) // P1.13 // NSS
+
+#define LORA_RESET (32 + 11) // P1.11 // RST
+#define LORA_DIO1 (32 + 12)  // P1.12 // IRQ
+#define LORA_DIO2 (32 + 10)  // P1.10 // BUSY
+#define LORA_SCK PIN_SPI_SCK
+#define LORA_MISO PIN_SPI_MISO
+#define LORA_MOSI PIN_SPI_MOSI
+#define LORA_CS PIN_SPI_NSS
+
+// supported modules list
+#define USE_LR1110
+
+#define LR1110_IRQ_PIN LORA_DIO1
+#define LR1110_NRESER_PIN LORA_RESET
+#define LR1110_BUSY_PIN LORA_DIO2
+#define LR1110_SPI_NSS_PIN LORA_CS
+#define LR1110_SPI_SCK_PIN LORA_SCK
+#define LR1110_SPI_MOSI_PIN LORA_MOSI
+#define LR1110_SPI_MISO_PIN LORA_MISO
+
+#define LR11X0_DIO3_TCXO_VOLTAGE 1.6
+#define LR11X0_DIO_AS_RF_SWITCH
+#define LR11X0_DIO_RF_SWITCH_CONFIG 0x0f, 0x0, 0x09, 0x0B, 0x0A, 0x0, 0x4, 0x0
+
+#define HAS_GPS 0
+
+#define PIN_GPS_EN -1
+#define GPS_EN_ACTIVE HIGH
+#define PIN_GPS_RESET -1
+#define GPS_VRTC_EN -1
+#define GPS_SLEEP_INT -1
+#define GPS_RTC_INT -1
+#define GPS_RESETB_OUT -1
+
+#define BATTERY_PIN -1
+#define ADC_MULTIPLIER (2.0F)
+
+#define ADC_RESOLUTION 14
+#define BATTERY_SENSE_RESOLUTION_BITS 12
+
+#undef AREF_VOLTAGE
+#define AREF_VOLTAGE 3.0
+#define VBAT_AR_INTERNAL AR_INTERNAL_3_0
+
+// Buzzer
+#define BUZZER_EN_PIN -1
+
+#ifdef __cplusplus
+}
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#endif // _VARIANT_ME25LS01_4Y10TD_

--- a/variants/ME25LS01-4Y10TD_e-ink/platformio.ini
+++ b/variants/ME25LS01-4Y10TD_e-ink/platformio.ini
@@ -14,7 +14,6 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/ME25LS01-4Y10TD_
 lib_deps = 
   ${nrf52840_base.lib_deps}
   zinggjm/GxEPD2@^1.5.8
-debug_tool = jlink
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
 upload_protocol = nrfutil
 upload_port = /dev/ttyACM1

--- a/variants/ME25LS01-4Y10TD_e-ink/platformio.ini
+++ b/variants/ME25LS01-4Y10TD_e-ink/platformio.ini
@@ -1,9 +1,9 @@
 [env:ME25LS01-4Y10TD_e-ink]
 extends = nrf52840_base
 board = me25ls01-4y10td
-; board_level = extra
+board_level = extra
 ; platform = https://github.com/maxgerhardt/platform-nordicnrf52#cac6fcf943a41accd2aeb4f3659ae297a73f422e
-build_flags = ${nrf52840_base.build_flags} -Ivariants/ME25LS01-4Y10TD_e-ink -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52 -DME25LS01_4Y10TD -DRADIOLIB_GODMODE
+build_flags = ${nrf52840_base.build_flags} -Ivariants/ME25LS01-4Y10TD_e-ink -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52 -DME25LS01_4Y10TD ;-DRADIOLIB_GODMODE
   -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
   -DEINK_DISPLAY_MODEL=GxEPD2_420_GDEY042T81

--- a/variants/ME25LS01-4Y10TD_e-ink/platformio.ini
+++ b/variants/ME25LS01-4Y10TD_e-ink/platformio.ini
@@ -1,0 +1,20 @@
+[env:ME25LS01-4Y10TD_e-ink]
+extends = nrf52840_base
+board = me25ls01-4y10td
+; board_level = extra
+; platform = https://github.com/maxgerhardt/platform-nordicnrf52#cac6fcf943a41accd2aeb4f3659ae297a73f422e
+build_flags = ${nrf52840_base.build_flags} -Ivariants/ME25LS01-4Y10TD_e-ink -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52 -DME25LS01_4Y10TD -DRADIOLIB_GODMODE
+  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
+  -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
+  -DEINK_DISPLAY_MODEL=GxEPD2_420_GDEY042T81
+  -DEINK_WIDTH=400
+  -DEINK_HEIGHT=300
+board_build.ldscript = src/platform/nrf52/nrf52840_s140_v7.ld
+build_src_filter = ${nrf52_base.build_src_filter} +<../variants/ME25LS01-4Y10TD_e-ink>
+lib_deps = 
+  ${nrf52840_base.lib_deps}
+  zinggjm/GxEPD2@^1.5.8
+debug_tool = jlink
+; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
+upload_protocol = nrfutil
+upload_port = /dev/ttyACM1

--- a/variants/ME25LS01-4Y10TD_e-ink/variant.cpp
+++ b/variants/ME25LS01-4Y10TD_e-ink/variant.cpp
@@ -1,0 +1,40 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  Copyright (c) 2018, Adafruit Industries (adafruit.com)
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "variant.h"
+#include "nrf.h"
+#include "wiring_constants.h"
+#include "wiring_digital.h"
+
+const uint32_t g_ADigitalPinMap[] = {
+    // P0
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+
+    // P1
+    32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47};
+
+void initVariant()
+{
+    pinMode(LED_PIN, OUTPUT);
+    digitalWrite(LED_PIN, LOW);
+
+    pinMode(PIN_3V3_EN, OUTPUT);
+    digitalWrite(PIN_3V3_EN, HIGH);
+}

--- a/variants/ME25LS01-4Y10TD_e-ink/variant.h
+++ b/variants/ME25LS01-4Y10TD_e-ink/variant.h
@@ -1,0 +1,162 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  Copyright (c) 2018, Adafruit Industries (adafruit.com)
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _VARIANT_ME25LS01_4Y10TD_
+#define _VARIANT_ME25LS01_4Y10TD_
+
+#define ME25LS01
+
+/** Master clock frequency */
+#define VARIANT_MCK (64000000ul)
+
+#define USE_LFXO // Board uses 32khz crystal for LF
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+// Number of pins defined in PinDescription array
+#define PINS_COUNT (48)
+#define NUM_DIGITAL_PINS (48)
+#define NUM_ANALOG_INPUTS (6)
+#define NUM_ANALOG_OUTPUTS (0)
+
+// Use the native nrf52 usb power detection
+#define NRF_APM
+
+#define PIN_3V3_EN (32 + 5) //-1
+#define PIN_3V3_ACC_EN -1
+
+#define PIN_LED1 (32 + 7) // P1.07 Blue D2
+
+#define LED_PIN PIN_LED1
+#define LED_BUILTIN -1
+
+#define LED_BLUE -1
+#define LED_STATE_ON 1 // State when LED is lit
+
+#define BUTTON_PIN (0 + 27) // P0.27 K3
+#define BUTTON_NEED_PULLUP
+
+#define HAS_WIRE 1
+
+#define WIRE_INTERFACES_COUNT 1
+
+#define PIN_WIRE_SDA (0 + 15) // P0.15
+#define PIN_WIRE_SCL (0 + 17) // P0.17
+
+/*
+ * Serial interfaces
+ */
+#define PIN_SERIAL1_RX (0 + 14) // P0.14
+#define PIN_SERIAL1_TX (0 + 13) // P0.13
+
+#define PIN_SERIAL2_RX (0 + 17) // P0.17
+#define PIN_SERIAL2_TX (0 + 16) // P0.16
+
+#define SPI_INTERFACES_COUNT 2
+
+// LoRa SPI
+#define PIN_SPI_MISO (0 + 29) // P0.20 // MISO
+#define PIN_SPI_MOSI (0 + 2)  // P0.02 // MOSI
+#define PIN_SPI_SCK (32 + 15) // P1.15 // SCK
+#define PIN_SPI_NSS (32 + 13) // P1.13 // NSS
+
+#define LORA_RESET (32 + 11) // P1.11 // RST
+#define LORA_DIO1 (32 + 12)  // P1.12 // IRQ
+#define LORA_DIO2 (32 + 10)  // P1.10 // BUSY
+#define LORA_SCK PIN_SPI_SCK
+#define LORA_MISO PIN_SPI_MISO
+#define LORA_MOSI PIN_SPI_MOSI
+#define LORA_CS PIN_SPI_NSS
+
+static const uint8_t SS = (32 + 13); // P1.13 // NSS
+static const uint8_t MOSI = PIN_SPI_MOSI;
+static const uint8_t MISO = PIN_SPI_MISO;
+static const uint8_t SCK = PIN_SPI_SCK;
+
+// EPD SPI
+#define PIN_SPI1_MISO (-1)     // Not Used for EPD
+#define PIN_SPI1_MOSI (0 + 10) // EPD_MOSI  P0.10
+#define PIN_SPI1_SCK (0 + 9)   // EPD_SCLK  P0.09
+
+/*
+ * eink display pins
+ */
+
+#define USE_EINK
+#define PIN_EINK_CS (32 + 0)   // EPD_CS
+#define PIN_EINK_BUSY (0 + 19) // EPD_BUSY
+#define PIN_EINK_DC (0 + 24)   // EPD_D/C
+#define PIN_EINK_RES (0 + 23)  // EPD_RESET
+#define PIN_EINK_SCLK (0 + 9)  // EPD_SCLK
+#define PIN_EINK_MOSI (0 + 10) // EPD_MOSI
+
+// supported modules list
+#define USE_LR1110
+
+#define LR1110_IRQ_PIN LORA_DIO1
+#define LR1110_NRESER_PIN LORA_RESET
+#define LR1110_BUSY_PIN LORA_DIO2
+#define LR1110_SPI_NSS_PIN LORA_CS
+#define LR1110_SPI_SCK_PIN LORA_SCK
+#define LR1110_SPI_MOSI_PIN LORA_MOSI
+#define LR1110_SPI_MISO_PIN LORA_MISO
+
+#define LR11X0_DIO3_TCXO_VOLTAGE 1.6
+#define LR11X0_DIO_AS_RF_SWITCH
+#define LR11X0_DIO_RF_SWITCH_CONFIG 0x0f, 0x0, 0x09, 0x0B, 0x0A, 0x0, 0x4, 0x0
+
+#define HAS_GPS 0
+
+#define PIN_GPS_EN -1
+#define GPS_EN_ACTIVE HIGH
+#define PIN_GPS_RESET -1
+#define GPS_VRTC_EN -1
+#define GPS_SLEEP_INT -1
+#define GPS_RTC_INT -1
+#define GPS_RESETB_OUT -1
+
+#define BATTERY_PIN -1
+#define ADC_MULTIPLIER (2.0F)
+
+#define ADC_RESOLUTION 14
+#define BATTERY_SENSE_RESOLUTION_BITS 12
+
+#undef AREF_VOLTAGE
+#define AREF_VOLTAGE 3.0
+#define VBAT_AR_INTERNAL AR_INTERNAL_3_0
+
+// Buzzer
+#define BUZZER_EN_PIN -1
+
+#ifdef __cplusplus
+}
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#endif // _VARIANT_ME25LS01_4Y10TD__


### PR DESCRIPTION
https://en.minewsemi.com/lora-module/lr1110-nrf52840-me25LS01

![image](https://github.com/user-attachments/assets/f483ab6e-35ef-457e-b9fd-105eec8f164a)

LR1110 LoRa Radio
nRF82540 CPU
I2C CardKb
4.2inch 400x300 e-ink display (GDEY042T81)
NO GPS support as the GPS has cloud requirement
USB Powered for the moment

https://meshtastic.discourse.group/t/new-device-wip-minewsemi-me25ls01-nrf82540-lr1110-4-2inch-e-ink/14087

