### PR TITLE
Add --change-mode to device-install/update scripts

### DIFF
--- a/bin/device-install.bat
+++ b/bin/device-install.bat
@@ -12,6 +12,7 @@ SET "BIGDB16=0"
 SET "ESPTOOL_BAUD=115200"
 SET "ESPTOOL_CMD="
 SET "LOGCOUNTER=0"
+SET "CHANGE_MODE=0"
 
 @REM FIXME: Determine mcu from PlatformIO variant, this is unmaintainable.
 SET "S3=s3 v3 t-deck wireless-paper wireless-tracker station-g2 unphone"
@@ -24,7 +25,7 @@ GOTO getopts
 :help
 ECHO Flash image file to device, but first erasing and writing system information.
 ECHO.
-ECHO Usage: %SCRIPT_NAME% -f filename [-p PORT] [-P python] (--web)
+ECHO Usage: %SCRIPT_NAME% -f filename [-p PORT] [-P python] (--web) [--change-mode]
 ECHO.
 ECHO Options:
 ECHO     -f filename      The firmware .bin file to flash.  Custom to your device type and region. (required)
@@ -35,13 +36,16 @@ ECHO     -P python        Specify alternate python interpreter to use to invoke 
 ECHO                      If supplied the script will use python.
 ECHO                      If not supplied the script will try to find esptool in Path.
 ECHO     --web            Enable WebUI. (default: false)
+ECHO     --change-mode    Attempt to place the device in correct mode. (1200bps Reset)
+ECHO                      Some hardware requires this twice.
 ECHO.
+ECHO Example: %SCRIPT_NAME% -p COM17 --change-mode
 ECHO Example: %SCRIPT_NAME% -f firmware-t-deck-tft-2.6.0.0b106d4.bin -p COM11
 ECHO Example: %SCRIPT_NAME% -f firmware-unphone-2.6.0.0b106d4.bin -p COM11 --web
 GOTO eof
 
 :version
-ECHO %SCRIPT_NAME% [Version 2.6.1]
+ECHO %SCRIPT_NAME% [Version 2.6.2]
 ECHO Meshtastic
 GOTO eof
 
@@ -58,9 +62,12 @@ IF "%~1"=="-p" SET "ESPTOOL_PORT=%~2" & SHIFT
 IF /I "%~1"=="--port" SET "ESPTOOL_PORT=%~2" & SHIFT
 IF "%~1"=="-P" SET "PYTHON=%~2" & SHIFT
 IF /I "%~1"=="--web" SET "WEB_APP=1"
+IF /I "%~1"=="--change-mode" SET "CHANGE_MODE=1"
 SHIFT
 GOTO getopts
 :endopts
