### PR TITLE
Add sx126x_ant_sw for Native

### DIFF
--- a/bin/config-dist.yaml
+++ b/bin/config-dist.yaml
@@ -9,6 +9,7 @@ Lora:
 #  IRQ: 16
 #  Busy: 20
 #  Reset: 18
+#  SX126X_ANT_SW: 6
 
 #  Module: sx1262  # Waveshare SX1302 LISTEN ONLY AT THIS TIME!
 #  CS: 7

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -52,6 +52,10 @@ template <typename T> bool SX126xInterface<T>::init()
     float tcxoVoltage = 0;
     if (settingsMap[dio3_tcxo_voltage])
         tcxoVoltage = 1.8;
+    if (settingsMap[sx126x_ant_sw] != RADIOLIB_NC) {
+        digitalWrite(settingsMap[sx126x_ant_sw], HIGH);
+        pinMode(settingsMap[sx126x_ant_sw], OUTPUT);
+    }
 // FIXME: correct logic to default to not using TCXO if no voltage is specified for SX126X_DIO3_TCXO_VOLTAGE
 #elif !defined(SX126X_DIO3_TCXO_VOLTAGE)
     float tcxoVoltage =

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -80,6 +80,7 @@ void portduinoSetup()
                                       irq,
                                       busy,
                                       reset,
+                                      sx126x_ant_sw,
                                       txen,
                                       rxen,
                                       displayDC,
@@ -180,6 +181,7 @@ void portduinoSetup()
             settingsMap[reset] = yamlConfig["Lora"]["Reset"].as<int>(RADIOLIB_NC);
             settingsMap[txen] = yamlConfig["Lora"]["TXen"].as<int>(RADIOLIB_NC);
             settingsMap[rxen] = yamlConfig["Lora"]["RXen"].as<int>(RADIOLIB_NC);
+            settingsMap[sx126x_ant_sw] = yamlConfig["Lora"]["SX126X_ANT_SW"].as<int>(RADIOLIB_NC);
             settingsMap[gpiochip] = yamlConfig["Lora"]["gpiochip"].as<int>(0);
             settingsMap[ch341Quirk] = yamlConfig["Lora"]["ch341_quirk"].as<bool>(false);
             settingsMap[spiSpeed] = yamlConfig["Lora"]["spiSpeed"].as<int>(2000000);
@@ -305,6 +307,8 @@ void portduinoSetup()
     gpioInit(max_GPIO + 1); // Done here so we can inform Portduino how many GPIOs we need.
 
     // Need to bind all the configured GPIO pins so they're not simulated
+    // TODO: Can we do this in the for loop above?
+    // TODO: If one of these fails, we should log and terminate
     if (settingsMap.count(cs) > 0 && settingsMap[cs] != RADIOLIB_NC) {
         if (initGPIOPin(settingsMap[cs], gpioChipName) != ERRNO_OK) {
             settingsMap[cs] = RADIOLIB_NC;
@@ -323,6 +327,11 @@ void portduinoSetup()
     if (settingsMap.count(reset) > 0 && settingsMap[reset] != RADIOLIB_NC) {
         if (initGPIOPin(settingsMap[reset], gpioChipName) != ERRNO_OK) {
             settingsMap[reset] = RADIOLIB_NC;
+        }
+    }
+    if (settingsMap.count(sx126x_ant_sw) > 0 && settingsMap[sx126x_ant_sw] != RADIOLIB_NC) {
+        if (initGPIOPin(settingsMap[sx126x_ant_sw], gpioChipName) != ERRNO_OK) {
+            settingsMap[sx126x_ant_sw] = RADIOLIB_NC;
         }
     }
     if (settingsMap.count(user) > 0 && settingsMap[user] != RADIOLIB_NC) {

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -8,6 +8,7 @@ enum configNames {
     irq,
     busy,
     reset,
+    sx126x_ant_sw,
     txen,
     rxen,
     dio2_as_rf_switch,


### PR DESCRIPTION
Some Native hats have a GPIO connected to the inverse control line of the Antenna switch chip. It's unclear if this is complete necessary, but does ensure that this pin is not put into the *wrong* state.