### PR TITLE
Move DecodedServiceEnvelope into its own file

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -2,6 +2,7 @@
 #include "MeshService.h"
 #include "NodeDB.h"
 #include "PowerFSM.h"
+#include "ServiceEnvelope.h"
 #include "configuration.h"
 #include "main.h"
 #include "mesh/Channels.h"
@@ -25,7 +26,6 @@
 #endif
 #include <Throttle.h>
 #include <assert.h>
-#include <pb_decode.h>
 #include <utility>
 
 #include <IPAddress.h>
@@ -46,23 +46,6 @@ constexpr int reconnectMax = 5;
 static uint8_t bytes[meshtastic_MqttClientProxyMessage_size + 30]; // 12 for channel name and 16 for nodeid
 
 static bool isMqttServerAddressPrivate = false;
-
-// meshtastic_ServiceEnvelope that automatically releases dynamically allocated memory when it goes out of scope.
-struct DecodedServiceEnvelope : public meshtastic_ServiceEnvelope {
-    DecodedServiceEnvelope() = delete;
-    DecodedServiceEnvelope(const uint8_t *payload, size_t length)
-        : meshtastic_ServiceEnvelope(meshtastic_ServiceEnvelope_init_default),
-          validDecode(pb_decode_from_bytes(payload, length, &meshtastic_ServiceEnvelope_msg, this))
-    {
-    }
-    ~DecodedServiceEnvelope()
-    {
-        if (validDecode)
-            pb_release(&meshtastic_ServiceEnvelope_msg, this);
-    }
-    // Clients must check that this is true before using.
-    const bool validDecode;
-};
 
 inline void onReceiveProto(char *topic, byte *payload, size_t length)
 {

--- a/src/mqtt/ServiceEnvelope.cpp
+++ b/src/mqtt/ServiceEnvelope.cpp
@@ -1,0 +1,23 @@
+#include "ServiceEnvelope.h"
+#include "mesh-pb-constants.h"
+#include <pb_decode.h>
+
+DecodedServiceEnvelope::DecodedServiceEnvelope(const uint8_t *payload, size_t length)
+    : meshtastic_ServiceEnvelope(meshtastic_ServiceEnvelope_init_default),
+      validDecode(pb_decode_from_bytes(payload, length, &meshtastic_ServiceEnvelope_msg, this))
+{
+}
+
+DecodedServiceEnvelope::DecodedServiceEnvelope(DecodedServiceEnvelope &&other)
+    : meshtastic_ServiceEnvelope(meshtastic_ServiceEnvelope_init_zero), validDecode(other.validDecode)
+{
+    std::swap(packet, other.packet);
+    std::swap(channel_id, other.channel_id);
+    std::swap(gateway_id, other.gateway_id);
+}
+
+DecodedServiceEnvelope::~DecodedServiceEnvelope()
+{
+    if (validDecode)
+        pb_release(&meshtastic_ServiceEnvelope_msg, this);
+}

--- a/src/mqtt/ServiceEnvelope.h
+++ b/src/mqtt/ServiceEnvelope.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "mesh/generated/meshtastic/mqtt.pb.h"
+
+// meshtastic_ServiceEnvelope that automatically releases dynamically allocated memory when it goes out of scope.
+struct DecodedServiceEnvelope : public meshtastic_ServiceEnvelope {
+    DecodedServiceEnvelope(const uint8_t *payload, size_t length);
+    DecodedServiceEnvelope(DecodedServiceEnvelope &) = delete;
+    DecodedServiceEnvelope(DecodedServiceEnvelope &&);
+    ~DecodedServiceEnvelope();
+    // Clients must check that this is true before using.
+    const bool validDecode;
+};


### PR DESCRIPTION
So it can be shared with [unit tests](https://github.com/esev/meshtastic-firmware/commit/7244bbeab110e87a2a6196632e76b1dfed216f70).

This PR also forbids using the copy constructor, as it would result in a double-free, and implements the move constructor.