### PR TITLE
Heltec Wireless Stick Lite V1/V2 support

### DIFF
--- a/variants/heltec_wsl_v2.1/platformio.ini
+++ b/variants/heltec_wsl_v2.1/platformio.ini
@@ -1,0 +1,7 @@
+[env:heltec-wsl-v2_1]
+extends = esp32_base
+board = heltec_wireless_stick_lite
+board_level = extra
+build_flags =
+  ${esp32_base.build_flags} -D PRIVATE_HW -I variants/heltec_wsl_v2.1
+  -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.

--- a/variants/heltec_wsl_v2.1/variant.h
+++ b/variants/heltec_wsl_v2.1/variant.h
@@ -1,0 +1,29 @@
+#define I2C_SCL SCL
+#define I2C_SDA SDA
+
+#define LED_PIN LED
+
+// active low, powers the Battery reader, but no lora antenna boost (?)
+// #define VEXT_ENABLE Vext
+// #define VEXT_ON_VALUE LOW
+
+#define BUTTON_PIN 0
+
+#define ADC_CTRL 21
+#define ADC_CTRL_ENABLED LOW
+#define BATTERY_PIN 37 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
+#define ADC_CHANNEL ADC1_CHANNEL_1
+// ratio of voltage divider = 3.20 (R1=100k, R2=220k)
+#define ADC_MULTIPLIER 3.2
+
+#define USE_RF95 // RFM95/SX127x
+
+#define LORA_DIO0 26
+#define LORA_RESET 14
+#define LORA_DIO1 35
+#define LORA_DIO2 34
+
+#define LORA_SCK 5
+#define LORA_MISO 19
+#define LORA_MOSI 27
+#define LORA_CS 18


### PR DESCRIPTION
I only have the V2.1 version, not sure if the HW is same with V1, or V2.
Given the few resources I could find I think it is.

ADC / Battery measure and TX/RX are working for my boards

The board uses ESP32-PICO-D4, and has a SX1272 Radio.

I do not know the official way to add HW support, I could have added support as UNKNOWN, which is better than nothing, but I also did the changes to the protobuf, not sure if it is the right way to do.

I can update my PR if I get some advice on it.