### PR TITLE
Renovate: Add changelogs for device-ui, cleanup

### DIFF
--- a/arch/esp32/esp32.ini
+++ b/arch/esp32/esp32.ini
@@ -59,7 +59,7 @@ lib_deps =
   # renovate: datasource=git-refs depName=meshtastic-ESP32_Codec2 packageName=https://github.com/meshtastic/ESP32_Codec2 gitBranch=master
   https://github.com/meshtastic/ESP32_Codec2/archive/633326c78ac251c059ab3a8c430fcdf25b41672f.zip
   # renovate: datasource=custom.pio depName=rweather/Crypto packageName=rweather/library/Crypto
-  rweather/Crypto@^0.4.0
+  rweather/Crypto@0.4.0
 
 lib_ignore = 
   segger_rtt

--- a/arch/esp32/esp32c6.ini
+++ b/arch/esp32/esp32c6.ini
@@ -1,7 +1,7 @@
 [esp32c6_base]
 extends = esp32_base
 platform =
-  # renovate: datasource=git-refs depName=ESP32c6 platform-espressif32 packageName=https://github.com/Jason2866/platform-espressif32 gitBranch=Arduino/IDF5
+  # Do not renovate until we have switched to pioarduino tagged builds
   https://github.com/Jason2866/platform-espressif32/archive/22faa566df8c789000f8136cd8d0aca49617af55.zip
 build_flags =
   ${arduino_base.build_flags}
@@ -32,7 +32,7 @@ lib_deps =
   # renovate: datasource=git-refs depName=meshtastic-ESP32_Codec2 packageName=https://github.com/meshtastic/ESP32_Codec2 gitBranch=master
   https://github.com/meshtastic/ESP32_Codec2/archive/633326c78ac251c059ab3a8c430fcdf25b41672f.zip
   # renovate: datasource=custom.pio depName=rweather/Crypto packageName=rweather/library/Crypto
-  rweather/Crypto@^0.4.0
+  rweather/Crypto@0.4.0
 
 build_src_filter = 
  ${esp32_base.build_src_filter} -<mesh/http> 

--- a/arch/nrf52/nrf52.ini
+++ b/arch/nrf52/nrf52.ini
@@ -28,7 +28,8 @@ build_src_filter =
 lib_deps=
   ${arduino_base.lib_deps}
   ${radiolib_base.lib_deps}
-  rweather/Crypto@^0.4.0
+  # renovate: datasource=custom.pio depName=rweather/Crypto packageName=rweather/library/Crypto
+  rweather/Crypto@0.4.0
 
 lib_ignore =
   BluetoothOTA

--- a/arch/portduino/portduino.ini
+++ b/arch/portduino/portduino.ini
@@ -25,7 +25,7 @@ lib_deps =
   ${radiolib_base.lib_deps}
   ${environmental_base.lib_deps}
   # renovate: datasource=custom.pio depName=rweather/Crypto packageName=rweather/library/Crypto
-  rweather/Crypto@^0.4.0
+  rweather/Crypto@0.4.0
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@^1.2.0
   # renovate: datasource=git-refs depName=libch341-spi-userspace packageName=https://github.com/pine64/libch341-spi-userspace gitBranch=main

--- a/platformio.ini
+++ b/platformio.ini
@@ -107,7 +107,7 @@ lib_deps =
 
 [device-ui_base]
 lib_deps =
-	# renovate: datasource=git-refs depName=meshtastic-device-ui packageName=https://github.com/meshtastic/device-ui gitBranch=master
+	# renovate: datasource=git-refs depName=meshtastic/device-ui packageName=https://github.com/meshtastic/device-ui gitBranch=master
 	https://github.com/meshtastic/device-ui/archive/b9e2ad1222db9f5a5080248b2f018c250f0efae5.zip
 
 ; Common libs for environmental measurements in telemetry module

--- a/renovate.json
+++ b/renovate.json
@@ -69,5 +69,11 @@
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}git{{/if}}"
     }
   ],
-  "packageRules": []
+  "packageRules": [
+    {
+      "matchPackageNames": ["meshtastic/device-ui"],
+      "reviewers": ["mverch67"],
+      "changelogUrl": "https://github.com/meshtastic/device-ui/compare/{{currentDigest}}...{{newDigest}}"
+    }
+  ]
 }


### PR DESCRIPTION
Renovate updates:
- Adds a changelogUrl for `meshtastic/device-ui` updates (so we can see what's actually been changed :sweat_smile:)
- Adds @mverch67 as a reviewer to `device-ui` update PRs automatically
- Removes esp32c6 renovate updates (for now)
- Fix a missing `rweather/Crypto` annotation and normalize versioning