### PR TITLE
Actions: Enforce PR labels

### DIFF
--- a/.github/workflows/pr_enforce_labels.yml
+++ b/.github/workflows/pr_enforce_labels.yml
@@ -1,0 +1,24 @@
+name: Check PR Labels
+
+on:
+  pull_request:
+    types: [opened, edited, labeled, unlabeled, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  check-label:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check for PR labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(label => label.name);
+            const requiredLabels = ['bugfix', 'enhancement', 'hardware-support', 'dependencies', 'submodules', 'github_actions', 'trunk'];
+            const hasRequiredLabel = labels.some(label => requiredLabels.includes(label));
+            if (!hasRequiredLabel) {
+              core.setFailed(`PR must have at least one of the following labels before it can be merged: ${requiredLabels.join(', ')}.`);
+            }

--- a/.github/workflows/release_channels.yml
+++ b/.github/workflows/release_channels.yml
@@ -103,8 +103,9 @@ jobs:
         with:
           base: ${{ github.event.repository.default_branch }}
           branch: create-pull-request/bump-version
+          labels: github_actions
           title: Bump release version
-          commit-message: automated bumps
+          commit-message: Automated version bumps
           add-paths: |
             version.properties
             debian/changelog

--- a/.github/workflows/update_protobufs.yml
+++ b/.github/workflows/update_protobufs.yml
@@ -34,7 +34,9 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           branch: create-pull-request/update-protobufs
+          labels: submodules
           title: Update protobufs and classes
+          commit-message: Update protobufs
           add-paths: |
             protobufs
             src/mesh


### PR DESCRIPTION
No label, no merge!

PRs must include a label:
- bugfix
- enhancement
- hardware-support
- dependencies
- submodules
- github_actions
- trunk

Add this workflow to the branch protection rules as a requirement, and you're off to the races.