### PR TITLE
Debian: Ensure deps exist for changelog bump

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -352,6 +352,12 @@ jobs:
         run: >-
           bin/bump_version.py
 
+      - name: Ensure debian deps are installed
+        shell: bash
+        run: |
+          sudo apt-get update -y --fix-missing
+          sudo apt-get install -y devscripts
+
       - name: Update debian changelog
         run: >-
           debian/ci_changelog.sh


### PR DESCRIPTION
This dependency is already included in the self-hosted runners. https://github.com/meshtastic/gh-runners/pull/1
This still will ensure the `devscripts` package (for dch) is also installed when using github-hosted runners.

Should also run quickly on the self-hosted runners since it's already installed there :+1: 