### PR TITLE
Construct StoreForwardModule for Portduino as well

### DIFF
--- a/src/modules/Modules.cpp
+++ b/src/modules/Modules.cpp
@@ -209,11 +209,13 @@ void setupModules()
 #if defined(USE_SX1280) && !MESHTASTIC_EXCLUDE_AUDIO
         audioModule = new AudioModule();
 #endif
-#if !MESHTASTIC_EXCLUDE_STOREFORWARD
-        storeForwardModule = new StoreForwardModule();
-#endif
 #if !MESHTASTIC_EXCLUDE_PAXCOUNTER
         paxcounterModule = new PaxcounterModule();
+#endif
+#endif
+#if defined(ARCH_ESP32) || defined(ARCH_PORTDUINO)
+#if !MESHTASTIC_EXCLUDE_STOREFORWARD
+        storeForwardModule = new StoreForwardModule();
 #endif
 #endif
 #if defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040)

--- a/src/modules/StoreForwardModule.cpp
+++ b/src/modules/StoreForwardModule.cpp
@@ -30,9 +30,6 @@
 
 StoreForwardModule *storeForwardModule;
 
-uint32_t lastHeartbeat = 0;
-uint32_t heartbeatInterval = 60; // Default to 60 seconds, adjust as needed
-
 int32_t StoreForwardModule::runOnce()
 {
 #if defined(ARCH_ESP32) || defined(ARCH_PORTDUINO)


### PR DESCRIPTION
This was still in the `ARCH_ESP32` clause only

<!-- download-section CI firmware-2.5.4.e0dd6db start -->
[Download firmware-2.5.4.e0dd6db.zip. This artifact will be available for 90 days from creation](https://nightly.link/meshtastic/firmware/actions/artifacts/1992930564.zip)

<!-- download-section CI firmware-2.5.4.e0dd6db end -->