### PR TITLE
Don't powersave on Wifi

### DIFF
--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -383,7 +383,7 @@ void PowerFSM_setup()
     // See: https://github.com/meshtastic/firmware/issues/1071
     // Don't add power saving transitions if we are a power saving tracker or sensor or have Wifi enabled. Sleep will be initiated through the
     // modules
-    if ((isRouter || config.power.is_power_saving && !isWifiAvailable()) && !isTrackerOrSensor) {
+    if ((isRouter || config.power.is_power_saving) && !isWifiAvailable() && !isTrackerOrSensor) {
         powerFSM.add_timed_transition(&stateNB, &stateLS,
                                       Default::getConfiguredOrDefaultMs(config.power.min_wake_secs, default_min_wake_secs), NULL,
                                       "Min wake timeout");

--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -19,6 +19,10 @@
 #include "sleep.h"
 #include "target_specific.h"
 
+#if HAS_WIFI && !defined(ARCH_PORTDUINO)
+#include "mesh/wifi/WiFiAPClient.h"
+#endif
+
 #ifndef SLEEP_TIME
 #define SLEEP_TIME 30
 #endif
@@ -377,9 +381,9 @@ void PowerFSM_setup()
 // We never enter light-sleep or NB states on NRF52 (because the CPU uses so little power normally)
 #ifdef ARCH_ESP32
     // See: https://github.com/meshtastic/firmware/issues/1071
-    // Don't add power saving transitions if we are a power saving tracker or sensor. Sleep will be initiated through the
+    // Don't add power saving transitions if we are a power saving tracker or sensor or have Wifi enabled. Sleep will be initiated through the
     // modules
-    if ((isRouter || config.power.is_power_saving) && !isTrackerOrSensor) {
+    if ((isRouter || config.power.is_power_saving && !isWifiAvailable()) && !isTrackerOrSensor) {
         powerFSM.add_timed_transition(&stateNB, &stateLS,
                                       Default::getConfiguredOrDefaultMs(config.power.min_wake_secs, default_min_wake_secs), NULL,
                                       "Min wake timeout");


### PR DESCRIPTION
Powersaving sleep transition is already cancelled when bluetooth is connected. This change rectifies the behavior with Wifi. Sleep transitions will be completely removed if Wifi is enabled.

Closes #5440