### PR TITLE
AdminModule session_passkey

### DIFF
--- a/src/mesh/generated/meshtastic/admin.pb.h
+++ b/src/mesh/generated/meshtastic/admin.pb.h
@@ -87,6 +87,7 @@ typedef struct _meshtastic_NodeRemoteHardwarePinsResponse {
     meshtastic_NodeRemoteHardwarePin node_remote_hardware_pins[16];
 } meshtastic_NodeRemoteHardwarePinsResponse;
 
+typedef PB_BYTES_ARRAY_T(8) meshtastic_AdminMessage_session_passkey_t;
 /* This message is handled by the Admin module and is responsible for all settings/channel read/write operations.
  This message is used to do settings operations to both remote AND local nodes.
  (Prior to 1.2 these operations were done via special ToRadio operations) */
@@ -187,6 +188,10 @@ typedef struct _meshtastic_AdminMessage {
         /* Tell the node to reset the nodedb. */
         int32_t nodedb_reset;
     };
+    /* The node generates this key and sends it with any get_x_response packets.
+ The client MUST include the same key with any set_x commands. Key expires after 300 seconds.
+ Prevents replay attacks for admin messages. */
+    meshtastic_AdminMessage_session_passkey_t session_passkey;
 } meshtastic_AdminMessage;
 
 
@@ -210,10 +215,10 @@ extern "C" {
 
 
 /* Initializer values for message structs */
-#define meshtastic_AdminMessage_init_default     {0, {0}}
+#define meshtastic_AdminMessage_init_default     {0, {0}, {0, {0}}}
 #define meshtastic_HamParameters_init_default    {"", 0, 0, ""}
 #define meshtastic_NodeRemoteHardwarePinsResponse_init_default {0, {meshtastic_NodeRemoteHardwarePin_init_default, meshtastic_NodeRemoteHardwarePin_init_default, meshtastic_NodeRemoteHardwarePin_init_default, meshtastic_NodeRemoteHardwarePin_init_default, meshtastic_NodeRemoteHardwarePin_init_default, meshtastic_NodeRemoteHardwarePin_init_default, meshtastic_NodeRemoteHardwarePin_init_default, meshtastic_NodeRemoteHardwarePin_init_default, meshtastic_NodeRemoteHardwarePin_init_default, meshtastic_NodeRemoteHardwarePin_init_default, meshtastic_NodeRemoteHardwarePin_init_default, meshtastic_NodeRemoteHardwarePin_init_default, meshtastic_NodeRemoteHardwarePin_init_default, meshtastic_NodeRemoteHardwarePin_init_default, meshtastic_NodeRemoteHardwarePin_init_default, meshtastic_NodeRemoteHardwarePin_init_default}}
-#define meshtastic_AdminMessage_init_zero        {0, {0}}
+#define meshtastic_AdminMessage_init_zero        {0, {0}, {0, {0}}}
 #define meshtastic_HamParameters_init_zero       {"", 0, 0, ""}
 #define meshtastic_NodeRemoteHardwarePinsResponse_init_zero {0, {meshtastic_NodeRemoteHardwarePin_init_zero, meshtastic_NodeRemoteHardwarePin_init_zero, meshtastic_NodeRemoteHardwarePin_init_zero, meshtastic_NodeRemoteHardwarePin_init_zero, meshtastic_NodeRemoteHardwarePin_init_zero, meshtastic_NodeRemoteHardwarePin_init_zero, meshtastic_NodeRemoteHardwarePin_init_zero, meshtastic_NodeRemoteHardwarePin_init_zero, meshtastic_NodeRemoteHardwarePin_init_zero, meshtastic_NodeRemoteHardwarePin_init_zero, meshtastic_NodeRemoteHardwarePin_init_zero, meshtastic_NodeRemoteHardwarePin_init_zero, meshtastic_NodeRemoteHardwarePin_init_zero, meshtastic_NodeRemoteHardwarePin_init_zero, meshtastic_NodeRemoteHardwarePin_init_zero, meshtastic_NodeRemoteHardwarePin_init_zero}}
 
@@ -265,6 +270,7 @@ extern "C" {
 #define meshtastic_AdminMessage_shutdown_seconds_tag 98
 #define meshtastic_AdminMessage_factory_reset_config_tag 99
 #define meshtastic_AdminMessage_nodedb_reset_tag 100
+#define meshtastic_AdminMessage_session_passkey_tag 101
 
 /* Struct field encoding specification for nanopb */
 #define meshtastic_AdminMessage_FIELDLIST(X, a) \
@@ -309,7 +315,8 @@ X(a, STATIC,   ONEOF,    BOOL,     (payload_variant,exit_simulator,exit_simulato
 X(a, STATIC,   ONEOF,    INT32,    (payload_variant,reboot_seconds,reboot_seconds),  97) \
 X(a, STATIC,   ONEOF,    INT32,    (payload_variant,shutdown_seconds,shutdown_seconds),  98) \
 X(a, STATIC,   ONEOF,    INT32,    (payload_variant,factory_reset_config,factory_reset_config),  99) \
-X(a, STATIC,   ONEOF,    INT32,    (payload_variant,nodedb_reset,nodedb_reset), 100)
+X(a, STATIC,   ONEOF,    INT32,    (payload_variant,nodedb_reset,nodedb_reset), 100) \
+X(a, STATIC,   SINGULAR, BYTES,    session_passkey, 101)
 #define meshtastic_AdminMessage_CALLBACK NULL
 #define meshtastic_AdminMessage_DEFAULT NULL
 #define meshtastic_AdminMessage_payload_variant_get_channel_response_MSGTYPE meshtastic_Channel
@@ -351,7 +358,7 @@ extern const pb_msgdesc_t meshtastic_NodeRemoteHardwarePinsResponse_msg;
 
 /* Maximum encoded size of messages (where known) */
 #define MESHTASTIC_MESHTASTIC_ADMIN_PB_H_MAX_SIZE meshtastic_AdminMessage_size
-#define meshtastic_AdminMessage_size             500
+#define meshtastic_AdminMessage_size             511
 #define meshtastic_HamParameters_size            31
 #define meshtastic_NodeRemoteHardwarePinsResponse_size 496
 

--- a/src/modules/AdminModule.h
+++ b/src/modules/AdminModule.h
@@ -25,6 +25,9 @@ class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Obser
   private:
     bool hasOpenEditTransaction = false;
 
+    uint8_t session_passkey[8] = {0};
+    uint session_time = 0;
+
     void saveChanges(int saveWhat, bool shouldReboot = true);
 
     /**
@@ -48,6 +51,12 @@ class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Obser
     void handleSetChannel();
     void handleSetHamMode(const meshtastic_HamParameters &req);
     void reboot(int32_t seconds);
+
+    void setPassKey(meshtastic_AdminMessage *res);
+    bool checkPassKey(meshtastic_AdminMessage *res);
+
+    bool messageIsResponse(meshtastic_AdminMessage *r);
+    bool messageIsRequest(meshtastic_AdminMessage *r);
 };
 
 extern AdminModule *adminModule;


### PR DESCRIPTION
To prevent replay attacks for remote admin messages, this adds a session key set by the node being administered, that must be included in any admin commands that change the state of the remote node.