### PR TITLE
CLIENT_HIDDDEN should never broadcast NeighborInfo

### DIFF
--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -121,6 +121,9 @@ Will be used for broadcast.
 */
 int32_t NeighborInfoModule::runOnce()
 {
+    if (config.device.role == meshtastic_Config_DeviceConfig_Role_CLIENT_HIDDEN) {
+        return UINT_MAX;
+    }
     if (moduleConfig.neighbor_info.transmit_over_lora && !channels.isDefaultChannel(channels.getPrimaryIndex()) &&
         airTime->isTxAllowedChannelUtil(true) && airTime->isTxAllowedAirUtil()) {
         sendNeighborInfo(NODENUM_BROADCAST, false);


### PR DESCRIPTION
We set the broadcast interval to UINT_MAX in the NodeDB setup. Howwever, in theory there would be a case where a HIDDEN node could reveal itself through this module.

This change means it will never send, and will always wait UINT_MAX before trying again if called.
