### PR TITLE
Expose INA219 measurement as battery voltage for Seeed Xiao ESP32S3

### DIFF
--- a/variants/seeed_xiao_s3/variant.h
+++ b/variants/seeed_xiao_s3/variant.h
@@ -36,7 +36,7 @@ L76K GPS Module Information : https://www.seeedstudio.com/L76K-GNSS-Module-for-S
 #define BUTTON_PIN 21 // This is the Program Button
 #define BUTTON_NEED_PULLUP
 
-#define BATTERY_PIN 1
+#define BATTERY_PIN -1
 #define ADC_CHANNEL ADC1_GPIO1_CHANNEL
 #define BATTERY_SENSE_RESOLUTION_BITS 12
 

--- a/variants/seeed_xiao_s3/variant.h
+++ b/variants/seeed_xiao_s3/variant.h
@@ -36,6 +36,10 @@ L76K GPS Module Information : https://www.seeedstudio.com/L76K-GNSS-Module-for-S
 #define BUTTON_PIN 21 // This is the Program Button
 #define BUTTON_NEED_PULLUP
 
+#define BATTERY_PIN 1
+#define ADC_CHANNEL ADC1_GPIO1_CHANNEL
+#define BATTERY_SENSE_RESOLUTION_BITS 12
+
 /*Warning:
     https://www.seeedstudio.com/L76K-GNSS-Module-for-Seeed-Studio-XIAO-p-5864.html
     L76K Expansion Board can not directly used, L76K Reset Pin needs to override or physically remove it,


### PR DESCRIPTION
The Meshtastic firmware lacks the ability to publish INA power monitor measurements as battery voltage readings when `BATTERY_PIN` is not defined. This limitation affects users who want to monitor battery levels using INA sensors.

Additionally, when a valid GPIO/A0 pin is assigned as `BATTERY_PIN`, users can measure analog voltage directly through that pin without requiring firmware recompilation. This feature provides more flexibility for hardware configurations.

This improvement would benefit users by:
1. Enabling battery voltage monitoring through INA sensors even without a dedicated battery pin
2. Allowing dynamic analog voltage measurements through GPIO pins
3. Reducing the need for custom firmware builds

Related issues:

https://github.com/meshtastic/firmware/issues/5248
https://github.com/meshtastic/firmware/issues/5880

