### PR TITLE
pass pointer to UDP multicast packet to protobuf decoder

### DIFF
--- a/src/mesh/udp/UdpMulticastThread.h
+++ b/src/mesh/udp/UdpMulticastThread.h
@@ -35,10 +35,8 @@ class UdpMulticastThread : public concurrency::OSThread
         size_t packetLength = packet.length();
         LOG_DEBUG("UDP broadcast from: %s, len=%u", packet.remoteIP().toString().c_str(), packetLength);
         meshtastic_MeshPacket mp;
-        uint8_t bytes[meshtastic_MeshPacket_size]; // Allocate buffer for the data
-        size_t packetSize = packet.readBytes(bytes, packet.length());
-        LOG_DEBUG("Decoding MeshPacket from UDP len=%u", packetSize);
-        bool isPacketDecoded = pb_decode_from_bytes(bytes, packetLength, &meshtastic_MeshPacket_msg, &mp);
+        LOG_DEBUG("Decoding MeshPacket from UDP len=%u", packetLength);
+        bool isPacketDecoded = pb_decode_from_bytes(packet.data(), packetLength, &meshtastic_MeshPacket_msg, &mp);
         if (isPacketDecoded && router) {
             UniquePacketPoolPacket p = packetPool.allocUniqueCopy(mp);
             // Unset received SNR/RSSI


### PR DESCRIPTION
The packet.readBytes API is not available on all targets:
- RP2040 & RP2340
- yet to be written portduino API
    
Instead pass the data buffer as-is.
It also removes a memcpy which do not need to exists.
    
I've tested it successfully on a tbeam.