### PR TITLE
Fix device flashing scripts so they work with esptool when it's installed via pipx

### DIFF
--- a/bin/device-install.bat
+++ b/bin/device-install.bat
@@ -2,13 +2,32 @@
 
 set PYTHON=python
 
+:: Determine the correct esptool command to use
+%PYTHON% -m esptool version >nul 2>&1
+if %ERRORLEVEL% EQU 0 (
+    set "ESPTOOL_CMD=%PYTHON% -m esptool"
+) else (
+    where esptool >nul 2>&1
+    if %ERRORLEVEL% EQU 0 (
+        set "ESPTOOL_CMD=esptool"
+    ) else (
+        where esptool.py >nul 2>&1
+        if %ERRORLEVEL% EQU 0 (
+            set "ESPTOOL_CMD=esptool.py"
+        ) else (
+            echo Error: esptool not found
+            exit /b 1
+        )
+    )
+)
+
 goto GETOPTS
 :HELP
 echo Usage: %~nx0 [-h] [-p ESPTOOL_PORT] [-P PYTHON] [-f FILENAME^|FILENAME]
 echo Flash image file to device, but first erasing and writing system information
 echo.
 echo     -h               Display this help and exit
-echo     -p ESPTOOL_PORT  Set the environment variable for ESPTOOL_PORT.  If not set, ESPTOOL iterates all ports (Dangerrous).
+echo     -p ESPTOOL_PORT  Set the environment variable for ESPTOOL_PORT.  If not set, ESPTOOL iterates all ports (Dangerous).
 echo     -P PYTHON        Specify alternate python interpreter to use to invoke esptool. (Default: %PYTHON%)
 echo     -f FILENAME      The .bin file to flash.  Custom to your device type and region.
 goto EOF
@@ -24,32 +43,32 @@ IF NOT "__%1__"=="____" goto GETOPTS
 
 IF "__%FILENAME%__" == "____" (
     echo "Missing FILENAME"
-	goto HELP
+    goto HELP
 )
 IF EXIST %FILENAME% IF x%FILENAME:update=%==x%FILENAME% (
     echo Trying to flash update %FILENAME%, but first erasing and writing system information"
-	%PYTHON% -m esptool --baud 115200 erase_flash
-	%PYTHON% -m esptool --baud 115200 write_flash 0x00 %FILENAME%
+    %ESPTOOL_CMD% --baud 115200 erase_flash
+    %ESPTOOL_CMD% --baud 115200 write_flash 0x00 %FILENAME%
     
     @REM Account for S3 and C3 board's different OTA partition
     IF x%FILENAME:s3=%==x%FILENAME% IF x%FILENAME:v3=%==x%FILENAME% IF x%FILENAME:t-deck=%==x%FILENAME% IF x%FILENAME:wireless-paper=%==x%FILENAME% IF x%FILENAME:wireless-tracker=%==x%FILENAME% IF x%FILENAME:station-g2=%==x%FILENAME% IF x%FILENAME:unphone=%==x%FILENAME% (
         IF x%FILENAME:esp32c3=%==x%FILENAME% (
-            %PYTHON% -m esptool --baud 115200 write_flash 0x260000 bleota.bin
+            %ESPTOOL_CMD% --baud 115200 write_flash 0x260000 bleota.bin
         ) else (
-            %PYTHON% -m esptool --baud 115200 write_flash 0x260000 bleota-c3.bin
+            %ESPTOOL_CMD% --baud 115200 write_flash 0x260000 bleota-c3.bin
         )
-	) else (
-        %PYTHON% -m esptool --baud 115200 write_flash 0x260000 bleota-s3.bin
+    ) else (
+        %ESPTOOL_CMD% --baud 115200 write_flash 0x260000 bleota-s3.bin
     )
     for %%f in (littlefs-*.bin) do (
-        %PYTHON% -m esptool --baud 115200 write_flash 0x300000 %%f
+        %ESPTOOL_CMD% --baud 115200 write_flash 0x300000 %%f
     )
 ) else (
     echo "Invalid file: %FILENAME%"
-	goto HELP
+    goto HELP
 ) else (
     echo "Invalid file: %FILENAME%"
-	goto HELP
+    goto HELP
 )
 
 :EOF

