### PR TITLE
chore(deps): update Bosch BSEC2 to v1.8.2610, BME68x to v1.2.40408

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -148,7 +148,7 @@ lib_deps =
 	# renovate: datasource=custom.pio depName=Adafruit MLX90614 packageName=adafruit/library/Adafruit MLX90614 Library
 	adafruit/Adafruit MLX90614 Library@2.1.5
 	# renovate: datasource=custom.pio depName=Bosch BME68x packageName=boschsensortec/library/BME68x Sensor Library
-	boschsensortec/BME68x Sensor Library@1.1.40407
+	boschsensortec/BME68x Sensor Library@1.2.40408
 	# renovate: datasource=github-tags depName=INA3221 packageName=KodinLanewave/INA3221
 	https://github.com/KodinLanewave/INA3221/archive/1.0.1.zip
 	# renovate: datasource=custom.pio depName=QMC5883L Compass packageName=mprograms/library/QMC5883LCompass
@@ -185,7 +185,7 @@ lib_deps =
 	sparkfun/SparkFun 9DoF IMU Breakout - ICM 20948 - Arduino Library@1.3.0
 	# renovate: datasource=custom.pio depName=ClosedCube OPT3001 packageName=closedcube/library/ClosedCube OPT3001
 	ClosedCube OPT3001@1.1.2
-	# renovate: datasource=github-tags depName=Bosch BSEC2 packageName=boschsensortec/Bosch-BSEC2-Library
-	 https://github.com/boschsensortec/Bosch-BSEC2-Library/archive/v1.7.2502.zip
+	# renovate: datasource=git-refs depName=Bosch BSEC2 packageName=https://github.com/meshtastic/Bosch-BSEC2-Library gitBranch=extra_script
+	https://github.com/meshtastic/Bosch-BSEC2-Library/archive/e16952dfe5addd4287e1eb8c4f6ecac0fa3dd3de.zip
 	# renovate: datasource=git-refs depName=meshtastic-DFRobot_LarkWeatherStation packageName=https://github.com/meshtastic/DFRobot_LarkWeatherStation gitBranch=master
 	https://github.com/meshtastic/DFRobot_LarkWeatherStation/archive/4de3a9cadef0f6a5220a8a906cf9775b02b0040d.zip

--- a/variants/Dongle_nRF52840-pca10059-v1/platformio.ini
+++ b/variants/Dongle_nRF52840-pca10059-v1/platformio.ini
@@ -3,7 +3,6 @@ board_level = extra
 extends = nrf52840_base
 board = nordic_pca10059
 build_flags = ${nrf52840_base.build_flags} -Ivariants/Dongle_nRF52840-pca10059-v1 -D NORDIC_PCA10059
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DEINK_DISPLAY_MODEL=GxEPD2_420_M01
   -DEINK_WIDTH=300
   -DEINK_HEIGHT=400

--- a/variants/ELECROW-ThinkNode-M1/platformio.ini
+++ b/variants/ELECROW-ThinkNode-M1/platformio.ini
@@ -9,7 +9,6 @@ debug_tool = jlink
 build_flags = ${nrf52840_base.build_flags} -Ivariants/ELECROW-ThinkNode-M1
   -DELECROW_ThinkNode_M1
   -DGPS_POWER_TOGGLE
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DUSE_EINK
   -DEINK_DISPLAY_MODEL=GxEPD2_154_D67
   -DEINK_WIDTH=200
@@ -39,7 +38,6 @@ build_flags =
   ${inkhud.build_flags}
   -I variants/ELECROW-ThinkNode-M1
   -D ELECROW_ThinkNode_M1
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
 build_src_filter = 
   ${nrf52_base.build_src_filter} 
   ${inkhud.build_src_filter}

--- a/variants/ME25LS01-4Y10TD/platformio.ini
+++ b/variants/ME25LS01-4Y10TD/platformio.ini
@@ -4,7 +4,6 @@ board = me25ls01-4y10td
 board_level = extra
 ; platform = https://github.com/maxgerhardt/platform-nordicnrf52#cac6fcf943a41accd2aeb4f3659ae297a73f422e
 build_flags = ${nrf52840_base.build_flags} -Ivariants/ME25LS01-4Y10TD -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52 -DME25LS01_4Y10TD
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
 board_build.ldscript = src/platform/nrf52/nrf52840_s140_v7.ld
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/ME25LS01-4Y10TD>

