### PR TITLE
Exclude InkHUD DIY build from cppcheck

### DIFF
--- a/variants/heltec_mesh_node_t114-inkhud/platformio.ini
+++ b/variants/heltec_mesh_node_t114-inkhud/platformio.ini
@@ -2,7 +2,6 @@
 board_level = extra
 extends = nrf52840_base, inkhud
 board = heltec_mesh_node_t114
-board_check = true
 build_flags = 
   ${nrf52840_base.build_flags}
   ${inkhud.build_flags}


### PR DESCRIPTION
https://github.com/meshtastic/firmware/pull/7039#issuecomment-2973735349

> The [check (heltec-mesh-node-t114-inkhud)](https://github.com/meshtastic/firmware/actions/runs/15657639614/job/44110857216#logs) jobs are failing after this merge @todd-herbert

___

The default build task for these variants fails intentionally:
```cpp
#error If not using a DIY preset, display model and resilience must be set manually
```

Is removing `board_check = true` from the platformio.ini file an appropriate solution here?

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
