### PR TITLE
Fix install script

### DIFF
--- a/bin/device-install.sh
+++ b/bin/device-install.sh
@@ -7,12 +7,7 @@ MCU=""
 
 # Variant groups
 BIGDB_8MB=(
-	# Check if FILENAME contains "-tft-" and set target partitionScheme accordingly.
-if [[ $FILENAME == *"-tft-"* ]]; then
-    TFT_BUILD=true
-fi
-
-# Extract BASENAME from %FILENAME% for later use.r-s3"
+	"picomputer-s3"
 	"unphone"
 	"seeed-sensecap-indicator"
 	"crowpanel-esp32s3"


### PR DESCRIPTION
This partially reverse 2ab717c (#7143), fixing the install script. It looks like a bad/missed copy/paste, as the removed code is then repeated later in correct place in that file.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