--- a/variants/ME25LS01-4Y10TD_e-ink/platformio.ini
+++ b/variants/ME25LS01-4Y10TD_e-ink/platformio.ini
@@ -4,7 +4,6 @@ board = me25ls01-4y10td
 board_level = extra
 ; platform = https://github.com/maxgerhardt/platform-nordicnrf52#cac6fcf943a41accd2aeb4f3659ae297a73f422e
 build_flags = ${nrf52840_base.build_flags} -Ivariants/ME25LS01-4Y10TD_e-ink -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52 -DME25LS01_4Y10TD
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
   -DEINK_DISPLAY_MODEL=GxEPD2_420_GDEY042T81
   -DEINK_WIDTH=400

--- a/variants/MS24SF1/platformio.ini
+++ b/variants/MS24SF1/platformio.ini
@@ -4,7 +4,6 @@ board = ms24sf1
 board_level = extra
 ; platform = https://github.com/maxgerhardt/platform-nordicnrf52#cac6fcf943a41accd2aeb4f3659ae297a73f422e
 build_flags = ${nrf52840_base.build_flags} -Ivariants/MS24SF1 -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
 board_build.ldscript = src/platform/nrf52/nrf52840_s140_v7.ld
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/MS24SF1>

--- a/variants/MakePython_nRF52840_eink/platformio.ini
+++ b/variants/MakePython_nRF52840_eink/platformio.ini
@@ -3,7 +3,6 @@ board_level = extra
 extends = nrf52840_base
 board = nordic_pca10059
 build_flags = ${nrf52840_base.build_flags} -Ivariants/MakePython_nRF52840_eink -D PRIVATE_HW
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -D PIN_EINK_EN
   -DEINK_DISPLAY_MODEL=GxEPD2_290_T5D
   -DEINK_WIDTH=296

--- a/variants/MakePython_nRF52840_oled/platformio.ini
+++ b/variants/MakePython_nRF52840_oled/platformio.ini
@@ -3,7 +3,6 @@ board_level = extra
 extends = nrf52840_base
 board = nordic_pca10059
 build_flags = ${nrf52840_base.build_flags} -Ivariants/MakePython_nRF52840_oled -D PRIVATE_HW
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/MakePython_nRF52840_oled>
 lib_deps = 
   ${nrf52840_base.lib_deps}

--- a/variants/Seeed_Solar_Node/platformio.ini
+++ b/variants/Seeed_Solar_Node/platformio.ini
@@ -6,7 +6,6 @@ build_flags = ${nrf52840_base.build_flags}
   -I $PROJECT_DIR/variants/Seeed_Solar_Node 
   -D SEEED_SOLAR_NODE 
   -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
 board_build.ldscript = src/platform/nrf52/nrf52840_s140_v7.ld
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/Seeed_Solar_Node>
 lib_deps =

--- a/variants/canaryone/platformio.ini
+++ b/variants/canaryone/platformio.ini
@@ -6,7 +6,6 @@ debug_tool = jlink
 
 # add -DCFG_SYSVIEW if you want to use the Segger systemview tool for OS profiling.
 build_flags = ${nrf52840_base.build_flags} -Ivariants/canaryone
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/canaryone>
 lib_deps = 
   ${nrf52840_base.lib_deps}

--- a/variants/diy/platformio.ini
+++ b/variants/diy/platformio.ini
@@ -50,7 +50,6 @@ board_level = extra
 build_flags = ${nrf52840_base.build_flags}
   -I variants/diy/nrf52_promicro_diy_xtal
   -D NRF52_PROMICRO_DIY
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/diy/nrf52_promicro_diy_xtal>
 lib_deps = 
   ${nrf52840_base.lib_deps}
@@ -64,7 +63,6 @@ board = promicro-nrf52840
 build_flags = ${nrf52840_base.build_flags}
   -I variants/diy/nrf52_promicro_diy_tcxo
   -D NRF52_PROMICRO_DIY
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/diy/nrf52_promicro_diy_tcxo>
 lib_deps = 
   ${nrf52840_base.lib_deps}
@@ -77,7 +75,6 @@ extends = nrf52840_base
 board_level = extra
 build_flags = ${nrf52840_base.build_flags} -Ivariants/diy/seeed-xiao-nrf52840-wio-sx1262 -D PRIVATE_HW
   -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
 board_build.ldscript = src/platform/nrf52/nrf52840_s140_v7.ld
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/diy/seeed-xiao-nrf52840-wio-sx1262>
 lib_deps =

