### PR TITLE
Add board support for FoBE IDEA Mesh Tracker C1

### DIFF
--- a/boards/fobe_idea_mesh_tracker_c1.json
+++ b/boards/fobe_idea_mesh_tracker_c1.json
@@ -1,0 +1,59 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "nrf52840_s140_v7.ld"
+    },
+    "core": "nRF5",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DARDUINO_MDBT50Q_RX -DNRF52840_XXAA",
+    "f_cpu": "64000000L",
+    "hwids": [
+      ["0x239A", "0x8029"],
+      ["0x239A", "0x0029"],
+      ["0x239A", "0x002A"],
+      ["0x239A", "0x802A"]
+    ],
+    "usb_product": "FOBEBOOT",
+    "mcu": "nrf52840",
+    "variant": "fobe_idea_mesh_tracker_c1",
+    "bsp": {
+      "name": "adafruit"
+    },
+    "softdevice": {
+      "sd_flags": "-DS140",
+      "sd_name": "s140",
+      "sd_version": "7.3.0",
+      "sd_fwid": "0x0123"
+    },
+    "bootloader": {
+      "settings_addr": "0xFF000"
+    }
+  },
+  "connectivity": ["bluetooth"],
+  "debug": {
+    "jlink_device": "nRF52840_xxAA",
+    "svd_path": "nrf52840.svd",
+    "openocd_target": "nrf52840-mdk-rs"
+  },
+  "frameworks": ["arduino"],
+  "name": "FoBE IDEA Mesh Tracker C1",
+  "upload": {
+    "maximum_ram_size": 248832,
+    "maximum_size": 815104,
+    "speed": 115200,
+    "protocol": "nrfutil",
+    "protocols": [
+      "jlink",
+      "nrfjprog",
+      "nrfutil",
+      "stlink",
+      "cmsis-dap",
+      "blackmagic"
+    ],
+    "use_1200bps_touch": true,
+    "require_upload_port": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://docs.fobestudio.com/product/f2102/applications",
+  "vendor": "fobe"
+}

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -138,6 +138,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if defined(SEEED_WIO_TRACKER_L1)
 #define SSD1306_ADDRESS 0x3D
 #define USE_SH1106
+#elif defined(FOBE_IDEA_MESH_TRACKER_C1)
+#define SSD1306_ADDRESS 0x3D
 #else
 #define SSD1306_ADDRESS 0x3C
 #endif

--- a/src/platform/nrf52/main-nrf52.cpp
+++ b/src/platform/nrf52/main-nrf52.cpp
@@ -278,6 +278,9 @@ void cpuDeepSleep(uint32_t msecToWake)
 #if HAS_WIRE
     Wire.end();
 #endif
+#if WIRE_INTERFACES_COUNT > 1
+    Wire1.end();
+#endif
     SPI.end();
 #if SPI_INTERFACES_COUNT > 1
     SPI1.end();
@@ -323,6 +326,16 @@ void cpuDeepSleep(uint32_t msecToWake)
     nrf_gpio_cfg_default(PIN_GPS_PPS);
     detachInterrupt(PIN_GPS_PPS);
     detachInterrupt(PIN_BUTTON1);
+#endif
+
+#ifdef FOBE_IDEA_MESH_TRACKER_C1
+    for (int pin = 0; pin < 48; pin++) {
+        if (pin == SX126X_CS || pin == SX126X_DIO1 || pin == SX126X_BUSY || pin == SX126X_RESET || pin == SX126X_RXEN ||
+            pin == PIN_SPI_MISO || pin == PIN_SPI_MOSI || pin == PIN_SPI_SCK || pin == BATTERY_PIN || pin == PIN_BUTTON1) {
+            continue;
+        }
+        nrf_gpio_cfg_default(pin);
+    }
 #endif
 
 #ifdef ELECROW_ThinkNode_M1

--- a/variants/nrf52840/fobe_idea_mesh_tracker_c1/platformio.ini
+++ b/variants/nrf52840/fobe_idea_mesh_tracker_c1/platformio.ini
@@ -1,0 +1,19 @@
+; FoBE IDEA Mesh Tracker C1: https://docs.fobestudio.com/product/f2102
+[env:fobe_idea_mesh_tracker_c1]
+extends = nrf52840_base
+board = fobe_idea_mesh_tracker_c1
+board_level = extra
+build_flags = ${nrf52840_base.build_flags}
+  -Ivariants/nrf52840/fobe_idea_mesh_tracker_c1
+  -Isrc/platform/nrf52/softdevice
+  -Isrc/platform/nrf52/softdevice/nrf52
+  -DFOBE_IDEA_MESH_TRACKER_C1
+  -DRADIOLIB_EXCLUDE_SX128X=1
+  -DRADIOLIB_EXCLUDE_SX127X=1
+  -DRADIOLIB_EXCLUDE_LR11X0=1
+  -DPRIVATE_HW
+board_build.ldscript = src/platform/nrf52/nrf52840_s140_v7.ld
+build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/fobe_idea_mesh_tracker_c1>
+lib_deps =
+  ${nrf52840_base.lib_deps}
+debug_tool = cmsis-dap

