### PR TITLE
Add more text message test cases for meshpacket serializer

### DIFF
--- a/test/test_meshpacket_serializer/ports/test_text_message.cpp
+++ b/test/test_meshpacket_serializer/ports/test_text_message.cpp
@@ -1,42 +1,112 @@
 #include "../test_helpers.h"
+#include <memory>
+
+// Helper function to test common packet fields and structure
+void verify_text_message_packet_structure(const std::string& json, const char* expected_text)
+{
+    TEST_ASSERT_TRUE(json.length() > 0);
+
+    // Use smart pointer for automatic memory management
+    std::unique_ptr<JSONValue> root(JSON::Parse(json.c_str()));
+    TEST_ASSERT_NOT_NULL(root.get());
+    TEST_ASSERT_TRUE(root->IsObject());
+
+    JSONObject jsonObj = root->AsObject();
+
+    // Check basic packet fields - use helper function to reduce duplication
+    auto check_field = [&](const char* field, uint32_t expected_value) {
+        auto it = jsonObj.find(field);
+        TEST_ASSERT_TRUE(it != jsonObj.end());
+        TEST_ASSERT_EQUAL(expected_value, (uint32_t)it->second->AsNumber());
+    };
+
+    check_field("from", 0x11223344);
+    check_field("to", 0x55667788);
+    check_field("id", 0x9999);
+
+    // Check message type
+    auto type_it = jsonObj.find("type");
+    TEST_ASSERT_TRUE(type_it != jsonObj.end());
+    TEST_ASSERT_EQUAL_STRING("text", type_it->second->AsString().c_str());
+
+    // Check payload
+    auto payload_it = jsonObj.find("payload");
+    TEST_ASSERT_TRUE(payload_it != jsonObj.end());
+    TEST_ASSERT_TRUE(payload_it->second->IsObject());
+
+    JSONObject payload = payload_it->second->AsObject();
+    auto text_it = payload.find("text");
+    TEST_ASSERT_TRUE(text_it != payload.end());
+    TEST_ASSERT_EQUAL_STRING(expected_text, text_it->second->AsString().c_str());
+    
+    // No need for manual delete with smart pointer
+}
 
 // Test TEXT_MESSAGE_APP port
 void test_text_message_serialization()
 {
     const char *test_text = "Hello Meshtastic!";
     meshtastic_MeshPacket packet =
-        create_test_packet(meshtastic_PortNum_TEXT_MESSAGE_APP, (const uint8_t *)test_text, strlen(test_text));
+        create_test_packet(meshtastic_PortNum_TEXT_MESSAGE_APP, 
+                          reinterpret_cast<const uint8_t*>(test_text), 
+                          strlen(test_text));
 
     std::string json = MeshPacketSerializer::JsonSerialize(&packet, false);
+    verify_text_message_packet_structure(json, test_text);
+}
+
+// Test with nullptr to check robustness
+void test_text_message_serialization_null()
+{
+    meshtastic_MeshPacket packet =
+        create_test_packet(meshtastic_PortNum_TEXT_MESSAGE_APP, nullptr, 0);
+
+    std::string json = MeshPacketSerializer::JsonSerialize(&packet, false);
+    verify_text_message_packet_structure(json, "");
+}
+
+// Test TEXT_MESSAGE_APP port with very long message (boundary testing)
+void test_text_message_serialization_long_text()
+{
+    // Test with actual message size limits
+    constexpr size_t MAX_MESSAGE_SIZE = 200; // Typical LoRa payload limit
+    std::string long_text(MAX_MESSAGE_SIZE, 'A');
+    
+    meshtastic_MeshPacket packet =
+        create_test_packet(meshtastic_PortNum_TEXT_MESSAGE_APP, 
+                          reinterpret_cast<const uint8_t*>(long_text.c_str()), 
+                          long_text.length());
+
+    std::string json = MeshPacketSerializer::JsonSerialize(&packet, false);
+    verify_text_message_packet_structure(json, long_text.c_str());
+}
+
+// Test with message over size limit (should fail)
+void test_text_message_serialization_oversized()
+{
+    constexpr size_t OVERSIZED_MESSAGE = 250; // Over the limit
+    std::string oversized_text(OVERSIZED_MESSAGE, 'B');
+    
+    meshtastic_MeshPacket packet =
+        create_test_packet(meshtastic_PortNum_TEXT_MESSAGE_APP, 
+                          reinterpret_cast<const uint8_t*>(oversized_text.c_str()), 
+                          oversized_text.length());
+
+    // Should fail or return empty/error
+    std::string json = MeshPacketSerializer::JsonSerialize(&packet, false);
+    // Should only verify first 234 characters for oversized messages
+    std::string expected_text = oversized_text.substr(0, 234);
+    verify_text_message_packet_structure(json, expected_text.c_str());
+}
+
+// Add test for malformed UTF-8 sequences
+void test_text_message_serialization_invalid_utf8()
+{
+    const uint8_t invalid_utf8[] = {0xFF, 0xFE, 0xFD, 0x00}; // Invalid UTF-8
+    meshtastic_MeshPacket packet =
+        create_test_packet(meshtastic_PortNum_TEXT_MESSAGE_APP, invalid_utf8, sizeof(invalid_utf8) - 1);
+
+    // Should not crash, may produce replacement characters
+    std::string json = MeshPacketSerializer::JsonSerialize(&packet, false);
     TEST_ASSERT_TRUE(json.length() > 0);
-
-    JSONValue *root = JSON::Parse(json.c_str());
-    TEST_ASSERT_NOT_NULL(root);
-    TEST_ASSERT_TRUE(root->IsObject());
-
-    JSONObject jsonObj = root->AsObject();
-
-    // Check basic packet fields
-    TEST_ASSERT_TRUE(jsonObj.find("from") != jsonObj.end());
-    TEST_ASSERT_EQUAL(0x11223344, (uint32_t)jsonObj["from"]->AsNumber());
-
-    TEST_ASSERT_TRUE(jsonObj.find("to") != jsonObj.end());
-    TEST_ASSERT_EQUAL(0x55667788, (uint32_t)jsonObj["to"]->AsNumber());
-
-    TEST_ASSERT_TRUE(jsonObj.find("id") != jsonObj.end());
-    TEST_ASSERT_EQUAL(0x9999, (uint32_t)jsonObj["id"]->AsNumber());
-
-    // Check message type
-    TEST_ASSERT_TRUE(jsonObj.find("type") != jsonObj.end());
-    TEST_ASSERT_EQUAL_STRING("text", jsonObj["type"]->AsString().c_str());
-
-    // Check payload
-    TEST_ASSERT_TRUE(jsonObj.find("payload") != jsonObj.end());
-    TEST_ASSERT_TRUE(jsonObj["payload"]->IsObject());
-
-    JSONObject payload = jsonObj["payload"]->AsObject();
-    TEST_ASSERT_TRUE(payload.find("text") != payload.end());
-    TEST_ASSERT_EQUAL_STRING("Hello Meshtastic!", payload["text"]->AsString().c_str());
-
-    delete root;
 }

