### PR TITLE
Canned Messages via InkHUD menu

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1474,12 +1474,13 @@ int Screen::handleInputEvent(const InputEvent *event)
     return 0;
 }
 
-int Screen::handleAdminMessage(const meshtastic_AdminMessage *arg)
+int Screen::handleAdminMessage(AdminModule_ObserverData *arg)
 {
-    switch (arg->which_payload_variant) {
+    switch (arg->request->which_payload_variant) {
     // Node removed manually (i.e. via app)
     case meshtastic_AdminMessage_remove_by_nodenum_tag:
         setFrames(FOCUS_PRESERVE);
+        *arg->result = AdminMessageHandleResult::HANDLED;
         break;
 
     // Default no-op, in case the admin message observable gets used by other classes in future

--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -193,8 +193,8 @@ class Screen : public concurrency::OSThread
         CallbackObserver<Screen, const UIFrameEvent *>(this, &Screen::handleUIFrameEvent); // Sent by Mesh Modules
     CallbackObserver<Screen, const InputEvent *> inputObserver =
         CallbackObserver<Screen, const InputEvent *>(this, &Screen::handleInputEvent);
-    CallbackObserver<Screen, const meshtastic_AdminMessage *> adminMessageObserver =
-        CallbackObserver<Screen, const meshtastic_AdminMessage *>(this, &Screen::handleAdminMessage);
+    CallbackObserver<Screen, AdminModule_ObserverData *> adminMessageObserver =
+        CallbackObserver<Screen, AdminModule_ObserverData *>(this, &Screen::handleAdminMessage);
 
   public:
     explicit Screen(ScanI2C::DeviceAddress, meshtastic_Config_DisplayConfig_OledType, OLEDDISPLAY_GEOMETRY);
@@ -546,7 +546,7 @@ class Screen : public concurrency::OSThread
     int handleTextMessage(const meshtastic_MeshPacket *arg);
     int handleUIFrameEvent(const UIFrameEvent *arg);
     int handleInputEvent(const InputEvent *arg);
-    int handleAdminMessage(const meshtastic_AdminMessage *arg);
+    int handleAdminMessage(AdminModule_ObserverData *arg);
 
     /// Used to force (super slow) eink displays to draw critical frames
     void forceDisplay(bool forceUiUpdate = false);

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -470,21 +470,37 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
             setPassKey(&res);
             myReply = allocDataProtobuf(res);
         } else if (mp.decoded.want_response) {
-            LOG_DEBUG("Did not responded to a request that wanted a respond. req.variant=%d", r->which_payload_variant);
+            LOG_DEBUG("Module API did not respond to admin message. req.variant=%d", r->which_payload_variant);
         } else if (handleResult != AdminMessageHandleResult::HANDLED) {
             // Probably a message sent by us or sent to our local node.  FIXME, we should avoid scanning these messages
-            LOG_DEBUG("Ignore irrelevant admin %d", r->which_payload_variant);
+            LOG_DEBUG("Module API did not handle admin message %d", r->which_payload_variant);
         }
         break;
+    }
+
+    // Allow any observers (e.g. the UI) to handle/respond
+    AdminMessageHandleResult observerResult = AdminMessageHandleResult::NOT_HANDLED;
+    meshtastic_AdminMessage observerResponse = meshtastic_AdminMessage_init_default;
+    AdminModule_ObserverData observerData = {
+        .request = r,
+        .response = &observerResponse,
+        .result = &observerResult,
+    };
+
+    notifyObservers(&observerData);
+
+    if (observerResult == AdminMessageHandleResult::HANDLED_WITH_RESPONSE) {
+        setPassKey(&observerResponse);
+        myReply = allocDataProtobuf(observerResponse);
+        LOG_DEBUG("Observer responded to admin message");
+    } else if (observerResult == AdminMessageHandleResult::HANDLED) {
+        LOG_DEBUG("Observer handled admin message");
     }
 
     // If asked for a response and it is not yet set, generate an 'ACK' response
     if (mp.decoded.want_response && !myReply) {
         myReply = allocErrorResponse(meshtastic_Routing_Error_NONE, &mp);
     }
-
-    // Allow any observers (e.g. the UI) to respond to this event
-    notifyObservers(r);
 
     return handled;
 }

--- a/src/modules/AdminModule.h
+++ b/src/modules/AdminModule.h
@@ -7,9 +7,18 @@
 #endif
 
 /**
+ * Datatype passed to Observers by AdminModule, to allow external handling of admin messages
+ */
+struct AdminModule_ObserverData {
+    const meshtastic_AdminMessage *request;
+    meshtastic_AdminMessage *response;
+    AdminMessageHandleResult *result;
+};
+
+/**
  * Admin module for admin messages
  */
-class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Observable<const meshtastic_AdminMessage *>
+class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Observable<AdminModule_ObserverData *>
 {
   public:
     /** Constructor


### PR DESCRIPTION
Active work-in-progress. Proof-of-concept working locally, just filling in and tidying up. 
This is an early disclosure of the proposed change needed to support the feature. 
No changes needed to CannedMessageModules; don't want to mess with the ongoing work there as part of BaseUI.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
