### PR TITLE
Don't send to public channel

### DIFF
--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -58,7 +58,7 @@ int32_t DetectionSensorModule::runOnce()
     // moduleConfig.detection_sensor.minimum_broadcast_secs = 30;
     // moduleConfig.detection_sensor.state_broadcast_secs = 120;
     // moduleConfig.detection_sensor.detection_trigger_type =
-    //          meshtastic_ModuleConfig_DetectionSensorConfig_TriggerType_LOGIC_HIGH;
+    // meshtastic_ModuleConfig_DetectionSensorConfig_TriggerType_LOGIC_HIGH;
     // strcpy(moduleConfig.detection_sensor.name, "Motion");
 
     if (moduleConfig.detection_sensor.enabled == false)
@@ -122,6 +122,7 @@ void DetectionSensorModule::sendDetectionMessage()
     char *message = new char[40];
     sprintf(message, "%s detected", moduleConfig.detection_sensor.name);
     meshtastic_MeshPacket *p = allocDataPacket();
+    p->to = nodeDB->getNodeNum(); //set destination to self or it would go to 0xffffffff
     p->want_ack = false;
     p->decoded.payload.size = strlen(message);
     memcpy(p->decoded.payload.bytes, message, p->decoded.payload.size);
@@ -140,8 +141,8 @@ void DetectionSensorModule::sendCurrentStateMessage(bool state)
 {
     char *message = new char[40];
     sprintf(message, "%s state: %i", moduleConfig.detection_sensor.name, state);
-
     meshtastic_MeshPacket *p = allocDataPacket();
+    p->to = nodeDB->getNodeNum(); //set destination to self or it would go to 0xffffffff
     p->want_ack = false;
     p->decoded.payload.size = strlen(message);
     memcpy(p->decoded.payload.bytes, message, p->decoded.payload.size);

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -131,9 +131,12 @@ void DetectionSensorModule::sendDetectionMessage()
         p->decoded.payload.bytes[p->decoded.payload.size + 1] = '\0'; // Bell character
         p->decoded.payload.size++;
     }
-    LOG_INFO("Send message id=%d, dest=%x, msg=%.*s", p->id, p->to, p->decoded.payload.size, p->decoded.payload.bytes);
     lastSentToMesh = millis();
-    service->sendToMesh(p);
+    if (!channels.isDefaultChannel(0)) {
+        LOG_INFO("Send message id=%d, dest=%x, msg=%.*s", p->id, p->to, p->decoded.payload.size, p->decoded.payload.bytes);
+        service->sendToMesh(p);
+    } else
+        LOG_ERROR("Message not allow on Public channel");
     delete[] message;
 }
 
@@ -146,9 +149,12 @@ void DetectionSensorModule::sendCurrentStateMessage(bool state)
     p->want_ack = false;
     p->decoded.payload.size = strlen(message);
     memcpy(p->decoded.payload.bytes, message, p->decoded.payload.size);
-    LOG_INFO("Send message id=%d, dest=%x, msg=%.*s", p->id, p->to, p->decoded.payload.size, p->decoded.payload.bytes);
     lastSentToMesh = millis();
-    service->sendToMesh(p);
+    if (!channels.isDefaultChannel(0)) {
+        LOG_INFO("Send message id=%d, dest=%x, msg=%.*s", p->id, p->to, p->decoded.payload.size, p->decoded.payload.bytes);
+        service->sendToMesh(p);
+    } else
+        LOG_ERROR("Message not allow on Public channel");
     delete[] message;
 }
 

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -122,7 +122,6 @@ void DetectionSensorModule::sendDetectionMessage()
     char *message = new char[40];
     sprintf(message, "%s detected", moduleConfig.detection_sensor.name);
     meshtastic_MeshPacket *p = allocDataPacket();
-    p->to = nodeDB->getNodeNum();    // set destination to self or it would go to 0xffffffff
     p->want_ack = false;
     p->decoded.payload.size = strlen(message);
     memcpy(p->decoded.payload.bytes, message, p->decoded.payload.size);
@@ -145,7 +144,6 @@ void DetectionSensorModule::sendCurrentStateMessage(bool state)
     char *message = new char[40];
     sprintf(message, "%s state: %i", moduleConfig.detection_sensor.name, state);
     meshtastic_MeshPacket *p = allocDataPacket();
-    p->to = nodeDB->getNodeNum();    // set destination to self or it would go to 0xffffffff
     p->want_ack = false;
     p->decoded.payload.size = strlen(message);
     memcpy(p->decoded.payload.bytes, message, p->decoded.payload.size);

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -122,7 +122,7 @@ void DetectionSensorModule::sendDetectionMessage()
     char *message = new char[40];
     sprintf(message, "%s detected", moduleConfig.detection_sensor.name);
     meshtastic_MeshPacket *p = allocDataPacket();
-    p->to = nodeDB->getNodeNum(); //set destination to self or it would go to 0xffffffff
+    p->to = nodeDB->getNodeNum();    // set destination to self or it would go to 0xffffffff
     p->want_ack = false;
     p->decoded.payload.size = strlen(message);
     memcpy(p->decoded.payload.bytes, message, p->decoded.payload.size);
@@ -142,7 +142,7 @@ void DetectionSensorModule::sendCurrentStateMessage(bool state)
     char *message = new char[40];
     sprintf(message, "%s state: %i", moduleConfig.detection_sensor.name, state);
     meshtastic_MeshPacket *p = allocDataPacket();
-    p->to = nodeDB->getNodeNum(); //set destination to self or it would go to 0xffffffff
+    p->to = nodeDB->getNodeNum();    // set destination to self or it would go to 0xffffffff
     p->want_ack = false;
     p->decoded.payload.size = strlen(message);
     memcpy(p->decoded.payload.bytes, message, p->decoded.payload.size);


### PR DESCRIPTION
`p->to` wasn't set and had the same value as broadcast, it's now set to our own NodeNum.

