### PR TITLE
Define BUTTON_PIN as -1 for RP2040-lora

### DIFF
--- a/variants/rp2040-lora/variant.h
+++ b/variants/rp2040-lora/variant.h
@@ -15,7 +15,7 @@
 // rxd = 9
 
 #define EXT_NOTIFY_OUT 22
-#undef BUTTON_PIN // Pin 17 used for antenna switching via DIO4
+#define BUTTON_PIN -1 // Pin 17 used for antenna switching via DIO4
 
 #define LED_PIN PIN_LED
 


### PR DESCRIPTION
The previous approach of undef'ing meant that it was impossible for users to change the button pin in the apps.

Fixes https://github.com/meshtastic/firmware/issues/5566