### PR TITLE
More toggles for InkHUD menu

### DIFF
--- a/src/graphics/niche/InkHUD/Applet.cpp
+++ b/src/graphics/niche/InkHUD/Applet.cpp
@@ -582,9 +582,12 @@ std::string InkHUD::Applet::getTimeString(uint32_t epochSeconds)
         uint32_t hour = hms / SEC_PER_HOUR;
         uint32_t min = (hms % SEC_PER_HOUR) / SEC_PER_MIN;
 
-        // Format the clock string
+        // Format the clock string, either 12 hour or 24 hour
         char clockStr[11];
-        sprintf(clockStr, "%u:%02u %s", (hour % 12 == 0 ? 12 : hour % 12), min, hour > 11 ? "PM" : "AM");
+        if (config.display.use_12h_clock)
+            sprintf(clockStr, "%u:%02u %s", (hour % 12 == 0 ? 12 : hour % 12), min, hour > 11 ? "PM" : "AM");
+        else
+            sprintf(clockStr, "%02u:%02u", hour, min);
 
         return clockStr;
     }

--- a/src/graphics/niche/InkHUD/Applets/System/Menu/MenuAction.h
+++ b/src/graphics/niche/InkHUD/Applets/System/Menu/MenuAction.h
@@ -22,15 +22,17 @@ enum MenuAction {
     SEND_POSITION,
     SHUTDOWN,
     NEXT_TILE,
+    TOGGLE_BACKLIGHT,
+    TOGGLE_GPS,
+    ENABLE_BLUETOOTH,
     TOGGLE_APPLET,
-    ACTIVATE_APPLETS, // Todo: remove? Possible redundant, handled by TOGGLE_APPLET?
     TOGGLE_AUTOSHOW_APPLET,
     SET_RECENTS,
     ROTATE,
     LAYOUT,
     TOGGLE_BATTERY_ICON,
     TOGGLE_NOTIFICATIONS,
-    TOGGLE_BACKLIGHT,
+    TOGGLE_12H_CLOCK,
 };
 
 } // namespace NicheGraphics::InkHUD

--- a/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
@@ -5,7 +5,12 @@
 #include "RTC.h"
 
 #include "airtime.h"
+#include "main.h"
 #include "power.h"
+
+#if !MESHTASTIC_EXCLUDE_GPS
+#include "GPS.h"
+#endif
 
 using namespace NicheGraphics;
 
@@ -161,12 +166,6 @@ void InkHUD::MenuApplet::execute(MenuItem item)
     case TOGGLE_APPLET:
         settings->userApplets.active[cursor] = !settings->userApplets.active[cursor];
         inkhud->updateAppletSelection();
-        // requestUpdate(Drivers::EInk::UpdateTypes::FULL); // Select FULL, seeing how this action doesn't auto exit
-        break;
-
-    case ACTIVATE_APPLETS:
-        // Todo: remove this action? Already handled by TOGGLE_APPLET?
-        inkhud->updateAppletSelection();
         break;
 
     case TOGGLE_AUTOSHOW_APPLET:
@@ -203,6 +202,25 @@ void InkHUD::MenuApplet::execute(MenuItem item)
             backlight->off();
         else
             backlight->latch();
+        break;
+
+    case TOGGLE_12H_CLOCK:
+        config.display.use_12h_clock = !config.display.use_12h_clock;
+        nodeDB->saveToDisk(SEGMENT_CONFIG);
+        break;
+
+    case TOGGLE_GPS:
+        gps->toggleGpsMode();
+        nodeDB->saveToDisk(SEGMENT_CONFIG);
+        break;
+
+    case ENABLE_BLUETOOTH:
+        // This helps users recover from a bad wifi config
+        LOG_INFO("Enabling Bluetooth");
+        config.network.wifi_enabled = false;
+        config.bluetooth.enabled = true;
+        nodeDB->saveToDisk();
+        rebootAtMsec = millis() + 2000;
         break;
 
     default:
@@ -242,13 +260,21 @@ void InkHUD::MenuApplet::showPage(MenuPage page)
 
     case OPTIONS:
         // Optional: backlight
-        if (settings->optionalMenuItems.backlight) {
-            assert(backlight);
+        if (settings->optionalMenuItems.backlight)
             items.push_back(MenuItem(backlight->isLatched() ? "Backlight Off" : "Keep Backlight On", // Label
                                      MenuAction::TOGGLE_BACKLIGHT,                                   // Action
                                      MenuPage::EXIT                                                  // Exit once complete
                                      ));
-        }
+
+        // Optional: GPS
+        if (config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_DISABLED)
+            items.push_back(MenuItem("Enable GPS", MenuAction::TOGGLE_GPS, MenuPage::EXIT));
+        if (config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED)
+            items.push_back(MenuItem("Disable GPS", MenuAction::TOGGLE_GPS, MenuPage::EXIT));
+
+        // Optional: Enable Bluetooth, in case of lost wifi connection
+        if (!config.bluetooth.enabled || config.network.wifi_enabled)
+            items.push_back(MenuItem("Enable Bluetooth", MenuAction::ENABLE_BLUETOOTH, MenuPage::EXIT));
 
         items.push_back(MenuItem("Applets", MenuPage::APPLETS));
         items.push_back(MenuItem("Auto-show", MenuPage::AUTOSHOW));
@@ -260,26 +286,14 @@ void InkHUD::MenuApplet::showPage(MenuPage page)
                                  &settings->optionalFeatures.notifications));
         items.push_back(MenuItem("Battery Icon", MenuAction::TOGGLE_BATTERY_ICON, MenuPage::OPTIONS,
                                  &settings->optionalFeatures.batteryIcon));
-
-        // TODO - GPS and Wifi switches
-        /*
-        // Optional: has GPS
-        if (config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_DISABLED)
-            items.push_back(MenuItem("Enable GPS", MenuPage::EXIT)); // TODO
-        if (config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED)
-            items.push_back(MenuItem("Disable GPS", MenuPage::EXIT)); // TODO
-
-        // Optional: using wifi
-        if (!config.bluetooth.enabled)
-            items.push_back(MenuItem("Enable Bluetooth", MenuPage::EXIT)); // TODO: escape hatch if wifi configured wrong
-        */
-
+        items.push_back(
+            MenuItem("12-Hour Clock", MenuAction::TOGGLE_12H_CLOCK, MenuPage::OPTIONS, &config.display.use_12h_clock));
         items.push_back(MenuItem("Exit", MenuPage::EXIT));
         break;
 
     case APPLETS:
         populateAppletPage();
-        items.push_back(MenuItem("Exit", MenuAction::ACTIVATE_APPLETS));
+        items.push_back(MenuItem("Exit", MenuPage::EXIT));
         break;
 
     case AUTOSHOW:
@@ -293,7 +307,6 @@ void InkHUD::MenuApplet::showPage(MenuPage page)
 
     case EXIT:
         sendToBackground(); // Menu applet dismissed, allow normal behavior to resume
-        // requestUpdate(Drivers::EInk::UpdateTypes::FULL);
         break;
 
     default:


### PR DESCRIPTION
Additional entries in InkHUD's Options sub-menu
- Enable / Disable GPS
- Enable Bluetooth (recover from a bad wifi config)
- 12 / 24 Hour Clock

GPS and Bluetooth entries are hidden if not applicable.

## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - LilyGo T-Echo
    - Heltec Vision Master E213
