### PR TITLE
Only gate PKC behind the simradio CLI flag

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -523,8 +523,10 @@ meshtastic_Routing_Error perhapsEncode(meshtastic_MeshPacket *p)
         // is not in the local nodedb
         // First, only PKC encrypt packets we are originating
         if (isFromUs(p) &&
+#if ARCH_PORTDUINO
             // Sim radio via the cli flag skips PKC
             !portduino_config.force_simradio &&
+#endif
             // Don't use PKC with Ham mode
             !owner.is_licensed &&
             // Don't use PKC if it's not explicitly requested and a non-primary channel is requested

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -523,8 +523,8 @@ meshtastic_Routing_Error perhapsEncode(meshtastic_MeshPacket *p)
         // is not in the local nodedb
         // First, only PKC encrypt packets we are originating
         if (isFromUs(p) &&
-            // Don't use PKC with simulator
-            radioType != SIM_RADIO &&
+            // Sim radio via the cli flag skips PKC
+            !portduino_config.force_simradio &&
             // Don't use PKC with Ham mode
             !owner.is_licensed &&
             // Don't use PKC if it's not explicitly requested and a non-primary channel is requested

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -34,7 +34,6 @@ std::ofstream traceFile;
 Ch341Hal *ch341Hal = nullptr;
 char *configPath = nullptr;
 char *optionMac = nullptr;
-bool forceSimulated = false;
 bool verboseEnabled = false;
 
 const char *argp_program_version = optstr(APP_VERSION);
@@ -67,7 +66,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
         configPath = arg;
         break;
     case 's':
-        forceSimulated = true;
+        portduino_config.force_simradio = true;
         break;
     case 'h':
         optionMac = arg;
@@ -190,7 +189,7 @@ void portduinoSetup()
 
     YAML::Node yamlConfig;
 
-    if (forceSimulated == true) {
+    if (portduino_config.force_simradio == true) {
         settingsMap[use_simradio] = true;
     } else if (configPath != nullptr) {
         if (loadConfig(configPath)) {

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -134,4 +134,5 @@ extern struct portduino_config_struct {
     bool has_rfswitch_table = false;
     uint32_t rfswitch_dio_pins[5] = {RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC};
     Module::RfSwitchMode_t rfswitch_table[8];
+    bool force_simradio = false;
 } portduino_config;


### PR DESCRIPTION
Testing PKC related features with the simulated radio is impossible as we block PKC encryption with simulated. This moves to simply blocking PKC encryption when the CLI flag is set.