### PR TITLE
Update GPSUpdateScheduling.cpp

### DIFF
--- a/src/gps/GPSUpdateScheduling.cpp
+++ b/src/gps/GPSUpdateScheduling.cpp
@@ -70,8 +70,7 @@ bool GPSUpdateScheduling::isUpdateDue()
 // Have we been searching for a GPS position for too long?
 bool GPSUpdateScheduling::searchedTooLong()
 {
-    uint32_t maxSearchMs =
-        Default::getConfiguredOrDefaultMs(config.position.position_broadcast_secs, default_broadcast_interval_secs);
+    uint32_t maxSearchMs = 15*60*1000;
 
     // If broadcast interval set to max, no such thing as "too long"
     if (maxSearchMs == UINT32_MAX)

--- a/src/gps/GPSUpdateScheduling.cpp
+++ b/src/gps/GPSUpdateScheduling.cpp
@@ -70,8 +70,10 @@ bool GPSUpdateScheduling::isUpdateDue()
 // Have we been searching for a GPS position for too long?
 bool GPSUpdateScheduling::searchedTooLong()
 {
-    uint32_t maxSearchMs = 15*60*1000;
-
+    uint32_t minimumOrConfiguredSecs = Default::getConfiguredOrMinimumValue(
+            moduleConfig.position.position_broadcast_secs, default_broadcast_interval_secs);
+    uint32_t maxSearchMs =
+        Default::getConfiguredOrDefaultMs(minimumOrConfiguredSecs, default_broadcast_interval_secs);
     // If broadcast interval set to max, no such thing as "too long"
     if (maxSearchMs == UINT32_MAX)
         return false;

--- a/src/gps/GPSUpdateScheduling.cpp
+++ b/src/gps/GPSUpdateScheduling.cpp
@@ -71,7 +71,7 @@ bool GPSUpdateScheduling::isUpdateDue()
 bool GPSUpdateScheduling::searchedTooLong()
 {
     uint32_t minimumOrConfiguredSecs = Default::getConfiguredOrMinimumValue(
-            moduleConfig.position.position_broadcast_secs, default_broadcast_interval_secs);
+            config.position.position_broadcast_secs, default_broadcast_interval_secs);
     uint32_t maxSearchMs =
         Default::getConfiguredOrDefaultMs(minimumOrConfiguredSecs, default_broadcast_interval_secs);
     // If broadcast interval set to max, no such thing as "too long"


### PR DESCRIPTION
Default value is too short, resulting in unstable GPS locks on T1000-E (possibly others). Fix has been tested an confirmed working with no adverse effects, by multiple users. Also discussed at length on Discord