### PR TITLE
fix mismatch between Exclude FSM include names

### DIFF
--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -26,7 +26,7 @@
 #ifndef SLEEP_TIME
 #define SLEEP_TIME 30
 #endif
-#if EXCLUDE_POWER_FSM
+#if MESHTASTIC_EXCLUDE_POWER_FSM
 FakeFsm powerFSM;
 void PowerFSM_setup(){};
 #else

--- a/src/PowerFSM.h
+++ b/src/PowerFSM.h
@@ -22,7 +22,7 @@
 #define EVENT_SHUTDOWN 16        // force a full shutdown now (not just sleep)
 #define EVENT_INPUT 17           // input broker wants something, we need to wake up and enable screen
 
-#if EXCLUDE_POWER_FSM
+#if MESHTASTIC_EXCLUDE_POWER_FSM
 class FakeFsm
 {
   public:

--- a/src/PowerFSMThread.h
+++ b/src/PowerFSMThread.h
@@ -18,7 +18,7 @@ class PowerFSMThread : public OSThread
   protected:
     int32_t runOnce() override
     {
-#if !EXCLUDE_POWER_FSM
+#if !MESHTASTIC_EXCLUDE_POWER_FSM
         powerFSM.run_machine();
 
         /// If we are in power state we force the CPU to wake every 10ms to check for serial characters (we don't yet wake

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -1137,7 +1137,7 @@ void AdminModule::handleGetDeviceConnectionStatus(const meshtastic_MeshPacket &r
 #endif
 #endif
     conn.has_serial = true; // No serial-less devices
-#if !EXCLUDE_POWER_FSM
+#if !MESHTASTIC_EXCLUDE_POWER_FSM
     conn.serial.is_connected = powerFSM.getState() == &stateSERIAL;
 #else
     conn.serial.is_connected = powerFSM.getState();


### PR DESCRIPTION
The MESHTASTIC_EXCLUDE_POWER_FSM define was being checked as EXCLUDE_POWER_FSM in several places.