### PR TITLE
Trunk: Add clang-tidy

### DIFF
--- a/.trunk/configs/.clang-tidy
+++ b/.trunk/configs/.clang-tidy
@@ -1,0 +1,39 @@
+Checks: >-
+  bugprone-*,
+  cppcoreguidelines-*,
+  google-*,
+  misc-*,
+  modernize-*,
+  performance-*,
+  readability-*,
+  -bugprone-lambda-function-name,
+  -bugprone-reserved-identifier,
+  -cppcoreguidelines-avoid-goto,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-avoid-non-const-global-variables,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-type-vararg,
+  -google-readability-braces-around-statements,
+  -google-readability-function-size,
+  -misc-no-recursion,
+  -modernize-return-braced-init-list,
+  -modernize-use-nodiscard,
+  -modernize-use-trailing-return-type,
+  -performance-unnecessary-value-param,
+  -readability-magic-numbers,
+
+CheckOptions:
+  - key: readability-function-cognitive-complexity.Threshold
+    value: 100
+  - key: readability-function-cognitive-complexity.IgnoreMacros
+    value: true
+  # Set naming conventions for your style below (there are dozens of naming settings possible):
+  # See https://clang.llvm.org/extra/clang-tidy/checks/readability/identifier-naming.html
+  # - key: readability-identifier-naming.ClassCase
+  #   value: CamelCase
+  # - key: readability-identifier-naming.NamespaceCase
+  #   value: lower_case
+  # - key: readability-identifier-naming.PrivateMemberSuffix
+  #   value: _
+  # - key: readability-identifier-naming.StructCase
+  #   value: CamelCase

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -30,6 +30,7 @@ lint:
     - git-diff-check
     - gitleaks@8.24.0
     - clang-format@16.0.3
+    - clang-tidy@16.0.3
   ignore:
     - linters: [ALL]
       paths:


### PR DESCRIPTION
Adds clang-tidy as a trunk linter per @elfring's suggestion in https://github.com/meshtastic/firmware/issues/6170.

For now using the default trunk.io `.clang_tidy` config, which may need modifications.