### PR TITLE
Trunk: userPrefs trailing commas begone!

### DIFF
--- a/.trunk/configs/.prettierrc
+++ b/.trunk/configs/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "overrides": [
+    {
+      "files": "userPrefs.jsonc",
+      "options": {
+        "trailingComma": "none"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This has been driving me insane for a while... This PR makes Trunk stop adding commas to the end of the `userPrefs.jsonc` file.