### PR TITLE
Disable automatic NodeInfo request when NodeDB is full

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -86,9 +86,9 @@ int MeshService::handleFromRadio(const meshtastic_MeshPacket *mp)
         LOG_DEBUG("Received telemetry response. Skip sending our NodeInfo"); //  because this potentially a Repeater which will
                                                                              //  ignore our request for its NodeInfo
     } else if (mp->which_payload_variant == meshtastic_MeshPacket_decoded_tag && !nodeDB->getMeshNode(mp->from)->has_user &&
-               nodeInfoModule && !isPreferredRebroadcaster) {
+               nodeInfoModule && !isPreferredRebroadcaster && !nodeDB->isFull()) {
         if (airTime->isTxAllowedChannelUtil(true)) {
-            LOG_INFO("Heard new node on ch. %d, sending NodeInfo and asking for a response", mp->channel);
+            LOG_INFO("Heard new node on ch. %d, send NodeInfo and ask for response", mp->channel);
             nodeInfoModule->sendOurNodeInfo(mp->from, true, mp->channel);
         } else {
             LOG_DEBUG("Skip sending NodeInfo > 25%% ch. util");

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1206,13 +1206,19 @@ meshtastic_NodeInfoLite *NodeDB::getMeshNode(NodeNum n)
     return NULL;
 }
 
+// returns true if the maximum number of nodes is reached or we are running low on memory
+bool NodeDB::isFull()
+{
+    return (numMeshNodes >= MAX_NUM_NODES) || (memGet.getFreeHeap() < MINIMUM_SAFE_FREE_HEAP);
+}
+
 /// Find a node in our DB, create an empty NodeInfo if missing
 meshtastic_NodeInfoLite *NodeDB::getOrCreateMeshNode(NodeNum n)
 {
     meshtastic_NodeInfoLite *lite = getMeshNode(n);
 
     if (!lite) {
-        if ((numMeshNodes >= MAX_NUM_NODES) || (memGet.getFreeHeap() < MINIMUM_SAFE_FREE_HEAP)) {
+        if (isFull()) {
             if (screen)
                 screen->print("Warn: node database full!\nErasing oldest entry\n");
             LOG_WARN("Node database full with %i nodes and %i bytes free! Erasing oldest entry", numMeshNodes,

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -147,6 +147,9 @@ class NodeDB
     meshtastic_NodeInfoLite *getMeshNode(NodeNum n);
     size_t getNumMeshNodes() { return numMeshNodes; }
 
+    // returns true if the maximum number of nodes is reached or we are running low on memory
+    bool isFull();
+
     void clearLocalPosition();
 
     void setLocalPosition(meshtastic_Position position, bool timeOnly = false)


### PR DESCRIPTION
Closes #5238.

When the NodeDB is full, nodes are cycled out every time, so the automatic NodeInfo request might create unnecessary traffic.

Tested using Portduino with `MAX_NUM_NODES` set to 2.
