### PR TITLE
Expand buffer to MqttClientProxyMessage_size

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -468,7 +468,7 @@ void MQTT::publishQueuedMessages()
         LOG_DEBUG("Publishing enqueued MQTT message\n");
         // FIXME - this size calculation is super sloppy, but it will go away once we dynamically alloc meshpackets
         meshtastic_ServiceEnvelope *env = mqttQueue.dequeuePtr(0);
-        static uint8_t bytes[meshtastic_MeshPacket_size + 64];
+        static uint8_t bytes[meshtastic_MqttClientProxyMessage_size];
         size_t numBytes = pb_encode_to_bytes(bytes, sizeof(bytes), &meshtastic_ServiceEnvelope_msg, env);
         std::string topic;
         if (env->packet->pki_encrypted) {
@@ -555,7 +555,7 @@ void MQTT::onSend(const meshtastic_MeshPacket &mp, const meshtastic_MeshPacket &
 
         if (moduleConfig.mqtt.proxy_to_client_enabled || this->isConnectedDirectly()) {
             // FIXME - this size calculation is super sloppy, but it will go away once we dynamically alloc meshpackets
-            static uint8_t bytes[meshtastic_MeshPacket_size + 64];
+            static uint8_t bytes[meshtastic_MqttClientProxyMessage_size];
             size_t numBytes = pb_encode_to_bytes(bytes, sizeof(bytes), &meshtastic_ServiceEnvelope_msg, env);
             std::string topic = cryptTopic + channelId + "/" + owner.id;
             LOG_DEBUG("MQTT Publish %s, %u bytes\n", topic.c_str(), numBytes);
@@ -651,7 +651,7 @@ void MQTT::perhapsReportToMap()
         se->packet = mp;
 
         // FIXME - this size calculation is super sloppy, but it will go away once we dynamically alloc meshpackets
-        static uint8_t bytes[meshtastic_MeshPacket_size + 64];
+        static uint8_t bytes[meshtastic_MqttClientProxyMessage_size];
         size_t numBytes = pb_encode_to_bytes(bytes, sizeof(bytes), &meshtastic_ServiceEnvelope_msg, se);
 
         LOG_INFO("MQTT Publish map report to %s\n", mapTopic.c_str());


### PR DESCRIPTION
While not technically an MqttClientProxyMessage, expanding the buffer to this size should give us a more room for ServiceEnvelopes with large MeshPackets and long topic names + gateway_ids. We may need to place some long term limitations on size of topic names, because these can get close to the MTU for bluetooth packets. So we'll need to circle back, but this should work for now hopefully.

Closes #4725 