### PR TITLE
COPR: Switch from hook to `copr_cli`

### DIFF
--- a/.github/workflows/hook_copr.yml
+++ b/.github/workflows/hook_copr.yml
@@ -3,9 +3,7 @@ name: Trigger COPR build
 on:
   workflow_call:
     secrets:
-      COPR_HOOK_DAILY:
-      COPR_HOOK_ALPHA:
-      COPR_HOOK_BETA:
+      COPR_API_CONFIG:
     inputs:
       copr_project:
         description: COPR project to target
@@ -32,30 +30,13 @@ jobs:
           pip install requests
 
       - name: Trigger COPR build
-        shell: python
-        run: |
-          import requests
-
-          project_name = "${{ inputs.copr_project }}"
-          if project_name == "daily":
-            hook_secret = "${{ secrets.COPR_HOOK_DAILY }}"
-            project_id = 160277
-          elif project_name == "alpha":
-            hook_secret = "${{ secrets.COPR_HOOK_ALPHA }}"
-            project_id = 160278
-          elif project_name == "beta":
-            hook_secret = "${{ secrets.COPR_HOOK_BETA }}"
-            project_id = 160279
-          else:
-            raise ValueError(f"Unknown COPR project: {project_name}")
-
-          webhook_url = f"https://copr.fedorainfracloud.org/webhooks/github/{project_id}/{hook_secret}/meshtasticd/"
-          copr_payload = {
-            "ref": "${{ github.ref }}",
-            "after": "${{ github.sha }}",
-            "repository": {
-              "clone_url": "${{ github.server_url }}/${{ github.repository }}.git",
-            }
-          }
-          r = requests.post(webhook_url, json=copr_payload, headers={"X-GitHub-Event": "push"})
-          r.raise_for_status()
+        uses: akdev1l/copr-build@main
+        id: copr_build
+        env:
+          COPR_API_TOKEN_CONFIG: ${{ secrets.COPR_API_CONFIG }}
+        with:
+          owner: meshtastic
+          package-name: meshtasticd
+          project-name: ${{ inputs.copr_project }}
+          git-remote: "${{ github.server_url }}/${{ github.repository }}.git"
+          committish: ${{ github.sha }}


### PR DESCRIPTION
The COPR webhook refuses to work correctly... despite returning `200`...

This PR switches to a copr-cli based solution.

Do not merge until `secrets.COPR_API_CONFIG` exists.