### PR TITLE
Added 'bluetooth' as a connectivity option for the LilyGo T-Watch-S3.…

### DIFF
--- a/boards/t-watch-s3.json
+++ b/boards/t-watch-s3.json
@@ -23,7 +23,7 @@
     "mcu": "esp32s3",
     "variant": "t-watch-s3"
   },
-  "connectivity": ["wifi"],
+  "connectivity": ["wifi", "bluetooth"],
   "debug": {
     "openocd_target": "esp32s3.cfg"
   },


### PR DESCRIPTION
… The T-Watch-S3 has an ESP32-S3 board which has both bluetooth and wifi connectivity.


## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [x] LilyGo T-Deck 
  - [x] LilyGo T-Beam
  - [x] RAK WisBlock 4631
  - [x] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
  - [x] LilyGo T-Watch-S3 
