### PR TITLE
Reject invalid configuration for the default MQTT server

### DIFF
--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -656,12 +656,17 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
         disableBluetooth();
     switch (c.which_payload_variant) {
     case meshtastic_ModuleConfig_mqtt_tag:
+#if MESHTASTIC_EXCLUDE_MQTT
+        LOG_WARN("Set module config: MESHTASTIC_EXCLUDE_MQTT is defined. Not setting MQTT config");
+        return false;
+#else
         LOG_INFO("Set module config: MQTT");
         if (!MQTT::isValidConfig(c.payload_variant.mqtt)) {
             return false;
         }
         moduleConfig.has_mqtt = true;
         moduleConfig.mqtt = c.payload_variant.mqtt;
+#endif
         break;
     case meshtastic_ModuleConfig_serial_tag:
         LOG_INFO("Set module config: Serial");

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -162,7 +162,9 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
 
     case meshtastic_AdminMessage_set_module_config_tag:
         LOG_INFO("Client set module config");
-        handleSetModuleConfig(r->set_module_config);
+        if (!handleSetModuleConfig(r->set_module_config)) {
+            myReply = allocErrorResponse(meshtastic_Routing_Error_BAD_REQUEST, &mp);
+        }
         break;
 
     case meshtastic_AdminMessage_set_channel_tag:
@@ -648,13 +650,16 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c)
     saveChanges(changes, requiresReboot);
 }
 
-void AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
+bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
 {
     if (!hasOpenEditTransaction)
         disableBluetooth();
     switch (c.which_payload_variant) {
     case meshtastic_ModuleConfig_mqtt_tag:
         LOG_INFO("Set module config: MQTT");
+        if (!MQTT::isValidConfig(c.payload_variant.mqtt)) {
+            return false;
+        }
         moduleConfig.has_mqtt = true;
         moduleConfig.mqtt = c.payload_variant.mqtt;
         break;
@@ -724,6 +729,7 @@ void AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
         break;
     }
     saveChanges(SEGMENT_MODULECONFIG);
+    return true;
 }
 
 void AdminModule::handleSetChannel(const meshtastic_Channel &cc)

--- a/src/modules/AdminModule.h
+++ b/src/modules/AdminModule.h
@@ -50,7 +50,7 @@ class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Obser
     void handleSetOwner(const meshtastic_User &o);
     void handleSetChannel(const meshtastic_Channel &cc);
     void handleSetConfig(const meshtastic_Config &c);
-    void handleSetModuleConfig(const meshtastic_ModuleConfig &c);
+    bool handleSetModuleConfig(const meshtastic_ModuleConfig &c);
     void handleSetChannel();
     void handleSetHamMode(const meshtastic_HamParameters &req);
     void handleStoreDeviceUIConfig(const meshtastic_DeviceUIConfig &uicfg);

--- a/src/mqtt/MQTT.h
+++ b/src/mqtt/MQTT.h
@@ -61,6 +61,8 @@ class MQTT : private concurrency::OSThread
 
     bool isUsingDefaultServer() { return isConfiguredForDefaultServer; }
 
+    static bool isValidConfig(const meshtastic_ModuleConfig_MQTTConfig &config);
+
   protected:
     struct QueueEntry {
         std::string topic;

--- a/test/test_mqtt/MQTT.cpp
+++ b/test/test_mqtt/MQTT.cpp
@@ -800,6 +800,38 @@ void test_customMqttRoot(void)
         [] { return pubsub->subscriptions_.count("custom/2/e/test/+") && pubsub->subscriptions_.count("custom/2/e/PKI/+"); }));
 }
 
+// Empty configuration is valid.
+void test_configurationEmptyIsValid(void)
+{
+    meshtastic_ModuleConfig_MQTTConfig config;
+
+    TEST_ASSERT_TRUE(MQTT::isValidConfig(config));
+}
+
+// Configuration with the default server is valid.
+void test_configWithDefaultServer(void)
+{
+    meshtastic_ModuleConfig_MQTTConfig config = {.address = default_mqtt_address};
+
+    TEST_ASSERT_TRUE(MQTT::isValidConfig(config));
+}
+
+// Configuration with the default server and port 8888 is invalid.
+void test_configWithDefaultServerAndInvalidPort(void)
+{
+    meshtastic_ModuleConfig_MQTTConfig config = {.address = default_mqtt_address ":8888"};
+
+    TEST_ASSERT_FALSE(MQTT::isValidConfig(config));
+}
+
+// Configuration with the default server and tls_enabled = true is invalid.
+void test_configWithDefaultServerAndInvalidTLSEnabled(void)
+{
+    meshtastic_ModuleConfig_MQTTConfig config = {.tls_enabled = true};
+
+    TEST_ASSERT_FALSE(MQTT::isValidConfig(config));
+}
+
 void setup()
 {
     initializeTestEnvironment();
@@ -843,6 +875,10 @@ void setup()
     RUN_TEST(test_enabled);
     RUN_TEST(test_disabled);
     RUN_TEST(test_customMqttRoot);
+    RUN_TEST(test_configurationEmptyIsValid);
+    RUN_TEST(test_configWithDefaultServer);
+    RUN_TEST(test_configWithDefaultServerAndInvalidPort);
+    RUN_TEST(test_configWithDefaultServerAndInvalidTLSEnabled);
     exit(UNITY_END());
 }
 #else


### PR DESCRIPTION
A MQTT configuration change will be rejected if the default server is used and:

- TLS is enabled. This is not supported by the default server.
- The port is not 1883. This is the only valid port.

This PR is addresses the additional feedback from https://github.com/meshtastic/firmware/issues/6056#issuecomment-2661120894