### PR TITLE
device-install/update: fix esptool --port

### DIFF
--- a/bin/device-install.bat
+++ b/bin/device-install.bat
@@ -121,6 +121,7 @@ CALL :LOG_MESSAGE DEBUG "Using esptool command: !ESPTOOL_CMD!"
 IF "__!ESPTOOL_PORT!__" == "____" (
     CALL :LOG_MESSAGE WARN "Using esptool port: UNSET."
 ) ELSE (
+    SET "ESPTOOL_CMD=!ESPTOOL_CMD! --port !ESPTOOL_PORT!"
     CALL :LOG_MESSAGE INFO "Using esptool port: !ESPTOOL_PORT!."
 )
 CALL :LOG_MESSAGE INFO "Using esptool baud: !ESPTOOL_BAUD!."

--- a/bin/device-install.bat
+++ b/bin/device-install.bat
@@ -34,7 +34,7 @@ ECHO Example: %SCRIPT_NAME% -f firmware-unphone-2.6.0.0b106d4.bin -p COM11 --web
 GOTO eof
 
 :version
-ECHO %SCRIPT_NAME% [Version 2.6.0]
+ECHO %SCRIPT_NAME% [Version 2.6.1]
 ECHO Meshtastic
 GOTO eof
 

--- a/bin/device-install.bat
+++ b/bin/device-install.bat
@@ -106,7 +106,7 @@ IF NOT "__%PYTHON%__"=="____" (
 
 CALL :LOG_MESSAGE DEBUG "Checking esptool command !ESPTOOL_CMD!..."
 !ESPTOOL_CMD! >nul 2>&1
-IF %ERRORLEVEL% GTR 2 (
+IF %ERRORLEVEL% GEQ 2 (
     @REM esptool exits with code 1 if help is displayed.
     CALL :LOG_MESSAGE ERROR "esptool not found: !ESPTOOL_CMD!"
     EXIT /B 1

--- a/bin/device-install.sh
+++ b/bin/device-install.sh
@@ -42,8 +42,8 @@ while [ $# -gt 0 ]; do
 		exit 0
 		;;
 	-p)
-		ESPTOOL_PORT="$2"
-		shift # Shift past the option argument
+		ESPTOOL_CMD="$ESPTOOL_CMD --port $2"
+		shift
 		;;
 	-P)
 		PYTHON="$2"

--- a/bin/device-update.bat
+++ b/bin/device-update.bat
@@ -71,7 +71,7 @@ IF NOT EXIST !FILENAME! (
 
 IF "!FILENAME:update=!"=="!FILENAME!" (
     CALL :LOG_MESSAGE DEBUG "We are NOT working with a *update* file. !FILENAME!"
-    CALL :LOG_MESSAGE INFO "Use script device-install.bat to flash update !FILENAME!."
+    CALL :LOG_MESSAGE INFO "Use script device-install.bat to flash !FILENAME!."
     GOTO eof
 ) ELSE (
     CALL :LOG_MESSAGE DEBUG "We are working with a *update* file. !FILENAME!"

--- a/bin/device-update.bat
+++ b/bin/device-update.bat
@@ -16,7 +16,7 @@ ECHO.
 ECHO Usage: %SCRIPT_NAME% -f filename [-p PORT] [-P python]
 ECHO.
 ECHO Options:
-ECHO     -f filename      The .bin file to flash.  Custom to your device type and region. (required)
+ECHO     -f filename      The update .bin file to flash.  Custom to your device type and region. (required)
 ECHO                      The file must be located in this current directory.
 ECHO     -p PORT          Set the environment variable for ESPTOOL_PORT.
 ECHO                      If not set, ESPTOOL iterates all ports (Dangerous).
@@ -28,7 +28,7 @@ ECHO Example: %SCRIPT_NAME% -f firmware-t-deck-tft-2.6.0.0b106d4-update.bin -p C
 GOTO eof
 
 :version
-ECHO %SCRIPT_NAME% [Version 2.6.0]
+ECHO %SCRIPT_NAME% [Version 2.6.1]
 ECHO Meshtastic
 GOTO eof
 
@@ -53,6 +53,7 @@ IF "__!FILENAME!__"=="____" (
     CALL :LOG_MESSAGE DEBUG "Missing -f filename input."
     GOTO help
 ) ELSE (
+    CALL :LOG_MESSAGE DEBUG "Filename: !FILENAME!"
     IF NOT "__!FILENAME: =!__"=="__!FILENAME!__" (
         CALL :LOG_MESSAGE ERROR "Filename containing spaces are not supported."
         GOTO help
@@ -62,7 +63,6 @@ IF "__!FILENAME!__"=="____" (
     SET "FILENAME=!FILENAME:./=!"
 )
 
-CALL :LOG_MESSAGE DEBUG "Filename: !FILENAME!"
 CALL :LOG_MESSAGE DEBUG "Checking if !FILENAME! exists..."
 IF NOT EXIST !FILENAME! (
     CALL :LOG_MESSAGE ERROR "File does not exist: !FILENAME!. Terminating."

--- a/bin/device-update.bat
+++ b/bin/device-update.bat
@@ -95,7 +95,7 @@ IF NOT "__%PYTHON%__"=="____" (
 
 CALL :LOG_MESSAGE DEBUG "Checking esptool command !ESPTOOL_CMD!..."
 !ESPTOOL_CMD! >nul 2>&1
-IF %ERRORLEVEL% GTR 2 (
+IF %ERRORLEVEL% GEQ 2 (
     @REM esptool exits with code 1 if help is displayed.
     CALL :LOG_MESSAGE ERROR "esptool not found: !ESPTOOL_CMD!"
     EXIT /B 1
@@ -110,6 +110,7 @@ CALL :LOG_MESSAGE DEBUG "Using esptool command: !ESPTOOL_CMD!"
 IF "__!ESPTOOL_PORT!__" == "____" (
     CALL :LOG_MESSAGE WARN "Using esptool port: UNSET."
 ) ELSE (
+    SET "ESPTOOL_CMD=!ESPTOOL_CMD! --port !ESPTOOL_PORT!"
     CALL :LOG_MESSAGE INFO "Using esptool port: !ESPTOOL_PORT!."
 )
 CALL :LOG_MESSAGE INFO "Using esptool baud: !ESPTOOL_BAUD!."

--- a/bin/device-update.sh
+++ b/bin/device-update.sh
@@ -35,8 +35,8 @@ while getopts ":hp:P:f:" opt; do
             show_help
             exit 0
             ;;
-        p)  export ESPTOOL_PORT=${OPTARG}
-	    ;;
+        p)  ESPTOOL_CMD="$ESPTOOL_CMD --port ${OPTARG}"
+	        ;;
         P)  PYTHON=${OPTARG}
             ;;
         f)  FILENAME=${OPTARG}


### PR DESCRIPTION
This PR adds `--port INPUT` to the esptool cmd used during flashing. This way the script targets the port the user specified.

Testing on Windows, the previous solution of `SET ESPTOOL_PORT` worked.
`device-update.sh` did have `ESPTOOL_PORT` set via `export ESPTOOL_PORT`, but `device-install.sh` did not.

All 4 scripts have been adjusted to use the `--port INPUT` syntax.

---

_also did some housekeeping, moving log statements, fixing help and log messages_

fixes: #6312

---

I have tested the new version of `device-install.bat` on my Windows host successfully flashing two different heltec v3 devices plugged in at the same time using different COM ports.
```batch
device-install.bat -f firmware-heltec-v3-2.6.1.7c3edde.bin -p COM24
device-install.bat -f firmware-heltec-v3-2.6.1.7c3edde.bin -p COM26
```
