### PR TITLE
Don't use PKC on a non-primary channel unless specifically requested

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -185,9 +185,12 @@ ErrorCode Router::sendLocal(meshtastic_MeshPacket *p, RxSource src)
             handleReceived(p, src);
         }
 
-        if (!p->channel) { // don't override if a channel was requested
-            p->channel = nodeDB->getMeshNodeChannel(p->to);
-            LOG_DEBUG("localSend to channel %d\n", p->channel);
+        if (!p->channel && !p->pki_encrypted) { // don't override if a channel was requested
+            meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(p->to);
+            if (node && node->user.public_key.size == 0) {
+                p->channel = node->channel;
+                LOG_DEBUG("localSend to channel %d\n", p->channel);
+            }
         }
 
         return send(p);


### PR DESCRIPTION
Since we still have some uses where we want to send to a specific node over a specific channel, this attempts to catch those cases and honor the request. Specifically the admin and serial channel.