### PR TITLE
Fixed UF2 generation problem when sys.executable path has spaces in it ( platformio-custom.py )

### DIFF
--- a/bin/platformio-custom.py
+++ b/bin/platformio-custom.py
@@ -83,7 +83,7 @@ if platform.name == "espressif32":
 
 if platform.name == "nordicnrf52":
     env.AddPostAction("$BUILD_DIR/${PROGNAME}.hex",
-                      env.VerboseAction(f"{sys.executable} ./bin/uf2conv.py $BUILD_DIR/firmware.hex -c -f 0xADA52840 -o $BUILD_DIR/firmware.uf2",
+                      env.VerboseAction(f"\"{sys.executable}\" ./bin/uf2conv.py $BUILD_DIR/firmware.hex -c -f 0xADA52840 -o $BUILD_DIR/firmware.uf2",
                                         "Generating UF2 file"))
 
 Import("projenv")


### PR DESCRIPTION
Classification: Firmware script build bug under Windows platforms.

This fixes a bug in `bin/platformio-custom.py` when generating a UF2 file for the `nordicnrf52` platform - it constructs a command line that has `{sys.executable}` in it. On a Windows platform, if this path has spaces (i.e, python got installed under `C:\Users\Sam Gamgee`  then it fails and the UF2 file is not generated. All this fix does is add escaped double quotes as in:  `\"{sys.executable}\"`.

Bug found under Windows 11, fix tested under Windows 11. No other OSes tested.

