### PR TITLE
InkHUD DIY builds for ProMicro & Heltec T114

### DIFF
--- a/variants/diy/nrf52_promicro_diy_tcxo/custom_build_tasks.py
+++ b/variants/diy/nrf52_promicro_diy_tcxo/custom_build_tasks.py
@@ -2,8 +2,9 @@
 # - build using custom task in Platformio's "Project Tasks" panel
 # - build with `pio run -e <variant> -t build_weact_154` (or similar)
 
+# Silence trunk's objections to the import statements
 # trunk-ignore-all(ruff/F821)
-# trunk-ignore-all(flake8/F821): For SConstruct imports
+# trunk-ignore-all(flake8/F821)
 
 from SCons.Script import COMMAND_LINE_TARGETS
 

--- a/variants/diy/nrf52_promicro_diy_tcxo/custom_build_tasks.py
+++ b/variants/diy/nrf52_promicro_diy_tcxo/custom_build_tasks.py
@@ -1,0 +1,61 @@
+# Simplifies DIY InkHUD builds, with presets for several common E-Ink displays
+# - build using custom task in Platformio's "Project Tasks" panel
+# - build with `pio run -e <variant> -t build_weact_154` (or similar)
+
+# trunk-ignore-all(ruff/F821)
+# trunk-ignore-all(flake8/F821): For SConstruct imports
+
+from SCons.Script import COMMAND_LINE_TARGETS
+
+Import("env")
+Import("projenv")
+
+# Custom targets
+# These wrappers just run the normal build task under a different target name
+# We intercept the build later on, based on the target name
+env.AddTarget(
+    name="build_weact_154",
+    dependencies=["buildprog"],
+    actions=None,
+    title='Build (WeAct 1.54")',
+)
+env.AddTarget(
+    name="build_weact_213",
+    dependencies=["buildprog"],
+    actions=None,
+    title='Build (WeAct 2.13")',
+)
+env.AddTarget(
+    name="build_weact_290",
+    dependencies=["buildprog"],
+    actions=None,
+    title='Build (WeAct 2.9")',
+)
+env.AddTarget(
+    name="build_weact_420",
+    dependencies=["buildprog"],
+    actions=None,
+    title='Build (WeAct 4.2")',
+)
+
+# Check whether a build was started via one of our custom targets above
+
+if "build_weact_154" in COMMAND_LINE_TARGETS:
+    print('Building for WeAct 1.54" Display')
+    projenv["CPPDEFINES"].append(("INKHUD_BUILDCONF_DRIVER", "ZJY200200_0154DAAMFGN"))
+    projenv["CPPDEFINES"].append(("INKHUD_BUILDCONF_DISPLAYRESILIENCE", "15"))
+
+elif "build_weact_213" in COMMAND_LINE_TARGETS:
+    print('Building for WeAct 2.13" Display')
+    projenv["CPPDEFINES"].append(("INKHUD_BUILDCONF_DRIVER", "HINK_E0213A289"))
+    projenv["CPPDEFINES"].append(("INKHUD_BUILDCONF_DISPLAYRESILIENCE", "10"))
+
+elif "build_weact_290" in COMMAND_LINE_TARGETS:
+    print('Building for WeAct 2.9" Display')
+    projenv["CPPDEFINES"].append(("INKHUD_BUILDCONF_DRIVER", "ZJY128296_029EAAMFGN"))
+    projenv["CPPDEFINES"].append(("INKHUD_BUILDCONF_DISPLAYRESILIENCE", "15"))
+
+elif "build_weact_420" in COMMAND_LINE_TARGETS:
+    print('Building for WeAct 4.2" Display')
+    projenv["CPPDEFINES"].append(("INKHUD_BUILDCONF_DRIVER", "HINK_E042A87"))
+    projenv["CPPDEFINES"].append(("INKHUD_BUILDCONF_DISPLAYRESILIENCE", "15"))

