### PR TITLE
StoreForward: (tapback) reply support

### DIFF
--- a/src/modules/StoreForwardModule.h
+++ b/src/modules/StoreForwardModule.h
@@ -13,7 +13,10 @@ struct PacketHistoryStruct {
     uint32_t time;
     uint32_t to;
     uint32_t from;
+    uint32_t id;
     uint8_t channel;
+    uint32_t reply_id;
+    bool emoji;
     uint8_t payload[meshtastic_Constants_DATA_PAYLOAD_LEN];
     pb_size_t payload_size;
 };


### PR DESCRIPTION
Fixes #5578.

This also adds the `reply_id`, `emoji` (as a bool) and also the original `id` to the StoreForward history to support (tapback) replies. 
Also increased the PSRAM usage from 2/3 to 3/4, since this is still the only module that uses PSRAM.

The S&F server will now re-send the packet with the original ID. Although (intermediate) nodes will ignore this when they've seen it within the `FLOOD_EXPIRE_TIME`, I think this is not really a problem since that is rather short (10 min. now), so the chance is high the requester already received this packet anyway.
