### PR TITLE
Airoha GPS - ignore estimated fixes

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1511,7 +1511,7 @@ bool GPS::lookForTime()
 
 #ifdef GNSS_AIROHA
     uint8_t fix = reader.fixQuality();
-    if (fix > 0) {
+    if (fix >= 1 && fix <= 5) {
         if (lastFixStartMsec > 0) {
             if (Throttle::isWithinTimespanMs(lastFixStartMsec, GPS_FIX_HOLD_TIME)) {
                 return false;
@@ -1566,7 +1566,7 @@ bool GPS::lookForLocation()
 #ifdef GNSS_AIROHA
     if ((config.position.gps_update_interval * 1000) >= (GPS_FIX_HOLD_TIME * 2)) {
         uint8_t fix = reader.fixQuality();
-        if (fix > 0) {
+        if (fix >= 1 && fix <= 5) {
             if (lastFixStartMsec > 0) {
                 if (Throttle::isWithinTimespanMs(lastFixStartMsec, GPS_FIX_HOLD_TIME)) {
                     return false;


### PR DESCRIPTION
TinyGPS Fix Quality has this information:
				0 - fix not available,
				1 - GPS fix,
				2 - Differential GPS fix (values above 2 are 2.3 features)
				3 = PPS fix
				4 = Real Time Kinematic
				5 = Float RTK
				6 = estimated (dead reckoning)
				7 = Manual input mode
				8 = Simulation mode

the previous Airoha code would allow quality >0 , which includes estimated positions. These wouldn't be passed through to the mesh due to other checks, but would affect the Airoha GPS_FIX_HOLD_TIME calculations.

Changes the calculation to 1 >= quality <=5 .

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [x] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
