### PR TITLE
Add missing linefeeds to gps code

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -507,19 +507,19 @@ bool GPS::setup()
             delay(250);
         } else if (gnssModel == GNSS_MODEL_AG3335) {
 
-            _serial_gps->write("$PAIR066,1,0,1,0,0,1*3B"); // Enable GPS+GALILEO+NAVIC
+            _serial_gps->write("$PAIR066,1,0,1,0,0,1*3B\r\n"); // Enable GPS+GALILEO+NAVIC
 
             // Configure NMEA (sentences will output once per fix)
-            _serial_gps->write("$PAIR062,0,0*3F"); // GGA ON
-            _serial_gps->write("$PAIR062,1,0*3F"); // GLL OFF
-            _serial_gps->write("$PAIR062,2,1*3D"); // GSA ON
-            _serial_gps->write("$PAIR062,3,0*3D"); // GSV OFF
-            _serial_gps->write("$PAIR062,4,0*3B"); // RMC ON
-            _serial_gps->write("$PAIR062,5,0*3B"); // VTG OFF
-            _serial_gps->write("$PAIR062,6,1*39"); // ZDA ON
+            _serial_gps->write("$PAIR062,0,0*3F\r\n"); // GGA ON
+            _serial_gps->write("$PAIR062,1,0*3F\r\n"); // GLL OFF
+            _serial_gps->write("$PAIR062,2,1*3D\r\n"); // GSA ON
+            _serial_gps->write("$PAIR062,3,0*3D\r\n"); // GSV OFF
+            _serial_gps->write("$PAIR062,4,0*3B\r\n"); // RMC ON
+            _serial_gps->write("$PAIR062,5,0*3B\r\n"); // VTG OFF
+            _serial_gps->write("$PAIR062,6,1*39\r\n"); // ZDA ON
 
             delay(250);
-            _serial_gps->write("$PAIR513*3D"); // save configuration
+            _serial_gps->write("$PAIR513*3D\r\n"); // save configuration
 
         } else if (gnssModel == GNSS_MODEL_UBLOX) {
             // Configure GNSS system to GPS+SBAS+GLONASS (Module may restart after this command)


### PR DESCRIPTION
As reported by @caveman99, the required CRLFs were missing from the AG3335 setup code.