### PR TITLE
Licensed usage compliance

### DIFF
--- a/src/mesh/Channels.h
+++ b/src/mesh/Channels.h
@@ -92,6 +92,8 @@ class Channels
     // Returns true if any of our channels have enabled MQTT uplink or downlink
     bool anyMqttEnabled();
 
+    bool ensureLicensedOperation();
+
   private:
     /** Given a channel index, change to use the crypto key specified by that index
      *

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -328,6 +328,11 @@ NodeDB::NodeDB()
     moduleConfig.neighbor_info.update_interval =
         Default::getConfiguredOrMinimumValue(moduleConfig.neighbor_info.update_interval, min_neighbor_info_broadcast_secs);
 
+    // Don't let licensed users to rebroadcast encrypted packets
+    if (owner.is_licensed) {
+        config.device.rebroadcast_mode = meshtastic_Config_DeviceConfig_RebroadcastMode_LOCAL_ONLY;
+    }
+
     if (devicestateCRC != crc32Buffer(&devicestate, sizeof(devicestate)))
         saveWhat |= SEGMENT_DEVICESTATE;
     if (nodeDatabaseCRC != crc32Buffer(&nodeDatabase, sizeof(nodeDatabase)))

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -448,6 +448,9 @@ void AdminModule::handleSetOwner(const meshtastic_User &o)
     if (owner.is_licensed != o.is_licensed) {
         changed = 1;
         owner.is_licensed = o.is_licensed;
+        if (channels.ensureLicensedOperation()) {
+            sendWarning("Licensed mode activated, removing admin channel and encryption from all channels");
+        }
     }
 
     if (changed) { // If nothing really changed, don't broadcast on the network or write to flash
@@ -730,6 +733,9 @@ void AdminModule::handleSetChannel(const meshtastic_Channel &cc)
 {
     channels.setChannel(cc);
     channels.onConfigChanged(); // tell the radios about this change
+    if (channels.ensureLicensedOperation()) {
+        sendWarning("Licensed mode activated, removing admin channel and encryption from all channels");
+    }
     saveChanges(SEGMENT_CHANNELS, false);
 }
 
@@ -1066,11 +1072,10 @@ void AdminModule::handleSetHamMode(const meshtastic_HamParameters &p)
 
     config.device.rebroadcast_mode = meshtastic_Config_DeviceConfig_RebroadcastMode_LOCAL_ONLY;
     // Remove PSK of primary channel for plaintext amateur usage
-    auto primaryChannel = channels.getByIndex(channels.getPrimaryIndex());
-    auto &channelSettings = primaryChannel.settings;
-    channelSettings.psk.bytes[0] = 0;
-    channelSettings.psk.size = 0;
-    channels.setChannel(primaryChannel);
+
+    if (channels.ensureLicensedOperation()) {
+        sendWarning("Licensed mode activated, removing admin channel and encryption from all channels");
+    }
     channels.onConfigChanged();
 
     service->reloadOwner(false);

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -732,10 +732,10 @@ void AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
 void AdminModule::handleSetChannel(const meshtastic_Channel &cc)
 {
     channels.setChannel(cc);
-    channels.onConfigChanged(); // tell the radios about this change
     if (channels.ensureLicensedOperation()) {
         sendWarning("Licensed mode activated, removing admin channel and encryption from all channels");
     }
+    channels.onConfigChanged(); // tell the radios about this change
     saveChanges(SEGMENT_CHANNELS, false);
 }
 

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -1079,7 +1079,7 @@ void AdminModule::handleSetHamMode(const meshtastic_HamParameters &p)
     channels.onConfigChanged();
 
     service->reloadOwner(false);
-    saveChanges(SEGMENT_CONFIG | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS);
+    saveChanges(SEGMENT_CONFIG | SEGMENT_NODEDATABASE | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS);
 }
 
 AdminModule::AdminModule() : ProtobufModule("Admin", meshtastic_PortNum_ADMIN_APP, &meshtastic_AdminMessage_msg)

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -449,7 +449,7 @@ void AdminModule::handleSetOwner(const meshtastic_User &o)
         changed = 1;
         owner.is_licensed = o.is_licensed;
         if (channels.ensureLicensedOperation()) {
-            sendWarning("Licensed mode activated, removing admin channel and encryption from all channels");
+            sendWarning(licensedModeMessage);
         }
     }
 
@@ -733,7 +733,7 @@ void AdminModule::handleSetChannel(const meshtastic_Channel &cc)
 {
     channels.setChannel(cc);
     if (channels.ensureLicensedOperation()) {
-        sendWarning("Licensed mode activated, removing admin channel and encryption from all channels");
+        sendWarning(licensedModeMessage);
     }
     channels.onConfigChanged(); // tell the radios about this change
     saveChanges(SEGMENT_CHANNELS, false);
@@ -1074,7 +1074,7 @@ void AdminModule::handleSetHamMode(const meshtastic_HamParameters &p)
     // Remove PSK of primary channel for plaintext amateur usage
 
     if (channels.ensureLicensedOperation()) {
-        sendWarning("Licensed mode activated, removing admin channel and encryption from all channels");
+        sendWarning(licensedModeMessage);
     }
     channels.onConfigChanged();
 

--- a/src/modules/AdminModule.h
+++ b/src/modules/AdminModule.h
@@ -64,6 +64,8 @@ class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Obser
     void sendWarning(const char *message);
 };
 
+static constexpr char *licensedModeMessage = "Licensed mode activated, removing admin channel and encryption from all channels";
+
 extern AdminModule *adminModule;
 
 void disableBluetooth();


### PR DESCRIPTION
This closes all of the loopholes of amateur radio licensed operation allowing both the legacy admin channel and any pre-shared encryption keys on channels.
The current behavior allows users to "get around" the `setHamMode` removal of the default encryption key and be in potential violation of licensed amateur radio usage.
Untested so far (Will test soon)