### PR TITLE
Configure Seeed Xiao S3 RX enable pin

### DIFF
--- a/variants/seeed_xiao_s3/variant.h
+++ b/variants/seeed_xiao_s3/variant.h
@@ -80,5 +80,7 @@ L76K GPS Module Information : https://www.seeedstudio.com/L76K-GNSS-Module-for-S
 
 //  DIO2 controlls an antenna switch and the TCXO voltage is controlled by DIO3
 #define SX126X_DIO2_AS_RF_SWITCH
+#define SX126X_RXEN 38
+#define SX126X_TXEN RADIOLIB_NC
 #define SX126X_DIO3_TCXO_VOLTAGE 1.8
 #endif


### PR DESCRIPTION
My Seeed Xiao S3 modules seemed a bit deaf on receive.  I was able to find a slightly different RF switch config in their [Arduino example](https://wiki.seeedstudio.com/wio_sx1262_xiao_esp32s3_for_lora_sensor_node/).  After making the change I can now receive from the nodes that I expected to hear, but I'd like to get @Dylanliacc to give feedback because I don't have a schematic for the board and am not 100% sure that everything is configured correctly with this change.

I have tested it with 2 other users and 5 boards, but that testing was mostly making sure that large packets didn't blow up the radio and hearing nodes that were previously only being heard by other devices.  I'm now getting 20-40dB stronger signals for nodes in my house and an SNR that I would expect.