### PR TITLE
meshtasticd: Set available.d dir in yaml

### DIFF
--- a/bin/config-dist.yaml
+++ b/bin/config-dist.yaml
@@ -197,5 +197,6 @@ General:
   MaxNodes: 200
   MaxMessageQueue: 100
   ConfigDirectory: /etc/meshtasticd/config.d/
+  AvailableDirectory: /etc/meshtasticd/available.d/
 #  MACAddress: AA:BB:CC:DD:EE:FF
 #  MACAddressSource: eth0

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -247,7 +247,7 @@ void portduinoSetup()
                 std::cerr << "autoconf: Unable to find config for " << autoconf_product << std::endl;
                 exit(EXIT_FAILURE);
             }
-            if (loadConfig(("/etc/meshtasticd/available.d/" + product_config).c_str())) {
+            if (loadConfig((settingsStrings[available_directory] + product_config).c_str())) {
                 std::cout << "autoconf: Using " << product_config << " as config file for " << autoconf_product << std::endl;
             } else {
                 std::cerr << "autoconf: Unable to use " << product_config << " as config file for " << autoconf_product
@@ -602,6 +602,8 @@ bool loadConfig(const char *configPath)
             settingsMap[maxnodes] = (yamlConfig["General"]["MaxNodes"]).as<int>(200);
             settingsMap[maxtophone] = (yamlConfig["General"]["MaxMessageQueue"]).as<int>(100);
             settingsStrings[config_directory] = (yamlConfig["General"]["ConfigDirectory"]).as<std::string>("");
+            settingsStrings[available_directory] =
+                (yamlConfig["General"]["AvailableDirectory"]).as<std::string>("/etc/meshtasticd/available.d/");
             if ((yamlConfig["General"]["MACAddress"]).as<std::string>("") != "" &&
                 (yamlConfig["General"]["MACAddressSource"]).as<std::string>("") != "") {
                 std::cout << "Cannot set both MACAddress and MACAddressSource!" << std::endl;

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -99,6 +99,7 @@ enum configNames {
     maxnodes,
     ascii_logs,
     config_directory,
+    available_directory,
     mac_address
 };
 enum { no_screen, x11, st7789, st7735, st7735s, st7796, ili9341, ili9342, ili9486, ili9488, hx8357d };


### PR DESCRIPTION
Allows the available.d config location to be specified in `config.yaml` for meshtasticd.

This allows distros/packaging with non-standard "`/etc`" locations like `FlatPaks` to be accounted for properly.

## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.

