### PR TITLE
Consider the MQTT TLS remote IP when checking for a private IP

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -412,36 +412,28 @@ void MQTT::reconnect()
         const char *serverAddr = default_mqtt_address;
         const char *mqttUsername = default_mqtt_username;
         const char *mqttPassword = default_mqtt_password;
+        MQTTClient *clientConnection = mqttClient.get();
 
         if (*moduleConfig.mqtt.address) {
             serverAddr = moduleConfig.mqtt.address;
             mqttUsername = moduleConfig.mqtt.username;
             mqttPassword = moduleConfig.mqtt.password;
         }
-#if HAS_WIFI && !defined(ARCH_PORTDUINO)
-#if !defined(CONFIG_IDF_TARGET_ESP32C6)
+#if HAS_WIFI && !defined(ARCH_PORTDUINO) && !defined(CONFIG_IDF_TARGET_ESP32C6)
         if (moduleConfig.mqtt.tls_enabled) {
             // change default for encrypted to 8883
             try {
                 serverPort = 8883;
                 wifiSecureClient.setInsecure();
-
-                pubSub.setClient(wifiSecureClient);
                 LOG_INFO("Use TLS-encrypted session");
+                clientConnection = &wifiSecureClient;
             } catch (const std::exception &e) {
                 LOG_ERROR("MQTT ERROR: %s", e.what());
             }
         } else {
             LOG_INFO("Use non-TLS-encrypted session");
-            pubSub.setClient(*mqttClient);
         }
-#else
-        pubSub.setClient(*mqttClient);
 #endif
-#elif HAS_NETWORKING
-        pubSub.setClient(*mqttClient);
-#endif
-
         std::pair<String, uint16_t> hostAndPort = parseHostAndPort(serverAddr, serverPort);
         serverAddr = hostAndPort.first.c_str();
         serverPort = hostAndPort.second;
@@ -451,13 +443,14 @@ void MQTT::reconnect()
         LOG_INFO("Connect directly to MQTT server %s, port: %d, username: %s, password: %s", serverAddr, serverPort, mqttUsername,
                  mqttPassword);
 
+        pubSub.setClient(*clientConnection);
         bool connected = pubSub.connect(owner.id, mqttUsername, mqttPassword);
         if (connected) {
             LOG_INFO("MQTT connected");
             enabled = true; // Start running background process again
             runASAP = true;
             reconnectCount = 0;
-            isMqttServerAddressPrivate = isPrivateIpAddress(mqttClient->remoteIP());
+            isMqttServerAddressPrivate = isPrivateIpAddress(clientConnection->remoteIP());
 
             publishNodeInfo();
             sendSubscriptions();


### PR DESCRIPTION
When TLS is enabled for the MQTT connection, consider whether the remote IP address is in a private IP range.

This is a follow-up to #5647 that covers the edge case of a TLS MQTT client.