--- a/variants/nrf52840/fobe_idea_mesh_tracker_c1/variant.cpp
+++ b/variants/nrf52840/fobe_idea_mesh_tracker_c1/variant.cpp
@@ -1,0 +1,36 @@
+#include "variant.h"
+#include "nrf.h"
+#include "wiring_constants.h"
+#include "wiring_digital.h"
+
+const uint32_t g_ADigitalPinMap[] = {
+    // P0
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+
+    // P1
+    32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47};
+
+void initVariant()
+{
+    // LED
+    pinMode(PIN_BUILTIN_LED, OUTPUT);
+    digitalWrite(PIN_BUILTIN_LED, HIGH);
+
+    // Button
+    pinMode(PIN_BUTTON1, INPUT);
+
+    // Battery Sense
+    pinMode(BATTERY_PIN, INPUT);
+
+    // Charging Detection
+    pinMode(EXT_CHRG_DETECT, INPUT);
+
+    // Peripheral Power
+    pinMode(PIN_PERI_EN, OUTPUT);
+    digitalWrite(PIN_PERI_EN, HIGH);
+
+    // Motion
+    pinMode(PIN_MOT_PWR, OUTPUT);
+    digitalWrite(PIN_MOT_PWR, HIGH);
+    pinMode(PIN_MOT_INT, INPUT);
+}

