### PR TITLE
Add GPS capability to RAK2560 (RAKwireless WisMesh Hub)

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -35,7 +35,11 @@ template <typename T, std::size_t N> std::size_t array_count(const T (&)[N])
 }
 
 #if defined(NRF52840_XXAA) || defined(NRF52833_XXAA) || defined(ARCH_ESP32) || defined(ARCH_PORTDUINO)
+#if defined(RAK2560)
+HardwareSerial *GPS::_serial_gps = &Serial2;
+#else
 HardwareSerial *GPS::_serial_gps = &Serial1;
+#endif
 #elif defined(ARCH_RP2040)
 SerialUART *GPS::_serial_gps = &Serial1;
 #else

--- a/variants/rak2560/platformio.ini
+++ b/variants/rak2560/platformio.ini
@@ -6,7 +6,6 @@ board_check = true
 build_flags = ${nrf52840_base.build_flags} -Ivariants/rak2560 -D RAK_4631
   -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
-  -DMESHTASTIC_EXCLUDE_GPS=1
   -DHAS_RAKPROT=1 ; Define if RAk OneWireSerial is used (disables GPS)
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/rak2560> +<mesh/eth/> +<mesh/api/> +<mqtt/>
 lib_deps = 


### PR DESCRIPTION
The RAK2560 WisMesh Hub can support GPS, but the serial port is Serial2, not Serial1.

This merge request adds a #ifdef to gps.cpp to select the correct serial port.

Even without a GPS module on board (it is optional), with the GPS support enabled, it is possible to set a "fake" location, which can be helpful for the building of coverage maps.