### PR TITLE
Fix rebroadcasting encrypted packets when `KNOWN_ONLY`/`LOCAL_ONLY` is used

### DIFF
--- a/src/modules/RoutingModule.cpp
+++ b/src/modules/RoutingModule.cpp
@@ -10,9 +10,6 @@ RoutingModule *routingModule;
 
 bool RoutingModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_Routing *r)
 {
-    printPacket("Routing sniffing", &mp);
-    router->sniffReceived(&mp, r);
-
     bool maybePKI = mp.which_payload_variant == meshtastic_MeshPacket_encrypted_tag && mp.channel == 0 && !isBroadcast(mp.to);
     // Beginning of logic whether to drop the packet based on Rebroadcast mode
     if (mp.which_payload_variant == meshtastic_MeshPacket_encrypted_tag &&
@@ -24,6 +21,9 @@ bool RoutingModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mesh
             (nodeDB->getMeshNode(mp.to) == NULL || !nodeDB->getMeshNode(mp.to)->has_user))
             return false;
     }
+
+    printPacket("Routing sniffing", &mp);
+    router->sniffReceived(&mp, r);
 
     // FIXME - move this to a non promsicious PhoneAPI module?
     // Note: we are careful not to send back packets that started with the phone back to the phone


### PR DESCRIPTION
Fixes #5106. 

This slipped in in 6eabbaf4321a3694fb48b4a55331c53d2ebb5d63. Already during sniffing, the FloodingRouter is rebroadcasting, so it should return before this.
