### PR TITLE
Update platformio.ini for 4.2 and 2.9 CrowPanel ESP32-S3 epaper and point GxEPD2 to meshtastic branch

### DIFF
--- a/variants/crowpanel-esp32s3-5-epaper/platformio.ini
+++ b/variants/crowpanel-esp32s3-5-epaper/platformio.ini
@@ -15,8 +15,6 @@ build_flags =
   -DBOARD_HAS_PSRAM
   -DGPS_POWER_TOGGLE
   -DEINK_DISPLAY_MODEL=GxEPD2_579_GDEY0579T93 ;https://www.good-display.com/product/439.html
-  ;-DEINK_DISPLAY_MODEL=GxEPD2_290_GDEY029T94 ;https://www.good-display.com/product/389.html
-  ;-DEINK_DISPLAY_MODEL=GxEPD2_420_GYE042A87   ; similar Panel: GDEY042T81 : https://www.good-display.com/product/386.html
   -DEINK_WIDTH=792
   -DEINK_HEIGHT=272
   -DUSE_EINK_DYNAMICDISPLAY            ; Enable Dynamic EInk
@@ -25,4 +23,58 @@ build_flags =
   ;-DEINK_LIMIT_RATE_RESPONSIVE_SEC=1 
 lib_deps =
   ${esp32s3_base.lib_deps}
-  https://github.com/markbirss/GxEPD2#markbirss-patch-1
+  https://github.com/meshtastic/GxEPD2
+
+[env:crowpanel-esp32s3-4-epaper]
+extends = esp32s3_base
+board_build.arduino.memory_type = qio_opi
+board_build.flash_mode = qio
+board_build.psram_type = opi
+board_upload.flash_size = 8MB
+board_upload.maximum_size = 8388608
+board = esp32-s3-devkitc-1
+upload_port = /dev/ttyUSB0
+board_level = extra
+upload_protocol = esptool
+build_flags = 
+  ${esp32_base.build_flags} -D CROWPANEL_ESP32S3_5_EPAPER -I variants/crowpanel-esp32s3-5-epaper
+  -D PRIVATE_HW
+  -DBOARD_HAS_PSRAM
+  -DGPS_POWER_TOGGLE
+  -DEINK_DISPLAY_MODEL=GxEPD2_420_GYE042A87   ; similar Panel: GDEY042T81 : https://www.good-display.com/product/386.html
+  -DEINK_WIDTH=400
+  -DEINK_HEIGHT=300
+  -DUSE_EINK_DYNAMICDISPLAY            ; Enable Dynamic EInk
+  -DEINK_LIMIT_FASTREFRESH=100          ; How many consecutive fast-refreshes are permitted
+  ;-DEINK_LIMIT_RATE_BACKGROUND_SEC=30  ; Minimum interval between BACKGROUND updates
+  ;-DEINK_LIMIT_RATE_RESPONSIVE_SEC=1 
+lib_deps =
+  ${esp32s3_base.lib_deps}
+  https://github.com/meshtastic/GxEPD2
+
+[env:crowpanel-esp32s3-2-epaper]
+extends = esp32s3_base
+board_build.arduino.memory_type = qio_opi
+board_build.flash_mode = qio
+board_build.psram_type = opi
+board_upload.flash_size = 8MB
+board_upload.maximum_size = 8388608
+board = esp32-s3-devkitc-1
+upload_port = /dev/ttyUSB0
+board_level = extra
+upload_protocol = esptool
+build_flags = 
+  ${esp32_base.build_flags} -D CROWPANEL_ESP32S3_5_EPAPER -I variants/crowpanel-esp32s3-5-epaper
+  -D PRIVATE_HW
+  -DBOARD_HAS_PSRAM
+  -DGPS_POWER_TOGGLE
+  -DEINK_DISPLAY_MODEL=GxEPD2_290_GDEY029T94 ;https://www.good-display.com/product/389.html
+  -DEINK_WIDTH=296
+  -DEINK_HEIGHT=128
+  -DUSE_EINK_DYNAMICDISPLAY            ; Enable Dynamic EInk
+  -DEINK_LIMIT_FASTREFRESH=100          ; How many consecutive fast-refreshes are permitted
+  ;-DEINK_LIMIT_RATE_BACKGROUND_SEC=30  ; Minimum interval between BACKGROUND updates
+  ;-DEINK_LIMIT_RATE_RESPONSIVE_SEC=1 
+lib_deps =
+  ${esp32s3_base.lib_deps}
+  https://github.com/meshtastic/GxEPD2


### PR DESCRIPTION
include platformio environments for the 2.9" and 4.2" inch also

crowpanel-esp32s3-5-epaper 5.79" 
crowpanel-esp32s3-4-epaper 4.2" device was already tested without radio
crowpanel-esp32s3-2-epaper 2.9" i dont have

will look at fonts sizes for the 4.2 and 2.9 in the furture

