### PR TITLE
Remove undefined declaration

### DIFF
--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -297,7 +297,6 @@ class GPS : private concurrency::OSThread
     virtual int32_t runOnce() override;
 
     // Get GNSS model
-    String getNMEA();
     GnssModel_t probe(int serialSpeed);
 
     // delay counter to allow more sats before fixed position stops GPS thread


### PR DESCRIPTION
The getNMEA method was introduced to the header but never defined in code. As it's unused, remove it.