### PR TITLE
Switch pio_deps to `native-tft` for flatpak

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -135,10 +135,10 @@ jobs:
       build_location: local
     secrets: inherit
 
-  package-pio-deps-native:
+  package-pio-deps-native-tft:
     uses: ./.github/workflows/package_pio_deps.yml
     with:
-      pio_env: native
+      pio_env: native-tft
     secrets: inherit
 
   test-native:
@@ -288,7 +288,7 @@ jobs:
     needs:
       - gather-artifacts
       - build-debian-src
-      - package-pio-deps-native
+      - package-pio-deps-native-tft
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -324,10 +324,10 @@ jobs:
           merge-multiple: true
           path: ./output/debian-src
 
-      - name: Download native pio deps
+      - name: Download `native-tft` pio deps
         uses: actions/download-artifact@v4
         with:
-          pattern: platformio-deps-native-${{ steps.version.outputs.long }}
+          pattern: platformio-deps-native-tft-${{ steps.version.outputs.long }}
           merge-multiple: true
           path: ./output/pio-deps-native
 


### PR DESCRIPTION
Switch pio_deps packaging to target the `native-tft` env.
Consumed in flatpak for "offline" builds.