### PR TITLE
Portduino: Don't filter the traditional UI

### DIFF
--- a/variants/portduino/platformio.ini
+++ b/variants/portduino/platformio.ini
@@ -41,7 +41,6 @@ build_flags = ${native_base.build_flags} -Os -lX11 -linput -lxkbcommon -ffunctio
   !pkg-config --libs openssl --silence-errors || :
 build_src_filter =
   ${native_base.build_src_filter}
-  -<graphics/TFTDisplay.cpp>
 
 [env:native-fb]
 extends = native_base
@@ -72,7 +71,6 @@ build_flags = ${native_base.build_flags} -Os -ffunction-sections -fdata-sections
   !pkg-config --libs openssl --silence-errors || :
 build_src_filter =
   ${native_base.build_src_filter}
-  -<graphics/TFTDisplay.cpp>
 
 [env:native-tft-debug]
 extends = native_base


### PR DESCRIPTION
Portduino: Do not filter out (exclude) the traditional UI on Linux.

Display selection should be left to the user in the yaml, not taken away at build time.


DRAFT compiles correctly but untested on real hardware.