### PR TITLE
Hello world support for UDP broadcasts over the LAN on ESP32

### DIFF
--- a/arch/esp32/esp32.ini
+++ b/arch/esp32/esp32.ini
@@ -37,6 +37,7 @@ build_flags =
   -DLIBPAX_ARDUINO
   -DLIBPAX_WIFI
   -DLIBPAX_BLE
+  -DHAS_UDP_MULTICAST=1
   ;-DDEBUG_HEAP
 
 lib_deps =

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,6 +114,11 @@ AccelerometerThread *accelerometerThread = nullptr;
 AudioThread *audioThread = nullptr;
 #endif
 
+#ifdef HAS_UDP_MULTICAST
+#include "mesh/udp/UdpMulticastThread.h"
+UdpMulticastThread *udpThread = nullptr;
+#endif
+
 #if defined(TCXO_OPTIONAL)
 float tcxoVoltage = SX126X_DIO3_TCXO_VOLTAGE; // if TCXO is optional, put this here so it can be changed further down.
 #endif
@@ -782,6 +787,11 @@ void setup()
 #ifdef HAS_I2S
     LOG_DEBUG("Start audio thread");
     audioThread = new AudioThread();
+#endif
+
+#ifdef HAS_UDP_MULTICAST
+    LOG_DEBUG("Start multicast thread");
+    udpThread = new UdpMulticastThread();
 #endif
     service = new MeshService();
     service->init();

--- a/src/main.h
+++ b/src/main.h
@@ -49,6 +49,11 @@ extern Adafruit_DRV2605 drv;
 extern AudioThread *audioThread;
 #endif
 
+#ifdef HAS_UDP_MULTICAST
+#include "mesh/udp/UdpMulticastThread.h"
+extern UdpMulticastThread *udpThread;
+#endif
+
 // Global Screen singleton.
 extern graphics::Screen *screen;
 

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -299,6 +299,8 @@ NodeDB::NodeDB()
     resetRadioConfig(); // If bogus settings got saved, then fix them
     // nodeDB->LOG_DEBUG("region=%d, NODENUM=0x%x, dbsize=%d", config.lora.region, myNodeInfo.my_node_num, numMeshNodes);
 
+    config.network.enabled_protocols = meshtastic_Config_NetworkConfig_ProtocolFlags_UDP_BROADCAST;
+
     // If we are setup to broadcast on the default channel, ensure that the telemetry intervals are coerced to the minimum value
     // of 30 minutes or more
     if (channels.isDefaultChannel(channels.getPrimaryIndex())) {

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -299,7 +299,8 @@ NodeDB::NodeDB()
     resetRadioConfig(); // If bogus settings got saved, then fix them
     // nodeDB->LOG_DEBUG("region=%d, NODENUM=0x%x, dbsize=%d", config.lora.region, myNodeInfo.my_node_num, numMeshNodes);
 
-    config.network.enabled_protocols = meshtastic_Config_NetworkConfig_ProtocolFlags_UDP_BROADCAST;
+    // Uncomment below to always enable UDP broadcasts
+    // config.network.enabled_protocols = meshtastic_Config_NetworkConfig_ProtocolFlags_UDP_BROADCAST;
 
     // If we are setup to broadcast on the default channel, ensure that the telemetry intervals are coerced to the minimum value
     // of 30 minutes or more

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -275,8 +275,7 @@ ErrorCode Router::send(meshtastic_MeshPacket *p)
             return encodeResult; // FIXME - this isn't a valid ErrorCode
         }
 #if HAS_UDP_MULTICAST
