### PR TITLE
Wait for lead up before enable longlong action

### DIFF
--- a/src/buzz/buzz.cpp
+++ b/src/buzz/buzz.cpp
@@ -140,6 +140,10 @@ bool playNextLeadUpNote()
     playTones(&note, 1); // Play single note using existing playTones function
 
     leadUpNoteIndex++;
+
+    if (leadUpNoteIndex >= leadUpNotesCount) {
+        return false; // this was the final note
+    }
     return true; // Note was played (playTones handles buzzer availability internally)
 }
 

--- a/src/input/ButtonThread.cpp
+++ b/src/input/ButtonThread.cpp
@@ -140,8 +140,7 @@ int32_t ButtonThread::runOnce()
     }
 
     // Progressive lead-up sound system
-    if (buttonCurrentlyPressed && (millis() - buttonPressStartTime) >= BUTTON_LEADUP_MS &&
-        (millis() - buttonPressStartTime) < _longLongPressTime) {
+    if (buttonCurrentlyPressed && (millis() - buttonPressStartTime) >= BUTTON_LEADUP_MS) {
 
         // Start the progressive sequence if not already active
         if (!leadUpSequenceActive) {
@@ -153,13 +152,14 @@ int32_t ButtonThread::runOnce()
         else if ((millis() - lastLeadUpNoteTime) >= 400) { // 400ms interval between notes
             if (playNextLeadUpNote()) {
                 lastLeadUpNoteTime = millis();
+            } else {
+                leadUpPlayed = true;
             }
         }
     }
 
     // Reset when button is released
     if (!buttonCurrentlyPressed && buttonWasPressed) {
-        leadUpPlayed = false;
         leadUpSequenceActive = false;
         resetLeadUpSequence();
     }
@@ -256,12 +256,13 @@ int32_t ButtonThread::runOnce()
 
             LOG_INFO("LONG PRESS RELEASE AFTER %u MILLIS", millis() - buttonPressStartTime);
             if (millis() > 30000 && _longLongPress != INPUT_BROKER_NONE &&
-                (millis() - buttonPressStartTime) >= _longLongPressTime) {
+                (millis() - buttonPressStartTime) >= _longLongPressTime && leadUpPlayed) {
                 evt.inputEvent = _longLongPress;
                 this->notifyObservers(&evt);
             }
             // Reset combination tracking
             waitingForLongPress = false;
+            leadUpPlayed = false;
 
             break;
         }

--- a/src/input/ButtonThread.h
+++ b/src/input/ButtonThread.h
@@ -92,7 +92,7 @@ class ButtonThread : public Observable<const InputEvent *>, public concurrency::
 
     voidFuncPtr _intRoutine = nullptr;
     uint16_t _longPressTime = 500;
-    uint16_t _longLongPressTime = 5000;
+    uint16_t _longLongPressTime = 3900;
     int _pinNum = 0;
     bool _activeLow = true;
     bool _touchQuirk = false;


### PR DESCRIPTION
Make sure the complete leadup plays before doing a longlong action like shutting down. This should make for more sane behaviors on eink devices where the thread may not run as often as we'd like.