### PR TITLE
fix(xiao_ble): Define xiao_ble I2C pins in parent variant (fixes #7163)

### DIFF
--- a/variants/seeed_xiao_nrf52840_kit/variant.h
+++ b/variants/seeed_xiao_nrf52840_kit/variant.h
@@ -179,7 +179,11 @@ static const uint8_t SCK = PIN_SPI_SCK;
 #define I2C_NO_RESCAN // I2C is a bit finicky, don't scan too much
 #define WIRE_INTERFACES_COUNT 1
 
-#if !defined(XIAO_BLE_LEGACY_PINOUT) && !defined(GPS_L76K)
+#if defined(XIAO_BLE_LEGACY_PINOUT)
+// Used for I2C by DIY xiao_ble variant
+#define PIN_WIRE_SDA D4
+#define PIN_WIRE_SCL D5
+#elif !defined(GPS_L76K)
 // If D6 and D7 are free, I2C is probably the most versatile assignment
 #define PIN_WIRE_SDA D6
 #define PIN_WIRE_SCL D7


### PR DESCRIPTION
Define xiao_ble I2C pins in parent variant (fixes #7163)

This restores the previously-defined I2C pins that got lost in the cleanup (#7024)

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] xiao_ble (by @bplein as I do not use the I2C presently)
