### PR TITLE
Fix USERPREFS_EVENT_MODE compile error

### DIFF
--- a/src/mesh/Channels.cpp
+++ b/src/mesh/Channels.cpp
@@ -347,7 +347,7 @@ bool Channels::anyMqttEnabled()
 {
 #if USERPREFS_EVENT_MODE
     // Don't publish messages on the public MQTT broker if we are in event mode
-    if (mqtt && mqtt.isUsingDefaultServer()) {
+    if (mqtt && mqtt->isUsingDefaultServer()) {
         return false;
     }
 #endif


### PR DESCRIPTION
Small fix for build error when using `USERPREFS_EVENT_MODE`.
```
src/mesh/Channels.cpp: In member function 'bool Channels::anyMqttEnabled()':
src/mesh/Channels.cpp:350:22: error: request for member 'isUsingDefaultServer' in 'mqtt', which is of pointer type 'MQTT*' (maybe you meant to use '->' ?)
     if (mqtt && mqtt.isUsingDefaultServer()) {
                      ^~~~~~~~~~~~~~~~~~~~
```

firmware compiles properly with `USERPREFS_EVENT_MODE = 1` after this change.