### PR TITLE
Honor flip & color for Heltec T114 and T190

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1670,11 +1670,9 @@ void Screen::setup()
     static_cast<SH1106Wire *>(dispdev)->setSubtype(7);
 #endif
 
-#ifdef USE_ST7789
-// Heltec T114 and T190: honor a custom text color, if defined in variant.h
-#ifdef TFT_MESH
+#if defined(USE_ST7789) && defined(TFT_MESH)
+    // Heltec T114 and T190: honor a custom text color, if defined in variant.h
     static_cast<ST7789Spi *>(dispdev)->setRGB(TFT_MESH);
-#endif
 #endif
 
     // Initialising the UI will init the display too.

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1670,6 +1670,13 @@ void Screen::setup()
     static_cast<SH1106Wire *>(dispdev)->setSubtype(7);
 #endif
 
+#ifdef USE_ST7789
+// Heltec T114 and T190: honor a custom text color, if defined in variant.h
+#ifdef TFT_MESH
+    static_cast<ST7789Spi *>(dispdev)->setRGB(TFT_MESH);
+#endif
+#endif
+
     // Initialising the UI will init the display too.
     ui->init();
 
@@ -1726,6 +1733,8 @@ void Screen::setup()
 #if defined(ST7701_CS) || defined(ST7735_CS) || defined(ILI9341_DRIVER) || defined(ST7701_CS) || defined(ST7789_CS) ||           \
     defined(RAK14014) || defined(HX8357_CS)
         static_cast<TFTDisplay *>(dispdev)->flipScreenVertically();
+#elif defined(USE_ST7789)
+        static_cast<ST7789Spi *>(dispdev)->flipScreenVertically();
 #else
         dispdev->flipScreenVertically();
 #endif

--- a/variants/heltec_mesh_node_t114/platformio.ini
+++ b/variants/heltec_mesh_node_t114/platformio.ini
@@ -14,4 +14,4 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/heltec_mesh_node
 lib_deps = 
   ${nrf52840_base.lib_deps}
   lewisxhe/PCF8563_Library@^1.0.1
-  https://github.com/meshtastic/st7789#7181320e7ed05c7fb5fd2d32f14723bce6088b7b
+  https://github.com/todd-herbert/meshtastic-st7789-heltec#flip-and-color

--- a/variants/heltec_mesh_node_t114/platformio.ini
+++ b/variants/heltec_mesh_node_t114/platformio.ini
@@ -14,4 +14,4 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/heltec_mesh_node
 lib_deps = 
   ${nrf52840_base.lib_deps}
   lewisxhe/PCF8563_Library@^1.0.1
-  https://github.com/todd-herbert/meshtastic-st7789-heltec#flip-and-color
+  https://github.com/meshtastic/st7789#bd33ea58ddfe4a5e4a66d53300ccbd38d66ac21f

--- a/variants/heltec_vision_master_t190/platformio.ini
+++ b/variants/heltec_vision_master_t190/platformio.ini
@@ -9,5 +9,5 @@ build_flags =
 lib_deps =
   ${esp32s3_base.lib_deps}
   lewisxhe/PCF8563_Library@^1.0.1
-  https://github.com/todd-herbert/meshtastic-st7789-heltec#flip-and-color
+  https://github.com/meshtastic/st7789#bd33ea58ddfe4a5e4a66d53300ccbd38d66ac21f
 upload_speed = 921600

--- a/variants/heltec_vision_master_t190/platformio.ini
+++ b/variants/heltec_vision_master_t190/platformio.ini
@@ -9,5 +9,5 @@ build_flags =
 lib_deps =
   ${esp32s3_base.lib_deps}
   lewisxhe/PCF8563_Library@^1.0.1
-  https://github.com/meshtastic/st7789#7181320e7ed05c7fb5fd2d32f14723bce6088b7b
+  https://github.com/todd-herbert/meshtastic-st7789-heltec#flip-and-color
 upload_speed = 921600


### PR DESCRIPTION
Resolves https://github.com/meshtastic/firmware/issues/4655
Tested working on T114, but needs testing on T190

To-do: update `lib_deps` to point at https://github.com/meshtastic/st7789/pull/1 once merged
___

* Honors `display.config.flip_screen` when set by user
* Honors `TFT_MESH` color if defined in variant.h