### PR TITLE
More accurately determine if MQTT uses the default server

### DIFF
--- a/src/mesh/Channels.cpp
+++ b/src/mesh/Channels.cpp
@@ -318,7 +318,7 @@ bool Channels::anyMqttEnabled()
 {
 #if USERPREFS_EVENT_MODE
     // Don't publish messages on the public MQTT broker if we are in event mode
-    if (strcmp(moduleConfig.mqtt.address, default_mqtt_address) == 0) {
+    if (mqtt && mqtt.isUsingDefaultServer()) {
         return false;
     }
 #endif

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -46,6 +46,7 @@ constexpr int reconnectMax = 5;
 static uint8_t bytes[meshtastic_MqttClientProxyMessage_size + 30]; // 12 for channel name and 16 for nodeid
 
 static bool isMqttServerAddressPrivate = false;
+static bool isDefaultMqttServer;
 
 // meshtastic_ServiceEnvelope that automatically releases dynamically allocated memory when it goes out of scope.
 struct DecodedServiceEnvelope : public meshtastic_ServiceEnvelope {
@@ -324,9 +325,10 @@ MQTT::MQTT() : concurrency::OSThread("mqtt"), mqttQueue(MAX_MQTT_QUEUE)
                 moduleConfig.mqtt.map_report_settings.publish_interval_secs, default_map_publish_interval_secs);
         }
 
+        String host = parseHostAndPort(moduleConfig.mqtt.address).first;
+        isDefaultMqttServer = host.length() == 0 || host == default_mqtt_address;
         IPAddress ip;
-        isMqttServerAddressPrivate =
-            ip.fromString(parseHostAndPort(moduleConfig.mqtt.address).first.c_str()) && isPrivateIpAddress(ip);
+        isMqttServerAddressPrivate = ip.fromString(host.c_str()) && isPrivateIpAddress(ip);
 
 #if HAS_NETWORKING
         if (!moduleConfig.mqtt.proxy_to_client_enabled)
@@ -633,9 +635,8 @@ void MQTT::onSend(const meshtastic_MeshPacket &mp_encrypted, const meshtastic_Me
             return;
         }
 
-        if (strcmp(moduleConfig.mqtt.address, default_mqtt_address) == 0 &&
-            (mp_decoded.decoded.portnum == meshtastic_PortNum_RANGE_TEST_APP ||
-             mp_decoded.decoded.portnum == meshtastic_PortNum_DETECTION_SENSOR_APP)) {
+        if (isDefaultMqttServer && (mp_decoded.decoded.portnum == meshtastic_PortNum_RANGE_TEST_APP ||
+                                    mp_decoded.decoded.portnum == meshtastic_PortNum_DETECTION_SENSOR_APP)) {
             LOG_DEBUG("MQTT onSend - Ignoring range test or detection sensor message on public mqtt");
             return;
         }

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -326,7 +326,7 @@ MQTT::MQTT() : concurrency::OSThread("mqtt"), mqttQueue(MAX_MQTT_QUEUE)
         }
 
         String host = parseHostAndPort(moduleConfig.mqtt.address).first;
-        isDefaultMqttServer = host.length() == 0 || host == default_mqtt_address;
+        isConfiguredForDefaultServer = host.length() == 0 || host == default_mqtt_address;
         IPAddress ip;
         isMqttServerAddressPrivate = ip.fromString(host.c_str()) && isPrivateIpAddress(ip);
 
@@ -635,8 +635,8 @@ void MQTT::onSend(const meshtastic_MeshPacket &mp_encrypted, const meshtastic_Me
             return;
         }
 
-        if (isDefaultMqttServer && (mp_decoded.decoded.portnum == meshtastic_PortNum_RANGE_TEST_APP ||
-                                    mp_decoded.decoded.portnum == meshtastic_PortNum_DETECTION_SENSOR_APP)) {
+        if (isConfiguredForDefaultServer && (mp_decoded.decoded.portnum == meshtastic_PortNum_RANGE_TEST_APP ||
+                                             mp_decoded.decoded.portnum == meshtastic_PortNum_DETECTION_SENSOR_APP)) {
             LOG_DEBUG("MQTT onSend - Ignoring range test or detection sensor message on public mqtt");
             return;
         }

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -46,7 +46,6 @@ constexpr int reconnectMax = 5;
 static uint8_t bytes[meshtastic_MqttClientProxyMessage_size + 30]; // 12 for channel name and 16 for nodeid
 
 static bool isMqttServerAddressPrivate = false;
-static bool isDefaultMqttServer;
 
 // meshtastic_ServiceEnvelope that automatically releases dynamically allocated memory when it goes out of scope.
 struct DecodedServiceEnvelope : public meshtastic_ServiceEnvelope {

--- a/src/mqtt/MQTT.h
+++ b/src/mqtt/MQTT.h
@@ -79,6 +79,8 @@ class MQTT : private concurrency::OSThread
 
     void start() { setIntervalFromNow(0); };
 
+    bool isUsingDefaultServer() { return isConfiguredForDefaultServer; }
+
   protected:
     struct QueueEntry {
         std::string topic;
@@ -87,6 +89,7 @@ class MQTT : private concurrency::OSThread
     PointerQueue<QueueEntry> mqttQueue;
 
     int reconnectCount = 0;
+    bool isConfiguredForDefaultServer = true;
 
     virtual int32_t runOnce() override;
 


### PR DESCRIPTION
This avoids needing to use strcmp each time a packet is sent as well.

Tested with the following values for `moduleConfig.mqtt.address`:
- An [empty string](https://github.com/meshtastic/firmware/blob/175ff218f1e8830b501dab26f8f2aa9e40d55051/src/mqtt/MQTT.cpp#L416) (`isDefaultMqttServer=true`)
- mqtt.meshtastic.org (`isDefaultMqttServer=true`)
- mqtt.meshtastic.org:1883 (`isDefaultMqttServer=true`)
- 192.168.1.10:1883 (`isDefaultMqttServer=false`)