### PR TITLE
Only call GPS Probe commands once per family

### DIFF
--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -48,6 +48,11 @@ enum GPSPowerState : uint8_t {
     GPS_OFF        // Powered off indefinitely
 };
 
+struct ChipInfo {
+    String chipName;        // The name of the chip (for logging)
+    String detectionString; // The string to match in the response
+    GnssModel_t driver;     // The driver to use
+};
 /**
  * A gps class that only reads from the GPS periodically and keeps the gps powered down except when reading
  *
@@ -229,6 +234,8 @@ class GPS : private concurrency::OSThread
     void publishUpdate();
 
     virtual int32_t runOnce() override;
+
+    GnssModel_t getProbeResponse(unsigned long timeout, const std::vector<ChipInfo> &responseMap);
 
     // Get GNSS model
     GnssModel_t probe(int serialSpeed);


### PR DESCRIPTION
In the GPS probe code we write commands on the serial line and
 determine which GPS we have based on the result.

GPS units in the same family sometimes use the same command,
 but return different results (eg AG3335 and AG3332 both use $PAIR021*39).
Currently we run the command once per GPS. Instead we should run each command only once per family, record the result, and select the GNSS MODEL
 based on the result, which is what this patch does.

Before the change, we put 12 commands on the serial bus. Now we only put 6.

This should markedly improve the speed and reliability of GPS detection.

Fixes https://github.com/meshtastic/firmware/issues/5193