### PR TITLE
Change out lewisxhe/PCF8563_Library

### DIFF
--- a/variants/canaryone/platformio.ini
+++ b/variants/canaryone/platformio.ini
@@ -11,4 +11,5 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/canaryone>
 lib_deps = 
   ${nrf52840_base.lib_deps}
   lewisxhe/PCF8563_Library@^1.0.1
+  # cdfer/pcf8563-rtc @ ^1.3.0 ; I don't have a device to test with.
 ;upload_protocol = fs

--- a/variants/heltec_mesh_node_t114/platformio.ini
+++ b/variants/heltec_mesh_node_t114/platformio.ini
@@ -13,5 +13,5 @@ build_flags = ${nrf52840_base.build_flags} -Ivariants/heltec_mesh_node_t114
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/heltec_mesh_node_t114> 
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1
+  cdfer/pcf8563-rtc @ ^1.3.0
   https://github.com/meshtastic/st7789#bd33ea58ddfe4a5e4a66d53300ccbd38d66ac21f

--- a/variants/heltec_vision_master_e213/platformio.ini
+++ b/variants/heltec_vision_master_e213/platformio.ini
@@ -19,5 +19,5 @@ build_flags =
 lib_deps =
   ${esp32s3_base.lib_deps}
   https://github.com/meshtastic/GxEPD2#b202ebfec6a4821e098cf7a625ba0f6f2400292d
-  lewisxhe/PCF8563_Library@^1.0.1
+  cdfer/pcf8563-rtc @ ^1.3.0
 upload_speed = 115200

--- a/variants/heltec_vision_master_e290/platformio.ini
+++ b/variants/heltec_vision_master_e290/platformio.ini
@@ -21,5 +21,5 @@ build_flags =
 lib_deps =
   ${esp32s3_base.lib_deps}
   https://github.com/meshtastic/GxEPD2#448c8538129fde3d02a7cb5e6fc81971ad92547f
-  lewisxhe/PCF8563_Library@^1.0.1
+  cdfer/pcf8563-rtc @ ^1.3.0
 upload_speed = 115200

--- a/variants/heltec_vision_master_t190/platformio.ini
+++ b/variants/heltec_vision_master_t190/platformio.ini
@@ -8,6 +8,6 @@ build_flags =
  ; -D PRIVATE_HW 
 lib_deps =
   ${esp32s3_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1
+  cdfer/pcf8563-rtc @ ^1.3.0
   https://github.com/meshtastic/st7789#bd33ea58ddfe4a5e4a66d53300ccbd38d66ac21f
 upload_speed = 921600

--- a/variants/heltec_wireless_paper/platformio.ini
+++ b/variants/heltec_wireless_paper/platformio.ini
@@ -19,5 +19,5 @@ build_flags =
 lib_deps =
   ${esp32s3_base.lib_deps}
   https://github.com/meshtastic/GxEPD2#b202ebfec6a4821e098cf7a625ba0f6f2400292d
-  lewisxhe/PCF8563_Library@^1.0.1
+  cdfer/pcf8563-rtc @ ^1.3.0
 upload_speed = 115200

--- a/variants/heltec_wireless_paper_v1/platformio.ini
+++ b/variants/heltec_wireless_paper_v1/platformio.ini
@@ -18,5 +18,5 @@ build_flags =
 lib_deps =
   ${esp32s3_base.lib_deps}
   https://github.com/meshtastic/GxEPD2#55f618961db45a23eff0233546430f1e5a80f63a
-  lewisxhe/PCF8563_Library@^1.0.1
+  cdfer/pcf8563-rtc @ ^1.3.0
 upload_speed = 115200

--- a/variants/m5stack_coreink/platformio.ini
+++ b/variants/m5stack_coreink/platformio.ini
@@ -18,7 +18,7 @@ build_flags =
 lib_deps = 
   ${esp32_base.lib_deps}
   zinggjm/GxEPD2@^1.5.3
-  lewisxhe/PCF8563_Library@^1.0.1
+  cdfer/pcf8563-rtc @ ^1.3.0
 lib_ignore =
   m5stack-coreink
 monitor_filters = esp32_exception_decoder

--- a/variants/nano-g2-ultra/platformio.ini
+++ b/variants/nano-g2-ultra/platformio.ini
@@ -10,4 +10,5 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nano-g2-ultra>
 lib_deps = 
   ${nrf52840_base.lib_deps}
   lewisxhe/PCF8563_Library@^1.0.1
+  # cdfer/pcf8563-rtc @ ^1.3.0 ;I don't have a device to test with.
 ;upload_protocol = fs

--- a/variants/t-echo/platformio.ini
+++ b/variants/t-echo/platformio.ini
@@ -24,4 +24,5 @@ lib_deps =
   ${nrf52840_base.lib_deps}
   https://github.com/meshtastic/GxEPD2#55f618961db45a23eff0233546430f1e5a80f63a
   lewisxhe/PCF8563_Library@^1.0.1
+  # cdfer/pcf8563-rtc @ ^1.3.0 ; I don't have a device to test with.
 ;upload_protocol = fs

--- a/variants/t-watch-s3/platformio.ini
+++ b/variants/t-watch-s3/platformio.ini
@@ -11,8 +11,8 @@ build_flags = ${esp32_base.build_flags}
   -DPCF8563_RTC=0x51
 
 lib_deps = ${esp32s3_base.lib_deps}
-	lovyan03/LovyanGFX@^1.1.9
-  lewisxhe/PCF8563_Library@1.0.1
+  lovyan03/LovyanGFX@^1.1.9
+  cdfer/pcf8563-rtc @ ^1.3.0
   adafruit/Adafruit DRV2605 Library@^1.2.2
   earlephilhower/ESP8266Audio@^1.9.7
   earlephilhower/ESP8266SAM@^1.0.1

--- a/variants/tbeam-s3-core/platformio.ini
+++ b/variants/tbeam-s3-core/platformio.ini
@@ -6,7 +6,7 @@ board_check = true
 
 lib_deps =
   ${esp32s3_base.lib_deps}
-  lewisxhe/PCF8563_Library@1.0.1
+  cdfer/pcf8563-rtc @ ^1.3.0
 
 build_flags = 
   ${esp32s3_base.build_flags} 


### PR DESCRIPTION
 * Replace lewisxhe/PCF8563_Library@^1.0.1 with cdfer/pcf8563-rtc @ ^1.3.0  for the ESP32S boards.

 * Add commented out line for the library on the NRF based boards for testing by someone that has an NRF board.