### PR TITLE
Fix Heltec T114 ADC multiplier

### DIFF
--- a/variants/nrf52840/heltec_mesh_node_t114/variant.h
+++ b/variants/nrf52840/heltec_mesh_node_t114/variant.h
@@ -208,7 +208,7 @@ No longer populated on PCB
 #undef AREF_VOLTAGE
 #define AREF_VOLTAGE 3.0
 #define VBAT_AR_INTERNAL AR_INTERNAL_3_0
-#define ADC_MULTIPLIER (4.90F)
+#define ADC_MULTIPLIER (4.99F)
 
 #define HAS_RTC 0
 #ifdef __cplusplus


### PR DESCRIPTION

The current ADC multiplier for the Heltec T114 reports 95% at a full battery charge. I've adjusted it to 4.99 to correct for this. A full charge now results in 100% battery being reported instead of 95%.
## 🤝 Attestations

    [✅] I have tested that my proposed changes behave as described.
    [✅] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
        [✅] Heltec T114 V2