### PR TITLE
Portduino: fix transitional symlinks for /usr/share/doc/

### DIFF
--- a/.github/workflows/package_amd64.yml
+++ b/.github/workflows/package_amd64.yml
@@ -69,8 +69,8 @@ jobs:
           # Transition /usr/share/doc/meshtasticd to /usr/share/meshtasticd
           echo "rm -rf /usr/share/doc/meshtasticd" > .debpkg/DEBIAN/preinst
           chmod +x .debpkg/DEBIAN/preinst
-          echo "/usr/share/meshtasticd /usr/share/doc/meshtasticd" > .debpkg/DEBIAN/meshtasticd.links
-          chmod +x .debpkg/DEBIAN/meshtasticd.links
+          echo "ln -sf /usr/share/meshtasticd /usr/share/doc/meshtasticd" > .debpkg/DEBIAN/postinst
+          chmod +x .debpkg/DEBIAN/postinst
 
       - uses: jiro4989/build-deb-action@v3
         with:

--- a/.github/workflows/package_raspbian.yml
+++ b/.github/workflows/package_raspbian.yml
@@ -69,8 +69,8 @@ jobs:
           # Transition /usr/share/doc/meshtasticd to /usr/share/meshtasticd
           echo "rm -rf /usr/share/doc/meshtasticd" > .debpkg/DEBIAN/preinst
           chmod +x .debpkg/DEBIAN/preinst
-          echo "/usr/share/meshtasticd /usr/share/doc/meshtasticd" > .debpkg/DEBIAN/meshtasticd.links
-          chmod +x .debpkg/DEBIAN/meshtasticd.links
+          echo "ln -sf /usr/share/meshtasticd /usr/share/doc/meshtasticd" > .debpkg/DEBIAN/postinst
+          chmod +x .debpkg/DEBIAN/postinst
 
       - uses: jiro4989/build-deb-action@v3
         with:

--- a/.github/workflows/package_raspbian_armv7l.yml
+++ b/.github/workflows/package_raspbian_armv7l.yml
@@ -69,8 +69,8 @@ jobs:
           # Transition /usr/share/doc/meshtasticd to /usr/share/meshtasticd
           echo "rm -rf /usr/share/doc/meshtasticd" > .debpkg/DEBIAN/preinst
           chmod +x .debpkg/DEBIAN/preinst
-          echo "/usr/share/meshtasticd /usr/share/doc/meshtasticd" > .debpkg/DEBIAN/meshtasticd.links
-          chmod +x .debpkg/DEBIAN/meshtasticd.links
+          echo "ln -sf /usr/share/meshtasticd /usr/share/doc/meshtasticd" > .debpkg/DEBIAN/postinst
+          chmod +x .debpkg/DEBIAN/postinst
 
       - uses: jiro4989/build-deb-action@v3
         with:


### PR DESCRIPTION
Should fix issue with symlinks not being created properly in #5548