### PR TITLE
Support TLORA_V3.0

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -4,31 +4,32 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.6.4
+      ref: v1.6.6
       uri: https://github.com/trunk-io/plugins
 lint:
   enabled:
-    - trufflehog@3.83.6
+    - prettier@3.4.2
+    - trufflehog@3.86.1
     - yamllint@1.35.1
-    - bandit@1.7.10
-    - checkov@3.2.287
+    - bandit@1.8.0
+    - checkov@3.2.334
     - terrascan@1.19.9
-    - trivy@0.56.2
+    - trivy@0.58.0
     #- trufflehog@3.63.2-rc0
     - taplo@0.9.3
-    - ruff@0.7.3
+    - ruff@0.8.3
     - isort@5.13.2
-    - markdownlint@0.42.0
-    - oxipng@9.1.2
+    - markdownlint@0.43.0
+    - oxipng@9.1.3
     - svgo@3.3.2
     - actionlint@1.7.4
     - flake8@7.1.1
-    - hadolint@2.12.0
+    - hadolint@2.12.1-beta
     - shfmt@3.6.0
     - shellcheck@0.10.0
     - black@24.10.0
     - git-diff-check
-    - gitleaks@8.21.1
+    - gitleaks@8.21.2
     - clang-format@16.0.3
     #- prettier@3.3.3
   ignore:
@@ -39,7 +40,7 @@ runtimes:
   enabled:
     - python@3.10.8
     - go@1.21.0
-    - node@18.12.1
+    - node@18.20.5
 actions:
   disabled:
     - trunk-announce

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,6 +16,7 @@ default_envs = tbeam
 ;default_envs = tlora-v2
 ;default_envs = tlora-v2-1-1_6
 ;default_envs = tlora-v2-1-1_6-tcxo
+;default_envs = tlora-v3-3-0-tcxo
 ;default_envs = tlora-t3s3-v1
 ;default_envs = t-echo
 ;default_envs = canaryone

--- a/variants/tlora_v2_1_18/platformio.ini
+++ b/variants/tlora_v2_1_18/platformio.ini
@@ -1,5 +1,6 @@
 [env:tlora-v2-1-1_8]
 extends = esp32_base
+board_level = extra
 board = ttgo-lora32-v21
 
 build_flags = 

--- a/variants/tlora_v3_3_0_tcxo/platformio.ini
+++ b/variants/tlora_v3_3_0_tcxo/platformio.ini
@@ -1,10 +1,11 @@
-[env:tlora-v2-1-1_6-tcxo]
+[env:tlora-v3-3-0-tcxo]
 extends = esp32_base
-board_level = extra
 board = ttgo-lora32-v21
+board_level = extra
 build_flags = 
   ${esp32_base.build_flags}
   -D TLORA_V2_1_16
   -I variants/tlora_v2_1_16
   -D GPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
-  -D LORA_TCXO_GPIO=33
+  -D LORA_TCXO_GPIO=12
+  -D BUTTON_PIN=0


### PR DESCRIPTION
- Support TLORA_V3.0. Update of the legendary 2.1_1.6.1 with solar charger, TCXO and IPEX connector.
- 'extra' some short-lived EOL intermediate boards in that range. If possible use T3S3 instead of all of these!
- update trunk to latest version

