### PR TITLE
Removed extra Chip select in SPI object

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -679,8 +679,8 @@ void setup()
     SPI.begin();
 #else
     // ESP32
-    SPI.begin(LORA_SCK, LORA_MISO, LORA_MOSI, LORA_CS);
-    LOG_DEBUG("SPI.begin(SCK=%d, MISO=%d, MOSI=%d, NSS=%d)\n", LORA_SCK, LORA_MISO, LORA_MOSI, LORA_CS);
+    SPI.begin(LORA_SCK, LORA_MISO, LORA_MOSI);
+    LOG_DEBUG("SPI.begin(SCK=%d, MISO=%d, MOSI=%d)\n", LORA_SCK, LORA_MISO, LORA_MOSI);
     SPI.setFrequency(4000000);
 #endif
 


### PR DESCRIPTION
This is useless here. It may colidate with other SPI devices on BUS later.

RadioLib take care about ChipSelect itself. So use CS on SPI object is pointless and may cause problems later.