### PR TITLE
Fix: Not being able to stop Ext. Notification nagging for screenless devices

### DIFF
--- a/src/ButtonThread.cpp
+++ b/src/ButtonThread.cpp
@@ -124,6 +124,11 @@ int32_t ButtonThread::runOnce()
         switch (btnEvent) {
         case BUTTON_EVENT_PRESSED: {
             LOG_BUTTON("press!\n");
+            // If a nag notification is running, stop it and prevent other actions
+            if (moduleConfig.external_notification.enabled && (externalNotificationModule->nagCycleCutoff != UINT32_MAX)) {
+                externalNotificationModule->stopNow();
+                return;
+            }
 #ifdef BUTTON_PIN
             if (((config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN) !=
                  moduleConfig.canned_message.inputbroker_pin_press) ||

--- a/src/ButtonThread.cpp
+++ b/src/ButtonThread.cpp
@@ -127,7 +127,7 @@ int32_t ButtonThread::runOnce()
             // If a nag notification is running, stop it and prevent other actions
             if (moduleConfig.external_notification.enabled && (externalNotificationModule->nagCycleCutoff != UINT32_MAX)) {
                 externalNotificationModule->stopNow();
-                return;
+                return 50;
             }
 #ifdef BUTTON_PIN
             if (((config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN) !=

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1884,13 +1884,8 @@ int32_t Screen::runOnce()
             handleSetOn(false);
             break;
         case Cmd::ON_PRESS:
-            // If a nag notification is running, stop it
-            if (moduleConfig.external_notification.enabled && (externalNotificationModule->nagCycleCutoff != UINT32_MAX)) {
-                externalNotificationModule->stopNow();
-            } else {
-                // Don't advance the screen if we just wanted to switch off the nag notification
-                handleOnPress();
-            }
+            // Don't advance the screen if we just wanted to switch off the nag notification
+            handleOnPress();
             break;
         case Cmd::SHOW_PREV_FRAME:
             handleShowPrevFrame();

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1884,7 +1884,6 @@ int32_t Screen::runOnce()
             handleSetOn(false);
             break;
         case Cmd::ON_PRESS:
-            // Don't advance the screen if we just wanted to switch off the nag notification
             handleOnPress();
             break;
         case Cmd::SHOW_PREV_FRAME:


### PR DESCRIPTION
I found this particularly annoying on the T1000-E, being held against my will by the buzzer until the nag timeout took place.

Tested on T1000-E