### PR TITLE
Fix L1 EInk HWModel

### DIFF
--- a/src/platform/nrf52/architecture.h
+++ b/src/platform/nrf52/architecture.h
@@ -91,6 +91,8 @@
 #define HW_VENDOR meshtastic_HardwareModel_HELTEC_MESH_POCKET
 #elif defined(NOMADSTAR_METEOR_PRO)
 #define HW_VENDOR meshtastic_HardwareModel_NOMADSTAR_METEOR_PRO
+#elif defined(SEEED_WIO_TRACKER_L1_EINK)
+#define HW_VENDOR meshtastic_HardwareModel_SEEED_WIO_TRACKER_L1_EINK
 #elif defined(SEEED_WIO_TRACKER_L1)
 #define HW_VENDOR meshtastic_HardwareModel_SEEED_WIO_TRACKER_L1
 #else

--- a/variants/seeed_wio_tracker_L1_eink/platformio.ini
+++ b/variants/seeed_wio_tracker_L1_eink/platformio.ini
@@ -4,7 +4,8 @@ extends = nrf52840_base, inkhud
 ;board_level = extra
 build_flags = ${nrf52840_base.build_flags}  ${inkhud.build_flags}
   -I $PROJECT_DIR/variants/seeed_wio_tracker_L1_eink
-  -D  SEEED_WIO_TRACKER_L1
+  -D SEEED_WIO_TRACKER_L1_EINK
+  -D SEEED_WIO_TRACKER_L1
   -Isrc/platform/nrf52/softdevice -Isrc/platform/nrf52/softdevice/nrf52
 board_build.ldscript = src/platform/nrf52/nrf52840_s140_v7.ld
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/seeed_wio_tracker_L1_eink> ${inkhud.build_src_filter}


### PR DESCRIPTION
I think this is correct. We still need the L1 macro for some of the base level specific behavior but we need the specific HW_MODEL in architecture.h to be the correct one.
@Dylanliacc 