### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+- package-ecosystem: docker
+  directory: devcontainer
+  schedule:
+    interval: daily
+    time: "05:00"
+    timezone: US/Pacific
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: daily
+    time: "05:00"
+    timezone: US/Pacific
+- package-ecosystem: gitsubmodule
+  directory: /
+  schedule:
+    interval: daily
+    time: "05:00"
+    timezone: US/Pacific
+- package-ecosystem: github-actions
+  directory: /.github/workflows
+  schedule:
+    interval: daily
+    time: "05:00"
+    timezone: US/Pacific

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,26 @@
 version: 2
 updates:
-- package-ecosystem: docker
-  directory: devcontainer
-  schedule:
-    interval: daily
-    time: "05:00"
-    timezone: US/Pacific
-- package-ecosystem: docker
-  directory: /
-  schedule:
-    interval: daily
-    time: "05:00"
-    timezone: US/Pacific
-- package-ecosystem: gitsubmodule
-  directory: /
-  schedule:
-    interval: daily
-    time: "05:00"
-    timezone: US/Pacific
-- package-ecosystem: github-actions
-  directory: /.github/workflows
-  schedule:
-    interval: daily
-    time: "05:00"
-    timezone: US/Pacific
+  - package-ecosystem: docker
+    directory: devcontainer
+    schedule:
+      interval: daily
+      time: 05:00
+      timezone: US/Pacific
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: daily
+      time: 05:00
+      timezone: US/Pacific
+  - package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+      interval: daily
+      time: 05:00
+      timezone: US/Pacific
+  - package-ecosystem: github-actions
+    directory: /.github/workflows
+    schedule:
+      interval: daily
+      time: 05:00
+      timezone: US/Pacific


### PR DESCRIPTION
## Description

Enables automatic [Dependabot](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide) dependency update PRs for the following package ecosystems:
- Docker
- Git Submodules
- Github Actions

Dependabot will create pull requests when there is a release of the upstream dependency.

## Actions Secrets vs. Dependabot Secrets

Dependabot uses a unique set of secrets and does not have access to [Organization](https://github.com/organizations/meshtastic/settings/secrets/actions) or [Repository](https://github.com/meshtastic/firmware/settings/secrets/actions) Actions secrets. This may cause pipelines to fail without the Actions secrets available.

To resolve this, [Organization](https://github.com/organizations/meshtastic/settings/secrets/dependabot) or [Repsitory](https://github.com/meshtastic/firmware/settings/secrets/dependabot) Dependabot secrets can be set.

As a workaround, authorized contributors can push an empty commit to a branch that Dependabot creates; Github Actions will then run workflows in the Actions secrets context.