### PR TITLE
add GPS in indicator board

### DIFF
--- a/variants/seeed-sensecap-indicator/variant.h
+++ b/variants/seeed-sensecap-indicator/variant.h
@@ -36,12 +36,13 @@
 #define TOUCH_I2C_PORT 0
 #define TOUCH_SLAVE_ADDRESS 0x48
 
-// Buzzer
-#define PIN_BUZZER 19
+// in future, we may want to add a buzzer and add all sensors to the indicator via a data protocol for now only GPS is supported
+// // Buzzer
+// #define PIN_BUZZER 19
 
-#define HAS_GPS 0
-#undef GPS_RX_PIN
-#undef GPS_TX_PIN
+#define GPS_RX_PIN 20
+#define GPS_TX_PIN 19
+#define HAS_GPS 1
 
 #define USE_SX1262
 #define USE_SX1268


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c21b69ac-77bf-4acb-9fbe-c105531b2861)

Based on the current hardware form of the indicator, GPS data needs to be collected through the RP2040 serial port and then forwarded to ESP32 (the core running meshtastic). We have set the serial port as a serial port connected by two chips and temporarily use serial port transparent transmission to support GPS data. The GPS uses Air530Z,Add another layer of suitable data protocol in the subsequent upgrade to enable RP2040 to support more sensors.  The firmware running on RP2040 can refer to the example code provided by this repository.
https://github.com/Dylanliacc/Serial-Protocol-of-RP2040-on-Indiactor-for-meshtastic .
https://wiki.seeedstudio.com/Grove-GPS-Air530/#features