### PR TITLE
Improve Lost and Found

### DIFF
--- a/src/mesh/Channels.cpp
+++ b/src/mesh/Channels.cpp
@@ -134,7 +134,11 @@ void Channels::initDefaultChannel(ChannelIndex chIndex)
     channelSettings.psk.bytes[0] = defaultpskIndex;
     channelSettings.psk.size = 1;
     strncpy(channelSettings.name, "", sizeof(channelSettings.name));
-    channelSettings.module_settings.position_precision = 13; // default to sending location on the primary channel
+    if (config.device.role == meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND) {
+        channelSettings.module_settings.position_precision = 32; // lost and found defaults to full precision
+    } else {
+        channelSettings.module_settings.position_precision = 13; // default to sending location on the primary channel
+    }
     channelSettings.has_module_settings = true;
 
     ch.has_settings = true;

--- a/src/mesh/FloodingRouter.cpp
+++ b/src/mesh/FloodingRouter.cpp
@@ -62,6 +62,7 @@ void FloodingRouter::perhapsCancelDupe(const meshtastic_MeshPacket *p)
 bool FloodingRouter::isRebroadcaster()
 {
     return config.device.role != meshtastic_Config_DeviceConfig_Role_CLIENT_MUTE &&
+           config.device.role != meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND &&
            config.device.rebroadcast_mode != meshtastic_Config_DeviceConfig_RebroadcastMode_NONE;
 }
 
@@ -87,7 +88,7 @@ void FloodingRouter::perhapsRebroadcast(const meshtastic_MeshPacket *p)
                 // We are careful not to call our hooked version of send() - because we don't want to check this again
                 Router::send(tosend);
             } else {
-                LOG_DEBUG("No rebroadcast: Role = CLIENT_MUTE or Rebroadcast Mode = NONE");
+                LOG_DEBUG("No rebroadcast: CLIENT_MUTE/LOST_AND_FOUND or Rebroadcast Mode = NONE");
             }
         } else {
             LOG_DEBUG("Ignore 0 id broadcast");


### PR DESCRIPTION
As suggested by @RCGV1, this patch sets LOST_AND_FOUND role to
* Broadcast full precision by default
* Save battery by not re-broadcasting

Fixes https://github.com/meshtastic/firmware/issues/5514