### PR TITLE
fix for nrf52 lfs assert boot loop

### DIFF
--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -56,10 +56,12 @@ extern "C" void lfs_assert(const char *reason)
     LOG_ERROR("LFS assert: %s", reason);
     lfs_assert_failed = true;
 
+#ifdef FSCom
     // CORRUPTED FILESYSTEM. This causes bootloop so
     // might as well try formatting now.
     LOG_ERROR("Trying FSCom.format()");
     FSCom.format();
+#endif
 }
 
 /**

--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -55,6 +55,11 @@ extern "C" void lfs_assert(const char *reason)
 {
     LOG_ERROR("LFS assert: %s", reason);
     lfs_assert_failed = true;
+
+    // CORRUPTED FILESYSTEM. This causes bootloop so
+    // might as well try formatting now.
+    LOG_ERROR("Trying FSCom.format()");
+    FSCom.format();
 }
 
 /**

--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -56,11 +56,13 @@ extern "C" void lfs_assert(const char *reason)
     LOG_ERROR("LFS assert: %s", reason);
     lfs_assert_failed = true;
 
+#ifndef ARCH_PORTDUINO
 #ifdef FSCom
     // CORRUPTED FILESYSTEM. This causes bootloop so
     // might as well try formatting now.
     LOG_ERROR("Trying FSCom.format()");
     FSCom.format();
+#endif
 #endif
 }
 


### PR DESCRIPTION
I actually don't have a way to test this fix because the corrupted filesystem is hard to reproduce but I do know that a call to FSCom.format() did fix my issue when I called it explicitly before FSCom.begin().