### PR TITLE
NimbleBluetooth.h is not required in MeshService.

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -19,10 +19,6 @@
 #include <assert.h>
 #include <string>
 
-#if defined(ARCH_ESP32) && !MESHTASTIC_EXCLUDE_BLUETOOTH
-#include "nimble/NimbleBluetooth.h"
-#endif
-
 #if ARCH_PORTDUINO
 #include "PortduinoGlue.h"
 #endif


### PR DESCRIPTION
There are no calls to the functions defined in Nimble from this class. See also older comment on line 8 about the dream to seperate mesh and bluetooth :)