### PR TITLE
MUI: fix packet queue full

### DIFF
--- a/src/mesh/api/PacketAPI.cpp
+++ b/src/mesh/api/PacketAPI.cpp
@@ -89,18 +89,20 @@ bool PacketAPI::receivePacket(void)
 
 bool PacketAPI::sendPacket(void)
 {
-    // fill dummy buffer; we don't use it, we directly send the fromRadio structure
-    uint32_t len = getFromRadio(txBuf);
-    if (len != 0) {
-        static uint32_t id = 0;
-        fromRadioScratch.id = ++id;
-        bool result = server->sendPacket(DataPacket<meshtastic_FromRadio>(id, fromRadioScratch));
-        if (!result) {
-            LOG_ERROR("send queue full");
+    if (server->available()) {
+        // fill dummy buffer; we don't use it, we directly send the fromRadio structure
+        uint32_t len = getFromRadio(txBuf);
+        if (len != 0) {
+            static uint32_t id = 0;
+            fromRadioScratch.id = ++id;
+            bool result = server->sendPacket(DataPacket<meshtastic_FromRadio>(id, fromRadioScratch));
+            if (!result) {
+                LOG_ERROR("send queue full");
+            }
+            return result;
         }
-        return result;
-    } else
-        return false;
+    }
+    return false;
 }
 
 bool PacketAPI::notifyProgrammingMode(void)


### PR DESCRIPTION
Fix to prevent packet queue getting full:
Previously the packet server was taking all meshpackets via a getFromRadio() call and adding it to the packet queue. As the processing in the MUI client is much slower than generating the configuration setup in the server, the packet queue randomly got full (and packets lost).

This PR adds a (simple) check if the queue size isn't full before adding new packets which effectively prevents any overrun. 