### PR TITLE
add RFC 3927 IP address space to private IP checks

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -746,7 +746,8 @@ bool MQTT::isPrivateIpAddress(const char address[])
     }
 
     // Check the easy ones first.
-    if (strcmp(address, "127.0.0.1") == 0 || strncmp(address, "10.", 3) == 0 || strncmp(address, "192.168", 7) == 0) {
+    if (strcmp(address, "127.0.0.1") == 0 || strncmp(address, "10.", 3) == 0 || strncmp(address, "192.168", 7) == 0 ||
+        strncmp(address, "169.254", 7) == 0) {
         return true;
     }
 


### PR DESCRIPTION
Per the comments of #5098 add the RFC 3927 IP address block (169.254.0.0/16), also referred to as IPIPA, to the private address checks for MQTT functionality.

[RFC3927 Reference](https://datatracker.ietf.org/doc/html/rfc3927)