-        if (udpThread && isFromUs(p) &&
-            config.network.enabled_protocols & meshtastic_Config_NetworkConfig_ProtocolFlags_UDP_BROADCAST) {
+        if (udpThread && config.network.enabled_protocols & meshtastic_Config_NetworkConfig_ProtocolFlags_UDP_BROADCAST) {
             udpThread->onSend(const_cast<meshtastic_MeshPacket *>(p));
         }
 #endif
@@ -630,12 +629,6 @@ void Router::handleReceived(meshtastic_MeshPacket *p, RxSource src)
         // After potentially altering it, publish received message to MQTT if we're not the original transmitter of the packet
         if ((decoded || p_encrypted->pki_encrypted) && moduleConfig.mqtt.enabled && !isFromUs(p) && mqtt)
             mqtt->onSend(*p_encrypted, *p, p->channel);
-#endif
-#if HAS_UDP_MULTICAST
-        if ((decoded || p_encrypted->pki_encrypted) && udpThread &&
-            config.network.enabled_protocols & meshtastic_Config_NetworkConfig_ProtocolFlags_UDP_BROADCAST) {
-            udpThread->onSend(const_cast<meshtastic_MeshPacket *>(p_encrypted));
-        }
 #endif
     }
 

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -632,7 +632,7 @@ void Router::handleReceived(meshtastic_MeshPacket *p, RxSource src)
             mqtt->onSend(*p_encrypted, *p, p->channel);
 #endif
 #if HAS_UDP_MULTICAST
