### PR TITLE
Fix traceroute not adding more than one SNR or route entry

### DIFF
--- a/src/modules/TraceRouteModule.cpp
+++ b/src/modules/TraceRouteModule.cpp
@@ -53,7 +53,7 @@ void TraceRouteModule::insertUnknownHops(meshtastic_MeshPacket &p, meshtastic_Ro
         uint8_t hopsTaken = p.hop_start - p.hop_limit;
         int8_t diff = hopsTaken - *route_count;
         for (uint8_t i = 0; i < diff; i++) {
-            if (*route_count < sizeof(*route) / sizeof(route[0])) {
+            if (*route_count < ROUTE_SIZE) {
                 route[*route_count] = NODENUM_BROADCAST; // This will represent an unknown hop
                 *route_count += 1;
             }
@@ -61,7 +61,7 @@ void TraceRouteModule::insertUnknownHops(meshtastic_MeshPacket &p, meshtastic_Ro
         // Add unknown SNR values if necessary
         diff = *route_count - *snr_count;
         for (uint8_t i = 0; i < diff; i++) {
-            if (*snr_count < sizeof(*snr_list) / sizeof(snr_list[0])) {
+            if (*snr_count < ROUTE_SIZE) {
                 snr_list[*snr_count] = INT8_MIN; // This will represent an unknown SNR
                 *snr_count += 1;
             }
@@ -89,7 +89,7 @@ void TraceRouteModule::appendMyIDandSNR(meshtastic_RouteDiscovery *updated, floa
         snr_list = updated->snr_back;
     }
 
-    if (*snr_count < sizeof(*snr_list) / sizeof(snr_list[0])) {
+    if (*snr_count < ROUTE_SIZE) {
         snr_list[*snr_count] = (int8_t)(snr * 4); // Convert SNR to 1 byte
         *snr_count += 1;
     }
@@ -97,7 +97,7 @@ void TraceRouteModule::appendMyIDandSNR(meshtastic_RouteDiscovery *updated, floa
         return;
 
     // Length of route array can normally not be exceeded due to the max. hop_limit of 7
-    if (*route_count < sizeof(*route) / sizeof(route[0])) {
+    if (*route_count < ROUTE_SIZE) {
         route[*route_count] = myNodeInfo.my_node_num;
         *route_count += 1;
     } else {

--- a/src/modules/TraceRouteModule.h
+++ b/src/modules/TraceRouteModule.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "ProtobufModule.h"
 
+#define ROUTE_SIZE sizeof(((meshtastic_RouteDiscovery *)0)->route) / sizeof(((meshtastic_RouteDiscovery *)0)->route[0])
+
 /**
  * A module that traces the route to a certain destination node
  */


### PR DESCRIPTION
@djholt reported https://github.com/meshtastic/firmware/pull/4485#issuecomment-2338437108 that the SNR in traceroutes for 2.5 always got only 1 entry. Seems this would also happen to the route as well, because the array size was not calculated correctly.