### PR TITLE
Send UDP packets to multicast address rather than broadcast address

### DIFF
--- a/src/mesh/udp/UdpMulticastThread.h
+++ b/src/mesh/udp/UdpMulticastThread.h
@@ -56,7 +56,7 @@ class UdpMulticastThread : public concurrency::OSThread
         LOG_DEBUG("Broadcasting packet over UDP (id=%u)", mp->id);
         uint8_t buffer[meshtastic_MeshPacket_size];
         size_t encodedLength = pb_encode_to_bytes(buffer, sizeof(buffer), &meshtastic_MeshPacket_msg, mp);
-        udp.broadcastTo(buffer, encodedLength, UDP_MULTICAST_DEFAUL_PORT);
+        udp.writeTo(buffer, encodedLength, udpIpAddress, UDP_MULTICAST_DEFAUL_PORT);
         return true;
     }
 


### PR DESCRIPTION
A smart router or switch is able to snoop the multicast address to only send the packets to nodes listening on the multicast address.

![image](https://github.com/user-attachments/assets/c0044006-097f-4a1b-ac25-f2bbc0c57123)

Before all machines reachable on the L2 layer would receive the packet.