### PR TITLE
GitHub Actions: Fix daily packaging perms

### DIFF
--- a/.github/workflows/daily_packaging.yml
+++ b/.github/workflows/daily_packaging.yml
@@ -1,4 +1,4 @@
-name: Nightly Packaging
+name: Daily Packaging
 on:
   schedule:
     - cron: 0 9 * * *

--- a/.github/workflows/hook_copr.yml
+++ b/.github/workflows/hook_copr.yml
@@ -12,7 +12,9 @@ on:
         required: true
         type: string
 
-permissions: read-all
+permissions:
+  contents: write
+  packages: write
 
 jobs:
   build-copr-hook:


### PR DESCRIPTION
Fixes permissions issue currently causing failure in GitHub Actions after #5735 
Also renames "nightly" to "daily" (because that's what all the repos are named)