### PR TITLE
meshtasticd flatpak: Include pio deps with release

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -135,6 +135,12 @@ jobs:
       build_location: local
     secrets: inherit
 
+  package-pio-deps-native:
+    uses: ./.github/workflows/package_pio_deps.yml
+    with:
+      pio_env: native
+    secrets: inherit
+
   test-native:
     uses: ./.github/workflows/test_native.yml
 
@@ -279,7 +285,10 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' }}
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
-    needs: [gather-artifacts, build-debian-src]
+    needs:
+      - gather-artifacts
+      - build-debian-src
+      - package-pio-deps-native
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -315,17 +324,27 @@ jobs:
           merge-multiple: true
           path: ./output/debian-src
 
-      - name: Zip source deb
+      - name: Download native pio deps
+        uses: actions/download-artifact@v4
+        with:
+          pattern: platformio-deps-native-${{ steps.version.outputs.long }}
+          merge-multiple: true
+          path: ./output/pio-deps-native
+
+      - name: Zip linux sources
         working-directory: output
-        run: zip -j -9 -r ./meshtasticd-${{ steps.version.outputs.deb }}-src.zip ./debian-src
+        run: |
+          zip -j -9 -r ./meshtasticd-${{ steps.version.outputs.deb }}-src.zip ./debian-src
+          zip -j -9 -r ./platformio-deps-native-${{ steps.version.outputs.long }}.zip ./pio-deps-native
 
       # For diagnostics
       - name: Display structure of downloaded files
         run: ls -lR
 
-      - name: Add source deb to release
+      - name: Add linux sources to release
         run: |
           gh release upload v${{ steps.version.outputs.long }} ./output/meshtasticd-${{ steps.version.outputs.deb }}-src.zip
+          gh release upload v${{ steps.version.outputs.long }} ./output/platformio-deps-native-${{ steps.version.outputs.long }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/package_pio_deps.yml
+++ b/.github/workflows/package_pio_deps.yml
@@ -1,0 +1,64 @@
+name: Package PlatformIO Library Dependencies
+# trunk-ignore-all(checkov/CKV_GHA_7): Allow workflow_dispatch inputs for testing
+
+on:
+  workflow_call:
+    inputs:
+      pio_env:
+        description: PlatformIO environment to target
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      pio_env:
+        description: PlatformIO environment to target
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  pkg-pio-libdeps:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: Install deps
+        shell: bash
+        run: |
+          pip install platformio
+
+      - name: Get release version string
+        run: |
+          echo "long=$(./bin/buildinfo.py long)" >> $GITHUB_OUTPUT
+        id: version
+
+      - name: Fetch libdeps
+        shell: bash
+        run: |-
+          platformio pkg install -e ${{ inputs.pio_env }}
+          platformio pkg install -e ${{ inputs.pio_env }} -t platformio/tool-scons@4.40502.0
+        env:
+          PLATFORMIO_LIBDEPS_DIR: pio/libdeps
+          PLATFORMIO_PACKAGES_DIR: pio/packages
+          PLATFORMIO_CORE_DIR: pio/core
+
+      - name: Store binaries as an artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: platformio-deps-${{ inputs.pio_env }}-${{ steps.version.outputs.long }}
+          overwrite: true
+          path: |
+            pio/*


### PR DESCRIPTION
Package platformio dependencies as a zip file included with the Release.

This will be consumed by the Meshtastic FlatHub flatpak, which cannot have internet access at build-time.