### PR TITLE
Radio Master Joystick

### DIFF
--- a/src/input/ExpressLRSFiveWay.cpp
+++ b/src/input/ExpressLRSFiveWay.cpp
@@ -136,7 +136,10 @@ int32_t ExpressLRSFiveWay::runOnce()
         if (longPressed) {
             LOG_INFO("Shutdown from long press\n");
             power->shutdown();
-        } else
+        } else if (!moduleConfig.canned_message.enabled)
+            // Allow "press" to act as user button. Canned message module won't do this for us if not enabled
+            powerFSM.trigger(EVENT_PRESS);
+        else
             raiseEvent(meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_SELECT);
         break;
     case ExpressLRSFiveWay::INPUT_KEY_NO_PRESS:

--- a/src/input/ExpressLRSFiveWay.cpp
+++ b/src/input/ExpressLRSFiveWay.cpp
@@ -241,8 +241,7 @@ void ExpressLRSFiveWay::shutdown()
 
     playShutdownMelody(); // In case user adds a buzzer
 
-    delay(3000); // Instead of trying to fire on button release, just delay.. Officially this is for the "shutdown melody"
-    power->shutdown();
+    shutdownAtMsec = millis() + 3000;
 }
 
 // Emulate user button, or canned message SELECT

--- a/src/input/ExpressLRSFiveWay.cpp
+++ b/src/input/ExpressLRSFiveWay.cpp
@@ -1,0 +1,167 @@
+
+#include "ExpressLRSFiveWay.h"
+
+#ifdef INPUTBROKER_EXPRESSLRSFIVEWAY_TYPE
+
+static const char inputSourceName[] = "ExpressLRS5Way"; // should match "allow input source" string
+
+/**
+ * @brief Calculate fuzz: half the distance to the next nearest neighbor for each joystick position.
+ *
+ * The goal is to avoid collisions between joystick positions while still maintaining
+ * the widest tolerance for the analog value.
+ *
+ * Example: {10,50,800,1000,300,1600}
+ * If we just choose the minimum difference for this array the value would
+ * be 40/2 = 20.
+ *
+ * 20 does not leave enough room for the joystick position using 1600 which
+ * could have a +-100 offset.
+ *
+ * Example Fuzz values: {20, 20, 100, 100, 125, 300} now the fuzz for the 1600
+ * position is 300 instead of 20
+ */
+void ExpressLRSFiveWay::calcFuzzValues()
+{
+    for (unsigned int i = 0; i < N_JOY_ADC_VALUES; i++) {
+        uint16_t closestDist = 0xffff;
+        uint16_t ival = joyAdcValues[i];
+        // Find the closest value to ival
+        for (unsigned int j = 0; j < N_JOY_ADC_VALUES; j++) {
+            // Don't compare value with itself
+            if (j == i)
+                continue;
+            uint16_t jval = joyAdcValues[j];
+            if (jval < ival && (ival - jval < closestDist))
+                closestDist = ival - jval;
+            if (jval > ival && (jval - ival < closestDist))
+                closestDist = jval - ival;
+        } // for j
+
+        // And the fuzz is half the distance to the closest value
+        fuzzValues[i] = closestDist / 2;
+        // DBG("joy%u=%u f=%u, ", i, ival, fuzzValues[i]);
+    } // for i
+}
+
+int ExpressLRSFiveWay::readKey()
+{
+    uint16_t value = analogRead(PIN_JOYSTICK);
+
+    constexpr uint8_t IDX_TO_INPUT[N_JOY_ADC_VALUES - 1] = {INPUT_KEY_UP_PRESS, INPUT_KEY_DOWN_PRESS, INPUT_KEY_LEFT_PRESS,
+                                                            INPUT_KEY_RIGHT_PRESS, INPUT_KEY_OK_PRESS};
+    for (unsigned int i = 0; i < N_JOY_ADC_VALUES - 1; ++i) {
+        if (value < (joyAdcValues[i] + fuzzValues[i]) && value > (joyAdcValues[i] - fuzzValues[i]))
+            return IDX_TO_INPUT[i];
+    }
+    return INPUT_KEY_NO_PRESS;
+}
+
+ExpressLRSFiveWay::ExpressLRSFiveWay() : concurrency::OSThread(inputSourceName) // Meshtastic: derive from threading class
+{
+    isLongPressed = false;
+    keyInProcess = INPUT_KEY_NO_PRESS;
+    keyDownStart = 0;
+
+    calcFuzzValues();
+
+    inputBroker->registerSource(this); // Meshtastic: register with canned messages
+}
+
+void ExpressLRSFiveWay::update(int *keyValue, bool *keyLongPressed)
+{
+    *keyValue = INPUT_KEY_NO_PRESS;
+
+    int newKey = readKey();
+    uint32_t now = millis();
+    if (keyInProcess == INPUT_KEY_NO_PRESS) {
+        // New key down
+        if (newKey != INPUT_KEY_NO_PRESS) {
+            keyDownStart = now;
+            // DBGLN("down=%u", newKey);
+        }
+    } else {
+        // if key released
+        if (newKey == INPUT_KEY_NO_PRESS) {
+            // DBGLN("up=%u", keyInProcess);
+            if (!isLongPressed) {
+                if ((now - keyDownStart) > KEY_DEBOUNCE_MS) {
+                    *keyValue = keyInProcess;
+                    *keyLongPressed = false;
+                }
+            }
+            isLongPressed = false;
+        }
+        // else if the key has changed while down, reset state for next go-around
+        else if (newKey != keyInProcess) {
+            newKey = INPUT_KEY_NO_PRESS;
+        }
+        // else still pressing, waiting for long if not already signaled
+        else if (!isLongPressed) {
+            if ((now - keyDownStart) > KEY_LONG_PRESS_MS) {
+                *keyValue = keyInProcess;
+                *keyLongPressed = true;
+                isLongPressed = true;
+            }
+        }
+    } // if keyInProcess != INPUT_KEY_NO_PRESS
+
+    keyInProcess = newKey;
+}
+
+int32_t ExpressLRSFiveWay::runOnce()
+{
+    uint32_t now = millis();
+
+    int keyValue;
+    bool longPressed;
+    update(&keyValue, &longPressed);
+
+    switch (keyValue) {
+    // Allow left and right keys to close the canned message frame
+    case ExpressLRSFiveWay::INPUT_KEY_LEFT_PRESS:
+    case ExpressLRSFiveWay::INPUT_KEY_RIGHT_PRESS:
+        if (cannedMessageModule->shouldDraw())
+            raiseEvent(meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_CANCEL);
+        else
+            raiseEvent((_meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar)keyValue);
+        break;
+    case ExpressLRSFiveWay::INPUT_KEY_UP_PRESS:
+    case ExpressLRSFiveWay::INPUT_KEY_DOWN_PRESS:
+        raiseEvent((_meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar)keyValue);
+        break;
+    case ExpressLRSFiveWay::INPUT_KEY_OK_PRESS:
+        // Canned message module interprets SELECT as user button short press when suitable,
+        // but doesn't handle long press, so we'll do that here
+        if (longPressed) {
+            LOG_INFO("Shutdown from long press\n");
+            power->shutdown();
+        } else
+            raiseEvent(meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_SELECT);
+        break;
+    case ExpressLRSFiveWay::INPUT_KEY_NO_PRESS:
+    default:
+        break;
+    }
+
+    // If there has been recent key activity, poll the joystick slightly more frequently
+    if (now < keyDownStart + (20 * 1000UL)) // Within last 20 seconds
+        return 100;
+
+    // Otherwise, poll slightly less often
+    // Too many missed pressed if much slower than 250ms
+    return 250;
+}
+
+// Feed input to the canned messages module
+void ExpressLRSFiveWay::raiseEvent(_meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar key)
+{
+    InputEvent e;
+    e.source = inputSourceName;
+    e.inputEvent = key;
+    notifyObservers(&e);
+}
+
+ExpressLRSFiveWay *expressLRSFiveWayInput = nullptr;
+
+#endif

