### PR TITLE
Add basic handling for is_manually_validated

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1655,7 +1655,7 @@ meshtastic_NodeInfoLite *NodeDB::getOrCreateMeshNode(NodeNum n)
             for (int i = 1; i < numMeshNodes; i++) {
                 // Simply the oldest non-favorite, non-ignored, non-verified node
                 if (!meshNodes->at(i).is_favorite && !meshNodes->at(i).is_ignored &&
-                    !(meshNodes->at(i).bitfield & NODEINFO_BITFIELD_IS_MANUALLY_VALIDATED_MASK) &&
+                    !(meshNodes->at(i).bitfield & NODEINFO_BITFIELD_IS_KEY_MANUALLY_VERIFIED_MASK) &&
                     meshNodes->at(i).last_heard < oldest) {
                     oldest = meshNodes->at(i).last_heard;
                     oldestIndex = i;

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1653,8 +1653,10 @@ meshtastic_NodeInfoLite *NodeDB::getOrCreateMeshNode(NodeNum n)
             int oldestIndex = -1;
             int oldestBoringIndex = -1;
             for (int i = 1; i < numMeshNodes; i++) {
-                // Simply the oldest non-favorite node
-                if (!meshNodes->at(i).is_favorite && !meshNodes->at(i).is_ignored && meshNodes->at(i).last_heard < oldest) {
+                // Simply the oldest non-favorite, non-ignored, non-verified node
+                if (!meshNodes->at(i).is_favorite && !meshNodes->at(i).is_ignored &&
+                    !(meshNodes->at(i).bitfield & NODEINFO_BITFIELD_IS_MANUALLY_VALIDATED_MASK) &&
+                    meshNodes->at(i).last_heard < oldest) {
                     oldest = meshNodes->at(i).last_heard;
                     oldestIndex = i;
                 }

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -274,8 +274,8 @@ extern meshtastic_CriticalErrorCode error_code;
  * A numeric error address (nonzero if available)
  */
 extern uint32_t error_address;
-#define NODEINFO_BITFIELD_IS_KEY_MANUALLY_VERIFIED_SHIFT = 0
-#define NODEINFO_BITFIELD_IS_KEY_MANUALLY_VERIFIED_MASK = (1 << NODEINFO_BITFIELD_IS_KEY_MANUALLY_VERIFIED_SHIFT)
+#define NODEINFO_BITFIELD_IS_KEY_MANUALLY_VERIFIED_SHIFT 0
+#define NODEINFO_BITFIELD_IS_KEY_MANUALLY_VERIFIED_MASK (1 << NODEINFO_BITFIELD_IS_KEY_MANUALLY_VERIFIED_SHIFT)
 
 #define Module_Config_size                                                                                                       \
     (ModuleConfig_CannedMessageConfig_size + ModuleConfig_ExternalNotificationConfig_size + ModuleConfig_MQTTConfig_size +       \

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -274,8 +274,8 @@ extern meshtastic_CriticalErrorCode error_code;
  * A numeric error address (nonzero if available)
  */
 extern uint32_t error_address;
-#define NODEINFO_BITFIELD_IS_MANUALLY_VALIDATED_SHIFT = 0
-#define NODEINFO_BITFIELD_IS_MANUALLY_VALIDATED_MASK = (1 << NODEINFO_BITFIELD_IS_MANUALLY_VALIDATED_SHIFT)
+#define NODEINFO_BITFIELD_IS_KEY_MANUALLY_VERIFIED_SHIFT = 0
+#define NODEINFO_BITFIELD_IS_KEY_MANUALLY_VERIFIED_MASK = (1 << NODEINFO_BITFIELD_IS_KEY_MANUALLY_VERIFIED_SHIFT)
 
 #define Module_Config_size                                                                                                       \
     (ModuleConfig_CannedMessageConfig_size + ModuleConfig_ExternalNotificationConfig_size + ModuleConfig_MQTTConfig_size +       \

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -274,6 +274,8 @@ extern meshtastic_CriticalErrorCode error_code;
  * A numeric error address (nonzero if available)
  */
 extern uint32_t error_address;
+#define NODEINFO_BITFIELD_IS_MANUALLY_VALIDATED_SHIFT = 0
+#define NODEINFO_BITFIELD_IS_MANUALLY_VALIDATED_MASK = (1 << NODEINFO_BITFIELD_IS_MANUALLY_VALIDATED_SHIFT)
 
 #define Module_Config_size                                                                                                       \
     (ModuleConfig_CannedMessageConfig_size + ModuleConfig_ExternalNotificationConfig_size + ModuleConfig_MQTTConfig_size +       \

--- a/src/mesh/TypeConversions.cpp
+++ b/src/mesh/TypeConversions.cpp
@@ -13,7 +13,7 @@ meshtastic_NodeInfo TypeConversions::ConvertToNodeInfo(const meshtastic_NodeInfo
     info.via_mqtt = lite->via_mqtt;
     info.is_favorite = lite->is_favorite;
     info.is_ignored = lite->is_ignored;
-    info.is_manually_validated = lite->bitfield & NODEINFO_BITFIELD_IS_MANUALLY_VALIDATED_MASK;
+    info.is_key_manually_verified = lite->bitfield & NODEINFO_BITFIELD_IS_KEY_MANUALLY_VERIFIED_MASK;
 
     if (lite->has_hops_away) {
         info.has_hops_away = true;

--- a/src/mesh/TypeConversions.cpp
+++ b/src/mesh/TypeConversions.cpp
@@ -13,6 +13,7 @@ meshtastic_NodeInfo TypeConversions::ConvertToNodeInfo(const meshtastic_NodeInfo
     info.via_mqtt = lite->via_mqtt;
     info.is_favorite = lite->is_favorite;
     info.is_ignored = lite->is_ignored;
+    info.is_manually_validated = lite->bitfield & NODEINFO_BITFIELD_IS_MANUALLY_VALIDATED_MASK;
 
     if (lite->has_hops_away) {
         info.has_hops_away = true;


### PR DESCRIPTION
Depends on protobufs/#689. Adds a nodeinfolight bitfield and the is_manually_validated bool to nodeinfo.

The intent is to set this through an out-of-band verification process.