### PR TITLE
MUI: native frame buffer support

### DIFF
--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -43,16 +43,24 @@ void tftSetup(void)
 #else
     if (settingsMap[displayPanel] != no_screen) {
         DisplayDriverConfig displayConfig;
-        static char *panels[] = {"NOSCREEN", "X11",     "ST7789",  "ST7735",  "ST7735S", "ST7796",
-                                 "ILI9341",  "ILI9342", "ILI9486", "ILI9488", "HX8357D"};
+        static char *panels[] = {"NOSCREEN", "X11",     "FB",      "ST7789",  "ST7735",  "ST7735S",
+                                 "ST7796",   "ILI9341", "ILI9342", "ILI9486", "ILI9488", "HX8357D"};
         static char *touch[] = {"NOTOUCH", "XPT2046", "STMPE610", "GT911", "FT5x06"};
-#ifdef USE_X11
+#if defined(USE_X11)
         if (settingsMap[displayPanel] == x11) {
             if (settingsMap[displayWidth] && settingsMap[displayHeight])
                 displayConfig = DisplayDriverConfig(DisplayDriverConfig::device_t::X11, (uint16_t)settingsMap[displayWidth],
                                                     (uint16_t)settingsMap[displayHeight]);
             else
                 displayConfig.device(DisplayDriverConfig::device_t::X11);
+        } else
+#elif defined(USE_FRAMEBUFFER)
+        if (settingsMap[displayPanel] == fb) {
+            if (settingsMap[displayWidth] && settingsMap[displayHeight])
+                displayConfig = DisplayDriverConfig(DisplayDriverConfig::device_t::FB, (uint16_t)settingsMap[displayWidth],
+                                                    (uint16_t)settingsMap[displayHeight]);
+            else
+                displayConfig.device(DisplayDriverConfig::device_t::FB);
         } else
 #endif
         {

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -531,6 +531,8 @@ bool loadConfig(const char *configPath)
                 settingsMap[displayPanel] = hx8357d;
             else if (yamlConfig["Display"]["Panel"].as<std::string>("") == "X11")
                 settingsMap[displayPanel] = x11;
+            else if (yamlConfig["Display"]["Panel"].as<std::string>("") == "FB")
+                settingsMap[displayPanel] = fb;
             settingsMap[displayHeight] = yamlConfig["Display"]["Height"].as<int>(0);
             settingsMap[displayWidth] = yamlConfig["Display"]["Width"].as<int>(0);
             settingsMap[displayDC] = yamlConfig["Display"]["DC"].as<int>(-1);

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -102,7 +102,7 @@ enum configNames {
     available_directory,
     mac_address
 };
-enum { no_screen, x11, st7789, st7735, st7735s, st7796, ili9341, ili9342, ili9486, ili9488, hx8357d };
+enum { no_screen, x11, fb, st7789, st7735, st7735s, st7796, ili9341, ili9342, ili9486, ili9488, hx8357d };
 enum { no_touchscreen, xpt2046, stmpe610, gt911, ft5x06 };
 enum { level_error, level_warn, level_info, level_debug, level_trace };
 

--- a/variants/portduino/platformio.ini
+++ b/variants/portduino/platformio.ini
@@ -43,6 +43,37 @@ build_src_filter =
   ${native_base.build_src_filter}
   -<graphics/TFTDisplay.cpp>
 
+[env:native-fb]
+extends = native_base
+build_type = release
+lib_deps =
+  ${native_base.lib_deps}
+  ${device-ui_base.lib_deps}
+board_level = extra
+build_flags = ${native_base.build_flags} -Os -ffunction-sections -fdata-sections -Wl,--gc-sections
+  -D MESHTASTIC_EXCLUDE_CANNEDMESSAGES=1
+  -D RAM_SIZE=8192
+  -D USE_FRAMEBUFFER=1
+  -D LV_COLOR_DEPTH=32
+  -D HAS_TFT=1
+  -D HAS_SCREEN=0
+  -D LV_BUILD_TEST=0
+  -D LV_USE_LOG=0
+  -D LV_USE_EVDEV=1
+  -D LV_LVGL_H_INCLUDE_SIMPLE
+  -D LV_CONF_INCLUDE_SIMPLE
+  -D LV_COMP_CONF_INCLUDE_SIMPLE
+  -D USE_LOG_DEBUG
+  -D LOG_DEBUG_INC=\"DebugConfiguration.h\"
+  -D USE_PACKET_API
+  -D VIEW_320x240
+  -D MAP_FULL_REDRAW
+  !pkg-config --libs libulfius --silence-errors || :
+  !pkg-config --libs openssl --silence-errors || :
+build_src_filter =
+  ${native_base.build_src_filter}
+  -<graphics/TFTDisplay.cpp>
+
 [env:native-tft-debug]
 extends = native_base
 build_type = debug


### PR DESCRIPTION
MUI frame buffer support for Linux /dev/fb0

For now it needs a new target definition (`native-fb`).

In _config.yaml_ define:
```
  Panel: FB
```

All input devices (mouse, keyboard, touchpad, ...) are auto-detected.

See also https://github.com/meshtastic/device-ui/pull/124

![IMG_0160](https://github.com/user-attachments/assets/3535f138-37ca-448e-9745-e208649b8734)


## 🤝 Attestations
- [X] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [X] Other (please specify below)
    - Raspberry Pi 5