--- a/src/input/ExpressLRSFiveWay.h
+++ b/src/input/ExpressLRSFiveWay.h
@@ -18,12 +18,13 @@
 
 #include "InputBroker.h"
 #include "MeshService.h" // For adhoc ping action
+#include "buzz.h"
 #include "concurrency/OSThread.h"
 #include "graphics/Screen.h" // Feedback for adhoc ping / toggle GPS
 #include "main.h"
 #include "modules/CannedMessageModule.h"
 
-#if !MESHTASTIC_EXCLUDE_GPS
+#if HAS_GPS && !MESHTASTIC_EXCLUDE_GPS
 #include "GPS.h" // For toggle GPS action
 #endif
 

--- a/src/input/ExpressLRSFiveWay.h
+++ b/src/input/ExpressLRSFiveWay.h
@@ -3,7 +3,7 @@
     Devices have a 5-button "resistor ladder" style joystick, read by ADC.
     These devices do not use the ADC to monitor input voltage.
 
-    Much of this code takes directly from ExpressLRS FiveWayButton class:
+    Much of this code taken directly from ExpressLRS FiveWayButton class:
     https://github.com/ExpressLRS/ExpressLRS/tree/d9f56f8bd6f9f7144d5f01caaca766383e1e0950/src/lib/SCREEN/FiveWayButton
 */
 
