### PR TITLE
Customize InkHUD for OpenSauce event firmware

### DIFF
--- a/variants/ELECROW-ThinkNode-M1/nicheGraphics.h
+++ b/variants/ELECROW-ThinkNode-M1/nicheGraphics.h
@@ -61,8 +61,9 @@ void setupNicheGraphics()
     InkHUD::Applet::fontSmall = FREESANS_6PT_WIN1252;
 
     // Customize default settings
-    inkhud->persistence->settings.userTiles.maxCount = 2;              // Two applets side-by-side
-    inkhud->persistence->settings.optionalFeatures.batteryIcon = true; // Device definitely has a battery
+    inkhud->persistence->settings.userTiles.maxCount = 2;                 // Two applets side-by-side
+    inkhud->persistence->settings.optionalFeatures.batteryIcon = true;    // Device definitely has a battery
+    inkhud->persistence->settings.optionalFeatures.notifications = false; // No notifications. Busy mesh.
 
     // Setup backlight controller
     // Note: button is attached further down
@@ -70,14 +71,16 @@ void setupNicheGraphics()
     backlight->setPin(PIN_EINK_EN);
 
     // Pick applets
-    // Note: order of applets determines priority of "auto-show" feature
-    inkhud->addApplet("All Messages", new InkHUD::AllMessageApplet, true, true); // Activated, autoshown
-    inkhud->addApplet("DMs", new InkHUD::DMApplet);                              // -
-    inkhud->addApplet("Channel 0", new InkHUD::ThreadedMessageApplet(0));        // -
-    inkhud->addApplet("Channel 1", new InkHUD::ThreadedMessageApplet(1));        // -
-    inkhud->addApplet("Positions", new InkHUD::PositionsApplet, true);           // Activated
-    inkhud->addApplet("Recents List", new InkHUD::RecentsListApplet);            // -
-    inkhud->addApplet("Heard", new InkHUD::HeardApplet, true, false, 0);         // Activated, no autoshow, default on tile 0
+    // Custom selection for OpenSauce
+    inkhud->addApplet("Channel 0", new InkHUD::ThreadedMessageApplet(0), true, false, 0); // Default tile 0
+    inkhud->addApplet("Channel 1", new InkHUD::ThreadedMessageApplet(1), true);
+    inkhud->addApplet("Channel 2", new InkHUD::ThreadedMessageApplet(2), true);
+    inkhud->addApplet("DMs", new InkHUD::DMApplet, true, true);          // Autoshown if new message
+    inkhud->addApplet("Heard", new InkHUD::HeardApplet, true, false, 1); // Default tile 1
+    // Disabled by default
+    inkhud->addApplet("All Messages", new InkHUD::AllMessageApplet);
+    inkhud->addApplet("Positions", new InkHUD::PositionsApplet);
+    inkhud->addApplet("Recents List", new InkHUD::RecentsListApplet);
 
     // Start running InkHUD
     inkhud->begin();

--- a/variants/diy/nrf52_promicro_diy_tcxo/nicheGraphics.h
+++ b/variants/diy/nrf52_promicro_diy_tcxo/nicheGraphics.h
@@ -65,16 +65,19 @@ void setupNicheGraphics()
     inkhud->persistence->settings.rotation = (driver->height > driver->width ? 1 : 0); // Rotate 90deg to landscape, if needed
     inkhud->persistence->settings.userTiles.maxCount = 4;
     inkhud->persistence->settings.optionalFeatures.batteryIcon = true;
+    inkhud->persistence->settings.optionalFeatures.notifications = false; // No notifications. Busy mesh.
 
     // Pick applets
-    // Note: order of applets determines priority of "auto-show" feature
+    // Custom selection for OpenSauce
+    inkhud->addApplet("Channel 0", new InkHUD::ThreadedMessageApplet(0), true, false, 0); // Default tile 0
+    inkhud->addApplet("Channel 1", new InkHUD::ThreadedMessageApplet(1), true);
+    inkhud->addApplet("Channel 2", new InkHUD::ThreadedMessageApplet(2), true);
+    inkhud->addApplet("DMs", new InkHUD::DMApplet, true, true);          // Autoshown if new message
+    inkhud->addApplet("Heard", new InkHUD::HeardApplet, true, false, 1); // Default tile 1
+    // Disabled by default
     inkhud->addApplet("All Messages", new InkHUD::AllMessageApplet);
