### PR TITLE
Run the AddressSanitizer during tests

### DIFF
--- a/.github/workflows/test_native.yml
+++ b/.github/workflows/test_native.yml
@@ -90,7 +90,7 @@ jobs:
         run: sed -i 's/-DBUILD_EPOCH=$UNIX_TIME/#-DBUILD_EPOCH=$UNIX_TIME/' platformio.ini
 
       - name: PlatformIO Tests
-        run: platformio test -e coverage --junit-output-path testreport.xml
+        run: platformio test -e coverage -v --junit-output-path testreport.xml
 
       - name: Save test results
         if: always() # run this step even if previous step failed

--- a/variants/portduino/platformio.ini
+++ b/variants/portduino/platformio.ini
@@ -12,4 +12,4 @@ build_src_filter = ${portduino_base.build_src_filter}
 
 [env:coverage]
 extends = env:native
-build_flags = -lgcov --coverage -fprofile-abs-path ${env:native.build_flags}
+build_flags = -lgcov --coverage -fprofile-abs-path -fsanitize=address ${env:native.build_flags}


### PR DESCRIPTION
The [AddressSanitizer](https://github.com/google/sanitizers/wiki/addresssanitizer) can detect

* [Use after free](https://github.com/google/sanitizers/wiki/AddressSanitizerExampleUseAfterFree) (dangling pointer dereference)
* [Heap buffer overflow](https://github.com/google/sanitizers/wiki/AddressSanitizerExampleHeapOutOfBounds)
* [Stack buffer overflow](https://github.com/google/sanitizers/wiki/AddressSanitizerExampleStackOutOfBounds)
* [Global buffer overflow](https://github.com/google/sanitizers/wiki/AddressSanitizerExampleGlobalOutOfBounds)
* [Use after return](https://github.com/google/sanitizers/wiki/AddressSanitizerExampleUseAfterReturn)
* [Use after scope](https://github.com/google/sanitizers/wiki/AddressSanitizerExampleUseAfterScope)
* [Initialization order bugs](https://github.com/google/sanitizers/wiki/AddressSanitizerInitializationOrderFiasco)
* [Memory leaks](https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer)

~~Starting this PR as a draft as it requires #5807 to be merged before the tests will pass.~~