### PR TITLE
Possible fix for use of pin 0 as PIN_GPS_EN

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1370,7 +1370,7 @@ GPS *GPS::createGps()
 
     GpioVirtPin *virtPin = new GpioVirtPin();
     new_gps->enablePin = virtPin; // Always at least populate a virtual pin
-    if (_en_gpio) {
+    #if defined(PIN_GPS_EN)
         GpioPin *p = new GpioHwPin(_en_gpio);
 
         if (!GPS_EN_ACTIVE) { // Need to invert the pin before hardware
@@ -1382,7 +1382,7 @@ GPS *GPS::createGps()
                 virtPin,
                 p); // We just leave this created object on the heap so it can stay watching virtPin and driving en_gpio
         }
-    }
+    #endif
 
 #ifdef PIN_GPS_PPS
     // pulse per second


### PR DESCRIPTION
As discussed on Discord [here](https://discord.com/channels/867578229534359593/919642584480112750/1355219959726346313)
we are using PIN 0.00 on NRF52 for PIN_GPS_EN this causes an issue because if it's set to 0 this skips all the code that creates the gps enable pin instance.

I thought about this for a possible solution, this is working correctly on our board.
Will this be ok?
Thanks!
