### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,24 @@
+FROM mcr.microsoft.com/devcontainers/cpp:1-debian-12
+
+# [Optional] Uncomment this section to install additional packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+    ca-certificates \
+    g++ \
+    git \
+    libbluetooth-dev \
+    libgpiod-dev \
+    liborcania-dev \
+    libssl-dev \
+    libulfius-dev \
+    libyaml-cpp-dev \
+    pkg-config \
+    python3 \
+    python3-pip \
+    python3-venv \
+    python3-wheel \
+    wget \
+    zip \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --no-cache-dir -U platformio==6.1.15

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/cpp
+{
+  "name": "Meshtastic Firmware Dev",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/python:1": {
+      "installTools": true,
+      "version": "latest"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools",
+        "platformio.platformio-ide",
+      ]
+    }
+  },
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [ 4403 ],
+
+  // Run commands to prepare the container for use
+  "postCreateCommand": ".devcontainer/setup.sh",
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+git submodule update --init


### PR DESCRIPTION
devcontainers can be used by [IDEs/editors](https://containers.dev/supporting) like [VS Code](https://containers.dev/supporting#visual-studio-code), [Intellij IDEA](https://containers.dev/supporting#intellij), and [GitHub Codespaces](https://containers.dev/supporting#github-codespaces) to create a standardized development environment in a container.

This adds the basics of a devcontainer with all the needed dependencies pre-installed. This devcontainer definition makes it easier for contributers to get up and going with a working development environment that is independent of anything else.

More information: https://containers.dev/