### PR TITLE
Remove scaling of smart position broadcast minimum interval specifically

### DIFF
--- a/src/modules/PositionModule.h
+++ b/src/modules/PositionModule.h
@@ -62,8 +62,7 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
     void sendLostAndFoundText();
     bool hasQualityTimesource();
 
-    const uint32_t minimumTimeThreshold =
-        Default::getConfiguredOrDefaultMsScaled(config.position.broadcast_smart_minimum_interval_secs, 30, numOnlineNodes);
+    const uint32_t minimumTimeThreshold = Default::getConfiguredOrDefaultMs(config.position.broadcast_smart_minimum_interval_secs, 30);
 };
 
 struct SmartPosition {

--- a/src/modules/PositionModule.h
+++ b/src/modules/PositionModule.h
@@ -62,7 +62,8 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
     void sendLostAndFoundText();
     bool hasQualityTimesource();
 
-    const uint32_t minimumTimeThreshold = Default::getConfiguredOrDefaultMs(config.position.broadcast_smart_minimum_interval_secs, 30);
+    const uint32_t minimumTimeThreshold =
+        Default::getConfiguredOrDefaultMs(config.position.broadcast_smart_minimum_interval_secs, 30);
 };
 
 struct SmartPosition {


### PR DESCRIPTION
For regularly position broadcast intervals, scaling based on active mesh size makes more sense, but for smart broadcast minimum intervals, which are more ad-hoc in nature, we can indulge in a higher degree of chatty-ness if a node is on the move.