### PR TITLE
meshtasticd: Add MeshToad - USB 1W 'MeshStick'

### DIFF
--- a/bin/config.d/lora-usb-meshtoad-e22.yaml
+++ b/bin/config.d/lora-usb-meshtoad-e22.yaml
@@ -1,0 +1,17 @@
+Lora:
+  Module: sx1262
+  CS: 0
+  IRQ: 6
+  Reset: 2
+  Busy: 4
+  RXen: 1
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+  spidev: ch341
+  USB_PID: 0x5512
+  USB_VID: 0x1A86
+  # Optional: Reduce power to 10 dBm to
+  # avoid over-drawing the USB port
+  # SX126X_MAX_POWER: 10
+  # Optional: Set the serial number for multi-radio support
+  # USB_Serialnum: 13374201


### PR DESCRIPTION
MeshToad :frog: a 1W / USB-C MeshStick, meant for easy assembly by JLCPCB.
Finally with a working pinout / PCB design!

The PCB will be released as open source hardware soon.

Designed with @wehooper4 :heart: 

![meshtoad](https://github.com/user-attachments/assets/d15ca55a-1544-4c2c-8034-29181f1e10f1)
