### PR TITLE
Add region BR

### DIFF
--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -65,6 +65,11 @@ const RegionInfo regions[] = {
     RDEF(ANZ, 915.0f, 928.0f, 100, 0, 30, true, false, false),
 
     /*
+        https://www.gov.br/anatel/pt-br/regulado/radiofrequencia/radiacao-restrita
+     */
+    RDEF(BR, 915.0f, 928.0f, 100, 0, 30, true, false, false),
+
+    /*
         https://digital.gov.ru/uploaded/files/prilozhenie-12-k-reshenyu-gkrch-18-46-03-1.pdf
 
         Note:


### PR DESCRIPTION
Create a new region-specific band for Brazil. Initially, this region will be a copy of the existing `ANZ` band. This is done to avoid any confusion for Brazilian users and the Meshtastic community.

Also, this region allows the users to keep using the project's MQTT server with the appropriate default root topic `msh/BR` (instead of using the `msh/ANZ`, which was always confusing.

Finally, according to Brazil's telecommunications agency (ANATEL), the ISM band can be used for LoRa. This includes the 915-928 MHz band (the same used by `ANZ`), but the 902-905 MHz can be used too. Then, keeping BR as a separate region makes it easier to deal with its particularities and use cases for future implementations.

# Testing

This PR was tested with a patched version of the Python client (to be sent upstream soon). The default MQTT root topic is `msh/BR` (as supposed) and the device can still communicate with the old `ANZ` region.
