### PR TITLE
Unify the native display config between legacy display and MUI

### DIFF
--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -666,6 +666,8 @@ class LGFX : public lgfx::LGFX_Device
   public:
     LGFX(void)
     {
+        int _width = 0;
+        int _height = 0;
         if (settingsMap[displayPanel] == st7789)
             _panel_instance = new lgfx::Panel_ST7789;
         else if (settingsMap[displayPanel] == st7735)
@@ -686,7 +688,13 @@ class LGFX : public lgfx::LGFX_Device
             _panel_instance = new lgfx::Panel_NULL;
             LOG_ERROR("Unknown display panel configured!");
         }
-
+        if (settingsMap[displayRotate]) {
+            _width = settingsMap[displayHeight];
+            _height = settingsMap[displayWidth];
+        } else {
+            _width = settingsMap[displayWidth];
+            _height = settingsMap[displayHeight];
+        }
         auto buscfg = _bus_instance.config();
         buscfg.spi_mode = 0;
         buscfg.spi_host = settingsMap[displayspidev];
@@ -700,11 +708,17 @@ class LGFX : public lgfx::LGFX_Device
         LOG_DEBUG("Height: %d, Width: %d ", settingsMap[displayHeight], settingsMap[displayWidth]);
         cfg.pin_cs = settingsMap[displayCS]; // Pin number where CS is connected (-1 = disable)
         cfg.pin_rst = settingsMap[displayReset];
-        cfg.panel_width = settingsMap[displayWidth];            // actual displayable width
-        cfg.panel_height = settingsMap[displayHeight];          // actual displayable height
+        cfg.panel_width = _width;            // actual displayable width
+        cfg.panel_height = _height;          // actual displayable height
         cfg.offset_x = settingsMap[displayOffsetX];             // Panel offset amount in X direction
         cfg.offset_y = settingsMap[displayOffsetY];             // Panel offset amount in Y direction
-        cfg.offset_rotation = settingsMap[displayOffsetRotate]; // Rotation direction value offset 0~7 (4~7 is mirrored)
+        if (settingsMap[displayOffsetRotate] = 3) {
+            cfg.offset_rotation = 0;
+        } else if (settingsMap[displayOffsetRotate] = 7) {
+            cfg.offset_rotation = 4;
+        } else {
+            cfg.offset_rotation = settingsMap[displayOffsetRotate] + 1; // Rotation direction value offset 0~7 (4~7 is mirrored)
+        }
         cfg.invert = settingsMap[displayInvert];                // Set to true if the light/darkness of the panel is reversed
 
         _panel_instance->config(cfg);
