### PR TITLE
Another missed define for the T114

### DIFF
--- a/boards/heltec_mesh_node_t114.json
+++ b/boards/heltec_mesh_node_t114.json
@@ -5,7 +5,7 @@
     },
     "core": "nRF5",
     "cpu": "cortex-m4",
-    "extra_flags": "-DARDUINO_NRF52840_PCA10056 -DNRF52840_XXAA",
+    "extra_flags": "-DHELTEC_T114 -DNRF52840_XXAA",
     "f_cpu": "64000000L",
     "hwids": [
       ["0x239A", "0x4405"],


### PR DESCRIPTION
HW_MODEL still isn't being set correctly. It looks like this change is needed to get the proper define. I flashed a firmware this change, and the model is finally showing as "heltec-mesh-node-t114" in the Android app.

fixes #4714 