### PR TITLE
When importing config, keep Bluetooth on and defer rebooting until co…

### DIFF
--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -592,7 +592,8 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c)
 
 void AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
 {
-    disableBluetooth();
+    if (!hasOpenEditTransaction)
+        disableBluetooth();
     switch (c.which_payload_variant) {
     case meshtastic_ModuleConfig_mqtt_tag:
         LOG_INFO("Setting module config: MQTT\n");
@@ -966,7 +967,7 @@ void AdminModule::saveChanges(int saveWhat, bool shouldReboot)
     } else {
         LOG_INFO("Delaying save of changes to disk until the open transaction is committed\n");
     }
-    if (shouldReboot) {
+    if (shouldReboot && !hasOpenEditTransaction) {
         reboot(DEFAULT_REBOOT_SECONDS);
     }
 }

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -583,7 +583,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c)
 
         break;
     }
-    if (requiresReboot) {
+    if (requiresReboot && !hasOpenEditTransaction) {
         disableBluetooth();
     }
 


### PR DESCRIPTION
…nfig is committed

With this change, importing the config from Android over Bluetooth hangs with the progress bar showing 92%, but I think all of the config does get imported. Maybe the device reboots before sending an acknowledgement for the commit edit settings packet?

fixes #481

<!-- download-section CI firmware-2.5.4.677e091 start -->
[Download firmware-2.5.4.677e091.zip. This artifact will be available for 90 days from creation](https://nightly.link/meshtastic/firmware/actions/artifacts/1992271328.zip)

<!-- download-section CI firmware-2.5.4.677e091 end -->nfig from Android over Bluetooth hangs with the progress bar showing 92%, but I think all of the config does get imported. Maybe the device reboots before sending an acknowledgement for the commit edit settings packet?

fixes #4812