### PR TITLE
Use `M5STACK_COREBASIC` instead for `M5STACK` to avoid confusion

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1606,7 +1606,7 @@ void Screen::handleSetOn(bool on, FrameCallback einkScreensaver)
 #endif
 
 #if defined(ST7789_CS) &&                                                                                                        \
-    !defined(M5STACK_CORE) // set display brightness when turning on screens. Just moved function from TFTDisplay to here.
+    !defined(M5STACK_COREBASIC) // set display brightness when turning on screens. Just moved function from TFTDisplay to here.
             static_cast<TFTDisplay *>(dispdev)->setDisplayBrightness(brightness);
 #endif
 

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1606,7 +1606,7 @@ void Screen::handleSetOn(bool on, FrameCallback einkScreensaver)
 #endif
 
 #if defined(ST7789_CS) &&                                                                                                        \
-    !defined(M5STACK) // set display brightness when turning on screens. Just moved function from TFTDisplay to here.
+    !defined(M5STACK_CORE) // set display brightness when turning on screens. Just moved function from TFTDisplay to here.
             static_cast<TFTDisplay *>(dispdev)->setDisplayBrightness(brightness);
 #endif
 

--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -718,7 +718,7 @@ void TFTDisplay::sendCommand(uint8_t com)
         display(true);
         if (settingsMap[displayBacklight] > 0)
             digitalWrite(settingsMap[displayBacklight], TFT_BACKLIGHT_ON);
-#elif !defined(RAK14014) && !defined(M5STACK) && !defined(UNPHONE)
+#elif !defined(RAK14014) && !defined(M5STACK_CORE) && !defined(UNPHONE)
         tft->wakeup();
         tft->powerSaveOff();
 #endif
@@ -730,7 +730,7 @@ void TFTDisplay::sendCommand(uint8_t com)
         unphone.backlight(true); // using unPhone library
 #endif
 #ifdef RAK14014
-#elif !defined(M5STACK) && !defined(ST7789_CS) // T-Deck gets brightness set in Screen.cpp in the handleSetOn function
+#elif !defined(M5STACK_CORE) && !defined(ST7789_CS) // T-Deck gets brightness set in Screen.cpp in the handleSetOn function
         tft->setBrightness(172);
 #endif
         break;
@@ -742,7 +742,7 @@ void TFTDisplay::sendCommand(uint8_t com)
         tft->clear();
         if (settingsMap[displayBacklight] > 0)
             digitalWrite(settingsMap[displayBacklight], !TFT_BACKLIGHT_ON);
-#elif !defined(RAK14014) && !defined(M5STACK) && !defined(UNPHONE)
+#elif !defined(RAK14014) && !defined(M5STACK_CORE) && !defined(UNPHONE)
         tft->sleep();
         tft->powerSaveOn();
 #endif
@@ -754,7 +754,7 @@ void TFTDisplay::sendCommand(uint8_t com)
         unphone.backlight(false); // using unPhone library
 #endif
 #ifdef RAK14014
-#elif !defined(M5STACK)
+#elif !defined(M5STACK_CORE)
         tft->setBrightness(0);
 #endif
         break;
@@ -788,7 +788,7 @@ bool TFTDisplay::hasTouch(void)
 {
 #ifdef RAK14014
     return true;
-#elif !defined(M5STACK)
+#elif !defined(M5STACK_CORE)
     return tft->touch() != nullptr;
 #else
     return false;
@@ -807,7 +807,7 @@ bool TFTDisplay::getTouch(int16_t *x, int16_t *y)
     } else {
         return false;
     }
-#elif !defined(M5STACK)
+#elif !defined(M5STACK_CORE)
     return tft->getTouch(x, y);
 #else
     return false;
@@ -839,7 +839,7 @@ bool TFTDisplay::connect()
 
     tft->init();
 
-#if defined(M5STACK)
+#if defined(M5STACK_CORE)
     tft->setRotation(0);
 #elif defined(RAK14014)
     tft->setRotation(1);

--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -718,7 +718,7 @@ void TFTDisplay::sendCommand(uint8_t com)
         display(true);
         if (settingsMap[displayBacklight] > 0)
             digitalWrite(settingsMap[displayBacklight], TFT_BACKLIGHT_ON);
