### PR TITLE
Define SX126X_ANT_SW for the RAK11200 on the RAK19007 base

### DIFF
--- a/variants/rak11200/variant.h
+++ b/variants/rak11200/variant.h
@@ -70,6 +70,7 @@ static const uint8_t SCK = 33;
 #define LORA_CS SS
 
 #define USE_SX1262
+#define SX126X_ANT_SW WB_IO2
 #define SX126X_CS SS // NSS for SX126X
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2


### PR DESCRIPTION
Fixes #3338, allows the RAK13300 and GNSS module to function correctly when used on the RAK19007 base with the RAK11200 core module by activating the 3.3V power rail correctly.

