### PR TITLE
Fix Critical Error #3 for LilyGo T-Echo

### DIFF
--- a/variants/t-echo/variant.h
+++ b/variants/t-echo/variant.h
@@ -139,6 +139,7 @@ External serial flash WP25R1635FZUIL0
 // Not really an E22 but TTGO seems to be trying to clone that
 #define SX126X_DIO2_AS_RF_SWITCH
 #define SX126X_DIO3_TCXO_VOLTAGE 1.8
+#define TCXO_OPTIONAL
 // Internally the TTGO module hooks the SX1262-DIO2 in to control the TX/RX switch (which is the default for the sx1262interface
 // code)
 
@@ -214,7 +215,7 @@ External serial flash WP25R1635FZUIL0
 #define VBAT_AR_INTERNAL AR_INTERNAL_3_0
 #define ADC_MULTIPLIER (2.0F)
 
-#define NO_EXT_GPIO 1
+//#define NO_EXT_GPIO 1
 
 #define HAS_RTC 1
 


### PR DESCRIPTION
Fix Critical Error #3

Hello, I followed the discussion a bit on #6294 and noticed that it needs `TCXO_OPTIONAL` defined to work and that setting `NO_EXT_GPIO` to 1 breaks it.

It's been broken for T-Echo since v2.5.20.

I managed to compile and flash on my T-Echo and it fixes the problem.

Kind Regards, Taha


## 🤝 Attestations
- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
  LilyGo T-Echo
