### PR TITLE
meshtasticd-debian: Auto-Publish to OBS, add source debs to Release

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -137,6 +137,13 @@ jobs:
   package-native:
     uses: ./.github/workflows/package_amd64.yml
 
+  build-debian-src:
+    uses: ./.github/workflows/build_debian_src.yml
+    with:
+      series: UNRELEASED
+      build_location: local
+    secrets: inherit
+
   test-native:
     uses: ./.github/workflows/test_native.yml
 
@@ -260,6 +267,7 @@ jobs:
         package-raspbian,
         package-raspbian-armv7l,
         package-native,
+        build-debian-src,
       ]
     steps:
       - name: Checkout
@@ -271,8 +279,12 @@ jobs:
           python-version: 3.x
 
       - name: Get release version string
-        run: echo "long=$(./bin/buildinfo.py long)" >> $GITHUB_OUTPUT
+        run: |
+          echo "long=$(./bin/buildinfo.py long)" >> $GITHUB_OUTPUT
+          echo "deb=$(./bin/buildinfo.py deb)" >> $GITHUB_OUTPUT
         id: version
+        env:
+          BUILD_LOCATION: local
 
       - name: Create release
         uses: softprops/action-gh-release@v2
@@ -292,6 +304,17 @@ jobs:
           merge-multiple: true
           path: ./output
 
+      - name: Download source deb
+        uses: actions/download-artifact@v4
+        with:
+          pattern: firmware-debian-${{ steps.version.outputs.deb }}~UNRELEASED-src
+          merge-multiple: true
+          path: ./output/debian-src
+
+      - name: Zip source deb
+        working-directory: output
+        run: zip -j -9 -r ./meshtasticd-${{ steps.version.outputs.deb }}-src.zip ./debian-src
+
       # For diagnostics
       - name: Display structure of downloaded files
         run: ls -lR
@@ -304,6 +327,7 @@ jobs:
             ./output/meshtasticd_${{ steps.version.outputs.long }}_arm64.deb
             ./output/meshtasticd_${{ steps.version.outputs.long }}_armhf.deb
             ./output/meshtasticd_${{ steps.version.outputs.long }}_amd64.deb
+            ./output/meshtasticd-${{ steps.version.outputs.deb }}-src.zip
 
       - name: Bump version.properties
         run: >-

--- a/.github/workflows/nightly_debian.yml
+++ b/.github/workflows/nightly_debian.yml
@@ -25,13 +25,13 @@ jobs:
         series: [plucky, oracular, noble, jammy]
     uses: ./.github/workflows/package_ppa.yml
     with:
-      ppa_repo: daily
+      ppa_repo: ppa:meshtastic/daily
       series: ${{ matrix.series }}
     secrets: inherit
 
   package-obs:
     uses: ./.github/workflows/package_obs.yml
     with:
-      obs_repo: meshtasticd
+      obs_project: home:meshtastic:daily
       series: unstable
     secrets: inherit

--- a/.github/workflows/package_obs.yml
+++ b/.github/workflows/package_obs.yml
@@ -3,11 +3,15 @@ name: Package for OpenSUSE Build Service
 on:
   workflow_call:
     secrets:
+      OBS_USERNAME:
+        required: true
+      OBS_PASSWORD:
+        required: true
       PPA_GPG_PRIVATE_KEY:
         required: true
     inputs:
-      obs_repo:
-        description: Meshtastic OBS repo to target
+      obs_project:
+        description: Meshtastic OBS project to target
         required: true
         type: string
       series:
@@ -64,40 +68,43 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -lah
 
-      # - name: Configure osc
-      #   shell: bash
-      #   env:
-      #     OBS_USERNAME: ${{ secrets.OBS_USERNAME }}
-      #     OBS_PASSWORD: ${{ secrets.OBS_PASSWORD }}
-      #   run: |
-      #     mkdir -p ~/.config/osc
-      #     echo -e "[https://api.opensuse.org]\n" > ~/.config/osc/oscrc
-      #     echo -e "user = $OBS_USERNAME" >> ~/.config/osc/oscrc
-      #     echo -e "pass = $OBS_PASSWORD" >> ~/.config/osc/oscrc
-      #     echo -e "aliases = obs" >> ~/.config/osc/oscrc
-      #     # Authenticate to OBS
-      #     osc meta prj -v
+      - name: Configure osc
+        run: |
+          # Setup OpenSUSE Build Service credentials
+          mkdir -p ~/.config/osc
+          echo "[general]" > ~/.config/osc/oscrc
+          echo "apiurl=https://api.opensuse.org" >> ~/.config/osc/oscrc
+          echo "[https://api.opensuse.org]" >> ~/.config/osc/oscrc
+          echo "user=${{ secrets.OBS_USERNAME }}" >> ~/.config/osc/oscrc
+          echo "pass=${{ secrets.OBS_PASSWORD }}" >> ~/.config/osc/oscrc
+          echo "credentials_mgr_class=osc.credentials.PlaintextConfigFileCredentialsManager" >> ~/.config/osc/oscrc
+          # Create a temporary directory for osc checkout
+          mkdir -p osc
 
