### PR TITLE
Honor custom userPrefs boot-screens in InkHUD 

### DIFF
--- a/src/graphics/niche/InkHUD/Applets/System/Logo/LogoApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/System/Logo/LogoApplet.cpp
@@ -54,28 +54,37 @@ void InkHUD::LogoApplet::onRender()
 
 #ifdef USERPREFS_OEM_IMAGE_DATA // Custom boot screen, if defined in userPrefs.jsonc
 
-    // Draw the custom logo
-    const uint8_t logo[] = USERPREFS_OEM_IMAGE_DATA;
-    drawXBitmap(logoCX - (USERPREFS_OEM_IMAGE_WIDTH / 2),  //  Left
-                logoCY - (USERPREFS_OEM_IMAGE_HEIGHT / 2), // Top
-                logo,                                      // XBM data
-                USERPREFS_OEM_IMAGE_WIDTH,                 // Width
-                USERPREFS_OEM_IMAGE_HEIGHT,                // Height
-                inverted ? WHITE : BLACK                   // Color
-    );
+    // Only show the custom screen at startup
+    // This allows us to draw the usual Meshtastic logo at shutdown
+    // The effect is similar to the two-stage userPrefs boot screen used by BaseUI
+    if (millis() < 10 * 1000UL) {
 
-    // Select the largest font which will still comfortably fit the custom text
-    setFont(fontLarge);
-    if (getTextWidth(USERPREFS_OEM_TEXT) > 0.8 * width())
-        setFont(fontMedium);
-    if (getTextWidth(USERPREFS_OEM_TEXT) > 0.8 * width())
-        setFont(fontSmall);
-    int16_t logoB = logoCY + (USERPREFS_OEM_IMAGE_HEIGHT / 2); // Bottom of the logo
+        // Draw the custom logo
+        const uint8_t logo[] = USERPREFS_OEM_IMAGE_DATA;
+        drawXBitmap(logoCX - (USERPREFS_OEM_IMAGE_WIDTH / 2),  //  Left
+                    logoCY - (USERPREFS_OEM_IMAGE_HEIGHT / 2), // Top
+                    logo,                                      // XBM data
+                    USERPREFS_OEM_IMAGE_WIDTH,                 // Width
+                    USERPREFS_OEM_IMAGE_HEIGHT,                // Height
+                    inverted ? WHITE : BLACK                   // Color
+        );
 
-    // Draw custom text below logo
-    printAt(X(0.5), logoB + Y(0.1), USERPREFS_OEM_TEXT, CENTER, TOP);
+        // Select the largest font which will still comfortably fit the custom text
+        setFont(fontLarge);
+        if (getTextWidth(USERPREFS_OEM_TEXT) > 0.8 * width())
+            setFont(fontMedium);
+        if (getTextWidth(USERPREFS_OEM_TEXT) > 0.8 * width())
+            setFont(fontSmall);
 
-#else // Standard boot screen
+        // Draw custom text below logo
+        int16_t logoB = logoCY + (USERPREFS_OEM_IMAGE_HEIGHT / 2); // Bottom of the logo
+        printAt(X(0.5), logoB + Y(0.1), USERPREFS_OEM_TEXT, CENTER, TOP);
+
+        // Don't draw the normal boot screen, we've already drawn our custom version
+        return;
+    }
+
+#endif
 
     drawLogo(logoCX, logoCY, logoW, logoH, inverted ? WHITE : BLACK);
 
@@ -94,8 +103,6 @@ void InkHUD::LogoApplet::onRender()
         setFont(fontTitle);
         printAt(X(0.5), logoB + Y(0.1), textTitle, CENTER, TOP);
     }
-
-#endif
 }
 
 void InkHUD::LogoApplet::onForeground()

--- a/src/graphics/niche/InkHUD/Applets/System/Logo/LogoApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/System/Logo/LogoApplet.cpp
@@ -52,6 +52,31 @@ void InkHUD::LogoApplet::onRender()
         setTextColor(WHITE);
     }
 
+#ifdef USERPREFS_OEM_IMAGE_DATA // Custom boot screen, if defined in userPrefs.jsonc
+
+    // Draw the custom logo
+    const uint8_t logo[] = USERPREFS_OEM_IMAGE_DATA;
+    drawXBitmap(logoCX - (USERPREFS_OEM_IMAGE_WIDTH / 2),  //  Left
+                logoCY - (USERPREFS_OEM_IMAGE_HEIGHT / 2), // Top
+                logo,                                      // XBM data
+                USERPREFS_OEM_IMAGE_WIDTH,                 // Width
+                USERPREFS_OEM_IMAGE_HEIGHT,                // Height
+                inverted ? WHITE : BLACK                   // Color
+    );
+
+    // Select the largest font which will still comfortably fit the custom text
+    setFont(fontLarge);
+    if (getTextWidth(USERPREFS_OEM_TEXT) > 0.8 * width())
+        setFont(fontMedium);
+    if (getTextWidth(USERPREFS_OEM_TEXT) > 0.8 * width())
+        setFont(fontSmall);
+    int16_t logoB = logoCY + (USERPREFS_OEM_IMAGE_HEIGHT / 2); // Bottom of the logo
+
+    // Draw custom text below logo
+    printAt(X(0.5), logoB + Y(0.1), USERPREFS_OEM_TEXT, CENTER, TOP);
+
+#else // Standard boot screen
+
     drawLogo(logoCX, logoCY, logoW, logoH, inverted ? WHITE : BLACK);
 
     if (!textLeft.empty()) {
@@ -69,6 +94,8 @@ void InkHUD::LogoApplet::onRender()
         setFont(fontTitle);
         printAt(X(0.5), logoB + Y(0.1), textTitle, CENTER, TOP);
     }
+
+#endif
 }
 
 void InkHUD::LogoApplet::onForeground()


### PR DESCRIPTION
Note: not tested on ESP (needs to be built under WSL on Windows machines)

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - Elecrow ThinkNode M1