### PR TITLE
Consume device-ui as a pio library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "protobufs"]
 	path = protobufs
 	url = https://github.com/meshtastic/protobufs.git
-[submodule "lib/device-ui"]
-	path = lib/device-ui
-	url = https://github.com/meshtastic/device-ui.git
 [submodule "meshtestic"]
 	path = meshtestic
 	url = https://github.com/meshtastic/meshTestic

--- a/bin/platformio-custom.py
+++ b/bin/platformio-custom.py
@@ -126,3 +126,8 @@ for flag in flags:
 projenv.Append(
     CCFLAGS=flags,
 )
+
+for lb in env.GetLibBuilders():
+    if lb.name == "meshtastic-device-ui":
+        lb.env.Append(CPPDEFINES=[("APP_VERSION", verObj["long"])])
+        break

--- a/platformio.ini
+++ b/platformio.ini
@@ -92,6 +92,10 @@ lib_deps =
 lib_deps =
 	jgromes/RadioLib@7.1.2
 
+[device-ui_base]
+lib_deps =
+	https://github.com/meshtastic/device-ui.git#8c3183e177a1d6452ce12b4f328bd3357bf7e21b
+
 ; Common libs for environmental measurements in telemetry module
 ; (not included in native / portduino)
 [environmental_base]

--- a/variants/mesh-tab/platformio.ini
+++ b/variants/mesh-tab/platformio.ini
@@ -47,14 +47,11 @@ build_flags = ${esp32s3_base.build_flags}
   -D LGFX_TOUCH_INT=41
   -D VIEW_320x240
   -D USE_PACKET_API
-  -I lib/device-ui/generated/ui_320x240
   -I variants/mesh-tab
 build_src_filter = ${esp32_base.build_src_filter}
-  +<../lib/device-ui/generated/ui_320x240>
-  +<../lib/device-ui/resources>
-  +<../lib/device-ui/locale>
-  +<../lib/device-ui/source>
-lib_deps = ${esp32_base.lib_deps}
+lib_deps =
+  ${esp32_base.lib_deps}
+  ${device-ui_base.lib_deps}
   lovyan03/LovyanGFX@^1.2.0
 
 [mesh_tab_xpt2046]

--- a/variants/picomputer-s3/platformio.ini
+++ b/variants/picomputer-s3/platformio.ini
@@ -54,11 +54,7 @@ build_flags =
   -D VIEW_320x240
 ;	-D USE_DOUBLE_BUFFER
   -D USE_PACKET_API
-	-I lib/device-ui/generated/ui_320x240
 
-build_src_filter =
-  ${env:picomputer-s3.build_src_filter}
-  +<../lib/device-ui/generated/ui_320x240>
-  +<../lib/device-ui/resources>
-  +<../lib/device-ui/locale>
-  +<../lib/device-ui/source>
+lib_deps =
+  ${env:picomputer-s3.lib_deps}
+  ${device-ui_base.lib_deps}

--- a/variants/portduino/platformio.ini
+++ b/variants/portduino/platformio.ini
@@ -18,6 +18,9 @@ build_flags = ${native_base.build_flags}
 [env:native-tft]
 extends = native_base
 build_type = release
+lib_deps =
+  ${native_base.lib_deps}
+  ${device-ui_base.lib_deps}
 build_flags = ${native_base.build_flags} -Os -lX11 -linput -lxkbcommon -ffunction-sections -fdata-sections -Wl,--gc-sections
   -D MESHTASTIC_EXCLUDE_CANNEDMESSAGES=1
   -D RAM_SIZE=16384
@@ -32,21 +35,19 @@ build_flags = ${native_base.build_flags} -Os -lX11 -linput -lxkbcommon -ffunctio
   -D USE_LOG_DEBUG
   -D LOG_DEBUG_INC=\"DebugConfiguration.h\"
   -D USE_PACKET_API
-  -I lib/device-ui/generated/ui_320x240
+  -D VIEW_320x240
   !pkg-config --libs libulfius --silence-errors || :
   !pkg-config --libs openssl --silence-errors || :
-build_src_filter = ${native_base.build_src_filter}
+build_src_filter =
+  ${native_base.build_src_filter}
   -<graphics/TFTDisplay.cpp>
