### PR TITLE
Fix position exchange throttling issue

### DIFF
--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -265,7 +265,6 @@ meshtastic_MeshPacket *PositionModule::allocPositionPacket()
     }
 
     LOG_INFO("Position packet: time=%i lat=%i lon=%i", p.time, p.latitude_i, p.longitude_i);
-    lastSentToMesh = millis();
 
     // TAK Tracker devices should send their position in a TAK packet over the ATAK port
     if (config.device.role == meshtastic_Config_DeviceConfig_Role_TAK_TRACKER)

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -276,13 +276,18 @@ meshtastic_MeshPacket *PositionModule::allocPositionPacket()
 
 meshtastic_MeshPacket *PositionModule::allocReply()
 {
-    if (config.device.role != meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND && lastSentToMesh &&
-        Throttle::isWithinTimespanMs(lastSentToMesh, 3 * 60 * 1000)) {
-        LOG_DEBUG("Skip Position reply since we sent it <3min ago");
+    if (config.device.role != meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND && lastSentReply &&
+        Throttle::isWithinTimespanMs(lastSentReply, 3 * 60 * 1000)) {
+        LOG_DEBUG("Skip Position reply since we sent a reply <3min ago");
         ignoreRequest = true; // Mark it as ignored for MeshModule
         return nullptr;
     }
-    return allocPositionPacket();
+
+    meshtastic_MeshPacket *reply = allocPositionPacket();
+    if (reply) {
+        lastSentReply = millis(); // Track when we sent this reply
+    }
+    return reply;
 }
 
 meshtastic_MeshPacket *PositionModule::allocAtakPli()

--- a/src/modules/PositionModule.h
+++ b/src/modules/PositionModule.h
@@ -64,6 +64,7 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
     bool hasQualityTimesource();
     bool hasGPS();
     uint32_t lastSentToMesh = 0; // Last time we sent our position to the mesh
+    uint32_t lastSentReply = 0;  // Last time we sent a position reply (separate from broadcasts)
 
     const uint32_t minimumTimeThreshold =
         Default::getConfiguredOrDefaultMs(config.position.broadcast_smart_minimum_interval_secs, 30);

--- a/src/modules/PositionModule.h
+++ b/src/modules/PositionModule.h
@@ -63,8 +63,7 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
     void sendLostAndFoundText();
     bool hasQualityTimesource();
     bool hasGPS();
-    uint32_t lastSentToMesh = 0; // Last time we sent our position to the mesh
-    uint32_t lastSentReply = 0;  // Last time we sent a position reply (separate from broadcasts)
+    uint32_t lastSentReply = 0; // Last time we sent a position reply (used for reply throttling only)
 
     const uint32_t minimumTimeThreshold =
         Default::getConfiguredOrDefaultMs(config.position.broadcast_smart_minimum_interval_secs, 30);


### PR DESCRIPTION
## Summary
This addresses a throttling issue that was preventing the "exchange position" feature from working properly in the Android app.

## What was happening
When a device received a position exchange request (a packet with `want_response: true`), it would sometimes refuse to respond. This happened because the reply logic was checking if ANY position packet had been sent recently, rather than checking specifically for recent replies.

## The issue
The `allocReply()` function was using `lastSentToMesh` for throttling, but this variable tracks all position packets - both regular broadcasts and replies to exchange requests. So if a device had recently sent a position broadcast, it would refuse to respond to exchange requests for 3 minutes.

## What this changes
- Adds a separate `lastSentReply` variable to track only position replies
- Updates the throttling logic to only consider previous replies, not broadcasts
- Keeps the existing 3-minute throttling window to prevent spam
- Preserves all existing behavior for position broadcasts

## Result
Position exchange should now work even if the device recently sent a position broadcast, while still preventing reply spam.

Tested and working on rak4631

Related:
https://github.com/meshtastic/Meshtastic-Android/pull/2169