### PR TITLE
New variant GaulixLCrp2040V1b platformio.ini

### DIFF
--- a/variants/GaulixLCrp2040V1b/platformio.ini
+++ b/variants/GaulixLCrp2040V1b/platformio.ini
@@ -1,0 +1,22 @@
+[env:GaulixLCrp2040V1b]
+extends = rp2040_base
+board = rakwireless_rak11300
+upload_protocol = picotool
+
+# add our variants files to the include and src paths
+build_flags = ${rp2040_base.build_flags} 
+  -DRAK11310
+  -Ivariants/rak11310
+  -DDEBUG_RP2040_PORT=Serial
+  -DRV3028_RTC=0x52
+  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m0plus"
+  #autorise le hardware remote
+  -DMESHTASTIC_EXCLUDE_REMOTEHARDWARE=0
+build_src_filter = ${rp2040_base.build_src_filter} +<../variants/rak11310> +<mesh/eth/> +<mesh/api/> +<mqtt/>
+lib_deps =
+  ${rp2040_base.lib_deps}
+  ${networking_base.lib_deps}
+  melopero/Melopero RV3028@^1.1.0
+  https://github.com/RAKWireless/RAK13800-W5100S.git#1.0.2
+debug_build_flags = ${rp2040_base.build_flags}, -g
+debug_tool = cmsis-dap ; for e.g. Picotool


### PR DESCRIPTION
https://gaulix.fr/carte-gaulix-low-cost-30dbm/ our new hardware in France

## 🙏 Thank you for sending in a pull request, here's some tips to get started!

### ❌ (Please delete all these tips and replace them with your text) ❌
- Before starting on some new big chunk of code, it it is optional but highly recommended to open an issue first
  to say "Hey, I think this idea X should be implemented and I'm starting work on it. My general plan is Y, any feedback
  is appreciated." This will allow other devs to potentially save you time by not accidentially duplicating work etc...
- Please do not check in files that don't have real changes
- Please do not reformat lines that you didn't have to change the code on
- We recommend using the [Visual Studio Code](https://platformio.org/install/ide?install=vscode) editor along with the ['Trunk Check' extension](https://marketplace.visualstudio.com/items?itemName=trunk.io) (In beta for windows, WSL2 for the linux version),
  because it automatically follows our indentation rules and its auto reformatting will not cause spurious changes to lines.
- If your PR fixes a bug, mention "fixes #bugnum" somewhere in your pull request description.
- If your other co-developers have comments on your PR please tweak as needed.
- Please also enable "Allow edits by maintainers".
- Please do not submit untested code.
- If you do not have the affected hardware to test your code changes adequately against regressions, please indicate this, so that contributors and commnunity members can help test your changes.
- If your PR gets accepted you can request a "Contributor" role in the Meshtastic Discord


## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
