### PR TITLE
add nodeId to nodeinfo update log lines and removed redundant nodeinfo update log line

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1243,7 +1243,6 @@ bool NodeDB::updateUser(uint32_t nodeId, meshtastic_User &p, uint8_t channelInde
         return false;
     }
 
-    LOG_DEBUG("old user %s/%s, channel=%d", info->user.long_name, info->user.short_name, info->channel);
 #if !(MESHTASTIC_EXCLUDE_PKI)
     if (p.public_key.size > 0) {
         printBytes("Incoming Pubkey: ", p.public_key.bytes, 32);
@@ -1267,7 +1266,8 @@ bool NodeDB::updateUser(uint32_t nodeId, meshtastic_User &p, uint8_t channelInde
     }
     if (nodeId != getNodeNum())
         info->channel = channelIndex; // Set channel we need to use to reach this node (but don't set our own channel)
-    LOG_DEBUG("Update changed=%d user %s/%s, channel=%d", changed, info->user.long_name, info->user.short_name, info->channel);
+    LOG_DEBUG("Update changed=%d user %s/%s, id=0x%08x, channel=%d", changed, info->user.long_name, info->user.short_name, nodeId,
+              info->channel);
     info->has_user = true;
 
     if (changed) {


### PR DESCRIPTION
This PR is part of my ongoing quest to be able to collect mesh metrics via the syslog data.

There is currently no log output which joins the value of NodeId and the node names.  This PR extends the existing log line by adding the source NodeId.

Additionally, there was a redundant log line which I removed as part of this PR.

**Previous Line**
`Update changed=0 user Node Marian - LRMesh.net/👰, channel=0`

**Current Line**
`Update changed=0 user Node Marian - LRMesh.net/👰, id=0x3f8558c3, channel=0`