### PR TITLE
Coerce minimum neighborinfo interval on startup

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -231,6 +231,9 @@ NodeDB::NodeDB()
         moduleConfig.telemetry.health_update_interval = Default::getConfiguredOrMinimumValue(
             moduleConfig.telemetry.health_update_interval, min_default_telemetry_interval_secs);
     }
+    // Ensure that the neighbor info update interval is coerced to the minimum
+    moduleConfig.neighbor_info.update_interval =
+        Default::getConfiguredOrMinimumValue(moduleConfig.neighbor_info.update_interval, min_neighbor_info_broadcast_secs);
 
     if (devicestateCRC != crc32Buffer(&devicestate, sizeof(devicestate)))
         saveWhat |= SEGMENT_DEVICESTATE;


### PR DESCRIPTION
This should ensure any problematically frequent legacy values don't bite us. 