### PR TITLE
Migrate NRF52 devices max nodes down to 80 for now to prevent file system blowouts

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -794,7 +794,7 @@ void NodeDB::loadFromDisk()
     // disk we will still factoryReset to restore things.
 
     // static DeviceState scratch; We no longer read into a tempbuf because this structure is 15KB of valuable RAM
-    auto state = loadProto(prefFileName, sizeof(meshtastic_DeviceState) + MAX_NUM_NODES * sizeof(meshtastic_NodeInfo),
+    auto state = loadProto(prefFileName, sizeof(meshtastic_DeviceState) + MAX_NUM_NODES_FS * sizeof(meshtastic_NodeInfo),
                            sizeof(meshtastic_DeviceState), &meshtastic_DeviceState_msg, &devicestate);
 
     // See https://github.com/meshtastic/firmware/issues/4184#issuecomment-2269390786
@@ -812,6 +812,10 @@ void NodeDB::loadFromDisk()
         LOG_INFO("Loaded saved devicestate version %d, with nodecount: %d", devicestate.version, devicestate.node_db_lite.size());
         meshNodes = &devicestate.node_db_lite;
         numMeshNodes = devicestate.node_db_lite.size();
+    }
+    if (numMeshNodes > MAX_NUM_NODES) {
+        LOG_WARN("Node count %d exceeds MAX_NUM_NODES %d, truncating", numMeshNodes, MAX_NUM_NODES);
+        numMeshNodes = MAX_NUM_NODES;
     }
     meshNodes->resize(MAX_NUM_NODES);
 

--- a/src/mesh/mesh-pb-constants.h
+++ b/src/mesh/mesh-pb-constants.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <vector>
 
+#include "architecture.h"
 #include "mesh/generated/meshtastic/admin.pb.h"
 #include "mesh/generated/meshtastic/deviceonly.pb.h"
 #include "mesh/generated/meshtastic/localonly.pb.h"
@@ -20,8 +21,14 @@
 
 /// max number of nodes allowed in the mesh
 #ifndef MAX_NUM_NODES
+#ifdef ARCH_NRF52
+#define MAX_NUM_NODES 80
+#else
 #define MAX_NUM_NODES 100
 #endif
+#endif
+
+#define MAX_NUM_NODES_FS 100
 
 /// Max number of channels allowed
 #define MAX_NUM_CHANNELS (member_size(meshtastic_ChannelFile, channels) / member_size(meshtastic_ChannelFile, channels[0]))


### PR DESCRIPTION
This method seems to behave better with migrating to a smaller nodedb size