### PR TITLE
Add portduino-buildroot variant

### DIFF
--- a/arch/portduino/portduino.ini
+++ b/arch/portduino/portduino.ini
@@ -1,6 +1,6 @@
-; The Portduino based sim environment on top of any host OS, all hardware will be simulated
+; The Portduino based 'native' environment. Currently supported on Linux targets with real LoRa hardware (or simulated).
 [portduino_base]
-platform = https://github.com/meshtastic/platform-native.git#7fcee253a928535ff8b142704035b4b982f7e2d2
+platform = https://github.com/meshtastic/platform-native.git#73bd1a21183ca8b00c4ea58bb21315df31a50dff
 framework = arduino
 
 build_src_filter = 

--- a/variants/portduino-buildroot/platformio.ini
+++ b/variants/portduino-buildroot/platformio.ini
@@ -1,0 +1,10 @@
+[env:buildroot]
+extends = portduino_base
+; The pkg-config commands below optionally add link flags.
+; the || : is just a "or run the null command" to avoid returning an error code
+build_flags = ${portduino_base.build_flags} -O0 -I variants/portduino-buildroot
+  !pkg-config --libs libulfius --silence-errors || :
+  !pkg-config --libs openssl --silence-errors || :
+board = buildroot
+lib_deps = ${portduino_base.lib_deps}
+build_src_filter = ${portduino_base.build_src_filter}

--- a/variants/portduino-buildroot/variant.h
+++ b/variants/portduino-buildroot/variant.h
@@ -1,0 +1,5 @@
+#define HAS_SCREEN 1
+#define CANNED_MESSAGE_MODULE_ENABLE 1
+#define HAS_GPS 1
+#define MAX_RX_TOPHONE settingsMap[maxtophone]
+#define MAX_NUM_NODES settingsMap[maxnodes]


### PR DESCRIPTION
Adds new variant `portduino-buildroot`, reliant upon [platform-native#6](https://github.com/meshtastic/platform-native/pull/6).

This will allow us to leverage cross-builder systems like Buildroot and OpenWRT (or others that use a similar convention).