### PR TITLE
Fix tlora v1 uploadspeed

### DIFF
--- a/variants/tlora_v1/platformio.ini
+++ b/variants/tlora_v1/platformio.ini
@@ -4,3 +4,4 @@ extends = esp32_base
 board = ttgo-lora32-v1
 build_flags = 
   ${esp32_base.build_flags} -D TLORA_V1 -I variants/tlora_v1
+upload_speed = 115200


### PR DESCRIPTION
Yesterday I created pull request #6595.
This morning I noticed, that I forgot to do the change for tlora v1, which is also affected by the problem.

TLDR:
`upload_speed` needs to be set to 115200 for uploading to be successful (as described in #6595).

## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
  - [x] I have not tested for those nodes but this change won't affect them.
