### PR TITLE
Fix KR920's Tx power limitation

### DIFF
--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -73,9 +73,10 @@ const RegionInfo regions[] = {
     RDEF(RU, 868.7f, 869.2f, 100, 0, 20, true, false, false),
 
     /*
-        ???
+        https://www.law.go.kr/LSW/admRulLsInfoP.do?admRulId=53943&efYd=0
+        https://resources.lora-alliance.org/technical-specifications/rp002-1-0-4-regional-parameters
      */
-    RDEF(KR, 920.0f, 923.0f, 100, 0, 0, true, false, false),
+    RDEF(KR, 920.0f, 923.0f, 100, 0, 23, true, false, false),
 
     /*
         Taiwan, 920-925Mhz, limited to 0.5W indoor or coastal, 1.0W outdoor.


### PR DESCRIPTION
This PR resolves the #6306 issue.

According to South Korea's radio law, this Non-license frequencies 920-923MHz band is defined as a maximum of 200mW.

- https://www.law.go.kr/LSW/admRulLsInfoP.do?admRulId=53943&efYd=0
- https://resources.lora-alliance.org/technical-specifications/rp002-1-0-4-regional-parameters

[heltec_v3.firmware.factory.bin.zip](https://github.com/user-attachments/files/19225923/heltec_v3.firmware.factory.bin.zip)

@fifieldt Thanks to give me advice :)