### PR TITLE
Coerce minimum telemetry interval of 30 minutes on defaults and make new default interval one hour

### DIFF
--- a/src/mesh/Default.cpp
+++ b/src/mesh/Default.cpp
@@ -43,6 +43,15 @@ uint32_t Default::getConfiguredOrDefaultMsScaled(uint32_t configured, uint32_t d
     return getConfiguredOrDefaultMs(configured, defaultValue) * congestionScalingCoefficient(numOnlineNodes);
 }
 
+uint32_t Default::getConfiguredOrMinimumValue(uint32_t configured, uint32_t minValue)
+{
+    // If zero, intervals should be coalesced later by getConfiguredOrDefault... methods
+    if (configured == 0)
+        return configured;
+
+    return configured < minValue ? minValue : configured;
+}
+
 uint8_t Default::getConfiguredOrDefaultHopLimit(uint8_t configured)
 {
 #if USERPREFS_EVENT_MODE

--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -6,8 +6,9 @@
 #define THIRTY_SECONDS_MS 30 * 1000
 #define FIVE_SECONDS_MS 5 * 1000
 
+#define min_default_telemetry_interval_secs 30 * 60
 #define default_gps_update_interval IF_ROUTER(ONE_DAY, 2 * 60)
-#define default_telemetry_broadcast_interval_secs IF_ROUTER(ONE_DAY / 2, 30 * 60)
+#define default_telemetry_broadcast_interval_secs IF_ROUTER(ONE_DAY / 2, 60 * 60)
 #define default_broadcast_interval_secs IF_ROUTER(ONE_DAY / 2, 15 * 60)
 #define default_wait_bluetooth_secs IF_ROUTER(1, 60)
 #define default_sds_secs IF_ROUTER(ONE_DAY, UINT32_MAX) // Default to forever super deep sleep
@@ -35,6 +36,7 @@ class Default
     static uint32_t getConfiguredOrDefault(uint32_t configured, uint32_t defaultValue);
     static uint32_t getConfiguredOrDefaultMsScaled(uint32_t configured, uint32_t defaultValue, uint32_t numOnlineNodes);
     static uint8_t getConfiguredOrDefaultHopLimit(uint8_t configured);
+    static uint32_t getConfiguredOrMinimumValue(uint32_t configured, uint32_t minValue);
 
   private:
     static float congestionScalingCoefficient(int numOnlineNodes)

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -174,7 +174,7 @@ NodeDB::NodeDB()
     // If we are setup to broadcast on the default channel, ensure that the telemetry intervals are coerced to the minimum value
     // of 30 minutes or more
     if (channels.isDefaultChannel(channels.getPrimaryIndex())) {
-        LOG_DEBUG("Coercing telemetry intervals to min of 30 minutes on default channel");
+        LOG_DEBUG("Coercing telemetry to min of 30 minutes on defaults");
         moduleConfig.telemetry.device_update_interval = Default::getConfiguredOrMinimumValue(
             moduleConfig.telemetry.device_update_interval, min_default_telemetry_interval_secs);
         moduleConfig.telemetry.environment_update_interval = Default::getConfiguredOrMinimumValue(

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -171,6 +171,22 @@ NodeDB::NodeDB()
     resetRadioConfig(); // If bogus settings got saved, then fix them
     // nodeDB->LOG_DEBUG("region=%d, NODENUM=0x%x, dbsize=%d", config.lora.region, myNodeInfo.my_node_num, numMeshNodes);
 
+    // If we are setup to broadcast on the default channel, ensure that the telemetry intervals are coerced to the minimum value
+    // of 30 minutes or more
+    if (channels.isDefaultChannel(channels.getPrimaryIndex())) {
+        LOG_DEBUG("Coercing telemetry intervals to min of 30 minutes on default channel");
+        moduleConfig.telemetry.device_update_interval = Default::getConfiguredOrMinimumValue(
+            moduleConfig.telemetry.device_update_interval, min_default_telemetry_interval_secs);
+        moduleConfig.telemetry.environment_update_interval = Default::getConfiguredOrMinimumValue(
+            moduleConfig.telemetry.environment_update_interval, min_default_telemetry_interval_secs);
+        moduleConfig.telemetry.air_quality_interval = Default::getConfiguredOrMinimumValue(
+            moduleConfig.telemetry.air_quality_interval, min_default_telemetry_interval_secs);
+        moduleConfig.telemetry.power_update_interval = Default::getConfiguredOrMinimumValue(
+            moduleConfig.telemetry.power_update_interval, min_default_telemetry_interval_secs);
+        moduleConfig.telemetry.health_update_interval = Default::getConfiguredOrMinimumValue(
+            moduleConfig.telemetry.health_update_interval, min_default_telemetry_interval_secs);
+    }
+
     if (devicestateCRC != crc32Buffer(&devicestate, sizeof(devicestate)))
         saveWhat |= SEGMENT_DEVICESTATE;
     if (configCRC != crc32Buffer(&config, sizeof(config)))


### PR DESCRIPTION
Starting to see Telemetry traffic quickly become the predominant generator of traffic on the public mesh. This is _another_ attempt to back some of that off to make more headroom for text messaging, node discovery, and position updates, as well as prevent inadvertent setting of these values to spammy intervals. I don't need to see everybody's battery level updated every 5 minutes. ;-)

The new standard would be:
1. No more frequent than 30-minute broadcasts of any telemetry on the default channel
2. New default of one-hour (up from 30 minutes) for regular interval broadcasts of telemetry.