### PR TITLE
Coalesce duplicated method GetTimeSinceMeshPacket

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -407,3 +407,15 @@ bool MeshService::isToPhoneQueueEmpty()
 {
     return toPhoneQueue.isEmpty();
 }
+
+uint32_t MeshService::GetTimeSinceMeshPacket(const meshtastic_MeshPacket *mp)
+{
+    uint32_t now = getTime();
+
+    uint32_t last_seen = mp->rx_time;
+    int delta = (int)(now - last_seen);
+    if (delta < 0) // our clock must be slightly off still - not set from GPS yet
+        delta = 0;
+
+    return delta;
+}

--- a/src/mesh/MeshService.h
+++ b/src/mesh/MeshService.h
@@ -151,6 +151,8 @@ class MeshService
 
     ErrorCode sendQueueStatusToPhone(const meshtastic_QueueStatus &qs, ErrorCode res, uint32_t mesh_packet_id);
 
+    uint32_t GetTimeSinceMeshPacket(const meshtastic_MeshPacket *mp);
+
   private:
 #if HAS_GPS
     /// Called when our gps position has changed - updates nodedb and sends Location message out into the mesh

--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -187,18 +187,6 @@ float EnvironmentTelemetryModule::CelsiusToFahrenheit(float c)
     return (c * 9) / 5 + 32;
 }
 
-uint32_t GetTimeSinceMeshPacket(const meshtastic_MeshPacket *mp)
-{
-    uint32_t now = getTime();
-
-    uint32_t last_seen = mp->rx_time;
-    int delta = (int)(now - last_seen);
-    if (delta < 0) // our clock must be slightly off still - not set from GPS yet
-        delta = 0;
-
-    return delta;
-}
-
 void EnvironmentTelemetryModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y)
 {
     display->setTextAlignment(TEXT_ALIGN_LEFT);
@@ -213,7 +201,7 @@ void EnvironmentTelemetryModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiSt
 
     // Decode the last measurement packet
     meshtastic_Telemetry lastMeasurement;
-    uint32_t agoSecs = GetTimeSinceMeshPacket(lastMeasurementPacket);
+    uint32_t agoSecs = service->GetTimeSinceMeshPacket(lastMeasurementPacket);
     const char *lastSender = getSenderShortName(*lastMeasurementPacket);
 
     const meshtastic_Data &p = lastMeasurementPacket->decoded;

--- a/src/modules/Telemetry/PowerTelemetry.cpp
+++ b/src/modules/Telemetry/PowerTelemetry.cpp
@@ -94,18 +94,6 @@ bool PowerTelemetryModule::wantUIFrame()
     return moduleConfig.telemetry.power_screen_enabled;
 }
 
-uint32_t GetTimeyWimeySinceMeshPacket(const meshtastic_MeshPacket *mp)
-{
-    uint32_t now = getTime();
-
-    uint32_t last_seen = mp->rx_time;
-    int delta = (int)(now - last_seen);
-    if (delta < 0) // our clock must be slightly off still - not set from GPS yet
-        delta = 0;
-
-    return delta;
-}
-
 void PowerTelemetryModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y)
 {
     display->setTextAlignment(TEXT_ALIGN_LEFT);
@@ -119,7 +107,7 @@ void PowerTelemetryModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *s
 
     meshtastic_Telemetry lastMeasurement;
 
-    uint32_t agoSecs = GetTimeyWimeySinceMeshPacket(lastMeasurementPacket);
+    uint32_t agoSecs = service->GetTimeSinceMeshPacket(lastMeasurementPacket);
     const char *lastSender = getSenderShortName(*lastMeasurementPacket);
 
     const meshtastic_Data &p = lastMeasurementPacket->decoded;


### PR DESCRIPTION
GetTimeSinceMeshPacket was duplicated in PowerTelemetry and EnvironmentalTelemetry, albeit one had a cooler name than the other.

As we add HealthTelemetry, to avoid creating a third instance of this method, let's move it somewhere that makese sense.

Adds a new method GetTimeSinceMeshPacket to MeshService and updates EnvironmentTelemetry and PowerTelemetry to use it.