### PR TITLE
MESHTASTIC_EXCLUDE_SCREEN excludes screen now

### DIFF
--- a/arch/portduino/portduino.ini
+++ b/arch/portduino/portduino.ini
@@ -21,6 +21,7 @@ build_src_filter =
 
 lib_deps =
   ${env.lib_deps}
+  ${screen_base.lib_deps}
   ${networking_base.lib_deps}
   ${radiolib_base.lib_deps}
   ${environmental_base.lib_deps}

--- a/arch/stm32/stm32.ini
+++ b/arch/stm32/stm32.ini
@@ -39,7 +39,7 @@ build_flags =
   -DHAL_RNG_MODULE_ENABLED
 
 build_src_filter =
-  ${arduino_base.build_src_filter} -<platform/esp32/> -<nimble/> -<mesh/api/> -<mesh/wifi/> -<mesh/http/> -<modules/esp32> -<mesh/eth/> -<input> -<buzz> -<modules/RemoteHardwareModule.cpp> -<platform/nrf52> -<platform/portduino> -<platform/rp2xx0> -<mesh/raspihttp>
+  ${arduino_base.build_src_filter} -<graphics/> -<platform/esp32/> -<nimble/> -<mesh/api/> -<mesh/wifi/> -<mesh/http/> -<modules/esp32> -<mesh/eth/> -<input> -<buzz> -<modules/RemoteHardwareModule.cpp> -<platform/nrf52> -<platform/portduino> -<platform/rp2xx0> -<mesh/raspihttp>
 
 board_upload.offset_address = 0x08000000
 upload_protocol = stlink

--- a/platformio.ini
+++ b/platformio.ini
@@ -59,8 +59,6 @@ build_flags = -Wno-missing-field-initializers
 monitor_speed = 115200
 monitor_filters = direct
 lib_deps =
-	# renovate: datasource=git-refs depName=meshtastic-esp8266-oled-ssd1306 packageName=https://github.com/meshtastic/esp8266-oled-ssd1306 gitBranch=master
-	https://github.com/meshtastic/esp8266-oled-ssd1306/archive/0119501e9983bd894830b02f545c377ee08d66fe.zip
 	# renovate: datasource=custom.pio depName=OneButton packageName=mathertel/library/OneButton
 	mathertel/OneButton@2.6.1
 	# renovate: datasource=git-refs depName=meshtastic-arduino-fsm packageName=https://github.com/meshtastic/arduino-fsm gitBranch=master
@@ -82,11 +80,18 @@ check_flags =
 	--suppressions-list=suppressions.txt
 	--inline-suppr
 
+; Common libs for platforms that support screens (not STM32)
+[screen_base]
+lib_deps =
+	# renovate: datasource=git-refs depName=meshtastic-esp8266-oled-ssd1306 packageName=https://github.com/meshtastic/esp8266-oled-ssd1306 gitBranch=master
+	https://github.com/meshtastic/esp8266-oled-ssd1306/archive/0119501e9983bd894830b02f545c377ee08d66fe.zip
+
 ; Common settings for conventional (non Portduino) Arduino targets
 [arduino_base]
 framework = arduino
 lib_deps =
 	${env.lib_deps}
+	${screen_base.lib_deps} ; arduino_base.lib_deps are not consumed by stm32wl
 	# renovate: datasource=custom.pio depName=NonBlockingRTTTL packageName=end2endzone/library/NonBlockingRTTTL
 	end2endzone/NonBlockingRTTTL@1.3.0
 build_flags = ${env.build_flags} -Os

--- a/src/FakeScreen.h
+++ b/src/FakeScreen.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "power.h"
+namespace graphics
+{
+// Noop class for MESHTASTIC_EXCLUDE_SCREEN
+class Screen
+{
+  public:
+    enum FrameFocus : uint8_t {
+        FOCUS_DEFAULT,
+        FOCUS_PRESERVE,
+        FOCUS_FAULT,
+        FOCUS_TEXTMESSAGE,
+        FOCUS_MODULE,
+        FOCUS_CLOCK,
+        FOCUS_SYSTEM,
+    };
+
+    explicit Screen(){};
+    void setup() {}
+    void setOn(bool) {}
+    void doDeepSleep() {}
+    void showSimpleBanner(const char *message, uint32_t durationMs = 0) {}
+    void setFrames(FrameFocus focus) {}
+};
+} // namespace graphics
+
+inline bool shouldWakeOnReceivedMessage()
+{
+    return false;
+}

--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -14,7 +14,11 @@
 #include "NodeDB.h"
 #include "PowerMon.h"
 #include "configuration.h"
+#if !MESHTASTIC_EXCLUDE_SCREEN
 #include "graphics/Screen.h"
+#else
+#include "FakeScreen.h"
+#endif
 #include "main.h"
 #include "sleep.h"
 #include "target_specific.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,7 +28,11 @@
 #endif
 #include "detect/einkScan.h"
 #include "graphics/RAKled.h"
+#if !MESHTASTIC_EXCLUDE_SCREEN
 #include "graphics/Screen.h"
+#else
+#include "FakeScreen.h"
+#endif
 #include "main.h"
 #include "mesh/generated/meshtastic/config.pb.h"
 #include "meshUtils.h"