-  +<../lib/device-ui/generated/ui_320x240>
-  +<../lib/device-ui/generated/ui_320x240/fonts>
-  +<../lib/device-ui/resources>
-  +<../lib/device-ui/portduino>
-  +<../lib/device-ui/locale>
-  +<../lib/device-ui/source>
 
 [env:native-tft-debug]
 extends = native_base
 build_type = debug
+lib_deps =
+  ${native_base.lib_deps}
+  ${device-ui_base.lib_deps}
 board_level = extra
 build_flags = ${native_base.build_flags} -O0 -fsanitize=address -lX11 -linput -lxkbcommon
   -D MESHTASTIC_EXCLUDE_CANNEDMESSAGES=1
@@ -69,7 +70,7 @@ build_flags = ${native_base.build_flags} -O0 -fsanitize=address -lX11 -linput -l
   -D USE_LOG_DEBUG
   -D LOG_DEBUG_INC=\"DebugConfiguration.h\"
   -D USE_PACKET_API
-  -I lib/device-ui/generated/ui_320x240
+  -D VIEW_320x240
   !pkg-config --libs libulfius --silence-errors || :
   !pkg-config --libs openssl --silence-errors || :
 build_src_filter = ${env:native-tft.build_src_filter}

--- a/variants/seeed-sensecap-indicator/platformio.ini
+++ b/variants/seeed-sensecap-indicator/platformio.ini
@@ -68,15 +68,8 @@ build_flags =
   -D VIEW_320x240
 ;	-D USE_DOUBLE_BUFFER
   -D USE_PACKET_API
-	-I lib/device-ui/generated/ui_320x240
-
-build_src_filter =
-  ${env:seeed-sensecap-indicator.build_src_filter}
-  +<../lib/device-ui/generated/ui_320x240>
-  +<../lib/device-ui/resources>
-  +<../lib/device-ui/locale>
-  +<../lib/device-ui/source>
 
 lib_deps =
   ${env:seeed-sensecap-indicator.lib_deps}
+  ${device-ui_base.lib_deps}
   https://github.com/bitbank2/bb_captouch.git#8f2f06462ff597847921739376a299db93612417 ; alternative touch library supporting FT6x36

--- a/variants/t-deck/platformio.ini
+++ b/variants/t-deck/platformio.ini
@@ -66,14 +66,7 @@ build_flags =
   -D VIEW_320x240
 ;	-D USE_DOUBLE_BUFFER
   -D USE_PACKET_API
-	-I lib/device-ui/generated/ui_320x240
-
-build_src_filter =
-  ${env:t-deck.build_src_filter}
-  +<../lib/device-ui/generated/ui_320x240>
-  +<../lib/device-ui/resources>
-  +<../lib/device-ui/locale>
-  +<../lib/device-ui/source>
 
 lib_deps =
   ${env:t-deck.lib_deps}
+  ${device-ui_base.lib_deps}

--- a/variants/unphone/platformio.ini
+++ b/variants/unphone/platformio.ini
@@ -63,11 +63,7 @@ build_flags =
   -D GFX_DRIVER_INC=\"graphics/LGFX/LGFX_UNPHONE.h\"
   -D VIEW_320x240
   -D USE_PACKET_API
-	-I lib/device-ui/generated/ui_320x240
 
-build_src_filter =
-  ${env:unphone.build_src_filter}
-  +<../lib/device-ui/generated/ui_320x240>
-  +<../lib/device-ui/resources>
-  +<../lib/device-ui/locale>
-  +<../lib/device-ui/source>
+lib_deps =
+  ${env:unphone.lib_deps}
+  ${device-ui_base.lib_deps}


### PR DESCRIPTION
Switches `device-ui` from being consumed as a git submodule to being consumed as a platformio library.

Currently `device-ui`'s dependencies (notably `lvgl`) are pulled on every build, even for non `-tft` builds. Consuming `device-ui` as a PlatformIO library resolves this issue.

Depends on:
- https://github.com/meshtastic/device-ui/pull/64
- https://github.com/meshtastic/device-ui/pull/73