### PR TITLE
Reduce power of EU433 to 10dBm

### DIFF
--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -32,9 +32,12 @@ const RegionInfo regions[] = {
     RDEF(US, 902.0f, 928.0f, 100, 0, 30, true, false, false),
 
     /*
-        https://lora-alliance.org/wp-content/uploads/2020/11/lorawan_regional_parameters_v1.0.3reva_0.pdf
+        EN300220 ETSI V3.2.1 [Table B.1, Item H, p. 21]
+
+        https://www.etsi.org/deliver/etsi_en/300200_300299/30022002/03.02.01_60/en_30022002v030201p.pdf
+        FIXME: https://github.com/meshtastic/firmware/issues/3371
      */
-    RDEF(EU_433, 433.0f, 434.0f, 10, 0, 12, true, false, false),
+    RDEF(EU_433, 433.0f, 434.0f, 10, 0, 10, true, false, false),
 
     /*
        https://www.thethingsnetwork.org/docs/lorawan/duty-cycle/


### PR DESCRIPTION
We are currently blocked from making the breaking change to fix EU_433 channel centres until 3.0 (https://github.com/meshtastic/firmware/issues/3371 )

However, as already updated in https://github.com/meshtastic/meshtastic/pull/919 the documentation, the power limit for EU_433 is 10dBm. We can change the power limit without breaking anything, so this patch sets the power limit to match the ETSI spec without changing any other settings.