### PR TITLE
Use the '+' wildcard for MQTT rather than '#'

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -376,12 +376,12 @@ void MQTT::sendSubscriptions()
         const auto &ch = channels.getByIndex(i);
         if (ch.settings.downlink_enabled) {
             hasDownlink = true;
-            std::string topic = cryptTopic + channels.getGlobalId(i) + "/#";
+            std::string topic = cryptTopic + channels.getGlobalId(i) + "/+";
             LOG_INFO("Subscribing to %s\n", topic.c_str());
             pubSub.subscribe(topic.c_str(), 1); // FIXME, is QOS 1 right?
 #ifndef ARCH_NRF52                              // JSON is not supported on nRF52, see issue #2804
             if (moduleConfig.mqtt.json_enabled == true) {
-                std::string topicDecoded = jsonTopic + channels.getGlobalId(i) + "/#";
+                std::string topicDecoded = jsonTopic + channels.getGlobalId(i) + "/+";
                 LOG_INFO("Subscribing to %s\n", topicDecoded.c_str());
                 pubSub.subscribe(topicDecoded.c_str(), 1); // FIXME, is QOS 1 right?
             }
@@ -390,7 +390,7 @@ void MQTT::sendSubscriptions()
     }
 #if !MESHTASTIC_EXCLUDE_PKI
     if (hasDownlink) {
-        std::string topic = cryptTopic + "PKI/#";
+        std::string topic = cryptTopic + "PKI/+";
         LOG_INFO("Subscribing to %s\n", topic.c_str());
         pubSub.subscribe(topic.c_str(), 1);
     }


### PR DESCRIPTION
This means we'll then be subscribing only to topics one nesting level deep, rather than any amount of nesting through the end of the topic, as `#` does.

Discussed briefly with some of y'all firmware devs but I believe this should be fine and limit what messages are getting sent to firmware a little bit. We're not publishing anything deeper than e.g. `msh/2/e/ChannelName/!12345678`, meaning `msh/2/e/ChannelName/+` will pick that up. Without this change, you could for example set your root topic to `msh/2/e/ChannelName`, which would then publish messages to `msh/2/e/ChannelName/2/e/DifferentChannelName/!abcdef01` and it would go to clients with just `msh` configured as the prefix and a downlink on the `ChannelName` channel.

I think that there's another improvement to be made in that we should probably only be subscribing to the json topic if and when the channel name is equal to `mqtt`, rather than subscribing to it on every channel and then throwing out everything that's not on the `mqtt` topic. But comparing strings in C++ is a project for a different day, for me :)