### PR TITLE
Use sys.executable to refer to python.

### DIFF
--- a/bin/platformio-custom.py
+++ b/bin/platformio-custom.py
@@ -81,7 +81,7 @@ if platform.name == "espressif32":
 
 if platform.name == "nordicnrf52":
     env.AddPostAction("$BUILD_DIR/${PROGNAME}.hex",
-                      env.VerboseAction(f"python3 ./bin/uf2conv.py $BUILD_DIR/firmware.hex -c -f 0xADA52840 -o $BUILD_DIR/firmware.uf2",
+                      env.VerboseAction(f"{sys.executable} ./bin/uf2conv.py $BUILD_DIR/firmware.hex -c -f 0xADA52840 -o $BUILD_DIR/firmware.uf2",
                                         "Generating UF2 file"))
 
 Import("projenv")


### PR DESCRIPTION
Thanks to @mrekin for testing the build on Windows. The previous fix for this UF2 call did not work.
sys.executable should fix it.
