### PR TITLE
[Board] DIY "t-energy-s3_e22"

### DIFF
--- a/variants/diy/platformio.ini
+++ b/variants/diy/platformio.ini
@@ -75,6 +75,7 @@ debug_tool = jlink
 [env:t-energy-s3_e22]
 extends = esp32s3_base
 board = esp32-s3-devkitc-1
+board_level = extra
 board_upload.flash_size = 16MB ;Specify the FLASH capacity as 16MB
 board_build.arduino.memory_type = qio_opi ;Enable internal PSRAM
 build_unflags =

--- a/variants/diy/platformio.ini
+++ b/variants/diy/platformio.ini
@@ -70,3 +70,20 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/diy/nrf52_promic
 lib_deps = 
   ${nrf52840_base.lib_deps}
 debug_tool = jlink
+
+; NanoVHF T-Energy-S3 + E22(0)-xxxM - DIY
+[env:t-energy-s3_e22]
+extends = esp32s3_base
+board = esp32-s3-devkitc-1
+board_upload.flash_size = 16MB ;Specify the FLASH capacity as 16MB
+board_build.arduino.memory_type = qio_opi ;Enable internal PSRAM
+build_unflags =
+  ${esp32s3_base.build_unflags}
+  -D ARDUINO_USB_MODE=1
+build_flags =
+  ${esp32s3_base.build_flags}
+  -D EBYTE_ESP32_S3
+  -D BOARD_HAS_PSRAM
+  -D ARDUINO_USB_MODE=0
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+  -I variants/diy/t-energy-s3_e22

--- a/variants/diy/t-energy-s3_e22/variant.h
+++ b/variants/diy/t-energy-s3_e22/variant.h
@@ -1,0 +1,46 @@
+// NanoVHF T-Energy-S3 + E22(0)-xxxM - DIY
+// https://github.com/NanoVHF/Meshtastic-DIY/tree/main/PCB/ESP-32-devkit_EBYTE-E22/Mesh-v1.06-TTGO-T18
+
+// Battery
+#define BATTERY_PIN 3
+#define ADC_MULTIPLIER 2.0
+#define ADC_CHANNEL ADC1_GPIO3_CHANNEL
+
+// Button on NanoVHF PCB
+#define BUTTON_PIN 39
+
+// I2C via connectors on NanoVHF PCB
+#define I2C_SCL 2
+#define I2C_SDA 42
+
+// Screen (disabled)
+#define HAS_SCREEN 0 // Assume no screen present by default to prevent crash...
+
+// GPS via T-Energy-S3 onboard connector
+#define HAS_GPS 1
+#define GPS_TX_PIN 43
+#define GPS_RX_PIN 44
+
+// LoRa
+#define USE_SX1262  // E22-900M30S, E22-900M22S, and E22-900MM22S (not E220!) use SX1262
+#define USE_SX1268  // E22-400M30S, E22-400M33S, E22-400M22S, and E22-400MM22S use SX1268
+
+#define SX126X_MAX_POWER 22  // SX126xInterface.cpp defaults to 22 if not defined, but here we define it for good practice
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8  // E22 series TCXO reference voltage is 1.8V
+
+#define SX126X_CS 5     // EBYTE module's NSS pin // FIXME: rename to SX126X_SS
+#define SX126X_SCK 6    // EBYTE module's SCK pin
+#define SX126X_MOSI 13  // EBYTE module's MOSI pin
+#define SX126X_MISO 4   // EBYTE module's MISO pin
+#define SX126X_RESET 1  // EBYTE module's NRST pin
+#define SX126X_BUSY 48  // EBYTE module's BUSY pin
+#define SX126X_DIO1 47  // EBYTE module's DIO1 pin
+
+#define SX126X_TXEN 10  // Schematic connects EBYTE module's TXEN pin to MCU
+#define SX126X_RXEN 12  // Schematic connects EBYTE module's RXEN pin to MCU
+
+#define LORA_CS SX126X_CS      // Compatibility with variant file configuration structure
+#define LORA_SCK SX126X_SCK    // Compatibility with variant file configuration structure
+#define LORA_MOSI SX126X_MOSI  // Compatibility with variant file configuration structure
+#define LORA_MISO SX126X_MISO  // Compatibility with variant file configuration structure
+#define LORA_DIO1 SX126X_DIO1  // Compatibility with variant file configuration structure

--- a/variants/diy/t-energy-s3_e22/variant.h
+++ b/variants/diy/t-energy-s3_e22/variant.h
@@ -22,25 +22,25 @@
 #define GPS_RX_PIN 44
 
 // LoRa
