### PR TITLE
Rate limit position replies to three minutes

### DIFF
--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -160,7 +160,8 @@ bool PositionModule::hasGPS()
 #endif
 }
 
-meshtastic_MeshPacket *PositionModule::allocReply()
+// Allocate a packet with our position data if we have one
+meshtastic_MeshPacket *PositionModule::allocPositionPacket()
 {
     if (precision == 0) {
         LOG_DEBUG("Skip location send because precision is set to 0!");
@@ -262,13 +263,24 @@ meshtastic_MeshPacket *PositionModule::allocReply()
         p.has_ground_speed = true;
     }
 
-    LOG_INFO("Position reply: time=%i lat=%i lon=%i", p.time, p.latitude_i, p.longitude_i);
+    LOG_INFO("Position packet: time=%i lat=%i lon=%i", p.time, p.latitude_i, p.longitude_i);
+    lastSentToMesh = millis();
 
     // TAK Tracker devices should send their position in a TAK packet over the ATAK port
     if (config.device.role == meshtastic_Config_DeviceConfig_Role_TAK_TRACKER)
         return allocAtakPli();
 
     return allocDataProtobuf(p);
+}
+
+meshtastic_MeshPacket *PositionModule::allocReply()
+{
+    if (lastSentToMesh && Throttle::isWithinTimespanMs(lastSentToMesh, 3 * 60 * 1000)) {
+        LOG_DEBUG("Skip Position reply since we sent it <3min ago");
+        ignoreRequest = true; // Mark it as ignored for MeshModule
+        return nullptr;
+    }
+    return allocPositionPacket();
 }
 
 meshtastic_MeshPacket *PositionModule::allocAtakPli()
@@ -333,9 +345,9 @@ void PositionModule::sendOurPosition(NodeNum dest, bool wantReplies, uint8_t cha
         precision = 0;
     }
 
-    meshtastic_MeshPacket *p = allocReply();
+    meshtastic_MeshPacket *p = allocPositionPacket();
     if (p == nullptr) {
-        LOG_DEBUG("allocReply returned a nullptr");
+        LOG_DEBUG("allocPositionPacket returned a nullptr");
         return;
     }
 

--- a/src/modules/PositionModule.h
+++ b/src/modules/PositionModule.h
@@ -55,6 +55,7 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
     virtual int32_t runOnce() override;
 
   private:
+    meshtastic_MeshPacket *allocPositionPacket();
     struct SmartPosition getDistanceTraveledSinceLastSend(meshtastic_PositionLite currentPosition);
     meshtastic_MeshPacket *allocAtakPli();
     void trySetRtc(meshtastic_Position p, bool isLocal, bool forceUpdate = false);
@@ -62,6 +63,7 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
     void sendLostAndFoundText();
     bool hasQualityTimesource();
     bool hasGPS();
+    uint32_t lastSentToMesh = 0; // Last time we sent our position to the mesh
 
     const uint32_t minimumTimeThreshold =
         Default::getConfiguredOrDefaultMs(config.position.broadcast_smart_minimum_interval_secs, 30);


### PR DESCRIPTION
Fixes #5914.

In order not to overwhelm the mesh, let’s rate limit position replies. Meaning that if we sent our position already in the last three minutes, we’ll not reply to position requests. Since position packets are not using PKI and are “promiscuous”, every node that has the channel key would have seen the previous packet already.

Note that this is specifically for replies upon a request; setting the periodic broadcast interval (or smart position) less than three minutes is still possible.