### PR TITLE
MQTT userprefs

### DIFF
--- a/src/mesh/Channels.cpp
+++ b/src/mesh/Channels.cpp
@@ -347,7 +347,7 @@ bool Channels::anyMqttEnabled()
 {
 #if USERPREFS_EVENT_MODE && !MESHTASTIC_EXCLUDE_MQTT
     // Don't publish messages on the public MQTT broker if we are in event mode
-    if (mqtt && mqtt->isUsingDefaultServer()) {
+    if (mqtt && mqtt->isUsingDefaultServer() && mqtt->isUsingDefaultRootTopic()) {
         return false;
     }
 #endif

--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -26,6 +26,8 @@
 #define default_mqtt_username "meshdev"
 #define default_mqtt_password "large4cats"
 #define default_mqtt_root "msh"
+#define default_mqtt_encryption_enabled true
+#define default_mqtt_tls_enabled false
 
 #define IF_ROUTER(routerVal, normalVal)                                                                                          \
     ((config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER) ? (routerVal) : (normalVal))

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -761,11 +761,39 @@ void NodeDB::installDefaultModuleConfig()
 
     moduleConfig.has_canned_message = true;
 
+#if USERPREFS_MQTT_ENABLED && !MESHTASTIC_EXCLUDE_MQTT
+    moduleConfig.mqtt.enabled = true;
+#endif
+#ifdef USERPREFS_MQTT_ADDRESS
+    strncpy(moduleConfig.mqtt.address, USERPREFS_MQTT_ADDRESS, sizeof(moduleConfig.mqtt.address));
+#else
     strncpy(moduleConfig.mqtt.address, default_mqtt_address, sizeof(moduleConfig.mqtt.address));
+#endif
+#ifdef USERPREFS_MQTT_USERNAME
+    strncpy(moduleConfig.mqtt.username, USERPREFS_MQTT_USERNAME, sizeof(moduleConfig.mqtt.username));
+#else
     strncpy(moduleConfig.mqtt.username, default_mqtt_username, sizeof(moduleConfig.mqtt.username));
+#endif
+#ifdef USERPREFS_MQTT_PASSWORD
+    strncpy(moduleConfig.mqtt.password, USERPREFS_MQTT_PASSWORD, sizeof(moduleConfig.mqtt.password));
+#else
     strncpy(moduleConfig.mqtt.password, default_mqtt_password, sizeof(moduleConfig.mqtt.password));
+#endif
+#ifdef USERPREFS_MQTT_ROOT_TOPIC
+    strncpy(moduleConfig.mqtt.root, USERPREFS_MQTT_ROOT_TOPIC, sizeof(moduleConfig.mqtt.root));
+#else
     strncpy(moduleConfig.mqtt.root, default_mqtt_root, sizeof(moduleConfig.mqtt.root));
-    moduleConfig.mqtt.encryption_enabled = true;
+#endif
+#ifdef USERPREFS_MQTT_ENCRYPTION_ENABLED
+    moduleConfig.mqtt.encryption_enabled = USERPREFS_MQTT_ENCRYPTION_ENABLED;
+#else
+    moduleConfig.mqtt.encryption_enabled = default_mqtt_encryption_enabled;
+#endif
+#ifdef USERPREFS_MQTT_TLS_ENABLED
+    moduleConfig.mqtt.tls_enabled = USERPREFS_MQTT_TLS_ENABLED;
+#else
+    moduleConfig.mqtt.tls_enabled = default_mqtt_tls_enabled;
+#endif
 
     moduleConfig.has_neighbor_info = true;
     moduleConfig.neighbor_info.enabled = false;

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -256,6 +256,11 @@ bool isDefaultServer(const String &host)
     return host.length() == 0 || host == default_mqtt_address;
 }
 
+bool isDefaultRootTopic(const String &root)
+{
+    return root.length() == 0 || root == default_mqtt_root;
+}
+
 struct PubSubConfig {
     explicit PubSubConfig(const meshtastic_ModuleConfig_MQTTConfig &config)
     {
@@ -387,10 +392,12 @@ MQTT::MQTT() : concurrency::OSThread("mqtt"), mqttQueue(MAX_MQTT_QUEUE)
             cryptTopic = moduleConfig.mqtt.root + cryptTopic;
             jsonTopic = moduleConfig.mqtt.root + jsonTopic;
             mapTopic = moduleConfig.mqtt.root + mapTopic;
+            isConfiguredForDefaultRootTopic = isDefaultRootTopic(moduleConfig.mqtt.root);
         } else {
             cryptTopic = "msh" + cryptTopic;
             jsonTopic = "msh" + jsonTopic;
             mapTopic = "msh" + mapTopic;
+            isConfiguredForDefaultRootTopic = true;
         }
 
         if (moduleConfig.mqtt.map_reporting_enabled && moduleConfig.mqtt.has_map_report_settings) {

--- a/src/mqtt/MQTT.h
+++ b/src/mqtt/MQTT.h
@@ -58,6 +58,7 @@ class MQTT : private concurrency::OSThread
     void start() { setIntervalFromNow(0); };
 
     bool isUsingDefaultServer() { return isConfiguredForDefaultServer; }
+    bool isUsingDefaultRootTopic() { return isConfiguredForDefaultRootTopic; }
 
     /// Validate the meshtastic_ModuleConfig_MQTTConfig.
     static bool isValidConfig(const meshtastic_ModuleConfig_MQTTConfig &config) { return isValidConfig(config, nullptr); }
@@ -71,6 +72,7 @@ class MQTT : private concurrency::OSThread
 
     int reconnectCount = 0;
     bool isConfiguredForDefaultServer = true;
+    bool isConfiguredForDefaultRootTopic = true;
 
     virtual int32_t runOnce() override;
 

--- a/userPrefs.jsonc
+++ b/userPrefs.jsonc
@@ -44,5 +44,12 @@
   // "USERPREFS_NETWORK_WIFI_ENABLED": "true",
   // "USERPREFS_NETWORK_WIFI_SSID": "wifi_ssid",
   // "USERPREFS_NETWORK_WIFI_PSK": "wifi_psk",
+  // "USERPREFS_MQTT_ENABLED": "1",
+  // "USERPREFS_MQTT_ADDRESS": "'mqtt.meshtastic.org'",
+  // "USERPREFS_MQTT_USERNAME": "meshdev",
+  // "USERPREFS_MQTT_PASSWORD": "large4cats",
+  // "USERPREFS_MQTT_ENCRYPTION_ENABLED": "true",
+  // "USERPREFS_MQTT_TLS_ENABLED": "false",
+  // "USERPREFS_MQTT_ROOT_TOPIC": "event/REPLACEME",
   "USERPREFS_TZ_STRING": "tzplaceholder                                         "
 }


### PR DESCRIPTION
Add USERPREF configs for MQTT :smile::skull_and_crossbones:

Also accounts for topic with `isDefaultRootTopic` when evaluating event_mode MQTT filters.

~DRAFT untested.~ Tested/working.