### PR TITLE
Increase `MAX_THREADS` for InkHUD variants with WiFi

### DIFF
--- a/variants/heltec_vision_master_e213/platformio.ini
+++ b/variants/heltec_vision_master_e213/platformio.ini
@@ -33,6 +33,7 @@ build_flags =
   ${inkhud.build_flags}
   -I variants/heltec_vision_master_e213
   -D HELTEC_VISION_MASTER_E213
+  -D MAX_THREADS=40
 lib_deps =
   ${inkhud.lib_deps} ; InkHUD libs first, so we get GFXRoot intead of AdafruitGFX
   ${esp32s3_base.lib_deps}

--- a/variants/heltec_vision_master_e290/platformio.ini
+++ b/variants/heltec_vision_master_e290/platformio.ini
@@ -37,6 +37,7 @@ build_flags =
   ${inkhud.build_flags}
   -I variants/heltec_vision_master_e290
   -D HELTEC_VISION_MASTER_E290
+  -D MAX_THREADS=40
 lib_deps =
   ${inkhud.lib_deps} ; InkHUD libs first, so we get GFXRoot intead of AdafruitGFX
   ${esp32s3_base.lib_deps}

--- a/variants/heltec_wireless_paper/platformio.ini
+++ b/variants/heltec_wireless_paper/platformio.ini
@@ -34,6 +34,7 @@ build_flags =
   ${inkhud.build_flags}
   -I variants/heltec_wireless_paper
   -D HELTEC_WIRELESS_PAPER
+  -D MAX_THREADS=40
 lib_deps =
   ${inkhud.lib_deps} ; InkHUD libs first, so we get GFXRoot intead of AdafruitGFX
   ${esp32s3_base.lib_deps}


### PR DESCRIPTION
I got into a reboot loop with the InkHUD and WiFi enabled, since then we’re above `MAX_THREADS`. I increased it to 40 for InkHUD variants that have WiFi, just like is done for the T-Deck already.

@todd-herbert very nice work by the way!
