### PR TITLE
Coerce user.id to always be derive from the nodenum

### DIFF
--- a/src/modules/NodeInfoModule.cpp
+++ b/src/modules/NodeInfoModule.cpp
@@ -14,6 +14,9 @@ bool NodeInfoModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
 {
     auto p = *pptr;
 
+    // Coerce user.id to be derived from the node number
+    snprintf(p.id, sizeof(p.id), "!%08x", getFrom(&mp));
+
     bool hasChanged = nodeDB->updateUser(getFrom(&mp), p, mp.channel);
 
     bool wasBroadcast = isBroadcast(mp.to);


### PR DESCRIPTION
Should close the loophole of User ID "spoofing". These already get omitted on the NodeInfo/UserLite persistence and then regenerated on want_config flow. This prevents us from informing the client API directly off of the nodeinfo packet of the bad User.id. Instead, we'll always generate it.