### PR TITLE
Build and deploy event firmwares

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -5,14 +5,20 @@ concurrency:
 on:
   # # Triggers the workflow on push but only for the master branch
   push:
-    branches: [master, develop]
+    branches:
+      - master
+      - develop
+      - event/*
     paths-ignore:
       - "**.md"
       - version.properties
 
   # Note: This is different from "pull_request". Need to specify ref when doing checkouts.
   pull_request_target:
-    branches: [master, develop]
+    branches:
+      - master
+      - develop
+      - event/*
     paths-ignore:
       - "**.md"
       #- "**.yml"
@@ -32,12 +38,12 @@ jobs:
         name: Checkout base
       - id: jsonStep
         run: |
-          if [[ "${{ github.head_ref }}" == "" ]]; then
+          if [[ "$GITHUB_HEAD_REF" == "" ]]; then
             TARGETS=$(./bin/generate_ci_matrix.py ${{matrix.arch}})
           else  
             TARGETS=$(./bin/generate_ci_matrix.py ${{matrix.arch}} quick)
           fi
-          echo "Name: ${{ github.ref_name }} Base: ${{ github.base_ref }} } Ref: ${{ github.ref }} Targets: $TARGETS"
+          echo "Name: $GITHUB_REF_NAME Base: $GITHUB_BASE_REF Ref: $GITHUB_REF Targets: $TARGETS"
           echo "${{matrix.arch}}=$(jq -cn --argjson environments "$TARGETS" '{board: $environments}')" >> $GITHUB_OUTPUT
     outputs:
       esp32: ${{ steps.jsonStep.outputs.esp32 }}
@@ -195,17 +201,6 @@ jobs:
       runs-on: ubuntu-24.04-arm
       push: false
 
-  after-checks:
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'workflow_dispatch' }}
-    needs: [check]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
-
   gather-artifacts:
     permissions:
       contents: write
@@ -350,7 +345,7 @@ jobs:
           merge-multiple: true
           path: ./output/pio-deps-native-tft
 
-      - name: Zip linux sources
+      - name: Zip Linux sources
         working-directory: output
         run: |
           zip -j -9 -r ./meshtasticd-${{ steps.version.outputs.deb }}-src.zip ./debian-src
@@ -360,7 +355,9 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -lR
 
-      - name: Add linux sources to release
+      - name: Add Linux sources to GtiHub Release
+        # Only run when targeting master branch with workflow_dispatch
+        if: ${{ github.ref_name == 'master' }}
         run: |
           gh release upload v${{ steps.version.outputs.long }} ./output/meshtasticd-${{ steps.version.outputs.deb }}-src.zip
           gh release upload v${{ steps.version.outputs.long }} ./output/platformio-deps-native-tft-${{ steps.version.outputs.long }}.zip
@@ -418,9 +415,28 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -lR
 
-      - name: Add bins and debug elfs to release
+      - name: Add bins and debug elfs to GitHub Release
+        # Only run when targeting master branch with workflow_dispatch
+        if: ${{ github.ref_name == 'master' }}
         run: |
           gh release upload v${{ steps.version.outputs.long }} ./firmware-${{matrix.arch}}-${{ steps.version.outputs.long }}.zip
           gh release upload v${{ steps.version.outputs.long }} ./debug-elfs-${{matrix.arch}}-${{ steps.version.outputs.long }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish firmware to meshtastic.github.io
+        uses: peaceiris/actions-gh-pages@v4
+        env:
+          # On event/* branches, use the event name as the destination prefix
+          DEST_PREFIX: ${{ contains(github.ref_name, 'event/') && format('{0}/', github.ref_name) || '' }}
+        with:
+          deploy_key: ${{ secrets.DIST_PAGES_DEPLOY_KEY }}
+          external_repository: meshtastic/meshtastic.github.io
+          publish_branch: master
+          publish_dir: ./output
+          destination_dir: ${{ env.DEST_PREFIX }}firmware-${{ steps.version.outputs.long }}
+          keep_files: true
+          user_name: github-actions[bot]
+          user_email: github-actions[bot]@users.noreply.github.com
+          commit_message: ${{ steps.version.outputs.long }} ${{ matrix.arch }}
+          enable_jekyll: true


### PR DESCRIPTION
Build and deploy firmware for Events from branches named `event/*`

Also adds automated uploads to [meshtastic.github.io](https://github.com/meshtastic/meshtastic.github.io) using the same methodology that we use on [meshtastic/openwrt](https://github.com/meshtastic/openwrt) and [meshtastic/openwrt-repo](https://github.com/meshtastic/openwrt-repo)

Firmwares uploaded to meshtastic.github.io will keep the current folder structure. Event firmwares will be prefixed with their branch name

```
# Example layout of meshtastic.github.io
# including build from `event/defcon33`:
|- firmware-2.6.4.b89355f
|- firmware-2.6.5.fc3d9f2
|- event
  |- defcon33
    |- firmware-2.6.6.deadcab
```