### PR TITLE
Fix Chatter 2 blank screen on boot

### DIFF
--- a/variants/chatter2/variant.h
+++ b/variants/chatter2/variant.h
@@ -66,6 +66,7 @@
 #define SCREEN_ROTATE
 #define SCREEN_TRANSITION_FRAMERATE 5 // fps
 #define DISPLAY_FORCE_SMALL_FONTS
+#define TFT_BACKLIGHT_ON LOW
 
 // Battery
 


### PR DESCRIPTION
As reported by @eureekasigns and @GPSFan, Chatter 2 had begun to show a blank screen on boot after recent TFT display changes.

Setting TFT_BACKLIGHT_ON LOW resolves the issue.

Fixes https://github.com/meshtastic/firmware/issues/4751