### PR TITLE
Add a second delay() to get the unit tests running on Rak4631

### DIFF
--- a/test/test_crypto/test_main.cpp
+++ b/test/test_crypto/test_main.cpp
@@ -129,6 +129,7 @@ void setup()
 {
     // NOTE!!! Wait for >2 secs
     // if board doesn't support software reset via Serial.DTR/RTS
+    delay(10);
     delay(2000);
 
     UNITY_BEGIN(); // IMPORTANT LINE!


### PR DESCRIPTION
Testing...
If you don't see any output for the first 10 secs, please reset board (press reset button)

test/test_crypto/test_main.cpp:136: test_SHA256 [PASSED]
test/test_crypto/test_main.cpp:137: test_ECB_AES256     [PASSED]
test/test_crypto/test_main.cpp:138: test_DH25519        [PASSED]
test/test_crypto/test_main.cpp:139: test_AES_CTR        [PASSED]
--------------------------------------------------------------------- rak4631:test_crypto [PASSED] Took 97.32 seconds ---------------------------------------------------------------------