### PR TITLE
Move printBytes to meshUtils

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -7,6 +7,7 @@
 #include "configuration.h"
 #include "main.h"
 #include "mesh-pb-constants.h"
+#include "meshUtils.h"
 #include "modules/RoutingModule.h"
 #if !MESHTASTIC_EXCLUDE_MQTT
 #include "mqtt/MQTT.h"
@@ -186,14 +187,6 @@ ErrorCode Router::sendLocal(meshtastic_MeshPacket *p, RxSource src)
 
         return send(p);
     }
-}
-
-void printBytes(const char *label, const uint8_t *p, size_t numbytes)
-{
-    LOG_DEBUG("%s: ", label);
-    for (size_t i = 0; i < numbytes; i++)
-        LOG_DEBUG("%02x ", p[i]);
-    LOG_DEBUG("\n");
 }
 
 /**

--- a/src/meshUtils.cpp
+++ b/src/meshUtils.cpp
@@ -57,3 +57,11 @@ char *strnstr(const char *s, const char *find, size_t slen)
     }
     return ((char *)s);
 }
+
+void printBytes(const char *label, const uint8_t *p, size_t numbytes)
+{
+    LOG_DEBUG("%s: ", label);
+    for (size_t i = 0; i < numbytes; i++)
+        LOG_DEBUG("%02x ", p[i]);
+    LOG_DEBUG("\n");
+}

--- a/src/meshUtils.h
+++ b/src/meshUtils.h
@@ -1,4 +1,6 @@
 #pragma once
+#include "DebugConfiguration.h"
+#include <stdint.h>
 
 /// C++ v17+ clamp function, limits a given value to a range defined by lo and hi
 template <class T> constexpr const T &clamp(const T &v, const T &lo, const T &hi)


### PR DESCRIPTION
Put printBytes into meshUtils so it can be easily used elsewhere as a helper function.