### PR TITLE
Beautify GPS_DEBUG getACK logging code

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -166,18 +166,21 @@ GPS_RESPONSE GPS::getACK(const char *message, uint32_t waitMillis)
             b = _serial_gps->read();
 
 #ifdef GPS_DEBUG
-            LOG_DEBUG("%02X", (char *)buffer);
+            LOG_DEBUG("%c", (b >= 32 && b <= 126) ? b : '.');
 #endif
             buffer[bytesRead] = b;
             bytesRead++;
             if ((bytesRead == 767) || (b == '\r')) {
                 if (strnstr((char *)buffer, message, bytesRead) != nullptr) {
 #ifdef GPS_DEBUG
-                    LOG_DEBUG("\r");
+                    LOG_DEBUG("\r\nFound: %s\r\n", message); // Log the found message
 #endif
                     return GNSS_RESPONSE_OK;
                 } else {
                     bytesRead = 0;
+#ifdef GPS_DEBUG
+                    LOG_DEBUG("\r\n");
+#endif
                 }
             }
         }


### PR DESCRIPTION
This getACK is used to look for ASCII responses, so print ASCII when GPS_DEBUG is enabled.

This markedly assisted with recent AG3335 debugging. It works great with other chips too (tested eg ATGM336H). Even UBLOX prints understandable "GPTXT,01,01,01,PDTI inv format*35." responses.

Credit to bluebrolly. on discord.