### PR TITLE
fix: don't broadcast public keys if the user is licensed

### DIFF
--- a/src/modules/NodeInfoModule.cpp
+++ b/src/modules/NodeInfoModule.cpp
@@ -81,6 +81,12 @@ meshtastic_MeshPacket *NodeInfoModule::allocReply()
         ignoreRequest = false; // Don't ignore requests anymore
         meshtastic_User &u = owner;
 
+        // Strip the public key if the user is licensed
+        if (u.is_licensed && u.public_key.size > 0) {
+            u.public_key.bytes[0] = 0;
+            u.public_key.size = 0;
+        }
+
         LOG_INFO("sending owner %s/%s/%s", u.id, u.long_name, u.short_name);
         lastSentToMesh = millis();
         return allocDataProtobuf(u);


### PR DESCRIPTION
prevents NodeInfo broadcasts with public keys when the user is licensed.