### PR TITLE
Small fix: debian, curl follow redirs

### DIFF
--- a/debian/ci_pack_sdeb.sh
+++ b/debian/ci_pack_sdeb.sh
@@ -11,7 +11,7 @@ platformio pkg install -e native -t platformio/tool-scons@4.40502.0
 tar -cf pio.tar pio/
 rm -rf pio
 # Download the latest meshtastic/web release build.tar to `web.tar`
-curl https://github.com/meshtastic/web/releases/download/latest/build.tar -o web.tar
+curl -L https://github.com/meshtastic/web/releases/download/latest/build.tar -o web.tar
 
 package=$(dpkg-parsechangelog --show-field Source)
 

--- a/debian/control
+++ b/debian/control
@@ -3,6 +3,8 @@ Section: misc
 Priority: optional
 Maintainer: Austin Lane <vidplace7@gmail.com>
 Build-Depends: debhelper-compat (= 13),
+               tar,
+               gzip,
                platformio,
                python3-protobuf,
                python3-grpcio,


### PR DESCRIPTION
curl previously downloaded a 0 byte file. `-L` allows it to follow redirects and download correctly.