### PR TITLE
Add quotes around ${platformio.build_dir} to avoid invalid paths

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -20,7 +20,7 @@ extra_scripts = bin/platformio-custom.py
 build_flags = -Wno-missing-field-initializers
 
 	-Wno-format
-	-Isrc -Isrc/mesh -Isrc/mesh/generated -Isrc/gps -Isrc/buzz -Wl,-Map,${platformio.build_dir}/output.map
+	-Isrc -Isrc/mesh -Isrc/mesh/generated -Isrc/gps -Isrc/buzz -Wl,-Map,"${platformio.build_dir}"/output.map
 	-DUSE_THREAD_NAMES
 	-DTINYGPS_OPTION_NO_CUSTOM_FIELDS
 	-DPB_ENABLE_MALLOC=1


### PR DESCRIPTION
Fixes #5898 (hopefully)