-    inkhud->addApplet("DMs", new InkHUD::DMApplet, true, false, 3);                       // Default on tile 3
-    inkhud->addApplet("Channel 0", new InkHUD::ThreadedMessageApplet(0), true, false, 2); // Default on tile 2
-    inkhud->addApplet("Channel 1", new InkHUD::ThreadedMessageApplet(1));
-    inkhud->addApplet("Positions", new InkHUD::PositionsApplet, true, false, 1);      // Default on tile 1
-    inkhud->addApplet("Recents List", new InkHUD::RecentsListApplet, true, false, 0); // Default on tile 0
-    inkhud->addApplet("Heard", new InkHUD::HeardApplet, true);                        // Background
+    inkhud->addApplet("Positions", new InkHUD::PositionsApplet);
+    inkhud->addApplet("Recents List", new InkHUD::RecentsListApplet);
 
     // Start running InkHUD
     inkhud->begin();

--- a/variants/heltec_mesh_node_t114-inkhud/nicheGraphics.h
+++ b/variants/heltec_mesh_node_t114-inkhud/nicheGraphics.h
@@ -66,16 +66,20 @@ void setupNicheGraphics()
     inkhud->persistence->settings.rotation = (driver->height > driver->width ? 1 : 0); // Rotate 90deg to landscape, if needed
     inkhud->persistence->settings.userTiles.maxCount = 4;
     inkhud->persistence->settings.optionalFeatures.batteryIcon = true;
+    inkhud->persistence->settings.optionalFeatures.notifications = false; // No notifications. Busy mesh.
 
     // Pick applets
-    // Note: order of applets determines priority of "auto-show" feature
+    // Custom selection for OpenSauce
+    inkhud->addApplet("Channel 0", new InkHUD::ThreadedMessageApplet(0), true, false, 0); // Default tile 0
+    inkhud->addApplet("Channel 1", new InkHUD::ThreadedMessageApplet(1), true);
+    inkhud->addApplet("Channel 2", new InkHUD::ThreadedMessageApplet(2), true);
+    inkhud->addApplet("DMs", new InkHUD::DMApplet, true, true);          // Autoshown if new message
+    inkhud->addApplet("Heard", new InkHUD::HeardApplet, true, false, 1); // Default tile 1
+    // Disabled by default
     inkhud->addApplet("All Messages", new InkHUD::AllMessageApplet);
-    inkhud->addApplet("DMs", new InkHUD::DMApplet, true, false, 3);                       // Default on tile 3
-    inkhud->addApplet("Channel 0", new InkHUD::ThreadedMessageApplet(0), true, false, 2); // Default on tile 2
-    inkhud->addApplet("Channel 1", new InkHUD::ThreadedMessageApplet(1));
-    inkhud->addApplet("Positions", new InkHUD::PositionsApplet, true, false, 1);      // Default on tile 1
-    inkhud->addApplet("Recents List", new InkHUD::RecentsListApplet, true, false, 0); // Default on tile 0
-    inkhud->addApplet("Heard", new InkHUD::HeardApplet, true);                        // Background
+    inkhud->addApplet("Positions", new InkHUD::PositionsApplet);
+    inkhud->addApplet("Recents List", new InkHUD::RecentsListApplet);
+    // Background
 
     // Start running InkHUD
     inkhud->begin();

--- a/variants/heltec_mesh_pocket/nicheGraphics.h
+++ b/variants/heltec_mesh_pocket/nicheGraphics.h
@@ -59,16 +59,19 @@ void setupNicheGraphics()
     inkhud->persistence->settings.rotation = 3;           // 270 degrees clockwise
     inkhud->persistence->settings.userTiles.count = 1;    // One tile only by default, keep things simple for new users
     inkhud->persistence->settings.optionalMenuItems.nextTile = true;
+    inkhud->persistence->settings.optionalFeatures.notifications = false; // No notifications. Busy mesh.
 
     // Pick applets
