### PR TITLE
[STM32] RAK3172 enable LED, enable serial debug (was mute), fix radio init and update platformio and variant

### DIFF
--- a/arch/stm32/stm32.ini
+++ b/arch/stm32/stm32.ini
@@ -20,7 +20,7 @@ build_flags =
   -DMESHTASTIC_EXCLUDE_MQTT
   -DMESHTASTIC_EXCLUDE_BLUETOOTH
   -DMESHTASTIC_EXCLUDE_GPS
-  -DDEBUG_MUTE
+  ;-DDEBUG_MUTE
   -fmerge-all-constants
   -ffunction-sections
   -fdata-sections

--- a/src/mesh/STM32WLE5JCInterface.cpp
+++ b/src/mesh/STM32WLE5JCInterface.cpp
@@ -19,7 +19,9 @@ bool STM32WLE5JCInterface::init()
     RadioLibInterface::init();
 
     // https://github.com/Seeed-Studio/LoRaWan-E5-Node/blob/main/Middlewares/Third_Party/SubGHz_Phy/stm32_radio_driver/radio_driver.c
+    #if (!defined(_VARIANT_RAK3172_))
     setTCXOVoltage(1.7);
+    #endif
 
     lora.setRfSwitchTable(rfswitch_pins, rfswitch_table);
 

--- a/src/mesh/STM32WLE5JCInterface.cpp
+++ b/src/mesh/STM32WLE5JCInterface.cpp
@@ -18,10 +18,10 @@ bool STM32WLE5JCInterface::init()
 {
     RadioLibInterface::init();
 
-    // https://github.com/Seeed-Studio/LoRaWan-E5-Node/blob/main/Middlewares/Third_Party/SubGHz_Phy/stm32_radio_driver/radio_driver.c
-    #if (!defined(_VARIANT_RAK3172_))
+// https://github.com/Seeed-Studio/LoRaWan-E5-Node/blob/main/Middlewares/Third_Party/SubGHz_Phy/stm32_radio_driver/radio_driver.c
+#if (!defined(_VARIANT_RAK3172_))
     setTCXOVoltage(1.7);
-    #endif
+#endif
 
     lora.setRfSwitchTable(rfswitch_pins, rfswitch_table);
 

--- a/variants/rak3172/platformio.ini
+++ b/variants/rak3172/platformio.ini
@@ -5,9 +5,6 @@ board_upload.maximum_size = 233472 ; reserve the last 28KB for filesystem
 build_flags =
   ${stm32_base.build_flags}
   -Ivariants/rak3172
-  -DSERIAL_UART_INSTANCE=1
-  -DPIN_SERIAL_RX=PB7
-  -DPIN_SERIAL_TX=PB6
   -DHAL_DAC_MODULE_ONLY
   -DHAL_RNG_MODULE_ENABLED
   -DRADIOLIB_EXCLUDE_SX128X=1
@@ -23,5 +20,4 @@ build_flags =
   -DMESHTASTIC_EXCLUDE_POWERMON=1
   ;-DPIO_FRAMEWORK_ARDUINO_NANOLIB_FLOAT_PRINTF
   ;-DCFG_DEBUG
-
 upload_port = stlink

--- a/variants/rak3172/variant.h
+++ b/variants/rak3172/variant.h
@@ -14,7 +14,7 @@ Do not expect a working Meshtastic device with this target.
 #define USE_STM32WLx
 #define MAX_NUM_NODES 10
 
-#define LED_PIN PA0     //Green LED
+#define LED_PIN PA0 // Green LED
 #define LED_STATE_ON 1
 
 #endif

--- a/variants/rak3172/variant.h
+++ b/variants/rak3172/variant.h
@@ -1,4 +1,9 @@
 /*
+STM32WLE5 Core Module for LoRaWAN® RAK3372
+https://store.rakwireless.com/products/wisblock-core-module-rak3372
+*/
+
+/*
 This variant is a work in progress.
 Do not expect a working Meshtastic device with this target.
 */
@@ -8,5 +13,8 @@ Do not expect a working Meshtastic device with this target.
 
 #define USE_STM32WLx
 #define MAX_NUM_NODES 10
+
+#define LED_PIN PA0     //Green LED
+#define LED_STATE_ON 1
 
 #endif


### PR DESCRIPTION
(user) user@user-B460MD3H:~/stm32/git$ cd firmware/.pio/build/rak3172/
(user) user@user-B460MD3H:~/stm32/git/firmware/.pio/build/rak3172$ pyocd commander -t stm32wle5jcix
0001066 E Error reading AP#1 IDR: Memory transfer fault [discovery]
Connected to STM32WLE5JCIx [Running]: E6614103E74A182F
pyocd> halt; erase; load firmware.hex; reset
Successfully halted device
[==================================================] 100%
Resetting target
pyocd> 


#############################################################################
INFO  | ??:??:?? 1 Power output set to 22
INFO  | ??:??:?? 1 STM32WL init success
DEBUG | ??:??:?? 1 LoRA bitrate =  bytes / sec
#22
#freqEnd:  ->  ( MHz)
#, power=30
#             
#############################################################################
INFO  | ??:??:?? 1 PowerFSM init, USB power=1
DEBUG | ??:??:?? 1 State: BOOT
