### PR TITLE
Use encoded ServiceEnvelope in mqttQueue

### DIFF
--- a/src/mqtt/MQTT.h
+++ b/src/mqtt/MQTT.h
@@ -78,7 +78,11 @@ class MQTT : private concurrency::OSThread
     void start() { setIntervalFromNow(0); };
 
   protected:
-    PointerQueue<meshtastic_ServiceEnvelope> mqttQueue;
+    struct QueueEntry {
+        std::string topic;
+        std::basic_string<uint8_t> envBytes; // binary/pb_encode_to_bytes ServiceEnvelope
+    };
+    PointerQueue<QueueEntry> mqttQueue;
 
     int reconnectCount = 0;
 


### PR DESCRIPTION
This fixes #5136, where the router's instance of a MeshPacket was added to mqttQueue, and then the router released the packet before it could be processed from the mqttQueue.

This PR stores the topic and a copy of the encoded (`pb_encode_to_bytes`) bytes of the ServiceEnvelope in the queue. That way the MQTT module owns all memory associated with the queued item.

This code is slightly less efficient for publishing queued messages to the JSON topic, as the MeshPacket must be decoded again. But I believe JSON is scheduled for removal here eventually.

I've also removed the `mqttPool` as after this PR it was only being used in one other place (`perhapsReportToMap()`). I refactored this method to no longer use a dynamic allocation of ServiceEnvelope.