### PR TITLE
meshtasticd-debian: Fix Beta promotions, deb versioning compliance, add OBS

### DIFF
--- a/.github/workflows/build_debian_src.yml
+++ b/.github/workflows/build_debian_src.yml
@@ -7,7 +7,11 @@ on:
         required: true
     inputs:
       series:
-        description: Ubuntu series to target
+        description: Ubuntu/Debian series to target
+        required: true
+        type: string
+      build_location:
+        description: Location where build will execute
         required: true
         type: string
 
@@ -47,6 +51,8 @@ jobs:
         working-directory: meshtasticd
         run: |
           echo "deb=$(./bin/buildinfo.py deb)" >> $GITHUB_OUTPUT
+        env:
+          BUILD_LOCATION: ${{ inputs.build_location }}
         id: version
 
       - name: Fetch libdeps, package debian source

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,13 +17,3 @@ jobs:
         uses: trunk-io/trunk-action@782e83f803ca6e369f035d64c6ba2768174ba61b
         with:
           trunk-token: ${{ secrets.TRUNK_TOKEN }}
-  package-ppa:
-    strategy:
-      fail-fast: false
-      matrix:
-        series: [plucky, oracular, noble, jammy]
-    uses: ./.github/workflows/package_ppa.yml
-    with:
-      ppa_repo: daily
-      series: ${{ matrix.series }}
-    secrets: inherit