--- a/variants/diy/nrf52_promicro_diy_tcxo/nicheGraphics.h
+++ b/variants/diy/nrf52_promicro_diy_tcxo/nicheGraphics.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include "configuration.h"
+
+#ifdef MESHTASTIC_INCLUDE_NICHE_GRAPHICS
+
+// InkHUD-specific components
+// ---------------------------
+#include "graphics/niche/InkHUD/InkHUD.h"
+
+// Applets
+#include "graphics/niche/InkHUD/Applets/User/AllMessage/AllMessageApplet.h"
+#include "graphics/niche/InkHUD/Applets/User/DM/DMApplet.h"
+#include "graphics/niche/InkHUD/Applets/User/Heard/HeardApplet.h"
+#include "graphics/niche/InkHUD/Applets/User/Positions/PositionsApplet.h"
+#include "graphics/niche/InkHUD/Applets/User/RecentsList/RecentsListApplet.h"
+#include "graphics/niche/InkHUD/Applets/User/ThreadedMessage/ThreadedMessageApplet.h"
+
+// Shared NicheGraphics components
+// --------------------------------
+#include "graphics/niche/Drivers/EInk/HINK_E0213A289.h"        // WeAct 2.13"
+#include "graphics/niche/Drivers/EInk/HINK_E042A87.h"          // WeAct 4.2"
+#include "graphics/niche/Drivers/EInk/ZJY128296_029EAAMFGN.h"  // WeAct 2.9"
+#include "graphics/niche/Drivers/EInk/ZJY200200_0154DAAMFGN.h" // WeACt 1.54"
+
+#include "graphics/niche/Inputs/TwoButton.h"
+
+#if !defined(INKHUD_BUILDCONF_DRIVER) || !defined(INKHUD_BUILDCONF_DISPLAYRESILIENCE)
+#error If not using a DIY preset, display model and resilience must be set manually
+#endif
+
+void setupNicheGraphics()
+{
+    using namespace NicheGraphics;
+
+    // SPI
+    // -----------------------------
+    SPI.begin();
+
+    // Driver
+    // -----------------------------
+
+    // Use E-Ink driver
+    Drivers::EInk *driver = new Drivers::INKHUD_BUILDCONF_DRIVER;
+    driver->begin(&SPI, PIN_EINK_DC, PIN_EINK_CS, PIN_EINK_BUSY, PIN_EINK_RES);
+
+    // InkHUD
+    // ----------------------------
+
+    InkHUD::InkHUD *inkhud = InkHUD::InkHUD::getInstance();
+
+    // Set the driver
+    inkhud->setDriver(driver);
+
+    // Set how many FAST updates per FULL update.
+    inkhud->setDisplayResilience(INKHUD_BUILDCONF_DISPLAYRESILIENCE); // Suggest roughly ten
+
+    // Prepare fonts
+    InkHUD::Applet::fontLarge = FREESANS_9PT_WIN1252;
+    InkHUD::Applet::fontSmall = FREESANS_6PT_WIN1252;
+
+    // Init settings, and customize defaults
+    // Values ignored individually if found saved to flash
+    inkhud->persistence->settings.rotation = (driver->height > driver->width ? 1 : 0); // Rotate 90deg to landscape, if needed
+    inkhud->persistence->settings.userTiles.maxCount = 4;
+    inkhud->persistence->settings.optionalFeatures.batteryIcon = true;
+
+    // Pick applets
+    // Note: order of applets determines priority of "auto-show" feature
+    inkhud->addApplet("All Messages", new InkHUD::AllMessageApplet);
+    inkhud->addApplet("DMs", new InkHUD::DMApplet, true, false, 3);                       // Default on tile 3
+    inkhud->addApplet("Channel 0", new InkHUD::ThreadedMessageApplet(0), true, false, 2); // Default on tile 2
+    inkhud->addApplet("Channel 1", new InkHUD::ThreadedMessageApplet(1));
+    inkhud->addApplet("Positions", new InkHUD::PositionsApplet, true, false, 1);      // Default on tile 1
+    inkhud->addApplet("Recents List", new InkHUD::RecentsListApplet, true, false, 0); // Default on tile 0
+    inkhud->addApplet("Heard", new InkHUD::HeardApplet, true);                        // Background
+
+    // Start running InkHUD
+    inkhud->begin();
+
+    // Buttons
+    // --------------------------
+
+    Inputs::TwoButton *buttons = Inputs::TwoButton::getInstance(); // Shared NicheGraphics component
+
+    // Setup the main user button
+    buttons->setWiring(0, Inputs::TwoButton::getUserButtonPin(), true); // Internal pull up
+    buttons->setHandlerShortPress(0, [inkhud]() { inkhud->shortpress(); });
+    buttons->setHandlerLongPress(0, [inkhud]() { inkhud->longpress(); });
+
+    buttons->start();
+}
+
+#endif

