### PR TITLE
Potential fix for bad Rx performance on T1000-E

### DIFF
--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -83,23 +83,6 @@ template <typename T> bool LR11x0Interface<T>::init()
 
 #endif
 
-// We need to do this before begin() call
-#ifdef LR11X0_DIO_AS_RF_SWITCH
-    LOG_DEBUG("Setting DIO RF switch\n");
-    bool dioAsRfSwitch = true;
-#elif defined(ARCH_PORTDUINO)
-    bool dioAsRfSwitch = false;
-    if (settingsMap[dio2_as_rf_switch]) {
-        LOG_DEBUG("Setting DIO RF switch\n");
-        dioAsRfSwitch = true;
-    }
-#else
-    bool dioAsRfSwitch = false;
-#endif
-
-    if (dioAsRfSwitch)
-        lora.setRfSwitchTable(rfswitch_dio_pins, rfswitch_table);
-
     int res = lora.begin(getFreq(), bw, sf, cr, syncWord, power, preambleLength, tcxoVoltage);
     // \todo Display actual typename of the adapter, not just `LR11x0`
     LOG_INFO("LR11x0 init result %d\n", res);
@@ -123,6 +106,22 @@ template <typename T> bool LR11x0Interface<T>::init()
     // FIXME: May want to set depending on a definition, currently all LR1110 variant files use the DC-DC regulator option
     if (res == RADIOLIB_ERR_NONE)
         res = lora.setRegulatorDCDC();
