### PR TITLE
Update OpenWRT_One_mikroBUS_sx1262.yaml

### DIFF
--- a/bin/config.d/OpenWRT_One_mikroBUS_sx1262.yaml
+++ b/bin/config.d/OpenWRT_One_mikroBUS_sx1262.yaml
@@ -2,7 +2,7 @@ Lora:
   Module: sx1262
   IRQ: 10
   Busy: 12
-  Reset: 2
+#  Reset: 2
   spidev: spidev2.0
   DIO2_AS_RF_SWITCH: true
   DIO3_TCXO_VOLTAGE: true


### PR DESCRIPTION
DEBUG | 07:14:15 0 SX126xInterface(cs=-1, irq=10, rst=-1, busy=12)
DEBUG | 07:14:15 0 SX126X_DIO3_TCXO_VOLTAGE defined, using DIO3 as TCXO reference voltage at 1.800000 V
INFO  | 07:14:15 0 Start meshradio init
INFO  | 07:14:15 0 Radio freq=906.875, config.lora.frequency_offset=0.000
INFO  | 07:14:15 0 Set radio: region=UNSET, name=LongFast, config=0, ch=19, power=30
INFO  | 07:14:15 0 myRegion->freqStart -> myRegion->freqEnd: 902.000000 -> 928.000000 (26.000000 MHz)
INFO  | 07:14:15 0 numChannels: 104 x 250.000kHz
INFO  | 07:14:15 0 channel_num: 20
INFO  | 07:14:15 0 frequency: 906.875000
INFO  | 07:14:15 0 Slot time: 77 msec
INFO  | 07:14:15 0 Set radio: final power level=22
INFO  | 07:14:15 0 SX126x init result 0
INFO  | 07:14:15 0 Frequency set to 906.875000
INFO  | 07:14:15 0 Bandwidth set to 250.000000
INFO  | 07:14:15 0 Power output set to 22
DEBUG | 07:14:15 0 Current limit set to 140.000000
DEBUG | 07:14:15 0 Current limit set result 0
DEBUG | 07:14:15 0 Set DIO2 as RF switch, result: 0
DEBUG | 07:14:15 0 Use MCU pin -1 as RXEN and pin -1 as TXEN to control RF switching
INFO  | 07:14:15 0 Set RX gain to boosted mode; result: 0
INFO  | 07:14:15 0 SX1262 init success