### PR TITLE
Add InkHUD driver for WeAct Studio 2.9" display module

### DIFF
--- a/src/graphics/niche/Drivers/EInk/DEPG0213BNS800.h
+++ b/src/graphics/niche/Drivers/EInk/DEPG0213BNS800.h
@@ -5,7 +5,7 @@ E-Ink display driver
     - Manufacturer: DKE
     - Size: 2.13 inch
     - Resolution: 122px x 250px
-    - Flex connector marking: FPC-7528B
+    - Flex connector marking (not a unique identifier): FPC-7528B
 
     Note: this is from an older generation of DKE panels, which still used Solomon Systech controller ICs.
     DKE's website suggests that the latest DEPG0213BN displays may use Fitipower controllers instead.

--- a/src/graphics/niche/Drivers/EInk/DEPG0290BNS800.h
+++ b/src/graphics/niche/Drivers/EInk/DEPG0290BNS800.h
@@ -5,7 +5,7 @@ E-Ink display driver
     - Manufacturer: DKE
     - Size: 2.9 inch
     - Resolution: 128px x 296px
-    - Flex connector marking: FPC-7519 rev.b
+    - Flex connector marking (not a unique identifier): FPC-7519 rev.b
 
 */
 

--- a/src/graphics/niche/Drivers/EInk/GDEY0154D67.h
+++ b/src/graphics/niche/Drivers/EInk/GDEY0154D67.h
@@ -5,7 +5,7 @@ E-Ink display driver
     - Manufacturer: Goodisplay
     - Size: 1.54 inch
     - Resolution: 200px x 200px
-    - Flex connector marking: FPC-B001
+    - Flex connector marking (not a unique identifier): FPC-B001
 
 */
 

--- a/src/graphics/niche/Drivers/EInk/GDEY0213B74.h
+++ b/src/graphics/niche/Drivers/EInk/GDEY0213B74.h
@@ -5,7 +5,9 @@ E-Ink display driver
     - Manufacturer: Goodisplay
     - Size: 2.13 inch
     - Resolution: 250px x 122px
-    - Flex connector marking: FPC-A002
+    - Flex connector marking (not a unique identifier):
+      - FPC-A002
+      - FPC-A005 20.06.15 TRX
 
 */
 

--- a/src/graphics/niche/Drivers/EInk/HINK_E042A87.h
+++ b/src/graphics/niche/Drivers/EInk/HINK_E042A87.h
@@ -5,7 +5,7 @@ E-Ink display driver
     - Manufacturer: Holitech
     - Size: 4.2 inch
     - Resolution: 400px x 300px
-    - Flex connector marking: HINK-E042A07-FPC-A1
+    - Flex connector marking (not a unique identifier): HINK-E042A07-FPC-A1
     - Silver sticker with QR code, marked: HE042A87
 
     Note: as of Feb. 2025, these panels are used for "WeActStudio 4.2in B&W" display modules

--- a/src/graphics/niche/Drivers/EInk/LCMEN2R13ECC1.h
+++ b/src/graphics/niche/Drivers/EInk/LCMEN2R13ECC1.h
@@ -5,7 +5,6 @@ E-Ink display driver
     - Manufacturer: WISEVAST
     - Size: 2.13 inch
     - Resolution: 122px x 255px
-    - Flex connector marking: Soldering connector, no connector is needed
 
 */
 

--- a/src/graphics/niche/Drivers/EInk/LCMEN2R13EFC1.h
+++ b/src/graphics/niche/Drivers/EInk/LCMEN2R13EFC1.h
@@ -5,7 +5,7 @@ E-Ink display driver
     - Manufacturer: Wisevast
     - Size: 2.13 inch
     - Resolution: 122px x 250px
-    - Flex connector marking: HINK-E0213A162-FPC-A0 (Hidden, printed on back-side)
+    - Flex connector marking (not a unique identifier): HINK-E0213A162-FPC-A0 (Hidden, printed on back-side)
 
 Note: this display uses an uncommon controller IC, Fitipower JD79656.
 It is implemented as a "one-off", directly inheriting the EInk base class, unlike SSD16XX displays.