-#elif !defined(RAK14014) && !defined(M5STACK_COREBASICBASIC) && !defined(UNPHONE)
+#elif !defined(RAK14014) && !defined(M5STACK_COREBASIC) && !defined(UNPHONE)
         tft->wakeup();
         tft->powerSaveOff();
 #endif
@@ -730,7 +730,7 @@ void TFTDisplay::sendCommand(uint8_t com)
         unphone.backlight(true); // using unPhone library
 #endif
 #ifdef RAK14014
-#elif !defined(M5STACK_COREBASICBASIC) && !defined(ST7789_CS) // T-Deck gets brightness set in Screen.cpp in the handleSetOn function
+#elif !defined(M5STACK_COREBASIC) && !defined(ST7789_CS) // T-Deck gets brightness set in Screen.cpp in the handleSetOn function
         tft->setBrightness(172);
 #endif
         break;
@@ -742,7 +742,7 @@ void TFTDisplay::sendCommand(uint8_t com)
         tft->clear();
         if (settingsMap[displayBacklight] > 0)
             digitalWrite(settingsMap[displayBacklight], !TFT_BACKLIGHT_ON);
-#elif !defined(RAK14014) && !defined(M5STACK_COREBASICBASIC) && !defined(UNPHONE)
+#elif !defined(RAK14014) && !defined(M5STACK_COREBASIC) && !defined(UNPHONE)
         tft->sleep();
         tft->powerSaveOn();
 #endif
@@ -754,7 +754,7 @@ void TFTDisplay::sendCommand(uint8_t com)
         unphone.backlight(false); // using unPhone library
 #endif
 #ifdef RAK14014
-#elif !defined(M5STACK_COREBASICBASIC)
+#elif !defined(M5STACK_COREBASIC)
         tft->setBrightness(0);
 #endif
         break;
@@ -788,7 +788,7 @@ bool TFTDisplay::hasTouch(void)
 {
 #ifdef RAK14014
     return true;
-#elif !defined(M5STACK_COREBASICBASIC)
+#elif !defined(M5STACK_COREBASIC)
     return tft->touch() != nullptr;
 #else
     return false;
@@ -807,7 +807,7 @@ bool TFTDisplay::getTouch(int16_t *x, int16_t *y)
     } else {
         return false;
     }
-#elif !defined(M5STACK_COREBASICBASIC)
+#elif !defined(M5STACK_COREBASIC)
     return tft->getTouch(x, y);
 #else
     return false;
@@ -839,7 +839,7 @@ bool TFTDisplay::connect()
 
     tft->init();
 
-#if defined(M5STACK_COREBASICBASIC)
+#if defined(M5STACK_COREBASIC)
     tft->setRotation(0);
 #elif defined(RAK14014)
     tft->setRotation(1);

--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -718,7 +718,7 @@ void TFTDisplay::sendCommand(uint8_t com)
         display(true);
         if (settingsMap[displayBacklight] > 0)
             digitalWrite(settingsMap[displayBacklight], TFT_BACKLIGHT_ON);
-#elif !defined(RAK14014) && !defined(M5STACK_CORE) && !defined(UNPHONE)
+#elif !defined(RAK14014) && !defined(M5STACK_COREBASICBASIC) && !defined(UNPHONE)
         tft->wakeup();
         tft->powerSaveOff();
 #endif
@@ -730,7 +730,7 @@ void TFTDisplay::sendCommand(uint8_t com)
         unphone.backlight(true); // using unPhone library
 #endif
 #ifdef RAK14014
-#elif !defined(M5STACK_CORE) && !defined(ST7789_CS) // T-Deck gets brightness set in Screen.cpp in the handleSetOn function
+#elif !defined(M5STACK_COREBASICBASIC) && !defined(ST7789_CS) // T-Deck gets brightness set in Screen.cpp in the handleSetOn function
         tft->setBrightness(172);
 #endif
         break;
@@ -742,7 +742,7 @@ void TFTDisplay::sendCommand(uint8_t com)
         tft->clear();
         if (settingsMap[displayBacklight] > 0)
             digitalWrite(settingsMap[displayBacklight], !TFT_BACKLIGHT_ON);
