### PR TITLE
Add sudo to apt-get commands for Raspbian Build

### DIFF
--- a/.github/workflows/build_raspbian.yml
+++ b/.github/workflows/build_raspbian.yml
@@ -13,8 +13,8 @@ jobs:
       - name: Install libbluetooth
         shell: bash
         run: |
-          apt-get update -y --fix-missing
-          apt-get install -y libbluetooth-dev libgpiod-dev libyaml-cpp-dev openssl libssl-dev libulfius-dev liborcania-dev
+          sudo apt-get update -y --fix-missing
+          sudp apt-get install -y libbluetooth-dev libgpiod-dev libyaml-cpp-dev openssl libssl-dev libulfius-dev liborcania-dev
 
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Without sudo, inadequate permissions to runs the commands meant the build was failing.