### PR TITLE
Ignore (from)Net time on positions with an unknown or fixed location source

### DIFF
--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -130,7 +130,7 @@ void PositionModule::trySetRtc(meshtastic_Position p, bool isLocal, bool forceUp
         return;
     }
     if (!isLocal && p.location_source < meshtastic_Position_LocSource_LOC_INTERNAL) {
-        LOG_DEBUG("Ignoring time from mesh because it has a unknown or manual source\n"); 
+        LOG_DEBUG("Ignoring time from mesh because it has a unknown or manual source\n");
         return;
     }
     struct timeval tv;
@@ -198,7 +198,7 @@ meshtastic_MeshPacket *PositionModule::allocReply()
     if (config.position.fixed_position) {
         p.location_source = meshtastic_Position_LocSource_LOC_MANUAL;
     }
-    
+
     if (pos_flags & meshtastic_Config_PositionConfig_PositionFlags_ALTITUDE) {
         if (pos_flags & meshtastic_Config_PositionConfig_PositionFlags_ALTITUDE_MSL) {
             p.altitude = localPosition.altitude;

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -129,6 +129,10 @@ void PositionModule::trySetRtc(meshtastic_Position p, bool isLocal, bool forceUp
         LOG_DEBUG("Ignoring time from mesh because we have a GPS, RTC, or Phone/NTP time source in the past day\n");
         return;
     }
+    if (!isLocal && p.location_source < meshtastic_Position_LocSource_LOC_INTERNAL) {
+        LOG_DEBUG("Ignoring time from mesh because it has a unknown or manual source\n"); 
+        return;
+    }
     struct timeval tv;
     uint32_t secs = p.time;
 
@@ -191,6 +195,10 @@ meshtastic_MeshPacket *PositionModule::allocReply()
     p.has_longitude_i = true;
     p.time = getValidTime(RTCQualityNTP) > 0 ? getValidTime(RTCQualityNTP) : localPosition.time;
 
+    if (config.position.fixed_position) {
+        p.location_source = meshtastic_Position_LocSource_LOC_MANUAL;
+    }
+    
     if (pos_flags & meshtastic_Config_PositionConfig_PositionFlags_ALTITUDE) {
         if (pos_flags & meshtastic_Config_PositionConfig_PositionFlags_ALTITUDE_MSL) {
             p.altitude = localPosition.altitude;


### PR DESCRIPTION
Idea here for location sourcing is: 

1. Clients (phone apps) with quality GPS position packets set location source of `EXTERNAL`
2. GPS.cpp sets its position with location source of `INTERNAL`
3. A node with fixed_position set gets alloc'd as location source of `MANUAL`

When considering a position packet as a potential time source of RTCQualityFromNet, the firmware will then ignore any position with a location source of `UNKNOWN` or `MANUAL`.