### PR TITLE
portduino-buildroot: Define C++ standard

### DIFF
--- a/variants/portduino-buildroot/platformio.ini
+++ b/variants/portduino-buildroot/platformio.ini
@@ -3,6 +3,7 @@ extends = portduino_base
 ; The pkg-config commands below optionally add link flags.
 ; the || : is just a "or run the null command" to avoid returning an error code
 build_flags = ${portduino_base.build_flags} -O0 -I variants/portduino-buildroot
+  -std=c++17
   !pkg-config --libs libulfius --silence-errors || :
   !pkg-config --libs openssl --silence-errors || :
 board = buildroot


### PR DESCRIPTION
Addendum to #5540 

Define C standard (C++17). This is required to build on `musl` and `UClibc` targets. Defining this here removes complexity in downstream packaging (openwrt/buildroot).