### PR TITLE
Add InkHUD driver for WeAct Studio 1.54" display module

### DIFF
--- a/src/graphics/niche/Drivers/EInk/GDEY0154D67.cpp
+++ b/src/graphics/niche/Drivers/EInk/GDEY0154D67.cpp
@@ -39,10 +39,10 @@ void GDEY0154D67::detachFromUpdate()
 {
     switch (updateType) {
     case FAST:
-        return beginPolling(50, 500); // At least 500ms for fast refresh
+        return beginPolling(50, 300); // At least 300ms for fast refresh
     case FULL:
     default:
-        return beginPolling(100, 2000); // At least 2 seconds for full refresh
+        return beginPolling(100, 1500); // At least 1.5 seconds for full refresh
     }
 }
 #endif // MESHTASTIC_INCLUDE_NICHE_GRAPHICS

--- a/src/graphics/niche/Drivers/EInk/GDEY0154D67.cpp
+++ b/src/graphics/niche/Drivers/EInk/GDEY0154D67.cpp
@@ -4,6 +4,16 @@
 
 using namespace NicheGraphics::Drivers;
 
+// Map the display controller IC's output to the connected panel
+void GDEY0154D67::configScanning()
+{
+    // "Driver output control"
+    sendCommand(0x01);
+    sendData(0xC7); // Scan until gate 199 (200px vertical res.)
+    sendData(0x00);
+    sendData(0x00);
+}
+
 // Specify which information is used to control the sequence of voltages applied to move the pixels
 // - For this display, configUpdateSequence() specifies that a suitable LUT will be loaded from
 //   the controller IC's OTP memory, when the update procedure begins.

--- a/src/graphics/niche/Drivers/EInk/GDEY0154D67.cpp
+++ b/src/graphics/niche/Drivers/EInk/GDEY0154D67.cpp
@@ -4,19 +4,6 @@
 
 using namespace NicheGraphics::Drivers;
 
-// Map the display controller IC's output to the connected panel
-void GDEY0154D67::configScanning()
-{
-    // "Driver output control"
-    sendCommand(0x01);
-    sendData(0xC7);
-    sendData(0x00);
-    sendData(0x00);
-
-    // To-do: delete this method?
-    // Values set here might be redundant: C7, 00, 00 seems to be default
-}
-
 // Specify which information is used to control the sequence of voltages applied to move the pixels
 // - For this display, configUpdateSequence() specifies that a suitable LUT will be loaded from
 //   the controller IC's OTP memory, when the update procedure begins.

--- a/src/graphics/niche/Drivers/EInk/GDEY0154D67.h
+++ b/src/graphics/niche/Drivers/EInk/GDEY0154D67.h
@@ -31,9 +31,8 @@ class GDEY0154D67 : public SSD16XX
     GDEY0154D67() : SSD16XX(width, height, supported) {}
 
   protected:
-    virtual void configScanning() override;
-    virtual void configWaveform() override;
-    virtual void configUpdateSequence() override;
+    void configWaveform() override;
+    void configUpdateSequence() override;
     void detachFromUpdate() override;
 };
 

--- a/src/graphics/niche/Drivers/EInk/GDEY0154D67.h
+++ b/src/graphics/niche/Drivers/EInk/GDEY0154D67.h
@@ -31,6 +31,7 @@ class GDEY0154D67 : public SSD16XX
     GDEY0154D67() : SSD16XX(width, height, supported) {}
 
   protected:
+    void configScanning() override;
     void configWaveform() override;
     void configUpdateSequence() override;
     void detachFromUpdate() override;

--- a/src/graphics/niche/Drivers/EInk/GDEY0213B74.cpp
+++ b/src/graphics/niche/Drivers/EInk/GDEY0213B74.cpp
@@ -12,9 +12,6 @@ void GDEY0213B74::configScanning()
     sendData(0xF9);
     sendData(0x00);
     sendData(0x00);
-
-    // To-do: delete this method?
-    // Values set here might be redundant: F9, 00, 00 seems to be default
 }
 
 // Specify which information is used to control the sequence of voltages applied to move the pixels

--- a/src/graphics/niche/Drivers/EInk/ZJY200200_0154DAAMFGN.h
+++ b/src/graphics/niche/Drivers/EInk/ZJY200200_0154DAAMFGN.h
@@ -1,0 +1,32 @@
+/*
+
+E-Ink display driver
+    - ZJY200200-0154DAAMFGN
+    - Manufacturer: Zhongjingyuan
+    - Size: 1.54 inch
+    - Resolution: 200px x 200px
+    - Flex connector marking: FPC-B001
+
+    Note: as of Feb. 2025, these panels are used for "WeActStudio 1.54in B&W" display modules
+
+    This *is* a distinct panel, however the driver is currently identical to GDEY0154D67
+    We recognize it as separate now, to avoid breaking any custom builds if the drivers do need to diverge in future.
+
+*/
+
+#pragma once
+
+#ifdef MESHTASTIC_INCLUDE_NICHE_GRAPHICS
+
+#include "configuration.h"
+
+#include "./GDEY0154D67.h"
+
+namespace NicheGraphics::Drivers
+{
+
+typedef GDEY0154D67 ZJY200200_0154DAAMFGN;
+
+} // namespace NicheGraphics::Drivers
+
+#endif // MESHTASTIC_INCLUDE_NICHE_GRAPHICS


### PR DESCRIPTION
Display model is `ZJY200200_0154DAAMFGN`. Currently identical to `GDEY0154D67`, and using same code base, but recognized as separate in case the drivers do diverge in future.

Optimizations made to the existing `GDEY0154D67` driver, and tested on affected devices. 

## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - NRF52 Pro-micro DIY (custom build)
    - LilyGo T-Echo
    -  Elecrow ThinkNode M1