-        if ((decoded || p_encrypted->pki_encrypted) && !isFromUs(p) && udpThread &&
+        if ((decoded || p_encrypted->pki_encrypted) && udpThread &&
             config.network.enabled_protocols & meshtastic_Config_NetworkConfig_ProtocolFlags_UDP_BROADCAST) {
             udpThread->onSend(const_cast<meshtastic_MeshPacket *>(p_encrypted));
         }

--- a/src/mesh/udp/UdpMulticastThread.h
+++ b/src/mesh/udp/UdpMulticastThread.h
@@ -36,7 +36,7 @@ class UdpMulticastThread : public concurrency::OSThread
         bool isPacketDecoded = pb_decode_from_bytes(bytes, packetLength, &meshtastic_MeshPacket_msg, &mp);
         if (isPacketDecoded && router) {
             UniquePacketPoolPacket p = packetPool.allocUniqueCopy(mp);
-            // Unset received SNR/RSSI which might have been added by the MQTT gateway
+            // Unset received SNR/RSSI
             p->rx_snr = 0;
             p->rx_rssi = 0;
             router->enqueueReceivedMessage(p.release());

--- a/src/mesh/udp/UdpMulticastThread.h
+++ b/src/mesh/udp/UdpMulticastThread.h
@@ -48,10 +48,9 @@ class UdpMulticastThread : public concurrency::OSThread
         if (!mp || WiFi.status() != WL_CONNECTED) {
             return false;
         }
-        LOG_DEBUG("Broadcasting MeshPacket (id=%u)", mp->id);
+        LOG_DEBUG("Broadcasting packet over UDP (id=%u)", mp->id);
         uint8_t buffer[meshtastic_MeshPacket_size];
         size_t encodedLength = pb_encode_to_bytes(buffer, sizeof(buffer), &meshtastic_MeshPacket_msg, mp);
-        LOG_DEBUG("Encoded MeshPacket size: %u", encodedLength);
         udp.broadcastTo(buffer, encodedLength, UDP_MULTICAST_DEFAUL_PORT);
         return true;
     }

--- a/src/mesh/udp/UdpMulticastThread.h
+++ b/src/mesh/udp/UdpMulticastThread.h
@@ -1,0 +1,71 @@
+#pragma once
+#if HAS_UDP_MULTICAST
+#include "configuration.h"
+#include "main.h"
+#include "mesh/Router.h"
+
+#include <AsyncUDP.h>
+#include <WiFi.h>
+
+#define UDP_MULTICAST_DEFAUL_PORT 4403 // Default port for UDP multicast is same as TCP api server
+#define UDP_MULTICAST_THREAD_INTERVAL_MS 15000
+
+class UdpMulticastThread : public concurrency::OSThread
+{
+  public:
+    UdpMulticastThread() : OSThread("UdpMulticast") { udpIpAddress = IPAddress(224, 0, 0, 69); }
+
+    void start()
+    {
+        if (udp.listenMulticast(udpIpAddress, UDP_MULTICAST_DEFAUL_PORT)) {
+            LOG_DEBUG("UDP Listening on IP: %s", WiFi.localIP().toString().c_str());
+            udp.onPacket([this](AsyncUDPPacket packet) { onReceive(packet); });
+        } else {
+            LOG_DEBUG("Failed to listen on UDP");
+        }
+    }
+
+    void onReceive(AsyncUDPPacket packet)
+    {
+        size_t packetLength = packet.length();
+        LOG_DEBUG("UDP broadcast from: %s, len=%u", packet.remoteIP().toString().c_str(), packetLength);
+        meshtastic_MeshPacket mp;
+        uint8_t bytes[meshtastic_MeshPacket_size]; // Allocate buffer for the data
+        size_t packetSize = packet.readBytes(bytes, packet.length());
+        LOG_DEBUG("Decoding MeshPacket from UDP len=%u", packetSize);
+        bool isPacketDecoded = pb_decode_from_bytes(bytes, packetLength, &meshtastic_MeshPacket_msg, &mp);
+        if (isPacketDecoded && router) {
+            UniquePacketPoolPacket p = packetPool.allocUniqueCopy(mp);
+            // Unset received SNR/RSSI which might have been added by the MQTT gateway
+            p->rx_snr = 0;
+            p->rx_rssi = 0;
+            router->enqueueReceivedMessage(p.release());
+        }
+    }
+
+    bool onSend(const meshtastic_MeshPacket *mp)
+    {
+        if (!mp || WiFi.status() != WL_CONNECTED) {
+            return false;
+        }
+        LOG_DEBUG("Broadcasting MeshPacket (id=%u)", mp->id);
+        uint8_t buffer[meshtastic_MeshPacket_size];
+        size_t encodedLength = pb_encode_to_bytes(buffer, sizeof(buffer), &meshtastic_MeshPacket_msg, mp);
+        LOG_DEBUG("Encoded MeshPacket size: %u", encodedLength);
+        udp.broadcastTo(buffer, encodedLength, UDP_MULTICAST_DEFAUL_PORT);
+        return true;
+    }
+
+  protected:
+    int32_t runOnce() override
+    {
+        canSleep = true;
+        // TODO: Might consider a heartbeat for discovery or keep alive?
+        return UDP_MULTICAST_THREAD_INTERVAL_MS;
+    }
+
+  private:
+    IPAddress udpIpAddress;
+    AsyncUDP udp;
+};
+#endif // ARCH_ESP32

--- a/src/mesh/udp/UdpMulticastThread.h
+++ b/src/mesh/udp/UdpMulticastThread.h
@@ -59,7 +59,7 @@ class UdpMulticastThread : public concurrency::OSThread
     int32_t runOnce() override
     {
         canSleep = true;
-        // TODO: Might consider a heartbeat for discovery or keep alive?
+        // TODO: Implement nodeinfo broadcast
         return UDP_MULTICAST_THREAD_INTERVAL_MS;
     }
 

--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -112,6 +112,12 @@ static void onNetworkConnected()
         APStartupComplete = true;
     }
 
+#if HAS_UDP_MULTICAST
+    if (udpThread) {
+        udpThread->start();
+    }
+#endif
+
     // FIXME this is kinda yucky, instead we should just have an observable for 'wifireconnected'
 #ifndef MESHTASTIC_EXCLUDE_MQTT
     if (mqtt)


### PR DESCRIPTION
Couple of remarks:
I have this hardcoded to the address `IPAddress(224, 0, 0, 69)`, which seems to be fine (for now). I have also pegged the port to `4403` because we know this port already on the TCP api side of things.

I would like to test this out over something like a Tailscale VPN to see if it can work over such network boundaries potentially. I'm not too well versed in lower level socket communications, so we'll see. I'd also like to make a client proxy mode for this too, so that we can enable BLE and serial only devices to play as well.
<img width="1070" alt="image" src="https://github.com/user-attachments/assets/931ba930-c69a-4f5e-a50c-86b311398610" />

The easiest way to test this locally is to join a couple of ESP32 nodes to your Wifi and set `lora.tx_enabled` to false