### PR TITLE
Revert "Decrease max nodes for NRF52 to 80 as workaround to prevent FS blowouts"

### DIFF
--- a/src/mesh/mesh-pb-constants.h
+++ b/src/mesh/mesh-pb-constants.h
@@ -20,11 +20,7 @@
 
 /// max number of nodes allowed in the mesh
 #ifndef MAX_NUM_NODES
-#ifdef ARCH_NRF52
-#define MAX_NUM_NODES 80
-#else
 #define MAX_NUM_NODES 100
-#endif
 #endif
 
 /// Max number of channels allowed


### PR DESCRIPTION
Reverting this guy because it did not play nice for my node which had 92 nodes in the db