### PR TITLE
De-duplicate log-level determination

### DIFF
--- a/src/RedirectablePrint.h
+++ b/src/RedirectablePrint.h
@@ -51,9 +51,9 @@ class RedirectablePrint : public Print
   protected:
     /// Subclasses can override if they need to change how we format over the serial port
     virtual void log_to_serial(const char *logLevel, const char *format, va_list arg);
+    meshtastic_LogRecord_Level getLogLevel(const char *logLevel);
 
   private:
     void log_to_syslog(const char *logLevel, const char *format, va_list arg);
     void log_to_ble(const char *logLevel, const char *format, va_list arg);
-    meshtastic_LogRecord_Level getLogLevel(const char *logLevel);
 };

--- a/src/SerialConsole.cpp
+++ b/src/SerialConsole.cpp
@@ -99,25 +99,7 @@ bool SerialConsole::handleToRadio(const uint8_t *buf, size_t len)
 void SerialConsole::log_to_serial(const char *logLevel, const char *format, va_list arg)
 {
     if (usingProtobufs && config.security.debug_log_api_enabled) {
-        meshtastic_LogRecord_Level ll = meshtastic_LogRecord_Level_UNSET; // default to unset
-        switch (logLevel[0]) {
-        case 'D':
-            ll = meshtastic_LogRecord_Level_DEBUG;
-            break;
-        case 'I':
-            ll = meshtastic_LogRecord_Level_INFO;
-            break;
-        case 'W':
-            ll = meshtastic_LogRecord_Level_WARNING;
-            break;
-        case 'E':
-            ll = meshtastic_LogRecord_Level_ERROR;
-            break;
-        case 'C':
-            ll = meshtastic_LogRecord_Level_CRITICAL;
-            break;
-        }
-
+        meshtastic_LogRecord_Level ll = RedirectablePrint::getLogLevel(logLevel);
         auto thread = concurrency::OSThread::currentThread;
         emitLogRecord(ll, thread ? thread->ThreadName.c_str() : "", format, arg);
     } else


### PR DESCRIPTION
RedirectablePrint had a method, getLogLevel, which did exactly what code in SerialConsole did. Let's use that method rather than duplicating the code.