### PR TITLE
Don't renovate toolchain-gccarmnoneeabi

### DIFF
--- a/arch/nrf52/nrf52.ini
+++ b/arch/nrf52/nrf52.ini
@@ -8,7 +8,7 @@ platform_packages =
   ; our custom Git version until they merge our PR
   # TODO renovate
   platformio/framework-arduinoadafruitnrf52 @ https://github.com/meshtastic/Adafruit_nRF52_Arduino#e13f5820002a4fb2a5e6754b42ace185277e5adf
-  # renovate: datasource=custom.pio depName=platformio/toolchain-gccarmnoneeabi packageName=platformio/tool/toolchain-gccarmnoneeabi
+  ; Don't renovate toolchain-gccarmnoneeabi
   platformio/toolchain-gccarmnoneeabi@~1.90301.0
 
 build_type = debug


### PR DESCRIPTION
Related to #6553 -- `toolchain-gccarmnoneeabi` cannot be updated and shouldn't be managed by renovate.
