### PR TITLE
feat(RadioInterface): Tx power gain calculation rework

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -80,10 +80,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // Override user saved region, for producing region-locked builds
 // #define REGULATORY_LORA_REGIONCODE meshtastic_Config_LoRaConfig_RegionCode_SG_923
 
-// Total system gain in dBm to subtract from Tx power to remain within regulatory ERP limit for non-licensed operators
-// This value should be set in variant.h and is PA gain + antenna gain (if system ships with an antenna)
-#ifndef REGULATORY_GAIN_LORA
-#define REGULATORY_GAIN_LORA 0
+// Total system gain in dBm to subtract from Tx power to remain within regulatory and Tx PA limits
+// This value should be set in variant.h and is PA gain + antenna gain (if variant has a non-removable antenna)
+#ifndef TX_GAIN_LORA
+#define TX_GAIN_LORA 0
 #endif
 
 // -----------------------------------------------------------------------------

--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -71,6 +71,8 @@ template <typename T> bool LR11x0Interface<T>::init()
 
     RadioLibInterface::init();
 
+    limitPower();
+
     if (power > LR1110_MAX_POWER) // Clamp power to maximum defined level
         power = LR1110_MAX_POWER;
 
@@ -79,8 +81,6 @@ template <typename T> bool LR11x0Interface<T>::init()
         power = LR1120_MAX_POWER;
         preambleLength = 12; // 12 is the default for operation above 2GHz
     }
-
-    limitPower();
 
 #ifdef LR11X0_RF_SWITCH_SUBGHZ
     pinMode(LR11X0_RF_SWITCH_SUBGHZ, OUTPUT);

--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -122,10 +122,10 @@ bool RF95Interface::init()
     power = dacDbValues.db;
 #endif
 
+    limitPower();
+
     if (power > RF95_MAX_POWER) // This chip has lower power limits than some
         power = RF95_MAX_POWER;
-
-    limitPower();
 
     iface = lora = new RadioLibRF95(&module);
 

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -528,8 +528,8 @@ void RadioInterface::applyModemConfig()
 
     power = loraConfig.tx_power;
 
-    if ((power == 0) || ((power + REGULATORY_GAIN_LORA > myRegion->powerLimit) && !devicestate.owner.is_licensed))
-        power = myRegion->powerLimit - REGULATORY_GAIN_LORA;
+    if ((power == 0) || ((power > myRegion->powerLimit) && !devicestate.owner.is_licensed))
+        power = myRegion->powerLimit;
 
     if (power == 0)
         power = 17; // Default to this power level if we don't have a valid regional power limit (powerLimit of myRegion defaults
@@ -616,7 +616,12 @@ void RadioInterface::limitPower()
         power = maxPower;
     }
 
-    LOG_INFO("Set radio: final power level=%d", power);
+    if (TX_GAIN_LORA > 0) {
+        LOG_INFO("Requested Tx power: %d dBm; Device LoRa Tx gain: %d dB", power, TX_GAIN_LORA);
+        power -= TX_GAIN_LORA;
+    }
+
+    LOG_INFO("Final Tx power: %d dBm", power);
 }
 
 void RadioInterface::deliverToReceiver(meshtastic_MeshPacket *p)

--- a/src/mesh/STM32WLE5JCInterface.cpp
+++ b/src/mesh/STM32WLE5JCInterface.cpp
@@ -25,10 +25,10 @@ bool STM32WLE5JCInterface::init()
 
     lora.setRfSwitchTable(rfswitch_pins, rfswitch_table);
 
+    limitPower();
+
     if (power > STM32WLx_MAX_POWER) // This chip has lower power limits than some
         power = STM32WLx_MAX_POWER;
-
-    limitPower();
 
     int res = lora.begin(getFreq(), bw, sf, cr, syncWord, power, preambleLength, tcxoVoltage);
 

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -69,10 +69,10 @@ template <typename T> bool SX126xInterface<T>::init()
 
     RadioLibInterface::init();
 