@@ -17,47 +17,66 @@
 #include <soc/adc_channel.h>
 
 #include "InputBroker.h"
+#include "MeshService.h" // For adhoc ping action
 #include "concurrency/OSThread.h"
+#include "graphics/Screen.h" // Feedback for adhoc ping / toggle GPS
 #include "main.h"
-#include "modules/cannedMessageModule.h"
+#include "modules/CannedMessageModule.h"
 
-// Number of values in JOY_ADC_VALUES, if defined
-// These must be ADC readings for {UP, DOWN, LEFT, RIGHT, ENTER, IDLE}
-constexpr size_t N_JOY_ADC_VALUES = 6;
+#if !MESHTASTIC_EXCLUDE_GPS
+#include "GPS.h" // For toggle GPS action
+#endif
 
 class ExpressLRSFiveWay : public Observable<const InputEvent *>, public concurrency::OSThread
 {
   private:
-    // These constants have been remapped to match Meshtastic canned message input events
-    // Main reason is to simplify handling with a switch in runOnce
-    typedef enum {
-        INPUT_KEY_LEFT_PRESS = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_LEFT,
-        INPUT_KEY_UP_PRESS = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_UP,
-        INPUT_KEY_RIGHT_PRESS = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_RIGHT,
-        INPUT_KEY_DOWN_PRESS = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_DOWN,
-        INPUT_KEY_OK_PRESS = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_SELECT,
-        INPUT_KEY_NO_PRESS = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_NONE
-    } Input_Key_Value_t;
+    // Number of values in JOY_ADC_VALUES, if defined
+    // These must be ADC readings for {UP, DOWN, LEFT, RIGHT, ENTER, IDLE}
+    static constexpr size_t N_JOY_ADC_VALUES = 6;
+    static constexpr uint32_t KEY_DEBOUNCE_MS = 25;
+    static constexpr uint32_t KEY_LONG_PRESS_MS = 3000; // How many milliseconds to hold key for a long press
 
+    // This merged an enum used by the ExpressLRS code, with meshtastic canned message values
+    // Key names are kept simple, to allow user customizaton
+    typedef enum {
+        UP = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_UP,
+        DOWN = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_DOWN,
+        LEFT = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_LEFT,
+        RIGHT = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_RIGHT,
+        OK = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_SELECT,
+        CANCEL = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_CANCEL,
+        NO_PRESS = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_NONE
+    } KeyType;
+
+    typedef enum { SHORT, LONG } PressLength;
+
+    // From ExpressLRS
     int keyInProcess;
     uint32_t keyDownStart;
     bool isLongPressed;
     const uint16_t joyAdcValues[N_JOY_ADC_VALUES] = {JOYSTICK_ADC_VALS};
     uint16_t fuzzValues[N_JOY_ADC_VALUES];
     void calcFuzzValues();
-
     int readKey();
+    void update(int *keyValue, bool *keyLongPressed);
 
-    // Meshtastic methods
-    void raiseEvent(_meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar key);
+    // Meshtastic code
+    void determineAction(KeyType key, PressLength length);
+    void sendKey(KeyType key);
+    inline bool inCannedMessageMenu() { return cannedMessageModule->shouldDraw(); }
     int32_t runOnce() override;
+
+    // Simplified Meshtastic actions, for easier remapping by user
+    void toggleGPS();
+    void sendAdhocPing();
+    void shutdown();
+    void click();
+
+    bool alerting = false;        // Is the screen showing an alert frame? Feedback for GPS toggle / adhoc ping actions
+    uint32_t alertingSinceMs = 0; // When did screen begin showing an alert frame? Used to auto-dismiss
 
   public:
     ExpressLRSFiveWay();
-    void update(int *keyValue, bool *keyLongPressed);
-
-    static constexpr uint32_t KEY_DEBOUNCE_MS = 25;
-    static constexpr uint32_t KEY_LONG_PRESS_MS = 5000;
 };
 
 extern ExpressLRSFiveWay *expressLRSFiveWayInput;