+
+#ifdef LR11X0_DIO_AS_RF_SWITCH
+    LOG_DEBUG("Setting DIO RF switch\n");
+    bool dioAsRfSwitch = true;
+#elif defined(ARCH_PORTDUINO)
+    bool dioAsRfSwitch = false;
+    if (settingsMap[dio2_as_rf_switch]) {
+        LOG_DEBUG("Setting DIO RF switch\n");
+        dioAsRfSwitch = true;
+    }
+#else
+    bool dioAsRfSwitch = false;
+#endif
+    if (dioAsRfSwitch)
+        lora.setRfSwitchTable(rfswitch_dio_pins, rfswitch_table);
+
     if (res == RADIOLIB_ERR_NONE) {
         if (config.lora.sx126x_rx_boosted_gain) { // the name is unfortunate but historically accurate
             res = lora.setRxBoostedGainMode(true);

--- a/variants/ME25LS01-4Y10TD/platformio.ini
+++ b/variants/ME25LS01-4Y10TD/platformio.ini
@@ -3,7 +3,7 @@ extends = nrf52840_base
 board = me25ls01-4y10td
 board_level = extra
 ; platform = https://github.com/maxgerhardt/platform-nordicnrf52#cac6fcf943a41accd2aeb4f3659ae297a73f422e
-build_flags = ${nrf52840_base.build_flags} -Ivariants/ME25LS01-4Y10TD -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52 -DME25LS01_4Y10TD ;-DRADIOLIB_GODMODE
+build_flags = ${nrf52840_base.build_flags} -Ivariants/ME25LS01-4Y10TD -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52 -DME25LS01_4Y10TD
   -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
 board_build.ldscript = src/platform/nrf52/nrf52840_s140_v7.ld

--- a/variants/ME25LS01-4Y10TD/rfswitch.h
+++ b/variants/ME25LS01-4Y10TD/rfswitch.h
@@ -1,0 +1,15 @@
+#include "RadioLib.h"
+#include "nrf.h"
+
+// set RF switch configuration for Wio WM1110
+// Wio WM1110 uses DIO5 and DIO6 for RF switching
+
+static const uint32_t rfswitch_dio_pins[] = {RADIOLIB_LR11X0_DIO5, RADIOLIB_LR11X0_DIO6, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC};
+
+static const Module::RfSwitchMode_t rfswitch_table[] = {
+    // mode                  DIO5  DIO6
+    {LR11x0::MODE_STBY, {LOW, LOW}},  {LR11x0::MODE_RX, {HIGH, LOW}},
+    {LR11x0::MODE_TX, {HIGH, HIGH}},  {LR11x0::MODE_TX_HP, {LOW, HIGH}},
+    {LR11x0::MODE_TX_HF, {LOW, LOW}}, {LR11x0::MODE_GNSS, {LOW, LOW}},
+    {LR11x0::MODE_WIFI, {LOW, LOW}},  END_OF_MODE_TABLE,
+};

--- a/variants/ME25LS01-4Y10TD/variant.h
+++ b/variants/ME25LS01-4Y10TD/variant.h
@@ -103,7 +103,6 @@ extern "C" {
 
 #define LR11X0_DIO3_TCXO_VOLTAGE 1.6
 #define LR11X0_DIO_AS_RF_SWITCH
-#define LR11X0_DIO_RF_SWITCH_CONFIG 0x0f, 0x0, 0x09, 0x0B, 0x0A, 0x0, 0x4, 0x0
 
 #define HAS_GPS 0
 

--- a/variants/ME25LS01-4Y10TD_e-ink/platformio.ini
+++ b/variants/ME25LS01-4Y10TD_e-ink/platformio.ini
@@ -3,7 +3,7 @@ extends = nrf52840_base
 board = me25ls01-4y10td
 board_level = extra
 ; platform = https://github.com/maxgerhardt/platform-nordicnrf52#cac6fcf943a41accd2aeb4f3659ae297a73f422e
-build_flags = ${nrf52840_base.build_flags} -Ivariants/ME25LS01-4Y10TD_e-ink -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52 -DME25LS01_4Y10TD ;-DRADIOLIB_GODMODE
+build_flags = ${nrf52840_base.build_flags} -Ivariants/ME25LS01-4Y10TD_e-ink -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52 -DME25LS01_4Y10TD
   -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
   -DEINK_DISPLAY_MODEL=GxEPD2_420_GDEY042T81

--- a/variants/ME25LS01-4Y10TD_e-ink/rfswitch.h
+++ b/variants/ME25LS01-4Y10TD_e-ink/rfswitch.h
@@ -1,0 +1,15 @@
+#include "RadioLib.h"
+#include "nrf.h"
+
+// set RF switch configuration for Wio WM1110
+// Wio WM1110 uses DIO5 and DIO6 for RF switching
+
+static const uint32_t rfswitch_dio_pins[] = {RADIOLIB_LR11X0_DIO5, RADIOLIB_LR11X0_DIO6, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC};
+
+static const Module::RfSwitchMode_t rfswitch_table[] = {
+    // mode                  DIO5  DIO6
+    {LR11x0::MODE_STBY, {LOW, LOW}},  {LR11x0::MODE_RX, {HIGH, LOW}},
+    {LR11x0::MODE_TX, {HIGH, HIGH}},  {LR11x0::MODE_TX_HP, {LOW, HIGH}},
+    {LR11x0::MODE_TX_HF, {LOW, LOW}}, {LR11x0::MODE_GNSS, {LOW, LOW}},
+    {LR11x0::MODE_WIFI, {LOW, LOW}},  END_OF_MODE_TABLE,
+};

--- a/variants/ME25LS01-4Y10TD_e-ink/variant.h
+++ b/variants/ME25LS01-4Y10TD_e-ink/variant.h
@@ -126,7 +126,6 @@ static const uint8_t SCK = PIN_SPI_SCK;
 
 #define LR11X0_DIO3_TCXO_VOLTAGE 1.6
 #define LR11X0_DIO_AS_RF_SWITCH
-#define LR11X0_DIO_RF_SWITCH_CONFIG 0x0f, 0x0, 0x09, 0x0B, 0x0A, 0x0, 0x4, 0x0
 
 #define HAS_GPS 0
 

--- a/variants/MakePython_nRF52840_eink/variant.h
+++ b/variants/MakePython_nRF52840_eink/variant.h
@@ -25,8 +25,6 @@ extern "C" {
 #define NUM_ANALOG_INPUTS (6)
 #define NUM_ANALOG_OUTPUTS (0)
 
-#define RADIOLIB_GODMODE
-
 // LEDs
 #define PIN_LED1 (32 + 10) // LED        P1.15
 #define PIN_LED2 (-1)      //

--- a/variants/MakePython_nRF52840_oled/variant.h
+++ b/variants/MakePython_nRF52840_oled/variant.h
@@ -25,8 +25,6 @@ extern "C" {
 #define NUM_ANALOG_INPUTS (6)
 #define NUM_ANALOG_OUTPUTS (0)
 
-#define RADIOLIB_GODMODE
-
 // LEDs
 #define PIN_LED1 (32 + 10) // LED        P1.15
 #define PIN_LED2 (-1)      //

--- a/variants/portduino/variant.h
+++ b/variants/portduino/variant.h
@@ -3,4 +3,3 @@
 #define HAS_GPS 1
 #define MAX_RX_TOPHONE settingsMap[maxtophone]
 #define MAX_NUM_NODES settingsMap[maxnodes]
-#define RADIOLIB_GODMODE 1

--- a/variants/tracker-t1000-e/rfswitch.h
+++ b/variants/tracker-t1000-e/rfswitch.h
@@ -1,0 +1,13 @@
+#include "RadioLib.h"
+#include "nrf.h"
+
+static const uint32_t rfswitch_dio_pins[Module::RFSWITCH_MAX_PINS] = {RADIOLIB_LR11X0_DIO5, RADIOLIB_LR11X0_DIO6,
+                                                                      RADIOLIB_LR11X0_DIO7, RADIOLIB_LR11X0_DIO8, RADIOLIB_NC};
+
+static const Module::RfSwitchMode_t rfswitch_table[] = {
+    // mode             DIO5  DIO6  DIO7  DIO8
+    {LR11x0::MODE_STBY, {LOW, LOW, LOW, LOW}},  {LR11x0::MODE_RX, {HIGH, LOW, LOW, HIGH}},
+    {LR11x0::MODE_TX, {HIGH, HIGH, LOW, HIGH}}, {LR11x0::MODE_TX_HP, {LOW, HIGH, LOW, HIGH}},
+    {LR11x0::MODE_TX_HF, {LOW, LOW, LOW, LOW}}, {LR11x0::MODE_GNSS, {LOW, LOW, HIGH, LOW}},
+    {LR11x0::MODE_WIFI, {LOW, LOW, LOW, LOW}},  END_OF_MODE_TABLE,
+};

--- a/variants/wio-sdk-wm1110/rfswitch.h
+++ b/variants/wio-sdk-wm1110/rfswitch.h
@@ -1,0 +1,15 @@
+#include "RadioLib.h"
+#include "nrf.h"
+
+// set RF switch configuration for Wio WM1110
+// Wio WM1110 uses DIO5 and DIO6 for RF switching
+
+static const uint32_t rfswitch_dio_pins[] = {RADIOLIB_LR11X0_DIO5, RADIOLIB_LR11X0_DIO6, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC};
+
+static const Module::RfSwitchMode_t rfswitch_table[] = {
+    // mode                  DIO5  DIO6
+    {LR11x0::MODE_STBY, {LOW, LOW}},  {LR11x0::MODE_RX, {HIGH, LOW}},
+    {LR11x0::MODE_TX, {HIGH, HIGH}},  {LR11x0::MODE_TX_HP, {LOW, HIGH}},
+    {LR11x0::MODE_TX_HF, {LOW, LOW}}, {LR11x0::MODE_GNSS, {LOW, LOW}},
+    {LR11x0::MODE_WIFI, {LOW, LOW}},  END_OF_MODE_TABLE,
+};

--- a/variants/wio-t1000-s/rfswitch.h
+++ b/variants/wio-t1000-s/rfswitch.h
@@ -1,0 +1,13 @@
+#include "RadioLib.h"
+#include "nrf.h"
+
+static const uint32_t rfswitch_dio_pins[Module::RFSWITCH_MAX_PINS] = {RADIOLIB_LR11X0_DIO5, RADIOLIB_LR11X0_DIO6,
+                                                                      RADIOLIB_LR11X0_DIO7, RADIOLIB_LR11X0_DIO8, RADIOLIB_NC};
+
+static const Module::RfSwitchMode_t rfswitch_table[] = {
+    // mode             DIO5  DIO6  DIO7  DIO8
+    {LR11x0::MODE_STBY, {LOW, LOW, LOW, LOW}},  {LR11x0::MODE_RX, {HIGH, LOW, LOW, HIGH}},
+    {LR11x0::MODE_TX, {HIGH, HIGH, LOW, HIGH}}, {LR11x0::MODE_TX_HP, {LOW, HIGH, LOW, HIGH}},
+    {LR11x0::MODE_TX_HF, {LOW, LOW, LOW, LOW}}, {LR11x0::MODE_GNSS, {LOW, LOW, HIGH, LOW}},
+    {LR11x0::MODE_WIFI, {LOW, LOW, LOW, LOW}},  END_OF_MODE_TABLE,
+};

--- a/variants/wio-t1000-s/variant.h
+++ b/variants/wio-t1000-s/variant.h
@@ -103,7 +103,6 @@ extern "C" {
 
 #define LR11X0_DIO3_TCXO_VOLTAGE 1.6
 #define LR11X0_DIO_AS_RF_SWITCH
-#define LR11X0_DIO_RF_SWITCH_CONFIG 0x0f, 0x0, 0x09, 0x0B, 0x0A, 0x0, 0x4, 0x0
 
 #define HAS_GPS 1
 #define GNSS_AIROHA

--- a/variants/wio-tracker-wm1110/rfswitch.h
+++ b/variants/wio-tracker-wm1110/rfswitch.h
@@ -1,0 +1,15 @@
+#include "RadioLib.h"
+#include "nrf.h"
+
+// set RF switch configuration for Wio WM1110
+// Wio WM1110 uses DIO5 and DIO6 for RF switching
+
+static const uint32_t rfswitch_dio_pins[] = {RADIOLIB_LR11X0_DIO5, RADIOLIB_LR11X0_DIO6, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC};
+
+static const Module::RfSwitchMode_t rfswitch_table[] = {
+    // mode                  DIO5  DIO6
+    {LR11x0::MODE_STBY, {LOW, LOW}},  {LR11x0::MODE_RX, {HIGH, LOW}},
+    {LR11x0::MODE_TX, {HIGH, HIGH}},  {LR11x0::MODE_TX_HP, {LOW, HIGH}},
+    {LR11x0::MODE_TX_HF, {LOW, LOW}}, {LR11x0::MODE_GNSS, {LOW, LOW}},
+    {LR11x0::MODE_WIFI, {LOW, LOW}},  END_OF_MODE_TABLE,
+};


### PR DESCRIPTION
This seems to fix the part of the issue from #4775 where it only hears SX126x/LR11x0 radios that are close.
While the RadioLib example mentions `setRfSwitchTable()` should be called before `begin()`, we called `setDioAsRfSwitch()` (which gets called inside `setRfSwitchTable()`) at this place before https://github.com/meshtastic/firmware/commit/2f0c19ebeac0054cb8b8f417b9f2952d18532fce. 
