### PR TITLE
Fix devcontainer Dockerfile build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     libssl-dev \
     libulfius-dev \
     libyaml-cpp-dev \
+    pipx \
     pkg-config \
     python3 \
     python3-pip \
@@ -21,4 +22,4 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     zip \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --no-cache-dir -U platformio==6.1.15
+RUN pipx install platformio==6.1.15


### PR DESCRIPTION
Adding the devcontainer configuration was a great initiative! With them (and the change in this pull request) I was finally able to successfully build the `native` environment on macOS.

VSCode would fail to create a devcontainer with the following message:

```
[2024-08-26T16:04:47.848Z] iner_auto_added_stage_label 3/3] RUN pip3 install --no-cache-dir -U platformio==6.1.15:
0.198 error: externally-managed-environment
0.198 
0.198 × This environment is externally managed
0.198 ╰─> To install Python packages system-wide, try apt install
0.198     python3-xyz, where xyz is the package you are trying to
0.198     install.
0.198     
0.198     If you wish to install a non-Debian-packaged Python package,
0.198     create a virtual environment using python3 -m venv path/to/venv.
0.198     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
0.198     sure you have python3-full installed.
0.198     
0.198     If you wish to install a non-Debian packaged Python application,
0.198     it may be easiest to use pipx install xyz, which will manage a
0.198     virtual environment for you. Make sure you have pipx installed.
0.198     
[2024-08-26T16:04:47.848Z] 
0.198     See /usr/share/doc/python3.11/README.venv for more information.
0.198 
0.198 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
0.198 hint: See PEP 668 for the detailed specification.
------
[2024-08-26T16:04:47.850Z] Dockerfile-with-features:26
--------------------
  24 |         && apt-get clean && rm -rf /var/lib/apt/lists/*
  25 |     
  26 | >>> RUN pip3 install --no-cache-dir -U platformio==6.1.15
  27 |     
  28 |     
--------------------
```