### PR TITLE
Fix building WiPhone variant

### DIFF
--- a/variants/wiphone/variant.h
+++ b/variants/wiphone/variant.h
@@ -24,7 +24,7 @@
 // This board has no GPS or Screen for now
 #undef GPS_RX_PIN
 #undef GPS_TX_PIN
-#define NO_GPS
+#define NO_GPS 1
 #define HAS_GPS 0
 #define NO_SCREEN
 #define HAS_SCREEN 0


### PR DESCRIPTION
One small typo with a macro in variant.h

## 🤝 Attestations
- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
