### PR TITLE
Enable range test on Linux Native

### DIFF
--- a/src/modules/RangeTestModule.cpp
+++ b/src/modules/RangeTestModule.cpp
@@ -31,7 +31,7 @@ uint32_t packetSequence = 0;
 
 int32_t RangeTestModule::runOnce()
 {
-#if defined(ARCH_ESP32) || defined(ARCH_NRF52)
+#if defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_PORTDUINO)
 
     /*
         Uncomment the preferences below if you want to use the module
@@ -130,7 +130,7 @@ void RangeTestModuleRadio::sendPayload(NodeNum dest, bool wantReplies)
 
 ProcessMessage RangeTestModuleRadio::handleReceived(const meshtastic_MeshPacket &mp)
 {
-#if defined(ARCH_ESP32) || defined(ARCH_NRF52)
+#if defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_PORTDUINO)
 
     if (moduleConfig.range_test.enabled) {
 


### PR DESCRIPTION
The Range Test Module was defined-out by architecture.

No reason it shouldn't work, so add PORTDUINO to the list of architectures that compile this module.

Tested on Ubuntu. Enables and configures OK, will send packets on the set time. However, for now the CSV file download is blank.

Fixes https://github.com/meshtastic/firmware/issues/5618