### PR TITLE
Enable S&F on any channel

### DIFF
--- a/readmejp.md
+++ b/readmejp.md
@@ -1,0 +1,29 @@
+## Setup env
+python3 -m venv venv     
+source venv/bin/activate   
+
+## Test on device
+
+### Station G2
+1. Enable Serial Debug:
+# Edit variants/esp32s3/station-g2/platformio.ini line 22:
+# Change: -DARDUINO_USB_MODE=0  
+# To:     -DARDUINO_USB_MODE=1
+2. Rebuild and Flash:
+pio run -e station-g2 -t upload
+3. Connect Serial:
+pio device monitor --baud 115200
+  
+
+### Heltec v3
+
+pio run -e heltec-v3 -t upload
+
+pio device monitor --baud 115200
+
+## If protobufs need updating 
+pip install protobuf grpcio-tools
+
+cd protobufs
+protoc --experimental_allow_proto3_optional --plugin=protoc-gen-nanopb=../.pio/libdeps/station-g2/Nanopb/generator/protoc-gen-nanopb --nanopb_out="-S.cpp
+  -v:../src/mesh/generated/" -I=../protobufs meshtastic/module_config.proto

--- a/src/modules/StoreForwardModule.cpp
+++ b/src/modules/StoreForwardModule.cpp
@@ -339,7 +339,7 @@ void StoreForwardModule::sendErrorTextMessage(NodeNum dest, bool want_response)
     if (this->busy) {
         str = "S&F - Busy. Try again shortly.";
     } else {
-        str = "S&F not permitted on the public channel.";
+        str = "Something went wrong with S&F on this custom firmware.";
     }
     LOG_WARN("%s", str);
     memcpy(pr->decoded.payload.bytes, str, strlen(str));
@@ -392,7 +392,8 @@ ProcessMessage StoreForwardModule::handleReceived(const meshtastic_MeshPacket &m
                 LOG_DEBUG("Legacy Request to send");
 
                 // Send the last 60 minutes of messages.
-                if (this->busy || channels.isDefaultChannel(mp.channel)) {
+                // if (this->busy || channels.isDefaultChannel(mp.channel)) {
+                if (this->busy) {
                     sendErrorTextMessage(getFrom(&mp), mp.decoded.want_response);
                 } else {
                     storeForwardModule->historySend(historyReturnWindow * 60, getFrom(&mp));
@@ -457,7 +458,8 @@ bool StoreForwardModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp,
             requests_history++;
             LOG_INFO("Client Request to send HISTORY");
             // Send the last 60 minutes of messages.
-            if (this->busy || channels.isDefaultChannel(mp.channel)) {
+            // if (this->busy || channels.isDefaultChannel(mp.channel)) {
+            if (this->busy) {
                 sendErrorTextMessage(getFrom(&mp), mp.decoded.want_response);
             } else {
                 if ((p->which_variant == meshtastic_StoreAndForward_history_tag) && (p->variant.history.window > 0)) {


### PR DESCRIPTION
Hello,

This is more of a question than an immediate PR for merging, but I thought it would be easier to show what I'm talking about.

I have a Station G2 that I want to permanently advertise on the mesh maps to help with adoption in my area. Therefore, I need channel 0 to be the default public channel on it as there's no way around that hardcoded limitation (I've tried).

Yet when I set up S&F, whenever I do testing (latest alpha firmware) with a private channel 1 shared across my devices, whenever they come back into range messages are not automatically sent to them that they missed. If I message the station node with "SF", I get back a reply: "S&F not permitted on the public channel."

That seems to render S&F unusable? Why?

By removing the checks as in my code below, I can have exactly this setup. Channel 0 reports the station on the maps, channel 1 is my private S&F shared with other devices.

Please help me understand if I'm missing something or if the current limitation with S&F is there for some other reason.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [x] Seeed Studio T-1000E tracker card
  - [x] Station G2
