### PR TITLE
Portduino: Move meshtasticd/web out of /usr/share/doc/

### DIFF
--- a/.github/workflows/package_amd64.yml
+++ b/.github/workflows/package_amd64.yml
@@ -47,18 +47,18 @@ jobs:
       - name: build .debpkg
         run: |
           mkdir -p .debpkg/DEBIAN
-          mkdir -p .debpkg/usr/share/doc/meshtasticd/web
+          mkdir -p .debpkg/usr/share/meshtasticd/web
           mkdir -p .debpkg/usr/sbin
           mkdir -p .debpkg/etc/meshtasticd
           mkdir -p .debpkg/etc/meshtasticd/config.d
           mkdir -p .debpkg/etc/meshtasticd/available.d
           mkdir -p .debpkg/usr/lib/systemd/system/
-          tar -xf build.tar -C .debpkg/usr/share/doc/meshtasticd/web
+          tar -xf build.tar -C .debpkg/usr/share/meshtasticd/web
           shopt -s dotglob nullglob
-          if [ -d .debpkg/usr/share/doc/meshtasticd/web/build ]; then mv  .debpkg/usr/share/doc/meshtasticd/web/build/* .debpkg/usr/share/doc/meshtasticd/web/; fi
-          if [ -d .debpkg/usr/share/doc/meshtasticd/web/build ]; then rmdir .debpkg/usr/share/doc/meshtasticd/web/build; fi
-          if [ -d .debpkg/usr/share/doc/meshtasticd/web/.DS_Store ]; then rm -f .debpkg/usr/share/doc/meshtasticd/web/.DS_Store; fi
-          gunzip .debpkg/usr/share/doc/meshtasticd/web/ -r
+          if [ -d .debpkg/usr/share/meshtasticd/web/build ]; then mv  .debpkg/usr/share/meshtasticd/web/build/* .debpkg/usr/share/meshtasticd/web/; fi
+          if [ -d .debpkg/usr/share/meshtasticd/web/build ]; then rmdir .debpkg/usr/share/meshtasticd/web/build; fi
+          if [ -d .debpkg/usr/share/meshtasticd/web/.DS_Store ]; then rm -f .debpkg/usr/share/meshtasticd/web/.DS_Store; fi
+          gunzip .debpkg/usr/share/meshtasticd/web/ -r
           cp release/meshtasticd_linux_x86_64 .debpkg/usr/sbin/meshtasticd
           cp bin/config-dist.yaml .debpkg/etc/meshtasticd/config.yaml
           cp bin/config.d/* .debpkg/etc/meshtasticd/available.d/ -r
@@ -66,6 +66,11 @@ jobs:
           cp bin/meshtasticd.service .debpkg/usr/lib/systemd/system/meshtasticd.service
           echo "/etc/meshtasticd/config.yaml" > .debpkg/DEBIAN/conffiles
           chmod +x .debpkg/DEBIAN/conffiles
+          # Transition /usr/share/doc/meshtasticd to /usr/share/meshtasticd
+          echo "rm -rf /usr/share/doc/meshtasticd" > .debpkg/DEBIAN/preinst
+          chmod +x .debpkg/DEBIAN/preinst
+          echo "/usr/share/meshtasticd /usr/share/doc/meshtasticd" > .debpkg/DEBIAN/meshtasticd.links
+          chmod +x .debpkg/DEBIAN/meshtasticd.links
 
       - uses: jiro4989/build-deb-action@v3
         with:

--- a/.github/workflows/package_raspbian.yml
+++ b/.github/workflows/package_raspbian.yml
@@ -47,18 +47,18 @@ jobs:
       - name: build .debpkg
         run: |
           mkdir -p .debpkg/DEBIAN
-          mkdir -p .debpkg/usr/share/doc/meshtasticd/web
+          mkdir -p .debpkg/usr/share/meshtasticd/web
           mkdir -p .debpkg/usr/sbin
           mkdir -p .debpkg/etc/meshtasticd
           mkdir -p .debpkg/etc/meshtasticd/config.d
           mkdir -p .debpkg/etc/meshtasticd/available.d
           mkdir -p .debpkg/usr/lib/systemd/system/
-          tar -xf build.tar -C .debpkg/usr/share/doc/meshtasticd/web
+          tar -xf build.tar -C .debpkg/usr/share/meshtasticd/web
           shopt -s dotglob nullglob
-          if [ -d .debpkg/usr/share/doc/meshtasticd/web/build ]; then mv  .debpkg/usr/share/doc/meshtasticd/web/build/* .debpkg/usr/share/doc/meshtasticd/web/; fi
-          if [ -d .debpkg/usr/share/doc/meshtasticd/web/build ]; then rmdir .debpkg/usr/share/doc/meshtasticd/web/build; fi
-          if [ -d .debpkg/usr/share/doc/meshtasticd/web/.DS_Store ]; then rm -f .debpkg/usr/share/doc/meshtasticd/web/.DS_Store; fi
-          gunzip .debpkg/usr/share/doc/meshtasticd/web/ -r
+          if [ -d .debpkg/usr/share/meshtasticd/web/build ]; then mv  .debpkg/usr/share/meshtasticd/web/build/* .debpkg/usr/share/meshtasticd/web/; fi
+          if [ -d .debpkg/usr/share/meshtasticd/web/build ]; then rmdir .debpkg/usr/share/meshtasticd/web/build; fi
+          if [ -d .debpkg/usr/share/meshtasticd/web/.DS_Store ]; then rm -f .debpkg/usr/share/meshtasticd/web/.DS_Store; fi
+          gunzip .debpkg/usr/share/meshtasticd/web/ -r
           cp release/meshtasticd_linux_aarch64 .debpkg/usr/sbin/meshtasticd
           cp bin/config-dist.yaml .debpkg/etc/meshtasticd/config.yaml
           cp bin/config.d/* .debpkg/etc/meshtasticd/available.d/ -r
@@ -66,6 +66,11 @@ jobs:
           cp bin/meshtasticd.service .debpkg/usr/lib/systemd/system/meshtasticd.service
           echo "/etc/meshtasticd/config.yaml" > .debpkg/DEBIAN/conffiles
           chmod +x .debpkg/DEBIAN/conffiles
+          # Transition /usr/share/doc/meshtasticd to /usr/share/meshtasticd
+          echo "rm -rf /usr/share/doc/meshtasticd" > .debpkg/DEBIAN/preinst
+          chmod +x .debpkg/DEBIAN/preinst
+          echo "/usr/share/meshtasticd /usr/share/doc/meshtasticd" > .debpkg/DEBIAN/meshtasticd.links
+          chmod +x .debpkg/DEBIAN/meshtasticd.links
 
       - uses: jiro4989/build-deb-action@v3
         with:

--- a/.github/workflows/package_raspbian_armv7l.yml
+++ b/.github/workflows/package_raspbian_armv7l.yml
@@ -47,18 +47,18 @@ jobs:
       - name: build .debpkg
         run: |
           mkdir -p .debpkg/DEBIAN
-          mkdir -p .debpkg/usr/share/doc/meshtasticd/web
+          mkdir -p .debpkg/usr/share/meshtasticd/web
           mkdir -p .debpkg/usr/sbin
           mkdir -p .debpkg/etc/meshtasticd
           mkdir -p .debpkg/etc/meshtasticd/config.d
           mkdir -p .debpkg/etc/meshtasticd/available.d
           mkdir -p .debpkg/usr/lib/systemd/system/
-          tar -xf build.tar -C .debpkg/usr/share/doc/meshtasticd/web
+          tar -xf build.tar -C .debpkg/usr/share/meshtasticd/web
           shopt -s dotglob nullglob
-          if [ -d .debpkg/usr/share/doc/meshtasticd/web/build ]; then mv  .debpkg/usr/share/doc/meshtasticd/web/build/* .debpkg/usr/share/doc/meshtasticd/web/; fi
-          if [ -d .debpkg/usr/share/doc/meshtasticd/web/build ]; then rmdir .debpkg/usr/share/doc/meshtasticd/web/build; fi
-          if [ -d .debpkg/usr/share/doc/meshtasticd/web/.DS_Store ]; then rm -f .debpkg/usr/share/doc/meshtasticd/web/.DS_Store; fi
-          gunzip .debpkg/usr/share/doc/meshtasticd/web/ -r
+          if [ -d .debpkg/usr/share/meshtasticd/web/build ]; then mv  .debpkg/usr/share/meshtasticd/web/build/* .debpkg/usr/share/meshtasticd/web/; fi
+          if [ -d .debpkg/usr/share/meshtasticd/web/build ]; then rmdir .debpkg/usr/share/meshtasticd/web/build; fi
+          if [ -d .debpkg/usr/share/meshtasticd/web/.DS_Store ]; then rm -f .debpkg/usr/share/meshtasticd/web/.DS_Store; fi
+          gunzip .debpkg/usr/share/meshtasticd/web/ -r
           cp release/meshtasticd_linux_armv7l .debpkg/usr/sbin/meshtasticd
           cp bin/config-dist.yaml .debpkg/etc/meshtasticd/config.yaml
           cp bin/config.d/* .debpkg/etc/meshtasticd/available.d/ -r
@@ -66,6 +66,11 @@ jobs:
           cp bin/meshtasticd.service .debpkg/usr/lib/systemd/system/meshtasticd.service
           echo "/etc/meshtasticd/config.yaml" > .debpkg/DEBIAN/conffiles
           chmod +x .debpkg/DEBIAN/conffiles
+          # Transition /usr/share/doc/meshtasticd to /usr/share/meshtasticd
+          echo "rm -rf /usr/share/doc/meshtasticd" > .debpkg/DEBIAN/preinst
+          chmod +x .debpkg/DEBIAN/preinst
+          echo "/usr/share/meshtasticd /usr/share/doc/meshtasticd" > .debpkg/DEBIAN/meshtasticd.links
+          chmod +x .debpkg/DEBIAN/meshtasticd.links
 
       - uses: jiro4989/build-deb-action@v3
         with:

--- a/bin/config-dist.yaml
+++ b/bin/config-dist.yaml
@@ -155,7 +155,7 @@ Logging:
 
 Webserver:
 #  Port: 443 # Port for Webserver & Webservices
-#  RootPath: /usr/share/doc/meshtasticd/web # Root Dir of WebServer
+#  RootPath: /usr/share/meshtasticd/web # Root Dir of WebServer
 
 General:
   MaxNodes: 200


### PR DESCRIPTION
Second attempt after #5323 was reverted, with changes to address the previous issue.

---

`/usr/share/doc` is the home of **documentation** on most Linux distros.
On minimal / embedded distros (such as buildroot) this directory is often removed by default to save disk space; akin to stripping manpages.

This PR moves `meshtasticd/web` out of `/usr/share/doc` and into `/usr/share` on Portduino platforms.

Includes a symlink from the new location to the previous location, to ease the transition.
https://manpages.debian.org/testing/debhelper/dh_link.1.en.html