### PR TITLE
Remove scary warning about full NodeDB

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1219,9 +1219,7 @@ meshtastic_NodeInfoLite *NodeDB::getOrCreateMeshNode(NodeNum n)
 
     if (!lite) {
         if (isFull()) {
-            if (screen)
-                screen->print("Warn: node database full!\nErasing oldest entry\n");
-            LOG_WARN("Node database full with %i nodes and %i bytes free! Erasing oldest entry", numMeshNodes,
+            LOG_INFO("Node database full with %i nodes and %i bytes free. Erasing oldest entry", numMeshNodes,
                      memGet.getFreeHeap());
             // look for oldest node and erase it
             uint32_t oldest = UINT32_MAX;


### PR DESCRIPTION
NodeDB becoming full at 100 entries and cycling out old entries is normal behaviour. The user doesn't need to take any action and shouldn't be concerned when this happens.

Remove the warning from the screen and reduce loglevel to info.

Fixes https://github.com/meshtastic/firmware/issues/5282