### PR TITLE
Add missing board definition for MESHLINK

### DIFF
--- a/src/platform/nrf52/architecture.h
+++ b/src/platform/nrf52/architecture.h
@@ -75,6 +75,8 @@
 #define HW_VENDOR meshtastic_HardwareModel_PRIVATE_HW
 #elif defined(HELTEC_T114)
 #define HW_VENDOR meshtastic_HardwareModel_HELTEC_MESH_NODE_T114
+#elif defined(MESHLINK)
+#define HW_VENDOR meshtastic_HardwareModel_MESHLINK
 #elif defined(SEEED_XIAO_NRF52840_KIT)
 #define HW_VENDOR meshtastic_HardwareModel_XIAO_NRF52_KIT
 #else


### PR DESCRIPTION
Hi, we forgot to add this line in order to make the board be recognized as MESHLINK and not NRF52_UNKNOWN.

It seems to be working now (watching protobuf message the board now advertises itself correctly as 87) but on the Android app we are still seeing UNRECOGNIZED , I was told we just have to wait for the new board to be added to the app, is this right? Is there anything else I can do?

Thanks