### PR TITLE
Try fix repeatedly getting a new NodeNum

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -121,6 +121,8 @@ NodeDB::NodeDB()
     owner.hw_model = HW_VENDOR;
     // Ensure user (nodeinfo) role is set to whatever we're configured to
     owner.role = config.device.role;
+    // Ensure macaddr is set to our macaddr as it will be copied in our info below
+    memcpy(owner.macaddr, ourMacAddr, sizeof(owner.macaddr));
 
     // Include our owner in the node db under our nodenum
     meshtastic_NodeInfoLite *info = getOrCreateMeshNode(getNodeNum());


### PR DESCRIPTION
We're comparing `ourMacAddr` to `user.macaddr` in `pickNewNodeNum()`, but `owner.macaddr` might not yet be set when we copy it to the `info` of our node in the DB here: 
https://github.com/meshtastic/firmware/blob/68d6ff8c24de3b98332dea07df4ad4f06532170b/src/mesh/NodeDB.cpp#L167 
