### PR TITLE
E-ink partial refresh limitation removed for free text screen

### DIFF
--- a/src/graphics/EInkDynamicDisplay.cpp
+++ b/src/graphics/EInkDynamicDisplay.cpp
@@ -324,6 +324,14 @@ void EInkDynamicDisplay::checkConsecutiveFastRefreshes()
     if (refresh != UNSPECIFIED)
         return;
 
+    // Bypass limit if UNLIMITED_FAST mode is active
+    if (frameFlags & UNLIMITED_FAST) {
+        refresh = FAST;
+        reason = NO_OBJECTIONS;
+        LOG_DEBUG("refresh=FAST, reason=UNLIMITED_FAST_MODE_ACTIVE, frameFlags=0x%x", frameFlags);
+        return;
+    }
+    
     // If too many FAST refreshes consecutively - force a FULL refresh
     if (fastRefreshCount >= EINK_LIMIT_FASTREFRESH) {
         refresh = FULL;

--- a/src/graphics/EInkDynamicDisplay.h
+++ b/src/graphics/EInkDynamicDisplay.h
@@ -23,6 +23,10 @@ class EInkDynamicDisplay : public EInkDisplay, protected concurrency::NotifiedWo
     EInkDynamicDisplay(uint8_t address, int sda, int scl, OLEDDISPLAY_GEOMETRY geometry, HW_I2C i2cBus);
     ~EInkDynamicDisplay();
 
+    // Methods to enable or disable unlimited fast refresh mode
+    void enableUnlimitedFastMode() { addFrameFlag(UNLIMITED_FAST); }
+    void disableUnlimitedFastMode() { frameFlags = (frameFlagTypes)(frameFlags & ~UNLIMITED_FAST); }
+
     // What kind of frame is this
     enum frameFlagTypes : uint8_t {
         BACKGROUND = (1 << 0),  // For frames via display()
@@ -30,6 +34,7 @@ class EInkDynamicDisplay : public EInkDisplay, protected concurrency::NotifiedWo
         COSMETIC = (1 << 2),    // For splashes
         DEMAND_FAST = (1 << 3), // Special case only
         BLOCKING = (1 << 4),    // Modifier - block while refresh runs
+        UNLIMITED_FAST = (1 << 5)
     };
     void addFrameFlag(frameFlagTypes flag);
 

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -1057,6 +1057,11 @@ void CannedMessageModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *st
         display->drawString(10 + x, 0 + y + FONT_HEIGHT_SMALL, "Canned Message\nModule disabled.");
     } else if (cannedMessageModule->runState == CANNED_MESSAGE_RUN_STATE_FREETEXT) {
         requestFocus(); // Tell Screen::setFrames to move to our module's frame
+#ifdef USE_EINK
+        EInkDynamicDisplay* einkDisplay = static_cast<EInkDynamicDisplay*>(display);
+        einkDisplay->enableUnlimitedFastMode();  // Enable unlimited fast refresh while typing
+#endif
+
 #if defined(USE_VIRTUAL_KEYBOARD)
         drawKeyboard(display, state, 0, 0);
 #else

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -1057,7 +1057,7 @@ void CannedMessageModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *st
         display->drawString(10 + x, 0 + y + FONT_HEIGHT_SMALL, "Canned Message\nModule disabled.");
     } else if (cannedMessageModule->runState == CANNED_MESSAGE_RUN_STATE_FREETEXT) {
         requestFocus(); // Tell Screen::setFrames to move to our module's frame
-#ifdef USE_EINK
+#if defined(USE_EINK) && defined(USE_EINK_DYNAMICDISPLAY)
         EInkDynamicDisplay* einkDisplay = static_cast<EInkDynamicDisplay*>(display);
         einkDisplay->enableUnlimitedFastMode();  // Enable unlimited fast refresh while typing
 #endif


### PR DESCRIPTION
added an UNLIMITED_FAST flag for eink displays to allow more input temporarily while using freetext screen. All other behavior remains unchanged. This will allow keyboard devices to type without the annoying full refresh flash. As mentioned on PR https://github.com/meshtastic/firmware/issues/6196