### PR TITLE
Fix a crash on Native reboot

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -724,10 +724,12 @@ void Power::reboot()
     SPI.end();
     Wire.end();
     Serial1.end();
-    if (screen)
+    if (screen) {
         delete screen;
+        screen = nullptr;
+    }
     LOG_DEBUG("final reboot!");
-    reboot();
+    ::reboot();
 #elif defined(ARCH_STM32WL)
     HAL_NVIC_SystemReset();
 #else

--- a/src/mesh/api/WiFiServerAPI.cpp
+++ b/src/mesh/api/WiFiServerAPI.cpp
@@ -17,7 +17,10 @@ void initApiServer(int port)
 }
 void deInitApiServer()
 {
-    delete apiPort;
+    if (apiPort) {
+        delete apiPort;
+        apiPort = nullptr;
+    }
 }
 
 WiFiServerAPI::WiFiServerAPI(WiFiClient &_client) : ServerAPI(_client)


### PR DESCRIPTION
A refactor unintentionally made the ``reboot()`` function call itself, rather than call back to the portduino reboot() function. While in there, set pointers to nullptr after calling delete.