### PR TITLE
TCA8418 initial config + Nokia 5130

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -110,11 +110,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // Define if screen should be mirrored left to right
 // #define SCREEN_MIRROR
 
-// I2C Keyboards (M5Stack, RAK14004, T-Deck)
+// I2C Keyboards (M5Stack, RAK14004, T-Deck, TCA8418)
 #define CARDKB_ADDR 0x5F
 #define TDECK_KB_ADDR 0x55
 #define BBQ10_KB_ADDR 0x1F
 #define MPR121_KB_ADDR 0x5A
+#define TCA8418_KB_ADDR 0x34
 
 // -----------------------------------------------------------------------------
 // SENSOR

--- a/src/detect/ScanI2C.cpp
+++ b/src/detect/ScanI2C.cpp
@@ -31,8 +31,8 @@ ScanI2C::FoundDevice ScanI2C::firstRTC() const
 
 ScanI2C::FoundDevice ScanI2C::firstKeyboard() const
 {
-    ScanI2C::DeviceType types[] = {CARDKB, TDECKKB, BBQ10KB, RAK14004, MPR121KB};
-    return firstOfOrNONE(5, types);
+    ScanI2C::DeviceType types[] = {CARDKB, TDECKKB, BBQ10KB, RAK14004, MPR121KB, TCA8418KB};
+    return firstOfOrNONE(6, types);
 }
 
 ScanI2C::FoundDevice ScanI2C::firstAccelerometer() const

--- a/src/detect/ScanI2C.h
+++ b/src/detect/ScanI2C.h
@@ -69,6 +69,7 @@ class ScanI2C
         DFROBOT_RAIN,
         DPS310,
         LTR390UV,
+        TCA8418KB,
     } DeviceType;
 
     // typedef uint8_t DeviceAddress;

--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -213,6 +213,7 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
 
                 SCAN_SIMPLE_CASE(TDECK_KB_ADDR, TDECKKB, "T-Deck keyboard", (uint8_t)addr.address);
                 SCAN_SIMPLE_CASE(BBQ10_KB_ADDR, BBQ10KB, "BB Q10", (uint8_t)addr.address);
+                SCAN_SIMPLE_CASE(TCA8418_KB_ADDR, TCA8418KB, "TCA8418 keyboard", (uint8_t)addr.address);
 
                 SCAN_SIMPLE_CASE(ST7567_ADDRESS, SCREEN_ST7567, "ST7567", (uint8_t)addr.address);
 #ifdef HAS_NCP5623

