### PR TITLE
Introducing Meshtastic Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CLA assistant](https://cla-assistant.io/readme/badge/meshtastic/firmware)](https://cla-assistant.io/meshtastic/firmware)
 [![Fiscal Contributors](https://opencollective.com/meshtastic/tiers/badge.svg?label=Fiscal%20Contributors&color=deeppink)](https://opencollective.com/meshtastic/)
 [![Vercel](https://img.shields.io/static/v1?label=Powered%20by&message=Vercel&style=flat&logo=vercel&color=000000)](https://vercel.com?utm_source=meshtastic&utm_campaign=oss)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Meshtastic%20Guru-006BFF)](https://gurubase.io/g/meshtastic)
 
 ## Overview
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Meshtastic Guru](https://gurubase.io/g/meshtastic) to Gurubase. Meshtastic Guru uses the data from this repo and data from the [docs](https://meshtastic.org/docs/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Meshtastic Guru", which highlights that Meshtastic now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Meshtastic Guru in Gurubase, just let me know that's totally fine.
