### PR TITLE
Include log messages in unit tests

### DIFF
--- a/src/DebugConfiguration.h
+++ b/src/DebugConfiguration.h
@@ -45,7 +45,7 @@
 #define LOG_CRIT(...) SEGGER_RTT_printf(0, __VA_ARGS__)
 #define LOG_TRACE(...) SEGGER_RTT_printf(0, __VA_ARGS__)
 #else
-#if defined(DEBUG_PORT) && !defined(DEBUG_MUTE) && !defined(PIO_UNIT_TESTING)
+#if defined(DEBUG_PORT) && !defined(DEBUG_MUTE)
 #define LOG_DEBUG(...) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_DEBUG, __VA_ARGS__)
 #define LOG_INFO(...) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_INFO, __VA_ARGS__)
 #define LOG_WARN(...) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_WARN, __VA_ARGS__)

--- a/test/TestUtil.cpp
+++ b/test/TestUtil.cpp
@@ -1,0 +1,10 @@
+#include "TestUtil.h"
+#include "SerialConsole.h"
+#include "concurrency/OSThread.h"
+
+void initializeTestEnvironment()
+{
+    concurrency::hasBeenSetup = true;
+    concurrency::OSThread::setup();
+    consoleInit();
+}

--- a/test/TestUtil.cpp
+++ b/test/TestUtil.cpp
@@ -1,10 +1,18 @@
-#include "TestUtil.h"
 #include "SerialConsole.h"
 #include "concurrency/OSThread.h"
+#include "gps/RTC.h"
+
+#include "TestUtil.h"
 
 void initializeTestEnvironment()
 {
     concurrency::hasBeenSetup = true;
-    concurrency::OSThread::setup();
     consoleInit();
+#if ARCH_PORTDUINO
+    struct timeval tv;
+    tv.tv_sec = time(NULL);
+    tv.tv_usec = 0;
+    perhapsSetRTC(RTCQualityNTP, &tv);
+#endif
+    concurrency::OSThread::setup();
 }

--- a/test/TestUtil.h
+++ b/test/TestUtil.h
@@ -1,0 +1,4 @@
+#pragma once
+
+// Initialize testing environment.
+void initializeTestEnvironment();

--- a/test/test_crypto/test_main.cpp
+++ b/test/test_crypto/test_main.cpp
@@ -1,5 +1,6 @@
 #include "CryptoEngine.h"
 
+#include "TestUtil.h"
 #include <unity.h>
 
 void HexToBytes(uint8_t *result, const std::string hex, size_t len = 0)
@@ -170,6 +171,7 @@ void setup()
     delay(10);
     delay(2000);
 
+    initializeTestEnvironment();
     UNITY_BEGIN(); // IMPORTANT LINE!
     RUN_TEST(test_SHA256);
     RUN_TEST(test_ECB_AES256);


### PR DESCRIPTION
Provide a minimal environment for unit tests that includes logging messages.

Makes it easier to troubleshoot when writing unit tests. And it ensures the log lines are tested as well. I've placed `initializeTestEnvironment()` in a separate file, as I'd also like to use it for a future unit test for MQTT as well.

Tested with: `pio test --environment native`