### PR TITLE
LR1110 - remove old comment referring to non-existent function.

### DIFF
--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -161,11 +161,6 @@ template <typename T> bool LR11x0Interface<T>::reconfigure()
     if (err != RADIOLIB_ERR_NONE)
         RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
 
-    // Hmm - seems to lower SNR when the signal levels are high.  Leaving off for now...
-    // TODO: Confirm gain registers are okay now
-    // err = lora.setRxGain(true);
-    // assert(err == RADIOLIB_ERR_NONE);
-
     err = lora.setSyncWord(syncWord);
     assert(err == RADIOLIB_ERR_NONE);
 


### PR DESCRIPTION
It seems like there was no setrxgain function in RadioLib. Since we're unlikely to uncomment and enable this non-existent feature, remove this code.