### PR TITLE
Actions: Move version bump into release_channels

### DIFF
--- a/.github/workflows/build_debian_src.yml
+++ b/.github/workflows/build_debian_src.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       PPA_GPG_PRIVATE_KEY:
-        required: true
+        required: false
     inputs:
       series:
         description: Ubuntu/Debian series to target

--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -136,6 +136,7 @@ jobs:
     secrets: inherit
 
   package-pio-deps-native-tft:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/package_pio_deps.yml
     with:
       pio_env: native-tft
@@ -329,13 +330,13 @@ jobs:
         with:
           pattern: platformio-deps-native-tft-${{ steps.version.outputs.long }}
           merge-multiple: true
-          path: ./output/pio-deps-native
+          path: ./output/pio-deps-native-tft
 
       - name: Zip linux sources
         working-directory: output
         run: |
           zip -j -9 -r ./meshtasticd-${{ steps.version.outputs.deb }}-src.zip ./debian-src
-          zip -9 -r ./platformio-deps-native-${{ steps.version.outputs.long }}.zip ./pio-deps-native
+          zip -9 -r ./platformio-deps-native-tft-${{ steps.version.outputs.long }}.zip ./pio-deps-native-tft
 
       # For diagnostics
       - name: Display structure of downloaded files
@@ -344,31 +345,9 @@ jobs:
       - name: Add linux sources to release
         run: |
           gh release upload v${{ steps.version.outputs.long }} ./output/meshtasticd-${{ steps.version.outputs.deb }}-src.zip
-          gh release upload v${{ steps.version.outputs.long }} ./output/platformio-deps-native-${{ steps.version.outputs.long }}.zip
+          gh release upload v${{ steps.version.outputs.long }} ./output/platformio-deps-native-tft-${{ steps.version.outputs.long }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Bump version.properties
-        run: >-
-          bin/bump_version.py
-
-      - name: Ensure debian deps are installed
-        shell: bash
-        run: |
-          sudo apt-get update -y --fix-missing
-          sudo apt-get install -y devscripts
-
-      - name: Update debian changelog
-        run: >-
-          debian/ci_changelog.sh
-
-      - name: Create version.properties pull request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          title: Bump version.properties
-          add-paths: |
-            version.properties
-            debian/changelog
 
   release-firmware:
     strategy:

--- a/.github/workflows/release_channels.yml
+++ b/.github/workflows/release_channels.yml
@@ -43,3 +43,49 @@ jobs:
       copr_project: |-
         ${{ contains(github.event.release.name, 'Beta') && 'beta' || contains(github.event.release.name, 'Alpha') && 'alpha' }}
     secrets: inherit
+
+  # Create a PR to bump version when a release is Published
+  bump-version:
+    if: ${{ github.event.release.published }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: Get release version string
+        run: |
+          echo "long=$(./bin/buildinfo.py long)" >> $GITHUB_OUTPUT
+          echo "deb=$(./bin/buildinfo.py deb)" >> $GITHUB_OUTPUT
+        id: version
+        env:
+          BUILD_LOCATION: local
+
+      - name: Bump version.properties
+        run: >-
+          bin/bump_version.py
+
+      - name: Ensure debian deps are installed
+        shell: bash
+        run: |
+          sudo apt-get update -y --fix-missing
+          sudo apt-get install -y devscripts
+
+      - name: Update debian changelog
+        run: >-
+          debian/ci_changelog.sh
+
+      - name: Create version.properties pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          title: Bump version.properties
+          add-paths: |
+            version.properties
+            debian/changelog


### PR DESCRIPTION
Moves the version bump process into_release channels.

Now the version bump PR will only be submitted after a new release has been *released* (un-drafted).

Also made some small changes to the platformio deps process for FlatPaks. Notably, now only generated during the *release* process.