### PR TITLE
Debian: Switch OBS repo to `network:Meshtastic`

### DIFF
--- a/.github/workflows/daily_packaging.yml
+++ b/.github/workflows/daily_packaging.yml
@@ -40,7 +40,7 @@ jobs:
   package-obs:
     uses: ./.github/workflows/package_obs.yml
     with:
-      obs_project: home:meshtastic:daily
+      obs_project: network:Meshtastic:daily
       series: unstable
     secrets: inherit
 

--- a/.github/workflows/release_channels.yml
+++ b/.github/workflows/release_channels.yml
@@ -32,7 +32,7 @@ jobs:
     uses: ./.github/workflows/package_obs.yml
     with:
       obs_project: |-
-        home:meshtastic:${{ contains(github.event.release.name, 'Beta') && 'beta' || contains(github.event.release.name, 'Alpha') && 'alpha' }}
+        network:Meshtastic:${{ contains(github.event.release.name, 'Beta') && 'beta' || contains(github.event.release.name, 'Alpha') && 'alpha' }}
       series: |-
         ${{ contains(github.event.release.name, 'Beta') && 'beta' || contains(github.event.release.name, 'Alpha') && 'alpha' }}
     secrets: inherit


### PR DESCRIPTION
The lovely folks at OpenSUSE Build Service have made a repo for us, `network:Meshtastic`. This PR moves our debian builds into this new location.