### PR TITLE
Small Fix: Don't run Dependabot on protobufs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,8 @@ updates:
       interval: daily
       time: "05:00"
       timezone: US/Pacific
+    ignore:
+      - dependency-name: protobufs
   - package-ecosystem: github-actions
     directory: /.github/workflows
     schedule:


### PR DESCRIPTION
We do our own thing for protobuf updates, including code generation.