### PR TITLE
Partial workaround for BLE-related corruption on shutdown / reboot

### DIFF
--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -210,7 +210,10 @@ void NRF52Bluetooth::shutdown()
             LOG_INFO("NRF52 bluetooth disconnecting handle %d", i);
             Bluefruit.disconnect(i);
         }
-        delay(100); // wait for ondisconnect;
+        // Wait for disconnection
+        while (Bluefruit.connected())
+            yield();
+        LOG_INFO("All bluetooth connections ended");
     }
     Bluefruit.Advertising.stop();
 }


### PR DESCRIPTION
This helps prevent one specific case, where BLE disconnection during shutdown / reboot can cause NRF52 flash corruption.

*This does not address the corruption which can occur when a phone moves out of range of a node.* See https://github.com/meshtastic/firmware/issues/5839#issuecomment-2592411905

Because BLE seems to vary from phone to phone, it would be good to have this one smoke-tested by a couple of people. 