### PR TITLE
Fix device-specific logic in install script

### DIFF
--- a/bin/device-install.sh
+++ b/bin/device-install.sh
@@ -138,7 +138,7 @@ if [ -f "${FILENAME}" ] && [ -n "${FILENAME##*"update"*}" ]; then
 
 	# littlefs* offset for BigDB 8mb and OTA OFFSET.
 	for variant in "${BIGDB_8MB[@]}"; do
-		if [ -n "${FILENAME##*"$variant"*}" ]; then
+		if [ ! -n "${FILENAME##*"$variant"*}" ]; then
 			OFFSET=0x670000
 			OTA_OFFSET=0x340000
 		fi
@@ -146,7 +146,7 @@ if [ -f "${FILENAME}" ] && [ -n "${FILENAME##*"update"*}" ]; then
 
 	# littlefs* offset for BigDB 16mb and OTA OFFSET.
 	for variant in "${BIGDB_16MB[@]}"; do
-		if [ -n "${FILENAME##*"$variant"*}" ]; then
+		if [ ! -n "${FILENAME##*"$variant"*}" ]; then
 			OFFSET=0xc90000
 			OTA_OFFSET=0x650000
 		fi
@@ -155,7 +155,7 @@ if [ -f "${FILENAME}" ] && [ -n "${FILENAME##*"update"*}" ]; then
 	# Account for S3 board's different OTA partition
 	# FIXME: Use PlatformIO info to determine MCU type, this is unmaintainable
 	for variant in "${S3_VARIANTS[@]}"; do
-		if [ -n "${FILENAME##*"$variant"*}" ]; then
+		if [ ! -n "${FILENAME##*"$variant"*}" ]; then
 			MCU="esp32s3"
 		fi
 	done

--- a/bin/device-install.sh
+++ b/bin/device-install.sh
@@ -138,7 +138,7 @@ if [ -f "${FILENAME}" ] && [ -n "${FILENAME##*"update"*}" ]; then
 
 	# littlefs* offset for BigDB 8mb and OTA OFFSET.
 	for variant in "${BIGDB_8MB[@]}"; do
-		if [ ! -n "${FILENAME##*"$variant"*}" ]; then
+		if [ -z "${FILENAME##*"$variant"*}" ]; then
 			OFFSET=0x670000
 			OTA_OFFSET=0x340000
 		fi
@@ -146,7 +146,7 @@ if [ -f "${FILENAME}" ] && [ -n "${FILENAME##*"update"*}" ]; then
 
 	# littlefs* offset for BigDB 16mb and OTA OFFSET.
 	for variant in "${BIGDB_16MB[@]}"; do
-		if [ ! -n "${FILENAME##*"$variant"*}" ]; then
+		if [ -z "${FILENAME##*"$variant"*}" ]; then
 			OFFSET=0xc90000
 			OTA_OFFSET=0x650000
 		fi
@@ -155,7 +155,7 @@ if [ -f "${FILENAME}" ] && [ -n "${FILENAME##*"update"*}" ]; then
 	# Account for S3 board's different OTA partition
 	# FIXME: Use PlatformIO info to determine MCU type, this is unmaintainable
 	for variant in "${S3_VARIANTS[@]}"; do
-		if [ ! -n "${FILENAME##*"$variant"*}" ]; then
+		if [ -z "${FILENAME##*"$variant"*}" ]; then
 			MCU="esp32s3"
 		fi
 	done


### PR DESCRIPTION
These new for loops to check for variants in a list should be checking for the string to _be empty_, not _non-empty_, if a match is found causing the replacement to fire.

Tested locally with Heltec V3

Fixes #6390.

## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
