### PR TITLE
[Add] nrf52_factory_erase submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "meshtestic"]
 	path = meshtestic
 	url = https://github.com/meshtastic/meshTestic
+[submodule "nrf52_factory_erase"]
+	path = nrf52_factory_erase
+	url = https://github.com/markbirss/nrf52_factory_erase


### PR DESCRIPTION
This is the platformio version of the meshtastic nrf52 factory erase firmware (previous version was based on arduino)

builds same as meshtastic firmware with 2 variants available
* s140_nrf52_611_softdevice
* s140_nrf52_730_softdevice

e.g
./bin/build-nrf52.sh s140_nrf52_611_softdevice
 
then find files in release directory