### PR TITLE
Fix displays showing "GPS Not Present" until first lock

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -447,10 +447,12 @@ bool GPS::setup()
                     }
                 }
             }
-            return false;
+        }
 
+        if (gnssModel != GNSS_MODEL_UNKNOWN) {
+            setConnected();
         } else {
-            gnssModel = GNSS_MODEL_UNKNOWN;
+            return false;
         }
 
         if (gnssModel == GNSS_MODEL_MTK) {
@@ -1009,6 +1011,7 @@ int32_t GPS::runOnce()
             }
         }
         GPSInitFinished = true;
+        publishUpdate();
     }
 
     // Repeaters have no need for GPS


### PR DESCRIPTION
https://github.com/meshtastic/firmware/pull/5160 introduced a change which made first publication of GPS information take up to 15mins. For that initial period, displays would show "No GPS Present", even if one was detected.

This change fixes that bug, triggering publication immediately after a GPS module is detected.