### PR TITLE
Update dependency versions

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -39,128 +39,123 @@ default_envs = tbeam
 ;default_envs = heltec_vision_master_e213
 ;default_envs = heltec_vision_master_e290
 ;default_envs = heltec_mesh_node_t114
-
 extra_configs =
-  arch/*/*.ini
-  variants/*/platformio.ini
+	arch/*/*.ini
+	variants/*/platformio.ini
+description = Meshtastic
 
 [env]
 test_build_src = true
 extra_scripts = bin/platformio-custom.py
-
 ; note: we add src to our include search path so that lmic_project_config can override
 ; note: TINYGPS_OPTION_NO_CUSTOM_FIELDS is VERY important.  We don't use custom fields and somewhere in that pile
 ; of code is a heap corruption bug!
 ; FIXME: fix lib/BluetoothOTA dependency back on src/ so we can remove -Isrc
 ; The Radiolib stuff will speed up building considerably. Exclud all the stuff we dont need.
 build_flags = -Wno-missing-field-initializers
-  -Wno-format
-  -Isrc -Isrc/mesh -Isrc/mesh/generated -Isrc/gps -Isrc/buzz -Wl,-Map,.pio/build/output.map
-  -DUSE_THREAD_NAMES
-  -DTINYGPS_OPTION_NO_CUSTOM_FIELDS
-  -DPB_ENABLE_MALLOC=1
-  -DRADIOLIB_EXCLUDE_CC1101=1
-  -DRADIOLIB_EXCLUDE_NRF24=1
-  -DRADIOLIB_EXCLUDE_RF69=1
-  -DRADIOLIB_EXCLUDE_SX1231=1
-  -DRADIOLIB_EXCLUDE_SX1233=1
-  -DRADIOLIB_EXCLUDE_SI443X=1
-  -DRADIOLIB_EXCLUDE_RFM2X=1
-  -DRADIOLIB_EXCLUDE_AFSK=1
-  -DRADIOLIB_EXCLUDE_BELL=1
-  -DRADIOLIB_EXCLUDE_HELLSCHREIBER=1
-  -DRADIOLIB_EXCLUDE_MORSE=1
-  -DRADIOLIB_EXCLUDE_RTTY=1
-  -DRADIOLIB_EXCLUDE_SSTV=1
-  -DRADIOLIB_EXCLUDE_AX25=1
-  -DRADIOLIB_EXCLUDE_DIRECT_RECEIVE=1
-  -DRADIOLIB_EXCLUDE_BELL=1
-  -DRADIOLIB_EXCLUDE_PAGER=1
-  -DRADIOLIB_EXCLUDE_FSK4=1
-  -DRADIOLIB_EXCLUDE_APRS=1
-  -DRADIOLIB_EXCLUDE_LORAWAN=1
-  -DMESHTASTIC_EXCLUDE_DROPZONE=1
-  -DMESHTASTIC_EXCLUDE_REMOTEHARDWARE=1
-  #-DBUILD_EPOCH=$UNIX_TIME
-  ;-D OLED_PL
-
+	-Wno-format
+	-Isrc -Isrc/mesh -Isrc/mesh/generated -Isrc/gps -Isrc/buzz -Wl,-Map,.pio/build/output.map
+	-DUSE_THREAD_NAMES
+	-DTINYGPS_OPTION_NO_CUSTOM_FIELDS
+	-DPB_ENABLE_MALLOC=1
+	-DRADIOLIB_EXCLUDE_CC1101=1
+	-DRADIOLIB_EXCLUDE_NRF24=1
+	-DRADIOLIB_EXCLUDE_RF69=1
+	-DRADIOLIB_EXCLUDE_SX1231=1
+	-DRADIOLIB_EXCLUDE_SX1233=1
+	-DRADIOLIB_EXCLUDE_SI443X=1
+	-DRADIOLIB_EXCLUDE_RFM2X=1
+	-DRADIOLIB_EXCLUDE_AFSK=1
+	-DRADIOLIB_EXCLUDE_BELL=1
+	-DRADIOLIB_EXCLUDE_HELLSCHREIBER=1
+	-DRADIOLIB_EXCLUDE_MORSE=1
+	-DRADIOLIB_EXCLUDE_RTTY=1
+	-DRADIOLIB_EXCLUDE_SSTV=1
+	-DRADIOLIB_EXCLUDE_AX25=1
+	-DRADIOLIB_EXCLUDE_DIRECT_RECEIVE=1
+	-DRADIOLIB_EXCLUDE_BELL=1
+	-DRADIOLIB_EXCLUDE_PAGER=1
+	-DRADIOLIB_EXCLUDE_FSK4=1
+	-DRADIOLIB_EXCLUDE_APRS=1
+	-DRADIOLIB_EXCLUDE_LORAWAN=1
+	-DMESHTASTIC_EXCLUDE_DROPZONE=1
+	-DMESHTASTIC_EXCLUDE_REMOTEHARDWARE=1
+        #-DBUILD_EPOCH=$UNIX_TIME
+        ;-D OLED_PL
 monitor_speed = 115200
 monitor_filters = direct