--- a/.github/workflows/nightly_debian.yml
+++ b/.github/workflows/nightly_debian.yml
@@ -1,0 +1,37 @@
+name: Nightly Debian Packaging
+on:
+  schedule:
+    - cron: 0 9 * * *
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - debian/**
+      - .github/workflows/nightly_debian.yml
+      - .github/workflows/build_debian_src.yml
+      - .github/workflows/package_ppa.yml
+      - .github/workflows/package_obs.yml
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  package-ppa:
+    strategy:
+      fail-fast: false
+      matrix:
+        series: [plucky, oracular, noble, jammy]
+    uses: ./.github/workflows/package_ppa.yml
+    with:
+      ppa_repo: daily
+      series: ${{ matrix.series }}
+    secrets: inherit
+
+  package-obs:
+    uses: ./.github/workflows/package_obs.yml
+    with:
+      obs_repo: meshtasticd
+      series: unstable
+    secrets: inherit

--- a/.github/workflows/package_obs.yml
+++ b/.github/workflows/package_obs.yml
@@ -1,0 +1,103 @@
+name: Package for OpenSUSE Build Service
+
+on:
+  workflow_call:
+    secrets:
+      PPA_GPG_PRIVATE_KEY:
+        required: true
+    inputs:
+      obs_repo:
+        description: Meshtastic OBS repo to target
+        required: true
+        type: string
+      series:
+        description: Debian series to target
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build-debian-src:
+    uses: ./.github/workflows/build_debian_src.yml
+    secrets: inherit
+    with:
+      series: ${{ inputs.series }}
+      build_location: obs
+
+  package-obs:
+    runs-on: ubuntu-24.04
+    needs: build-debian-src
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: meshtasticd
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - name: Install OpenSUSE Build Service deps
+        shell: bash
+        run: |
+          echo 'deb http://download.opensuse.org/repositories/openSUSE:/Tools/xUbuntu_24.04/ /' | sudo tee /etc/apt/sources.list.d/openSUSE:Tools.list
+          curl -fsSL https://download.opensuse.org/repositories/openSUSE:Tools/xUbuntu_24.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/openSUSE_Tools.gpg > /dev/null
+          sudo apt-get update -y --fix-missing
+          sudo apt-get install -y osc
+
+      - name: Get release version string
+        working-directory: meshtasticd
+        run: |
+          echo "deb=$(./bin/buildinfo.py deb)" >> $GITHUB_OUTPUT
+        env:
+          BUILD_LOCATION: obs
+        id: version
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: firmware-debian-${{ steps.version.outputs.deb }}~${{ inputs.series }}-src
+          merge-multiple: true
+
+      - name: Display structure of downloaded files
+        run: ls -lah
+
+      # - name: Configure osc
+      #   shell: bash
+      #   env:
+      #     OBS_USERNAME: ${{ secrets.OBS_USERNAME }}
+      #     OBS_PASSWORD: ${{ secrets.OBS_PASSWORD }}
+      #   run: |
+      #     mkdir -p ~/.config/osc
+      #     echo -e "[https://api.opensuse.org]\n" > ~/.config/osc/oscrc
+      #     echo -e "user = $OBS_USERNAME" >> ~/.config/osc/oscrc
+      #     echo -e "pass = $OBS_PASSWORD" >> ~/.config/osc/oscrc
+      #     echo -e "aliases = obs" >> ~/.config/osc/oscrc
+      #     # Authenticate to OBS
+      #     osc meta prj -v
+
+      # - name: Upload Package to OBS
+      #   shell: bash
+      #   run: |
+      #     # Define your OBS project and repository
+      #     OBS_PROJECT="application:meshtastic"
+      #     OBS_REPO="${{ inputs.obs_repo }}"
+
+      #     # Create a temporary directory for osc
+      #     mkdir -p /tmp/osc/$OBS_PROJECT/$OBS_REPO
+      #     cd /tmp/osc/$OBS_PROJECT/$OBS_REPO
+
+      #     # Initialize the package directory
+      #     osc checkout $OBS_PROJECT $OBS_REPO
+
+      #     # Copy package files to the osc directory
+      #     cp $GITHUB_WORKSPACE/*.dsc .
+      #     cp $GITHUB_WORKSPACE/*.tar.xz .
+
+      #     # Add files to osc
+      #     osc addremove
+
+      #     # Commit and push the changes
+      #     osc commit -m "Automated upload from GitHub Actions"

--- a/.github/workflows/package_ppa.yml
+++ b/.github/workflows/package_ppa.yml
@@ -1,4 +1,4 @@
-name: Package Launchpad PPA
+name: Package for Launchpad PPA
 
 on:
   workflow_call:
@@ -14,7 +14,6 @@ on:
         description: Ubuntu series to target
         required: true
         type: string
-  workflow_dispatch:
 
 permissions:
   contents: write
@@ -26,6 +25,7 @@ jobs:
     secrets: inherit
     with:
       series: ${{ inputs.series }}
+      build_location: ppa
 
   package-ppa:
     runs-on: ubuntu-24.04
@@ -55,6 +55,8 @@ jobs:
         working-directory: meshtasticd
         run: |
           echo "deb=$(./bin/buildinfo.py deb)" >> $GITHUB_OUTPUT
+        env:
+          BUILD_LOCATION: ppa
         id: version
 
       - name: Download artifacts

--- a/.github/workflows/release_channels.yml
+++ b/.github/workflows/release_channels.yml
@@ -2,7 +2,7 @@ name: Trigger release workflows upon Publish
 
 on:
   release:
-    types: [published]
+    types: [published, released]
 
 permissions: read-all
 
@@ -18,3 +18,10 @@ jobs:
         ${{ contains(github.event.release.name, 'Beta') && 'beta' || contains(github.event.release.name, 'Alpha') && 'alpha' }}
       series: ${{ matrix.series }}
     secrets: inherit
+
+  # package-obs:
+  #   uses: ./.github/workflows/package_obs.yml
+  #   with:
+  #     obs_repo: meshtasticd
+  #     series: ${{ contains(github.event.release.name, 'Beta') && 'beta' || contains(github.event.release.name, 'Alpha') && 'alpha' }}
+  #   secrets: inherit

--- a/bin/readprops.py
+++ b/bin/readprops.py
@@ -2,6 +2,7 @@ import configparser
 import subprocess
 import os
 run_number = os.getenv('GITHUB_RUN_NUMBER', '0')
+build_location = os.getenv('BUILD_LOCATION', 'local')
 
 def readProps(prefsLoc):
     """Read the version of our project as a string"""
@@ -11,8 +12,8 @@ def readProps(prefsLoc):
     version = dict(config.items("VERSION"))
     verObj = dict(
         short="{}.{}.{}".format(version["major"], version["minor"], version["build"]),
-        deb="unset",
         long="unset",
+        deb="unset",
     )
 
     # Try to find current build SHA if if the workspace is clean.  This could fail if git is not installed
@@ -30,12 +31,12 @@ def readProps(prefsLoc):
         #     # short for 'dirty', we want to keep our verstrings source for protobuf reasons
         #     suffix = sha + "-d"
         verObj["long"] = "{}.{}".format(verObj["short"], suffix)
-        verObj["deb"] = "{}-{}~ppa{}".format(verObj["short"], run_number, sha)
+        verObj["deb"] = "{}.{}~{}{}".format(verObj["short"], run_number, build_location, sha)
     except:
         # print("Unexpected error:", sys.exc_info()[0])
         # traceback.print_exc()
         verObj["long"] = verObj["short"]
-        verObj["deb"] = "{}-{}~ppa".format(verObj["short"], run_number)
+        verObj["deb"] = "{}.{}~{}".format(verObj["short"], run_number, build_location)
 
     # print("firmware version " + verStr)
     return verObj

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-meshtasticd (2.5.19) UNRELEASED; urgency=medium
+meshtasticd (2.5.19.0) UNRELEASED; urgency=medium
 
   * Initial packaging
 

--- a/debian/ci_changelog.sh
+++ b/debian/ci_changelog.sh
@@ -2,6 +2,6 @@
 export DEBEMAIL="github-actions[bot]@users.noreply.github.com"
 PKG_VERSION=$(python3 bin/buildinfo.py short)
 
-dch --newversion "$PKG_VERSION-1" \
+dch --newversion "$PKG_VERSION.0" \
 	--distribution UNRELEASED \
 	"GitHub Actions Automatic version bump"


### PR DESCRIPTION
Fix version numbers to be compliant with debian `3.0 (native)` format.
These version compliance issues manifest as warnings in Launchpad PPAs, but are fatal in OpenSUSE OBS.

Adds initial (but not automated) support for OBS build system. Should generate source debs that are compatible with OBS, but does not *yet* automatically upload them.

Testing here https://build.opensuse.org/project/show/home:vidplace7