### PR TITLE
Actions: Fix end to end tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,10 @@ on:
     - cron: 0 0 * * * # Run every day at midnight
   workflow_dispatch: {}
 
-permissions: read-all
+permissions:
+  contents: read
+  actions: read
+  checks: write
 
 jobs:
   native-tests:
@@ -44,7 +47,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
Fix end to end tests, which have been failing for some time with the following error:

> [Invalid workflow file: .github/workflows/tests.yml#L11](https://github.com/meshtastic/firmware/actions/runs/14918706470/workflow)
The workflow is not valid. .github/workflows/tests.yml (Line: 11, Col: 3): Error calling workflow 'meshtastic/firmware/.github/workflows/test_native.yml@981ecfdb61bd231c47988bdec9c55e28bdaeef79'. The nested job 'generate-reports' is requesting 'checks: write', but is only allowed 'checks: read'.