### PR TITLE
Fixed compile error when using GPS_DEBUG

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -794,7 +794,7 @@ void GPS::writePinEN(bool on)
     // Write and log
     enablePin->set(on);
 #ifdef GPS_DEBUG
-    LOG_DEBUG("Pin EN %s", val == HIGH ? "HI" : "LOW");
+    LOG_DEBUG("Pin EN %s", on == HIGH ? "HI" : "LOW");
 #endif
 }
 


### PR DESCRIPTION
Fixes compile error when using `#define GPS_DEBUG` in variant.h
