### PR TITLE
Update INA3221 to 1.0.1

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -159,7 +159,7 @@ lib_deps =
 
   https://github.com/boschsensortec/Bosch-BSEC2-Library#v1.7.2502
   boschsensortec/BME68x Sensor Library@^1.1.40407
-  https://github.com/KodinLanewave/INA3221@^1.0.0
+  https://github.com/KodinLanewave/INA3221@^1.0.1
   lewisxhe/SensorLib@0.2.0
   mprograms/QMC5883LCompass@^1.2.0
   


### PR DESCRIPTION
Added new release with compiler error fixes for INA3221 library - updating dependencies so new release will be included

<!-- download-section CI firmware-2.5.4.7b570b6 start -->
[Download firmware-2.5.4.7b570b6.zip. This artifact will be available for 90 days from creation](https://nightly.link/meshtastic/firmware/actions/artifacts/1992320111.zip)

<!-- download-section CI firmware-2.5.4.7b570b6 end -->library - updating dependencies so new release will be included

<!-- download-section CI firmware-2.5.4.90b553a start -->
[Download firmware-2.5.4.90b553a.zip. This artifact will be available for 90 days from creation](https://nightly.link/meshtastic/firmware/actions/artifacts/1992386950.zip)

<!-- download-section CI firmware-2.5.4.90b553a end -->library - updating dependencies so new release will be included

<!-- download-section CI firmware-2.5.4.7b570b6 start -->
[Download firmware-2.5.4.7b570b6.zip. This artifact will be available for 90 days from creation](https://nightly.link/meshtastic/firmware/actions/artifacts/1992320111.zip)

<!-- download-section CI firmware-2.5.4.7b570b6 end -->library - updating dependencies so new release will be included
