### PR TITLE
Add brightness settings for nodes with supported screen

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1046,6 +1046,22 @@ void Screen::decreaseBrightness()
     /* TO DO: add little popup in center of screen saying what brightness level it is set to*/
 }
 
+void Screen::setBrightness(uint8_t _brightness)
+{
+    brightness = _brightness;
+
+#if defined(ST7789_CS)
+    static_cast<TFTDisplay *>(dispdev)->setDisplayBrightness(brightness);
+#else
+    dispdev->setBrightness(brightness);
+#endif
+}
+
+uint8_t Screen::getBrightness()
+{
+    return brightness;
+}
+
 void Screen::setFunctionSymbol(std::string sym)
 {
     if (std::find(functionSymbol.begin(), functionSymbol.end(), sym) == functionSymbol.end()) {
@@ -1270,7 +1286,7 @@ int Screen::handleInputEvent(const InputEvent *event)
                     menuHandler::switchToMUIMenu();
 #else
                 } else if (this->ui->getUiState()->currentFrame == framesetInfo.positions.memory) {
-                    menuHandler::BuzzerModeMenu();
+                    menuHandler::systemActionMenu();
 #endif
 #if HAS_GPS
                 } else if (this->ui->getUiState()->currentFrame == framesetInfo.positions.gps && gps) {

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -475,6 +475,12 @@ void Screen::setup()
 
     // === Turn on display and trigger first draw ===
     handleSetOn(true);
+    
+    // === Restore saved brightness from UI config ===
+    if (uiconfig.screen_brightness > 0) {
+        setBrightness(uiconfig.screen_brightness);
+    }
+    
     determineResolution(dispdev->height(), dispdev->width());
     ui->update();
 #ifndef USE_EINK

--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -86,7 +86,11 @@ class Screen
 
 // 0 to 255, though particular variants might define different defaults
 #ifndef BRIGHTNESS_DEFAULT
+#ifdef USE_SSD1306
+#define BRIGHTNESS_DEFAULT 255
+#else
 #define BRIGHTNESS_DEFAULT 150
+#endif
 #endif
 
 // Meters to feet conversion

--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -318,6 +318,8 @@ class Screen : public concurrency::OSThread
     // functions for display brightness
     void increaseBrightness();
     void decreaseBrightness();
+    void setBrightness(uint8_t _brightness);
+    uint8_t getBrightness();
 
     void setFunctionSymbol(std::string sym);
     void removeFunctionSymbol(std::string sym);

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -427,40 +427,56 @@ void menuHandler::BuzzerModeMenu()
 
 void menuHandler::systemActionMenu()
 {
-#ifdef USE_SSD1306
-    static const char *optionsArray[] = {"Back", "Beep Action", "Brightness"};
-    screen->showOverlayBanner(
-        "System Action", 30000, optionsArray, 3,
-        [](int selected) -> void {
-            switch (selected) {
-            case 0:
-                // Back - do nothing, menu will close
-                break;
-            case 1:
-                menuQueue = beep_action_menu;
-                break;
-            case 2:
-                menuQueue = contrast_action_menu;
-                break;
-            }
-        },
-        0);
-#else
-    static const char *optionsArray[] = {"Back", "Beep Action"};
-    screen->showOverlayBanner(
-        "System Action", 30000, optionsArray, 2,
-        [](int selected) -> void {
-            switch (selected) {
-            case 0:
-                // Back - do nothing, menu will close
-                break;
-            case 1:
-                menuQueue = beep_action_menu;
-                break;
-            }
-        },
-        0);
+    // Check if current display supports brightness adjustment
+    // This includes SSD1306 (detected at runtime), TFT displays, and ST7789 displays
+    bool supportsBrightness = false;
+    
+    // Runtime detection for SSD1306/SH1106 displays
+    if (screen && (screen->model == meshtastic_Config_DisplayConfig_OledType_OLED_SSD1306 ||
+        screen->model == meshtastic_Config_DisplayConfig_OledType_OLED_SH1106 ||
+        screen->model == meshtastic_Config_DisplayConfig_OledType_OLED_AUTO)) {
+        supportsBrightness = true;
+    }
+    
+    // Compile-time detection for displays that definitely support brightness
+#if defined(USE_SSD1306) || defined(ST7789_CS) || defined(ST7735_CS) || defined(ILI9341_DRIVER) || defined(ILI9342_DRIVER) || defined(ST7701_CS) || defined(HX8357_CS) || defined(ILI9488_CS) || defined(RAK14014)
+    supportsBrightness = true;
 #endif
+
+    if (supportsBrightness) {
+        static const char *optionsArray[] = {"Back", "Beep Action", "Brightness"};
+        screen->showOverlayBanner(
+            "System Action", 30000, optionsArray, 3,
+            [](int selected) -> void {
+                switch (selected) {
+                case 0:
+                    // Back - do nothing, menu will close
+                    break;
+                case 1:
+                    menuQueue = beep_action_menu;
+                    break;
+                case 2:
+                    menuQueue = contrast_action_menu;
+                    break;
+                }
+            },
+            0);
+    } else {
+        static const char *optionsArray[] = {"Back", "Beep Action"};
+        screen->showOverlayBanner(
+            "System Action", 30000, optionsArray, 2,
+            [](int selected) -> void {
+                switch (selected) {
+                case 0:
+                    // Back - do nothing, menu will close
+                    break;
+                case 1:
+                    menuQueue = beep_action_menu;
+                    break;
+                }
+            },
+            0);
+    }
 }
 
 void menuHandler::contrastActionMenu()

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -472,13 +472,20 @@ void menuHandler::contrastActionMenu()
             if (selected > 0) {
                 // Map selection to brightness values: 1->64, 2->128, 3->192, 4->255
                 uint8_t brightnessValues[] = {0, 64, 128, 192, 255};
-                screen->setBrightness(brightnessValues[selected]);
+                uint8_t newBrightness = brightnessValues[selected];
+                
+                // Set screen brightness
+                screen->setBrightness(newBrightness);
+                
+                // Save to persistent configuration
+                uiconfig.screen_brightness = newBrightness;
+                nodeDB->saveProto(uiconfigFileName, meshtastic_DeviceUIConfig_size, &meshtastic_DeviceUIConfig_msg, &uiconfig);
             }
         },
-        // Find current brightness level for initial selection
-        screen->getBrightness() <= 64 ? 1 : 
-        screen->getBrightness() <= 128 ? 2 : 
-        screen->getBrightness() <= 192 ? 3 : 4);
+        // Find current brightness level for initial selection based on saved config
+        uiconfig.screen_brightness <= 64 ? 1 : 
+        uiconfig.screen_brightness <= 128 ? 2 : 
+        uiconfig.screen_brightness <= 192 ? 3 : 4);
 }
 
 void menuHandler::switchToMUIMenu()

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -465,13 +465,13 @@ void menuHandler::systemActionMenu()
 
 void menuHandler::contrastActionMenu()
 {
-    static const char *optionsArray[] = {"Back", "Low", "Medium", "High", "Very High"};
+    static const char *optionsArray[] = {"Back", "Very Low", "Low", "Medium", "High", "Very High"};
     screen->showOverlayBanner(
-        "Brightness", 30000, optionsArray, 5,
+        "Brightness", 30000, optionsArray, 6,
         [](int selected) -> void {
             if (selected > 0) {
-                // Map selection to brightness values: 1->64, 2->128, 3->192, 4->255
-                uint8_t brightnessValues[] = {0, 64, 128, 192, 255};
+                // Map selection to brightness values: 1->1, 2->64, 3->128, 4->192, 5->255
+                uint8_t brightnessValues[] = {0, 1, 64, 128, 192, 255};
                 uint8_t newBrightness = brightnessValues[selected];
                 
                 // Set screen brightness
@@ -483,9 +483,10 @@ void menuHandler::contrastActionMenu()
             }
         },
         // Find current brightness level for initial selection based on saved config
-        uiconfig.screen_brightness <= 64 ? 1 : 
-        uiconfig.screen_brightness <= 128 ? 2 : 
-        uiconfig.screen_brightness <= 192 ? 3 : 4);
+        uiconfig.screen_brightness <= 1 ? 1 :
+        uiconfig.screen_brightness <= 64 ? 2 : 
+        uiconfig.screen_brightness <= 128 ? 3 : 
+        uiconfig.screen_brightness <= 192 ? 4 : 5);
 }
 
 void menuHandler::switchToMUIMenu()

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -425,6 +425,62 @@ void menuHandler::BuzzerModeMenu()
         config.device.buzzer_mode);
 }
 
