### PR TITLE
Small fix: Reference COPR group correctly (with `@`)

### DIFF
--- a/.github/workflows/hook_copr.yml
+++ b/.github/workflows/hook_copr.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           COPR_API_TOKEN_CONFIG: ${{ secrets.COPR_API_CONFIG }}
         with:
-          owner: meshtastic
+          owner: "@meshtastic"
           package-name: meshtasticd
           project-name: ${{ inputs.copr_project }}
           git-remote: "${{ github.server_url }}/${{ github.repository }}.git"


### PR DESCRIPTION
Addendum to #5871.

COPR groups should be referenced with a preceding `@`