### PR TITLE
Renovate: fix device-ui match (tiny fix)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -71,7 +71,7 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": ["meshtastic/device-ui"],
+      "matchDepNames": ["meshtastic/device-ui"],
       "reviewers": ["mverch67"],
       "changelogUrl": "https://github.com/meshtastic/device-ui/compare/{{currentDigest}}...{{newDigest}}"
     }


### PR DESCRIPTION
Tiny addendum to https://github.com/meshtastic/firmware/pull/6733

Fix depname match for device-ui