@@ -977,11 +991,7 @@ TFTDisplay::TFTDisplay(uint8_t address, int sda, int scl, OLEDDISPLAY_GEOMETRY g
     backlightEnable = p;
 
 #if ARCH_PORTDUINO
-    if (settingsMap[displayRotate]) {
-        setGeometry(GEOMETRY_RAWMODE, settingsMap[configNames::displayHeight], settingsMap[configNames::displayWidth]);
-    } else {
-        setGeometry(GEOMETRY_RAWMODE, settingsMap[configNames::displayWidth], settingsMap[configNames::displayHeight]);
-    }
+    setGeometry(GEOMETRY_RAWMODE, settingsMap[configNames::displayWidth], settingsMap[configNames::displayHeight]);
 
 #elif defined(SCREEN_ROTATE)
     setGeometry(GEOMETRY_RAWMODE, TFT_HEIGHT, TFT_WIDTH);

--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -666,8 +666,6 @@ class LGFX : public lgfx::LGFX_Device
   public:
     LGFX(void)
     {
-        int _width = 0;
-        int _height = 0;
         if (settingsMap[displayPanel] == st7789)
             _panel_instance = new lgfx::Panel_ST7789;
         else if (settingsMap[displayPanel] == st7735)
@@ -688,13 +686,7 @@ class LGFX : public lgfx::LGFX_Device
             _panel_instance = new lgfx::Panel_NULL;
             LOG_ERROR("Unknown display panel configured!");
         }
-        if (settingsMap[displayRotate]) {
-            _width = settingsMap[displayHeight];
-            _height = settingsMap[displayWidth];
-        } else {
-            _width = settingsMap[displayWidth];
-            _height = settingsMap[displayHeight];
-        }
+
         auto buscfg = _bus_instance.config();
         buscfg.spi_mode = 0;
         buscfg.spi_host = settingsMap[displayspidev];
@@ -705,20 +697,19 @@ class LGFX : public lgfx::LGFX_Device
         _panel_instance->setBus(&_bus_instance); // set the bus on the panel.
 
         auto cfg = _panel_instance->config(); // Gets a structure for display panel settings.
-        LOG_DEBUG("Height: %d, Width: %d ", settingsMap[displayHeight], settingsMap[displayWidth]);
+        LOG_DEBUG("Width: %d, Height: %d", settingsMap[displayWidth], settingsMap[displayHeight]);
         cfg.pin_cs = settingsMap[displayCS]; // Pin number where CS is connected (-1 = disable)
         cfg.pin_rst = settingsMap[displayReset];
-        cfg.panel_width = _width;            // actual displayable width
-        cfg.panel_height = _height;          // actual displayable height
+        if (settingsMap[displayRotate]) {
+            cfg.panel_width = settingsMap[displayHeight]; // actual displayable width
+            cfg.panel_height = settingsMap[displayWidth]; // actual displayable height
+        } else {
+            cfg.panel_width = settingsMap[displayWidth];   // actual displayable width
+            cfg.panel_height = settingsMap[displayHeight]; // actual displayable height
+        }
         cfg.offset_x = settingsMap[displayOffsetX];             // Panel offset amount in X direction
         cfg.offset_y = settingsMap[displayOffsetY];             // Panel offset amount in Y direction
-        if (settingsMap[displayOffsetRotate] = 3) {
-            cfg.offset_rotation = 0;
-        } else if (settingsMap[displayOffsetRotate] = 7) {
-            cfg.offset_rotation = 4;
-        } else {
-            cfg.offset_rotation = settingsMap[displayOffsetRotate] + 1; // Rotation direction value offset 0~7 (4~7 is mirrored)
-        }
+        cfg.offset_rotation = settingsMap[displayOffsetRotate]; // Rotation direction value offset 0~7 (4~7 is mirrored)
         cfg.invert = settingsMap[displayInvert];                // Set to true if the light/darkness of the panel is reversed
 
         _panel_instance->config(cfg);
@@ -991,7 +982,11 @@ TFTDisplay::TFTDisplay(uint8_t address, int sda, int scl, OLEDDISPLAY_GEOMETRY g
     backlightEnable = p;
 
 #if ARCH_PORTDUINO
-    setGeometry(GEOMETRY_RAWMODE, settingsMap[configNames::displayWidth], settingsMap[configNames::displayHeight]);
+    if (settingsMap[displayRotate]) {
+        setGeometry(GEOMETRY_RAWMODE, settingsMap[configNames::displayWidth], settingsMap[configNames::displayHeight]);
+    } else {
+        setGeometry(GEOMETRY_RAWMODE, settingsMap[configNames::displayHeight], settingsMap[configNames::displayWidth]);
+    }
 
 #elif defined(SCREEN_ROTATE)
     setGeometry(GEOMETRY_RAWMODE, TFT_HEIGHT, TFT_WIDTH);
@@ -1179,6 +1174,8 @@ bool TFTDisplay::connect()
     tft->setRotation(1); // T-Deck has the TFT in landscape
 #elif defined(T_WATCH_S3) || defined(SENSECAP_INDICATOR)
     tft->setRotation(2); // T-Watch S3 left-handed orientation
+#elif defined(ARCH_PORTDUINO)
+    tft->setRotation(0);
 #else
     tft->setRotation(3); // Orient horizontal and wide underneath the silkscreen name label
 #endif


### PR DESCRIPTION
WIP. I specifically don't understand why the OffsetRotate needs to be different between MUI and the legacy display.