### PR TITLE
Shorter nodeinfo timeout redux

### DIFF
--- a/src/mesh/ReliableRouter.cpp
+++ b/src/mesh/ReliableRouter.cpp
@@ -4,6 +4,7 @@
 #include "MeshTypes.h"
 #include "configuration.h"
 #include "mesh-pb-constants.h"
+#include "modules/NodeInfoModule.h"
 
 // ReliableRouter::ReliableRouter() {}
 
@@ -107,6 +108,11 @@ void ReliableRouter::sniffReceived(const meshtastic_MeshPacket *p, const meshtas
         if (p->want_ack) {
             if (MeshModule::currentReply) {
                 LOG_DEBUG("Some other module has replied to this message, no need for a 2nd ack\n");
+            } else if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag && c &&
+                       c->error_reason == meshtastic_Routing_Error_NO_CHANNEL) {
+                if (owner.public_key.size == 32)
+                    // This seems like a PKI decrypt failure, so send a NodeInfo
+                    nodeInfoModule->sendOurNodeInfo(p->from, false, p->channel, true);
             } else if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
                 sendAckNak(meshtastic_Routing_Error_NONE, getFrom(p), p->id, p->channel, p->hop_start, p->hop_limit);
             } else {

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -302,7 +302,9 @@ typedef enum _meshtastic_Routing_Error {
  (i.e you did not send the request on the required bound channel) */
     meshtastic_Routing_Error_NOT_AUTHORIZED = 33,
     /* The client specified a PKI transport, but the node was unable to send the packet using PKI (and did not send the message at all) */
-    meshtastic_Routing_Error_PKI_FAILED = 34
+    meshtastic_Routing_Error_PKI_FAILED = 34,
+    /* The receiving node does not have a Public Key to decode with */
+    meshtastic_Routing_Error_PKI_UNKNOWN_PUBKEY = 35
 } meshtastic_Routing_Error;
 
 /* The priority of this message for sending.
@@ -995,8 +997,8 @@ extern "C" {
 #define _meshtastic_Position_AltSource_ARRAYSIZE ((meshtastic_Position_AltSource)(meshtastic_Position_AltSource_ALT_BAROMETRIC+1))
 
 #define _meshtastic_Routing_Error_MIN meshtastic_Routing_Error_NONE
-#define _meshtastic_Routing_Error_MAX meshtastic_Routing_Error_PKI_FAILED
-#define _meshtastic_Routing_Error_ARRAYSIZE ((meshtastic_Routing_Error)(meshtastic_Routing_Error_PKI_FAILED+1))
+#define _meshtastic_Routing_Error_MAX meshtastic_Routing_Error_PKI_UNKNOWN_PUBKEY
+#define _meshtastic_Routing_Error_ARRAYSIZE ((meshtastic_Routing_Error)(meshtastic_Routing_Error_PKI_UNKNOWN_PUBKEY+1))
 
 #define _meshtastic_MeshPacket_Priority_MIN meshtastic_MeshPacket_Priority_UNSET
 #define _meshtastic_MeshPacket_Priority_MAX meshtastic_MeshPacket_Priority_MAX

--- a/src/modules/NodeInfoModule.cpp
+++ b/src/modules/NodeInfoModule.cpp
@@ -32,19 +32,22 @@ bool NodeInfoModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
     return false; // Let others look at this message also if they want
 }
 
-void NodeInfoModule::sendOurNodeInfo(NodeNum dest, bool wantReplies, uint8_t channel)
+void NodeInfoModule::sendOurNodeInfo(NodeNum dest, bool wantReplies, uint8_t channel, bool _shorterTimeout)
 {
     // cancel any not yet sent (now stale) position packets
     if (prevPacketId) // if we wrap around to zero, we'll simply fail to cancel in that rare case (no big deal)
         service->cancelSending(prevPacketId);
-
+    shorterTimeout = _shorterTimeout;
     meshtastic_MeshPacket *p = allocReply();
     if (p) { // Check whether we didn't ignore it
         p->to = dest;
         p->decoded.want_response = (config.device.role != meshtastic_Config_DeviceConfig_Role_TRACKER &&
                                     config.device.role != meshtastic_Config_DeviceConfig_Role_SENSOR) &&
                                    wantReplies;
-        p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
+        if (_shorterTimeout)
+            p->priority = meshtastic_MeshPacket_Priority_DEFAULT;
+        else
+            p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
         if (channel > 0) {
             LOG_DEBUG("sending ourNodeInfo to channel %d\n", channel);
             p->channel = channel;
@@ -53,6 +56,7 @@ void NodeInfoModule::sendOurNodeInfo(NodeNum dest, bool wantReplies, uint8_t cha
         prevPacketId = p->id;
 
         service->sendToMesh(p);
+        shorterTimeout = false;
     }
 }
 
@@ -65,8 +69,12 @@ meshtastic_MeshPacket *NodeInfoModule::allocReply()
     }
     uint32_t now = millis();
     // If we sent our NodeInfo less than 5 min. ago, don't send it again as it may be still underway.
-    if (lastSentToMesh && (now - lastSentToMesh) < (5 * 60 * 1000)) {
+    if (!shorterTimeout && lastSentToMesh && (now - lastSentToMesh) < (5 * 60 * 1000)) {
         LOG_DEBUG("Skip sending NodeInfo since we just sent it less than 5 minutes ago.\n");
+        ignoreRequest = true; // Mark it as ignored for MeshModule
+        return NULL;
+    } else if (shorterTimeout && lastSentToMesh && (now - lastSentToMesh) < (60 * 1000)) {
+        LOG_DEBUG("Skip sending actively requested NodeInfo since we just sent it less than 60 seconds ago.\n");
         ignoreRequest = true; // Mark it as ignored for MeshModule
         return NULL;
     } else {

--- a/src/modules/NodeInfoModule.h
+++ b/src/modules/NodeInfoModule.h
@@ -20,7 +20,8 @@ class NodeInfoModule : public ProtobufModule<meshtastic_User>, private concurren
     /**
      * Send our NodeInfo into the mesh
      */
-    void sendOurNodeInfo(NodeNum dest = NODENUM_BROADCAST, bool wantReplies = false, uint8_t channel = 0);
+    void sendOurNodeInfo(NodeNum dest = NODENUM_BROADCAST, bool wantReplies = false, uint8_t channel = 0,
+                         bool _shorterTimeout = false);
 
   protected:
     /** Called to handle a particular incoming message
@@ -38,6 +39,7 @@ class NodeInfoModule : public ProtobufModule<meshtastic_User>, private concurren
 
   private:
     uint32_t lastSentToMesh = 0; // Last time we sent our NodeInfo to the mesh
+    bool shorterTimeout = false;
 };
 
 extern NodeInfoModule *nodeInfoModule;


### PR DESCRIPTION
A NodeInfo message sent directly to the node, with wantAck set to true, triggers a higher priority NodeInfo packet with a quicker cool off period. We try to trigger this when a response indicates a PKI decrypt failure.