### PR TITLE
Move variant-specific lines back to variant

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -437,6 +437,10 @@ static const int serialSpeeds[3] = {9600, 115200, 38400};
 static const int rareSerialSpeeds[3] = {4800, 57600, GPS_BAUDRATE};
 #endif
 
+#ifndef GPS_PROBETRIES
+#define GPS_PROBETRIES 2
+#endif
+
 /**
  * @brief  Setup the GPS based on the model detected.
  *  We detect the GPS by cycling through a set of baud rates, first common then rare.
@@ -460,11 +464,7 @@ bool GPS::setup()
             digitalWrite(PIN_GPS_EN, HIGH);
             delay(1000);
 #endif
-#ifdef TRACKER_T1000_E
-            if (probeTries < 5) {
-#else
-            if (probeTries < 2) {
-#endif
+            if (probeTries < GPS_PROBETRIES) {
                 LOG_DEBUG("Probe for GPS at %d", serialSpeeds[speedSelect]);
                 gnssModel = probe(serialSpeeds[speedSelect]);
                 if (gnssModel == GNSS_MODEL_UNKNOWN) {
@@ -475,11 +475,7 @@ bool GPS::setup()
                 }
             }
             // Rare Serial Speeds
-#ifdef TRACKER_T1000_E
-            if (probeTries == 5) {
-#else
-            if (probeTries == 2) {
-#endif
+            if (probeTries == GPS_PROBETRIES) {
                 LOG_DEBUG("Probe for GPS at %d", rareSerialSpeeds[speedSelect]);
                 gnssModel = probe(rareSerialSpeeds[speedSelect]);
                 if (gnssModel == GNSS_MODEL_UNKNOWN) {

--- a/variants/tracker-t1000-e/variant.h
+++ b/variants/tracker-t1000-e/variant.h
@@ -111,6 +111,7 @@ extern "C" {
 #define GPS_TX_PIN PIN_SERIAL1_TX
 
 #define GPS_BAUDRATE 115200
+#define GPS_PROBETRIES 5
 
 #define PIN_GPS_EN (32 + 11) // P1.11
 #define GPS_EN_ACTIVE HIGH


### PR DESCRIPTION
Last release a change introduced different branching functions in gps.cpp based on the model of a device. This makes the code less readable and introduces the potential for bugs.

This patch creates a new variable, GPS_PROBETRIES that can be set in variant.h of devices that will control how many times we will probe for GPS presence. It sets up the T1000-E to use this variable and cleans the code in gps.c