### PR TITLE
Cache Python & PlatformIO dependencies

### DIFF
--- a/.github/actions/build-variant/action.yml
+++ b/.github/actions/build-variant/action.yml
@@ -68,6 +68,12 @@ runs:
           sed -i '/DDEBUG_HEAP/d' ${INI_FILE}
         done
 
+    - name: PlatformIO ${{ inputs.arch }} download cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.platformio/.cache
+        key: pio-cache-${{ inputs.arch }}-${{ hashFiles('.github/actions/**', '**.ini') }}
+
     - name: Build ${{ inputs.board }}
       shell: bash
       run: ${{ inputs.build-script-path }} ${{ inputs.board }}

--- a/.github/actions/setup-base/action.yml
+++ b/.github/actions/setup-base/action.yml
@@ -26,13 +26,10 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.x
-
-    # - name: Cache python libs
-    #   uses: actions/cache@v4
-    #   id: cache-pip # needed in if test
-    #   with:
-    #     path: ~/.cache/pip
-    #     key: ${{ runner.os }}-pip
+        cache: pip
+        cache-dependency-path: |
+          .github/actions/**
+          **.ini
 
     - name: Upgrade python tools
       shell: bash


### PR DESCRIPTION
There is one cache for Python/pip files and a cache per architecture for the PlatformIO downloads. This saves a few minutes for the CI workflow when the caches are present.

The caches are invalidated on changes to the .github/actions or any of the PlatformIO .ini files. The total cache size is 2.2G.