### PR TITLE
Revert "Cache Python & PlatformIO dependencies"

### DIFF
--- a/.github/actions/build-variant/action.yml
+++ b/.github/actions/build-variant/action.yml
@@ -68,12 +68,6 @@ runs:
           sed -i '/DDEBUG_HEAP/d' ${INI_FILE}
         done
 
-    - name: PlatformIO ${{ inputs.arch }} download cache
-      uses: actions/cache@v4
-      with:
-        path: ~/.platformio/.cache
-        key: pio-cache-${{ inputs.arch }}-${{ hashFiles('.github/actions/**', '**.ini') }}
-
     - name: Build ${{ inputs.board }}
       shell: bash
       run: ${{ inputs.build-script-path }} ${{ inputs.board }}

--- a/.github/actions/setup-base/action.yml
+++ b/.github/actions/setup-base/action.yml
@@ -26,10 +26,13 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.x
-        cache: pip
-        cache-dependency-path: |
-          .github/actions/**
-          **.ini
+
+    # - name: Cache python libs
+    #   uses: actions/cache@v4
+    #   id: cache-pip # needed in if test
+    #   with:
+    #     path: ~/.cache/pip
+    #     key: ${{ runner.os }}-pip
 
     - name: Upgrade python tools
       shell: bash


### PR DESCRIPTION
Reverts meshtastic/firmware#5822

Still fails on the master branch.