### PR TITLE
MUI: increase stack, cache and drawbuffer

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -94,7 +94,8 @@ lib_deps =
 
 [device-ui_base]
 lib_deps =
-	https://github.com/meshtastic/device-ui.git#74e739ed4532ca10393df9fc89ae5a22f0bab2b1
+	;https://github.com/meshtastic/device-ui.git#7a6ffba3c86901b0e3234b6c056aa803b4cd8854
+	symlink:///home/manuel/Documents/PlatformIO/Projects/device-ui
 
 ; Common libs for environmental measurements in telemetry module
 ; (not included in native / portduino)

--- a/platformio.ini
+++ b/platformio.ini
@@ -94,8 +94,7 @@ lib_deps =
 
 [device-ui_base]
 lib_deps =
-	;https://github.com/meshtastic/device-ui.git#7a6ffba3c86901b0e3234b6c056aa803b4cd8854
-	symlink:///home/manuel/Documents/PlatformIO/Projects/device-ui
+	https://github.com/meshtastic/device-ui.git#7a6ffba3c86901b0e3234b6c056aa803b4cd8854
 
 ; Common libs for environmental measurements in telemetry module
 ; (not included in native / portduino)

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -119,7 +119,7 @@ void tftSetup(void)
 #ifdef ARCH_ESP32
     tftSleepObserver.observe(&notifyLightSleep);
     endSleepObserver.observe(&notifyLightSleepEnd);
-    xTaskCreatePinnedToCore(tft_task_handler, "tft", 8192, NULL, 1, NULL, 0);
+    xTaskCreatePinnedToCore(tft_task_handler, "tft", 10240, NULL, 1, NULL, 0);
 #endif
 }
 

--- a/variants/portduino/platformio.ini
+++ b/variants/portduino/platformio.ini
@@ -27,6 +27,7 @@ build_flags = ${native_base.build_flags} -Os -lX11 -linput -lxkbcommon -ffunctio
   -D USE_X11=1
   -D HAS_TFT=1
   -D HAS_SCREEN=0
+  -D LV_CACHE_DEF_SIZE=6291456
   -D LV_BUILD_TEST=0
   -D LV_USE_LIBINPUT=1
   -D LV_LVGL_H_INCLUDE_SIMPLE
@@ -56,7 +57,7 @@ build_flags = ${native_base.build_flags} -O0 -fsanitize=address -lX11 -linput -l
   -D USE_X11=1
   -D HAS_TFT=1
   -D HAS_SCREEN=0
-;  -D CALIBRATE_TOUCH=0
+  -D LV_CACHE_DEF_SIZE=6291456
   -D LV_BUILD_TEST=0
   -D LV_USE_LOG=1
   -D LV_USE_SYSMON=1

--- a/variants/t-deck/platformio.ini
+++ b/variants/t-deck/platformio.ini
@@ -66,7 +66,7 @@ build_flags =
   -D VIEW_320x240
 ;	-D USE_DOUBLE_BUFFER
   -D USE_PACKET_API
-;  -D MAP_FULL_REDRAW
+  -D MAP_FULL_REDRAW
 
 lib_deps =
   ${env:t-deck.lib_deps}

--- a/variants/t-deck/platformio.ini
+++ b/variants/t-deck/platformio.ini
@@ -42,7 +42,7 @@ build_flags =
   -D HAS_SCREEN=0
   -D HAS_TFT=1
   -D USE_I2S_BUZZER
-  -D RAM_SIZE=4096
+  -D RAM_SIZE=5120
 	-D LV_LVGL_H_INCLUDE_SIMPLE
 	-D LV_CONF_INCLUDE_SIMPLE
 	-D LV_COMP_CONF_INCLUDE_SIMPLE
@@ -66,6 +66,7 @@ build_flags =
   -D VIEW_320x240
 ;	-D USE_DOUBLE_BUFFER
   -D USE_PACKET_API
+;  -D MAP_FULL_REDRAW
 
 lib_deps =
   ${env:t-deck.lib_deps}


### PR DESCRIPTION
Fixes slow map scrolling and/or artifacts, maybe also Indicator crash https://github.com/meshtastic/device-ui/issues/68

- increase stack size to 10k (+2k)
- increase png decode cache to 6 tiles (1.5Mb) / 32 tiles (native)
- increase drawbuffer to 100% (avoids duplicated loading (open/read/close) of tiles from SD
- bump device-ui commit version

Note:
Increasing the drawbuffer requires Linux arm targets with TFT SPI display to increase the spidev bufsize to `width * height  * 3`, e.g.
```bash
$ echo "options spidev bufsiz=230400" | sudo tee -a /etc/modprobe.d/spidev.conf
$ sudo rmmod spidev
$ sudo modprobe spidev
$ cat /sys/module/spidev/parameters/bufsiz
230400
```