### PR TITLE
graphics: Add GDEY0213B74 E-Ink display driver

### DIFF
--- a/src/graphics/niche/Drivers/EInk/GDEY0213B74.cpp
+++ b/src/graphics/niche/Drivers/EInk/GDEY0213B74.cpp
@@ -1,0 +1,61 @@
+#include "./GDEY0213B74.h"
+
+#ifdef MESHTASTIC_INCLUDE_NICHE_GRAPHICS
+
+using namespace NicheGraphics::Drivers;
+
+// Map the display controller IC's output to the connected panel
+void GDEY0213B74::configScanning()
+{
+    // "Driver output control"
+    sendCommand(0x01);
+    sendData(0xF9);
+    sendData(0x00);
+    sendData(0x00);
+
+    // To-do: delete this method?
+    // Values set here might be redundant: F9, 00, 00 seems to be default
+}
+
+// Specify which information is used to control the sequence of voltages applied to move the pixels
+// - For this display, configUpdateSequence() specifies that a suitable LUT will be loaded from
+//   the controller IC's OTP memory, when the update procedure begins.
+void GDEY0213B74::configWaveform()
+{
+    sendCommand(0x3C); // Border waveform:
+    sendData(0x05);    // Screen border should follow LUT1 waveform (actively drive pixels white)
+
+    sendCommand(0x18); // Temperature sensor:
+    sendData(0x80);    // Use internal temperature sensor to select an appropriate refresh waveform
+}
+
+void GDEY0213B74::configUpdateSequence()
+{
+    switch (updateType) {
+    case FAST:
+        sendCommand(0x22); // Set "update sequence"
+        sendData(0xFF);    // Will load LUT from OTP memory, Display mode 2 "differential refresh"
+        break;
+
+    case FULL:
+    default:
+        sendCommand(0x22); // Set "update sequence"
+        sendData(0xF7);    // Will load LUT from OTP memory
+        break;
+    }
+}
+
+// Once the refresh operation has been started,
+// begin periodically polling the display to check for completion, using the normal Meshtastic threading code
+// Only used when refresh is "async"
+void GDEY0213B74::detachFromUpdate()
+{
+    switch (updateType) {
+    case FAST:
+        return beginPolling(50, 500); // At least 500ms for fast refresh
+    case FULL:
+    default:
+        return beginPolling(100, 2000); // At least 2 seconds for full refresh
+    }
+}
+#endif // MESHTASTIC_INCLUDE_NICHE_GRAPHICS

--- a/src/graphics/niche/Drivers/EInk/GDEY0213B74.h
+++ b/src/graphics/niche/Drivers/EInk/GDEY0213B74.h
@@ -1,0 +1,42 @@
+/*
+
+E-Ink display driver
+    - GDEY0213B74
+    - Manufacturer: Goodisplay
+    - Size: 2.13 inch
+    - Resolution: 250px x 122px
+    - Flex connector marking: FPC-A002
+
+*/
+
+#pragma once
+
+#ifdef MESHTASTIC_INCLUDE_NICHE_GRAPHICS
+
+#include "configuration.h"
+
+#include "./SSD16XX.h"
+
+namespace NicheGraphics::Drivers
+{
+class GDEY0213B74 : public SSD16XX
+{
+    // Display properties
+  private:
+    static constexpr uint32_t width = 122;
+    static constexpr uint32_t height = 250;
+    static constexpr UpdateTypes supported = (UpdateTypes)(FULL | FAST);
+
+  public:
+    GDEY0213B74() : SSD16XX(width, height, supported) {}
+
+  protected:
+    virtual void configScanning() override;
+    virtual void configWaveform() override;
+    virtual void configUpdateSequence() override;
+    void detachFromUpdate() override;
+};
+
+} // namespace NicheGraphics::Drivers
+
+#endif // MESHTASTIC_INCLUDE_NICHE_GRAPHICS


### PR DESCRIPTION
Implement the GDEY0213B74 driver with configuration methods for scanning, waveform, update sequence, and polling for refresh completion. This driver supports both fast and full update types for the 2.13 inch E-Ink display.

Signed-off-by: ChihoSin chihosin@icloud.com

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] RAK WisBlock 4631 with E-Ink Display GDEY0213B74, build with InkHUD
