### PR TITLE
Enabling Ve pin on T114

### DIFF
--- a/variants/heltec_mesh_node_t114/variant.h
+++ b/variants/heltec_mesh_node_t114/variant.h
@@ -154,8 +154,11 @@ No longer populated on PCB
 
 // #define PIN_GPS_RESET (32 + 6) // An output to reset L76K GPS. As per datasheet, low for > 100ms will reset the L76K
 #define GPS_RESET_MODE LOW
-#define PIN_GPS_EN (21)
-#define GPS_EN_ACTIVE HIGH
+//#define PIN_GPS_EN (21)
+#define VEXT_ENABLE (0+21)
+#define PERIPHERAL_WARMUP_MS 1000 // Make sure I2C QuickLink has stable power before continuing
+#define VEXT_ON_VALUE HIGH
+//#define GPS_EN_ACTIVE HIGH
 #define PIN_GPS_STANDBY (32 + 2) // An output to wake GPS, low means allow sleep, high means force wake
 #define PIN_GPS_PPS (32 + 4)
 // Seems to be missing on this new board

--- a/variants/heltec_mesh_node_t114/variant.h
+++ b/variants/heltec_mesh_node_t114/variant.h
@@ -154,11 +154,11 @@ No longer populated on PCB
 
 // #define PIN_GPS_RESET (32 + 6) // An output to reset L76K GPS. As per datasheet, low for > 100ms will reset the L76K
 #define GPS_RESET_MODE LOW
-//#define PIN_GPS_EN (21)
-#define VEXT_ENABLE (0+21)
+// #define PIN_GPS_EN (21)
+#define VEXT_ENABLE (0 + 21)
 #define PERIPHERAL_WARMUP_MS 1000 // Make sure I2C QuickLink has stable power before continuing
 #define VEXT_ON_VALUE HIGH
-//#define GPS_EN_ACTIVE HIGH
+// #define GPS_EN_ACTIVE HIGH
 #define PIN_GPS_STANDBY (32 + 2) // An output to wake GPS, low means allow sleep, high means force wake
 #define PIN_GPS_PPS (32 + 4)
 // Seems to be missing on this new board


### PR DESCRIPTION
Problem:
The Ve pin was not enabled in the firmware, and it was supposed to control the power to the GPS via the GPS_EN pin. As a result, users were forced to rely on the 3.3V pin to power their additional peripherals, which caused a constant power draw from the battery, even when the node was in deep sleep mode.

Solution:
To resolve this, @todd-herbert and I decided to remove the GPS power toggle after testing revealed that the GPS only consumes 1mA in soft sleep mode. This minimal power consumption allowed us to enable the Ve pin without causing significant battery drain. Additionally, we added a delay to the I2C initialization process, as the Ve pin requires a few milliseconds to stabilize, which could prevent some peripherals from booting up in time.

Result:

- The GPS operates as usual, drawing only 1mA of power.
- The keyboard and other peripherals attached to the Ve pin now power off correctly when the node is shut down.
- The I2C check initiates without issues after the delay, allowing all peripherals to function smoothly.

