### PR TITLE
[Board] Support Heltec LoRa32 v3.2 charge status

### DIFF
--- a/variants/heltec_v3.2/platformio.ini
+++ b/variants/heltec_v3.2/platformio.ini
@@ -1,0 +1,8 @@
+[env:heltec-v3_2] 
+extends = esp32s3_base
+board = heltec_wifi_lora_32_V3
+board_check = true
+# Temporary until espressif creates a release with this new target
+build_flags = 
+  ${esp32s3_base.build_flags} -D HELTEC_V3 -I variants/heltec_v3.2
+  -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.

--- a/variants/heltec_v3.2/variant.h
+++ b/variants/heltec_v3.2/variant.h
@@ -1,0 +1,42 @@
+#define LED_PIN LED
+
+#define USE_SSD1306 // Heltec_v3 has a SSD1306 display
+
+#define RESET_OLED RST_OLED
+#define I2C_SDA SDA_OLED // I2C pins for this board
+#define I2C_SCL SCL_OLED
+
+// Enable secondary bus for external periherals
+#define I2C_SDA1 SDA
+#define I2C_SCL1 SCL
+
+#define VEXT_ENABLE Vext // active low, powers the oled display and the lora antenna boost
+#define BUTTON_PIN 0
+
+#define ADC_CTRL 37
+#define ADC_CTRL_ENABLED HIGH
+#define BATTERY_PIN 1 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
+#define ADC_CHANNEL ADC1_GPIO1_CHANNEL
+#define ADC_ATTENUATION ADC_ATTEN_DB_2_5 // lower dB for high resistance voltage divider
+#define ADC_MULTIPLIER 4.9 * 1.045
+
+#define USE_SX1262
+
+#define LORA_DIO0 -1 // a No connect on the SX1262 module
+#define LORA_RESET 12
+#define LORA_DIO1 14 // SX1262 IRQ
+#define LORA_DIO2 13 // SX1262 BUSY
+#define LORA_DIO3    // Not connected on PCB, but internally on the TTGO SX1262, if DIO3 is high the TXCO is enabled
+
+#define LORA_SCK 9
+#define LORA_MISO 11
+#define LORA_MOSI 10
+#define LORA_CS 8
+
+#define SX126X_CS LORA_CS
+#define SX126X_DIO1 LORA_DIO1
+#define SX126X_BUSY LORA_DIO2
+#define SX126X_RESET LORA_RESET
+
+#define SX126X_DIO2_AS_RF_SWITCH
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8


### PR DESCRIPTION
Tested with `pio run -e heltec-v3_2`` and uploading to a v3.2 board. Now shows battery status properly.

fixes #5127