### PR TITLE
retain `fixed_position` during reset-nodedb

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -556,7 +556,8 @@ void NodeDB::installDefaultChannels()
 
 void NodeDB::resetNodes()
 {
-    clearLocalPosition();
+    if (!config.position.fixed_position)
+        clearLocalPosition();
     numMeshNodes = 1;
     std::fill(devicestate.node_db_lite.begin() + 1, devicestate.node_db_lite.end(), meshtastic_NodeInfoLite());
     devicestate.has_rx_text_message = false;


### PR DESCRIPTION
Restores functionality for:
- https://github.com/meshtastic/firmware/issues/2939

https://github.com/meshtastic/firmware/pull/2951 was keeping all positions, not just `fixed_position`. later https://github.com/meshtastic/firmware/pull/3451 removed all position data.

this PR ensures local position is not cleared when `fixed_position` is set.