### PR TITLE
Fall back to default modem preset if requested bandwidth is too large

### DIFF
--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -412,72 +412,93 @@ void RadioInterface::applyModemConfig()
     // Set up default configuration
     // No Sync Words in LORA mode
     meshtastic_Config_LoRaConfig &loraConfig = config.lora;
-    if (loraConfig.use_preset) {
+    bool validConfig = false; // We need to check for a valid configuration
+    while (!validConfig) {
+        if (loraConfig.use_preset) {
 
-        switch (loraConfig.modem_preset) {
-        case meshtastic_Config_LoRaConfig_ModemPreset_SHORT_TURBO:
-            bw = (myRegion->wideLora) ? 812.5 : 500;
-            cr = 5;
-            sf = 7;
-            break;
-        case meshtastic_Config_LoRaConfig_ModemPreset_SHORT_FAST:
-            bw = (myRegion->wideLora) ? 812.5 : 250;
-            cr = 5;
-            sf = 7;
-            break;
-        case meshtastic_Config_LoRaConfig_ModemPreset_SHORT_SLOW:
-            bw = (myRegion->wideLora) ? 812.5 : 250;
-            cr = 5;
-            sf = 8;
-            break;
-        case meshtastic_Config_LoRaConfig_ModemPreset_MEDIUM_FAST:
-            bw = (myRegion->wideLora) ? 812.5 : 250;
-            cr = 5;
-            sf = 9;
-            break;
-        case meshtastic_Config_LoRaConfig_ModemPreset_MEDIUM_SLOW:
-            bw = (myRegion->wideLora) ? 812.5 : 250;
-            cr = 5;
-            sf = 10;
-            break;
-        default: // Config_LoRaConfig_ModemPreset_LONG_FAST is default. Gracefully use this is preset is something illegal.
-            bw = (myRegion->wideLora) ? 812.5 : 250;
-            cr = 5;
-            sf = 11;
-            break;
-        case meshtastic_Config_LoRaConfig_ModemPreset_LONG_MODERATE:
-            bw = (myRegion->wideLora) ? 406.25 : 125;
-            cr = 8;
-            sf = 11;
-            break;
-        case meshtastic_Config_LoRaConfig_ModemPreset_LONG_SLOW:
-            bw = (myRegion->wideLora) ? 406.25 : 125;
-            cr = 8;
-            sf = 12;
-            break;
-        case meshtastic_Config_LoRaConfig_ModemPreset_VERY_LONG_SLOW:
-            bw = (myRegion->wideLora) ? 203.125 : 62.5;
-            cr = 8;
-            sf = 12;
-            break;
+            switch (loraConfig.modem_preset) {
+            case meshtastic_Config_LoRaConfig_ModemPreset_SHORT_TURBO:
+                bw = (myRegion->wideLora) ? 812.5 : 500;
+                cr = 5;
+                sf = 7;
+                break;
+            case meshtastic_Config_LoRaConfig_ModemPreset_SHORT_FAST:
+                bw = (myRegion->wideLora) ? 812.5 : 250;
+                cr = 5;
+                sf = 7;
+                break;
+            case meshtastic_Config_LoRaConfig_ModemPreset_SHORT_SLOW:
+                bw = (myRegion->wideLora) ? 812.5 : 250;
+                cr = 5;
+                sf = 8;
+                break;
+            case meshtastic_Config_LoRaConfig_ModemPreset_MEDIUM_FAST:
+                bw = (myRegion->wideLora) ? 812.5 : 250;
+                cr = 5;
+                sf = 9;
+                break;
+            case meshtastic_Config_LoRaConfig_ModemPreset_MEDIUM_SLOW:
+                bw = (myRegion->wideLora) ? 812.5 : 250;
+                cr = 5;
+                sf = 10;
+                break;
+            default: // Config_LoRaConfig_ModemPreset_LONG_FAST is default. Gracefully use this is preset is something illegal.
+                bw = (myRegion->wideLora) ? 812.5 : 250;
+                cr = 5;
+                sf = 11;
+                break;
+            case meshtastic_Config_LoRaConfig_ModemPreset_LONG_MODERATE:
+                bw = (myRegion->wideLora) ? 406.25 : 125;
+                cr = 8;
+                sf = 11;
+                break;
+            case meshtastic_Config_LoRaConfig_ModemPreset_LONG_SLOW:
+                bw = (myRegion->wideLora) ? 406.25 : 125;
+                cr = 8;
+                sf = 12;
+                break;
+            case meshtastic_Config_LoRaConfig_ModemPreset_VERY_LONG_SLOW:
+                bw = (myRegion->wideLora) ? 203.125 : 62.5;
+                cr = 8;
+                sf = 12;
+                break;
+            }
+        } else {
+            sf = loraConfig.spread_factor;
+            cr = loraConfig.coding_rate;
+            bw = loraConfig.bandwidth;
+
+            if (bw == 31) // This parameter is not an integer
+                bw = 31.25;
+            if (bw == 62) // Fix for 62.5Khz bandwidth
+                bw = 62.5;
+            if (bw == 200)
+                bw = 203.125;
+            if (bw == 400)
+                bw = 406.25;
+            if (bw == 800)
+                bw = 812.5;
+            if (bw == 1600)
+                bw = 1625.0;
         }
-    } else {
-        sf = loraConfig.spread_factor;
-        cr = loraConfig.coding_rate;
-        bw = loraConfig.bandwidth;
 
-        if (bw == 31) // This parameter is not an integer
-            bw = 31.25;
-        if (bw == 62) // Fix for 62.5Khz bandwidth
-            bw = 62.5;
-        if (bw == 200)
-            bw = 203.125;
-        if (bw == 400)
-            bw = 406.25;
-        if (bw == 800)
-            bw = 812.5;
-        if (bw == 1600)
-            bw = 1625.0;
+        if ((myRegion->freqEnd - myRegion->freqStart) < bw / 1000) {
+            static const char *err_string =
+                "Regional frequency range is smaller than bandwidth. Falling back to default preset.\n";
+            LOG_ERROR(err_string);
+            RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+
+            meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
+            cn->level = meshtastic_LogRecord_Level_ERROR;
+            sprintf(cn->message, err_string);
+            service->sendClientNotification(cn);
+
+            // Set to default modem preset
+            loraConfig.use_preset = true;
+            loraConfig.modem_preset = meshtastic_Config_LoRaConfig_ModemPreset_LONG_FAST;
+        } else {
+            validConfig = true;
+        }
     }
 
     power = loraConfig.tx_power;

--- a/src/mesh/RadioInterface.h
+++ b/src/mesh/RadioInterface.h
@@ -5,6 +5,7 @@
 #include "Observer.h"
 #include "PointerQueue.h"
 #include "airtime.h"
+#include "error.h"
 
 #define MAX_TX_QUEUE 16 // max number of packets which can be waiting for transmission
 


### PR DESCRIPTION
Needed for `SHORT_TURBO` preset, which is not allowed in some regions, but also applies if you don't use a preset. Will print an error, record a critical error and send a ClientNotification.
