### PR TITLE
Extend Length of Source and Destination Node IDs Logged

### DIFF
--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -284,7 +284,7 @@ uint32_t RadioInterface::getTxDelayMsecWeighted(float snr)
 void printPacket(const char *prefix, const meshtastic_MeshPacket *p)
 {
 #ifdef DEBUG_PORT
-    std::string out = DEBUG_PORT.mt_sprintf("%s (id=0x%08x fr=0x%02x to=0x%02x, WantAck=%d, HopLim=%d Ch=0x%x", prefix, p->id,
+    std::string out = DEBUG_PORT.mt_sprintf("%s (id=0x%08x fr=0x%08x to=0x%08x, WantAck=%d, HopLim=%d Ch=0x%x", prefix, p->id,
                                             p->from & 0xff, p->to & 0xff, p->want_ack, p->hop_limit, p->channel);
     if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
         auto &s = p->decoded;

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -285,7 +285,7 @@ void printPacket(const char *prefix, const meshtastic_MeshPacket *p)
 {
 #ifdef DEBUG_PORT
     std::string out = DEBUG_PORT.mt_sprintf("%s (id=0x%08x fr=0x%08x to=0x%08x, WantAck=%d, HopLim=%d Ch=0x%x", prefix, p->id,
-                                            p->from & 0xff, p->to & 0xff, p->want_ack, p->hop_limit, p->channel);
+                                            p->from, p->to, p->want_ack, p->hop_limit, p->channel);
     if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
         auto &s = p->decoded;
 


### PR DESCRIPTION
I am working on a project to collect metrics from the mesh in our area.  I currently have it functioning by maintaining a constant connection to a node via the serial interface and utilizing the Python libraries to extract the relevant information which works, but is not very efficient.

While transitioning this functionality to use syslog as it is lighter and creates the possibility to collect data from multiple nodes, I noticed that the syslog output, specifically for the `Lora RX` lines, do not include the full source and destination Node IDs.

I was unable to find any record of why these fields were truncated, so this PR attempts to extend them to their full length.

**Previous Example**
`Lora RX (id=0x3d820dc9 fr=0x1b to=0x9a, WantAck=0, HopLim=3 Ch=0x8 encrypted rxSNR=-1 rxRSSI=-110 hopStart=3)`

**Example with PR Applied**
`Lora RX (id=0x3d820dc9 fr=0xc0065b1b to=0xa6e7499a, WantAck=0, HopLim=2 Ch=0x8 encrypted rxSNR=5.5 rxRSSI=-71 hopStart=3)`