### PR TITLE
copy the has_relative_humidity value to full telem packet from AHTX0 packet

### DIFF
--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -376,12 +376,14 @@ bool EnvironmentTelemetryModule::getEnvironmentTelemetry(meshtastic_Telemetry *m
             LOG_INFO("AHTX0+BMP280 module detected: using temp from BMP280 and humy from AHTX0");
             aht10Sensor.getMetrics(&m_ahtx);
             m->variant.environment_metrics.relative_humidity = m_ahtx.variant.environment_metrics.relative_humidity;
+            m->variant.environment_metrics.has_relative_humidity = m_ahtx.variant.environment_metrics.has_relative_humidity;
         } else {
             // prefer bmp3xx temp if both sensors are present, fetch only humidity
             meshtastic_Telemetry m_ahtx = meshtastic_Telemetry_init_zero;
             LOG_INFO("AHTX0+BMP3XX module detected: using temp from BMP3XX and humy from AHTX0");
             aht10Sensor.getMetrics(&m_ahtx);
             m->variant.environment_metrics.relative_humidity = m_ahtx.variant.environment_metrics.relative_humidity;
+            m->variant.environment_metrics.has_relative_humidity = m_ahtx.variant.environment_metrics.has_relative_humidity;
         }
     }
     if (max17048Sensor.hasSensor()) {


### PR DESCRIPTION
This is for when AHTX0+BMP280 module detected: using temp from BMP280 and humy from AHTX0.  Humidity is pulled from AHTX0 and value is copied into the full telemetry packet but the has_relative_humidity flag was not copied over and so the humi value is skipped in protobuf encoding.

I copied the value from the AHTX0 packet instead of setting to true explicity. Don't think that matters though.

mentioned here https://github.com/meshtastic/firmware/issues/5139