### PR TITLE
Don't use assert() in MeshService to guard queueing packets

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -309,7 +309,10 @@ void MeshService::sendToPhone(meshtastic_MeshPacket *p)
         }
     }
 
-    assert(toPhoneQueue.enqueue(p, 0));
+    if(toPhoneQueue.enqueue(p, 0) == false) {
+        LOG_CRIT("Failed to queue a packet into toPhoneQueue!");
+        abort();
+    }
     fromNum++;
 }
 
@@ -323,7 +326,10 @@ void MeshService::sendMqttMessageToClientProxy(meshtastic_MqttClientProxyMessage
             releaseMqttClientProxyMessageToPool(d);
     }
 
-    assert(toPhoneMqttProxyQueue.enqueue(m, 0));
+    if(toPhoneMqttProxyQueue.enqueue(m, 0) == false) {
+        LOG_CRIT("Failed to queue a packet into toPhoneMqttProxyQueue!");
+        abort();
+    }
     fromNum++;
 }
 
@@ -337,7 +343,10 @@ void MeshService::sendClientNotification(meshtastic_ClientNotification *n)
             releaseClientNotificationToPool(d);
     }
 
-    assert(toPhoneClientNotificationQueue.enqueue(n, 0));
+    if(toPhoneClientNotificationQueue.enqueue(n, 0) == false) {
+        LOG_CRIT("Failed to queue a notification into toPhoneClientNotificationQueue!");
+        abort();
+    }
     fromNum++;
 }
 

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -309,7 +309,7 @@ void MeshService::sendToPhone(meshtastic_MeshPacket *p)
         }
     }
 
-    if(toPhoneQueue.enqueue(p, 0) == false) {
+    if (toPhoneQueue.enqueue(p, 0) == false) {
         LOG_CRIT("Failed to queue a packet into toPhoneQueue!");
         abort();
     }
@@ -326,7 +326,7 @@ void MeshService::sendMqttMessageToClientProxy(meshtastic_MqttClientProxyMessage
             releaseMqttClientProxyMessageToPool(d);
     }
 
-    if(toPhoneMqttProxyQueue.enqueue(m, 0) == false) {
+    if (toPhoneMqttProxyQueue.enqueue(m, 0) == false) {
         LOG_CRIT("Failed to queue a packet into toPhoneMqttProxyQueue!");
         abort();
     }
@@ -343,7 +343,7 @@ void MeshService::sendClientNotification(meshtastic_ClientNotification *n)
             releaseClientNotificationToPool(d);
     }
 
-    if(toPhoneClientNotificationQueue.enqueue(n, 0) == false) {
+    if (toPhoneClientNotificationQueue.enqueue(n, 0) == false) {
         LOG_CRIT("Failed to queue a notification into toPhoneClientNotificationQueue!");
         abort();
     }


### PR DESCRIPTION
Fixes crashes on STM32WL, where Arduino_Core_STM32 defines NDEBUG as a default option.
