### PR TITLE
Fix preamble detected IRQ flag

### DIFF
--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -247,8 +247,8 @@ template <typename T> void LR11x0Interface<T>::startReceive()
     lora.setPreambleLength(preambleLength); // Solve RX ack fail after direct message sent.  Not sure why this is needed.
 
     // We use a 16 bit preamble so this should save some power by letting radio sit in standby mostly.
-    // Furthermore, we need the PREAMBLE_DETECTED and HEADER_VALID IRQ flag to detect whether we are actively receiving
-    int err = lora.startReceive(RADIOLIB_LR11X0_RX_TIMEOUT_INF, RADIOLIB_IRQ_RX_DEFAULT_FLAGS, RADIOLIB_IRQ_RX_DEFAULT_MASK, 0);
+    int err =
+        lora.startReceive(RADIOLIB_LR11X0_RX_TIMEOUT_INF, MESHTASTIC_RADIOLIB_IRQ_RX_FLAGS, RADIOLIB_IRQ_RX_DEFAULT_MASK, 0);
     assert(err == RADIOLIB_ERR_NONE);
 
     RadioLibInterface::startReceive();

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -16,6 +16,9 @@
 
 #define RADIOLIB_PIN_TYPE uint32_t
 
+// In addition to the default Rx flags, we need the PREAMBLE_DETECTED flag to detect whether we are actively receiving
+#define MESHTASTIC_RADIOLIB_IRQ_RX_FLAGS (RADIOLIB_IRQ_RX_DEFAULT_FLAGS | (1 << RADIOLIB_IRQ_PREAMBLE_DETECTED))
+
 /**
  * We need to override the RadioLib ArduinoHal class to add mutex protection for SPI bus access
  */

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -277,8 +277,7 @@ template <typename T> void SX126xInterface<T>::startReceive()
     setStandby();
 
     // We use a 16 bit preamble so this should save some power by letting radio sit in standby mostly.
-    // Furthermore, we need the PREAMBLE_DETECTED and HEADER_VALID IRQ flag to detect whether we are actively receiving
-    int err = lora.startReceiveDutyCycleAuto(preambleLength, 8, RADIOLIB_IRQ_RX_DEFAULT_FLAGS | RADIOLIB_IRQ_PREAMBLE_DETECTED);
+    int err = lora.startReceiveDutyCycleAuto(preambleLength, 8, MESHTASTIC_RADIOLIB_IRQ_RX_FLAGS);
     if (err != RADIOLIB_ERR_NONE)
         LOG_ERROR("SX126X startReceiveDutyCycleAuto %s%d", radioLibErr, err);
     assert(err == RADIOLIB_ERR_NONE);

--- a/src/mesh/SX128xInterface.cpp
+++ b/src/mesh/SX128xInterface.cpp
@@ -260,8 +260,7 @@ template <typename T> void SX128xInterface<T>::startReceive()
 #endif
 #endif
 
-    // We use the PREAMBLE_DETECTED and HEADER_VALID IRQ flag to detect whether we are actively receiving
-    int err = lora.startReceive(RADIOLIB_SX128X_RX_TIMEOUT_INF, RADIOLIB_IRQ_RX_DEFAULT_FLAGS | RADIOLIB_IRQ_PREAMBLE_DETECTED);
+    int err = lora.startReceive(RADIOLIB_SX128X_RX_TIMEOUT_INF, MESHTASTIC_RADIOLIB_IRQ_RX_FLAGS);
 
     if (err != RADIOLIB_ERR_NONE)
         LOG_ERROR("SX128X startReceive %s%d", radioLibErr, err);


### PR DESCRIPTION
As reported by Discord user johntitor, #4621 caused the `PREAMBLE_DETECTED` IRQ flag not to be set anymore. The generic IRQ flags are an enum representing a bit position and hence must be shifted, instead of being the mask already. We got "lucky" that bit 2 is actually `RX_DONE`, which was set already.

Since those are now generic flags, I added the definition in RadioLibInterface. Confirmed that SX126x radio now occasionally shows "Ignore false preamble detection" again.
LR11x0 has all flags enabled by default, so it doesn't actually affect that radio.

## 🤝 Attestations
- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [X] Seeed Studio T-1000E tracker card
  - [X] LilyGo T-Echo
