### PR TITLE
meshtasticd deb: Build armv6-compatible binary

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,6 +3,7 @@ Section: misc
 Priority: optional
 Maintainer: Austin Lane <vidplace7@gmail.com>
 Build-Depends: debhelper-compat (= 13),
+               lsb-release,
                tar,
                gzip,
                platformio,

--- a/debian/rules
+++ b/debian/rules
@@ -11,6 +11,15 @@ PIO_ENV:=\
 	PLATFORMIO_LIBDEPS_DIR=pio/libdeps \
 	PLATFORMIO_PACKAGES_DIR=pio/packages
 
+# Raspbian armhf builds should be compatible with armv6-hardfloat
+# https://www.valvers.com/open-software/raspberry-pi/bare-metal-programming-in-c-part-1/#rpi1-compiler-flags
+ifneq (,$(findstring Raspbian,$(shell lsb_release -is)))
+ifeq ($(DEB_BUILD_ARCH),armhf)
+PIO_ENV+=\
+	PLATFORMIO_BUILD_FLAGS="-mfloat-abi=hard -mfpu=vfp -march=armv6zk"
+endif
+endif
+
 override_dh_auto_build:
 	# Extract tarballs within source deb
 	tar -xf pio.tar


### PR DESCRIPTION
This should allow us to compile Raspbian `armhf` binaries that are compatible with the PiZero/Pi1 in our current armv7l build environments. Inspiration for this was taken from Raspbian's own packaging.

https://www.valvers.com/open-software/raspberry-pi/bare-metal-programming-in-c-part-1/#rpi1-compiler-flags

This mess is a side-effect of Debian 12 drawing the line at armv7 and calling it `armhf` while Raspbian 12 supports armv6 + hard-float and also calls it "armhf".

Building test builds here https://build.opensuse.org/package/show/home:vidplace7:meshtastic:daily/meshtasticd