### PR TITLE
Update classes on protobufs update

### DIFF
--- a/.github/workflows/update_protobufs.yml
+++ b/.github/workflows/update_protobufs.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
     paths:
-      - meshtastic/**
+      - protobufs/**
 
 jobs:
   update-protobufs:
@@ -33,4 +33,4 @@ jobs:
           author_name: CI Bot
           author_email: meshtastic-ci-bot@users.noreply.github.com
           default_author: github_actor
-          message: Update classes from protobugs
+          message: Update classes from protobufs

--- a/.github/workflows/update_protobufs.yml
+++ b/.github/workflows/update_protobufs.yml
@@ -1,5 +1,10 @@
-name: "Update protobufs and regenerate classes"
-on: workflow_dispatch
+name: Update protobufs and regenerate classes
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - meshtastic/**
 
 jobs:
   update-protobufs:
@@ -11,10 +16,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Update submodule
-        run: |
-          git submodule update --remote protobufs
-
       - name: Download nanopb
         run: |
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8-linux-x86.tar.gz
@@ -25,10 +26,11 @@ jobs:
         run: |
           ./bin/regen-protos.sh
 
-      - name: Create pull request
-        uses: peter-evans/create-pull-request@v7
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v9
         with:
-          title: Update protobufs and classes
-          add-paths: |
-            protobufs
-            src/mesh
+          add: src/mesh
+          author_name: CI Bot
+          author_email: meshtastic-ci-bot@users.noreply.github.com
+          default_author: github_actor
+          message: Update classes from protobugs


### PR DESCRIPTION
This PR changes the update process for Protobufs. Every time a change is made to the `meshtastic` submodule in a PR, the `regen-protos.sh` will be run and the changes committed to the PR's branch.

This enables class regeneration on Dependabot's PRs and also on any other users PR where `meshtastic/` is updated. Additionally it ensures that on any PRs where the protobufs have changed that the classes match.