### PR TITLE
Initial PhoneAPI rate-limiting of messages on certain ports

### DIFF
--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -3,6 +3,8 @@
 #include <cstdint>
 #define ONE_DAY 24 * 60 * 60
 #define ONE_MINUTE_MS 60 * 1000
+#define THIRTY_SECONDS_MS 30 * 1000
+#define FIVE_SECONDS_MS 5 * 1000
 
 #define default_gps_update_interval IF_ROUTER(ONE_DAY, 2 * 60)
 #define default_telemetry_broadcast_interval_secs IF_ROUTER(ONE_DAY / 2, 30 * 60)

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -25,6 +25,7 @@
 #if !MESHTASTIC_EXCLUDE_MQTT
 #include "mqtt/MQTT.h"
 #endif
+#include <RTC.h>
 
 PhoneAPI::PhoneAPI()
 {
@@ -541,14 +542,37 @@ bool PhoneAPI::available()
     return false;
 }
 
+void PhoneAPI::sendNotification(meshtastic_LogRecord_Level level, uint32_t replyId, const char *message)
+{
+    meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
+    cn->has_reply_id = true;
+    cn->reply_id = replyId;
+    cn->level = meshtastic_LogRecord_Level_WARNING;
+    cn->time = getValidTime(RTCQualityFromNet);
+    strncpy(cn->message, message, sizeof(cn->message));
+    service->sendClientNotification(cn);
+    delete cn;
+}
+
 /**
  * Handle a packet that the phone wants us to send.  It is our responsibility to free the packet to the pool
  */
 bool PhoneAPI::handleToRadioPacket(meshtastic_MeshPacket &p)
 {
     printPacket("PACKET FROM PHONE", &p);
+    if (p.decoded.portnum == meshtastic_PortNum_TRACEROUTE_APP && lastPortNumToRadio[p.decoded.portnum] &&
+        (millis() - lastPortNumToRadio[p.decoded.portnum]) < (THIRTY_SECONDS_MS)) {
+        LOG_WARN("Rate limiting portnum %d\n", p.decoded.portnum);
+        sendNotification(meshtastic_LogRecord_Level_WARNING, p.id, "TraceRoute can only be sent once every 30 seconds");
+        return false;
+    } else if (p.decoded.portnum == meshtastic_PortNum_POSITION_APP && lastPortNumToRadio[p.decoded.portnum] &&
+               (millis() - lastPortNumToRadio[p.decoded.portnum]) < (FIVE_SECONDS_MS)) {
+        LOG_WARN("Rate limiting portnum %d\n", p.decoded.portnum);
+        sendNotification(meshtastic_LogRecord_Level_WARNING, p.id, "Position can only be sent once every 5 seconds");
+        return false;
+    }
+    lastPortNumToRadio[p.decoded.portnum] = millis();
     service->handleToRadio(p);
-
     return true;
 }
 

--- a/src/mesh/PhoneAPI.h
+++ b/src/mesh/PhoneAPI.h
@@ -2,8 +2,10 @@
 
 #include "Observer.h"
 #include "mesh-pb-constants.h"
+#include "meshtastic/portnums.pb.h"
 #include <iterator>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 // Make sure that we never let our packets grow too large for one BLE packet
@@ -47,6 +49,9 @@ class PhoneAPI
     State state = STATE_SEND_NOTHING;
 
     uint8_t config_state = 0;
+
+    // Hashmap of timestamps for last time we received a packet on the API per portnum
+    std::unordered_map<meshtastic_PortNum, uint32_t> lastPortNumToRadio;
 
     /**
      * Each packet sent to the phone has an incrementing count
@@ -98,6 +103,11 @@ class PhoneAPI
      * @return true true if a packet was queued for sending (so that caller can yield)
      */
     virtual bool handleToRadio(const uint8_t *buf, size_t len);
+
+    /**
+     * Send a (client)notification to the phone
+     */
+    virtual void sendNotification(meshtastic_LogRecord_Level level, uint32_t replyId, const char *message);
 
     /**
      * Get the next packet we want to send to the phone


### PR DESCRIPTION
Initial PhoneAPI rate-limiting of messages on certain ports to prevent problematic app interactions and give feedback in the form of a client notification to the app. I have personally witnessed the first couple of these:

1. Traceroute spam: because the user didn't get the response they expected, they continue to click the button and inundate the network with requests which illicit responses congesting the network. We will limit these to every 30 seconds.
2. Position rate insanity: I have seen rogue BLEManager instances in the iOS firing positions packets in the phone as fast as the Bluetooth protocol will allow. If this happens again, we will have a nice ClientNotification alerting the phone of its spurious behavior. We will limit these to every 5 seconds.

We may eventually add more of these if we get log jammed with TAK packet payloads from ATAK for instance as well.