### PR TITLE
meshtasticd: include `.hidden` (.git) dirs in pio-deps

### DIFF
--- a/.github/workflows/package_pio_deps.yml
+++ b/.github/workflows/package_pio_deps.yml
@@ -60,5 +60,6 @@ jobs:
         with:
           name: platformio-deps-${{ inputs.pio_env }}-${{ steps.version.outputs.long }}
           overwrite: true
+          include-hidden-files: true
           path: |
             pio/*


### PR DESCRIPTION
Addendum to #6025 

Include `.hidden` files / directories in `pio` deps upload (should include `.git` dirs pio needs now)