### PR TITLE
Add Meshtastic Linux desktop metadata

### DIFF
--- a/bin/org.meshtastic.meshtasticd.desktop
+++ b/bin/org.meshtastic.meshtasticd.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Meshtastic
+Comment=Meshtastic App
+Exec=meshtasticd
+Icon=org.meshtastic.meshtasticd
+Terminal=true
+Type=Application
+Categories=Network;Chat;HamRadio;

--- a/bin/org.meshtastic.meshtasticd.metainfo.xml
+++ b/bin/org.meshtastic.meshtasticd.metainfo.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.meshtastic.meshtasticd</id>
+
+  <name>Meshtastic</name>
+  <summary>Decentralized mesh communication</summary>
+
+  <metadata_license>CC-BY-4.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+
+  <developer id="org.meshtastic">
+    <name>Meshtastic</name>
+  </developer>
+
+  <description>
+    <p>
+      Meshtastic is an open source project for creating off-grid, affordable, and resilient communication with LoRa mesh networks.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">org.meshtastic.meshtasticd.desktop</launchable>
+
+  <categories>
+    <category>Network</category>
+    <category>Chat</category>
+    <category>HamRadio</category>
+  </categories>
+  <keywords>
+    <keyword>mesh</keyword>
+    <keyword>LoRa</keyword>
+  </keywords>
+
+  <recommends>
+    <control>keyboard</control>
+    <control>pointing</control>
+    <control>touch</control>
+  </recommends>
+  <requires>
+    <display_length compare="ge">360</display_length>
+  </requires>
+
+  <branding>
+    <color type="primary" scheme_preference="light">#97be89</color>
+    <color type="primary" scheme_preference="dark">#206538</color>
+  </branding>
+
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-chat">intense</content_attribute>
+    <content_attribute id="social-location">intense</content_attribute>
+  </content_rating>
+
+  <url type="bugtracker">https://github.com/meshtastic/firmware/issues</url>
+  <url type="homepage">https://meshtastic.org/</url>
+  <url type="donation">https://opencollective.com/meshtastic</url>
+  <url type="faq">https://meshtastic.org/docs/software/linux/usage/</url>
+  <url type="vcs-browser">https://github.com/meshtastic/firmware/</url>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://meshtastic.org/img/software/meshtastic-ui/mui_home_dashboard_dark.webp</image>
+      <caption>Home Dashboard</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://meshtastic.org/img/software/meshtastic-ui/mui_initial_boot.webp</image>
+      <caption>Setup</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://meshtastic.org/img/software/meshtastic-ui/mui_node_list_dark.webp</image>
+      <caption>Nodes List</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://meshtastic.org/img/software/meshtastic-ui/mui_chat_list_dark.webp</image>
+      <caption>Chats List</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://meshtastic.org/img/software/meshtastic-ui/mui_chat_message_dark.webp</image>
+      <caption>Messages</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://meshtastic.org/img/software/meshtastic-ui/mui_map_dark.webp</image>
+      <caption>Map</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://meshtastic.org/img/software/meshtastic-ui/mui_settings_dark.webp</image>
+      <caption>Settings</caption>
+    </screenshot>
+  </screenshots>
+
+  <releases>
+    <release version="v2.6.4.b89355f" date="2025-04-10">
+      <url type="details">https://github.com/meshtastic/firmware/releases/tag/v2.6.4.b89355f</url>
+    </release>
+  </releases>
+</component>

--- a/bin/org.meshtastic.meshtasticd.svg
+++ b/bin/org.meshtastic.meshtasticd.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="512" height="512" viewBox="0 0 512 512" xml:space="preserve">
+<desc>Created with Fabric.js 4.6.0</desc>
+<defs>
+</defs>
+<g transform="matrix(1 0 0 1 256 256)" id="xYQ9Gk9Jwpgj_HMOXB3F_"  >
+<path style="stroke: rgb(213,130,139); stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(103,234,148); fill-rule: nonzero; opacity: 1;" vector-effect="non-scaling-stroke"  transform=" translate(-256, -256)" d="M 0 0 L 512 0 L 512 512 L 0 512 z" stroke-linecap="round" />
+</g>
+<g transform="matrix(1.79 0 0 1.79 313.74 258.36)" id="1xBsk2n9FZp60Rz1O-ceJ"  >
+<path style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: round; stroke-miterlimit: 2; fill: rgb(44,45,60); fill-rule: evenodd; opacity: 1;" vector-effect="non-scaling-stroke"  transform=" translate(-250.97, -362.41)" d="M 250.908 330.267 L 193.126 415.005 L 180.938 406.694 L 244.802 313.037 C 246.174 311.024 248.453 309.819 250.889 309.816 C 253.326 309.814 255.606 311.015 256.982 313.026 L 320.994 406.536 L 308.821 414.869 L 250.908 330.267 Z" stroke-linecap="round" />
+</g>
+<g transform="matrix(1.81 0 0 1.81 145 256.15)" id="KxN7E9YpbyPgz0S4z4Cl6"  >
+<path style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: round; stroke-miterlimit: 2; fill: rgb(44,45,60); fill-rule: evenodd; opacity: 1;" vector-effect="non-scaling-stroke"  transform=" translate(-115.14, -528.06)" d="M 87.642 581.398 L 154.757 482.977 L 142.638 474.713 L 75.523 573.134 L 87.642 581.398 Z" stroke-linecap="round" />
+</g>
+</svg>


### PR DESCRIPTION
Adds Metadata / desktop entries for org.meshtastic.meshtasticd as required by the FlatHub submission https://github.com/flathub/flathub/pull/6366.
