### PR TITLE
Update HostMetrics.cpp - don't try to print the user string

### DIFF
--- a/src/modules/Telemetry/HostMetrics.cpp
+++ b/src/modules/Telemetry/HostMetrics.cpp
@@ -32,12 +32,12 @@ bool HostMetricsModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, 
         if (t->variant.host_metrics.has_user_string)
             t->variant.host_metrics.user_string[sizeof(t->variant.host_metrics.user_string) - 1] = '\0';
 
-        LOG_INFO("(Received Host Metrics from %s): uptime=%u, diskfree=%lu, memory free=%lu, load=%04.2f, %04.2f, %04.2f",
-                 sender, t->variant.host_metrics.uptime_seconds, t->variant.host_metrics.diskfree1_bytes,
+        LOG_INFO("(Received Host Metrics from %s): uptime=%u, diskfree=%lu, memory free=%lu, load=%04.2f, %04.2f, %04.2f", sender,
+                 t->variant.host_metrics.uptime_seconds, t->variant.host_metrics.diskfree1_bytes,
                  t->variant.host_metrics.freemem_bytes, static_cast<float>(t->variant.host_metrics.load1) / 100,
                  static_cast<float>(t->variant.host_metrics.load5) / 100,
                  static_cast<float>(t->variant.host_metrics.load15) / 100);
-                 // t->variant.host_metrics.has_user_string ? t->variant.host_metrics.user_string : "");
+        // t->variant.host_metrics.has_user_string ? t->variant.host_metrics.user_string : "");
 #endif
     }
     return false; // Let others look at this message also if they want
@@ -129,7 +129,7 @@ bool HostMetricsModule::sendMetrics()
              telemetry.variant.host_metrics.freemem_bytes, static_cast<float>(telemetry.variant.host_metrics.load1) / 100,
              static_cast<float>(telemetry.variant.host_metrics.load5) / 100,
              static_cast<float>(telemetry.variant.host_metrics.load15) / 100);
-             // telemetry.variant.host_metrics.has_user_string ? telemetry.variant.host_metrics.user_string : "");
+    // telemetry.variant.host_metrics.has_user_string ? telemetry.variant.host_metrics.user_string : "");
 
     meshtastic_MeshPacket *p = allocDataProtobuf(telemetry);
     p->to = NODENUM_BROADCAST;

--- a/src/modules/Telemetry/HostMetrics.cpp
+++ b/src/modules/Telemetry/HostMetrics.cpp
@@ -32,12 +32,12 @@ bool HostMetricsModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, 
         if (t->variant.host_metrics.has_user_string)
             t->variant.host_metrics.user_string[sizeof(t->variant.host_metrics.user_string) - 1] = '\0';
 
-        LOG_INFO("(Received Host Metrics from %s): uptime=%u, diskfree=%lu, memory free=%lu, load=%04.2f, %04.2f, %04.2f, %s",
+        LOG_INFO("(Received Host Metrics from %s): uptime=%u, diskfree=%lu, memory free=%lu, load=%04.2f, %04.2f, %04.2f",
                  sender, t->variant.host_metrics.uptime_seconds, t->variant.host_metrics.diskfree1_bytes,
                  t->variant.host_metrics.freemem_bytes, static_cast<float>(t->variant.host_metrics.load1) / 100,
                  static_cast<float>(t->variant.host_metrics.load5) / 100,
-                 static_cast<float>(t->variant.host_metrics.load15) / 100,
-                 t->variant.host_metrics.has_user_string ? t->variant.host_metrics.user_string : "");
+                 static_cast<float>(t->variant.host_metrics.load15) / 100);
+                 // t->variant.host_metrics.has_user_string ? t->variant.host_metrics.user_string : "");
 #endif
     }
     return false; // Let others look at this message also if they want
@@ -124,12 +124,12 @@ meshtastic_Telemetry HostMetricsModule::getHostMetrics()
 bool HostMetricsModule::sendMetrics()
 {
     meshtastic_Telemetry telemetry = getHostMetrics();
-    LOG_INFO("Send: uptime=%u, diskfree=%lu, memory free=%lu, load=%04.2f, %04.2f, %04.2f %s",
+    LOG_INFO("Send: uptime=%u, diskfree=%lu, memory free=%lu, load=%04.2f, %04.2f, %04.2f",
              telemetry.variant.host_metrics.uptime_seconds, telemetry.variant.host_metrics.diskfree1_bytes,
              telemetry.variant.host_metrics.freemem_bytes, static_cast<float>(telemetry.variant.host_metrics.load1) / 100,
              static_cast<float>(telemetry.variant.host_metrics.load5) / 100,
-             static_cast<float>(telemetry.variant.host_metrics.load15) / 100,
-             telemetry.variant.host_metrics.has_user_string ? telemetry.variant.host_metrics.user_string : "");
+             static_cast<float>(telemetry.variant.host_metrics.load15) / 100);
+             // telemetry.variant.host_metrics.has_user_string ? telemetry.variant.host_metrics.user_string : "");
 
     meshtastic_MeshPacket *p = allocDataProtobuf(telemetry);
     p->to = NODENUM_BROADCAST;


### PR DESCRIPTION
It's unclear why this has been crashing, but this should put an end to it.