### PR TITLE
Revert "meshtasticd: Set available.d dir in yaml (#6481)"

### DIFF
--- a/bin/config-dist.yaml
+++ b/bin/config-dist.yaml
@@ -197,6 +197,5 @@ General:
   MaxNodes: 200
   MaxMessageQueue: 100
   ConfigDirectory: /etc/meshtasticd/config.d/
-  AvailableDirectory: /etc/meshtasticd/available.d/
 #  MACAddress: AA:BB:CC:DD:EE:FF
 #  MACAddressSource: eth0

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -247,7 +247,7 @@ void portduinoSetup()
                 std::cerr << "autoconf: Unable to find config for " << autoconf_product << std::endl;
                 exit(EXIT_FAILURE);
             }
-            if (loadConfig((settingsStrings[available_directory] + product_config).c_str())) {
+            if (loadConfig(("/etc/meshtasticd/available.d/" + product_config).c_str())) {
                 std::cout << "autoconf: Using " << product_config << " as config file for " << autoconf_product << std::endl;
             } else {
                 std::cerr << "autoconf: Unable to use " << product_config << " as config file for " << autoconf_product
@@ -602,8 +602,6 @@ bool loadConfig(const char *configPath)
             settingsMap[maxnodes] = (yamlConfig["General"]["MaxNodes"]).as<int>(200);
             settingsMap[maxtophone] = (yamlConfig["General"]["MaxMessageQueue"]).as<int>(100);
             settingsStrings[config_directory] = (yamlConfig["General"]["ConfigDirectory"]).as<std::string>("");
-            settingsStrings[available_directory] =
-                (yamlConfig["General"]["AvailableDirectory"]).as<std::string>("/etc/meshtasticd/available.d/");
             if ((yamlConfig["General"]["MACAddress"]).as<std::string>("") != "" &&
                 (yamlConfig["General"]["MACAddressSource"]).as<std::string>("") != "") {
                 std::cout << "Cannot set both MACAddress and MACAddressSource!" << std::endl;

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -99,7 +99,6 @@ enum configNames {
     maxnodes,
     ascii_logs,
     config_directory,
-    available_directory,
     mac_address
 };
 enum { no_screen, x11, st7789, st7735, st7735s, st7796, ili9341, ili9342, ili9486, ili9488, hx8357d };


### PR DESCRIPTION
This reverts commit ef18a9b5b5a2a756ad15009ce9cd7e0b7717d077.

Fixes #6683, I have not tried to understand *why* this work, this was found by `git bisect`:
```
git bisect start
# status: waiting for both good and bad commits
# bad: [b4e8f7dbb656518aa277869358f56201dc8eb14e] Update Adafruit BusIO digest to 159f86a (#6681)
git bisect bad b4e8f7dbb656518aa277869358f56201dc8eb14e
# status: waiting for good commit(s), bad commit known
# good: [6429eca5e47aa1d438012a9886632a5cdbbec898] udp-multicast: do not listen for incoming udp multicast packets if disabled (#6397)
git bisect good 6429eca5e47aa1d438012a9886632a5cdbbec898
# bad: [1b1d4625aa83c8a76855422db1dfc19846fdb125] chore: update ubx.h (#6522)
git bisect bad 1b1d4625aa83c8a76855422db1dfc19846fdb125
# good: [89cde1a8e61344f1f0ff80a12bd338f587c529a0] udp-multicast: bump platform-native to UDP with error handling support (#6433)
git bisect good 89cde1a8e61344f1f0ff80a12bd338f587c529a0
# good: [2c01fad798e17bcc5e6feb4644ba15c12e32fffa] meshtasticd: Add FrequencyLabs MeshAdv-Mini Hat (#6458)
git bisect good 2c01fad798e17bcc5e6feb4644ba15c12e32fffa
# bad: [01102754945ac2bc8d52062fcb2b4a446ea35b35] Revert "Try-fix ESP32 wifi disconnects (#6363)" (#6493)
git bisect bad 01102754945ac2bc8d52062fcb2b4a446ea35b35
# bad: [ef18a9b5b5a2a756ad15009ce9cd7e0b7717d077] meshtasticd: Set available.d dir in yaml (#6481)
git bisect bad ef18a9b5b5a2a756ad15009ce9cd7e0b7717d077
# good: [ea4ce8d827d45e82e7ce5b377d956e324f80733c] MUI unPhone-tft: fix defaults (#6477)
git bisect good ea4ce8d827d45e82e7ce5b377d956e324f80733c
# good: [f6ed10f3298abf6896892ca7906d3231c8b3f567] Added initial support for Texas Instruments LP5562 (#6381)
git bisect good f6ed10f3298abf6896892ca7906d3231c8b3f567
# good: [67fddcc2142bed7e6748d0a5485d4848f32856fc] Upgrade trunk (#6480)
git bisect good 67fddcc2142bed7e6748d0a5485d4848f32856fc
# first bad commit: [ef18a9b5b5a2a756ad15009ce9cd7e0b7717d077] meshtasticd: Set available.d dir in yaml (#6481)
```
I have tested this patch and it does work as expected after reverting.