--- a/variants/diy/nrf52_promicro_diy_tcxo/variant.h
+++ b/variants/diy/nrf52_promicro_diy_tcxo/variant.h
@@ -22,26 +22,26 @@ extern "C" {
 /*
 NRF52 PRO MICRO PIN ASSIGNMENT
 
-| Pin   | Function    |     | Pin      | Function     | RF95  |
+| Pin ï¿½ | Function ï¿½  | ï¿½   | Pin ï¿½ ï¿½  | Function ï¿½ ï¿½ | RF95  |
 | ----- | ----------- | --- | -------- | ------------ | ----- |
-| Gnd   |             |     | vbat     |              |       |
-| P0.06 | Serial2 RX  |     | vbat     |              |       |
-| P0.08 | Serial2 TX  |     | Gnd      |              |       |
-| Gnd   |             |     | reset    |              |       |
-| Gnd   |             |     | ext_vcc  | *see 0.13    |       |
-| P0.17 | RXEN        |     | P0.31    | BATTERY_PIN  |       |
-| P0.20 | GPS_RX      |     | P0.29    | BUSY         | DIO0  |
-| P0.22 | GPS_TX      |     | P0.02    | MISO         | MISO  |
-| P0.24 | GPS_EN      |     | P1.15    | MOSI         | MOSI  |
-| P1.00 | BUTTON_PIN  |     | P1.13    | CS           | CS    |
-| P0.11 | SCL         |     | P1.11    | SCK          | SCK   |
-| P1.04 | SDA         |     | P0.10    | DIO1/IRQ     | DIO1  |
-| P1.06 | Free pin    |     | P0.09    | RESET        | RST   |
-|       |             |     |          |              |       |
-|       | Mid board   |     |          | Internal     |       |
-| P1.01 | Free pin    |     | 0.15     | LED          |       |
-| P1.02 | Free pin    |     | 0.13     | 3V3_EN       |       |
-| P1.07 | Free pin    |     |          |              |       |
+| Gnd ï¿½ | ï¿½ ï¿½ ï¿½ ï¿½ ï¿½ ï¿½ | ï¿½   | vbat ï¿½ ï¿½ | ï¿½ ï¿½ ï¿½ ï¿½ ï¿½ ï¿½  |       |
+| P0.06 | Serial2 RX  | ï¿½   | vbat ï¿½ ï¿½ | ï¿½ ï¿½ ï¿½ ï¿½ ï¿½ ï¿½  |       |
+| P0.08 | Serial2 TX  | ï¿½   | Gnd ï¿½ ï¿½  | ï¿½ ï¿½ ï¿½ ï¿½ ï¿½ ï¿½  |       |
+| Gnd ï¿½ | ï¿½ ï¿½ ï¿½ ï¿½ ï¿½ ï¿½ | ï¿½   | reset ï¿½  | ï¿½ ï¿½ ï¿½ ï¿½ ï¿½ ï¿½  |       |
+| Gnd ï¿½ | ï¿½ ï¿½ ï¿½ ï¿½ ï¿½ ï¿½ | ï¿½   | ext_vcc  | *see 0.13 ï¿½  |       |
+| P0.17 | RXEN ï¿½ ï¿½ ï¿½  | ï¿½   | P0.31 ï¿½  | BATTERY_PIN  |       |
+| P0.20 | GPS_RX ï¿½ ï¿½  | ï¿½   | P0.29 ï¿½  | BUSY ï¿½ ï¿½ ï¿½ ï¿½ | DIO0  |
+| P0.22 | GPS_TX ï¿½ ï¿½  | ï¿½   | P0.02 ï¿½  | MISO         | MISO  |
+| P0.24 | GPS_EN ï¿½ ï¿½  | ï¿½   | P1.15 ï¿½  | MOSI ï¿½ ï¿½ ï¿½ ï¿½ | MOSI  |
+| P1.00 | BUTTON_PIN  | ï¿½   | P1.13 ï¿½  | CS ï¿½ ï¿½ ï¿½ ï¿½ ï¿½ | CS ï¿½  |
+| P0.11 | SCL ï¿½ ï¿½ ï¿½ ï¿½ | ï¿½   | P1.11 ï¿½  | SCK ï¿½ ï¿½ ï¿½ ï¿½  | SCK   |
+| P1.04 | SDA ï¿½ ï¿½ ï¿½ ï¿½ | ï¿½   | P0.10 ï¿½  | DIO1/IRQ ï¿½ ï¿½ | DIO1  |
+| P1.06 | Free pin ï¿½  | ï¿½   | P0.09 ï¿½  | RESET ï¿½ ï¿½ ï¿½  | RST   |
+| ï¿½ ï¿½ ï¿½ | ï¿½ ï¿½ ï¿½ ï¿½ ï¿½ ï¿½ | ï¿½   | ï¿½ ï¿½ ï¿½ ï¿½  | ï¿½ ï¿½ ï¿½ ï¿½ ï¿½ ï¿½  |       |
+| ï¿½ ï¿½ ï¿½ | Mid board ï¿½ | ï¿½   | ï¿½ ï¿½ ï¿½ ï¿½  | Internal ï¿½ ï¿½ |       |
+| P1.01 | Free pin ï¿½  | ï¿½   | 0.15 ï¿½ ï¿½ | LED ï¿½ ï¿½ ï¿½ ï¿½  |       |
+| P1.02 | Free pin ï¿½  | ï¿½   | 0.13 ï¿½ ï¿½ | 3V3_EN ï¿½ ï¿½ ï¿½ |       |
+| P1.07 | Free pin ï¿½  | ï¿½   | ï¿½ ï¿½ ï¿½ ï¿½  | ï¿½ ï¿½ ï¿½ ï¿½ ï¿½ ï¿½  |       |
 */
 
 // Number of pins defined in PinDescription array
@@ -184,6 +184,12 @@ settings.
 
 #define SX126X_DIO3_TCXO_VOLTAGE 1.8
 #define TCXO_OPTIONAL // make it so that the firmware can try both TCXO and XTAL
+
+// E-Ink DIY
+#define PIN_EINK_CS (32 + 7)
+#define PIN_EINK_DC (32 + 2)
+#define PIN_EINK_RES (32 + 1)
+#define PIN_EINK_BUSY (32 + 6)
 
 #ifdef __cplusplus
 }

