### PR TITLE
Which Module wants a UI Frame?

### DIFF
--- a/src/mesh/MeshModule.cpp
+++ b/src/mesh/MeshModule.cpp
@@ -240,7 +240,7 @@ std::vector<MeshModule *> MeshModule::GetMeshModulesWithUIFrames()
         for (auto i = modules->begin(); i != modules->end(); ++i) {
             auto &pi = **i;
             if (pi.wantUIFrame()) {
-                LOG_DEBUG("Module wants a UI Frame\n");
+                LOG_DEBUG("%s wants a UI Frame\n", pi.name);
                 modulesWithUIFrames.push_back(&pi);
             }
         }
@@ -255,7 +255,7 @@ void MeshModule::observeUIEvents(Observer<const UIFrameEvent *> *observer)
             auto &pi = **i;
             Observable<const UIFrameEvent *> *observable = pi.getUIFrameObservable();
             if (observable != NULL) {
-                LOG_DEBUG("Module wants a UI Frame\n");
+                LOG_DEBUG("%s wants a UI Frame\n", pi.name);
                 observer->observe(observable);
             }
         }


### PR DESCRIPTION
Previously our debug message for screens blandly stated "Module wants a UI Frame"

This patch replaces the word Module with the name of the Module in need of a frame a frame, enhancing debugging ability.