### PR TITLE
TFT speed improvements

### DIFF
--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -681,29 +681,92 @@ void TFTDisplay::display(bool fromBlank)
     // tft->clear();
     concurrency::LockGuard g(spiLock);
 
-    uint16_t x, y;
+    uint32_t x, y;
+    uint32_t y_byteIndex;
+    uint8_t y_byteMask;
+    uint32_t x_FirstPixelUpdate;
+    uint32_t x_LastPixelUpdate;
+    bool isset, dblbuf_isset;
+    uint16_t colorTftMesh, colorTftBlack;
+    bool somethingChanged = false;
+
+    // Store colors byte-reversed so that TFT_eSPI doesn't have to swap bytes in a separate step
+    colorTftMesh = (TFT_MESH >> 8) | ((TFT_MESH & 0xFF) << 8);
+    colorTftBlack = (TFT_BLACK >> 8) | ((TFT_BLACK & 0xFF) << 8);
 
     for (y = 0; y < displayHeight; y++) {
-        for (x = 0; x < displayWidth; x++) {
-            auto isset = buffer[x + (y / 8) * displayWidth] & (1 << (y & 7));
+        y_byteIndex = (y / 8) * displayWidth;
+        y_byteMask = (1 << (y & 7));
+
+        // Step 1: Do a quick scan of 8 rows together. This allows fast-forwarding over unchanged screen areas.
+        if (y_byteMask == 1) {
             if (!fromBlank) {
-                // get src pixel in the page based ordering the OLED lib uses FIXME, super inefficent
-                auto dblbuf_isset = buffer_back[x + (y / 8) * displayWidth] & (1 << (y & 7));
+                for (x = 0; x < displayWidth; x++) {
+                    if (buffer[x + y_byteIndex] != buffer_back[x + y_byteIndex])
+                        break;
+                }
+            } else {
+                for (x = 0; x < displayWidth; x++) {
+                    if (buffer[x + y_byteIndex] != 0)
+                        break;
+                }
+            }
+            if (x >= displayWidth) {
+                // No changed pixels found in these 8 rows, fast-forward to the next 8
+                y = y + 7;
+                continue;
+            }
+        }
+
+        // Step 2: Scan each of the 8 rows individually. Find the first pixel in each row that needs updating
+        for (x_FirstPixelUpdate = 0; x_FirstPixelUpdate < displayWidth; x_FirstPixelUpdate++) {
+            isset = buffer[x_FirstPixelUpdate + y_byteIndex] & y_byteMask;
+
+            if (!fromBlank) {
+                // get src pixel in the page based ordering the OLED lib uses
+                dblbuf_isset = buffer_back[x_FirstPixelUpdate + y_byteIndex] & y_byteMask;
                 if (isset != dblbuf_isset) {
-                    tft->drawPixel(x, y, isset ? TFT_MESH : TFT_BLACK);
+                    break;
                 }
             } else if (isset) {
-                tft->drawPixel(x, y, TFT_MESH);
+                break;
             }
+        }
+
+        // Did we find a pixel that needs updating on this row?
+        if (x_FirstPixelUpdate < displayWidth) {
+
+            // Quickly write out the first changed pixel (saves another array lookup)
+            linePixelBuffer[x_FirstPixelUpdate] = isset ? colorTftMesh : colorTftBlack;
+            x_LastPixelUpdate = x_FirstPixelUpdate;
+
+            // Step 3: copy all remaining pixels in this row into the pixel line buffer,
+            // while also recording the last pixel in the row that needs updating
+            for (x = x_FirstPixelUpdate + 1; x < displayWidth; x++) {
+                isset = buffer[x + y_byteIndex] & y_byteMask;
+                linePixelBuffer[x] = isset ? colorTftMesh : colorTftBlack;
+
+                if (!fromBlank) {
+                    dblbuf_isset = buffer_back[x + y_byteIndex] & y_byteMask;
+                    if (isset != dblbuf_isset) {
+                        x_LastPixelUpdate = x;
+                    }
+                } else if (isset) {
+                    x_LastPixelUpdate = x;
+                }
+            }
+
+            // Step 4: Send the changed pixels on this line to the screen as a single block transfer.
+            // This function accepts pixel data MSB first so it can dump the memory straight out the SPI port.
+            tft->pushRect(x_FirstPixelUpdate, y, (x_LastPixelUpdate - x_FirstPixelUpdate + 1), 1,
+                          &linePixelBuffer[x_FirstPixelUpdate]);
+
+            somethingChanged = true;
         }
     }
     // Copy the Buffer to the Back Buffer
-    for (y = 0; y < (displayHeight / 8); y++) {
-        for (x = 0; x < displayWidth; x++) {
-            uint16_t pos = x + y * displayWidth;
-            buffer_back[pos] = buffer[pos];
-        }
-    }
+    if (somethingChanged)
+        memcpy(buffer_back, buffer, displayBufferSize);
 }
 
 // Send a command to the display (low level function)
