### PR TITLE
Dependencies: minor version updates

### DIFF
--- a/arch/esp32/esp32.ini
+++ b/arch/esp32/esp32.ini
@@ -2,7 +2,7 @@
 [esp32_base]
 extends = arduino_base
 custom_esp32_kind = esp32
-platform = platformio/espressif32@6.9.0
+platform = platformio/espressif32@6.10.0
 
 build_src_filter = 
   ${arduino_base.build_src_filter} -<platform/nrf52/> -<platform/stm32wl> -<platform/rp2xx0> -<mesh/eth/> -<mesh/raspihttp>
@@ -45,9 +45,9 @@ lib_deps =
   ${environmental_base.lib_deps}
   ${radiolib_base.lib_deps}
   https://github.com/meshtastic/esp32_https_server.git#23665b3adc080a311dcbb586ed5941b5f94d6ea2
-  h2zero/NimBLE-Arduino@^1.4.2
+  h2zero/NimBLE-Arduino@^1.4.3
   https://github.com/dbinfrago/libpax.git#3cdc0371c375676a97967547f4065607d4c53fd1
-  lewisxhe/XPowersLib@^0.2.6
+  lewisxhe/XPowersLib@^0.2.7
   https://github.com/meshtastic/ESP32_Codec2.git#633326c78ac251c059ab3a8c430fcdf25b41672f
   rweather/Crypto@^0.4.0
 

--- a/arch/esp32/esp32c6.ini
+++ b/arch/esp32/esp32c6.ini
@@ -24,7 +24,7 @@ lib_deps =
   ${networking_base.lib_deps}
   ${environmental_base.lib_deps}
   ${radiolib_base.lib_deps}
-  lewisxhe/XPowersLib@^0.2.6
+  lewisxhe/XPowersLib@^0.2.7
   https://github.com/meshtastic/ESP32_Codec2.git#633326c78ac251c059ab3a8c430fcdf25b41672f
   rweather/Crypto@^0.4.0
 

--- a/arch/stm32/stm32.ini
+++ b/arch/stm32/stm32.ini
@@ -1,7 +1,7 @@
 [stm32_base]
 extends = arduino_base
 platform = ststm32
-platform_packages = platformio/framework-arduinoststm32@https://github.com/stm32duino/Arduino_Core_STM32.git#ea74156acd823b6d14739f389e6cdc648f8ee36e
+platform_packages = platformio/framework-arduinoststm32@^4.20900.0
 
 build_type = release
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -59,7 +59,7 @@ lib_deps =
 	https://github.com/meshtastic/arduino-fsm.git#7db3702bf0cfe97b783d6c72595e3f38e0b19159
 	https://github.com/meshtastic/TinyGPSPlus.git#71a82db35f3b973440044c476d4bcdc673b104f4
 	https://github.com/meshtastic/ArduinoThread.git#1ae8778c85d0a2a729f989e0b1e7d7c4dc84eef0
-	nanopb/Nanopb@0.4.9
+	nanopb/Nanopb@0.4.91
 	erriez/ErriezCRC32@1.0.1
 
 ; Used for the code analysis in PIO Home / Inspect

--- a/variants/Dongle_nRF52840-pca10059-v1/platformio.ini
+++ b/variants/Dongle_nRF52840-pca10059-v1/platformio.ini
@@ -10,5 +10,5 @@ build_flags = ${nrf52840_base.build_flags} -Ivariants/Dongle_nRF52840-pca10059-v
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/Dongle_nRF52840-pca10059-v1>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  zinggjm/GxEPD2@^1.4.9
+  zinggjm/GxEPD2@^1.6.2
 debug_tool = jlink

--- a/variants/ME25LS01-4Y10TD_e-ink/platformio.ini
+++ b/variants/ME25LS01-4Y10TD_e-ink/platformio.ini
@@ -13,7 +13,7 @@ board_build.ldscript = src/platform/nrf52/nrf52840_s140_v7.ld
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/ME25LS01-4Y10TD_e-ink>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  zinggjm/GxEPD2@^1.5.8
+  zinggjm/GxEPD2@^1.6.2
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
 upload_protocol = nrfutil
 upload_port = /dev/ttyACM1

--- a/variants/MakePython_nRF52840_eink/platformio.ini
+++ b/variants/MakePython_nRF52840_eink/platformio.ini
@@ -9,7 +9,7 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/MakePython_nRF52
 lib_deps = 
   ${nrf52840_base.lib_deps}
   https://github.com/meshtastic/ESP32_Codec2.git#633326c78ac251c059ab3a8c430fcdf25b41672f
