### PR TITLE
Space out periodic broadcasts of modules automatically

### DIFF
--- a/src/mesh/MeshModule.cpp
+++ b/src/mesh/MeshModule.cpp
@@ -10,6 +10,7 @@
 std::vector<MeshModule *> *MeshModule::modules;
 
 const meshtastic_MeshPacket *MeshModule::currentRequest;
+uint8_t MeshModule::numPeriodicModules = 0;
 
 /**
  * If any of the current chain of modules has already sent a reply, it will be here.  This is useful to allow
@@ -33,6 +34,15 @@ MeshModule::~MeshModule()
     auto it = std::find(modules->begin(), modules->end(), this);
     assert(it != modules->end());
     modules->erase(it);
+}
+
+// Set the start delay for a module that broadcasts periodically
+int32_t MeshModule::setStartDelay()
+{
+    int32_t startDelay = MESHMODULE_MIN_BROADCAST_DELAY_MS + numPeriodicModules * MESHMODULE_BROADCAST_SPACING_MS;
+    numPeriodicModules++;
+
+    return startDelay;
 }
 
 meshtastic_MeshPacket *MeshModule::allocAckNak(meshtastic_Routing_Error err, NodeNum to, PacketId idFrom, ChannelIndex chIndex,

--- a/src/mesh/MeshModule.cpp
+++ b/src/mesh/MeshModule.cpp
@@ -36,7 +36,7 @@ MeshModule::~MeshModule()
     modules->erase(it);
 }
 
-// Set the start delay for a module that broadcasts periodically
+// ⚠️ **Only call once** to set the initial delay before a module starts broadcasting periodically
 int32_t MeshModule::setStartDelay()
 {
     int32_t startDelay = MESHMODULE_MIN_BROADCAST_DELAY_MS + numPeriodicModules * MESHMODULE_BROADCAST_SPACING_MS;

--- a/src/mesh/MeshModule.h
+++ b/src/mesh/MeshModule.h
@@ -9,6 +9,9 @@
 #include <OLEDDisplayUi.h>
 #endif
 
+#define MESHMODULE_MIN_BROADCAST_DELAY_MS 30 * 1000 // Min. delay after boot before sending first broadcast by any module
+#define MESHMODULE_BROADCAST_SPACING_MS 15 * 1000   // Initial spacing between broadcasts of different modules
+
 /** handleReceived return enumeration
  *
  * Use ProcessMessage::CONTINUE to allows other modules to process a message.
@@ -118,6 +121,12 @@ class MeshModule
      * plumodulegin at a time.
      */
     static const meshtastic_MeshPacket *currentRequest;
