### PR TITLE
Lock SPI bus while in use by InkHUD

### DIFF
--- a/src/graphics/niche/Drivers/EInk/LCMEN2R13EFC1.cpp
+++ b/src/graphics/niche/Drivers/EInk/LCMEN2R13EFC1.cpp
@@ -1,8 +1,10 @@
-#include "./LCMEN2R13EFC1.h"
-
 #ifdef MESHTASTIC_INCLUDE_NICHE_GRAPHICS
 
+#include "./LCMEN2R13EFC1.h"
+
 #include <assert.h>
+
+#include "SPILock.h"
 
 using namespace NicheGraphics::Drivers;
 
@@ -150,6 +152,9 @@ void LCMEN213EFC1::reset()
 
 void LCMEN213EFC1::sendCommand(const uint8_t command)
 {
+    // Take firmware's SPI lock
+    spiLock->lock();
+
     spi->beginTransaction(spiSettings);
     digitalWrite(pin_dc, LOW); // DC pin low indicates command
     digitalWrite(pin_cs, LOW);
@@ -157,6 +162,8 @@ void LCMEN213EFC1::sendCommand(const uint8_t command)
     digitalWrite(pin_cs, HIGH);
     digitalWrite(pin_dc, HIGH);
     spi->endTransaction();
+
+    spiLock->unlock();
 }
 
 void LCMEN213EFC1::sendData(uint8_t data)
@@ -166,6 +173,9 @@ void LCMEN213EFC1::sendData(uint8_t data)
 
 void LCMEN213EFC1::sendData(const uint8_t *data, uint32_t size)
 {
+    // Take firmware's SPI lock
+    spiLock->lock();
+
     spi->beginTransaction(spiSettings);
     digitalWrite(pin_dc, HIGH); // DC pin HIGH indicates data, instead of command
     digitalWrite(pin_cs, LOW);
@@ -183,6 +193,8 @@ void LCMEN213EFC1::sendData(const uint8_t *data, uint32_t size)
     digitalWrite(pin_cs, HIGH);
     digitalWrite(pin_dc, HIGH);
     spi->endTransaction();
+
+    spiLock->unlock();
 }
 
 void LCMEN213EFC1::configFull()

--- a/src/graphics/niche/Drivers/EInk/SSD16XX.cpp
+++ b/src/graphics/niche/Drivers/EInk/SSD16XX.cpp
@@ -1,6 +1,9 @@
+#ifdef MESHTASTIC_INCLUDE_NICHE_GRAPHICS
+
 #include "./SSD16XX.h"
 
-#ifdef MESHTASTIC_INCLUDE_NICHE_GRAPHICS
+#include "SPILock.h"
+
 using namespace NicheGraphics::Drivers;
 
 SSD16XX::SSD16XX(uint16_t width, uint16_t height, UpdateTypes supported, uint8_t bufferOffsetX)
@@ -82,6 +85,9 @@ void SSD16XX::sendCommand(const uint8_t command)
     if (failed)
         return;
 
+    // Take firmware's SPI lock
+    spiLock->lock();
+
     spi->beginTransaction(spiSettings);
     digitalWrite(pin_dc, LOW); // DC pin low indicates command
     digitalWrite(pin_cs, LOW);
@@ -89,6 +95,8 @@ void SSD16XX::sendCommand(const uint8_t command)
     digitalWrite(pin_cs, HIGH);
     digitalWrite(pin_dc, HIGH);
     spi->endTransaction();
+
+    spiLock->unlock();
 }
 
 void SSD16XX::sendData(uint8_t data)
@@ -102,6 +110,9 @@ void SSD16XX::sendData(const uint8_t *data, uint32_t size)
     // This will unlock again once we have failed-through the entire process
     if (failed)
         return;
+
+    // Take firmware's SPI lock
+    spiLock->lock();
 
     spi->beginTransaction(spiSettings);
     digitalWrite(pin_dc, HIGH); // DC pin HIGH indicates data, instead of command
@@ -119,6 +130,8 @@ void SSD16XX::sendData(const uint8_t *data, uint32_t size)
     digitalWrite(pin_cs, HIGH);
     digitalWrite(pin_dc, HIGH);
     spi->endTransaction();
+
+    spiLock->unlock();
 }
 
 void SSD16XX::configFullscreen()

--- a/src/graphics/niche/FlashData.h
+++ b/src/graphics/niche/FlashData.h
@@ -13,6 +13,7 @@ Avoid bloating everyone's protobuf code for our one-off UI implementations
 
 #include "configuration.h"
 
+#include "SPILock.h"
 #include "SafeFile.h"
 
 namespace NicheGraphics
@@ -46,6 +47,9 @@ template <typename T> class FlashData
   public:
     static bool load(T *data, const char *label)
     {
+        // Take firmware's SPI lock
+        concurrency::LockGuard guard(spiLock);
+
         // Set false if we run into issues
         bool okay = true;
 
@@ -103,14 +107,18 @@ template <typename T> class FlashData
         return okay;
     }
 
-    // Save module's custom data (settings?) to flash. Does use protobufs
+    // Save module's custom data (settings?) to flash. Doesn't use protobufs
+    // Takes the firmware's SPI lock, in case the files are stored on SD card
+    // Need to lock and unlock around specific FS methods, as the SafeFile class takes the lock for itself internally.
     static void save(T *data, const char *label)
     {
         // Get a filename based on the label
         std::string filename = getFilename(label);
 
 #ifdef FSCom
+        spiLock->lock();
         FSCom.mkdir("/NicheGraphics");
+        spiLock->unlock();
 
         auto f = SafeFile(filename.c_str(), true); // "true": full atomic. Write new data to temp file, then rename.
 
@@ -119,10 +127,10 @@ template <typename T> class FlashData
         // Calculate a hash of the data
         uint32_t hash = getHash(data);
 
+        spiLock->lock();
         f.write((uint8_t *)data, sizeof(T));     // Write the actual data
         f.write((uint8_t *)&hash, sizeof(hash)); // Append the hash
-
-        // f.flush();
+        spiLock->unlock();
 
         bool writeSucceeded = f.close();
 
@@ -138,6 +146,9 @@ template <typename T> class FlashData
 // Erase contents of the NicheGraphics data directory
 inline void clearFlashData()
 {
+
+    // Take firmware's SPI lock, in case the files are stored on SD card
+    concurrency::LockGuard guard(spiLock);
 
 #ifdef FSCom
     File dir = FSCom.open("/NicheGraphics"); // Open the directory


### PR DESCRIPTION
Follows https://github.com/meshtastic/firmware/pull/6637#issuecomment-2817077608
Adds the usual `concurrency::Lock` around SPI and filesystem calls in the InkHUD code. 

This shouldn't actually be required by any of InkHUD's features. Just handling it now as a bit of future proofing.

## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - LilyGo T-Echo 
    - Heltec Wireless Paper
    - Heltec Vision Master E290