### PR TITLE
Remove remaining \n from log lines.

### DIFF
--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -458,11 +458,11 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
                 i2cBus->endTransmission();
                 len = i2cBus->readBytes(info, 5);
                 if (len == 5 && memcmp(expectedInfo, info, len) == 0) {
-                    LOG_INFO("NXP SE050 crypto chip found\n");
+                    LOG_INFO("NXP SE050 crypto chip found");
                     type = NXP_SE050;
 
                 } else {
-                    LOG_INFO("FT6336U touchscreen found\n");
+                    LOG_INFO("FT6336U touchscreen found");
                     type = FT6336U;
                 }
                 break;

--- a/src/input/MPR121Keyboard.cpp
+++ b/src/input/MPR121Keyboard.cpp
@@ -87,7 +87,7 @@ uint8_t MPR121_KeyMap[12] = {2, 5, 8, 11, 1, 4, 7, 10, 0, 3, 6, 9};
 
 MPR121Keyboard::MPR121Keyboard() : m_wire(nullptr), m_addr(0), readCallback(nullptr), writeCallback(nullptr)
 {
-    // LOG_DEBUG("MPR121 @ %02x\n", m_addr);
+    // LOG_DEBUG("MPR121 @ %02x", m_addr);
     state = Init;
     last_key = -1;
     last_tap = 0L;

--- a/src/input/TouchScreenBase.cpp
+++ b/src/input/TouchScreenBase.cpp
@@ -113,13 +113,13 @@ int32_t TouchScreenBase::runOnce()
         if (_tapped) {
             _tapped = false;
             e.touchEvent = static_cast<char>(TOUCH_ACTION_TAP);
-            LOG_DEBUG("action TAP(%d/%d)\n", _last_x, _last_y);
+            LOG_DEBUG("action TAP(%d/%d)", _last_x, _last_y);
         }
     } else {
         if (_tapped && (time_t(millis()) - _start) > TIME_LONG_PRESS - 50) {
             _tapped = false;
             e.touchEvent = static_cast<char>(TOUCH_ACTION_TAP);
-            LOG_DEBUG("action TAP(%d/%d)\n", _last_x, _last_y);
+            LOG_DEBUG("action TAP(%d/%d)", _last_x, _last_y);
         }
     }
 #else

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1059,7 +1059,7 @@ void NodeDB::loadFromDisk()
     state = loadProto(uiconfigFileName, meshtastic_DeviceUIConfig_size, sizeof(meshtastic_DeviceUIConfig),
                       &meshtastic_DeviceUIConfig_msg, &uiconfig);
     if (state == LoadFileResult::LOAD_SUCCESS) {
-        LOG_INFO("Loaded UIConfig\n");
+        LOG_INFO("Loaded UIConfig");
     }
 
     // 2.4.X - configuration migration to update new default intervals

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -201,7 +201,7 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
         break;
 
     case STATE_SEND_UIDATA:
-        LOG_INFO("getFromRadio=STATE_SEND_UIDATA\n");
+        LOG_INFO("getFromRadio=STATE_SEND_UIDATA");
         fromRadioScratch.which_payload_variant = meshtastic_FromRadio_deviceuiConfig_tag;
         fromRadioScratch.deviceuiConfig = uiconfig;
         state = STATE_SEND_OWN_NODEINFO;

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -176,7 +176,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         handleSetHamMode(r->set_ham_mode);
         break;
     case meshtastic_AdminMessage_get_ui_config_request_tag: {
-        LOG_INFO("Client is getting device-ui config\n");
+        LOG_INFO("Client is getting device-ui config");
         handleGetDeviceUIConfig(mp);
         handled = true;
         break;
@@ -241,7 +241,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         break;
     }
     case meshtastic_AdminMessage_store_ui_config_tag: {
-        LOG_INFO("Storing device-ui config\n");
+        LOG_INFO("Storing device-ui config");
         handleStoreDeviceUIConfig(r->store_ui_config);
         break;
     }