--- a/bin/device-install.bat
+++ b/bin/device-install.bat
@@ -3,22 +3,11 @@
 set PYTHON=python
 
 :: Determine the correct esptool command to use
-%PYTHON% -m esptool version >nul 2>&1
+where esptool >nul 2>&1
 if %ERRORLEVEL% EQU 0 (
-    set "ESPTOOL_CMD=%PYTHON% -m esptool"
+    set "ESPTOOL_CMD=esptool"
 ) else (
-    where esptool >nul 2>&1
-    if %ERRORLEVEL% EQU 0 (
-        set "ESPTOOL_CMD=esptool"
-    ) else (
-        where esptool.py >nul 2>&1
-        if %ERRORLEVEL% EQU 0 (
-            set "ESPTOOL_CMD=esptool.py"
-        ) else (
-            echo Error: esptool not found
-            exit /b 1
-        )
-    )
+    set "ESPTOOL_CMD=%PYTHON% -m esptool"
 )
 
 goto GETOPTS
@@ -27,7 +16,7 @@ echo Usage: %~nx0 [-h] [-p ESPTOOL_PORT] [-P PYTHON] [-f FILENAME^|FILENAME]
 echo Flash image file to device, but first erasing and writing system information
 echo.
 echo     -h               Display this help and exit
-echo     -p ESPTOOL_PORT  Set the environment variable for ESPTOOL_PORT.  If not set, ESPTOOL iterates all ports (Dangerous).
+echo     -p ESPTOOL_PORT  Set the environment variable for ESPTOOL_PORT.  If not set, ESPTOOL iterates all ports (Dangerrous).
 echo     -P PYTHON        Specify alternate python interpreter to use to invoke esptool. (Default: %PYTHON%)
 echo     -f FILENAME      The .bin file to flash.  Custom to your device type and region.
 goto EOF

--- a/bin/device-update.bat
+++ b/bin/device-update.bat
@@ -3,22 +3,11 @@
 set PYTHON=python
 
 :: Determine the correct esptool command to use
-%PYTHON% -m esptool version >nul 2>&1
+where esptool >nul 2>&1
 if %ERRORLEVEL% EQU 0 (
-    set "ESPTOOL_CMD=%PYTHON% -m esptool"
+    set "ESPTOOL_CMD=esptool"
 ) else (
-    where esptool >nul 2>&1
-    if %ERRORLEVEL% EQU 0 (
-        set "ESPTOOL_CMD=esptool"
-    ) else (
-        where esptool.py >nul 2>&1
-        if %ERRORLEVEL% EQU 0 (
-            set "ESPTOOL_CMD=esptool.py"
-        ) else (
-            echo Error: esptool not found
-            exit /b 1
-        )
-    )
+    set "ESPTOOL_CMD=%PYTHON% -m esptool"
 )
 
 goto GETOPTS
@@ -27,7 +16,7 @@ echo Usage: %~nx0 [-h] [-p ESPTOOL_PORT] [-P PYTHON] [-f FILENAME^|FILENAME]
 echo Flash image file to device, leave existing system intact.
 echo.
 echo     -h               Display this help and exit
-echo     -p ESPTOOL_PORT  Set the environment variable for ESPTOOL_PORT.  If not set, ESPTOOL iterates all ports (Dangerous).
+echo     -p ESPTOOL_PORT  Set the environment variable for ESPTOOL_PORT.  If not set, ESPTOOL iterates all ports (Dangerrous).
 echo     -P PYTHON        Specify alternate python interpreter to use to invoke esptool. (Default: %PYTHON%)
 echo     -f FILENAME      The *update.bin file to flash.  Custom to your device type.
 goto EOF

--- a/bin/device-update.bat
+++ b/bin/device-update.bat
@@ -2,13 +2,32 @@
 
 set PYTHON=python
 
+:: Determine the correct esptool command to use
+%PYTHON% -m esptool version >nul 2>&1
+if %ERRORLEVEL% EQU 0 (
+    set "ESPTOOL_CMD=%PYTHON% -m esptool"
+) else (
+    where esptool >nul 2>&1
+    if %ERRORLEVEL% EQU 0 (
+        set "ESPTOOL_CMD=esptool"
+    ) else (
+        where esptool.py >nul 2>&1
+        if %ERRORLEVEL% EQU 0 (
+            set "ESPTOOL_CMD=esptool.py"
+        ) else (
+            echo Error: esptool not found
+            exit /b 1
+        )
+    )
+)
+
 goto GETOPTS
 :HELP
 echo Usage: %~nx0 [-h] [-p ESPTOOL_PORT] [-P PYTHON] [-f FILENAME^|FILENAME]
 echo Flash image file to device, leave existing system intact.
 echo.
 echo     -h               Display this help and exit
