### PR TITLE
Update xiao_esp32 fully support L76K

### DIFF
--- a/variants/seeed_xiao_s3/variant.h
+++ b/variants/seeed_xiao_s3/variant.h
@@ -41,7 +41,7 @@ L76K GPS Module Information : https://www.seeedstudio.com/L76K-GNSS-Module-for-S
     L76K Expansion Board can not directly used, L76K Reset Pin needs to override or physically remove it,
     otherwise it will conflict with the SPI pins
 */
-// #define GPS_L76K
+#define GPS_L76K
 #ifdef GPS_L76K
 #define GPS_RX_PIN 44
 #define GPS_TX_PIN 43


### PR DESCRIPTION

Due to the hardware redesign of the L76K module, the reset pin has been migrated, and now it can fully support the L76K module