### PR TITLE
DevContainers: Include meshtasticd dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,9 +27,11 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     hwdata \
     gpg \
     gnupg2 \
+    libusb-1.0-0-dev \
+    libi2c-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN pipx install platformio==6.1.15
+RUN pipx install platformio
 
 COPY 99-platformio-udev.rules /etc/udev/rules.d/99-platformio-udev.rules
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,10 @@
+# trunk-ignore-all(terrascan/AC_DOCKER_0002): Known terrascan issue
+# trunk-ignore-all(hadolint/DL3008): Do not pin apt package versions
+# trunk-ignore-all(hadolint/DL3013): Do not pin pip package versions
 FROM mcr.microsoft.com/devcontainers/cpp:1-debian-12
 
 USER root
 
-# trunk-ignore(terrascan/AC_DOCKER_0002): Known terrascan issue
-# trunk-ignore(hadolint/DL3008): Use latest version of packages
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
     ca-certificates \

--- a/bin/build-native.sh
+++ b/bin/build-native.sh
@@ -24,7 +24,7 @@ mkdir -p $OUTDIR/
 rm -r $OUTDIR/* || true
 
 # Important to pull latest version of libs into all device flavors, otherwise some devices might be stale
-platformio pkg update --environment native || platformioFailed
+pio pkg update --environment native || platformioFailed
 pio run --environment native || platformioFailed
 cp .pio/build/native/program "$OUTDIR/meshtasticd_linux_$(uname -m)"
 cp bin/native-install.* $OUTDIR


### PR DESCRIPTION
This includes changes that support two docker dev container issues:

* Support for floating PlatformIO (locking is causing issues with rebuild) to latest
* Inclusion of additional dependencies in the the devcontiner for building native / `meshtasticd`
** libusb
** libi2c