### PR TITLE
Add TFT docker builds (for CI)

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: boolean
         default: false
+      pio_env:
+        description: PlatformIO environment to build
+        required: false
+        type: string
+        default: native
     outputs:
       digest:
         description: Digest of built image
@@ -90,3 +95,5 @@ jobs:
           push: ${{ inputs.push }}
           tags: ${{ steps.meta.outputs.tags }} # Tag is only meant to be consumed by the "manifest" job
           platforms: ${{ inputs.platform }}
+          build-args: |
+            PIO_ENV=${{ inputs.pio_env }}

--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -145,7 +145,7 @@ jobs:
   test-native:
     uses: ./.github/workflows/test_native.yml
 
-  docker-debian-amd64:
+  docker-deb-amd64:
     uses: ./.github/workflows/docker_build.yml
     with:
       distro: debian
@@ -153,7 +153,16 @@ jobs:
       runs-on: ubuntu-24.04
       push: false
 
-  docker-alpine-amd64:
+  docker-deb-amd64-tft:
+    uses: ./.github/workflows/docker_build.yml
+    with:
+      distro: debian
+      platform: linux/amd64
+      runs-on: ubuntu-24.04
+      push: false
+      pio_env: native-tft
+
+  docker-alp-amd64:
     uses: ./.github/workflows/docker_build.yml
     with:
       distro: alpine
@@ -161,7 +170,16 @@ jobs:
       runs-on: ubuntu-24.04
       push: false
 
-  docker-debian-arm64:
+  docker-alp-amd64-tft:
+    uses: ./.github/workflows/docker_build.yml
+    with:
+      distro: alpine
+      platform: linux/amd64
+      runs-on: ubuntu-24.04
+      push: false
+      pio_env: native-tft
+
+  docker-deb-arm64:
     uses: ./.github/workflows/docker_build.yml
     with:
       distro: debian
@@ -169,7 +187,7 @@ jobs:
       runs-on: ubuntu-24.04-arm
       push: false
 
-  docker-debian-armv7:
+  docker-deb-armv7:
     uses: ./.github/workflows/docker_build.yml
     with:
       distro: debian

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # trunk-ignore-all(terrascan/AC_DOCKER_0002): Known terrascan issue
 # trunk-ignore-all(trivy/DS002): We must run as root for this container
-# trunk-ignore-all(checkov/CKV_DOCKER_8): We must run as root for this container
 # trunk-ignore-all(hadolint/DL3002): We must run as root for this container
 # trunk-ignore-all(hadolint/DL3008): Do not pin apt package versions
 # trunk-ignore-all(hadolint/DL3013): Do not pin pip package versions
+ARG PIO_ENV=native
 
 FROM python:3.13-bookworm AS builder
 ENV DEBIAN_FRONTEND=noninteractive
@@ -12,9 +12,10 @@ ENV TZ=Etc/UTC
 # Install Dependencies
 ENV PIP_ROOT_USER_ACTION=ignore
 RUN apt-get update && apt-get install --no-install-recommends -y \
-        curl wget g++ zip git ca-certificates \
+        curl wget g++ zip git ca-certificates pkg-config \
         libgpiod-dev libyaml-cpp-dev libbluetooth-dev libi2c-dev libuv1-dev \
-        libusb-1.0-0-dev libulfius-dev liborcania-dev libssl-dev pkg-config \
+        libusb-1.0-0-dev libulfius-dev liborcania-dev libssl-dev \
+        libx11-dev libinput-dev libxkbcommon-x11-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir -U platformio \
     && mkdir /tmp/firmware
@@ -24,7 +25,7 @@ WORKDIR /tmp/firmware
 COPY . /tmp/firmware
 
 # Build
-RUN bash ./bin/build-native.sh && \
+RUN bash ./bin/build-native.sh "$PIO_ENV" && \
     cp "/tmp/firmware/release/meshtasticd_linux_$(uname -m)" "/tmp/firmware/release/meshtasticd"
 
 # Fetch web assets
