### PR TITLE
Avoid a potential NULL pointer reference in nrf52/BluetoothPhoneAPI

### DIFF
--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -44,11 +44,7 @@ class BluetoothPhoneAPI : public PhoneAPI
     }
 
     /// Check the current underlying physical link to see if the client is currently connected
-    virtual bool checkIsConnected() override
-    {
-        BLEConnection *connection = Bluefruit.Connection(connectionHandle);
-        return connection->connected();
-    }
+    virtual bool checkIsConnected() override { return Bluefruit.connected(connectionHandle); }
 };
 
 static BluetoothPhoneAPI *bluetoothPhoneAPI;


### PR DESCRIPTION
[Bluefruit.Connection](https://github.com/adafruit/Adafruit_nRF52_Arduino/blob/4dcfa3b7960a6dafec6736a5dbea255b0946be83/libraries/Bluefruit52Lib/src/bluefruit.cpp#L655) can return NULL if handle is not connected. [Bluefruit.connected](https://github.com/adafruit/Adafruit_nRF52_Arduino/blob/4dcfa3b7960a6dafec6736a5dbea255b0946be83/libraries/Bluefruit52Lib/src/bluefruit.cpp#L604) handles checking for the NULL pointer first.