### PR TITLE
Synchronize test workflow packages with native

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,11 +9,11 @@ jobs:
   test-simulator:
     runs-on: ubuntu-latest
     steps:
-      - name: Install libbluetooth
+      - name: Install libs needed for native build
         shell: bash
         run: |
           sudo apt-get update --fix-missing
-          sudo apt-get install -y libbluetooth-dev libgpiod-dev libyaml-cpp-dev openssl libssl-dev libulfius-dev liborcania-dev
+          sudo apt-get install -y libbluetooth-dev libgpiod-dev libyaml-cpp-dev openssl libssl-dev libulfius-dev liborcania-dev libusb-1.0-0-dev libi2c-dev
 
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Setting the package installations in `tests.yml` to match those in `build_native.yml` 

https://github.com/meshtastic/firmware/blob/175ff218f1e8830b501dab26f8f2aa9e40d55051/.github/workflows/build_native.yml#L13-L17