### PR TITLE
Portduino: specify C++ standard and link pthread

### DIFF
--- a/arch/portduino/portduino.ini
+++ b/arch/portduino/portduino.ini
@@ -34,7 +34,9 @@ build_flags =
   -Isrc/platform/portduino
   -DRADIOLIB_EEPROM_UNSUPPORTED
   -DPORTDUINO_LINUX_HARDWARE
+  -lpthread
   -lstdc++fs
   -lbluetooth
   -lgpiod
   -lyaml-cpp
+  -std=c++17

--- a/variants/portduino-buildroot/platformio.ini
+++ b/variants/portduino-buildroot/platformio.ini
@@ -3,7 +3,6 @@ extends = portduino_base
 ; Optional libraries should be appended to `PLATFORMIO_BUILD_FLAGS`
 ; environment variable in the buildroot environment.
 build_flags = ${portduino_base.build_flags} -O0 -I variants/portduino-buildroot
-  -std=c++17
 board = buildroot
 lib_deps = ${portduino_base.lib_deps}
 build_src_filter = ${portduino_base.build_src_filter}


### PR DESCRIPTION
Similar to #5547, it seems specifying the C++ standard is now required (for `std::string_view`) e.g. when compiling on a Raspberry Pi 3 also, so I moved it to the `portduino_base`. Furthermore, after #5474, linking of `pthread` is needed as well.