### PR TITLE
Add MAX17048 lipo fuel gauge

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -146,6 +146,7 @@ lib_deps =
   adafruit/Adafruit VEML7700 Library@^2.1.6
   adafruit/Adafruit SHT4x Library@^1.0.4
   adafruit/Adafruit TSL2591 Library@^1.4.5
+  adafruit/Adafruit MAX1704X@^1.0.3
   sparkfun/SparkFun Qwiic Scale NAU7802 Arduino Library@^1.0.5
   ClosedCube OPT3001@^1.1.2
   emotibit/EmotiBit MLX90632@^1.0.8

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -139,6 +139,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MLX90632_ADDR 0x3A
 #define DFROBOT_LARK_ADDR 0x42
 #define NAU7802_ADDR 0x2A
+#define MAX1704X_ADDR 0x36
 
 // -----------------------------------------------------------------------------
 // ACCELEROMETER

--- a/src/detect/ScanI2C.h
+++ b/src/detect/ScanI2C.h
@@ -52,7 +52,8 @@ class ScanI2C
         AHT10,
         BMX160,
         DFROBOT_LARK,
-        NAU7802
+        NAU7802,
+        MAX17048
     } DeviceType;
 
     // typedef uint8_t DeviceAddress;

--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -377,6 +377,7 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
                 SCAN_SIMPLE_CASE(OPT3001_ADDR, OPT3001, "OPT3001 light sensor found\n");
                 SCAN_SIMPLE_CASE(MLX90632_ADDR, MLX90632, "MLX90632 IR temp sensor found\n");
                 SCAN_SIMPLE_CASE(NAU7802_ADDR, NAU7802, "NAU7802 based scale found\n");
+                SCAN_SIMPLE_CASE(MAX1704X_ADDR, MAX17048, "MAX17048 1S lipo battery sensor found\n");
 
             default:
                 LOG_INFO("Device found at address 0x%x was not able to be enumerated\n", addr.address);

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -2568,7 +2568,7 @@ void DebugInfo::drawFrameSettings(OLEDDisplay *display, OLEDDisplayUiState *stat
         int batV = powerStatus->getBatteryVoltageMv() / 1000;
         int batCv = (powerStatus->getBatteryVoltageMv() % 1000) / 10;
 
-        snprintf(batStr, sizeof(batStr), "B %01d.%02dV %3d%% %c%c", batV, batCv, powerStatus->getBatteryChargePercent(),
+        snprintf(batStr, sizeof(batStr), "B %01d.%02d V %3d%% %c%c", batV, batCv, powerStatus->getBatteryChargePercent(),
                  powerStatus->getIsCharging() ? '+' : ' ', powerStatus->getHasUSB() ? 'U' : ' ');
 
         // Line 1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -569,6 +569,7 @@ void setup()
     SCANNER_TO_SENSORS_MAP(ScanI2C::DeviceType::SHT4X, meshtastic_TelemetrySensorType_SHT4X)
     SCANNER_TO_SENSORS_MAP(ScanI2C::DeviceType::AHT10, meshtastic_TelemetrySensorType_AHT10)
     SCANNER_TO_SENSORS_MAP(ScanI2C::DeviceType::DFROBOT_LARK, meshtastic_TelemetrySensorType_DFROBOT_LARK)
+    SCANNER_TO_SENSORS_MAP(ScanI2C::DeviceType::MAX17048, meshtastic_TelemetrySensorType_MAX17048)
 
     i2cScanner.reset();
 #endif

--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -37,6 +37,7 @@
 #include "Sensor/T1000xSensor.h"
 #include "Sensor/TSL2591Sensor.h"
 #include "Sensor/VEML7700Sensor.h"
+#include "Sensor/MAX17048Sensor.h"
 
 BMP085Sensor bmp085Sensor;
 BMP280Sensor bmp280Sensor;
@@ -56,6 +57,7 @@ MLX90632Sensor mlx90632Sensor;
 DFRobotLarkSensor dfRobotLarkSensor;
 NAU7802Sensor nau7802Sensor;
 BMP3XXSensor bmp3xxSensor;
+MAX17048Sensor max17048Sensor;
 #ifdef T1000X_SENSOR_EN
 T1000xSensor t1000xSensor;
 #endif
@@ -143,6 +145,8 @@ int32_t EnvironmentTelemetryModule::runOnce()
                 result = mlx90632Sensor.runOnce();
             if (nau7802Sensor.hasSensor())
                 result = nau7802Sensor.runOnce();
+            if (max17048Sensor.hasSensor())
+                result = max17048Sensor.runOnce();
 #endif
         }
         return result;
@@ -397,6 +401,10 @@ bool EnvironmentTelemetryModule::getEnvironmentTelemetry(meshtastic_Telemetry *m
             m->variant.environment_metrics.relative_humidity = m_ahtx.variant.environment_metrics.relative_humidity;
         }
     }
