### PR TITLE
InkHUD shouldn't nag about timezone

### DIFF
--- a/src/graphics/niche/InkHUD/Applets/System/Tips/TipsApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/System/Tips/TipsApplet.cpp
@@ -174,10 +174,9 @@ void InkHUD::TipsApplet::onActivate()
     if (settings.tips.firstBoot)
         tipQueue.push_back(Tip::WELCOME);
 
-    // Region and/or Timezone
-    // Shown until sets region and tz
-    if (config.lora.region == meshtastic_Config_LoRaConfig_RegionCode_UNSET ||
-        !(*config.device.tzdef && config.device.tzdef[0] != 0))
+    // Antenna, region, timezone
+    // Shown at boot if region not yet set
+    if (config.lora.region == meshtastic_Config_LoRaConfig_RegionCode_UNSET)
         tipQueue.push_back(Tip::FINISH_SETUP);
 
     // Shutdown info


### PR DESCRIPTION
On boot, a tip may instruct users to complete setup by configuring LoRa region and timezone.

**Previously:** tip triggered if either unset region or unset tz.
**Now:** tip triggered only by unset region. Info on the tip does still advise user to set tz.

I had seen the timezone slipstreaming code in the firmware and made a bad assumption that this was already happening quietly for most users during flashing. My fault for not investigating further.