### PR TITLE
Fix for MESHTASTIC_MINIMIZE_BUILD

### DIFF
--- a/src/input/cardKbI2cImpl.cpp
+++ b/src/input/cardKbI2cImpl.cpp
@@ -9,7 +9,7 @@ CardKbI2cImpl::CardKbI2cImpl() : KbI2cBase("cardKB") {}
 
 void CardKbI2cImpl::init()
 {
-#ifndef ARCH_PORTDUINO
+#if !MESHTASTIC_EXCLUDE_I2C && !defined(ARCH_PORTDUINO)
     if (cardkb_found.address == 0x00) {
         LOG_DEBUG("Rescanning for I2C keyboard\n");
         uint8_t i2caddr_scan[] = {CARDKB_ADDR, TDECK_KB_ADDR, BBQ10_KB_ADDR};

--- a/src/platform/extra_variants/heltec_wireless_tracker/variant.cpp
+++ b/src/platform/extra_variants/heltec_wireless_tracker/variant.cpp
@@ -10,10 +10,14 @@
 void lateInitVariant()
 {
     // LOG_DEBUG("Heltec tracker initVariant\n");
-#ifdef VEXT_ENABLE
-    GpioPin *hwEnable = new GpioHwPin(VEXT_ENABLE);
-    GpioVirtPin *virtGpsEnable = gps ? gps->enablePin : new GpioVirtPin();
 
+#ifndef MESHTASTIC_EXCLUDE_GPS
+    GpioVirtPin *virtGpsEnable = gps ? gps->enablePin : new GpioVirtPin();
+#else
+    GpioVirtPin *virtGpsEnable = new GpioVirtPin();
+#endif
+
+#ifndef MESHTASTIC_EXCLUDE_SCREEN
     // On this board we are actually using the backlightEnable signal to already be controlling a physical enable to the
     // display controller.  But we'd _ALSO_ like to have that signal drive a virtual GPIO.  So nest it as needed.
     GpioVirtPin *virtScreenEnable = new GpioVirtPin();
@@ -25,8 +29,11 @@ void lateInitVariant()
         // Assume screen is initially powered
         splitter->set(true);
     }
+#endif
 
+#if defined(VEXT_ENABLE) && (!defined(MESHTASTIC_EXCLUDE_GPS) || !defined(MESHTASTIC_EXCLUDE_SCREEN))
     // If either the GPS or the screen is on, turn on the external power regulator
+    GpioPin *hwEnable = new GpioHwPin(VEXT_ENABLE);
     new GpioBinaryTransformer(virtGpsEnable, virtScreenEnable, hwEnable, GpioBinaryTransformer::Or);
 #endif
 }


### PR DESCRIPTION
This is a minor fix so minimal build works when any/all of these flags are set:

- MESHTASTIC_MINIMIZE_BUILD
- MESHTASTIC_EXCLUDE_I2C
- MESHTASTIC_EXCLUDE_GPS
- MESHTASTIC_EXCLUDE_SCREEN

No change to functionality