--- a/src/input/TCA8418Keyboard.cpp
+++ b/src/input/TCA8418Keyboard.cpp
@@ -1,0 +1,399 @@
+// Based on the BBQ10 Keyboard and Adafruit TCA8418 library
+
+#include "TCA8418Keyboard.h"
+#include "configuration.h"
+
+#include <Arduino.h>
+
+// REGISTERS
+// #define _TCA8418_REG_RESERVED 0x00
+#define _TCA8418_REG_CFG 0x01             // Configuration register
+#define _TCA8418_REG_INT_STAT 0x02        // Interrupt status
+#define _TCA8418_REG_KEY_LCK_EC 0x03      // Key lock and event counter
+#define _TCA8418_REG_KEY_EVENT_A 0x04     // Key event register A
+#define _TCA8418_REG_KEY_EVENT_B 0x05     // Key event register B
+#define _TCA8418_REG_KEY_EVENT_C 0x06     // Key event register C
+#define _TCA8418_REG_KEY_EVENT_D 0x07     // Key event register D
+#define _TCA8418_REG_KEY_EVENT_E 0x08     // Key event register E
+#define _TCA8418_REG_KEY_EVENT_F 0x09     // Key event register F
+#define _TCA8418_REG_KEY_EVENT_G 0x0A     // Key event register G
+#define _TCA8418_REG_KEY_EVENT_H 0x0B     // Key event register H
+#define _TCA8418_REG_KEY_EVENT_I 0x0C     // Key event register I
+#define _TCA8418_REG_KEY_EVENT_J 0x0D     // Key event register J
+#define _TCA8418_REG_KP_LCK_TIMER 0x0E    // Keypad lock1 to lock2 timer
+#define _TCA8418_REG_UNLOCK_1 0x0F        // Unlock register 1
+#define _TCA8418_REG_UNLOCK_2 0x10        // Unlock register 2
+#define _TCA8418_REG_GPIO_INT_STAT_1 0x11 // GPIO interrupt status 1
+#define _TCA8418_REG_GPIO_INT_STAT_2 0x12 // GPIO interrupt status 2
+#define _TCA8418_REG_GPIO_INT_STAT_3 0x13 // GPIO interrupt status 3
+#define _TCA8418_REG_GPIO_DAT_STAT_1 0x14 // GPIO data status 1
+#define _TCA8418_REG_GPIO_DAT_STAT_2 0x15 // GPIO data status 2
+#define _TCA8418_REG_GPIO_DAT_STAT_3 0x16 // GPIO data status 3
+#define _TCA8418_REG_GPIO_DAT_OUT_1 0x17  // GPIO data out 1
+#define _TCA8418_REG_GPIO_DAT_OUT_2 0x18  // GPIO data out 2
+#define _TCA8418_REG_GPIO_DAT_OUT_3 0x19  // GPIO data out 3
+#define _TCA8418_REG_GPIO_INT_EN_1 0x1A   // GPIO interrupt enable 1
+#define _TCA8418_REG_GPIO_INT_EN_2 0x1B   // GPIO interrupt enable 2
+#define _TCA8418_REG_GPIO_INT_EN_3 0x1C   // GPIO interrupt enable 3
+#define _TCA8418_REG_KP_GPIO_1 0x1D       // Keypad/GPIO select 1
+#define _TCA8418_REG_KP_GPIO_2 0x1E       // Keypad/GPIO select 2
+#define _TCA8418_REG_KP_GPIO_3 0x1F       // Keypad/GPIO select 3
+#define _TCA8418_REG_GPI_EM_1 0x20        // GPI event mode 1
+#define _TCA8418_REG_GPI_EM_2 0x21        // GPI event mode 2
+#define _TCA8418_REG_GPI_EM_3 0x22        // GPI event mode 3
+#define _TCA8418_REG_GPIO_DIR_1 0x23      // GPIO data direction 1
+#define _TCA8418_REG_GPIO_DIR_2 0x24      // GPIO data direction 2
+#define _TCA8418_REG_GPIO_DIR_3 0x25      // GPIO data direction 3
+#define _TCA8418_REG_GPIO_INT_LVL_1 0x26  // GPIO edge/level detect 1
+#define _TCA8418_REG_GPIO_INT_LVL_2 0x27  // GPIO edge/level detect 2
+#define _TCA8418_REG_GPIO_INT_LVL_3 0x28  // GPIO edge/level detect 3
+#define _TCA8418_REG_DEBOUNCE_DIS_1 0x29  // Debounce disable 1
+#define _TCA8418_REG_DEBOUNCE_DIS_2 0x2A  // Debounce disable 2
+#define _TCA8418_REG_DEBOUNCE_DIS_3 0x2B  // Debounce disable 3
+#define _TCA8418_REG_GPIO_PULL_1 0x2C     // GPIO pull-up disable 1
+#define _TCA8418_REG_GPIO_PULL_2 0x2D     // GPIO pull-up disable 2
+#define _TCA8418_REG_GPIO_PULL_3 0x2E     // GPIO pull-up disable 3
+// #define _TCA8418_REG_RESERVED 0x2F
+
+// FIELDS CONFIG REGISTER  1
+#define _TCA8418_REG_CFG_AI 0x80           // Auto-increment for read/write
+#define _TCA8418_REG_CFG_GPI_E_CGF 0x40    // Event mode config
+#define _TCA8418_REG_CFG_OVR_FLOW_M 0x20   // Overflow mode enable
+#define _TCA8418_REG_CFG_INT_CFG 0x10      // Interrupt config
+#define _TCA8418_REG_CFG_OVR_FLOW_IEN 0x08 // Overflow interrupt enable
+#define _TCA8418_REG_CFG_K_LCK_IEN 0x04    // Keypad lock interrupt enable
+#define _TCA8418_REG_CFG_GPI_IEN 0x02      // GPI interrupt enable
+#define _TCA8418_REG_CFG_KE_IEN 0x01       // Key events interrupt enable
+
+// FIELDS INT_STAT REGISTER  2
+#define _TCA8418_REG_STAT_CAD_INT 0x10      // Ctrl-alt-del seq status
+#define _TCA8418_REG_STAT_OVR_FLOW_INT 0x08 // Overflow interrupt status
+#define _TCA8418_REG_STAT_K_LCK_INT 0x04    // Key lock interrupt status
+#define _TCA8418_REG_STAT_GPI_INT 0x02      // GPI interrupt status
+#define _TCA8418_REG_STAT_K_INT 0x01        // Key events interrupt status
+
+// FIELDS  KEY_LCK_EC REGISTER 3
+#define _TCA8418_REG_LCK_EC_K_LCK_EN 0x40 // Key lock enable
+#define _TCA8418_REG_LCK_EC_LCK_2 0x20    // Keypad lock status 2
+#define _TCA8418_REG_LCK_EC_LCK_1 0x10    // Keypad lock status 1
+#define _TCA8418_REG_LCK_EC_KLEC_3 0x08   // Key event count bit 3
+#define _TCA8418_REG_LCK_EC_KLEC_2 0x04   // Key event count bit 2
+#define _TCA8418_REG_LCK_EC_KLEC_1 0x02   // Key event count bit 1
+#define _TCA8418_REG_LCK_EC_KLEC_0 0x01   // Key event count bit 0
+
+// Pin IDs for matrix rows/columns
+enum {
+    _TCA8418_ROW0, // Pin ID for row 0
+    _TCA8418_ROW1, // Pin ID for row 1
+    _TCA8418_ROW2, // Pin ID for row 2
+    _TCA8418_ROW3, // Pin ID for row 3
+    _TCA8418_ROW4, // Pin ID for row 4
+    _TCA8418_ROW5, // Pin ID for row 5
+    _TCA8418_ROW6, // Pin ID for row 6
+    _TCA8418_ROW7, // Pin ID for row 7
+    _TCA8418_COL0, // Pin ID for column 0
+    _TCA8418_COL1, // Pin ID for column 1
+    _TCA8418_COL2, // Pin ID for column 2
+    _TCA8418_COL3, // Pin ID for column 3
+    _TCA8418_COL4, // Pin ID for column 4
+    _TCA8418_COL5, // Pin ID for column 5
+    _TCA8418_COL6, // Pin ID for column 6
+    _TCA8418_COL7, // Pin ID for column 7
+    _TCA8418_COL8, // Pin ID for column 8
+    _TCA8418_COL9  // Pin ID for column 9
+};
+
+#define _TCA8418_ROWS 8
+#define _TCA8418_COLS 10
+
+TCA8418Keyboard::TCA8418Keyboard() : m_wire(nullptr), m_addr(0), readCallback(nullptr), writeCallback(nullptr) {}
+
+void TCA8418Keyboard::begin(uint8_t addr, TwoWire *wire)
+{
+    m_addr = addr;
+    m_wire = wire;
+
+    m_wire->begin();
+
+    reset();
+}
+
+void TCA8418Keyboard::begin(i2c_com_fptr_t r, i2c_com_fptr_t w, uint8_t addr)
+{
+    m_addr = addr;
+    m_wire = nullptr;
+    writeCallback = w;
+    readCallback = r;
+    reset();
+}
+
+void TCA8418Keyboard::reset()
+{
+    LOG_DEBUG("TCA8418 Reset");
+    //  GPIO
+    //  set default all GIO pins to INPUT
+    writeRegister(_TCA8418_REG_GPIO_DIR_1, 0x00);
+    writeRegister(_TCA8418_REG_GPIO_DIR_2, 0x00);
+    writeRegister(_TCA8418_REG_GPIO_DIR_3, 0x00);
+
+    //  add all pins to key events
+    writeRegister(_TCA8418_REG_GPI_EM_1, 0xFF);
+    writeRegister(_TCA8418_REG_GPI_EM_2, 0xFF);
+    writeRegister(_TCA8418_REG_GPI_EM_3, 0xFF);
+
+    //  set all pins to FALLING interrupts
+    writeRegister(_TCA8418_REG_GPIO_INT_LVL_1, 0x00);
+    writeRegister(_TCA8418_REG_GPIO_INT_LVL_2, 0x00);
+    writeRegister(_TCA8418_REG_GPIO_INT_LVL_3, 0x00);
+
+    //  add all pins to interrupts
+    writeRegister(_TCA8418_REG_GPIO_INT_EN_1, 0xFF);
+    writeRegister(_TCA8418_REG_GPIO_INT_EN_2, 0xFF);
+    writeRegister(_TCA8418_REG_GPIO_INT_EN_3, 0xFF);
+
+    matrix(_TCA8418_ROWS, _TCA8418_COLS);
+    enableDebounce();
+    flush();
+}
+
+bool TCA8418Keyboard::matrix(uint8_t rows, uint8_t columns)
+{
+    if ((rows > 8) || (columns > 10))
+        return false;
+
+    //  Skip zero size matrix
+    if ((rows != 0) && (columns != 0)) {
+        // Setup the keypad matrix.
+        uint8_t mask = 0x00;
+        for (int r = 0; r < rows; r++) {
+            mask <<= 1;
+            mask |= 1;
+        }
+        writeRegister(_TCA8418_REG_KP_GPIO_1, mask);
+
+        mask = 0x00;
+        for (int c = 0; c < columns && c < 8; c++) {
+            mask <<= 1;
+            mask |= 1;
+        }
+        writeRegister(_TCA8418_REG_KP_GPIO_2, mask);
+
+        if (columns > 8) {
+            if (columns == 9)
+                mask = 0x01;
+            else
+                mask = 0x03;
+            writeRegister(_TCA8418_REG_KP_GPIO_3, mask);
+        }
+    }
+
+    return true;
+}
+
+uint8_t TCA8418Keyboard::keyCount() const
+{
+    uint8_t eventCount = readRegister(_TCA8418_REG_KEY_LCK_EC);
+    eventCount &= 0x0F; //  lower 4 bits only
+    return eventCount;
+}
+
+TCA8418Keyboard::KeyEvent TCA8418Keyboard::keyEvent() const
+{
+    KeyEvent event = {.key = '\0', .state = Idle};
+    if (keyCount() == 0)
+        return event;
+
+    uint8_t k = readRegister(_TCA8418_REG_KEY_EVENT_A);
+    event.key = k & 0x7F;
+    if (k & 0x80) {
+        event.state = TCA8418Keyboard::Press;
+    } else {
+        event.state = TCA8418Keyboard::Release;
+    }
+    return event;
+}
+
+uint8_t TCA8418Keyboard::flush()
+{
+    //  Flush key events
+    uint8_t count = 0;
+    while (readRegister(_TCA8418_REG_KEY_EVENT_A) != 0)
+        count++;
+    //  Flush gpio events
+    readRegister(_TCA8418_REG_GPIO_INT_STAT_1);
+    readRegister(_TCA8418_REG_GPIO_INT_STAT_2);
+    readRegister(_TCA8418_REG_GPIO_INT_STAT_3);
+    //  Clear INT_STAT register
+    writeRegister(_TCA8418_REG_INT_STAT, 3);
+    return count;
+}
+
+uint8_t TCA8418Keyboard::digitalRead(uint8_t pinnum) const
+{
+    if (pinnum > _TCA8418_COL9)
+        return 0xFF;
+
+    uint8_t reg = _TCA8418_REG_GPIO_DAT_STAT_1 + pinnum / 8;
+    uint8_t mask = (1 << (pinnum % 8));
+
+    // Level  0 = low  other = high
+    uint8_t value = readRegister(reg);
+    if (value & mask)
+        return HIGH;
+    return LOW;
+}
+
+bool TCA8418Keyboard::digitalWrite(uint8_t pinnum, uint8_t level)
+{
+    if (pinnum > _TCA8418_COL9)
+        return false;
+
+    uint8_t reg = _TCA8418_REG_GPIO_DAT_OUT_1 + pinnum / 8;
+    uint8_t mask = (1 << (pinnum % 8));
+
+    // Level  0 = low  other = high
+    uint8_t value = readRegister(reg);
+    if (level == LOW)
+        value &= ~mask;
+    else
+        value |= mask;
+    writeRegister(reg, value);
+    return true;
+}
+
+bool TCA8418Keyboard::pinMode(uint8_t pinnum, uint8_t mode)
+{
+    if (pinnum > _TCA8418_COL9)
+        return false;
+    // if (mode > INPUT_PULLUP) return false; ?s
+
+    uint8_t idx = pinnum / 8;
+    uint8_t reg = _TCA8418_REG_GPIO_DIR_1 + idx;
+    uint8_t mask = (1 << (pinnum % 8));
+
+    // Mode  0 = input   1 = output
+    uint8_t value = readRegister(reg);
+    if (mode == OUTPUT)
+        value |= mask;
+    else
+        value &= ~mask;
+    writeRegister(reg, value);
+
+    // Pullup  0 = enabled   1 = disabled
+    reg = _TCA8418_REG_GPIO_PULL_1 + idx;
+    value = readRegister(reg);
+    if (mode == INPUT_PULLUP)
+        value &= ~mask;
+    else
+        value |= mask;
+    writeRegister(reg, value);
+
+    return true;
+}
+
+bool TCA8418Keyboard::pinIRQMode(uint8_t pinnum, uint8_t mode)
+{
+    if (pinnum > _TCA8418_COL9)
+        return false;
+    if ((mode != RISING) && (mode != FALLING))
+        return false;
+
+    //  Mode  0 = falling   1 = rising
+    uint8_t idx = pinnum / 8;
+    uint8_t reg = _TCA8418_REG_GPIO_INT_LVL_1 + idx;
+    uint8_t mask = (1 << (pinnum % 8));
+
+    uint8_t value = readRegister(reg);
+    if (mode == RISING)
+        value |= mask;
+    else
+        value &= ~mask;
+    writeRegister(reg, value);
+
+    // Enable interrupt
+    reg = _TCA8418_REG_GPIO_INT_EN_1 + idx;
+    value = readRegister(reg);
+    value |= mask;
+    writeRegister(reg, value);
+
+    return true;
+}
+
+void TCA8418Keyboard::enableInterrupts()
+{
+    uint8_t value = readRegister(_TCA8418_REG_CFG);
+    value |= (_TCA8418_REG_CFG_GPI_IEN | _TCA8418_REG_CFG_KE_IEN);
+    writeRegister(_TCA8418_REG_CFG, value);
+};
+
+void TCA8418Keyboard::disableInterrupts()
+{
+    uint8_t value = readRegister(_TCA8418_REG_CFG);
+    value &= ~(_TCA8418_REG_CFG_GPI_IEN | _TCA8418_REG_CFG_KE_IEN);
+    writeRegister(_TCA8418_REG_CFG, value);
+};
+
+void TCA8418Keyboard::enableMatrixOverflow()
+{
+    uint8_t value = readRegister(_TCA8418_REG_CFG);
+    value |= _TCA8418_REG_CFG_OVR_FLOW_M;
+    writeRegister(_TCA8418_REG_CFG, value);
+};
+
+void TCA8418Keyboard::disableMatrixOverflow()
+{
+    uint8_t value = readRegister(_TCA8418_REG_CFG);
+    value &= ~_TCA8418_REG_CFG_OVR_FLOW_M;
+    writeRegister(_TCA8418_REG_CFG, value);
+};
+
+void TCA8418Keyboard::enableDebounce()
+{
+    writeRegister(_TCA8418_REG_DEBOUNCE_DIS_1, 0x00);
+    writeRegister(_TCA8418_REG_DEBOUNCE_DIS_2, 0x00);
+    writeRegister(_TCA8418_REG_DEBOUNCE_DIS_3, 0x00);
+}
+
+void TCA8418Keyboard::disableDebounce()
+{
+    writeRegister(_TCA8418_REG_DEBOUNCE_DIS_1, 0xFF);
+    writeRegister(_TCA8418_REG_DEBOUNCE_DIS_2, 0xFF);
+    writeRegister(_TCA8418_REG_DEBOUNCE_DIS_3, 0xFF);
+}
+
+uint8_t TCA8418Keyboard::readRegister(uint8_t reg) const
+{
+    if (m_wire) {
+        m_wire->beginTransmission(m_addr);
+        m_wire->write(reg);
+        m_wire->endTransmission();
+
+        m_wire->requestFrom(m_addr, (uint8_t)1);
+        if (m_wire->available() < 1)
+            return 0;
+
+        return m_wire->read();
+    }
+    if (readCallback) {
+        uint8_t data;
+        readCallback(m_addr, reg, &data, 1);
+        return data;
+    }
+    return 0;
+}
+
+void TCA8418Keyboard::writeRegister(uint8_t reg, uint8_t value)
+{
+    uint8_t data[2];
+    data[0] = reg;
+    data[1] = value;
+
+    if (m_wire) {
+        m_wire->beginTransmission(m_addr);
+        m_wire->write(data, sizeof(uint8_t) * 2);
+        m_wire->endTransmission();
+    }
+    if (writeCallback) {
+        writeCallback(m_addr, data[0], &(data[1]), 1);
+    }
+}

