### PR TITLE
fix(device-update.sh): safely filter args without breaking parsing

### DIFF
--- a/bin/device-update.sh
+++ b/bin/device-update.sh
@@ -31,17 +31,16 @@ EOF
 }
 
 # Check for --change-mode and remove it from arguments
-NEW_ARGS=""
+NEW_ARGS=()
 for arg in "$@"; do
     if [ "$arg" = "--change-mode" ]; then
         CHANGE_MODE=true
     else
-        NEW_ARGS="$NEW_ARGS \"\$arg\""
+        NEW_ARGS+=("$arg")
     fi
 done
 
-# Reset positional parameters to filtered list
-eval set -- $NEW_ARGS
+set -- "${NEW_ARGS[@]}"
 
 while getopts ":hp:P:f:" opt; do
     case "${opt}" in


### PR DESCRIPTION
The previous method of removing `--change-mode` from the argument list used a string (`NEW_ARGS`) and `eval set -- $NEW_ARGS` to reconstruct the positional parameters. This was both unsafe and incorrect.

Because `NEW_ARGS` was built using quoted literal `$arg` strings instead of the actual values, it resulted in all filtered arguments being set to the same last value of `$arg`. This caused `getopts` to receive incorrect input and silently fail to parse options like `-p` and `-f`, leading to broken behavior and unset variables (e.g., `ESPTOOL_CMD` never got a port).

This patch rewrites the logic to use an array (`NEW_ARGS+=("$arg")`), and resets positional parameters via `set -- "${NEW_ARGS[@]}"`. This preserves argument integrity and avoids the unsafe use of `eval`.

Example of the broken behavior before this fix:

```
  ./device-update.sh -p /dev/ttyACM0 -f firmware.bin
```

Resulted in:

```
  set -- firmware.bin firmware.bin firmware.bin firmware.bin
```

Now:

```
  set -- -p /dev/ttyACM0 -f firmware.bin
```

as expected.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [x] LilyGo T-Deck
  - [x] LilyGo T-Beam
  - [x] RAK WisBlock 4631
  - [x] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
  
Fix to update-device.sh script, not affecting any devices.