### PR TITLE
Fix another heap leak

### DIFF
--- a/src/mesh/ReliableRouter.cpp
+++ b/src/mesh/ReliableRouter.cpp
@@ -176,9 +176,9 @@ bool ReliableRouter::stopRetransmission(GlobalPacketId key)
         if (old->numRetransmissions < NUM_RETRANSMISSIONS - 1) {
             // remove the 'original' (identified by originator and packet->id) from the txqueue and free it
             cancelSending(getFrom(p), p->id);
-            // now free the pooled copy for retransmission too
-            packetPool.release(p);
         }
+        // now free the pooled copy for retransmission too
+        packetPool.release(p);
         auto numErased = pending.erase(key);
         assert(numErased == 1);
         return true;


### PR DESCRIPTION
Should at least partially fix #5316 and/or #5317.

`p` is a copy that is in the `pending` list, not the copy that is in the TxQueue, so it should be freed always when stopping a retransmission.
