### PR TITLE
Set title for version bump PRs

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -351,5 +351,6 @@ jobs:
       - name: Create version.properties pull request
         uses: peter-evans/create-pull-request@v6
         with:
+          title: Bump version.properties
           add-paths: |
             version.properties


### PR DESCRIPTION
## Description
Sets the title of PRs created by the workflow step `Create version.properties pull request` from _Changes by create-pull-request action_ to _Bump version.properties_

### Example of current behaviour

https://github.com/meshtastic/firmware/pull/4789