### PR TITLE
More priorities for different types of MeshPackets

### DIFF
--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -107,6 +107,7 @@ void NeighborInfoModule::sendNeighborInfo(NodeNum dest, bool wantReplies)
     // because we want to get neighbors for the next cycle
     p->to = dest;
     p->decoded.want_response = wantReplies;
+    p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
     printNeighborInfo("SENDING", &neighborInfo);
     service->sendToMesh(p, RX_SRC_LOCAL, true);
 }


### PR DESCRIPTION
It seems it's important, especially in busy meshes, to reorder the transmit queue appropriately: https://github.com/meshtastic/firmware/pull/4592#issuecomment-2323146203

With this:
- Responses get the new `RESPONSE` priority;
- Admin packets get `HIGH` priority;
- Packets with `want_response` also get the `RELIABLE` priority;
- NeighborInfo will be set to `BACKGROUND`.
