### PR TITLE
Only log "Setting DIO2 as RF switch" when doing so and fix battery level

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -1068,10 +1068,9 @@ bool Power::axpChipInit()
 #if !MESHTASTIC_EXCLUDE_I2C && !defined(ARCH_PORTDUINO) && !defined(ARCH_STM32WL)
 
 /**
- * Wrapper class for an I2C MAX17048 Lipo battery sensor. If there is no
- * I2C sensor present, the class falls back to analog battery sensing
+ * Wrapper class for an I2C MAX17048 Lipo battery sensor.
  */
-class LipoBatteryLevel : public AnalogBatteryLevel
+class LipoBatteryLevel : public HasBatteryLevel
 {
   private:
     MAX17048Singleton *max17048 = nullptr;
@@ -1096,52 +1095,27 @@ class LipoBatteryLevel : public AnalogBatteryLevel
     /**
      * Battery state of charge, from 0 to 100 or -1 for unknown
      */
-    virtual int getBatteryPercent() override
-    {
-        if (!max17048->isInitialised())
-            return AnalogBatteryLevel::getBatteryPercent();
-        return max17048->getBusBatteryPercent();
-    }
+    virtual int getBatteryPercent() override { return max17048->getBusBatteryPercent(); }
 
     /**
      * The raw voltage of the battery in millivolts, or NAN if unknown
      */
-    virtual uint16_t getBattVoltage() override
-    {
-        if (!max17048->isInitialised())
-            return AnalogBatteryLevel::getBattVoltage();
-        return max17048->getBusVoltageMv();
-    }
+    virtual uint16_t getBattVoltage() override { return max17048->getBusVoltageMv(); }
 
     /**
      * return true if there is a battery installed in this unit
      */
-    virtual bool isBatteryConnect() override
-    {
-        if (!max17048->isInitialised())
-            return AnalogBatteryLevel::isBatteryConnect();
-        return max17048->isBatteryConnected();
-    }
+    virtual bool isBatteryConnect() override { return max17048->isBatteryConnected(); }
 
     /**
      * return true if there is an external power source detected
      */
-    virtual bool isVbusIn() override
-    {
-        if (!max17048->isInitialised())
-            return AnalogBatteryLevel::isVbusIn();
-        return max17048->isExternallyPowered();
-    }
+    virtual bool isVbusIn() override { return max17048->isExternallyPowered(); }
 
     /**
      * return true if the battery is currently charging
      */
-    virtual bool isCharging() override
-    {
-        if (!max17048->isInitialised())
-            return AnalogBatteryLevel::isCharging();
-        return max17048->isBatteryCharging();
-    }
+    virtual bool isCharging() override { return max17048->isBatteryCharging(); }
 };
 
 LipoBatteryLevel lipoLevel;
@@ -1153,6 +1127,8 @@ bool Power::lipoInit()
 {
     bool result = lipoLevel.runOnce();
     LOG_DEBUG("Power::lipoInit lipo sensor is %s\n", result ? "ready" : "not ready yet");
+    if (!result)
+        return false;
     batteryLevel = &lipoLevel;
     return true;
 }

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -103,21 +103,19 @@ template <typename T> bool SX126xInterface<T>::init()
     LOG_DEBUG("Current limit set to %f\n", currentLimit);
     LOG_DEBUG("Current limit set result %d\n", res);
 
-#ifdef SX126X_DIO2_AS_RF_SWITCH
-    LOG_DEBUG("Setting DIO2 as RF switch\n");
-    bool dio2AsRfSwitch = true;
-#elif defined(ARCH_PORTDUINO)
-    bool dio2AsRfSwitch = false;
-    if (settingsMap[dio2_as_rf_switch]) {
-        LOG_DEBUG("Setting DIO2 as RF switch\n");
-        dio2AsRfSwitch = true;
-    }
-#else
-    LOG_DEBUG("Setting DIO2 as not RF switch\n");
-    bool dio2AsRfSwitch = false;
-#endif
     if (res == RADIOLIB_ERR_NONE) {
+#ifdef SX126X_DIO2_AS_RF_SWITCH
+        bool dio2AsRfSwitch = true;
+#elif defined(ARCH_PORTDUINO)
+        bool dio2AsRfSwitch = false;
+        if (settingsMap[dio2_as_rf_switch]) {
+            dio2AsRfSwitch = true;
+        }
+#else
+        bool dio2AsRfSwitch = false;
+#endif
         res = lora.setDio2AsRfSwitch(dio2AsRfSwitch);
+        LOG_DEBUG("Set DIO2 as %sRF switch, result: %d\n", dio2AsRfSwitch ? "" : "not ", res);
     }
 
     // If a pin isn't defined, we set it to RADIOLIB_NC, it is safe to always do external RF switching with RADIOLIB_NC as it has


### PR DESCRIPTION
…do it. Also, if there's an error setting DIO2, log the error code.

Super minor, but I mentioned this in Discord a few days ago, and it seemed like @jp-bennett thought it was a good idea?