### PR TITLE
We don't gotTime if time is 2019.

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1504,7 +1504,7 @@ static int32_t toDegInt(RawDegrees d)
  * Perform any processing that should be done only while the GPS is awake and looking for a fix.
  * Override this method to check for new locations
  *
- * @return true if we've acquired a new location
+ * @return true if we've set a new time
  */
 bool GPS::lookForTime()
 {
@@ -1544,11 +1544,12 @@ The Unix epoch (or Unix time or POSIX time or Unix timestamp) is the number of s
         if (t.tm_mon > -1) {
             LOG_DEBUG("NMEA GPS time %02d-%02d-%02d %02d:%02d:%02d age %d", d.year(), d.month(), t.tm_mday, t.tm_hour, t.tm_min,
                       t.tm_sec, ti.age());
-            if (perhapsSetRTC(RTCQualityGPS, t) == RTCSetResultInvalidTime) {
-                // Clear the GPS buffer if we got an invalid time
-                clearBuffer();
+            if (perhapsSetRTC(RTCQualityGPS, t) == RTCSetResultSuccess) {
+                LOG_DEBUG("Time set.");
+                return true;
+            } else {
+                return false;
             }
-            return true;
         } else
             return false;
     } else


### PR DESCRIPTION
There are certain GPS chips that have a hard-coded time in firmware that they will return before lock. We set our own hard-coded time, BUILD_EPOCH, that should be newer and use the comparison to not set a bad time.

In https://github.com/meshtastic/firmware/pull/7261 we introduced the RTCSetResult and improved it in https://github.com/meshtastic/firmware/pull/7375 .

However, the original try-fix left logic in GPS.cpp that could still result in broadcasting the bad time.

Further, as part of our fix we cleared the GPS buffer if we didn't get a good time. The mesh was hurting at the time, so this was a reasonable approach. However, given time tends to come in when we're trying to get early lock, this had the potential side effect of throwing away valuable information to get position lock.

This change reverses the clearBuffer and changes the logic so if time is not set it will not be broadcast.

Fixes https://github.com/meshtastic/firmware/issues/7771 
Fixes https://github.com/meshtastic/firmware/issues/7750
