### PR TITLE
Fix incorrect va_start calls

### DIFF
--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -290,7 +290,7 @@ void RedirectablePrint::log(const char *logLevel, const char *format, ...)
     if (strcmp(logLevel, MESHTASTIC_LOG_LEVEL_TRACE) == 0) {
         if (settingsStrings[traceFilename] != "") {
             va_list arg;
-            va_start(arg, newFormat);
+            va_start(arg, format);
             try {
                 traceFile << va_arg(arg, char *) << std::endl;
             } catch (const std::ios_base::failure &e) {
@@ -326,7 +326,7 @@ void RedirectablePrint::log(const char *logLevel, const char *format, ...)
 #endif
 
         va_list arg;
-        va_start(arg, newFormat);
+        va_start(arg, format);
 
         log_to_serial(logLevel, newFormat, arg);
         log_to_syslog(logLevel, newFormat, arg);


### PR DESCRIPTION
The 2nd argument of va_start must always be the function parameter immediately before the "..." argument. Otherwise, the behavior is undefined.

Reproducer (compile with `gcc -Wvarargs`):
```c
#include <stdarg.h>
#include <stdio.h>

void wrong_va_arg(const char *format, ...) {
    va_list ap;
    const char *newFormat = "whatever";
    (void)format;

    va_start(ap, newFormat);
    vprintf(newFormat, ap);
    va_end(ap);
}
```

godbolt link to reproducer: https://godbolt.org/z/YMoGKb9xh