### PR TITLE
COPR: Switch to forked GitHub Action

### DIFF
--- a/.github/workflows/hook_copr.yml
+++ b/.github/workflows/hook_copr.yml
@@ -25,12 +25,8 @@ jobs:
           ref: ${{ github.ref }}
           repository: ${{ github.repository }}
 
-      - name: Install Python dependencies
-        run: |
-          pip install requests
-
       - name: Trigger COPR build
-        uses: akdev1l/copr-build@main
+        uses: vidplace7/copr-build@main
         id: copr_build
         env:
           COPR_API_TOKEN_CONFIG: ${{ secrets.COPR_API_CONFIG }}


### PR DESCRIPTION
Overhauled the COPR hook action to use CentOS 9 Stream (previously Fedora 38), and correctly act as a Container-based action.
See: https://github.com/vidplace7/copr-build