### PR TITLE
Enable QZSS on UC6580

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -496,10 +496,10 @@ bool GPS::setup()
             }
         } else if (gnssModel == GNSS_MODEL_UC6580) {
             // The Unicore UC6580 can use a lot of sat systems, enable it to
-            // use GPS L1 & L5 + BDS B1I & B2a + GLONASS L1 + GALILEO E1 & E5a + SBAS
+            // use GPS L1 & L5 + BDS B1I & B2a + GLONASS L1 + GALILEO E1 & E5a + SBAS + QZSS
             // This will reset the receiver, so wait a bit afterwards
             // The paranoid will wait for the OK*04 confirmation response after each command.
-            _serial_gps->write("$CFGSYS,h25155\r\n");
+            _serial_gps->write("$CFGSYS,h35155\r\n");
             delay(750);
             // Must be done after the CFGSYS command
             // Turn off GSV messages, we don't really care about which and where the sats are, maybe someday.


### PR DESCRIPTION
@allanmac noted we were not enabling QZSS on the UC6580. QZSS is an augmentation service that runs on the same frequency as GPS, so turning it on should not have any impact on usage other than improving performance for users in the Asia Pacific.

Fixes https://github.com/meshtastic/firmware/issues/5009