--- a/variants/ec_catsniffer/platformio.ini
+++ b/variants/ec_catsniffer/platformio.ini
@@ -8,7 +8,6 @@ build_flags = ${rp2040_base.build_flags}
   -Ivariants/ec_catsniffer
   -DDEBUG_RP2040_PORT=Serial
   # -DHW_SPI1_DEVICE
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m0plus"
 lib_deps =
   ${rp2040_base.lib_deps}
 debug_build_flags = ${rp2040_base.build_flags}, -g

--- a/variants/feather_diy/platformio.ini
+++ b/variants/feather_diy/platformio.ini
@@ -3,7 +3,6 @@
 extends = nrf52840_base
 board = adafruit_feather_nrf52840
 build_flags = ${nrf52840_base.build_flags} -Ivariants/feather_diy -Dfeather_diy
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/feather_diy>
 lib_deps = 
   ${nrf52840_base.lib_deps}

--- a/variants/feather_rp2040_rfm95/platformio.ini
+++ b/variants/feather_rp2040_rfm95/platformio.ini
@@ -9,7 +9,6 @@ build_flags = ${rp2040_base.build_flags}
   -Ivariants/feather_rp2040_rfm95
   -DDEBUG_RP2040_PORT=Serial
   -DHW_SPI1_DEVICE
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m0plus"
 lib_deps =
   ${rp2040_base.lib_deps}
 debug_build_flags = ${rp2040_base.build_flags}

--- a/variants/heltec_mesh_node_t114/platformio.ini
+++ b/variants/heltec_mesh_node_t114/platformio.ini
@@ -6,7 +6,6 @@ debug_tool = jlink
 
 # add -DCFG_SYSVIEW if you want to use the Segger systemview tool for OS profiling.
 build_flags = ${nrf52840_base.build_flags} -Ivariants/heltec_mesh_node_t114
-        -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
         -DGPS_POWER_TOGGLE
         -DHELTEC_T114
 

--- a/variants/heltec_mesh_pocket/platformio.ini
+++ b/variants/heltec_mesh_pocket/platformio.ini
@@ -6,7 +6,6 @@ debug_tool = jlink
 
 # add -DCFG_SYSVIEW if you want to use the Segger systemview tool for OS profiling.
 build_flags = ${nrf52840_base.build_flags} -Ivariants/heltec_mesh_pocket
-        -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DHELTEC_MESH_POCKET
   -DHELTEC_MESH_POCKET_BATTERY_5000
   -DUSE_EINK
@@ -36,7 +35,6 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/heltec_mesh_pock
 build_flags = 
   ${inkhud.build_flags}
   ${nrf52840_base.build_flags} 
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -I variants/heltec_mesh_pocket
   -D HELTEC_MESH_POCKET
   -D HELTEC_MESH_POCKET_BATTERY_5000
@@ -53,7 +51,6 @@ debug_tool = jlink
 
 # add -DCFG_SYSVIEW if you want to use the Segger systemview tool for OS profiling.
 build_flags = ${nrf52840_base.build_flags} -Ivariants/heltec_mesh_pocket
-        -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DHELTEC_MESH_POCKET
   -DHELTEC_MESH_POCKET_BATTERY_10000
   -DUSE_EINK
@@ -83,7 +80,6 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/heltec_mesh_pock
 build_flags = 
   ${inkhud.build_flags}
   ${nrf52840_base.build_flags} 
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -I variants/heltec_mesh_pocket
   -D HELTEC_MESH_POCKET
   -D HELTEC_MESH_POCKET_BATTERY_10000

--- a/variants/meshlink/platformio.ini
+++ b/variants/meshlink/platformio.ini
@@ -6,7 +6,6 @@ extends = nrf52840_base
 board = meshlink
 ;board_check = true
 build_flags = ${nrf52840_base.build_flags} -I variants/meshlink -D MESHLINK
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -D GPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
   -D EINK_DISPLAY_MODEL=GxEPD2_213_B74
   -D EINK_WIDTH=250

--- a/variants/meshlink_eink/platformio.ini
+++ b/variants/meshlink_eink/platformio.ini
@@ -6,7 +6,6 @@ extends = nrf52840_base
 board = meshlink
 ;board_check = true
 build_flags = ${nrf52840_base.build_flags} -I variants/meshlink_eink -D MESHLINK
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -D GPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
   -D EINK_DISPLAY_MODEL=GxEPD2_213_B74
   -D EINK_WIDTH=250