+    if (max17048Sensor.hasSensor()) {
+        valid = valid && max17048Sensor.getMetrics(m);
+        hasSensor = true;
+    }
 
 #endif
     return valid && hasSensor;
@@ -584,6 +592,11 @@ AdminMessageHandleResult EnvironmentTelemetryModule::handleAdminMessageForModule
     }
     if (aht10Sensor.hasSensor()) {
         result = aht10Sensor.handleAdminMessage(mp, request, response);
+        if (result != AdminMessageHandleResult::NOT_HANDLED)
+            return result;
+    }
+    if (max17048Sensor.hasSensor()) {
+        result = max17048Sensor.handleAdminMessage(mp, request, response);
         if (result != AdminMessageHandleResult::NOT_HANDLED)
             return result;
     }

--- a/src/modules/Telemetry/PowerTelemetry.cpp
+++ b/src/modules/Telemetry/PowerTelemetry.cpp
@@ -59,6 +59,8 @@ int32_t PowerTelemetryModule::runOnce()
                 result = ina260Sensor.runOnce();
             if (ina3221Sensor.hasSensor() && !ina3221Sensor.isInitialized())
                 result = ina3221Sensor.runOnce();
+            if (max17048Sensor.hasSensor() && !max17048Sensor.isInitialized())
+                result = max17048Sensor.runOnce();
         }
         return result;
 #else
@@ -129,18 +131,23 @@ void PowerTelemetryModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *s
     }
 
     display->setFont(FONT_SMALL);
-    String last_temp = String(lastMeasurement.variant.environment_metrics.temperature, 0) + "°C";
     display->drawString(x, y += _fontHeight(FONT_MEDIUM) - 2, "From: " + String(lastSender) + "(" + String(agoSecs) + "s)");
-    if (lastMeasurement.variant.power_metrics.ch1_voltage != 0) {
+
+    // Display current and voltage based on ...power_metrics.has_[channel/voltage/current]... flags
+    if (lastMeasurement.variant.power_metrics.has_ch1_voltage || lastMeasurement.variant.power_metrics.has_ch1_current) {
         display->drawString(x, y += _fontHeight(FONT_SMALL),
-                            "Ch 1 Volt/Cur: " + String(lastMeasurement.variant.power_metrics.ch1_voltage, 0) + "V / " +
-                                String(lastMeasurement.variant.power_metrics.ch1_current, 0) + "mA");
+            "Ch1 Volt: " + String(lastMeasurement.variant.power_metrics.ch1_voltage, 2) + "V / Curr: " +
+            String(lastMeasurement.variant.power_metrics.ch1_current, 0) + "mA");
+    }
+    if (lastMeasurement.variant.power_metrics.has_ch2_voltage || lastMeasurement.variant.power_metrics.has_ch2_current) {
         display->drawString(x, y += _fontHeight(FONT_SMALL),
-                            "Ch 2 Volt/Cur: " + String(lastMeasurement.variant.power_metrics.ch2_voltage, 0) + "V / " +
-                                String(lastMeasurement.variant.power_metrics.ch2_current, 0) + "mA");
+            "Ch2 Volt: " + String(lastMeasurement.variant.power_metrics.ch2_voltage, 2) + "V / Curr: " +
+            String(lastMeasurement.variant.power_metrics.ch2_current, 0) + "mA");
+    }
+    if (lastMeasurement.variant.power_metrics.has_ch3_voltage || lastMeasurement.variant.power_metrics.has_ch3_current) {
         display->drawString(x, y += _fontHeight(FONT_SMALL),
-                            "Ch 3 Volt/Cur: " + String(lastMeasurement.variant.power_metrics.ch3_voltage, 0) + "V / " +
-                                String(lastMeasurement.variant.power_metrics.ch3_current, 0) + "mA");
+            "Ch3 Volt: " + String(lastMeasurement.variant.power_metrics.ch3_voltage, 2) + "V / Curr: " +
+            String(lastMeasurement.variant.power_metrics.ch3_current, 0) + "mA");
     }
 }
 
