### PR TITLE
Update XIAO_NRF_KIT RXEN Pin definition

### DIFF
--- a/variants/seeed_xiao_nrf52840_kit/variant.h
+++ b/variants/seeed_xiao_nrf52840_kit/variant.h
@@ -114,8 +114,8 @@ static const uint8_t SCK = PIN_SPI_SCK;
 
 #define SX126X_TXEN RADIOLIB_NC
 
-#define SX126X_RXEN D4
-#define SX126X_DIO2_AS_RF_SWITCH // DIO2 is used to control the RF switch really necessary!!!
+#define SX126X_RXEN D5           // This is used to control the RX side of the RF switch
+#define SX126X_DIO2_AS_RF_SWITCH // DIO2 is used to control the TX side of the RF switch
 #define SX126X_DIO3_TCXO_VOLTAGE 1.8
 
 /*


### PR DESCRIPTION
The XIAO NRF kit comes with a hat which has a slightly different pinout than the one supplied with the XIAO S3. At the last update, the RXEN pin was not moved with the rest.

[XIAO NRF pinout](https://wiki.seeedstudio.com/xiao_nrf52840&_wio_SX1262_kit_for_meshtastic/#pinout)
[XIAO S3 pintout](https://wiki.seeedstudio.com/wio_sx1262_and_xiao_esp32s3_kit_with_3dprinted_enclosure_introduction_and_assembly_guide/#hardware-overview)

I opened issue #6688 to address this, but given that its a straightforward change it seemed a good idea... It can be converted to draft if necessary.


## 🤝 Attestations
- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
