### PR TITLE
Welp it's 7.0.2 now but the branch is still open :-)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -89,7 +89,8 @@ monitor_speed = 115200
 monitor_filters = direct
 
 lib_deps =
-  jgromes/RadioLib@~7.0.1
+  ;jgromes/RadioLib@~7.0.2
+  https://github.com/jgromes/RadioLib.git#5a9ff5a4912f87918390348c8caa54ea8a6afada ; Radiolib 7.0.2pre
   https://github.com/meshtastic/esp8266-oled-ssd1306.git#e16cee124fe26490cb14880c679321ad8ac89c95 ; ESP8266_SSD1306
   https://github.com/mathertel/OneButton@~2.6.1 ; OneButton library for non-blocking button debounce
   https://github.com/meshtastic/arduino-fsm.git#7db3702bf0cfe97b783d6c72595e3f38e0b19159


### PR DESCRIPTION
fix https://github.com/meshtastic/firmware/issues/490

<!-- download-section CI firmware-2.5.4.5fcad1d start -->
[Download firmware-2.5.4.5fcad1d.zip. This artifact will be available for 90 days from creation](https://nightly.link/meshtastic/firmware/actions/artifacts/1996649834.zip)

<!-- download-section CI firmware-2.5.4.5fcad1d end -->