### PR TITLE
SimRadio: clean-up and emulate collisions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,7 +83,7 @@ NRF52Bluetooth *nrf52Bluetooth = nullptr;
 #include "STM32WLE5JCInterface.h"
 #endif
 
-#if !HAS_RADIO && defined(ARCH_PORTDUINO)
+#if defined(ARCH_PORTDUINO)
 #include "platform/portduino/SimRadio.h"
 #endif
 
@@ -897,7 +897,7 @@ void setup()
     }
 #endif
 
-#if !HAS_RADIO && defined(ARCH_PORTDUINO)
+#if defined(ARCH_PORTDUINO)
     if (!rIf) {
         rIf = new SimRadio;
         if (!rIf->init()) {

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -166,27 +166,10 @@ NodeNum MeshService::getNodenumFromRequestId(uint32_t request_id)
  */
 void MeshService::handleToRadio(meshtastic_MeshPacket &p)
 {
-#if defined(ARCH_PORTDUINO) && !HAS_RADIO
-    // Simulates device received a packet via the LoRa chip
-    if (p.decoded.portnum == meshtastic_PortNum_SIMULATOR_APP) {
-        // Simulator packet (=Compressed packet) is encapsulated in a MeshPacket, so need to unwrap first
-        meshtastic_Compressed scratch;
-        meshtastic_Compressed *decoded = NULL;
-        if (p.which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
-            memset(&scratch, 0, sizeof(scratch));
-            p.decoded.payload.size =
-                pb_decode_from_bytes(p.decoded.payload.bytes, p.decoded.payload.size, &meshtastic_Compressed_msg, &scratch);
-            if (p.decoded.payload.size) {
-                decoded = &scratch;
-                // Extract the original payload and replace
-                memcpy(&p.decoded.payload, &decoded->data, sizeof(decoded->data));
-                // Switch the port from PortNum_SIMULATOR_APP back to the original PortNum
-                p.decoded.portnum = decoded->portnum;
-            } else
-                LOG_ERROR("Error decoding proto for simulator message!");
-        }
-        // Let SimRadio receive as if it did via its LoRa chip
-        SimRadio::instance->startReceive(&p);
+#if defined(ARCH_PORTDUINO)
+    if (SimRadio::instance && p.decoded.portnum == meshtastic_PortNum_SIMULATOR_APP) {
+        // Simulates device received a packet via the LoRa chip
+        SimRadio::instance->unPackAndReceive(p);
         return;
     }
 #endif

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -169,7 +169,7 @@ void MeshService::handleToRadio(meshtastic_MeshPacket &p)
 #if defined(ARCH_PORTDUINO)
     if (SimRadio::instance && p.decoded.portnum == meshtastic_PortNum_SIMULATOR_APP) {
         // Simulates device received a packet via the LoRa chip
-        SimRadio::instance->unPackAndReceive(p);
+        SimRadio::instance->unpackAndReceive(p);
         return;
     }
 #endif

--- a/src/mesh/MeshService.h
+++ b/src/mesh/MeshService.h
@@ -10,7 +10,7 @@
 #include "MeshTypes.h"
 #include "Observer.h"
 #include "PointerQueue.h"
-#if defined(ARCH_PORTDUINO) && !HAS_RADIO
+#if defined(ARCH_PORTDUINO)
 #include "../platform/portduino/SimRadio.h"
 #endif
 #if defined(ARCH_ESP32) || defined(ARCH_PORTDUINO)

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -613,13 +613,14 @@ bool PhoneAPI::handleToRadioPacket(meshtastic_MeshPacket &p)
 {
     printPacket("PACKET FROM PHONE", &p);
 
-// For use with the simulator, we should not ignore duplicate packets
-#if !(defined(ARCH_PORTDUINO) && !HAS_RADIO)
-    if (p.id > 0 && wasSeenRecently(p.id)) {
-        LOG_DEBUG("Ignore packet from phone, already seen recently");
-        return false;
-    }
+#if defined(ARCH_PORTDUINO)
+    // For use with the simulator, we should not ignore duplicate packets from the phone
+    if (SimRadio::instance == nullptr)
 #endif
+        if (p.id > 0 && wasSeenRecently(p.id)) {
+            LOG_DEBUG("Ignore packet from phone, already seen recently");
+            return false;
+        }
 
     if (p.decoded.portnum == meshtastic_PortNum_TRACEROUTE_APP && lastPortNumToRadio[p.decoded.portnum] &&
         Throttle::isWithinTimespanMs(lastPortNumToRadio[p.decoded.portnum], THIRTY_SECONDS_MS)) {

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -6,6 +6,7 @@
 #include "NodeDB.h"
 #include "RTC.h"
 #include "configuration.h"
+#include "detect/LoRaRadioType.h"
 #include "main.h"
 #include "mesh-pb-constants.h"
 #include "meshUtils.h"
@@ -492,6 +493,8 @@ meshtastic_Routing_Error perhapsEncode(meshtastic_MeshPacket *p)
         // is not in the local nodedb
         // First, only PKC encrypt packets we are originating
         if (isFromUs(p) &&
+            // Don't use PKC with simulator
+            radioType != SIM_RADIO &&
             // Don't use PKC with Ham mode
             !owner.is_licensed &&
             // Don't use PKC if it's not explicitly requested and a non-primary channel is requested

--- a/src/modules/Telemetry/DeviceTelemetry.cpp
+++ b/src/modules/Telemetry/DeviceTelemetry.cpp
@@ -130,6 +130,14 @@ meshtastic_Telemetry DeviceTelemetryModule::getLocalStatsTelemetry()
         telemetry.variant.local_stats.num_packets_rx_bad = RadioLibInterface::instance->rxBad;
         telemetry.variant.local_stats.num_tx_relay = RadioLibInterface::instance->txRelay;
     }
+#ifdef ARCH_PORTDUINO
+    if (SimRadio::instance) {
+        telemetry.variant.local_stats.num_packets_tx = SimRadio::instance->txGood;
+        telemetry.variant.local_stats.num_packets_rx = SimRadio::instance->rxGood + SimRadio::instance->rxBad;
+        telemetry.variant.local_stats.num_packets_rx_bad = SimRadio::instance->rxBad;
+        telemetry.variant.local_stats.num_tx_relay = SimRadio::instance->txRelay;
+    }
+#endif
     if (router) {
         telemetry.variant.local_stats.num_rx_dupe = router->rxDupe;
         telemetry.variant.local_stats.num_tx_relay_canceled = router->txRelayCanceled;

--- a/src/platform/portduino/SimRadio.cpp
+++ b/src/platform/portduino/SimRadio.cpp
@@ -203,6 +203,29 @@ void SimRadio::startSend(meshtastic_MeshPacket *txp)
     service->sendToPhone(p); // Sending back to simulator
 }
 
+// Simulates device received a packet via the LoRa chip
+void SimRadio::unPackAndReceive(meshtastic_MeshPacket &p)
+{
+    // Simulator packet (=Compressed packet) is encapsulated in a MeshPacket, so need to unwrap first
+    meshtastic_Compressed scratch;
+    meshtastic_Compressed *decoded = NULL;
+    if (p.which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
+        memset(&scratch, 0, sizeof(scratch));
+        p.decoded.payload.size =
+            pb_decode_from_bytes(p.decoded.payload.bytes, p.decoded.payload.size, &meshtastic_Compressed_msg, &scratch);
+        if (p.decoded.payload.size) {
+            decoded = &scratch;
+            // Extract the original payload and replace
+            memcpy(&p.decoded.payload, &decoded->data, sizeof(decoded->data));
+            // Switch the port from PortNum_SIMULATOR_APP back to the original PortNum
+            p.decoded.portnum = decoded->portnum;
+        } else
+            LOG_ERROR("Error decoding proto for simulator message!");
+    }
+    // Let SimRadio receive as if it did via its LoRa chip
+    startReceive(&p);
+}
+
 void SimRadio::startReceive(meshtastic_MeshPacket *p)
 {
     isReceiving = true;

--- a/src/platform/portduino/SimRadio.h
+++ b/src/platform/portduino/SimRadio.h
@@ -47,6 +47,9 @@ class SimRadio : public RadioInterface, protected concurrency::NotifiedWorkerThr
 
     meshtastic_QueueStatus getQueueStatus() override;
 
+    // Convert Compressed_msg to normal msg and receive it
+    void unPackAndReceive(meshtastic_MeshPacket &p);
+
   protected:
     /// are _trying_ to receive a packet currently (note - we might just be waiting for one)
     bool isReceiving = false;

--- a/src/platform/portduino/SimRadio.h
+++ b/src/platform/portduino/SimRadio.h
@@ -11,11 +11,6 @@ class SimRadio : public RadioInterface, protected concurrency::NotifiedWorkerThr
 {
     enum PendingISR { ISR_NONE = 0, ISR_RX, ISR_TX, TRANSMIT_DELAY_COMPLETED };
 
-    /**
-     * Debugging counts
-     */
-    uint32_t rxBad = 0, rxGood = 0, txGood = 0;
-
     MeshPacketQueue txQueue = MeshPacketQueue(MAX_TX_QUEUE);
 
   public:
@@ -50,9 +45,14 @@ class SimRadio : public RadioInterface, protected concurrency::NotifiedWorkerThr
     // Convert Compressed_msg to normal msg and receive it
     void unPackAndReceive(meshtastic_MeshPacket &p);
 
+    /**
+     * Debugging counts
+     */
+    uint32_t rxBad = 0, rxGood = 0, txGood = 0, txRelay = 0;
+
   protected:
     /// are _trying_ to receive a packet currently (note - we might just be waiting for one)
-    bool isReceiving = false;
+    bool isReceiving = true;
 
   private:
     void setTransmitDelay();
@@ -64,7 +64,7 @@ class SimRadio : public RadioInterface, protected concurrency::NotifiedWorkerThr
     void startTransmitTimerSNR(float snr);
 
     void handleTransmitInterrupt();
-    void handleReceiveInterrupt(meshtastic_MeshPacket *p);
+    void handleReceiveInterrupt();
 
     void onNotify(uint32_t notification);
 
@@ -75,6 +75,8 @@ class SimRadio : public RadioInterface, protected concurrency::NotifiedWorkerThr
     size_t getPacketLength(meshtastic_MeshPacket *p);
 
     int16_t readData(uint8_t *str, size_t len);
+
+    meshtastic_MeshPacket *receivingPacket = nullptr; // The packet we are currently receiving
 
   protected:
     /** Could we send right now (i.e. either not actively receiving or transmitting)? */

--- a/src/platform/portduino/SimRadio.h
+++ b/src/platform/portduino/SimRadio.h
@@ -43,7 +43,7 @@ class SimRadio : public RadioInterface, protected concurrency::NotifiedWorkerThr
     meshtastic_QueueStatus getQueueStatus() override;
 
     // Convert Compressed_msg to normal msg and receive it
-    void unPackAndReceive(meshtastic_MeshPacket &p);
+    void unpackAndReceive(meshtastic_MeshPacket &p);
 
     /**
      * Debugging counts

--- a/src/platform/portduino/architecture.h
+++ b/src/platform/portduino/architecture.h
@@ -11,6 +11,9 @@
 #ifndef HAS_WIFI
 #define HAS_WIFI 1
 #endif
+#ifndef HAS_RADIO
+#define HAS_RADIO 1
+#endif
 #ifndef HAS_RTC
 #define HAS_RTC 1
 #endif


### PR DESCRIPTION
This cleans up some of the guarding for the simulator. Actually all Portduino variants have `HAS_RADIO` still set to 0, but only when the SimRadio is actually initialized, we should handle the packets from the simulator. `HAS_RADIO` can now thus be set to 1 for Portduino as well, and when it doesn’t have a radio configured, it will fall back to SimRadio.

Also, the simulator can’t handle PKC packets, so this avoids using it when SimRadio is used.

Furthermore, SimRadio now emulates collisions when it receives a packet while it is currently sending or receiving another one. Those bad packets are now counted as well, and sent with the LocalStats.
