### PR TITLE
Add Indicator Upload Speed

### DIFF
--- a/variants/seeed-sensecap-indicator/platformio.ini
+++ b/variants/seeed-sensecap-indicator/platformio.ini
@@ -32,6 +32,7 @@ lib_deps = ${esp32s3_base.lib_deps}
 [env:seeed-sensecap-indicator-tft]
 extends = env:seeed-sensecap-indicator
 board_level = main
+upload_speed = 115200
 board_build.partitions = default_8MB.csv ; must be here for some reason, board.json is not enough !?
 
 build_flags =


### PR DESCRIPTION
Adding a PR for this but feel free to reject if need be. Reason for PR is upload will **always** fail for indicator if upload_speed is not set. 