### PR TITLE
LIS3DH (WisMesh Pocket) - Honor Wake On Tap Or Motion

### DIFF
--- a/src/motion/LIS3DHSensor.cpp
+++ b/src/motion/LIS3DHSensor.cpp
@@ -22,7 +22,7 @@ int32_t LIS3DHSensor::runOnce()
 {
     if (sensor.getClick() > 0) {
         uint8_t click = sensor.getClick();
-        if (!config.device.double_tap_as_button_press) {
+        if (!config.device.double_tap_as_button_press && config.display.wake_on_tap_or_motion) {
             wakeScreen();
         }
 


### PR DESCRIPTION
As reported by @Mason10198, the WisMesh Pocket was always waking on accelerometer motion.

This change gates the LIS3DH sensor's call to wakeScreen based on config.display.wake_on_tap_or_motion .

fixes https://github.com/meshtastic/firmware/issues/5579