--- a/src/input/ExpressLRSFiveWay.h
+++ b/src/input/ExpressLRSFiveWay.h
@@ -1,0 +1,65 @@
+/*
+    Input source for Radio Master Bandit Nano, and similar hardware.
+    Devices have a 5-button "resistor ladder" style joystick, read by ADC.
+    These devices do not use the ADC to monitor input voltage.
+
+    Much of this code takes directly from ExpressLRS FiveWayButton class:
+    https://github.com/ExpressLRS/ExpressLRS/tree/d9f56f8bd6f9f7144d5f01caaca766383e1e0950/src/lib/SCREEN/FiveWayButton
+*/
+
+#pragma once
+
+#include "configuration.h"
+
+#ifdef INPUTBROKER_EXPRESSLRSFIVEWAY_TYPE
+
+#include <esp_adc_cal.h>
+#include <soc/adc_channel.h>
+
+#include "InputBroker.h"
+#include "concurrency/OSThread.h"
+#include "main.h"
+#include "modules/cannedMessageModule.h"
+
+// Number of values in JOY_ADC_VALUES, if defined
+// These must be ADC readings for {UP, DOWN, LEFT, RIGHT, ENTER, IDLE}
+constexpr size_t N_JOY_ADC_VALUES = 6;
+
+class ExpressLRSFiveWay : public Observable<const InputEvent *>, public concurrency::OSThread
+{
+  private:
+    // These constants have been remapped to match Meshtastic canned message input events
+    // Main reason is to simplify handling with a switch in runOnce
+    typedef enum {
+        INPUT_KEY_LEFT_PRESS = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_LEFT,
+        INPUT_KEY_UP_PRESS = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_UP,
+        INPUT_KEY_RIGHT_PRESS = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_RIGHT,
+        INPUT_KEY_DOWN_PRESS = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_DOWN,
+        INPUT_KEY_OK_PRESS = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_SELECT,
+        INPUT_KEY_NO_PRESS = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_NONE
+    } Input_Key_Value_t;
+
+    int keyInProcess;
+    uint32_t keyDownStart;
+    bool isLongPressed;
+    const uint16_t joyAdcValues[N_JOY_ADC_VALUES] = {JOYSTICK_ADC_VALS};
+    uint16_t fuzzValues[N_JOY_ADC_VALUES];
+    void calcFuzzValues();
+
+    int readKey();
+
+    // Meshtastic methods
+    void raiseEvent(_meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar key);
+    int32_t runOnce() override;
+
+  public:
+    ExpressLRSFiveWay();
+    void update(int *keyValue, bool *keyLongPressed);
+
+    static constexpr uint32_t KEY_DEBOUNCE_MS = 25;
+    static constexpr uint32_t KEY_LONG_PRESS_MS = 5000;
+};
+
+extern ExpressLRSFiveWay *expressLRSFiveWayInput;
+
+#endif

