### PR TITLE
add ignore_direct radio testing option

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -654,6 +654,14 @@ void Router::perhapsHandleReceived(meshtastic_MeshPacket *p)
         return;
     }
 
+    for (int i = 0; i < config.lora.ignore_direct.size; i++) {
+        if (p->from & 0xff == config.lora.ignore_direct.bytes[i]) {
+            LOG_DEBUG("Ignore direct msg, 0x%x matches our direct ignore list", p->from);
+            packetPool.release(p);
+            return;
+        }
+    }
+
     meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(p->from);
     if (node != NULL && node->is_ignored) {
         LOG_DEBUG("Ignore msg, 0x%x is ignored", p->from);

--- a/src/mesh/generated/meshtastic/apponly.pb.h
+++ b/src/mesh/generated/meshtastic/apponly.pb.h
@@ -55,7 +55,7 @@ extern const pb_msgdesc_t meshtastic_ChannelSet_msg;
 
 /* Maximum encoded size of messages (where known) */
 #define MESHTASTIC_MESHTASTIC_APPONLY_PB_H_MAX_SIZE meshtastic_ChannelSet_size
-#define meshtastic_ChannelSet_size               679
+#define meshtastic_ChannelSet_size               685
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/mesh/generated/meshtastic/localonly.pb.h
+++ b/src/mesh/generated/meshtastic/localonly.pb.h
@@ -187,7 +187,7 @@ extern const pb_msgdesc_t meshtastic_LocalModuleConfig_msg;
 
 /* Maximum encoded size of messages (where known) */
 #define MESHTASTIC_MESHTASTIC_LOCALONLY_PB_H_MAX_SIZE meshtastic_LocalConfig_size
-#define meshtastic_LocalConfig_size              735
+#define meshtastic_LocalConfig_size              741
 #define meshtastic_LocalModuleConfig_size        699
 
 #ifdef __cplusplus


### PR DESCRIPTION
This allows to exercise the meshing at a hardware level while the devices are meters appart and I find that useful while testing.
https://github.com/meshtastic/protobufs/pull/631