### PR TITLE
Portduino: Set Web SSL Cert / Key paths from yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,8 @@ USER root
 RUN apt-get update && apt-get --no-install-recommends -y install libc-bin libc6 libgpiod2 libyaml-cpp0.7 libi2c0 libulfius2.7 libusb-1.0-0-dev liborcania2.3 libssl3 && \
     apt-get clean && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /var/lib/meshtasticd \
-    && mkdir -p /etc/meshtasticd/config.d
+    && mkdir -p /etc/meshtasticd/config.d \
+    && mkdir -p /etc/meshtasticd/ssl
 
 # Fetch compiled binary from the builder
 COPY --from=builder /tmp/firmware/release/meshtasticd /usr/sbin/

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -29,7 +29,8 @@ USER root
 
 RUN apk add libstdc++ libgpiod yaml-cpp libusb i2c-tools \
     && mkdir -p /var/lib/meshtasticd \
-    && mkdir -p /etc/meshtasticd/config.d
+    && mkdir -p /etc/meshtasticd/config.d \
+    && mkdir -p /etc/meshtasticd/ssl
 COPY --from=builder /tmp/firmware/release/meshtasticd /usr/sbin/
 
 WORKDIR /var/lib/meshtasticd

--- a/bin/config-dist.yaml
+++ b/bin/config-dist.yaml
@@ -184,6 +184,8 @@ Logging:
 Webserver:
 #  Port: 443 # Port for Webserver & Webservices
 #  RootPath: /usr/share/meshtasticd/web # Root Dir of WebServer
+#  SSLKey: /etc/meshtasticd/ssl/private_key.pem # Path to SSL Key, generated if not present
+#  SSLCert: /etc/meshtasticd/ssl/certificate.pem # Path to SSL Certificate, generated if not present
 
 General:
   MaxNodes: 200

--- a/debian/meshtasticd.dirs
+++ b/debian/meshtasticd.dirs
@@ -2,3 +2,4 @@ etc/meshtasticd
 etc/meshtasticd/config.d
 etc/meshtasticd/available.d
 usr/share/meshtasticd/web
+etc/meshtasticd/ssl

--- a/meshtasticd.spec.rpkg
+++ b/meshtasticd.spec.rpkg
@@ -72,6 +72,8 @@ install -D -m 0644 bin/meshtasticd.service %{buildroot}%{_unitdir}/meshtasticd.s
 # Install the web files under /usr/share/meshtasticd/web
 mkdir -p %{buildroot}%{_datadir}/meshtasticd/web
 cp -r web/* %{buildroot}%{_datadir}/meshtasticd/web
+# Install default SSL storage directory (for web)
+mkdir -p %{buildroot}%{_sysconfdir}/meshtasticd/ssl
 
 %files
 %license LICENSE
@@ -86,6 +88,7 @@ cp -r web/* %{buildroot}%{_datadir}/meshtasticd/web
 %dir %{_datadir}/meshtasticd
 %dir %{_datadir}/meshtasticd/web
 %{_datadir}/meshtasticd/web/*
+%dir %{_sysconfdir}/meshtasticd/ssl
 
 %changelog
 %autochangelog

--- a/src/mesh/raspihttp/PiWebServer.cpp
+++ b/src/mesh/raspihttp/PiWebServer.cpp
@@ -65,6 +65,9 @@ mail:   marchammermann@googlemail.com
 #define DEFAULT_REALM "default_realm"
 #define PREFIX ""
 
+#define KEY_PATH settingsStrings[websslkeypath].c_str()
+#define CERT_PATH settingsStrings[websslcertpath].c_str()
+
 struct _file_config configWeb;
 
 // We need to specify some content-type mapping, so the resources get delivered with the
@@ -384,13 +387,13 @@ char *read_file_into_string(const char *filename)
 int PiWebServerThread::CheckSSLandLoad()
 {
     // read certificate
-    cert_pem = read_file_into_string("certificate.pem");
+    cert_pem = read_file_into_string(CERT_PATH);
     if (cert_pem == NULL) {
         LOG_ERROR("ERROR SSL Certificate File can't be loaded or is missing");
         return 1;
     }
     // read private key
-    key_pem = read_file_into_string("private_key.pem");
+    key_pem = read_file_into_string(KEY_PATH);
     if (key_pem == NULL) {
         LOG_ERROR("ERROR file private_key can't be loaded or is missing");
         return 2;
@@ -415,8 +418,8 @@ int PiWebServerThread::CreateSSLCertificate()
         return 2;
     }
 
-    // Ope file to write private key file
-    FILE *pkey_file = fopen("private_key.pem", "wb");
+    // Open file to write private key file
+    FILE *pkey_file = fopen(KEY_PATH, "wb");
     if (!pkey_file) {
         LOG_ERROR("Error opening private key file");
         return 3;
@@ -426,18 +429,19 @@ int PiWebServerThread::CreateSSLCertificate()
     fclose(pkey_file);
 
     // open Certificate file
-    FILE *x509_file = fopen("certificate.pem", "wb");
+    FILE *x509_file = fopen(CERT_PATH, "wb");
     if (!x509_file) {
         LOG_ERROR("Error opening cert");
         return 4;
     }
-    // write cirtificate
+    // write certificate
     PEM_write_X509(x509_file, x509);
     fclose(x509_file);
 
     EVP_PKEY_free(pkey);
+    LOG_INFO("Create SSL Key %s successful", KEY_PATH);
     X509_free(x509);
-    LOG_INFO("Create SSL Cert -certificate.pem- succesfull ");
+    LOG_INFO("Create SSL Cert %s successful", CERT_PATH);
     return 0;
 }
 

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -524,7 +524,12 @@ bool loadConfig(const char *configPath)
 
         if (yamlConfig["Webserver"]) {
             settingsMap[webserverport] = (yamlConfig["Webserver"]["Port"]).as<int>(-1);
-            settingsStrings[webserverrootpath] = (yamlConfig["Webserver"]["RootPath"]).as<std::string>("");
+            settingsStrings[webserverrootpath] =
+                (yamlConfig["Webserver"]["RootPath"]).as<std::string>("/usr/share/meshtasticd/web");
+            settingsStrings[websslkeypath] =
+                (yamlConfig["Webserver"]["SSLKey"]).as<std::string>("/etc/meshtasticd/ssl/private_key.pem");
+            settingsStrings[websslcertpath] =
+                (yamlConfig["Webserver"]["SSLCert"]).as<std::string>("/etc/meshtasticd/ssl/certificate.pem");
         }
 
         if (yamlConfig["General"]) {

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -81,6 +81,8 @@ enum configNames {
     webserver,
     webserverport,
     webserverrootpath,
+    websslkeypath,
+    websslcertpath,
     maxtophone,
     maxnodes,
     ascii_logs,


### PR DESCRIPTION
Allows SSL web certificate / key locations to be set in the meshtasticd config.yaml.

Additionally, sets the default directory for ssl storage to `/etc/meshtasticd/ssl`, and creates this directory in the Linux packaging.

Example:
```yaml
Webserver:
  Port: 443 # Port for Webserver & Webservices
  RootPath: /usr/share/meshtasticd/web # Root Dir of WebServer
  SSLKey: /etc/meshtasticd/ssl/private_key.pem
  SSLCert: /etc/meshtasticd/ssl/certificate.pem
```

Resolves #5944