### PR TITLE
fix(xiao_ble): Typo preventing SX1262 init (SX126X_CS gets stuck)

### DIFF
--- a/variants/seeed_xiao_nrf52840_kit/variant.h
+++ b/variants/seeed_xiao_nrf52840_kit/variant.h
@@ -201,7 +201,7 @@ static const uint8_t SCL = PIN_WIRE_SCL;
  * - SX1262X CS on XIAO BLE legacy pinout
  */
 
-#if !defined(GPS_L76K) && !defined(SEEED_XIAO_WIO_BTB) && !defined(XIAO_BLE_OLD_PINOUT)
+#if !defined(GPS_L76K) && !defined(SEEED_XIAO_WIO_BTB) && !defined(XIAO_BLE_LEGACY_PINOUT)
 #define BUTTON_PIN D0
 #endif
 


### PR DESCRIPTION
A small yet high impact typo affecting the xiao_ble variant.

Apologies for the insufficient testing. Looks good to me now.

![{0101B5A6-78AE-41AE-BBF3-B5E9788F82C0}](https://github.com/user-attachments/assets/d018d398-d827-4201-bbb0-85ee50cb6012)

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] xiao_ble