-
 lib_deps =
-  jgromes/RadioLib@7.0.2
-  https://github.com/meshtastic/esp8266-oled-ssd1306.git#e16cee124fe26490cb14880c679321ad8ac89c95 ; ESP8266_SSD1306
-  mathertel/OneButton@2.6.1 ; OneButton library for non-blocking button debounce
-  https://github.com/meshtastic/arduino-fsm.git#7db3702bf0cfe97b783d6c72595e3f38e0b19159
-  https://github.com/meshtastic/TinyGPSPlus.git#71a82db35f3b973440044c476d4bcdc673b104f4
-  https://github.com/meshtastic/ArduinoThread.git#1ae8778c85d0a2a729f989e0b1e7d7c4dc84eef0
-  nanopb/Nanopb@0.4.9
-  erriez/ErriezCRC32@1.0.1
-  
+	jgromes/RadioLib@7.0.2
+	https://github.com/meshtastic/esp8266-oled-ssd1306.git#e16cee124fe26490cb14880c679321ad8ac89c95
+	mathertel/OneButton@2.6.1
+	https://github.com/meshtastic/arduino-fsm.git#7db3702bf0cfe97b783d6c72595e3f38e0b19159
+	https://github.com/meshtastic/TinyGPSPlus.git#71a82db35f3b973440044c476d4bcdc673b104f4
+	https://github.com/meshtastic/ArduinoThread.git#1ae8778c85d0a2a729f989e0b1e7d7c4dc84eef0
+	nanopb/Nanopb@0.4.9
+	erriez/ErriezCRC32@1.0.1
 ; Used for the code analysis in PIO Home / Inspect
 check_tool = cppcheck
 check_skip_packages = yes
 check_flags =
-  -DAPP_VERSION=1.0.0
-  --suppressions-list=suppressions.txt
-  --inline-suppr
+	-DAPP_VERSION=1.0.0
+	--suppressions-list=suppressions.txt
+	--inline-suppr
 
 ; Common settings for conventional (non Portduino) Arduino targets
 [arduino_base]
 framework = arduino
 lib_deps =
-  ${env.lib_deps}
-  end2endzone/NonBlockingRTTTL@1.3.0
-  https://github.com/meshtastic/SparkFun_ATECCX08a_Arduino_Library.git#5cf62b36c6f30bc72a07bdb2c11fc9a22d1e31da
-
+	${env.lib_deps}
+	end2endzone/NonBlockingRTTTL@1.3.0
+	https://github.com/meshtastic/SparkFun_ATECCX08a_Arduino_Library.git#5cf62b36c6f30bc72a07bdb2c11fc9a22d1e31da
 build_flags = ${env.build_flags} -Os
 build_src_filter = ${env.build_src_filter} -<platform/portduino/>
 
 ; Common libs for communicating over TCP/IP networks such as MQTT
 [networking_base]
 lib_deps =
-  knolleary/PubSubClient@2.8
-  arduino-libraries/NTPClient@3.1.0
-  arcao/Syslog@2.0.0
+	knolleary/PubSubClient@2.8
+	arduino-libraries/NTPClient@3.1.0
+	arcao/Syslog@2.0.0
 
 ; Common libs for environmental measurements in telemetry module
 ; (not included in native / portduino)
 [environmental_base]
 lib_deps =
