### PR TITLE
cleanup Shutting down -> Shutting Down awkwardness

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -682,7 +682,7 @@ bool Power::setup()
 
 void Power::shutdown()
 {
-    LOG_INFO("Shutting down");
+    LOG_INFO("Shutting Down");
 
 #if defined(ARCH_NRF52) || defined(ARCH_ESP32) || defined(ARCH_RP2040)
 #ifdef PIN_LED1

--- a/src/input/ExpressLRSFiveWay.cpp
+++ b/src/input/ExpressLRSFiveWay.cpp
@@ -235,7 +235,7 @@ void ExpressLRSFiveWay::shutdown()
 {
     LOG_INFO("Shutdown from long press");
     powerFSM.trigger(EVENT_PRESS);
-    screen->startAlert("Shutting down...");
+    screen->startAlert("Shutting Down...");
     // Don't set alerting = true. We don't want to auto-dismiss this alert.
 
     playShutdownMelody(); // In case user adds a buzzer

--- a/src/modules/SystemCommandsModule.cpp
+++ b/src/modules/SystemCommandsModule.cpp
@@ -107,8 +107,8 @@ int SystemCommandsModule::handleInputEvent(const InputEvent *event)
         return true;
     // Power control
     case INPUT_BROKER_SHUTDOWN:
-        LOG_ERROR("Shutting down");
-        IF_SCREEN(screen->showOverlayBanner("Shutting down..."));
+        LOG_ERROR("Shutting Down");
+        IF_SCREEN(screen->showOverlayBanner("Shutting Down..."));
         nodeDB->saveToDisk();
         shutdownAtMsec = millis() + DEFAULT_SHUTDOWN_SECONDS * 1000;
         // runState = CANNED_MESSAGE_RUN_STATE_INACTIVE;


### PR DESCRIPTION
Noticed inconsistency when using >5sec press of user button to trigger device to shutdown... it would say "Shutting down" and then .5s later switch to "Shutting Down".  Thought I imagined it until it happened a second time so quick little PR to fix that up.

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [X] RAK WisBlock 4631
  - [X] Other (please specify below)
    - `nrf52_promicro_diy_tcxo`