### PR TITLE
add the non routable portions of the 44Net/HamNet/AMPRNet IP blocks to the private address comparison

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -750,6 +750,11 @@ bool MQTT::isPrivateIpAddress(const char address[])
         return true;
     }
 
+    // Check to see if it is a HamNet address which we also consider private.
+    if (strncmp(address, "44.", 3) == 0) {
+        return true;
+    }
+
     // See if it's definitely not a 172 address.
     if (strncmp(address, "172", 3) != 0) {
         return false;


### PR DESCRIPTION
This PR adds the 44Net aka HamNet IP space to the private IP address check which enables the exchange of data via MQTT.

This IP address space is commonly used by Ham Radio operators for data communications.

https://www.ardc.net/44net/