### PR TITLE
Update 'Adafruit BusIO' to 1.17.1

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -113,8 +113,8 @@ lib_deps =
 ; Common libs for environmental measurements in telemetry module
 [environmental_base]
 lib_deps =
-	# renovate: datasource=git-refs depName=Adafruit BusIO packageName=https://github.com/adafruit/Adafruit_BusIO gitBranch=master
-	https://github.com/adafruit/Adafruit_BusIO/archive/159f86a3bd64485227f63ef2f60abe35877051d0.zip
+	# renovate: datasource=custom.pio depName=Adafruit BusIO packageName=adafruit/library/Adafruit BusIO
+	adafruit/Adafruit BusIO@1.17.1
 	# renovate: datasource=custom.pio depName=Adafruit Unified Sensor packageName=adafruit/library/Adafruit Unified Sensor
 	adafruit/Adafruit Unified Sensor@1.1.15
 	# renovate: datasource=custom.pio depName=Adafruit BMP280 packageName=adafruit/library/Adafruit BMP280 Library


### PR DESCRIPTION
Update Adafruit BusIO to 1.17.1 -- incorporating @jp-bennett's change for Portduino.

https://github.com/adafruit/Adafruit_BusIO/pull/144