### PR TITLE
Portduino: Return CH341 Product String

### DIFF
--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -210,7 +210,10 @@ void portduinoSetup()
         }
         char serial[9] = {0};
         ch341Hal->getSerialString(serial, 8);
-        std::cout << "Serial " << serial << std::endl;
+        std::cout << "CH341 Serial " << serial << std::endl;
+        char product_string[96] = {0};
+        ch341Hal->getProductString(product_string, 95);
+        std::cout << "CH341 Product " << product_string << std::endl;
         if (strlen(serial) == 8 && settingsStrings[mac_address].length() < 12) {
             uint8_t hash[32] = {0};
             memcpy(hash, serial, 8);

--- a/src/platform/portduino/USBHal.h
+++ b/src/platform/portduino/USBHal.h
@@ -61,6 +61,12 @@ class Ch341Hal : public RadioLibHal
         strncpy(_serial, pinedio.serial_number, len);
     }
 
+    void getProductString(char *_product_string, size_t len)
+    {
+        len = len > 95 ? 95 : len;
+        strncpy(_product_string, pinedio.product_string, len);
+    }
+
     void init() override {}
     void term() override {}
 


### PR DESCRIPTION
Extend CH341Hal to return the Product String. This will be consumed in auto-configuration later.