### PR TITLE
meshtasticd: Fix web download location

### DIFF
--- a/debian/ci_pack_sdeb.sh
+++ b/debian/ci_pack_sdeb.sh
@@ -11,7 +11,7 @@ platformio pkg install -e native -t platformio/tool-scons@4.40502.0
 tar -cf pio.tar pio/
 rm -rf pio
 # Download the latest meshtastic/web release build.tar to `web.tar`
-curl -L https://github.com/meshtastic/web/releases/download/latest/build.tar -o web.tar
+curl -L https://github.com/meshtastic/web/releases/latest/download/build.tar -o web.tar
 
 package=$(dpkg-parsechangelog --show-field Source)
 

--- a/meshtasticd.spec.rpkg
+++ b/meshtasticd.spec.rpkg
@@ -21,7 +21,7 @@ Summary:        Meshtastic daemon for communicating with Meshtastic devices
 License:        GPL-3.0
 URL:            https://github.com/meshtastic/firmware
 Source0:        {{{ git_dir_pack }}}
-Source1:        https://github.com/meshtastic/web/releases/download/latest/build.tar
+Source1:        https://github.com/meshtastic/web/releases/latest/download/build.tar
 
 BuildRequires: systemd-rpm-macros
 BuildRequires: python3-devel


### PR DESCRIPTION
Previously pointed at a release *named* latest (from Sept 2024), instead of the *latest* release :facepalm: 
https://github.com/meshtastic/web/releases/tag/latest vs https://github.com/meshtastic/web/releases/latest

This change should correct the issue. I'll fix the packages out of band by applying this change on top of the v2.5.20 and v2.5.21 releases and re-uploading to the package repos (OBS, PPA, COPR).

Thanks @ianmcorvidae for pointing this out!