### PR TITLE
Move BLE toggle menu option and add confirmation for canned messages in L1

### DIFF
--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -27,7 +27,6 @@ bool test_enabled = false;
 uint8_t test_count = 0;
 
 void menuHandler::LoraRegionPicker(uint32_t duration)
-// ...existing code...
 {
     static const char *optionsArray[] = {"Back",
                                          "US",
@@ -356,11 +355,7 @@ void menuHandler::homeBaseMenu()
             InputEvent event = {.inputEvent = (input_broker_event)INPUT_BROKER_SEND_PING, .kbchar = 0, .touchX = 0, .touchY = 0};
             inputBroker->injectInputEvent(&event);
         } else if (selected == Preset) {
-#if CANNED_MESSAGE_ADD_CONFIRMATION
-            showConfirmationBanner("Send message?", [] { cannedMessageModule->LaunchWithDestination(NODENUM_BROADCAST); });
-#else
             cannedMessageModule->LaunchWithDestination(NODENUM_BROADCAST);
-#endif
         } else if (selected == Freetext) {
             cannedMessageModule->LaunchFreetextWithDestination(NODENUM_BROADCAST);
         }
@@ -389,11 +384,7 @@ void menuHandler::textMessageBaseMenu()
     bannerOptions.optionsCount = options;
     bannerOptions.bannerCallback = [](int selected) -> void {
         if (selected == Preset) {
-#if CANNED_MESSAGE_ADD_CONFIRMATION
-            showConfirmationBanner("Send message?", [] { cannedMessageModule->LaunchWithDestination(NODENUM_BROADCAST); });
-#else
             cannedMessageModule->LaunchWithDestination(NODENUM_BROADCAST);
-#endif
         } else if (selected == Freetext) {
             cannedMessageModule->LaunchFreetextWithDestination(NODENUM_BROADCAST);
         }

--- a/src/graphics/draw/MenuHandler.h
+++ b/src/graphics/draw/MenuHandler.h
@@ -43,6 +43,7 @@ class menuHandler
 
     static void LoraRegionPicker(uint32_t duration = 30000);
     static void handleMenuSwitch(OLEDDisplay *display);
+    static void showConfirmationBanner(const char *message, std::function<void()> onConfirm);
     static void clockMenu();
     static void TZPicker();
     static void TwelveHourPicker();

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -600,9 +600,16 @@ bool CannedMessageModule::handleMessageSelectorInput(const InputEvent *event, bo
             ChannelIndex chan = channel;
 #if CANNED_MESSAGE_ADD_CONFIRMATION
             graphics::menuHandler::showConfirmationBanner("Send message?", [this, destNode, chan, current]() {
-                // this->sendText(destNode, chan, current, false);
+                this->sendText(destNode, chan, current, false);
                 payload = runState;
-                runState = CANNED_MESSAGE_RUN_STATE_ACTION_SELECT;
+                runState = CANNED_MESSAGE_RUN_STATE_INACTIVE;
+                currentMessageIndex = -1;
+
+                // Notify UI to regenerate frame set and redraw
+                UIFrameEvent e;
+                e.action = UIFrameEvent::Action::REGENERATE_FRAMESET;
+                notifyObservers(&e);
+                screen->forceDisplay();
             });
 #else
             payload = runState;

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -598,8 +598,10 @@ bool CannedMessageModule::handleMessageSelectorInput(const InputEvent *event, bo
             // Show confirmation dialog before sending canned message
             NodeNum destNode = dest;
             ChannelIndex chan = channel;
+#if CANNED_MESSAGE_ADD_CONFIRMATION
             graphics::menuHandler::showConfirmationBanner(
-                "Send preset message?", [this, destNode, chan, current]() { this->sendText(destNode, chan, current, false); });
+                "Send message?", [this, destNode, chan, current]() { this->sendText(destNode, chan, current, false); });
+#endif
             // Do not immediately set runState; wait for confirmation
             handled = true;
         }

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -599,10 +599,14 @@ bool CannedMessageModule::handleMessageSelectorInput(const InputEvent *event, bo
             NodeNum destNode = dest;
             ChannelIndex chan = channel;
 #if CANNED_MESSAGE_ADD_CONFIRMATION
-            graphics::menuHandler::showConfirmationBanner(
-                "Send message?", [this, destNode, chan, current]() { this->sendText(destNode, chan, current, false); });
+            graphics::menuHandler::showConfirmationBanner("Send message?", [this, destNode, chan, current]() {
+                // this->sendText(destNode, chan, current, false);
+                payload = runState;
+                runState = CANNED_MESSAGE_RUN_STATE_ACTION_SELECT;
+            });
 #else
-            this->sendText(destNode, chan, current, false);
+            payload = runState;
+            runState = CANNED_MESSAGE_RUN_STATE_ACTION_SELECT;
 #endif
             // Do not immediately set runState; wait for confirmation
             handled = true;
@@ -1719,7 +1723,7 @@ void CannedMessageModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *st
                     // Text: split by words and wrap inside word if needed
                     String text = token.second;
                     pos = 0;
-                    while (pos < text.length()) {
+                    while (pos < static_cast<int>(text.length())) {
                         // Find next space (or end)
                         int spacePos = text.indexOf(' ', pos);
                         int endPos = (spacePos == -1) ? text.length() : spacePos + 1; // Include space

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -601,6 +601,8 @@ bool CannedMessageModule::handleMessageSelectorInput(const InputEvent *event, bo
 #if CANNED_MESSAGE_ADD_CONFIRMATION
             graphics::menuHandler::showConfirmationBanner(
                 "Send message?", [this, destNode, chan, current]() { this->sendText(destNode, chan, current, false); });
+#else
+            this->sendText(destNode, chan, current, false);
 #endif
             // Do not immediately set runState; wait for confirmation
             handled = true;

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -595,8 +595,12 @@ bool CannedMessageModule::handleMessageSelectorInput(const InputEvent *event, bo
         // Normal canned message selection
         if (runState == CANNED_MESSAGE_RUN_STATE_INACTIVE || runState == CANNED_MESSAGE_RUN_STATE_DISABLED) {
         } else {
-            payload = runState;
-            runState = CANNED_MESSAGE_RUN_STATE_ACTION_SELECT;
+            // Show confirmation dialog before sending canned message
+            NodeNum destNode = dest;
+            ChannelIndex chan = channel;
+            graphics::menuHandler::showConfirmationBanner(
+                "Send preset message?", [this, destNode, chan, current]() { this->sendText(destNode, chan, current, false); });
+            // Do not immediately set runState; wait for confirmation
             handled = true;
         }
     }

--- a/variants/nrf52840/seeed_wio_tracker_L1/variant.h
+++ b/variants/nrf52840/seeed_wio_tracker_L1/variant.h
@@ -162,6 +162,8 @@ static const uint8_t SCL = PIN_WIRE_SCL;
 
 #define CANNED_MESSAGE_MODULE_ENABLE 1
 
+#define CANNED_MESSAGE_ADD_CONFIRMATION 1
+
 // trackball
 #define HAS_TRACKBALL 1
 #define TB_UP 25


### PR DESCRIPTION
Based on some feedback about how easy it is to accidentally fire off messages and disable bluetooth with Seeed L1 Tracker Pro inside of a bag, we're adding a bit of friction to the process:
1) Move bluetooth to system menu where it makes more sense
2) Add a confirmation dialog for sending canned messages for this target. Other targets can opt in to this with the `CANNED_MESSAGE_ADD_CONFIRMATION` macro

Tested on:

- [x] L1 Tracker Pro
- [x] RAK4631