### PR TITLE
fix(mqtt): prioritize respecting ok-to-mqtt

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -624,7 +624,7 @@ void MQTT::onSend(const meshtastic_MeshPacket &mp_encrypted, const meshtastic_Me
         // For uplinking other's packets, check if it's not OK to MQTT or if it's an older packet without the bitfield
         bool dontUplink = !mp_decoded.decoded.has_bitfield || !(mp_decoded.decoded.bitfield & BITFIELD_OK_TO_MQTT_MASK);
         // check for the lowest bit of the data bitfield set false, and the use of one of the default keys.
-        if (!isFromUs(&mp_decoded) && !isMqttServerAddressPrivate && dontUplink &&
+        if (!isFromUs(&mp_decoded) && dontUplink && !isMqttServerAddressPrivate &&
             (ch.settings.psk.size < 2 || (ch.settings.psk.size == 16 && memcmp(ch.settings.psk.bytes, defaultpsk, 16)) ||
              (ch.settings.psk.size == 32 && memcmp(ch.settings.psk.bytes, eventpsk, 32)))) {
             LOG_INFO("MQTT onSend - Not forwarding packet due to DontMqttMeBro flag");

--- a/test/test_mqtt/MQTT.cpp
+++ b/test/test_mqtt/MQTT.cpp
@@ -409,31 +409,6 @@ void test_dontMqttMeOnPublicServer(void)
     TEST_ASSERT_TRUE(pubsub->published_.empty());
 }
 
-// A packet without the OK to MQTT bit set should be published to a private server.
-void test_okToMqttOnPrivateServer(void)
-{
-    // Cause a disconnect.
-    pubsub->connected_ = false;
-    pubsub->refuseConnection_ = true;
-    TEST_ASSERT_TRUE(loopUntil([] { return !unitTest->getPubSub().connected(); }));
-
-    // Use 127.0.0.1 for the server's IP.
-    pubsub->ipAddress_ = 0x7f000001;
-
-    // Reconnect.
-    pubsub->refuseConnection_ = false;
-    TEST_ASSERT_TRUE(loopUntil([] { return unitTest->getPubSub().connected(); }));
-
-    // Send the same packet as test_dontMqttMeOnPublicServer.
-    meshtastic_MeshPacket p = decoded;
-    p.decoded.bitfield = 0;
-    p.decoded.has_bitfield = 0;
-
-    mqtt->onSend(encrypted, p, 0);
-
-    TEST_ASSERT_EQUAL(1, pubsub->published_.size());
-}
-
 // Range tests messages are not uplinked to the default server.
 void test_noRangeTestAppOnDefaultServer(void)
 {

--- a/test/test_mqtt/MQTT.cpp
+++ b/test/test_mqtt/MQTT.cpp
@@ -786,7 +786,6 @@ void setup()
     RUN_TEST(test_proxyToMeshServiceDecoded);
     RUN_TEST(test_proxyToMeshServiceEncrypted);
     RUN_TEST(test_dontMqttMeOnPublicServer);
-    RUN_TEST(test_okToMqttOnPrivateServer);
     RUN_TEST(test_noRangeTestAppOnDefaultServer);
     RUN_TEST(test_noDetectionSensorAppOnDefaultServer);
     RUN_TEST(test_sendQueued);


### PR DESCRIPTION
If I'm reading this code correctly, if an MQTT server resolves to an RFC1918 address the packet will always be forwarded to the broker, even if the "OK to MQTT" flag is set to `false`.  

This smells like a bit of a privacy concern.  If users have explicitly opted out of having their packets published to an MQTT broker, it shouldn't matter if that server is resolving to an RFC1918 address or not.  It's very trivial to run an MQTT broker that is publicly accessible, but configure your client to post to this via a simple TCP proxy that suddenly violates the "OK to MQTT" flag that other clients may have specified.

It's possible this logic exists for some other reason that I don't understand, so happy to close this if I'm wrong here.