### PR TITLE
Fix detection for some RadSens hardware versions

### DIFF
--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -425,11 +425,14 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
 
             case CGRADSENS_ADDR:
                 // Register 0x00 of the RadSens sensor contains is product identifier 0x7D
+                // Undocumented, but some devices return a product identifier of 0x7A
                 registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x00), 1);
-                if (registerValue == 0x7D) {
+                if (registerValue == 0x7D || registerValue == 0x7A) {
                     type = CGRADSENS;
                     logFoundDevice("ClimateGuard RadSens", (uint8_t)addr.address);
                     break;
+                } else {
+                    LOG_DEBUG("Unexpected Device ID for RadSense: addr=0x%x id=0x%x", CGRADSENS_ADDR, registerValue);
                 }
                 break;
 


### PR DESCRIPTION
The RadSens data sheet indicates that register 0x00 contains the device ID of 0x7D.  However, in practice, users have reported that some devices return the undocumented device ID of 0x7A.  Currently, when this happens, the I2C scan for the RadSens fails silently.

This pull request adds 0x7A as an allowable device ID for the detection of the RadSens dosimeter.

It also adds a log message to alert when a device is detected at address 0x66 but fails the device ID check.  This is to allow us to detect other undocumented device identifiers in the future.  Hopefully this is not necessary, but it is better than failing silently.