### PR TITLE
Build: Update platformio with `pkg install`

### DIFF
--- a/bin/build-esp32.sh
+++ b/bin/build-esp32.sh
@@ -11,7 +11,7 @@ rm -f $OUTDIR/firmware*
 rm -r $OUTDIR/* || true
 
 # Important to pull latest version of libs into all device flavors, otherwise some devices might be stale
-platformio pkg update -e $1
+platformio pkg install -e $1
 
 echo "Building for $1 with $PLATFORMIO_BUILD_FLAGS"
 rm -f .pio/build/$1/firmware.*

--- a/bin/build-native.sh
+++ b/bin/build-native.sh
@@ -25,7 +25,7 @@ mkdir -p $OUTDIR/
 rm -r $OUTDIR/* || true
 
 # Important to pull latest version of libs into all device flavors, otherwise some devices might be stale
-pio pkg update --environment "$PIO_ENV" || platformioFailed
+pio pkg install --environment "$PIO_ENV" || platformioFailed
 pio run --environment "$PIO_ENV" || platformioFailed
 cp ".pio/build/$PIO_ENV/program" "$OUTDIR/meshtasticd_linux_$(uname -m)"
 cp bin/native-install.* $OUTDIR

--- a/bin/build-nrf52.sh
+++ b/bin/build-nrf52.sh
@@ -11,7 +11,7 @@ rm -f $OUTDIR/firmware*
 rm -r $OUTDIR/* || true
 
 # Important to pull latest version of libs into all device flavors, otherwise some devices might be stale
-platformio pkg update -e $1
+platformio pkg install -e $1
 
 echo "Building for $1 with $PLATFORMIO_BUILD_FLAGS"
 rm -f .pio/build/$1/firmware.*

--- a/bin/build-rp2xx0.sh
+++ b/bin/build-rp2xx0.sh
@@ -11,7 +11,7 @@ rm -f $OUTDIR/firmware*
 rm -r $OUTDIR/* || true
 
 # Important to pull latest version of libs into all device flavors, otherwise some devices might be stale
-platformio pkg update -e $1
+platformio pkg install -e $1
 
 echo "Building for $1 with $PLATFORMIO_BUILD_FLAGS"
 rm -f .pio/build/$1/firmware.*

--- a/bin/build-stm32wl.sh
+++ b/bin/build-stm32wl.sh
@@ -11,7 +11,7 @@ rm -f $OUTDIR/firmware*
 rm -r $OUTDIR/* || true
 
 # Important to pull latest version of libs into all device flavors, otherwise some devices might be stale
-platformio pkg update -e $1
+platformio pkg install -e $1
 
 echo "Building for $1 with $PLATFORMIO_BUILD_FLAGS"
 rm -f .pio/build/$1/firmware.*


### PR DESCRIPTION
Update platformio packages with `platformio pkg install` instead of `platformio pkg update`.

The `install` command updates packages in addition to **removing** any packages that have been removed since PlatformIO last updated dependencies. This is useful for our new container-based CI process.