### PR TITLE
fix(nrf52): Add button wake-up support for T-1000-E tracker in deep sleep

### DIFF
--- a/src/platform/nrf52/main-nrf52.cpp
+++ b/src/platform/nrf52/main-nrf52.cpp
@@ -378,6 +378,14 @@ void cpuDeepSleep(uint32_t msecToWake)
         nrf_gpio_cfg_sense_set(PIN_BUTTON2, sense1);
 #endif
 
+#ifdef TRACKER_T1000_E
+        // Configure button wake-up for T-1000-E
+        // T-1000-E: BUTTON_ACTIVE_LOW=false (active high), BUTTON_ACTIVE_PULLUP=false (uses pulldown)
+        nrf_gpio_cfg_input(BUTTON_PIN, NRF_GPIO_PIN_PULLDOWN);
+        nrf_gpio_pin_sense_t sense_t1000e = NRF_GPIO_PIN_SENSE_HIGH;
+        nrf_gpio_cfg_sense_set(BUTTON_PIN, sense_t1000e);
+#endif
+
         auto ok = sd_power_system_off();
         if (ok != NRF_SUCCESS) {
             LOG_ERROR("FIXME: Ignoring soft device (EasyDMA pending?) and forcing system-off!");


### PR DESCRIPTION
## Problem
T-1000-E tracker devices enter deep sleep mode when configured with device role "Tracker" and power saving enabled, but button presses have no effect during deep sleep. Users cannot wake the device or send GPS location updates when the device is sleeping.

## Solution
- Configure GPIO P0.06 (BUTTON_PIN) for wake-up from NRF52 system-off mode
- Use pulldown resistor and sense high to match T-1000-E button electrical design  
- T-1000-E button is active high, different from other NRF52 devices like ELECROW
- Follows the same pattern as existing ELECROW_ThinkNode_M1 wake configuration

## Changes
- Added `#ifdef TRACKER_T1000_E` block in `cpuDeepSleep()` function in `src/platform/nrf52/main-nrf52.cpp`
- Configured button GPIO with `NRF_GPIO_PIN_PULLDOWN` and `NRF_GPIO_PIN_SENSE_HIGH`
- Matches T-1000-E hardware specification: `BUTTON_ACTIVE_LOW=false`, uses pulldown resistor

## Hardware Details
- **Device:** T-1000-E (Seeed Studio tracker)
- **Button Pin:** P0.06 (GPIO 6) 
- **Configuration:** Active high, pulldown resistor
- **Wake Condition:** Button press should wake device from deep sleep

## Testing
- [x] Verified GPIO constants match Nordic SDK requirements
- [x] Confirmed electrical configuration matches T-1000-E variant.h definitions
- [ ] Tested button wake functionality on T-1000-E hardware
- [ ] Confirmed normal button operation still works during wake state
- [ ] Tested tracker mode with power saving enabled

Resolves button functionality for T-1000-E devices when in tracker mode with power saving enabled.