### PR TITLE
Add 100 msecond delay in tft_task_handler when deviceScreen is null

### DIFF
--- a/arch/portduino/portduino.ini
+++ b/arch/portduino/portduino.ini
@@ -2,7 +2,7 @@
 [portduino_base]
 platform =
   # renovate: datasource=git-refs depName=platform-native packageName=https://github.com/meshtastic/platform-native gitBranch=develop
-  https://github.com/meshtastic/platform-native/archive/e19f77e034590669feaaf26214667b76d0821d06.zip
+  https://github.com/meshtastic/platform-native/archive/622341c6de8a239704318b10c3dbb00c21a3eab3.zip
 framework = arduino
 
 build_src_filter = 

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -31,6 +31,8 @@ void tft_task_handler(void *param = nullptr)
             deviceScreen->task_handler();
             spiLock->unlock();
             deviceScreen->sleep();
+        } else {
+            delay(100);
         }
     }
 }

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -27,12 +27,10 @@ CallbackObserver<DeviceScreen, esp_sleep_wakeup_cause_t> endSleepObserver =
 void tft_task_handler(void *param = nullptr)
 {
     while (true) {
-        if (deviceScreen) {
-            spiLock->lock();
-            deviceScreen->task_handler();
-            spiLock->unlock();
-            deviceScreen->sleep();
-        }
+        spiLock->lock();
+        deviceScreen->task_handler();
+        spiLock->unlock();
+        deviceScreen->sleep();
     }
 }
 

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -11,6 +11,7 @@
 
 #ifdef ARCH_PORTDUINO
 #include "PortduinoGlue.h"
+#include <thread>
 #endif
 
 DeviceScreen *deviceScreen = nullptr;
@@ -31,8 +32,6 @@ void tft_task_handler(void *param = nullptr)
             deviceScreen->task_handler();
             spiLock->unlock();
             deviceScreen->sleep();
-        } else {
-            delay(100);
         }
     }
 }
@@ -118,11 +117,15 @@ void tftSetup(void)
     }
 #endif
 
+    if (deviceScreen) {
 #ifdef ARCH_ESP32
-    tftSleepObserver.observe(&notifyLightSleep);
-    endSleepObserver.observe(&notifyLightSleepEnd);
-    xTaskCreatePinnedToCore(tft_task_handler, "tft", 10240, NULL, 1, NULL, 0);
+        tftSleepObserver.observe(&notifyLightSleep);
+        endSleepObserver.observe(&notifyLightSleepEnd);
+        xTaskCreatePinnedToCore(tft_task_handler, "tft", 10240, NULL, 1, NULL, 0);
+#elif defined(ARCH_PORTDUINO)
+        std::thread *tft_task = new std::thread([] { tft_task_handler(); });
 #endif
+    }
 }
 
 #endif


### PR DESCRIPTION
This fixes the 100% device usage bug observed on Native Linux