### PR TITLE
Fix create pull request

### DIFF
--- a/.github/workflows/release_channels.yml
+++ b/.github/workflows/release_channels.yml
@@ -95,6 +95,8 @@ jobs:
           pip install -r bin/bump_metainfo/requirements.txt -q
           chmod +x ./bin/bump_metainfo/bump_metainfo.py
           ./bin/bump_metainfo/bump_metainfo.py --file bin/org.meshtastic.meshtasticd.metainfo.xml "${{ steps.version.outputs.short }}"
+        env:
+          PIP_DISABLE_PIP_VERSION_CHECK: 1
 
       - name: Create Bumps pull request
         uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/release_channels.yml
+++ b/.github/workflows/release_channels.yml
@@ -99,6 +99,7 @@ jobs:
       - name: Create Bumps pull request
         uses: peter-evans/create-pull-request@v7
         with:
+          base: ${{ github.event.repository.default_branch }}
           title: Bump release version
           commit-message: automated bumps
           add-paths: |

--- a/bin/org.meshtastic.meshtasticd.metainfo.xml
+++ b/bin/org.meshtastic.meshtasticd.metainfo.xml
@@ -87,6 +87,9 @@
   </screenshots>
 
   <releases>
+    <release version="2.6.7" date="2025-04-28">
+      <url type="details">https://github.com/meshtastic/firmware/releases?q=tag%3Av2.6.7</url>
+    </release>
     <release version="2.6.6" date="2025-04-15">
       <url type="details">https://github.com/meshtastic/firmware/releases?q=tag%3Av2.6.6</url>
     </release>

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 [VERSION]  
 major = 2
 minor = 6
-build = 6
+build = 7


### PR DESCRIPTION
- Quick fix for https://github.com/meshtastic/firmware/actions/runs/14713484251/job/41291395635#step:9:53.
  Turns out the default usage of `peter-evans/create-pull-request@v7` is to create a PR into the checked out branch.
  Adding `base: ${{ github.event.repository.default_branch }}` will target the PR to the default branch of the repo (in this case `master`). _hopefully_

- Include manual bump to 2.6.7. Due to the error in the previous run, the files did not get bumped on release publish.

- Also added `PIP_DISABLE_PIP_VERSION_CHECK=1` to the `bump_metainfo.py` step to tidy up the logs just a little bit more.
  > Notice:  A new release of pip is available: 25.0.1 -> 25.1
  > Notice:  To update, run: pip install --upgrade pip