### PR TITLE
fix esp32c3 clock speed

### DIFF
--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -71,8 +71,8 @@ void setCPUFast(bool on)
          * (Added: Dec 23, 2021 by Jm Casler)
          */
 #ifndef CONFIG_IDF_TARGET_ESP32C3
-        LOG_DEBUG("Set CPU to 240MHz because WiFi is in use");
-        setCpuFrequencyMhz(240);
+        LOG_DEBUG("Set CPU to 160MHz because WiFi is in use");
+        setCpuFrequencyMhz(160);
 #endif
         return;
     }


### PR DESCRIPTION
ESP32C3 max clock speed is 160MHz, but in firmware we were setting it to 240MHz, I don't think it may cause any issues but it should be safer to set it to the right clock speed
