### PR TITLE
Make local stats number of Rx packets sum of good and bad

### DIFF
--- a/src/modules/Telemetry/DeviceTelemetry.cpp
+++ b/src/modules/Telemetry/DeviceTelemetry.cpp
@@ -124,7 +124,7 @@ void DeviceTelemetryModule::sendLocalStatsToPhone()
     telemetry.variant.local_stats.num_total_nodes = nodeDB->getNumMeshNodes();
     if (RadioLibInterface::instance) {
         telemetry.variant.local_stats.num_packets_tx = RadioLibInterface::instance->txGood;
-        telemetry.variant.local_stats.num_packets_rx = RadioLibInterface::instance->rxGood;
+        telemetry.variant.local_stats.num_packets_rx = RadioLibInterface::instance->rxGood + RadioLibInterface::instance->rxBad;
         telemetry.variant.local_stats.num_packets_rx_bad = RadioLibInterface::instance->rxBad;
     }
 


### PR DESCRIPTION
Number of received packets are both the “good” and “bad” ones. This way the error rate is really `bad/(good+bad)` when doing `num_packets_rx_bad/num_packets_rx`, as e.g. iOS has already.