### PR TITLE
chore: better err logging in radiolib

### DIFF
--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -222,12 +222,16 @@ bool RF95Interface::reconfigure()
         RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
 
     err = lora->setSyncWord(syncWord);
-    if (err != RADIOLIB_ERR_NONE)
+    if (err == RADIOLIB_ERR_WRONG_MODEM)
+        LOG_ERROR("RF95 setSyncWord: WRONG MODEM error %s%d", radioLibErr, err);
+    else if (err != RADIOLIB_ERR_NONE)
         LOG_ERROR("RF95 setSyncWord %s%d", radioLibErr, err);
     assert(err == RADIOLIB_ERR_NONE);
 
     err = lora->setCurrentLimit(currentLimit);
-    if (err != RADIOLIB_ERR_NONE)
+    if (err == RADIOLIB_ERR_INVALID_CURRENT_LIMIT)
+        LOG_ERROR("RF95 setCurrentLimit: INVALID CURRENT LIMIT error %s%d", radioLibErr, err);
+    else if (err != RADIOLIB_ERR_NONE)
         LOG_ERROR("RF95 setCurrentLimit %s%d", radioLibErr, err);
     assert(err == RADIOLIB_ERR_NONE);
 
@@ -237,6 +241,10 @@ bool RF95Interface::reconfigure()
     assert(err == RADIOLIB_ERR_NONE);
 
     err = lora->setFrequency(getFreq());
+    if (err == RADIOLIB_ERR_INVALID_FREQUENCY)
+        LOG_ERROR("RF95 setFrequency: INVALID FREQUENCY error %s%d", radioLibErr, err);
+    else if (err == RADIOLIB_ERR_INVALID_BIT_RANGE)
+        LOG_ERROR("RF95 setFrequency: INVALID BIT RANGE error %s%d", radioLibErr, err);
     if (err != RADIOLIB_ERR_NONE)
         RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
 

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -195,17 +195,23 @@ template <typename T> bool SX126xInterface<T>::reconfigure()
         RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
 
     err = lora.setSyncWord(syncWord);
-    if (err != RADIOLIB_ERR_NONE)
-        LOG_ERROR("SX126X setSyncWord %s%d", radioLibErr, err);
+    if (err == RADIOLIB_ERR_WRONG_MODEM)
+        LOG_ERROR("SX128X setSyncWord: WRONG MODEM error %s%d", radioLibErr, err);
+    else if (err != RADIOLIB_ERR_NONE)
+        LOG_ERROR("SX128X setSyncWord %s%d", radioLibErr, err);
     assert(err == RADIOLIB_ERR_NONE);
 
     err = lora.setCurrentLimit(currentLimit);
-    if (err != RADIOLIB_ERR_NONE)
+    if (err == RADIOLIB_ERR_INVALID_CURRENT_LIMIT)
+        LOG_ERROR("SX126X setCurrentLimit: INVALID CURRENT LIMIT error %s%d", radioLibErr, err);
+    else if (err != RADIOLIB_ERR_NONE)
         LOG_ERROR("SX126X setCurrentLimit %s%d", radioLibErr, err);
     assert(err == RADIOLIB_ERR_NONE);
 
     err = lora.setPreambleLength(preambleLength);
-    if (err != RADIOLIB_ERR_NONE)
+    if (err == RADIOLIB_ERR_INVALID_BIT_RANGE)
+        LOG_ERROR("SX126X setPreambleLength: INVALID BIT RANGE error %s%d", radioLibErr, err);
+    else if (err != RADIOLIB_ERR_NONE)
         LOG_ERROR("SX126X setPreambleLength %s%d", radioLibErr, err);
     assert(err == RADIOLIB_ERR_NONE);
 
@@ -217,7 +223,9 @@ template <typename T> bool SX126xInterface<T>::reconfigure()
         power = SX126X_MAX_POWER;
 
     err = lora.setOutputPower(power);
-    if (err != RADIOLIB_ERR_NONE)
+    if (err == RADIOLIB_ERR_INVALID_OUTPUT_POWER)
+        LOG_ERROR("SX126X setOutputPower: INVALID OUTPUT POWER error %s%d", radioLibErr, err);
+    else if (err != RADIOLIB_ERR_NONE)
         LOG_ERROR("SX126X setOutputPower %s%d", radioLibErr, err);
     assert(err == RADIOLIB_ERR_NONE);
 

--- a/src/mesh/SX128xInterface.cpp
+++ b/src/mesh/SX128xInterface.cpp
@@ -131,7 +131,9 @@ template <typename T> bool SX128xInterface<T>::reconfigure()
         RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
 
     err = lora.setSyncWord(syncWord);
-    if (err != RADIOLIB_ERR_NONE)
+    if (err == RADIOLIB_ERR_WRONG_MODEM)
+        LOG_ERROR("SX128X setSyncWord: WRONG MODEM error %s%d", radioLi / bErr, err);
+    else if (err != RADIOLIB_ERR_NONE)
         LOG_ERROR("SX128X setSyncWord %s%d", radioLibErr, err);
     assert(err == RADIOLIB_ERR_NONE);
 
@@ -148,7 +150,11 @@ template <typename T> bool SX128xInterface<T>::reconfigure()
         power = SX128X_MAX_POWER;
 
     err = lora.setOutputPower(power);
-    if (err != RADIOLIB_ERR_NONE)
+    if (err == RADIOLIB_ERR_INVALID_OUTPUT_POWER)
+        LOG_ERROR("SX128X setOutputPower invalid power level %d, error: %s%d", power, radioLibErr, err);
+    else if (err == RADIOLIB_ERR_SPI_CMD_TIMEOUT)
+        LOG_ERROR("SX128X setOutputPower SPI timeout, error: %s%d", radioLibErr, err);
+    else if (err != RADIOLIB_ERR_NONE)
         LOG_ERROR("SX128X setOutputPower %s%d", radioLibErr, err);
     assert(err == RADIOLIB_ERR_NONE);
 


### PR DESCRIPTION
I added an additional check for specific Radiolib and included logs.

Should I also add logs in places where there are none? For example:

```cpp
    err = lora.setBandwidth(bw);
    if (err != RADIOLIB_ERR_NONE)
        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
```