### PR TITLE
Don't reject network time updates unintentionally

### DIFF
--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -140,7 +140,7 @@ void PositionModule::trySetRtc(meshtastic_Position p, bool isLocal, bool forceUp
 
 bool PositionModule::hasQualityTimesource()
 {
-    bool setFromPhoneOrNtpToday = (millis() - lastSetFromPhoneNtpOrGps) <= (SEC_PER_DAY * 1000UL);
+    bool setFromPhoneOrNtpToday = lastSetFromPhoneNtpOrGps == 0 ? false : (millis() - lastSetFromPhoneNtpOrGps) <= (SEC_PER_DAY * 1000UL);
     bool hasGpsOrRtc = (gps && gps->isConnected()) || (rtc_found.address != ScanI2C::ADDRESS_NONE.address);
     return hasGpsOrRtc || setFromPhoneOrNtpToday;
 }


### PR DESCRIPTION
Minor flaw in the new time setting logic, was refusing to set time from the network for the first 24 hours after boot. Namely because the default value of 0 was unintentionally indicating that time was set within the first second of boot. Solution is to treat lastSetFromPhoneNtpOrGps of 0 as a special case.