@@ -150,8 +157,8 @@ bool PowerTelemetryModule::handleReceivedProtobuf(const meshtastic_MeshPacket &m
 #ifdef DEBUG_PORT
         const char *sender = getSenderShortName(mp);
 
-        LOG_INFO("(Received from %s): ch1_voltage=%f, ch1_current=%f, ch2_voltage=%f, ch2_current=%f, "
-                 "ch3_voltage=%f, ch3_current=%f\n",
+        LOG_INFO("(Received from %s): ch1_voltage=%.1f, ch1_current=%.1f, ch2_voltage=%.1f, ch2_current=%.1f, "
+                 "ch3_voltage=%.1f, ch3_current=%.1f\n",
                  sender, t->variant.power_metrics.ch1_voltage, t->variant.power_metrics.ch1_current,
                  t->variant.power_metrics.ch2_voltage, t->variant.power_metrics.ch2_current, t->variant.power_metrics.ch3_voltage,
                  t->variant.power_metrics.ch3_current);
@@ -171,13 +178,7 @@ bool PowerTelemetryModule::getPowerTelemetry(meshtastic_Telemetry *m)
     bool valid = false;
     m->time = getTime();
     m->which_variant = meshtastic_Telemetry_power_metrics_tag;
-
-    m->variant.power_metrics.ch1_voltage = 0;
-    m->variant.power_metrics.ch1_current = 0;
-    m->variant.power_metrics.ch2_voltage = 0;
-    m->variant.power_metrics.ch2_current = 0;
-    m->variant.power_metrics.ch3_voltage = 0;
-    m->variant.power_metrics.ch3_current = 0;
+    m->variant.power_metrics = meshtastic_PowerMetrics_init_zero;
 #if HAS_TELEMETRY && !defined(ARCH_PORTDUINO)
     if (ina219Sensor.hasSensor())
         valid = ina219Sensor.getMetrics(m);
@@ -185,6 +186,8 @@ bool PowerTelemetryModule::getPowerTelemetry(meshtastic_Telemetry *m)
         valid = ina260Sensor.getMetrics(m);
     if (ina3221Sensor.hasSensor())
         valid = ina3221Sensor.getMetrics(m);
+    if (max17048Sensor.hasSensor())
+        valid = max17048Sensor.getMetrics(m);
 #endif
 
     return valid;

--- a/src/modules/Telemetry/Sensor/MAX17048Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/MAX17048Sensor.cpp
@@ -1,0 +1,156 @@
+#include "configuration.h"
+
+#if !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR || !MESHTASTIC_EXCLUDE_POWER_TELEMETRY || !MESHTASTIC_EXCLUDE_POWERMON
+
+#include "MAX17048Sensor.h"
+
+MAX17048Sensor::MAX17048Sensor() : TelemetrySensor(meshtastic_TelemetrySensorType_MAX17048, "MAX17048") {}
+
+int32_t MAX17048Sensor::runOnce()
+{
+    if (isInitialized())
+    {
+        LOG_INFO("Init sensor: %s is already initialised\n", sensorName);
+        return true;
+    }
+
+    LOG_INFO("Init sensor: %s\n", sensorName);
+    if (!hasSensor())
+    {
+        return DEFAULT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS;
+    }
+
+    status = max17048.begin(nodeTelemetrySensorsMap[sensorType].second);
+    return initI2CSensor();
+}
+
+void MAX17048Sensor::setup() {}
+
+bool MAX17048Sensor::getMetrics(meshtastic_Telemetry *measurement)
+{
+    LOG_DEBUG("MAX17048Sensor::getMetrics id: %i\n", measurement->which_variant);
+
+    float volts = max17048.cellVoltage();
+    if (isnan(volts))
+    {
+        LOG_DEBUG("MAX17048Sensor::getMetrics battery is disconnected\n");
+        return true;
+    }
+
+    float rate = max17048.chargeRate();     // charge/discharge rate in percent/hr
+    float soc = max17048.cellPercent();     // state of charge in percent 0 to 100
+    soc = clamp(round(soc),0.0f,100.0f);    // clamp soc between 0 and 100%
+    float ttg = (100.0f - soc) / rate;      // calculate hours to charge/discharge
+
+    LOG_DEBUG("MAX17048Sensor::getMetrics volts: %.3fV soc: %.1f%% ttg: %.1f hours\n", volts, soc, ttg);
+    if ((int)measurement->which_variant == meshtastic_Telemetry_power_metrics_tag)
+    {
+        measurement->variant.power_metrics.has_ch1_voltage = true;
+        measurement->variant.power_metrics.ch1_voltage = volts;
+    }
+    else if ((int)measurement->which_variant == meshtastic_Telemetry_device_metrics_tag)
+    {
+        measurement->variant.device_metrics.has_battery_level = true;
+        measurement->variant.device_metrics.has_voltage = true;
+        measurement->variant.device_metrics.battery_level = (uint32_t)round(soc);
+        measurement->variant.device_metrics.voltage = volts;
+    }
+    return true;
+}
+
+uint16_t MAX17048Sensor::getBusVoltageMv()
+{
+    float volts = max17048.cellVoltage();
+    if (isnan(volts))
+    {
+        LOG_DEBUG("MAX17048Sensor::getMetrics battery is disconnected\n");
+        return 0;
+    }
+
+    LOG_DEBUG("MAX17048Sensor::getBusVoltageMv %.3fmV\n", volts);
+    return (uint16_t)(volts * 1000.0f);
+}
+
+uint8_t MAX17048Sensor::getBusBatteryPercent()
+{
+    float soc = max17048.cellPercent();     // state of charge in percent 0 to 100
+    soc = clamp(round(soc),0.0f,100.0f);    // clamp soc between 0 and 100%
+    LOG_DEBUG("MAX17048Sensor::getBusBatteryPercent %.1f%%\n", soc);
+    return static_cast<uint8_t>(soc);
+}
+
+uint16_t MAX17048Sensor::getTimeToGoSecs()
+{
+    float rate = max17048.chargeRate();             // charge/discharge rate in percent/hr
+    float soc = max17048.cellPercent();             // state of charge in percent 0 to 100
+    soc = clamp(round(soc),0.0f,100.0f);            // clamp soc between 0 and 100%
+    float ttg = ((100.0f - soc) / rate) * 3600.0f;  // calculate seconds to charge/discharge
+    LOG_DEBUG("MAX17048Sensor::getTimeToGoSecs %.0f seconds\n", ttg);
+    return (uint16_t)ttg;
+}
+
+bool MAX17048Sensor::isBatteryCharging()
+{
+    float volts = max17048.cellVoltage();
+    if (isnan(volts))
+    {
+        LOG_DEBUG("MAX17048Sensor::isCharging battery is disconnected\n");
+        return 0;
+    }
+
+    MAX17048ChargeSample sample;
+    sample.chargeRate = max17048.chargeRate();   // charge/discharge rate in percent/hr
+    sample.cellPercent = max17048.cellPercent(); // state of charge in percent 0 to 100
+    chargeSamples.push(sample);                  // save a sample into a fifo buffer
+
+    // keep the fifo buffer trimmed
+    while (chargeSamples.size() > MAX17048_CHARGING_SAMPLES)
+        chargeSamples.pop();
+
+    // based on the past n samples, is the lipo charging, discharging or idle
+    if (chargeSamples.front().chargeRate > MAX17048_CHARGING_MINIMUM_RATE &&
+        chargeSamples.back().chargeRate > MAX17048_CHARGING_MINIMUM_RATE)
+    {
+        if (chargeSamples.front().cellPercent > chargeSamples.back().cellPercent)
+            chargeState = MAX17048ChargeState::EXPORT;
+        else if (chargeSamples.front().cellPercent < chargeSamples.back().cellPercent)
+            chargeState = MAX17048ChargeState::IMPORT;
+        else
+            chargeState = MAX17048ChargeState::IDLE;
+    }
+    else
+    {
+        chargeState = MAX17048ChargeState::IDLE;
+    }
+
+    LOG_DEBUG("MAX17048Sensor::isCharging %s volts: %.3f soc: %.3f rate: %.3f\n",
+        chargeLabels[chargeState], volts, sample.cellPercent, sample.chargeRate);
+    return chargeState == MAX17048ChargeState::IMPORT;
+}
+
+bool MAX17048Sensor::isBatteryConnected()
+{
+    float volts = max17048.cellVoltage();
+    if (isnan(volts))
+    {
+        LOG_DEBUG("MAX17048Sensor::isBatteryConnected battery is disconnected\n");
+        return false;
+    }
+
+    // if a valid voltage is returned, then battery must be connected
+    return true;
+}
+
+bool MAX17048Sensor::isExternallyPowered()
+{
+    float volts = max17048.cellVoltage();
+    if (isnan(volts))
+    {
+        LOG_DEBUG("MAX17048Sensor::isExternallyPowered battery is disconnected\n");
+        return false;
+    }
+    // if the bus voltage is over MAX17048_BUS_POWER_VOLTS, then the battery is charging
+    return volts >= MAX17048_BUS_POWER_VOLTS;
+}
+
+#endif

--- a/src/modules/Telemetry/Sensor/MAX17048Sensor.h
+++ b/src/modules/Telemetry/Sensor/MAX17048Sensor.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#ifndef MAX17048_SENSOR_H
+#define MAX17048_SENSOR_H
+
+#include "configuration.h"
+
+#if !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR || !MESHTASTIC_EXCLUDE_POWER_TELEMETRY || !MESHTASTIC_EXCLUDE_POWERMON
+
+// samples to store in a buffer to determine if the battery is charging or discharging
+#define MAX17048_CHARGING_SAMPLES 3
+
+// threshold to determine if the battery is on charge, in percent/hour
+#define MAX17048_CHARGING_MINIMUM_RATE 1.0f
+
+// threshold to determine if the board has bus power
+#define MAX17048_BUS_POWER_VOLTS 4.195f
+
+#include "../mesh/generated/meshtastic/telemetry.pb.h"
+#include <Adafruit_MAX1704X.h>
+#include "meshUtils.h"
+#include "TelemetrySensor.h"
+#include "VoltageSensor.h"
+
+#include<bits/stdc++.h>
+ 
+struct MAX17048ChargeSample{         
+  float cellPercent;      
+  float chargeRate;  
+};       
+
+enum MAX17048ChargeState {
+  IDLE,
+  EXPORT,
+  IMPORT
+};
+
+class MAX17048Sensor : public TelemetrySensor, VoltageSensor
+{
+  private:
+    Adafruit_MAX17048 max17048;
+    std::queue<MAX17048ChargeSample> chargeSamples;
+    MAX17048ChargeState chargeState = IDLE;
+    const String chargeLabels[3] = { F("idle"), F("export"), F("import") };
+
+  protected:
+    virtual void setup() override;
+
+  public:
+    MAX17048Sensor();
+    virtual int32_t runOnce() override;
+    virtual bool getMetrics(meshtastic_Telemetry *measurement) override;
+    virtual uint16_t getBusVoltageMv() override;
+    virtual uint8_t getBusBatteryPercent();
+    virtual uint16_t getTimeToGoSecs();
+    virtual bool isBatteryCharging();
+    virtual bool isBatteryConnected();  
+    virtual bool isExternallyPowered();
+};
+
+#endif
+
+#endif

--- a/src/power.h
+++ b/src/power.h
@@ -43,9 +43,11 @@ extern RTC_NOINIT_ATTR uint64_t RTC_reg_b;
 #include "modules/Telemetry/Sensor/INA219Sensor.h"
 #include "modules/Telemetry/Sensor/INA260Sensor.h"
 #include "modules/Telemetry/Sensor/INA3221Sensor.h"
+#include "modules/Telemetry/Sensor/MAX17048Sensor.h"
 extern INA260Sensor ina260Sensor;
 extern INA219Sensor ina219Sensor;
 extern INA3221Sensor ina3221Sensor;
+extern MAX17048Sensor max17048Sensor;
 #endif
 
 #if HAS_RAKPROT && !defined(ARCH_PORTDUINO)
@@ -82,6 +84,8 @@ class Power : private concurrency::OSThread
     bool axpChipInit();
     /// Setup a simple ADC input based battery sensor
     bool analogInit();
+    /// Setup a MAX17048 Lipo battery level sensor
+    bool lipoInit();
 
   private:
     // open circuit voltage lookup table


### PR DESCRIPTION
Hi this PR adds MAX17048 lipo fuel gauge as a new battery sensor for the telemetry & power module

Its linked to https://github.com/meshtastic/protobufs/pull/540 that added the necessary enums to [telemetry.proto](https://github.com/meshtastic/protobufs/blob/master/meshtastic/telemetry.proto)

This follows pretty much same pattern as other Telemetry sensors, as well as adding requisite code to integrate this sensor into the device power functionality in similar fashion to the axp192 power management IC

Appreciate your review and any comments

Thanks

Dave