### PR TITLE
fix seeed_tracker_L1_eink bug of cant't switch between two applets side-by-side 

### DIFF
--- a/variants/seeed_wio_tracker_L1_eink/nicheGraphics.h
+++ b/variants/seeed_wio_tracker_L1_eink/nicheGraphics.h
@@ -66,7 +66,6 @@ void setupNicheGraphics()
     inkhud->persistence->settings.optionalFeatures.batteryIcon = true; // Device definitely has a battery
     inkhud->persistence->settings.optionalMenuItems.backlight = true;  // Until proves capacitive button works by touching it
     inkhud->persistence->settings.userTiles.count = 1; // One tile only by default, keep things simple for new users
-    inkhud->persistence->settings.optionalMenuItems.nextTile = false; // Behavior handled by aux button instead
 
     // Setup backlight controller
     // Note: AUX button attached further down


### PR DESCRIPTION
# fix bug of cant't switch between two applets side-by-side

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] seeed_tracker_L1_eink 
