### PR TITLE
Use IPAddress.fromString in MQTT.cpp for parsing private IPs

### DIFF
--- a/src/mqtt/MQTT.h
+++ b/src/mqtt/MQTT.h
@@ -121,10 +121,6 @@ class MQTT : private concurrency::OSThread
     // Check if we should report unencrypted information about our node for consumption by a map
     void perhapsReportToMap();
 
-    /// Determines if the given address is a private IPv4 address, i.e. not routable on the public internet.
-    /// These are the ranges: 127.0.0.1, 10.0.0.0-10.255.255.255, 172.16.0.0-172.31.255.255, 192.168.0.0-192.168.255.255.
-    bool isPrivateIpAddress(const char address[]);
-
     /// Return 0 if sleep is okay, veto sleep if we are connected to pubsub server
     // int preflightSleepCb(void *unused = NULL) { return pubSub.connected() ? 1 : 0; }
 };


### PR DESCRIPTION
Substitute the custom string parsing in `MQTT::isPrivateIpAddress` with the built-in IPAddress.fromString method.

Related: I'd also like to make this work for host names too, after they are resolved to an IP address (https://github.com/meshtastic/firmware/issues/5306#issuecomment-2555799859 / [Discord](https://discord.com/channels/867578229534359593/871553604652240948/1319766795392909342)). I can do that in a follow-up PR if it is acceptable.

```diff
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -438,6 +438,9 @@ void MQTT::reconnect()
             enabled = true; // Start running background process again
             runASAP = true;
             reconnectCount = 0;
+#if !defined(ARCH_PORTDUINO)
+            isMqttServerAddressPrivate = isPrivateIpAddress(mqttClient.remoteIP());
+#endif
 
             publishNodeInfo();
             sendSubscriptions();
```