### PR TITLE
[esp32] Define BUTTON_PIN (-1) by default, fixes #6213

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -110,6 +110,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // Define if screen should be mirrored left to right
 // #define SCREEN_MIRROR
 
+// Define BUTTON_PIN to ensure button setup is always done
+#ifndef BUTTON_PIN
+#define BUTTON_PIN (-1)
+#endif
+
 // I2C Keyboards (M5Stack, RAK14004, T-Deck)
 #define CARDKB_ADDR 0x5F
 #define TDECK_KB_ADDR 0x55


### PR DESCRIPTION
ESP32 - Define BUTTON_PIN (-1) by default, fixes #6213 because button setup is always done in https://github.com/meshtastic/firmware/blob/1e4a0134e6ed6d455e54cd21f64232389280781b/src/main.cpp#L375-L392 and https://github.com/meshtastic/firmware/blob/1e4a0134e6ed6d455e54cd21f64232389280781b/src/ButtonThread.cpp#L31-L58 when the user preference for button pin is configured.