### PR TITLE
Add PKI channel for MQTT

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -152,7 +152,8 @@ void MQTT::onReceive(char *topic, byte *payload, size_t length)
                     LOG_INFO("Ignoring downlink message we originally sent.\n");
             } else {
                 // Find channel by channel_id and check downlink_enabled
-                if (strcmp(e.channel_id, channels.getGlobalId(ch.index)) == 0 && e.packet && ch.settings.downlink_enabled) {
+                if ((strcmp(e.channel_id, "PKI") && e.packet) ||
+                    (strcmp(e.channel_id, channels.getGlobalId(ch.index)) == 0 && e.packet && ch.settings.downlink_enabled)) {
                     LOG_INFO("Received MQTT topic %s, len=%u\n", topic, length);
                     meshtastic_MeshPacket *p = packetPool.allocCopy(*e.packet);
                     p->via_mqtt = true; // Mark that the packet was received via MQTT
@@ -162,7 +163,9 @@ void MQTT::onReceive(char *topic, byte *payload, size_t length)
                     }
 
                     // ignore messages if we don't have the channel key
-                    if (router && perhapsDecode(p))
+                    if (router && p->which_payload_variant == meshtastic_MeshPacket_encrypted_tag && p->channel == 0)
+                        router->enqueueReceivedMessage(p);
+                    else if (router && perhapsDecode(p))
                         router->enqueueReceivedMessage(p);
                     else
                         packetPool.release(p);
@@ -377,6 +380,11 @@ void MQTT::sendSubscriptions()
 #endif // ARCH_NRF52
         }
     }
+#if !MESHTASTIC_EXCLUDE_PKI
+    std::string topic = cryptTopic + "PKI/#";
+    LOG_INFO("Subscribing to %s\n", topic.c_str());
+    pubSub.subscribe(topic.c_str(), 1);
+#endif
 #endif
 }
 
@@ -452,8 +460,12 @@ void MQTT::publishQueuedMessages()
         meshtastic_ServiceEnvelope *env = mqttQueue.dequeuePtr(0);
         static uint8_t bytes[meshtastic_MeshPacket_size + 64];
         size_t numBytes = pb_encode_to_bytes(bytes, sizeof(bytes), &meshtastic_ServiceEnvelope_msg, env);
-
-        std::string topic = cryptTopic + env->channel_id + "/" + owner.id;
+        std::string topic;
+        if (env->packet->pki_encrypted) {
+            topic = cryptTopic + "PKI/" + owner.id;
+        } else {
+            topic = cryptTopic + env->channel_id + "/" + owner.id;
+        }
         LOG_INFO("publish %s, %u bytes from queue\n", topic.c_str(), numBytes);
 
         publish(topic.c_str(), bytes, numBytes, false);
@@ -463,7 +475,12 @@ void MQTT::publishQueuedMessages()
             // handle json topic
             auto jsonString = MeshPacketSerializer::JsonSerialize(env->packet);
             if (jsonString.length() != 0) {
-                std::string topicJson = jsonTopic + env->channel_id + "/" + owner.id;
+                std::string topicJson;
+                if (env->packet->pki_encrypted) {
+                    topicJson = jsonTopic + "PKI/" + owner.id;
+                } else {
+                    topicJson = jsonTopic + env->channel_id + "/" + owner.id;
+                }
                 LOG_INFO("JSON publish message to %s, %u bytes: %s\n", topicJson.c_str(), jsonString.length(),
                          jsonString.c_str());
                 publish(topicJson.c_str(), jsonString.c_str(), false);
@@ -513,8 +530,12 @@ void MQTT::onSend(const meshtastic_MeshPacket &mp, const meshtastic_MeshPacket &
             // FIXME - this size calculation is super sloppy, but it will go away once we dynamically alloc meshpackets
             static uint8_t bytes[meshtastic_MeshPacket_size + 64];
             size_t numBytes = pb_encode_to_bytes(bytes, sizeof(bytes), &meshtastic_ServiceEnvelope_msg, env);
-
-            std::string topic = cryptTopic + channelId + "/" + owner.id;
+            std::string topic;
+            if (mp.pki_encrypted) {
+                topic = cryptTopic + "PKI/" + owner.id;
+            } else {
+                topic = cryptTopic + channelId + "/" + owner.id;
+            }
             LOG_DEBUG("MQTT Publish %s, %u bytes\n", topic.c_str(), numBytes);
 
             publish(topic.c_str(), bytes, numBytes, false);
@@ -524,7 +545,12 @@ void MQTT::onSend(const meshtastic_MeshPacket &mp, const meshtastic_MeshPacket &
                 // handle json topic
                 auto jsonString = MeshPacketSerializer::JsonSerialize((meshtastic_MeshPacket *)&mp_decoded);
                 if (jsonString.length() != 0) {
-                    std::string topicJson = jsonTopic + channelId + "/" + owner.id;
+                    std::string topicJson;
+                    if (mp.pki_encrypted) {
+                        topicJson = jsonTopic + "PKI/" + owner.id;
+                    } else {
+                        topicJson = jsonTopic + channelId + "/" + owner.id;
+                    }
                     LOG_INFO("JSON publish message to %s, %u bytes: %s\n", topicJson.c_str(), jsonString.length(),
                              jsonString.c_str());
                     publish(topicJson.c_str(), jsonString.c_str(), false);

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -162,9 +162,10 @@ void MQTT::onReceive(char *topic, byte *payload, size_t length)
                         p->channel = ch.index;
                     }
 
-                    // ignore messages if we don't have the channel key
+                    // PKI messages get accepted even if we can't decrypt
                     if (router && p->which_payload_variant == meshtastic_MeshPacket_encrypted_tag && p->channel == 0)
                         router->enqueueReceivedMessage(p);
+                    // ignore messages if we don't have the channel key
                     else if (router && perhapsDecode(p))
                         router->enqueueReceivedMessage(p);
                     else


### PR DESCRIPTION
If we are connecting to MQTT, this adds the root/2/e/PKI topic for PKI messages.