### PR TITLE
Adds MESHTASTIC_EXCLUDE_TZ option

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -257,6 +257,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MESHTASTIC_EXCLUDE_POWERMON 1
 #define MESHTASTIC_EXCLUDE_I2C 1
 #define MESHTASTIC_EXCLUDE_POWER_FSM 1
+#define MESHTASTIC_EXCLUDE_TZ 1
 #endif
 
 // Turn off all optional modules

--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -256,6 +256,7 @@ uint32_t getValidTime(RTCQuality minQuality, bool local)
 
 time_t gm_mktime(struct tm *tm)
 {
+#if !MESHTASTIC_EXCLUDE_TZ
     setenv("TZ", "GMT0", 1);
     time_t res = mktime(tm);
     if (*config.device.tzdef) {
@@ -264,4 +265,7 @@ time_t gm_mktime(struct tm *tm)
         setenv("TZ", "UTC0", 1);
     }
     return res;
+#else
+    return mktime(tm);
+#endif
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -689,6 +689,7 @@ void setup()
     screen = new graphics::Screen(screen_found, screen_model, screen_geometry);
 
     // setup TZ prior to time actions.
+#if !MESHTASTIC_EXCLUDE_TZ
     if (*config.device.tzdef) {
         setenv("TZ", config.device.tzdef, 1);
     } else {
@@ -696,6 +697,7 @@ void setup()
     }
     tzset();
     LOG_DEBUG("Set Timezone to %s\n", getenv("TZ"));
+#endif
 
     readFromRTC(); // read the main CPU RTC at first (in case we can't get GPS time)
 


### PR DESCRIPTION
While timezone support is amazing for targets with screens, it's useless for repeaters, and is a few more bytes to shave off.