### PR TITLE
Add back some details to the PhoneAPI logs

### DIFF
--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -218,62 +218,70 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
     }
 
     case STATE_SEND_METADATA:
-        LOG_DEBUG("Send Metadata");
+        LOG_DEBUG("Send device metadata");
         fromRadioScratch.which_payload_variant = meshtastic_FromRadio_metadata_tag;
         fromRadioScratch.metadata = getDeviceMetadata();
         state = STATE_SEND_CHANNELS;
         break;
 
     case STATE_SEND_CHANNELS:
-        LOG_DEBUG("Send Channels");
         fromRadioScratch.which_payload_variant = meshtastic_FromRadio_channel_tag;
         fromRadioScratch.channel = channels.getByIndex(config_state);
         config_state++;
         // Advance when we have sent all of our Channels
         if (config_state >= MAX_NUM_CHANNELS) {
+            LOG_DEBUG("Send channels %d", config_state);
             state = STATE_SEND_CONFIG;
             config_state = _meshtastic_AdminMessage_ConfigType_MIN + 1;
         }
         break;
 
     case STATE_SEND_CONFIG:
-        LOG_DEBUG("Send Radio config");
         fromRadioScratch.which_payload_variant = meshtastic_FromRadio_config_tag;
         switch (config_state) {
         case meshtastic_Config_device_tag:
+            LOG_DEBUG("Send config: device");
             fromRadioScratch.config.which_payload_variant = meshtastic_Config_device_tag;
             fromRadioScratch.config.payload_variant.device = config.device;
             break;
         case meshtastic_Config_position_tag:
+            LOG_DEBUG("Send config: position");
             fromRadioScratch.config.which_payload_variant = meshtastic_Config_position_tag;
             fromRadioScratch.config.payload_variant.position = config.position;
             break;
         case meshtastic_Config_power_tag:
+            LOG_DEBUG("Send config: power");
             fromRadioScratch.config.which_payload_variant = meshtastic_Config_power_tag;
             fromRadioScratch.config.payload_variant.power = config.power;
             fromRadioScratch.config.payload_variant.power.ls_secs = default_ls_secs;
             break;
         case meshtastic_Config_network_tag:
+            LOG_DEBUG("Send config: network");
             fromRadioScratch.config.which_payload_variant = meshtastic_Config_network_tag;
             fromRadioScratch.config.payload_variant.network = config.network;
             break;
         case meshtastic_Config_display_tag:
+            LOG_DEBUG("Send config: display");
             fromRadioScratch.config.which_payload_variant = meshtastic_Config_display_tag;
             fromRadioScratch.config.payload_variant.display = config.display;
             break;
         case meshtastic_Config_lora_tag:
+            LOG_DEBUG("Send config: lora");
             fromRadioScratch.config.which_payload_variant = meshtastic_Config_lora_tag;
             fromRadioScratch.config.payload_variant.lora = config.lora;
             break;
         case meshtastic_Config_bluetooth_tag:
+            LOG_DEBUG("Send config: bluetooth");
             fromRadioScratch.config.which_payload_variant = meshtastic_Config_bluetooth_tag;
             fromRadioScratch.config.payload_variant.bluetooth = config.bluetooth;
             break;
         case meshtastic_Config_security_tag:
+            LOG_DEBUG("Send config: security");
             fromRadioScratch.config.which_payload_variant = meshtastic_Config_security_tag;
             fromRadioScratch.config.payload_variant.security = config.security;
             break;
         case meshtastic_Config_sessionkey_tag:
+            LOG_DEBUG("Send config: sessionkey");
             fromRadioScratch.config.which_payload_variant = meshtastic_Config_sessionkey_tag;
             break;
         default:
@@ -292,58 +300,70 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
         break;
 
     case STATE_SEND_MODULECONFIG:
-        LOG_DEBUG("Send Module Config");
         fromRadioScratch.which_payload_variant = meshtastic_FromRadio_moduleConfig_tag;
         switch (config_state) {
         case meshtastic_ModuleConfig_mqtt_tag:
+            LOG_DEBUG("Send module config: mqtt");
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_mqtt_tag;
             fromRadioScratch.moduleConfig.payload_variant.mqtt = moduleConfig.mqtt;
             break;
         case meshtastic_ModuleConfig_serial_tag:
+            LOG_DEBUG("Send module config: serial");
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_serial_tag;
             fromRadioScratch.moduleConfig.payload_variant.serial = moduleConfig.serial;
             break;
         case meshtastic_ModuleConfig_external_notification_tag:
+            LOG_DEBUG("Send module config: ext notification");
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_external_notification_tag;
             fromRadioScratch.moduleConfig.payload_variant.external_notification = moduleConfig.external_notification;
             break;
         case meshtastic_ModuleConfig_store_forward_tag:
+            LOG_DEBUG("Send module config: store forward");
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_store_forward_tag;
             fromRadioScratch.moduleConfig.payload_variant.store_forward = moduleConfig.store_forward;
             break;
         case meshtastic_ModuleConfig_range_test_tag:
+            LOG_DEBUG("Send module config: range test");
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_range_test_tag;
             fromRadioScratch.moduleConfig.payload_variant.range_test = moduleConfig.range_test;
             break;
         case meshtastic_ModuleConfig_telemetry_tag:
+            LOG_DEBUG("Send module config: telemetry");
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_telemetry_tag;
             fromRadioScratch.moduleConfig.payload_variant.telemetry = moduleConfig.telemetry;
             break;
         case meshtastic_ModuleConfig_canned_message_tag:
+            LOG_DEBUG("Send module config: canned message");
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_canned_message_tag;
             fromRadioScratch.moduleConfig.payload_variant.canned_message = moduleConfig.canned_message;
             break;
         case meshtastic_ModuleConfig_audio_tag:
+            LOG_DEBUG("Send module config: audio");
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_audio_tag;
             fromRadioScratch.moduleConfig.payload_variant.audio = moduleConfig.audio;
             break;
         case meshtastic_ModuleConfig_remote_hardware_tag:
+            LOG_DEBUG("Send module config: remote hardware");
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_remote_hardware_tag;
             fromRadioScratch.moduleConfig.payload_variant.remote_hardware = moduleConfig.remote_hardware;
             break;
         case meshtastic_ModuleConfig_neighbor_info_tag:
+            LOG_DEBUG("Send module config: neighbor info");
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_neighbor_info_tag;
             fromRadioScratch.moduleConfig.payload_variant.neighbor_info = moduleConfig.neighbor_info;
             break;
         case meshtastic_ModuleConfig_detection_sensor_tag:
+            LOG_DEBUG("Send module config: detection sensor");
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_detection_sensor_tag;
             fromRadioScratch.moduleConfig.payload_variant.detection_sensor = moduleConfig.detection_sensor;
             break;
         case meshtastic_ModuleConfig_ambient_lighting_tag:
+            LOG_DEBUG("Send module config: ambient lighting");
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_ambient_lighting_tag;
             fromRadioScratch.moduleConfig.payload_variant.ambient_lighting = moduleConfig.ambient_lighting;
             break;
         case meshtastic_ModuleConfig_paxcounter_tag:
+            LOG_DEBUG("Send module config: paxcounter");
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_paxcounter_tag;
             fromRadioScratch.moduleConfig.payload_variant.paxcounter = moduleConfig.paxcounter;
             break;
@@ -443,7 +463,7 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
         return numbytes;
     }
 
-    LOG_DEBUG("no FromRadio packet available");
+    LOG_DEBUG("No FromRadio packet available");
     return 0;
 }
 


### PR DESCRIPTION
In my zealotry to cull superfluous information from the log strings, I took things too far with the PhoneAPI. This should bring back some clarity.