### PR TITLE
Update M5Stack Core / Basic Pin Defs

### DIFF
--- a/variants/esp32/m5stack_core/variant.h
+++ b/variants/esp32/m5stack_core/variant.h
@@ -1,14 +1,13 @@
-// #define BUTTON_NEED_PULLUP // if set we need to turn on the internal CPU pullup during sleep
+// Note: The M5Stack Core is now referred to as the M5Stack "Basic"
 
 #define I2C_SDA 21
 #define I2C_SCL 22
 
-// #define BUTTON_PIN 39 // 38, 37
-// #define BUTTON_PIN 0
-#define BUTTON_NEED_PULLUP
 // #define EXT_NOTIFY_OUT 13 // Default pin to use for Ext Notify Plugin.
 
 #define BUTTON_PIN 38
+// #define BUTTON_NEED_PULLUP // if set we need to turn on the internal CPU pullup during sleep
+#define BUTTON_NEED_PULLUP
 
 #define PIN_BUZZER 25
 
@@ -23,8 +22,8 @@
 #define LORA_CS 5
 
 #define USE_RF95
-#define LORA_DIO0 36 // a No connect on the SX1262 module
-#define LORA_RESET 26
+#define LORA_DIO0 35 // IRQ
+#define LORA_RESET 25
 #define LORA_DIO1 RADIOLIB_NC // Not really used
 #define LORA_DIO2 RADIOLIB_NC // Not really used
 


### PR DESCRIPTION
The m5stack_core variant was originally set up to use the v1 version of m5stack's original lora module (now obsolete).

The newer modules retain the same MISO/MOSI/SCK/CS pin definitions, but the pins for DIO0 (IRQ) and RESET have changed.

This PR updates the pin defs for the m5stack core (now actually referred to as the m5stack basic) to work with the currently available lora modules.

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [X ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [X] Other: M5Stack Core