-echo     -p ESPTOOL_PORT  Set the environment variable for ESPTOOL_PORT.  If not set, ESPTOOL iterates all ports (Dangerrous).
+echo     -p ESPTOOL_PORT  Set the environment variable for ESPTOOL_PORT.  If not set, ESPTOOL iterates all ports (Dangerous).
 echo     -P PYTHON        Specify alternate python interpreter to use to invoke esptool. (Default: %PYTHON%)
 echo     -f FILENAME      The *update.bin file to flash.  Custom to your device type.
 goto EOF
@@ -24,17 +43,17 @@ IF NOT "__%1__"=="____" goto GETOPTS
 
 IF "__%FILENAME%__" == "____" (
     echo "Missing FILENAME"
-	goto HELP
+    goto HELP
 )
 IF EXIST %FILENAME% IF NOT x%FILENAME:update=%==x%FILENAME% (
     echo Trying to flash update %FILENAME%
-    %PYTHON% -m esptool --baud 115200 write_flash 0x10000 %FILENAME%
+    %ESPTOOL_CMD% --baud 115200 write_flash 0x10000 %FILENAME%
 ) else (
     echo "Invalid file: %FILENAME%"
-	goto HELP
+    goto HELP
 ) else (
     echo "Invalid file: %FILENAME%"
-	goto HELP
+    goto HELP
 )
 
 :EOF

--- a/bin/device-update.sh
+++ b/bin/device-update.sh
@@ -2,6 +2,18 @@
 
 PYTHON=${PYTHON:-$(which python3 python|head -n 1)}
 
+# Determine the correct esptool command to use
+if "$PYTHON" -m esptool version >/dev/null 2>&1; then
+    ESPTOOL_CMD="$PYTHON -m esptool"
+elif command -v esptool >/dev/null 2>&1; then
+    ESPTOOL_CMD="esptool"
+elif command -v esptool.py >/dev/null 2>&1; then
+    ESPTOOL_CMD="esptool.py"
+else
+    echo "Error: esptool not found"
+    exit 1
+fi
+
 # Usage info
 show_help() {
 cat << EOF
@@ -9,7 +21,7 @@ Usage: $(basename $0) [-h] [-p ESPTOOL_PORT] [-P PYTHON] [-f FILENAME|FILENAME]
 Flash image file to device, leave existing system intact."
 
     -h               Display this help and exit
-    -p ESPTOOL_PORT  Set the environment variable for ESPTOOL_PORT.  If not set, ESPTOOL iterates all ports (Dangerrous).
+    -p ESPTOOL_PORT  Set the environment variable for ESPTOOL_PORT.  If not set, ESPTOOL iterates all ports (Dangerous).
     -P PYTHON        Specify alternate python interpreter to use to invoke esptool. (Default: "$PYTHON")
     -f FILENAME      The *update.bin file to flash.  Custom to your device type.
     
@@ -30,7 +42,7 @@ while getopts ":hp:P:f:" opt; do
         f)  FILENAME=${OPTARG}
             ;;
         *)
- 	    echo "Invalid flag."
+ 	        echo "Invalid flag."
             show_help >&2
             exit 1
             ;;
@@ -45,7 +57,7 @@ shift "$((OPTIND-1))"
 
 if [ -f "${FILENAME}" ] && [ -z "${FILENAME##*"update"*}" ]; then
 	printf "Trying to flash update ${FILENAME}"
-	$PYTHON -m esptool --baud 115200 write_flash 0x10000 ${FILENAME}
+	$ESPTOOL_CMD --baud 115200 write_flash 0x10000 ${FILENAME}
 else
 	show_help
 	echo "Invalid file: ${FILENAME}"


### PR DESCRIPTION
When installing esptool via `pipx install esptool` it doesn't work to use `python -m esptool`.  

In linux `esptool.py` is used and in Windows `esptool`.

This PR adds checks to first determine which command should be used, before executing the commands to flash the devices.