+void menuHandler::systemActionMenu()
+{
+#ifdef USE_SSD1306
+    static const char *optionsArray[] = {"Back", "Beep Action", "Brightness"};
+    screen->showOverlayBanner(
+        "System Action", 30000, optionsArray, 3,
+        [](int selected) -> void {
+            switch (selected) {
+            case 0:
+                // Back - do nothing, menu will close
+                break;
+            case 1:
+                menuQueue = beep_action_menu;
+                break;
+            case 2:
+                menuQueue = contrast_action_menu;
+                break;
+            }
+        },
+        0);
+#else
+    static const char *optionsArray[] = {"Back", "Beep Action"};
+    screen->showOverlayBanner(
+        "System Action", 30000, optionsArray, 2,
+        [](int selected) -> void {
+            switch (selected) {
+            case 0:
+                // Back - do nothing, menu will close
+                break;
+            case 1:
+                menuQueue = beep_action_menu;
+                break;
+            }
+        },
+        0);
+#endif
+}
+
+void menuHandler::contrastActionMenu()
+{
+    static const char *optionsArray[] = {"Back", "Low", "Medium", "High", "Very High"};
+    screen->showOverlayBanner(
+        "Brightness", 30000, optionsArray, 5,
+        [](int selected) -> void {
+            if (selected > 0) {
+                // Map selection to brightness values: 1->64, 2->128, 3->192, 4->255
+                uint8_t brightnessValues[] = {0, 64, 128, 192, 255};
+                screen->setBrightness(brightnessValues[selected]);
+            }
+        },
+        // Find current brightness level for initial selection
+        screen->getBrightness() <= 64 ? 1 : 
+        screen->getBrightness() <= 128 ? 2 : 
+        screen->getBrightness() <= 192 ? 3 : 4);
+}
+
 void menuHandler::switchToMUIMenu()
 {
     static const char *optionsArray[] = {"Yes", "No"};
@@ -469,6 +525,15 @@ void menuHandler::handleMenuSwitch()
         break;
     case reset_node_db_menu:
         resetNodeDBMenu();
+        break;
+    case system_action_menu:
+        systemActionMenu();
+        break;
+    case beep_action_menu:
+        BuzzerModeMenu();
+        break;
+    case contrast_action_menu:
+        contrastActionMenu();
         break;
     }
     menuQueue = menu_none;

