### PR TITLE
Fix NRF52 default append write mode of files

### DIFF
--- a/src/SafeFile.cpp
+++ b/src/SafeFile.cpp
@@ -9,7 +9,9 @@ static File openFile(const char *filename, bool fullAtomic)
     LOG_DEBUG("Opening %s, fullAtomic=%d", filename, fullAtomic);
 #ifdef ARCH_NRF52
     lfs_assert_failed = false;
-    return FSCom.open(filename, FILE_O_WRITE);
+    File file = FSCom.open(filename, FILE_O_WRITE);
+    file.seek(0);
+    return file;
 #endif
     if (!fullAtomic)
         FSCom.remove(filename); // Nuke the old file to make space (ignore if it !exists)
@@ -57,6 +59,9 @@ bool SafeFile::close()
 {
     if (!f)
         return false;
+#ifdef ARCH_NRF52
+    f.truncate();
+#endif
 
     spiLock->lock();
     f.close();

--- a/src/SafeFile.cpp
+++ b/src/SafeFile.cpp
@@ -59,11 +59,11 @@ bool SafeFile::close()
 {
     if (!f)
         return false;
+
+    spiLock->lock();
 #ifdef ARCH_NRF52
     f.truncate();
 #endif
-
-    spiLock->lock();
     f.close();
     spiLock->unlock();
 


### PR DESCRIPTION
@esev suggestion on the truncate after the seek, instead of deleting the whole file first.

Seems to be working well so far between nodedb resets and normal writes. I'll continue to monitor, but I'm cautiously optimistic.