### PR TITLE
Add support for LS20031 GPS module.

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1190,6 +1190,8 @@ GnssModel_t GPS::probe(int serialSpeed)
     PROBE_SIMPLE("L76B", "$PMTK605*31", "Quectel-L76B", GNSS_MODEL_MTK_L76B, 500);
     PROBE_SIMPLE("PA1616S", "$PMTK605*31", "1616S", GNSS_MODEL_MTK_PA1616S, 500);
 
+    PROBE_SIMPLE("LS20031", "$PMTK605*31", "MC-1513", GNSS_MODEL_LS20031, 500);
+
     uint8_t cfg_rate[] = {0xB5, 0x62, 0x06, 0x08, 0x00, 0x00, 0x00, 0x00};
     UBXChecksum(cfg_rate, sizeof(cfg_rate));
     clearBuffer();

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -29,7 +29,8 @@ typedef enum {
     GNSS_MODEL_MTK_L76B,
     GNSS_MODEL_MTK_PA1616S,
     GNSS_MODEL_AG3335,
-    GNSS_MODEL_AG3352
+    GNSS_MODEL_AG3352,
+    GNSS_MODEL_LS20031
 } GnssModel_t;
 
 typedef enum {


### PR DESCRIPTION
Adds support for the LOCOSYS LS20031 66-Channel GPS Receiver Module. Confirmed working via `linux-native` on a Raspberry Pi.

```
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:51 57 [GPS] Probe for GPS at 57600
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:51 57 [GPS] Trying $PDTINFO (UC6580)...
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:51 57 [GPS] Trying $PDTINFO (UM600)...
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:52 58 [GPS] Trying $PCAS06,1*1A (ATGM336H)...
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:52 58 [GPS] Trying $PCAS06,1*1A (ATGM332D)...
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:53 59 [GPS] Trying $PAIR021*39 (AG3335)...
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:53 59 [GPS] Trying $PAIR021*39 (AG3352)...
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:54 60 [GPS] Trying $PQTMVERNO*58 (LC86)...
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:54 60 [GPS] Trying $PCAS06,0*1B (L76K)...
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:55 61 [GPS] Trying $PMTK605*31 (L76B)...
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:55 61 [GPS] Trying $PMTK605*31 (PA1616S)...
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:56 62 [GPS] Trying $PMTK314,-1*04 (LS20031)...
Jan 01 18:45:57 indelible-base meshtasticd[5424]: INFO  | 23:45:56 62 [GPS] LS20031 detected, using GNSS_MODEL_LS20031 Module
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:56 62 [GPS] Publish pos@0:2, hasVal=0, Sats=0, GPSlock=0
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:56 62 [GPS] No GPS lock
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:56 62 [GPS] onGPSChanged() pos@0 time=1735775156 lat=0 lon=0 alt=0
====SNIP====
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:56 62 [GPS] NMEA GPS time 2025-01-01 23:45:57 age 0
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:56 62 [GPS] Upgrade time to quality GPS
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:57 62 [GPS] Read RTC time as 1735775157
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:57 62 [GPS] hasValidLocation RISING EDGE
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:57 62 [GPS] Took 62s to get lock
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:57 62 [GPS] Predict 0s to get next lock
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:57 62 [GPS] 120s until next search
Jan 01 18:45:57 indelible-base meshtasticd[5424]: INFO  | 23:45:57 62 [GPS] GPS power state move from ACTIVE to HARDSLEEP
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:57 62 [GPS] Publish pos@6775d3b5:2, hasVal=1, Sats=8, GPSlock=1
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:57 62 [GPS] New GPS pos@6775d3b5:3 lat=(REDACTED) lon=(REDACTED) alt=239 pdop=1.31 track=354.21 speed=0.00 sats=8
Jan 01 18:45:57 indelible-base meshtasticd[5424]: DEBUG | 23:45:57 62 [GPS] onGPSChanged() pos@6775d3b5 time=1735775157 lat=(REDACTED) lon=(REDACTED) alt=239
Jan 01 18:46:01 indelible-base meshtasticd[5424]: INFO  | 23:45:57 62 [GPS] updatePosition LOCAL pos@6775d3b5 time=1735775157 lat=(REDACTED) lon=(REDACTED) alt=239
Jan 01 18:46:01 indelible-base meshtasticd[5424]: DEBUG | 23:45:57 62 [GPS] Set local position: lat=(REDACTED) lon=(REDACTED) time=1735775157 timestamp=1735775157
```

Datasheet: https://cdn.sparkfun.com/datasheets/GPS/LS20030~3_datasheet_v1.3.pdf
