### PR TITLE
Make UF2 build command windows-friendly

### DIFF
--- a/bin/platformio-custom.py
+++ b/bin/platformio-custom.py
@@ -81,7 +81,7 @@ if platform.name == "espressif32":
 
 if platform.name == "nordicnrf52":
     env.AddPostAction("$BUILD_DIR/${PROGNAME}.hex",
-                      env.VerboseAction(f"/usr/bin/env python3 ./bin/uf2conv.py $BUILD_DIR/firmware.hex -c -f 0xADA52840 -o $BUILD_DIR/firmware.uf2",
+                      env.VerboseAction(f"python3 ./bin/uf2conv.py $BUILD_DIR/firmware.hex -c -f 0xADA52840 -o $BUILD_DIR/firmware.uf2",
                                         "Generating UF2 file"))
 
 Import("projenv")


### PR DESCRIPTION
As reported by @mrekin, the previous changes to the platformio custom build script may not work on windows. Change to use python3 instead of a call to /usr/bin/env python3.