### PR TITLE
Take control of our PRs!

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -45,7 +45,7 @@ jobs:
           if [[ "$GITHUB_HEAD_REF" == "" ]]; then
             TARGETS=$(./bin/generate_ci_matrix.py ${{matrix.arch}})
           else  
-            TARGETS=$(./bin/generate_ci_matrix.py ${{matrix.arch}} quick)
+            TARGETS=$(./bin/generate_ci_matrix.py ${{matrix.arch}} pr)
           fi
           echo "Name: $GITHUB_REF_NAME Base: $GITHUB_BASE_REF Ref: $GITHUB_REF Targets: $TARGETS"
           echo "${{matrix.arch}}=$(jq -cn --argjson environments "$TARGETS" '{board: $environments}')" >> $GITHUB_OUTPUT

--- a/bin/generate_ci_matrix.py
+++ b/bin/generate_ci_matrix.py
@@ -45,24 +45,28 @@ for pio_env in pio_envs:
   all_envs.append(env)
 
 # Filter outputs based on options
-# Check is currently mutually exclusive with other options
+# Check is mutually exclusive with other options (except 'pr')
 if "check" in options:
   for env in all_envs:
     if env['board_check']:
-      outlist.append(env['name'])
+      if "pr" in options:
+        if env['board_level'] == 'pr':
+          outlist.append(env['name'])
+      else:
+        outlist.append(env['name'])
 # Filter (non-check) builds by platform
 else:
   for env in all_envs:
     if options[0] == env['platform']:
-      # If no board level is specified, always include it
-      if not env['board_level']:
+      # Always include board_level = 'pr'
+      if env['board_level'] == 'pr':
         outlist.append(env['name'])
-      # Include `extra` boards when requested
+      # Include board_level = 'extra' when requested
       elif "extra" in options and env['board_level'] == "extra":
+        outlist.append(env['name'])
+      # If no board level is specified, include in release builds (not PR)
+      elif "pr" not in options and not env['board_level']:
         outlist.append(env['name'])
 
 # Return as a JSON list
-if ("quick" in options) and (len(outlist) > 3):
-    print(json.dumps(random.sample(outlist, 3)))
-else:
-    print(json.dumps(outlist))
+print(json.dumps(outlist))

--- a/variants/esp32/rak11200/platformio.ini
+++ b/variants/esp32/rak11200/platformio.ini
@@ -1,6 +1,7 @@
 [env:rak11200]
 extends = esp32_base
 board = wiscore_rak11200
+board_level = pr
 board_check = true
 build_flags = 
   ${esp32_base.build_flags}

--- a/variants/esp32/tbeam/platformio.ini
+++ b/variants/esp32/tbeam/platformio.ini
@@ -2,6 +2,7 @@
 [env:tbeam]
 extends = esp32_base
 board = ttgo-t-beam
+board_level = pr
 board_check = true
 lib_deps =
   ${esp32_base.lib_deps}

--- a/variants/esp32c3/heltec_esp32c3/platformio.ini
+++ b/variants/esp32c3/heltec_esp32c3/platformio.ini
@@ -1,6 +1,7 @@
 [env:heltec-ht62-esp32c3-sx1262]
 extends = esp32c3_base
 board = esp32-c3-devkitm-1
+board_level = pr
 build_flags = 
   ${esp32_base.build_flags}
   -D HELTEC_HT62

--- a/variants/esp32c6/tlora_c6/platformio.ini
+++ b/variants/esp32c6/tlora_c6/platformio.ini
@@ -1,6 +1,7 @@
 [env:tlora-c6]
 extends = esp32c6_base
 board = esp32-c6-devkitm-1
+board_level = pr
 build_flags = 
   ${esp32c6_base.build_flags}
   -D TLORA_C6

--- a/variants/esp32s3/elecrow_panel/platformio.ini
+++ b/variants/esp32s3/elecrow_panel/platformio.ini
@@ -98,6 +98,7 @@ build_flags =
 
 [env:elecrow-adv-35-tft]
 extends = crowpanel_small_esp32s3_base
+board_level = pr
 build_flags =
   ${crowpanel_small_esp32s3_base.build_flags}
   -D LV_CACHE_DEF_SIZE=2097152

