### PR TITLE
Only PKC encrypt when packet originates from us

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -489,8 +489,9 @@ meshtastic_Routing_Error perhapsEncode(meshtastic_MeshPacket *p)
         meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(p->to);
         // We may want to retool things so we can send a PKC packet when the client specifies a key and nodenum, even if the node
         // is not in the local nodedb
-        if (isFromUs(p) && // Only PKC encrypt packets we are originating
-                           // Don't use PKC with Ham mode
+        // First, only PKC encrypt packets we are originating
+        if (isFromUs(p) &&
+            // Don't use PKC with Ham mode
             !owner.is_licensed &&
             // Don't use PKC if it's not explicitly requested and a non-primary channel is requested
             !(p->pki_encrypted != true && p->channel > 0) &&

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -489,8 +489,8 @@ meshtastic_Routing_Error perhapsEncode(meshtastic_MeshPacket *p)
         meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(p->to);
         // We may want to retool things so we can send a PKC packet when the client specifies a key and nodenum, even if the node
         // is not in the local nodedb
-        if (
-            // Don't use PKC with Ham mode
+        if (isFromUs(p) && // Only PKC encrypt packets we are originating
+                           // Don't use PKC with Ham mode
             !owner.is_licensed &&
             // Don't use PKC if it's not explicitly requested and a non-primary channel is requested
             !(p->pki_encrypted != true && p->channel > 0) &&


### PR DESCRIPTION
This should fix the issue when a node using firmware <2.5 sends a direct message to a 2.5 node, and it hops through another 2.5 node. Currently, as reported on Discord, the intermediate 2.5 node would PKC encrypt it with its own public key when the DM was received on its primary channel, because it could decrypt it and then before rebroadcasting, this passes: 
https://github.com/meshtastic/firmware/blob/982190936dfe47b20a7147d4a6627a3ade7ac3c5/src/mesh/Router.cpp#L495-L496

Only when a packet originates from us, we should PKC encrypt.