### PR TITLE
STM32WL improvements

### DIFF
--- a/arch/stm32/stm32.ini
+++ b/arch/stm32/stm32.ini
@@ -21,7 +21,7 @@ build_flags =
   -fdata-sections
   
 build_src_filter = 
-  ${arduino_base.build_src_filter} -<platform/esp32/> -<nimble/> -<mesh/api/> -<mesh/wifi/> -<mesh/http/> -<modules/esp32> -<mesh/eth/> -<input> -<buzz> -<modules/Telemetry> -<platform/nrf52> -<platform/portduino> -<platform/rp2040> -<mesh/raspihttp>
+  ${arduino_base.build_src_filter} -<platform/esp32/> -<nimble/> -<mesh/api/> -<mesh/wifi/> -<mesh/http/> -<modules/esp32> -<mesh/eth/> -<input> -<buzz> -<platform/nrf52> -<platform/portduino> -<platform/rp2040> -<mesh/raspihttp>
 
 board_upload.offset_address = 0x08000000
 upload_protocol = stlink

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -563,8 +563,16 @@ void NodeDB::installDefaultDeviceState()
 
     // Set default owner name
     pickNewNodeNum(); // based on macaddr now
+#ifdef CONFIG_OWNER_LONG_NAME_USERPREFS
+    snprintf(owner.long_name, sizeof(owner.long_name), CONFIG_OWNER_LONG_NAME_USERPREFS);
+#else
     snprintf(owner.long_name, sizeof(owner.long_name), "Meshtastic %02x%02x", ourMacAddr[4], ourMacAddr[5]);
+#endif
+#ifdef CONFIG_OWNER_SHORT_NAME_USERPREFS
+    snprintf(owner.short_name, sizeof(owner.short_name), CONFIG_OWNER_SHORT_NAME_USERPREFS);
+#else
     snprintf(owner.short_name, sizeof(owner.short_name), "%02x%02x", ourMacAddr[4], ourMacAddr[5]);
+#endif
     snprintf(owner.id, sizeof(owner.id), "!%08x", getNodeNum()); // Default node ID now based on nodenum
     memcpy(owner.macaddr, ourMacAddr, sizeof(owner.macaddr));
 }

--- a/src/platform/stm32wl/architecture.h
+++ b/src/platform/stm32wl/architecture.h
@@ -9,6 +9,9 @@
 #ifndef HAS_RADIO
 #define HAS_RADIO 1
 #endif
+#ifndef HAS_TELEMETRY
+#define HAS_TELEMETRY 1
+#endif
 
 //
 // set HW_VENDOR

--- a/src/platform/stm32wl/architecture.h
+++ b/src/platform/stm32wl/architecture.h
@@ -16,8 +16,11 @@
 //
 // set HW_VENDOR
 //
-
-#ifndef HW_VENDOR
+#ifdef _VARIANT_WIOE5_
+#define HW_VENDOR meshtastic_HardwareModel_WIO_E5
+#elif defined(_VARIANT_RAK3172_)
+#define HW_VENDOR meshtastic_HardwareModel_RAK3172
+#else
 #define HW_VENDOR meshtastic_HardwareModel_PRIVATE_HW
 #endif
 

--- a/userPrefs.h
+++ b/userPrefs.h
@@ -19,6 +19,9 @@
 // #define CHANNEL_0_NAME_USERPREFS "DEFCONnect"
 // #define CHANNEL_0_PRECISION_USERPREFS 13
 
+// #define CONFIG_OWNER_LONG_NAME_USERPREFS "My Long Name"
+// #define CONFIG_OWNER_SHORT_NAME_USERPREFS "MLN"
+
 // #define SPLASH_TITLE_USERPREFS "DEFCONtastic"
 // #define icon_width 34
 // #define icon_height 29


### PR DESCRIPTION
- Add new hardware models.
- Add long/short name user preference options (since the filesystem doesn't work yet).
- Enable DeviceTelemetry.

Tested on the Wio-E5 with the CLI.