### PR TITLE
Update device-install scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text=auto eol=lf
 *.{cmd,[cC][mM][dD]} text eol=crlf
 *.{bat,[bB][aA][tT]} text eol=crlf
+*.{ps1,[pP][sS]} text eol=crlf
 *.{sh,[sS][hH]} text eol=lf

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,8 @@
   "cmake.configureOnOpen": false,
   "[cpp]": {
     "editor.defaultFormatter": "trunk.io"
+  },
+  "[powershell]": {
+    "editor.defaultFormatter": "ms-vscode.powershell"
   }
 }

--- a/bin/device-install.bat
+++ b/bin/device-install.bat
@@ -20,7 +20,7 @@ ECHO.
 ECHO Usage: %SCRIPT_NAME% -f filename [-p PORT] [-P python] (--web)
 ECHO.
 ECHO Options:
-ECHO     -f filename      The .bin file to flash.  Custom to your device type and region. (required)
+ECHO     -f filename      The firmware .bin file to flash.  Custom to your device type and region. (required)
 ECHO                      The file must be located in this current directory.
 ECHO     -p PORT          Set the environment variable for ESPTOOL_PORT.
 ECHO                      If not set, ESPTOOL iterates all ports (Dangerous).
@@ -60,8 +60,13 @@ IF "__!FILENAME!__"=="____" (
     CALL :LOG_MESSAGE DEBUG "Missing -f filename input."
     GOTO help
 ) ELSE (
+    CALL :LOG_MESSAGE DEBUG "Filename: !FILENAME!"
     IF NOT "__!FILENAME: =!__"=="__!FILENAME!__" (
         CALL :LOG_MESSAGE ERROR "Filename containing spaces are not supported."
+        GOTO help
+    )
+    IF "__!FILENAME:firmware-=!__"=="__!FILENAME!__" (
+        CALL :LOG_MESSAGE ERROR "Filename must be a firmware-* file."
         GOTO help
     )
     @REM Remove ".\" or "./" file prefix if present.
@@ -69,7 +74,6 @@ IF "__!FILENAME!__"=="____" (
     SET "FILENAME=!FILENAME:./=!"
 )
 
-CALL :LOG_MESSAGE DEBUG "Filename: !FILENAME!"
 CALL :LOG_MESSAGE DEBUG "Checking if !FILENAME! exists..."
 IF NOT EXIST !FILENAME! (
     CALL :LOG_MESSAGE ERROR "File does not exist: !FILENAME!. Terminating."

--- a/bin/device-install.bat
+++ b/bin/device-install.bat
@@ -30,7 +30,7 @@ ECHO                      If not supplied the script will try to find esptool in
 ECHO     --web            Enable WebUI. (default: false)
 ECHO.
 ECHO Example: %SCRIPT_NAME% -f firmware-t-deck-tft-2.6.0.0b106d4.bin -p COM11
-ECHO Example: %SCRIPT_NAME% -f littlefs-unphone-2.6.0.0b106d4.bin -p COM11 --web
+ECHO Example: %SCRIPT_NAME% -f firmware-unphone-2.6.0.0b106d4.bin -p COM11 --web
 GOTO eof
 
 :version

--- a/bin/device-install.sh
+++ b/bin/device-install.sh
@@ -29,7 +29,7 @@ Flash image file to device, but first erasing and writing system information.
     -h               Display this help and exit.
     -p ESPTOOL_PORT  Set the environment variable for ESPTOOL_PORT.  If not set, ESPTOOL iterates all ports (Dangerous).
     -P PYTHON        Specify alternate python interpreter to use to invoke esptool. (Default: "$PYTHON")
-    -f FILENAME      The .bin file to flash.  Custom to your device type and region.
+    -f FILENAME      The firmware .bin file to flash.  Custom to your device type and region.
     --web            Enable WebUI. (Default: false)
 
 EOF
@@ -72,6 +72,11 @@ done
 	FILENAME=$1
 	shift
 }
+
+if [[ $FILENAME != firmware-* ]]; then
+  echo "Filename must be a firmware-* file."
+  exit 1
+fi
 
 # Check if FILENAME contains "-tft-" and set target partitionScheme accordingly.
 if [[ ${FILENAME//-tft-/} != "$FILENAME" ]]; then

--- a/bin/device-install_test.ps1
+++ b/bin/device-install_test.ps1
@@ -25,10 +25,10 @@ param()
 function New-EmptyFile() {
     [CmdletBinding()]
     param (
-        [Parameter(Position=0,Mandatory=$true)]
+        [Parameter(Position = 0, Mandatory = $true)]
         # Specifies the file name.
         [string]$FileName,
-        [Parameter(Position=1)]
+        [Parameter(Position = 1)]
         # Specifies the target path. (Get-Location).Path is the default.
         [string]$Directory = (Get-Location).Path
     )
@@ -42,10 +42,10 @@ function New-EmptyFile() {
 function Remove-EmptyFile() {
     [CmdletBinding()]
     param (
-        [Parameter(Position=0,Mandatory=$true)]
+        [Parameter(Position = 0, Mandatory = $true)]
         # Specifies the file name.
         [string]$FileName,
-        [Parameter(Position=1)]
+        [Parameter(Position = 1)]
         # Specifies the target path. (Get-Location).Path is the default.
         [string]$Directory = (Get-Location).Path
     )
@@ -60,14 +60,14 @@ function Remove-EmptyFile() {
 $TestCases = New-Object -TypeName PSObject -Property @{
     # Use this PSObject to define testcases according to this syntax:
     # "testname" = @("firmware-testname","bleota","littlefs-testname","args")
-    "t-deck" = @("firmware-t-deck-2.6.0.0b106d4.bin", "bleota-s3.bin", "littlefs-t-deck-2.6.0.0b106d4.bin","")
-    "t-deck_web" = @("firmware-t-deck-2.6.0.0b106d4.bin", "bleota-s3.bin", "littlefswebui-t-deck-2.6.0.0b106d4.bin","--web")
-    "t-deck-tft" = @("firmware-t-deck-tft-2.6.0.0b106d4.bin", "bleota-s3.bin", "littlefs-t-deck-tft-2.6.0.0b106d4.bin","")
-    "heltec-ht62-esp32c3" = @("firmware-heltec-ht62-esp32c3-sx1262-2.6.0.0b106d4.bin", "bleota-c3.bin", "littlefs-heltec-ht62-esp32c3-sx1262-2.6.0.0b106d4.bin","")
-    "tlora-c6" = @("firmware-tlora-c6-2.6.0.0b106d4.bin", "bleota.bin", "littlefs-tlora-c6-2.6.0.0b106d4.bin","")
-    "heltec-v3_web" = @("firmware-heltec-v3-2.6.0.0b106d4.bin", "bleota-s3.bin", "littlefswebui-heltec-v3-2.6.0.0b106d4.bin","--web")
-    "seeed-sensecap-indicator-tft" = @("firmware-seeed-sensecap-indicator-tft-2.6.0.0b106d4.bin", "bleota.bin", "littlefs-seeed-sensecap-indicator-tft-2.6.0.0b106d4.bin","")
-    "picomputer-s3-tft" = @("firmware-picomputer-s3-tft-2.6.0.0b106d4.bin", "bleota-s3.bin", "littlefs-picomputer-s3-tft-2.6.0.0b106d4.bin","")
+    "t-deck"                       = @("firmware-t-deck-2.6.0.0b106d4.bin", "bleota-s3.bin", "littlefs-t-deck-2.6.0.0b106d4.bin", "")
+    "t-deck_web"                   = @("firmware-t-deck-2.6.0.0b106d4.bin", "bleota-s3.bin", "littlefswebui-t-deck-2.6.0.0b106d4.bin", "--web")
+    "t-deck-tft"                   = @("firmware-t-deck-tft-2.6.0.0b106d4.bin", "bleota-s3.bin", "littlefs-t-deck-tft-2.6.0.0b106d4.bin", "")
+    "heltec-ht62-esp32c3"          = @("firmware-heltec-ht62-esp32c3-sx1262-2.6.0.0b106d4.bin", "bleota-c3.bin", "littlefs-heltec-ht62-esp32c3-sx1262-2.6.0.0b106d4.bin", "")
+    "tlora-c6"                     = @("firmware-tlora-c6-2.6.0.0b106d4.bin", "bleota.bin", "littlefs-tlora-c6-2.6.0.0b106d4.bin", "")
+    "heltec-v3_web"                = @("firmware-heltec-v3-2.6.0.0b106d4.bin", "bleota-s3.bin", "littlefswebui-heltec-v3-2.6.0.0b106d4.bin", "--web")
+    "seeed-sensecap-indicator-tft" = @("firmware-seeed-sensecap-indicator-tft-2.6.0.0b106d4.bin", "bleota.bin", "littlefs-seeed-sensecap-indicator-tft-2.6.0.0b106d4.bin", "")
+    "picomputer-s3-tft"            = @("firmware-picomputer-s3-tft-2.6.0.0b106d4.bin", "bleota-s3.bin", "littlefs-picomputer-s3-tft-2.6.0.0b106d4.bin", "")
 }
 
 foreach ($TestCase in $TestCases.PSObject.Properties) {
@@ -88,9 +88,10 @@ foreach ($TestCase in $TestCases.PSObject.Properties) {
 
     foreach ($Line in $Test) {
         if ($Line -match "Set OTA_OFFSET to" -or `
-            $Line -match "Set SPIFFS_OFFSET to") {
+                $Line -match "Set SPIFFS_OFFSET to") {
             Write-Host -Object "$($Line -replace "^.*?Set","Set")" -ForegroundColor Blue
-        } elseif ($VerbosePreference -eq "Continue") {
+        }
+        elseif ($VerbosePreference -eq "Continue") {
             Write-Host -Object $Line
         }
         if ($Line -match "ERROR") {
@@ -100,7 +101,7 @@ foreach ($TestCase in $TestCases.PSObject.Properties) {
     }
     if ($null -ne $Errors) {
         Write-Host -Object "$Counter ERROR(s) detected!" -ForegroundColor Red
-        if (-not ($VerbosePreference -eq "Continue")) {Write-Host -Object $Errors}
+        if (-not ($VerbosePreference -eq "Continue")) { Write-Host -Object $Errors }
     }
 
     foreach ($File in $Files) {


### PR DESCRIPTION
Basically a continuation of https://github.com/meshtastic/firmware/pull/6248.

- Added good ideas by @gjelsoe 👍
  The scripts now check for `firmware-` in the input.
  Updated help sections to match.
  
- Added `.gitattributes` and `editor.defaultFormatter` for powershell.

I did also resave and commit the windows scripts as CRLF.
This needs some testing on different machines, if the windows scripts are LF they do **not** work at all.
