### PR TITLE
Enable Tx interrupt immediately after `startTransmit()`

### DIFF
--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -501,13 +501,12 @@ bool RadioLibInterface::startSend(meshtastic_MeshPacket *txp)
             powerMon->clearState(meshtastic_PowerMon_State_Lora_TXOn); // Transmitter off now
             startReceive(); // Restart receive mode (because startTransmit failed to put us in xmit mode)
         } else {
+            // Must be done AFTER, starting transmit, because startTransmit clears (possibly stale) interrupt pending register
+            // bits
+            enableInterrupt(isrTxLevel0);
             lastTxStart = millis();
             printPacket("Started Tx", txp);
         }
-
-        // Must be done AFTER, starting transmit, because startTransmit clears (possibly stale) interrupt pending register
-        // bits
-        enableInterrupt(isrTxLevel0);
 
         return res == RADIOLIB_ERR_NONE;
     }


### PR DESCRIPTION
Try-fix for #5816. 

From the logs it looks like at the last transmission attempt before the critical error, a Bluetooth callback happens (based on the log `FromRadio=STATE_SEND_PACKETS`) in between `startTransmit()` and `enableInterrupt()`, which could cause it to miss the `TX_DONE` interrupt and thus it would eventually think it's transmitting for more than 60 seconds. 
