### PR TITLE
Toggle Bluetooth with Fn+b shortcut

### DIFF
--- a/src/input/InputBroker.h
+++ b/src/input/InputBroker.h
@@ -18,6 +18,7 @@
 #define INPUT_BROKER_MSG_RIGHT 0xb7
 #define INPUT_BROKER_MSG_FN_SYMBOL_ON 0xf1
 #define INPUT_BROKER_MSG_FN_SYMBOL_OFF 0xf2
+#define INPUT_BROKER_MSG_BLUETOOTH_TOGGLE 0xAA
 
 typedef struct _InputEvent {
     const char *source;

--- a/src/input/kbI2cBase.cpp
+++ b/src/input/kbI2cBase.cpp
@@ -297,6 +297,7 @@ int32_t KbI2cBase::runOnce()
             case 0x9e: // fn+g      INPUT_BROKER_MSG_GPS_TOGGLE
             case 0xaf: // fn+space  INPUT_BROKER_MSG_SEND_PING
             case 0x8b: // fn+del    INPUT_BROKEN_MSG_DISMISS_FRAME
+            case 0xAA: // fn+b      INPUT_BROKER_MSG_BLUETOOTH_TOGGLE
                 // just pass those unmodified
                 e.inputEvent = ANYKEY;
                 e.kbchar = c;

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -12,6 +12,7 @@
 #include "detect/ScanI2C.h"
 #include "input/ScanAndSelect.h"
 #include "mesh/generated/meshtastic/cannedmessages.pb.h"
+#include "modules/AdminModule.h"
 
 #include "main.h"                               // for cardkb_found
 #include "modules/ExternalNotificationModule.h" // for buzzer control
@@ -268,21 +269,21 @@ int CannedMessageModule::handleInputEvent(const InputEvent *event)
             showTemporaryMessage("GPS Toggled");
 #endif
             break;
-        case INPUT_BROKER_MSG_BLUETOOTH_TOGGLE: // toggle Bluetooth on/off
-            if (config.bluetooth.enabled == true) {
-                config.bluetooth.enabled = false;
-                LOG_INFO("User toggled Bluetooth. Now DISABLED.\n");
-                nodeDB->saveToDisk();
-                rebootAtMsec = millis() + 2000;
-                showTemporaryMessage("Bluetooth OFF\nReboot");
-            } else if (config.bluetooth.enabled == false) {
-                config.bluetooth.enabled = true;
-                LOG_INFO("User toggled Bluetooth. Now ENABLED\n");
-                nodeDB->saveToDisk();
-                rebootAtMsec = millis() + 2000;
-                showTemporaryMessage("Bluetooth ON\nReboot");
-            }
-            break;
+case INPUT_BROKER_MSG_BLUETOOTH_TOGGLE: // toggle Bluetooth on/off
+    if (config.bluetooth.enabled == true) {
+        config.bluetooth.enabled = false;
+        LOG_INFO("User toggled Bluetooth. Now DISABLED.\n");
+        nodeDB->saveToDisk();
+        disableBluetooth();
+        showTemporaryMessage("Bluetooth OFF");
+    } else if (config.bluetooth.enabled == false) {
+        config.bluetooth.enabled = true;
+        LOG_INFO("User toggled Bluetooth. Now ENABLED\n");
+        nodeDB->saveToDisk();
+        rebootAtMsec = millis() + 2000;
+        showTemporaryMessage("Bluetooth ON\nReboot");
+    }
+    break;
         case INPUT_BROKER_MSG_SEND_PING: // fn+space send network ping like double press does
             service->refreshLocalMeshNode();
             if (service->trySendPosition(NODENUM_BROADCAST, true)) {

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -269,21 +269,21 @@ int CannedMessageModule::handleInputEvent(const InputEvent *event)
             showTemporaryMessage("GPS Toggled");
 #endif
             break;
-case INPUT_BROKER_MSG_BLUETOOTH_TOGGLE: // toggle Bluetooth on/off
-    if (config.bluetooth.enabled == true) {
-        config.bluetooth.enabled = false;
-        LOG_INFO("User toggled Bluetooth. Now DISABLED.\n");
-        nodeDB->saveToDisk();
-        disableBluetooth();
-        showTemporaryMessage("Bluetooth OFF");
-    } else if (config.bluetooth.enabled == false) {
-        config.bluetooth.enabled = true;
-        LOG_INFO("User toggled Bluetooth. Now ENABLED\n");
-        nodeDB->saveToDisk();
-        rebootAtMsec = millis() + 2000;
-        showTemporaryMessage("Bluetooth ON\nReboot");
-    }
-    break;
+        case INPUT_BROKER_MSG_BLUETOOTH_TOGGLE: // toggle Bluetooth on/off
+            if (config.bluetooth.enabled == true) {
+                config.bluetooth.enabled = false;
+                LOG_INFO("User toggled Bluetooth");
+                nodeDB->saveToDisk();
+                disableBluetooth();
+                showTemporaryMessage("Bluetooth OFF");
+            } else if (config.bluetooth.enabled == false) {
+                config.bluetooth.enabled = true;
+                LOG_INFO("User toggled Bluetooth");
+                nodeDB->saveToDisk();
+                rebootAtMsec = millis() + 2000;
+                showTemporaryMessage("Bluetooth ON\nReboot");
+            }
+            break;
         case INPUT_BROKER_MSG_SEND_PING: // fn+space send network ping like double press does
             service->refreshLocalMeshNode();
             if (service->trySendPosition(NODENUM_BROADCAST, true)) {

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -268,6 +268,21 @@ int CannedMessageModule::handleInputEvent(const InputEvent *event)
             showTemporaryMessage("GPS Toggled");
 #endif
             break;
+        case INPUT_BROKER_MSG_BLUETOOTH_TOGGLE: // toggle Bluetooth on/off
+            if (config.bluetooth.enabled == true) {
+                config.bluetooth.enabled = false;
+                LOG_INFO("User toggled Bluetooth. Now DISABLED.\n");
+                nodeDB->saveToDisk();
+                rebootAtMsec = millis() + 2000;
+                showTemporaryMessage("Bluetooth OFF\nReboot");
+            } else if (config.bluetooth.enabled == false) {
+                config.bluetooth.enabled = true;
+                LOG_INFO("User toggled Bluetooth. Now ENABLED\n");
+                nodeDB->saveToDisk();
+                rebootAtMsec = millis() + 2000;
+                showTemporaryMessage("Bluetooth ON\nReboot");
+            }
+            break;
         case INPUT_BROKER_MSG_SEND_PING: // fn+space send network ping like double press does
             service->refreshLocalMeshNode();
             if (service->trySendPosition(NODENUM_BROADCAST, true)) {
@@ -1145,7 +1160,6 @@ void CannedMessageModule::loadProtoForModule()
         installDefaultCannedMessageModuleConfig();
     }
 }
-
 /**
  * @brief Save the module config to file.
  *


### PR DESCRIPTION
Problem:
As many are aware, ESP32 devices are known for their high power consumption. For instance, the Heltec ESP32 V3 draws around 110mA when powered on with the screen active and connected to a phone via Bluetooth. The Bluetooth radio alone is responsible for approximately 50mA of that consumption. For keyboard-based standalone devices, which rarely need Bluetooth other than for changing settings, users were forced to keep Bluetooth on regardless of necessity. There was no way to toggle Bluetooth on or off without physically connecting the device to a computer via serial or using the admin channel, which required another node for access.

Solution:
I implemented a new feature that allows users to turn off Bluetooth on keyboard devices by pressing Fn+b and turn it back on when needed. This enhancement significantly improves power efficiency for these devices.

Result:
With Bluetooth off, the device now consumes only 55mA. When combined with Power Save mode, the consumption can drop as low as 11mA, a substantial reduction from the previous 110mA. Users can still easily reconnect to a phone using the shortcut when necessary, offering greater flexibility and extended battery life.

Issue discussed on #4315
and can possible be repurposed for #4687 by someone else.