### PR TITLE
4-hop EVENT_MODE experiment!

### DIFF
--- a/src/graphics/niche/InkHUD/Applets/Bases/Map/MapApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/Bases/Map/MapApplet.cpp
@@ -46,7 +46,7 @@ void InkHUD::MapApplet::onRender()
         constexpr uint16_t csMax = 12;
 
         // Too many hops away
-        if (m.hasHopsAway && m.hopsAway > config.lora.hop_limit) // Too many mops
+        if (m.hasHopsAway && m.hopsAway > config.lora.hop_limit) // Too many hops
             printAt(x, y, "!", CENTER, MIDDLE);
         else if (!m.hasHopsAway) // Unknown hops
             drawCross(x, y, csMin);

--- a/src/mesh/FloodingRouter.cpp
+++ b/src/mesh/FloodingRouter.cpp
@@ -72,10 +72,15 @@ void FloodingRouter::perhapsRebroadcast(const meshtastic_MeshPacket *p)
 
                 tosend->hop_limit--; // bump down the hop count
 #if USERPREFS_EVENT_MODE
-                if (tosend->hop_limit > 2) {
+#if USERPREFS_LORACONFIG_MODEM_PRESET == meshtastic_Config_LoRaConfig_ModemPreset_SHORT_TURBO
+                static const uint8_t correctionLimit = 3; // For SHORT_TURBO events, correct to 3 additional hops
+#else
+                static const uint8_t correctionLimit = 2; // For event mode, correct to 2 additional hops
+#endif
+                if (tosend->hop_limit > correctionLimit) {
                     // if we are "correcting" the hop_limit, "correct" the hop_start by the same amount to preserve hops away.
-                    tosend->hop_start -= (tosend->hop_limit - 2);
-                    tosend->hop_limit = 2;
+                    tosend->hop_start -= (tosend->hop_limit - correctionLimit);
+                    tosend->hop_limit = correctionLimit;
                 }
 #endif
                 tosend->next_hop = NO_NEXT_HOP_PREFERENCE; // this should already be the case, but just in case

--- a/src/mesh/MeshTypes.h
+++ b/src/mesh/MeshTypes.h
@@ -37,8 +37,12 @@ enum RxSource {
  **/
 #define HOP_MAX 7
 
-/// We normally just use max 3 hops for sending reliable messages
+// Use 4 hops for EVENT_MODE SHORT_TURBO.
+#if USERPREFS_EVENT_MODE && USERPREFS_LORACONFIG_MODEM_PRESET == meshtastic_Config_LoRaConfig_ModemPreset_SHORT_TURBO
+#define HOP_RELIABLE 4
+#else // We normally just use max 3 hops for sending reliable messages
 #define HOP_RELIABLE 3
+#endif
 
 // For old firmware or when falling back to flooding, there is no next-hop preference
 #define NO_NEXT_HOP_PREFERENCE 0


### PR DESCRIPTION
Blame @thebentern

Change the default hop limit to `4` for `EVENT_MODE` firmwares with `SHORT_TURBO` preset set in userPrefs.