### PR TITLE
Revert "tlora_v2_1_16: Unset BUTTON_PIN and BUTTON_NEED_PULLUP (#5535)"

### DIFF
--- a/variants/tlora_v2_1_16/variant.h
+++ b/variants/tlora_v2_1_16/variant.h
@@ -8,7 +8,10 @@
 #define I2C_SDA 21 // I2C pins for this board
 #define I2C_SCL 22
 
-#define LED_PIN 25 // If defined we will blink this LED
+#define LED_PIN 25    // If defined we will blink this LED
+#define BUTTON_PIN 12 // If defined, this will be used for user button presses,
+
+#define BUTTON_NEED_PULLUP
 
 #define USE_RF95
 #define LORA_DIO0 26 // a No connect on the SX1262 module


### PR DESCRIPTION
Because the button thread doesn't start without a BUTTON_PIN defined, user-defined button GPIO doesn't work, even after a reboot.

Since there is no developer time to rework the button thread code, revert this for now for existing users that depend on this functionality, even though moving forward, variants without a button should not have it defined.

This reverts commit 3ae85e2c829427b3a6a64506afa9b6ecdf3ad081. Fixes #6213

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