--- a/src/input/TCA8418Keyboard.cpp
+++ b/src/input/TCA8418Keyboard.cpp
@@ -1,4 +1,4 @@
-// Based on the BBQ10 Keyboard and Adafruit TCA8418 library
+// Based on the MPR121 Keyboard and Adafruit TCA8418 library
 
 #include "TCA8418Keyboard.h"
 #include "configuration.h"
@@ -103,10 +103,61 @@ enum {
     _TCA8418_COL9  // Pin ID for column 9
 };
 
-#define _TCA8418_ROWS 8
-#define _TCA8418_COLS 10
+// Nokia 5130 keyboard size
+#define _TCA8418_ROWS 5
+#define _TCA8418_COLS 5
+#define _TCA8418_NUM_KEYS 16
 
-TCA8418Keyboard::TCA8418Keyboard() : m_wire(nullptr), m_addr(0), readCallback(nullptr), writeCallback(nullptr) {}
+#define _TCA8418_LONG_PRESS_THRESHOLD 2000
+#define _TCA8418_MULTI_TAP_THRESHOLD 750
+
+uint8_t TCA8418TapMod[16] = {1, 1, 1, 1, 13, 7, 9, 2,
+                             7, 7, 7, 2, 7,  7, 9, 2}; // Num chars per key, Modulus for rotating through characters
+
+unsigned char TCA8418TapMap[16][13] = {{_TCA8418_BSP},                                                     // C
+                                       {_TCA8418_SELECT},                                                  // Navi
+                                       {_TCA8418_UP},                                                      // Up
+                                       {_TCA8418_DOWN},                                                    // Down
+                                       {'1', '.', ',', '?', '!', ':', ';', '-', '_', '\\', '/', '(', ')'}, // 1
+                                       {'4', 'g', 'h', 'i', 'G', 'H', 'I'},                                // 4
+                                       {'7', 'p', 'q', 'r', 's', 'P', 'Q', 'R', 'S'},                      // 7
+                                       {'*', '+'},                                                         // *
+                                       {'2', 'a', 'b', 'c', 'A', 'B', 'C'},                                // 2
+                                       {'5', 'j', 'k', 'l', 'J', 'K', 'L'},                                // 5
+                                       {'8', 't', 'u', 'v', 'T', 'U', 'V'},                                // 8
+                                       {'0', ' '},                                                         // 0
+                                       {'3', 'd', 'e', 'f', 'D', 'E', 'F'},                                // 3
+                                       {'6', 'm', 'n', 'o', 'M', 'N', 'O'},                                // 6
+                                       {'9', 'w', 'x', 'y', 'z', 'W', 'X', 'Y', 'Z'},                      // 9
+                                       {'#', '@'}};                                                        // #
+
+unsigned char TCA8418LongPressMap[16] = {
+    _TCA8418_ESC,    // C
+    _TCA8418_NONE,   // Navi
+    _TCA8418_NONE,   // Up
+    _TCA8418_NONE,   // Down
+    _TCA8418_NONE,   // 1
+    _TCA8418_LEFT,   // 4
+    _TCA8418_NONE,   // 7
+    _TCA8418_NONE,   // *
+    _TCA8418_UP,     // 2
+    _TCA8418_NONE,   // 5
+    _TCA8418_DOWN,   // 8
+    _TCA8418_NONE,   // 0
+    _TCA8418_NONE,   // 3
+    _TCA8418_RIGHT,  // 6
+    _TCA8418_NONE,   // 9
+    _TCA8418_REBOOT, // #
+};
+
+TCA8418Keyboard::TCA8418Keyboard() : m_wire(nullptr), m_addr(0), readCallback(nullptr), writeCallback(nullptr)
+{
+    state = Init;
+    last_key = -1;
+    last_tap = 0L;
+    char_idx = 0;
+    queue = "";
+}
 
 void TCA8418Keyboard::begin(uint8_t addr, TwoWire *wire)
 {
@@ -134,7 +185,10 @@ void TCA8418Keyboard::reset()
     //  set default all GIO pins to INPUT
     writeRegister(_TCA8418_REG_GPIO_DIR_1, 0x00);
     writeRegister(_TCA8418_REG_GPIO_DIR_2, 0x00);
-    writeRegister(_TCA8418_REG_GPIO_DIR_3, 0x00);
+    // Set COL9 as GPIO output
+    writeRegister(_TCA8418_REG_GPIO_DIR_3, 0x02);
+    // Switch off keyboard backlight (COL9 = LOW)
+    writeRegister(_TCA8418_REG_GPIO_DAT_OUT_3, 0x00);
 
     //  add all pins to key events
     writeRegister(_TCA8418_REG_GPI_EM_1, 0xFF);
@@ -151,9 +205,11 @@ void TCA8418Keyboard::reset()
     writeRegister(_TCA8418_REG_GPIO_INT_EN_2, 0xFF);
     writeRegister(_TCA8418_REG_GPIO_INT_EN_3, 0xFF);
 
+    // Set keyboard matrix size
     matrix(_TCA8418_ROWS, _TCA8418_COLS);
     enableDebounce();
     flush();
+    state = Idle;
 }
 
 bool TCA8418Keyboard::matrix(uint8_t rows, uint8_t columns)
