### PR TITLE
Tweak interval trottling

### DIFF
--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -61,12 +61,17 @@ class Default
                 throttlingFactor = 0.04;
             else if (config.lora.use_preset && config.lora.modem_preset == meshtastic_Config_LoRaConfig_ModemPreset_MEDIUM_FAST)
                 throttlingFactor = 0.02;
-            else if (config.lora.use_preset && config.lora.modem_preset == meshtastic_Config_LoRaConfig_ModemPreset_SHORT_SLOW)
-                throttlingFactor = 0.01;
             else if (config.lora.use_preset &&
                      IS_ONE_OF(config.lora.modem_preset, meshtastic_Config_LoRaConfig_ModemPreset_SHORT_FAST,
-                               meshtastic_Config_LoRaConfig_ModemPreset_SHORT_TURBO))
-                return 1.0; // Don't bother throttling for highest bandwidth presets
+                               meshtastic_Config_LoRaConfig_ModemPreset_SHORT_TURBO,
+                               meshtastic_Config_LoRaConfig_ModemPreset_SHORT_SLOW))
+                throttlingFactor = 0.01;
+
+#if USERPREFS_EVENT_MODE
+            // If we are in event mode, scale down the throttling factor
+            throttlingFactor = 0.04;
+#endif
+
             // Scaling up traffic based on number of nodes over 40
             int nodesOverForty = (numOnlineNodes - 40);
             return 1.0 + (nodesOverForty * throttlingFactor); // Each number of online node scales by 0.075 (default)


### PR DESCRIPTION
Annex short-turbo and short-fast to the current short-slow throttling 

For the new event fixed throttling, a 30 minute interval yields: 
50 nodes: 1.0 + (10 * 0.04) = 1.4 → interval becomes 1.4 × 30 = 42 minutes
60 nodes: 1.0 + (20 * 0.04) = 1.8 → interval becomes 1.8 × 30 = 54 minutes
100 nodes: 1.0 + (60 * 0.04) = 3.4 → interval becomes 3.4 × 30 = 102 minutes (1.7 hours)