### PR TITLE
Add lsb-release on the github runner

### DIFF
--- a/.github/actions/setup-base/action.yml
+++ b/.github/actions/setup-base/action.yml
@@ -20,7 +20,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get -y update --fix-missing
-        sudo apt-get install -y cppcheck libbluetooth-dev libgpiod-dev libyaml-cpp-dev
+        sudo apt-get install -y cppcheck libbluetooth-dev libgpiod-dev libyaml-cpp-dev lsb-release
 
     - name: Setup Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
Attempting to get python-setup caching to work. This should be a no-op for all but the failing jobs.

I don't see the line I modified in the logs. I suspect that is because the workflow from the master branch is being used.