### PR TITLE
RP2040: Update core; add mDNS support

### DIFF
--- a/arch/rp2xx0/rp2040.ini
+++ b/arch/rp2xx0/rp2040.ini
@@ -2,7 +2,7 @@
 [rp2040_base]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git#a606be683748c73e9a0d46baf70163478d298f0f ; For arduino-pico 4.2.0
 extends = arduino_base
-platform_packages = framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#f5c4136b941e87d679b82f15227319df63b1575c ; 4.2.0+ with SimpleMDNS
+platform_packages = framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#5a428647d4cf842fc38208e8e58365e98301151e ; 4.2.0+ with SimpleMDNS
 
 board_build.core = earlephilhower
 board_build.filesystem_size = 0.5m

--- a/arch/rp2xx0/rp2040.ini
+++ b/arch/rp2xx0/rp2040.ini
@@ -2,7 +2,7 @@
 [rp2040_base]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git#a606be683748c73e9a0d46baf70163478d298f0f ; For arduino-pico 4.2.0
 extends = arduino_base
-platform_packages = framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#5a428647d4cf842fc38208e8e58365e98301151e ; 4.2.0+ with SimpleMDNS
+platform_packages = framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#4.2.1
 
 board_build.core = earlephilhower
 board_build.filesystem_size = 0.5m

--- a/arch/rp2xx0/rp2040.ini
+++ b/arch/rp2xx0/rp2040.ini
@@ -1,8 +1,8 @@
 ; Common settings for rp2040 Processor based targets
 [rp2040_base]
-platform = https://github.com/maxgerhardt/platform-raspberrypi.git#v1.2.0-gcc12
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git#a606be683748c73e9a0d46baf70163478d298f0f ; For arduino-pico 4.2.0
 extends = arduino_base
-platform_packages = framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#4.0.3
+platform_packages = framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#f5c4136b941e87d679b82f15227319df63b1575c ; 4.2.0+ with SimpleMDNS
 
 board_build.core = earlephilhower
 board_build.filesystem_size = 0.5m

--- a/arch/rp2xx0/rp2350.ini
+++ b/arch/rp2xx0/rp2350.ini
@@ -2,7 +2,7 @@
 [rp2350_base]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git#a606be683748c73e9a0d46baf70163478d298f0f ; For arduino-pico 4.2.0
 extends = arduino_base
-platform_packages = framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#5a428647d4cf842fc38208e8e58365e98301151e ; 4.2.0+ with SimpleMDNS
+platform_packages = framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#4.2.1
 
 board_build.core = earlephilhower
 board_build.filesystem_size = 0.5m

--- a/arch/rp2xx0/rp2350.ini
+++ b/arch/rp2xx0/rp2350.ini
@@ -1,8 +1,8 @@
 ; Common settings for rp2040 Processor based targets
 [rp2350_base]
-platform = https://github.com/maxgerhardt/platform-raspberrypi.git#9e55f6db5c56b9867c69fe473f388beea4546672
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git#a606be683748c73e9a0d46baf70163478d298f0f ; For arduino-pico 4.2.0
 extends = arduino_base
-platform_packages = framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#a6ab6e1f95bc1428d667d55ea7173c0744acc03c ; 4.0.2+
+platform_packages = framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#f5c4136b941e87d679b82f15227319df63b1575c ; 4.2.0+ with SimpleMDNS
 
 board_build.core = earlephilhower
 board_build.filesystem_size = 0.5m

--- a/arch/rp2xx0/rp2350.ini
+++ b/arch/rp2xx0/rp2350.ini
@@ -2,7 +2,7 @@
 [rp2350_base]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git#a606be683748c73e9a0d46baf70163478d298f0f ; For arduino-pico 4.2.0
 extends = arduino_base
-platform_packages = framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#f5c4136b941e87d679b82f15227319df63b1575c ; 4.2.0+ with SimpleMDNS
+platform_packages = framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#5a428647d4cf842fc38208e8e58365e98301151e ; 4.2.0+ with SimpleMDNS
 
 board_build.core = earlephilhower
 board_build.filesystem_size = 0.5m

--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -20,7 +20,7 @@
 #include <ESPmDNS.h>
 #include <esp_wifi.h>
 static void WiFiEvent(WiFiEvent_t event);
-#else // ARCH_RP2040
+#elif defined(ARCH_RP2040)
 #include <SimpleMDNS.h>
 #endif
 
