### PR TITLE
add a .yml to setup a Gitpod instance quickly

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,2 @@
+tasks:
+  - init: pip install platformio

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,2 +1,2 @@
 tasks:
-  - init: pip install platformio
+  - init: pip install platformio && pip install --upgrade pip


### PR DESCRIPTION
See also https://github.com/meshtastic/meshtastic/pull/1392

With this added, the `pip install plarformio` can be skipped, saving valuable seconds.
