### PR TITLE
Add localhost exception for dontMqttMeBro

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -544,7 +544,7 @@ void MQTT::onSend(const meshtastic_MeshPacket &mp, const meshtastic_MeshPacket &
         }
 
         // check for the lowest bit of the data bitfield set false, and the use of one of the default keys.
-        if (!isFromUs(&mp_decoded) && mp_decoded.decoded.has_bitfield &&
+        if (!isFromUs(&mp_decoded) && strcmp(moduleConfig.mqtt.address, "127.0.0.1") != 0 && mp_decoded.decoded.has_bitfield &&
             !(mp_decoded.decoded.bitfield & BITFIELD_OK_TO_MQTT_MASK) &&
             (ch.settings.psk.size < 2 || (ch.settings.psk.size == 16 && memcmp(ch.settings.psk.bytes, defaultpsk, 16)) ||
              (ch.settings.psk.size == 32 && memcmp(ch.settings.psk.bytes, eventpsk, 32)))) {


### PR DESCRIPTION
The OkToMqtt bit is great for blocking unintended traffic uploads to the public MQTT broker. It's also a real pain for users trying to do legitimate local data capture. This patch seeks a middle road, making an allowance for an MQTT server on localhost. Yes this could be abused, but it's less problematic than a popular fork that just strips the bit altogether.