### PR TITLE
STM32: Properly ignore OneButton

### DIFF
--- a/arch/stm32/stm32.ini
+++ b/arch/stm32/stm32.ini
@@ -47,4 +47,4 @@ lib_deps =
   https://github.com/caveman99/Crypto/archive/eae9c768054118a9399690f8af202853d1ae8516.zip
 
 lib_ignore =
-  mathertel/OneButton@2.6.1
+  OneButton


### PR DESCRIPTION
Properly ignore OneButton on STM32 platform.

~This saves \~15% flash utilization.~ I got excited too quickly, this was a result of `-DDEBUG_MUTE`