### PR TITLE
Manage when destructor is called for native webAPI

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -92,6 +92,7 @@ NRF52Bluetooth *nrf52Bluetooth = nullptr;
 #include "mesh/raspihttp/PiWebServer.h"
 #include "platform/portduino/PortduinoGlue.h"
 #include "platform/portduino/USBHal.h"
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -1159,6 +1160,7 @@ void setup()
 #if __has_include(<ulfius.h>)
     if (settingsMap[webserverport] != -1) {
         piwebServerThread = new PiWebServerThread();
+        std::atexit([] { delete piwebServerThread; });
     }
 #endif
     initApiServer(TCPPort);

--- a/src/mesh/raspihttp/PiWebServer.cpp
+++ b/src/mesh/raspihttp/PiWebServer.cpp
@@ -82,8 +82,6 @@ char contentTypes[][2][32] = {{".txt", "text/plain"},      {".html", "text/html"
 volatile bool isWebServerReady;
 volatile bool isCertReady;
 
-HttpAPI webAPI;
-
 PiWebServerThread *piwebServerThread;
 
 /**
@@ -247,7 +245,7 @@ int handleAPIv1ToRadio(const struct _u_request *req, struct _u_response *res, vo
     portduinoVFS->mountpoint(configWeb.rootPath);
 
     LOG_DEBUG("Received %d bytes from PUT request", s);
-    webAPI.handleToRadio(buffer, s);
+    static_cast<HttpAPI *>(user_data)->handleToRadio(buffer, s);
     LOG_DEBUG("end web->radio  ");
     return U_CALLBACK_COMPLETE;
 }
@@ -279,7 +277,7 @@ int handleAPIv1FromRadio(const struct _u_request *req, struct _u_response *res, 
 
     if (valueAll == "true") {
         while (len) {
-            len = webAPI.getFromRadio(txBuf);
+            len = static_cast<HttpAPI *>(user_data)->getFromRadio(txBuf);
             ulfius_set_response_properties(res, U_OPT_STATUS, 200, U_OPT_BINARY_BODY, txBuf, len);
             const char *tmpa = (const char *)txBuf;
             ulfius_set_string_body_response(res, 200, tmpa);
@@ -289,7 +287,7 @@ int handleAPIv1FromRadio(const struct _u_request *req, struct _u_response *res, 
         }
         // Otherwise, just return one protobuf
     } else {
-        len = webAPI.getFromRadio(txBuf);
+        len = static_cast<HttpAPI *>(user_data)->getFromRadio(txBuf);
         const char *tmpa = (const char *)txBuf;
         ulfius_set_binary_body_response(res, 200, tmpa, len);
         // LOG_DEBUG("\n----webAPI response:");
@@ -497,10 +495,10 @@ PiWebServerThread::PiWebServerThread()
         u_map_put(instanceWeb.default_headers, "Access-Control-Allow-Origin", "*");
         // Maximum body size sent by the client is 1 Kb
         instanceWeb.max_post_body_size = 1024;
-        ulfius_add_endpoint_by_val(&instanceWeb, "GET", PREFIX, "/api/v1/fromradio/*", 1, &handleAPIv1FromRadio, NULL);
-        ulfius_add_endpoint_by_val(&instanceWeb, "OPTIONS", PREFIX, "/api/v1/fromradio/*", 1, &handleAPIv1FromRadio, NULL);
-        ulfius_add_endpoint_by_val(&instanceWeb, "PUT", PREFIX, "/api/v1/toradio/*", 1, &handleAPIv1ToRadio, configWeb.rootPath);
-        ulfius_add_endpoint_by_val(&instanceWeb, "OPTIONS", PREFIX, "/api/v1/toradio/*", 1, &handleAPIv1ToRadio, NULL);
+        ulfius_add_endpoint_by_val(&instanceWeb, "GET", PREFIX, "/api/v1/fromradio/*", 1, &handleAPIv1FromRadio, &webAPI);
+        ulfius_add_endpoint_by_val(&instanceWeb, "OPTIONS", PREFIX, "/api/v1/fromradio/*", 1, &handleAPIv1FromRadio, &webAPI);
+        ulfius_add_endpoint_by_val(&instanceWeb, "PUT", PREFIX, "/api/v1/toradio/*", 1, &handleAPIv1ToRadio, &webAPI);
+        ulfius_add_endpoint_by_val(&instanceWeb, "OPTIONS", PREFIX, "/api/v1/toradio/*", 1, &handleAPIv1ToRadio, &webAPI);
 
         // Add callback function to all endpoints for the Web Server
         ulfius_add_endpoint_by_val(&instanceWeb, "GET", NULL, "/*", 2, &callback_static_file, &configWeb);
@@ -525,10 +523,9 @@ PiWebServerThread::~PiWebServerThread()
     u_map_clean(&configWeb.mime_types);
 
     ulfius_stop_framework(&instanceWeb);
-    ulfius_stop_framework(&instanceWeb);
+    ulfius_clean_instance(&instanceWeb);
     free(configWeb.rootPath);
-    ulfius_clean_instance(&instanceService);
-    ulfius_clean_instance(&instanceService);
+    free(key_pem);
     free(cert_pem);
     LOG_INFO("End framework");
 }

--- a/src/mesh/raspihttp/PiWebServer.h
+++ b/src/mesh/raspihttp/PiWebServer.h
@@ -23,24 +23,6 @@ struct _file_config {
     char *rootPath;
 };
 
-class PiWebServerThread
-{
-  private:
-    char *key_pem = NULL;
-    char *cert_pem = NULL;
-    // struct _u_map mime_types;
-    std::string webrootpath;
-
-  public:
-    PiWebServerThread();
-    ~PiWebServerThread();
-    int CreateSSLCertificate();
-    int CheckSSLandLoad();
-    uint32_t requestRestart = 0;
-    struct _u_instance instanceWeb;
-    struct _u_instance instanceService;
-};
-
 class HttpAPI : public PhoneAPI
 {
 
@@ -53,6 +35,24 @@ class HttpAPI : public PhoneAPI
   protected:
     /// Check the current underlying physical link to see if the client is currently connected
     virtual bool checkIsConnected() override { return true; } // FIXME, be smarter about this
+};
+
+class PiWebServerThread
+{
+  private:
+    char *key_pem = NULL;
+    char *cert_pem = NULL;
+    // struct _u_map mime_types;
+    std::string webrootpath;
+    HttpAPI webAPI;
+
+  public:
+    PiWebServerThread();
+    ~PiWebServerThread();
+    int CreateSSLCertificate();
+    int CheckSSLandLoad();
+    uint32_t requestRestart = 0;
+    struct _u_instance instanceWeb;
 };
 
 extern PiWebServerThread *piwebServerThread;


### PR DESCRIPTION
This is intended to avoid a Static Initialization (Destruction) Order Fiasco issue that happens at shutdown. I believe the [settingsMap](https://github.com/meshtastic/firmware/blob/f18a92e8c5be5a483a47b97adc58886808b12fc5/src/platform/portduino/PortduinoGlue.cpp#L26) is currently being destroyed before the [webAPI](https://github.com/meshtastic/firmware/blob/f18a92e8c5be5a483a47b97adc58886808b12fc5/src/mesh/raspihttp/PiWebServer.cpp#L85). A log message in `PhoneAPI::close()` depends on `settingsMap[logoutputlevel]`

```
==16==ERROR: AddressSanitizer: heap-use-after-free on address 0x50400000212c at pc 0x556140daede5 bp 0x7fffbce7e5e0 sp 0x7fffbce7e5d8
READ of size 4 at 0x50400000212c thread T0
SCARINESS: 45 (4-byte-read-heap-use-after-free)
    #0 0x556140daede4 in std::__1::less<configNames>::operator()[abi:ne180100](configNames const&, configNames const&) const /usr/local/bin/../include/c++/v1/__functional
/operations.h:358:18
    #1 0x556140daeb0c in std::__1::__map_value_compare<configNames, std::__1::__value_type<configNames, int>, std::__1::less<configNames>, true>::operator()[abi:ne180100]
(configNames const&, std::__1::__value_type<configNames, int> const&) const /usr/local/bin/../include/c++/v1/map:643:12
    #2 0x556140daf626 in std::__1::__tree_node_base<void*>*& std::__1::__tree<std::__1::__value_type<configNames, int>, std::__1::__map_value_compare<configNames, std::__
1::__value_type<configNames, int>, std::__1::less<configNames>, true>, std::__1::allocator<std::__1::__value_type<configNames, int>>>::__find_equal<configNames>(std::__1:
:__tree_end_node<std::__1::__tree_node_base<void*>*>*&, configNames const&) /usr/local/bin/../include/c++/v1/__tree:1687:11
    #3 0x556140daf0e5 in std::__1::pair<std::__1::__tree_iterator<std::__1::__value_type<configNames, int>, std::__1::__tree_node<std::__1::__value_type<configNames, int>
, void*>*, long>, bool> std::__1::__tree<std::__1::__value_type<configNames, int>, std::__1::__map_value_compare<configNames, std::__1::__value_type<configNames, int>, std::__1::less<configNames>, true>, std::__1::allocator<std::__1::__value_type<configNames, int>>>::__emplace_unique_key_args<configNames, std::__1::piecewise_construct_t const&, std::__1::tuple<configNames&&>, std::__1::tuple<>>(configNames const&, std::__1::piecewise_construct_t const&, std::__1::tuple<configNames&&>&&, std::__1::tuple<>&&) /usr/local/bin/../include/c++/v1/__tree:1782:34
    #4 0x556140d9c4ff in std::__1::map<configNames, int, std::__1::less<configNames>, std::__1::allocator<std::__1::pair<configNames const, int>>>::operator[](configNames&&) /usr/local/bin/../include/c++/v1/map:1529:8
    #5 0x556140de28b1 in RedirectablePrint::log(char const*, char const*, ...) /src/firmware/src/RedirectablePrint.cpp:305:9
    #6 0x556140f7648f in PhoneAPI::close() /src/firmware/src/mesh/PhoneAPI.cpp:70:5
    #7 0x556140f75bbe in PhoneAPI::~PhoneAPI() /src/firmware/src/mesh/PhoneAPI.cpp:41:5
    #8 0x556140fd80b4 in HttpAPI::~HttpAPI() /src/firmware/src/mesh/raspihttp/PiWebServer.h:44:7
    #9 0x7f99cc9c78a6  (/out/lib/libc.so.6+0x468a6) (BuildId: 0702430aef5fa3dda43986563e9ffcc47efbd75e)
    #10 0x7f99cc9c7a5f in exit (/out/lib/libc.so.6+0x46a5f) (BuildId: 0702430aef5fa3dda43986563e9ffcc47efbd75e)
    #11 0x556140ad1e88 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
    #12 0x556140afd202 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #13 0x7f99cc9a5082 in __libc_start_main (/out/lib/libc.so.6+0x24082) (BuildId: 0702430aef5fa3dda43986563e9ffcc47efbd75e)
    #14 0x556140ac46ad in _start (/out/router_fuzzer+0x2616ad)
```

I've also included a few changes to `PiWebServerThread::~PiWebServerThread()` to clean-up variables, and removed a seemingly unused `instanceService` member from that class.

~~Still to-do:~~
- ~~[x] Test the handleAPIv1FromRadio & handleAPIv1ToRadio handler changes locally~~

Tested locally using https://github.com/meshtastic/web/releases/download/v2.5.4/build.tar