### PR TITLE
Whoops! Re-Add nRF52 OTA zips

### DIFF
--- a/.github/workflows/build_nrf52.yml
+++ b/.github/workflows/build_nrf52.yml
@@ -36,3 +36,4 @@ jobs:
           path: |
             release/*.uf2
             release/*.elf
+            release/*-ota.zip


### PR DESCRIPTION
Missed this in #7268 -- capture nRF52 ota zips.

~~DRAFT until [gh-action-firmware](https://github.com/meshtastic/gh-action-firmware/actions/runs/16157290611) update is complete.~~