### PR TITLE
Fix rak11310 Voltage Read

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -295,6 +295,22 @@ class AnalogBatteryLevel : public HasBatteryLevel
             raw = raw / BATTERY_SENSE_SAMPLES;
             scaled = operativeAdcMultiplier * ((1000 * AREF_VOLTAGE) / pow(2, BATTERY_SENSE_RESOLUTION_BITS)) * raw;
 #endif
+#if defined(RAK11310)
+            float voltage_raw = operativeAdcMultiplier * ((1000 * AREF_VOLTAGE) / 1023) * raw;
+            
+            LOG_INFO("[POWER DEBUG] AREF=%.2fV, ADC_RAW=%u, ADC_MULT=%.2f", 
+                     (double)AREF_VOLTAGE, 
+                     raw, 
+                     (double)operativeAdcMultiplier);
+            
+            scaled = (voltage_raw * 1.22f) - 0.1f;
+            scaled = operativeAdcMultiplier * ((1000 * AREF_VOLTAGE) / 4096) * raw;
+            LOG_INFO("[POWER CORRECTION] Before=%.2fmV, After=%.2fmV", 
+                     (double)voltage_raw, 
+                     (double)scaled);
+#else
+            scaled = operativeAdcMultiplier * ((1000 * AREF_VOLTAGE) / 1023) * raw;
+#endif          
             adcDisable();
 
             if (!initial_read_done) {


### PR DESCRIPTION
add voltage read correction for rak11310

## 🙏 Thank you for sending in a pull request, here's some tips to get started!

### ❌ (Please delete all these tips and replace them with your text) ❌
- Before starting on some new big chunk of code, it it is optional but highly recommended to open an issue first
  to say "Hey, I think this idea X should be implemented and I'm starting work on it. My general plan is Y, any feedback
  is appreciated." This will allow other devs to potentially save you time by not accidentially duplicating work etc...
- Please do not check in files that don't have real changes
- Please do not reformat lines that you didn't have to change the code on
- We recommend using the [Visual Studio Code](https://platformio.org/install/ide?install=vscode) editor along with the ['Trunk Check' extension](https://marketplace.visualstudio.com/items?itemName=trunk.io) (In beta for windows, WSL2 for the linux version),
  because it automatically follows our indentation rules and its auto reformatting will not cause spurious changes to lines.
- If your PR fixes a bug, mention "fixes #bugnum" somewhere in your pull request description.
- If your other co-developers have comments on your PR please tweak as needed.
- Please also enable "Allow edits by maintainers".
- Please do not submit untested code.
- If you do not have the affected hardware to test your code changes adequately against regressions, please indicate this, so that contributors and commnunity members can help test your changes.
- If your PR gets accepted you can request a "Contributor" role in the Meshtastic Discord


## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
