### PR TITLE
Fix bootloop for T-Watch S3 when using WiFi

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -497,7 +497,7 @@ void Screen::drawDigitalClockFrame(OLEDDisplay *display, OLEDDisplayUiState *sta
         display->drawString(x + 20, y + 2, batteryPercent);
     }
 
-    if (nimbleBluetooth->isConnected()) {
+    if (nimbleBluetooth && nimbleBluetooth->isConnected()) {
         drawBluetoothConnectedIcon(display, display->getWidth() - 18, y + 2);
     }
 
@@ -729,7 +729,7 @@ void Screen::drawAnalogClockFrame(OLEDDisplay *display, OLEDDisplayUiState *stat
         display->drawString(x + 20, y + 2, batteryPercent);
     }
 
-    if (nimbleBluetooth->isConnected()) {
+    if (nimbleBluetooth && nimbleBluetooth->isConnected()) {
         drawBluetoothConnectedIcon(display, display->getWidth() - 18, y + 2);
     }
 


### PR DESCRIPTION
Fixes #4981 (hopefully)

I can reproduce and solve the issue on my makeshift T-Watch test device.
It'd be good to get this checked on the actual hardware just to confirm.