### PR TITLE
Minimize time between channel scan and actual transmit

### DIFF
--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -601,8 +601,6 @@ size_t RadioInterface::beginSending(meshtastic_MeshPacket *p)
     // LOG_DEBUG("Send queued packet on mesh (txGood=%d,rxGood=%d,rxBad=%d)", rf95.txGood(), rf95.rxGood(), rf95.rxBad());
     assert(p->which_payload_variant == meshtastic_MeshPacket_encrypted_tag); // It should have already been encoded by now
 
-    lastTxStart = millis();
-
     radioBuffer.header.from = p->from;
     radioBuffer.header.to = p->to;
     radioBuffer.header.id = p->id;


### PR DESCRIPTION
We should really try to minimize the time between the Channel Activity Detection procedure (`scanChannel()`) and the actual transmit (`startTransmit()`) to minimize the chance someone else is starting a packet during this time. I therefore moved a call to `millis()` and a debug print to after `startTransmit()`, and added a note about trying to keep this time as short as possible.