### PR TITLE
Don't check for node channels on broadcast address

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -187,7 +187,7 @@ ErrorCode Router::sendLocal(meshtastic_MeshPacket *p, RxSource src)
         }
 
         // don't override if a channel was requested and no need to set it when PKI is enforced
-        if (!p->channel && !p->pki_encrypted) {
+        if (!p->channel && !p->pki_encrypted && !isBroadcast(p->to)) {
             meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(p->to);
             if (node) {
                 p->channel = node->channel;


### PR DESCRIPTION
Ran into an odd getMeshNode check on the broadcast num while debugging to my new NodeDB persistence locally. Figured I might as well fix it upstream.