### PR TITLE
Fix display of more Unicode symbols

### DIFF
--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -327,10 +327,15 @@ class Screen : public concurrency::OSThread
             SKIPREST = false;
             return (uint8_t)ch;
         }
+
+        case 0xC3: {
+            SKIPREST = false;
+            return (uint8_t)(ch | 0xC0);
+        }
         }
 
         // We want to strip out prefix chars for two-byte char formats
-        if (ch == 0xC2)
+        if (ch == 0xC2 || ch == 0xC3)
             return (uint8_t)0;
 
 #if defined(OLED_PL)


### PR DESCRIPTION
The PR adds handling of Unicode symbols with left byte 0xC3, exactly the same way as in #4610.
These symbols include umlauts (ä, ö, ü etc.) but also other characters used by languages written in the latin script. Most of these characters already exist in the default font. Characters that exist in the 0xC3 range, but have not been defined in the default font such as the euro sign (€), are still handled the same way as other unknown characters, showing up as ¿. OLED_PL, OLED_UA and OLED_RU have this fix already.
Changes have been tested with two LilyGo T-Beam Supremes.