--- a/variants/monteops_hw1/platformio.ini
+++ b/variants/monteops_hw1/platformio.ini
@@ -4,7 +4,6 @@ board_level = extra
 extends = nrf52840_base
 board = wiscore_rak4631
 build_flags = ${nrf52840_base.build_flags} -Ivariants/monteops_hw1 -D MONTEOPS_HW1
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/monteops_hw1> +<mesh/eth/> +<mesh/api/> +<mqtt/>
 lib_deps = 
   ${nrf52840_base.lib_deps}

--- a/variants/nano-g2-ultra/platformio.ini
+++ b/variants/nano-g2-ultra/platformio.ini
@@ -5,7 +5,6 @@ board = nano-g2-ultra
 debug_tool = jlink
 
 build_flags = ${nrf52840_base.build_flags} -Ivariants/nano-g2-ultra -D NANO_G2_ULTRA
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nano-g2-ultra>
 lib_deps = 
   ${nrf52840_base.lib_deps}

--- a/variants/nibble_rp2040/platformio.ini
+++ b/variants/nibble_rp2040/platformio.ini
@@ -10,7 +10,6 @@ build_flags = ${rp2040_base.build_flags}
   -Ivariants/nibble_rp2040
   -DDEBUG_RP2040_PORT=Serial
   -DHW_SPI1_DEVICE
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m0plus"
 lib_deps =
   ${rp2040_base.lib_deps}
 debug_build_flags = ${rp2040_base.build_flags}, -g

--- a/variants/rak11310/platformio.ini
+++ b/variants/rak11310/platformio.ini
@@ -9,7 +9,6 @@ build_flags = ${rp2040_base.build_flags}
   -Ivariants/rak11310
   -DDEBUG_RP2040_PORT=Serial
   -DRV3028_RTC=0x52
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m0plus"
 build_src_filter = ${rp2040_base.build_src_filter} +<../variants/rak11310> +<mesh/eth/> +<mesh/api/> +<mqtt/>
 lib_deps =
   ${rp2040_base.lib_deps}

--- a/variants/rak2560/platformio.ini
+++ b/variants/rak2560/platformio.ini
@@ -4,7 +4,6 @@ extends = nrf52840_base
 board = wiscore_rak4631
 board_check = true
 build_flags = ${nrf52840_base.build_flags} -Ivariants/rak2560 -D RAK_4631
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
   -DRADIOLIB_EXCLUDE_SX128X=1
   -DRADIOLIB_EXCLUDE_SX127X=1

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -4,7 +4,6 @@ extends = nrf52840_base
 board = wiscore_rak4631
 board_check = true
 build_flags = ${nrf52840_base.build_flags} -Ivariants/rak4631 -D RAK_4631
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
   -DEINK_DISPLAY_MODEL=GxEPD2_213_BN
   -DEINK_WIDTH=250

--- a/variants/rak4631_epaper/platformio.ini
+++ b/variants/rak4631_epaper/platformio.ini
@@ -3,7 +3,6 @@
 extends = nrf52840_base
 board = wiscore_rak4631
 build_flags = ${nrf52840_base.build_flags} -Ivariants/rak4631_epaper -D RAK_4631
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DEINK_DISPLAY_MODEL=GxEPD2_213_BN
   -DEINK_WIDTH=250
   -DEINK_HEIGHT=122

--- a/variants/rak4631_epaper_onrxtx/platformio.ini
+++ b/variants/rak4631_epaper_onrxtx/platformio.ini
@@ -4,7 +4,6 @@ board_level = extra
 extends = nrf52840_base
 board = wiscore_rak4631
 build_flags = ${nrf52840_base.build_flags} -Ivariants/rak4631_epaper -D RAK_4631
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -D PIN_EINK_EN=34
   -D EINK_DISPLAY_MODEL=GxEPD2_213_BN
   -D EINK_WIDTH=250

--- a/variants/rak4631_eth_gw/platformio.ini
+++ b/variants/rak4631_eth_gw/platformio.ini
@@ -4,7 +4,6 @@ extends = nrf52840_base
 board = wiscore_rak4631
 board_check = true
 build_flags = ${nrf52840_base.build_flags} -Ivariants/rak4631_eth_gw -D RAK_4631
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
   -DEINK_DISPLAY_MODEL=GxEPD2_213_BN
   -DEINK_WIDTH=250

--- a/variants/rak_wismeshtap/platformio.ini
+++ b/variants/rak_wismeshtap/platformio.ini
@@ -3,7 +3,6 @@
 extends = nrf52840_base
 board = wiscore_rak4631
 build_flags = ${nrf52840_base.build_flags} -Ivariants/rak_wismeshtap -DWISMESH_TAP -DRAK_4631
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
   -DEINK_DISPLAY_MODEL=GxEPD2_213_BN
   -DEINK_WIDTH=250

