### PR TITLE
Only send Neighbours if we have some to send.

### DIFF
--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -112,8 +112,8 @@ void NeighborInfoModule::sendNeighborInfo(NodeNum dest, bool wantReplies)
     // only send neighbours if we have some to send
     if (neighborInfo.neighbors_count > 0) {
         printNeighborInfo("SENDING", &neighborInfo);
+        service->sendToMesh(p, RX_SRC_LOCAL, true);
     }
-    service->sendToMesh(p, RX_SRC_LOCAL, true);
 }
 
 /*

--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -106,12 +106,13 @@ void NeighborInfoModule::sendNeighborInfo(NodeNum dest, bool wantReplies)
     meshtastic_NeighborInfo neighborInfo = meshtastic_NeighborInfo_init_zero;
     collectNeighborInfo(&neighborInfo);
     meshtastic_MeshPacket *p = allocDataProtobuf(neighborInfo);
-    // send regardless of whether or not we have neighbors in our DB,
-    // because we want to get neighbors for the next cycle
     p->to = dest;
     p->decoded.want_response = wantReplies;
     p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
-    printNeighborInfo("SENDING", &neighborInfo);
+    // only send neighbours if we have some to send
+    if (neighborInfo.neighbors_count > 0) {
+        printNeighborInfo("SENDING", &neighborInfo);
+    }
     service->sendToMesh(p, RX_SRC_LOCAL, true);
 }
 

--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -105,12 +105,12 @@ void NeighborInfoModule::sendNeighborInfo(NodeNum dest, bool wantReplies)
 {
     meshtastic_NeighborInfo neighborInfo = meshtastic_NeighborInfo_init_zero;
     collectNeighborInfo(&neighborInfo);
-    meshtastic_MeshPacket *p = allocDataProtobuf(neighborInfo);
-    p->to = dest;
-    p->decoded.want_response = wantReplies;
-    p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
     // only send neighbours if we have some to send
     if (neighborInfo.neighbors_count > 0) {
+        meshtastic_MeshPacket *p = allocDataProtobuf(neighborInfo);
+        p->to = dest;
+        p->decoded.want_response = wantReplies;
+        p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
         printNeighborInfo("SENDING", &neighborInfo);
         service->sendToMesh(p, RX_SRC_LOCAL, true);
     }


### PR DESCRIPTION
The original intent of NeighborInfo was that when a NeighbourInfo was sent all of the nodes that saw it would reply with NeighbourInfo. So, NeighbourInfo was sent even if there were no hop-zero nodes in the NodeDB.

Since 2023, when this was implemented, our understanding of running city-wide meshes has improved substantially. We have taken steps to reduce the impact of NeighborInfo over LoRa.

This change aligns with those ideas: we will now only send NeighborInfo if we have some neighbors to contribute.

The impact of this change is that a node must first see another directly connected node in another packet type before NeighborInfo is sent. Nodes will, however, receive the regular periodic broadcast of NeighborInfo, and will be able to send NeighborInfo if it has at least 1 neighbor.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
