### PR TITLE
Move 115200 baud GNSS probe earlier

### DIFF
--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -75,7 +75,7 @@ class GPS : private concurrency::OSThread
     uint8_t fixType = 0;      // fix type from GPGSA
 #endif
   private:
-    const int serialSpeeds[6] = {9600, 115200, 4800, 38400, 57600, 9600};
+    const int serialSpeeds[6] = {9600, 115200, 38400, 4800, 57600, 9600};
     uint32_t lastWakeStartMsec = 0, lastSleepStartMsec = 0, lastFixStartMsec = 0;
     uint32_t rx_gpio = 0;
     uint32_t tx_gpio = 0;

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -75,7 +75,7 @@ class GPS : private concurrency::OSThread
     uint8_t fixType = 0;      // fix type from GPGSA
 #endif
   private:
-    const int serialSpeeds[6] = {9600, 4800, 38400, 57600, 115200, 9600};
+    const int serialSpeeds[6] = {9600, 115200, 4800, 38400, 57600, 9600};
     uint32_t lastWakeStartMsec = 0, lastSleepStartMsec = 0, lastFixStartMsec = 0;
     uint32_t rx_gpio = 0;
     uint32_t tx_gpio = 0;


### PR DESCRIPTION
Since most GPS modules are defaulted to 9600 or 115200, moving the 115200 probe earlier should statistically speed up detection time and avoid wasted cycles on irrelevant baud rates