### PR TITLE
fix missing includes

### DIFF
--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -7,7 +7,8 @@
 #include "linux/LinuxHardwareI2C.h"
 #endif
 #if !defined(ARCH_PORTDUINO) && !defined(ARCH_STM32WL)
-#include "main.h" // atecc
+#include "main.h"      // atecc
+#include "meshUtils.h" // vformat
 #endif
 
 // AXP192 and AXP2101 have the same device address, we just need to identify it in Power.cpp

--- a/src/motion/LIS3DHSensor.cpp
+++ b/src/motion/LIS3DHSensor.cpp
@@ -1,4 +1,5 @@
 #include "LIS3DHSensor.h"
+#include "NodeDB.h"
 
 #if !defined(ARCH_PORTDUINO) && !defined(ARCH_STM32WL) && !MESHTASTIC_EXCLUDE_I2C
 

--- a/src/motion/LSM6DS3Sensor.cpp
+++ b/src/motion/LSM6DS3Sensor.cpp
@@ -1,4 +1,5 @@
 #include "LSM6DS3Sensor.h"
+#include "NodeDB.h"
 
 #if !defined(ARCH_PORTDUINO) && !defined(ARCH_STM32WL) && !MESHTASTIC_EXCLUDE_I2C
 

--- a/src/motion/MotionSensor.h
+++ b/src/motion/MotionSensor.h
@@ -14,6 +14,7 @@
 #include "../graphics/Screen.h"
 #include "../graphics/ScreenFonts.h"
 #include "../power.h"
+#include "Wire.h"
 
 // Base class for motion processing
 class MotionSensor


### PR DESCRIPTION
When excluding telemetry and/or environment sensors from the build there are a couple of compiler errors due to missing includes, because they are normally (falsely) included via some other includes...

e.g. using the global variable `config` must include NodeDB.h