--- a/test/test_meshpacket_serializer/test_serializer.cpp
+++ b/test/test_meshpacket_serializer/test_serializer.cpp
@@ -4,6 +4,10 @@
 
 // Forward declarations for test functions
 void test_text_message_serialization();
+void test_text_message_serialization_null();
+void test_text_message_serialization_long_text();
+void test_text_message_serialization_oversized();
+void test_text_message_serialization_invalid_utf8();
 void test_position_serialization();
 void test_nodeinfo_serialization();
 void test_waypoint_serialization();
@@ -21,6 +25,10 @@ void setup()
 
     // Text message tests
     RUN_TEST(test_text_message_serialization);
+    RUN_TEST(test_text_message_serialization_null);
+    RUN_TEST(test_text_message_serialization_long_text);
+    RUN_TEST(test_text_message_serialization_oversized);
+    RUN_TEST(test_text_message_serialization_invalid_utf8);
 
     // Position tests
     RUN_TEST(test_position_serialization);


### PR DESCRIPTION
## Summary

- Refactored the main test to use a helper for verifying packet structure.
- Added new tests for:
  - Null payloads
  - Long messages (boundary size)
  - Oversized messages (truncation)
  - Invalid UTF-8 sequences
- Registered these new tests in the test suite.

## 🤝 Attestations

- [V] I have tested that my proposed changes behave as described.
- [V] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [V] Heltec (Lora32) V3
