### PR TITLE
Add more test case for encrypted packet test

### DIFF
--- a/test/test_meshpacket_serializer/ports/test_encrypted.cpp
+++ b/test/test_meshpacket_serializer/ports/test_encrypted.cpp
@@ -1,20 +1,32 @@
 #include "../test_helpers.h"
 
-// Test encrypted packet serialization
-void test_encrypted_packet_serialization()
+// test data initialization
+const int from = 0x11223344;
+const int to = 0x55667788;
+const int id = 0x9999;
+
+// Helper function to create a test encrypted packet
+meshtastic_MeshPacket create_test_encrypted_packet(uint32_t from, uint32_t to, uint32_t id, const char *data)
 {
     meshtastic_MeshPacket packet = meshtastic_MeshPacket_init_zero;
-    packet.from = 0x11223344;
-    packet.to = 0x55667788;
-    packet.id = 0x9999;
+    packet.from = from;
+    packet.to = to;
+    packet.id = id;
     packet.which_payload_variant = meshtastic_MeshPacket_encrypted_tag;
 
-    // Add some dummy encrypted data
-    const char *encrypted_data = "encrypted_payload_data";
-    packet.encrypted.size = strlen(encrypted_data);
-    memcpy(packet.encrypted.bytes, encrypted_data, packet.encrypted.size);
+    if (data) {
+        packet.encrypted.size = strlen(data);
+        memcpy(packet.encrypted.bytes, data, packet.encrypted.size);
+    }
 
-    std::string json = MeshPacketSerializer::JsonSerializeEncrypted(&packet);
+    return packet;
+}
+
+// Comprehensive helper function for all encrypted packet assertions
+void assert_encrypted_packet(const std::string &json, uint32_t expected_from, uint32_t expected_to, uint32_t expected_id,
+                             size_t expected_size)
+{
+    // Parse and validate JSON
     TEST_ASSERT_TRUE(json.length() > 0);
 
     JSONValue *root = JSON::Parse(json.c_str());
@@ -23,28 +35,48 @@ void test_encrypted_packet_serialization()
 
     JSONObject jsonObj = root->AsObject();
 
-    // Check basic packet fields
+    // Assert basic packet fields
     TEST_ASSERT_TRUE(jsonObj.find("from") != jsonObj.end());
-    TEST_ASSERT_EQUAL(0x11223344, (uint32_t)jsonObj["from"]->AsNumber());
+    TEST_ASSERT_EQUAL(expected_from, (uint32_t)jsonObj.at("from")->AsNumber());
 
     TEST_ASSERT_TRUE(jsonObj.find("to") != jsonObj.end());
-    TEST_ASSERT_EQUAL(0x55667788, (uint32_t)jsonObj["to"]->AsNumber());
+    TEST_ASSERT_EQUAL(expected_to, (uint32_t)jsonObj.at("to")->AsNumber());
 
     TEST_ASSERT_TRUE(jsonObj.find("id") != jsonObj.end());
-    TEST_ASSERT_EQUAL(0x9999, (uint32_t)jsonObj["id"]->AsNumber());
+    TEST_ASSERT_EQUAL(expected_id, (uint32_t)jsonObj.at("id")->AsNumber());
 
-    // Check that it has encrypted data fields (not "payload" but "bytes" and "size")
+    // Assert encrypted data fields
     TEST_ASSERT_TRUE(jsonObj.find("bytes") != jsonObj.end());
-    TEST_ASSERT_TRUE(jsonObj["bytes"]->IsString());
+    TEST_ASSERT_TRUE(jsonObj.at("bytes")->IsString());
 
     TEST_ASSERT_TRUE(jsonObj.find("size") != jsonObj.end());
-    TEST_ASSERT_EQUAL(22, (int)jsonObj["size"]->AsNumber()); // strlen("encrypted_payload_data") = 22
+    TEST_ASSERT_EQUAL(expected_size, (int)jsonObj.at("size")->AsNumber());
 
-    // The encrypted data should be hex-encoded
+    // Assert hex encoding
     std::string encrypted_hex = jsonObj["bytes"]->AsString();
-    TEST_ASSERT_TRUE(encrypted_hex.length() > 0);
-    // Should be twice the size of the original data (hex encoding)
-    TEST_ASSERT_EQUAL(44, encrypted_hex.length()); // 22 * 2 = 44
+    TEST_ASSERT_EQUAL(expected_size * 2, encrypted_hex.length());
 
     delete root;
+}
+
+// Test encrypted packet serialization
+void test_encrypted_packet_serialization()
+{
+    const char *data = "encrypted_payload_data";
+
+    meshtastic_MeshPacket packet = create_test_encrypted_packet(from, to, id, data);
+    std::string json = MeshPacketSerializer::JsonSerializeEncrypted(&packet);
+
+    assert_encrypted_packet(json, from, to, id, strlen(data));
+}
+
+// Test empty encrypted packet
+void test_empty_encrypted_packet()
+{
+    const char *data = "";
+
+    meshtastic_MeshPacket packet = create_test_encrypted_packet(from, to, id, data);
+    std::string json = MeshPacketSerializer::JsonSerializeEncrypted(&packet);
+
+    assert_encrypted_packet(json, from, to, id, strlen(data));
 }

--- a/test/test_meshpacket_serializer/test_serializer.cpp
+++ b/test/test_meshpacket_serializer/test_serializer.cpp
@@ -18,6 +18,7 @@ void test_telemetry_environment_metrics_missing_fields();
 void test_telemetry_environment_metrics_complete_coverage();
 void test_telemetry_environment_metrics_unset_fields();
 void test_encrypted_packet_serialization();
+void test_empty_encrypted_packet();
 
 void setup()
 {
@@ -49,6 +50,7 @@ void setup()
 
     // Encrypted packet test
     RUN_TEST(test_encrypted_packet_serialization);
+    RUN_TEST(test_empty_encrypted_packet);
 
     UNITY_END();
 }


### PR DESCRIPTION
## Summary
-  Refactored the main test to use a helper for verifying packet structure.
-  Added new tests for:
    -  empty packet
-  Registered these new tests in the test suite.
 ## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
