### PR TITLE
Build RP2350 (Pi Pico 2)

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -30,7 +30,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [esp32, esp32s3, esp32c3, esp32c6, nrf52840, rp2040, stm32, check]
+        arch:
+          - esp32
+          - esp32s3
+          - esp32c3
+          - esp32c6
+          - nrf52840
+          - rp2040
+          - rp2350
+          - stm32
+          - check
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -56,6 +65,7 @@ jobs:
       esp32c6: ${{ steps.jsonStep.outputs.esp32c6 }}
       nrf52840: ${{ steps.jsonStep.outputs.nrf52840 }}
       rp2040: ${{ steps.jsonStep.outputs.rp2040 }}
+      rp2350: ${{ steps.jsonStep.outputs.rp2350 }}
       stm32: ${{ steps.jsonStep.outputs.stm32 }}
       check: ${{ steps.jsonStep.outputs.check }}
 
@@ -145,7 +155,7 @@ jobs:
       pio_env: ${{ matrix.board }}
       platform: nrf52840
 
-  build-rpi2040:
+  build-rp2040:
     needs: [setup, version]
     strategy:
       fail-fast: false
@@ -155,6 +165,17 @@ jobs:
       version: ${{ needs.version.outputs.long }}
       pio_env: ${{ matrix.board }}
       platform: rp2040
+
+  build-rp2350:
+    needs: [setup, version]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.rp2350) }}
+    uses: ./.github/workflows/build_firmware.yml
+    with:
+      version: ${{ needs.version.outputs.long }}
+      pio_env: ${{ matrix.board }}
+      platform: rp2350
 
   build-stm32:
     needs: [setup, version]
@@ -243,7 +264,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [esp32, esp32s3, esp32c3, esp32c6, nrf52840, rp2040, stm32]
+        arch:
+          - esp32
+          - esp32s3
+          - esp32c3
+          - esp32c6
+          - nrf52840
+          - rp2040
+          - rp2350
+          - stm32
     runs-on: ubuntu-latest
     needs:
       [
@@ -253,7 +282,8 @@ jobs:
         build-esp32c3,
         build-esp32c6,
         build-nrf52840,
-        build-rpi2040,
+        build-rp2040,
+        build-rp2350,
         build-stm32,
       ]
     steps:
@@ -392,7 +422,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [esp32, esp32s3, esp32c3, esp32c6, nrf52840, rp2040, stm32]
+        arch:
+          - esp32
+          - esp32s3
+          - esp32c3
+          - esp32c6
+          - nrf52840
+          - rp2040
+          - rp2350
+          - stm32
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' }}
     needs: [release-artifacts, version]
@@ -449,7 +487,8 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' }}
     needs: [release-firmware, version]
     env:
-      targets: esp32,esp32s3,esp32c3,esp32c6,nrf52840,rp2040,stm32
+      targets: |-
+        esp32,esp32s3,esp32c3,esp32c6,nrf52840,rp2040,rp2350,stm32
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/bin/build-firmware.sh
+++ b/bin/build-firmware.sh
@@ -11,7 +11,7 @@ elif (echo $2 | grep -q "nrf52"); then
 elif (echo $2 | grep -q "stm32"); then
   bin/build-stm32.sh $1
 elif (echo $2 | grep -q "rpi2040"); then
-  bin/build-rpi2040.sh $1
+  bin/build-rp2xx0.sh $1
 else
   echo "Unknown target $2"
   exit 1

--- a/variants/rp2040/rpipicow/platformio.ini
+++ b/variants/rp2040/rpipicow/platformio.ini
@@ -2,6 +2,7 @@
 extends = rp2040_base
 board = rpipicow
 board_level = pr
+board_check = true
 upload_protocol = picotool
 # add our variants files to the include and src paths
 build_flags = 

--- a/variants/rp2350/rpipico2w/platformio.ini
+++ b/variants/rp2350/rpipico2w/platformio.ini
@@ -2,6 +2,7 @@
 extends = rp2350_base
 board = rpipico2w
 board_level = pr
+board_check = true
 upload_protocol = jlink
 # debug settings for external openocd with RP2040 support (custom build)
 debug_tool = custom


### PR DESCRIPTION
Meshtastic has supported the `rp2350` platform for a while now, let's build it in CI!

This change will result in 2 additional builds (upon PR and upon release)
- `pico2`
- `pico2w`

Additionally, adds `check` jobs for `picow` and `pico2w`, currently there are no rp2040/rp2350 boards with `board_check` defined :astonished: 