### PR TITLE
Based default Node Names on NodeNum, rather than MAC address

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -852,12 +852,12 @@ void NodeDB::installDefaultDeviceState()
 #ifdef USERPREFS_CONFIG_OWNER_LONG_NAME
     snprintf(owner.long_name, sizeof(owner.long_name), USERPREFS_CONFIG_OWNER_LONG_NAME);
 #else
-    snprintf(owner.long_name, sizeof(owner.long_name), "Meshtastic %02x%02x", ourMacAddr[4], ourMacAddr[5]);
+    snprintf(owner.long_name, sizeof(owner.long_name), "Meshtastic %04x", getNodeNum() & 0x0ffff);
 #endif
 #ifdef USERPREFS_CONFIG_OWNER_SHORT_NAME
     snprintf(owner.short_name, sizeof(owner.short_name), USERPREFS_CONFIG_OWNER_SHORT_NAME);
 #else
-    snprintf(owner.short_name, sizeof(owner.short_name), "%02x%02x", ourMacAddr[4], ourMacAddr[5]);
+    snprintf(owner.short_name, sizeof(owner.short_name), "%04x", getNodeNum() & 0x0ffff);
 #endif
     snprintf(owner.id, sizeof(owner.id), "!%08x", getNodeNum()); // Default node ID now based on nodenum
     memcpy(owner.macaddr, ourMacAddr, sizeof(owner.macaddr));


### PR DESCRIPTION
Presently we base the default long name (Meshtastic XXXX) and short names (XXXX) on a node's MAC address. This works fine, unless you have a node with no bluetooth, like Portduino.

Our logic for node numbers is also based on MAC address. However, it has the added feature that it will create a random node number if the Mac address is no good. The name is always "Meshtastic 0001".

This change switches node names (long and short) to instead rely on the node number for defaults. For nodes with mac addresses, there should be no user-visible change. For nodes without, they'll now have a name other than "Meshtastic 0001".

Fixes https://github.com/meshtastic/firmware/issues/5370