--- a/variants/nrf52840/fobe_idea_mesh_tracker_c1/variant.h
+++ b/variants/nrf52840/fobe_idea_mesh_tracker_c1/variant.h
@@ -1,0 +1,150 @@
+#ifndef _FOBE_QUILL_NRF52840_R1L_H_
+#define _FOBE_QUILL_NRF52840_R1L_H_
+/** Master clock frequency */
+#define VARIANT_MCK (64000000ul)
+
+#define USE_LFXO // Board uses 32khz crystal for LF
+// #define USE_LFRC    // Board uses RC for LF
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+// Use the native nrf52 usb power detection
+#define NRF_APM
+
+// Pin definitions
+#define PINS_COUNT (48)
+#define NUM_DIGITAL_PINS (48)
+#define NUM_ANALOG_INPUTS (1) // A5 is used for battery
+#define NUM_ANALOG_OUTPUTS (0)
+#define SPI_SCK (0 + 20)
+#define SPI_MOSI (0 + 22)
+#define SPI_MISO (0 + 24)
+#define PIN_BUILTIN_LED (32 + 11)
+#define PIN_RESET (0 + 18)
+#define PIN_I2C_SDA (0 + 7)
+#define PIN_I2C_SCL (0 + 27)
+#define PIN_PERI_EN (0 + 16)
+#define PIN_ROTARY_ENCODER_A (32 + 6)
+#define PIN_ROTARY_ENCODER_B (32 + 2)
+#define PIN_ROTARY_ENCODER_S (32 + 4)
+#define PIN_MOT_PWR (32 + 15)
+#define PIN_MOT_INT (32 + 14)
+#define PIN_MOT_SCL (32 + 13)
+#define PIN_MOT_SDA (32 + 10)
+
+/*
+ * LEDs
+ */
+#define PIN_LED1 PIN_BUILTIN_LED
+#define LED_RED PIN_LED1
+#define LED_BLUE PIN_LED1
+#define LED_GREEN PIN_LED1
+#define LED_BUILTIN PIN_LED1
+#define LED_STATE_ON 0
+
+/*
+ * Buttons
+ */
+#define PIN_BUTTON1 (32 + 0)
+#define BUTTON_SENSE_TYPE INPUT_PULLUP_SENSE
+
+/*
+ * Battery
+ */
+#define BATTERY_PIN (0 + 5)
+#define BATTERY_SENSE_RESOLUTION_BITS 12
+#define BATTERY_SENSE_RESOLUTION 4096.0
+#undef AREF_VOLTAGE
+#define AREF_VOLTAGE 3.0
+#define VBAT_AR_INTERNAL AR_INTERNAL_3_0
+#define ADC_MULTIPLIER 1.73
+#define EXT_CHRG_DETECT (32 + 12)
+#define EXT_CHRG_DETECT_VALUE LOW
+
+/*
+ * Wire Interfaces
+ */
+#define HAS_WIRE 1
+#define WIRE_INTERFACES_COUNT 2
+#define I2C_NO_RESCAN
+#define PIN_WIRE_SDA PIN_I2C_SDA
+#define PIN_WIRE_SCL PIN_I2C_SCL
+#define PIN_WIRE1_SDA PIN_MOT_SDA
+#define PIN_WIRE1_SCL PIN_MOT_SCL
+#define HAS_SCREEN 1
+#define USE_SSD1306 1
+
+/*
+ * Serial interfaces
+ */
+#define PIN_SERIAL2_RX (-1)
+#define PIN_SERIAL2_TX (-1)
+#define PIN_SERIAL1_RX (0 + 12)
+#define PIN_SERIAL1_TX (32 + 9)
+
+/*
+ * SPI Interfaces
+ */
+#define SPI_INTERFACES_COUNT 1
+#define PIN_SPI_MISO SPI_MISO
+#define PIN_SPI_MOSI SPI_MOSI
+#define PIN_SPI_SCK SPI_SCK
+static const uint8_t SS = (32 + 8);
+static const uint8_t MOSI = PIN_SPI_MOSI;
+static const uint8_t MISO = PIN_SPI_MISO;
+static const uint8_t SCK = PIN_SPI_SCK;
+
+/*
+ * LoRa
+ */
+#define USE_SX1262
+#define SX126X_CS (32 + 8)
+#define SX126X_DIO1 (0 + 17)
+#define SX126X_BUSY (0 + 15)
+#define SX126X_RESET (0 + 13)
+#define SX126X_TXEN RADIOLIB_NC
+#define SX126X_RXEN (0 + 11)
+#define SX126X_DIO2_AS_RF_SWITCH
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8
+
+/*
+ * GNSS
+ */
+#define GPS_L76K
+#define PIN_GPS_RX PIN_SERIAL1_TX
+#define PIN_GPS_TX PIN_SERIAL1_RX
+#define HAS_GPS 1
+#define GPS_POWER_TOGGLE
+#define GPS_BAUDRATE 9600
+#define GPS_THREAD_INTERVAL 50
+#define PIN_GPS_RESET (0 + 13)
+#define GPS_RESET_MODE LOW
+#define PIN_GPS_STANDBY (0 + 6)
+#define PIN_GPS_EN (0 + 26)
+#define PIN_GPS_PPS (0 + 8)
+#define GPS_EN_ACTIVE HIGH
+#define GPS_THREAD_INTERVAL 50
+
+// Buzzer
+#define PIN_BUZZER (0 + 14)
+
+// Canned Messages
+#define CANNED_MESSAGE_MODULE_ENABLE 1
+
+#ifdef __cplusplus
+}
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#endif


### PR DESCRIPTION
This pull request adds support for the FoBE IDEA Mesh Tracker C1 hardware variant, including board configuration, pin mappings, and relevant platform definitions. The changes introduce a new board definition, update platform-specific code to recognize the new hardware, and ensure proper initialization and power management for the board.

**FoBE IDEA Mesh Tracker C1 Support:**

* Added a new board definition file `boards/fobe_idea_mesh_tracker_c1.json` with hardware details, USB IDs, memory sizes, and upload protocols.
* Created a new PlatformIO environment in `variants/nrf52840/fobe_idea_mesh_tracker_c1/platformio.ini` for building firmware targeting this board.
* Implemented pin mappings and hardware configuration in `variants/nrf52840/fobe_idea_mesh_tracker_c1/variant.h` and initialization logic in `variant.cpp`.

**Platform Integration and Configuration:**

* Updated platform-specific headers and deep sleep logic to support the new board, including setting the correct hardware vendor, I2C/SPI interface handling, and pin state management during sleep in `src/platform/nrf52/main-nrf52.cpp`.
* Configured the SSD1306 display address for the new board in `src/configuration.h`.

Product doc: [https://docs.fobestudio.com/product/f2102](https://docs.fobestudio.com/product/f2102)


![](https://docs.fobestudio.com/img/products/f2102-r1lg.main.png)
<img width="1042" height="828" alt="image" src="https://github.com/user-attachments/assets/3548bdf4-3941-4385-b61e-d087e8af441f" />


## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] FoBE IDEA Mesh Tracker C1