### PR TITLE
Add nrf internal temperature sensor

### DIFF
--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -198,6 +198,11 @@ T1000xSensor t1000xSensor;
 IndicatorSensor indicatorSensor;
 #endif
 
+#ifdef ARCH_NRF52
+#include "Sensor/NRFTempSensor.h"
+NRFTempSensor nrfTempSensor;
+#endif
+
 #define FAILED_STATE_SENSOR_READ_MULTIPLIER 10
 #define DISPLAY_RECEIVEID_MEASUREMENTS_ON_SCREEN true
 
@@ -242,6 +247,9 @@ int32_t EnvironmentTelemetryModule::runOnce()
 #ifdef T1000X_SENSOR_EN
             result = t1000xSensor.runOnce();
 #elif !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR_EXTERNAL
+#ifdef ARCH_NRF52
+            result = nrfTempSensor.runOnce();
+#endif
             if (dfRobotLarkSensor.hasSensor())
                 result = dfRobotLarkSensor.runOnce();
             if (dfRobotGravitySensor.hasSensor())
@@ -548,6 +556,11 @@ bool EnvironmentTelemetryModule::getEnvironmentTelemetry(meshtastic_Telemetry *m
     valid = valid && t1000xSensor.getMetrics(m);
     hasSensor = true;
 #else
+#ifdef ARCH_NRF52
+    valid = valid && nrfTempSensor.getMetrics(m);
+    hasSensor = true;
+#endif
+
     if (dfRobotLarkSensor.hasSensor()) {
         valid = valid && dfRobotLarkSensor.getMetrics(m);
         hasSensor = true;
@@ -670,6 +683,7 @@ bool EnvironmentTelemetryModule::getEnvironmentTelemetry(meshtastic_Telemetry *m
         valid = valid && cgRadSens.getMetrics(m);
         hasSensor = true;
     }
+
     if (pct2075Sensor.hasSensor()) {
         valid = valid && pct2075Sensor.getMetrics(m);
         hasSensor = true;

--- a/src/modules/Telemetry/Sensor/NRFTempSensor.cpp
+++ b/src/modules/Telemetry/Sensor/NRFTempSensor.cpp
@@ -1,0 +1,38 @@
+/*
+ *  nrf52840 internal die temperature sensor
+ */
+
+#include "configuration.h"
+
+#if !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR && defined(ARCH_NRF52)
+
+#include "../mesh/generated/meshtastic/telemetry.pb.h"
+#include "NRFTempSensor.h"
+#include <nrf_soc.h>
+
+#include <typeinfo>
+
+NRFTempSensor::NRFTempSensor() {}
+
+int32_t NRFTempSensor::runOnce()
+{
+    LOG_INFO("Init sensor: NRFTemp");
+    return DEFAULT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS;
+}
+
+bool NRFTempSensor::getMetrics(meshtastic_Telemetry *measurement)
+{
+    LOG_DEBUG("NRFTemp getMetrics");
+
+    int32_t temp;
+    if (sd_temp_get(&temp) != NRF_SUCCESS)
+        return false;
+
+    measurement->variant.environment_metrics.has_temperature = true;
+
+    measurement->variant.environment_metrics.temperature = temp / 4.f;
+
+    return true;
+}
+
+#endif

--- a/src/modules/Telemetry/Sensor/NRFTempSensor.h
+++ b/src/modules/Telemetry/Sensor/NRFTempSensor.h
@@ -1,0 +1,20 @@
+/*
+ *  nrf52840 internal die temperature sensor
+ */
+
+#include "configuration.h"
+
+#if !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR && defined(ARCH_NRF52)
+
+#include "../mesh/generated/meshtastic/telemetry.pb.h"
+#include "TelemetrySensor.h"
+
+class NRFTempSensor
+{
+  public:
+    NRFTempSensor();
+    int32_t runOnce();
+    bool getMetrics(meshtastic_Telemetry *measurement);
+};
+
+#endif


### PR DESCRIPTION
Useful as Enviroment Telemetry, in absence of a better temperture sensor.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [x] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
