### PR TITLE
Generate a coverage report for End to end tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,15 @@ on:
 jobs:
   test-simulator:
     runs-on: ubuntu-latest
+    env:
+      LCOV_CAPTURE_FLAGS: --quiet --capture --include "${PWD}/src/*" --exclude '*/src/mesh/generated/*' --directory .pio/build/coverage/src --base-directory "${PWD}"
     steps:
       - name: Install libs needed for native build
         shell: bash
         run: |
           sudo apt-get update --fix-missing
           sudo apt-get install -y libbluetooth-dev libgpiod-dev libyaml-cpp-dev openssl libssl-dev libulfius-dev liborcania-dev libusb-1.0-0-dev libi2c-dev
+          sudo apt-get install -y lcov
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -24,7 +27,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          pip install -U platformio adafruit-nrfutil
+          pip install -U platformio adafruit-nrfutil dotmap
           pip install -U meshtastic --pre
 
       - name: Upgrade platformio
@@ -36,17 +39,23 @@ jobs:
         run: bin/build-native.sh
 
       # We now run integration test before other build steps (to quickly see runtime failures)
-      - name: Build for native
-        run: platformio run -e native
+      - name: Build for native/coverage
+        run: |
+          platformio run -e coverage
+          lcov ${{ env.LCOV_CAPTURE_FLAGS }} --initial --output-file coverage_base.info
 
       - name: Integration test
         run: |
-          .pio/build/native/program & sleep 10 # 5 seconds was not enough
+          .pio/build/coverage/program & sleep 10 # 5 seconds was not enough
           echo "Simulator started, launching python test..."
           python3 -c 'from meshtastic.test import testSimulator; testSimulator()'
+          sleep 10
+          lcov ${{ env.LCOV_CAPTURE_FLAGS }} --test-name integration --output-file coverage_integration.info
 
       - name: PlatformIO Tests
-        run: platformio test -e native --junit-output-path testreport.xml
+        run: |
+          platformio test -e coverage --junit-output-path testreport.xml
+          lcov ${{ env.LCOV_CAPTURE_FLAGS }} --test-name tests --output-file coverage_tests.info
 
       - name: Test Report
         uses: dorny/test-reporter@v1.9.1
@@ -55,6 +64,19 @@ jobs:
           name: PlatformIO Tests
           path: testreport.xml
           reporter: java-junit
+
+      - name: Generate Code Coverage Report
+        run: |
+          lcov --quiet --add-tracefile coverage_base.info --add-tracefile coverage_integration.info --add-tracefile coverage_tests.info --output-file coverage_src.info
+          mkdir code-coverage-report
+          genhtml --quiet --legend --prefix "${PWD}" coverage_src.info --output-directory code-coverage-report
+          mv coverage_*.info code-coverage-report
+
+      - name: Save Code Coverage Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report
+          path: code-coverage-report
 
   hardware-tests:
     runs-on: test-runner

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,10 +46,12 @@ jobs:
 
       - name: Integration test
         run: |
-          .pio/build/coverage/program & sleep 10 # 5 seconds was not enough
+          .pio/build/coverage/program &
+          PID=$!
+          timeout 20 bash -c "until ls -al /proc/$PID/fd | grep socket; do sleep 1; done"
           echo "Simulator started, launching python test..."
           python3 -c 'from meshtastic.test import testSimulator; testSimulator()'
-          sleep 10
+          wait
           lcov ${{ env.LCOV_CAPTURE_FLAGS }} --test-name integration --output-file coverage_integration.info
 
       - name: PlatformIO Tests

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -358,7 +358,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
 #ifdef ARCH_PORTDUINO
     case meshtastic_AdminMessage_exit_simulator_tag:
         LOG_INFO("Exiting simulator");
-        _exit(0);
+        exit(0);
         break;
 #endif
 

--- a/test/test_crypto/test_main.cpp
+++ b/test/test_crypto/test_main.cpp
@@ -176,9 +176,7 @@ void setup()
     RUN_TEST(test_DH25519);
     RUN_TEST(test_AES_CTR);
     RUN_TEST(test_PKC_Decrypt);
+    exit(UNITY_END()); // stop unit testing
 }
 
-void loop()
-{
-    UNITY_END(); // stop unit testing
-}
+void loop() {}

--- a/variants/portduino/platformio.ini
+++ b/variants/portduino/platformio.ini
@@ -9,3 +9,7 @@ build_flags = ${portduino_base.build_flags} -O0 -I variants/portduino
 board = cross_platform
 lib_deps = ${portduino_base.lib_deps}
 build_src_filter = ${portduino_base.build_src_filter}
+
+[env:coverage]
+extends = env:native
+build_flags = -lgcov --coverage -fprofile-abs-path ${env:native.build_flags}


### PR DESCRIPTION
For coverage to be saved, the application under test needs to exit cleanly, calling all exit handling logic. This happens when the application calls `exit()`. I've modified the simulator and the crypto unit test so they exit and save the coverage details.

Demo: see the `code-coverage-report` artifact on https://github.com/esev/meshtastic-firmware/actions/runs/12497423501

The `code-coverage-report/coverage_src.info` file should be compatible with most coverage tools like CodeCov/Coveralls.