### PR TITLE
Second Wire is PIN_WIRE1_SDA

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -213,7 +213,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef WIRE_INTERFACES_COUNT
 // Officially an NRF52 macro
 // Repurposed cross-platform to identify devices using Wire1
-#if defined(I2C_SDA1) || defined(PIN_WIRE_SDA)
+#if defined(I2C_SDA1) || defined(PIN_WIRE1_SDA)
 #define WIRE_INTERFACES_COUNT 2
 #elif HAS_WIRE
 #define WIRE_INTERFACES_COUNT 1


### PR DESCRIPTION
Based on #4745, PIN_WIRE1_SDA is the 'second' wire interface.

This pach amends the check to determine whether a device has two wire interfaces should use PIN_WIRE1_SDA, rather than PIN_WIRE_SDA.