### PR TITLE
Fix nugget s3 lora variant issues

### DIFF
--- a/variants/nugget_s3_lora/platformio.ini
+++ b/variants/nugget_s3_lora/platformio.ini
@@ -2,5 +2,5 @@
 extends = esp32s3_base
 board = lolin_s3_mini
 board_level = extra
-build_flags = 
-  ${esp32s3_base.build_flags} -D PRIVATE_HW -I variants/nugget_s3_lora
+build_flags =
+  ${esp32s3_base.build_flags} -D ARDUINO_USB_CDC_ON_BOOT=1 -D PRIVATE_HW -I variants/nugget_s3_lora

--- a/variants/nugget_s3_lora/variant.h
+++ b/variants/nugget_s3_lora/variant.h
@@ -1,5 +1,8 @@
-#define I2C_SDA 34 // I2C pins for this board
-#define I2C_SCL 38
+#define I2C_SDA 35 // I2C pins for this board
+#define I2C_SCL 36
+
+#define USE_SSD1306
+#define DISPLAY_FLIP_SCREEN
 
 #define LED_PIN 15 // If defined we will blink this LED
 
@@ -8,7 +11,8 @@
 #define NEOPIXEL_DATA 10                     // gpio pin used to send data to the neopixels
 #define NEOPIXEL_TYPE (NEO_GRB + NEO_KHZ800) // type of neopixels in use
 
-#define BUTTON_PIN 0 // If defined, this will be used for user button presses
+// Button A (44), B (43), R (12), U (13), L (11), D (18)
+#define BUTTON_PIN 44 // If defined, this will be used for user button presses
 #define BUTTON_NEED_PULLUP
 
 #define USE_RF95


### PR DESCRIPTION
I had some issues to build a new firmware for the _Bluetooth Nugget + LoRa Node_, which was part of a workshop where a friend of mine was attending. [Here is a blog post about it](https://retia.io/blogs/news/bluetooth-nugget-meshtastic-nodes?_pos=2&_sid=b8e934324&_ss=r). There are some builds which work (https://github.com/RetiaLLC/38c3-Meshtastic) and luckily there where also some upstream (here) changes to support this board. But the OLED did not work and the USB Serial interface did not work either. Only Bluetooth and RF.

Setting `ARDUINO_USB_CDC_ON_BOOT=1` did the trick to get serial working.

To get the OLED working the I2C pin definitions must be corrected. In addition to the pin definition changes for I2C I added:
- `USE_SSD1306` so there is no strange line break
- `DISPLAY_FLIP_SCREEN` to correct the orientation 
- Set the `BUTTON_PIN` to `44`, which is the Button A

I do not know if there are other hardware revisions which break with these changes. If anybody knows I could add a variant.

I could not find any issues related to this board. 

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
  - [x] Nugget rev 3.13 
