### PR TITLE
udp-multicast: remove the thread from the multicast thread API

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -124,8 +124,8 @@ extern void tftSetup(void);
 #endif
 
 #ifdef HAS_UDP_MULTICAST
-#include "mesh/udp/UdpMulticastThread.h"
-UdpMulticastThread *udpThread = nullptr;
+#include "mesh/udp/UdpMulticastHandler.h"
+UdpMulticastHandler *udpHandler = nullptr;
 #endif
 
 #if defined(TCXO_OPTIONAL)
@@ -918,12 +918,12 @@ void setup()
 
 #ifdef HAS_UDP_MULTICAST
     LOG_DEBUG("Start multicast thread");
-    udpThread = new UdpMulticastThread();
+    udpHandler = new UdpMulticastHandler();
 #ifdef ARCH_PORTDUINO
     // FIXME: portduino does not ever call onNetworkConnected so call it here because I don't know what happen if I call
     // onNetworkConnected there
     if (config.network.enabled_protocols & meshtastic_Config_NetworkConfig_ProtocolFlags_UDP_BROADCAST) {
-        udpThread->start();
+        udpHandler->start();
     }
 #endif
 #endif

--- a/src/main.h
+++ b/src/main.h
@@ -51,8 +51,8 @@ extern AudioThread *audioThread;
 #endif
 
 #ifdef HAS_UDP_MULTICAST
-#include "mesh/udp/UdpMulticastThread.h"
-extern UdpMulticastThread *udpThread;
+#include "mesh/udp/UdpMulticastHandler.h"
+extern UdpMulticastHandler *udpHandler;
 #endif
 
 // Global Screen singleton.

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -293,8 +293,8 @@ ErrorCode Router::send(meshtastic_MeshPacket *p)
     }
 
 #if HAS_UDP_MULTICAST
-    if (udpThread && config.network.enabled_protocols & meshtastic_Config_NetworkConfig_ProtocolFlags_UDP_BROADCAST) {
-        udpThread->onSend(const_cast<meshtastic_MeshPacket *>(p));
+    if (udpHandler && config.network.enabled_protocols & meshtastic_Config_NetworkConfig_ProtocolFlags_UDP_BROADCAST) {
+        udpHandler->onSend(const_cast<meshtastic_MeshPacket *>(p));
     }
 #endif
 

--- a/src/mesh/udp/UdpMulticastHandler.h
+++ b/src/mesh/udp/UdpMulticastHandler.h
@@ -13,12 +13,11 @@
 #endif // HAS_ETHERNET
 
 #define UDP_MULTICAST_DEFAUL_PORT 4403 // Default port for UDP multicast is same as TCP api server
-#define UDP_MULTICAST_THREAD_INTERVAL_MS 15000
 
-class UdpMulticastThread final
+class UdpMulticastHandler final
 {
   public:
-    UdpMulticastThread() { udpIpAddress = IPAddress(224, 0, 0, 69); }
+    UdpMulticastHandler() { udpIpAddress = IPAddress(224, 0, 0, 69); }
 
     void start()
     {

--- a/src/mesh/udp/UdpMulticastThread.h
+++ b/src/mesh/udp/UdpMulticastThread.h
@@ -15,10 +15,10 @@
 #define UDP_MULTICAST_DEFAUL_PORT 4403 // Default port for UDP multicast is same as TCP api server
 #define UDP_MULTICAST_THREAD_INTERVAL_MS 15000
 
-class UdpMulticastThread : public concurrency::OSThread
+class UdpMulticastThread final
 {
   public:
-    UdpMulticastThread() : OSThread("UdpMulticast") { udpIpAddress = IPAddress(224, 0, 0, 69); }
+    UdpMulticastThread() { udpIpAddress = IPAddress(224, 0, 0, 69); }
 
     void start()
     {
@@ -69,14 +69,6 @@ class UdpMulticastThread : public concurrency::OSThread
         size_t encodedLength = pb_encode_to_bytes(buffer, sizeof(buffer), &meshtastic_MeshPacket_msg, mp);
         udp.writeTo(buffer, encodedLength, udpIpAddress, UDP_MULTICAST_DEFAUL_PORT);
         return true;
-    }
-
-  protected:
-    int32_t runOnce() override
-    {
-        canSleep = true;
-        // TODO: Implement nodeinfo broadcast
-        return UDP_MULTICAST_THREAD_INTERVAL_MS;
     }
 
   private:

--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -133,8 +133,8 @@ static void onNetworkConnected()
     }
 
 #if HAS_UDP_MULTICAST
-    if (udpThread && config.network.enabled_protocols & meshtastic_Config_NetworkConfig_ProtocolFlags_UDP_BROADCAST) {
-        udpThread->start();
+    if (udpHandler && config.network.enabled_protocols & meshtastic_Config_NetworkConfig_ProtocolFlags_UDP_BROADCAST) {
+        udpHandler->start();
     }
 #endif
 }


### PR DESCRIPTION
The whole API is parallel & asynchronous we don't need to start a thread ourself,
the implementation probably does when we call start listening already.