@@ -69,7 +69,7 @@ static void onNetworkConnected()
 #ifdef ARCH_ESP32
             MDNS.addService("http", "tcp", 80);
             MDNS.addService("https", "tcp", 443);
-#else
+#elif defined(ARCH_RP2040)
             // ARCH_RP2040 does not support HTTPS, create a "meshtastic" service
             MDNS.addService("meshtastic", "tcp", 4403);
             // ESP32 handles this in WiFiEvent
@@ -133,7 +133,7 @@ static int32_t reconnectWiFi()
         // Make sure we clear old connection credentials
 #ifdef ARCH_ESP32
         WiFi.disconnect(false, true);
-#else
+#elif defined(ARCH_RP2040)
         WiFi.disconnect(false);
 #endif
         LOG_INFO("Reconnecting to WiFi access point %s", wifiName);
@@ -197,7 +197,7 @@ void deinitWifi()
     if (isWifiAvailable()) {
 #ifdef ARCH_ESP32
         WiFi.disconnect(true, false);
-#else
+#elif defined(ARCH_RP2040)
         WiFi.disconnect(true);
 #endif
         WiFi.mode(WIFI_OFF);
@@ -233,15 +233,15 @@ bool initWifi()
 
             if (config.network.address_mode == meshtastic_Config_NetworkConfig_AddressMode_STATIC &&
                 config.network.ipv4_config.ip != 0) {
-#ifndef ARCH_RP2040
+#ifdef ARCH_ESP32
                 WiFi.config(config.network.ipv4_config.ip, config.network.ipv4_config.gateway, config.network.ipv4_config.subnet,
                             config.network.ipv4_config.dns);
-#else
+#elif defined(ARCH_RP2040)
                 WiFi.config(config.network.ipv4_config.ip, config.network.ipv4_config.dns, config.network.ipv4_config.gateway,
                             config.network.ipv4_config.subnet);
 #endif
             }
-#ifndef ARCH_RP2040
+#ifdef ARCH_ESP32
             WiFi.onEvent(WiFiEvent);
             WiFi.setAutoReconnect(true);
             WiFi.setSleep(false);

--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -20,6 +20,8 @@
 #include <ESPmDNS.h>
 #include <esp_wifi.h>
 static void WiFiEvent(WiFiEvent_t event);
+#else // ARCH_RP2040
+#include <SimpleMDNS.h>
 #endif
 
 #ifndef DISABLE_NTP
@@ -59,17 +61,19 @@ static void onNetworkConnected()
         // Start web server
         LOG_INFO("Start WiFi network services");
 
+// start mdns
 #ifdef ARCH_ESP32
-        // start mdns
         if (!MDNS.begin("Meshtastic")) {
             LOG_ERROR("Error setting up MDNS responder!");
         } else {
-            LOG_INFO("mDNS responder started");
             LOG_INFO("mDNS Host: Meshtastic.local");
             MDNS.addService("http", "tcp", 80);
             MDNS.addService("https", "tcp", 443);
         }
-#else // ESP32 handles this in WiFiEvent
+#else
+        MDNS.begin("Meshtastic");
+        // ARCH_RP2040 does not support HTTPS
+        MDNS.addService("meshtastic", "tcp", 4403);
         LOG_INFO("Obtained IP address: %s", WiFi.localIP().toString().c_str());
 #endif
 
@@ -106,7 +110,7 @@ static void onNetworkConnected()
         APStartupComplete = true;
     }
 
-    // FIXME this is kinda yucky, instead we should just have an observable for 'wifireconnected'
+// FIXME this is kinda yucky, instead we should just have an observable for 'wifireconnected'
 #ifndef MESHTASTIC_EXCLUDE_MQTT
     if (mqtt)
         mqtt->reconnect();

--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -61,21 +61,21 @@ static void onNetworkConnected()
         // Start web server
         LOG_INFO("Start WiFi network services");
 
-// start mdns
-#ifdef ARCH_ESP32
+        // start mdns
         if (!MDNS.begin("Meshtastic")) {
             LOG_ERROR("Error setting up MDNS responder!");
         } else {
             LOG_INFO("mDNS Host: Meshtastic.local");
+#ifdef ARCH_ESP32
             MDNS.addService("http", "tcp", 80);
             MDNS.addService("https", "tcp", 443);
-        }
 #else