@@ -352,9 +356,11 @@ void setup()
     SPISettings spiSettings(4000000, MSBFIRST, SPI_MODE0);
 #endif
 
+#if !MESHTASTIC_EXCLUDE_SCREEN
     meshtastic_Config_DisplayConfig_OledType screen_model =
         meshtastic_Config_DisplayConfig_OledType::meshtastic_Config_DisplayConfig_OledType_OLED_AUTO;
     OLEDDISPLAY_GEOMETRY screen_geometry = GEOMETRY_128_64;
+#endif
 
 #ifdef USE_SEGGER
     auto mode = false ? SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL : SEGGER_RTT_MODE_NO_BLOCK_TRIM;
@@ -750,6 +756,7 @@ void setup()
     else
         playStartMelody();
 
+#if !MESHTASTIC_EXCLUDE_SCREEN
     // fixed screen override?
     if (config.display.oled != meshtastic_Config_DisplayConfig_OledType_OLED_AUTO)
         screen_model = config.display.oled;
@@ -762,6 +769,7 @@ void setup()
 #if defined(USE_SH1107_128_64)
     screen_model = meshtastic_Config_DisplayConfig_OledType_OLED_SH1107; // keep dimension of 128x64
 #endif
+#endif // MESHTASTIC_EXCLUDE_SCREEN
 
 #if !MESHTASTIC_EXCLUDE_I2C
 #if !defined(ARCH_STM32WL)

--- a/src/main.h
+++ b/src/main.h
@@ -5,7 +5,11 @@
 #include "NodeStatus.h"
 #include "PowerStatus.h"
 #include "detect/ScanI2C.h"
+#if !MESHTASTIC_EXCLUDE_SCREEN
 #include "graphics/Screen.h"
+#else
+#include "FakeScreen.h"
+#endif
 #include "memGet.h"
 #include "mesh/generated/meshtastic/config.pb.h"
 #include "mesh/generated/meshtastic/telemetry.pb.h"

--- a/src/modules/Telemetry/DeviceTelemetry.cpp
+++ b/src/modules/Telemetry/DeviceTelemetry.cpp
@@ -10,8 +10,10 @@
 #include "configuration.h"
 #include "main.h"
 #include "memGet.h"
+#if !MESHTASTIC_EXCLUDE_SCREEN
 #include <OLEDDisplay.h>
 #include <OLEDDisplayUi.h>
+#endif
 #include <meshUtils.h>
 
 #define MAGIC_USB_BATTERY_LEVEL 101

--- a/src/modules/Telemetry/DeviceTelemetry.h
+++ b/src/modules/Telemetry/DeviceTelemetry.h
@@ -2,8 +2,10 @@
 #include "../mesh/generated/meshtastic/telemetry.pb.h"
 #include "NodeDB.h"
 #include "ProtobufModule.h"
+#if !MESHTASTIC_EXCLUDE_SCREEN
 #include <OLEDDisplay.h>
 #include <OLEDDisplayUi.h>
+#endif
 
 class DeviceTelemetryModule : private concurrency::OSThread, public ProtobufModule<meshtastic_Telemetry>
 {

--- a/src/modules/TextMessageModule.cpp
+++ b/src/modules/TextMessageModule.cpp
@@ -4,7 +4,11 @@
 #include "PowerFSM.h"
 #include "buzz.h"
 #include "configuration.h"
+#if !MESHTASTIC_EXCLUDE_SCREEN
 #include "graphics/Screen.h"
+#else
+#include "FakeScreen.h"
+#endif
 TextMessageModule *textMessageModule;
 
 ProcessMessage TextMessageModule::handleReceived(const meshtastic_MeshPacket &mp)

--- a/src/modules/WaypointModule.cpp
+++ b/src/modules/WaypointModule.cpp
@@ -2,12 +2,12 @@
 #include "NodeDB.h"
 #include "PowerFSM.h"
 #include "configuration.h"
-#include "graphics/draw/CompassRenderer.h"
 
 #if HAS_SCREEN
 #include "gps/RTC.h"
 #include "graphics/Screen.h"
 #include "graphics/TimeFormatters.h"
+#include "graphics/draw/CompassRenderer.h"
 #include "graphics/draw/NodeListRenderer.h"
 #include "main.h"
 #endif

--- a/src/motion/MotionSensor.cpp
+++ b/src/motion/MotionSensor.cpp
@@ -1,7 +1,7 @@
 #include "MotionSensor.h"
-#include "graphics/draw/CompassRenderer.h"
 
 #if !defined(ARCH_STM32WL) && !MESHTASTIC_EXCLUDE_I2C
+#include "graphics/draw/CompassRenderer.h"
 
 char timeRemainingBuffer[12];
 


### PR DESCRIPTION
- Exclude `graphics` on STM32WL
- Split Meshtastic OLED library from base lib_deps to `screen_base` lib_deps
  - Include `screen_base` in arduino_base, and portduino.
- Use `MESHTASTIC_EXCLUDE_SCREEN` macro to exclude `<graphics/*.h> includes`
- Create minimal FakeScreen which does not rely on `OLEDDisplay.h`

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)

Builds correctly. Not yet tested on-device.

RAK3172
<img width="779" height="85" alt="image" src="https://github.com/user-attachments/assets/ee5d07ba-3b82-45ad-b9f7-1ac4041f02aa" />
