### PR TITLE
Fix off-by-one error with log writes

### DIFF
--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -79,17 +79,17 @@ size_t RedirectablePrint::vprintf(const char *logLevel, const char *format, va_l
     }
     if (color && logLevel != nullptr) {
         if (strcmp(logLevel, MESHTASTIC_LOG_LEVEL_DEBUG) == 0)
-            Print::write("\u001b[34m", 6);
+            Print::write("\u001b[34m", 5);
         if (strcmp(logLevel, MESHTASTIC_LOG_LEVEL_INFO) == 0)
-            Print::write("\u001b[32m", 6);
+            Print::write("\u001b[32m", 5);
         if (strcmp(logLevel, MESHTASTIC_LOG_LEVEL_WARN) == 0)
-            Print::write("\u001b[33m", 6);
+            Print::write("\u001b[33m", 5);
         if (strcmp(logLevel, MESHTASTIC_LOG_LEVEL_ERROR) == 0)
-            Print::write("\u001b[31m", 6);
+            Print::write("\u001b[31m", 5);
     }
     len = Print::write(printBuf, len);
     if (color && logLevel != nullptr) {
-        Print::write("\u001b[0m", 5);
+        Print::write("\u001b[0m", 4);
     }
     return len;
 }
@@ -107,15 +107,15 @@ void RedirectablePrint::log_to_serial(const char *logLevel, const char *format, 
     // include the header
     if (color) {
         if (strcmp(logLevel, MESHTASTIC_LOG_LEVEL_DEBUG) == 0)
-            Print::write("\u001b[34m", 6);
+            Print::write("\u001b[34m", 5);
         if (strcmp(logLevel, MESHTASTIC_LOG_LEVEL_INFO) == 0)
-            Print::write("\u001b[32m", 6);
+            Print::write("\u001b[32m", 5);
         if (strcmp(logLevel, MESHTASTIC_LOG_LEVEL_WARN) == 0)
-            Print::write("\u001b[33m", 6);
+            Print::write("\u001b[33m", 5);
         if (strcmp(logLevel, MESHTASTIC_LOG_LEVEL_ERROR) == 0)
-            Print::write("\u001b[31m", 6);
+            Print::write("\u001b[31m", 5);
         if (strcmp(logLevel, MESHTASTIC_LOG_LEVEL_TRACE) == 0)
-            Print::write("\u001b[35m", 6);
+            Print::write("\u001b[35m", 5);
     }
 
     uint32_t rtc_sec = getValidTime(RTCQuality::RTCQualityDevice, true); // display local time on logfile


### PR DESCRIPTION
As reported by @jstockdale, when writing coloured logs we were writing the full string, including a null terminator. This caused issues for programs consuming our logs. The fix as identified is not to write the null.

Fixes https://github.com/meshtastic/firmware/issues/5945