### PR TITLE
Fix for "has default channel" with empty channel name

### DIFF
--- a/src/mesh/Channels.cpp
+++ b/src/mesh/Channels.cpp
@@ -309,12 +309,14 @@ const char *Channels::getName(size_t chIndex)
     return channelName;
 }
 
-bool Channels::isDefaultChannel(const meshtastic_Channel &ch)
+bool Channels::isDefaultChannel(ChannelIndex chIndex)
 {
+    const auto &ch = getByIndex(chIndex);
     if (ch.settings.psk.size == 1 && ch.settings.psk.bytes[0] == 1) {
+        const char *name = getName(chIndex);
         const char *presetName = DisplayFormatters::getModemPresetDisplayName(config.lora.modem_preset, false);
         // Check if the name is the default derived from the modem preset
-        if (strcmp(ch.settings.name, presetName) == 0)
+        if (strcmp(name, presetName) == 0)
             return true;
     }
     return false;
@@ -327,8 +329,7 @@ bool Channels::hasDefaultChannel()
         return false;
     // Check if any of the channels are using the default name and PSK
     for (size_t i = 0; i < getNumChannels(); i++) {
-        const auto &ch = getByIndex(i);
-        if (isDefaultChannel(ch))
+        if (isDefaultChannel(i))
             return true;
     }
     return false;

--- a/src/mesh/Channels.h
+++ b/src/mesh/Channels.h
@@ -84,7 +84,7 @@ class Channels
     int16_t setActiveByIndex(ChannelIndex channelIndex);
 
     // Returns true if the channel has the default name and PSK
-    bool isDefaultChannel(const meshtastic_Channel &ch);
+    bool isDefaultChannel(ChannelIndex chIndex);
 
     // Returns true if we can be reached via a channel with the default settings given a region and modem preset
     bool hasDefaultChannel();

--- a/src/modules/esp32/StoreForwardModule.cpp
+++ b/src/modules/esp32/StoreForwardModule.cpp
@@ -382,7 +382,7 @@ ProcessMessage StoreForwardModule::handleReceived(const meshtastic_MeshPacket &m
                 LOG_DEBUG("*** Legacy Request to send\n");
 
                 // Send the last 60 minutes of messages.
-                if (this->busy || channels.isDefaultChannel(channels.getByIndex(mp.channel))) {
+                if (this->busy || channels.isDefaultChannel(mp.channel)) {
                     sendErrorTextMessage(getFrom(&mp), mp.decoded.want_response);
                 } else {
                     storeForwardModule->historySend(historyReturnWindow * 60, getFrom(&mp));
@@ -447,7 +447,7 @@ bool StoreForwardModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp,
             requests_history++;
             LOG_INFO("*** Client Request to send HISTORY\n");
             // Send the last 60 minutes of messages.
-            if (this->busy || channels.isDefaultChannel(channels.getByIndex(mp.channel))) {
+            if (this->busy || channels.isDefaultChannel(mp.channel)) {
                 sendErrorTextMessage(getFrom(&mp), mp.decoded.want_response);
             } else {
                 if ((p->which_variant == meshtastic_StoreAndForward_history_tag) && (p->variant.history.window > 0)) {


### PR DESCRIPTION
The refactor in #4282 caused "has default channel" to be `false` when the name was empty.