--- a/variants/esp32s3/heltec_v3/platformio.ini
+++ b/variants/esp32s3/heltec_v3/platformio.ini
@@ -1,6 +1,7 @@
 [env:heltec-v3] 
 extends = esp32s3_base
 board = heltec_wifi_lora_32_V3
+board_level = pr
 board_check = true
 board_build.partitions = default_8MB.csv
 build_flags = 

--- a/variants/esp32s3/heltec_vision_master_e213/platformio.ini
+++ b/variants/esp32s3/heltec_vision_master_e213/platformio.ini
@@ -24,6 +24,7 @@ upload_speed = 115200
 [env:heltec-vision-master-e213-inkhud]
 extends = esp32s3_base, inkhud
 board = heltec_vision_master_e213
+board_level = pr
 board_build.partitions = default_8MB.csv
 build_src_filter =
   ${esp32_base.build_src_filter}

--- a/variants/esp32s3/rak3312/platformio.ini
+++ b/variants/esp32s3/rak3312/platformio.ini
@@ -1,6 +1,7 @@
 [env:rak3312]
 extends = esp32s3_base
 board = wiscore_rak3312
+board_level = pr
 board_check = true
 upload_protocol = esptool
 

--- a/variants/esp32s3/seeed-sensecap-indicator/platformio.ini
+++ b/variants/esp32s3/seeed-sensecap-indicator/platformio.ini
@@ -31,7 +31,7 @@ lib_deps = ${esp32s3_base.lib_deps}
 
 [env:seeed-sensecap-indicator-tft]
 extends = env:seeed-sensecap-indicator
-board_level = main
+board_level = pr
 upload_speed = 460800
 
 build_flags =

--- a/variants/esp32s3/seeed_xiao_s3/platformio.ini
+++ b/variants/esp32s3/seeed_xiao_s3/platformio.ini
@@ -1,6 +1,7 @@
 [env:seeed-xiao-s3]
 extends = esp32s3_base
 board = seeed-xiao-s3
+board_level = pr
 board_check = true
 board_build.partitions = default_8MB.csv
 upload_protocol = esptool

--- a/variants/esp32s3/station-g2/platformio.ini
+++ b/variants/esp32s3/station-g2/platformio.ini
@@ -1,6 +1,7 @@
 [env:station-g2]
 extends = esp32s3_base
 board = station-g2
+board_level = pr
 board_check = true
 board_build.partitions = default_16MB.csv
 board_build.mcu = esp32s3

--- a/variants/esp32s3/t-deck/platformio.ini
+++ b/variants/esp32s3/t-deck/platformio.ini
@@ -19,6 +19,7 @@ lib_deps = ${esp32s3_base.lib_deps}
 
 [env:t-deck-tft]
 extends = env:t-deck
+board_level = pr
 
 build_flags =
   ${env:t-deck.build_flags}

--- a/variants/esp32s3/t-eth-elite/platformio.ini
+++ b/variants/esp32s3/t-eth-elite/platformio.ini
@@ -1,6 +1,7 @@
 [env:t-eth-elite]
 extends = esp32s3_base
 board = esp32s3box
+board_level = pr
 board_check = true
 board_build.partitions = default_16MB.csv
 build_flags = 

--- a/variants/nrf52840/heltec_mesh_node_t114/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_node_t114/platformio.ini
@@ -2,6 +2,7 @@
 [env:heltec-mesh-node-t114]
 extends = nrf52840_base
 board = heltec_mesh_node_t114
+board_level = pr
 debug_tool = jlink
 
 # add -DCFG_SYSVIEW if you want to use the Segger systemview tool for OS profiling.

--- a/variants/nrf52840/rak4631/platformio.ini
+++ b/variants/nrf52840/rak4631/platformio.ini
@@ -2,6 +2,7 @@
 [env:rak4631]
 extends = nrf52840_base
 board = wiscore_rak4631
+board_level = pr
 board_check = true
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/rak4631

--- a/variants/nrf52840/seeed_xiao_nrf52840_kit/platformio.ini
+++ b/variants/nrf52840/seeed_xiao_nrf52840_kit/platformio.ini
@@ -2,6 +2,7 @@
 [env:seeed_xiao_nrf52840_kit]
 extends = nrf52840_base
 board = xiao_ble_sense
