### PR TITLE
Fix cppcheck HIGH error

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1160,6 +1160,7 @@ extern meshtastic_DeviceMetadata getDeviceMetadata()
     deviceMetadata.position_flags = config.position.position_flags;
     deviceMetadata.hw_model = HW_VENDOR;
     deviceMetadata.hasRemoteHardware = moduleConfig.remote_hardware.enabled;
+    deviceMetadata.excluded_modules = meshtastic_ExcludedModules_EXCLUDED_NONE;
 #if !(MESHTASTIC_EXCLUDE_PKI)
     deviceMetadata.hasPKC = true;
 #endif


### PR DESCRIPTION
https://github.com/meshtastic/firmware/pull/5247 introduced new protobufs, particularly the excluded_modules feature.

Immediately afterward, cppcheck started sounding klaxons about an unitialized variable. This patch simply sets excluded_modules to none as a temporary measure while the feature from protobuf is integrated into code.