### PR TITLE
Fix INA226 Sensor Voltage Readings

### DIFF
--- a/src/modules/Telemetry/Sensor/INA226Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/INA226Sensor.cpp
@@ -40,14 +40,14 @@ bool INA226Sensor::getMetrics(meshtastic_Telemetry *measurement)
     measurement->variant.environment_metrics.has_current = true;
 
     // mV conversion to V
-    measurement->variant.environment_metrics.voltage = ina226.getBusVoltage() / 1000;
+    measurement->variant.environment_metrics.voltage = ina226.getBusVoltage();
     measurement->variant.environment_metrics.current = ina226.getCurrent_mA();
     return true;
 }
 
 uint16_t INA226Sensor::getBusVoltageMv()
 {
-    return lround(ina226.getBusVoltage());
+    return lround(ina226.getBusVoltage() * 1000);
 }
 
 int16_t INA226Sensor::getCurrentMa()


### PR DESCRIPTION
They were off by a factor of 1000 due to the difference between
Volts and MilliVolts, as reported by @morcant .

Fixes https://github.com/meshtastic/firmware/issues/5969