### PR TITLE
Smarter traffic scaling

### DIFF
--- a/src/mesh/Default.cpp
+++ b/src/mesh/Default.cpp
@@ -1,5 +1,6 @@
 #include "Default.h"
 #include "../userPrefs.h"
+#include "meshUtils.h"
 
 uint32_t Default::getConfiguredOrDefaultMs(uint32_t configuredInterval, uint32_t defaultInterval)
 {
@@ -38,6 +39,10 @@ uint32_t Default::getConfiguredOrDefaultMsScaled(uint32_t configured, uint32_t d
 {
     // If we are a router, we don't scale the value. It's already significantly higher.
     if (config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER)
+        return getConfiguredOrDefaultMs(configured, defaultValue);
+
+    // Additionally if we're a tracker or sensor, we want priority to send position and telemetry
+    if (IS_ONE_OF(config.device.role, meshtastic_Config_DeviceConfig_Role_SENSOR, meshtastic_Config_DeviceConfig_Role_TRACKER))
         return getConfiguredOrDefaultMs(configured, defaultValue);
 
     return getConfiguredOrDefaultMs(configured, defaultValue) * congestionScalingCoefficient(numOnlineNodes);


### PR DESCRIPTION
Closes #964 

This PR addresses a few issues with the current mesh size based intervalled traffic management:

1. Smaller networks (backpacking, small towns, etc) of <= 40 are encouraged to transmit more frequently.
2. Sensors and trackers don't get telemetry / position throttled because these are crucial data points for their respective roles.
3. The coefficient for throttling back the interval has more judicious values for the faster presets now, so it's less of a one size fits all poorly approach.