-  zinggjm/GxEPD2@^1.4.9
+  zinggjm/GxEPD2@^1.6.2
   -DEINK_DISPLAY_MODEL=GxEPD2_290_T5D
   -DEINK_WIDTH=296
   -DEINK_HEIGHT=128

--- a/variants/TWC_mesh_v4/platformio.ini
+++ b/variants/TWC_mesh_v4/platformio.ini
@@ -6,5 +6,5 @@ build_flags = ${nrf52840_base.build_flags} -I variants/TWC_mesh_v4 -D TWC_mesh_v
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/TWC_mesh_v4>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  zinggjm/GxEPD2@^1.4.9
+  zinggjm/GxEPD2@^1.6.2
 debug_tool = jlink

--- a/variants/esp32-s3-pico/platformio.ini
+++ b/variants/esp32-s3-pico/platformio.ini
@@ -21,5 +21,5 @@ build_flags = ${esp32s3_base.build_flags}
   -DEINK_HEIGHT=128
 
 lib_deps = ${esp32s3_base.lib_deps}
-  zinggjm/GxEPD2@^1.5.3
+  zinggjm/GxEPD2@^1.6.2
   adafruit/Adafruit NeoPixel @ ^1.12.0

--- a/variants/m5stack_coreink/platformio.ini
+++ b/variants/m5stack_coreink/platformio.ini
@@ -17,7 +17,7 @@ build_flags =
   -DM5STACK
 lib_deps = 
   ${esp32_base.lib_deps}
-  zinggjm/GxEPD2@^1.5.3
+  zinggjm/GxEPD2@^1.6.2
   lewisxhe/PCF8563_Library@^1.0.1
 lib_ignore =
   m5stack-coreink

--- a/variants/my_esp32s3_diy_eink/platformio.ini
+++ b/variants/my_esp32s3_diy_eink/platformio.ini
@@ -9,10 +9,10 @@ upload_protocol = esptool
 ;upload_port = /dev/ttyACM1
 upload_speed = 921600
 platform_packages =
-  tool-esptoolpy@^1.40500.0
+  tool-esptoolpy@^1.40801.0
 lib_deps =
   ${esp32_base.lib_deps}
-  zinggjm/GxEPD2@^1.5.1
+  zinggjm/GxEPD2@^1.6.2
   adafruit/Adafruit NeoPixel @ ^1.12.0
 build_unflags =
   ${esp32s3_base.build_unflags}

--- a/variants/my_esp32s3_diy_oled/platformio.ini
+++ b/variants/my_esp32s3_diy_oled/platformio.ini
@@ -9,7 +9,7 @@ upload_protocol = esptool
 ;upload_port = /dev/ttyACM0
 upload_speed = 921600
 platform_packages =
-  tool-esptoolpy@^1.40500.0
+  tool-esptoolpy@^1.40801.0
 lib_deps =
   ${esp32_base.lib_deps}
   adafruit/Adafruit NeoPixel @ ^1.12.0

--- a/variants/rak4631_epaper/platformio.ini
+++ b/variants/rak4631_epaper/platformio.ini
@@ -13,7 +13,7 @@ build_flags = ${nrf52840_base.build_flags} -Ivariants/rak4631_epaper -D RAK_4631
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/rak4631_epaper>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  zinggjm/GxEPD2@^1.4.9
+  zinggjm/GxEPD2@^1.6.2
   melopero/Melopero RV3028@^1.1.0
   rakwireless/RAKwireless NCP5623 RGB LED library@^1.0.2
   beegee-tokyo/RAKwireless RAK12034@^1.0.0

--- a/variants/rak4631_epaper_onrxtx/platformio.ini
+++ b/variants/rak4631_epaper_onrxtx/platformio.ini
@@ -15,7 +15,7 @@ build_flags = ${nrf52840_base.build_flags} -Ivariants/rak4631_epaper -D RAK_4631
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/rak4631_epaper_onrxtx>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  zinggjm/GxEPD2@^1.5.1
+  zinggjm/GxEPD2@^1.6.2
   melopero/Melopero RV3028@^1.1.0
   rakwireless/RAKwireless NCP5623 RGB LED library@^1.0.2
   beegee-tokyo/RAKwireless RAK12034@^1.0.0


### PR DESCRIPTION
platformio/espressif32@6.9.0 --> 6.10.0
lewisxhe/XPowersLib@^0.2.6 --> 0.2.7
platformio/framework-arduinoststm32@~Oct 2024 --> 4.20900.0
zinggjm/GxEPD2@^1.4.9 --> 1.6.2
tool-esptoolpy@^1.40500.0 --> 1.40801.0

Used platformio tool to check, kept to minor version updates, checked release notes for any breaking changes.