@@ -44,7 +45,9 @@ ENV TZ=Etc/UTC
 USER root
 
 RUN apt-get update && apt-get --no-install-recommends -y install \
-        libc-bin libc6 libgpiod2 libyaml-cpp0.7 libi2c0 libuv1 libusb-1.0-0-dev liborcania2.3 libulfius2.7 libssl3 \
+        libc-bin libc6 libgpiod2 libyaml-cpp0.7 libi2c0 libuv1 libusb-1.0-0-dev \
+        liborcania2.3 libulfius2.7 libssl3 \
+        libx11-6 libinput10 libxkbcommon-x11-0 \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /var/lib/meshtasticd \
     && mkdir -p /etc/meshtasticd/config.d \

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -1,8 +1,8 @@
 # trunk-ignore-all(trivy/DS002): We must run as root for this container
-# trunk-ignore-all(checkov/CKV_DOCKER_8): We must run as root for this container
 # trunk-ignore-all(hadolint/DL3002): We must run as root for this container
 # trunk-ignore-all(hadolint/DL3018): Do not pin apk package versions
 # trunk-ignore-all(hadolint/DL3013): Do not pin pip package versions
+ARG PIO_ENV=native
 
 FROM python:3.13-alpine3.21 AS builder
 
@@ -10,6 +10,7 @@ ENV PIP_ROOT_USER_ACTION=ignore
 RUN apk --no-cache add \
         bash g++ libstdc++-dev linux-headers zip git ca-certificates libgpiod-dev yaml-cpp-dev bluez-dev \
         libusb-dev i2c-tools-dev libuv-dev openssl-dev pkgconf argp-standalone \
+        libx11-dev libinput-dev libxkbcommon-dev \
     && rm -rf /var/cache/apk/* \
     && pip install --no-cache-dir -U platformio \
     && mkdir /tmp/firmware
@@ -21,7 +22,7 @@ COPY . /tmp/firmware
 # Add `argp` for musl
 ENV PLATFORMIO_BUILD_FLAGS="-Os -ffunction-sections -fdata-sections -Wl,--gc-sections -largp"
 
-RUN bash ./bin/build-native.sh && \
+RUN bash ./bin/build-native.sh "$PIO_ENV" && \
     cp "/tmp/firmware/release/meshtasticd_linux_$(uname -m)" "/tmp/firmware/release/meshtasticd"
 
 # ##### PRODUCTION BUILD #############
@@ -33,6 +34,7 @@ USER root
 
 RUN apk --no-cache add \
         libstdc++ libgpiod yaml-cpp libusb i2c-tools libuv \
+        libx11 libinput libxkbcommon \
     && rm -rf /var/cache/apk/* \
     && mkdir -p /var/lib/meshtasticd \
     && mkdir -p /etc/meshtasticd/config.d \

--- a/bin/build-native.sh
+++ b/bin/build-native.sh
@@ -15,6 +15,7 @@ platformioFailed() {
 
 VERSION=$(bin/buildinfo.py long)
 SHORT_VERSION=$(bin/buildinfo.py short)
+PIO_ENV=${1:-native}
 
 OUTDIR=release/
 
@@ -24,7 +25,7 @@ mkdir -p $OUTDIR/
 rm -r $OUTDIR/* || true
 
 # Important to pull latest version of libs into all device flavors, otherwise some devices might be stale
-pio pkg update --environment native || platformioFailed
-pio run --environment native || platformioFailed
-cp .pio/build/native/program "$OUTDIR/meshtasticd_linux_$(uname -m)"
+pio pkg update --environment "$PIO_ENV" || platformioFailed
+pio run --environment "$PIO_ENV" || platformioFailed
+cp ".pio/build/$PIO_ENV/program" "$OUTDIR/meshtasticd_linux_$(uname -m)"
 cp bin/native-install.* $OUTDIR


### PR DESCRIPTION
Adds docker-tft builds. These builds are not for release, and are only for CI purposes to ensure changes don't regress our linux tft targets.

~DRAFT while I test this.~ Testing looks good locally :+1: 