### PR TITLE
Validate short and long names so whitespace or empty names cannot be used

### DIFF
--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -7,6 +7,7 @@
 #include "SPILock.h"
 #include "meshUtils.h"
 #include <FSCommon.h>
+#include <ctype.h> // for better whitespace handling
 #if defined(ARCH_ESP32) && !MESHTASTIC_EXCLUDE_BLUETOOTH
 #include "BleOta.h"
 #endif
@@ -155,12 +156,13 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
      */
     case meshtastic_AdminMessage_set_owner_tag:
         LOG_DEBUG("Client set owner");
-        // Validate names before processing
+        // Validate names
         if (*r->set_owner.long_name) {
             const char *start = r->set_owner.long_name;
-            while (*start == ' ' || *start == '\t')
-                start++; // Skip whitespace
-            if (strlen(start) < 1) {
+            // Skip all whitespace (space, tab, newline, unicode, etc)
+            while (*start && isspace((unsigned char)*start))
+                start++;
+            if (*start == '\0') {
                 LOG_WARN("Rejected long_name: must contain at least 1 non-whitespace character");
                 myReply = allocErrorResponse(meshtastic_Routing_Error_BAD_REQUEST, &mp);
                 break;
@@ -168,9 +170,9 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         }
         if (*r->set_owner.short_name) {
             const char *start = r->set_owner.short_name;
-            while (*start == ' ' || *start == '\t')
-                start++; // Skip whitespace
-            if (strlen(start) < 1) {
+            while (*start && isspace((unsigned char)*start))
+                start++;
+            if (*start == '\0') {
                 LOG_WARN("Rejected short_name: must contain at least 1 non-whitespace character");
                 myReply = allocErrorResponse(meshtastic_Routing_Error_BAD_REQUEST, &mp);
                 break;

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -485,13 +485,30 @@ void AdminModule::handleSetOwner(const meshtastic_User &o)
 {
     int changed = 0;
 
+    // Validate long_name and short names have meaningful content
     if (*o.long_name) {
-        changed |= strcmp(owner.long_name, o.long_name);
-        strncpy(owner.long_name, o.long_name, sizeof(owner.long_name));
+        const char *start = o.long_name;
+        while (*start == ' ' || *start == '\t')
+            start++; // Skip whitespace
+
+        if (strlen(start) >= 1) {
+            changed |= strcmp(owner.long_name, o.long_name);
+            strncpy(owner.long_name, o.long_name, sizeof(owner.long_name));
+        } else {
+            LOG_WARN("Rejected long_name: must contain at least 1 non-whitespace character");
+        }
     }
     if (*o.short_name) {
-        changed |= strcmp(owner.short_name, o.short_name);
-        strncpy(owner.short_name, o.short_name, sizeof(owner.short_name));
+        const char *start = o.short_name;
+        while (*start == ' ' || *start == '\t')
+            start++;
+
+        if (strlen(start) >= 1) {
+            changed |= strcmp(owner.short_name, o.short_name);
+            strncpy(owner.short_name, o.short_name, sizeof(owner.short_name));
+        } else {
+            LOG_WARN("Rejected short_name: must contain at least 1 non-whitespace character");
+        }
     }
     if (*o.id) {
         changed |= strcmp(owner.id, o.id);

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -159,7 +159,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         // Validate names
         if (*r->set_owner.long_name) {
             const char *start = r->set_owner.long_name;
-            // Skip all whitespace (space, tab, newline, unicode, etc)
+            // Skip all whitespace (space, tab, newline, etc)
             while (*start && isspace((unsigned char)*start))
                 start++;
             if (*start == '\0') {
@@ -1176,6 +1176,27 @@ void AdminModule::handleStoreDeviceUIConfig(const meshtastic_DeviceUIConfig &uic
 
 void AdminModule::handleSetHamMode(const meshtastic_HamParameters &p)
 {
+    // Validate ham parameters before setting since this would bypass validation in the owner struct
+    if (*p.call_sign) {
+        const char *start = p.call_sign;
+        // Skip all whitespace
+        while (*start && isspace((unsigned char)*start))
+            start++;
+        if (*start == '\0') {
+            LOG_WARN("Rejected ham call_sign: must contain at least 1 non-whitespace character");
+            return;
+        }
+    }
+    if (*p.short_name) {
+        const char *start = p.short_name;
+        while (*start && isspace((unsigned char)*start))
+            start++;
+        if (*start == '\0') {
+            LOG_WARN("Rejected ham short_name: must contain at least 1 non-whitespace character");
+            return;
+        }
+    }
+
     // Set call sign and override lora limitations for licensed use
     strncpy(owner.long_name, p.call_sign, sizeof(owner.long_name));
     strncpy(owner.short_name, p.short_name, sizeof(owner.short_name));

--- a/userPrefs.jsonc
+++ b/userPrefs.jsonc
@@ -21,7 +21,7 @@
   // "USERPREFS_CONFIG_LORA_REGION": "meshtastic_Config_LoRaConfig_RegionCode_US",
   // "USERPREFS_CONFIG_OWNER_LONG_NAME": "My Long Name",
   // "USERPREFS_CONFIG_OWNER_SHORT_NAME": "MLN",
-  // "USERPREFS_CONFIG_DEVICE_ROLE": "meshtastic_Config_DeviceConfig_Role_CLIENT", // Defaults to CLIENT, ROUTER*, LOST AND FOUND, and REPEATER roles are restricted.
+  // "USERPREFS_CONFIG_DEVICE_ROLE": "meshtastic_Config_DeviceConfig_Role_CLIENT", // Defaults to CLIENT. ROUTER*, LOST AND FOUND, and REPEATER roles are restricted.
   // "USERPREFS_EVENT_MODE": "1",
   // "USERPREFS_FIXED_BLUETOOTH": "121212",
   // "USERPREFS_FIXED_GPS": "",

--- a/userPrefs.jsonc
+++ b/userPrefs.jsonc
@@ -21,6 +21,7 @@
   // "USERPREFS_CONFIG_LORA_REGION": "meshtastic_Config_LoRaConfig_RegionCode_US",
   // "USERPREFS_CONFIG_OWNER_LONG_NAME": "My Long Name",
   // "USERPREFS_CONFIG_OWNER_SHORT_NAME": "MLN",
+  // "USERPREFS_CONFIG_DEVICE_ROLE": "meshtastic_Config_DeviceConfig_Role_CLIENT", // Defaults to CLIENT, ROUTER*, LOST AND FOUND, and REPEATER roles are restricted.
   // "USERPREFS_EVENT_MODE": "1",
   // "USERPREFS_FIXED_BLUETOOTH": "121212",
   // "USERPREFS_FIXED_GPS": "",


### PR DESCRIPTION
I saw feature request https://github.com/meshtastic/firmware/issues/6867 and figured this would be a good addition to the firmware and Python CLI.

I have added validation for empty and whitespace characters as short, long, and ham names. When trying to set them via the CLI, I see the following below in the serial output logs.

Should these be ERROR instead of WARN? I have also modified the Python CLI and will create a PR on that so that you get an error when trying to set blank or whitespace names.

```
DEBUG | 08:26:41 75 [Router] Client set owner
WARN | 08:26:41 75 [Router] Rejected long_name: must contain at least 1 non-whitespace character

DEBUG | 08:27:24 116 [Router] Client set owner
WARN | 08:27:24 116 [Router] Rejected short_name: must contain at least 1 non-whitespace character

DEBUG | 08:28:55 35 [Router] Client set owner
WARN | 08:28:55 35 [Router] Rejected ham short_name: must contain at least 1 non-whitespace character
```

I have also added userPrefs.jsonc USERPREFS_CONFIG_DEVICE_ROLE example addition for [#6972](https://github.com/meshtastic/firmware/pull/6972) since I forgot to add it in my last PR.

Please let me know if there is anything that needs to be added or modified. I have no idea what I am doing with Android SDK/development, so I believe someone will need to add this validation so the app also gives an error/warning when trying to set these.

## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [x] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [x] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
