### PR TITLE
fix: Correct underlying cause of T-Watch not functioning when set to a 16MB filesystem

### DIFF
--- a/bin/device-install.bat
+++ b/bin/device-install.bat
@@ -17,8 +17,8 @@ SET "LOGCOUNTER=0"
 SET "S3=s3 v3 t-deck wireless-paper wireless-tracker station-g2 unphone"
 SET "C3=esp32c3"
 @REM FIXME: Determine flash size from PlatformIO variant, this is unmaintainable.
-SET "BIGDB_8MB=picomputer-s3 unphone seeed-sensecap-indicator crowpanel-esp32s3 heltec_capsule_sensor_v3 heltec-v3 heltec-vision-master-e213 heltec-vision-master-e290 heltec-vision-master-t190 heltec-wireless-paper heltec-wireless-tracker heltec-wsl-v3 icarus seeed-xiao-s3 tbeam-s3-core t-watch-s3 tracksenger"
-SET "BIGDB_16MB=t-deck mesh-tab t-energy-s3 dreamcatcher ESP32-S3-Pico m5stack-cores3 station-g2 t-eth-elite"
+SET "BIGDB_8MB=picomputer-s3 unphone seeed-sensecap-indicator crowpanel-esp32s3 heltec_capsule_sensor_v3 heltec-v3 heltec-vision-master-e213 heltec-vision-master-e290 heltec-vision-master-t190 heltec-wireless-paper heltec-wireless-tracker heltec-wsl-v3 icarus seeed-xiao-s3 tbeam-s3-core tracksenger"
+SET "BIGDB_16MB=t-deck mesh-tab t-energy-s3 dreamcatcher ESP32-S3-Pico m5stack-cores3 station-g2 t-eth-elite t-watch-s3"
 
 GOTO getopts
 :help

--- a/bin/device-install.sh
+++ b/bin/device-install.sh
@@ -22,7 +22,6 @@ BIGDB_8MB=(
 	"icarus"
 	"seeed-xiao-s3"
 	"tbeam-s3-core"
-	"t-watch-s3"
 	"tracksenger"
 )
 BIGDB_16MB=(
@@ -34,6 +33,7 @@ BIGDB_16MB=(
 	"m5stack-cores3"
 	"station-g2"
 	"t-eth-elite"
+	"t-watch-s3"
 )
 S3_VARIANTS=(
 	"s3"

--- a/boards/t-watch-s3.json
+++ b/boards/t-watch-s3.json
@@ -24,16 +24,16 @@
     "mcu": "esp32s3",
     "variant": "t-watch-s3"
   },
-  "connectivity": ["wifi", "bluetooth"],
+  "connectivity": ["wifi", "bluetooth", "lora"],
   "debug": {
     "openocd_target": "esp32s3.cfg"
   },
   "frameworks": ["arduino"],
   "name": "LilyGo T-Watch 2020 V3",
   "upload": {
-    "flash_size": "8MB",
+    "flash_size": "16MB",
     "maximum_ram_size": 327680,
-    "maximum_size": 8388608,
+    "maximum_size": 16777216,
     "require_upload_port": true,
     "use_1200bps_touch": true,
     "wait_for_upload_port": true,

--- a/variants/t-watch-s3/platformio.ini
+++ b/variants/t-watch-s3/platformio.ini
@@ -3,7 +3,7 @@
 extends = esp32s3_base
 board = t-watch-s3
 board_check = true
-board_build.partitions = default_8MB.csv
+board_build.partitions = default_16MB.csv
 upload_protocol = esptool
 
 build_flags = ${esp32_base.build_flags} 


### PR DESCRIPTION
While looking at recent commits, I spotted the problem with the LilyGo T-Watch S3 behaving as if it only had 8MB of flash when LilyGo claims it has 16MB: The original board definition from when the T-Watch was first added incorrectly set the maximum flash size to 8MB instead of 16MB. Fixing that allows the full 16MB filesystem image to upload and work successfully. This PR also reverts #6407 as those changes to bump the device down to the 8MB filesystem are no longer required.

## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] LilyGo T-Watch S3
