### PR TITLE
adds MINIMUM_SAFE_FREE_HEAP macro

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -193,6 +193,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DEFAULT_SHUTDOWN_SECONDS 2
 #endif
 
+#ifndef MINIMUM_SAFE_FREE_HEAP
+#define MINIMUM_SAFE_FREE_HEAP 1500
+#endif
+
 /* Step #3: mop up with disabled values for HAS_ options not handled by the above two */
 
 #ifndef HAS_WIFI

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1057,7 +1057,7 @@ meshtastic_NodeInfoLite *NodeDB::getOrCreateMeshNode(NodeNum n)
     meshtastic_NodeInfoLite *lite = getMeshNode(n);
 
     if (!lite) {
-        if ((numMeshNodes >= MAX_NUM_NODES) || (memGet.getFreeHeap() < meshtastic_NodeInfoLite_size * 3)) {
+        if ((numMeshNodes >= MAX_NUM_NODES) || (memGet.getFreeHeap() < MINIMUM_SAFE_FREE_HEAP)) {
             if (screen)
                 screen->print("Warn: node database full!\nErasing oldest entry\n");
             LOG_WARN("Node database full with %i nodes and %i bytes free! Erasing oldest entry\n", numMeshNodes,

--- a/src/meshUtils.h
+++ b/src/meshUtils.h
@@ -13,3 +13,5 @@ template <class T> constexpr const T &clamp(const T &v, const T &lo, const T &hi
 #include <string.h>
 char *strnstr(const char *s, const char *find, size_t slen);
 #endif
+
+void printBytes(const char *label, const uint8_t *p, size_t numbytes);


### PR DESCRIPTION
Prepping for landing the PKI PR. This gets away from determining how much free memory is safe based on NodeDB size, and instead sets it to a conservative 1.5k. In testing, this hasn't been a problem for any devices.