### PR TITLE
Fix InkHUD builds for ESP32 on unify-tft branch

### DIFF
--- a/src/graphics/niche/InkHUD/PlatformioConfig.ini
+++ b/src/graphics/niche/InkHUD/PlatformioConfig.ini
@@ -6,6 +6,7 @@ build_flags =
   -D MESHTASTIC_INCLUDE_NICHE_GRAPHICS ; Use NicheGraphics
   -D MESHTASTIC_INCLUDE_INKHUD ; Use InkHUD (a NicheGraphics UI)
   -D MESHTASTIC_EXCLUDE_SCREEN ; Suppress default Screen class
+  -D MESHTASTIC_EXCLUDE_INPUTBROKER ; Suppress default input handling
   -D HAS_BUTTON=0 ; Suppress default ButtonThread
 lib_deps =
   https://github.com/ZinggJM/GFX_Root#2.0.0 ; Used by InkHUD as a "slimmer" version of AdafruitGFX


### PR DESCRIPTION
When testing InkHUD builds of the unify-tft branch, I found that Heltec VM-E290 reboots ~4 seconds into start-up, shortly after the `Trackball GPIO initialized` log line. I'm assuming all ESP32 devices are affected, but I didn't follow up.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - Heltec VM-E290
    - LilyGo T-Echo