-    // Note: order of applets determines priority of "auto-show" feature
-    inkhud->addApplet("All Messages", new InkHUD::AllMessageApplet, true, true); // Activated, autoshown
-    inkhud->addApplet("DMs", new InkHUD::DMApplet);                              // -
-    inkhud->addApplet("Channel 0", new InkHUD::ThreadedMessageApplet(0));        // -
-    inkhud->addApplet("Channel 1", new InkHUD::ThreadedMessageApplet(1));        // -
-    inkhud->addApplet("Positions", new InkHUD::PositionsApplet, true);           // Activated
-    inkhud->addApplet("Recents List", new InkHUD::RecentsListApplet);            // -
-    inkhud->addApplet("Heard", new InkHUD::HeardApplet, true, false, 0);         // Activated, no autoshow, default on tile 0
+    // Custom selection for OpenSauce
+    inkhud->addApplet("Channel 0", new InkHUD::ThreadedMessageApplet(0), true, false, 0); // Default tile 0
+    inkhud->addApplet("Channel 1", new InkHUD::ThreadedMessageApplet(1), true);
+    inkhud->addApplet("Channel 2", new InkHUD::ThreadedMessageApplet(2), true);
+    inkhud->addApplet("DMs", new InkHUD::DMApplet, true, true);          // Autoshown if new message
+    inkhud->addApplet("Heard", new InkHUD::HeardApplet, true, false, 1); // Default tile 1
+    // Disabled by default
+    inkhud->addApplet("All Messages", new InkHUD::AllMessageApplet);
+    inkhud->addApplet("Positions", new InkHUD::PositionsApplet);
+    inkhud->addApplet("Recents List", new InkHUD::RecentsListApplet);
 
     // Start running InkHUD
     inkhud->begin();

--- a/variants/heltec_vision_master_e213/nicheGraphics.h
+++ b/variants/heltec_vision_master_e213/nicheGraphics.h
@@ -62,17 +62,20 @@ void setupNicheGraphics()
     inkhud->persistence->settings.userTiles.maxCount = 2; // How many tiles can the display handle?
     inkhud->persistence->settings.rotation = 3;           // 270 degrees clockwise
     inkhud->persistence->settings.userTiles.count = 1;    // One tile only by default, keep things simple for new users
-    inkhud->persistence->settings.optionalMenuItems.nextTile = false; // Behavior handled by aux button instead
+    inkhud->persistence->settings.optionalMenuItems.nextTile = false;     // Behavior handled by aux button instead
+    inkhud->persistence->settings.optionalFeatures.notifications = false; // No notifications. Busy mesh.
 
     // Pick applets
-    // Note: order of applets determines priority of "auto-show" feature
-    inkhud->addApplet("All Messages", new InkHUD::AllMessageApplet, true, true); // Activated, autoshown
-    inkhud->addApplet("DMs", new InkHUD::DMApplet);                              // -
-    inkhud->addApplet("Channel 0", new InkHUD::ThreadedMessageApplet(0));        // -
-    inkhud->addApplet("Channel 1", new InkHUD::ThreadedMessageApplet(1));        // -
-    inkhud->addApplet("Positions", new InkHUD::PositionsApplet, true);           // Activated
-    inkhud->addApplet("Recents List", new InkHUD::RecentsListApplet);            // -
-    inkhud->addApplet("Heard", new InkHUD::HeardApplet, true, false, 0);         // Activated, not autoshown, default on tile 0
+    // Custom selection for OpenSauce
+    inkhud->addApplet("Channel 0", new InkHUD::ThreadedMessageApplet(0), true, false, 0); // Default tile 0
+    inkhud->addApplet("Channel 1", new InkHUD::ThreadedMessageApplet(1), true);
+    inkhud->addApplet("Channel 2", new InkHUD::ThreadedMessageApplet(2), true);
+    inkhud->addApplet("DMs", new InkHUD::DMApplet, true, true);          // Autoshown if new message
+    inkhud->addApplet("Heard", new InkHUD::HeardApplet, true, false, 1); // Default tile 1
+    // Disabled by default
+    inkhud->addApplet("All Messages", new InkHUD::AllMessageApplet);
+    inkhud->addApplet("Positions", new InkHUD::PositionsApplet);
+    inkhud->addApplet("Recents List", new InkHUD::RecentsListApplet);
 
     // Start running InkHUD
     inkhud->begin();

--- a/variants/heltec_vision_master_e290/nicheGraphics.h
+++ b/variants/heltec_vision_master_e290/nicheGraphics.h
@@ -75,17 +75,20 @@ void setupNicheGraphics()
     inkhud->persistence->settings.userTiles.maxCount = 2; // How many tiles can the display handle?
     inkhud->persistence->settings.rotation = 1;           // 90 degrees clockwise
     inkhud->persistence->settings.userTiles.count = 1;    // One tile only by default, keep things simple for new users
