### PR TITLE
assigning SDA/SCL so it actually works 8|

### DIFF
--- a/variants/diy/seeed-xiao-nrf52840-wio-sx1262/variant.h
+++ b/variants/diy/seeed-xiao-nrf52840-wio-sx1262/variant.h
@@ -84,17 +84,15 @@ static const uint8_t A5 = PIN_A5;
 #define PIN_NFC2 (31)
 
 // RX and TX pins
-#define PIN_SERIAL1_RX (6)
-#define PIN_SERIAL1_TX (7)
+#define PIN_SERIAL1_RX (-1)
+#define PIN_SERIAL1_TX (-1)
 // complains if not defined
 #define PIN_SERIAL2_RX (-1)
 #define PIN_SERIAL2_TX (-1)
 
 // 4 is used as RF_SW and 5 for USR button so...
-#define PIN_WIRE_SDA (-1)
-#define PIN_WIRE_SCL (-1)
-// #define PIN_WIRE_SDA (6)
-// #define PIN_WIRE_SCL (7)
+#define PIN_WIRE_SDA (6)
+#define PIN_WIRE_SCL (7)
 
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;


### PR DESCRIPTION
Turns out... [setting SDA/SCL to pin -1 makes things crashy crashy](https://discord.com/channels/867578229534359593/938197090935398451/1340338466277294241) on the DIY Xiao nRF52840 + Wio SX1262:
```
INFO  | ??:??:?? 1 

//\ E S H T /\ S T / C

DEBUG | ??:??:?? 1 Filesystem files:
DEBUG | ??:??:?? 1 Power::lipoInit lipo sensor is not ready yet
DEBUG | ??:??:?? 1 Use analog input 32 for battery level
INFO  | ??:??:?? 1 Scan for i2c devices
DEBUG | ??:??:?? 1 Scan for I2C devices on port 1
```
(node freezes)

Removing SERIAL1_RX/TX and using Pins 6/7 confirmed working at the cost of Serial Port -  I will now go back to hiding in the corner of shame for an appropriate amount of time.