--- a/src/modules/Modules.cpp
+++ b/src/modules/Modules.cpp
@@ -1,5 +1,6 @@
 #include "configuration.h"
 #if !MESHTASTIC_EXCLUDE_INPUTBROKER
+#include "input/ExpressLRSFiveWay.h"
 #include "input/InputBroker.h"
 #include "input/RotaryEncoderInterruptImpl1.h"
 #include "input/ScanAndSelect.h"
@@ -175,6 +176,9 @@ void setupModules()
 #if HAS_TRACKBALL && !MESHTASTIC_EXCLUDE_INPUTBROKER
         trackballInterruptImpl1 = new TrackballInterruptImpl1();
         trackballInterruptImpl1->init();
+#endif
+#ifdef INPUTBROKER_EXPRESSLRSFIVEWAY_TYPE
+        expressLRSFiveWayInput = new ExpressLRSFiveWay();
 #endif
 #if HAS_SCREEN && !MESHTASTIC_EXCLUDE_CANNEDMESSAGES
         cannedMessageModule = new CannedMessageModule();

--- a/variants/radiomaster_900_bandit_nano/variant.h
+++ b/variants/radiomaster_900_bandit_nano/variant.h
@@ -41,14 +41,11 @@
 
 /*
   Five way button when using ADC.
-  2.632V, 2.177V, 1.598V, 1.055V, 0V
-
-  Possible ADC Values:
-  { UP, DOWN, LEFT, RIGHT, ENTER, IDLE }
-  3227, 0 ,1961, 2668, 1290, 4095
+  https://github.com/ExpressLRS/targets/blob/f3215b5ec891108db1a13523e4163950cfcadaac/TX/Radiomaster%20Bandit.json#L41
 */
-#define BUTTON_PIN 39
-#define BUTTON_NEED_PULLUP
+#define INPUTBROKER_EXPRESSLRSFIVEWAY_TYPE
+#define PIN_JOYSTICK 39
+#define JOYSTICK_ADC_VALS /*UP*/ 3227, /*DOWN*/ 0, /*LEFT*/ 1961, /*RIGHT*/ 2668, /*OK*/ 1290, /*IDLE*/ 4095
 
 #define DISPLAY_FLIP_SCREEN
 


### PR DESCRIPTION
Closes #4407. Don't have the hardware myself, but well tested by @gjelsoe 

Creates a canned message input for the in-built joystick on Radio Master Bandit Nano.
Ports the `FiveWayButton` class from the radio's official [ExpressLRS firmware](https://github.com/ExpressLRS/ExpressLRS/tree/d9f56f8bd6f9f7144d5f01caaca766383e1e0950/src/lib/SCREEN/FiveWayButton)
Fully guarded to build solely for Radio Master Bandit Nano hardware (I hope)

No opportunity to use interrupts(?)
Supposedly, interrupts on ES32 GPIO39 cause issues with WiFi / BLE.
![356156666-180a28eb-6226-4b51-b0d9-256f96a20bf9](https://github.com/user-attachments/assets/0d0dbada-3afc-4414-9147-a165acc8c039)
