### PR TITLE
meshtasticd docker: Support webui

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV TZ=Etc/UTC
 # Install Dependencies
 ENV PIP_ROOT_USER_ACTION=ignore
 RUN apt-get update && apt-get install --no-install-recommends -y \
-        wget g++ zip git ca-certificates \
+        curl wget g++ zip git ca-certificates \
         libgpiod-dev libyaml-cpp-dev libbluetooth-dev libi2c-dev libuv1-dev \
         libusb-1.0-0-dev libulfius-dev liborcania-dev libssl-dev pkg-config \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
@@ -27,6 +27,12 @@ COPY . /tmp/firmware
 RUN bash ./bin/build-native.sh && \
     cp "/tmp/firmware/release/meshtasticd_linux_$(uname -m)" "/tmp/firmware/release/meshtasticd"
 
+# Fetch web assets
+RUN curl -L "https://github.com/meshtastic/web/releases/download/v$(cat /tmp/firmware/bin/web.version)/build.tar" -o /tmp/web.tar \
+    && mkdir -p /tmp/web \
+    && tar -xf /tmp/web.tar -C /tmp/web/ \
+    && gzip -dr /tmp/web \
+    && rm /tmp/web.tar
 
 ##### PRODUCTION BUILD #############
 
@@ -46,6 +52,7 @@ RUN apt-get update && apt-get --no-install-recommends -y install \
 
 # Fetch compiled binary from the builder
 COPY --from=builder /tmp/firmware/release/meshtasticd /usr/sbin/
+COPY --from=builder /tmp/web /usr/share/meshtasticd/
 # Copy config templates
 COPY ./bin/config.d /etc/meshtasticd/available.d
 
@@ -54,6 +61,8 @@ VOLUME /var/lib/meshtasticd
 
 # Expose Meshtastic TCP API port from the host
 EXPOSE 4403
+# Expose Meshtastic Web UI port from the host
+EXPOSE 443
 
 CMD [ "sh", "-cx", "meshtasticd -d /var/lib/meshtasticd" ]
 


### PR DESCRIPTION
Adds support for webui to debian docker containers.

Not available on Alpine because ulfius/orcania/yder are not packaged there.

~DRAFT~ pending:
- #6500 