### PR TITLE
Addition of Device Role inside of userPrefs.jsonc

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -502,10 +502,8 @@ void NodeDB::installDefaultConfig(bool preserveKey = false)
 
 #ifdef USERPREFS_CONFIG_DEVICE_ROLE
     // Restrict ROUTER*, LOST AND FOUND, and REPEATER roles for security reasons
-    if (IS_ONE_OF(USERPREFS_CONFIG_DEVICE_ROLE,
-                  meshtastic_Config_DeviceConfig_Role_ROUTER,
-                  meshtastic_Config_DeviceConfig_Role_ROUTER_LATE,
-                  meshtastic_Config_DeviceConfig_Role_REPEATER,
+    if (IS_ONE_OF(USERPREFS_CONFIG_DEVICE_ROLE, meshtastic_Config_DeviceConfig_Role_ROUTER,
+                  meshtastic_Config_DeviceConfig_Role_ROUTER_LATE, meshtastic_Config_DeviceConfig_Role_REPEATER,
                   meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND)) {
         LOG_WARN("ROUTER roles are restricted, falling back to CLIENT role");
         config.device.role = meshtastic_Config_DeviceConfig_Role_CLIENT;
@@ -689,7 +687,7 @@ void NodeDB::installDefaultConfig(bool preserveKey = false)
 #endif
 
 #ifdef USERPREFS_CONFIG_DEVICE_ROLE
-    //Apply role-specific defaults when role is set via user preferences
+    // Apply role-specific defaults when role is set via user preferences
     installRoleDefaults(config.device.role);
 #endif
 

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -499,6 +499,26 @@ void NodeDB::installDefaultConfig(bool preserveKey = false)
         true; // FIXME: maybe false in the future, and setting region to enable it. (unset region forces it off)
     config.lora.override_duty_cycle = false;
     config.lora.config_ok_to_mqtt = false;
+// IS ONE OF macro - thanks Ben
+#define IS_ONE_OF(value, ...) \
+    ((value == __VA_ARGS__) || ...)
+
+#ifdef USERPREFS_CONFIG_DEVICE_ROLE
+    // Restrict ROUTER*, LOST AND FOUND, and REPEATER roles for security reasons
+    if (IS_ONE_OF(USERPREFS_CONFIG_DEVICE_ROLE,
+                  meshtastic_Config_DeviceConfig_Role_ROUTER,
+                  meshtastic_Config_DeviceConfig_Role_ROUTER_LATE,
+                  meshtastic_Config_DeviceConfig_Role_REPEATER,
+                  meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND)) {
+        LOG_WARN("ROUTER roles are restricted, falling back to CLIENT role");
+        config.device.role = meshtastic_Config_DeviceConfig_Role_CLIENT;
+    } else {
+        config.device.role = USERPREFS_CONFIG_DEVICE_ROLE;
+    }
+#else
+    config.device.role = meshtastic_Config_DeviceConfig_Role_CLIENT; // Default to client.
+#endif
+
 #ifdef USERPREFS_CONFIG_LORA_REGION
     config.lora.region = USERPREFS_CONFIG_LORA_REGION;
 #else
@@ -669,6 +689,11 @@ void NodeDB::installDefaultConfig(bool preserveKey = false)
     if (WiFiOTA::isUpdated()) {
         WiFiOTA::recoverConfig(&config.network);
     }
+#endif
+
+#ifdef USERPREFS_CONFIG_DEVICE_ROLE
+    //Apply role-specific defaults when role is set via user preferences
+    installRoleDefaults(config.device.role);
 #endif
 
     initConfigIntervals();

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -499,9 +499,6 @@ void NodeDB::installDefaultConfig(bool preserveKey = false)
         true; // FIXME: maybe false in the future, and setting region to enable it. (unset region forces it off)
     config.lora.override_duty_cycle = false;
     config.lora.config_ok_to_mqtt = false;
-// IS ONE OF macro - thanks Ben
-#define IS_ONE_OF(value, ...) \
-    ((value == __VA_ARGS__) || ...)
 
 #ifdef USERPREFS_CONFIG_DEVICE_ROLE
     // Restrict ROUTER*, LOST AND FOUND, and REPEATER roles for security reasons


### PR DESCRIPTION
This would make USERPREFS_CONFIG_DEVICE_ROLE usable inside of userPrefs.jsonc. 
ROUTER*, LOST_AND_FOUND, and REPEATER disabled.

After talking with Ben and folks on the discord, decided to PR this based off this issue: https://github.com/meshtastic/firmware/issues/6946

## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described. I have a private branch of this utilizing my builder to build nodes with device roles.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [x] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
  
  I have not been able to test with other nodes as of yet, but this should not be breaking or cause any regression.
