### PR TITLE
Add `-p` flag

### DIFF
--- a/bin/native-install.sh
+++ b/bin/native-install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 cp "release/meshtasticd_linux_$(uname -m)" /usr/sbin/meshtasticd
-mkdir /etc/meshtasticd
+mkdir -p /etc/meshtasticd
 if [[ -f "/etc/meshtasticd/config.yaml" ]]; then
 	cp bin/config-dist.yaml /etc/meshtasticd/config-upgrade.yaml
 else


### PR DESCRIPTION
Add the `-p` flag to the `mkdir` command so it doesn't fail when the folder already exists.
