### PR TITLE
Fixed --change-mode option in device-update.sh

### DIFF
--- a/bin/device-update.sh
+++ b/bin/device-update.sh
@@ -30,6 +30,18 @@ Flash image file to device, leave existing system intact."
 EOF
 }
 
+# Check for --change-mode and remove it from arguments
+NEW_ARGS=""
+for arg in "$@"; do
+    if [ "$arg" = "--change-mode" ]; then
+        CHANGE_MODE=true
+    else
+        NEW_ARGS="$NEW_ARGS \"\$arg\""
+    fi
+done
+
+# Reset positional parameters to filtered list
+eval set -- $NEW_ARGS
 
 while getopts ":hp:P:f:" opt; do
     case "${opt}" in
@@ -43,9 +55,6 @@ while getopts ":hp:P:f:" opt; do
             ;;
         f)  FILENAME=${OPTARG}
             ;;
-	    --change-mode)
-            CHANGE_MODE=true
-            ;;
         *)
             echo "Invalid flag."
             show_help >&2
@@ -55,7 +64,7 @@ while getopts ":hp:P:f:" opt; do
 done
 shift "$((OPTIND-1))"
 
-if [[ $CHANGE_MODE == true ]]; then
+if [ "$CHANGE_MODE" = true ]; then
 	$ESPTOOL_CMD --baud 1200 --after no_reset read_flash_status
     exit 0
 fi


### PR DESCRIPTION
getopts can't parse double-dash options so it had to be done separately.  Also fixed where CHANGE_MODE was checked since it wasn't working either.

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [X] Other (please specify below)
  -- Station G2
