### PR TITLE
Fix non-primary channel usage for non-PKC packets

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -187,9 +187,10 @@ ErrorCode Router::sendLocal(meshtastic_MeshPacket *p, RxSource src)
             handleReceived(p, src);
         }
 
-        if (!p->channel && !p->pki_encrypted) { // don't override if a channel was requested
+        // don't override if a channel was requested and no need to set it when PKI is enforced
+        if (!p->channel && !p->pki_encrypted) {
             meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(p->to);
-            if (node && node->user.public_key.size == 0) {
+            if (node) {
                 p->channel = node->channel;
                 LOG_DEBUG("localSend to channel %d", p->channel);
             }


### PR DESCRIPTION
Even if we have the public key of a node, for some packets we use the legacy channels (e.g., traceroute, NodeInfo, Routing) and those should use the channel corresponding to a node. In `perhapsEncode()`, the channel will be set back to 0 when we do use PKC. Also this clause will still pass if the client explicitly requested PKC: 

https://github.com/meshtastic/firmware/blob/439c1dec08a29beaa4939458aeb75a9924a67c74/src/mesh/Router.cpp#L497 
