### PR TITLE
Add a static_assert to verify assumption about NodeInfoLite size

### DIFF
--- a/src/mesh/mesh-pb-constants.h
+++ b/src/mesh/mesh-pb-constants.h
@@ -18,6 +18,10 @@
 #define MAX_RX_TOPHONE 32
 #endif
 
+/// Verify baseline assumption of node size. If it increases, we need to reevaluate
+/// the impact of its memory footprint, notably on MAX_NUM_NODES.
+static_assert(sizeof(meshtastic_NodeInfoLite) <= 192, "NodeInfoLite size increased. Reconsider impact on MAX_NUM_NODES.");
+
 /// max number of nodes allowed in the nodeDB
 #ifndef MAX_NUM_NODES
 #if defined(ARCH_STM32WL)


### PR DESCRIPTION
This is my first PR. Adding this nice-to-have for multiple reasons:
1. It only affects compile time, so cost on device is free.
2. It highlights a baseline assumption that MAX_NUM_NODES is dependent on. Reductions in this assertion boundary could encourage reevaluation of memory limits such as MAX_NUM_NODES.
3. Changes to NodeInfoLite, especially those that increase its memory footprint, will force PRs to highlight this fact by modifying the value. This should be useful during code review.
4. This is a baby step toward implementing #6427. It's not strictly necessary, but a good way to show off the impact.