### PR TITLE
Fixed localization on bigger screens

### DIFF
--- a/src/graphics/ScreenFonts.h
+++ b/src/graphics/ScreenFonts.h
@@ -16,63 +16,61 @@
 #include "graphics/fonts/OLEDDisplayFontsCS.h"
 #endif
 
+#ifdef OLED_PL
+#define FONT_SMALL_LOCAL ArialMT_Plain_10_PL
+#else
+#ifdef OLED_RU
+#define FONT_SMALL_LOCAL ArialMT_Plain_10_RU
+#else
+#ifdef OLED_UA
+#define FONT_SMALL_LOCAL ArialMT_Plain_10_UA // Height: 13
+#else
+#ifdef OLED_CS
+#define FONT_SMALL_LOCAL ArialMT_Plain_10_CS
+#else
+#define FONT_SMALL_LOCAL ArialMT_Plain_10 // Height: 13
+#endif
+#endif
+#endif
+#endif
+#ifdef OLED_PL
+#define FONT_MEDIUM_LOCAL ArialMT_Plain_16_PL // Height: 19
+#else
+#ifdef OLED_UA
+#define FONT_MEDIUM_LOCAL ArialMT_Plain_16_UA // Height: 19
+#else
+#ifdef OLED_CS
+#define FONT_MEDIUM_LOCAL ArialMT_Plain_16_CS
+#else
+#define FONT_MEDIUM_LOCAL ArialMT_Plain_16 // Height: 19
+#endif
+#endif
+#endif
+#ifdef OLED_PL
+#define FONT_LARGE_LOCAL ArialMT_Plain_24_PL // Height: 28
+#else
+#ifdef OLED_UA
+#define FONT_LARGE_LOCAL ArialMT_Plain_24_UA // Height: 28
+#else
+#ifdef OLED_CS
+#define FONT_LARGE_LOCAL ArialMT_Plain_24_CS // Height: 28
+#else
+#define FONT_LARGE_LOCAL ArialMT_Plain_24 // Height: 28
+#endif
+#endif
+#endif
+
 #if (defined(USE_EINK) || defined(ILI9341_DRIVER) || defined(ILI9342_DRIVER) || defined(ST7701_CS) || defined(ST7735_CS) ||      \
      defined(ST7789_CS) || defined(USE_ST7789) || defined(HX8357_CS)) &&                                                         \
     !defined(DISPLAY_FORCE_SMALL_FONTS)
 // The screen is bigger so use bigger fonts
-#ifdef OLED_PL
-#define FONT_SMALL ArialMT_Plain_16_PL  // Height: 19
-#define FONT_MEDIUM ArialMT_Plain_24_PL // Height: 28
-#define FONT_LARGE ArialMT_Plain_24_PL  // Height: 28
+#define FONT_SMALL FONT_MEDIUM_LOCAL // Height: 19
+#define FONT_MEDIUM FONT_LARGE_LOCAL // Height: 28
+#define FONT_LARGE FONT_LARGE_LOCAL  // Height: 28
 #else
-#define FONT_SMALL ArialMT_Plain_16  // Height: 19
-#define FONT_MEDIUM ArialMT_Plain_24 // Height: 28
-#define FONT_LARGE ArialMT_Plain_24  // Height: 28
-#endif
-#else
-#ifdef OLED_PL
-#define FONT_SMALL ArialMT_Plain_10_PL
-#else
-#ifdef OLED_RU
-#define FONT_SMALL ArialMT_Plain_10_RU
-#else
-#ifdef OLED_UA
-#define FONT_SMALL ArialMT_Plain_10_UA // Height: 13
-#else
-#ifdef OLED_CS
-#define FONT_SMALL ArialMT_Plain_10_CS
-#else
-#define FONT_SMALL ArialMT_Plain_10 // Height: 13
-#endif
-#endif
-#endif
-#endif
-#ifdef OLED_PL
-#define FONT_MEDIUM ArialMT_Plain_16_PL // Height: 19
-#else
-#ifdef OLED_UA
-#define FONT_MEDIUM ArialMT_Plain_16_UA // Height: 19
-#else
-#ifdef OLED_CS
-#define FONT_MEDIUM ArialMT_Plain_16_CS
-#else
-#define FONT_MEDIUM ArialMT_Plain_16 // Height: 19
-#endif
-#endif
-#endif
-#ifdef OLED_PL
-#define FONT_LARGE ArialMT_Plain_24_PL // Height: 28
-#else
-#ifdef OLED_UA
-#define FONT_LARGE ArialMT_Plain_24_UA // Height: 28
-#else
-#ifdef OLED_CS
-#define FONT_LARGE ArialMT_Plain_24_CS // Height: 28
-#else
-#define FONT_LARGE ArialMT_Plain_24 // Height: 28
-#endif
-#endif
-#endif
+#define FONT_SMALL FONT_SMALL_LOCAL   // Height: 13
+#define FONT_MEDIUM FONT_MEDIUM_LOCAL // Height: 19
+#define FONT_LARGE FONT_LARGE_LOCAL   // Height: 28
 #endif
 
 #define _fontHeight(font) ((font)[1] + 1) // height is position 1


### PR DESCRIPTION
Hi. There is a bug, that if the firmware is compiled with bigger screen, then default text localization is used even if custom localization build flag is set. It is caused by this [condition](https://github.com/meshtastic/firmware/blob/master/src/graphics/ScreenFonts.h#L19) in the beginning.

I've fixed macros to always use the localized glyph array (if available) and just change font size assignments for different displays. Will appreciate any idea how to make it even more readable.
Relates to #5661.
