### PR TITLE
fix: ina226 was not calibrated during init

### DIFF
--- a/src/modules/Telemetry/Sensor/INA226Sensor.h
+++ b/src/modules/Telemetry/Sensor/INA226Sensor.h
@@ -15,6 +15,9 @@ class INA226Sensor : public TelemetrySensor, VoltageSensor, CurrentSensor
     TwoWire *_wire = &Wire;
     INA226 ina226 = INA226(_addr, _wire);
 
+    bool getEnvironmentMetrics(meshtastic_Telemetry *measurement);
+    bool getPowerMetrics(meshtastic_Telemetry *measurement);
+
   protected:
     virtual void setup() override;
     void begin(TwoWire *wire = &Wire, uint8_t addr = INA_ADDR);


### PR DESCRIPTION
fixes #7521

Added the missing write to the config register expecting a shunt of 100mOhm. This leads to a maximum current of 0.8A. Both values should be mentioned in the documentation.

Also added the distinction between power- and environment-telemetry. 

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)

tested on LilyGo T3S3 v1.2