-  adafruit/Adafruit BusIO@1.16.2
-  adafruit/Adafruit Unified Sensor@1.1.11
-  adafruit/Adafruit BMP280 Library@2.6.8
-  adafruit/Adafruit BMP085 Library@1.2.4
-  adafruit/Adafruit BME280 Library@2.2.2
-  adafruit/Adafruit BMP3XX Library@2.1.5
-  adafruit/Adafruit MCP9808 Library@2.0.0
-  adafruit/Adafruit INA260 Library@1.5.0
-  adafruit/Adafruit INA219@1.2.3
-  adafruit/Adafruit MAX1704X@1.0.3
-  adafruit/Adafruit SHTC3 Library@1.0.1
-  adafruit/Adafruit LPS2X@2.0.4
-  adafruit/Adafruit SHT31 Library@2.2.2
-  adafruit/Adafruit PM25 AQI Sensor@1.1.1
-  adafruit/Adafruit MPU6050@2.2.4
-  adafruit/Adafruit LIS3DH@1.3.0
-  adafruit/Adafruit AHTX0@2.0.5
-  adafruit/Adafruit LSM6DS@4.7.2
-  adafruit/Adafruit VEML7700 Library@2.1.6
-  adafruit/Adafruit SHT4x Library@1.0.4
-  adafruit/Adafruit TSL2591 Library@1.4.5
-  sparkfun/SparkFun Qwiic Scale NAU7802 Arduino Library@1.0.6
-  sparkfun/SparkFun 9DoF IMU Breakout - ICM 20948 - Arduino Library@1.2.13
-  ClosedCube OPT3001@1.1.2
-  emotibit/EmotiBit MLX90632@1.0.8
-  dfrobot/DFRobot_RTU@1.0.3
-  sparkfun/SparkFun MAX3010x Pulse and Proximity Sensor Library@1.1.2
-  adafruit/Adafruit MLX90614 Library@2.1.5
+	adafruit/Adafruit BusIO@1.16.2
+	adafruit/Adafruit Unified Sensor@1.1.14
+	adafruit/Adafruit BMP280 Library@2.6.8
+	adafruit/Adafruit BMP085 Library@1.2.4
+	adafruit/Adafruit BME280 Library@2.2.4
+	adafruit/Adafruit BMP3XX Library@2.1.5
+	adafruit/Adafruit MCP9808 Library@2.0.2
+	adafruit/Adafruit INA260 Library@1.5.2
+	adafruit/Adafruit INA219@1.2.3
+	adafruit/Adafruit MAX1704X@1.0.3
+	adafruit/Adafruit SHTC3 Library@1.0.1
+	adafruit/Adafruit LPS2X@2.0.6
+	adafruit/Adafruit SHT31 Library@2.2.2
+	adafruit/Adafruit PM25 AQI Sensor@1.1.1
+	adafruit/Adafruit MPU6050@2.2.6
+	adafruit/Adafruit LIS3DH@1.3.0
+	adafruit/Adafruit AHTX0@2.0.5
+	adafruit/Adafruit LSM6DS@4.7.3
+	adafruit/Adafruit VEML7700 Library@2.1.6
+	adafruit/Adafruit SHT4x Library@1.0.5
+	adafruit/Adafruit TSL2591 Library@1.4.5
+	sparkfun/SparkFun Qwiic Scale NAU7802 Arduino Library@1.0.6
+	sparkfun/SparkFun 9DoF IMU Breakout - ICM 20948 - Arduino Library@1.2.13
+	ClosedCube OPT3001@1.1.2
+	emotibit/EmotiBit MLX90632@1.0.8
+	dfrobot/DFRobot_RTU@1.0.3
+	sparkfun/SparkFun MAX3010x Pulse and Proximity Sensor Library@1.1.2
+	adafruit/Adafruit MLX90614 Library@2.1.5
 
-  https://github.com/boschsensortec/Bosch-BSEC2-Library#v1.7.2502
-  boschsensortec/BME68x Sensor Library@1.1.40407
-  https://github.com/KodinLanewave/INA3221@1.0.1
-  lewisxhe/SensorLib@0.2.0
-  mprograms/QMC5883LCompass@1.2.0
-  
-  https://github.com/meshtastic/DFRobot_LarkWeatherStation#4de3a9cadef0f6a5220a8a906cf9775b02b0040d
-  https://github.com/gjelsoe/STK8xxx-Accelerometer.git#v0.1.1
+	https://github.com/boschsensortec/Bosch-BSEC2-Library#v1.7.2502
+	boschsensortec/BME68x Sensor Library@1.1.40407
+	https://github.com/KodinLanewave/INA3221@1.0.1
+	lewisxhe/SensorLib@0.2.0
+	mprograms/QMC5883LCompass@1.2.3
+
+	https://github.com/meshtastic/DFRobot_LarkWeatherStation#4de3a9cadef0f6a5220a8a906cf9775b02b0040d
+	https://github.com/gjelsoe/STK8xxx-Accelerometer.git#v0.1.1


### PR DESCRIPTION
Using platformio pkg outdated, discover that some versions are not up-to-date. Update all apart from RadioLib (existing pull) and SensorLib (doesn't compile).

Also, trunk had an attempt at formatting platformio.ini

```
Package                   Current    Wanted     Latest     Type     Environments
------------------------  ---------  ---------  ---------  -------  --------------------------
Adafruit BME280 Library   2.2.2      2.2.2      2.2.4      Library  tracker-t1000-e
Adafruit INA260 Library   1.5.0      1.5.0      1.5.2      Library  tracker-t1000-e
Adafruit LPS2X            2.0.4      2.0.4      2.0.6      Library  tracker-t1000-e
Adafruit LSM6DS           4.7.2      4.7.2      4.7.3      Library  tracker-t1000-e
Adafruit MCP9808 Library  2.0.0      2.0.0      2.0.2      Library  tracker-t1000-e
Adafruit MPU6050          2.2.4      2.2.4      2.2.6      Library  tracker-t1000-e
Adafruit SHT4x Library    1.0.4      1.0.4      1.0.5      Library  tracker-t1000-e
Adafruit Unified Sensor   1.1.11     1.1.11     1.1.14     Library  tracker-t1000-e
BME68x Sensor library     1.1.40407  1.1.40407  1.2.40408  Library  tracker-t1000-e
QMC5883LCompass           1.2.0      1.2.0      1.2.3      Library  tracker-t1000-e
RadioLib                  7.0.2      7.0.2      7.1.0      Library  wio-sdk-wm1110
SensorLib                 0.2.0      0.2.0      0.2.2      Library  tbeam
```