### PR TITLE
Update ICM 20948 to latest release, move out of extra

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -161,7 +161,9 @@ lib_deps =
 	robtillaart/INA226@0.6.4
 	# renovate: datasource=custom.pio depName=SparkFun MAX3010x packageName=sparkfun/library/SparkFun MAX3010x Pulse and Proximity Sensor Library
 	sparkfun/SparkFun MAX3010x Pulse and Proximity Sensor Library@1.1.2
-
+	# renovate: datasource=custom.pio depName=SparkFun 9DoF IMU Breakout ICM 20948 packageName=sparkfun/library/SparkFun 9DoF IMU Breakout - ICM 20948 - Arduino Library
+	sparkfun/SparkFun 9DoF IMU Breakout - ICM 20948 - Arduino Library@1.3.0
+ 
 ; (not included in native / portduino)
 [environmental_extra]
 lib_deps =
@@ -181,8 +183,6 @@ lib_deps =
 	adafruit/Adafruit SHT4x Library@1.0.5
 	# renovate: datasource=custom.pio depName=SparkFun Qwiic Scale NAU7802 packageName=sparkfun/library/SparkFun Qwiic Scale NAU7802 Arduino Library
 	sparkfun/SparkFun Qwiic Scale NAU7802 Arduino Library@1.0.6
-	# renovate: datasource=custom.pio depName=SparkFun 9DoF IMU Breakout ICM 20948 packageName=sparkfun/library/SparkFun 9DoF IMU Breakout - ICM 20948 - Arduino Library
-	sparkfun/SparkFun 9DoF IMU Breakout - ICM 20948 - Arduino Library@1.3.0
 	# renovate: datasource=custom.pio depName=ClosedCube OPT3001 packageName=closedcube/library/ClosedCube OPT3001
 	ClosedCube OPT3001@1.1.2
 	# renovate: datasource=github-tags depName=Bosch BSEC2 packageName=boschsensortec/Bosch-BSEC2-Library


### PR DESCRIPTION
My fix for PORTDUINO landed in the upstream 20948 library, and they already bumped the version. So update here.