### PR TITLE
Fixes CORS for meshtasticd to allow use of clients on other origins

### DIFF
--- a/src/mesh/raspihttp/PiWebServer.cpp
+++ b/src/mesh/raspihttp/PiWebServer.cpp
@@ -232,9 +232,9 @@ int handleAPIv1ToRadio(const struct _u_request *req, struct _u_response *res, vo
     ulfius_add_header_to_response(res, "X-Protobuf-Schema",
                                   "https://raw.githubusercontent.com/meshtastic/protobufs/master/meshtastic/mesh.proto");
 
-    if (req->http_verb == "OPTIONS") {
+    if (strcmp(req->http_verb, "OPTIONS") == 0) {
         ulfius_set_response_properties(res, U_OPT_STATUS, 204);
-        return U_CALLBACK_CONTINUE;
+        return U_CALLBACK_COMPLETE;
     }
 
     byte buffer[MAX_TO_FROM_RADIO_SIZE];
@@ -268,6 +268,11 @@ int handleAPIv1FromRadio(const struct _u_request *req, struct _u_response *res, 
     ulfius_add_header_to_response(res, "Access-Control-Allow-Methods", "GET");
     ulfius_add_header_to_response(res, "X-Protobuf-Schema",
                                   "https://raw.githubusercontent.com/meshtastic/protobufs/master/meshtastic/mesh.proto");
+
+    if (strcmp(req->http_verb, "OPTIONS") == 0) {
+        ulfius_set_response_properties(res, U_OPT_STATUS, 204);
+        return U_CALLBACK_COMPLETE;
+    }
 
     uint8_t txBuf[MAX_STREAM_BUF_SIZE];
     uint32_t len = 1;
@@ -493,7 +498,9 @@ PiWebServerThread::PiWebServerThread()
         // Maximum body size sent by the client is 1 Kb
         instanceWeb.max_post_body_size = 1024;
         ulfius_add_endpoint_by_val(&instanceWeb, "GET", PREFIX, "/api/v1/fromradio/*", 1, &handleAPIv1FromRadio, NULL);
+        ulfius_add_endpoint_by_val(&instanceWeb, "OPTIONS", PREFIX, "/api/v1/fromradio/*", 1, &handleAPIv1FromRadio, NULL);
         ulfius_add_endpoint_by_val(&instanceWeb, "PUT", PREFIX, "/api/v1/toradio/*", 1, &handleAPIv1ToRadio, configWeb.rootPath);
+        ulfius_add_endpoint_by_val(&instanceWeb, "OPTIONS", PREFIX, "/api/v1/toradio/*", 1, &handleAPIv1ToRadio, NULL);
 
         // Add callback function to all endpoints for the Web Server
         ulfius_add_endpoint_by_val(&instanceWeb, "GET", NULL, "/*", 2, &callback_static_file, &configWeb);


### PR DESCRIPTION
I am receiving `404 Not Found` when clients using `@meshtastic/js` in a web browser make an `OPTIONS` request to `/api/v1/toradio` and `/api/v1/fromradio` on a `meshtasticd` node when using a custom client on another origin.

This results in not being able to communicate with the node.

#5386 fixed this when connecting to the built in ESP32 server over WiFi, this PR fixes the same thing but for the `meshtasticd` server as well :)

It seems there was already checks for the options requests, but they wouldn't ever be hit since only `GET` and `POST` handlers were registered.

I also changed the `http_verb` comparison to use `strcmp` as the `==` check never passed.

<img width="498" alt="Screenshot 2024-11-27 at 4 31 38 PM" src="https://github.com/user-attachments/assets/bbff7936-d6a4-4b86-a6ed-b50bd7e5c660">
