### PR TITLE
Debian: use native-tft compile target

### DIFF
--- a/debian/ci_pack_sdeb.sh
+++ b/debian/ci_pack_sdeb.sh
@@ -5,8 +5,8 @@ export PLATFORMIO_PACKAGES_DIR=pio/packages
 export PLATFORMIO_CORE_DIR=pio/core
 
 # Download libraries to `pio`
-platformio pkg install -e native
-platformio pkg install -e native -t platformio/tool-scons@4.40502.0
+platformio pkg install -e native-tft
+platformio pkg install -e native-tft -t platformio/tool-scons@4.40502.0
 # Compress `pio` directory to prevent dh_clean from sanitizing it
 tar -cf pio.tar pio/
 rm -rf pio

--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,10 @@ Build-Depends: debhelper-compat (= 13),
                openssl,
                libssl-dev,
                libulfius-dev,
-               liborcania-dev
+               liborcania-dev,
+               libx11-dev,
+               libinput-dev,
+               libxkbcommon-x11-dev
 Standards-Version: 4.6.2
 Homepage: https://github.com/meshtastic/firmware
 Rules-Requires-Root: no

--- a/debian/meshtasticd.install
+++ b/debian/meshtasticd.install
@@ -1,8 +1,8 @@
-.pio/build/native/meshtasticd  usr/sbin
+.pio/build/native-tft/meshtasticd  usr/sbin
 
-bin/config.yaml                etc/meshtasticd
-bin/config.d/*                 etc/meshtasticd/available.d
+bin/config.yaml                    etc/meshtasticd
+bin/config.d/*                     etc/meshtasticd/available.d
 
-bin/meshtasticd.service        lib/systemd/system
+bin/meshtasticd.service            lib/systemd/system
 
-web/*                          usr/share/meshtasticd/web
+web/*                              usr/share/meshtasticd/web

--- a/debian/rules
+++ b/debian/rules
@@ -26,7 +26,7 @@ override_dh_auto_build:
 	mkdir -p web && tar -xf web.tar -C web
 	gunzip web/ -r
 	# Build with platformio
-	$(PIO_ENV) platformio run -e native
+	$(PIO_ENV) platformio run -e native-tft
 	# Move the binary and default config to the correct name
-	mv .pio/build/native/program .pio/build/native/meshtasticd
+	mv .pio/build/native-tft/program .pio/build/native-tft/meshtasticd
 	cp bin/config-dist.yaml bin/config.yaml


### PR DESCRIPTION
Switch debian / ubuntu builds from `native` to `native-tft`. We are *not* enabling the UI by default.

This only requires that the user (automatically) install a few extra libraries and does *not* require a desktop environment.