-        MDNS.begin("Meshtastic");
-        // ARCH_RP2040 does not support HTTPS
-        MDNS.addService("meshtastic", "tcp", 4403);
-        LOG_INFO("Obtained IP address: %s", WiFi.localIP().toString().c_str());
+            // ARCH_RP2040 does not support HTTPS, create a "meshtastic" service
+            MDNS.addService("meshtastic", "tcp", 4403);
+            // ESP32 handles this in WiFiEvent
+            LOG_INFO("Obtained IP address: %s", WiFi.localIP().toString().c_str());
 #endif
+        }
 
 #ifndef DISABLE_NTP
         LOG_INFO("Start NTP time client");
@@ -110,7 +110,7 @@ static void onNetworkConnected()
         APStartupComplete = true;
     }
 
-// FIXME this is kinda yucky, instead we should just have an observable for 'wifireconnected'
+    // FIXME this is kinda yucky, instead we should just have an observable for 'wifireconnected'
 #ifndef MESHTASTIC_EXCLUDE_MQTT
     if (mqtt)
         mqtt->reconnect();

--- a/variants/rak11310/platformio.ini
+++ b/variants/rak11310/platformio.ini
@@ -13,5 +13,5 @@ build_flags = ${rp2040_base.build_flags}
   -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m0plus"
 lib_deps =
   ${rp2040_base.lib_deps}
-debug_build_flags = ${rp2040_base.build_flags}
+debug_build_flags = ${rp2040_base.build_flags}, -g
 debug_tool = cmsis-dap ; for e.g. Picotool

--- a/variants/rak11310/platformio.ini
+++ b/variants/rak11310/platformio.ini
@@ -3,6 +3,7 @@ extends = rp2040_base
 board = wiscore_rak11300
 upload_protocol = picotool
 # keep an old SDK to use less memory.
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git#v1.2.0-gcc12
 platform_packages = framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#3.7.2
 
 # add our variants files to the include and src paths

--- a/variants/rp2040-lora/platformio.ini
+++ b/variants/rp2040-lora/platformio.ini
@@ -12,5 +12,5 @@ build_flags = ${rp2040_base.build_flags}
   -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m0plus"
 lib_deps =
   ${rp2040_base.lib_deps}
-debug_build_flags = ${rp2040_base.build_flags}
+debug_build_flags = ${rp2040_base.build_flags}, -g
 debug_tool = cmsis-dap ; for e.g. Picotool

--- a/variants/rpipico/platformio.ini
+++ b/variants/rpipico/platformio.ini
@@ -12,5 +12,5 @@ build_flags = ${rp2040_base.build_flags}
   -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m0plus"
 lib_deps =
   ${rp2040_base.lib_deps}
-debug_build_flags = ${rp2040_base.build_flags}
+debug_build_flags = ${rp2040_base.build_flags}, -g
 debug_tool = cmsis-dap ; for e.g. Picotool

--- a/variants/rpipico2/platformio.ini
+++ b/variants/rpipico2/platformio.ini
@@ -12,5 +12,5 @@ build_flags = ${rp2350_base.build_flags}
   -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m0plus"
 lib_deps =
   ${rp2350_base.lib_deps}
-debug_build_flags = ${rp2350_base.build_flags}
+debug_build_flags = ${rp2350_base.build_flags}, -g
 debug_tool = cmsis-dap ; for e.g. Picotool

--- a/variants/rpipicow/platformio.ini
+++ b/variants/rpipicow/platformio.ini
@@ -14,5 +14,5 @@ build_src_filter = ${rp2040_base.build_src_filter} +<mesh/wifi/>
 lib_deps =
   ${rp2040_base.lib_deps}
   ${networking_base.lib_deps}
-debug_build_flags = ${rp2040_base.build_flags}
+debug_build_flags = ${rp2040_base.build_flags}, -g
 debug_tool = cmsis-dap ; for e.g. Picotool


### PR DESCRIPTION
Updated the core, hopefully to fix potential FreeRTOS issues. 
It also includes a new `SimpleMDNS` library that does work with FreeRTOS. Added a "meshtastic" service as there is no HTTP/HTTPS service, which the Android app now also looks for: https://github.com/meshtastic/Meshtastic-Android/pull/1401. Tested this and it indeed finds the IP address now.

Lastly, added the `-g` option to link the source files for debugging.
