### PR TITLE
Update URL for ThinkNode M1

### DIFF
--- a/boards/ThinkNode-M1.json
+++ b/boards/ThinkNode-M1.json
@@ -48,6 +48,6 @@
     "require_upload_port": true,
     "wait_for_upload_port": true
   },
-  "url": "FIXME",
+  "url": "https://www.elecrow.com/thinknode-m1-meshtastic-lora-signal-transceiver-powered-by-nrf52840-with-154-screen-support-gps.html",
   "vendor": "ELECROW"
 }


### PR DESCRIPTION
This addresses the FIXME for the ThinkNode M1's URL