### PR TITLE
Fix T-Echo display light blink on LoRa TX

### DIFF
--- a/src/graphics/niche/Inputs/TwoButton.cpp
+++ b/src/graphics/niche/Inputs/TwoButton.cpp
@@ -181,7 +181,7 @@ void TwoButton::isrSecondary()
 void TwoButton::startThread()
 {
     if (!OSThread::enabled) {
-        OSThread::setInterval(50);
+        OSThread::setInterval(10);
         OSThread::enabled = true;
     }
 }

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -210,6 +210,14 @@ bool RadioLibInterface::canSleep()
     return res;
 }
 
+/** Allow other firmware components to ask whether we are currently sending a packet
+Initially implemented to protect T-Echo's capacitive touch button from spurious presses during tx
+*/
+bool RadioLibInterface::isSending()
+{
+    return sendingPacket != NULL;
+}
+
 /** Attempt to cancel a previously sent packet.  Returns true if a packet was found we could cancel */
 bool RadioLibInterface::cancelSending(NodeNum from, PacketId id)
 {

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -132,6 +132,11 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
      */
     virtual bool isActivelyReceiving() = 0;
 
+    /** Are we are currently sending a packet?
+     * This method is public, intending to expose this information to other firmware components
+     */
+    virtual bool isSending();
+
     /** Attempt to cancel a previously sent packet.  Returns true if a packet was found we could cancel */
     virtual bool cancelSending(NodeNum from, PacketId id) override;
 

--- a/variants/t-echo/nicheGraphics.h
+++ b/variants/t-echo/nicheGraphics.h
@@ -29,6 +29,12 @@
 #include "graphics/niche/Fonts/FreeSans6pt8bCyrillic.h"
 #include <Fonts/FreeSans9pt7b.h>
 
+// Special case - fix T-Echo's touch button
+// ----------------------------------------
+// On a handful of T-Echos, LoRa TX triggers the capacitive touch
+// To avoid this, we lockout the button during TX
+#include "mesh/RadioLibInterface.h"
+
 void setupNicheGraphics()
 {
     using namespace NicheGraphics;
@@ -115,13 +121,22 @@ void setupNicheGraphics()
     buttons->setWiring(TOUCH_BUTTON, PIN_BUTTON_TOUCH);
     buttons->setTiming(TOUCH_BUTTON, 50, 5000); // 5 seconds before latch - limited by T-Echo's capacitive touch IC
     buttons->setHandlerDown(TOUCH_BUTTON, [backlight]() {
+        // Discard the button press if radio is active
+        // Rare hardware fault: LoRa activity triggers touch button
+        if (!RadioLibInterface::instance || RadioLibInterface::instance->isSending())
+            return;
+
+        // Backlight on (while held)
         backlight->peek();
-        InkHUD::InkHUD::getInstance()->persistence->settings.optionalMenuItems.backlight =
-            false; // We've proved user still has the button. No need to make backlight togglable via the menu.
+
+        // Handler has run, which confirms touch button wasn't removed as part of DIY build.
+        // No longer need the fallback backlight toggle in menu.
+        InkHUD::InkHUD::getInstance()->persistence->settings.optionalMenuItems.backlight = false;
     });
     buttons->setHandlerLongPress(TOUCH_BUTTON, [backlight]() { backlight->latch(); });
     buttons->setHandlerShortPress(TOUCH_BUTTON, [backlight]() { backlight->off(); });
 
+    // Begin handling button events
     buttons->start();
 }
 


### PR DESCRIPTION
*The rumors are true...*
> caveman99 🇩🇪
>  — 
> 4/2/22, 2:18 AM
> the one thing i've seen interfere in device designs was the T-ECHO touch button which is routed right next to the lora u.FL. 
> every time you transmit it would register a longpress...

___

Discord user Fidian reports that their T-Echo registers a long-press of the capacitive touch button during LoRa TX. With InkHUD, this causes the display's light to blink on and off.

With this PR, the T-Echo ignores presses of the touch button during LoRa TX. Fidian has tested the fix and reports that it resolves the issue. My T-Echo does not exhibit the same hardware issue, but I *have* tested the changes to confirm that they are non-intrusive. 

## 🤝 Attestations
- [ ] I have tested that my proposed changes behave as described.
  *Tested by Discord user: Fidian*
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    * T-Echo (InkHUD)
