### PR TITLE
Revert "Rak4631 remove spi1 (#6042)"

### DIFF
--- a/src/detect/einkScan.h
+++ b/src/detect/einkScan.h
@@ -6,28 +6,28 @@
 
 void d_writeCommand(uint8_t c)
 {
-    SPI.beginTransaction(SPISettings(4000000, MSBFIRST, SPI_MODE0));
+    SPI1.beginTransaction(SPISettings(4000000, MSBFIRST, SPI_MODE0));
     if (PIN_EINK_DC >= 0)
         digitalWrite(PIN_EINK_DC, LOW);
     if (PIN_EINK_CS >= 0)
         digitalWrite(PIN_EINK_CS, LOW);
-    SPI.transfer(c);
+    SPI1.transfer(c);
     if (PIN_EINK_CS >= 0)
         digitalWrite(PIN_EINK_CS, HIGH);
     if (PIN_EINK_DC >= 0)
         digitalWrite(PIN_EINK_DC, HIGH);
-    SPI.endTransaction();
+    SPI1.endTransaction();
 }
 
 void d_writeData(uint8_t d)
 {
-    SPI.beginTransaction(SPISettings(4000000, MSBFIRST, SPI_MODE0));
+    SPI1.beginTransaction(SPISettings(4000000, MSBFIRST, SPI_MODE0));
     if (PIN_EINK_CS >= 0)
         digitalWrite(PIN_EINK_CS, LOW);
-    SPI.transfer(d);
+    SPI1.transfer(d);
     if (PIN_EINK_CS >= 0)
         digitalWrite(PIN_EINK_CS, HIGH);
-    SPI.endTransaction();
+    SPI1.endTransaction();
 }
 
 unsigned long d_waitWhileBusy(uint16_t busy_time)
@@ -53,7 +53,7 @@ unsigned long d_waitWhileBusy(uint16_t busy_time)
 
 void scanEInkDevice(void)
 {
-    SPI.begin();
+    SPI1.begin();
     d_writeCommand(0x22);
     d_writeData(0x83);
     d_writeCommand(0x20);
@@ -62,6 +62,6 @@ void scanEInkDevice(void)
         LOG_DEBUG("EInk display found");
     else
         LOG_DEBUG("EInk display not found");
-    SPI.end();
+    SPI1.end();
 }
 #endif

--- a/variants/rak4631/variant.h
+++ b/variants/rak4631/variant.h
@@ -107,11 +107,15 @@ static const uint8_t AREF = PIN_AREF;
 /*
  * SPI Interfaces
  */
-#define SPI_INTERFACES_COUNT 1
+#define SPI_INTERFACES_COUNT 2
 
-#define PIN_SPI_MISO (29)
-#define PIN_SPI_MOSI (30)
-#define PIN_SPI_SCK (3)
+#define PIN_SPI_MISO (45)
+#define PIN_SPI_MOSI (44)
+#define PIN_SPI_SCK (43)
+
+#define PIN_SPI1_MISO (29) // (0 + 29)
+#define PIN_SPI1_MOSI (30) // (0 + 30)
+#define PIN_SPI1_SCK (3)   // (0 + 3)
 
 static const uint8_t SS = 42;
 static const uint8_t MOSI = PIN_SPI_MOSI;
@@ -126,8 +130,8 @@ static const uint8_t SCK = PIN_SPI_SCK;
 #define PIN_EINK_BUSY (0 + 4)
 #define PIN_EINK_DC (0 + 17)
 #define PIN_EINK_RES (-1)
-#define PIN_EINK_SCLK PIN_SPI_SCK
-#define PIN_EINK_MOSI PIN_SPI_MOSI // also called SDI
+#define PIN_EINK_SCLK (0 + 3)
+#define PIN_EINK_MOSI (0 + 30) // also called SDI
 
 // #define USE_EINK
 
@@ -255,7 +259,7 @@ SO GPIO 39/TXEN MAY NOT BE DEFINED FOR SUCCESSFUL OPERATION OF THE SX1262 - TG
 
 #define PIN_ETHERNET_RESET 21
 #define PIN_ETHERNET_SS PIN_EINK_CS
-#define ETH_SPI_PORT SPI
+#define ETH_SPI_PORT SPI1
 #define AQ_SET_PIN 10
 
 #ifdef __cplusplus


### PR DESCRIPTION
This reverts commit 9b46cb4ef08688a2f424c76d8425561e4f5db844.

It breaks the detection of the LoRa radio. While technically it's correct that only one SPI device is exposed, there seems to be an internal SPI device that is used to connect to the radio.
