### PR TITLE
Portduino: Set C standard to 17

### DIFF
--- a/arch/portduino/portduino.ini
+++ b/arch/portduino/portduino.ini
@@ -47,4 +47,5 @@ build_flags =
   -lyaml-cpp
   -li2c
   -luv
+  -std=gnu17
   -std=c++17


### PR DESCRIPTION
Sets C standard to `17` for Portduino.
Fedora 42 (and probably others in the future), have increased the default c standard from `gnu17` to `gnu23` and this is causing builds to fail.

~DRAFT until I can test properly.~
Building correctly against Fedora 42 (previously broken), building correctly on `musl` targets.