### PR TITLE
Radiomaster Bandit Accelerometer support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -161,3 +161,4 @@ lib_deps =
   
 
   https://github.com/meshtastic/DFRobot_LarkWeatherStation#dee914270dc7cb3e43fbf034edd85a63a16a12ee
+  https://github.com/gjelsoe/STK8xxx-Accelerometer.git#v0.1.1

--- a/src/AccelerometerThread.h
+++ b/src/AccelerometerThread.h
@@ -205,11 +205,7 @@ class AccelerometerThread : public concurrency::OSThread
             stk8baxx.STK8xxx_Anymotion_init();
             pinMode(STK8XXX_INT, INPUT_PULLUP);
             attachInterrupt(
-                digitalPinToInterrupt(STK8XXX_INT),
-                [] {
-                    STK_IRQ = true;
-                },
-                RISING);
+                digitalPinToInterrupt(STK8XXX_INT), [] { STK_IRQ = true; }, RISING);
 #endif
         } else if (acceleremoter_type == ScanI2C::DeviceType::LIS3DH && lis.begin(accelerometer_found.address)) {
             LOG_DEBUG("LIS3DH initializing\n");

--- a/src/AccelerometerThread.h
+++ b/src/AccelerometerThread.h
@@ -11,6 +11,9 @@
 #include <Adafruit_LIS3DH.h>
 #include <Adafruit_LSM6DS3TRC.h>
 #include <Adafruit_MPU6050.h>
+#ifdef STK8XXX_INT
+#include <stk8baxx.h>
+#endif
 #include <Arduino.h>
 #include <SensorBMA423.hpp>
 #include <Wire.h>
@@ -23,6 +26,8 @@
 
 #define ACCELEROMETER_CHECK_INTERVAL_MS 100
 #define ACCELEROMETER_CLICK_THRESHOLD 40
+
+volatile static bool STK_IRQ;
 
 static inline int readRegister(uint8_t address, uint8_t reg, uint8_t *data, uint8_t len)
 {
@@ -79,6 +84,11 @@ class AccelerometerThread : public concurrency::OSThread
 
         if (acceleremoter_type == ScanI2C::DeviceType::MPU6050 && mpu.getMotionInterruptStatus()) {
             wakeScreen();
+        } else if (acceleremoter_type == ScanI2C::DeviceType::STK8BAXX && STK_IRQ) {
+            STK_IRQ = false;
+            if (config.display.wake_on_tap_or_motion) {
+                wakeScreen();
+            }
         } else if (acceleremoter_type == ScanI2C::DeviceType::LIS3DH && lis.getClick() > 0) {
             uint8_t click = lis.getClick();
             if (!config.device.double_tap_as_button_press) {
@@ -188,6 +198,19 @@ class AccelerometerThread : public concurrency::OSThread
             mpu.setMotionDetectionDuration(20);
             mpu.setInterruptPinLatch(true); // Keep it latched.  Will turn off when reinitialized.
             mpu.setInterruptPinPolarity(true);
+#ifdef STK8XXX_INT
+        } else if (acceleremoter_type == ScanI2C::DeviceType::STK8BAXX && stk8baxx.STK8xxx_Initialization(STK8xxx_VAL_RANGE_2G)) {
+            STK_IRQ = false;
+            LOG_DEBUG("STX8BAxx initialized\n");
+            stk8baxx.STK8xxx_Anymotion_init();
+            pinMode(STK8XXX_INT, INPUT_PULLUP);
+            attachInterrupt(
+                digitalPinToInterrupt(STK8XXX_INT),
+                [] {
+                    STK_IRQ = true;
+                },
+                RISING);
+#endif
         } else if (acceleremoter_type == ScanI2C::DeviceType::LIS3DH && lis.begin(accelerometer_found.address)) {
             LOG_DEBUG("LIS3DH initializing\n");
             lis.setRange(LIS3DH_RANGE_2_G);
@@ -262,6 +285,9 @@ class AccelerometerThread : public concurrency::OSThread
     ScanI2C::DeviceType acceleremoter_type;
     Adafruit_MPU6050 mpu;
     Adafruit_LIS3DH lis;
+#ifdef STK8XXX_INT
+    STK8xxx stk8baxx;
+#endif
     Adafruit_LSM6DS3TRC lsm;
     SensorBMA423 bmaSensor;
     bool BMA_IRQ = false;

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -144,6 +144,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // ACCELEROMETER
 // -----------------------------------------------------------------------------
 #define MPU6050_ADDR 0x68
+#define STK8BXX_ADR 0x18
 #define LIS3DH_ADR 0x18
 #define BMA423_ADDR 0x19
 #define LSM6DS3_ADDR 0x6A

--- a/src/detect/ScanI2C.cpp
+++ b/src/detect/ScanI2C.cpp
@@ -37,8 +37,8 @@ ScanI2C::FoundDevice ScanI2C::firstKeyboard() const
 
 ScanI2C::FoundDevice ScanI2C::firstAccelerometer() const
 {
-    ScanI2C::DeviceType types[] = {MPU6050, LIS3DH, BMA423, LSM6DS3, BMX160};
-    return firstOfOrNONE(5, types);
+    ScanI2C::DeviceType types[] = {MPU6050, LIS3DH, BMA423, LSM6DS3, BMX160, STK8BAXX};
+    return firstOfOrNONE(6, types);
 }
 
 ScanI2C::FoundDevice ScanI2C::find(ScanI2C::DeviceType) const

--- a/src/detect/ScanI2C.h
+++ b/src/detect/ScanI2C.h
@@ -52,7 +52,8 @@ class ScanI2C
         AHT10,
         BMX160,
         DFROBOT_LARK,
-        NAU7802
+        NAU7802,
+        STK8BAXX
     } DeviceType;
 
     // typedef uint8_t DeviceAddress;

--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -313,34 +313,34 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
                 }
                 break;
             case MCP9808_ADDR:
-            // We need to check for STK8BAXX first, since register 0x07 is new data flag for the z-axis and can produce some weird result.
-            // and register 0x00 doesn't seems to be colliding with MCP9808 and LIS3DH chips.
-            {
-                // Check register 0x00 for 0x8700 response to ID STK8BA53 chip.
-                registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x00), 2);
-                if (registerValue == 0x8700) {
-                    type = STK8BAXX;
-                    LOG_INFO("STK8BAXX accelerometer found\n");
+                // We need to check for STK8BAXX first, since register 0x07 is new data flag for the z-axis and can produce some
+                // weird result. and register 0x00 doesn't seems to be colliding with MCP9808 and LIS3DH chips.
+                {
+                    // Check register 0x00 for 0x8700 response to ID STK8BA53 chip.
+                    registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x00), 2);
+                    if (registerValue == 0x8700) {
+                        type = STK8BAXX;
+                        LOG_INFO("STK8BAXX accelerometer found\n");
+                        break;
+                    }
+
+                    // Check register 0x07 for 0x0400 response to ID MCP9808 chip.
+                    registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x07), 2);
+                    if (registerValue == 0x0400) {
+                        type = MCP9808;
+                        LOG_INFO("MCP9808 sensor found\n");
+                        break;
+                    }
+
+                    // Check register 0x0F for 0x3300 response to ID LIS3DH chip.
+                    registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x0F), 2);
+                    if (registerValue == 0x3300) {
+                        type = LIS3DH;
+                        LOG_INFO("LIS3DH accelerometer found\n");
+                    }
+
                     break;
                 }
