### PR TITLE
Updted protobuf url in X-Protobuf-Schema header

### DIFF
--- a/src/mesh/http/ContentHandler.cpp
+++ b/src/mesh/http/ContentHandler.cpp
@@ -161,7 +161,7 @@ void handleAPIv1FromRadio(HTTPRequest *req, HTTPResponse *res)
     res->setHeader("Content-Type", "application/x-protobuf");
     res->setHeader("Access-Control-Allow-Origin", "*");
     res->setHeader("Access-Control-Allow-Methods", "GET");
-    res->setHeader("X-Protobuf-Schema", "https://raw.githubusercontent.com/meshtastic/protobufs/master/mesh.proto");
+    res->setHeader("X-Protobuf-Schema", "https://raw.githubusercontent.com/meshtastic/protobufs/master/meshtastic/mesh.proto");
 
     uint8_t txBuf[MAX_STREAM_BUF_SIZE];
     uint32_t len = 1;
@@ -205,7 +205,7 @@ void handleAPIv1ToRadio(HTTPRequest *req, HTTPResponse *res)
     res->setHeader("Access-Control-Allow-Headers", "Content-Type");
     res->setHeader("Access-Control-Allow-Origin", "*");
     res->setHeader("Access-Control-Allow-Methods", "PUT, OPTIONS");
-    res->setHeader("X-Protobuf-Schema", "https://raw.githubusercontent.com/meshtastic/protobufs/master/mesh.proto");
+    res->setHeader("X-Protobuf-Schema", "https://raw.githubusercontent.com/meshtastic/protobufs/master/meshtastic/mesh.proto");
 
     if (req->getMethod() == "OPTIONS") {
         res->setStatusCode(204); // Success with no content

--- a/src/mesh/raspihttp/PiWebServer.cpp
+++ b/src/mesh/raspihttp/PiWebServer.cpp
@@ -230,7 +230,7 @@ int handleAPIv1ToRadio(const struct _u_request *req, struct _u_response *res, vo
     ulfius_add_header_to_response(res, "Access-Control-Allow-Origin", "*");
     ulfius_add_header_to_response(res, "Access-Control-Allow-Methods", "PUT, OPTIONS");
     ulfius_add_header_to_response(res, "X-Protobuf-Schema",
-                                  "https://raw.githubusercontent.com/meshtastic/protobufs/master/mesh.proto");
+                                  "https://raw.githubusercontent.com/meshtastic/protobufs/master/meshtastic/mesh.proto");
 
     if (req->http_verb == "OPTIONS") {
         ulfius_set_response_properties(res, U_OPT_STATUS, 204);
@@ -267,7 +267,7 @@ int handleAPIv1FromRadio(const struct _u_request *req, struct _u_response *res, 
     ulfius_add_header_to_response(res, "Access-Control-Allow-Origin", "*");
     ulfius_add_header_to_response(res, "Access-Control-Allow-Methods", "GET");
     ulfius_add_header_to_response(res, "X-Protobuf-Schema",
-                                  "https://raw.githubusercontent.com/meshtastic/protobufs/master/mesh.proto");
+                                  "https://raw.githubusercontent.com/meshtastic/protobufs/master/meshtastic/mesh.proto");
 
     uint8_t txBuf[MAX_STREAM_BUF_SIZE];
     uint32_t len = 1;


### PR DESCRIPTION
Hello, in meshtastic/web#154, the issue was raised that the X-Protobuf-Schema header serves an invalid link to meshtastic protobuf. This should close this issue.