### PR TITLE
Unset received SNR/RSSI values upon receiving packet via MQTT

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -96,6 +96,9 @@ inline void onReceiveProto(char *topic, byte *payload, size_t length)
 
     UniquePacketPoolPacket p = packetPool.allocUniqueCopy(*e.packet);
     p->via_mqtt = true; // Mark that the packet was received via MQTT
+    // Unset received SNR/RSSI which might have been added by the MQTT gateway
+    p->rx_snr = 0;
+    p->rx_rssi = 0;
 
     if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
         if (moduleConfig.mqtt.encryption_enabled) {


### PR DESCRIPTION
When nodes receive a packet via LoRa, they publish it to MQTT without subtracting a hop, but with their received SNR/RSSI added to the packet. This means that when another node then receives this packet via MQTT, they will see *their* SNR/RSSI with `hops_away = 0`. Let's unset these values as they are confusing.
