### PR TITLE
Update platform-native to pick up portduino crash fix

### DIFF
--- a/arch/portduino/portduino.ini
+++ b/arch/portduino/portduino.ini
@@ -1,6 +1,6 @@
 ; The Portduino based sim environment on top of any host OS, all hardware will be simulated
 [portduino_base]
-platform = https://github.com/meshtastic/platform-native.git#ad8112adf82ce1f5b917092cf32be07a077801a0
+platform = https://github.com/meshtastic/platform-native.git#6b3796d697481c8f6e3f4aa5c111bd9979f29e64
 framework = arduino
 
 build_src_filter = 


### PR DESCRIPTION
Treating an int as a string pointer in a log call could cause a crash in startup on Native clients with real hardware.