### PR TITLE
Fix Bold and Inverted Displays to actually show Uptime

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -2664,13 +2664,18 @@ void DebugInfo::drawFrameSettings(OLEDDisplay *display, OLEDDisplayUiState *stat
     // minutes %= 60;
     // hours %= 24;
 
+    // Show uptime as days, hours, minutes OR seconds
+    std::string uptime = screen->drawTimeDelta(days, hours, minutes, seconds);
+
+    // Line 1 (Still)
+    display->drawString(x + SCREEN_WIDTH - display->getStringWidth(uptime.c_str()), y, uptime.c_str());
+    if (config.display.heading_bold)
+        display->drawString(x - 1 + SCREEN_WIDTH - display->getStringWidth(uptime.c_str()), y, uptime.c_str());
+
     display->setColor(WHITE);
 
     // Setup string to assemble analogClock string
     std::string analogClock = "";
-
-    // Show uptime as days, hours, minutes OR seconds
-    std::string uptime = screen->drawTimeDelta(days, hours, minutes, seconds);
 
     uint32_t rtc_sec = getValidTime(RTCQuality::RTCQualityDevice, true); // Display local timezone
     if (rtc_sec > 0) {
@@ -2704,9 +2709,6 @@ void DebugInfo::drawFrameSettings(OLEDDisplay *display, OLEDDisplayUiState *stat
         analogClock += timebuf;
     }
 
-    // Line 1
-    display->drawString(x + SCREEN_WIDTH - display->getStringWidth(uptime.c_str()), y, uptime.c_str());
-
     // Line 2
     display->drawString(x, y + FONT_HEIGHT_SMALL * 1, analogClock.c_str());
 
@@ -2728,7 +2730,7 @@ void DebugInfo::drawFrameSettings(OLEDDisplay *display, OLEDDisplayUiState *stat
         drawGPSpowerstat(display, x, y + FONT_HEIGHT_SMALL * 2, gpsStatus);
     }
 #endif
-    /* Display a heartbeat pixel that blinks every time the frame is redrawn */
+/* Display a heartbeat pixel that blinks every time the frame is redrawn */
 #ifdef SHOW_REDRAWS
     if (heartbeat)
         display->setPixel(0, 0);


### PR DESCRIPTION
Fix Bold and Inverted Displays to actually show Uptime, this was missed in the original PR and is now corrected.

![IMG_2568](https://github.com/user-attachments/assets/89aec068-6b8e-42ec-b439-ac0cfca42c34)
![IMG_2569](https://github.com/user-attachments/assets/72120d72-dcea-4282-8e3d-97315547d549)
![IMG_2570](https://github.com/user-attachments/assets/464d3061-ba25-4f51-9170-6ab915c0a2a7)
![IMG_2571](https://github.com/user-attachments/assets/260fca01-c9a0-4f45-bdec-7bf3ac218824)
