### PR TITLE
RAK13800 Ethernet improvements

### DIFF
--- a/src/DebugConfiguration.cpp
+++ b/src/DebugConfiguration.cpp
@@ -97,12 +97,14 @@ Syslog &Syslog::logMask(uint8_t priMask)
 
 void Syslog::enable()
 {
+    this->_client->begin(this->_port);
     this->_enabled = true;
 }
 
 void Syslog::disable()
 {
     this->_enabled = false;
+    this->_client->stop();
 }
 
 bool Syslog::isEnabled()

--- a/src/mesh/api/ServerAPI.h
+++ b/src/mesh/api/ServerAPI.h
@@ -31,7 +31,7 @@ template <class T> class ServerAPI : public StreamAPI, private concurrency::OSTh
 };
 
 /**
- * Listens for incoming connections and does accepts and creates instances of WiFiServerAPI as needed
+ * Listens for incoming connections and does accepts and creates instances of ServerAPI as needed
  */
 template <class T, class U> class APIServerPort : public U, private concurrency::OSThread
 {
@@ -41,6 +41,10 @@ template <class T, class U> class APIServerPort : public U, private concurrency:
      * delegate to the worker.  Once coroutines are implemented we can relax this restriction.
      */
     T *openAPI = NULL;
+#if RAK_4631
+    // Track wait time for RAK13800 Ethernet requests
+    int32_t waitTime = 100;
+#endif
 
   public:
     explicit APIServerPort(int port);

--- a/src/mesh/api/ethServerAPI.h
+++ b/src/mesh/api/ethServerAPI.h
@@ -14,7 +14,7 @@ class ethServerAPI : public ServerAPI<EthernetClient>
 };
 
 /**
- * Listens for incoming connections and does accepts and creates instances of WiFiServerAPI as needed
+ * Listens for incoming connections and does accepts and creates instances of EthernetServerAPI as needed
  */
 class ethServerPort : public APIServerPort<ethServerAPI, EthernetServer>
 {

--- a/src/mesh/eth/ethClient.cpp
+++ b/src/mesh/eth/ethClient.cpp
@@ -38,7 +38,7 @@ static int32_t reconnectETH()
         Ethernet.maintain();
         if (!ethStartupComplete) {
             // Start web server
-            LOG_INFO("... Starting network services\n");
+            LOG_INFO("Starting Ethernet network services\n");
 
 #ifndef DISABLE_NTP
             LOG_INFO("Starting NTP time client\n");
@@ -131,7 +131,8 @@ bool initEthernet()
             status = Ethernet.begin(mac);
         } else if (config.network.address_mode == meshtastic_Config_NetworkConfig_AddressMode_STATIC) {
             LOG_INFO("starting Ethernet Static\n");
-            Ethernet.begin(mac, config.network.ipv4_config.ip, config.network.ipv4_config.dns, config.network.ipv4_config.subnet);
+            Ethernet.begin(mac, config.network.ipv4_config.ip, config.network.ipv4_config.dns, config.network.ipv4_config.gateway,
+                           config.network.ipv4_config.subnet);
             status = 1;
         } else {
             LOG_INFO("Ethernet Disabled\n");

--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -15,9 +15,7 @@
 #include <WiFiUdp.h>
 #ifdef ARCH_ESP32
 #if !MESHTASTIC_EXCLUDE_WEBSERVER
-#if !MESHTASTIC_EXCLUDE_WEBSERVER
 #include "mesh/http/WebServer.h"
-#endif
 #endif
 #include <ESPmDNS.h>
 #include <esp_wifi.h>
@@ -58,7 +56,7 @@ static void onNetworkConnected()
 {
     if (!APStartupComplete) {
         // Start web server
-        LOG_INFO("Starting network services\n");
+        LOG_INFO("Starting WiFi network services\n");
 
 #ifdef ARCH_ESP32
         // start mdns


### PR DESCRIPTION
Fixes (#3618) by allowing more time for slower requests.
Resolve Syslog not maintaining client causing issues on RAK13800.
Resolve Ethernet static IP setting subnet as gateway IP.
Reduce comment and log message ambiguity around API.
Remove duplicate #if !MESHTASTIC_EXCLUDE_WEBSERVER block.