### PR TITLE
Fix: Update xiao_ble E22-900M30S regulatory gain to 7 dB

### DIFF
--- a/variants/xiao_ble/variant.h
+++ b/variants/xiao_ble/variant.h
@@ -143,9 +143,10 @@ static const uint8_t SCK = PIN_SPI_SCK;
 #define SX126X_DIO2_AS_RF_SWITCH
 #define SX126X_DIO3_TCXO_VOLTAGE 1.8
 #ifdef EBYTE_E22_900M30S
-// 10dB PA gain and 30dB rated output; based on PA output table from Ebyte Robin <sales06@ebyte.com>
-#define REGULATORY_GAIN_LORA 10
-#define SX126X_MAX_POWER 20
+// 10dB PA gain and 30dB rated output; based on measurements from
+// https://github.com/S5NC/EBYTE_ESP32-S3/blob/main/E22-900M30S%20power%20output%20testing.txt
+#define REGULATORY_GAIN_LORA 7
+#define SX126X_MAX_POWER 22
 #endif
 #ifdef EBYTE_E22_900M33S
 // 25dB PA gain and 33dB rated output; based on TX Power Curve from E22-900M33S_UserManual_EN_v1.0.pdf


### PR DESCRIPTION
Allow 3 dBm increase in power from previous value of 10 dB gain, based on actual measurements from https://github.com/S5NC/EBYTE_ESP32-S3/blob/main/E22-900M30S%20power%20output%20testing.txt

## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] XIAO BLE
    - [x] Heltec T114v2
