### PR TITLE
Revert "Permanently engage !CTRL"

### DIFF
--- a/variants/rp2040-lora/variant.h
+++ b/variants/rp2040-lora/variant.h
@@ -54,7 +54,7 @@
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_BUSY
 #define SX126X_RESET LORA_RESET
-#define SX126X_DIO2_AS_RF_SWITCH  // Antenna switch CTRL
-#define SX126X_POWER_EN LORA_DIO4 // Antenna switch !CTRL via GPIO17
+#define SX126X_DIO2_AS_RF_SWITCH // Antenna switch CTRL
+#define SX126X_RXEN LORA_DIO4    // Antenna switch !CTRL via GPIO17
 // #define SX126X_DIO3_TCXO_VOLTAGE 1.8
 #endif


### PR DESCRIPTION
Reverts meshtastic/firmware#5036

Schematic says this is not ideal but it is right.