### PR TITLE
I2C for Heltec Mesh Node T114

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -210,6 +210,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MINIMUM_SAFE_FREE_HEAP 1500
 #endif
 
+#ifndef WIRE_INTERFACES_COUNT
+// Officially an NRF52 macro
+// Repurposed cross-platform to identify devices using Wire1
+#if defined(I2C_SDA1) || defined(PIN_WIRE_SDA)
+#define WIRE_INTERFACES_COUNT 2
+#elif HAS_WIRE
+#define WIRE_INTERFACES_COUNT 1
+#endif
+#endif
+
 /* Step #3: mop up with disabled values for HAS_ options not handled by the above two */
 
 #ifndef HAS_WIFI

--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -162,13 +162,13 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
     Melopero_RV3028 rtc;
 #endif
 
-#ifdef I2C_SDA1
+#if defined(I2C_SDA1) || (defined(NRF52840_XXAA) && (WIRE_INTERFACES_COUNT == 2))
     if (port == I2CPort::WIRE1) {
         i2cBus = &Wire1;
     } else {
 #endif
         i2cBus = &Wire;
-#ifdef I2C_SDA1
+#if defined(I2C_SDA1) || (defined(NRF52840_XXAA) && (WIRE_INTERFACES_COUNT == 2))
     }
 #endif
 
