### PR TITLE
Abandon std::sort in NodeDB, and associated fixes

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1157,7 +1157,7 @@ void NodeDB::loadFromDisk()
         LOG_WARN("Node count %d exceeds MAX_NUM_NODES %d, truncating", numMeshNodes, MAX_NUM_NODES);
         numMeshNodes = MAX_NUM_NODES;
     }
-    meshNodes->resize(MAX_NUM_NODES + 1); // The rp2040, rp2035, and maybe other targets, have a problem doing a sort() when full
+    meshNodes->resize(MAX_NUM_NODES);
 
     // static DeviceState scratch; We no longer read into a tempbuf because this structure is 15KB of valuable RAM
     state = loadProto(deviceStateFileName, meshtastic_DeviceState_size, sizeof(meshtastic_DeviceState),

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1000,7 +1000,8 @@ void NodeDB::cleanupMeshDB()
                     meshNodes->at(i).user.public_key.size = 0;
                 }
             }
-            meshNodes->at(newPos++) = meshNodes->at(i);
+            if (newPos != i)
+                meshNodes->at(newPos++) = meshNodes->at(i);
         } else {
             removed++;
         }

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1696,6 +1696,8 @@ void NodeDB::sortMeshDB()
         lastSort = millis();
         std::sort(meshNodes->begin(), meshNodes->begin() + numMeshNodes,
                   [](const meshtastic_NodeInfoLite &a, const meshtastic_NodeInfoLite &b) {
+                      if (a.num == myNodeInfo.my_node_num && b.num == myNodeInfo.my_node_num) // in theory impossible
+                          return false;
                       if (a.num == myNodeInfo.my_node_num) {
                           return true;
                       }
@@ -1706,9 +1708,7 @@ void NodeDB::sortMeshDB()
                       bool bFav = b.is_favorite;
                       if (aFav != bFav)
                           return aFav;
-                      if (a.last_heard != b.last_heard)
-                          return a.last_heard > b.last_heard;
-                      return a.num > b.num;
+                      return a.last_heard > b.last_heard;
                   });
     }
 }

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -966,7 +966,6 @@ void NodeDB::resetNodes()
 
 void NodeDB::removeNodeByNum(NodeNum nodeNum)
 {
-    std::lock_guard<std::mutex> guard(nodeDB_mutex);
     int newPos = 0, removed = 0;
     for (int i = 0; i < numMeshNodes; i++) {
         if (meshNodes->at(i).num != nodeNum)
@@ -1474,7 +1473,6 @@ uint32_t sinceReceived(const meshtastic_MeshPacket *p)
 
 size_t NodeDB::getNumOnlineMeshNodes(bool localOnly)
 {
-    std::lock_guard<std::mutex> guard(nodeDB_mutex);
     size_t numseen = 0;
 
     // FIXME this implementation is kinda expensive
@@ -1496,7 +1494,6 @@ size_t NodeDB::getNumOnlineMeshNodes(bool localOnly)
 void NodeDB::updatePosition(uint32_t nodeId, const meshtastic_Position &p, RxSource src)
 {
     meshtastic_NodeInfoLite *info = getOrCreateMeshNode(nodeId);
-    std::unique_lock<std::mutex> guard(nodeDB_mutex);
     if (!info) {
         return;
     }
@@ -1533,7 +1530,6 @@ void NodeDB::updatePosition(uint32_t nodeId, const meshtastic_Position &p, RxSou
     }
     info->has_position = true;
     updateGUIforNode = info;
-    guard.unlock();
     notifyObservers(true); // Force an update whether or not our node counts have changed
 }
 
@@ -1543,7 +1539,6 @@ void NodeDB::updatePosition(uint32_t nodeId, const meshtastic_Position &p, RxSou
 void NodeDB::updateTelemetry(uint32_t nodeId, const meshtastic_Telemetry &t, RxSource src)
 {
     meshtastic_NodeInfoLite *info = getOrCreateMeshNode(nodeId);
-    std::unique_lock<std::mutex> guard(nodeDB_mutex);
     // Environment metrics should never go to NodeDb but we'll safegaurd anyway
     if (!info || t.which_variant != meshtastic_Telemetry_device_metrics_tag) {
         return;
@@ -1558,7 +1553,6 @@ void NodeDB::updateTelemetry(uint32_t nodeId, const meshtastic_Telemetry &t, RxS
     info->device_metrics = t.variant.device_metrics;
     info->has_device_metrics = true;
     updateGUIforNode = info;
-    guard.unlock();
     notifyObservers(true); // Force an update whether or not our node counts have changed
 }
 
@@ -1568,7 +1562,6 @@ void NodeDB::updateTelemetry(uint32_t nodeId, const meshtastic_Telemetry &t, RxS
 void NodeDB::addFromContact(meshtastic_SharedContact contact)
 {
     meshtastic_NodeInfoLite *info = getOrCreateMeshNode(contact.node_num);
-    std::lock_guard<std::mutex> guard(nodeDB_mutex);
     if (!info) {
         return;
     }
@@ -1601,7 +1594,6 @@ void NodeDB::addFromContact(meshtastic_SharedContact contact)
 bool NodeDB::updateUser(uint32_t nodeId, meshtastic_User &p, uint8_t channelIndex)
 {
     meshtastic_NodeInfoLite *info = getOrCreateMeshNode(nodeId);
-    std::unique_lock<std::mutex> guard(nodeDB_mutex);
     if (!info) {
         return false;
     }
@@ -1650,6 +1642,7 @@ bool NodeDB::updateUser(uint32_t nodeId, meshtastic_User &p, uint8_t channelInde
 
     if (changed) {
         updateGUIforNode = info;
+        notifyObservers(true); // Force an update whether or not our node counts have changed
 
         // We just changed something about a User,
         // store our DB unless we just did so less than a minute ago
@@ -1660,8 +1653,6 @@ bool NodeDB::updateUser(uint32_t nodeId, meshtastic_User &p, uint8_t channelInde
         } else {
             LOG_DEBUG("Defer NodeDB saveToDisk for now");
         }
-        guard.unlock();
-        notifyObservers(true); // Force an update whether or not our node counts have changed
     }
 
     return changed;
@@ -1679,7 +1670,6 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
         LOG_DEBUG("Update DB node 0x%x, rx_time=%u", mp.from, mp.rx_time);
 
         meshtastic_NodeInfoLite *info = getOrCreateMeshNode(getFrom(&mp));
-        std::lock_guard<std::mutex> guard(nodeDB_mutex);
         if (!info) {
             return;
         }
@@ -1735,12 +1725,9 @@ uint8_t NodeDB::getMeshNodeChannel(NodeNum n)
 /// NOTE: This function might be called from an ISR
 meshtastic_NodeInfoLite *NodeDB::getMeshNode(NodeNum n)
 {
-    std::lock_guard<std::mutex> guard(nodeDB_mutex);
-    for (int i = 0; i < numMeshNodes; i++) {
-        if (meshNodes->at(i).num == n) {
+    for (int i = 0; i < numMeshNodes; i++)
+        if (meshNodes->at(i).num == n)
             return &meshNodes->at(i);
-        }
-    }
 
     return NULL;
 }
@@ -1755,7 +1742,6 @@ bool NodeDB::isFull()
 meshtastic_NodeInfoLite *NodeDB::getOrCreateMeshNode(NodeNum n)
 {
     meshtastic_NodeInfoLite *lite = getMeshNode(n);
-    std::lock_guard<std::mutex> guard(nodeDB_mutex);
 
     if (!lite) {
         if (isFull()) {

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1718,7 +1718,7 @@ void NodeDB::sortMeshDB()
                 }
             }
         }
-        LOG_WARN("Sort took %u milliseconds", millis() - lastSort);
+        LOG_INFO("Sort took %u milliseconds", millis() - lastSort);
     }
 }
 

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1088,8 +1088,8 @@ LoadFileResult NodeDB::loadProto(const char *filename, size_t protoSize, size_t 
     if (f) {
         LOG_INFO("Load %s", filename);
         pb_istream_t stream = {&readcb, &f, protoSize};
-
-        memset(dest_struct, 0, objSize);
+        if (fields != &meshtastic_NodeDatabase_msg) // contains a vector object
+            memset(dest_struct, 0, objSize);
         if (!pb_decode(&stream, fields, dest_struct)) {
             LOG_ERROR("Error: can't decode protobuf %s", PB_GET_ERROR(&stream));
             state = LoadFileResult::DECODE_FAILED;

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1694,22 +1694,20 @@ void NodeDB::sortMeshDB()
 {
     if (!Throttle::isWithinTimespanMs(lastSort, 1000 * 5)) {
         lastSort = millis();
-        std::sort(meshNodes->begin(), meshNodes->begin() + numMeshNodes,
-                  [](const meshtastic_NodeInfoLite &a, const meshtastic_NodeInfoLite &b) {
-                      if (a.num == myNodeInfo.my_node_num && b.num == myNodeInfo.my_node_num) // in theory impossible
-                          return false;
-                      if (a.num == myNodeInfo.my_node_num) {
-                          return true;
-                      }
-                      if (b.num == myNodeInfo.my_node_num) {
-                          return false;
-                      }
-                      bool aFav = a.is_favorite;
-                      bool bFav = b.is_favorite;
-                      if (aFav != bFav)
-                          return aFav;
-                      return a.last_heard > b.last_heard;
-                  });
+        bool changed = true;
+        while (changed) { // dumb reverse bubble sort, but probably not bad for what we're doing
+            changed = false;
+            for (int i = numMeshNodes - 1; i > 1; i--) { // lowest case this should examine is i == 2
+                if (meshNodes->at(i).is_favorite && !meshNodes->at(i - 1).is_favorite) {
+                    std::swap(meshNodes->at(i), meshNodes->at(i - 1));
+                    changed = true;
+                } else if (meshNodes->at(i).last_heard > meshNodes->at(i - 1).last_heard) {
+                    std::swap(meshNodes->at(i), meshNodes->at(i - 1));
+                    changed = true;
+                }
+            }
+        }
+        LOG_WARN("Sort took %u milliseconds", millis() - lastSort);
     }
 }
 

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -4,7 +4,6 @@
 #include <Arduino.h>
 #include <algorithm>
 #include <assert.h>
-#include <mutex>
 #include <pb_encode.h>
 #include <vector>
 
@@ -151,7 +150,6 @@ class NodeDB
     meshtastic_NodeInfoLite *updateGUIforNode = NULL; // if currently showing this node, we think you should update the GUI
     Observable<const meshtastic::NodeStatus *> newStatus;
     pb_size_t numMeshNodes;
-    std::mutex nodeDB_mutex;
 
     bool keyIsLowEntropy = false;
     bool hasWarned = false;

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -208,9 +208,6 @@ class NodeDB
     their denial?)
     */
 
-    /// pick a provisional nodenum we hope no one is using
-    void pickNewNodeNum();
-
     // get channel channel index we heard a nodeNum on, defaults to 0 if not found
     uint8_t getMeshNodeChannel(NodeNum n);
 
@@ -285,6 +282,9 @@ class NodeDB
     uint32_t lastSort = 0;          // When last sorted the nodeDB
     /// Find a node in our DB, create an empty NodeInfoLite if missing
     meshtastic_NodeInfoLite *getOrCreateMeshNode(NodeNum n);
+
+    /// pick a provisional nodenum we hope no one is using
+    void pickNewNodeNum();
 
     /// Notify observers of changes to the DB
     void notifyObservers(bool forceUpdate = false)

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -4,6 +4,7 @@
 #include <Arduino.h>
 #include <algorithm>
 #include <assert.h>
+#include <mutex>
 #include <pb_encode.h>
 #include <vector>
 
@@ -150,6 +151,7 @@ class NodeDB
     meshtastic_NodeInfoLite *updateGUIforNode = NULL; // if currently showing this node, we think you should update the GUI
     Observable<const meshtastic::NodeStatus *> newStatus;
     pb_size_t numMeshNodes;
+    std::mutex nodeDB_mutex;
 
     bool keyIsLowEntropy = false;
     bool hasWarned = false;

--- a/src/nimble/NimbleBluetooth.cpp
+++ b/src/nimble/NimbleBluetooth.cpp
@@ -9,6 +9,7 @@
 #include "mesh/mesh-pb-constants.h"
 #include "sleep.h"
 #include <NimBLEDevice.h>
+#include <mutex>
 
 NimBLECharacteristic *fromNumCharacteristic;
 NimBLECharacteristic *BatteryCharacteristic;
@@ -17,8 +18,36 @@ NimBLEServer *bleServer;
 
 static bool passkeyShowing;
 
-class BluetoothPhoneAPI : public PhoneAPI
+class BluetoothPhoneAPI : public PhoneAPI, public concurrency::OSThread
 {
+  public:
+    BluetoothPhoneAPI() : concurrency::OSThread("NimbleBluetooth") { nimble_queue.resize(3); }
+    std::vector<NimBLEAttValue> nimble_queue;
+    std::mutex nimble_mutex;
+    uint8_t queue_size = 0;
+    bool has_fromRadio = false;
+    uint8_t fromRadioBytes[meshtastic_FromRadio_size] = {0};
+    size_t numBytes = 0;
+    bool hasChecked = false;
+
+  protected:
+    virtual int32_t runOnce() override
+    {
+        std::lock_guard<std::mutex> guard(nimble_mutex);
+        if (queue_size > 0) {
+            for (uint8_t i = 0; i < queue_size; i++) {
+                handleToRadio(nimble_queue.at(i).data(), nimble_queue.at(i).length());
+            }
+            LOG_WARN("Queue_size %u", queue_size);
+            queue_size = 0;
+        }
+        if (hasChecked == false) {
+            numBytes = getFromRadio(fromRadioBytes);
+            hasChecked = true;
+        }
+
+        return 100;
+    }
     /**
      * Subclasses can use this as a hook to provide custom notifications for their transport (i.e. bluetooth notifies)
      */
@@ -51,15 +80,16 @@ class NimbleBluetoothToRadioCallback : public NimBLECharacteristicCallbacks
 {
     virtual void onWrite(NimBLECharacteristic *pCharacteristic)
     {
-        LOG_DEBUG("To Radio onwrite");
         auto val = pCharacteristic->getValue();
 
         if (memcmp(lastToRadio, val.data(), val.length()) != 0) {
-            LOG_DEBUG("New ToRadio packet");
-            memcpy(lastToRadio, val.data(), val.length());
-            bluetoothPhoneAPI->handleToRadio(val.data(), val.length());
-        } else {
-            LOG_DEBUG("Drop dup ToRadio packet we just saw");
+            if (bluetoothPhoneAPI->queue_size < 3) {
+                memcpy(lastToRadio, val.data(), val.length());
+                std::lock_guard<std::mutex> guard(bluetoothPhoneAPI->nimble_mutex);
+                bluetoothPhoneAPI->nimble_queue.at(bluetoothPhoneAPI->queue_size) = val;
+                bluetoothPhoneAPI->queue_size++;
+                bluetoothPhoneAPI->setIntervalFromNow(0);
+            }
         }
     }
 };
@@ -68,12 +98,19 @@ class NimbleBluetoothFromRadioCallback : public NimBLECharacteristicCallbacks
 {
     virtual void onRead(NimBLECharacteristic *pCharacteristic)
     {
-        uint8_t fromRadioBytes[meshtastic_FromRadio_size];
-        size_t numBytes = bluetoothPhoneAPI->getFromRadio(fromRadioBytes);
-
-        std::string fromRadioByteString(fromRadioBytes, fromRadioBytes + numBytes);
-
+        while (!bluetoothPhoneAPI->hasChecked) {
+            bluetoothPhoneAPI->setIntervalFromNow(0);
+            delay(20);
+        }
+        std::lock_guard<std::mutex> guard(bluetoothPhoneAPI->nimble_mutex);
+        std::string fromRadioByteString(bluetoothPhoneAPI->fromRadioBytes,
+                                        bluetoothPhoneAPI->fromRadioBytes + bluetoothPhoneAPI->numBytes);
         pCharacteristic->setValue(fromRadioByteString);
+
+        if (bluetoothPhoneAPI->numBytes != 0) // if we did send something, queue it up right away to reload
+            bluetoothPhoneAPI->setIntervalFromNow(0);
+        bluetoothPhoneAPI->numBytes = 0;
+        bluetoothPhoneAPI->hasChecked = false;
     }
 };
 


### PR DESCRIPTION
Fixes a few things I found while troubleshooting the std::sort problem. The one additional change I want to propose is to make NodeDB::meshNodes a private member, but that requires changes in inkhud.

This does seem to slow down the initial connection of Bluetooth just a bit, but it's exceptionally safer, so worth it IMHO. There are likely speedups that could be done to offset this. 