-    inkhud->persistence->settings.optionalMenuItems.nextTile = false; // Behavior handled by aux button instead
+    inkhud->persistence->settings.optionalMenuItems.nextTile = false;     // Behavior handled by aux button instead
+    inkhud->persistence->settings.optionalFeatures.notifications = false; // No notifications. Busy mesh.
 
     // Pick applets
-    // Note: order of applets determines priority of "auto-show" feature
-    inkhud->addApplet("All Messages", new InkHUD::AllMessageApplet, true, true); // Activated, autoshown
-    inkhud->addApplet("DMs", new InkHUD::DMApplet);                              // -
-    inkhud->addApplet("Channel 0", new InkHUD::ThreadedMessageApplet(0));        // -
-    inkhud->addApplet("Channel 1", new InkHUD::ThreadedMessageApplet(1));        // -
-    inkhud->addApplet("Positions", new InkHUD::PositionsApplet, true);           // Activated
-    inkhud->addApplet("Recents List", new InkHUD::RecentsListApplet);            // -
-    inkhud->addApplet("Heard", new InkHUD::HeardApplet, true, false, 0);         // Activated, not autoshown, default on tile 0
+    // Custom selection for OpenSauce
+    inkhud->addApplet("Channel 0", new InkHUD::ThreadedMessageApplet(0), true, false, 0); // Default tile 0
+    inkhud->addApplet("Channel 1", new InkHUD::ThreadedMessageApplet(1), true);
+    inkhud->addApplet("Channel 2", new InkHUD::ThreadedMessageApplet(2), true);
+    inkhud->addApplet("DMs", new InkHUD::DMApplet, true, true);          // Autoshown if new message
+    inkhud->addApplet("Heard", new InkHUD::HeardApplet, true, false, 1); // Default tile 1
+    // Disabled by default
+    inkhud->addApplet("All Messages", new InkHUD::AllMessageApplet);
+    inkhud->addApplet("Positions", new InkHUD::PositionsApplet);
+    inkhud->addApplet("Recents List", new InkHUD::RecentsListApplet);
 
     // Start running InkHUD
     inkhud->begin();

--- a/variants/heltec_wireless_paper/nicheGraphics.h
+++ b/variants/heltec_wireless_paper/nicheGraphics.h
@@ -59,16 +59,18 @@ void setupNicheGraphics()
     inkhud->persistence->settings.userTiles.maxCount = 2; // How many tiles can the display handle?
     inkhud->persistence->settings.rotation = 3;           // 270 degrees clockwise
     inkhud->persistence->settings.userTiles.count = 1;    // One tile only by default, keep things simple for new users
-
+    inkhud->persistence->settings.optionalFeatures.notifications = false; // No notifications. Busy mesh.
     // Pick applets
-    // Note: order of applets determines priority of "auto-show" feature
-    inkhud->addApplet("All Messages", new InkHUD::AllMessageApplet, true, true); // Activated, autoshown
-    inkhud->addApplet("DMs", new InkHUD::DMApplet);                              // -
-    inkhud->addApplet("Channel 0", new InkHUD::ThreadedMessageApplet(0));        // -
-    inkhud->addApplet("Channel 1", new InkHUD::ThreadedMessageApplet(1));        // -
-    inkhud->addApplet("Positions", new InkHUD::PositionsApplet, true);           // Activated
-    inkhud->addApplet("Recents List", new InkHUD::RecentsListApplet);            // -
-    inkhud->addApplet("Heard", new InkHUD::HeardApplet, true, false, 0);         // Activated, not autoshown, default on tile 0
+    // Custom selection for OpenSauce
+    inkhud->addApplet("Channel 0", new InkHUD::ThreadedMessageApplet(0), true, false, 0); // Default tile 0
+    inkhud->addApplet("Channel 1", new InkHUD::ThreadedMessageApplet(1), true);
+    inkhud->addApplet("Channel 2", new InkHUD::ThreadedMessageApplet(2), true);
+    inkhud->addApplet("DMs", new InkHUD::DMApplet, true, true);          // Autoshown if new message
+    inkhud->addApplet("Heard", new InkHUD::HeardApplet, true, false, 1); // Default tile 1
+    // Disabled by default
+    inkhud->addApplet("All Messages", new InkHUD::AllMessageApplet);
+    inkhud->addApplet("Positions", new InkHUD::PositionsApplet);
+    inkhud->addApplet("Recents List", new InkHUD::RecentsListApplet);
 
     // Start running InkHUD
     inkhud->begin();

