### PR TITLE
Fix MQTT over TLS crash loop

### DIFF
--- a/src/mesh/eth/ethClient.cpp
+++ b/src/mesh/eth/ethClient.cpp
@@ -5,9 +5,6 @@
 #include "configuration.h"
 #include "main.h"
 #include "mesh/api/ethServerAPI.h"
-#if !MESHTASTIC_EXCLUDE_MQTT
-#include "mqtt/MQTT.h"
-#endif
 #include "target_specific.h"
 #include <RAK13800_W5100S.h>
 #include <SPI.h>
@@ -72,12 +69,6 @@ static int32_t reconnectETH()
 
             ethStartupComplete = true;
         }
-#if !MESHTASTIC_EXCLUDE_MQTT
-        // FIXME this is kinda yucky, instead we should just have an observable for 'wifireconnected'
-        if (mqtt && !moduleConfig.mqtt.proxy_to_client_enabled && !mqtt->isConnectedDirectly()) {
-            mqtt->reconnect();
-        }
-#endif
     }
 
 #ifndef DISABLE_NTP

--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -7,9 +7,6 @@
 
 #include "main.h"
 #include "mesh/api/WiFiServerAPI.h"
-#if !MESHTASTIC_EXCLUDE_MQTT
-#include "mqtt/MQTT.h"
-#endif
 #include "target_specific.h"
 #include <WiFi.h>
 #include <WiFiUdp.h>
@@ -111,12 +108,6 @@ static void onNetworkConnected()
 #endif
         APStartupComplete = true;
     }
-
-    // FIXME this is kinda yucky, instead we should just have an observable for 'wifireconnected'
-#ifndef MESHTASTIC_EXCLUDE_MQTT
-    if (mqtt)
-        mqtt->reconnect();
-#endif
 }
 
 static int32_t reconnectWiFi()

--- a/src/mqtt/MQTT.h
+++ b/src/mqtt/MQTT.h
@@ -47,10 +47,6 @@ class MQTT : private concurrency::OSThread
      */
     void onSend(const meshtastic_MeshPacket &mp_encrypted, const meshtastic_MeshPacket &mp_decoded, ChannelIndex chIndex);
 
-    /** Attempt to connect to server if necessary
-     */
-    void reconnect();
-
     bool isConnectedDirectly();
 
     bool publish(const char *topic, const char *payload, bool retained);
@@ -114,6 +110,10 @@ class MQTT : private concurrency::OSThread
     /** return true if we have a channel that wants uplink/downlink or map reporting is enabled
      */
     bool wantsLink() const;
+
+    /** Attempt to connect to server if necessary
+     */
+    void reconnect();
 
     /** Tell the server what subscriptions we want (based on channels.downlink_enabled)
      */

--- a/test/test_mqtt/MQTT.cpp
+++ b/test/test_mqtt/MQTT.cpp
@@ -242,6 +242,7 @@ class MQTTUnitTest : public MQTT
         mqttClient.release();
         delete pubsub;
     }
+    using MQTT::reconnect;
     int queueSize() { return mqttQueue.numUsed(); }
     void reportToMap(std::optional<uint32_t> precision = std::nullopt)
     {
@@ -488,7 +489,7 @@ void test_reconnectProxyDoesNotReconnectMqtt(void)
     moduleConfig.mqtt.proxy_to_client_enabled = true;
     MQTTUnitTest::restart();
 
-    mqtt->reconnect();
+    unitTest->reconnect();
 
     TEST_ASSERT_FALSE(pubsub->connected_);
 }


### PR DESCRIPTION
This PR removes the logic that establishes a MQTT connection immediately after WiFi is connected. The MQTT connection is established instead within 5 seconds of WiFi being connected by the `MQTT::runOnce` callback.

This is being done because the stack size of the task that notifies of WiFi connection state changes is too small to support TLS connections. See #6056 for further details.

Fixes #6056