### PR TITLE
Move Time set from system to main

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -258,6 +258,12 @@ void setup()
 #ifdef DEBUG_PORT
     consoleInit(); // Set serial baud rate and init our mesh console
 #endif
+#if ARCH_PORTDUINO
+    struct timeval tv;
+    tv.tv_sec = time(NULL);
+    tv.tv_usec = 0;
+    perhapsSetRTC(RTCQualityNTP, &tv);
+#endif
     powerMonInit();
 
     serialSinceMsec = millis();

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -1,6 +1,5 @@
 #include "CryptoEngine.h"
 #include "PortduinoGPIO.h"
-#include "RTC.h"
 #include "SPIChip.h"
 #include "mesh/RF95Interface.h"
 #include "sleep.h"
@@ -8,7 +7,6 @@
 
 #include <Utility.h>
 #include <assert.h>
-#include <time.h>
 
 #include "PortduinoGlue.h"
 #include "linux/gpio/LinuxGPIOPin.h"
@@ -371,11 +369,6 @@ void portduinoSetup()
             exit(EXIT_FAILURE);
         }
     }
-
-    struct timeval tv;
-    tv.tv_sec = time(NULL);
-    tv.tv_usec = 0;
-    perhapsSetRTC(RTCQualityNTP, &tv);
 
     return;
 }


### PR DESCRIPTION
We run into a precedence issue here, where we can't set the time before the console is inited, and we can init the console before concurrency::hasBeenSetup is set to true. So we move it into main.