### PR TITLE
Canned messages: allow GPIO0 with "scan and select" input

### DIFF
--- a/src/input/ScanAndSelect.cpp
+++ b/src/input/ScanAndSelect.cpp
@@ -30,7 +30,9 @@ bool ScanAndSelectInput::init()
     if (strcasecmp(moduleConfig.canned_message.allow_input_source, name) != 0)
         return false;
 
-    // Use any available inputbroker pin as the button
+    // Determine which pin to use for the single scan-and-select button
+    // User can specify this by setting any of the inputbroker pins
+    // If all values are zero, we'll assume the user *does* want GPIO0
     if (moduleConfig.canned_message.inputbroker_pin_press)
         pin = moduleConfig.canned_message.inputbroker_pin_press;
     else if (moduleConfig.canned_message.inputbroker_pin_a)
@@ -38,7 +40,18 @@ bool ScanAndSelectInput::init()
     else if (moduleConfig.canned_message.inputbroker_pin_b)
         pin = moduleConfig.canned_message.inputbroker_pin_b;
     else
-        return false; // Short circuit: no button found
+        pin = 0; // GPIO 0 then
+
+// Short circuit: if selected pin conficts with the user button
+#ifdef USERPREFS_BUTTON_PIN
+    int pinUserButton = config.device.button_gpio ? config.device.button_gpio : USERPREFS_BUTTON_PIN; // Resolved button pin
+#else
+    int pinUserButton = config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN; // Resolved button pin
+#endif
+    if (pin == pinUserButton) {
+        LOG_ERROR("ScanAndSelect conflict with user button");
+        return false;
+    }
 
     // Set-up the button
     pinMode(pin, INPUT_PULLUP);

--- a/src/input/ScanAndSelect.cpp
+++ b/src/input/ScanAndSelect.cpp
@@ -7,6 +7,9 @@
 #include "ScanAndSelect.h"
 #include "modules/CannedMessageModule.h"
 #include <Throttle.h>
+#ifdef ARCH_PORTDUINO // Only to check for pin conflict with user button
+#include "platform/portduino/PortduinoGlue.h"
+#endif
 
 // Config
 static const char name[] = "scanAndSelect"; // should match "allow input source" string

--- a/src/input/ScanAndSelect.cpp
+++ b/src/input/ScanAndSelect.cpp
@@ -42,11 +42,18 @@ bool ScanAndSelectInput::init()
     else
         pin = 0; // GPIO 0 then
 
-// Short circuit: if selected pin conficts with the user button
-#ifdef USERPREFS_BUTTON_PIN
-    int pinUserButton = config.device.button_gpio ? config.device.button_gpio : USERPREFS_BUTTON_PIN; // Resolved button pin
+        // Short circuit: if selected pin conficts with the user button
+#if defined(ARCH_PORTDUINO)
+    int pinUserButton = 0;
+    if (settingsMap.count(user) != 0 && settingsMap[user] != RADIOLIB_NC) {
+        pinUserButton = settingsMap[user];
+    }
+#elif defined(USERPREFS_BUTTON_PIN)
+    int pinUserButton = config.device.button_gpio ? config.device.button_gpio : USERPREFS_BUTTON_PIN;
+#elif defined(BUTTON_PIN)
+    int pinUserButton = config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN;
 #else
-    int pinUserButton = config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN; // Resolved button pin
+    int pinUserButton = config.device.button_gpio;
 #endif
     if (pin == pinUserButton) {
         LOG_ERROR("ScanAndSelect conflict with user button");

--- a/src/input/ScanAndSelect.cpp
+++ b/src/input/ScanAndSelect.cpp
@@ -45,7 +45,7 @@ bool ScanAndSelectInput::init()
         // Short circuit: if selected pin conficts with the user button
 #if defined(ARCH_PORTDUINO)
     int pinUserButton = 0;
-    if (settingsMap.count(user) != 0 && settingsMap[user] != RADIOLIB_NC) {
+    if (settingsMap.count(user) != 0) {
         pinUserButton = settingsMap[user];
     }
 #elif defined(USERPREFS_BUTTON_PIN)


### PR DESCRIPTION
Fixes #5834

Previously, the module required users to [set one of the input broker pins](https://meshtastic.org/docs/configuration/module/canned-message/#scan-and-select). This prevented the use of GPIO0.

Now, if the input broker pins are set to 0, GPIO0 will be used as the pin for the canned message module's `scanAndSelect` input method. 

An additional check is added to scanAndSelect init, which disables canned messages if the selected pin conflicts with the user button assignment. Users can resolve a conflict by remapping the user button in device settings.