### PR TITLE
DetectionSensor: broadcast all state changes

### DIFF
--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -49,10 +49,16 @@ int32_t DetectionSensorModule::runOnce()
 
     // LOG_DEBUG("Detection Sensor Module: Current pin state: %i\n", digitalRead(moduleConfig.detection_sensor.monitor_pin));
 
-    if ((millis() - lastSentToMesh) >= Default::getConfiguredOrDefaultMs(moduleConfig.detection_sensor.minimum_broadcast_secs) &&
-        hasDetectionEvent()) {
-        sendDetectionMessage();
-        return DELAYED_INTERVAL;
+    if ((millis() - lastSentToMesh) >= Default::getConfiguredOrDefaultMs(moduleConfig.detection_sensor.minimum_broadcast_secs)) {
+        if (hasDetectionEvent()) {
+            wasDetected = true;
+            sendDetectionMessage();
+            return DELAYED_INTERVAL;
+        } else if (wasDetected) {
+            wasDetected = false;
+            sendCurrentStateMessage();
+            return DELAYED_INTERVAL;
+        }
     }
     // Even if we haven't detected an event, broadcast our current state to the mesh on the scheduled interval as a sort
     // of heartbeat. We only do this if the minimum broadcast interval is greater than zero, otherwise we'll only broadcast state

--- a/src/modules/DetectionSensorModule.h
+++ b/src/modules/DetectionSensorModule.h
@@ -15,6 +15,7 @@ class DetectionSensorModule : public SinglePortModule, private concurrency::OSTh
   private:
     bool firstTime = true;
     uint32_t lastSentToMesh = 0;
+    bool wasDetected = false;
     void sendDetectionMessage();
     void sendCurrentStateMessage();
     bool hasDetectionEvent();


### PR DESCRIPTION
As discussed in #4753 this PR addresses the fact that previously only state changes not_triggered->triggered were broadcasted to the mesh so there wasn't a way to know when the change triggered->not_triggered happens without waiting for `state_broadcast_secs`.
I'm not sure if this new behavior should be gated behind a config flag and in that case what the flag should default to so I'm open to suggestions :)


Fixes #4753.