### PR TITLE
Mask out random bits when doing queue ordering

### DIFF
--- a/src/mesh/MeshPacketQueue.cpp
+++ b/src/mesh/MeshPacketQueue.cpp
@@ -20,8 +20,9 @@ bool CompareMeshPacketFunc(const meshtastic_MeshPacket *p1, const meshtastic_Mes
     // If priorities differ, use that
     // for equal priorities, order by id (older packets have higher priority - this will briefly be wrong when IDs roll over but
     // no big deal)
-    return (p1p != p2p) ? (p1p < p2p)         // prefer bigger priorities
-                        : (p1->id >= p2->id); // prefer smaller packet ids
+    return (p1p != p2p)
+               ? (p1p < p2p)                                                 // prefer bigger priorities
+               : ((p1->id & ID_COUNTER_MASK) >= (p2->id & ID_COUNTER_MASK)); // Mask to counter portion, prefer smaller packet ids
 }
 
 MeshPacketQueue::MeshPacketQueue(size_t _maxLen) : maxLen(_maxLen) {}

--- a/src/mesh/MeshTypes.h
+++ b/src/mesh/MeshTypes.h
@@ -14,9 +14,9 @@ typedef uint32_t PacketId; // A packet sequence number
     1 // Reserved to only deliver packets over high speed (non-lora) transports, such as MQTT or BLE mesh (not yet implemented)
 #define ERRNO_OK 0
 #define ERRNO_NO_INTERFACES 33
-#define ERRNO_UNKNOWN 32                 // pick something that doesn't conflict with RH_ROUTER_ERROR_UNABLE_TO_DELIVER
-#define ERRNO_DISABLED 34                // the interface is disabled
-#define ID_COUNTER_MASK UINT32_MAX >> 22 // mask to select the counter portion of the ID
+#define ERRNO_UNKNOWN 32                   // pick something that doesn't conflict with RH_ROUTER_ERROR_UNABLE_TO_DELIVER
+#define ERRNO_DISABLED 34                  // the interface is disabled
+#define ID_COUNTER_MASK (UINT32_MAX >> 22) // mask to select the counter portion of the ID
 
 /*
  * Source of a received message

--- a/src/mesh/MeshTypes.h
+++ b/src/mesh/MeshTypes.h
@@ -14,8 +14,9 @@ typedef uint32_t PacketId; // A packet sequence number
     1 // Reserved to only deliver packets over high speed (non-lora) transports, such as MQTT or BLE mesh (not yet implemented)
 #define ERRNO_OK 0
 #define ERRNO_NO_INTERFACES 33
-#define ERRNO_UNKNOWN 32  // pick something that doesn't conflict with RH_ROUTER_ERROR_UNABLE_TO_DELIVER
-#define ERRNO_DISABLED 34 // the interface is disabled
+#define ERRNO_UNKNOWN 32                 // pick something that doesn't conflict with RH_ROUTER_ERROR_UNABLE_TO_DELIVER
+#define ERRNO_DISABLED 34                // the interface is disabled
+#define ID_COUNTER_MASK UINT32_MAX >> 22 // mask to select the counter portion of the ID
 
 /*
  * Source of a received message

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -109,7 +109,7 @@ PacketId generatePacketId()
 
     rollingPacketId++;
 
-    rollingPacketId &= UINT32_MAX >> 22;                                   // Mask out the top 22 bits
+    rollingPacketId &= ID_COUNTER_MASK;                                    // Mask out the top 22 bits
     PacketId id = rollingPacketId | random(UINT32_MAX & 0x7fffffff) << 10; // top 22 bits
     LOG_DEBUG("Partially randomized packet id %u\n", id);
     return id;


### PR DESCRIPTION
Unintended consequence of randomizing top bits of Packet IDs was that we do use those values to determine packet order in the queue. Simple fix, to mask out the random bits when doing that comparison.