### PR TITLE
unPhone TFT: include into build, enable SD card, increase PSRAM

### DIFF
--- a/variants/unphone/platformio.ini
+++ b/variants/unphone/platformio.ini
@@ -32,7 +32,6 @@ lib_deps = ${esp32s3_base.lib_deps}
 
 [env:unphone-tft]
 extends = env:unphone
-board_level = extra
 board_build.partitions = default_8MB.csv
 build_flags =
   ${env:unphone.build_flags}
@@ -48,7 +47,7 @@ build_flags =
   -D HAS_SCREEN=0
   -D HAS_TFT=1
   -D DISPLAY_SET_RESOLUTION
-  -D RAM_SIZE=1024
+  -D RAM_SIZE=3072
 	-D LV_LVGL_H_INCLUDE_SIMPLE
 	-D LV_CONF_INCLUDE_SIMPLE
 	-D LV_COMP_CONF_INCLUDE_SIMPLE

--- a/variants/unphone/variant.h
+++ b/variants/unphone/variant.h
@@ -48,7 +48,8 @@
 #undef GPS_RX_PIN
 #undef GPS_TX_PIN
 
-// #define HAS_SDCARD 1 // causes hang if defined
+#define HAS_SDCARD 1
+#define SD_SPI_FREQUENCY 25000000
 #define SDCARD_CS 43
 
 #define LED_PIN 13     // the red part of the RGB LED


### PR DESCRIPTION
unPhone-tft: 

- include into build after fix compiler error
- enable SD card, 
- increase assigned PSRAM

Short test looks good, SD card is detected correctly. LoRa communication as well. Programming mode is working, too.