### PR TITLE
Fix for ICM-20948 not initializing

### DIFF
--- a/src/motion/ICM20948Sensor.cpp
+++ b/src/motion/ICM20948Sensor.cpp
@@ -190,12 +190,18 @@ bool ICM20948Singleton::init(ScanI2C::FoundDevice device)
 #endif
 
 // startup
-#ifdef Wire1
-    ICM_20948_Status_e status =
-        begin(device.address.port == ScanI2C::I2CPort::WIRE1 ? Wire1 : Wire, device.address.address == ICM20948_ADDR ? 1 : 0);
-#else
-    ICM_20948_Status_e status = begin(Wire, device.address.address == ICM20948_ADDR ? 1 : 0);
-#endif
+    #if defined(WIRE_INTERFACES_COUNT) && (WIRE_INTERFACES_COUNT > 1)
+        TwoWire &bus = (device.address.port == ScanI2C::I2CPort::WIRE1 ? Wire1 : Wire);
+    #else
+        TwoWire &bus = Wire; // fallback if only one I2C interface
+    #endif
+
+    bool bAddr = (device.address.address == 0x69);
+    delay(100);
+
+    LOG_DEBUG("ICM20948 begin on addr 0x%02X (port=%d, bAddr=%d)", device.address.address, device.address.port, bAddr);
+
+    ICM_20948_Status_e status = begin(bus, bAddr);
     if (status != ICM_20948_Stat_Ok) {
         LOG_DEBUG("ICM20948 init begin - %s", statusString());
         return false;

--- a/src/motion/ICM20948Sensor.cpp
+++ b/src/motion/ICM20948Sensor.cpp
@@ -189,12 +189,12 @@ bool ICM20948Singleton::init(ScanI2C::FoundDevice device)
     enableDebugging();
 #endif
 
-// startup
-    #if defined(WIRE_INTERFACES_COUNT) && (WIRE_INTERFACES_COUNT > 1)
-        TwoWire &bus = (device.address.port == ScanI2C::I2CPort::WIRE1 ? Wire1 : Wire);
-    #else
-        TwoWire &bus = Wire; // fallback if only one I2C interface
-    #endif
+    // startup
+#if defined(WIRE_INTERFACES_COUNT) && (WIRE_INTERFACES_COUNT > 1)
+    TwoWire &bus = (device.address.port == ScanI2C::I2CPort::WIRE1 ? Wire1 : Wire);
+#else
+    TwoWire &bus = Wire; // fallback if only one I2C interface
+#endif
 
     bool bAddr = (device.address.address == 0x69);
     delay(100);


### PR DESCRIPTION
Problem:
The ICM-20948 Accelerometer was failing to initialize on boot on the Heltec T114, T3S3, and Heltec V3 but worked fine on Rak4631

![image](https://github.com/user-attachments/assets/65c58ee9-b80e-453d-8b95-f9d7363e8744)

Cause:
The code was trying to figure out if the board supports a second I2C port (Wire1), but it was checking the wrong way. That caused it to pick the wrong I2C port, so the sensor couldn’t communicate properly on some boards.

Fix:
I changed the code to correctly detect which I2C port the board supports and use the one the sensor is actually connected to. After this change, the accelerometer initializes properly on all boards.

Tested on all Heltec T114, T3S3, and Heltec V3 and RAK4631