### PR TITLE
RP2xx0: Add UDP Multicast support

### DIFF
--- a/src/mesh/udp/UdpMulticastThread.h
+++ b/src/mesh/udp/UdpMulticastThread.h
@@ -70,4 +70,4 @@ class UdpMulticastThread : public concurrency::OSThread
     IPAddress udpIpAddress;
     AsyncUDP udp;
 };
-#endif // ARCH_ESP32
+#endif // HAS_UDP_MULTICAST

--- a/variants/rpipico2w/platformio.ini
+++ b/variants/rpipico2w/platformio.ini
@@ -23,6 +23,7 @@ build_flags = ${rp2350_base.build_flags}
   -DHAS_WIFI=1
   -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m33"
   -fexceptions  # for exception handling in MQTT
+  -DHAS_UDP_MULTICAST=1
 build_src_filter = ${rp2350_base.build_src_filter} +<mesh/wifi/>
 lib_deps =
   ${rp2350_base.lib_deps}

--- a/variants/rpipicow/platformio.ini
+++ b/variants/rpipicow/platformio.ini
@@ -10,6 +10,7 @@ build_flags = ${rp2040_base.build_flags}
   -DHW_SPI1_DEVICE
   -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m0plus"
   -fexceptions  # for exception handling in MQTT
+  -DHAS_UDP_MULTICAST=1
 build_src_filter = ${rp2040_base.build_src_filter} +<mesh/wifi/>
 lib_deps =
   ${rp2040_base.lib_deps}


### PR DESCRIPTION
Adds support for UDP Multicast to RP2040 and RP2350 variants which have wifi onboard.

[arduino-pico](https://github.com/earlephilhower/arduino-pico/tree/master/libraries) includes AsyncUDP support, seems it's just slightly different than the ESP32 implementation (ultimately based on the same upstream work)

Depends on:
- #6333

DRAFT as I do not have a means to test it yet (need a pico lora hat). Compiles correctly at least :+1: 