### PR TITLE
Docker: Switch tags to newline-seperated

### DIFF
--- a/.github/workflows/docker_manifest.yml
+++ b/.github/workflows/docker_manifest.yml
@@ -128,9 +128,14 @@ jobs:
             }
           }
 
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-            fh.write(f"debian={','.join(tags[release_channel]['debian'])}\n")
-            fh.write(f"alpine={','.join(tags[release_channel]['alpine'])}\n")
+          with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+            fh.write("debian<<EOF\n")
+            fh.write("\n".join(tags[release_channel]["debian"]))
+            fh.write("\nEOF\n")
+
+            fh.write("alpine<<EOF\n")
+            fh.write("\n".join(tags[release_channel]["alpine"]))
+            fh.write("\nEOF\n")
         id: tags
 
       - name: Docker login
@@ -144,14 +149,16 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: meshtastic/meshtasticd
-          tags: ${{ steps.tags.outputs.debian }}
+          tags: |
+            ${{ steps.tags.outputs.debian }}
           flavor: latest=false
 
       - name: Create Docker manifest (Debian)
         id: manifest_debian
         uses: int128/docker-manifest-create-action@v2
         with:
-          tags: ${{ steps.meta_debian.outputs.tags }}
+          tags: |
+            ${{ steps.meta_debian.outputs.tags }}
           push: true
           sources: |
             meshtastic/meshtasticd@${{ needs.docker-debian-amd64.outputs.digest }}
@@ -163,13 +170,15 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: meshtastic/meshtasticd
-          tags: ${{ steps.tags.outputs.alpine }}
+          tags: |
+            ${{ steps.tags.outputs.alpine }}
 
       - name: Create Docker manifest (Alpine)
         id: manifest_alpine
         uses: int128/docker-manifest-create-action@v2
         with:
-          tags: ${{ steps.meta_alpine.outputs.tags }}
+          tags: |
+            ${{ steps.meta_alpine.outputs.tags }}
           push: true
           sources: |
             meshtastic/meshtasticd@${{ needs.docker-alpine-amd64.outputs.digest }}


### PR DESCRIPTION
The docker meta task only appears to be grabbing the first tag in the (comma-separated) list.

Upon further review, tags in `raw` format need to be newline separated.
This PR switches to newlines, following the guidance [here](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings).