### PR TITLE
Add bluetooth capability marker to some ESP32S3 boards

### DIFF
--- a/boards/CDEBYTE_EoRa-S3.json
+++ b/boards/CDEBYTE_EoRa-S3.json
@@ -19,7 +19,7 @@
     "mcu": "esp32s3",
     "variant": "CDEBYTE_EoRa-S3"
   },
-  "connectivity": ["wifi"],
+  "connectivity": ["wifi", "bluetooth"],
   "debug": {
     "openocd_target": "esp32s3.cfg"
   },

--- a/boards/ESP32-S3-WROOM-1-N4.json
+++ b/boards/ESP32-S3-WROOM-1-N4.json
@@ -19,7 +19,7 @@
     "mcu": "esp32s3",
     "variant": "ESP32-S3-WROOM-1-N4"
   },
-  "connectivity": ["wifi"],
+  "connectivity": ["wifi", "bluetooth"],
   "debug": {
     "default_tool": "esp-builtin",
     "onboard_tools": ["esp-builtin"],

--- a/boards/tlora-t3s3-v1.json
+++ b/boards/tlora-t3s3-v1.json
@@ -19,7 +19,7 @@
     "mcu": "esp32s3",
     "variant": "tlora-t3s3-v1"
   },
-  "connectivity": ["wifi"],
+  "connectivity": ["wifi", "bluetooth"],
   "debug": {
     "openocd_target": "esp32s3.cfg"
   },


### PR DESCRIPTION
It may or may not be needed, but I spotted it via https://github.com/platformio/platform-espressif32/pull/1334 also mentioning https://github.com/platformio/platform-espressif32/commit/f6ec3926f9f660ee9abada8540ffe1e205da4bbf

I think it does nothing, as it seems to work fine without it. Please test, I can manually add it to the rest of [the S3 board files](https://github.com/search?q=repo%3Ameshtastic%2Ffirmware++path%3A*.json+esp32s3+content%3Aconnectivity&type=code) if it results in a change