### PR TITLE
Fix bug sending wrong sleep command to U-Blox chips

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -849,7 +849,7 @@ void GPS::setPowerUBLOX(bool on, uint32_t sleepMs)
         }
 
         // Determine hardware version
-        if (gnssModel == GNSS_MODEL_UBLOX10) {
+        if (gnssModel != GNSS_MODEL_UBLOX10) {
             // Encode the sleep time in millis into the packet
             for (int i = 0; i < 4; i++)
                 gps->_message_PMREQ[0 + i] = sleepMs >> (i * 8);


### PR DESCRIPTION
The "U-Blox readable" patch introduced a bug where sleep commands for the 10 and other versions were reversed.
