### PR TITLE
remove checkov from trunk config

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -12,7 +12,6 @@ lint:
     - trufflehog@3.88.23
     - yamllint@1.37.0
     - bandit@1.8.3
-    - checkov@3.2.398
     - terrascan@1.19.9
     - trivy@0.61.0
     - taplo@0.9.3


### PR DESCRIPTION
We don't have terraform, cloudformation, helm templates ... and this check pushes out new versions very frequently which is annoying with out automation :)
