### PR TITLE
Add missing build_unflags

### DIFF
--- a/variants/my_esp32s3_diy_eink/platformio.ini
+++ b/variants/my_esp32s3_diy_eink/platformio.ini
@@ -14,7 +14,9 @@ lib_deps =
   ${esp32_base.lib_deps}
   zinggjm/GxEPD2@^1.5.1
   adafruit/Adafruit NeoPixel @ ^1.12.0
-build_unflags = -DARDUINO_USB_MODE=1
+build_unflags =
+  ${esp32s3_base.build_unflags}
+  -DARDUINO_USB_MODE=1
 build_flags = 
   ;${esp32_base.build_flags} -D MY_ESP32S3_DIY -I variants/my_esp32s3_diy_eink
   ${esp32_base.build_flags} -D PRIVATE_HW -I variants/my_esp32s3_diy_eink

--- a/variants/my_esp32s3_diy_oled/platformio.ini
+++ b/variants/my_esp32s3_diy_oled/platformio.ini
@@ -13,7 +13,9 @@ platform_packages =
 lib_deps =
   ${esp32_base.lib_deps}
   adafruit/Adafruit NeoPixel @ ^1.12.0
-build_unflags = -DARDUINO_USB_MODE=1
+build_unflags =
+  ${esp32s3_base.build_unflags}
+  -DARDUINO_USB_MODE=1
 build_flags = 
   ;${esp32_base.build_flags} -D MY_ESP32S3_DIY -I variants/my_esp32s3_diy_oled
   ${esp32_base.build_flags} -D PRIVATE_HW -I variants/my_esp32s3_diy_oled


### PR DESCRIPTION
Fixes 'undefined reference to app_main' build error for `my_esp32s3_diy_eink` and `my_esp32s3_diy_oled` variants.
