### PR TITLE
Fix timezone definition for UTC in TZPicker function

### DIFF
--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -187,7 +187,7 @@ void menuHandler::TZPicker()
         } else if (selected == 7) { // Eastern
             strncpy(config.device.tzdef, "EST5EDT,M3.2.0,M11.1.0", sizeof(config.device.tzdef));
         } else if (selected == 8) { // UTC
-            strncpy(config.device.tzdef, "UTC", sizeof(config.device.tzdef));
+            strncpy(config.device.tzdef, "UTC0", sizeof(config.device.tzdef));
         } else if (selected == 9) { // EU/Western
             strncpy(config.device.tzdef, "GMT0BST,M3.5.0/1,M10.5.0", sizeof(config.device.tzdef));
         } else if (selected == 10) { // EU/Central


### PR DESCRIPTION
This pull request includes a minor update to the `TZPicker` method in the `MenuHandler` class to ensure proper timezone definitions.

Timezone definition update:

* [`src/graphics/draw/MenuHandler.cpp`](diffhunk://#diff-42b779fbaf784d6b09c1770397a59db686044c519108888f421651113995f1a7L190-R190): Updated the timezone definition for UTC from `"UTC"` to `"UTC0"` to align with standard timezone formatting.
* This way, the schedule is updated as soon as it changes. There is no need to reset the device.

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [X] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
