### PR TITLE
Hostmetrics user string

### DIFF
--- a/bin/config-dist.yaml
+++ b/bin/config-dist.yaml
@@ -197,6 +197,7 @@ Webserver:
 HostMetrics:
 #  ReportInterval: 30 # Interval in minutes between HostMetrics report packets, or 0 for disabled
 #  Channel: 0 # channel to send Host Metrics over. Defaults to the primary channel.
+#  UserStringCommand: cat /sys/firmware/devicetree/base/serial-number # Command to execute, to send the results as the userString
 
 
 General:

--- a/src/modules/Telemetry/HostMetrics.cpp
+++ b/src/modules/Telemetry/HostMetrics.cpp
@@ -30,8 +30,8 @@ bool HostMetricsModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, 
 #ifdef DEBUG_PORT
         const char *sender = getSenderShortName(mp);
 
-        LOG_INFO("(Received Host Metrics from %s): uptime=%u, diskfree=%lu, memory free=%lu, load=%04.2f, %04.2f, %04.2f, %s", sender,
-                 t->variant.host_metrics.uptime_seconds, t->variant.host_metrics.diskfree1_bytes,
+        LOG_INFO("(Received Host Metrics from %s): uptime=%u, diskfree=%lu, memory free=%lu, load=%04.2f, %04.2f, %04.2f, %s",
+                 sender, t->variant.host_metrics.uptime_seconds, t->variant.host_metrics.diskfree1_bytes,
                  t->variant.host_metrics.freemem_bytes, static_cast<float>(t->variant.host_metrics.load1) / 100,
                  static_cast<float>(t->variant.host_metrics.load5) / 100,
                  static_cast<float>(t->variant.host_metrics.load15) / 100, t->variant.host_metrics.user_string);
@@ -110,9 +110,8 @@ meshtastic_Telemetry HostMetricsModule::getHostMetrics()
     if (settingsStrings[hostMetrics_user_command] != "") {
         std::string userCommandResult = exec(settingsStrings[hostMetrics_user_command].c_str());
         if (userCommandResult.length() > 1) {
-        strncpy(t.variant.host_metrics.user_string, userCommandResult.c_str(), 200);
-        t.variant.host_metrics.has_user_string = true;
-
+            strncpy(t.variant.host_metrics.user_string, userCommandResult.c_str(), 200);
+            t.variant.host_metrics.has_user_string = true;
         }
     }
     return t;

--- a/src/modules/Telemetry/HostMetrics.cpp
+++ b/src/modules/Telemetry/HostMetrics.cpp
@@ -30,11 +30,11 @@ bool HostMetricsModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, 
 #ifdef DEBUG_PORT
         const char *sender = getSenderShortName(mp);
 
-        LOG_INFO("(Received Host Metrics from %s): uptime=%u, diskfree=%lu, memory free=%lu, load=%04.2f, %04.2f, %04.2f", sender,
+        LOG_INFO("(Received Host Metrics from %s): uptime=%u, diskfree=%lu, memory free=%lu, load=%04.2f, %04.2f, %04.2f, %s", sender,
                  t->variant.host_metrics.uptime_seconds, t->variant.host_metrics.diskfree1_bytes,
                  t->variant.host_metrics.freemem_bytes, static_cast<float>(t->variant.host_metrics.load1) / 100,
                  static_cast<float>(t->variant.host_metrics.load5) / 100,
-                 static_cast<float>(t->variant.host_metrics.load15) / 100);
+                 static_cast<float>(t->variant.host_metrics.load15) / 100, t->variant.host_metrics.user_string);
 #endif
     }
     return false; // Let others look at this message also if they want
@@ -107,18 +107,25 @@ meshtastic_Telemetry HostMetricsModule::getHostMetrics()
             proc_loadavg.close();
         }
     }
+    if (settingsStrings[hostMetrics_user_command] != "") {
+        std::string userCommandResult = exec(settingsStrings[hostMetrics_user_command].c_str());
+        if (userCommandResult.length() > 1) {
+        strncpy(t.variant.host_metrics.user_string, userCommandResult.c_str(), 200);
+        t.variant.host_metrics.has_user_string = true;
 
+        }
+    }
     return t;
 }
 
 bool HostMetricsModule::sendMetrics()
 {
     meshtastic_Telemetry telemetry = getHostMetrics();
-    LOG_INFO("Send: uptime=%u, diskfree=%lu, memory free=%lu, load=%04.2f, %04.2f, %04.2f",
+    LOG_INFO("Send: uptime=%u, diskfree=%lu, memory free=%lu, load=%04.2f, %04.2f, %04.2f %s",
              telemetry.variant.host_metrics.uptime_seconds, telemetry.variant.host_metrics.diskfree1_bytes,
              telemetry.variant.host_metrics.freemem_bytes, static_cast<float>(telemetry.variant.host_metrics.load1) / 100,
              static_cast<float>(telemetry.variant.host_metrics.load5) / 100,
-             static_cast<float>(telemetry.variant.host_metrics.load15) / 100);
+             static_cast<float>(telemetry.variant.host_metrics.load15) / 100, telemetry.variant.host_metrics.user_string);
 
     meshtastic_MeshPacket *p = allocDataProtobuf(telemetry);
     p->to = NODENUM_BROADCAST;

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -604,7 +604,6 @@ bool loadConfig(const char *configPath)
             settingsMap[hostMetrics_channel] = (yamlConfig["HostMetrics"]["Channel"]).as<int>(0);
             settingsMap[hostMetrics_interval] = (yamlConfig["HostMetrics"]["ReportInterval"]).as<int>(0);
             settingsStrings[hostMetrics_user_command] = (yamlConfig["HostMetrics"]["UserStringCommand"]).as<std::string>("");
-            
         }
 
         if (yamlConfig["General"]) {

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -603,6 +603,8 @@ bool loadConfig(const char *configPath)
         if (yamlConfig["HostMetrics"]) {
             settingsMap[hostMetrics_channel] = (yamlConfig["HostMetrics"]["Channel"]).as<int>(0);
             settingsMap[hostMetrics_interval] = (yamlConfig["HostMetrics"]["ReportInterval"]).as<int>(0);
+            settingsStrings[hostMetrics_user_command] = (yamlConfig["HostMetrics"]["UserStringCommand"]).as<std::string>("");
+            
         }
 
         if (yamlConfig["General"]) {

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -102,7 +102,8 @@ enum configNames {
     available_directory,
     mac_address,
     hostMetrics_interval,
-    hostMetrics_channel
+    hostMetrics_channel,
+    hostMetrics_user_command
 };
 enum { no_screen, x11, fb, st7789, st7735, st7735s, st7796, ili9341, ili9342, ili9486, ili9488, hx8357d };
 enum { no_touchscreen, xpt2046, stmpe610, gt911, ft5x06 };


### PR DESCRIPTION
User can now specify a command in config.yaml, and the results of which will be sent as the user string inside a host metrics telemetry packet.