### PR TITLE
native: do not include `device-ui` in build sources

### DIFF
--- a/variants/portduino/platformio.ini
+++ b/variants/portduino/platformio.ini
@@ -14,6 +14,9 @@ extends = native_base
 build_flags = ${native_base.build_flags}
   !pkg-config --libs libulfius --silence-errors || :
   !pkg-config --libs openssl --silence-errors || :
+; Exclude the `device-ui`
+build_src_filter = ${native_base.build_src_filter}
+  -<../lib/device-ui>
 
 [env:native-tft]
 extends = native_base


### PR DESCRIPTION
With the inclusion of the `device-ui` submodule in `master` now, `native` debian-src builds have ballooned from 110 MB to 800 MB.
This is mostly thanks to the `lvgl` dependency included for `device-ui`.

These deps aren't needed unless you're building with the UI bundled (`native-tft`), so let's exclude them.