### PR TITLE
Ignore seen phoneapi packets

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -8,7 +8,7 @@ plugins:
       uri: https://github.com/trunk-io/plugins
 lint:
   enabled:
-    - trufflehog@3.82.4
+    - trufflehog@3.82.5
     - yamllint@1.35.1
     - bandit@1.7.10
     - checkov@3.2.255

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -8,6 +8,7 @@
 
 #include "MeshTypes.h"
 #include "NodeStatus.h"
+#include "configuration.h"
 #include "mesh-pb-constants.h"
 #include "mesh/generated/meshtastic/mesh.pb.h" // For CriticalErrorCode
 

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -578,7 +578,7 @@ bool PhoneAPI::handleToRadioPacket(meshtastic_MeshPacket &p)
 {
     printPacket("PACKET FROM PHONE", &p);
 
-    if (wasSeenRently(p)) {
+    if (wasSeenRently(p, true)) {
         LOG_DEBUG("Ignoring packet from phone, already seen recently\n");
         return false;
     }

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -596,7 +596,7 @@ bool PhoneAPI::handleToRadioPacket(meshtastic_MeshPacket &p)
 {
     printPacket("PACKET FROM PHONE", &p);
 
-    if (wasSeenRecently(p.id)) {
+    if (p.id > 0 && wasSeenRecently(p.id)) {
         LOG_DEBUG("Ignoring packet from phone, already seen recently\n");
         return false;
     }

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -609,7 +609,7 @@ bool PhoneAPI::handleToRadioPacket(meshtastic_MeshPacket &p)
     } else if (p.decoded.portnum == meshtastic_PortNum_POSITION_APP && lastPortNumToRadio[p.decoded.portnum] &&
                Throttle::isWithinTimespanMs(lastPortNumToRadio[p.decoded.portnum], FIVE_SECONDS_MS)) {
         LOG_WARN("Rate limiting portnum %d\n", p.decoded.portnum);
-        // FIXME: Figure out why this continues to happen 
+        // FIXME: Figure out why this continues to happen
         // sendNotification(meshtastic_LogRecord_Level_WARNING, p.id, "Position can only be sent once every 5 seconds");
         return false;
     }

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -32,6 +32,7 @@
 PhoneAPI::PhoneAPI()
 {
     lastContactMsec = millis();
+    std::fill(std::begin(recentToRadioPacketIds), std::end(recentToRadioPacketIds), 0);
 }
 
 PhoneAPI::~PhoneAPI()

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -609,7 +609,8 @@ bool PhoneAPI::handleToRadioPacket(meshtastic_MeshPacket &p)
     } else if (p.decoded.portnum == meshtastic_PortNum_POSITION_APP && lastPortNumToRadio[p.decoded.portnum] &&
                Throttle::isWithinTimespanMs(lastPortNumToRadio[p.decoded.portnum], FIVE_SECONDS_MS)) {
         LOG_WARN("Rate limiting portnum %d\n", p.decoded.portnum);
-        sendNotification(meshtastic_LogRecord_Level_WARNING, p.id, "Position can only be sent once every 5 seconds");
+        // FIXME: Figure out why this continues to happen 
+        // sendNotification(meshtastic_LogRecord_Level_WARNING, p.id, "Position can only be sent once every 5 seconds");
         return false;
     }
     lastPortNumToRadio[p.decoded.portnum] = millis();

--- a/src/mesh/PhoneAPI.h
+++ b/src/mesh/PhoneAPI.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Observer.h"
+#include "PacketHistory.h"
 #include "mesh-pb-constants.h"
 #include "meshtastic/portnums.pb.h"
 #include <iterator>
@@ -30,7 +31,8 @@
  * for that connection)
  */
 class PhoneAPI
-    : public Observer<uint32_t> // FIXME, we shouldn't be inheriting from Observer, instead use CallbackObserver as a member
+    : public Observer<uint32_t>,
+      protected PacketHistory // FIXME, we shouldn't be inheriting from Observer, instead use CallbackObserver as a member
 {
     enum State {
         STATE_SEND_NOTHING, // Initial state, don't send anything until the client starts asking for config

--- a/src/mesh/PhoneAPI.h
+++ b/src/mesh/PhoneAPI.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Observer.h"
-#include "PacketHistory.h"
 #include "mesh-pb-constants.h"
 #include "meshtastic/portnums.pb.h"
 #include <iterator>
@@ -31,8 +30,7 @@
  * for that connection)
  */
 class PhoneAPI
-    : public Observer<uint32_t>,
-      protected PacketHistory // FIXME, we shouldn't be inheriting from Observer, instead use CallbackObserver as a member
+    : public Observer<uint32_t> // FIXME, we shouldn't be inheriting from Observer, instead use CallbackObserver as a member
 {
     enum State {
         STATE_SEND_NOTHING, // Initial state, don't send anything until the client starts asking for config
@@ -54,6 +52,7 @@ class PhoneAPI
 
     // Hashmap of timestamps for last time we received a packet on the API per portnum
     std::unordered_map<meshtastic_PortNum, uint32_t> lastPortNumToRadio;
+    uint32_t recentToRadioPacketIds[20]; // Last 20 ToRadio MeshPacket IDs we have seen
 
     /**
      * Each packet sent to the phone has an incrementing count
@@ -160,6 +159,8 @@ class PhoneAPI
 
     /// begin a new connection
     void handleStartConfig();
+
+    bool wasSeenRecently(uint32_t packetId);
 
     /**
      * Handle a packet that the phone wants us to send.  We can write to it but can not keep a reference to it

--- a/src/nimble/NimbleBluetooth.cpp
+++ b/src/nimble/NimbleBluetooth.cpp
@@ -44,6 +44,9 @@ static BluetoothPhoneAPI *bluetoothPhoneAPI;
  * Subclasses can use this as a hook to provide custom notifications for their transport (i.e. bluetooth notifies)
  */
 
+// Last ToRadio value received from the phone
+static uint8_t lastToRadio[MAX_TO_FROM_RADIO_SIZE];
+
 class NimbleBluetoothToRadioCallback : public NimBLECharacteristicCallbacks
 {
     virtual void onWrite(NimBLECharacteristic *pCharacteristic)
@@ -51,7 +54,13 @@ class NimbleBluetoothToRadioCallback : public NimBLECharacteristicCallbacks
         LOG_INFO("To Radio onwrite\n");
         auto val = pCharacteristic->getValue();
 
-        bluetoothPhoneAPI->handleToRadio(val.data(), val.length());
+        if (memcmp(lastToRadio, val.data(), val.length()) != 0) {
+            LOG_DEBUG("New ToRadio packet\n");
+            memcpy(lastToRadio, val.data(), val.length());
+            bluetoothPhoneAPI->handleToRadio(val.data(), val.length());
+        } else {
+            LOG_DEBUG("Dropping duplicate ToRadio packet we just saw\n");
+        }
     }
 };
 

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -147,11 +147,11 @@ static uint8_t lastToRadio[MAX_TO_FROM_RADIO_SIZE];
 void onToRadioWrite(uint16_t conn_hdl, BLECharacteristic *chr, uint8_t *data, uint16_t len)
 {
     LOG_INFO("toRadioWriteCb data %p, len %u\n", data, len);
-    if (memcmp(lastToRadio, data, len) == 0) {
-        LOG_DEBUG("Dropping duplicate ToRadio packet we just saw\n");
-    } else {
+    if (memcmp(lastToRadio, data, len) != 0) {
         memcpy(lastToRadio, data, len);
         bluetoothPhoneAPI->handleToRadio(data, len);
+    } else {
+        LOG_DEBUG("Dropping duplicate ToRadio packet we just saw\n");
     }
 }
 

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -141,10 +141,18 @@ void onFromRadioAuthorize(uint16_t conn_hdl, BLECharacteristic *chr, ble_gatts_e
     }
     authorizeRead(conn_hdl);
 }
+// Last ToRadio value received from the phone
+static uint8_t lastToRadio[MAX_TO_FROM_RADIO_SIZE];
+
 void onToRadioWrite(uint16_t conn_hdl, BLECharacteristic *chr, uint8_t *data, uint16_t len)
 {
     LOG_INFO("toRadioWriteCb data %p, len %u\n", data, len);
-    bluetoothPhoneAPI->handleToRadio(data, len);
+    if (memcmp(lastToRadio, data, len) == 0) {
+        LOG_DEBUG("Dropping duplicate ToRadio packet we just saw\n");
+    } else {
+        memcpy(lastToRadio, data, len);
+        bluetoothPhoneAPI->handleToRadio(data, len);
+    }
 }
 
 void setupMeshService(void)

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -148,6 +148,7 @@ void onToRadioWrite(uint16_t conn_hdl, BLECharacteristic *chr, uint8_t *data, ui
 {
     LOG_INFO("toRadioWriteCb data %p, len %u\n", data, len);
     if (memcmp(lastToRadio, data, len) != 0) {
+        LOG_DEBUG("New ToRadio packet\n");
         memcpy(lastToRadio, data, len);
         bluetoothPhoneAPI->handleToRadio(data, len);
     } else {


### PR DESCRIPTION
Turns out some of the Phone API spam is actually replaying the same packets. This completely silences the Rate limit notification spam on my devices.