### PR TITLE
Release no-LoRa packet after sending to phone

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -255,8 +255,13 @@ void MeshService::sendToMesh(meshtastic_MeshPacket *p, RxSource src, bool ccToPh
         LOG_DEBUG("Can't send status to phone");
     }
 
-    if (res == ERRNO_OK && ccToPhone) { // Check if p is not released in case it couldn't be sent
+    if ((res == ERRNO_OK || res == ERRNO_SHOULD_RELEASE) && ccToPhone) { // Check if p is not released in case it couldn't be sent
         sendToPhone(packetPool.allocCopy(*p));
+    }
+
+    // Router may ask us to release the packet if it wasn't sent
+    if (res == ERRNO_SHOULD_RELEASE) {
+        releaseToPool(p);
     }
 }
 

--- a/src/mesh/MeshTypes.h
+++ b/src/mesh/MeshTypes.h
@@ -16,6 +16,7 @@ typedef uint32_t PacketId; // A packet sequence number
 #define ERRNO_NO_INTERFACES 33
 #define ERRNO_UNKNOWN 32                   // pick something that doesn't conflict with RH_ROUTER_ERROR_UNABLE_TO_DELIVER
 #define ERRNO_DISABLED 34                  // the interface is disabled
+#define ERRNO_SHOULD_RELEASE 35            // no error, but the packet should still be released
 #define ID_COUNTER_MASK (UINT32_MAX >> 22) // mask to select the counter portion of the ID
 
 /*

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -186,6 +186,11 @@ ErrorCode RadioLibInterface::send(meshtastic_MeshPacket *p)
 
 #endif
 
+    if (p->to == NODENUM_BROADCAST_NO_LORA) {
+        LOG_DEBUG("Drop no-LoRa pkt");
+        return ERRNO_SHOULD_RELEASE;
+    }
+
     // Sometimes when testing it is useful to be able to never turn on the xmitter
 #ifndef LORA_DISABLE_SENDING
     printPacket("enqueuing for send", p);
@@ -276,10 +281,8 @@ void RadioLibInterface::onNotify(uint32_t notification)
                     // Send any outgoing packets we have ready
                     meshtastic_MeshPacket *txp = txQueue.dequeue();
                     assert(txp);
-                    bool isLoraTx = txp->to != NODENUM_BROADCAST_NO_LORA;
-                    startSend(txp);
-
-                    if (isLoraTx) {
+                    bool sent = startSend(txp);
+                    if (sent) {
                         // Packet has been sent, count it toward our TX airtime utilization.
                         uint32_t xmitMsec = getPacketTime(txp);
                         airTime->logAirtime(TX_LOG, xmitMsec);
@@ -465,15 +468,13 @@ void RadioLibInterface::setStandby()
 }
 
 /** start an immediate transmit */
-void RadioLibInterface::startSend(meshtastic_MeshPacket *txp)
+bool RadioLibInterface::startSend(meshtastic_MeshPacket *txp)
 {
     printPacket("Starting low level send", txp);
-    if (txp->to == NODENUM_BROADCAST_NO_LORA) {
-        LOG_DEBUG("Drop Tx packet because dest is broadcast no-lora");
-        packetPool.release(txp);
-    } else if (disabled || !config.lora.tx_enabled) {
+    if (disabled || !config.lora.tx_enabled) {
         LOG_WARN("Drop Tx packet because LoRa Tx disabled");
         packetPool.release(txp);
+        return false;
     } else {
         configHardwareForSend(); // must be after setStandby
 
@@ -493,5 +494,7 @@ void RadioLibInterface::startSend(meshtastic_MeshPacket *txp)
         // Must be done AFTER, starting transmit, because startTransmit clears (possibly stale) interrupt pending register
         // bits
         enableInterrupt(isrTxLevel0);
+
+        return res == RADIOLIB_ERR_NONE;
     }
 }

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -162,8 +162,9 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
 
     /** start an immediate transmit
      *  This method is virtual so subclasses can hook as needed, subclasses should not call directly
+     *  @return true if packet was sent
      */
-    virtual void startSend(meshtastic_MeshPacket *txp);
+    virtual bool startSend(meshtastic_MeshPacket *txp);
 
     meshtastic_QueueStatus getQueueStatus();
 


### PR DESCRIPTION
Try-fix for #5235. 

I can’t seem to reproduce the issue, but someone on Discord mentioned the same problem and at least this looks wrong to me. I’m not quite happy with it, but `sendToPhone()` should really be after `sendLocal()`, so this is the best I could come up with.
