### PR TITLE
Add MQTT exception for private IP address server

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -556,7 +556,8 @@ void NodeDB::installDefaultChannels()
 
 void NodeDB::resetNodes()
 {
-    clearLocalPosition();
+    if (!config.position.fixed_position)
+        clearLocalPosition();
     numMeshNodes = 1;
     std::fill(devicestate.node_db_lite.begin() + 1, devicestate.node_db_lite.end(), meshtastic_NodeInfoLite());
     devicestate.has_rx_text_message = false;

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -707,22 +707,17 @@ bool MQTT::isValidJsonEnvelope(JSONObject &json)
 bool MQTT::isPrivateIpAddress(const char ip[])
 {
     // Check the easy ones first.
-    if (strcmp(ip, "127.0.0.1") == 0 ||
-        strncmp(ip, "10.", 3) == 0 ||
-        strncmp(ip, "192.168", 7) == 0)
-    {
+    if (strcmp(ip, "127.0.0.1") == 0 || strncmp(ip, "10.", 3) == 0 || strncmp(ip, "192.168", 7) == 0) {
         return true;
     }
 
     // See if it's definitely not a 172 address.
-    if (strncmp(ip, "172", 3) != 0)
-    {
+    if (strncmp(ip, "172", 3) != 0) {
         return false;
     }
 
     // We know it's a 172 address, now see if the second octet is 2 digits.
-    if (ip[6] != '.')
-    {
+    if (ip[6] != '.') {
         return false;
     }
 

--- a/src/mqtt/MQTT.h
+++ b/src/mqtt/MQTT.h
@@ -120,6 +120,10 @@ class MQTT : private concurrency::OSThread
     // returns true if this is a valid JSON envelope which we accept on downlink
     bool isValidJsonEnvelope(JSONObject &json);
 
+    /// Determines if the given IP address is a private address, i.e. not routable on the public internet.
+    /// These are the ranges: 127.0.0.1, 10.0.0.0-10.255.255.255, 172.16.0.0-172.31.255.255, 192.168.0.0-192.168.255.255.
+    bool isPrivateIpAddress(const char ip[]);
+
     /// Return 0 if sleep is okay, veto sleep if we are connected to pubsub server
     // int preflightSleepCb(void *unused = NULL) { return pubSub.connected() ? 1 : 0; }
 };


### PR DESCRIPTION
Related to issue #5000 and implementing what was suggested in #5023.

Allowing MQTT publishing regardless of the flag setting if the server being published to is local (for local automation scenarios).

I have not completed testing yet, but wanted to get early feedback.