--- a/variants/rp2040-lora/platformio.ini
+++ b/variants/rp2040-lora/platformio.ini
@@ -9,7 +9,6 @@ build_flags = ${rp2040_base.build_flags}
   -Ivariants/rp2040-lora
   -DDEBUG_RP2040_PORT=Serial
   -DHW_SPI1_DEVICE
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m0plus"
 lib_deps =
   ${rp2040_base.lib_deps}
 debug_build_flags = ${rp2040_base.build_flags}, -g

--- a/variants/rpipico-slowclock/platformio.ini
+++ b/variants/rpipico-slowclock/platformio.ini
@@ -19,7 +19,6 @@ build_flags = ${rp2040_base.build_flags}
   -Ivariants/rpipico-slowclock
   -DDEBUG_RP2040_PORT=Serial2
   -DHW_SPI1_DEVICE
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m0plus"
   -g
   -DNO_USB
 lib_deps =

--- a/variants/rpipico/platformio.ini
+++ b/variants/rpipico/platformio.ini
@@ -9,7 +9,6 @@ build_flags = ${rp2040_base.build_flags}
   -Ivariants/rpipico
   -DDEBUG_RP2040_PORT=Serial
   -DHW_SPI1_DEVICE
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m0plus"
 lib_deps =
   ${rp2040_base.lib_deps}
 debug_build_flags = ${rp2040_base.build_flags}, -g

--- a/variants/rpipico2/platformio.ini
+++ b/variants/rpipico2/platformio.ini
@@ -9,7 +9,6 @@ build_flags = ${rp2350_base.build_flags}
   -Ivariants/rpipico2
   -DDEBUG_RP2040_PORT=Serial
   -DHW_SPI1_DEVICE
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m33"
 lib_deps =
   ${rp2350_base.lib_deps}
 debug_build_flags = ${rp2350_base.build_flags}, -g

--- a/variants/rpipico2w/platformio.ini
+++ b/variants/rpipico2w/platformio.ini
@@ -21,7 +21,6 @@ build_flags = ${rp2350_base.build_flags}
   -DARDUINO_RASPBERRY_PI_PICO_2W
   -DARDUINO_ARCH_RP2040
   -DHAS_WIFI=1
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m33"
   -fexceptions  # for exception handling in MQTT
   -DHAS_UDP_MULTICAST=1
 build_src_filter = ${rp2350_base.build_src_filter} +<mesh/wifi/>

--- a/variants/rpipicow/platformio.ini
+++ b/variants/rpipicow/platformio.ini
@@ -8,7 +8,6 @@ build_flags = ${rp2040_base.build_flags}
   -DRPI_PICO
   -Ivariants/rpipicow
   -DHW_SPI1_DEVICE
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m0plus"
   -fexceptions  # for exception handling in MQTT
   -DHAS_UDP_MULTICAST=1
 build_src_filter = ${rp2040_base.build_src_filter} +<mesh/wifi/>

--- a/variants/seeed_xiao_nrf52840_kit/platformio.ini
+++ b/variants/seeed_xiao_nrf52840_kit/platformio.ini
@@ -3,7 +3,6 @@
 extends = nrf52840_base
 board = xiao_ble_sense
 build_flags = ${nrf52840_base.build_flags} -Ivariants/seeed_xiao_nrf52840_kit -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52  -DSEEED_XIAO_NRF52840_KIT
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
 board_build.ldscript = src/platform/nrf52/nrf52840_s140_v7.ld
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/seeed_xiao_nrf52840_kit>
 lib_deps = 

--- a/variants/senselora_rp2040/platformio.ini
+++ b/variants/senselora_rp2040/platformio.ini
@@ -9,6 +9,5 @@ build_flags = ${rp2040_base.build_flags}
   -DSENSELORA_RP2040
   -Ivariants/senselora_rp2040
   -DDEBUG_RP2040_PORT=Serial
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m0plus"
 lib_deps =
   ${rp2040_base.lib_deps}

--- a/variants/t-echo/platformio.ini
+++ b/variants/t-echo/platformio.ini
@@ -8,7 +8,6 @@ debug_tool = jlink
 # add -DCFG_SYSVIEW if you want to use the Segger systemview tool for OS profiling.
 build_flags = ${nrf52840_base.build_flags} -Ivariants/t-echo
   -DGPS_POWER_TOGGLE
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DEINK_DISPLAY_MODEL=GxEPD2_154_D67
   -DEINK_WIDTH=200
   -DEINK_HEIGHT=200
