### PR TITLE
Enable RED Power LED for WIO-E5 Mini and WIO-E5 DEV Kit 

### DIFF
--- a/variants/wio-e5/variant.h
+++ b/variants/wio-e5/variant.h
@@ -15,4 +15,7 @@ Do not expect a working Meshtastic device with this target.
 #define USE_STM32WLx
 #define MAX_NUM_NODES 10
 
+#define LED_PIN PB5
+#define LED_STATE_ON 1
+
 #endif


### PR DESCRIPTION
Enables the onboard RED Power LED

![image](https://github.com/user-attachments/assets/b64a589d-270c-4c5c-9433-79067bebef43)

![image](https://github.com/user-attachments/assets/8fc689f5-5486-4df5-8e02-27ca8ac54b8f)

