### PR TITLE
Set the T114 TCXO Voltage to 3.3

### DIFF
--- a/variants/heltec_mesh_node_t114/variant.h
+++ b/variants/heltec_mesh_node_t114/variant.h
@@ -139,7 +139,7 @@ No longer populated on PCB
 #define SX126X_RESET (0 + 25)
 // Not really an E22 but TTGO seems to be trying to clone that
 #define SX126X_DIO2_AS_RF_SWITCH
-#define SX126X_DIO3_TCXO_VOLTAGE 1.8
+#define SX126X_DIO3_TCXO_VOLTAGE 3.3
 
 #define PIN_SPI1_MISO                                                                                                            \
     ST7789_MISO // FIXME not really needed, but for now the SPI code requires something to be defined, pick an used GPIO


### PR DESCRIPTION
As per https://github.com/meshtastic/firmware/issues/4723#issuecomment-2369336696 setting the TCXO voltage to 3.3 can help with TX errors with the T114. Seems reasonable to get this into wider testing. Thoughts @Heltec-Aaron-Lee ?