@@ -197,33 +253,133 @@ uint8_t TCA8418Keyboard::keyCount() const
     return eventCount;
 }
 
-TCA8418Keyboard::KeyEvent TCA8418Keyboard::keyEvent() const
+bool TCA8418Keyboard::hasEvent()
 {
-    KeyEvent event = {.key = '\0', .state = Idle};
-    if (keyCount() == 0)
-        return event;
+    return queue.length() > 0;
+}
 
-    uint8_t k = readRegister(_TCA8418_REG_KEY_EVENT_A);
-    event.key = k & 0x7F;
-    if (k & 0x80) {
-        event.state = TCA8418Keyboard::Press;
-    } else {
-        event.state = TCA8418Keyboard::Release;
+void TCA8418Keyboard::queueEvent(char next)
+{
+    if (next == _TCA8418_NONE) {
+        return;
     }
-    return event;
+    queue.concat(next);
+}
+
+char TCA8418Keyboard::dequeueEvent()
+{
+    if (queue.length() < 1) {
+        return _TCA8418_NONE;
+    }
+    char next = queue.charAt(0);
+    queue.remove(0, 1);
+    return next;
+}
+
+void TCA8418Keyboard::trigger()
+{
+    if (keyCount() == 0) {
+        return;
+    }
+    if (state != Init) {
+        // Read the key register
+        uint8_t k = readRegister(_TCA8418_REG_KEY_EVENT_A);
+        uint8_t key = k & 0x7F;
+        if (k & 0x80) {
+            if (state == Idle)
+                pressed(key);
+            return;
+        } else {
+            if (state == Held) {
+                released();
+            }
+            state = Idle;
+            return;
+        }
+    } else {
+        reset();
+    }
+}
+
+void TCA8418Keyboard::pressed(uint8_t key)
+{
+    if (state == Init || state == Busy) {
+        return;
+    }
+    uint8_t next_key = 0;
+    if (key > 40) {          // 3, 6, 9, #
+        next_key = key - 30; // TCA8418_TapMap[12...15]
+    } else if (key > 30) {   // 2, 5, 8, 0
+        next_key = key - 24; // TCA8418_TapMap[8...11]
+    } else if (key > 20) {   // 1, 4, 7, *
+        next_key = key - 18; // TCA8418_TapMap[4..7]
+    } else if (key == 12) {  // Clear
+        next_key = 0;        // TCA8418_TapMap[0]
+    } else if (key == 13) {  // Navi
+        next_key = 1;        // TCA8418_TapMap[1]
+    } else if (key == 15) {  // Up
+        next_key = 2;        // TCA8418_TapMap[2]
+    } else if (key == 4) {   // Down
+        next_key = 3;        // TCA8418_TapMap[3]
+    }
+
+    // LOG_DEBUG("TCA8418: %u %u", key, next_key);
+    state = Held;
+    uint32_t now = millis();
+    tap_interval = now - last_tap;
+    if (tap_interval < 0) {
+        // long running, millis has overflowed.
+        last_tap = 0;
+        state = Busy;
+        return;
+    }
+    if (next_key != last_key || tap_interval > _TCA8418_MULTI_TAP_THRESHOLD) {
+        char_idx = 0;
+    } else {
+        char_idx += 1;
+    }
+    last_key = next_key;
+    last_tap = now;
+}
+
+void TCA8418Keyboard::released()
+{
+    if (state != Held) {
+        return;
+    }
+
+    if (last_key < 0 || last_key > _TCA8418_NUM_KEYS) { // reset to idle if last_key out of bounds
+        last_key = -1;
+        state = Idle;
+        return;
+    }
+    uint32_t now = millis();
+    int32_t held_interval = now - last_tap;
+    last_tap = now;
+    if (tap_interval < _TCA8418_MULTI_TAP_THRESHOLD) {
+        queueEvent(_TCA8418_BSP);
+    }
+    if (held_interval > _TCA8418_LONG_PRESS_THRESHOLD) {
+        queueEvent(TCA8418LongPressMap[last_key]);
+        // LOG_DEBUG("Long Press Key: %i Map: %i", last_key, TCA8418LongPressMap[last_key]);
+    } else {
+        queueEvent(TCA8418TapMap[last_key][(char_idx % TCA8418TapMod[last_key])]);
+        // LOG_DEBUG("Key Press: %i Index:%i if %i Map: %c", last_key, char_idx, TCA8418TapMod[last_key],
+        //           TCA8418TapMap[last_key][(char_idx % TCA8418TapMod[last_key])]);
+    }
 }
 
 uint8_t TCA8418Keyboard::flush()
 {
-    //  Flush key events
+    // Flush key events
     uint8_t count = 0;
     while (readRegister(_TCA8418_REG_KEY_EVENT_A) != 0)
         count++;
-    //  Flush gpio events
+    // Flush gpio events
     readRegister(_TCA8418_REG_GPIO_INT_STAT_1);
     readRegister(_TCA8418_REG_GPIO_INT_STAT_2);
     readRegister(_TCA8418_REG_GPIO_INT_STAT_3);
-    //  Clear INT_STAT register
+    // Clear INT_STAT register
     writeRegister(_TCA8418_REG_INT_STAT, 3);
     return count;
 }
@@ -265,7 +421,6 @@ bool TCA8418Keyboard::pinMode(uint8_t pinnum, uint8_t mode)
 {
     if (pinnum > _TCA8418_COL9)
         return false;
-    // if (mode > INPUT_PULLUP) return false; ?s
 
     uint8_t idx = pinnum / 8;
     uint8_t reg = _TCA8418_REG_GPIO_DIR_1 + idx;
@@ -361,6 +516,15 @@ void TCA8418Keyboard::disableDebounce()
     writeRegister(_TCA8418_REG_DEBOUNCE_DIS_3, 0xFF);
 }
 
+void TCA8418Keyboard::setBacklight(bool on)
+{
+    if (on) {
+        digitalWrite(_TCA8418_COL9, HIGH);
+    } else {
+        digitalWrite(_TCA8418_COL9, LOW);
+    }
+}
+
 uint8_t TCA8418Keyboard::readRegister(uint8_t reg) const
 {
     if (m_wire) {
@@ -396,4 +560,4 @@ void TCA8418Keyboard::writeRegister(uint8_t reg, uint8_t value)
     if (writeCallback) {
         writeCallback(m_addr, data[0], &(data[1]), 1);
     }
-}
+} 

--- a/src/input/TCA8418Keyboard.h
+++ b/src/input/TCA8418Keyboard.h
@@ -1,0 +1,61 @@
+// Based on the BBQ10 Keyboard and Adafruit TCA8418 library
+
+#include "configuration.h"
+#include <Wire.h>
+
+class TCA8418Keyboard
+{
+  public:
+    typedef uint8_t (*i2c_com_fptr_t)(uint8_t dev_addr, uint8_t reg_addr, uint8_t *data, uint8_t len);
+
+    enum KeyState { Idle = 0, Release, Press };
+
+    struct KeyEvent {
+        char key;
+        KeyState state;
+    };
+
+    TCA8418Keyboard();
+
+    void begin(uint8_t addr = TCA8418_KB_ADDR, TwoWire *wire = &Wire);
+    void begin(i2c_com_fptr_t r, i2c_com_fptr_t w, uint8_t addr = TCA8418_KB_ADDR);
+
+    void reset(void);
+    //  Configure the size of the keypad.
+    //  All other rows and columns are set as inputs.
+    bool matrix(uint8_t rows, uint8_t columns);
+
+    //  Flush all events in the FIFO buffer + GPIO events.
+    uint8_t flush(void);
+
+    //  Key events available in the internal FIFO buffer.
+    uint8_t keyCount(void) const;
+    // Read key event from internal FIFO buffer
+    KeyEvent keyEvent(void) const;
+
+    uint8_t digitalRead(uint8_t pinnum) const;
+    bool digitalWrite(uint8_t pinnum, uint8_t level);
+    bool pinMode(uint8_t pinnum, uint8_t mode);
+    bool pinIRQMode(uint8_t pinnum, uint8_t mode); // MODE  FALLING or RISING
+
+    //  enable / disable interrupts for matrix and GPI pins
+    void enableInterrupts();
+    void disableInterrupts();
+
+    //  ignore key events when FIFO buffer is full or not.
+    void enableMatrixOverflow();
+    void disableMatrixOverflow();
+
+    //  debounce keys.
+    void enableDebounce();
+    void disableDebounce();
+
+    uint8_t readRegister(uint8_t reg) const;
+    void writeRegister(uint8_t reg, uint8_t value);
+
+  private:
+    TwoWire *m_wire;
+    uint8_t m_addr;
+    i2c_com_fptr_t readCallback;
+    i2c_com_fptr_t writeCallback;
+};

--- a/src/input/cardKbI2cImpl.cpp
+++ b/src/input/cardKbI2cImpl.cpp
@@ -12,8 +12,8 @@ void CardKbI2cImpl::init()
 #if !MESHTASTIC_EXCLUDE_I2C && !defined(ARCH_PORTDUINO) && !defined(I2C_NO_RESCAN)
     if (cardkb_found.address == 0x00) {
         LOG_DEBUG("Rescan for I2C keyboard");
-        uint8_t i2caddr_scan[] = {CARDKB_ADDR, TDECK_KB_ADDR, BBQ10_KB_ADDR, MPR121_KB_ADDR};
-        uint8_t i2caddr_asize = 4;
+        uint8_t i2caddr_scan[] = {CARDKB_ADDR, TDECK_KB_ADDR, BBQ10_KB_ADDR, MPR121_KB_ADDR, TCA8418_KB_ADDR};
+        uint8_t i2caddr_asize = 5;
         auto i2cScanner = std::unique_ptr<ScanI2CTwoWire>(new ScanI2CTwoWire());
 
 #if WIRE_INTERFACES_COUNT == 2
@@ -42,6 +42,10 @@ void CardKbI2cImpl::init()
             case ScanI2C::DeviceType::MPR121KB:
                 // assign an arbitrary value to distinguish from other models
                 kb_model = 0x37;
+                break;
+            case ScanI2C::DeviceType::TCA8418KB:
+                // assign an arbitrary value to distinguish from other models
+                kb_model = 0x84;
                 break;
             default:
                 // use this as default since it's also just zero

--- a/src/input/kbI2cBase.cpp
+++ b/src/input/kbI2cBase.cpp
@@ -226,7 +226,7 @@ int32_t KbI2cBase::runOnce()
                 break;
             }
             if (e.inputEvent != meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_NONE) {
-                // LOG_DEBUG("TCA8418 Notifying: %i Char: %c", e.inputEvent, e.kbchar);
+                LOG_DEBUG("TCA8418 Notifying: %i Char: %c", e.inputEvent, e.kbchar);
                 this->notifyObservers(&e);
             }
         }

