### PR TITLE
Stop preventing sleep on low battery for NRF52

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -871,12 +871,16 @@ void Power::readPowerStatus()
             LOG_DEBUG("Low voltage counter: %d/10", low_voltage_counter);
             if (low_voltage_counter > 10) {
 #ifdef ARCH_NRF52
-                // We can't trigger deep sleep on NRF52, it's freezing the board
-                LOG_DEBUG("Low voltage detected, but not trigger deep sleep");
-#else
-                LOG_INFO("Low voltage detected, trigger deep sleep");
-                powerFSM.trigger(EVENT_LOW_BATTERY);
+                // NRF52 doesn't wake from super deep sleep for some reason
+                // Only trigger it if Super Deep Sleep Seconds is UINT32_MAX
+                if (config.power.sds_secs != UINT32_MAX) {
+                    LOG_DEBUG("Low voltage detected, but not triggering deep sleep");
+                } else
 #endif
+                {
+                    LOG_INFO("Low voltage detected, trigger deep sleep");
+                    powerFSM.trigger(EVENT_LOW_BATTERY);
+                }
             }
         } else {
             low_voltage_counter = 0;


### PR DESCRIPTION
This PR removes code that inhibits low battery sleep on NRF52-based nodes. The "freezing" noted in the [comment](https://github.com/meshtastic/firmware/commit/92fd5511ecb82bf312aeb2324b3f6411675a71d5) when it was added in 2022 is not well documented, or explained anywhere else as far as I can find. <strike>More importantly, it doesn't appear to be happening anymore.</strike> It would seem to me that its not only safe, but necessary to remove this workaround and prevent batteries from over-discharging.

EDIT: I've updated the PR to only avoid low battery sleep when necessary. See my [update comment](https://github.com/meshtastic/firmware/pull/7285#issuecomment-3076518179) for details.

Fixes #4378

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] <strike>Heltec (Lora32) V3</strike> N/A
  - [ ]  <strike>LilyGo T-Deck</strike> N/A
  - [ ]  <strike>LilyGo T-Beam</strike> N/A
  - [x] RAK WisBlock 4631
  - [x] Seeed Studio T-1000E tracker card

I've also tested this PR cherrypicked to the latest beta release (v2.6.11)