### PR TITLE
TFT_MESH Fixes Across Various Devices

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -294,13 +294,13 @@ Screen::Screen(ScanI2C::DeviceAddress address, meshtastic_Config_DisplayConfig_O
     LOG_INFO("Protobuf Value uiconfig.screen_rgb_color: %d", uiconfig.screen_rgb_color);
     int32_t rawRGB = uiconfig.screen_rgb_color;
     if (rawRGB > 0 && rawRGB <= 255255255) {
-        uint8_t r = (rawRGB >> 16) & 0xFF;
-        uint8_t g = (rawRGB >> 8) & 0xFF;
-        uint8_t b = rawRGB & 0xFF;
-        LOG_INFO("Values of r,g,b: %d, %d, %d", r, g, b);
+        uint8_t TFT_MESH_r = (rawRGB >> 16) & 0xFF;
+        uint8_t TFT_MESH_g = (rawRGB >> 8) & 0xFF;
+        uint8_t TFT_MESH_b = rawRGB & 0xFF;
+        LOG_INFO("Values of r,g,b: %d, %d, %d", TFT_MESH_r, TFT_MESH_g, TFT_MESH_b);
 
-        if (r <= 255 && g <= 255 && b <= 255) {
-            TFT_MESH = COLOR565(r, g, b);
+        if (TFT_MESH_r <= 255 && TFT_MESH_g <= 255 && TFT_MESH_b <= 255) {
+            TFT_MESH = COLOR565(TFT_MESH_r, TFT_MESH_g, TFT_MESH_b);
         }
     }
 

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -313,8 +313,8 @@ Screen::Screen(ScanI2C::DeviceAddress address, meshtastic_Config_DisplayConfig_O
                             ST7789_MISO, ST7789_SCK);
 #else
     dispdev = new ST7789Spi(&SPI1, ST7789_RESET, ST7789_RS, ST7789_NSS, GEOMETRY_RAWMODE, TFT_WIDTH, TFT_HEIGHT);
-    static_cast<ST7789Spi *>(dispdev)->setRGB(TFT_MESH);
 #endif
+    static_cast<ST7789Spi *>(dispdev)->setRGB(TFT_MESH);
 #elif defined(USE_SSD1306)
     dispdev = new SSD1306Wire(address.address, -1, -1, geometry,
                               (address.port == ScanI2C::I2CPort::WIRE1) ? HW_I2C::I2C_TWO : HW_I2C::I2C_ONE);

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -677,52 +677,52 @@ void menuHandler::TFTColorPickerMenu(OLEDDisplay *display)
     bannerOptions.optionsArrayPtr = optionsArray;
     bannerOptions.optionsCount = 10;
     bannerOptions.bannerCallback = [display](int selected) -> void {
-        uint8_t r = 0;
-        uint8_t g = 0;
-        uint8_t b = 0;
+        uint8_t TFT_MESH_r = 0;
+        uint8_t TFT_MESH_g = 0;
+        uint8_t TFT_MESH_b = 0;
         if (selected == 1) {
             LOG_INFO("Setting color to system default or defined variant");
             // Given just before we set all these to zero, we will allow this to go through
         } else if (selected == 2) {
             LOG_INFO("Setting color to Meshtastic Green");
-            r = 103;
-            g = 234;
-            b = 148;
+            TFT_MESH_r = 103;
+            TFT_MESH_g = 234;
+            TFT_MESH_b = 148;
         } else if (selected == 3) {
             LOG_INFO("Setting color to Yellow");
-            r = 255;
-            g = 255;
-            b = 128;
+            TFT_MESH_r = 255;
+            TFT_MESH_g = 255;
+            TFT_MESH_b = 128;
         } else if (selected == 4) {
             LOG_INFO("Setting color to Red");
-            r = 255;
-            g = 64;
-            b = 64;
+            TFT_MESH_r = 255;
+            TFT_MESH_g = 64;
+            TFT_MESH_b = 64;
         } else if (selected == 5) {
             LOG_INFO("Setting color to Orange");
-            r = 255;
-            g = 160;
-            b = 20;
+            TFT_MESH_r = 255;
+            TFT_MESH_g = 160;
+            TFT_MESH_b = 20;
         } else if (selected == 6) {
             LOG_INFO("Setting color to Purple");
-            r = 204;
-            g = 153;
-            b = 255;
+            TFT_MESH_r = 204;
+            TFT_MESH_g = 153;
+            TFT_MESH_b = 255;
         } else if (selected == 7) {
             LOG_INFO("Setting color to Teal");
-            r = 64;
-            g = 224;
-            b = 208;
+            TFT_MESH_r = 64;
+            TFT_MESH_g = 224;
+            TFT_MESH_b = 208;
         } else if (selected == 8) {
             LOG_INFO("Setting color to Pink");
-            r = 255;
-            g = 105;
-            b = 180;
+            TFT_MESH_r = 255;
+            TFT_MESH_g = 105;
+            TFT_MESH_b = 180;
         } else if (selected == 9) {
             LOG_INFO("Setting color to White");
-            r = 255;
-            g = 255;
-            b = 255;
+            TFT_MESH_r = 255;
+            TFT_MESH_g = 255;
+            TFT_MESH_b = 255;
         }
 
 #if defined(HELTEC_MESH_NODE_T114) || defined(HELTEC_VISION_MASTER_T190) || HAS_TFT
@@ -731,14 +731,14 @@ void menuHandler::TFTColorPickerMenu(OLEDDisplay *display)
             display->fillRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
             display->setColor(WHITE);
 
-            if (r == 0 && g == 0 && b == 0) {
+            if (TFT_MESH_r == 0 && TFT_MESH_g == 0 && TFT_MESH_b == 0) {
 #ifdef TFT_MESH_OVERRIDE
                 TFT_MESH = TFT_MESH_OVERRIDE;
 #else
                 TFT_MESH = COLOR565(0x67, 0xEA, 0x94);
 #endif
             } else {
-                TFT_MESH = COLOR565(r, g, b);
+                TFT_MESH = COLOR565(TFT_MESH_r, TFT_MESH_g, TFT_MESH_b);
             }
 
 #if defined(HELTEC_MESH_NODE_T114) || defined(HELTEC_VISION_MASTER_T190)
@@ -746,10 +746,10 @@ void menuHandler::TFTColorPickerMenu(OLEDDisplay *display)
 #endif
 
             screen->setFrames(graphics::Screen::FOCUS_SYSTEM);
-            if (r == 0 && g == 0 && b == 0) {
+            if (TFT_MESH_r == 0 && TFT_MESH_g == 0 && TFT_MESH_b == 0) {
                 uiconfig.screen_rgb_color = 0;
             } else {
-                uiconfig.screen_rgb_color = (r << 16) | (g << 8) | b;
+                uiconfig.screen_rgb_color = (TFT_MESH_r << 16) | (TFT_MESH_g << 8) | TFT_MESH_b;
             }
             LOG_INFO("Storing Value of %d to uiconfig.screen_rgb_color", uiconfig.screen_rgb_color);
             nodeDB->saveProto("/prefs/uiconfig.proto", meshtastic_DeviceUIConfig_size, &meshtastic_DeviceUIConfig_msg, &uiconfig);

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -358,6 +358,9 @@ void menuHandler::systemBaseMenu()
     static int optionsEnumArray[7] = {Back};
     int options = 1;
 
+    optionsArray[options] = "Reboot";
+    optionsEnumArray[options++] = Reboot;
+
     optionsArray[options] = "Beeps Action";
     optionsEnumArray[options++] = Beeps;
 
@@ -365,9 +368,6 @@ void menuHandler::systemBaseMenu()
         optionsArray[options] = "Brightness";
         optionsEnumArray[options++] = Brightness;
     }
-
-    optionsArray[options] = "Reboot";
-    optionsEnumArray[options++] = Reboot;
 
 #if defined(HELTEC_MESH_NODE_T114) || defined(HELTEC_VISION_MASTER_T190) || HAS_TFT
     optionsArray[options] = "Screen Color";


### PR DESCRIPTION
Targeted Fixes
- [Fixed] T190 losses color on boot
- Future proof variable usage for TFT_MESH to avoid any re-use problems
- Adjust Reboot to first item on System menu