@@ -33,7 +32,6 @@ build_flags =
   ${nrf52840_base.build_flags}
   ${inkhud.build_flags}
   -I variants/t-echo
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
 build_src_filter = 
   ${nrf52_base.build_src_filter} 
   ${inkhud.build_src_filter}

--- a/variants/tlora_c6/platformio.ini
+++ b/variants/tlora_c6/platformio.ini
@@ -7,4 +7,3 @@ build_flags =
   -I variants/tlora_c6
   -DARDUINO_USB_CDC_ON_BOOT=1
   -DARDUINO_USB_MODE=1
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/esp32c3"

--- a/variants/tracker-t1000-e/platformio.ini
+++ b/variants/tracker-t1000-e/platformio.ini
@@ -2,7 +2,6 @@
 extends = nrf52840_base
 board = tracker-t1000-e
 build_flags = ${nrf52840_base.build_flags} -Ivariants/tracker-t1000-e -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52 -DTRACKER_T1000_E
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DGPS_POWER_TOGGLE
   -DMESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR_EXTERNAL=1
   -DMESHTASTIC_EXCLUDE_CANNEDMESSAGES=1

--- a/variants/wio-sdk-wm1110/platformio.ini
+++ b/variants/wio-sdk-wm1110/platformio.ini
@@ -10,7 +10,6 @@ extra_scripts =
 # Remove adafruit USB serial from the build (it is incompatible with using the ch340 serial chip on this board)
 build_unflags = ${nrf52840_base:build_unflags} -DUSBCON -DUSE_TINYUSB
 build_flags = ${nrf52840_base.build_flags} -Ivariants/wio-sdk-wm1110 -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52 -DWIO_WM1110
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
   -DCFG_TUD_CDC=0
 board_build.ldscript = src/platform/nrf52/nrf52840_s140_v7.ld

--- a/variants/wio-t1000-s/platformio.ini
+++ b/variants/wio-t1000-s/platformio.ini
@@ -4,7 +4,6 @@ extends = nrf52840_base
 board = wio-t1000-s
 board_level = extra
 build_flags = ${nrf52840_base.build_flags} -Ivariants/wio-t1000-s -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52 -DWIO_WM1110
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
 board_build.ldscript = src/platform/nrf52/nrf52840_s140_v7.ld
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/wio-t1000-s>

--- a/variants/wio-tracker-wm1110/platformio.ini
+++ b/variants/wio-tracker-wm1110/platformio.ini
@@ -3,7 +3,6 @@
 extends = nrf52840_base
 board = wio-tracker-wm1110
 build_flags = ${nrf52840_base.build_flags} -Ivariants/wio-tracker-wm1110 -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52 -DWIO_WM1110
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
   -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
 board_build.ldscript = src/platform/nrf52/nrf52840_s140_v7.ld
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/wio-tracker-wm1110>

--- a/variants/xiao_ble/platformio.ini
+++ b/variants/xiao_ble/platformio.ini
@@ -4,7 +4,6 @@ extends = nrf52840_base
 board = xiao_ble_sense
 board_level = extra
 build_flags = ${nrf52840_base.build_flags} -Ivariants/xiao_ble -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52 -D EBYTE_E22 -DEBYTE_E22_900M30S -DPRIVATE_HW
-  -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
 board_build.ldscript = src/platform/nrf52/nrf52840_s140_v7.ld
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/xiao_ble>
 lib_deps = 


### PR DESCRIPTION
Update bsec / bme68x libraries, which must be upgraded in-tandem.

This package, as-is from bosch, is broken on nrf52 and esp32c6 targets. I have forked the bsec2 package into the `meshtastic` org until this can be resolved.

See changes in: https://github.com/boschsensortec/Bosch-BSEC2-Library/pull/55

Huge Bonus! These changes allow us to remove all those nasty linker flags (as seen in the 42 changes in `variants/`)

| Package | Update | Change |
|---|---|---|
| [Bosch BSEC2](https://redirect.github.com/boschsensortec/Bosch-BSEC2-Library) | minor | `v1.7.2502` -> `v1.8.2610`  ([meshtastic fork](https://github.com/meshtastic/Bosch-BSEC2-Library/tree/extra_script))|
| [Bosch BME68x](https://registry.platformio.org/library/boschsensortec/BME68x%20Sensor%20library) | minor | `1.1.40407` -> `1.2.40408` |