### PR TITLE
Add setting to transmit NeighborInfo over LoRa

### DIFF
--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -19,7 +19,7 @@
 #define default_node_info_broadcast_secs 3 * 60 * 60
 #define default_neighbor_info_broadcast_secs 6 * 60 * 60
 #define min_node_info_broadcast_secs 60 * 60 // No regular broadcasts of more than once an hour
-#define min_neighbor_info_broadcast_secs 2 * 60 * 60
+#define min_neighbor_info_broadcast_secs 4 * 60 * 60
 
 #define default_mqtt_address "mqtt.meshtastic.org"
 #define default_mqtt_username "meshdev"

--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -121,7 +121,12 @@ Will be used for broadcast.
 */
 int32_t NeighborInfoModule::runOnce()
 {
-    sendNeighborInfo(NODENUM_BROADCAST_NO_LORA, false);
+    if (moduleConfig.neighbor_info.transmit_over_lora && !channels.isDefaultChannel(channels.getPrimaryIndex()) &&
+        airTime->isTxAllowedChannelUtil(true) && airTime->isTxAllowedAirUtil()) {
+        sendNeighborInfo(NODENUM_BROADCAST, false);
+    } else {
+        sendNeighborInfo(NODENUM_BROADCAST_NO_LORA, false);
+    }
     return Default::getConfiguredOrDefaultMs(moduleConfig.neighbor_info.update_interval, default_neighbor_info_broadcast_secs);
 }
 


### PR DESCRIPTION
As discussed in #5082 and https://github.com/meshtastic/protobufs/pull/618. 

When setting `neighbor_info.transmit_over_lora` to true (default to false), next to sending it to MQTT/PhoneAPI, it will also broadcast it over LoRa to be able to obtain it from remote nodes. This happens only when not using the default channel as primary, and the channel utilization allows it. 

Furthermore, the absolute minimum you can set the NeighborInfo broadcast interval to is bumped to 14400 (4 hours).