### PR TITLE
musl compatibility

### DIFF
--- a/arch/portduino/portduino.ini
+++ b/arch/portduino/portduino.ini
@@ -1,6 +1,6 @@
 ; The Portduino based sim environment on top of any host OS, all hardware will be simulated
 [portduino_base]
-platform = https://github.com/meshtastic/platform-native.git#6b3796d697481c8f6e3f4aa5c111bd9979f29e64
+platform = https://github.com/meshtastic/platform-native.git#bcd02436cfca91f7d28ad0f7dab977c6aaa781af
 framework = arduino
 
 build_src_filter = 

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -4,8 +4,8 @@
 #include "RadioInterface.h"
 #include "concurrency/NotifiedWorkerThread.h"
 
-#include <sys/types.h>
 #include <RadioLib.h>
+#include <sys/types.h>
 
 // ESP32 has special rules about ISR code
 #ifdef ARDUINO_ARCH_ESP32

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -4,6 +4,7 @@
 #include "RadioInterface.h"
 #include "concurrency/NotifiedWorkerThread.h"
 
+#include <sys/types.h>
 #include <RadioLib.h>
 
 // ESP32 has special rules about ISR code

--- a/src/modules/AdminModule.h
+++ b/src/modules/AdminModule.h
@@ -1,3 +1,5 @@
+#include <sys/types.h>
+
 #pragma once
 #include "ProtobufModule.h"
 #if HAS_WIFI

--- a/src/serialization/MeshPacketSerializer.cpp
+++ b/src/serialization/MeshPacketSerializer.cpp
@@ -11,6 +11,7 @@
 #include "../mesh/generated/meshtastic/paxcount.pb.h"
 #endif
 #include "mesh/generated/meshtastic/remote_hardware.pb.h"
+#include <sys/types.h>
 
 std::string MeshPacketSerializer::JsonSerialize(const meshtastic_MeshPacket *mp, bool shouldLog)
 {


### PR DESCRIPTION
Existing meshtasticd code currently fails to compile with musl.

This PR seeks to resolve compilation errors for musl so that it can be used with [buildroot-meshtastic](https://github.com/vidplace7/buildroot-meshtastic).

Including `#include <sys/types.h>` resolves issues caused by musl not including `uint` and `ulong` type definitions by default.

Cousin PR: https://github.com/meshtastic/framework-portduino/pull/36