### PR TITLE
Changed SD library for nrf52 and got S&F working on nrf52

### DIFF
--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -32,8 +32,7 @@ SPIClass SDHandler = SPIClass(VSPI);
 #ifndef SD_SPI_FREQUENCY
 #define SD_SPI_FREQUENCY 4000000U
 #endif
-#endif                // HAS_SDCARD
-
+#endif // HAS_SDCARD
 
 #if defined(ARCH_STM32WL)
 
@@ -373,9 +372,11 @@ void setupSDCard()
 #if (defined(ARCH_ESP32) || defined(ARCH_NRF52))
 #if (defined(ARCH_ESP32))
     SDHandler.begin(SPI_SCK, SPI_MISO, SPI_MOSI);
+#elif (defined(ARCH_NRF52))
+    SDHandler.begin();
 #endif
-    if (!SD.begin(SDCARD_CS, SDHandlerr, SD_SPI_FREQUENCY)) { // param SDHandler only used for esp32
 
+    if (!SD.begin(SDCARD_CS, SDHandler, SD_SPI_FREQUENCY)) {
         LOG_DEBUG("No SD_MMC card detected");
         return;
     }
@@ -384,23 +385,23 @@ void setupSDCard()
         LOG_DEBUG("No SD_MMC card attached");
         return;
     }
-    LOG_DEBUG("SD_MMC Card Type: ");
     if (cardType == CARD_MMC) {
-        LOG_DEBUG("MMC");
+        LOG_DEBUG("SD_MMC Card Type: MMC");
     } else if (cardType == CARD_SD) {
-        LOG_DEBUG("SDSC");
+        LOG_DEBUG("SD_MMC Card Type: SDSC");
     } else if (cardType == CARD_SDHC) {
-        LOG_DEBUG("SDHC");
+        LOG_DEBUG("SD_MMC Card Type: SDHC");
     } else {
-        LOG_DEBUG("UNKNOWN");
+        LOG_DEBUG("SD_MMC Card Type: UNKNOWN");
     }
 
     uint64_t cardSize = SD.cardSize() / (1024 * 1024);
     LOG_DEBUG("SD Card Size: %lu MB", (uint32_t)cardSize);
     LOG_DEBUG("Total space: %lu MB", (uint32_t)(SD.totalBytes() / (1024 * 1024)));
-#if (defined(ARCH_ESP32)) // not implemented in arduino sd library
+    LOG_INFO("Now scanning free clusters on SD card");
+    delay(100); // let serial print the above statement properly
     LOG_DEBUG("Used space: %lu MB", (uint32_t)(SD.usedBytes() / (1024 * 1024)));
-#endif
+
 #endif
 #endif
 }

--- a/src/modules/Modules.cpp
+++ b/src/modules/Modules.cpp
@@ -217,7 +217,7 @@ void setupModules()
         paxcounterModule = new PaxcounterModule();
 #endif
 #endif
-#if defined(ARCH_ESP32) || defined(ARCH_PORTDUINO)
+#if defined(ARCH_ESP32) || defined(ARCH_PORTDUINO) || defined(HAS_SDCARD)
 #if !MESHTASTIC_EXCLUDE_STOREFORWARD
         storeForwardModule = new StoreForwardModule();
 #endif

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -20,7 +20,7 @@ lib_deps =
   https://github.com/RAKWireless/RAK13800-W5100S.git#1.0.2
   rakwireless/RAKwireless NCP5623 RGB LED library@^1.0.2
   https://github.com/RAKWireless/RAK12034-BMX160.git#dcead07ffa267d3c906e9ca4a1330ab989e957e2
-  https://github.com/Woutvstk/arduino_SD.git#909c2a4a14f5b053bb69958709f0c874aa358c38 ;library to acces SD card
+  https://github.com/Woutvstk/SdFat_wrapper25.git#6f8f48d56c15cbeac753560dfeede4a487f81f4c
 
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
 ; Note: as of 6/2013 the serial/bootloader based programming takes approximately 30 seconds

--- a/variants/rak4631/variant.h
+++ b/variants/rak4631/variant.h
@@ -138,6 +138,12 @@ static const uint8_t SCK = PIN_SPI_SCK;
 #define SPI_MISO PIN_SPI1_MISO
 #define SDCARD_CS (26)
 
+// Some settings for the SdFat library to optimize flash usage
+#define SDFAT_FILE_TYPE 1 // only support FAT16/FAT32, not exFAT
+#define CHECK_FLASH_PROGRAMMING                                                                                                  \
+    0 // this reduces flash usage but may cause higher power usage when sd card is idle TODO:Check if power usage is higher
+#define MAINTAIN_FREE_CLUSTER_COUNT 1 // maintain free cluster count
+
 /*
  * eink display pins
  */


### PR DESCRIPTION
- Changed library from deprecated arduino SD library to wrapper of SdFat library
- Fixed some bugs in the S&F code for SD card storage Now the S&F functionality works on nrf52 (tested on rak4631 with RAK15002)
