### PR TITLE
Update heltec t114 URL

### DIFF
--- a/boards/heltec_mesh_node_t114.json
+++ b/boards/heltec_mesh_node_t114.json
@@ -48,6 +48,6 @@
     "require_upload_port": true,
     "wait_for_upload_port": true
   },
-  "url": "FIXME",
+  "url": "https://heltec.org/project/mesh-node-t114/",
   "vendor": "Heltec"
 }


### PR DESCRIPTION
This is a very minor update to fix the FIXME item in the JSON with the correct product URL.