### PR TITLE
Fix duplicate PR comments

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -235,7 +235,7 @@ jobs:
           path: ./*.elf
           retention-days: 30
 
-      - uses: PicoCentauri/comment-artifact@main
+      - uses: scruplelesswizard/comment-artifact@main
         with:
           name: firmware-${{ steps.version.outputs.version }}
           description: "Download firmware-${{ steps.version.outputs.version }}.zip. This artifact will be available for 90 days from creation"


### PR DESCRIPTION
Prevent duplicate comments on PRs by using a forked action with fixes

See https://github.com/PicoCentauri/comment-artifact/commit/5f21850ef11b3fadd774066b63b9f60cfe09a077 for applicable change

<!-- download-section CI firmware-2.5.4.b529099 start -->
[Download firmware-2.5.4.b529099.zip. This artifact will be available for 90 days from creation](https://nightly.link/meshtastic/firmware/actions/artifacts/1993545033.zip)

<!-- download-section CI firmware-2.5.4.b529099 end -->