--- a/src/input/kbI2cBase.h
+++ b/src/input/kbI2cBase.h
@@ -3,6 +3,7 @@
 #include "BBQ10Keyboard.h"
 #include "InputBroker.h"
 #include "MPR121Keyboard.h"
+#include "TCA8418Keyboard.h"
 #include "Wire.h"
 #include "concurrency/OSThread.h"
 
@@ -21,5 +22,6 @@ class KbI2cBase : public Observable<const InputEvent *>, public concurrency::OST
 
     BBQ10Keyboard Q10keyboard;
     MPR121Keyboard MPRkeyboard;
+    TCA8418Keyboard TCAKeyboard;
     bool is_sym = false;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -568,6 +568,10 @@ void setup()
             // assign an arbitrary value to distinguish from other models
             kb_model = 0x37;
             break;
+        case ScanI2C::DeviceType::TCA8418KB:
+            // assign an arbitrary value to distinguish from other models
+            kb_model = 0x84;
+            break;
         default:
             // use this as default since it's also just zero
             LOG_WARN("kb_info.type is unknown(0x%02x), setting kb_model=0x00", kb_info.type);


### PR DESCRIPTION
pull request for adding the TCA8418, the config now is for a Nokia 5130 key matrix with backlight

the issue i see at this moment is that the TCA8418 supports up to 80 buttons, the config for the 5130 uses 16 buttons and 1 pin as an output for the backlight.

Is there a good way on how to select the button mapping?

Thanks to @Mictronics for writing the code in his fork
@NomDeTom paging you to.

I'm in the process of ordering parts myself for a 4x3 button matrix.