### PR TITLE
Fix Ublox GPS for Heltec T114

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -810,13 +810,6 @@ void GPS::setPowerState(GPSPowerState newState, uint32_t sleepTime)
     powerState = newState;
     LOG_INFO("GPS power state move from %s to %s", getGPSPowerStateString(oldState), getGPSPowerStateString(newState));
 
-#ifdef HELTEC_MESH_NODE_T114
-    if ((oldState == GPS_OFF || oldState == GPS_HARDSLEEP) && (newState != GPS_OFF && newState != GPS_HARDSLEEP)) {
-        _serial_gps->begin(serialSpeeds[speedSelect]);
-    } else if ((newState == GPS_OFF || newState == GPS_HARDSLEEP) && (oldState != GPS_OFF && oldState != GPS_HARDSLEEP)) {
-        _serial_gps->end();
-    }
-#endif
     switch (newState) {
     case GPS_ACTIVE:
     case GPS_IDLE:


### PR DESCRIPTION
Fixes a crash specific to the T114, which occurs when a UBlox M10 GPS module moves into the `GPS_HARDSLEEP` or `GPS_OFF` states. 

Code which specifically targeted the T114 was ending the serial port, interfering with the serial messages used to put UBlox hardware into low-power states. 

Discord user hckr2000 reports that removing this code resolves the issue. I tested this with the T114's official L76K module and didn't notice any change in function or current draw.

## 🤝 Attestations
- [ ] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
     - Heltec Mesh Node T114