### PR TITLE
seeed_xiao_nrf52840_kit improvements

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -482,19 +482,6 @@ void setup()
 
     fsInit();
 
-#if defined(_SEEED_XIAO_NRF52840_SENSE_H_)
-
-    pinMode(CHARGE_LED, INPUT); // sets to detect if charge LED is on or off to see if USB is plugged in
-
-    pinMode(HICHG, OUTPUT);
-    digitalWrite(HICHG, LOW); // 100 mA charging current if set to LOW and 50mA (actually about 20mA) if set to HIGH
-
-    pinMode(BAT_READ, OUTPUT);
-    digitalWrite(BAT_READ, LOW); // This is pin P0_14 = 14 and by pullling low to GND it provices path to read on pin 32 (P0,31)
-                                 // PIN_VBAT the voltage from divider on XIAO board
-
-#endif
-
 #if !MESHTASTIC_EXCLUDE_I2C
 #if defined(I2C_SDA1) && defined(ARCH_RP2040)
     Wire1.setSDA(I2C_SDA1);

--- a/variants/diy/seeed-xiao-nrf52840-wio-sx1262/variant.cpp
+++ b/variants/diy/seeed-xiao-nrf52840-wio-sx1262/variant.cpp
@@ -53,3 +53,14 @@ const uint32_t g_ADigitalPinMap[] = {
     // VBAT
     31, // D32 is P0.10 (VBAT)
 };
+
+void initVariant()
+{
+    // Set BQ25101 ISET to 100mA instead of 50mA
+    pinMode(HICHG, OUTPUT);
+    digitalWrite(HICHG, LOW);
+
+    // Provide P0.14: VBAT voltage divider sink
+    pinMode(BAT_READ, OUTPUT);
+    digitalWrite(BAT_READ, LOW);
+}

--- a/variants/diy/seeed-xiao-nrf52840-wio-sx1262/variant.cpp
+++ b/variants/diy/seeed-xiao-nrf52840-wio-sx1262/variant.cpp
@@ -59,8 +59,4 @@ void initVariant()
     // Set BQ25101 ISET to 100mA instead of 50mA
     pinMode(HICHG, OUTPUT);
     digitalWrite(HICHG, LOW);
-
-    // Provide P0.14: VBAT voltage divider sink
-    pinMode(BAT_READ, OUTPUT);
-    digitalWrite(BAT_READ, LOW);
 }

--- a/variants/diy/seeed-xiao-nrf52840-wio-sx1262/variant.h
+++ b/variants/diy/seeed-xiao-nrf52840-wio-sx1262/variant.h
@@ -164,7 +164,8 @@ static const uint8_t SCK = PIN_SPI_SCK;
 // -------
 // P0_14 = 14  Reads battery voltage from divider on signal board.
 // PIN_VBAT is reading voltage divider on XIAO and is program pin 32 / or P0.31
-#define BAT_READ 14
+#define ADC_CTRL VBAT_ENABLE
+#define ADC_CTRL_ENABLED LOW
 #define BATTERY_SENSE_RESOLUTION_BITS 10
 #define CHARGE_LED 23 // P0_17 = 17  D23   YELLOW CHARGE LED
 #define HICHG 22      // P0_13 = 13  D22   Charge-select pin for Lipo for 100 mA instead of default 50mA charge

