### PR TITLE
Parse own short name on InkHUD shutdown screen

### DIFF
--- a/src/graphics/niche/InkHUD/Applets/System/Logo/LogoApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/System/Logo/LogoApplet.cpp
@@ -111,9 +111,10 @@ void InkHUD::LogoApplet::onShutdown()
 
     // Prepare for the powered-off screen now
     // We can change these values because the initial "shutting down" screen has already rendered at this point
+    meshtastic_NodeInfoLite *ourNode = nodeDB->getMeshNode(nodeDB->getNodeNum());
     textLeft = "";
     textRight = "";
-    textTitle = owner.short_name;
+    textTitle = parseShortName(ourNode);
     fontTitle = fontLarge;
 
     // This is then drawn by InkHUD::Events::onShutdown, with a blocking FULL update, after InkHUD's flash write is complete


### PR DESCRIPTION
Parse UTF-8 characters in our own short name. One that got missed by https://github.com/meshtastic/firmware/pull/6889


## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - Elecrow ThinkNode M1
