### PR TITLE
InkHUD: add missing parsing of UTF-8 chars

### DIFF
--- a/src/graphics/niche/InkHUD/Applets/System/Notification/NotificationApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/System/Notification/NotificationApplet.cpp
@@ -213,7 +213,7 @@ std::string InkHUD::NotificationApplet::getNotificationText(uint16_t widthAvaila
 
         // Sender id
         if (node && node->has_user)
-            text += node->user.short_name;
+            text += parseShortName(node);
         else
             text += hexifyNodeNum(message->sender);
 
@@ -227,7 +227,7 @@ std::string InkHUD::NotificationApplet::getNotificationText(uint16_t widthAvaila
 
             // Sender id
             if (node && node->has_user)
-                text += node->user.short_name;
+                text += parseShortName(node);
             else
                 text += hexifyNodeNum(message->sender);
 

--- a/src/graphics/niche/InkHUD/Applets/User/AllMessage/AllMessageApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/User/AllMessage/AllMessageApplet.cpp
@@ -67,13 +67,13 @@ void InkHUD::AllMessageApplet::onRender()
     }
 
     // Sender's id
-    // - shortname, if available, or
+    // - short name and long name, if available, or
     // - node id
     meshtastic_NodeInfoLite *sender = nodeDB->getMeshNode(message->sender);
     if (sender && sender->has_user) {
-        header += sender->user.short_name;
+        header += parseShortName(sender); // May be last-four of node if unprintable (emoji, etc)
         header += " (";
-        header += sender->user.long_name;
+        header += parse(sender->user.long_name);
         header += ")";
     } else
         header += hexifyNodeNum(message->sender);

--- a/src/graphics/niche/InkHUD/Applets/User/DM/DMApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/User/DM/DMApplet.cpp
@@ -63,13 +63,13 @@ void InkHUD::DMApplet::onRender()
     }
 
     // Sender's id
-    // - shortname, if available, or
+    // - shortname and long name, if available, or
     // - node id
     meshtastic_NodeInfoLite *sender = nodeDB->getMeshNode(latestMessage->dm.sender);
     if (sender && sender->has_user) {
-        header += sender->user.short_name;
+        header += parseShortName(sender); // May be last-four of node if unprintable (emoji, etc)
         header += " (";
-        header += sender->user.long_name;
+        header += parse(sender->user.long_name);
         header += ")";
     } else
         header += hexifyNodeNum(latestMessage->dm.sender);


### PR DESCRIPTION
Fixes a few places where UTF-8 chars in device names weren't being parsed

## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - LilyGo T-Echo
