### PR TITLE
Set high priority for text messages

### DIFF
--- a/src/mesh/MeshPacketQueue.cpp
+++ b/src/mesh/MeshPacketQueue.cpp
@@ -40,19 +40,22 @@ void fixPriority(meshtastic_MeshPacket *p)
     // We might receive acks from other nodes (and since generated remotely, they won't have priority assigned.  Check for that
     // and fix it
     if (p->priority == meshtastic_MeshPacket_Priority_UNSET) {
-        // if acks give high priority
         // if a reliable message give a bit higher default priority
-        p->priority = (p->decoded.portnum == meshtastic_PortNum_ROUTING_APP)
-                          ? meshtastic_MeshPacket_Priority_ACK
-                          : (p->want_ack ? meshtastic_MeshPacket_Priority_RELIABLE : meshtastic_MeshPacket_Priority_DEFAULT);
+        p->priority = (p->want_ack ? meshtastic_MeshPacket_Priority_RELIABLE : meshtastic_MeshPacket_Priority_DEFAULT);
+        if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
+            // if acks/naks give very high priority
+            if (p->decoded.portnum == meshtastic_PortNum_ROUTING_APP)
+                p->priority = meshtastic_MeshPacket_Priority_ACK;
+            // if text give high priority
+            else if (p->decoded.portnum == meshtastic_PortNum_TEXT_MESSAGE_APP)
+                p->priority = meshtastic_MeshPacket_Priority_HIGH;
+        }
     }
 }
 
 /** enqueue a packet, return false if full */
 bool MeshPacketQueue::enqueue(meshtastic_MeshPacket *p)
 {
-    fixPriority(p);
-
     // no space - try to replace a lower priority packet in the queue
     if (queue.size() >= maxLen) {
         return replaceLowerPriorityPacket(p);

--- a/src/mesh/MeshTypes.h
+++ b/src/mesh/MeshTypes.h
@@ -49,3 +49,6 @@ extern Allocator<meshtastic_MeshPacket> &packetPool;
  * the local node. If from is zero this function returns our node number instead
  */
 NodeNum getFrom(const meshtastic_MeshPacket *p);
+
+/* Some clients might not properly set priority, therefore we fix it here. */
+void fixPriority(meshtastic_MeshPacket *p);

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -252,6 +252,8 @@ ErrorCode Router::send(meshtastic_MeshPacket *p)
         return meshtastic_Routing_Error_BAD_REQUEST;
     }
 
+    fixPriority(p); // Before encryption, fix the priority if it's unset
+
     // If the packet is not yet encrypted, do so now
     if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
         ChannelIndex chIndex = p->channel; // keep as a local because we are about to change it


### PR DESCRIPTION
Use the new `HIGH` priority for text messages in the Tx queue. Fixes #4576.

When working on this, I saw that `fixPriority()` was called in `MeshPacketQueue::enqueue()`, but that is always *after* encryption, while it was checking `p->decoded` without checking the payload variant. Not sure why this never failed, but I think it wouldn't set the ACK priority correctly before. I therefore moved it to before encryption (confirmed there's no other MeshPacketQueue than the `txQueue`).