@@ -423,7 +423,7 @@ TwoWire *ScanI2CTwoWire::fetchI2CBus(ScanI2C::DeviceAddress address) const
     if (address.port == ScanI2C::I2CPort::WIRE) {
         return &Wire;
     } else {
-#ifdef I2C_SDA1
+#if defined(I2C_SDA1) || (defined(NRF52840_XXAA) && (WIRE_INTERFACES_COUNT == 2))
         return &Wire1;
 #else
         return &Wire;

--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -162,13 +162,13 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
     Melopero_RV3028 rtc;
 #endif
 
-#if defined(I2C_SDA1) || (defined(NRF52840_XXAA) && (WIRE_INTERFACES_COUNT == 2))
+#if WIRE_INTERFACES_COUNT == 2
     if (port == I2CPort::WIRE1) {
         i2cBus = &Wire1;
     } else {
 #endif
         i2cBus = &Wire;
-#if defined(I2C_SDA1) || (defined(NRF52840_XXAA) && (WIRE_INTERFACES_COUNT == 2))
+#if WIRE_INTERFACES_COUNT == 2
     }
 #endif
 
@@ -423,7 +423,7 @@ TwoWire *ScanI2CTwoWire::fetchI2CBus(ScanI2C::DeviceAddress address) const
     if (address.port == ScanI2C::I2CPort::WIRE) {
         return &Wire;
     } else {
-#if defined(I2C_SDA1) || (defined(NRF52840_XXAA) && (WIRE_INTERFACES_COUNT == 2))
+#if WIRE_INTERFACES_COUNT == 2
         return &Wire1;
 #else
         return &Wire;

--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -29,7 +29,7 @@ void readFromRTC()
     if (rtc_found.address == RV3028_RTC) {
         uint32_t now = millis();
         Melopero_RV3028 rtc;
-#if defined(I2C_SDA1) || (defined(NRF52840_XXAA) && (WIRE_INTERFACES_COUNT == 2))
+#if WIRE_INTERFACES_COUNT == 2
         rtc.initI2C(rtc_found.port == ScanI2C::I2CPort::WIRE1 ? Wire1 : Wire);
 #else
         rtc.initI2C();
@@ -58,7 +58,7 @@ void readFromRTC()
         uint32_t now = millis();
         PCF8563_Class rtc;
 
-#if defined(I2C_SDA1) || (defined(NRF52840_XXAA) && (WIRE_INTERFACES_COUNT == 2))
+#if WIRE_INTERFACES_COUNT == 2
         rtc.begin(rtc_found.port == ScanI2C::I2CPort::WIRE1 ? Wire1 : Wire);
 #else
         rtc.begin();
@@ -150,7 +150,7 @@ bool perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpdate)
 #ifdef RV3028_RTC
         if (rtc_found.address == RV3028_RTC) {
             Melopero_RV3028 rtc;
-#if defined(I2C_SDA1) || (defined(NRF52840_XXAA) && (WIRE_INTERFACES_COUNT == 2))
+#if WIRE_INTERFACES_COUNT == 2
             rtc.initI2C(rtc_found.port == ScanI2C::I2CPort::WIRE1 ? Wire1 : Wire);
 #else
             rtc.initI2C();
@@ -164,7 +164,7 @@ bool perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpdate)
         if (rtc_found.address == PCF8563_RTC) {
             PCF8563_Class rtc;
 
-#if defined(I2C_SDA1) || (defined(NRF52840_XXAA) && (WIRE_INTERFACES_COUNT == 2))
+#if WIRE_INTERFACES_COUNT == 2
             rtc.begin(rtc_found.port == ScanI2C::I2CPort::WIRE1 ? Wire1 : Wire);
 #else
             rtc.begin();

--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -29,7 +29,7 @@ void readFromRTC()
     if (rtc_found.address == RV3028_RTC) {
         uint32_t now = millis();
         Melopero_RV3028 rtc;
-#ifdef I2C_SDA1
+#if defined(I2C_SDA1) || (defined(NRF52840_XXAA) && (WIRE_INTERFACES_COUNT == 2))
         rtc.initI2C(rtc_found.port == ScanI2C::I2CPort::WIRE1 ? Wire1 : Wire);
 #else
         rtc.initI2C();
@@ -58,7 +58,7 @@ void readFromRTC()
         uint32_t now = millis();
         PCF8563_Class rtc;
 
-#ifdef I2C_SDA1
+#if defined(I2C_SDA1) || (defined(NRF52840_XXAA) && (WIRE_INTERFACES_COUNT == 2))
         rtc.begin(rtc_found.port == ScanI2C::I2CPort::WIRE1 ? Wire1 : Wire);
 #else
         rtc.begin();
@@ -150,7 +150,7 @@ bool perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpdate)
 #ifdef RV3028_RTC
         if (rtc_found.address == RV3028_RTC) {
             Melopero_RV3028 rtc;
-#ifdef I2C_SDA1
+#if defined(I2C_SDA1) || (defined(NRF52840_XXAA) && (WIRE_INTERFACES_COUNT == 2))
             rtc.initI2C(rtc_found.port == ScanI2C::I2CPort::WIRE1 ? Wire1 : Wire);
 #else
             rtc.initI2C();
@@ -164,7 +164,7 @@ bool perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpdate)
         if (rtc_found.address == PCF8563_RTC) {
             PCF8563_Class rtc;
 
-#ifdef I2C_SDA1
+#if defined(I2C_SDA1) || (defined(NRF52840_XXAA) && (WIRE_INTERFACES_COUNT == 2))
             rtc.begin(rtc_found.port == ScanI2C::I2CPort::WIRE1 ? Wire1 : Wire);
 #else
             rtc.begin();

--- a/src/input/cardKbI2cImpl.cpp
+++ b/src/input/cardKbI2cImpl.cpp
@@ -16,7 +16,7 @@ void CardKbI2cImpl::init()
         uint8_t i2caddr_asize = 3;
         auto i2cScanner = std::unique_ptr<ScanI2CTwoWire>(new ScanI2CTwoWire());
 
-#if defined(I2C_SDA1)
+#if defined(I2C_SDA1) || (defined(NRF52840_XXAA) && (WIRE_INTERFACES_COUNT == 2))
         i2cScanner->scanPort(ScanI2C::I2CPort::WIRE1, i2caddr_scan, i2caddr_asize);
 #endif
         i2cScanner->scanPort(ScanI2C::I2CPort::WIRE, i2caddr_scan, i2caddr_asize);

--- a/src/input/cardKbI2cImpl.cpp
+++ b/src/input/cardKbI2cImpl.cpp
@@ -16,7 +16,7 @@ void CardKbI2cImpl::init()
         uint8_t i2caddr_asize = 3;
         auto i2cScanner = std::unique_ptr<ScanI2CTwoWire>(new ScanI2CTwoWire());
 
-#if defined(I2C_SDA1) || (defined(NRF52840_XXAA) && (WIRE_INTERFACES_COUNT == 2))
+#if WIRE_INTERFACES_COUNT == 2
         i2cScanner->scanPort(ScanI2C::I2CPort::WIRE1, i2caddr_scan, i2caddr_asize);
 #endif
         i2cScanner->scanPort(ScanI2C::I2CPort::WIRE, i2caddr_scan, i2caddr_asize);

--- a/src/input/kbI2cBase.cpp
+++ b/src/input/kbI2cBase.cpp
@@ -33,7 +33,7 @@ int32_t KbI2cBase::runOnce()
     if (!i2cBus) {
         switch (cardkb_found.port) {
         case ScanI2C::WIRE1:
-#ifdef I2C_SDA1
+#if defined(I2C_SDA1) || (defined(NRF52840_XXAA) && (WIRE_INTERFACES_COUNT == 2))
             LOG_DEBUG("Using I2C Bus 1 (the second one)\n");
             i2cBus = &Wire1;
             if (cardkb_found.address == BBQ10_KB_ADDR) {

--- a/src/input/kbI2cBase.cpp
+++ b/src/input/kbI2cBase.cpp
@@ -33,7 +33,7 @@ int32_t KbI2cBase::runOnce()
     if (!i2cBus) {
         switch (cardkb_found.port) {
         case ScanI2C::WIRE1:
-#if defined(I2C_SDA1) || (defined(NRF52840_XXAA) && (WIRE_INTERFACES_COUNT == 2))
+#if WIRE_INTERFACES_COUNT == 2
             LOG_DEBUG("Using I2C Bus 1 (the second one)\n");
             i2cBus = &Wire1;
             if (cardkb_found.address == BBQ10_KB_ADDR) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -360,7 +360,7 @@ void setup()
     Wire1.begin();
 #elif defined(I2C_SDA1) && !defined(ARCH_RP2040)
     Wire1.begin(I2C_SDA1, I2C_SCL1);
-#elif defined(NRF52840_XXAA) && (WIRE_INTERFACES_COUNT == 2)
+#elif WIRE_INTERFACES_COUNT == 2
     Wire1.begin();
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -360,6 +360,8 @@ void setup()
     Wire1.begin();
 #elif defined(I2C_SDA1) && !defined(ARCH_RP2040)
     Wire1.begin(I2C_SDA1, I2C_SCL1);
+#elif defined(NRF52840_XXAA) && (WIRE_INTERFACES_COUNT == 2)
+    Wire1.begin();
 #endif
 
 #if defined(I2C_SDA) && defined(ARCH_RP2040)
@@ -426,6 +428,8 @@ void setup()
     i2cScanner->scanPort(ScanI2C::I2CPort::WIRE1);
 #elif defined(I2C_SDA1) && !defined(ARCH_RP2040)
     Wire1.begin(I2C_SDA1, I2C_SCL1);
+    i2cScanner->scanPort(ScanI2C::I2CPort::WIRE1);
+#elif defined(NRF52840_XXAA) && (WIRE_INTERFACES_COUNT == 2)
     i2cScanner->scanPort(ScanI2C::I2CPort::WIRE1);
 #endif
 

--- a/variants/heltec_mesh_node_t114/variant.h
+++ b/variants/heltec_mesh_node_t114/variant.h
@@ -92,13 +92,22 @@ No longer populated on PCB
 #define PIN_SERIAL2_TX (0 + 10)
 //  #define PIN_SERIAL2_EN (0 + 17)
 
-/**
-    Wire Interfaces
-    */
-#define WIRE_INTERFACES_COUNT 1
+/*
+ * I2C
+ */
 
-#define PIN_WIRE_SDA (26)
-#define PIN_WIRE_SCL (27)
+#define WIRE_INTERFACES_COUNT 2
+
+// I2C bus 0
+// Routed to footprint for PCF8563TS RTC
+// Not populated on T114 V1, maybe in future?
+#define PIN_WIRE_SDA (0 + 26) // P0.26
+#define PIN_WIRE_SCL (0 + 27) // P0.27
+
+// I2C bus 1
+// Available on header pins, for general use
+#define PIN_WIRE1_SDA (0 + 13) // P0.13
+#define PIN_WIRE1_SCL (0 + 16) // P0.16
 
 // QSPI Pins
 #define PIN_QSPI_SCK (32 + 14)

--- a/variants/heltec_mesh_node_t114/variant.h
+++ b/variants/heltec_mesh_node_t114/variant.h
@@ -106,8 +106,8 @@ No longer populated on PCB
 
 // I2C bus 1
 // Available on header pins, for general use
-#define PIN_WIRE1_SDA (0 + 13) // P0.13
-#define PIN_WIRE1_SCL (0 + 16) // P0.16
+#define PIN_WIRE1_SDA (0 + 16) // P0.16
+#define PIN_WIRE1_SCL (0 + 13) // P0.13
 
 // QSPI Pins
 #define PIN_QSPI_SCK (32 + 14)


### PR DESCRIPTION
Resolves https://github.com/meshtastic/firmware/issues/4605

Adds an I2C bus, assigned to P0.13 (SDA) and P0.16 (SCL), which are available on the header pins.

This is implemented using a second I2C bus.
Bus 0 retains its original assignment from Heltec: routed to the footprint for an RTC which is not populated on the current hardware version.

Another option would be to simply reassign the pins for the currently unused I2C bus 0. 
Is there reason to consider this instead?