### PR TITLE
Remove Ubuntu oracular

### DIFF
--- a/.github/workflows/daily_packaging.yml
+++ b/.github/workflows/daily_packaging.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        series: [plucky, oracular, noble, jammy]
+        series: [plucky, noble, jammy]
     uses: ./.github/workflows/package_ppa.yml
     with:
       ppa_repo: ppa:meshtastic/daily

--- a/.github/workflows/release_channels.yml
+++ b/.github/workflows/release_channels.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        series: [plucky, oracular, noble, jammy]
+        series: [plucky, noble, jammy]
     uses: ./.github/workflows/package_ppa.yml
     with:
       ppa_repo: |-


### PR DESCRIPTION
Ubuntu 24.10 `oracular` has been removed upstream (no longer builds in PPA).
Let's remove it from our CI.