### PR TITLE
Remove unused define

### DIFF
--- a/src/RF95Configuration.h
+++ b/src/RF95Configuration.h
@@ -3,5 +3,4 @@
 #define RF95_RESET LORA_RESET
 #define RF95_IRQ LORA_DIO0  // on SX1262 version this is a no connect DIO0
 #define RF95_DIO1 LORA_DIO1 // Note: not really used for RF95, but used for pure SX127x
-#define RF95_DIO2 LORA_DIO2 // Note: not really used for RF95
 #endif


### PR DESCRIPTION
Neither RF95_DIO2 nor LORA_DIO2 are found anywhere in the code.