### PR TITLE
Increase esp32c3 stability over wifi

### DIFF
--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -143,6 +143,9 @@ static int32_t reconnectWiFi()
         delay(5000);
 
         if (!WiFi.isConnected()) {
+            WiFi.mode(WIFI_MODE_NULL);
+            WiFi.useStaticBuffers(true);
+            WiFi.mode(WIFI_STA);
             WiFi.begin(wifiName, wifiPsw);
         }
         isReconnecting = false;

--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -143,9 +143,11 @@ static int32_t reconnectWiFi()
         delay(5000);
 
         if (!WiFi.isConnected()) {
+#ifdef CONFIG_IDF_TARGET_ESP32C3
             WiFi.mode(WIFI_MODE_NULL);
             WiFi.useStaticBuffers(true);
             WiFi.mode(WIFI_STA);
+#endif
             WiFi.begin(wifiName, wifiPsw);
         }
         isReconnecting = false;


### PR DESCRIPTION
I had many issues with wifi stability on my Heltec HT-CT62 (esp32c3 based).
Initially I thought it was related to hardware design but I checked multiple times and it was following design recommendations.

I also tried adding `WiFi.setTxPower(WIFI_POWER_8_5dBm);`  which was needed due to a hardware issues in earlier esp32c3 models but did no difference.

In the end I tried with `WiFi.useStaticBuffers(true);` and it was finally working as it should, no more wifi disconnections or intermittent loading.

I would be happy if someone with same issues could try this changes and report if working but that's been game changing for me