--- a/variants/diy/nrf52_promicro_diy_tcxo/variant.h
+++ b/variants/diy/nrf52_promicro_diy_tcxo/variant.h
@@ -22,26 +22,26 @@ extern "C" {
 /*
 NRF52 PRO MICRO PIN ASSIGNMENT
 
-| Pin � | Function �  | �   | Pin � �  | Function � � | RF95  |
+| Pin   | Function    |     | Pin      | Function     | RF95  |
 | ----- | ----------- | --- | -------- | ------------ | ----- |
-| Gnd � | � � � � � � | �   | vbat � � | � � � � � �  |       |
-| P0.06 | Serial2 RX  | �   | vbat � � | � � � � � �  |       |
-| P0.08 | Serial2 TX  | �   | Gnd � �  | � � � � � �  |       |
-| Gnd � | � � � � � � | �   | reset �  | � � � � � �  |       |
-| Gnd � | � � � � � � | �   | ext_vcc  | *see 0.13 �  |       |
-| P0.17 | RXEN � � �  | �   | P0.31 �  | BATTERY_PIN  |       |
-| P0.20 | GPS_RX � �  | �   | P0.29 �  | BUSY � � � � | DIO0  |
-| P0.22 | GPS_TX � �  | �   | P0.02 �  | MISO         | MISO  |
-| P0.24 | GPS_EN � �  | �   | P1.15 �  | MOSI � � � � | MOSI  |
-| P1.00 | BUTTON_PIN  | �   | P1.13 �  | CS � � � � � | CS �  |
-| P0.11 | SCL � � � � | �   | P1.11 �  | SCK � � � �  | SCK   |
-| P1.04 | SDA � � � � | �   | P0.10 �  | DIO1/IRQ � � | DIO1  |
-| P1.06 | Free pin �  | �   | P0.09 �  | RESET � � �  | RST   |
-| � � � | � � � � � � | �   | � � � �  | � � � � � �  |       |
-| � � � | Mid board � | �   | � � � �  | Internal � � |       |
-| P1.01 | Free pin �  | �   | 0.15 � � | LED � � � �  |       |
-| P1.02 | Free pin �  | �   | 0.13 � � | 3V3_EN � � � |       |
-| P1.07 | Free pin �  | �   | � � � �  | � � � � � �  |       |
+| Gnd   |             |     | vbat     |              |       |
+| P0.06 | Serial2 RX  |     | vbat     |              |       |
+| P0.08 | Serial2 TX  |     | Gnd      |              |       |
+| Gnd   |             |     | reset    |              |       |
+| Gnd   |             |     | ext_vcc  | *see 0.13    |       |
+| P0.17 | RXEN        |     | P0.31    | BATTERY_PIN  |       |
+| P0.20 | GPS_RX      |     | P0.29    | BUSY         | DIO0  |
+| P0.22 | GPS_TX      |     | P0.02    | MISO         | MISO  |
+| P0.24 | GPS_EN      |     | P1.15    | MOSI         | MOSI  |
+| P1.00 | BUTTON_PIN  |     | P1.13    | CS           | CS    |
+| P0.11 | SCL         |     | P1.11    | SCK          | SCK   |
+| P1.04 | SDA         |     | P0.10    | DIO1/IRQ     | DIO1  |
+| P1.06 | Free pin    |     | P0.09    | RESET        | RST   |
+|       |             |     |          |              |       |
+|       | Mid board   |     |          | Internal     |       |
+| P1.01 | Free pin    |     | 0.15     | LED          |       |
+| P1.02 | Free pin    |     | 0.13     | 3V3_EN       |       |
+| P1.07 | Free pin    |     |          |              |       |
 */
 
 // Number of pins defined in PinDescription array

--- a/variants/diy/platformio.ini
+++ b/variants/diy/platformio.ini
@@ -68,6 +68,27 @@ lib_deps =
   ${nrf52840_base.lib_deps}
 debug_tool = jlink
 
+; NRF52 ProMicro w/ E-Ink display
+[env:nrf52_promicro_diy-inkhud]
+board_level = extra
+extends = nrf52840_base, inkhud
+board = promicro-nrf52840
+build_flags =
+  ${nrf52840_base.build_flags}
+  ${inkhud.build_flags}
+  -I variants/diy/nrf52_promicro_diy_tcxo
+  -D NRF52_PROMICRO_DIY
+build_src_filter =
+  ${nrf52_base.build_src_filter}
+  ${inkhud.build_src_filter}
+  +<../variants/diy/nrf52_promicro_diy_tcxo>
+lib_deps =
+  ${inkhud.lib_deps} ; InkHUD libs first, so we get GFXRoot instead of AdafruitGFX
+  ${nrf52840_base.lib_deps}
+extra_scripts =
+  ${env.extra_scripts}
+  variants/diy/nrf52_promicro_diy_tcxo/custom_build_tasks.py ; Add to PIO's Project Tasks pane: preset builds for common displays
+
 ; Seeed XIAO nRF52840 + XIAO Wio SX1262 DIY
 [env:seeed-xiao-nrf52840-wio-sx1262]
 board = xiao_ble_sense

--- a/variants/heltec_mesh_node_t114-inkhud/custom_build_tasks.py
+++ b/variants/heltec_mesh_node_t114-inkhud/custom_build_tasks.py
@@ -2,8 +2,9 @@
 # - build using custom task in Platformio's "Project Tasks" panel
 # - build with `pio run -e <variant> -t build_weact_154` (or similar)
 
+# Silence trunk's objections to the import statements
 # trunk-ignore-all(ruff/F821)
-# trunk-ignore-all(flake8/F821): For SConstruct imports
+# trunk-ignore-all(flake8/F821)
 
 from SCons.Script import COMMAND_LINE_TARGETS
 

--- a/variants/heltec_mesh_node_t114-inkhud/custom_build_tasks.py
+++ b/variants/heltec_mesh_node_t114-inkhud/custom_build_tasks.py
@@ -1,0 +1,61 @@
+# Simplifies DIY InkHUD builds, with presets for several common E-Ink displays
+# - build using custom task in Platformio's "Project Tasks" panel
+# - build with `pio run -e <variant> -t build_weact_154` (or similar)
+
+# trunk-ignore-all(ruff/F821)
+# trunk-ignore-all(flake8/F821): For SConstruct imports
+
+from SCons.Script import COMMAND_LINE_TARGETS
+
+Import("env")
+Import("projenv")
+
+# Custom targets
+# These wrappers just run the normal build task under a different target name
+# We intercept the build later on, based on the target name
+env.AddTarget(
+    name="build_weact_154",
+    dependencies=["buildprog"],
+    actions=None,
+    title='Build (WeAct 1.54")',
+)
+env.AddTarget(
+    name="build_weact_213",
+    dependencies=["buildprog"],
+    actions=None,
+    title='Build (WeAct 2.13")',
+)
+env.AddTarget(
+    name="build_weact_290",
+    dependencies=["buildprog"],
+    actions=None,
+    title='Build (WeAct 2.9")',
+)
+env.AddTarget(
+    name="build_weact_420",
+    dependencies=["buildprog"],
+    actions=None,
+    title='Build (WeAct 4.2")',
+)
+
+# Check whether a build was started via one of our custom targets above
+
+if "build_weact_154" in COMMAND_LINE_TARGETS:
+    print('Building for WeAct 1.54" Display')
+    projenv["CPPDEFINES"].append(("INKHUD_BUILDCONF_DRIVER", "ZJY200200_0154DAAMFGN"))
+    projenv["CPPDEFINES"].append(("INKHUD_BUILDCONF_DISPLAYRESILIENCE", "15"))
+
+elif "build_weact_213" in COMMAND_LINE_TARGETS:
+    print('Building for WeAct 2.13" Display')
+    projenv["CPPDEFINES"].append(("INKHUD_BUILDCONF_DRIVER", "HINK_E0213A289"))
+    projenv["CPPDEFINES"].append(("INKHUD_BUILDCONF_DISPLAYRESILIENCE", "10"))
+
+elif "build_weact_290" in COMMAND_LINE_TARGETS:
+    print('Building for WeAct 2.9" Display')
+    projenv["CPPDEFINES"].append(("INKHUD_BUILDCONF_DRIVER", "ZJY128296_029EAAMFGN"))
+    projenv["CPPDEFINES"].append(("INKHUD_BUILDCONF_DISPLAYRESILIENCE", "15"))
+
+elif "build_weact_420" in COMMAND_LINE_TARGETS:
+    print('Building for WeAct 4.2" Display')
+    projenv["CPPDEFINES"].append(("INKHUD_BUILDCONF_DRIVER", "HINK_E042A87"))
+    projenv["CPPDEFINES"].append(("INKHUD_BUILDCONF_DISPLAYRESILIENCE", "15"))

--- a/variants/heltec_mesh_node_t114-inkhud/nicheGraphics.h
+++ b/variants/heltec_mesh_node_t114-inkhud/nicheGraphics.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include "configuration.h"
+
+#ifdef MESHTASTIC_INCLUDE_NICHE_GRAPHICS
+
+// InkHUD-specific components
+// ---------------------------
+#include "graphics/niche/InkHUD/InkHUD.h"
+
+// Applets
+#include "graphics/niche/InkHUD/Applets/User/AllMessage/AllMessageApplet.h"
+#include "graphics/niche/InkHUD/Applets/User/DM/DMApplet.h"
+#include "graphics/niche/InkHUD/Applets/User/Heard/HeardApplet.h"
+#include "graphics/niche/InkHUD/Applets/User/Positions/PositionsApplet.h"
+#include "graphics/niche/InkHUD/Applets/User/RecentsList/RecentsListApplet.h"
+#include "graphics/niche/InkHUD/Applets/User/ThreadedMessage/ThreadedMessageApplet.h"
+
+// Shared NicheGraphics components
+// --------------------------------
+#include "graphics/niche/Drivers/EInk/HINK_E0213A289.h"        // WeAct 2.13"
+#include "graphics/niche/Drivers/EInk/HINK_E042A87.h"          // WeAct 4.2"
+#include "graphics/niche/Drivers/EInk/ZJY128296_029EAAMFGN.h"  // WeAct 2.9"
+#include "graphics/niche/Drivers/EInk/ZJY200200_0154DAAMFGN.h" // WeACt 1.54"
+
+#include "graphics/niche/Inputs/TwoButton.h"
+
+#if !defined(INKHUD_BUILDCONF_DRIVER) || !defined(INKHUD_BUILDCONF_DISPLAYRESILIENCE)
+#error If not using a DIY preset, display model and resilience must be set manually
+#endif
+
+void setupNicheGraphics()
+{
+    using namespace NicheGraphics;
+
+    // SPI
+    // -----------------------------
+    SPI1.begin();
+
+    // Driver
+    // -----------------------------
+
+    // Use E-Ink driver
+    Drivers::EInk *driver = new Drivers::INKHUD_BUILDCONF_DRIVER;
+    driver->begin(&SPI1, PIN_EINK_DC, PIN_EINK_CS, PIN_EINK_BUSY, PIN_EINK_RES);
+
+    // InkHUD
+    // ----------------------------
+
+    InkHUD::InkHUD *inkhud = InkHUD::InkHUD::getInstance();
+
+    // Set the driver
+    inkhud->setDriver(driver);
+
+    // Set how many FAST updates per FULL update.
+    inkhud->setDisplayResilience(INKHUD_BUILDCONF_DISPLAYRESILIENCE); // Suggest roughly ten
+
+    // Prepare fonts
+    InkHUD::Applet::fontLarge = FREESANS_9PT_WIN1252;
+    InkHUD::Applet::fontSmall = FREESANS_6PT_WIN1252;
+
+    // Init settings, and customize defaults
+    // Values ignored individually if found saved to flash
+    inkhud->persistence->settings.rotation = (driver->height > driver->width ? 1 : 0); // Rotate 90deg to landscape, if needed
+    inkhud->persistence->settings.userTiles.maxCount = 4;
+    inkhud->persistence->settings.optionalFeatures.batteryIcon = true;
+
+    // Pick applets
+    // Note: order of applets determines priority of "auto-show" feature
+    inkhud->addApplet("All Messages", new InkHUD::AllMessageApplet);
+    inkhud->addApplet("DMs", new InkHUD::DMApplet, true, false, 3);                       // Default on tile 3
+    inkhud->addApplet("Channel 0", new InkHUD::ThreadedMessageApplet(0), true, false, 2); // Default on tile 2
+    inkhud->addApplet("Channel 1", new InkHUD::ThreadedMessageApplet(1));
+    inkhud->addApplet("Positions", new InkHUD::PositionsApplet, true, false, 1);      // Default on tile 1
+    inkhud->addApplet("Recents List", new InkHUD::RecentsListApplet, true, false, 0); // Default on tile 0
+    inkhud->addApplet("Heard", new InkHUD::HeardApplet, true);                        // Background
+
+    // Start running InkHUD
+    inkhud->begin();
+
+    // Buttons
+    // --------------------------
+
+    Inputs::TwoButton *buttons = Inputs::TwoButton::getInstance(); // Shared NicheGraphics component
+
+    // #0: Main User Button
+    buttons->setWiring(0, Inputs::TwoButton::getUserButtonPin());
+    buttons->setHandlerShortPress(0, [inkhud]() { inkhud->shortpress(); });
+    buttons->setHandlerLongPress(0, [inkhud]() { inkhud->longpress(); });
+
+    buttons->start();
+}
+
+#endif

--- a/variants/heltec_mesh_node_t114-inkhud/platformio.ini
+++ b/variants/heltec_mesh_node_t114-inkhud/platformio.ini
@@ -1,0 +1,19 @@
+[env:heltec-mesh-node-t114-inkhud]
+board_level = extra
+extends = nrf52840_base, inkhud
+board = heltec_mesh_node_t114
+board_check = true
+build_flags = 
+  ${nrf52840_base.build_flags}
+  ${inkhud.build_flags}
+  -I variants/heltec_mesh_node_t114-inkhud
+build_src_filter = 
+  ${nrf52_base.build_src_filter} 
+  ${inkhud.build_src_filter}
+lib_deps = 
+  ${inkhud.lib_deps} ; InkHUD libs first, so we get GFXRoot instead of AdafruitGFX
+  ${nrf52840_base.lib_deps}
+  lewisxhe/PCF8563_Library@^1.0.1
+extra_scripts =
+  ${env.extra_scripts}
+  variants/diy/nrf52_promicro_diy_tcxo/custom_build_tasks.py ; Add to PIO's Project Tasks pane: preset builds for common displays

--- a/variants/heltec_mesh_node_t114-inkhud/variant.cpp
+++ b/variants/heltec_mesh_node_t114-inkhud/variant.cpp
@@ -1,0 +1,38 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  Copyright (c) 2018, Adafruit Industries (adafruit.com)
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "variant.h"
+#include "nrf.h"
+#include "wiring_constants.h"
+#include "wiring_digital.h"
+
+const uint32_t g_ADigitalPinMap[] = {
+    // P0 - pins 0 and 1 are hardwired for xtal and should never be enabled
+    0xff, 0xff, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+
+    // P1
+    32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47};
+
+void initVariant()
+{
+    // LED1
+    pinMode(PIN_LED1, OUTPUT);
+    ledOff(PIN_LED1);
+}

--- a/variants/heltec_mesh_node_t114-inkhud/variant.h
+++ b/variants/heltec_mesh_node_t114-inkhud/variant.h
@@ -1,0 +1,175 @@
+// Unlike many other InkHUD variants, this environment does require its own variant.h file
+// This is because the default T114 variant maps SPI1 pins to the optional TFT display, and those pins are not broken out
+
+#ifndef _VARIANT_HELTEC_NRF_
+#define _VARIANT_HELTEC_NRF_
+/** Master clock frequency */
+#define VARIANT_MCK (64000000ul)
+
+#define USE_LFXO // Board uses 32khz crystal for LF
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#define HELTEC_MESH_NODE_T114
+
+// Number of pins defined in PinDescription array
+#define PINS_COUNT (48)
+#define NUM_DIGITAL_PINS (48)
+#define NUM_ANALOG_INPUTS (1)
+#define NUM_ANALOG_OUTPUTS (0)
+
+// LEDs
+#define PIN_LED1 (32 + 3) // green (confirmed on 1.0 board)
+#define LED_BLUE PIN_LED1 // fake for bluefruit library
+#define LED_GREEN PIN_LED1
+#define LED_BUILTIN LED_GREEN
+#define LED_STATE_ON 0 // State when LED is lit
+
+#define HAS_NEOPIXEL                         // Enable the use of neopixels
+#define NEOPIXEL_COUNT 2                     // How many neopixels are connected
+#define NEOPIXEL_DATA 14                     // gpio pin used to send data to the neopixels
+#define NEOPIXEL_TYPE (NEO_GRB + NEO_KHZ800) // type of neopixels in use
+
+/*
+ * Buttons
+ */
+#define PIN_BUTTON1 (32 + 10)
+// #define PIN_BUTTON2 (0 + 18)      // 0.18 is labeled on the board as RESET but we configure it in the bootloader as a regular
+// GPIO
+
+/*
+No longer populated on PCB
+*/
+#define PIN_SERIAL2_RX (0 + 9)
+#define PIN_SERIAL2_TX (0 + 10)
+//  #define PIN_SERIAL2_EN (0 + 17)
+
+/*
+ * I2C
+ */
+
+#define WIRE_INTERFACES_COUNT 2
+
+// I2C bus 0
+// Routed to footprint for PCF8563TS RTC
+// Not populated on T114 V1, maybe in future?
+#define PIN_WIRE_SDA (0 + 26) // P0.26
+#define PIN_WIRE_SCL (0 + 27) // P0.27
+
+// I2C bus 1
+// Available on header pins, for general use
+#define PIN_WIRE1_SDA (0 + 16) // P0.16
+#define PIN_WIRE1_SCL (0 + 13) // P0.13
+
+/*
+ * Lora radio
+ */
+
+#define USE_SX1262
+// #define USE_SX1268
+#define SX126X_CS (0 + 24) // FIXME - we really should define LORA_CS instead
+#define LORA_CS (0 + 24)
+#define SX126X_DIO1 (0 + 20)
+// Note DIO2 is attached internally to the module to an analog switch for TX/RX switching
+// #define SX1262_DIO3 (0 + 21)
+// This is used as an *output* from the sx1262 and connected internally to power the tcxo, do not drive from the
+//    main
+// CPU?
+#define SX126X_BUSY (0 + 17)
+#define SX126X_RESET (0 + 25)
+// Not really an E22 but TTGO seems to be trying to clone that
+#define SX126X_DIO2_AS_RF_SWITCH
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8
+
+/*
+ * E-Ink DIY
+ */
+#define PIN_EINK_MOSI (0 + 8) // also called SDA
+#define PIN_EINK_SCLK (0 + 7)
+#define PIN_EINK_CS (32 + 12)
+#define PIN_EINK_DC (32 + 14)
+#define PIN_EINK_RES (0 + 5)
+#define PIN_EINK_BUSY (32 + 15)
+
+/*
+ * GPS pins
+ */
+
+#define GPS_L76K
+
+// #define PIN_GPS_RESET (32 + 6) // An output to reset L76K GPS. As per datasheet, low for > 100ms will reset the L76K
+#define GPS_RESET_MODE LOW
+// #define PIN_GPS_EN (21)
+#define VEXT_ENABLE (0 + 21)
+#define PERIPHERAL_WARMUP_MS 1000 // Make sure I2C QuickLink has stable power before continuing
+#define VEXT_ON_VALUE HIGH
+// #define GPS_EN_ACTIVE HIGH
+#define PIN_GPS_STANDBY (32 + 2) // An output to wake GPS, low means allow sleep, high means force wake
+#define PIN_GPS_PPS (32 + 4)
+// Seems to be missing on this new board
+// #define PIN_GPS_PPS (32 + 4)  // Pulse per second input from the GPS
+#define GPS_TX_PIN (32 + 5) // This is for bits going TOWARDS the CPU
+#define GPS_RX_PIN (32 + 7) // This is for bits going TOWARDS the GPS
+
+#define GPS_THREAD_INTERVAL 50
+
+#define PIN_SERIAL1_RX GPS_TX_PIN
+#define PIN_SERIAL1_TX GPS_RX_PIN
+
+// PCF8563 RTC Module
+#define PCF8563_RTC 0x51
+
+/*
+ * SPI Interfaces
+ */
+#define SPI_INTERFACES_COUNT 2
+
+// For LORA, spi 0
+#define PIN_SPI_MISO (0 + 23)
+#define PIN_SPI_MOSI (0 + 22)
+#define PIN_SPI_SCK (0 + 19)
+
+#define PIN_SPI1_MISO -1
+#define PIN_SPI1_MOSI PIN_EINK_MOSI
+#define PIN_SPI1_SCK PIN_EINK_SCLK
+
+// #define PIN_PWR_EN (0 + 6)
+
+// To debug via the segger JLINK console rather than the CDC-ACM serial device
+// #define USE_SEGGER
+
+// Battery
+// The battery sense is hooked to pin A0 (4)
+// it is defined in the anlaolgue pin section of this file
+// and has 12 bit resolution
+
+#define ADC_CTRL 6
+#define ADC_CTRL_ENABLED HIGH
+#define BATTERY_PIN 4
+#define ADC_RESOLUTION 14
+
+#define BATTERY_SENSE_RESOLUTION_BITS 12
+#define BATTERY_SENSE_RESOLUTION 4096.0
+#undef AREF_VOLTAGE
+#define AREF_VOLTAGE 3.0
+#define VBAT_AR_INTERNAL AR_INTERNAL_3_0
+#define ADC_MULTIPLIER (4.90F)
+
+#define HAS_RTC 0
+#ifdef __cplusplus
+}
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#endif


### PR DESCRIPTION
Adds PlatformIO envs (`board_level = extra`) for DIY InkHUD builds based on either NRF52 ProMicro or Heltec MeshNode T114.

Based around the common WeAct Studio E-Paper modules (B&W):
* 1.54"
* 2.13" (2025 revision)
* 2.9"
* 4.2"

Display model must be selected by user at build-time. To simplify this, the two environments have been given custom pio build tasks.

![custom pio task](https://github.com/user-attachments/assets/04360ce5-096d-416f-a1f8-bb4971e64ec3)
```
pio run -e <variant> -t build_weact_154
```
(or specify display model by manually modifying nicheGraphics.h) 

I'll write documentation on the supported hardware and build process shortly.

## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck 
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - NRF52 ProMicro DIY
    - Heltec Mesh Node T114 
