### PR TITLE
Flag semgrep to not run on self-hosted

### DIFF
--- a/.github/workflows/sec_sast_semgrep_cron.yml
+++ b/.github/workflows/sec_sast_semgrep_cron.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   semgrep-full:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: semgrep/semgrep
 


### PR DESCRIPTION
The semgrep action runs inside a docker container,
and docker in podman just doesn't work.