### PR TITLE
InkHUD: ad-hoc ping using the menu

### DIFF
--- a/src/graphics/niche/InkHUD/Applets/System/Menu/MenuAction.h
+++ b/src/graphics/niche/InkHUD/Applets/System/Menu/MenuAction.h
@@ -18,8 +18,7 @@ namespace NicheGraphics::InkHUD
 
 enum MenuAction {
     NO_ACTION,
-    SEND_NODEINFO,
-    SEND_POSITION,
+    SEND_PING,
     SHUTDOWN,
     NEXT_TILE,
     TOGGLE_BACKLIGHT,


### PR DESCRIPTION
Implements the adhoc-ping feature for InkHUD. This is accessed using the menu, by selecting *Send > Ping*.

The "Send" submenu is currently redundant, but will also handle canned messages in future.

The ping itself is identical to the one sent by the OLED UI.

No changes outside of InkHUD.

## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    * LilyGo T-Echo
