### PR TITLE
Add support for Quectel-L96, a MT3333 module

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1206,7 +1206,8 @@ GnssModel_t GPS::probe(int serialSpeed)
     delay(20);
     std::vector<ChipInfo> mtk = {{"L76B", "Quectel-L76B", GNSS_MODEL_MTK_L76B},
                                  {"PA1616S", "1616S", GNSS_MODEL_MTK_PA1616S},
-                                 {"LS20031", "MC-1513", GNSS_MODEL_MTK_L76B}};
+                                 {"LS20031", "MC-1513", GNSS_MODEL_MTK_L76B},
+                                 {"L96", "Quectel-L96", GNSS_MODEL_MTK_L76B}};
     PROBE_FAMILY("MTK Family", "$PMTK605*31", mtk, 500);
 
     uint8_t cfg_rate[] = {0xB5, 0x62, 0x06, 0x08, 0x00, 0x00, 0x00, 0x00};


### PR DESCRIPTION
This expands the MT3333 based GPS list to include Quectel-L96. 

Output from the PMKT705 string:
DEBUG | ??:??:?? 5 [GPS] $PMTK705,MT3333_AXN5.1.9_MODULE_STD_F0,0008,Quectel-L96,

Works with my DIY ProMicro NRF52 setup.

## 🤝 Attestations
- [X ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
