### PR TITLE
Revert "DetectionSensor: broadcast all state changes"

### DIFF
--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -49,16 +49,10 @@ int32_t DetectionSensorModule::runOnce()
 
     // LOG_DEBUG("Detection Sensor Module: Current pin state: %i\n", digitalRead(moduleConfig.detection_sensor.monitor_pin));
 
-    if ((millis() - lastSentToMesh) >= Default::getConfiguredOrDefaultMs(moduleConfig.detection_sensor.minimum_broadcast_secs)) {
-        if (hasDetectionEvent()) {
-            wasDetected = true;
-            sendDetectionMessage();
-            return DELAYED_INTERVAL;
-        } else if (wasDetected) {
-            wasDetected = false;
-            sendCurrentStateMessage();
-            return DELAYED_INTERVAL;
-        }
+    if ((millis() - lastSentToMesh) >= Default::getConfiguredOrDefaultMs(moduleConfig.detection_sensor.minimum_broadcast_secs) &&
+        hasDetectionEvent()) {
+        sendDetectionMessage();
+        return DELAYED_INTERVAL;
     }
     // Even if we haven't detected an event, broadcast our current state to the mesh on the scheduled interval as a sort
     // of heartbeat. We only do this if the minimum broadcast interval is greater than zero, otherwise we'll only broadcast state

--- a/src/modules/DetectionSensorModule.h
+++ b/src/modules/DetectionSensorModule.h
@@ -15,7 +15,6 @@ class DetectionSensorModule : public SinglePortModule, private concurrency::OSTh
   private:
     bool firstTime = true;
     uint32_t lastSentToMesh = 0;
-    bool wasDetected = false;
     void sendDetectionMessage();
     void sendCurrentStateMessage();
     bool hasDetectionEvent();


### PR DESCRIPTION
Reverts meshtastic/firmware#4767

@augustozanellato reverting this for now. I think we should add a new configuration to the protobufs to manage whether or not to notify on the state change _back_ to the false detection state. Many use-cases do not want this extra chatter, for example the initial one we tested on: doppler and PIR motion sensor events, as well as recently I've seen use of button as a "man down" detector.