### PR TITLE
Remove heltec-specific gps code from main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -294,19 +294,9 @@ void setup()
     digitalWrite(VEXT_ENABLE, 0); // turn on the display power
 #endif
 
-#if defined(VGNSS_CTRL_V03)
-    pinMode(VGNSS_CTRL_V03, OUTPUT);
-    digitalWrite(VGNSS_CTRL_V03, LOW);
-#endif
-
 #if defined(VTFT_CTRL_V03)
     pinMode(VTFT_CTRL_V03, OUTPUT);
     digitalWrite(VTFT_CTRL_V03, LOW);
-#endif
-
-#if defined(VGNSS_CTRL)
-    pinMode(VGNSS_CTRL, OUTPUT);
-    digitalWrite(VGNSS_CTRL, LOW);
 #endif
 
 #if defined(VTFT_CTRL)


### PR DESCRIPTION
After the recent GPS power work we have an clear set of definitions for turning GPS on and off. Rather than manipulating specific heltec tracker-related pins in main setup, the relevant power management code in the GPS module will turn things on/off later as needed.