### PR TITLE
Fix excluded_modules metadata with InkHUD

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1225,8 +1225,12 @@ extern meshtastic_DeviceMetadata getDeviceMetadata()
 #if MESHTASTIC_EXCLUDE_AUDIO
     deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_AUDIO_CONFIG;
 #endif
-#if !HAS_SCREEN || NO_EXT_GPIO
-    deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_CANNEDMSG_CONFIG | meshtastic_ExcludedModules_EXTNOTIF_CONFIG;
+// Option to explicitly include canned messages for edge cases, e.g. niche graphics
+#if (!HAS_SCREEN && NO_EXT_GPIO) && !MESHTASTIC_INCLUDE_CANNEDMSG
+    deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_CANNEDMSG_CONFIG;
+#endif
+#if NO_EXT_GPIO
+    deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_EXTNOTIF_CONFIG;
 #endif
 // Only edge case here is if we apply this a device with built in Accelerometer and want to detect interrupts
 // We'll have to macro guard against those targets potentially


### PR DESCRIPTION
The `getDeviceMetadata` method controls which modules' config is exposed to users in the apps.

Previously, the _canned message_ and _external notification_ modules were enabled only if `HAS_SCREEN`.
InkHUD defines `HAS_SCREEN=0` to suppress the original OLED screen class.

This PR adjusts the macros in `getDeviceMetadata` so that:
* External notification module does not require `HAS_SCREEN`.
  This restores the feature for variants like `heltec-vision-master-e290-inkhud`.
  
* Canned message module can be explicitly included with the `MESHTASTIC_INCLUDE_CANNEDMSG` macro.
  The intention is for "scan and select style" canned messages to be made available via the InkHUD menu in the future, even for devices like Wireless Paper / T-Echo which have `NO_EXT_GPIO`.
