### PR TITLE
PlatformIO: Bump ArduinoThread / device-ui versions

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -60,7 +60,7 @@ lib_deps =
 	mathertel/OneButton@2.6.1
 	https://github.com/meshtastic/arduino-fsm.git#7db3702bf0cfe97b783d6c72595e3f38e0b19159
 	https://github.com/meshtastic/TinyGPSPlus.git#71a82db35f3b973440044c476d4bcdc673b104f4
-	https://github.com/meshtastic/ArduinoThread.git#1ae8778c85d0a2a729f989e0b1e7d7c4dc84eef0
+	https://github.com/meshtastic/ArduinoThread.git#7c3ee9e1951551b949763b1f5280f8db1fa4068d
 	nanopb/Nanopb@0.4.91
 	erriez/ErriezCRC32@1.0.1
 
@@ -94,7 +94,7 @@ lib_deps =
 
 [device-ui_base]
 lib_deps =
-	https://github.com/meshtastic/device-ui.git#8c3183e177a1d6452ce12b4f328bd3357bf7e21b
+	https://github.com/meshtastic/device-ui.git#d7b18e98704f988fcda9e5fa7404e677b3d11f8c
 
 ; Common libs for environmental measurements in telemetry module
 ; (not included in native / portduino)


### PR DESCRIPTION
Bump versions of `ArduinoThread` and `device-ui` (which consumes ArduinoThread).

Fixes intermittent "cannot find Thread.h" compile issues.

See
- https://github.com/meshtastic/ArduinoThread/pull/3
- https://github.com/meshtastic/device-ui/pull/78