+
+IF %CHANGE_MODE% EQU 1 GOTO skip-filename
 
 CALL :LOG_MESSAGE DEBUG "Checking FILENAME parameter..."
 IF "__!FILENAME!__"=="____" (
@@ -94,6 +101,9 @@ IF NOT "!FILENAME:update=!"=="!FILENAME!" (
 ) ELSE (
     CALL :LOG_MESSAGE DEBUG "We are NOT working with a *update* file. !FILENAME!"
 )
+
+:skip-filename
+SET "ESPTOOL_BAUD=1200"
 
 CALL :LOG_MESSAGE DEBUG "Determine the correct esptool command to use..."
 IF NOT "__%PYTHON%__"=="____" (
@@ -132,6 +142,12 @@ IF "__!ESPTOOL_PORT!__" == "____" (
     CALL :LOG_MESSAGE INFO "Using esptool port: !ESPTOOL_PORT!."
 )
 CALL :LOG_MESSAGE INFO "Using esptool baud: !ESPTOOL_BAUD!."
+
+IF %CHANGE_MODE% EQU 1 (
+    @REM Attempt to change mode via 1200bps Reset.
+    CALL :RUN_ESPTOOL !ESPTOOL_BAUD! --after no_reset read_flash_status
+    GOTO eof
+)
 
 @REM Check if FILENAME contains "-tft-" and set target partitionScheme accordingly.
 @REM https://github.com/meshtastic/web-flasher/blob/main/types/resources.ts#L3
@@ -254,6 +270,7 @@ EXIT /B %ERRORLEVEL%
 IF %DEBUG% EQU 1 CALL :LOG_MESSAGE DEBUG "About to run command: !ESPTOOL_CMD! --baud %~1 %~2 %~3 %~4"
 CALL :RESET_ERROR
 !ESPTOOL_CMD! --baud %~1 %~2 %~3 %~4
+IF %CHANGE_MODE% EQU 1 GOTO :eof
 IF %ERRORLEVEL% NEQ 0 (
     CALL :LOG_MESSAGE ERROR "Error running command: !ESPTOOL_CMD! --baud %~1 %~2 %~3 %~4"
     EXIT /B %ERRORLEVEL%

--- a/bin/device-install.sh
+++ b/bin/device-install.sh
@@ -2,6 +2,7 @@
 
 PYTHON=${PYTHON:-$(which python3 python | head -n 1)}
 WEB_APP=false
+CHANGE_MODE=false
 TFT_BUILD=false
 MCU=""
 
@@ -62,7 +63,7 @@ set -e
 # Usage info
 show_help() {
 	cat <<EOF
-Usage: $(basename $0) [-h] [-p ESPTOOL_PORT] [-P PYTHON] [-f FILENAME] [--web]
+Usage: $(basename $0) [-h] [-p ESPTOOL_PORT] [-P PYTHON] [-f FILENAME] [--web] [--change-mode]
 Flash image file to device, but first erasing and writing system information.
 
     -h               Display this help and exit.
@@ -70,6 +71,7 @@ Flash image file to device, but first erasing and writing system information.
     -P PYTHON        Specify alternate python interpreter to use to invoke esptool. (Default: "$PYTHON")
     -f FILENAME      The firmware .bin file to flash.  Custom to your device type and region.
     --web            Enable WebUI. (Default: false)
+	--change-mode    Attempt to place the device in correct mode. Some hardware requires this twice. (1200bps Reset)
 
 EOF
 }
@@ -95,6 +97,9 @@ while [ $# -gt 0 ]; do
 	--web)
 		WEB_APP=true
 		;;
+	--change-mode)
+		CHANGE_MODE=true
+		;;
 	--) # Stop parsing options
 		shift
 		break
@@ -106,6 +111,10 @@ while [ $# -gt 0 ]; do
 	esac
 	shift # Move to the next argument
 done
+
+if [[ $WEB_APP == true ]]; then
+	$ESPTOOL_CMD --baud 1200 --after no_reset read_flash_status
+fi
 
 [ -z "$FILENAME" -a -n "$1" ] && {
 	FILENAME=$1

--- a/bin/device-install.sh
+++ b/bin/device-install.sh
@@ -114,6 +114,7 @@ done
 
 if [[ $WEB_APP == true ]]; then
 	$ESPTOOL_CMD --baud 1200 --after no_reset read_flash_status
+	exit 0
 fi
 
 [ -z "$FILENAME" -a -n "$1" ] && {

--- a/bin/device-install.sh
+++ b/bin/device-install.sh
@@ -71,7 +71,7 @@ Flash image file to device, but first erasing and writing system information.
     -P PYTHON        Specify alternate python interpreter to use to invoke esptool. (Default: "$PYTHON")
     -f FILENAME      The firmware .bin file to flash.  Custom to your device type and region.
     --web            Enable WebUI. (Default: false)
-	--change-mode    Attempt to place the device in correct mode. Some hardware requires this twice. (1200bps Reset)
+    --change-mode    Attempt to place the device in correct mode. Some hardware requires this twice. (1200bps Reset)
 
 EOF
 }

--- a/bin/device-update.bat
+++ b/bin/device-update.bat
@@ -8,12 +8,13 @@ SET "PYTHON="
 SET "ESPTOOL_BAUD=115200"
 SET "ESPTOOL_CMD="
 SET "LOGCOUNTER=0"
+SET "CHANGE_MODE=0"
 
 GOTO getopts
 :help
 ECHO Flash image file to device, but leave existing system intact.
 ECHO.
-ECHO Usage: %SCRIPT_NAME% -f filename [-p PORT] [-P python]
+ECHO Usage: %SCRIPT_NAME% -f filename [-p PORT] [-P python] [--change-mode]
 ECHO.
 ECHO Options:
 ECHO     -f filename      The update .bin file to flash.  Custom to your device type and region. (required)
@@ -23,12 +24,15 @@ ECHO                      If not set, ESPTOOL iterates all ports (Dangerous).
 ECHO     -P python        Specify alternate python interpreter to use to invoke esptool. (default: python)
 ECHO                      If supplied the script will use python.
 ECHO                      If not supplied the script will try to find esptool in Path.
+ECHO     --change-mode    Attempt to place the device in correct mode. (1200bps Reset)
+ECHO                      Some hardware requires this twice.
 ECHO.
+ECHO Example: %SCRIPT_NAME% -p COM17 --change-mode
 ECHO Example: %SCRIPT_NAME% -f firmware-t-deck-tft-2.6.0.0b106d4-update.bin -p COM11
 GOTO eof
 
 :version
-ECHO %SCRIPT_NAME% [Version 2.6.1]
+ECHO %SCRIPT_NAME% [Version 2.6.2]
 ECHO Meshtastic
 GOTO eof
 
@@ -44,9 +48,12 @@ IF /I "%~1"=="-f" SET "FILENAME=%~2" & SHIFT
 IF "%~1"=="-p" SET "ESPTOOL_PORT=%~2" & SHIFT
 IF /I "%~1"=="--port" SET "ESPTOOL_PORT=%~2" & SHIFT
 IF "%~1"=="-P" SET "PYTHON=%~2" & SHIFT
+IF /I "%~1"=="--change-mode" SET "CHANGE_MODE=1"
 SHIFT
 GOTO getopts
 :endopts
+
+IF %CHANGE_MODE% EQU 1 GOTO skip-filename
 
 CALL :LOG_MESSAGE DEBUG "Checking FILENAME parameter..."
 IF "__!FILENAME!__"=="____" (
@@ -76,6 +83,9 @@ IF "!FILENAME:update=!"=="!FILENAME!" (
 ) ELSE (
     CALL :LOG_MESSAGE DEBUG "We are working with a *update* file. !FILENAME!"
 )
+
+:skip-filename
+SET "ESPTOOL_BAUD=1200"
 
 CALL :LOG_MESSAGE DEBUG "Determine the correct esptool command to use..."
 IF NOT "__%PYTHON%__"=="____" (
@@ -115,6 +125,12 @@ IF "__!ESPTOOL_PORT!__" == "____" (
 )
 CALL :LOG_MESSAGE INFO "Using esptool baud: !ESPTOOL_BAUD!."
 
+IF %CHANGE_MODE% EQU 1 (
+    @REM Attempt to change mode via 1200bps Reset.
+    CALL :RUN_ESPTOOL !ESPTOOL_BAUD! --after no_reset read_flash_status
+    GOTO eof
+)
+
 @REM Flashing operations.
 CALL :LOG_MESSAGE INFO "Trying to flash update "!FILENAME!" at OFFSET 0x10000..."
 CALL :RUN_ESPTOOL !ESPTOOL_BAUD! write_flash 0x10000 "!FILENAME!" || GOTO eof
@@ -135,6 +151,7 @@ EXIT /B %ERRORLEVEL%
 IF %DEBUG% EQU 1 CALL :LOG_MESSAGE DEBUG "About to run command: !ESPTOOL_CMD! --baud %~1 %~2 %~3 %~4"
 CALL :RESET_ERROR
 !ESPTOOL_CMD! --baud %~1 %~2 %~3 %~4
+IF %CHANGE_MODE% EQU 1 GOTO :eof
 IF %ERRORLEVEL% NEQ 0 (
     CALL :LOG_MESSAGE ERROR "Error running command: !ESPTOOL_CMD! --baud %~1 %~2 %~3 %~4"
     EXIT /B %ERRORLEVEL%

--- a/bin/device-update.sh
+++ b/bin/device-update.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 PYTHON=${PYTHON:-$(which python3 python|head -n 1)}
+CHANGE_MODE=false
 
 # Determine the correct esptool command to use
 if "$PYTHON" -m esptool version >/dev/null 2>&1; then
@@ -17,14 +18,15 @@ fi
 # Usage info
 show_help() {
 cat << EOF
-Usage: $(basename $0) [-h] [-p ESPTOOL_PORT] [-P PYTHON] [-f FILENAME|FILENAME]
-Flash image file to device, leave existing system intact."
+Usage: $(basename $0) [-h] [-p ESPTOOL_PORT] [-P PYTHON] [-f FILENAME|FILENAME] [--change-mode]
+Flash image file to device, leave existing system intact.
 
     -h               Display this help and exit
     -p ESPTOOL_PORT  Set the environment variable for ESPTOOL_PORT.  If not set, ESPTOOL iterates all ports (Dangerous).
     -P PYTHON        Specify alternate python interpreter to use to invoke esptool. (Default: "$PYTHON")
     -f FILENAME      The *update.bin file to flash.  Custom to your device type.
-    
+    --change-mode    Attempt to place the device in correct mode. Some hardware requires this twice. (1200bps Reset)
+
 EOF
 }
 
@@ -41,6 +43,9 @@ while getopts ":hp:P:f:" opt; do
             ;;
         f)  FILENAME=${OPTARG}
             ;;
+	    --change-mode)
+            CHANGE_MODE=true
+            ;;
         *)
  	        echo "Invalid flag."
             show_help >&2
@@ -49,6 +54,11 @@ while getopts ":hp:P:f:" opt; do
     esac
 done
 shift "$((OPTIND-1))"
+
+if [[ $WEB_APP == true ]]; then
+	$ESPTOOL_CMD --baud 1200 --after no_reset read_flash_status
+    exit 0
+fi
 
 [ -z "$FILENAME" -a -n "$1" ] && {
     FILENAME=$1


### PR DESCRIPTION
This PR adds a `--change-mode` option to the device-install/update scripts.

`--change-mode` performs `esptool --baud 1200 --after no_reset read_flash_status` while accouting for user provided `-p` and discovered `esptool`.

This would allow users to _attempt_ to set their device to update mode without hardware interaction prior to running the scripts. Akin to pressing the `1200bps Reset` button on the web-flasher.

This change should not effect normal opreations.

---

This operation is working on a LILYGO T-Deck Plus device _running 2.6.4.b89355f with MUI from the web-flasher_ during local testing on a Windows 11 host with esptool v4.8.1.

Running the command once sets the T-Deck to a different COM mode (new device in device manager) but still not in update mode.
Running the command again reboots into proper update mode. (black screen)

```bat
>device-install.bat -p COM17 --change-mode
INFO  | 22:36:03 5 Using esptool port: COM17.
INFO  | 22:36:03 6 Using esptool baud: 1200.
esptool.py v4.8.1
Serial port COM17

A fatal error occurred: Failed to set baud rate 1200. The driver may not support this rate.

>device-install.bat -p COM18 --change-mode
INFO  | 22:36:24 5 Using esptool port: COM18.
INFO  | 22:36:24 6 Using esptool baud: 1200.
esptool.py v4.8.1
Serial port COM18
Connecting...
Detecting chip type... ESP32-S3
Chip is ESP32-S3 (QFN56) (revision v0.2)
Features: WiFi, BLE, Embedded PSRAM 8MB (AP_3v3)
Crystal is 40MHz
MAC: 3c:84:27:ed:a3:e8
Uploading stub...
Running stub...
Stub running...
Status value: 0x0200
Staying in bootloader.
```

fix #6529 