--- a/variants/seeed_wio_tracker_L1_eink/nicheGraphics.h
+++ b/variants/seeed_wio_tracker_L1_eink/nicheGraphics.h
@@ -67,6 +67,7 @@ void setupNicheGraphics()
     inkhud->persistence->settings.optionalFeatures.batteryIcon = true; // Device definitely has a battery
     inkhud->persistence->settings.optionalMenuItems.backlight = true;  // Until proves capacitive button works by touching it
     inkhud->persistence->settings.userTiles.count = 1; // One tile only by default, keep things simple for new users
+    inkhud->persistence->settings.optionalFeatures.notifications = false; // No notifications. Busy mesh.
 
     // Setup backlight controller
     // Note: AUX button attached further down
@@ -74,14 +75,16 @@ void setupNicheGraphics()
     backlight->setPin(PIN_EINK_EN);
 
     // Pick applets
-    // Note: order of applets determines priority of "auto-show" feature
-    inkhud->addApplet("All Messages", new InkHUD::AllMessageApplet, true, true); // Activated, autoshown
-    inkhud->addApplet("DMs", new InkHUD::DMApplet);                              // -
-    inkhud->addApplet("Channel 0", new InkHUD::ThreadedMessageApplet(0));        // -
-    inkhud->addApplet("Channel 1", new InkHUD::ThreadedMessageApplet(1));        // -
-    inkhud->addApplet("Positions", new InkHUD::PositionsApplet, true);           // Activated
-    inkhud->addApplet("Recents List", new InkHUD::RecentsListApplet);            // -
-    inkhud->addApplet("Heard", new InkHUD::HeardApplet, true, false, 0);         // Activated, no autoshow, default on tile 0
+    // Custom selection for OpenSauce
+    inkhud->addApplet("Channel 0", new InkHUD::ThreadedMessageApplet(0), true, false, 0); // Default tile 0
+    inkhud->addApplet("Channel 1", new InkHUD::ThreadedMessageApplet(1), true);
+    inkhud->addApplet("Channel 2", new InkHUD::ThreadedMessageApplet(2), true);
+    inkhud->addApplet("DMs", new InkHUD::DMApplet, true, true);          // Autoshown if new message
+    inkhud->addApplet("Heard", new InkHUD::HeardApplet, true, false, 1); // Default tile 1
+    // Disabled by default
+    inkhud->addApplet("All Messages", new InkHUD::AllMessageApplet);
+    inkhud->addApplet("Positions", new InkHUD::PositionsApplet);
+    inkhud->addApplet("Recents List", new InkHUD::RecentsListApplet);
 
     inkhud->persistence->settings.rotation = 1;
     // inkhud->persistence->printSettings(&inkhud->persistence->settings);

--- a/variants/t-echo/nicheGraphics.h
+++ b/variants/t-echo/nicheGraphics.h
@@ -62,10 +62,11 @@ void setupNicheGraphics()
     InkHUD::Applet::fontSmall = FREESANS_6PT_WIN1252;
 
     // Customize default settings
-    inkhud->persistence->settings.userTiles.maxCount = 2;              // Two applets side-by-side
-    inkhud->persistence->settings.rotation = 3;                        // 270 degrees clockwise
-    inkhud->persistence->settings.optionalFeatures.batteryIcon = true; // Device definitely has a battery
-    inkhud->persistence->settings.optionalMenuItems.backlight = true;  // Until proves capacitive button works by touching it
+    inkhud->persistence->settings.userTiles.maxCount = 2;                 // Two applets side-by-side
+    inkhud->persistence->settings.rotation = 3;                           // 270 degrees clockwise
+    inkhud->persistence->settings.optionalFeatures.batteryIcon = true;    // Device definitely has a battery
+    inkhud->persistence->settings.optionalMenuItems.backlight = true;     // Until proves capacitive button works by touching it
+    inkhud->persistence->settings.optionalFeatures.notifications = false; // No notifications. Busy mesh.
 
     // Setup backlight controller
     // Note: AUX button attached further down
@@ -73,14 +74,16 @@ void setupNicheGraphics()
     backlight->setPin(PIN_EINK_EN);
 
     // Pick applets
