### PR TITLE
GitHub Actions: Trigger PPA release builds upon publish

### DIFF
--- a/.github/workflows/release_channels.yml
+++ b/.github/workflows/release_channels.yml
@@ -1,0 +1,20 @@
+name: Trigger release workflows upon Publish
+
+on:
+  release:
+    types: [published]
+
+permissions: read-all
+
+jobs:
+  package-ppa:
+    strategy:
+      fail-fast: false
+      matrix:
+        series: [plucky, oracular, noble, jammy]
+    uses: ./.github/workflows/package_ppa.yml
+    with:
+      ppa_repo: |-
+        ${{ contains(github.event.release.name, 'Beta') && 'beta' || contains(github.event.release.name, 'Alpha') && 'alpha' }}
+      series: ${{ matrix.series }}
+    secrets: inherit


### PR DESCRIPTION
Should trigger upon *publish* of a pre-release (Alpha) or release (Beta), and send PPA jobs to the Alpha/Beta PPA repos