### PR TITLE
On T114 do no wake into loader instead of application.

### DIFF
--- a/src/platform/nrf52/main-nrf52.cpp
+++ b/src/platform/nrf52/main-nrf52.cpp
@@ -270,6 +270,11 @@ void cpuDeepSleep(uint32_t msecToWake)
         delay(msecToWake);
         NVIC_SystemReset();
     } else {
+        // Resume on user button press
+        // https://github.com/lyusupov/SoftRF/blob/81c519ca75693b696752235d559e881f2e0511ee/software/firmware/source/SoftRF/src/platform/nRF52.cpp#L1738
+        constexpr uint32_t DFU_MAGIC_SKIP = 0x6d;
+        sd_power_gpregret_set(0, DFU_MAGIC_SKIP); // Equivalent NRF_POWER->GPREGRET = DFU_MAGIC_SKIP
+
         // FIXME, use system off mode with ram retention for key state?
         // FIXME, use non-init RAM per
         // https://devzone.nordicsemi.com/f/nordic-q-a/48919/ram-retention-settings-with-softdevice-enabled


### PR DESCRIPTION
In shutdown, on button press, wake back to application rather than into the loader.
Suggested by lyusupov and implemented by todd-herbert.
fixes #4651