-      # - name: Upload Package to OBS
-      #   shell: bash
-      #   run: |
-      #     # Define your OBS project and repository
-      #     OBS_PROJECT="application:meshtastic"
-      #     OBS_REPO="${{ inputs.obs_repo }}"
+      # Intentionally fail if credentials are invalid
+      # Update secrets if this returns `401`
+      - name: Verify OBS authentication
+        run: osc token
 
-      #     # Create a temporary directory for osc
-      #     mkdir -p /tmp/osc/$OBS_PROJECT/$OBS_REPO
-      #     cd /tmp/osc/$OBS_PROJECT/$OBS_REPO
+      - name: Upload package to OBS
+        shell: bash
+        working-directory: osc
+        env:
+          OBS_PROJECT: ${{ inputs.obs_project }}
+          OBS_PACKAGE: meshtasticd
+        run: |
+          # Initialize the package in the current directory
+          osc checkout --output-dir . $OBS_PROJECT $OBS_PACKAGE
 
-      #     # Initialize the package directory
-      #     osc checkout $OBS_PROJECT $OBS_REPO
+          # Remove the existing package files
+          rm -rf *.dsc *.tar.xz
 
-      #     # Copy package files to the osc directory
-      #     cp $GITHUB_WORKSPACE/*.dsc .
-      #     cp $GITHUB_WORKSPACE/*.tar.xz .
+          # Copy new package files to the directory
+          cp $GITHUB_WORKSPACE/*.dsc .
+          cp $GITHUB_WORKSPACE/*.tar.xz .
 
-      #     # Add files to osc
-      #     osc addremove
+          # Add/Remove the files
+          osc addremove
 
-      #     # Commit and push the changes
-      #     osc commit -m "Automated upload from GitHub Actions"
+          # Commit changes and push to OpenSUSE Build Service
+          osc commit -m "GitHub Actions: ${{ steps.version.outputs.deb }}~${{ inputs.series }}"

--- a/.github/workflows/package_ppa.yml
+++ b/.github/workflows/package_ppa.yml
@@ -71,4 +71,4 @@ jobs:
       - name: Publish with dput
         if: ${{ github.event_name != 'pull_request_target' && github.event_name != 'pull_request' }}
         run: |
-          dput ppa:meshtastic/${{ inputs.ppa_repo }} meshtasticd_${{ steps.version.outputs.deb }}~${{ inputs.series }}_source.changes
+          dput ${{ inputs.ppa_repo }} meshtasticd_${{ steps.version.outputs.deb }}~${{ inputs.series }}_source.changes

--- a/.github/workflows/release_channels.yml
+++ b/.github/workflows/release_channels.yml
@@ -15,13 +15,15 @@ jobs:
     uses: ./.github/workflows/package_ppa.yml
     with:
       ppa_repo: |-
-        ${{ contains(github.event.release.name, 'Beta') && 'beta' || contains(github.event.release.name, 'Alpha') && 'alpha' }}
+        ppa:meshtastic/${{ contains(github.event.release.name, 'Beta') && 'beta' || contains(github.event.release.name, 'Alpha') && 'alpha' }}
       series: ${{ matrix.series }}
     secrets: inherit
 
-  # package-obs:
-  #   uses: ./.github/workflows/package_obs.yml
-  #   with:
-  #     obs_repo: meshtasticd
-  #     series: ${{ contains(github.event.release.name, 'Beta') && 'beta' || contains(github.event.release.name, 'Alpha') && 'alpha' }}
-  #   secrets: inherit
+  package-obs:
+    uses: ./.github/workflows/package_obs.yml
+    with:
+      obs_project: |-
+        home:meshtastic:${{ contains(github.event.release.name, 'Beta') && 'beta' || contains(github.event.release.name, 'Alpha') && 'alpha' }}
+      series: |-
+        ${{ contains(github.event.release.name, 'Beta') && 'beta' || contains(github.event.release.name, 'Alpha') && 'alpha' }}
+    secrets: inherit


### PR DESCRIPTION
~~DRAFT until the [`Network:Meshtastic` project](https://bugzilla.opensuse.org/show_bug.cgi?id=1235395) exists, and the secrets exist.~~

Auto-Publish source debs to OpenSUSE Build Service at [`home:meshtastic:daily`](https://build.opensuse.org/project/show/home:meshtastic:daily).

Also adds source deb publishing to the main *Release* workflow, as `.deb` builds will soon be removed.