### PR TITLE
meshtastic-debian: `--create requires` missing changelog

### DIFF
--- a/debian/ci_pack_sdeb.sh
+++ b/debian/ci_pack_sdeb.sh
@@ -9,6 +9,7 @@ platformio pkg install -e native
 package=$(dpkg-parsechangelog --show-field Source)
 pkg_version=$(dpkg-parsechangelog --show-field Version | cut -d- -f1)
 
+rm -rf debian/changelog
 dch --create --distribution $SERIES --package $package --newversion $pkg_version-ppa${REVISION::7}~$SERIES \
 	"GitHub Actions Automatic packaging for $SERIES"
 


### PR DESCRIPTION
Small fix for dch