### PR TITLE
Added ADC control pin automatic logic switch function for Heltec LoRa 32 V3

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -155,8 +155,15 @@ static void adcEnable()
 #ifdef ADC_USE_PULLUP
     pinMode(ADC_CTRL, INPUT_PULLUP);
 #else
+#ifdef HELTEC_V3
+    pinMode(ADC_CTRL,INPUT);
+    uint8_t adc_ctl_enable_value=!(digitalRead(ADC_CTRL));
+    pinMode(ADC_CTRL, OUTPUT);
+    digitalWrite(ADC_CTRL, adc_ctl_enable_value);
+#else
     pinMode(ADC_CTRL, OUTPUT);
     digitalWrite(ADC_CTRL, ADC_CTRL_ENABLED);
+#endif
 #endif
     delay(10);
 #endif
@@ -168,7 +175,11 @@ static void adcDisable()
 #ifdef ADC_USE_PULLUP
     pinMode(ADC_CTRL, INPUT_PULLDOWN);
 #else
+#ifdef HELTEC_V3
+    pinMode(ADC_CTRL,ANALOG);
+#else
     digitalWrite(ADC_CTRL, !ADC_CTRL_ENABLED);
+#endif
 #endif
 #endif
 }


### PR DESCRIPTION
In version V3.2, the ADC control pin is changed from MOS-FET to triode, which will optimize the low power consumption of LoRa 32 about 6~7uA. The logic of ADC_Ctrl is changed from `LOW enable` to `HIGH enable`.

The added code will automatically identify the pin control logic.