--- a/src/graphics/niche/Drivers/EInk/ZJY128296_029EAAMFGN.cpp
+++ b/src/graphics/niche/Drivers/EInk/ZJY128296_029EAAMFGN.cpp
@@ -1,0 +1,59 @@
+#include "./ZJY128296_029EAAMFGN.h"
+
+#ifdef MESHTASTIC_INCLUDE_NICHE_GRAPHICS
+
+using namespace NicheGraphics::Drivers;
+
+// Map the display controller IC's output to the connected panel
+void ZJY128296_029EAAMFGN::configScanning()
+{
+    // "Driver output control"
+    // Scan gates from 0 to 295 (vertical resolution 296px)
+    sendCommand(0x01);
+    sendData(0x27); // Number of gates (295, bits 0-7)
+    sendData(0x01); // Number of gates (295, bit 8)
+    sendData(0x00); // (Do not invert scanning order)
+}
+
+// Specify which information is used to control the sequence of voltages applied to move the pixels
+// - For this display, configUpdateSequence() specifies that a suitable LUT will be loaded from
+//   the controller IC's OTP memory, when the update procedure begins.
+void ZJY128296_029EAAMFGN::configWaveform()
+{
+    sendCommand(0x3C); // Border waveform:
+    sendData(0x05);    // Screen border should follow LUT1 waveform (actively drive pixels white)
+
+    sendCommand(0x18); // Temperature sensor:
+    sendData(0x80);    // Use internal temperature sensor to select an appropriate refresh waveform
+}
+
+void ZJY128296_029EAAMFGN::configUpdateSequence()
+{
+    switch (updateType) {
+    case FAST:
+        sendCommand(0x22); // Set "update sequence"
+        sendData(0xFF);    // Will load LUT from OTP memory, Display mode 2 "differential refresh"
+        break;
+
+    case FULL:
+    default:
+        sendCommand(0x22); // Set "update sequence"
+        sendData(0xF7);    // Will load LUT from OTP memory
+        break;
+    }
+}
+
+// Once the refresh operation has been started,
+// begin periodically polling the display to check for completion, using the normal Meshtastic threading code
+// Only used when refresh is "async"
+void ZJY128296_029EAAMFGN::detachFromUpdate()
+{
+    switch (updateType) {
+    case FAST:
+        return beginPolling(50, 300); // At least 300ms for fast refresh
+    case FULL:
+    default:
+        return beginPolling(100, 2000); // At least 2 seconds for full refresh
+    }
+}
+#endif // MESHTASTIC_INCLUDE_NICHE_GRAPHICS

--- a/src/graphics/niche/Drivers/EInk/ZJY128296_029EAAMFGN.h
+++ b/src/graphics/niche/Drivers/EInk/ZJY128296_029EAAMFGN.h
@@ -5,7 +5,7 @@ E-Ink display driver
     - Manufacturer: Zhongjingyuan
     - Size: 2.9 inch
     - Resolution: 128px x 296px
-    - Flex connector label (hints id only): FPC-A005 20.06.15 TRX
+    - Flex connector label (not a unique identifier): FPC-A005 20.06.15 TRX
 
     Note: as of Feb. 2025, these panels are used for "WeActStudio 2.9in B&W" display modules
 

--- a/src/graphics/niche/Drivers/EInk/ZJY128296_029EAAMFGN.h
+++ b/src/graphics/niche/Drivers/EInk/ZJY128296_029EAAMFGN.h
@@ -1,0 +1,44 @@
+/*
+
+E-Ink display driver
+    - ZJY128296-029EAAMFGN
+    - Manufacturer: Zhongjingyuan
+    - Size: 2.9 inch
+    - Resolution: 128px x 296px
+    - Flex connector label (hints id only): FPC-A005 20.06.15 TRX
+
+    Note: as of Feb. 2025, these panels are used for "WeActStudio 2.9in B&W" display modules
+
+*/
+
+#pragma once
+
+#ifdef MESHTASTIC_INCLUDE_NICHE_GRAPHICS
+
+#include "configuration.h"
+
+#include "./SSD16XX.h"
+
+namespace NicheGraphics::Drivers
+{
+class ZJY128296_029EAAMFGN : public SSD16XX
+{
+    // Display properties
+  private:
+    static constexpr uint32_t width = 128;
+    static constexpr uint32_t height = 296;
+    static constexpr UpdateTypes supported = (UpdateTypes)(FULL | FAST);
+
+  public:
+    ZJY128296_029EAAMFGN() : SSD16XX(width, height, supported) {}
+
+  protected:
+    void configScanning() override;
+    void configWaveform() override;
+    void configUpdateSequence() override;
+    void detachFromUpdate() override;
+};
+
+} // namespace NicheGraphics::Drivers
+
+#endif // MESHTASTIC_INCLUDE_NICHE_GRAPHICS


### PR DESCRIPTION
Display model is ZJY128296-029EAAMFGN. An attractive choice for a DIY build. This is the same display hardware used by the MeshLink device(https://github.com/meshtastic/firmware/pull/5736).

Addressing a concern at https://github.com/meshtastic/firmware/pull/6879#discussion_r2106153161,  code comments clarify that flex connector marking is *not* a definitive identifier. To standardize everything, PR also applies this clarification to existing drivers.  

## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - NRF52 Pro-micro DIY (custom build)
