### PR TITLE
Fix UC6580 ifdefs

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -400,8 +400,6 @@ bool GPS::setup()
     int msglen = 0;
 
     if (!didSerialInit) {
-#if !defined(GPS_UC6580)
-
         if (tx_gpio && gnssModel == GNSS_MODEL_UNKNOWN) {
 
             // if GPS_BAUDRATE is specified in variant (i.e. not 9600), skip to the specified rate.
@@ -424,9 +422,6 @@ bool GPS::setup()
         } else {
             gnssModel = GNSS_MODEL_UNKNOWN;
         }
-#else
-        gnssModel = GNSS_MODEL_UC6580;
-#endif
 
         if (gnssModel == GNSS_MODEL_MTK) {
             /*


### PR DESCRIPTION
meshtastic/firmware#4319 added autodetect code for UC6580, and removed these ifdefs. However, they were inadvertantly re-added by meshtastic/firmware#4328 .