+board_level = pr
 build_flags = ${nrf52840_base.build_flags}
   -Ivariants/nrf52840/seeed_xiao_nrf52840_kit
   -Isrc/platform/nrf52/softdevice

--- a/variants/nrf52840/t-echo/platformio.ini
+++ b/variants/nrf52840/t-echo/platformio.ini
@@ -2,6 +2,7 @@
 [env:t-echo]
 extends = nrf52840_base
 board = t-echo
+board_level = pr
 board_check = true
 debug_tool = jlink
 
@@ -27,6 +28,7 @@ lib_deps =
 [env:t-echo-inkhud]
 extends = nrf52840_base, inkhud
 board = t-echo
+board_level = pr
 board_check = true
 debug_tool = jlink
 build_flags = 

--- a/variants/nrf52840/tracker-t1000-e/platformio.ini
+++ b/variants/nrf52840/tracker-t1000-e/platformio.ini
@@ -1,6 +1,7 @@
 [env:tracker-t1000-e]
 extends = nrf52840_base
 board = tracker-t1000-e
+board_level = pr
 build_flags = ${nrf52840_base.build_flags}
   -Ivariants/nrf52840/tracker-t1000-e
   -Isrc/platform/nrf52/softdevice

--- a/variants/rp2040/rak11310/platformio.ini
+++ b/variants/rp2040/rak11310/platformio.ini
@@ -1,6 +1,7 @@
 [env:rak11310]
 extends = rp2040_base
 board = rakwireless_rak11300
+board_level = pr
 upload_protocol = picotool
 # add our variants files to the include and src paths
 build_flags = 

--- a/variants/rp2040/rpipico/platformio.ini
+++ b/variants/rp2040/rpipico/platformio.ini
@@ -1,6 +1,7 @@
 [env:pico]
 extends = rp2040_base
 board = rpipico
+board_level = pr
 upload_protocol = picotool
 
 # add our variants files to the include and src paths

--- a/variants/rp2040/rpipicow/platformio.ini
+++ b/variants/rp2040/rpipicow/platformio.ini
@@ -1,6 +1,7 @@
 [env:picow]
 extends = rp2040_base
 board = rpipicow
+board_level = pr
 upload_protocol = picotool
 # add our variants files to the include and src paths
 build_flags = 

--- a/variants/rp2350/rpipico2/platformio.ini
+++ b/variants/rp2350/rpipico2/platformio.ini
@@ -1,6 +1,7 @@
 [env:pico2]
 extends = rp2350_base
 board = rpipico2
+board_level = pr
 upload_protocol = picotool
 
 # add our variants files to the include and src paths

--- a/variants/rp2350/rpipico2w/platformio.ini
+++ b/variants/rp2350/rpipico2w/platformio.ini
@@ -1,6 +1,7 @@
 [env:pico2w]
 extends = rp2350_base
 board = rpipico2w
+board_level = pr
 upload_protocol = jlink
 # debug settings for external openocd with RP2040 support (custom build)
 debug_tool = custom

--- a/variants/stm32/rak3172/platformio.ini
+++ b/variants/stm32/rak3172/platformio.ini
@@ -1,6 +1,7 @@
 [env:rak3172]
 extends = stm32_base
 board = wiscore_rak3172
+board_level = pr
 board_upload.maximum_size = 233472 ; reserve the last 28KB for filesystem
 build_flags =
   ${stm32_base.build_flags}

--- a/variants/stm32/wio-e5/platformio.ini
+++ b/variants/stm32/wio-e5/platformio.ini
@@ -1,6 +1,7 @@
 [env:wio-e5]
 extends = stm32_base
 board = lora_e5_dev_board
+board_level = pr
 board_upload.maximum_size = 233472 ; reserve the last 28KB for filesystem
 build_flags =
   ${stm32_base.build_flags}


### PR DESCRIPTION
Adds `board_level` **pr** PlatformIO env option.

Tag a platformio environment with `board_level = pr` and it will always be built on each PR. This replaces our current behavior of randomly selecting envs.

**check** jobs now run on PR for every env where `board_level = pr` and `board_check = true`.

### Regarding changes in `variants/`
I tried to choose some variety here (inkhud, tft, platforms with interesting hardware, etc). Suggestions welcomed!