### PR TITLE
Improve environment telemetry display

### DIFF
--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -246,11 +246,12 @@ void EnvironmentTelemetryModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiSt
     // Display pressure
     if (lastMeasurement.variant.environment_metrics.has_barometric_pressure) {
         display->drawString(x, y += _fontHeight(FONT_SMALL),
-                            "Press: " + String(lastMeasurement.variant.environment_metrics.barometric_pressure, 0) + "hPA");
+                            "Pressure: " + String(lastMeasurement.variant.environment_metrics.barometric_pressure, 0) + "hPA");
     }
 
     // Display voltage
-    if (lastMeasurement.variant.environment_metrics.has_voltage) {
+    if (lastMeasurement.variant.environment_metrics.has_voltage ||
+            lastMeasurement.variant.environment_metrics.has_current) {
         display->drawString(x, y += _fontHeight(FONT_SMALL),
                             "Volt/Cur: " + String(lastMeasurement.variant.environment_metrics.voltage, 0) + "V / " +
                                 String(lastMeasurement.variant.environment_metrics.current, 0) + "mA");

--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -80,7 +80,7 @@ int32_t EnvironmentTelemetryModule::runOnce()
     */
 
     // moduleConfig.telemetry.environment_measurement_enabled = 1;
-    //  moduleConfig.telemetry.environment_screen_enabled = 1;
+    // moduleConfig.telemetry.environment_screen_enabled = 1;
     // moduleConfig.telemetry.environment_update_interval = 15;
 
     if (!(moduleConfig.telemetry.environment_measurement_enabled || moduleConfig.telemetry.environment_screen_enabled)) {


### PR DESCRIPTION
This is a small PR just to make the Environment display in the Telemetry module look very slightly cleaner, and also use the proper flag for each reading e.g. "....environment_metrics.has_[reading type]" to determine what's displayed, as opposed to checking for a value in the reading itself (hope this makes sense)

