### PR TITLE
Dismiss ExternalNotification nagging on InkHUD button press

### DIFF
--- a/src/graphics/niche/InkHUD/Events.cpp
+++ b/src/graphics/niche/InkHUD/Events.cpp
@@ -4,6 +4,7 @@
 
 #include "RTC.h"
 #include "modules/AdminModule.h"
+#include "modules/ExternalNotificationModule.h"
 #include "modules/TextMessageModule.h"
 #include "sleep.h"
 
@@ -37,6 +38,10 @@ void InkHUD::Events::begin()
 
 void InkHUD::Events::onButtonShort()
 {
+    // Cancel any beeping, buzzing, blinking
+    // Some button handling suppressed if we are dismissing an external notification (see below)
+    bool dismissedExt = dismissExternalNotification();
+
     // Check which system applet wants to handle the button press (if any)
     SystemApplet *consumer = nullptr;
     for (SystemApplet *sa : inkhud->systemApplets) {
@@ -49,7 +54,7 @@ void InkHUD::Events::onButtonShort()
     // If no system applet is handling input, default behavior instead is to cycle applets
     if (consumer)
         consumer->onButtonShortPress();
-    else
+    else if (!dismissedExt) // Don't change applet if this button press silenced the external notification module
         inkhud->nextApplet();
 }
 
@@ -203,5 +208,25 @@ int InkHUD::Events::beforeLightSleep(void *unused)
     return 0; // No special status to report. Ignored anyway by this Observable
 }
 #endif
+
+// Silence all ongoing beeping, blinking, buzzing, coming from the external notification module
+// Returns true if an external notification was active, and we dismissed it
+// Button handling changes depending on our result
+bool InkHUD::Events::dismissExternalNotification()
+{
+    // Abort if not using external notifications
+    if (!moduleConfig.external_notification.enabled)
+        return false;
+
+    // Abort if nothing to dismiss
+    if (!externalNotificationModule->nagging())
+        return false;
+
+    // Stop the beep buzz blink
+    externalNotificationModule->stopNow();
+
+    // Inform that we did indeed dismiss an external notification
+    return true;
+}
 
 #endif

--- a/src/graphics/niche/InkHUD/Events.h
+++ b/src/graphics/niche/InkHUD/Events.h
@@ -62,6 +62,9 @@ class Events
     CallbackObserver<Events, void *> lightSleepObserver = CallbackObserver<Events, void *>(this, &Events::beforeLightSleep);
 #endif
 
+    // End any externalNotification beeping, buzzing, blinking etc
+    bool dismissExternalNotification();
+
     // If set, InkHUD's data will be erased during onReboot
     bool eraseOnReboot = false;
 };

--- a/src/modules/ExternalNotificationModule.cpp
+++ b/src/modules/ExternalNotificationModule.cpp
@@ -293,6 +293,12 @@ bool ExternalNotificationModule::getExternal(uint8_t index)
     return externalCurrentState[index];
 }
 
+// Allow other firmware components to determine whether a notification is ongoing
+bool ExternalNotificationModule::nagging()
+{
+    return isNagging;
+}
+
 void ExternalNotificationModule::stopNow()
 {
     rtttl::stop();

--- a/src/modules/ExternalNotificationModule.h
+++ b/src/modules/ExternalNotificationModule.h
@@ -40,6 +40,8 @@ class ExternalNotificationModule : public SinglePortModule, private concurrency:
     void setMute(bool mute) { isMuted = mute; }
     bool getMute() { return isMuted; }
 
+    bool nagging();
+
     void stopNow();
 
     void handleGetRingtone(const meshtastic_MeshPacket &req, meshtastic_AdminMessage *response);


### PR DESCRIPTION
## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - Elecrow ThinkNode M1
    - Heltec VM-E290 (w/ active buzzer)
    - Heltec VM-E290 (w/ passive buzzer)
