### PR TITLE
Fix number of options in TZPicker

### DIFF
--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -167,7 +167,7 @@ void menuHandler::TZPicker()
     BannerOverlayOptions bannerOptions;
     bannerOptions.message = "Pick Timezone";
     bannerOptions.optionsArrayPtr = optionsArray;
-    bannerOptions.optionsCount = 17;
+    bannerOptions.optionsCount = 18;
     bannerOptions.bannerCallback = [](int selected) -> void {
         if (selected == 0) {
             menuHandler::menuQueue = menuHandler::clock_menu;


### PR DESCRIPTION
This pull request updates the `TZPicker` method in `MenuHandler.cpp` to accommodate the Pacific/NZ timezone option (was not showing).

* **Timezone Picker Update**:
  * [`src/graphics/draw/MenuHandler.cpp`](diffhunk://#diff-42b779fbaf784d6b09c1770397a59db686044c519108888f421651113995f1a7L170-R170): Increased the `optionsCount` for the timezone picker from 17 to 18 to reflect the addition of the Pacific/NZ timezone option.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
