### PR TITLE
router: on linux add a mutex around the queue

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -64,6 +64,10 @@ Router::Router() : concurrency::OSThread("Router"), fromRadioQueue(MAX_RX_FROMRA
  */
 int32_t Router::runOnce()
 {
+#ifdef ARCH_PORTDUINO
+    const std::lock_guard<std::mutex> lock(queueMutex);
+#endif
+
     meshtastic_MeshPacket *mp;
     while ((mp = fromRadioQueue.dequeuePtr(0)) != NULL) {
         // printPacket("handle fromRadioQ", mp);
@@ -80,6 +84,10 @@ int32_t Router::runOnce()
  */
 void Router::enqueueReceivedMessage(meshtastic_MeshPacket *p)
 {
+#ifdef ARCH_PORTDUINO
+    const std::lock_guard<std::mutex> lock(queueMutex);
+#endif
+
     // Try enqueue until successful
     while (!fromRadioQueue.enqueue(p, 0)) {
         meshtastic_MeshPacket *old_p;

--- a/src/mesh/Router.h
+++ b/src/mesh/Router.h
@@ -8,6 +8,9 @@
 #include "PointerQueue.h"
 #include "RadioInterface.h"
 #include "concurrency/OSThread.h"
+#ifdef ARCH_PORTDUINO
+#include <mutex>
+#endif
 
 /**
  * A mesh aware router that supports multiple interfaces.
@@ -18,6 +21,12 @@ class Router : protected concurrency::OSThread, protected PacketHistory
     /// Packets which have just arrived from the radio, ready to be processed by this service and possibly
     /// forwarded to the phone.
     PointerQueue<meshtastic_MeshPacket> fromRadioQueue;
+
+#ifdef ARCH_PORTDUINO
+    /// linux calls enqueueReceivedMessage from an other thread when receiving UDP packets,
+    /// to avoid a data race with LoRa, lock that method.
+    std::mutex queueMutex;
+#endif
 
   protected:
     RadioInterface *iface = NULL;


### PR DESCRIPTION
UDP reception happens on an other thread, avoid data races and potential data corruption issues.