### PR TITLE
Add packages to devcontainer for build native-tft

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,6 +30,9 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     gnupg2 \
     libusb-1.0-0-dev \
     libi2c-dev \
+    libxcb-xkb-dev \
+    libxkbcommon-dev \
+    libinput-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN pipx install platformio


### PR DESCRIPTION
Adding the following 3 packages to the devcontainer allows for `build` and `test` on `env:native-tft` using PlatformIO.
```
libxcb-xkb-dev
libxkbcommon-dev
libinput-dev
```

## Output
```
Processing native-tft (board: cross_platform; platform: https://github.com/meshtastic/platform-native.git#562d189828f09fbf4c4093b3c0104bae9d8e9ff9; framework: arduino)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Verbose mode can be enabled via `-v, --verbose` option
CONFIGURATION: https://docs.platformio.org/page/boards/native/cross_platform.html
PLATFORM: Native (1.2.1+sha.562d189) > Portduino
HARDWARE: 95.37MB RAM, 95.37MB Flash
PACKAGES: 
 - framework-portduino @ 0.0.1+sha.bebaf2d
LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
LDF Modes: Finder ~ chain, Compatibility ~ soft
[nanopb] No generation needed.
[nanopb] Installing Protocol Buffers dependencies
Requirement already satisfied: protobuf>=3.19.1 in /home/vscode/.platformio/penv/lib/python3.13/site-packages (5.29.3)
[nanopb] No generation needed.
Found 22 compatible libraries
Scanning dependencies...
Dependency Graph
|-- ESP8266 and ESP32 OLED driver for SSD1306 displays @ 4.4.1+sha.e16cee1
|-- OneButton @ 2.6.1
|-- arduino-fsm @ 2.2.0+sha.7db3702
|-- TinyGPSPlus @ 1.0.3+sha.71a82db
|-- ArduinoThread @ 0.0.0+sha.7c3ee9e
|-- Nanopb @ 0.4.91
|-- ErriezCRC32 @ 1.0.1
|-- PubSubClient @ 2.8.0
|-- NTPClient @ 3.1.0
|-- Syslog @ 2.0.0
|-- RadioLib @ 7.1.2
|-- Crypto @ 0.4.0
|-- LovyanGFX @ 1.2.0
|-- Pine libch341-spi Userspace library @ 0.0.1+sha.a9b17e3
|-- meshtastic-device-ui @ 1.0.0+sha.74e739e
|-- SPI
|-- WiFi @ 1.2.7
|-- Wire
Building in release mode
Using meshtastic platformio-custom.py, firmware version 2.6.1.ac79509c on native-tft
Using flags:
-DAPP_VERSION=2.6.1.ac79509c
-DAPP_VERSION_SHORT=2.6.1
-DAPP_ENV=native-tft
-DUSERPREFS_TZ_STRING=\"tzplaceholder         
....
========================================================================= [SUCCESS] Took 26.46 seconds =========================================================================

Environment    Status    Duration
-------------  --------  ------------
native-tft     SUCCESS   00:00:26.458
========================================================================== 1 succeeded in 00:00:26.458 ==========================================================================
```

fixes: #6296