-
-                // Check register 0x07 for 0x0400 response to ID MCP9808 chip.
-                registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x07), 2);
-                if (registerValue == 0x0400) {
-                    type = MCP9808;
-                    LOG_INFO("MCP9808 sensor found\n");
-                    break;
-                }
-
-                // Check register 0x0F for 0x3300 response to ID LIS3DH chip.
-                registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x0F), 2);
-                if (registerValue == 0x3300) {
-                    type = LIS3DH;
-                    LOG_INFO("LIS3DH accelerometer found\n");
-                }
-
-                break;
-            }
             case SHT31_4x_ADDR:
                 registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x89), 2);
                 if (registerValue == 0x11a2 || registerValue == 0x11da || registerValue == 0xe9c) {

--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -313,17 +313,34 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
                 }
                 break;
             case MCP9808_ADDR:
+            // We need to check for STK8BAXX first, since register 0x07 is new data flag for the z-axis and can produce some weird result.
+            // and register 0x00 doesn't seems to be colliding with MCP9808 and LIS3DH chips.
+            {
+                // Check register 0x00 for 0x8700 response to ID STK8BA53 chip.
+                registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x00), 2);
+                if (registerValue == 0x8700) {
+                    type = STK8BAXX;
+                    LOG_INFO("STK8BAXX accelerometer found\n");
+                    break;
+                }
+
+                // Check register 0x07 for 0x0400 response to ID MCP9808 chip.
                 registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x07), 2);
                 if (registerValue == 0x0400) {
                     type = MCP9808;
                     LOG_INFO("MCP9808 sensor found\n");
-                } else {
+                    break;
+                }
+
+                // Check register 0x0F for 0x3300 response to ID LIS3DH chip.
+                registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x0F), 2);
+                if (registerValue == 0x3300) {
                     type = LIS3DH;
                     LOG_INFO("LIS3DH accelerometer found\n");
                 }
 
                 break;
-
+            }
             case SHT31_4x_ADDR:
                 registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x89), 2);
                 if (registerValue == 0x11a2 || registerValue == 0x11da || registerValue == 0xe9c) {

--- a/variants/radiomaster_900_bandit/variant.h
+++ b/variants/radiomaster_900_bandit/variant.h
@@ -11,11 +11,16 @@
 
 /*
   I2C SDA and SCL.
-  0x18 - STK8XXX Accelerometer, Not supported yet.
+  0x18 - STK8XXX Accelerometer
   0x3C - SH1115 Display Driver
 */
 #define I2C_SDA 14
 #define I2C_SCL 12
+
+/*
+  I2C STK8XXX Accelerometer Interrupt PIN to ESP32 Pin 6 - SENSOR_CAPP (GPIO37)
+*/
+#define STK8XXX_INT 37
 
 /*
   No GPS - but free pins are available.


### PR DESCRIPTION
This PR will enable accelerometer support and **tap** to wake screen for the Radiomaster Bandit
STK8Bxxx library should also work with following IDs

STK8321 or STK8323 CHIP ID 0x23
STK8327 CHIP ID 0x26
// S or R resolution = 10 bit
STK8BA50 CHIP ID 0x86
STK8BA5X CHIP ID 0x87

STK8BA53 is currently used in Radiomaster Bandit.