### PR TITLE
Add detection code for SCD4X

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -146,6 +146,7 @@ lib_deps =
 	adafruit/Adafruit TSL2591 Library@1.4.5
 	# renovate: datasource=custom.pio depName=EmotiBit MLX90632 packageName=emotibit/library/EmotiBit MLX90632
 	emotibit/EmotiBit MLX90632@1.0.8
+        sensirion/Sensirion I2C SCD4x@^0.4.0
 	# renovate: datasource=custom.pio depName=Adafruit MLX90614 packageName=adafruit/library/Adafruit MLX90614 Library
 	adafruit/Adafruit MLX90614 Library@2.1.5
 	# renovate: datasource=github-tags depName=INA3221 packageName=KodinLanewave/INA3221

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -189,6 +189,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DFROBOT_RAIN_ADDR 0x1d
 #define NAU7802_ADDR 0x2A
 #define MAX30102_ADDR 0x57
+#define SCD4X_ADDR 0x62
 #define MLX90614_ADDR_DEF 0x5A
 #define CGRADSENS_ADDR 0x66
 #define LTR390UV_ADDR 0x53

--- a/src/detect/ScanI2C.h
+++ b/src/detect/ScanI2C.h
@@ -61,6 +61,7 @@ class ScanI2C
         FT6336U,
         STK8BAXX,
         ICM20948,
+        SCD4X,
         MAX30102,
         TPS65233,
         MPR121KB,

--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -447,6 +447,7 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
                 SCAN_SIMPLE_CASE(DFROBOT_RAIN_ADDR, DFROBOT_RAIN, "DFRobot Rain Gauge", (uint8_t)addr.address);
                 SCAN_SIMPLE_CASE(LTR390UV_ADDR, LTR390UV, "LTR390UV", (uint8_t)addr.address);
                 SCAN_SIMPLE_CASE(PCT2075_ADDR, PCT2075, "PCT2075", (uint8_t)addr.address);
+                SCAN_SIMPLE_CASE(SCD4X_ADDR, SCD4X, "SCD4X", (uint8_t)addr.address);
                 SCAN_SIMPLE_CASE(BMM150_ADDR, BMM150, "BMM150", (uint8_t)addr.address);
 #ifdef HAS_TPS65233
                 SCAN_SIMPLE_CASE(TPS65233_ADDR, TPS65233, "TPS65233", (uint8_t)addr.address);


### PR DESCRIPTION
This patch adds I2C detection support SCD40/SDC41 CO2 sensors.

It's a start to get #4601 over the line :)

Co-Authored-By: @Coloradohusky