### PR TITLE
tlora_v2_1_16: Unset BUTTON_PIN and BUTTON_NEED_PULLUP

### DIFF
--- a/variants/tlora_v2_1_16/variant.h
+++ b/variants/tlora_v2_1_16/variant.h
@@ -8,10 +8,7 @@
 #define I2C_SDA 21 // I2C pins for this board
 #define I2C_SCL 22
 
-#define LED_PIN 25    // If defined we will blink this LED
-#define BUTTON_PIN 12 // If defined, this will be used for user button presses,
-
-#define BUTTON_NEED_PULLUP
+#define LED_PIN 25 // If defined we will blink this LED
 
 #define USE_RF95
 #define LORA_DIO0 26 // a No connect on the SX1262 module


### PR DESCRIPTION
Unset BUTTON_PIN and BUTTON_NEED_PULLUP as the board ships without a user button.

Devices and users expecting a button on GPIO12 have to set [GPIO for user button](https://meshtastic.org/docs/configuration/radio/device/#gpio-for-user-button) to 12 (or any GPIO pin the momentary switch was connected to) to restore functionality.