### PR TITLE
Temporarily disable MDNS when MQTT is enabled on RP2040

### DIFF
--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -62,7 +62,11 @@ static void onNetworkConnected()
         LOG_INFO("Start WiFi network services");
 
         // start mdns
-        if (!MDNS.begin("Meshtastic")) {
+        if (
+#ifdef ARCH_RP2040
+            !moduleConfig.mqtt.enabled && // MDNS is not supported when MQTT is enabled on ARCH_RP2040
+#endif
+            !MDNS.begin("Meshtastic")) {
             LOG_ERROR("Error setting up MDNS responder!");
         } else {
             LOG_INFO("mDNS Host: Meshtastic.local");


### PR DESCRIPTION
It leads to a panic (see call stack below), which I don't see an easy fix for.

```
_exit@0x100b555c (~/.platformio/packages/framework-arduinopico/cores/rp2040/sdkoverride/newlib_interface.c:45)
panic@0x10056d0e (/panic.dbgasm:16)
sys_timeout_abs@0x1006425c (Unknown Source:190)
sys_timeout@0x100642ec (/sys_timeout.dbgasm:16)
mdns_probe_and_announce@0x1006851c (Unknown Source:2348)
sys_check_timeouts@0x10064404 (/sys_check_timeouts.dbgasm:28)
__wrap_sys_check_timeouts@0x10055ca4 (~/.platformio/packages/framework-arduinopico/cores/rp2040/lwip_wrap.cpp:318)
lwip_timeout_reached@0x1006763e (Unknown Source:25)
async_context_base_execute_once@0x1006a69e (/async_context_base_execute_once.dbgasm:18)
process_under_lock@0x1006a27c (Unknown Source:251)
low_priority_irq_handler@0x1006a3de (Unknown Source:293)
<signal handler called>@0xfffffffd (Unknown Source:0)
vApplicationIdleHook@0x10052986 (~/.platformio/packages/framework-arduinopico/libraries/FreeRTOS/src/variantHooks.cpp:273)
prvIdleTask@0x10051cda (~/.platformio/packages/framework-arduinopico/libraries/FreeRTOS/lib/FreeRTOS-Kernel/tasks.c:5819)
vPortStartFirstTask@0x10052bc8 (~/.platformio/packages/framework-arduinopico/libraries/FreeRTOS/lib/FreeRTOS-Kernel/portable/ThirdParty/GCC/RP2040/port.c:242)
```