### PR TITLE
set tz config from string if unset

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -718,6 +718,7 @@ void setup()
             setenv("TZ", "GMT0", 1);
         } else {
             setenv("TZ", (const char *)slipstreamTZString, 1);
+            strcpy(config.device.tzdef, (const char *)slipstreamTZString);
         }
     }
     tzset();


### PR DESCRIPTION
There's a couple other places in the code that checks the tz config, and as such our slipstreamed timezone wasn't sticking. This change goes ahead and sets the config setting from the string.