### PR TITLE
Always Announce MDNS meshtastic service

### DIFF
--- a/src/mesh/api/ServerAPI.h
+++ b/src/mesh/api/ServerAPI.h
@@ -2,6 +2,8 @@
 
 #include "StreamAPI.h"
 
+#define SERVER_API_DEFAULT_PORT 4403
+
 /**
  * Provides both debug printing and, if the client starts sending protobufs to us, switches to send/receive protobufs
  * (and starts dropping debug printing - FIXME, eventually those prints should be encapsulated in protobufs).

--- a/src/mesh/api/WiFiServerAPI.h
+++ b/src/mesh/api/WiFiServerAPI.h
@@ -22,5 +22,5 @@ class WiFiServerPort : public APIServerPort<WiFiServerAPI, WiFiServer>
     explicit WiFiServerPort(int port);
 };
 
-void initApiServer(int port = 4403);
+void initApiServer(int port = SERVER_API_DEFAULT_PORT);
 void deInitApiServer();

--- a/src/mesh/api/ethServerAPI.h
+++ b/src/mesh/api/ethServerAPI.h
@@ -22,4 +22,4 @@ class ethServerPort : public APIServerPort<ethServerAPI, EthernetServer>
     explicit ethServerPort(int port);
 };
 
-void initApiServer(int port = 4403);
+void initApiServer(int port = SERVER_API_DEFAULT_PORT);

--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -71,7 +71,7 @@ static void onNetworkConnected()
             MDNS.addService("https", "tcp", 443);
 #elif defined(ARCH_RP2040)
             // ARCH_RP2040 does not support HTTPS, create a "meshtastic" service
-            MDNS.addService("meshtastic", "tcp", 4403);
+            MDNS.addService("meshtastic", "tcp", SERVER_API_DEFAULT_PORT);
             // ESP32 handles this in WiFiEvent
             LOG_INFO("Obtained IP address: %s", WiFi.localIP().toString().c_str());
 #endif

--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -66,13 +66,13 @@ static void onNetworkConnected()
             LOG_ERROR("Error setting up MDNS responder!");
         } else {
             LOG_INFO("mDNS Host: Meshtastic.local");
+            MDNS.addService("meshtastic", "tcp", SERVER_API_DEFAULT_PORT);
 #ifdef ARCH_ESP32
             MDNS.addService("http", "tcp", 80);
             MDNS.addService("https", "tcp", 443);
+            // ESP32 prints obtained IP address in WiFiEvent
 #elif defined(ARCH_RP2040)
-            // ARCH_RP2040 does not support HTTPS, create a "meshtastic" service
-            MDNS.addService("meshtastic", "tcp", SERVER_API_DEFAULT_PORT);
-            // ESP32 handles this in WiFiEvent
+            // ARCH_RP2040 does not support HTTPS
             LOG_INFO("Obtained IP address: %s", WiFi.localIP().toString().c_str());
 #endif
         }

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -9,6 +9,7 @@
 #include <assert.h>
 
 #include "PortduinoGlue.h"
+#include "api/ServerAPI.h"
 #include "linux/gpio/LinuxGPIOPin.h"
 #include "yaml-cpp/yaml.h"
 #include <filesystem>
@@ -34,7 +35,7 @@ void cpuDeepSleep(uint32_t msecs)
 
 void updateBatteryLevel(uint8_t level) NOT_IMPLEMENTED("updateBatteryLevel");
 
-int TCPPort = 4403;
+int TCPPort = SERVER_API_DEFAULT_PORT;
 
 static error_t parse_opt(int key, char *arg, struct argp_state *state)
 {


### PR DESCRIPTION
The meshtastic mdns service should always be announced when available and be independent of the fact if http/https is being offered. 

Related to #5355