### PR TITLE
Windows script lineendings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 * text=auto eol=lf
-*.{cmd,[cC][mM][dD]} text eol=crlf
-*.{bat,[bB][aA][tT]} text eol=crlf
-*.{ps1,[pP][sS]} text eol=crlf
+*.cmd text eol=crlf
+*.bat text eol=crlf
+*.ps1 text eol=crlf
 *.{sh,[sS][hH]} text eol=lf


### PR DESCRIPTION
See: https://github.com/meshtastic/firmware/discussions/6288
I downloaded the new release on my machine, and yes, the windows files got delivered as `LF`.

This PR updates .gitattributes syntax to keep windows files in the `CRLF` format.

Tested on my machine using commands like
```bash
git clone -b windows-crlf https://github.com/ThatKalle/firmware.git firmwaretest
git clone https://github.com/meshtastic/firmware.git firmwareorig
```
and comparing the lineendings of `.bat` and `.ps1`

I don't see any capitalizations
```bash
$ git ls-files | grep -i '\.bat$'
device-install.bat
device-update.bat
regen-protos.bat
uf2-convert.bat
$ git ls-files | grep -i '\.ps1$'
device-install_test.ps1
$ git ls-files | grep -i '\.cmd$'
```