### PR TITLE
fix(grammar): change shutdown to shut down when used as a verb

### DIFF
--- a/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
@@ -239,7 +239,7 @@ void InkHUD::MenuApplet::showPage(MenuPage page)
         // items.push_back(MenuItem("Send", MenuPage::SEND)); // TODO
         items.push_back(MenuItem("Options", MenuPage::OPTIONS));
         // items.push_back(MenuItem("Display Off", MenuPage::EXIT)); // TODO
-        items.push_back(MenuItem("Save & Shutdown", MenuAction::SHUTDOWN));
+        items.push_back(MenuItem("Save & Shut down", MenuAction::SHUTDOWN));
         items.push_back(MenuItem("Exit", MenuPage::EXIT));
         break;
 

--- a/src/graphics/niche/InkHUD/Applets/System/Tips/TipsApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/System/Tips/TipsApplet.cpp
@@ -53,7 +53,7 @@ void InkHUD::TipsApplet::onRender()
 
         setFont(fontSmall);
         std::string shutdown;
-        shutdown += "Before removing power, please shutdown from InkHUD menu, or a client app. \n";
+        shutdown += "Before removing power, please shut down from InkHUD menu, or a client app. \n";
         shutdown += "\n";
         shutdown += "This ensures data is saved.";
         printWrapped(0, fontLarge.lineHeight() * 1.5, width(), shutdown);


### PR DESCRIPTION
fixes #6211 