-#elif !defined(RAK14014) && !defined(M5STACK_CORE) && !defined(UNPHONE)
+#elif !defined(RAK14014) && !defined(M5STACK_COREBASICBASIC) && !defined(UNPHONE)
         tft->sleep();
         tft->powerSaveOn();
 #endif
@@ -754,7 +754,7 @@ void TFTDisplay::sendCommand(uint8_t com)
         unphone.backlight(false); // using unPhone library
 #endif
 #ifdef RAK14014
-#elif !defined(M5STACK_CORE)
+#elif !defined(M5STACK_COREBASICBASIC)
         tft->setBrightness(0);
 #endif
         break;
@@ -788,7 +788,7 @@ bool TFTDisplay::hasTouch(void)
 {
 #ifdef RAK14014
     return true;
-#elif !defined(M5STACK_CORE)
+#elif !defined(M5STACK_COREBASICBASIC)
     return tft->touch() != nullptr;
 #else
     return false;
@@ -807,7 +807,7 @@ bool TFTDisplay::getTouch(int16_t *x, int16_t *y)
     } else {
         return false;
     }
-#elif !defined(M5STACK_CORE)
+#elif !defined(M5STACK_COREBASICBASIC)
     return tft->getTouch(x, y);
 #else
     return false;
@@ -839,7 +839,7 @@ bool TFTDisplay::connect()
 
     tft->init();
 
-#if defined(M5STACK_CORE)
+#if defined(M5STACK_COREBASICBASIC)
     tft->setRotation(0);
 #elif defined(RAK14014)
     tft->setRotation(1);

--- a/src/platform/esp32/architecture.h
+++ b/src/platform/esp32/architecture.h
@@ -102,8 +102,8 @@
 #define HW_VENDOR meshtastic_HardwareModel_PRIVATE_HW
 #elif defined(NANO_G1)
 #define HW_VENDOR meshtastic_HardwareModel_NANO_G1
-#elif defined(M5STACK_CORE)
-#define HW_VENDOR meshtastic_HardwareModel_M5STACK_CORE
+#elif defined(M5STACK_COREBASIC)
+#define HW_VENDOR meshtastic_HardwareModel_M5STACK_COREBASIC
 #elif defined(STATION_G1)
 #define HW_VENDOR meshtastic_HardwareModel_STATION_G1
 #elif defined(DR_DEV)

--- a/src/platform/esp32/architecture.h
+++ b/src/platform/esp32/architecture.h
@@ -102,8 +102,8 @@
 #define HW_VENDOR meshtastic_HardwareModel_PRIVATE_HW
 #elif defined(NANO_G1)
 #define HW_VENDOR meshtastic_HardwareModel_NANO_G1
-#elif defined(M5STACK)
-#define HW_VENDOR meshtastic_HardwareModel_M5STACK
+#elif defined(M5STACK_CORE)
+#define HW_VENDOR meshtastic_HardwareModel_M5STACK_CORE
 #elif defined(STATION_G1)
 #define HW_VENDOR meshtastic_HardwareModel_STATION_G1
 #elif defined(DR_DEV)

--- a/variants/m5stack_core/platformio.ini
+++ b/variants/m5stack_core/platformio.ini
@@ -7,7 +7,7 @@ build_src_filter =
 build_flags = 
   ${esp32_base.build_flags} -I variants/m5stack_core
   -DILI9341_DRIVER
-  -DM5STACK
+  -DM5STACK_CORE
   -DUSER_SETUP_LOADED
   -DTFT_SDA_READ
   -DTFT_DRIVER=0x9341

--- a/variants/m5stack_core/platformio.ini
+++ b/variants/m5stack_core/platformio.ini
@@ -7,7 +7,7 @@ build_src_filter =
 build_flags = 
   ${esp32_base.build_flags} -I variants/m5stack_core
   -DILI9341_DRIVER
-  -DM5STACK_CORE
+  -DM5STACK_COREBASIC
   -DUSER_SETUP_LOADED
   -DTFT_SDA_READ
   -DTFT_DRIVER=0x9341


### PR DESCRIPTION
We can use `M5STACK_COREBASIC` instead for `M5STACK` which is a brand and not a model to avoid confusion.
` M5STACK_COREBASIC = 77;`

In fact, it's clear that some users have tried to use the M5Stack variant with a M5Stack Core2 or CoreS3 module.