### PR TITLE
Don't use a static decleration in a header file

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,6 +120,8 @@ float tcxoVoltage = SX126X_DIO3_TCXO_VOLTAGE; // if TCXO is optional, put this h
 
 using namespace concurrency;
 
+volatile static const char slipstreamTZString[] = USERPREFS_TZ_STRING;
+
 // We always create a screen object, but we only init it if we find the hardware
 graphics::Screen *screen = nullptr;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -707,15 +707,15 @@ void setup()
 
     // setup TZ prior to time actions.
 #if !MESHTASTIC_EXCLUDE_TZ
-    LOG_DEBUG("Using compiled/slipstreamed %s\n", USERPREFS_TZ_STRING); // important, removing this clobbers our magic string
+    LOG_DEBUG("Using compiled/slipstreamed %s\n", slipstreamTZString); // important, removing this clobbers our magic string
     if (*config.device.tzdef && config.device.tzdef[0] != 0) {
         LOG_DEBUG("Saved TZ: %s \n", config.device.tzdef);
         setenv("TZ", config.device.tzdef, 1);
     } else {
-        if (strncmp((const char *)USERPREFS_TZ_STRING, "tzpl", 4) == 0) {
+        if (strncmp((const char *)slipstreamTZString, "tzpl", 4) == 0) {
             setenv("TZ", "GMT0", 1);
         } else {
-            setenv("TZ", (const char *)USERPREFS_TZ_STRING, 1);
+            setenv("TZ", (const char *)slipstreamTZString, 1);
         }
     }
     tzset();

--- a/userPrefs.h
+++ b/userPrefs.h
@@ -1,6 +1,10 @@
 #ifndef _USERPREFS_
 #define _USERPREFS_
-volatile static const char USERPREFS_TZ_STRING[] = "tzplaceholder                                         ";
+
+// Slipstream values:
+
+#define USERPREFS_TZ_STRING "tzplaceholder                                         "
+
 // Uncomment and modify to set device defaults
 
 // #define USERPREFS_EVENT_MODE 1


### PR DESCRIPTION
Cleans up the TZ_STRING a bit, and gets away from putting a static string in a header.