### PR TITLE
Update variant.h for T-Echo RGB Matrix LED

### DIFF
--- a/variants/t-echo/variant.h
+++ b/variants/t-echo/variant.h
@@ -43,17 +43,18 @@ extern "C" {
 #define NUM_ANALOG_OUTPUTS (0)
 
 // LEDs
-#define PIN_LED1 (0 + 14) // 13 red (confirmed on 1.0 board)
-// Unused(by firmware) LEDs:
-#define PIN_LED2 (0 + 15) // 14 blue
-#define PIN_LED3 (0 + 13) // 15 green
+// After Reviev of vendors scematic (wrong labeling in my version!) and RGB Module FM-B2020RGBA-HG Datasheet and Checking with my sample of T-Echo from 11/2024
+#define PIN_LED1 (32 + 3) // P1.03 red (confirmed on 11/2024 board)
+#define PIN_LED2 (32 + 1) // P1.01 green (confirmed on 11/2024 board)
+#define PIN_LED3 (0 + 14) // P0.14 blue (confirmed on 11/2024 board)
 
-#define LED_RED PIN_LED3
-#define LED_BLUE PIN_LED1
+#define LED_RED PIN_LED1
 #define LED_GREEN PIN_LED2
+#define LED_BLUE PIN_LED3
+
 
 #define LED_BUILTIN LED_BLUE
-#define LED_CONN PIN_GREEN
+#define LED_CONN LED_GREEN
 
 #define LED_STATE_ON 0 // State when LED is lit
 


### PR DESCRIPTION
Changed/Corrected mapping of (left) RGB Matrix LED.

Confirmed by reviewing the vendors sceamtic ( My version 2021/6/23 has wrong labeling for colors ) and checking the datasheet of the Matrix LED FM-B2020RGBA-HG mentioned in the scematic.

Tryed it out with my sample of T-Echo delivered 11/2024 seeing Pin 0.14 ( 0 +14) blinked blue with the "old" code and trying green led with External Messaging module succsessfully on Pin P1.01 (32 + 1)
