### PR TITLE
feat: event mode - limit smart position updates to at most every 5m

### DIFF
--- a/src/modules/PositionModule.h
+++ b/src/modules/PositionModule.h
@@ -65,8 +65,15 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
     bool hasGPS();
     uint32_t lastSentReply = 0; // Last time we sent a position reply (used for reply throttling only)
 
+#if USERPREFS_EVENT_MODE
+    // In event mode we want to prevent excessive position broadcasts
+    // we set the minimum interval to 5m
+    const uint32_t minimumTimeThreshold =
+        max(600, Default::getConfiguredOrDefaultMs(config.position.broadcast_smart_minimum_interval_secs, 30));
+#else
     const uint32_t minimumTimeThreshold =
         Default::getConfiguredOrDefaultMs(config.position.broadcast_smart_minimum_interval_secs, 30);
+#endif
 };
 
 struct SmartPosition {


### PR DESCRIPTION
**Summary**
Update builds to limit smart position updates using a hardcoded config limit of 5m (300s)


**Background**
We are working on some changes for Meshtastic that help it scale to 1000s of nodes. One of those changes is to enforce a minimum interval for position broadcasts.

Fixed interval metric broadcasts are already covered by different code paths that use `congestionScalingCoefficient` which would be applying a scaling factor based on online nodes.

This PR will cover smart position updates, which currently did not depend on any mesh conditions as scaling factors.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
