### PR TITLE
Add suppport for Quectel L80

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1250,11 +1250,9 @@ GnssModel_t GPS::probe(int serialSpeed)
     // Close all NMEA sentences, valid for MTK3333 and MTK3339 platforms
     _serial_gps->write("$PMTK514,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0*2E\r\n");
     delay(20);
-    std::vector<ChipInfo> mtk = {{"L76B", "Quectel-L76B", GNSS_MODEL_MTK_L76B},
-                                 {"PA1010D", "1010D", GNSS_MODEL_MTK_PA1010D},
-                                 {"PA1616S", "1616S", GNSS_MODEL_MTK_PA1616S},
-                                 {"LS20031", "MC-1513", GNSS_MODEL_MTK_L76B},
-                                 {"L96", "Quectel-L96", GNSS_MODEL_MTK_L76B}};
+    std::vector<ChipInfo> mtk = {{"L76B", "Quectel-L76B", GNSS_MODEL_MTK_L76B}, {"PA1010D", "1010D", GNSS_MODEL_MTK_PA1010D},
+                                 {"PA1616S", "1616S", GNSS_MODEL_MTK_PA1616S},  {"LS20031", "MC-1513", GNSS_MODEL_MTK_L76B},
+                                 {"L96", "Quectel-L96", GNSS_MODEL_MTK_L76B},   {"L80", "QUECTEL-L80", GNSS_MODEL_MTK_L76B}};
 
     PROBE_FAMILY("MTK Family", "$PMTK605*31", mtk, 500);
 

--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1252,7 +1252,8 @@ GnssModel_t GPS::probe(int serialSpeed)
     delay(20);
     std::vector<ChipInfo> mtk = {{"L76B", "Quectel-L76B", GNSS_MODEL_MTK_L76B}, {"PA1010D", "1010D", GNSS_MODEL_MTK_PA1010D},
                                  {"PA1616S", "1616S", GNSS_MODEL_MTK_PA1616S},  {"LS20031", "MC-1513", GNSS_MODEL_MTK_L76B},
-                                 {"L96", "Quectel-L96", GNSS_MODEL_MTK_L76B},   {"L80", "QUECTEL-L80", GNSS_MODEL_MTK_L76B}};
+                                 {"L96", "Quectel-L96", GNSS_MODEL_MTK_L76B},   {"L80-R", "_3337_", GNSS_MODEL_MTK_L76B},
+                                 {"L80", "_3339_", GNSS_MODEL_MTK_L76B}};
 
     PROBE_FAMILY("MTK Family", "$PMTK605*31", mtk, 500);
 


### PR DESCRIPTION
Another PMTK family chip, requires only a modification to the probe code.