### PR TITLE
More Beeps, More Boops

### DIFF
--- a/src/graphics/niche/InkHUD/Events.cpp
+++ b/src/graphics/niche/InkHUD/Events.cpp
@@ -3,6 +3,7 @@
 #include "./Events.h"
 
 #include "RTC.h"
+#include "buzz.h"
 #include "modules/AdminModule.h"
 #include "modules/TextMessageModule.h"
 #include "sleep.h"
@@ -37,6 +38,10 @@ void InkHUD::Events::begin()
 
 void InkHUD::Events::onButtonShort()
 {
+    // Audio feedback (via buzzer)
+    // Short low tone
+    playBoop();
+
     // Check which system applet wants to handle the button press (if any)
     SystemApplet *consumer = nullptr;
     for (SystemApplet *sa : inkhud->systemApplets) {
@@ -55,6 +60,10 @@ void InkHUD::Events::onButtonShort()
 
 void InkHUD::Events::onButtonLong()
 {
+    // Audio feedback (via buzzer)
+    // Low tone, longer than playBoop
+    playBeep();
+
     // Check which system applet wants to handle the button press (if any)
     SystemApplet *consumer = nullptr;
     for (SystemApplet *sa : inkhud->systemApplets) {
@@ -101,6 +110,10 @@ int InkHUD::Events::beforeDeepSleep(void *unused)
 
     inkhud->forceUpdate(Drivers::EInk::UpdateTypes::FULL, false);
     delay(1000); // Cooldown, before potentially yanking display power
+
+    // InkHUD shutdown complete
+    // Firmware shutdown continues for several seconds more; flash write still pending
+    playShutdownMelody();
 
     return 0; // We agree: deep sleep now
 }

--- a/variants/ELECROW-ThinkNode-M1/nicheGraphics.h
+++ b/variants/ELECROW-ThinkNode-M1/nicheGraphics.h
@@ -22,6 +22,9 @@
 #include "graphics/niche/Drivers/EInk/GDEY0154D67.h"
 #include "graphics/niche/Inputs/TwoButton.h"
 
+// Button feedback
+#include "buzz.h"
+
 void setupNicheGraphics()
 {
     using namespace NicheGraphics;
@@ -98,8 +101,14 @@ void setupNicheGraphics()
     buttons->setWiring(1, PIN_BUTTON1);
     buttons->setTiming(1, 50, 500); // 500ms before latch
     buttons->setHandlerDown(1, [backlight]() { backlight->peek(); });
-    buttons->setHandlerLongPress(1, [backlight]() { backlight->latch(); });
-    buttons->setHandlerShortPress(1, [backlight]() { backlight->off(); });
+    buttons->setHandlerLongPress(1, [backlight]() {
+        backlight->latch();
+        playBeep();
+    });
+    buttons->setHandlerShortPress(1, [backlight]() {
+        backlight->off();
+        playBoop();
+    });
 
     // Begin handling button events
     buttons->start();

--- a/variants/heltec_vision_master_e213/nicheGraphics.h
+++ b/variants/heltec_vision_master_e213/nicheGraphics.h
@@ -21,6 +21,9 @@
 #include "graphics/niche/Drivers/EInk/LCMEN2R13EFC1.h"
 #include "graphics/niche/Inputs/TwoButton.h"
 
+// Button feedback
+#include "buzz.h"
+
 void setupNicheGraphics()
 {
     using namespace NicheGraphics;
@@ -85,7 +88,10 @@ void setupNicheGraphics()
 
     // #1: Aux Button
     buttons->setWiring(1, BUTTON_PIN_SECONDARY);
-    buttons->setHandlerShortPress(1, [inkhud]() { inkhud->nextTile(); });
+    buttons->setHandlerShortPress(1, [inkhud]() {
+        inkhud->nextTile();
+        playBoop();
+    });
 
     // Begin handling button events
     buttons->start();

--- a/variants/heltec_vision_master_e290/nicheGraphics.h
+++ b/variants/heltec_vision_master_e290/nicheGraphics.h
@@ -34,6 +34,9 @@ Different NicheGraphics UIs and different hardware variants will each have their
 #include "graphics/niche/Drivers/EInk/DEPG0290BNS800.h"
 #include "graphics/niche/Inputs/TwoButton.h"
 
+// Button feedback
+#include "buzz.h"
+
 void setupNicheGraphics()
 {
     using namespace NicheGraphics;
@@ -98,7 +101,10 @@ void setupNicheGraphics()
 
     // #1: Aux Button
     buttons->setWiring(1, BUTTON_PIN_SECONDARY);
-    buttons->setHandlerShortPress(1, [inkhud]() { inkhud->nextTile(); });
+    buttons->setHandlerShortPress(1, [inkhud]() {
+        inkhud->nextTile();
+        playBoop();
+    });
 
     // Begin handling button events
     buttons->start();


### PR DESCRIPTION
Audible feedback (via passive buzzer) for button presses within InkHUD

## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - Elecrow ThinkNode M1
    - Heltec VM-E290 (with passive buzzer)
