### PR TITLE
Give Semgrep permission to write its report

### DIFF
--- a/.github/workflows/sec_sast_semgrep_cron.yml
+++ b/.github/workflows/sec_sast_semgrep_cron.yml
@@ -6,7 +6,10 @@ on:
   schedule:
     - cron: 0 1 * * 6
 
-permissions: read-all
+permissions:
+  actions: read
+  contents: read
+  security-events: write
 
 jobs:
   semgrep-full:


### PR DESCRIPTION
Previously semgrep had read-all permission. This patch limits read slightly and adds write permissions to security-events.