### PR TITLE
Slight rework of CH341 HAL

### DIFF
--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -196,7 +196,8 @@ void portduinoSetup()
     // if we're using a usermode driver, we need to initialize it here, to get a serial number back for mac address
     if (settingsStrings[spidev] == "ch341") {
         try {
-            ch341Hal = new Ch341Hal(0, settingsStrings[lora_usb_serial_num], settingsMap[lora_usb_vid], settingsMap[lora_usb_pid]);
+            ch341Hal =
+                new Ch341Hal(0, settingsStrings[lora_usb_serial_num], settingsMap[lora_usb_vid], settingsMap[lora_usb_pid]);
         } catch (std::exception &e) {
             std::cerr << e.what() << std::endl;
             std::cerr << "Could not initialize CH341 device!" << std::endl;
@@ -206,7 +207,7 @@ void portduinoSetup()
         ch341Hal->getSerialString(serial, 8);
         std::cout << "Serial " << serial << std::endl;
         if (strlen(serial) == 8 && settingsStrings[mac_address].length() < 12) {
-            uint8_t *hash = (uint8_t*)serial;
+            uint8_t *hash = (uint8_t *)serial;
             crypto->hash(hash, 8);
             char macBuf[13] = {0};
             sprintf(macBuf, "%02X%02X%02X%02X%02X%02X", ((hash[0] << 4) | 2), hash[1], hash[2], hash[3], hash[4], hash[5]);

--- a/src/platform/portduino/USBHal.h
+++ b/src/platform/portduino/USBHal.h
@@ -4,10 +4,10 @@
 // include RadioLib
 #include "platform/portduino/PortduinoGlue.h"
 #include <RadioLib.h>
-#include <libpinedio-usb.h>
-#include <unistd.h>
 #include <csignal>
 #include <iostream>
+#include <libpinedio-usb.h>
+#include <unistd.h>
 
 // include the library for Raspberry GPIO pins
 
@@ -27,7 +27,8 @@ class Ch341Hal : public RadioLibHal
 {
   public:
     // default constructor - initializes the base HAL and any needed private members
-    explicit Ch341Hal(uint8_t spiChannel, std::string serial = "", uint32_t vid = 0x1A86, uint32_t pid = 0x5512, uint32_t spiSpeed = 2000000, uint8_t spiDevice = 0, uint8_t gpioDevice = 0)
+    explicit Ch341Hal(uint8_t spiChannel, std::string serial = "", uint32_t vid = 0x1A86, uint32_t pid = 0x5512,
+                      uint32_t spiSpeed = 2000000, uint8_t spiDevice = 0, uint8_t gpioDevice = 0)
         : RadioLibHal(PI_INPUT, PI_OUTPUT, PI_LOW, PI_HIGH, PI_RISING, PI_FALLING)
     {
         if (serial != "") {
@@ -44,7 +45,7 @@ class Ch341Hal : public RadioLibHal
         int32_t ret = pinedio_init(&pinedio, NULL);
         if (ret != 0) {
             std::string s = "Could not open SPI: ";
-            throw (s + std::to_string(ret));
+            throw(s + std::to_string(ret));
         }
 
         pinedio_set_option(&pinedio, PINEDIO_OPTION_AUTO_CS, 0);
@@ -52,10 +53,7 @@ class Ch341Hal : public RadioLibHal
         pinedio_set_pin_mode(&pinedio, 5, true);
     }
 
-    ~Ch341Hal()
-    {
-        pinedio_deinit(&pinedio);
-    }
+    ~Ch341Hal() { pinedio_deinit(&pinedio); }
 
     void getSerialString(char *_serial, size_t len)
     {
@@ -110,10 +108,7 @@ class Ch341Hal : public RadioLibHal
         pinedio_deattach_interrupt(&this->pinedio, (pinedio_int_pin)interruptNum);
     }
 
-    void delay(unsigned long ms) override
-    {
-        delayMicroseconds(ms * 1000);
-    }
+    void delay(unsigned long ms) override { delayMicroseconds(ms * 1000); }
 
     void delayMicroseconds(unsigned long us) override
     {
@@ -153,7 +148,7 @@ class Ch341Hal : public RadioLibHal
     {
         int32_t ret = pinedio_transceive(&this->pinedio, out, in, len);
         if (ret < 0) {
-            std::cerr << "Could not perform SPI transfer: " << ret << std::endl;;
+            std::cerr << "Could not perform SPI transfer: " << ret << std::endl;
         }
     }
 

--- a/src/platform/portduino/USBHal.h
+++ b/src/platform/portduino/USBHal.h
@@ -4,9 +4,10 @@
 // include RadioLib
 #include "platform/portduino/PortduinoGlue.h"
 #include <RadioLib.h>
-#include <csignal>
 #include <libpinedio-usb.h>
 #include <unistd.h>
+#include <csignal>
+#include <iostream>
 
 // include the library for Raspberry GPIO pins
 
@@ -26,30 +27,44 @@ class Ch341Hal : public RadioLibHal
 {
   public:
     // default constructor - initializes the base HAL and any needed private members
-    explicit Ch341Hal(uint8_t spiChannel, uint32_t spiSpeed = 2000000, uint8_t spiDevice = 0, uint8_t gpioDevice = 0)
+    explicit Ch341Hal(uint8_t spiChannel, std::string serial = "", uint32_t vid = 0x1A86, uint32_t pid = 0x5512, uint32_t spiSpeed = 2000000, uint8_t spiDevice = 0, uint8_t gpioDevice = 0)
         : RadioLibHal(PI_INPUT, PI_OUTPUT, PI_LOW, PI_HIGH, PI_RISING, PI_FALLING)
     {
+        if (serial != "") {
+            strncpy(pinedio.serial_number, serial.c_str(), 8);
+            pinedio_set_option(&pinedio, PINEDIO_OPTION_SEARCH_SERIAL, 1);
+        }
+        // LOG_INFO("USB Serial: %s", pinedio.serial_number);
+
+        // There is no vendor with 0x0 -> so check
+        if (vid != 0x0) {
+            pinedio_set_option(&pinedio, PINEDIO_OPTION_VID, vid);
+            pinedio_set_option(&pinedio, PINEDIO_OPTION_PID, pid);
+        }
+        int32_t ret = pinedio_init(&pinedio, NULL);
+        if (ret != 0) {
+            std::string s = "Could not open SPI: ";
+            throw (s + std::to_string(ret));
+        }
+
+        pinedio_set_option(&pinedio, PINEDIO_OPTION_AUTO_CS, 0);
+        pinedio_set_pin_mode(&pinedio, 3, true);
+        pinedio_set_pin_mode(&pinedio, 5, true);
+    }
+
+    ~Ch341Hal()
+    {
+        pinedio_deinit(&pinedio);
     }
 
     void getSerialString(char *_serial, size_t len)
     {
-        if (!pinedio_is_init) {
-            return;
-        }
+        len = len > 8 ? 8 : len;
         strncpy(_serial, pinedio.serial_number, len);
     }
 
-    void init() override
-    {
-        // now the SPI
-        spiBegin();
-    }
-
-    void term() override
-    {
-        // stop the SPI
-        spiEnd();
-    }
+    void init() override {}
+    void term() override {}
 
     // GPIO-related methods (pinMode, digitalWrite etc.) should check
     // RADIOLIB_NC as an alias for non-connected pins
@@ -79,7 +94,7 @@ class Ch341Hal : public RadioLibHal
 
     void attachInterrupt(uint32_t interruptNum, void (*interruptCb)(void), uint32_t mode) override
     {
-        if ((interruptNum == RADIOLIB_NC)) {
+        if (interruptNum == RADIOLIB_NC) {
             return;
         }
         // LOG_DEBUG("Attach interrupt to pin %d", interruptNum);
@@ -88,22 +103,16 @@ class Ch341Hal : public RadioLibHal
 
     void detachInterrupt(uint32_t interruptNum) override
     {
-        if ((interruptNum == RADIOLIB_NC)) {
+        if (interruptNum == RADIOLIB_NC) {
             return;
         }
         // LOG_DEBUG("Detach interrupt from pin %d", interruptNum);
-
         pinedio_deattach_interrupt(&this->pinedio, (pinedio_int_pin)interruptNum);
     }
 
     void delay(unsigned long ms) override
     {
-        if (ms == 0) {
-            sched_yield();
-            return;
-        }
-
-        usleep(ms * 1000);
+        delayMicroseconds(ms * 1000);
     }
 
     void delayMicroseconds(unsigned long us) override
@@ -133,62 +142,26 @@ class Ch341Hal : public RadioLibHal
 
     long pulseIn(uint32_t pin, uint32_t state, unsigned long timeout) override
     {
-        fprintf(stderr, "pulseIn for pin %u is not supported!\n", pin);
+        std::cerr << "pulseIn for pin " << pin << "is not supported!" << std::endl;
         return 0;
     }
 
-    void spiBegin()
-    {
-        if (!pinedio_is_init) {
-            if (serial != "") {
-                strncpy(pinedio.serial_number, serial.c_str(), 8);
-                pinedio_set_option(&pinedio, PINEDIO_OPTION_SEARCH_SERIAL, 1);
-            }
-            pinedio_set_option(&pinedio, PINEDIO_OPTION_PID, pid);
-            pinedio_set_option(&pinedio, PINEDIO_OPTION_VID, vid);
-            int32_t ret = pinedio_init(&pinedio, NULL);
-            if (ret != 0) {
-                fprintf(stderr, "Could not open SPI: %d\n", ret);
-            } else {
-                pinedio_is_init = true;
-                // LOG_INFO("USB Serial: %s", pinedio.serial_number);
-                pinedio_set_option(&pinedio, PINEDIO_OPTION_AUTO_CS, 0);
-                pinedio_set_pin_mode(&pinedio, 3, true);
-                pinedio_set_pin_mode(&pinedio, 5, true);
-            }
-        }
-    }
-
+    void spiBegin() {}
     void spiBeginTransaction() {}
 
     void spiTransfer(uint8_t *out, size_t len, uint8_t *in)
     {
-        int32_t result = pinedio_transceive(&this->pinedio, out, in, len);
-        if (result < 0) {
-            fprintf(stderr, "Could not perform SPI transfer: %d\n", result);
+        int32_t ret = pinedio_transceive(&this->pinedio, out, in, len);
+        if (ret < 0) {
+            std::cerr << "Could not perform SPI transfer: " << ret << std::endl;;
         }
     }
 
     void spiEndTransaction() {}
-
-    void spiEnd()
-    {
-        if (pinedio_is_init) {
-            pinedio_deinit(&pinedio);
-            pinedio_is_init = false;
-        }
-    }
-
-    bool isInit() { return pinedio_is_init; }
-
-    std::string serial = "";
-    uint32_t pid = 0x5512;
-    uint32_t vid = 0x1A86;
+    void spiEnd() {}
 
   private:
-    // the HAL can contain any additional private members
     pinedio_inst pinedio = {0};
-    bool pinedio_is_init = false;
 };
 
 #endif


### PR DESCRIPTION
I noticed, that the CH341 HAL could be a bit cleaned up. First, use the constructor / deconstructor of C++ to initiate/cleanup pinedio. Constructor throws error, in case not possible, which is then subsequently catched. Second, reworked the establishment of a MAC address for the CH341 HAL. The `getMacAddr` employs its parameter as an output. Thus, definining a similar variable that gets set upfront, it not useful for understanding the code.