### PR TITLE
Bosch bsec2: Switch back to official releases

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -147,8 +147,6 @@ lib_deps =
 	emotibit/EmotiBit MLX90632@1.0.8
 	# renovate: datasource=custom.pio depName=Adafruit MLX90614 packageName=adafruit/library/Adafruit MLX90614 Library
 	adafruit/Adafruit MLX90614 Library@2.1.5
-	# renovate: datasource=custom.pio depName=Bosch BME68x packageName=boschsensortec/library/BME68x Sensor Library
-	boschsensortec/BME68x Sensor Library@1.2.40408
 	# renovate: datasource=github-tags depName=INA3221 packageName=KodinLanewave/INA3221
 	https://github.com/KodinLanewave/INA3221/archive/1.0.1.zip
 	# renovate: datasource=custom.pio depName=QMC5883L Compass packageName=mprograms/library/QMC5883LCompass
@@ -185,7 +183,9 @@ lib_deps =
 	sparkfun/SparkFun Qwiic Scale NAU7802 Arduino Library@1.0.6
 	# renovate: datasource=custom.pio depName=ClosedCube OPT3001 packageName=closedcube/library/ClosedCube OPT3001
 	ClosedCube OPT3001@1.1.2
-	# renovate: datasource=git-refs depName=Bosch BSEC2 packageName=https://github.com/meshtastic/Bosch-BSEC2-Library gitBranch=extra_script
-	https://github.com/meshtastic/Bosch-BSEC2-Library/archive/e16952dfe5addd4287e1eb8c4f6ecac0fa3dd3de.zip
+	# renovate: datasource=custom.pio depName=Bosch BSEC2 packageName=boschsensortec/library/bsec2
+	boschsensortec/bsec2@1.10.2610
+	# renovate: datasource=custom.pio depName=Bosch BME68x packageName=boschsensortec/library/BME68x Sensor Library
+	boschsensortec/BME68x Sensor Library@1.3.40408
 	# renovate: datasource=git-refs depName=meshtastic-DFRobot_LarkWeatherStation packageName=https://github.com/meshtastic/DFRobot_LarkWeatherStation gitBranch=master
 	https://github.com/meshtastic/DFRobot_LarkWeatherStation/archive/4de3a9cadef0f6a5220a8a906cf9775b02b0040d.zip


### PR DESCRIPTION
https://github.com/boschsensortec/Bosch-BSEC2-Library/pull/55 has been merged :tada:

This PR changes the bsec2 library back to the official tagged releases, as our fork is no longer needed.

Also moves `BME68x Sensor Library` into environmental_extra, as it relies upon bsec2 / does not work in portduino.