### PR TITLE
Remove unnecessary null pointer checks

### DIFF
--- a/src/AudioThread.h
+++ b/src/AudioThread.h
@@ -41,10 +41,8 @@ class AudioThread : public concurrency::OSThread
             delete i2sRtttl;
             i2sRtttl = nullptr;
         }
-        if (rtttlFile != nullptr) {
-            delete rtttlFile;
-            rtttlFile = nullptr;
-        }
+        delete rtttlFile;
+        rtttlFile = nullptr;
 
         setCPUFast(false);
     }

--- a/src/mesh/CryptoEngine.cpp
+++ b/src/mesh/CryptoEngine.cpp
@@ -161,10 +161,8 @@ void CryptoEngine::hash(uint8_t *bytes, size_t numBytes)
 
 void CryptoEngine::aesSetKey(const uint8_t *key_bytes, size_t key_len)
 {
-    if (aes) {
-        delete aes;
-        aes = nullptr;
-    }
+    delete aes;
+    aes = nullptr;
     if (key_len != 0) {
         aes = new AESSmall256();
         aes->setKey(key_bytes, key_len);

--- a/src/motion/AccelerometerThread.h
+++ b/src/motion/AccelerometerThread.h
@@ -160,10 +160,8 @@ class AccelerometerThread : public concurrency::OSThread
     void clean()
     {
         isInitialised = false;
-        if (sensor != nullptr) {
-            delete sensor;
-            sensor = nullptr;
-        }
+        delete sensor;
+        sensor = nullptr;
     }
 };
 


### PR DESCRIPTION
As reported by @elfring, we had several points in our code where it was unnecessary to check pointers were non-null before deleting them.

Fixes https://github.com/meshtastic/firmware/issues/6170