### PR TITLE
Use relative paths in coverage info files

### DIFF
--- a/.github/workflows/test_native.yml
+++ b/.github/workflows/test_native.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           sudo apt-get install -y lcov
           lcov ${{ env.LCOV_CAPTURE_FLAGS }} --initial --output-file coverage_base.info
+          sed -i -e "s#${PWD}#.#" coverage_base.info # Make paths relative.
 
       - name: Integration test
         run: |
@@ -48,7 +49,9 @@ jobs:
 
       - name: Capture coverage information
         if: always() # run this step even if previous step failed
-        run: lcov ${{ env.LCOV_CAPTURE_FLAGS }} --test-name integration --output-file coverage_integration.info
+        run: |
+          lcov ${{ env.LCOV_CAPTURE_FLAGS }} --test-name integration --output-file coverage_integration.info
+          sed -i -e "s#${PWD}#.#" coverage_integration.info # Make paths relative.
 
       - name: Get release version string
         if: always() # run this step even if previous step failed
@@ -97,6 +100,7 @@ jobs:
         run: |
           sudo apt-get install -y lcov
           lcov ${{ env.LCOV_CAPTURE_FLAGS }} --test-name tests --output-file coverage_tests.info
+          sed -i -e "s#${PWD}#.#" coverage_tests.info # Make paths relative.
 
       - name: Save coverage information
         uses: actions/upload-artifact@v4
@@ -140,21 +144,21 @@ jobs:
           path: testreport.xml
           reporter: java-junit
 
-      # - name: Download coverage artifacts
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     pattern: lcov-coverage-info-native-*-${{ steps.version.outputs.version }}.zip
-      #     path: code-coverage-report
-      #     merge-multiple: true
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: lcov-coverage-info-native-*-${{ steps.version.outputs.version }}.zip
+          path: code-coverage-report
+          merge-multiple: true
 
-      # - name: Generate Code Coverage Report
-      #   run: |
-      #     sudo apt-get install -y lcov
-      #     lcov --quiet --add-tracefile code-coverage-report/coverage_base.info --add-tracefile code-coverage-report/coverage_integration.info --add-tracefile code-coverage-report/coverage_tests.info --output-file code-coverage-report/coverage_src.info
-      #     genhtml --quiet --legend --prefix "${PWD}" code-coverage-report/coverage_src.info --output-directory code-coverage-report
+      - name: Generate Code Coverage Report
+        run: |
+          sudo apt-get install -y lcov
+          lcov --quiet --add-tracefile code-coverage-report/coverage_base.info --add-tracefile code-coverage-report/coverage_integration.info --add-tracefile code-coverage-report/coverage_tests.info --output-file code-coverage-report/coverage_src.info
+          genhtml --quiet --legend --prefix "${PWD}" code-coverage-report/coverage_src.info --output-directory code-coverage-report
 
-      # - name: Save Code Coverage Report
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: code-coverage-report-${{ steps.version.outputs.version }}.zip
-      #     path: code-coverage-report
+      - name: Save Code Coverage Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report-${{ steps.version.outputs.version }}.zip
+          path: code-coverage-report


### PR DESCRIPTION
This handles the case where runners have a different working directory (ex: `/home/runner/work/` vs `/home/runner/_work/`) as was seen in https://github.com/meshtastic/firmware/actions/runs/12576207177/job/35052519666

Tested: https://github.com/esev/meshtastic-firmware/actions/runs/12577663463