### PR TITLE
t-echo: fix phantom pps led on shutdown

### DIFF
--- a/src/platform/nrf52/main-nrf52.cpp
+++ b/src/platform/nrf52/main-nrf52.cpp
@@ -253,9 +253,16 @@ void cpuDeepSleep(uint32_t msecToWake)
 #endif
 #endif
 
-#ifdef HELTEC_MESH_NODE_T114
+#ifdef PIN_GPS_PPS
     nrf_gpio_cfg_default(PIN_GPS_PPS);
     detachInterrupt(PIN_GPS_PPS);
+#ifdef TTGO_T_ECHO
+    pinMode(PIN_GPS_PPS, OUTPUT);
+    digitalWrite(PIN_GPS_PPS, LOW);
+#endif
+#endif
+
+#ifdef HELTEC_MESH_NODE_T114
     detachInterrupt(PIN_BUTTON1);
 #endif
     // Sleepy trackers or sensors can low power "sleep"

--- a/variants/t-echo/variant.h
+++ b/variants/t-echo/variant.h
@@ -177,10 +177,9 @@ External serial flash WP25R1635FZUIL0
 #define PIN_GPS_REINIT (32 + 5) // An output to reset L76K GPS. As per datasheet, low for > 100ms will reset the L76K
 
 #define PIN_GPS_STANDBY (32 + 2) // An output to wake GPS, low means allow sleep, high means force wake
-// Seems to be missing on this new board
-// #define PIN_GPS_PPS (32 + 4)  // Pulse per second input from the GPS
-#define GPS_TX_PIN (32 + 9) // This is for bits going TOWARDS the CPU
-#define GPS_RX_PIN (32 + 8) // This is for bits going TOWARDS the GPS
+#define PIN_GPS_PPS (32 + 4)     // Pulse per second input from the GPS
+#define GPS_TX_PIN (32 + 9)      // This is for bits going TOWARDS the CPU
+#define GPS_RX_PIN (32 + 8)      // This is for bits going TOWARDS the GPS
 
 #define GPS_THREAD_INTERVAL 50
 


### PR DESCRIPTION
T-Echo have GPS PPS connected to both P1.04 and to an active high led (see [schematics](https://github.com/Xinyuan-LilyGO/T-Echo/blob/main/T-Echo_Schematic.pdf)), on shutdown the led is faintly on (see attached image) causing unnecessary battery drain.

This PR addresses the issue by defining the PPS pin in target config and by pulling it low on shutdown.

![image](https://github.com/user-attachments/assets/c69f61dc-8dfe-4082-94bf-3e1f7cb87a62)