### PR TITLE
fix for T-Deck Plus: disable touch IRQ / enable custom touch driver

### DIFF
--- a/variants/t-deck/platformio.ini
+++ b/variants/t-deck/platformio.ini
@@ -67,7 +67,9 @@ build_flags =
 ;	-D USE_DOUBLE_BUFFER
   -D USE_PACKET_API
   -D MAP_FULL_REDRAW
+  -D CUSTOM_TOUCH_DRIVER
 
 lib_deps =
   ${env:t-deck.lib_deps}
   ${device-ui_base.lib_deps}
+  https://github.com/bitbank2/bb_captouch/archive/refs/tags/1.3.1.zip


### PR DESCRIPTION
implements workaround for the T-Deck Plus touch driver IRQ issue
closes #6969 
requires https://github.com/meshtastic/device-ui/pull/149 to be merged into master

## 🤝 Attestations
- [X] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [X] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
