### PR TITLE
Can't trust RTCs to tell the time.

### DIFF
--- a/src/gps/RTC.h
+++ b/src/gps/RTC.h
@@ -48,7 +48,7 @@ uint32_t getTime(bool local = false);
 /// Return time since 1970 in secs.  If quality is RTCQualityNone return zero
 uint32_t getValidTime(RTCQuality minQuality, bool local = false);
 
-void readFromRTC();
+RTCSetResult readFromRTC();
 
 time_t gm_mktime(struct tm *tm);
 


### PR DESCRIPTION
Further to https://github.com/meshtastic/firmware/pull/7772 , we discovered that some RTCs have hard-coded start times well in the past.

This patch gives RTCs the same treatment as GPS - if the time is earlier than BUILD_EPOCH, we don't use it.

Fixes #7771
Fixes #7750