### PR TITLE
Update platformio.ini fix build-flags ${esp32s3_base.build_flags}

### DIFF
--- a/variants/crowpanel-esp32s3-5-epaper/platformio.ini
+++ b/variants/crowpanel-esp32s3-5-epaper/platformio.ini
@@ -11,7 +11,7 @@ board = esp32-s3-devkitc-1
 board_level = extra
 upload_protocol = esptool
 build_flags = 
-  ${esp32_base.build_flags} -D CROWPANEL_ESP32S3_5_EPAPER -I variants/crowpanel-esp32s3-5-epaper
+  ${esp32s3_base.build_flags} -D CROWPANEL_ESP32S3_5_EPAPER -I variants/crowpanel-esp32s3-5-epaper
   -D PRIVATE_HW
   -DBOARD_HAS_PSRAM
   -DGPS_POWER_TOGGLE
@@ -39,7 +39,7 @@ board = esp32-s3-devkitc-1
 board_level = extra
 upload_protocol = esptool
 build_flags = 
-  ${esp32_base.build_flags} -D CROWPANEL_ESP32S3_4_EPAPER -I variants/crowpanel-esp32s3-5-epaper
+  ${esp32s3_base.build_flags} -D CROWPANEL_ESP32S3_4_EPAPER -I variants/crowpanel-esp32s3-5-epaper
   -D PRIVATE_HW
   -DBOARD_HAS_PSRAM
   -DGPS_POWER_TOGGLE
@@ -67,7 +67,7 @@ board = esp32-s3-devkitc-1
 board_level = extra
 upload_protocol = esptool
 build_flags = 
-  ${esp32_base.build_flags} -D CROWPANEL_ESP32S3_2_EPAPER -I variants/crowpanel-esp32s3-5-epaper
+  ${esp32s3_base.build_flags} -D CROWPANEL_ESP32S3_2_EPAPER -I variants/crowpanel-esp32s3-5-epaper
   -D PRIVATE_HW
   -DBOARD_HAS_PSRAM
   -DGPS_POWER_TOGGLE


### PR DESCRIPTION
Only affects CrowPanel e-ink and tested on CrowPanel 5.79

## 🤝 Attestations
- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
