### PR TITLE
Don't use channel index for encrypted packet

### DIFF
--- a/src/mesh/Channels.cpp
+++ b/src/mesh/Channels.cpp
@@ -178,12 +178,11 @@ CryptoKey Channels::getKey(ChannelIndex chIndex)
 {
     meshtastic_Channel &ch = getByIndex(chIndex);
     const meshtastic_ChannelSettings &channelSettings = ch.settings;
-    assert(ch.has_settings);
 
     CryptoKey k;
     memset(k.bytes, 0, sizeof(k.bytes)); // In case the user provided a short key, we want to pad the rest with zeros
 
-    if (ch.role == meshtastic_Channel_Role_DISABLED) {
+    if (!ch.has_settings || ch.role == meshtastic_Channel_Role_DISABLED) {
         k.length = -1; // invalid
     } else {
         memcpy(k.bytes, channelSettings.psk.bytes, channelSettings.psk.size);

--- a/src/mesh/FloodingRouter.cpp
+++ b/src/mesh/FloodingRouter.cpp
@@ -36,7 +36,8 @@ bool FloodingRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
         if (isRepeated) {
             LOG_DEBUG("Repeated reliable tx");
             if (!perhapsRebroadcast(p) && isToUs(p) && p->want_ack) {
-                sendAckNak(meshtastic_Routing_Error_NONE, getFrom(p), p->id, p->channel, 0);
+                // FIXME - channel index should be used, but the packet is still encrypted here
+                sendAckNak(meshtastic_Routing_Error_NONE, getFrom(p), p->id, 0, 0);
             }
         }
 

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -271,6 +271,7 @@ ErrorCode Router::send(meshtastic_MeshPacket *p)
         auto encodeResult = perhapsEncode(p);
         if (encodeResult != meshtastic_Routing_Error_NONE) {
             packetPool.release(p_decoded);
+            p->channel = 0; // Reset the channel to 0, so we don't use the failing hash again
             abortSendAndNak(encodeResult, p);
             return encodeResult; // FIXME - this isn't a valid ErrorCode
         }


### PR DESCRIPTION
Temporary fix for #5508.

During filtering the packet is not yet decrypted, and thus the channel is still the hash, not an index. As a temporary solution, always use the primary channel for sending the ACK. This will be properly fixed with the NextHopRouter.