@@ -856,6 +919,15 @@ bool TFTDisplay::connect()
     tft->setRotation(3); // Orient horizontal and wide underneath the silkscreen name label
 #endif
     tft->fillScreen(TFT_BLACK);
+
+    if (this->linePixelBuffer == NULL) {
+        this->linePixelBuffer = (uint16_t *)malloc(sizeof(uint16_t) * displayWidth);
+
+        if (!this->linePixelBuffer) {
+            LOG_INFO("Not enough memory to create TFT line buffer\n");
+            return false;
+        }
+    }
 
     return true;
 }

--- a/src/graphics/TFTDisplay.h
+++ b/src/graphics/TFTDisplay.h
@@ -48,6 +48,8 @@ class TFTDisplay : public OLEDDisplay
      */
     static GpioPin *backlightEnable;
 
+    uint16_t *linePixelBuffer;
+
   protected:
     // the header size of the buffer used, e.g. for the SPI command header
     virtual int getBufferOffset(void) override { return 0; }


### PR DESCRIPTION
Screen update performance with TFT displays is... slow. Particularly on nRF processors with the default Arduino SPI driver. This PR greatly improves TFT screen update speed. I have measured a 32x speedup with a 128x160 TFT screen running on a RAK4631.

Note I don't have any ESP32 boards to test with but I expect a similar improvement. Someone with a T-deck please check.


**Issue 1:**
The `TFTDisplay.cpp` translation layer uses a pixel-by-pixel screen update strategy which is simple but slow. The following strategy is implemented here:

1. Quickly scan 8 rows at a time for modified pixels that need updating. This is efficient for the OLEDDisplay buffer format where 8 vertical pixels are stored in each byte.
2. If modified pixels are found, scan each row individually and record where the first modified pixel is found (in the X direction).
3. From the first modified pixel in that row until the end of the row, write 565 pixel data into a line buffer while also recording the last modified pixel in that row.
4. Send the line buffer to the TFT display as a single block write, but only from the first to the last modified pixel.
5. Repeat 2-4 for each of the 8 rows that might be modified.
6. Repeat 1-5 for the next block of 8 rows.
7. Copy display buffer to back buffer using memcpy (more efficient), but only if the display data has changed.

Not only does this speed up TFT screen updates, it also reduces idle CPU usage. The screen update function is called once every second and this PR is much more efficient processing unchanged frames.

I measure a 4x speed increase with the above changes on a nRF / RAK4631. ESP32s should experience a greater speedup as they already have support for SPI block transfers.


**Issue 2:**
The default Arduino SPI driver on nRF platforms does not support multi-byte transfers, limiting the effectiveness of the above improvements. I have forked the TFT_eSPI library to implement uint16, uint32, and large block transfers on nRF:
[https://github.com/robertfisk/TFT_eSPI](https://github.com/robertfisk/TFT_eSPI)

Change the following line in your variant's `platformio.ini` lib_deps section from:
`bodmer/TFT_eSPI`
to:
`https://github.com/robertfisk/TFT_eSPI.git#nrf_faster_spi`

This forked library takes the 4x speed boost up to a 32x speed boost on nRF platforms.

**Bonus Speedboost**
On nRF platforms, add the following line to your variant.h to increase the second SPI port's maximum speed from 8MHz to 32MHz:
`#define SPI_32MHZ_INTERFACE 1`
Then configure SPI_FREQUENCY to some number between 8000000 and 32000000 depending on the capability of your hardware.