-#define USE_SX1262  // E22-900M30S, E22-900M22S, and E22-900MM22S (not E220!) use SX1262
-#define USE_SX1268  // E22-400M30S, E22-400M33S, E22-400M22S, and E22-400MM22S use SX1268
+#define USE_SX1262 // E22-900M30S, E22-900M22S, and E22-900MM22S (not E220!) use SX1262
+#define USE_SX1268 // E22-400M30S, E22-400M33S, E22-400M22S, and E22-400MM22S use SX1268
 
-#define SX126X_MAX_POWER 22  // SX126xInterface.cpp defaults to 22 if not defined, but here we define it for good practice
-#define SX126X_DIO3_TCXO_VOLTAGE 1.8  // E22 series TCXO reference voltage is 1.8V
+#define SX126X_MAX_POWER 22          // SX126xInterface.cpp defaults to 22 if not defined, but here we define it for good practice
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8 // E22 series TCXO reference voltage is 1.8V
 
-#define SX126X_CS 5     // EBYTE module's NSS pin // FIXME: rename to SX126X_SS
-#define SX126X_SCK 6    // EBYTE module's SCK pin
-#define SX126X_MOSI 13  // EBYTE module's MOSI pin
-#define SX126X_MISO 4   // EBYTE module's MISO pin
-#define SX126X_RESET 1  // EBYTE module's NRST pin
-#define SX126X_BUSY 48  // EBYTE module's BUSY pin
-#define SX126X_DIO1 47  // EBYTE module's DIO1 pin
+#define SX126X_CS 5    // EBYTE module's NSS pin // FIXME: rename to SX126X_SS
+#define SX126X_SCK 6   // EBYTE module's SCK pin
+#define SX126X_MOSI 13 // EBYTE module's MOSI pin
+#define SX126X_MISO 4  // EBYTE module's MISO pin
+#define SX126X_RESET 1 // EBYTE module's NRST pin
+#define SX126X_BUSY 48 // EBYTE module's BUSY pin
+#define SX126X_DIO1 47 // EBYTE module's DIO1 pin
 
-#define SX126X_TXEN 10  // Schematic connects EBYTE module's TXEN pin to MCU
-#define SX126X_RXEN 12  // Schematic connects EBYTE module's RXEN pin to MCU
+#define SX126X_TXEN 10 // Schematic connects EBYTE module's TXEN pin to MCU
+#define SX126X_RXEN 12 // Schematic connects EBYTE module's RXEN pin to MCU
 
-#define LORA_CS SX126X_CS      // Compatibility with variant file configuration structure
-#define LORA_SCK SX126X_SCK    // Compatibility with variant file configuration structure
-#define LORA_MOSI SX126X_MOSI  // Compatibility with variant file configuration structure
-#define LORA_MISO SX126X_MISO  // Compatibility with variant file configuration structure
-#define LORA_DIO1 SX126X_DIO1  // Compatibility with variant file configuration structure
+#define LORA_CS SX126X_CS     // Compatibility with variant file configuration structure
+#define LORA_SCK SX126X_SCK   // Compatibility with variant file configuration structure
+#define LORA_MOSI SX126X_MOSI // Compatibility with variant file configuration structure
+#define LORA_MISO SX126X_MISO // Compatibility with variant file configuration structure
+#define LORA_DIO1 SX126X_DIO1 // Compatibility with variant file configuration structure


### PR DESCRIPTION
New variant `t-energy-s3_e22`
- Lilygo [T-Energy-S3](https://www.lilygo.cc/products/t-energy-s3)
- NanoVHF ["Mesh-v1.06-TTGO-T18"](https://github.com/NanoVHF/Meshtastic-DIY/tree/main/PCB/ESP-32-devkit_EBYTE-E22/Mesh-v1.06-TTGO-T18) board
  - This design has existed for many years. My new variant submission just adds a definition for the new T-Energy-S3
  - [More Info](https://github.com/NanoVHF/Meshtastic-DIY/blob/main/PCB/ESP-32-devkit_EBYTE-E22/README.md#meshtastic-diy_v106---ttgo-t-energy-t18-v30-hat)
- Ebyte E22 series (tested with [E22-900M30S](https://www.cdebyte.com/products/E22-900M30S))

![PXL_20240919_012141649](https://github.com/user-attachments/assets/1b350e09-a07f-43f0-a1c0-b28710870f20)
![PXL_20240910_235624521](https://github.com/user-attachments/assets/0837c817-b7a5-46eb-9e90-1f80b6966699)

See also: https://github.com/meshtastic/firmware/issues/4781
