### PR TITLE
Add Viet Nam regions VN_433 & VN_923

### DIFF
--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -186,6 +186,17 @@ const RegionInfo regions[] = {
     RDEF(BR_902, 902.0f, 907.5f, 100, 0, 30, true, false, false),
 
     /*
+        Viet Nam
+        Main document:
+        https://datafiles.chinhphu.vn/cpp/files/vbpq/2021/10/08-btttt.signed.pdf
+            Item 39: 433.05 - 434.79 MHz <= 25 mW ERP
+            Item 45: 920 - 923 MHz <= 25 mW ERP
+            Gateways: 10% maximum duty cycle
+    */
+    RDEF(VN_433, 433.05f, 434.79f, 10, 0, 14, true, false, false),
+    RDEF(VN_923, 920.0f, 923.0f, 10, 0, 14, true, false, false),
+
+    /*
        2.4 GHZ WLAN Band equivalent. Only for SX128x chips.
     */
     RDEF(LORA_24, 2400.0f, 2483.5f, 100, 0, 10, true, false, true),


### PR DESCRIPTION
Hijacking [firmware #7357](https://github.com/meshtastic/firmware/pull/7357) to add VN_433 and VN_923 for Viet Nam.

Full document: https://datafiles.chinhphu.vn/cpp/files/vbpq/2021/10/08-btttt.signed.pdf

In Appendix 2 (Page 16), accepted frequencies by the Vietnamese government are:
- Item 39: 433.05–434.79 MHz ≤25 mW ERP @ 10% duty cycle
- Item 45: 920–923 MHz ≤25 mW ERP @ 10% duty cycle

In Appendix 19 (Page 48):
- Gateways: 10% maximum duty cycle

Since Meshtastic retransmits and stores-forwards packets, we apply the 10% duty cycle cap.

Will link the protobuf PR here later.
