### PR TITLE
DIO3_TCXO_VOLTAGE in config.yaml can now take an exact voltage

### DIFF
--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -48,8 +48,10 @@ template <typename T> bool LR11x0Interface<T>::init()
     digitalWrite(LR11X0_POWER_EN, HIGH);
 #endif
 
+#if ARCH_PORTDUINO
+    float tcxoVoltage = (float)settingsMap[dio3_tcxo_voltage] / 1000;
 // FIXME: correct logic to default to not using TCXO if no voltage is specified for LR11x0_DIO3_TCXO_VOLTAGE
-#if !defined(LR11X0_DIO3_TCXO_VOLTAGE)
+#elif !defined(LR11X0_DIO3_TCXO_VOLTAGE)
     float tcxoVoltage =
         0; // "TCXO reference voltage to be set on DIO3. Defaults to 1.6 V, set to 0 to skip." per
            // https://github.com/jgromes/RadioLib/blob/690a050ebb46e6097c5d00c371e961c1caa3b52e/src/modules/LR11x0/LR11x0.h#L471C26-L471C104

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -50,9 +50,7 @@ template <typename T> bool SX126xInterface<T>::init()
 #endif
 
 #if ARCH_PORTDUINO
-    float tcxoVoltage = 0;
-    if (settingsMap[dio3_tcxo_voltage])
-        tcxoVoltage = 1.8;
+    float tcxoVoltage = (float)settingsMap[dio3_tcxo_voltage] / 1000;
     if (settingsMap[sx126x_ant_sw] != RADIOLIB_NC) {
         digitalWrite(settingsMap[sx126x_ant_sw], HIGH);
         pinMode(settingsMap[sx126x_ant_sw], OUTPUT);

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -365,7 +365,10 @@ bool loadConfig(const char *configPath)
                 settingsMap[use_sx1268] = true;
             }
             settingsMap[dio2_as_rf_switch] = yamlConfig["Lora"]["DIO2_AS_RF_SWITCH"].as<bool>(false);
-            settingsMap[dio3_tcxo_voltage] = yamlConfig["Lora"]["DIO3_TCXO_VOLTAGE"].as<bool>(false);
+            settingsMap[dio3_tcxo_voltage] = yamlConfig["Lora"]["DIO3_TCXO_VOLTAGE"].as<float>(0) * 1000;
+            if (settingsMap[dio3_tcxo_voltage] == 0 && yamlConfig["Lora"]["DIO3_TCXO_VOLTAGE"].as<bool>(false)) {
+                settingsMap[dio3_tcxo_voltage] = 1800; // default millivolts for "true"
+            }
             settingsMap[cs] = yamlConfig["Lora"]["CS"].as<int>(RADIOLIB_NC);
             settingsMap[irq] = yamlConfig["Lora"]["IRQ"].as<int>(RADIOLIB_NC);
             settingsMap[busy] = yamlConfig["Lora"]["Busy"].as<int>(RADIOLIB_NC);


### PR DESCRIPTION
So far we've just been setting TCXO to either 0 or 1.8, but some devices need other values. So the config.yaml setting can now take a voltage, in addition to true or false.