### PR TITLE
Don't use pin 0 on RAK for input

### DIFF
--- a/src/input/RotaryEncoderInterruptBase.cpp
+++ b/src/input/RotaryEncoderInterruptBase.cpp
@@ -18,14 +18,23 @@ void RotaryEncoderInterruptBase::init(
     this->_eventCcw = eventCcw;
     this->_eventPressed = eventPressed;
 
-    pinMode(pinPress, INPUT_PULLUP);
-    pinMode(this->_pinA, INPUT_PULLUP);
-    pinMode(this->_pinB, INPUT_PULLUP);
+    bool isRAK = false;
+#ifdef RAK_4631
+    isRAK = true;
+#endif
 
-    //    attachInterrupt(pinPress, onIntPress, RISING);
-    attachInterrupt(pinPress, onIntPress, RISING);
-    attachInterrupt(this->_pinA, onIntA, CHANGE);
-    attachInterrupt(this->_pinB, onIntB, CHANGE);
+    if (!RAK_4631 || pinPress != 0) {
+        pinMode(pinPress, INPUT_PULLUP);
+        attachInterrupt(pinPress, onIntPress, RISING);
+    }
+    if (!RAK_4631 || this->_pinA != 0) {
+        pinMode(this->_pinA, INPUT_PULLUP);
+        attachInterrupt(this->_pinA, onIntA, CHANGE);
+    }
+    if (!RAK_4631 || this->_pinA != 0) {
+        pinMode(this->_pinB, INPUT_PULLUP);
+        attachInterrupt(this->_pinB, onIntB, CHANGE);
+    }
 
     this->rotaryLevelA = digitalRead(this->_pinA);
     this->rotaryLevelB = digitalRead(this->_pinB);

--- a/src/input/UpDownInterruptBase.cpp
+++ b/src/input/UpDownInterruptBase.cpp
@@ -15,14 +15,23 @@ void UpDownInterruptBase::init(uint8_t pinDown, uint8_t pinUp, uint8_t pinPress,
     this->_eventDown = eventDown;
     this->_eventUp = eventUp;
     this->_eventPressed = eventPressed;
+    bool isRAK = false;
+#ifdef RAK_4631
+    isRAK = true;
+#endif
 
-    pinMode(pinPress, INPUT_PULLUP);
-    pinMode(this->_pinDown, INPUT_PULLUP);
-    pinMode(this->_pinUp, INPUT_PULLUP);
-
-    attachInterrupt(pinPress, onIntPress, RISING);
-    attachInterrupt(this->_pinDown, onIntDown, RISING);
-    attachInterrupt(this->_pinUp, onIntUp, RISING);
+    if (!RAK_4631 || pinPress != 0) {
+        pinMode(pinPress, INPUT_PULLUP);
+        attachInterrupt(pinPress, onIntPress, RISING);
+    }
+    if (!RAK_4631 || this->_pinDown != 0) {
+        pinMode(this->_pinDown, INPUT_PULLUP);
+        attachInterrupt(this->_pinDown, onIntDown, RISING);
+    }
+    if (!RAK_4631 || this->_pinUp != 0) {
+        pinMode(this->_pinUp, INPUT_PULLUP);
+        attachInterrupt(this->_pinUp, onIntUp, RISING);
+    }
 
     LOG_DEBUG("Up/down/press GPIO initialized (%d, %d, %d)", this->_pinUp, this->_pinDown, pinPress);
 


### PR DESCRIPTION
The rotary encoder and updown input types are very easy to accidentally misconfigure, and soft-brick a RAK 4631 by claiming pin 0, the boot pin. This PR checks for this combination, and just refuses to init pin 0 on the RAK.