+
+    // We keep track of the number of modules that send a periodic broadcast to schedule them spaced out over time
+    static uint8_t numPeriodicModules;
+
+    // Set the start delay for module that broadcasts periodically
+    int32_t setStartDelay();
 
     /**
      * If your handler wants to send a response, simply set currentReply and it will be sent at the end of response handling.

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -81,7 +81,7 @@ int32_t DetectionSensorModule::runOnce()
         }
         LOG_INFO("Detection Sensor Module: init");
 
-        return DELAYED_INTERVAL;
+        return setStartDelay();
     }
 
     // LOG_DEBUG("Detection Sensor Module: Current pin state: %i", digitalRead(moduleConfig.detection_sensor.monitor_pin));

--- a/src/modules/NodeInfoModule.cpp
+++ b/src/modules/NodeInfoModule.cpp
@@ -97,8 +97,9 @@ NodeInfoModule::NodeInfoModule()
     : ProtobufModule("nodeinfo", meshtastic_PortNum_NODEINFO_APP, &meshtastic_User_msg), concurrency::OSThread("NodeInfo")
 {
     isPromiscuous = true; // We always want to update our nodedb, even if we are sniffing on others
-    setIntervalFromNow(30 *
-                       1000); // Send our initial owner announcement 30 seconds after we start (to give network time to setup)
+
+    setIntervalFromNow(setStartDelay()); // Send our initial owner announcement 30 seconds
+                                         // after we start (to give network time to setup)
 }
 
 int32_t NodeInfoModule::runOnce()

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -28,8 +28,9 @@ PositionModule::PositionModule()
     nodeStatusObserver.observe(&nodeStatus->onNewStatus);
 
     if (config.device.role != meshtastic_Config_DeviceConfig_Role_TRACKER &&
-        config.device.role != meshtastic_Config_DeviceConfig_Role_TAK_TRACKER)
-        setIntervalFromNow(60 * 1000);
+        config.device.role != meshtastic_Config_DeviceConfig_Role_TAK_TRACKER) {
+        setIntervalFromNow(setStartDelay());
+    }
 
     // Power saving trackers should clear their position on startup to avoid waking up and sending a stale position
     if ((config.device.role == meshtastic_Config_DeviceConfig_Role_TRACKER ||

--- a/src/modules/Telemetry/AirQualityTelemetry.cpp
+++ b/src/modules/Telemetry/AirQualityTelemetry.cpp
@@ -50,12 +50,12 @@ int32_t AirQualityTelemetryModule::runOnce()
                     nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_PMSA003I].first = found.address.address;
                     nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_PMSA003I].second =
                         i2cScanner->fetchI2CBus(found.address);
-                    return 1000;
+                    return setStartDelay();
                 }
 #endif
                 return disable();
             }
-            return 1000;
+            return setStartDelay();
         }
         return disable();
     } else {

--- a/src/modules/Telemetry/DeviceTelemetry.h
+++ b/src/modules/Telemetry/DeviceTelemetry.h
@@ -18,7 +18,7 @@ class DeviceTelemetryModule : private concurrency::OSThread, public ProtobufModu
         uptimeWrapCount = 0;
         uptimeLastMs = millis();
         nodeStatusObserver.observe(&nodeStatus->onNewStatus);
-        setIntervalFromNow(45 * 1000); // Wait until NodeInfo is sent
+        setIntervalFromNow(setStartDelay()); // Wait until NodeInfo is sent
     }
     virtual bool wantUIFrame() { return false; }
 

--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -107,8 +107,6 @@ int32_t EnvironmentTelemetryModule::runOnce()
 
         if (moduleConfig.telemetry.environment_measurement_enabled) {
             LOG_INFO("Environment Telemetry: init");
-            // it's possible to have this module enabled, only for displaying values on the screen.
-            // therefore, we should only enable the sensor loop if measurement is also enabled
 #ifdef SENSECAP_INDICATOR
             result = indicatorSensor.runOnce();
 #endif
@@ -171,7 +169,9 @@ int32_t EnvironmentTelemetryModule::runOnce()
 #endif
 #endif
         }
-        return result;
+        // it's possible to have this module enabled, only for displaying values on the screen.
+        // therefore, we should only enable the sensor loop if measurement is also enabled
+        return result == UINT32_MAX ? disable() : setStartDelay();
     } else {
         // if we somehow got to a second run of this module with measurement disabled, then just wait forever
         if (!moduleConfig.telemetry.environment_measurement_enabled) {

--- a/src/modules/Telemetry/HealthTelemetry.cpp
+++ b/src/modules/Telemetry/HealthTelemetry.cpp
@@ -62,7 +62,7 @@ int32_t HealthTelemetryModule::runOnce()
             if (max30102Sensor.hasSensor())
                 result = max30102Sensor.runOnce();
         }
-        return result;
+        return result == UINT32_MAX ? disable() : setStartDelay();
     } else {
         // if we somehow got to a second run of this module with measurement disabled, then just wait forever
         if (!moduleConfig.telemetry.health_measurement_enabled) {

--- a/src/modules/Telemetry/PowerTelemetry.cpp
+++ b/src/modules/Telemetry/PowerTelemetry.cpp
@@ -65,7 +65,7 @@ int32_t PowerTelemetryModule::runOnce()
             if (max17048Sensor.hasSensor() && !max17048Sensor.isInitialized())
                 result = max17048Sensor.runOnce();
         }
-        return result;
+        return result == UINT32_MAX ? disable() : setStartDelay();
 #else
         return disable();
 #endif


### PR DESCRIPTION
Some modules have by default the same broadcast interval (or multiples of each other) and are also started at the same time, resulting in them being sent quickly after each other, thereby making delivery harder considering the packets are being propagated through the mesh also.
I’ve seen a workaround of @b8b8 to set the intervals to, e.g., 3600, 3615, 3630 seconds, etc. With this PR, we space periodic broadcasts of modules by 15 seconds by letting them start 15 seconds after each other (which was manually done for NodeInfo, DeviceTelemetry and Position already).