-    // Note: order of applets determines priority of "auto-show" feature
-    inkhud->addApplet("All Messages", new InkHUD::AllMessageApplet, true, true); // Activated, autoshown
-    inkhud->addApplet("DMs", new InkHUD::DMApplet);                              // -
-    inkhud->addApplet("Channel 0", new InkHUD::ThreadedMessageApplet(0));        // -
-    inkhud->addApplet("Channel 1", new InkHUD::ThreadedMessageApplet(1));        // -
-    inkhud->addApplet("Positions", new InkHUD::PositionsApplet, true);           // Activated
-    inkhud->addApplet("Recents List", new InkHUD::RecentsListApplet);            // -
-    inkhud->addApplet("Heard", new InkHUD::HeardApplet, true, false, 0);         // Activated, no autoshow, default on tile 0
+    // Custom selection for OpenSauce
+    inkhud->addApplet("Channel 0", new InkHUD::ThreadedMessageApplet(0), true, false, 0); // Default tile 0
+    inkhud->addApplet("Channel 1", new InkHUD::ThreadedMessageApplet(1), true);
+    inkhud->addApplet("Channel 2", new InkHUD::ThreadedMessageApplet(2), true);
+    inkhud->addApplet("DMs", new InkHUD::DMApplet, true, true);          // Autoshown if new message
+    inkhud->addApplet("Heard", new InkHUD::HeardApplet, true, false, 1); // Default tile 1
+    // Disabled by default
+    inkhud->addApplet("All Messages", new InkHUD::AllMessageApplet);
+    inkhud->addApplet("Positions", new InkHUD::PositionsApplet);
+    inkhud->addApplet("Recents List", new InkHUD::RecentsListApplet);
 
     // Start running InkHUD
     inkhud->begin();

--- a/variants/tlora_t3s3_epaper/nicheGraphics.h
+++ b/variants/tlora_t3s3_epaper/nicheGraphics.h
@@ -59,16 +59,19 @@ void setupNicheGraphics()
     inkhud->persistence->settings.userTiles.maxCount = 2; // How many tiles can the display handle?
     inkhud->persistence->settings.rotation = 3;           // 270 degrees clockwise
     inkhud->persistence->settings.userTiles.count = 1;    // One tile only by default, keep things simple for new users
+    inkhud->persistence->settings.optionalFeatures.notifications = false; // No notifications. Busy mesh.
 
     // Pick applets
-    // Note: order of applets determines priority of "auto-show" feature
-    inkhud->addApplet("All Messages", new InkHUD::AllMessageApplet, true, true); // Activated, autoshown
-    inkhud->addApplet("DMs", new InkHUD::DMApplet);                              // -
-    inkhud->addApplet("Channel 0", new InkHUD::ThreadedMessageApplet(0));        // -
-    inkhud->addApplet("Channel 1", new InkHUD::ThreadedMessageApplet(1));        // -
-    inkhud->addApplet("Positions", new InkHUD::PositionsApplet, true);           // Activated
-    inkhud->addApplet("Recents List", new InkHUD::RecentsListApplet);            // -
-    inkhud->addApplet("Heard", new InkHUD::HeardApplet, true, false, 0);         // Activated, not autoshown, default on tile 0
+    // Custom selection for OpenSauce
+    inkhud->addApplet("Channel 0", new InkHUD::ThreadedMessageApplet(0), true, false, 0); // Default tile 0
+    inkhud->addApplet("Channel 1", new InkHUD::ThreadedMessageApplet(1), true);
+    inkhud->addApplet("Channel 2", new InkHUD::ThreadedMessageApplet(2), true);
+    inkhud->addApplet("DMs", new InkHUD::DMApplet, true, true);          // Autoshown if new message
+    inkhud->addApplet("Heard", new InkHUD::HeardApplet, true, false, 1); // Default tile 1
+    // Disabled by default
+    inkhud->addApplet("All Messages", new InkHUD::AllMessageApplet);
+    inkhud->addApplet("Positions", new InkHUD::PositionsApplet);
+    inkhud->addApplet("Recents List", new InkHUD::RecentsListApplet);
 
     // Start running InkHUD
     inkhud->begin();


### PR DESCRIPTION
Really just a demonstration, although don't foresee any problems. It did pass a quick smoke-test here.

- adds an extra `ThreadedMessageApplet` (one for each event channel)
- adjust default config
   - disable on-screen notifications (busy mesh)
   - enable autoshow for `DMapplet` only (show new DMs as they arrive) 

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
