### PR TITLE
meshtasticd: Add FrequencyLabs MeshAdv-Mini Hat

### DIFF
--- a/bin/config.d/lora-MeshAdv-900M30S.yaml
+++ b/bin/config.d/lora-MeshAdv-900M30S.yaml
@@ -1,3 +1,5 @@
+# MeshAdv-Pi E22-900M30S
+# https://github.com/chrismyers2000/MeshAdv-Pi-Hat
 Lora:
   Module: sx1262
   CS: 21

--- a/bin/config.d/lora-MeshAdv-Mini-900M22S.yaml
+++ b/bin/config.d/lora-MeshAdv-Mini-900M22S.yaml
@@ -1,0 +1,11 @@
+# MeshAdv Mini E22-900M22S
+# https://github.com/chrismyers2000/MeshAdv-Mini
+Lora:
+  Module: sx1262  # Ebyte E22-900M22S 
+  CS: 8
+  IRQ: 16
+  Busy: 20
+  Reset: 24
+  TXen: 13
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -11,6 +11,7 @@
 inline const std::unordered_map<std::string, std::string> configProducts = {{"MESHTOAD", "lora-usb-meshtoad-e22.yaml"},
                                                                             {"MESHSTICK", "lora-meshstick-1262.yaml"},
                                                                             {"MESHADV-PI", "lora-MeshAdv-900M30S.yaml"},
+                                                                            {"MESHADV-MINI", "lora-MeshAdv-Mini-900M22S.yaml"},
                                                                             {"POWERPI", "lora-MeshAdv-900M30S.yaml"}};
 
 enum configNames {


### PR DESCRIPTION
Add meshtasticd pin definition for FrequencyLabs (@chrismyers2000) new board, [MeshAdv-Mini](https://github.com/chrismyers2000/MeshAdv-Mini).

![image](https://github.com/user-attachments/assets/bce9ff7e-191a-408c-a869-8a35b3a9fb8a)

These boards include EEPROM for HAT+ support, pending rebase on:
- #6446