### PR TITLE
Add BR_902, Brazil 902MHz-907.5MHz

### DIFF
--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -67,6 +67,7 @@ const RegionInfo regions[] = {
     /*
         https://www.iot.org.au/wp/wp-content/uploads/2016/12/IoTSpectrumFactSheet.pdf
         https://iotalliance.org.nz/wp-content/uploads/sites/4/2019/05/IoT-Spectrum-in-NZ-Briefing-Paper.pdf
+        Also used in Brazil.
      */
     RDEF(ANZ, 915.0f, 928.0f, 100, 0, 30, true, false, false),
 
@@ -168,6 +169,13 @@ const RegionInfo regions[] = {
                                 https://github.com/meshtastic/firmware/issues/7204
     */
     RDEF(KZ_433, 433.075f, 434.775f, 100, 0, 10, true, false, false), RDEF(KZ_863, 863.0f, 868.0f, 100, 0, 30, true, false, true),
+
+    /*
+        Brazil
+        902 - 907.5 MHz , 1W power limit, no duty cycle restrictions
+        https://github.com/meshtastic/firmware/issues/3741
+    */
+    RDEF(BR_902, 902.0f, 907.5f, 100, 0, 30, true, false, false),
 
     /*
        2.4 GHZ WLAN Band equivalent. Only for SX128x chips.


### PR DESCRIPTION
As reported by @barbabarros , the Brazilian government has specific support for LoRA[1] across multiple frequencies[2][3].

We currently support Brazil through the ANZ/AU915 band. However, Brazil also has another frequency available for use:

902 - 907.5 MHz , 1W power limit, no duty cycle restrictions


[1]  https://sistemas.anatel.gov.br/anexar-api/publico/anexos/download/a028ab5cc4e3f97442830bba0c8bd1dd  [2] 
https://informacoes.anatel.gov.br/legislacao/resolucoes/2025/2001-resolucao-772  [3] https://informacoes.anatel.gov.br/legislacao/atos-de-certificacao-de-produtos/2017/1139-ato-14448#item10

Protobuf patch: https://github.com/meshtastic/protobufs/pull/737

Fixes https://github.com/meshtastic/firmware/issues/3741
