### PR TITLE
Prevent licensed users from rebroadcasting unlicensed traffic

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1567,6 +1567,17 @@ bool NodeDB::hasValidPosition(const meshtastic_NodeInfoLite *n)
     return n->has_position && (n->position.latitude_i != 0 || n->position.longitude_i != 0);
 }
 
+/// If we have a node / user and they report is_licensed = true
+/// we consider them licensed
+UserLicenseStatus NodeDB::getLicenseStatus(uint32_t nodeNum)
+{
+    meshtastic_NodeInfoLite *info = getMeshNode(nodeNum);
+    if (!info || !info->has_user) {
+        return UserLicenseStatus::NotKnown;
+    }
+    return info->user.is_licensed ? UserLicenseStatus::Licensed : UserLicenseStatus::NotLicensed;
+}
+
 /// Record an error that should be reported via analytics
 void recordCriticalError(meshtastic_CriticalErrorCode code, uint32_t address, const char *filename)
 {

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -68,6 +68,8 @@ enum LoadFileResult {
     OTHER_FAILURE = 5
 };
 
+enum UserLicenseStatus { NotKnown, NotLicensed, Licensed };
+
 class NodeDB
 {
     // NodeNum provisionalNodeNum; // if we are trying to find a node num this is our current attempt
@@ -166,6 +168,8 @@ class NodeDB
 
     virtual meshtastic_NodeInfoLite *getMeshNode(NodeNum n);
     size_t getNumMeshNodes() { return numMeshNodes; }
+
+    UserLicenseStatus getLicenseStatus(uint32_t nodeNum);
 
     size_t getMaxNodesAllocatedSize()
     {

--- a/src/modules/RoutingModule.cpp
+++ b/src/modules/RoutingModule.cpp
@@ -20,6 +20,12 @@ bool RoutingModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mesh
         if ((nodeDB->getMeshNode(mp.from) == NULL || !nodeDB->getMeshNode(mp.from)->has_user) &&
             (nodeDB->getMeshNode(mp.to) == NULL || !nodeDB->getMeshNode(mp.to)->has_user))
             return false;
+    } else if (owner.is_licensed && nodeDB->getMeshNode(mp.from) != NULL && nodeDB->getMeshNode(mp.from)->has_user &&
+               !nodeDB->getMeshNode(mp.from)->user.is_licensed) {
+        // Don't let licensed users to rebroadcast packets from unlicensed users
+        // If we know they are in-fact unlicensed
+        LOG_DEBUG("Packet from unlicensed user, ignoring packet");
+        return false;
     }
 
     printPacket("Routing sniffing", &mp);

--- a/src/modules/RoutingModule.cpp
+++ b/src/modules/RoutingModule.cpp
@@ -20,8 +20,7 @@ bool RoutingModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mesh
         if ((nodeDB->getMeshNode(mp.from) == NULL || !nodeDB->getMeshNode(mp.from)->has_user) &&
             (nodeDB->getMeshNode(mp.to) == NULL || !nodeDB->getMeshNode(mp.to)->has_user))
             return false;
-    } else if (owner.is_licensed && nodeDB->getMeshNode(mp.from) != NULL && nodeDB->getMeshNode(mp.from)->has_user &&
-               !nodeDB->getMeshNode(mp.from)->user.is_licensed) {
+    } else if (owner.is_licensed && nodeDB->getLicenseStatus(mp.from) == UserLicenseStatus::NotLicensed) {
         // Don't let licensed users to rebroadcast packets from unlicensed users
         // If we know they are in-fact unlicensed
         LOG_DEBUG("Packet from unlicensed user, ignoring packet");


### PR DESCRIPTION
As is (on 2.6), licensed users have rebroadcast_mode set to LOCAL_ONLY and this requires that all channels have no encryption keys, so we are effectively preventing encrypted traffic from traversing the mesh. We currently rebroadcast any plaintext traffic in good faith.
This PR takes the distinction a step further by asserting that if we have an unecrypted packet and we know that the user does not claim to be licensed, we should not rebroadcast that packet.