### PR TITLE
Disable BUILD_EPOCH for unit tests

### DIFF
--- a/.github/workflows/test_native.yml
+++ b/.github/workflows/test_native.yml
@@ -84,6 +84,11 @@ jobs:
         run: echo "version=$(./bin/buildinfo.py long)" >> $GITHUB_OUTPUT
         id: version
 
+      # Disable (comment-out) BUILD_EPOCH. It causes a full rebuild between tests and resets the
+      # coverage information each time.
+      - name: Disable BUILD_EPOCH
+        run: sed -i 's/-DBUILD_EPOCH=$UNIX_TIME/#-DBUILD_EPOCH=$UNIX_TIME/' platformio.ini
+
       - name: PlatformIO Tests
         run: platformio test -e coverage --junit-output-path testreport.xml
 


### PR DESCRIPTION
PlatformIO runs the build step for each unit test. This builds only the unit test files as long as the other source files don't change. But setting BUILD_EPOCH to $UNIX_TIME will trigger a full rebuild of the source for each unit test. This also has a side-effect of resetting the incremental coverage data before each test. This PR adds a step to disable adding the BUILD_EPOCH define while running the unit tests.