### PR TITLE
Enable external (UART) GPS support on Seeed WM1110 tracker dev board

### DIFF
--- a/variants/wio-tracker-wm1110/variant.h
+++ b/variants/wio-tracker-wm1110/variant.h
@@ -103,6 +103,11 @@ extern "C" {
 
 #define LR1110_GNSS_ANT_PIN (32 + 5) // P1.05 37
 
+#define GPS_RX_PIN PIN_SERIAL1_RX
+#define GPS_TX_PIN PIN_SERIAL1_TX
+
+#define HAS_GPS 1
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Prior to these changes, upon initial boot, the lack of `HAS_GPS` macro definition resulted in the gps mode being set to `NOT_PRESENT` and the Seeed studio groove connector GPS module would never be scanned for and detected. 
After these changes, it is detected as an L76K and seems to work fine.