### PR TITLE
Fix INA3221 higher current wrong readings

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -158,7 +158,7 @@ lib_deps =
 	# renovate: datasource=custom.pio depName=Adafruit MLX90614 packageName=adafruit/library/Adafruit MLX90614 Library
 	adafruit/Adafruit MLX90614 Library@2.1.5
 	# renovate: datasource=github-tags depName=INA3221 packageName=sgtwilko/INA3221
-	https://github.com/sgtwilko/INA3221#FixOverflow
+	https://github.com/sgtwilko/INA3221#bb03d7e9bfcc74fc798838a54f4f99738f29fc6a
 	# renovate: datasource=custom.pio depName=QMC5883L Compass packageName=mprograms/library/QMC5883LCompass
 	mprograms/QMC5883LCompass@1.2.3
 	# renovate: datasource=custom.pio depName=DFRobot_RTU packageName=dfrobot/library/DFRobot_RTU

--- a/platformio.ini
+++ b/platformio.ini
@@ -157,8 +157,8 @@ lib_deps =
 	emotibit/EmotiBit MLX90632@1.0.8
 	# renovate: datasource=custom.pio depName=Adafruit MLX90614 packageName=adafruit/library/Adafruit MLX90614 Library
 	adafruit/Adafruit MLX90614 Library@2.1.5
-	# renovate: datasource=github-tags depName=INA3221 packageName=KodinLanewave/INA3221
-	https://github.com/KodinLanewave/INA3221/archive/1.0.1.zip
+	# renovate: datasource=github-tags depName=INA3221 packageName=sgtwilko/INA3221
+	https://github.com/sgtwilko/INA3221#FixOverflow
 	# renovate: datasource=custom.pio depName=QMC5883L Compass packageName=mprograms/library/QMC5883LCompass
 	mprograms/QMC5883LCompass@1.2.3
 	# renovate: datasource=custom.pio depName=DFRobot_RTU packageName=dfrobot/library/DFRobot_RTU

--- a/platformio.ini
+++ b/platformio.ini
@@ -118,7 +118,7 @@ lib_deps =
 [device-ui_base]
 lib_deps =
 	# renovate: datasource=git-refs depName=meshtastic/device-ui packageName=https://github.com/meshtastic/device-ui gitBranch=master
-	https://github.com/meshtastic/device-ui/archive/8019704395b7539600d581330499208edcd80804.zip
+	https://github.com/meshtastic/device-ui/archive/10f02441ec7dcd099c4c5165c709afc3e0e3cb88.zip
 
 ; Common libs for environmental measurements in telemetry module
 [environmental_base]


### PR DESCRIPTION
WIth the [current library](https://github.com/KodinLanewave/INA3221/archive/1.0.1.zip) reading higher current values with INA3221 caused misreadings. The original author of the library @KodinLanewave didn't approve the pull request which was fixing those issues so we could include the fork from @sgtwilko which was including those.

This change in `platformio.ini` should fix these issues by including that branch from @sgtwilko

fixes https://github.com/meshtastic/firmware/issues/5933
