### PR TITLE
Use sys.executable to refer to python.

### DIFF
--- a/bin/platformio-custom.py
+++ b/bin/platformio-custom.py
@@ -81,7 +81,7 @@ if platform.name == "espressif32":
 
 if platform.name == "nordicnrf52":
     env.AddPostAction("$BUILD_DIR/${PROGNAME}.hex",
-                      env.VerboseAction(f"/usr/bin/env python3 ./bin/uf2conv.py $BUILD_DIR/firmware.hex -c -f 0xADA52840 -o $BUILD_DIR/firmware.uf2",
+                      env.VerboseAction(f"{sys.executable} ./bin/uf2conv.py $BUILD_DIR/firmware.hex -c -f 0xADA52840 -o $BUILD_DIR/firmware.uf2",
                                         "Generating UF2 file"))
 
 Import("projenv")

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -228,7 +228,14 @@ typedef enum _meshtastic_CriticalErrorCode {
     meshtastic_CriticalErrorCode_SX1262_FAILURE = 10,
     /* A (likely software but possibly hardware) failure was detected while trying to send packets.
  If this occurs on your board, please post in the forum so that we can ask you to collect some information to allow fixing this bug */
-    meshtastic_CriticalErrorCode_RADIO_SPI_BUG = 11
+    meshtastic_CriticalErrorCode_RADIO_SPI_BUG = 11,
+    /* Corruption was detected on the flash filesystem but we were able to repair things.
+ If you see this failure in the field please post in the forum because we are interested in seeing if this is occurring in the field. */
+    meshtastic_CriticalErrorCode_FLASH_CORRUPTION_RECOVERABLE = 12,
+    /* Corruption was detected on the flash filesystem but we were unable to repair things.
+ NOTE: Your node will probably need to be reconfigured the next time it reboots (it will lose the region code etc...)
+ If you see this failure in the field please post in the forum because we are interested in seeing if this is occurring in the field. */
+    meshtastic_CriticalErrorCode_FLASH_CORRUPTION_UNRECOVERABLE = 13
 } meshtastic_CriticalErrorCode;
 
 /* How the location was acquired: manual, onboard GPS, external (EUD) GPS */
@@ -931,8 +938,8 @@ extern "C" {
 #define _meshtastic_Constants_ARRAYSIZE ((meshtastic_Constants)(meshtastic_Constants_DATA_PAYLOAD_LEN+1))
 
 #define _meshtastic_CriticalErrorCode_MIN meshtastic_CriticalErrorCode_NONE
-#define _meshtastic_CriticalErrorCode_MAX meshtastic_CriticalErrorCode_RADIO_SPI_BUG
-#define _meshtastic_CriticalErrorCode_ARRAYSIZE ((meshtastic_CriticalErrorCode)(meshtastic_CriticalErrorCode_RADIO_SPI_BUG+1))
+#define _meshtastic_CriticalErrorCode_MAX meshtastic_CriticalErrorCode_FLASH_CORRUPTION_UNRECOVERABLE
+#define _meshtastic_CriticalErrorCode_ARRAYSIZE ((meshtastic_CriticalErrorCode)(meshtastic_CriticalErrorCode_FLASH_CORRUPTION_UNRECOVERABLE+1))
 
 #define _meshtastic_Position_LocSource_MIN meshtastic_Position_LocSource_LOC_UNSET
 #define _meshtastic_Position_LocSource_MAX meshtastic_Position_LocSource_LOC_EXTERNAL


### PR DESCRIPTION
Thanks to @mrekin for testing the build on Windows. The previous fix for this UF2 call did not work. sys.executable should fix it.