### PR TITLE
Update T114 LED definitions to include only one simple controllable LED and two NEOPIXELs.

### DIFF
--- a/variants/heltec_mesh_node_t114/variant.cpp
+++ b/variants/heltec_mesh_node_t114/variant.cpp
@@ -32,13 +32,7 @@ const uint32_t g_ADigitalPinMap[] = {
 
 void initVariant()
 {
-    // LED1 & LED2
+    // LED1
     pinMode(PIN_LED1, OUTPUT);
     ledOff(PIN_LED1);
-
-    pinMode(PIN_LED2, OUTPUT);
-    ledOff(PIN_LED2);
-
-    pinMode(PIN_LED3, OUTPUT);
-    ledOff(PIN_LED3);
 }

--- a/variants/heltec_mesh_node_t114/variant.h
+++ b/variants/heltec_mesh_node_t114/variant.h
@@ -67,19 +67,16 @@ extern "C" {
 #define NUM_ANALOG_OUTPUTS (0)
 
 // LEDs
-#define PIN_LED1 (32 + 3) // 13 red (confirmed on 1.0 board)
-// Unused(by firmware) LEDs:
-#define PIN_LED2 (1 + 1)  // 14 blue
-#define PIN_LED3 (1 + 11) // 15 green
-
-#define LED_RED PIN_LED3
-#define LED_BLUE PIN_LED1
-#define LED_GREEN PIN_LED2
-
-#define LED_BUILTIN LED_BLUE
-#define LED_CONN PIN_GREEN
-
+#define PIN_LED1 (32 + 3) // green (confirmed on 1.0 board)
+#define LED_BLUE PIN_LED1 // fake for bluefruit library
+#define LED_GREEN PIN_LED1
+#define LED_BUILTIN LED_GREEN
 #define LED_STATE_ON 0 // State when LED is lit
+
+#define HAS_NEOPIXEL                         // Enable the use of neopixels
+#define NEOPIXEL_COUNT 2                     // How many neopixels are connected
+#define NEOPIXEL_DATA 14                     // gpio pin used to send data to the neopixels
+#define NEOPIXEL_TYPE (NEO_GRB + NEO_KHZ800) // type of neopixels in use
 
 /*
  * Buttons


### PR DESCRIPTION
Fixes #4706.

An alias LED_BLUE for LED_GREEN/PIN_LED1 is maintained to keep bluefruit happy.

For reference: https://resource.heltec.cn/download/Mesh%20Node%20T114/schematic_diagram.pdf