### PR TITLE
Add PKINonces array, to check for PKI replays

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -338,6 +338,18 @@ bool perhapsDecode(meshtastic_MeshPacket *p)
                 p->public_key.size = 32;
                 // memcpy(bytes, ScratchEncrypted, rawSize); // TODO: Rename the bytes buffers
                 // chIndex = 8;
+                for (int i = 0; i < 100; i++) {
+                    if (p->id == router->PKINonces[i][0] && p->from == router->PKINonces[i][1]) {
+                        LOG_WARN("PKI Nonce re-used, possible replay attack");
+                        return false;
+                    }
+                }
+                router->PKINonces[router->noncePointer][0] = p->id;
+                router->PKINonces[router->noncePointer][1] = p->from;
+                router->noncePointer++;
+                if (router->noncePointer > 99)
+                    router->noncePointer = 0;
+
             } else {
                 return false;
             }

--- a/src/mesh/Router.h
+++ b/src/mesh/Router.h
@@ -82,6 +82,12 @@ class Router : protected concurrency::OSThread
      */
     virtual ErrorCode send(meshtastic_MeshPacket *p);
 
+// used for replay detection
+#if !MESHTASTIC_EXCLUDE_PKI
+    uint64_t PKINonces[100][2] = {0};
+    uint8_t noncePointer;
+#endif
+
   protected:
     friend class RoutingModule;
 


### PR DESCRIPTION
I'm not 100% sold on this idea. Replay protection is great, but we really don't have enough ram or flash to do it properly. I'm not sure if a sliding window of only 100 packets, that gets dropped on reboot, is enough protection against replays to justify the 800 bytes of ram, and the processing time to check against the list.

I say this particularly because we have replay protection for admin messages (actual code todo, but the approach is decided) and we can do much more robust replay checking in mobile clients.