### PR TITLE
feat: New variant esp32c3_super_mini

### DIFF
--- a/variants/diy/esp32c3_super_mini/pins_arduino.h
+++ b/variants/diy/esp32c3_super_mini/pins_arduino.h
@@ -1,0 +1,24 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+static const uint8_t TX = 21;
+static const uint8_t RX = 20;
+
+static const uint8_t SDA = 1;
+static const uint8_t SCL = 0;
+
+static const uint8_t SS = 8;
+static const uint8_t MOSI = 7;
+static const uint8_t MISO = 6;
+static const uint8_t SCK = 10;
+
+static const uint8_t A0 = 0;
+static const uint8_t A1 = 1;
+static const uint8_t A2 = 2;
+static const uint8_t A3 = 3;
+static const uint8_t A4 = 4;
+static const uint8_t A5 = 5;
+
+#endif /* Pins_Arduino_h */

--- a/variants/diy/esp32c3_super_mini/variant.h
+++ b/variants/diy/esp32c3_super_mini/variant.h
@@ -1,0 +1,61 @@
+#ifndef _VARIANT_ESP32C3_SUPER_MINI_
+#define _VARIANT_ESP32C3_SUPER_MINI_
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+// I2C (Wire) & OLED
+#define WIRE_INTERFACES_COUNT (1)
+#define I2C_SDA (1)
+#define I2C_SCL (0)
+
+#define USE_SSD1306
+
+// GPS
+#undef GPS_RX_PIN
+#undef GPS_TX_PIN
+#define GPS_RX_PIN (20)
+#define GPS_TX_PIN (21)
+
+// Button
+#define BUTTON_PIN (9) // BOOT button
+
+// LoRa
+#define USE_LLCC68
+#define USE_SX1262
+// #define USE_RF95
+#define USE_SX1268
+
+#define LORA_DIO0 RADIOLIB_NC
+#define LORA_RESET (5)
+#define LORA_DIO1 (3)
+#define LORA_RXEN (2)
+#define LORA_BUSY (4)
+#define LORA_SCK (10)
+#define LORA_MISO (6)
+#define LORA_MOSI (7)
+#define LORA_CS (8)
+
+#define SX126X_CS LORA_CS
+#define SX126X_DIO1 LORA_DIO1
+#define SX126X_BUSY LORA_BUSY
+#define SX126X_RESET LORA_RESET
+#define SX126X_RXEN LORA_RXEN
+
+#define SX126X_DIO3_TCXO_VOLTAGE (1.8)
+#define TCXO_OPTIONAL // make it so that the firmware can try both TCXO and XTAL
+
+#ifdef __cplusplus
+}
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#endif

--- a/variants/diy/platformio.ini
+++ b/variants/diy/platformio.ini
@@ -141,3 +141,16 @@ build_flags =
   -D ARDUINO_USB_MODE=0
   -D ARDUINO_USB_CDC_ON_BOOT=1
   -I variants/diy/t-energy-s3_e22
+
+; ESP32 C3 Super Mini Development Board
+; https://www.espboards.dev/esp32/esp32-c3-super-mini/
+[env:esp32c3_super_mini]
+extends = esp32c3_base
+board = esp32-c3-devkitm-1
+build_flags =
+  ${esp32_base.build_flags}
+  -D PRIVATE_HW
+  -I variants/diy/esp32c3_super_mini
+  -D ARDUINO_USB_MODE=1
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+board_level = extra


### PR DESCRIPTION
https://www.espboards.dev/esp32/esp32-c3-super-mini/

DIY build by @AntonKartajaya on Meshtastic Discord and a PCB version WIP by https://github.com/NomDeTom.

- I2C
  - I2C_SDA: 1
  - I2C_SCL: 0
  - OLED: SSD1306
- GPS
  - GPS_RX_PIN: 20
  - GPS_TX_PIN: 21
- Button
  - BUTTON_PIN: 9
- SPI
  - SCK: 10
  - MISO: 6
  - MOSI: 7
  - CS: 8
- LoRa: SX1262
  - LORA_RESET: 5
  - LORA_DIO1: 3
  - LORA_RXEN: 2
  - LORA_BUSY: 4

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