+    limitPower();
+
     if (power > SX126X_MAX_POWER) // Clamp power to maximum defined level
         power = SX126X_MAX_POWER;
-
-    limitPower();
 
     int res = lora.begin(getFreq(), bw, sf, cr, syncWord, power, preambleLength, tcxoVoltage, useRegulatorLDO);
     // \todo Display actual typename of the adapter, not just `SX126x`

--- a/src/mesh/SX128xInterface.cpp
+++ b/src/mesh/SX128xInterface.cpp
@@ -62,10 +62,10 @@ template <typename T> bool SX128xInterface<T>::init()
 
     RadioLibInterface::init();
 
+    limitPower();
+
     if (power > SX128X_MAX_POWER) // This chip has lower power limits than some
         power = SX128X_MAX_POWER;
-
-    limitPower();
 
     preambleLength = 12; // 12 is the default for this chip, 32 does not RX at all
 

--- a/variants/xiao_ble/variant.h
+++ b/variants/xiao_ble/variant.h
@@ -145,12 +145,12 @@ static const uint8_t SCK = PIN_SPI_SCK;
 #ifdef EBYTE_E22_900M30S
 // 10dB PA gain and 30dB rated output; based on measurements from
 // https://github.com/S5NC/EBYTE_ESP32-S3/blob/main/E22-900M30S%20power%20output%20testing.txt
-#define REGULATORY_GAIN_LORA 7
+#define TX_GAIN_LORA 7
 #define SX126X_MAX_POWER 22
 #endif
 #ifdef EBYTE_E22_900M33S
 // 25dB PA gain and 33dB rated output; based on TX Power Curve from E22-900M33S_UserManual_EN_v1.0.pdf
-#define REGULATORY_GAIN_LORA 25
+#define TX_GAIN_LORA 25
 #define SX126X_MAX_POWER 8
 #endif
 #endif


### PR DESCRIPTION
- Rename REGULATORY_GAIN_LORA to TX_GAIN_LORA
- Move gain-based Tx power clamping from RadioInterface::applyModemConfig() to RadioInterface::limitPower()
  - User-configured Tx power now matches the Tx power out of the device connector
- Re-order [LoRa Chip]Interface.cpp limitPower() to take place before the final Tx power clamping so we clamp based on the pre-PA Tx power rather than user-configured Tx power

Tested on XIAO BLE variant.

## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
    - [x] XIAO BLE

![image](https://github.com/user-attachments/assets/55083125-402b-40eb-a298-cf3eeee08464)

```
> meshtastic --get lora.tx_power
Connected to radio
lora.tx_power: 27
Completed getting preferences
```

```
INFO  | ??:??:?? 0 Start meshradio init
INFO  | ??:??:?? 0 Radio freq=922.875, config.lora.frequency_offset=0.000
INFO  | ??:??:?? 0 Set radio: region=MY_919, name=LongFast, config=0, ch=15, power=27
INFO  | ??:??:?? 0 myRegion->freqStart -> myRegion->freqEnd: 919.000000 -> 924.000000 (5.000000 MHz)
INFO  | ??:??:?? 0 numChannels: 20 x 250.000kHz
INFO  | ??:??:?? 0 channel_num: 16
INFO  | ??:??:?? 0 frequency: 922.875000
INFO  | ??:??:?? 0 Slot time: 28 msec
INFO  | ??:??:?? 0 Requested Tx power: 27 dBm; Device LoRa Tx gain: 7 dB
INFO  | ??:??:?? 0 Final Tx power: 20 dBm
INFO  | ??:??:?? 0 SX126x init result 0
INFO  | ??:??:?? 0 Frequency set to 922.875000
INFO  | ??:??:?? 0 Bandwidth set to 250.000000
INFO  | ??:??:?? 0 Power output set to 20
```