### PR TITLE
udp-multicast: do not listen for incoming udp multicast packets if disabled

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -829,7 +829,9 @@ void setup()
 #ifdef ARCH_PORTDUINO
     // FIXME: portduino does not ever call onNetworkConnected so call it here because I don't know what happen if I call
     // onNetworkConnected there
-    udpThread->start();
+    if (config.network.enabled_protocols & meshtastic_Config_NetworkConfig_ProtocolFlags_UDP_BROADCAST) {
+        udpThread->start();
+    }
 #endif
 #endif
     service = new MeshService();

--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -133,7 +133,7 @@ static void onNetworkConnected()
     }
 
 #if HAS_UDP_MULTICAST
-    if (udpThread) {
+    if (udpThread && config.network.enabled_protocols & meshtastic_Config_NetworkConfig_ProtocolFlags_UDP_BROADCAST) {
         udpThread->start();
     }
 #endif


### PR DESCRIPTION
Currently the config flag only control if packets are sent, not received.

As we discussed in VC this is not what was intended.