### PR TITLE
Only accept PKI messages for MQTT downlink for known nodes

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -164,10 +164,14 @@ void MQTT::onReceive(char *topic, byte *payload, size_t length)
 
                     // PKI messages get accepted even if we can't decrypt
                     if (router && p->which_payload_variant == meshtastic_MeshPacket_encrypted_tag &&
-                        strcmp(e.channel_id, "PKI") == 0)
-                        router->enqueueReceivedMessage(p);
-                    // ignore messages if we don't have the channel key
-                    else if (router && perhapsDecode(p))
+                        strcmp(e.channel_id, "PKI") == 0) {
+                        meshtastic_NodeInfoLite *tx = nodeDB->getMeshNode(getFrom(p));
+                        meshtastic_NodeInfoLite *rx = nodeDB->getMeshNode(p->to);
+                        // Only accept PKI messages if we have both the sender and receiver in our nodeDB, as then it's likely
+                        // they discovered each other via a channel we have downlink enabled for
+                        if (tx && tx->has_user && rx && rx->has_user)
+                            router->enqueueReceivedMessage(p);
+                    } else if (router && perhapsDecode(p)) // ignore messages if we don't have the channel key
                         router->enqueueReceivedMessage(p);
                     else
                         packetPool.release(p);


### PR DESCRIPTION
We're potentially receiving a lot of DMs on an MQTT root topic if we have downlink enabled on a (private) channel, but not all are of interest. Let's only accept PKI messages when we know the transmitter and receiver, as then it's (more) likely they would normally have communicated via a channel we have downlink enabled.
