### PR TITLE
NodeInfo request: don't bother if too far away

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -88,8 +88,16 @@ int MeshService::handleFromRadio(const meshtastic_MeshPacket *mp)
     } else if (mp->which_payload_variant == meshtastic_MeshPacket_decoded_tag && !nodeDB->getMeshNode(mp->from)->has_user &&
                nodeInfoModule && !isPreferredRebroadcaster && !nodeDB->isFull()) {
         if (airTime->isTxAllowedChannelUtil(true)) {
-            LOG_INFO("Heard new node on ch. %d, send NodeInfo and ask for response", mp->channel);
-            nodeInfoModule->sendOurNodeInfo(mp->from, true, mp->channel);
+            // Hops used by the request. If somebody in between running modified firmware modified it, ignore it
+            auto hopStart = mp->hop_start;
+            auto hopLimit = mp->hop_limit;
+            uint8_t hopsUsed = hopStart < hopLimit ? config.lora.hop_limit : hopStart - hopLimit;
+            if (hopsUsed > config.lora.hop_limit + 2) {
+                LOG_DEBUG("Skip send NodeInfo: %d hops away is too far away", hopsUsed);
+            } else {
+                LOG_INFO("Heard new node on ch. %d, send NodeInfo and ask for response", mp->channel);
+                nodeInfoModule->sendOurNodeInfo(mp->from, true, mp->channel);
+            }
         } else {
             LOG_DEBUG("Skip sending NodeInfo > 25%% ch. util");
         }


### PR DESCRIPTION
In my dense urban environment, I see many nodes that are >= 5 hops away, but sending their NodeInfo with a hopStart of 6 or 7.

So: when we receive a NodeInfo from a new node, if it is more than 2 hops beyond our configured hop limit away from us, don't bother to send a NodeInfo back to it.  In most cases I can imagine, doing so seems like a waste of airtime.

Sample logs of it working (I only had to wait a few minutes):
```
DEBUG | 15:28:32 1116 [Router] Delivering rx packet (id=0x9d46cefa fr=0x8eaef435 to=0xffffffff, WantAck=0, HopLim=0 Ch=0x0 Portnum=67 rxtime=1741361312 rxSNR=-8.5 rxRSSI=-110 hopStart=7)
DEBUG | 15:28:32 1116 [Router] Update DB node 0x8eaef435, rx_time=1741361312
INFO  | 15:28:32 1116 [Router] Adding node to database with 35 nodes and 145320 bytes free!
DEBUG | 15:28:32 1116 [Router] Skip send NodeInfo: 7 hops away is too far away
```