### PR TITLE
Implement optional hops_away on NodeInfo/Lite

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1112,8 +1112,10 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
         info->via_mqtt = mp.via_mqtt; // Store if we received this packet via MQTT
 
         // If hopStart was set and there wasn't someone messing with the limit in the middle, add hopsAway
-        if (mp.hop_start != 0 && mp.hop_limit <= mp.hop_start)
+        if (mp.hop_start != 0 && mp.hop_limit <= mp.hop_start) {
+            info->has_hops_away = true;
             info->hops_away = mp.hop_start - mp.hop_limit;
+        }
     }
 }
 

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -194,7 +194,7 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
         auto us = nodeDB->readNextMeshNode(readIndex);
         if (us) {
             nodeInfoForPhone = TypeConversions::ConvertToNodeInfo(us);
-            nodeInfoForPhone.hops_away = 0;
+            nodeInfoForPhone.has_hops_away = false;
             nodeInfoForPhone.is_favorite = true;
             fromRadioScratch.which_payload_variant = meshtastic_FromRadio_node_info_tag;
             fromRadioScratch.node_info = nodeInfoForPhone;

--- a/src/mesh/TypeConversions.cpp
+++ b/src/mesh/TypeConversions.cpp
@@ -11,8 +11,12 @@ meshtastic_NodeInfo TypeConversions::ConvertToNodeInfo(const meshtastic_NodeInfo
     info.last_heard = lite->last_heard;
     info.channel = lite->channel;
     info.via_mqtt = lite->via_mqtt;
-    info.hops_away = lite->hops_away;
     info.is_favorite = lite->is_favorite;
+    
+    if (lite->has_hops_away) {
+        info.has_hops_away = true;
+        info.hops_away = lite->hops_away;
+    }
 
     if (lite->has_position) {
         info.has_position = true;

--- a/src/mesh/TypeConversions.cpp
+++ b/src/mesh/TypeConversions.cpp
@@ -12,7 +12,7 @@ meshtastic_NodeInfo TypeConversions::ConvertToNodeInfo(const meshtastic_NodeInfo
     info.channel = lite->channel;
     info.via_mqtt = lite->via_mqtt;
     info.is_favorite = lite->is_favorite;
-    
+
     if (lite->has_hops_away) {
         info.has_hops_away = true;
         info.hops_away = lite->hops_away;


### PR DESCRIPTION
@garthvh question from the app consumer perspective: Do you want the current node to have a null hops_away or hops_away of zero? I elected to use the former.