### PR TITLE
Don't run `test-native` for event firmwares

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -149,6 +149,7 @@ jobs:
     secrets: inherit
 
   test-native:
+    if: ${{ !contains(github.ref_name, 'event/') }}
     uses: ./.github/workflows/test_native.yml
 
   docker-deb-amd64:


### PR DESCRIPTION
Exclude `test-native` from event firmwares. These fail in event_mode and can be skipped.