### PR TITLE
Fix: T-Echo frontlight on at boot when using OLED UI

### DIFF
--- a/src/graphics/EInkDisplay2.cpp
+++ b/src/graphics/EInkDisplay2.cpp
@@ -128,11 +128,7 @@ bool EInkDisplay::connect()
 #ifdef PIN_EINK_EN
     // backlight power, HIGH is backlight on, LOW is off
     pinMode(PIN_EINK_EN, OUTPUT);
-#ifdef ELECROW_ThinkNode_M1
     digitalWrite(PIN_EINK_EN, LOW);
-#else
-    digitalWrite(PIN_EINK_EN, HIGH);
-#endif
 #endif
 
 #if defined(TTGO_T_ECHO) || defined(ELECROW_ThinkNode_M1)


### PR DESCRIPTION
In recent firmware builds, the T-Echo's display front-light is on at boot when using the OLED UI. This PR restores the original behavior of default off.

## 🤝 Attestations
- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [X] Other (please specify below)
    - LilyGo T-Echo (OLED UI) 
    - LilyGo T-Echo (InkHUD UI)
