### PR TITLE
Fix memory leaks by adding missing `free()` calls before early returns in `MQTT::onReceive`

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -167,17 +167,26 @@ void MQTT::onReceive(char *topic, byte *payload, size_t length)
                     if (isFromUs(p)) {
                         LOG_INFO("Ignore downlink message we originally sent");
                         packetPool.release(p);
+                        free(e.channel_id);
+                        free(e.gateway_id);
+                        free(e.packet);
                         return;
                     }
                     if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
                         if (moduleConfig.mqtt.encryption_enabled) {
                             LOG_INFO("Ignore decoded message on MQTT, encryption is enabled");
                             packetPool.release(p);
+                            free(e.channel_id);
+                            free(e.gateway_id);
+                            free(e.packet);
                             return;
                         }
                         if (p->decoded.portnum == meshtastic_PortNum_ADMIN_APP) {
                             LOG_INFO("Ignore decoded admin packet");
                             packetPool.release(p);
+                            free(e.channel_id);
+                            free(e.gateway_id);
+                            free(e.packet);
                             return;
                         }
                         p->channel = ch.index;


### PR DESCRIPTION
This fix addresses memory leaks in the `MQTT::onReceive` function by ensuring that dynamically allocated resources (`e.channel_id`, `e.gateway_id` and `e.packet`) are properly freed before each early return. Previously, these resources were only freed at the end of the function, leaving them unhandled in certain exit paths. Adding the missing `free()` calls prevents memory leaks and ensures proper resource cleanup in all scenarios.

Fixes #5387