### PR TITLE
Icarus - Fix platform dependency version and add selection button

### DIFF
--- a/variants/icarus/platformio.ini
+++ b/variants/icarus/platformio.ini
@@ -6,7 +6,7 @@ board_check = true
 board_build.mcu = esp32s3
 upload_protocol = esptool
 upload_speed = 921600
-platform_packages = framework-arduinoespressif32@https://github.com/PowerFeather/powerfeather-meshtastic-arduino-lib/releases/download/2.0.16b/esp32-2.0.16.zip
+platform_packages = framework-arduinoespressif32@https://github.com/PowerFeather/powerfeather-meshtastic-arduino-lib/releases/download/2.0.16a/esp32-2.0.16.zip
 lib_deps =
   ${esp32s3_base.lib_deps}
 build_unflags =

--- a/variants/icarus/variant.h
+++ b/variants/icarus/variant.h
@@ -7,8 +7,9 @@
 #define I2C_SDA1 18
 #define I2C_SCL1 6
 
+#define BUTTON_PIN 7 // Selection button
 
-// XIAO S3 LORA module
+// RA-01SH/HT-RA62 LORA module
 #define USE_SX1262
 
 #define LORA_MISO 39


### PR DESCRIPTION
Sorry for another PR, but it seemes like the previous one had the wrong esp32 platform dependency version, that's all fixed now and  I also added a button.