### PR TITLE
remove deprecated serial/bt logging options (fix #4375)

### DIFF
--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -213,7 +213,7 @@ void RedirectablePrint::log_to_syslog(const char *logLevel, const char *format, 
 void RedirectablePrint::log_to_ble(const char *logLevel, const char *format, va_list arg)
 {
 #if !MESHTASTIC_EXCLUDE_BLUETOOTH
-    if (config.security.bluetooth_logging_enabled && !pauseBluetoothLogging) {
+    if (config.security.debug_log_api_enabled && !pauseBluetoothLogging) {
         bool isBleConnected = false;
 #ifdef ARCH_ESP32
         isBleConnected = nimbleBluetooth && nimbleBluetooth->isActive() && nimbleBluetooth->isConnected();

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -127,7 +127,6 @@ NodeDB::NodeDB()
     if (!config.has_security) {
         config.has_security = true;
         config.security.serial_enabled = config.device.serial_enabled;
-        config.security.bluetooth_logging_enabled = config.bluetooth.device_logging_enabled;
         config.security.is_managed = config.device.is_managed;
     }
 #if !(MESHTASTIC_EXCLUDE_PKI)

--- a/src/mesh/generated/meshtastic/config.pb.h
+++ b/src/mesh/generated/meshtastic/config.pb.h
@@ -284,10 +284,6 @@ typedef struct _meshtastic_Config_DeviceConfig {
     /* Disabling this will disable the SerialConsole by not initilizing the StreamAPI
  Moved to SecurityConfig */
     bool serial_enabled;
-    /* By default we turn off logging as soon as an API client connects (to keep shared serial link quiet).
- Set this to true to leave the debug log outputting even when API is active.
- Moved to SecurityConfig */
-    bool debug_log_enabled;
     /* For boards without a hard wired button, this is the pin number that will be used
  Boards that have more than one button can swap the function with this one. defaults to BUTTON_PIN if defined. */
     uint32_t button_gpio;
@@ -523,9 +519,6 @@ typedef struct _meshtastic_Config_BluetoothConfig {
     meshtastic_Config_BluetoothConfig_PairingMode mode;
     /* Specified PIN for PairingMode.FixedPin */
     uint32_t fixed_pin;
-    /* Enables device (serial style logs) over Bluetooth
- Moved to SecurityConfig */
-    bool device_logging_enabled;
 } meshtastic_Config_BluetoothConfig;
 
 typedef PB_BYTES_ARRAY_T(32) meshtastic_Config_SecurityConfig_public_key_t;
@@ -546,10 +539,8 @@ typedef struct _meshtastic_Config_SecurityConfig {
     /* Serial Console over the Stream API." */
     bool serial_enabled;
     /* By default we turn off logging as soon as an API client connects (to keep shared serial link quiet).
- Output live debug logging over serial. */
+ Output live debug logging over serial or bluetooth is set to true. */
     bool debug_log_api_enabled;
-    /* Enables device (serial style logs) over Bluetooth */
-    bool bluetooth_logging_enabled;
     /* Allow incoming device control over the insecure legacy admin channel. */
     bool admin_channel_enabled;
 } meshtastic_Config_SecurityConfig;
@@ -658,32 +649,31 @@ extern "C" {
 
 /* Initializer values for message structs */
 #define meshtastic_Config_init_default           {0, {meshtastic_Config_DeviceConfig_init_default}}
-#define meshtastic_Config_DeviceConfig_init_default {_meshtastic_Config_DeviceConfig_Role_MIN, 0, 0, 0, 0, _meshtastic_Config_DeviceConfig_RebroadcastMode_MIN, 0, 0, 0, 0, "", 0}
+#define meshtastic_Config_DeviceConfig_init_default {_meshtastic_Config_DeviceConfig_Role_MIN, 0, 0, 0, _meshtastic_Config_DeviceConfig_RebroadcastMode_MIN, 0, 0, 0, 0, "", 0}
 #define meshtastic_Config_PositionConfig_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, _meshtastic_Config_PositionConfig_GpsMode_MIN}
 #define meshtastic_Config_PowerConfig_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_Config_NetworkConfig_init_default {0, "", "", "", 0, _meshtastic_Config_NetworkConfig_AddressMode_MIN, false, meshtastic_Config_NetworkConfig_IpV4Config_init_default, ""}
 #define meshtastic_Config_NetworkConfig_IpV4Config_init_default {0, 0, 0, 0}
 #define meshtastic_Config_DisplayConfig_init_default {0, _meshtastic_Config_DisplayConfig_GpsCoordinateFormat_MIN, 0, 0, 0, _meshtastic_Config_DisplayConfig_DisplayUnits_MIN, _meshtastic_Config_DisplayConfig_OledType_MIN, _meshtastic_Config_DisplayConfig_DisplayMode_MIN, 0, 0, _meshtastic_Config_DisplayConfig_CompassOrientation_MIN}
 #define meshtastic_Config_LoRaConfig_init_default {0, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, 0, 0, 0, 0, _meshtastic_Config_LoRaConfig_RegionCode_MIN, 0, 0, 0, 0, 0, 0, 0, 0, 0, {0, 0, 0}, 0}
-#define meshtastic_Config_BluetoothConfig_init_default {0, _meshtastic_Config_BluetoothConfig_PairingMode_MIN, 0, 0}
-#define meshtastic_Config_SecurityConfig_init_default {{0, {0}}, {0, {0}}, {0, {0}}, 0, 0, 0, 0, 0}
+#define meshtastic_Config_BluetoothConfig_init_default {0, _meshtastic_Config_BluetoothConfig_PairingMode_MIN, 0}
+#define meshtastic_Config_SecurityConfig_init_default {{0, {0}}, {0, {0}}, {0, {0}}, 0, 0, 0, 0}
 #define meshtastic_Config_SessionkeyConfig_init_default {0}
 #define meshtastic_Config_init_zero              {0, {meshtastic_Config_DeviceConfig_init_zero}}
-#define meshtastic_Config_DeviceConfig_init_zero {_meshtastic_Config_DeviceConfig_Role_MIN, 0, 0, 0, 0, _meshtastic_Config_DeviceConfig_RebroadcastMode_MIN, 0, 0, 0, 0, "", 0}
+#define meshtastic_Config_DeviceConfig_init_zero {_meshtastic_Config_DeviceConfig_Role_MIN, 0, 0, 0, _meshtastic_Config_DeviceConfig_RebroadcastMode_MIN, 0, 0, 0, 0, "", 0}
 #define meshtastic_Config_PositionConfig_init_zero {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, _meshtastic_Config_PositionConfig_GpsMode_MIN}
 #define meshtastic_Config_PowerConfig_init_zero  {0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_Config_NetworkConfig_init_zero {0, "", "", "", 0, _meshtastic_Config_NetworkConfig_AddressMode_MIN, false, meshtastic_Config_NetworkConfig_IpV4Config_init_zero, ""}
 #define meshtastic_Config_NetworkConfig_IpV4Config_init_zero {0, 0, 0, 0}
 #define meshtastic_Config_DisplayConfig_init_zero {0, _meshtastic_Config_DisplayConfig_GpsCoordinateFormat_MIN, 0, 0, 0, _meshtastic_Config_DisplayConfig_DisplayUnits_MIN, _meshtastic_Config_DisplayConfig_OledType_MIN, _meshtastic_Config_DisplayConfig_DisplayMode_MIN, 0, 0, _meshtastic_Config_DisplayConfig_CompassOrientation_MIN}
 #define meshtastic_Config_LoRaConfig_init_zero   {0, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, 0, 0, 0, 0, _meshtastic_Config_LoRaConfig_RegionCode_MIN, 0, 0, 0, 0, 0, 0, 0, 0, 0, {0, 0, 0}, 0}
-#define meshtastic_Config_BluetoothConfig_init_zero {0, _meshtastic_Config_BluetoothConfig_PairingMode_MIN, 0, 0}
-#define meshtastic_Config_SecurityConfig_init_zero {{0, {0}}, {0, {0}}, {0, {0}}, 0, 0, 0, 0, 0}
+#define meshtastic_Config_BluetoothConfig_init_zero {0, _meshtastic_Config_BluetoothConfig_PairingMode_MIN, 0}
+#define meshtastic_Config_SecurityConfig_init_zero {{0, {0}}, {0, {0}}, {0, {0}}, 0, 0, 0, 0}
 #define meshtastic_Config_SessionkeyConfig_init_zero {0}
 
 /* Field tags (for use in manual encoding/decoding) */
 #define meshtastic_Config_DeviceConfig_role_tag  1
 #define meshtastic_Config_DeviceConfig_serial_enabled_tag 2
-#define meshtastic_Config_DeviceConfig_debug_log_enabled_tag 3
 #define meshtastic_Config_DeviceConfig_button_gpio_tag 4
 #define meshtastic_Config_DeviceConfig_buzzer_gpio_tag 5
 #define meshtastic_Config_DeviceConfig_rebroadcast_mode_tag 6
@@ -758,14 +748,12 @@ extern "C" {
 #define meshtastic_Config_BluetoothConfig_enabled_tag 1
 #define meshtastic_Config_BluetoothConfig_mode_tag 2
 #define meshtastic_Config_BluetoothConfig_fixed_pin_tag 3
-#define meshtastic_Config_BluetoothConfig_device_logging_enabled_tag 4
 #define meshtastic_Config_SecurityConfig_public_key_tag 1
 #define meshtastic_Config_SecurityConfig_private_key_tag 2
 #define meshtastic_Config_SecurityConfig_admin_key_tag 3
 #define meshtastic_Config_SecurityConfig_is_managed_tag 4
 #define meshtastic_Config_SecurityConfig_serial_enabled_tag 5
 #define meshtastic_Config_SecurityConfig_debug_log_api_enabled_tag 6
-#define meshtastic_Config_SecurityConfig_bluetooth_logging_enabled_tag 7
 #define meshtastic_Config_SecurityConfig_admin_channel_enabled_tag 8
 #define meshtastic_Config_device_tag             1
 #define meshtastic_Config_position_tag           2
@@ -803,7 +791,6 @@ X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,sessionkey,payload_variant.s
 #define meshtastic_Config_DeviceConfig_FIELDLIST(X, a) \
 X(a, STATIC,   SINGULAR, UENUM,    role,              1) \
 X(a, STATIC,   SINGULAR, BOOL,     serial_enabled,    2) \
-X(a, STATIC,   SINGULAR, BOOL,     debug_log_enabled,   3) \
 X(a, STATIC,   SINGULAR, UINT32,   button_gpio,       4) \
 X(a, STATIC,   SINGULAR, UINT32,   buzzer_gpio,       5) \
 X(a, STATIC,   SINGULAR, UENUM,    rebroadcast_mode,   6) \
@@ -906,8 +893,7 @@ X(a, STATIC,   SINGULAR, BOOL,     ignore_mqtt,     104)
 #define meshtastic_Config_BluetoothConfig_FIELDLIST(X, a) \
 X(a, STATIC,   SINGULAR, BOOL,     enabled,           1) \
 X(a, STATIC,   SINGULAR, UENUM,    mode,              2) \
-X(a, STATIC,   SINGULAR, UINT32,   fixed_pin,         3) \
-X(a, STATIC,   SINGULAR, BOOL,     device_logging_enabled,   4)
+X(a, STATIC,   SINGULAR, UINT32,   fixed_pin,         3)
 #define meshtastic_Config_BluetoothConfig_CALLBACK NULL
 #define meshtastic_Config_BluetoothConfig_DEFAULT NULL
 
@@ -918,7 +904,6 @@ X(a, STATIC,   SINGULAR, BYTES,    admin_key,         3) \
 X(a, STATIC,   SINGULAR, BOOL,     is_managed,        4) \
 X(a, STATIC,   SINGULAR, BOOL,     serial_enabled,    5) \
 X(a, STATIC,   SINGULAR, BOOL,     debug_log_api_enabled,   6) \
-X(a, STATIC,   SINGULAR, BOOL,     bluetooth_logging_enabled,   7) \
 X(a, STATIC,   SINGULAR, BOOL,     admin_channel_enabled,   8)
 #define meshtastic_Config_SecurityConfig_CALLBACK NULL
 #define meshtastic_Config_SecurityConfig_DEFAULT NULL
@@ -955,15 +940,15 @@ extern const pb_msgdesc_t meshtastic_Config_SessionkeyConfig_msg;
 
 /* Maximum encoded size of messages (where known) */
 #define MESHTASTIC_MESHTASTIC_CONFIG_PB_H_MAX_SIZE meshtastic_Config_size
-#define meshtastic_Config_BluetoothConfig_size   12
-#define meshtastic_Config_DeviceConfig_size      100
+#define meshtastic_Config_BluetoothConfig_size   10
+#define meshtastic_Config_DeviceConfig_size      98
 #define meshtastic_Config_DisplayConfig_size     30
 #define meshtastic_Config_LoRaConfig_size        82
 #define meshtastic_Config_NetworkConfig_IpV4Config_size 20
 #define meshtastic_Config_NetworkConfig_size     196
 #define meshtastic_Config_PositionConfig_size    62
 #define meshtastic_Config_PowerConfig_size       52
-#define meshtastic_Config_SecurityConfig_size    112
+#define meshtastic_Config_SecurityConfig_size    110
 #define meshtastic_Config_SessionkeyConfig_size  0
 #define meshtastic_Config_size                   199
 

--- a/src/mesh/generated/meshtastic/deviceonly.pb.h
+++ b/src/mesh/generated/meshtastic/deviceonly.pb.h
@@ -358,7 +358,7 @@ extern const pb_msgdesc_t meshtastic_OEMStore_msg;
 #define MESHTASTIC_MESHTASTIC_DEVICEONLY_PB_H_MAX_SIZE meshtastic_OEMStore_size
 #define meshtastic_ChannelFile_size              718
 #define meshtastic_NodeInfoLite_size             183
-#define meshtastic_OEMStore_size                 3502
+#define meshtastic_OEMStore_size                 3496
 #define meshtastic_PositionLite_size             28
 #define meshtastic_UserLite_size                 96
 

--- a/src/mesh/generated/meshtastic/localonly.pb.h
+++ b/src/mesh/generated/meshtastic/localonly.pb.h
@@ -187,7 +187,7 @@ extern const pb_msgdesc_t meshtastic_LocalModuleConfig_msg;
 
 /* Maximum encoded size of messages (where known) */
 #define MESHTASTIC_MESHTASTIC_LOCALONLY_PB_H_MAX_SIZE meshtastic_LocalModuleConfig_size
-#define meshtastic_LocalConfig_size              669
+#define meshtastic_LocalConfig_size              663
 #define meshtastic_LocalModuleConfig_size        687
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fix #4375 - see that issue for discussion.  

> no need to preserve the old options when changing to this new simpler
single boolean because they were newish, rarely used and only for 'advanced'
developers.  Also uses the new 'security' config section.