### PR TITLE
Shorter audio feedback for InkHUD buttons

### DIFF
--- a/src/graphics/niche/InkHUD/Events.cpp
+++ b/src/graphics/niche/InkHUD/Events.cpp
@@ -39,8 +39,8 @@ void InkHUD::Events::begin()
 void InkHUD::Events::onButtonShort()
 {
     // Audio feedback (via buzzer)
-    // Short low tone
-    playBoop();
+    // Short tone
+    playChirp();
     // Cancel any beeping, buzzing, blinking
     // Some button handling suppressed if we are dismissing an external notification (see below)
     bool dismissedExt = dismissExternalNotification();
@@ -64,8 +64,8 @@ void InkHUD::Events::onButtonShort()
 void InkHUD::Events::onButtonLong()
 {
     // Audio feedback (via buzzer)
-    // Low tone, longer than playBoop
-    playBeep();
+    // Slightly longer than playChirp
+    playBoop();
 
     // Check which system applet wants to handle the button press (if any)
     SystemApplet *consumer = nullptr;

--- a/variants/ELECROW-ThinkNode-M1/nicheGraphics.h
+++ b/variants/ELECROW-ThinkNode-M1/nicheGraphics.h
@@ -104,11 +104,11 @@ void setupNicheGraphics()
     buttons->setHandlerDown(1, [backlight]() { backlight->peek(); });
     buttons->setHandlerLongPress(1, [backlight]() {
         backlight->latch();
-        playBeep();
+        playBoop();
     });
     buttons->setHandlerShortPress(1, [backlight]() {
         backlight->off();
-        playBoop();
+        playChirp();
     });
 
     // Begin handling button events

--- a/variants/heltec_vision_master_e213/nicheGraphics.h
+++ b/variants/heltec_vision_master_e213/nicheGraphics.h
@@ -107,7 +107,7 @@ void setupNicheGraphics()
     buttons->setWiring(1, PIN_BUTTON2);
     buttons->setHandlerShortPress(1, [inkhud]() {
         inkhud->nextTile();
-        playBoop();
+        playChirp();
     });
 
     // Begin handling button events

--- a/variants/heltec_vision_master_e290/nicheGraphics.h
+++ b/variants/heltec_vision_master_e290/nicheGraphics.h
@@ -104,7 +104,7 @@ void setupNicheGraphics()
     buttons->setWiring(1, PIN_BUTTON2);
     buttons->setHandlerShortPress(1, [inkhud]() {
         inkhud->nextTile();
-        playBoop();
+        playChirp();
     });
 
     // Begin handling button events


### PR DESCRIPTION
Makes use of the recently added `playChirp` method.

Short press: swapped from `playBoop` to `playChirp`
Long press: swapped from `playBeep` to `playBoop`

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - Elecrow ThinkNode M1