### PR TITLE
Add note to hydra to note that the button pin has no pull-up

### DIFF
--- a/variants/diy/hydra/variant.h
+++ b/variants/diy/hydra/variant.h
@@ -9,6 +9,8 @@
 #define GPS_POWER_TOGGLE // Moved definition from platformio.ini to here
 
 #define BUTTON_PIN 39  // The middle button GPIO on the T-Beam
+// Note: On the ESP32 base version, gpio34-39 are input-only, and do not have internal pull-ups.
+// If 39 is not being used for a button, it is suggested to remove the #define.
 #define BATTERY_PIN 35 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
 #define ADC_CHANNEL ADC1_GPIO35_CHANNEL
 #define ADC_MULTIPLIER 1.85 // (R1 = 470k, R2 = 680k)


### PR DESCRIPTION
Add note to hydra to note that the button pin has no pull-up. Use an external resistor or remove the `#define`.

Leaving the below, as it's technically correct.

## 🤝 Attestations
- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
