### PR TITLE
If GPS sleepTime is Zero, don't sleep.

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1019,7 +1019,7 @@ void GPS::down()
     LOG_DEBUG("%us until next search\n", sleepTime / 1000);
 
     // If update interval less than 10 seconds, no attempt to sleep
-    if (updateInterval <= 10 * 1000UL)
+    if (updateInterval <= 10 * 1000UL || sleepTime == 0)
         setPowerState(GPS_IDLE);
 
     else {


### PR DESCRIPTION
At the moment if the result of sleepTime calculations comes out to zero, we put the GPS into HARDSLEEP (losing all its status) and then immediately make it ACTIVE again.

This patch avoids that toga.

fixes https://github.com/meshtastic/firmware/issues/4657