### PR TITLE
Fix run out of heap on ESP32

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -232,7 +232,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 #ifndef MINIMUM_SAFE_FREE_HEAP
+#ifdef ESP32
 #define MINIMUM_SAFE_FREE_HEAP 15000
+#else
+#define MINIMUM_SAFE_FREE_HEAP 1500
+#endif
 #endif
 
 #ifndef WIRE_INTERFACES_COUNT

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -232,7 +232,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 #ifndef MINIMUM_SAFE_FREE_HEAP
-#define MINIMUM_SAFE_FREE_HEAP 1500
+#define MINIMUM_SAFE_FREE_HEAP 15000
 #endif
 
 #ifndef WIRE_INTERFACES_COUNT


### PR DESCRIPTION

## 🤝 Attestations
- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [X] Other (please specify below)

ESP32 devices.
