### PR TITLE
device-install.sh: detect t-eth-elite as s3 device

### DIFF
--- a/bin/device-install.sh
+++ b/bin/device-install.sh
@@ -44,6 +44,15 @@ S3_VARIANTS=(
 	"station-g2"
 	"unphone"
 	"t-eth-elite"
+ 	"mesh-tab"
+	"dreamcatcher"
+	"ESP32-S3-Pico"
+	"seeed-sensecap-indicator"
+	"heltec_capsule_sensor_v3"
+	"vision-master"
+	"icarus"
+	"tracksenger"
+	"elecrow-adv"
 )
 
 # Determine the correct esptool command to use

--- a/bin/device-install.sh
+++ b/bin/device-install.sh
@@ -43,6 +43,7 @@ S3_VARIANTS=(
 	"wireless-tracker"
 	"station-g2"
 	"unphone"
+	"t-eth-elite"
 )
 
 # Determine the correct esptool command to use


### PR DESCRIPTION
Fixes https://github.com/meshtastic/firmware/issues/6754#issuecomment-2857468902

Thanks @mverch67!

Installed a Lilygo T-ETH-Elite using this patch and it worked. Should be tested against a different esp32 s3 and non-s3 device also, but I do not have access to any.

Any help testing other esp32 devices is appreciated!

## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [x ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other: Lilygo T-ETH-Elite
