### PR TITLE
Update build-native.sh

### DIFF
--- a/bin/build-native.sh
+++ b/bin/build-native.sh
@@ -28,4 +28,3 @@ platformio pkg update --environment native || platformioFailed
 pio run --environment native || platformioFailed
 cp .pio/build/native/program "$OUTDIR/meshtasticd_linux_$(uname -m)"
 cp bin/native-install.* $OUTDIR
-cp bin/native-run.* $OUTDIR

--- a/bin/build-native.sh
+++ b/bin/build-native.sh
@@ -27,5 +27,5 @@ rm -r $OUTDIR/* || true
 platformio pkg update --environment native || platformioFailed
 pio run --environment native || platformioFailed
 cp .pio/build/native/program "$OUTDIR/meshtasticd_linux_$(uname -m)"
-cp bin/device-install.* $OUTDIR
-cp bin/device-update.* $OUTDIR
+cp bin/native-install.* $OUTDIR
+cp bin/native-run.* $OUTDIR


### PR DESCRIPTION
Device-install.sh and device-update.sh are not used on Linux native platform, skip copying to release directory after build and copy native-install.sh and native-run.sh instead.


