### PR TITLE
Fix python call in UF2 generation.

### DIFF
--- a/bin/platformio-custom.py
+++ b/bin/platformio-custom.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # trunk-ignore-all(ruff/F821)
 # trunk-ignore-all(flake8/F821): For SConstruct imports
 import sys
@@ -80,7 +81,7 @@ if platform.name == "espressif32":
 
 if platform.name == "nordicnrf52":
     env.AddPostAction("$BUILD_DIR/${PROGNAME}.hex",
-                      env.VerboseAction(f"python ./bin/uf2conv.py $BUILD_DIR/firmware.hex -c -f 0xADA52840 -o $BUILD_DIR/firmware.uf2",
+                      env.VerboseAction(f"/usr/bin/env python3 ./bin/uf2conv.py $BUILD_DIR/firmware.hex -c -f 0xADA52840 -o $BUILD_DIR/firmware.uf2",
                                         "Generating UF2 file"))
 
 Import("projenv")


### PR DESCRIPTION
The call to generate UF2 files in the platformio custom script was a bare call to python. In some environments, this command won't exist in this way. Instead, use the standard env approach to find the right python.

Without this change, a user may see:
"""
Generating UF2 file
sh: 1: python: not found
"""

Additionally, add the shebang line on line 1 so this script can be executed standalone if needed.