--- a/src/graphics/draw/MenuHandler.h
+++ b/src/graphics/draw/MenuHandler.h
@@ -15,7 +15,10 @@ class menuHandler
         position_base_menu,
         gps_toggle_menu,
         compass_point_north_menu,
-        reset_node_db_menu
+        reset_node_db_menu,
+        system_action_menu,
+        beep_action_menu,
+        contrast_action_menu
     };
     static screenMenus menuQueue;
 
@@ -35,6 +38,8 @@ class menuHandler
     static void switchToMUIMenu();
     static void nodeListMenu();
     static void resetNodeDBMenu();
+    static void systemActionMenu();
+    static void contrastActionMenu();
 };
 
 } // namespace graphics

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -63,7 +63,11 @@ EXT_RAM_BSS_ATTR meshtastic_DeviceState devicestate;
 meshtastic_MyNodeInfo &myNodeInfo = devicestate.my_node;
 meshtastic_NodeDatabase nodeDatabase;
 meshtastic_LocalConfig config;
+#ifdef USE_SSD1306
+meshtastic_DeviceUIConfig uiconfig{.screen_brightness = 255, .screen_timeout = 30};
+#else
 meshtastic_DeviceUIConfig uiconfig{.screen_brightness = 153, .screen_timeout = 30};
+#endif
 meshtastic_LocalModuleConfig moduleConfig;
 meshtastic_ChannelFile channelFile;
 


### PR DESCRIPTION
Add brightness (contrast) settings on SSD1306 with 4 level: Low, Medium, High, Very Hight.

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] GAT562
  - [x] Meshtiny