### PR TITLE
Fix crash when clearing NRF52 BLE bonds 

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -450,7 +450,6 @@ bool NodeDB::factoryReset(bool eraseBleBonds)
         nvs_flash_erase();
 #endif
 #ifdef ARCH_NRF52
-        Bluefruit.begin();
         LOG_INFO("Clear bluetooth bonds!");
         bond_print_list(BLE_GAP_ROLE_PERIPH);
         bond_print_list(BLE_GAP_ROLE_CENTRAL);

--- a/src/platform/nrf52/NRF52Bluetooth.h
+++ b/src/platform/nrf52/NRF52Bluetooth.h
@@ -19,4 +19,7 @@ class NRF52Bluetooth : BluetoothApi
     static void onConnectionSecured(uint16_t conn_handle);
     static bool onPairingPasskey(uint16_t conn_handle, uint8_t const passkey[6], bool match_request);
     static void onPairingCompleted(uint16_t conn_handle, uint8_t auth_status);
+
+    static bool onUnwantedPairing(uint16_t conn_handle, uint8_t const passkey[6], bool match_request);
+    static void disconnect();
 };


### PR DESCRIPTION
When performing a device factory reset on NRF52, a crash occurs before BLE bonds are cleared.  This PR prevents the crash, and resolves a subsequently unmasked issue, where Android devices attempt to re-pair BLE during factory reset.

This PR applies only to device factory reset. The behavior of config factory reset remains the same, with BLE bonds preserved.

I haven't tested this with any hardware which uses Soft Device 7, so it could be helpful if anyone wants to give this a run on something like a T-1000E.

## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
  * Android App 2.5.21
  * iOS App 2.5.22
  * Python CLI 2.6.0
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    * Heltec Mesh Node T114
 