### PR TITLE
meshtasticd-docker: simplify, add USB compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Absolute path to the local meshtastic config.yaml file
+CONFIG_PATH=/path/to/meshtastic/config.yaml
+# USB device to passthrough (`lsusb -t`: look for `ch341`)
+USB_DEVICE=/dev/bus/usb/001/037

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -10,33 +10,12 @@ jobs:
   build-native:
     runs-on: ubuntu-latest
     steps:
-      - name: Install libs needed for native build
-        shell: bash
-        run: |
-          sudo apt-get update --fix-missing
-          sudo apt-get install -y libbluetooth-dev libgpiod-dev libyaml-cpp-dev openssl libssl-dev libulfius-dev liborcania-dev libusb-1.0-0-dev
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           submodules: recursive
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
-
-      - name: Upgrade python tools
-        shell: bash
-        run: |
-          python -m pip install --upgrade pip
-          pip install -U platformio adafruit-nrfutil
-          pip install -U meshtastic --pre
-
-      - name: Upgrade platformio
-        shell: bash
-        run: |
-          pio upgrade
-
-      - name: Build Native
-        run: bin/build-native.sh
 
       - name: Get release version string
         run: echo "version=$(./bin/buildinfo.py long)" >> $GITHUB_OUTPUT

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,29 @@
-FROM debian:bookworm-slim AS builder
+# trunk-ignore-all(terrascan/AC_DOCKER_0002): Known terrascan issue
+# trunk-ignore-all(hadolint/DL3008): Use latest version of apt packages for buildchain
+# trunk-ignore-all(trivy/DS002): We must run as root for this container
+# trunk-ignore-all(checkov/CKV_DOCKER_8): We must run as root for this container
+# trunk-ignore-all(hadolint/DL3002): We must run as root for this container
 
+FROM python:3.12-bookworm AS builder
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
+# Install Dependencies
+ENV PIP_ROOT_USER_ACTION=ignore
+RUN apt-get update && apt-get install --no-install-recommends -y wget g++ zip git ca-certificates \
+        libgpiod-dev libyaml-cpp-dev libbluetooth-dev libi2c-dev \
+        libusb-1.0-0-dev libulfius-dev liborcania-dev libssl-dev pkg-config && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    pip install --no-cache-dir -U platformio==6.1.16 && \
+    mkdir /tmp/firmware
 
-# Install build deps
-USER root
-
-# trunk-ignore(terrascan/AC_DOCKER_0002): Known terrascan issue
-# trunk-ignore(hadolint/DL3008): Use latest version of packages for buildchain
-RUN apt-get update && apt-get install --no-install-recommends -y wget python3 python3-pip python3-wheel python3-venv g++ zip git \
-                           ca-certificates libgpiod-dev libyaml-cpp-dev libbluetooth-dev \
-                           libusb-1.0-0-dev libulfius-dev liborcania-dev libssl-dev pkg-config && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* && mkdir /tmp/firmware
-
-RUN groupadd -g 1000 mesh && useradd -ml -u 1000 -g 1000 mesh && chown mesh:mesh /tmp/firmware
-USER mesh
-
+# Copy source code
 WORKDIR /tmp/firmware
-RUN python3 -m venv /tmp/firmware 
-RUN bash -o pipefail -c "source bin/activate; pip3 install --no-cache-dir -U platformio==6.1.15"
-# trunk-ignore(terrascan/AC_DOCKER_00024): We would actually like these files to be owned by mesh tyvm
-COPY --chown=mesh:mesh . /tmp/firmware
-RUN bash -o pipefail -c "source ./bin/activate && bash ./bin/build-native.sh"
-RUN cp "/tmp/firmware/release/meshtasticd_linux_$(uname -m)" "/tmp/firmware/release/meshtasticd"
+COPY . /tmp/firmware
+
+# Build
+RUN bash ./bin/build-native.sh && \
+    cp "/tmp/firmware/release/meshtasticd_linux_$(uname -m)" "/tmp/firmware/release/meshtasticd"
 
 
 ##### PRODUCTION BUILD #############
@@ -35,20 +32,25 @@ FROM debian:bookworm-slim
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 
-# trunk-ignore(terrascan/AC_DOCKER_0002): Known terrascan issue
-# trunk-ignore(hadolint/DL3008): Use latest version of packages for buildchain
-RUN apt-get update && apt-get --no-install-recommends -y install libc-bin libc6 libgpiod2 libyaml-cpp0.7 libulfius2.7 libusb-1.0-0-dev liborcania2.3 libssl3 && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+# nosemgrep: dockerfile.security.last-user-is-root.last-user-is-root
+USER root
 
-RUN groupadd -g 1000 mesh && useradd -ml -u 1000 -g 1000 mesh
-USER mesh
+RUN apt-get update && apt-get --no-install-recommends -y install libc-bin libc6 libgpiod2 libyaml-cpp0.7 libi2c0 libulfius2.7 libusb-1.0-0-dev liborcania2.3 libssl3 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /var/lib/meshtasticd \
+    && mkdir -p /etc/meshtasticd/config.d
 
-WORKDIR /home/mesh
-COPY --from=builder /tmp/firmware/release/meshtasticd /home/mesh/
+# Fetch compiled binary from the builder
+COPY --from=builder /tmp/firmware/release/meshtasticd /usr/sbin/
+# Copy config templates
+COPY ./bin/config.d /etc/meshtasticd/available.d
 
-RUN mkdir data
-VOLUME /home/mesh/data
+WORKDIR /var/lib/meshtasticd
+VOLUME /var/lib/meshtasticd
 
-CMD [ "sh",  "-cx", "./meshtasticd -d /home/mesh/data --hwid=${HWID:-$RANDOM}" ]
+# Expose Meshtastic TCP API port from the host
+EXPOSE 4403
+
+CMD [ "sh", "-cx", "meshtasticd -d /var/lib/meshtasticd" ]
 
 HEALTHCHECK NONE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,26 @@
-version: "3.7"
+# USB-Based Meshtastic container-node!
+
+# Copy .env.example to .env and set the USB_DEVICE and CONFIG_PATH variables
 
 services:
   meshtastic-node:
     build: .
-    deploy:
-      mode: replicated
-      replicas: 4
-    networks:
-      - mesh
+    container_name: meshtasticd
 
-networks:
-  mesh:
+    # Pass USB device through to the container
+    devices:
+      - "${USB_DEVICE}"
+
+    # Mount local config file and named volume for data persistence
+    volumes:
+      - "${CONFIG_PATH}:/etc/meshtasticd/config.yaml:ro"
+      - meshtastic_data:/var/lib/meshtasticd
+
+    # Forward the container’s port 4403 to the host
+    ports:
+      - 4403:4403
+
+    restart: unless-stopped
+
+volumes:
+  meshtastic_data:


### PR DESCRIPTION
Simplify the debian docker container, rework `docker-compose` to allow for testing USB CH341 devices.