### PR TITLE
Read voltage during init fixes #5276

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -271,7 +271,7 @@ class AnalogBatteryLevel : public HasBatteryLevel
             config.power.adc_multiplier_override > 0 ? config.power.adc_multiplier_override : ADC_MULTIPLIER;
         // Do not call analogRead() often.
         const uint32_t min_read_interval = 5000;
-        if (!Throttle::isWithinTimespanMs(last_read_time_ms, min_read_interval)) {
+        if (!initial_read_done || !Throttle::isWithinTimespanMs(last_read_time_ms, min_read_interval)) {
             last_read_time_ms = millis();
 
             uint32_t raw = 0;


### PR DESCRIPTION
Power::readPowerStatus is called on startup,
but AnalogBatteryLevel::getBattVoltage
skips the read because 5 seconds have not
elapsed since last_read_time_ms, which
is initialized to zero.

`batMv=3100` is reported because
AnalogBatteryLevel::last_read_value is
initialized as:
```
float last_read_value = (OCV[NUM_OCV_POINTS - 1] * NUM_CELLS);
```
