### PR TITLE
fix: set upload_speed for tlora_v1_3 & tlora_v2_1_16

### DIFF
--- a/variants/tlora_v1_3/platformio.ini
+++ b/variants/tlora_v1_3/platformio.ini
@@ -4,3 +4,4 @@ extends = esp32_base
 board = ttgo-lora32-v1
 build_flags = 
   ${esp32_base.build_flags} -D TLORA_V1_3 -I variants/tlora_v1_3
+upload_speed = 115200

--- a/variants/tlora_v2_1_16/platformio.ini
+++ b/variants/tlora_v2_1_16/platformio.ini
@@ -5,3 +5,4 @@ board_check = true
 build_flags = 
   ${esp32_base.build_flags} -D TLORA_V2_1_16 -I variants/tlora_v2_1_16
   -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
+upload_speed = 115200

--- a/variants/tlora_v2_1_16_tcxo/platformio.ini
+++ b/variants/tlora_v2_1_16_tcxo/platformio.ini
@@ -8,3 +8,4 @@ build_flags =
   -I variants/tlora_v2_1_16
   -D GPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
   -D LORA_TCXO_GPIO=33
+upload_speed = 115200


### PR DESCRIPTION
I was not able to flash 2 of my LilyGo nodes through PlatformIO (tlora v1.3 & tlora v1.6).
This problem occurred with all of our nodes of that type.
The error:

```sh
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 921600
Changed.

A fatal error occurred: Unable to verify flash chip connection (Invalid head of packet (0xE0): Possible serial noise or corruption.).
*** [uploadfs] Error 2
====================================================================================== [FAILED] Took 13.84 seconds ======================================================================================

Environment     Status    Duration
--------------  --------  ------------
tlora-v2-1-1_6  FAILED    00:00:13.845
================================================================================= 1 failed, 0 succeeded in 00:00:13.845 =================================================================================
```

Uploading through the `device-install.sh` worked.

Adding
```
upload_speed = 115200
```
fixed our issue on both types of nodes.

```sh
platformio run --target upload --environment tlora-v2-1-1_6
...
Writing at 0x00200fcd... (98 %)
Writing at 0x00206800... (100 %)
Wrote 2072160 bytes (1287399 compressed) at 0x00010000 in 125.4 seconds (effective 132.2 kbit/s)...
Hash of data verified.

Leaving...
Hard resetting via RTS pin...
===================================================================================== [SUCCESS] Took 210.23 seconds =====================================================================================

Environment     Status    Duration
--------------  --------  ------------
tlora-v2-1-1_6  SUCCESS   00:03:30.229
====================================================================================== 1 succeeded in 00:03:30.229 ======================================================================================
```
now works.

## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [] Heltec (Lora32) V3
  - [] LilyGo T-Deck 
  - [] LilyGo T-Beam
  - [] RAK WisBlock 4631
  - [] Seeed Studio T-1000E tracker card
  - [] Other (please specify below)
  - [x] I have not tested for those nodes but this change won't affect them.