--- a/variants/seeed_xiao_nrf52840_kit/variant.cpp
+++ b/variants/seeed_xiao_nrf52840_kit/variant.cpp
@@ -34,9 +34,9 @@ const uint32_t g_ADigitalPinMap[] = {
     11, // D18 is P0.11 (6D_INT1)
 
     // MIC
-    42, // 17,//42,  // D19 is P1.10 (MIC_PWR)
-    32, // 26,//32,  // D20 is P1.00 (PDM_CLK)
-    16, // 25,//16,  // D21 is P0.16 (PDM_DATA)
+    42, // D19 is P1.10 (MIC_PWR)
+    32, // D20 is P1.00 (PDM_CLK)
+    16, // D21 is P0.16 (PDM_DATA)
 
     // BQ25100
     13, // D22 is P0.13 (HICHG)
@@ -80,13 +80,21 @@ const uint32_t g_ADigitalPinMap[] = {
 
 void initVariant()
 {
-    // LED1 & LED2
-    pinMode(21, OUTPUT);
-    digitalWrite(21, LOW);
-    // LED1 & LED2
-    pinMode(22, OUTPUT);
-    digitalWrite(22, LOW);
+    // Set BQ25101 ISET to 100mA instead of 50mA
+    pinMode(HICHG, OUTPUT);
+    digitalWrite(HICHG, LOW);
 
-    pinMode(PIN_WIRE_SDA, INPUT_PULLUP);
-    pinMode(PIN_WIRE_SCL, INPUT_PULLUP);
+    // Provide P0.14: VBAT voltage divider sink
+    pinMode(BAT_READ, OUTPUT);
+    digitalWrite(BAT_READ, LOW);
+
+    // LEDs
+    pinMode(PIN_LED1, OUTPUT);
+    ledOff(PIN_LED1);
+
+    pinMode(PIN_LED2, OUTPUT);
+    ledOff(PIN_LED2);
+
+    pinMode(PIN_LED3, OUTPUT);
+    ledOff(PIN_LED3);
 }

--- a/variants/seeed_xiao_nrf52840_kit/variant.cpp
+++ b/variants/seeed_xiao_nrf52840_kit/variant.cpp
@@ -84,10 +84,6 @@ void initVariant()
     pinMode(HICHG, OUTPUT);
     digitalWrite(HICHG, LOW);
 
-    // Provide P0.14: VBAT voltage divider sink
-    pinMode(BAT_READ, OUTPUT);
-    digitalWrite(BAT_READ, LOW);
-
     // LEDs
     pinMode(PIN_LED1, OUTPUT);
     ledOff(PIN_LED1);

--- a/variants/seeed_xiao_nrf52840_kit/variant.h
+++ b/variants/seeed_xiao_nrf52840_kit/variant.h
@@ -154,7 +154,8 @@ static const uint8_t SCL = PIN_WIRE_SCL;
  */
 #define BATTERY_PIN PIN_VBAT      // P0.31: VBAT voltage divider
 #define ADC_MULTIPLIER (3)        // ... R17=1M, R18=510k
-#define BAT_READ VBAT_ENABLE      // P0.14: VBAT voltage divider sink
+#define ADC_CTRL VBAT_ENABLE      // P0.14: VBAT voltage divider
+#define ADC_CTRL_ENABLED LOW      // ... sink
 #define EXT_CHRG_DETECT (23)      // P0.17: Charge LED
 #define EXT_CHRG_DETECT_VALUE LOW // ... BQ25101 ~CHG indicates charging
 #define HICHG (22)                // P0.13: BQ25101 ISET 100mA instead of 50mA

--- a/variants/seeed_xiao_nrf52840_kit/variant.h
+++ b/variants/seeed_xiao_nrf52840_kit/variant.h
@@ -23,27 +23,8 @@ extern "C" {
 #define NUM_ANALOG_OUTPUTS (0)
 
 /*
- * LEDs
+ * Digital Pins
  */
-#define LED_STATE_ON (0) // RGB LED is common anode
-#define LED_RED (11)
-#define LED_GREEN (13)
-#define LED_BLUE (12)
-
-#define PIN_LED1 LED_GREEN // PIN_LED1 is used in src/platform/nrf52/architecture.h to define LED_PIN
-#define PIN_LED2 LED_BLUE
-#define PIN_LED3 LED_RED
-
-#define LED_BUILTIN LED_RED // LED_BUILTIN is used by framework-arduinoadafruitnrf52 to indicate flash writes
-
-#define LED_PWR LED_RED
-#define USER_LED LED_BLUE
-
-/*
- * Buttons
- */
-
-// Digital PINs
 #define D0 (0ul)
 #define D1 (1ul)
 #define D2 (2ul)
@@ -55,14 +36,6 @@ extern "C" {
 #define D8 (8ul)
 #define D9 (9ul)
 #define D10 (10ul)
-
-/*
- *  D0 is shared with PIN_GPS_STANDBY on the L76K GNSS Module.
- *  There are some technical solutions that can solve this problem, and we are
- *  currently exploring and researching them.
- */
-
-// #define BUTTON_PIN D0
 
 /*
  * Analog pins
@@ -84,6 +57,38 @@ static const uint8_t A4 = PIN_A4;
 static const uint8_t A5 = PIN_A5;
 #define ADC_RESOLUTION 12
 
+/*
+ * LEDs
+ */
+#define LED_STATE_ON (0) // RGB LED is common anode
+#define LED_RED (11)
+#define LED_GREEN (13)
+#define LED_BLUE (12)
+
+#define PIN_LED1 LED_GREEN // PIN_LED1 is used in src/platform/nrf52/architecture.h to define LED_PIN
+#define PIN_LED2 LED_BLUE
+#define PIN_LED3 LED_RED
+
+#define LED_BUILTIN LED_RED // LED_BUILTIN is used by framework-arduinoadafruitnrf52 to indicate flash writes
+
+#define LED_PWR LED_RED
+#define USER_LED LED_BLUE
+
+/*
+ * Buttons
+ */
+
+/*
+ *  D0 is shared with PIN_GPS_STANDBY on the L76K GNSS Module.
+ *  There are some technical solutions that can solve this problem, and we are
+ *  currently exploring and researching them.
+ */
+
+// #define BUTTON_PIN D0
+
+/*
+ * Serial Interfaces
+ */
 #define PIN_SERIAL2_RX (-1)
 #define PIN_SERIAL2_TX (-1)
 

--- a/variants/seeed_xiao_nrf52840_kit/variant.h
+++ b/variants/seeed_xiao_nrf52840_kit/variant.h
@@ -19,25 +19,25 @@ extern "C" {
 
 #define PINS_COUNT (33)
 #define NUM_DIGITAL_PINS (33)
-#define NUM_ANALOG_INPUTS (8) // A6 is used for battery, A7 is analog reference
+#define NUM_ANALOG_INPUTS (8)
 #define NUM_ANALOG_OUTPUTS (0)
 
-// LEDs
+/*
+ * LEDs
+ */
+#define LED_STATE_ON (0) // RGB LED is common anode
+#define LED_RED (11)
+#define LED_GREEN (13)
+#define LED_BLUE (12)
 
-#define LED_RED 11
-#define LED_BLUE 12
-#define LED_GREEN 13
-
-#define PIN_LED1 LED_GREEN
+#define PIN_LED1 LED_GREEN // PIN_LED1 is used in src/platform/nrf52/architecture.h to define LED_PIN
 #define PIN_LED2 LED_BLUE
 #define PIN_LED3 LED_RED
 
-#define PIN_LED PIN_LED1
-#define LED_PWR (PINS_COUNT)
+#define LED_BUILTIN LED_RED // LED_BUILTIN is used by framework-arduinoadafruitnrf52 to indicate flash writes
 
-#define LED_BUILTIN PIN_LED
-
-#define LED_STATE_ON 1 // State when LED is lit
+#define LED_PWR LED_RED
+#define USER_LED LED_BLUE
 
 /*
  * Buttons
@@ -56,14 +56,13 @@ extern "C" {
 #define D9 (9ul)
 #define D10 (10ul)
 
-/*Due to the lack of pins,and have to make sure gps standby work well we have temporarily removed the button.
-There are some technical solutions that can solve this problem,
-and we are currently exploring and researching them*/
+/*
+ *  D0 is shared with PIN_GPS_STANDBY on the L76K GNSS Module.
+ *  There are some technical solutions that can solve this problem, and we are
+ *  currently exploring and researching them.
+ */
 
-// #define BUTTON_PIN D0 // This is the Program Button
-// // #define BUTTON_NEED_PULLUP   1
-// #define BUTTON_ACTIVE_LOW true
-// #define BUTTON_ACTIVE_PULLUP false
+// #define BUTTON_PIN D0
 
 /*
  * Analog pins
@@ -102,11 +101,9 @@ static const uint8_t MOSI = PIN_SPI_MOSI;
 static const uint8_t MISO = PIN_SPI_MISO;
 static const uint8_t SCK = PIN_SPI_SCK;
 
-// supported modules list
 #define USE_SX1262
 
-// common pinouts for SX126X modules
-
+// Pinout for SX126X
 #define SX126X_CS D4
 #define SX126X_DIO1 D1
 #define SX126X_BUSY D3
@@ -121,16 +118,19 @@ static const uint8_t SCK = PIN_SPI_SCK;
 /*
  * Wire Interfaces
  */
-
 #define I2C_NO_RESCAN           // I2C is a bit finicky, don't scan too much
 #define WIRE_INTERFACES_COUNT 1 // 2
 
-#define PIN_WIRE_SDA (24) // change to use the correct pins if needed
-#define PIN_WIRE_SCL (25) // change to use the correct pins if needed
+// LSM6DS3TR on XIAO nRF52840 Series
+#define PIN_WIRE_SDA (17)
+#define PIN_WIRE_SCL (16)
 
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;
 
+/*
+ * GPS
+ */
 // GPS L76KB
 #define GPS_L76K
 #ifdef GPS_L76K
@@ -144,20 +144,17 @@ static const uint8_t SCL = PIN_WIRE_SCL;
 #define PIN_GPS_STANDBY D0
 #endif
 
-// Battery
+/*
+ * Battery
+ */
+#define BATTERY_PIN PIN_VBAT      // P0.31: VBAT voltage divider
+#define ADC_MULTIPLIER (3)        // ... R17=1M, R18=510k
+#define BAT_READ VBAT_ENABLE      // P0.14: VBAT voltage divider sink
+#define EXT_CHRG_DETECT (23)      // P0.17: Charge LED
+#define EXT_CHRG_DETECT_VALUE LOW // ... BQ25101 ~CHG indicates charging
+#define HICHG (22)                // P0.13: BQ25101 ISET 100mA instead of 50mA
 
-#define BAT_READ                                                                                                                 \
-    14 // P0_14 = 14  Reads battery voltage from divider on signal board. (PIN_VBAT is reading voltage divider on XIAO and is
-       // program pin 32 / or P0.31)
-#define BATTERY_SENSE_RESOLUTION_BITS 10
-#define CHARGE_LED 23 // P0_17 = 17  D23   YELLOW CHARGE LED
-#define HICHG 22      // P0_13 = 13  D22   Charge-select pin for Lipo for 100 mA instead of default 50mA charge
-
-// The battery sense is hooked to pin A0 (5)
-#define BATTERY_PIN PIN_VBAT // PIN_A0
-
-// ratio of voltage divider = 3.0 (R17=1M, R18=510k)
-#define ADC_MULTIPLIER 3 // 3.0 + a bit for being optimistic
+#define BATTERY_SENSE_RESOLUTION_BITS (10)
 
 #ifdef __cplusplus
 }

--- a/variants/xiao_ble/variant.cpp
+++ b/variants/xiao_ble/variant.cpp
@@ -53,3 +53,14 @@ const uint32_t g_ADigitalPinMap[] = {
     // VBAT
     31, // D32 is P0.10 (VBAT)
 };
+
+void initVariant()
+{
+    // Set BQ25101 ISET to 100mA instead of 50mA
+    pinMode(HICHG, OUTPUT);
+    digitalWrite(HICHG, LOW);
+
+    // Provide P0.14: VBAT voltage divider sink
+    pinMode(BAT_READ, OUTPUT);
+    digitalWrite(BAT_READ, LOW);
+}

--- a/variants/xiao_ble/variant.cpp
+++ b/variants/xiao_ble/variant.cpp
@@ -59,8 +59,4 @@ void initVariant()
     // Set BQ25101 ISET to 100mA instead of 50mA
     pinMode(HICHG, OUTPUT);
     digitalWrite(HICHG, LOW);
-
-    // Provide P0.14: VBAT voltage divider sink
-    pinMode(BAT_READ, OUTPUT);
-    digitalWrite(BAT_READ, LOW);
 }

--- a/variants/xiao_ble/variant.h
+++ b/variants/xiao_ble/variant.h
@@ -189,9 +189,8 @@ static const uint8_t SCL = PIN_WIRE_SCL;
 
 // Battery
 
-#define BAT_READ                                                                                                                 \
-    14 // P0_14 = 14  Reads battery voltage from divider on signal board. (PIN_VBAT is reading voltage divider on XIAO and is
-       // program pin 32 / or P0.31)
+#define ADC_CTRL VBAT_ENABLE // P0.14: VBAT voltage divider
+#define ADC_CTRL_ENABLED LOW // ... sink
 #define BATTERY_SENSE_RESOLUTION_BITS 10
 #define CHARGE_LED 23 // P0_17 = 17  D23   YELLOW CHARGE LED
 #define HICHG 22      // P0_13 = 13  D22   Charge-select pin for Lipo for 100 mA instead of default 50mA charge


### PR DESCRIPTION
- LEDs:
  - Change RGB LED to be active low as it is common anode
  - Remove re-definition of LED_PIN
  - Use red LED to indicate flash writes
  - Use blue LED as user LED (External Notification module)
- GPIO: Re-word unused BUTTON_PIN comment
- Wire: Set I2C pins to match XIAO nRF52840 Sense's LSM6DS3TR IMU
- Battery:
  - Use charge LED to detect charging state
  - Move voltage divider boilerplate out of src/main.cpp and into initVariant()
  - Use ADC_CTRL
  - Fix dependencies for above in related XIAO BLE DIY variants
- Re-order generic GPIO definitions

## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] seeed_xiao_nrf52840_kit

Build tested variants:
- seeed_xiao_nrf52840_kit
- xiao_ble
- seeed-xiao-nrf52840-wio-sx1262

Flashed to and tested on hardware:
- seeed_xiao_nrf52840_kit