### PR TITLE
Disable coverage generation

### DIFF
--- a/.github/workflows/test_native.yml
+++ b/.github/workflows/test_native.yml
@@ -140,14 +140,14 @@ jobs:
           path: code-coverage-report
           merge-multiple: true
 
-      - name: Generate Code Coverage Report
-        run: |
-          sudo apt-get install -y lcov
-          lcov --quiet --add-tracefile code-coverage-report/coverage_base.info --add-tracefile code-coverage-report/coverage_integration.info --add-tracefile code-coverage-report/coverage_tests.info --output-file code-coverage-report/coverage_src.info
-          genhtml --quiet --legend --prefix "${PWD}" code-coverage-report/coverage_src.info --output-directory code-coverage-report
+      # - name: Generate Code Coverage Report
+      #   run: |
+      #     sudo apt-get install -y lcov
+      #     lcov --quiet --add-tracefile code-coverage-report/coverage_base.info --add-tracefile code-coverage-report/coverage_integration.info --add-tracefile code-coverage-report/coverage_tests.info --output-file code-coverage-report/coverage_src.info
+      #     genhtml --quiet --legend --prefix "${PWD}" code-coverage-report/coverage_src.info --output-directory code-coverage-report
 
-      - name: Save Code Coverage Report
-        uses: actions/upload-artifact@v4
-        with:
-          name: code-coverage-report-${{ steps.version.outputs.version }}.zip
-          path: code-coverage-report
+      # - name: Save Code Coverage Report
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: code-coverage-report-${{ steps.version.outputs.version }}.zip
+      #     path: code-coverage-report

--- a/.github/workflows/test_native.yml
+++ b/.github/workflows/test_native.yml
@@ -120,25 +120,25 @@ jobs:
         run: echo "version=$(./bin/buildinfo.py long)" >> $GITHUB_OUTPUT
         id: version
 
-      - name: Download test artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: platformio-test-report-${{ steps.version.outputs.version }}.zip
-          merge-multiple: true
+      # - name: Download test artifacts
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: platformio-test-report-${{ steps.version.outputs.version }}.zip
+      #     merge-multiple: true
 
-      - name: Test Report
-        uses: dorny/test-reporter@v1.9.1
-        with:
-          name: PlatformIO Tests
-          path: testreport.xml
-          reporter: java-junit
+      # - name: Test Report
+      #   uses: dorny/test-reporter@v1.9.1
+      #   with:
+      #     name: PlatformIO Tests
+      #     path: testreport.xml
+      #     reporter: java-junit
 
-      - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: lcov-coverage-info-native-*-${{ steps.version.outputs.version }}.zip
-          path: code-coverage-report
-          merge-multiple: true
+      # - name: Download coverage artifacts
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     pattern: lcov-coverage-info-native-*-${{ steps.version.outputs.version }}.zip
+      #     path: code-coverage-report
+      #     merge-multiple: true
 
       # - name: Generate Code Coverage Report
       #   run: |


### PR DESCRIPTION
I noticed that `genhtml` is failing. Let's disable that for now until I can reproduce the issue locally and provide a fix.

https://github.com/meshtastic/firmware/actions/runs/12576207177/job/35052519666