### PR TITLE
Consider an admin timestamp to be higher quality than from mesh

### DIFF
--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -288,7 +288,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         tv.tv_sec = r->set_time_only;
         tv.tv_usec = 0;
 
-        perhapsSetRTC(RTCQualityFromNet, &tv, false);
+        perhapsSetRTC(RTCQualityNTP, &tv, false);
         break;
     }
     case meshtastic_AdminMessage_enter_dfu_mode_request_tag: {


### PR DESCRIPTION
Particularly with changes to the iOS app, more users are complaining that their local node times are wrong. I suspect this is why. In PositionModule, when the time source is local, we use RTCQualityNTP. Suggest we do the same here. This should ensure that a bogus time from the net gets overwritten by a good time from the local client.