@@ -488,7 +488,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c)
             IS_ONE_OF(config.device.role, meshtastic_Config_DeviceConfig_Role_ROUTER,
                       meshtastic_Config_DeviceConfig_Role_REPEATER)) {
             config.device.rebroadcast_mode = meshtastic_Config_DeviceConfig_RebroadcastMode_ALL;
-            const char *warning = "Rebroadcast mode can't be set to NONE for a router or repeater\n";
+            const char *warning = "Rebroadcast mode can't be set to NONE for a router or repeater";
             LOG_WARN(warning);
             sendWarning(warning);
         }

--- a/src/motion/QMA6100PSensor.cpp
+++ b/src/motion/QMA6100PSensor.cpp
@@ -88,13 +88,13 @@ bool QMA6100PSingleton::init(ScanI2C::FoundDevice device)
     bool status = begin(device.address.address, &Wire);
 #endif
     if (status != true) {
-        LOG_WARN("QMA6100P init begin failed\n");
+        LOG_WARN("QMA6100P init begin failed");
         return false;
     }
     delay(20);
     // SW reset to make sure the device starts in a known state
     if (softwareReset() != true) {
-        LOG_WARN("QMA6100P init reset failed\n");
+        LOG_WARN("QMA6100P init reset failed");
         return false;
     }
     delay(20);

--- a/variants/rak2560/RAK9154Sensor.cpp
+++ b/variants/rak2560/RAK9154Sensor.cpp
@@ -37,11 +37,11 @@ static void onewire_evt(const uint8_t pid, const uint8_t sid, const SNHUBAPI_EVT
         break;
 
     case SNHUBAPI_EVT_ADD_SID:
-        // LOG_INFO("+ADD:SID:[%02x]\r\n", msg[0]);
+        // LOG_INFO("+ADD:SID:[%02x]", msg[0]);
         break;
 
     case SNHUBAPI_EVT_ADD_PID:
-        // LOG_INFO("+ADD:PID:[%02x]\r\n", msg[0]);
+        // LOG_INFO("+ADD:PID:[%02x]", msg[0]);
 #ifdef BOOT_DATA_REQ
         provision = msg[0];
 #endif
@@ -55,12 +55,12 @@ static void onewire_evt(const uint8_t pid, const uint8_t sid, const SNHUBAPI_EVT
 
     case SNHUBAPI_EVT_SDATA_REQ:
 
-        // LOG_INFO("+EVT:PID[%02x],IPSO[%02x]\r\n",pid,msg[0]);
+        // LOG_INFO("+EVT:PID[%02x],IPSO[%02x]",pid,msg[0]);
         // for( uint16_t i=1; i<len; i++)
         // {
         //     LOG_INFO("%02x,", msg[i]);
         // }
-        // LOG_INFO("\r\n");
+        // LOG_INFO("");
         switch (msg[0]) {
         case RAK_IPSO_CAPACITY:
             dc_prec = msg[1];
@@ -82,12 +82,12 @@ static void onewire_evt(const uint8_t pid, const uint8_t sid, const SNHUBAPI_EVT
         break;
     case SNHUBAPI_EVT_REPORT:
 
-        // LOG_INFO("+EVT:PID[%02x],IPSO[%02x]\r\n",pid,msg[0]);
+        // LOG_INFO("+EVT:PID[%02x],IPSO[%02x]",pid,msg[0]);
         // for( uint16_t i=1; i<len; i++)
         // {
         //     LOG_INFO("%02x,", msg[i]);
         // }
-        // LOG_INFO("\r\n");
+        // LOG_INFO("");
 
         switch (msg[0]) {
         case RAK_IPSO_CAPACITY:
@@ -110,11 +110,11 @@ static void onewire_evt(const uint8_t pid, const uint8_t sid, const SNHUBAPI_EVT
         break;
 
     case SNHUBAPI_EVT_CHKSUM_ERR:
-        LOG_INFO("+ERR:CHKSUM\r\n");
+        LOG_INFO("+ERR:CHKSUM");
         break;
 
     case SNHUBAPI_EVT_SEQ_ERR:
-        LOG_INFO("+ERR:SEQUCE\r\n");
+        LOG_INFO("+ERR:SEQUCE");
         break;
 
     default:


### PR DESCRIPTION
\n was previously removed from log lines. This patch brings some missed line endings up to date with our standard.