### PR TITLE
Portduino config refactor

### DIFF
--- a/.clusterfuzzlite/router_fuzzer.cpp
+++ b/.clusterfuzzlite/router_fuzzer.cpp
@@ -132,7 +132,7 @@ int portduino_main(int argc, char **argv); // Renamed "main" function from Mesht
 // Start Meshtastic in a thread and wait till it has reached the ON state.
 int LLVMFuzzerInitialize(int *argc, char ***argv)
 {
-    settingsMap[maxtophone] = 5;
+    portduino_config.maxtophone = 5;
 
     meshtasticThread = std::thread([program = *argv[0]]() {
         char nodeIdStr[12];

--- a/.clusterfuzzlite/router_fuzzer.cpp
+++ b/.clusterfuzzlite/router_fuzzer.cpp
@@ -76,7 +76,7 @@ bool loopCanSleep()
 // Called just prior to starting Meshtastic. Allows for setting config values before startup.
 void lateInitVariant()
 {
-    settingsMap[logoutputlevel] = level_error;
+    portduino_config.logoutputlevel = level_error;
     channelFile.channels[0] = meshtastic_Channel{
         .has_settings = true,
         .settings =

--- a/src/DebugConfiguration.cpp
+++ b/src/DebugConfiguration.cpp
@@ -146,7 +146,7 @@ inline bool Syslog::_sendLog(uint16_t pri, const char *appName, const char *mess
 {
     int result;
 #ifdef ARCH_PORTDUINO
-    bool utf = !settingsMap[ascii_logs];
+    bool utf = !portduino_config.ascii_logs;
 #else
     bool utf = true;
 #endif

--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -57,7 +57,7 @@ size_t RedirectablePrint::vprintf(const char *logLevel, const char *format, va_l
 #endif
 
 #ifdef ARCH_PORTDUINO
-    bool color = !settingsMap[ascii_logs];
+    bool color = !portduino_config.ascii_logs;
 #else
     bool color = true;
 #endif
@@ -99,7 +99,7 @@ void RedirectablePrint::log_to_serial(const char *logLevel, const char *format, 
     size_t r = 0;
 
 #ifdef ARCH_PORTDUINO
-    bool color = !settingsMap[ascii_logs];
+    bool color = !portduino_config.ascii_logs;
 #else
     bool color = true;
 #endif
@@ -288,7 +288,7 @@ void RedirectablePrint::log(const char *logLevel, const char *format, ...)
 #if ARCH_PORTDUINO
     // level trace is special, two possible ways to handle it.
     if (strcmp(logLevel, MESHTASTIC_LOG_LEVEL_TRACE) == 0) {
-        if (settingsStrings[traceFilename] != "") {
+        if (portduino_config.traceFilename != "") {
             va_list arg;
             va_start(arg, format);
             try {
@@ -297,18 +297,18 @@ void RedirectablePrint::log(const char *logLevel, const char *format, ...)
             }
             va_end(arg);
         }
-        if (settingsMap[logoutputlevel] < level_trace && strcmp(logLevel, MESHTASTIC_LOG_LEVEL_TRACE) == 0) {
+        if (portduino_config.logoutputlevel < level_trace && strcmp(logLevel, MESHTASTIC_LOG_LEVEL_TRACE) == 0) {
             delete[] newFormat;
             return;
         }
     }
-    if (settingsMap[logoutputlevel] < level_debug && strcmp(logLevel, MESHTASTIC_LOG_LEVEL_DEBUG) == 0) {
+    if (portduino_config.logoutputlevel < level_debug && strcmp(logLevel, MESHTASTIC_LOG_LEVEL_DEBUG) == 0) {
         delete[] newFormat;
         return;
-    } else if (settingsMap[logoutputlevel] < level_info && strcmp(logLevel, MESHTASTIC_LOG_LEVEL_INFO) == 0) {
+    } else if (portduino_config.logoutputlevel < level_info && strcmp(logLevel, MESHTASTIC_LOG_LEVEL_INFO) == 0) {
         delete[] newFormat;
         return;
-    } else if (settingsMap[logoutputlevel] < level_warn && strcmp(logLevel, MESHTASTIC_LOG_LEVEL_WARN) == 0) {
+    } else if (portduino_config.logoutputlevel < level_warn && strcmp(logLevel, MESHTASTIC_LOG_LEVEL_WARN) == 0) {
         delete[] newFormat;
         return;
     }

--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1414,7 +1414,7 @@ GPS *GPS::createGps()
         _en_gpio = PIN_GPS_EN;
 #endif
 #ifdef ARCH_PORTDUINO
-    if (!settingsMap[has_gps])
+    if (!portduino_config.has_gps)
         return nullptr;
 #endif
     if (!_rx_gpio || !_serial_gps) // Configured to have no GPS at all

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -618,7 +618,7 @@ void Screen::setup()
 
 #if ARCH_PORTDUINO
     if (config.display.displaymode != meshtastic_Config_DisplayConfig_DisplayMode_COLOR) {
-        if (settingsMap[touchscreenModule]) {
+        if (portduino_config.touchscreenModule) {
             touchScreenImpl1 =
                 new TouchScreenImpl1(dispdev->getWidth(), dispdev->getHeight(), static_cast<TFTDisplay *>(dispdev)->getTouch);
             touchScreenImpl1->init();

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -370,7 +370,7 @@ Screen::Screen(ScanI2C::DeviceAddress address, meshtastic_Config_DisplayConfig_O
                              (address.port == ScanI2C::I2CPort::WIRE1) ? HW_I2C::I2C_TWO : HW_I2C::I2C_ONE);
 #elif ARCH_PORTDUINO
     if (config.display.displaymode != meshtastic_Config_DisplayConfig_DisplayMode_COLOR) {
-        if (settingsMap[displayPanel] != no_screen) {
+        if (portduino_config.displayPanel != no_screen) {
             LOG_DEBUG("Make TFTDisplay!");
             dispdev = new TFTDisplay(address.address, -1, -1, geometry,
                                      (address.port == ScanI2C::I2CPort::WIRE1) ? HW_I2C::I2C_TWO : HW_I2C::I2C_ONE);

--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -797,15 +797,15 @@ class LGFX : public lgfx::LGFX_Device
         buscfg.spi_mode = 0;
         buscfg.spi_host = portduino_config.display_spi_dev_int;
 
-        buscfg.pin_dc = settingsMap[displayDC]; // Set SPI DC pin number (-1 = disable)
+        buscfg.pin_dc = portduino_config.pinMappings[displayDC].pin; // Set SPI DC pin number (-1 = disable)
 
         _bus_instance.config(buscfg);            // applies the set value to the bus.
         _panel_instance->setBus(&_bus_instance); // set the bus on the panel.
 
         auto cfg = _panel_instance->config(); // Gets a structure for display panel settings.
         LOG_DEBUG("Width: %d, Height: %d", settingsMap[displayWidth], settingsMap[displayHeight]);
-        cfg.pin_cs = settingsMap[displayCS]; // Pin number where CS is connected (-1 = disable)
-        cfg.pin_rst = settingsMap[displayReset];
+        cfg.pin_cs = portduino_config.pinMappings[displayCS].pin; // Pin number where CS is connected (-1 = disable)
+        cfg.pin_rst = portduino_config.pinMappings[displayReset].pin;
         if (settingsMap[displayRotate]) {
             cfg.panel_width = settingsMap[displayHeight]; // actual displayable width
             cfg.panel_height = settingsMap[displayWidth]; // actual displayable height
@@ -831,12 +831,12 @@ class LGFX : public lgfx::LGFX_Device
             }
             auto touch_cfg = _touch_instance->config();
 
-            touch_cfg.pin_cs = settingsMap[touchscreenCS];
+            touch_cfg.pin_cs = portduino_config.pinMappings[touchscreenCS].pin;
             touch_cfg.x_min = 0;
             touch_cfg.x_max = settingsMap[displayHeight] - 1;
             touch_cfg.y_min = 0;
             touch_cfg.y_max = settingsMap[displayWidth] - 1;
-            touch_cfg.pin_int = settingsMap[touchscreenIRQ];
+            touch_cfg.pin_int = portduino_config.pinMappings[touchscreenIRQ].pin;
             touch_cfg.bus_shared = true;
             touch_cfg.offset_rotation = settingsMap[touchscreenRotate];
             if (settingsMap[touchscreenI2CAddr] != -1) {
@@ -1279,8 +1279,8 @@ void TFTDisplay::sendCommand(uint8_t com)
         backlightEnable->set(true);
 #if ARCH_PORTDUINO
         display(true);
-        if (settingsMap[displayBacklight] > 0)
-            digitalWrite(settingsMap[displayBacklight], TFT_BACKLIGHT_ON);
+        if (portduino_config.pinMappings[displayBacklight].pin > 0)
+            digitalWrite(portduino_config.pinMappings[displayBacklight].pin, TFT_BACKLIGHT_ON);
 #elif !defined(RAK14014) && !defined(M5STACK) && !defined(UNPHONE)
         tft->wakeup();
         tft->powerSaveOff();
@@ -1303,8 +1303,8 @@ void TFTDisplay::sendCommand(uint8_t com)
         backlightEnable->set(false);
 #if ARCH_PORTDUINO
         tft->clear();
-        if (settingsMap[displayBacklight] > 0)
-            digitalWrite(settingsMap[displayBacklight], !TFT_BACKLIGHT_ON);
+        if (portduino_config.pinMappings[displayBacklight].pin > 0)
+            digitalWrite(portduino_config.pinMappings[displayBacklight].pin, !TFT_BACKLIGHT_ON);
 #elif !defined(RAK14014) && !defined(M5STACK) && !defined(UNPHONE)
         tft->sleep();
         tft->powerSaveOn();

--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -797,15 +797,15 @@ class LGFX : public lgfx::LGFX_Device
         buscfg.spi_mode = 0;
         buscfg.spi_host = portduino_config.display_spi_dev_int;
 
-        buscfg.pin_dc = portduino_config.pinMappings[displayDC].pin; // Set SPI DC pin number (-1 = disable)
+        buscfg.pin_dc = portduino_config.displayDC.pin; // Set SPI DC pin number (-1 = disable)
 
         _bus_instance.config(buscfg);            // applies the set value to the bus.
         _panel_instance->setBus(&_bus_instance); // set the bus on the panel.
 
         auto cfg = _panel_instance->config(); // Gets a structure for display panel settings.
         LOG_DEBUG("Width: %d, Height: %d", portduino_config.displayWidth, portduino_config.displayHeight);
-        cfg.pin_cs = portduino_config.pinMappings[displayCS].pin; // Pin number where CS is connected (-1 = disable)
-        cfg.pin_rst = portduino_config.pinMappings[displayReset].pin;
+        cfg.pin_cs = portduino_config.displayCS.pin; // Pin number where CS is connected (-1 = disable)
+        cfg.pin_rst = portduino_config.displayReset.pin;
         if (portduino_config.displayRotate) {
             cfg.panel_width = portduino_config.displayHeight; // actual displayable width
             cfg.panel_height = portduino_config.displayWidth; // actual displayable height
@@ -831,12 +831,12 @@ class LGFX : public lgfx::LGFX_Device
             }
             auto touch_cfg = _touch_instance->config();
 
-            touch_cfg.pin_cs = portduino_config.pinMappings[touchscreenCS].pin;
+            touch_cfg.pin_cs = portduino_config.touchscreenCS.pin;
             touch_cfg.x_min = 0;
             touch_cfg.x_max = portduino_config.displayHeight - 1;
             touch_cfg.y_min = 0;
             touch_cfg.y_max = portduino_config.displayWidth - 1;
-            touch_cfg.pin_int = portduino_config.pinMappings[touchscreenIRQ].pin;
+            touch_cfg.pin_int = portduino_config.touchscreenIRQ.pin;
             touch_cfg.bus_shared = true;
             touch_cfg.offset_rotation = portduino_config.touchscreenRotate;
             if (portduino_config.touchscreenI2CAddr != -1) {
@@ -1279,8 +1279,8 @@ void TFTDisplay::sendCommand(uint8_t com)
         backlightEnable->set(true);
 #if ARCH_PORTDUINO
         display(true);
-        if (portduino_config.pinMappings[displayBacklight].pin > 0)
-            digitalWrite(portduino_config.pinMappings[displayBacklight].pin, TFT_BACKLIGHT_ON);
+        if (portduino_config.displayBacklight.pin > 0)
+            digitalWrite(portduino_config.displayBacklight.pin, TFT_BACKLIGHT_ON);
 #elif !defined(RAK14014) && !defined(M5STACK) && !defined(UNPHONE)
         tft->wakeup();
         tft->powerSaveOff();
@@ -1303,8 +1303,8 @@ void TFTDisplay::sendCommand(uint8_t com)
         backlightEnable->set(false);
 #if ARCH_PORTDUINO
         tft->clear();
-        if (portduino_config.pinMappings[displayBacklight].pin > 0)
-            digitalWrite(portduino_config.pinMappings[displayBacklight].pin, !TFT_BACKLIGHT_ON);
+        if (portduino_config.displayBacklight.pin > 0)
+            digitalWrite(portduino_config.displayBacklight.pin, !TFT_BACKLIGHT_ON);
 #elif !defined(RAK14014) && !defined(M5STACK) && !defined(UNPHONE)
         tft->sleep();
         tft->powerSaveOn();

--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -767,24 +767,24 @@ class LGFX : public lgfx::LGFX_Device
 
     LGFX(void)
     {
-        if (settingsMap[displayPanel] == st7789)
+        if (portduino_config.displayPanel == st7789)
             _panel_instance = new lgfx::Panel_ST7789;
-        else if (settingsMap[displayPanel] == st7735)
+        else if (portduino_config.displayPanel == st7735)
             _panel_instance = new lgfx::Panel_ST7735;
-        else if (settingsMap[displayPanel] == st7735s)
+        else if (portduino_config.displayPanel == st7735s)
             _panel_instance = new lgfx::Panel_ST7735S;
-        else if (settingsMap[displayPanel] == st7796)
+        else if (portduino_config.displayPanel == st7796)
             _panel_instance = new lgfx::Panel_ST7796;
-        else if (settingsMap[displayPanel] == ili9341)
+        else if (portduino_config.displayPanel == ili9341)
             _panel_instance = new lgfx::Panel_ILI9341;
-        else if (settingsMap[displayPanel] == ili9342)
+        else if (portduino_config.displayPanel == ili9342)
             _panel_instance = new lgfx::Panel_ILI9342;
-        else if (settingsMap[displayPanel] == ili9488)
+        else if (portduino_config.displayPanel == ili9488)
             _panel_instance = new lgfx::Panel_ILI9488;
-        else if (settingsMap[displayPanel] == hx8357d)
+        else if (portduino_config.displayPanel == hx8357d)
             _panel_instance = new lgfx::Panel_HX8357D;
 #if defined(LGFX_SDL)
-        else if (settingsMap[displayPanel] == x11) {
+        else if (portduino_config.displayPanel == x11) {
             _panel_instance = new lgfx::Panel_sdl;
         }
 #endif
@@ -803,20 +803,20 @@ class LGFX : public lgfx::LGFX_Device
         _panel_instance->setBus(&_bus_instance); // set the bus on the panel.
 
         auto cfg = _panel_instance->config(); // Gets a structure for display panel settings.
-        LOG_DEBUG("Width: %d, Height: %d", settingsMap[displayWidth], settingsMap[displayHeight]);
+        LOG_DEBUG("Width: %d, Height: %d", portduino_config.displayWidth, portduino_config.displayHeight);
         cfg.pin_cs = portduino_config.pinMappings[displayCS].pin; // Pin number where CS is connected (-1 = disable)
         cfg.pin_rst = portduino_config.pinMappings[displayReset].pin;
-        if (settingsMap[displayRotate]) {
-            cfg.panel_width = settingsMap[displayHeight]; // actual displayable width
-            cfg.panel_height = settingsMap[displayWidth]; // actual displayable height
+        if (portduino_config.displayRotate) {
+            cfg.panel_width = portduino_config.displayHeight; // actual displayable width
+            cfg.panel_height = portduino_config.displayWidth; // actual displayable height
         } else {
-            cfg.panel_width = settingsMap[displayWidth];   // actual displayable width
-            cfg.panel_height = settingsMap[displayHeight]; // actual displayable height
+            cfg.panel_width = portduino_config.displayWidth;   // actual displayable width
+            cfg.panel_height = portduino_config.displayHeight; // actual displayable height
         }
-        cfg.offset_x = settingsMap[displayOffsetX];             // Panel offset amount in X direction
-        cfg.offset_y = settingsMap[displayOffsetY];             // Panel offset amount in Y direction
-        cfg.offset_rotation = settingsMap[displayOffsetRotate]; // Rotation direction value offset 0~7 (4~7 is mirrored)
-        cfg.invert = settingsMap[displayInvert];                // Set to true if the light/darkness of the panel is reversed
+        cfg.offset_x = portduino_config.displayOffsetX;             // Panel offset amount in X direction
+        cfg.offset_y = portduino_config.displayOffsetY;             // Panel offset amount in Y direction
+        cfg.offset_rotation = portduino_config.displayOffsetRotate; // Rotation direction value offset 0~7 (4~7 is mirrored)
+        cfg.invert = portduino_config.displayInvert;                // Set to true if the light/darkness of the panel is reversed
 
         _panel_instance->config(cfg);
 
@@ -833,12 +833,12 @@ class LGFX : public lgfx::LGFX_Device
 
             touch_cfg.pin_cs = portduino_config.pinMappings[touchscreenCS].pin;
             touch_cfg.x_min = 0;
-            touch_cfg.x_max = settingsMap[displayHeight] - 1;
+            touch_cfg.x_max = portduino_config.displayHeight - 1;
             touch_cfg.y_min = 0;
-            touch_cfg.y_max = settingsMap[displayWidth] - 1;
+            touch_cfg.y_max = portduino_config.displayWidth - 1;
             touch_cfg.pin_int = portduino_config.pinMappings[touchscreenIRQ].pin;
             touch_cfg.bus_shared = true;
-            touch_cfg.offset_rotation = settingsMap[touchscreenRotate];
+            touch_cfg.offset_rotation = portduino_config.touchscreenRotate;
             if (portduino_config.touchscreenI2CAddr != -1) {
                 touch_cfg.i2c_addr = portduino_config.touchscreenI2CAddr;
             } else {
@@ -849,7 +849,7 @@ class LGFX : public lgfx::LGFX_Device
             _panel_instance->setTouch(_touch_instance);
         }
 #if defined(LGFX_SDL)
-        if (settingsMap[displayPanel] == x11) {
+        if (portduino_config.displayPanel == x11) {
             lgfx::Panel_sdl *sdl_panel_ = (lgfx::Panel_sdl *)_panel_instance;
             sdl_panel_->setup();
             sdl_panel_->addKeyCodeMapping(SDLK_RETURN, SDL_SCANCODE_KP_ENTER);
@@ -1115,10 +1115,10 @@ TFTDisplay::TFTDisplay(uint8_t address, int sda, int scl, OLEDDISPLAY_GEOMETRY g
     backlightEnable = p;
 
 #if ARCH_PORTDUINO
-    if (settingsMap[displayRotate]) {
-        setGeometry(GEOMETRY_RAWMODE, settingsMap[configNames::displayWidth], settingsMap[configNames::displayHeight]);
+    if (portduino_config.displayRotate) {
+        setGeometry(GEOMETRY_RAWMODE, portduino_config.displayWidth, portduino_config.displayWidth);
     } else {
-        setGeometry(GEOMETRY_RAWMODE, settingsMap[configNames::displayHeight], settingsMap[configNames::displayWidth]);
+        setGeometry(GEOMETRY_RAWMODE, portduino_config.displayHeight, portduino_config.displayHeight);
     }
 
 #elif defined(SCREEN_ROTATE)
@@ -1231,7 +1231,7 @@ void TFTDisplay::sdlLoop()
 #if defined(LGFX_SDL)
     static int lastPressed = 0;
     static int shuttingDown = false;
-    if (settingsMap[displayPanel] == x11) {
+    if (portduino_config.displayPanel == x11) {
         lgfx::Panel_sdl *sdl_panel_ = (lgfx::Panel_sdl *)tft->_panel_instance;
         if (sdl_panel_->loop() && !shuttingDown) {
             LOG_WARN("Window Closed!");

--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -795,7 +795,7 @@ class LGFX : public lgfx::LGFX_Device
 
         auto buscfg = _bus_instance.config();
         buscfg.spi_mode = 0;
-        buscfg.spi_host = settingsMap[displayspidev];
+        buscfg.spi_host = portduino_config.display_spi_dev_int;
 
         buscfg.pin_dc = settingsMap[displayDC]; // Set SPI DC pin number (-1 = disable)
 
@@ -842,7 +842,7 @@ class LGFX : public lgfx::LGFX_Device
             if (settingsMap[touchscreenI2CAddr] != -1) {
                 touch_cfg.i2c_addr = settingsMap[touchscreenI2CAddr];
             } else {
-                touch_cfg.spi_host = settingsMap[touchscreenspidev];
+                touch_cfg.spi_host = portduino_config.touchscreen_spi_dev_int;
             }
 
             _touch_instance->config(touch_cfg);

--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -821,12 +821,12 @@ class LGFX : public lgfx::LGFX_Device
         _panel_instance->config(cfg);
 
         // Configure settings for touch  control.
-        if (settingsMap[touchscreenModule]) {
-            if (settingsMap[touchscreenModule] == xpt2046) {
+        if (portduino_config.touchscreenModule) {
+            if (portduino_config.touchscreenModule == xpt2046) {
                 _touch_instance = new lgfx::Touch_XPT2046;
-            } else if (settingsMap[touchscreenModule] == stmpe610) {
+            } else if (portduino_config.touchscreenModule == stmpe610) {
                 _touch_instance = new lgfx::Touch_STMPE610;
-            } else if (settingsMap[touchscreenModule] == ft5x06) {
+            } else if (portduino_config.touchscreenModule == ft5x06) {
                 _touch_instance = new lgfx::Touch_FT5x06;
             }
             auto touch_cfg = _touch_instance->config();
@@ -839,8 +839,8 @@ class LGFX : public lgfx::LGFX_Device
             touch_cfg.pin_int = portduino_config.pinMappings[touchscreenIRQ].pin;
             touch_cfg.bus_shared = true;
             touch_cfg.offset_rotation = settingsMap[touchscreenRotate];
-            if (settingsMap[touchscreenI2CAddr] != -1) {
-                touch_cfg.i2c_addr = settingsMap[touchscreenI2CAddr];
+            if (portduino_config.touchscreenI2CAddr != -1) {
+                touch_cfg.i2c_addr = portduino_config.touchscreenI2CAddr;
             } else {
                 touch_cfg.spi_host = portduino_config.touchscreen_spi_dev_int;
             }

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -104,13 +104,13 @@ void tftSetup(void)
                     .type = touch[portduino_config.touchscreenModule],
                     .freq = (uint32_t)portduino_config.touchscreenBusFrequency,
                     .x_min = 0,
-                    .x_max =
-                        (int16_t)((portduino_config.touchscreenRotate & 1 ? portduino_config.displayWidth : portduino_config.displayHeight) -
-                                  1),
+                    .x_max = (int16_t)((portduino_config.touchscreenRotate & 1 ? portduino_config.displayWidth
+                                                                               : portduino_config.displayHeight) -
+                                       1),
                     .y_min = 0,
-                    .y_max =
-                        (int16_t)((portduino_config.touchscreenRotate & 1 ? portduino_config.displayHeight : portduino_config.displayWidth) -
-                                  1),
+                    .y_max = (int16_t)((portduino_config.touchscreenRotate & 1 ? portduino_config.displayHeight
+                                                                               : portduino_config.displayWidth) -
+                                       1),
                     .pin_int = (int16_t)portduino_config.pinMappings[touchscreenIRQ].pin,
                     .offset_rotation = (uint8_t)portduino_config.touchscreenRotate,
                     .i2c{.i2c_addr = (uint8_t)portduino_config.touchscreenI2CAddr}});

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -89,9 +89,9 @@ void tftSetup(void)
                     .pin_bl = (int16_t)portduino_config.pinMappings[displayBacklight].pin,
                     .pwm_channel = (int8_t)portduino_config.pinMappings[displayBacklightPWMChannel].pin,
                     .invert = (bool)settingsMap[displayBacklightInvert]});
-            if (settingsMap[touchscreenI2CAddr] == -1) {
+            if (portduino_config.touchscreenI2CAddr == -1) {
                 displayConfig.touch(
-                    DisplayDriverConfig::touch_config_t{.type = touch[settingsMap[touchscreenModule]],
+                    DisplayDriverConfig::touch_config_t{.type = touch[portduino_config.touchscreenModule],
                                                         .freq = (uint32_t)settingsMap[touchscreenBusFrequency],
                                                         .pin_int = (int16_t)portduino_config.pinMappings[touchscreenIRQ].pin,
                                                         .offset_rotation = (uint8_t)settingsMap[touchscreenRotate],
@@ -101,7 +101,7 @@ void tftSetup(void)
                                                         .pin_cs = (int16_t)portduino_config.pinMappings[touchscreenCS].pin});
             } else {
                 displayConfig.touch(DisplayDriverConfig::touch_config_t{
-                    .type = touch[settingsMap[touchscreenModule]],
+                    .type = touch[portduino_config.touchscreenModule],
                     .freq = (uint32_t)settingsMap[touchscreenBusFrequency],
                     .x_min = 0,
                     .x_max =
@@ -113,7 +113,7 @@ void tftSetup(void)
                                   1),
                     .pin_int = (int16_t)portduino_config.pinMappings[touchscreenIRQ].pin,
                     .offset_rotation = (uint8_t)settingsMap[touchscreenRotate],
-                    .i2c{.i2c_addr = (uint8_t)settingsMap[touchscreenI2CAddr]}});
+                    .i2c{.i2c_addr = (uint8_t)portduino_config.touchscreenI2CAddr}});
             }
         }
         deviceScreen = &DeviceScreen::create(&displayConfig);

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -82,9 +82,9 @@ void tftSetup(void)
                                                        .freq_read = 16000000,
                                                        .spi{.pin_dc = (int8_t)settingsMap[displayDC],
                                                             .use_lock = true,
-                                                            .spi_host = (uint16_t)settingsMap[displayspidev]}})
-                .input(DisplayDriverConfig::input_config_t{.keyboardDevice = settingsStrings[keyboardDevice],
-                                                           .pointerDevice = settingsStrings[pointerDevice]})
+                                                            .spi_host = (uint16_t)portduino_config.display_spi_dev_int}})
+                .input(DisplayDriverConfig::input_config_t{.keyboardDevice = portduino_config.keyboardDevice,
+                                                           .pointerDevice = portduino_config.pointerDevice})
                 .light(DisplayDriverConfig::light_config_t{.pin_bl = (int16_t)settingsMap[displayBacklight],
                                                            .pwm_channel = (int8_t)settingsMap[displayBacklightPWMChannel],
                                                            .invert = (bool)settingsMap[displayBacklightInvert]});
@@ -95,7 +95,7 @@ void tftSetup(void)
                                                         .pin_int = (int16_t)settingsMap[touchscreenIRQ],
                                                         .offset_rotation = (uint8_t)settingsMap[touchscreenRotate],
                                                         .spi{
-                                                            .spi_host = (int8_t)settingsMap[touchscreenspidev],
+                                                            .spi_host = (int8_t)portduino_config.touchscreen_spi_dev_int,
                                                         },
                                                         .pin_cs = (int16_t)settingsMap[touchscreenCS]});
             } else {

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -85,10 +85,9 @@ void tftSetup(void)
                                                             .spi_host = (uint16_t)portduino_config.display_spi_dev_int}})
                 .input(DisplayDriverConfig::input_config_t{.keyboardDevice = portduino_config.keyboardDevice,
                                                            .pointerDevice = portduino_config.pointerDevice})
-                .light(DisplayDriverConfig::light_config_t{
-                    .pin_bl = (int16_t)portduino_config.displayBacklight.pin,
-                    .pwm_channel = (int8_t)portduino_config.displayBacklightPWMChannel.pin,
-                    .invert = (bool)portduino_config.displayBacklightInvert});
+                .light(DisplayDriverConfig::light_config_t{.pin_bl = (int16_t)portduino_config.displayBacklight.pin,
+                                                           .pwm_channel = (int8_t)portduino_config.displayBacklightPWMChannel.pin,
+                                                           .invert = (bool)portduino_config.displayBacklightInvert});
             if (portduino_config.touchscreenI2CAddr == -1) {
                 displayConfig.touch(
                     DisplayDriverConfig::touch_config_t{.type = touch[portduino_config.touchscreenModule],

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -69,8 +69,8 @@ void tftSetup(void)
                                                            .panel_width = (uint16_t)settingsMap[displayWidth],
                                                            .panel_height = (uint16_t)settingsMap[displayHeight],
                                                            .rotation = (bool)settingsMap[displayRotate],
-                                                           .pin_cs = (int16_t)settingsMap[displayCS],
-                                                           .pin_rst = (int16_t)settingsMap[displayReset],
+                                                           .pin_cs = (int16_t)portduino_config.pinMappings[displayCS].pin,
+                                                           .pin_rst = (int16_t)portduino_config.pinMappings[displayReset].pin,
                                                            .offset_x = (uint16_t)settingsMap[displayOffsetX],
                                                            .offset_y = (uint16_t)settingsMap[displayOffsetY],
                                                            .offset_rotation = (uint8_t)settingsMap[displayOffsetRotate],
@@ -80,24 +80,25 @@ void tftSetup(void)
                                                                          settingsMap[displayPanel] == ili9488})
                 .bus(DisplayDriverConfig::bus_config_t{.freq_write = (uint32_t)settingsMap[displayBusFrequency],
                                                        .freq_read = 16000000,
-                                                       .spi{.pin_dc = (int8_t)settingsMap[displayDC],
+                                                       .spi{.pin_dc = (int8_t)portduino_config.pinMappings[displayDC].pin,
                                                             .use_lock = true,
                                                             .spi_host = (uint16_t)portduino_config.display_spi_dev_int}})
                 .input(DisplayDriverConfig::input_config_t{.keyboardDevice = portduino_config.keyboardDevice,
                                                            .pointerDevice = portduino_config.pointerDevice})
-                .light(DisplayDriverConfig::light_config_t{.pin_bl = (int16_t)settingsMap[displayBacklight],
-                                                           .pwm_channel = (int8_t)settingsMap[displayBacklightPWMChannel],
-                                                           .invert = (bool)settingsMap[displayBacklightInvert]});
+                .light(DisplayDriverConfig::light_config_t{
+                    .pin_bl = (int16_t)portduino_config.pinMappings[displayBacklight].pin,
+                    .pwm_channel = (int8_t)portduino_config.pinMappings[displayBacklightPWMChannel].pin,
+                    .invert = (bool)settingsMap[displayBacklightInvert]});
             if (settingsMap[touchscreenI2CAddr] == -1) {
                 displayConfig.touch(
                     DisplayDriverConfig::touch_config_t{.type = touch[settingsMap[touchscreenModule]],
                                                         .freq = (uint32_t)settingsMap[touchscreenBusFrequency],
-                                                        .pin_int = (int16_t)settingsMap[touchscreenIRQ],
+                                                        .pin_int = (int16_t)portduino_config.pinMappings[touchscreenIRQ].pin,
                                                         .offset_rotation = (uint8_t)settingsMap[touchscreenRotate],
                                                         .spi{
                                                             .spi_host = (int8_t)portduino_config.touchscreen_spi_dev_int,
                                                         },
-                                                        .pin_cs = (int16_t)settingsMap[touchscreenCS]});
+                                                        .pin_cs = (int16_t)portduino_config.pinMappings[touchscreenCS].pin});
             } else {
                 displayConfig.touch(DisplayDriverConfig::touch_config_t{
                     .type = touch[settingsMap[touchscreenModule]],
@@ -110,7 +111,7 @@ void tftSetup(void)
                     .y_max =
                         (int16_t)((settingsMap[touchscreenRotate] & 1 ? settingsMap[displayHeight] : settingsMap[displayWidth]) -
                                   1),
-                    .pin_int = (int16_t)settingsMap[touchscreenIRQ],
+                    .pin_int = (int16_t)portduino_config.pinMappings[touchscreenIRQ].pin,
                     .offset_rotation = (uint8_t)settingsMap[touchscreenRotate],
                     .i2c{.i2c_addr = (uint8_t)settingsMap[touchscreenI2CAddr]}});
             }

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -69,8 +69,8 @@ void tftSetup(void)
                                                            .panel_width = (uint16_t)portduino_config.displayWidth,
                                                            .panel_height = (uint16_t)portduino_config.displayHeight,
                                                            .rotation = (bool)portduino_config.displayRotate,
-                                                           .pin_cs = (int16_t)portduino_config.pinMappings[displayCS].pin,
-                                                           .pin_rst = (int16_t)portduino_config.pinMappings[displayReset].pin,
+                                                           .pin_cs = (int16_t)portduino_config.displayCS.pin,
+                                                           .pin_rst = (int16_t)portduino_config.displayReset.pin,
                                                            .offset_x = (uint16_t)portduino_config.displayOffsetX,
                                                            .offset_y = (uint16_t)portduino_config.displayOffsetY,
                                                            .offset_rotation = (uint8_t)portduino_config.displayOffsetRotate,
@@ -80,25 +80,25 @@ void tftSetup(void)
                                                                          portduino_config.displayPanel == ili9488})
                 .bus(DisplayDriverConfig::bus_config_t{.freq_write = (uint32_t)portduino_config.displayBusFrequency,
                                                        .freq_read = 16000000,
-                                                       .spi{.pin_dc = (int8_t)portduino_config.pinMappings[displayDC].pin,
+                                                       .spi{.pin_dc = (int8_t)portduino_config.displayDC.pin,
                                                             .use_lock = true,
                                                             .spi_host = (uint16_t)portduino_config.display_spi_dev_int}})
                 .input(DisplayDriverConfig::input_config_t{.keyboardDevice = portduino_config.keyboardDevice,
                                                            .pointerDevice = portduino_config.pointerDevice})
                 .light(DisplayDriverConfig::light_config_t{
-                    .pin_bl = (int16_t)portduino_config.pinMappings[displayBacklight].pin,
-                    .pwm_channel = (int8_t)portduino_config.pinMappings[displayBacklightPWMChannel].pin,
+                    .pin_bl = (int16_t)portduino_config.displayBacklight.pin,
+                    .pwm_channel = (int8_t)portduino_config.displayBacklightPWMChannel.pin,
                     .invert = (bool)portduino_config.displayBacklightInvert});
             if (portduino_config.touchscreenI2CAddr == -1) {
                 displayConfig.touch(
                     DisplayDriverConfig::touch_config_t{.type = touch[portduino_config.touchscreenModule],
                                                         .freq = (uint32_t)portduino_config.touchscreenBusFrequency,
-                                                        .pin_int = (int16_t)portduino_config.pinMappings[touchscreenIRQ].pin,
+                                                        .pin_int = (int16_t)portduino_config.touchscreenIRQ.pin,
                                                         .offset_rotation = (uint8_t)portduino_config.touchscreenRotate,
                                                         .spi{
                                                             .spi_host = (int8_t)portduino_config.touchscreen_spi_dev_int,
                                                         },
-                                                        .pin_cs = (int16_t)portduino_config.pinMappings[touchscreenCS].pin});
+                                                        .pin_cs = (int16_t)portduino_config.touchscreenCS.pin});
             } else {
                 displayConfig.touch(DisplayDriverConfig::touch_config_t{
                     .type = touch[portduino_config.touchscreenModule],
@@ -111,7 +111,7 @@ void tftSetup(void)
                     .y_max = (int16_t)((portduino_config.touchscreenRotate & 1 ? portduino_config.displayHeight
                                                                                : portduino_config.displayWidth) -
                                        1),
-                    .pin_int = (int16_t)portduino_config.pinMappings[touchscreenIRQ].pin,
+                    .pin_int = (int16_t)portduino_config.touchscreenIRQ.pin,
                     .offset_rotation = (uint8_t)portduino_config.touchscreenRotate,
                     .i2c{.i2c_addr = (uint8_t)portduino_config.touchscreenI2CAddr}});
             }

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -41,44 +41,44 @@ void tftSetup(void)
     PacketAPI::create(PacketServer::init());
     deviceScreen->init(new PacketClient);
 #else
-    if (settingsMap[displayPanel] != no_screen) {
+    if (portduino_config.displayPanel != no_screen) {
         DisplayDriverConfig displayConfig;
         static char *panels[] = {"NOSCREEN", "X11",     "FB",      "ST7789",  "ST7735",  "ST7735S",
                                  "ST7796",   "ILI9341", "ILI9342", "ILI9486", "ILI9488", "HX8357D"};
         static char *touch[] = {"NOTOUCH", "XPT2046", "STMPE610", "GT911", "FT5x06"};
 #if defined(USE_X11)
-        if (settingsMap[displayPanel] == x11) {
-            if (settingsMap[displayWidth] && settingsMap[displayHeight])
-                displayConfig = DisplayDriverConfig(DisplayDriverConfig::device_t::X11, (uint16_t)settingsMap[displayWidth],
-                                                    (uint16_t)settingsMap[displayHeight]);
+        if (portduino_config.displayPanel == x11) {
+            if (portduino_config.displayWidth && portduino_config.displayHeight)
+                displayConfig = DisplayDriverConfig(DisplayDriverConfig::device_t::X11, (uint16_t)portduino_config.displayWidth,
+                                                    (uint16_t)portduino_config.displayHeight);
             else
                 displayConfig.device(DisplayDriverConfig::device_t::X11);
         } else
 #elif defined(USE_FRAMEBUFFER)
-        if (settingsMap[displayPanel] == fb) {
-            if (settingsMap[displayWidth] && settingsMap[displayHeight])
-                displayConfig = DisplayDriverConfig(DisplayDriverConfig::device_t::FB, (uint16_t)settingsMap[displayWidth],
-                                                    (uint16_t)settingsMap[displayHeight]);
+        if (portduino_config.displayPanel == fb) {
+            if (portduino_config.displayWidth && portduino_config.displayHeight)
+                displayConfig = DisplayDriverConfig(DisplayDriverConfig::device_t::FB, (uint16_t)portduino_config.displayWidth,
+                                                    (uint16_t)portduino_config.displayHeight);
             else
                 displayConfig.device(DisplayDriverConfig::device_t::FB);
         } else
 #endif
         {
             displayConfig.device(DisplayDriverConfig::device_t::CUSTOM_TFT)
-                .panel(DisplayDriverConfig::panel_config_t{.type = panels[settingsMap[displayPanel]],
-                                                           .panel_width = (uint16_t)settingsMap[displayWidth],
-                                                           .panel_height = (uint16_t)settingsMap[displayHeight],
-                                                           .rotation = (bool)settingsMap[displayRotate],
+                .panel(DisplayDriverConfig::panel_config_t{.type = panels[portduino_config.displayPanel],
+                                                           .panel_width = (uint16_t)portduino_config.displayWidth,
+                                                           .panel_height = (uint16_t)portduino_config.displayHeight,
+                                                           .rotation = (bool)portduino_config.displayRotate,
                                                            .pin_cs = (int16_t)portduino_config.pinMappings[displayCS].pin,
                                                            .pin_rst = (int16_t)portduino_config.pinMappings[displayReset].pin,
-                                                           .offset_x = (uint16_t)settingsMap[displayOffsetX],
-                                                           .offset_y = (uint16_t)settingsMap[displayOffsetY],
-                                                           .offset_rotation = (uint8_t)settingsMap[displayOffsetRotate],
-                                                           .invert = settingsMap[displayInvert] ? true : false,
-                                                           .rgb_order = (bool)settingsMap[displayRGBOrder],
-                                                           .dlen_16bit = settingsMap[displayPanel] == ili9486 ||
-                                                                         settingsMap[displayPanel] == ili9488})
-                .bus(DisplayDriverConfig::bus_config_t{.freq_write = (uint32_t)settingsMap[displayBusFrequency],
+                                                           .offset_x = (uint16_t)portduino_config.displayOffsetX,
+                                                           .offset_y = (uint16_t)portduino_config.displayOffsetY,
+                                                           .offset_rotation = (uint8_t)portduino_config.displayOffsetRotate,
+                                                           .invert = portduino_config.displayInvert ? true : false,
+                                                           .rgb_order = (bool)portduino_config.displayRGBOrder,
+                                                           .dlen_16bit = portduino_config.displayPanel == ili9486 ||
+                                                                         portduino_config.displayPanel == ili9488})
+                .bus(DisplayDriverConfig::bus_config_t{.freq_write = (uint32_t)portduino_config.displayBusFrequency,
                                                        .freq_read = 16000000,
                                                        .spi{.pin_dc = (int8_t)portduino_config.pinMappings[displayDC].pin,
                                                             .use_lock = true,
@@ -88,13 +88,13 @@ void tftSetup(void)
                 .light(DisplayDriverConfig::light_config_t{
                     .pin_bl = (int16_t)portduino_config.pinMappings[displayBacklight].pin,
                     .pwm_channel = (int8_t)portduino_config.pinMappings[displayBacklightPWMChannel].pin,
-                    .invert = (bool)settingsMap[displayBacklightInvert]});
+                    .invert = (bool)portduino_config.displayBacklightInvert});
             if (portduino_config.touchscreenI2CAddr == -1) {
                 displayConfig.touch(
                     DisplayDriverConfig::touch_config_t{.type = touch[portduino_config.touchscreenModule],
-                                                        .freq = (uint32_t)settingsMap[touchscreenBusFrequency],
+                                                        .freq = (uint32_t)portduino_config.touchscreenBusFrequency,
                                                         .pin_int = (int16_t)portduino_config.pinMappings[touchscreenIRQ].pin,
-                                                        .offset_rotation = (uint8_t)settingsMap[touchscreenRotate],
+                                                        .offset_rotation = (uint8_t)portduino_config.touchscreenRotate,
                                                         .spi{
                                                             .spi_host = (int8_t)portduino_config.touchscreen_spi_dev_int,
                                                         },
@@ -102,17 +102,17 @@ void tftSetup(void)
             } else {
                 displayConfig.touch(DisplayDriverConfig::touch_config_t{
                     .type = touch[portduino_config.touchscreenModule],
-                    .freq = (uint32_t)settingsMap[touchscreenBusFrequency],
+                    .freq = (uint32_t)portduino_config.touchscreenBusFrequency,
                     .x_min = 0,
                     .x_max =
-                        (int16_t)((settingsMap[touchscreenRotate] & 1 ? settingsMap[displayWidth] : settingsMap[displayHeight]) -
+                        (int16_t)((portduino_config.touchscreenRotate & 1 ? portduino_config.displayWidth : portduino_config.displayHeight) -
                                   1),
                     .y_min = 0,
                     .y_max =
-                        (int16_t)((settingsMap[touchscreenRotate] & 1 ? settingsMap[displayHeight] : settingsMap[displayWidth]) -
+                        (int16_t)((portduino_config.touchscreenRotate & 1 ? portduino_config.displayHeight : portduino_config.displayWidth) -
                                   1),
                     .pin_int = (int16_t)portduino_config.pinMappings[touchscreenIRQ].pin,
-                    .offset_rotation = (uint8_t)settingsMap[touchscreenRotate],
+                    .offset_rotation = (uint8_t)portduino_config.touchscreenRotate,
                     .i2c{.i2c_addr = (uint8_t)portduino_config.touchscreenI2CAddr}});
             }
         }

--- a/src/input/LinuxInput.cpp
+++ b/src/input/LinuxInput.cpp
@@ -33,9 +33,9 @@ int32_t LinuxInput::runOnce()
 {
 
     if (firstTime) {
-        if (settingsStrings[keyboardDevice] == "")
+        if (portduino_config.keyboardDevice == "")
             return disable();
-        fd = open(settingsStrings[keyboardDevice].c_str(), O_RDWR);
+        fd = open(portduino_config.keyboardDevice.c_str(), O_RDWR);
         if (fd < 0)
             return disable();
         ret = ioctl(fd, EVIOCGRAB, (void *)1);

--- a/src/input/TouchScreenImpl1.cpp
+++ b/src/input/TouchScreenImpl1.cpp
@@ -18,7 +18,7 @@ TouchScreenImpl1::TouchScreenImpl1(uint16_t width, uint16_t height, bool (*getTo
 void TouchScreenImpl1::init()
 {
 #if ARCH_PORTDUINO
-    if (settingsMap[touchscreenModule]) {
+    if (portduino_config.touchscreenModule) {
         TouchScreenBase::init(true);
         inputBroker->registerSource(this);
     } else {

--- a/src/input/TrackballInterruptBase.h
+++ b/src/input/TrackballInterruptBase.h
@@ -6,7 +6,7 @@
 #ifndef TB_DIRECTION
 #if ARCH_PORTDUINO
 #include "PortduinoGlue.h"
-#define TB_DIRECTION (PinStatus) settingsMap[tbDirection]
+#define TB_DIRECTION (PinStatus) portduino_config.lora_usb_vid
 #else
 #define TB_DIRECTION RISING
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -390,7 +390,7 @@ void setup()
 
     concurrency::hasBeenSetup = true;
 #if ARCH_PORTDUINO
-    SPISettings spiSettings(settingsMap[spiSpeed], MSBFIRST, SPI_MODE0);
+    SPISettings spiSettings(portduino_config.spiSpeed, MSBFIRST, SPI_MODE0);
 #else
     SPISettings spiSettings(4000000, MSBFIRST, SPI_MODE0);
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -982,13 +982,13 @@ void setup()
 #endif
 #if defined(ARCH_PORTDUINO)
 
-    if (portduino_config.pinMappings[userButtonPin].enabled) {
+    if (portduino_config.userButtonPin.enabled) {
 
-        LOG_DEBUG("Use GPIO%02d for button", portduino_config.pinMappings[userButtonPin].pin);
+        LOG_DEBUG("Use GPIO%02d for button", portduino_config.userButtonPin.pin);
         UserButtonThread = new ButtonThread("UserButton");
         if (screen) {
             ButtonConfig config;
-            config.pinNumber = (uint8_t)portduino_config.pinMappings[userButtonPin].pin;
+            config.pinNumber = (uint8_t)portduino_config.userButtonPin.pin;
             config.activeLow = true;
             config.activePullup = true;
             config.pullupSense = INPUT_PULLUP;
@@ -1196,9 +1196,9 @@ void setup()
     } else {
         RadioLibHAL = new LockingArduinoHal(SPI, spiSettings);
     }
-    rIf = loraModuleInterface((LockingArduinoHal *)RadioLibHAL, portduino_config.pinMappings[cs_pin].pin,
-                              portduino_config.pinMappings[irq_pin].pin, portduino_config.pinMappings[reset_pin].pin,
-                              portduino_config.pinMappings[busy_pin].pin);
+    rIf = loraModuleInterface((LockingArduinoHal *)RadioLibHAL, portduino_config.lora_cs_pin.pin,
+                              portduino_config.lora_irq_pin.pin, portduino_config.lora_reset_pin.pin,
+                              portduino_config.lora_busy_pin.pin);
 
     if (!rIf->init()) {
         LOG_WARN("No %s radio", portduino_config.loraModules[portduino_config.lora_module].c_str());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1196,9 +1196,9 @@ void setup()
     } else {
         RadioLibHAL = new LockingArduinoHal(SPI, spiSettings);
     }
-    rIf = loraModuleInterface((LockingArduinoHal *)RadioLibHAL, portduino_config.lora_cs_pin.pin,
-                              portduino_config.lora_irq_pin.pin, portduino_config.lora_reset_pin.pin,
-                              portduino_config.lora_busy_pin.pin);
+    rIf =
+        loraModuleInterface((LockingArduinoHal *)RadioLibHAL, portduino_config.lora_cs_pin.pin, portduino_config.lora_irq_pin.pin,
+                            portduino_config.lora_reset_pin.pin, portduino_config.lora_busy_pin.pin);
 
     if (!rIf->init()) {
         LOG_WARN("No %s radio", portduino_config.loraModules[portduino_config.lora_module].c_str());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -982,13 +982,13 @@ void setup()
 #endif
 #if defined(ARCH_PORTDUINO)
 
-    if (settingsMap.count(userButtonPin) != 0 && settingsMap[userButtonPin] != RADIOLIB_NC) {
+    if (portduino_config.pinMappings[userButtonPin].enabled) {
 
-        LOG_DEBUG("Use GPIO%02d for button", settingsMap[userButtonPin]);
+        LOG_DEBUG("Use GPIO%02d for button", portduino_config.pinMappings[userButtonPin].pin);
         UserButtonThread = new ButtonThread("UserButton");
         if (screen) {
             ButtonConfig config;
-            config.pinNumber = (uint8_t)settingsMap[userButtonPin];
+            config.pinNumber = (uint8_t)portduino_config.pinMappings[userButtonPin].pin;
             config.activeLow = true;
             config.activePullup = true;
             config.pullupSense = INPUT_PULLUP;
@@ -1196,8 +1196,9 @@ void setup()
     } else {
         RadioLibHAL = new LockingArduinoHal(SPI, spiSettings);
     }
-    rIf = loraModuleInterface((LockingArduinoHal *)RadioLibHAL, settingsMap[cs_pin], settingsMap[irq_pin], settingsMap[reset_pin],
-                              settingsMap[busy_pin]);
+    rIf = loraModuleInterface((LockingArduinoHal *)RadioLibHAL, portduino_config.pinMappings[cs_pin].pin,
+                              portduino_config.pinMappings[irq_pin].pin, portduino_config.pinMappings[reset_pin].pin,
+                              portduino_config.pinMappings[busy_pin].pin);
 
     if (!rIf->init()) {
         LOG_WARN("No %s radio", portduino_config.loraModules[portduino_config.lora_module].c_str());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -881,7 +881,7 @@ void setup()
     defined(ST7789_CS) || defined(HX8357_CS) || defined(USE_ST7789) || defined(ILI9488_CS) || defined(ST7796_CS)
         screen = new graphics::Screen(screen_found, screen_model, screen_geometry);
 #elif defined(ARCH_PORTDUINO)
-        if ((screen_found.port != ScanI2C::I2CPort::NO_I2C || settingsMap[displayPanel]) &&
+        if ((screen_found.port != ScanI2C::I2CPort::NO_I2C || portduino_config.displayPanel) &&
             config.display.displaymode != meshtastic_Config_DisplayConfig_DisplayMode_COLOR) {
             screen = new graphics::Screen(screen_found, screen_model, screen_geometry);
         }
@@ -1145,7 +1145,7 @@ void setup()
     if (screen)
         screen->setup();
 #elif defined(ARCH_PORTDUINO)
-    if ((screen_found.port != ScanI2C::I2CPort::NO_I2C || settingsMap[displayPanel]) &&
+    if ((screen_found.port != ScanI2C::I2CPort::NO_I2C || portduino_config.displayPanel) &&
         config.display.displaymode != meshtastic_Config_DisplayConfig_DisplayMode_COLOR) {
         screen->setup();
     }
@@ -1444,7 +1444,7 @@ void setup()
 
 #ifdef ARCH_PORTDUINO
 #if __has_include(<ulfius.h>)
-    if (settingsMap[webserverport] != -1) {
+    if (portduino_config.webserverport != -1) {
         piwebServerThread = new PiWebServerThread();
         std::atexit([] { delete piwebServerThread; });
     }

--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -21,7 +21,7 @@ static const Module::RfSwitchMode_t rfswitch_table[] = {
 // Particular boards might define a different max power based on what their hardware can do, default to max power output if not
 // specified (may be dangerous if using external PA and LR11x0 power config forgotten)
 #if ARCH_PORTDUINO
-#define LR1110_MAX_POWER settingsMap[lr1110_max_power]
+#define LR1110_MAX_POWER portduino_config.lr1110_max_power
 #endif
 #ifndef LR1110_MAX_POWER
 #define LR1110_MAX_POWER 22
@@ -30,7 +30,7 @@ static const Module::RfSwitchMode_t rfswitch_table[] = {
 // the 2.4G part maxes at 13dBm
 
 #if ARCH_PORTDUINO
-#define LR1120_MAX_POWER settingsMap[lr1120_max_power]
+#define LR1120_MAX_POWER portduino_config.lr1120_max_power
 #endif
 #ifndef LR1120_MAX_POWER
 #define LR1120_MAX_POWER 13
@@ -55,7 +55,7 @@ template <typename T> bool LR11x0Interface<T>::init()
 #endif
 
 #if ARCH_PORTDUINO
-    float tcxoVoltage = (float)settingsMap[dio3_tcxo_voltage] / 1000;
+    float tcxoVoltage = (float)portduino_config.dio3_tcxo_voltage / 1000;
 // FIXME: correct logic to default to not using TCXO if no voltage is specified for LR11x0_DIO3_TCXO_VOLTAGE
 #elif !defined(LR11X0_DIO3_TCXO_VOLTAGE)
     float tcxoVoltage =

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -673,7 +673,7 @@ void NodeDB::installDefaultConfig(bool preserveKey = false)
 #endif
 #elif ARCH_PORTDUINO
     bool hasScreen = false;
-    if (settingsMap[displayPanel])
+    if (portduino_config.displayPanel)
         hasScreen = true;
     else
         hasScreen = screen_found.port != ScanI2C::I2CPort::NO_I2C;
@@ -1334,8 +1334,8 @@ void NodeDB::loadFromDisk()
     }
 #if ARCH_PORTDUINO
     // set any config overrides
-    if (settingsMap[has_configDisplayMode]) {
-        config.display.displaymode = (_meshtastic_Config_DisplayConfig_DisplayMode)settingsMap[configDisplayMode];
+    if (portduino_config.has_configDisplayMode) {
+        config.display.displaymode = (_meshtastic_Config_DisplayConfig_DisplayMode)portduino_config.configDisplayMode;
     }
 
 #endif

--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -10,7 +10,7 @@
 #endif
 
 #if ARCH_PORTDUINO
-#define RF95_MAX_POWER settingsMap[rf95_max_power]
+#define RF95_MAX_POWER portduino_config.rf95_max_power
 #endif
 #ifndef RF95_MAX_POWER
 #define RF95_MAX_POWER 20

--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -94,16 +94,16 @@ void RF95Interface::setTransmitEnable(bool txon)
 #ifdef RF95_TXEN
     digitalWrite(RF95_TXEN, txon ? 1 : 0);
 #elif ARCH_PORTDUINO
-    if (settingsMap[txen_pin] != RADIOLIB_NC) {
-        digitalWrite(settingsMap[txen_pin], txon ? 1 : 0);
+    if (portduino_config.pinMappings[txen_pin].pin != RADIOLIB_NC) {
+        digitalWrite(portduino_config.pinMappings[txen_pin].pin, txon ? 1 : 0);
     }
 #endif
 
 #ifdef RF95_RXEN
     digitalWrite(RF95_RXEN, txon ? 0 : 1);
 #elif ARCH_PORTDUINO
-    if (settingsMap[rxen_pin] != RADIOLIB_NC) {
-        digitalWrite(settingsMap[rxen_pin], txon ? 0 : 1);
+    if (portduino_config.pinMappings[rxen_pin].pin != RADIOLIB_NC) {
+        digitalWrite(portduino_config.pinMappings[rxen_pin].pin, txon ? 0 : 1);
     }
 #endif
 }
@@ -164,13 +164,13 @@ bool RF95Interface::init()
     digitalWrite(RF95_RXEN, 1);
 #endif
 #if ARCH_PORTDUINO
-    if (settingsMap[txen_pin] != RADIOLIB_NC) {
-        pinMode(settingsMap[txen_pin], OUTPUT);
-        digitalWrite(settingsMap[txen_pin], 0);
+    if (portduino_config.pinMappings[txen_pin].pin != RADIOLIB_NC) {
+        pinMode(portduino_config.pinMappings[txen_pin].pin, OUTPUT);
+        digitalWrite(portduino_config.pinMappings[txen_pin].pin, 0);
     }
-    if (settingsMap[rxen_pin] != RADIOLIB_NC) {
-        pinMode(settingsMap[rxen_pin], OUTPUT);
-        digitalWrite(settingsMap[rxen_pin], 0);
+    if (portduino_config.pinMappings[rxen_pin].pin != RADIOLIB_NC) {
+        pinMode(portduino_config.pinMappings[rxen_pin].pin, OUTPUT);
+        digitalWrite(portduino_config.pinMappings[rxen_pin].pin, 0);
     }
 #endif
     setTransmitEnable(false);

--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -94,16 +94,16 @@ void RF95Interface::setTransmitEnable(bool txon)
 #ifdef RF95_TXEN
     digitalWrite(RF95_TXEN, txon ? 1 : 0);
 #elif ARCH_PORTDUINO
-    if (portduino_config.pinMappings[txen_pin].pin != RADIOLIB_NC) {
-        digitalWrite(portduino_config.pinMappings[txen_pin].pin, txon ? 1 : 0);
+    if (portduino_config.lora_txen_pin.pin != RADIOLIB_NC) {
+        digitalWrite(portduino_config.lora_txen_pin.pin, txon ? 1 : 0);
     }
 #endif
 
 #ifdef RF95_RXEN
     digitalWrite(RF95_RXEN, txon ? 0 : 1);
 #elif ARCH_PORTDUINO
-    if (portduino_config.pinMappings[rxen_pin].pin != RADIOLIB_NC) {
-        digitalWrite(portduino_config.pinMappings[rxen_pin].pin, txon ? 0 : 1);
+    if (portduino_config.lora_rxen_pin.pin != RADIOLIB_NC) {
+        digitalWrite(portduino_config.lora_rxen_pin.pin, txon ? 0 : 1);
     }
 #endif
 }
@@ -164,13 +164,13 @@ bool RF95Interface::init()
     digitalWrite(RF95_RXEN, 1);
 #endif
 #if ARCH_PORTDUINO
-    if (portduino_config.pinMappings[txen_pin].pin != RADIOLIB_NC) {
-        pinMode(portduino_config.pinMappings[txen_pin].pin, OUTPUT);
-        digitalWrite(portduino_config.pinMappings[txen_pin].pin, 0);
+    if (portduino_config.lora_txen_pin.pin != RADIOLIB_NC) {
+        pinMode(portduino_config.lora_txen_pin.pin, OUTPUT);
+        digitalWrite(portduino_config.lora_txen_pin.pin, 0);
     }
-    if (portduino_config.pinMappings[rxen_pin].pin != RADIOLIB_NC) {
-        pinMode(portduino_config.pinMappings[rxen_pin].pin, OUTPUT);
-        digitalWrite(portduino_config.pinMappings[rxen_pin].pin, 0);
+    if (portduino_config.lora_rxen_pin.pin != RADIOLIB_NC) {
+        pinMode(portduino_config.lora_rxen_pin.pin, OUTPUT);
+        digitalWrite(portduino_config.lora_rxen_pin.pin, 0);
     }
 #endif
     setTransmitEnable(false);

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -417,7 +417,7 @@ void RadioLibInterface::handleReceiveInterrupt()
 
     int state = iface->readData((uint8_t *)&radioBuffer, length);
 #if ARCH_PORTDUINO
-    if (settingsMap[logoutputlevel] == level_trace) {
+    if (portduino_config.logoutputlevel == level_trace) {
         printBytes("Raw incoming packet: ", (uint8_t *)&radioBuffer, length);
     }
 #endif

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -446,7 +446,7 @@ DecodeState perhapsDecode(meshtastic_MeshPacket *p)
 #if ENABLE_JSON_LOGGING
         LOG_TRACE("%s", MeshPacketSerializer::JsonSerialize(p, false).c_str());
 #elif ARCH_PORTDUINO
-        if (settingsStrings[traceFilename] != "" || settingsMap[logoutputlevel] == level_trace) {
+        if (portduino_config.traceFilename != "" || portduino_config.logoutputlevel == level_trace) {
             LOG_TRACE("%s", MeshPacketSerializer::JsonSerialize(p, false).c_str());
         }
 #endif
@@ -685,7 +685,7 @@ void Router::perhapsHandleReceived(meshtastic_MeshPacket *p)
     LOG_TRACE("%s", MeshPacketSerializer::JsonSerializeEncrypted(p).c_str());
 #elif ARCH_PORTDUINO
     // Even ignored packets get logged in the trace
-    if (settingsStrings[traceFilename] != "" || settingsMap[logoutputlevel] == level_trace) {
+    if (portduino_config.traceFilename != "" || portduino_config.logoutputlevel == level_trace) {
         p->rx_time = getValidTime(RTCQualityFromNet); // store the arrival timestamp for the phone
         LOG_TRACE("%s", MeshPacketSerializer::JsonSerializeEncrypted(p).c_str());
     }

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -54,9 +54,9 @@ template <typename T> bool SX126xInterface<T>::init()
 
 #if ARCH_PORTDUINO
     tcxoVoltage = (float)settingsMap[dio3_tcxo_voltage] / 1000;
-    if (settingsMap[sx126x_ant_sw_pin] != RADIOLIB_NC) {
-        digitalWrite(settingsMap[sx126x_ant_sw_pin], HIGH);
-        pinMode(settingsMap[sx126x_ant_sw_pin], OUTPUT);
+    if (portduino_config.pinMappings[sx126x_ant_sw_pin].pin != RADIOLIB_NC) {
+        digitalWrite(portduino_config.pinMappings[sx126x_ant_sw_pin].pin, HIGH);
+        pinMode(portduino_config.pinMappings[sx126x_ant_sw_pin].pin, OUTPUT);
     }
 #endif
     if (tcxoVoltage == 0.0)
@@ -112,9 +112,9 @@ template <typename T> bool SX126xInterface<T>::init()
     // no effect
 #if ARCH_PORTDUINO
     if (res == RADIOLIB_ERR_NONE) {
-        LOG_DEBUG("Use MCU pin %i as RXEN and pin %i as TXEN to control RF switching", settingsMap[rxen_pin],
-                  settingsMap[txen_pin]);
-        lora.setRfSwitchPins(settingsMap[rxen_pin], settingsMap[txen_pin]);
+        LOG_DEBUG("Use MCU pin %i as RXEN and pin %i as TXEN to control RF switching", portduino_config.pinMappings[rxen_pin].pin,
+                  portduino_config.pinMappings[txen_pin].pin);
+        lora.setRfSwitchPins(portduino_config.pinMappings[rxen_pin].pin, portduino_config.pinMappings[txen_pin].pin);
     }
 #else
 #ifndef SX126X_RXEN

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -12,7 +12,7 @@
 // Particular boards might define a different max power based on what their hardware can do, default to max power output if not
 // specified (may be dangerous if using external PA and SX126x power config forgotten)
 #if ARCH_PORTDUINO
-#define SX126X_MAX_POWER settingsMap[sx126x_max_power]
+#define SX126X_MAX_POWER portduino_config.sx126x_max_power
 #endif
 #ifndef SX126X_MAX_POWER
 #define SX126X_MAX_POWER 22
@@ -53,7 +53,7 @@ template <typename T> bool SX126xInterface<T>::init()
 #endif
 
 #if ARCH_PORTDUINO
-    tcxoVoltage = (float)settingsMap[dio3_tcxo_voltage] / 1000;
+    tcxoVoltage = (float)portduino_config.dio3_tcxo_voltage / 1000;
     if (portduino_config.pinMappings[sx126x_ant_sw_pin].pin != RADIOLIB_NC) {
         digitalWrite(portduino_config.pinMappings[sx126x_ant_sw_pin].pin, HIGH);
         pinMode(portduino_config.pinMappings[sx126x_ant_sw_pin].pin, OUTPUT);
@@ -98,7 +98,7 @@ template <typename T> bool SX126xInterface<T>::init()
         bool dio2AsRfSwitch = true;
 #elif defined(ARCH_PORTDUINO)
         bool dio2AsRfSwitch = false;
-        if (settingsMap[dio2_as_rf_switch]) {
+        if (portduino_config.dio2_as_rf_switch) {
             dio2AsRfSwitch = true;
         }
 #else

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -54,9 +54,9 @@ template <typename T> bool SX126xInterface<T>::init()
 
 #if ARCH_PORTDUINO
     tcxoVoltage = (float)portduino_config.dio3_tcxo_voltage / 1000;
-    if (portduino_config.pinMappings[sx126x_ant_sw_pin].pin != RADIOLIB_NC) {
-        digitalWrite(portduino_config.pinMappings[sx126x_ant_sw_pin].pin, HIGH);
-        pinMode(portduino_config.pinMappings[sx126x_ant_sw_pin].pin, OUTPUT);
+    if (portduino_config.lora_sx126x_ant_sw_pin.pin != RADIOLIB_NC) {
+        digitalWrite(portduino_config.lora_sx126x_ant_sw_pin.pin, HIGH);
+        pinMode(portduino_config.lora_sx126x_ant_sw_pin.pin, OUTPUT);
     }
 #endif
     if (tcxoVoltage == 0.0)
@@ -112,9 +112,9 @@ template <typename T> bool SX126xInterface<T>::init()
     // no effect
 #if ARCH_PORTDUINO
     if (res == RADIOLIB_ERR_NONE) {
-        LOG_DEBUG("Use MCU pin %i as RXEN and pin %i as TXEN to control RF switching", portduino_config.pinMappings[rxen_pin].pin,
-                  portduino_config.pinMappings[txen_pin].pin);
-        lora.setRfSwitchPins(portduino_config.pinMappings[rxen_pin].pin, portduino_config.pinMappings[txen_pin].pin);
+        LOG_DEBUG("Use MCU pin %i as RXEN and pin %i as TXEN to control RF switching", portduino_config.lora_rxen_pin.pin,
+                  portduino_config.lora_txen_pin.pin);
+        lora.setRfSwitchPins(portduino_config.lora_rxen_pin.pin, portduino_config.lora_txen_pin.pin);
     }
 #else
 #ifndef SX126X_RXEN

--- a/src/mesh/SX128xInterface.cpp
+++ b/src/mesh/SX128xInterface.cpp
@@ -41,13 +41,13 @@ template <typename T> bool SX128xInterface<T>::init()
 #endif
 
 #if ARCH_PORTDUINO
-    if (settingsMap[rxen_pin] != RADIOLIB_NC) {
-        pinMode(settingsMap[rxen_pin], OUTPUT);
-        digitalWrite(settingsMap[rxen_pin], LOW); // Set low before becoming an output
+    if (portduino_config.pinMappings[rxen_pin].pin != RADIOLIB_NC) {
+        pinMode(portduino_config.pinMappings[rxen_pin].pin, OUTPUT);
+        digitalWrite(portduino_config.pinMappings[rxen_pin].pin, LOW); // Set low before becoming an output
     }
-    if (settingsMap[txen_pin] != RADIOLIB_NC) {
-        pinMode(settingsMap[txen_pin], OUTPUT);
-        digitalWrite(settingsMap[txen_pin], LOW); // Set low before becoming an output
+    if (portduino_config.pinMappings[txen_pin].pin != RADIOLIB_NC) {
+        pinMode(portduino_config.pinMappings[txen_pin].pin, OUTPUT);
+        digitalWrite(portduino_config.pinMappings[txen_pin].pin, LOW); // Set low before becoming an output
     }
 #else
 #if defined(SX128X_RXEN) && (SX128X_RXEN != RADIOLIB_NC) // set not rx or tx mode
@@ -93,8 +93,9 @@ template <typename T> bool SX128xInterface<T>::init()
         lora.setRfSwitchPins(SX128X_RXEN, SX128X_TXEN);
     }
 #elif ARCH_PORTDUINO
-    if (res == RADIOLIB_ERR_NONE && settingsMap[rxen_pin] != RADIOLIB_NC && settingsMap[txen_pin] != RADIOLIB_NC) {
-        lora.setRfSwitchPins(settingsMap[rxen_pin], settingsMap[txen_pin]);
+    if (res == RADIOLIB_ERR_NONE && portduino_config.pinMappings[rxen_pin].pin != RADIOLIB_NC &&
+        portduino_config.pinMappings[txen_pin].pin != RADIOLIB_NC) {
+        lora.setRfSwitchPins(portduino_config.pinMappings[rxen_pin].pin, portduino_config.pinMappings[txen_pin].pin);
     }
 #endif
 
@@ -174,11 +175,11 @@ template <typename T> void SX128xInterface<T>::setStandby()
         LOG_ERROR("SX128x standby %s%d", radioLibErr, err);
     assert(err == RADIOLIB_ERR_NONE);
 #if ARCH_PORTDUINO
-    if (settingsMap[rxen_pin] != RADIOLIB_NC) {
-        digitalWrite(settingsMap[rxen_pin], LOW);
+    if (portduino_config.pinMappings[rxen_pin].pin != RADIOLIB_NC) {
+        digitalWrite(portduino_config.pinMappings[rxen_pin].pin, LOW);
     }
-    if (settingsMap[txen_pin] != RADIOLIB_NC) {
-        digitalWrite(settingsMap[txen_pin], LOW);
+    if (portduino_config.pinMappings[txen_pin].pin != RADIOLIB_NC) {
+        digitalWrite(portduino_config.pinMappings[txen_pin].pin, LOW);
     }
 #else
 #if defined(SX128X_RXEN) && (SX128X_RXEN != RADIOLIB_NC) // we have RXEN/TXEN control - turn off RX and TX power
@@ -210,11 +211,11 @@ template <typename T> void SX128xInterface<T>::addReceiveMetadata(meshtastic_Mes
 template <typename T> void SX128xInterface<T>::configHardwareForSend()
 {
 #if ARCH_PORTDUINO
-    if (settingsMap[txen_pin] != RADIOLIB_NC) {
-        digitalWrite(settingsMap[txen_pin], HIGH);
+    if (portduino_config.pinMappings[txen_pin].pin != RADIOLIB_NC) {
+        digitalWrite(portduino_config.pinMappings[txen_pin].pin, HIGH);
     }
-    if (settingsMap[rxen_pin] != RADIOLIB_NC) {
-        digitalWrite(settingsMap[rxen_pin], LOW);
+    if (portduino_config.pinMappings[rxen_pin].pin != RADIOLIB_NC) {
+        digitalWrite(portduino_config.pinMappings[rxen_pin].pin, LOW);
     }
 
 #else
@@ -241,11 +242,11 @@ template <typename T> void SX128xInterface<T>::startReceive()
     setStandby();
 
 #if ARCH_PORTDUINO
-    if (settingsMap[rxen_pin] != RADIOLIB_NC) {
-        digitalWrite(settingsMap[rxen_pin], HIGH);
+    if (portduino_config.pinMappings[rxen_pin].pin != RADIOLIB_NC) {
+        digitalWrite(portduino_config.pinMappings[rxen_pin].pin, HIGH);
     }
-    if (settingsMap[txen_pin] != RADIOLIB_NC) {
-        digitalWrite(settingsMap[txen_pin], LOW);
+    if (portduino_config.pinMappings[txen_pin].pin != RADIOLIB_NC) {
+        digitalWrite(portduino_config.pinMappings[txen_pin].pin, LOW);
     }
 
 #else

--- a/src/mesh/SX128xInterface.cpp
+++ b/src/mesh/SX128xInterface.cpp
@@ -41,13 +41,13 @@ template <typename T> bool SX128xInterface<T>::init()
 #endif
 
 #if ARCH_PORTDUINO
-    if (portduino_config.pinMappings[rxen_pin].pin != RADIOLIB_NC) {
-        pinMode(portduino_config.pinMappings[rxen_pin].pin, OUTPUT);
-        digitalWrite(portduino_config.pinMappings[rxen_pin].pin, LOW); // Set low before becoming an output
+    if (portduino_config.lora_rxen_pin.pin != RADIOLIB_NC) {
+        pinMode(portduino_config.lora_rxen_pin.pin, OUTPUT);
+        digitalWrite(portduino_config.lora_rxen_pin.pin, LOW); // Set low before becoming an output
     }
-    if (portduino_config.pinMappings[txen_pin].pin != RADIOLIB_NC) {
-        pinMode(portduino_config.pinMappings[txen_pin].pin, OUTPUT);
-        digitalWrite(portduino_config.pinMappings[txen_pin].pin, LOW); // Set low before becoming an output
+    if (portduino_config.lora_txen_pin.pin != RADIOLIB_NC) {
+        pinMode(portduino_config.lora_txen_pin.pin, OUTPUT);
+        digitalWrite(portduino_config.lora_txen_pin.pin, LOW); // Set low before becoming an output
     }
 #else
 #if defined(SX128X_RXEN) && (SX128X_RXEN != RADIOLIB_NC) // set not rx or tx mode
@@ -93,9 +93,9 @@ template <typename T> bool SX128xInterface<T>::init()
         lora.setRfSwitchPins(SX128X_RXEN, SX128X_TXEN);
     }
 #elif ARCH_PORTDUINO
-    if (res == RADIOLIB_ERR_NONE && portduino_config.pinMappings[rxen_pin].pin != RADIOLIB_NC &&
-        portduino_config.pinMappings[txen_pin].pin != RADIOLIB_NC) {
-        lora.setRfSwitchPins(portduino_config.pinMappings[rxen_pin].pin, portduino_config.pinMappings[txen_pin].pin);
+    if (res == RADIOLIB_ERR_NONE && portduino_config.lora_rxen_pin.pin != RADIOLIB_NC &&
+        portduino_config.lora_txen_pin.pin != RADIOLIB_NC) {
+        lora.setRfSwitchPins(portduino_config.lora_rxen_pin.pin, portduino_config.lora_txen_pin.pin);
     }
 #endif
 
@@ -175,11 +175,11 @@ template <typename T> void SX128xInterface<T>::setStandby()
         LOG_ERROR("SX128x standby %s%d", radioLibErr, err);
     assert(err == RADIOLIB_ERR_NONE);
 #if ARCH_PORTDUINO
-    if (portduino_config.pinMappings[rxen_pin].pin != RADIOLIB_NC) {
-        digitalWrite(portduino_config.pinMappings[rxen_pin].pin, LOW);
+    if (portduino_config.lora_rxen_pin.pin != RADIOLIB_NC) {
+        digitalWrite(portduino_config.lora_rxen_pin.pin, LOW);
     }
-    if (portduino_config.pinMappings[txen_pin].pin != RADIOLIB_NC) {
-        digitalWrite(portduino_config.pinMappings[txen_pin].pin, LOW);
+    if (portduino_config.lora_txen_pin.pin != RADIOLIB_NC) {
+        digitalWrite(portduino_config.lora_txen_pin.pin, LOW);
     }
 #else
 #if defined(SX128X_RXEN) && (SX128X_RXEN != RADIOLIB_NC) // we have RXEN/TXEN control - turn off RX and TX power
@@ -211,11 +211,11 @@ template <typename T> void SX128xInterface<T>::addReceiveMetadata(meshtastic_Mes
 template <typename T> void SX128xInterface<T>::configHardwareForSend()
 {
 #if ARCH_PORTDUINO
-    if (portduino_config.pinMappings[txen_pin].pin != RADIOLIB_NC) {
-        digitalWrite(portduino_config.pinMappings[txen_pin].pin, HIGH);
+    if (portduino_config.lora_txen_pin.pin != RADIOLIB_NC) {
+        digitalWrite(portduino_config.lora_txen_pin.pin, HIGH);
     }
-    if (portduino_config.pinMappings[rxen_pin].pin != RADIOLIB_NC) {
-        digitalWrite(portduino_config.pinMappings[rxen_pin].pin, LOW);
+    if (portduino_config.lora_rxen_pin.pin != RADIOLIB_NC) {
+        digitalWrite(portduino_config.lora_rxen_pin.pin, LOW);
     }
 
 #else
@@ -242,11 +242,11 @@ template <typename T> void SX128xInterface<T>::startReceive()
     setStandby();
 
 #if ARCH_PORTDUINO
-    if (portduino_config.pinMappings[rxen_pin].pin != RADIOLIB_NC) {
-        digitalWrite(portduino_config.pinMappings[rxen_pin].pin, HIGH);
+    if (portduino_config.lora_rxen_pin.pin != RADIOLIB_NC) {
+        digitalWrite(portduino_config.lora_rxen_pin.pin, HIGH);
     }
-    if (portduino_config.pinMappings[txen_pin].pin != RADIOLIB_NC) {
-        digitalWrite(portduino_config.pinMappings[txen_pin].pin, LOW);
+    if (portduino_config.lora_txen_pin.pin != RADIOLIB_NC) {
+        digitalWrite(portduino_config.lora_txen_pin.pin, LOW);
     }
 
 #else

--- a/src/mesh/SX128xInterface.cpp
+++ b/src/mesh/SX128xInterface.cpp
@@ -11,7 +11,7 @@
 
 // Particular boards might define a different max power based on what their hardware can do
 #if ARCH_PORTDUINO
-#define SX128X_MAX_POWER settingsMap[sx128x_max_power]
+#define SX128X_MAX_POWER portduino_config.sx128x_max_power
 #endif
 #ifndef SX128X_MAX_POWER
 #define SX128X_MAX_POWER 13

--- a/src/mesh/raspihttp/PiWebServer.cpp
+++ b/src/mesh/raspihttp/PiWebServer.cpp
@@ -458,8 +458,8 @@ PiWebServerThread::PiWebServerThread()
         }
     }
 
-    if (settingsMap[webserverport] != 0) {
-        webservport = settingsMap[webserverport];
+    if (portduino_config.webserverport != 0) {
+        webservport = portduino_config.webserverport;
         LOG_INFO("Use webserver port from yaml config %i ", webservport);
     } else {
         LOG_INFO("Webserver port in yaml config set to 0, defaulting to port 9443");

--- a/src/mesh/raspihttp/PiWebServer.cpp
+++ b/src/mesh/raspihttp/PiWebServer.cpp
@@ -65,8 +65,8 @@ mail:   marchammermann@googlemail.com
 #define DEFAULT_REALM "default_realm"
 #define PREFIX ""
 
-#define KEY_PATH settingsStrings[websslkeypath].c_str()
-#define CERT_PATH settingsStrings[websslcertpath].c_str()
+#define KEY_PATH portduino_config.webserver_ssl_key_path.c_str()
+#define CERT_PATH portduino_config.webserver_ssl_cert_path.c_str()
 
 struct _file_config configWeb;
 
@@ -490,7 +490,7 @@ PiWebServerThread::PiWebServerThread()
         u_map_put(&configWeb.mime_types, ".ico", "image/x-icon");
         u_map_put(&configWeb.mime_types, ".svg", "image/svg+xml");
 
-        webrootpath = settingsStrings[webserverrootpath];
+        webrootpath = portduino_config.webserver_root_path;
 
         configWeb.files_path = (char *)webrootpath.c_str();
         configWeb.url_prefix = "";

--- a/src/modules/Telemetry/HostMetrics.cpp
+++ b/src/modules/Telemetry/HostMetrics.cpp
@@ -9,11 +9,11 @@
 int32_t HostMetricsModule::runOnce()
 {
 #if ARCH_PORTDUINO
-    if (settingsMap[hostMetrics_interval] == 0) {
+    if (portduino_config.hostMetrics_interval == 0) {
         return disable();
     } else {
         sendMetrics();
-        return 60 * 1000 * settingsMap[hostMetrics_interval];
+        return 60 * 1000 * portduino_config.hostMetrics_interval;
     }
 #else
     return disable();
@@ -135,7 +135,7 @@ bool HostMetricsModule::sendMetrics()
     p->to = NODENUM_BROADCAST;
     p->decoded.want_response = false;
     p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
-    p->channel = settingsMap[hostMetrics_channel];
+    p->channel = portduino_config.hostMetrics_channel;
     LOG_INFO("Send packet to mesh");
     service->sendToMesh(p, RX_SRC_LOCAL, true);
     return true;

--- a/src/modules/Telemetry/HostMetrics.cpp
+++ b/src/modules/Telemetry/HostMetrics.cpp
@@ -110,8 +110,8 @@ meshtastic_Telemetry HostMetricsModule::getHostMetrics()
             proc_loadavg.close();
         }
     }
-    if (settingsStrings[hostMetrics_user_command] != "") {
-        std::string userCommandResult = exec(settingsStrings[hostMetrics_user_command].c_str());
+    if (portduino_config.hostMetrics_user_command != "") {
+        std::string userCommandResult = exec(portduino_config.hostMetrics_user_command.c_str());
         if (userCommandResult.length() > 1) {
             strncpy(t.variant.host_metrics.user_string, userCommandResult.c_str(), sizeof(t.variant.host_metrics.user_string));
             t.variant.host_metrics.user_string[sizeof(t.variant.host_metrics.user_string) - 1] = '\0';

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -186,7 +186,6 @@ void portduinoSetup()
         portduino_config.lora_module = use_simradio;
     }
 
-
     if (portduino_config.config_directory != "") {
         std::string filetype = ".yaml";
         for (const std::filesystem::directory_entry &entry :
@@ -211,7 +210,6 @@ void portduinoSetup()
         return;
     }
 
-
     // If LoRa `Module: auto` (default in config.yaml),
     // attempt to auto config based on Product Strings
     if (portduino_config.lora_module == use_autoconf) {
@@ -219,8 +217,8 @@ void portduinoSetup()
         // Try CH341
         try {
             std::cout << "autoconf: Looking for CH341 device..." << std::endl;
-            ch341Hal =
-                new Ch341Hal(0, portduino_config.lora_usb_serial_num, portduino_config.lora_usb_vid, portduino_config.lora_usb_pid);
+            ch341Hal = new Ch341Hal(0, portduino_config.lora_usb_serial_num, portduino_config.lora_usb_vid,
+                                    portduino_config.lora_usb_pid);
             ch341Hal->getProductString(autoconf_product, 95);
             delete ch341Hal;
             std::cout << "autoconf: Found CH341 device " << autoconf_product << std::endl;
@@ -345,8 +343,8 @@ void portduinoSetup()
     uint8_t dmac[6] = {0};
     if (portduino_config.lora_spi_dev == "ch341") {
         try {
-            ch341Hal =
-                new Ch341Hal(0, portduino_config.lora_usb_serial_num, portduino_config.lora_usb_vid, portduino_config.lora_usb_pid);
+            ch341Hal = new Ch341Hal(0, portduino_config.lora_usb_serial_num, portduino_config.lora_usb_vid,
+                                    portduino_config.lora_usb_pid);
         } catch (std::exception &e) {
             std::cerr << e.what() << std::endl;
             std::cerr << "Could not initialize CH341 device!" << std::endl;
@@ -582,7 +580,7 @@ bool loadConfig(const char *configPath)
 
             for (auto &screen_name : portduino_config.screen_names) {
                 if (yamlConfig["Display"]["Panel"].as<std::string>("") == screen_name.second)
-                portduino_config.displayPanel = screen_name.first;
+                    portduino_config.displayPanel = screen_name.first;
             }
             portduino_config.displayHeight = yamlConfig["Display"]["Height"].as<int>(0);
             portduino_config.displayWidth = yamlConfig["Display"]["Width"].as<int>(0);

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -499,7 +499,6 @@ bool loadConfig(const char *configPath)
                 for (auto this_pin : portduino_config.all_pins) {
                     if (this_pin->config_section == "Lora") {
                         readGPIOFromYaml(yamlConfig["Lora"][this_pin->config_name], *this_pin);
-      
                     }
                 }
             }
@@ -590,8 +589,7 @@ bool loadConfig(const char *configPath)
             readGPIOFromYaml(yamlConfig["Display"]["DC"], portduino_config.displayDC, -1);
             readGPIOFromYaml(yamlConfig["Display"]["CS"], portduino_config.displayCS, -1);
             readGPIOFromYaml(yamlConfig["Display"]["Backlight"], portduino_config.displayBacklight, -1);
-            readGPIOFromYaml(yamlConfig["Display"]["BacklightPWMChannel"],
-                             portduino_config.displayBacklightPWMChannel, -1);
+            readGPIOFromYaml(yamlConfig["Display"]["BacklightPWMChannel"], portduino_config.displayBacklightPWMChannel, -1);
             readGPIOFromYaml(yamlConfig["Display"]["Reset"], portduino_config.displayReset, -1);
 
             portduino_config.displayBacklightInvert = yamlConfig["Display"]["BacklightInvert"].as<bool>(false);

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -6,6 +6,7 @@
 #include "LR11x0Interface.h"
 #include "Module.h"
 #include "platform/portduino/USBHal.h"
+#include "yaml-cpp/yaml.h"
 
 // Product strings for auto-configuration
 // {"PRODUCT_STRING", "CONFIG.YAML"}
@@ -20,7 +21,6 @@ inline const std::unordered_map<std::string, std::string> configProducts = {
     {"RAK6421-13300-S2", "lora-RAK6421-13300-slot2.yaml"}};
 
 enum configNames {
-    default_gpiochip,
     cs_pin,
     cs_line,
     cs_gpiochip,
@@ -49,17 +49,6 @@ enum configNames {
     rf95_max_power,
     dio2_as_rf_switch,
     dio3_tcxo_voltage,
-    use_simradio,
-    use_autoconf,
-    use_rf95,
-    use_sx1262,
-    use_sx1268,
-    use_sx1280,
-    use_lr1110,
-    use_lr1120,
-    use_lr1121,
-    use_llcc68,
-    lora_usb_serial_num,
     lora_usb_pid,
     lora_usb_vid,
     userButtonPin,
@@ -69,9 +58,7 @@ enum configNames {
     tbRightPin,
     tbPressPin,
     tbDirection,
-    spidev,
     spiSpeed,
-    i2cdev,
     has_gps,
     touchscreenModule,
     touchscreenCS,
@@ -79,8 +66,6 @@ enum configNames {
     touchscreenI2CAddr,
     touchscreenBusFrequency,
     touchscreenRotate,
-    touchscreenspidev,
-    displayspidev,
     displayBusFrequency,
     displayPanel,
     displayWidth,
@@ -97,33 +82,55 @@ enum configNames {
     displayOffsetX,
     displayOffsetY,
     displayInvert,
-    keyboardDevice,
-    pointerDevice,
-    logoutputlevel,
-    traceFilename,
-    webserver,
     webserverport,
-    webserverrootpath,
-    websslkeypath,
-    websslcertpath,
     maxtophone,
     maxnodes,
-    ascii_logs,
-    config_directory,
-    available_directory,
-    mac_address,
     hostMetrics_interval,
     hostMetrics_channel,
-    hostMetrics_user_command,
     configDisplayMode,
     has_configDisplayMode
 };
 enum { no_screen, x11, fb, st7789, st7735, st7735s, st7796, ili9341, ili9342, ili9486, ili9488, hx8357d };
 enum { no_touchscreen, xpt2046, stmpe610, gt911, ft5x06 };
-enum { level_error, level_warn, level_info, level_debug, level_trace };
+enum portduino_log_level { level_error, level_warn, level_info, level_debug, level_trace };
+enum lora_module_enum {
+    use_simradio,
+    use_autoconf,
+    use_rf95,
+    use_sx1262,
+    use_sx1268,
+    use_sx1280,
+    use_lr1110,
+    use_lr1120,
+    use_lr1121,
+    use_llcc68
+};
+/*
+enum gpio_pins {
+    cs_pin,
+    irq_pin,
+    busy_pin,
+    reset_pin,
+    sx126x_ant_sw_pin,
+    txen_pin,
+    rxen_pin,
+    displayDC,
+    displayCS,
+    displayBacklight,
+    displayBacklightPWMChannel,
+    displayReset,
+    touchscreenCS,
+    touchscreenIRQ,
+    userButtonPin,
+    tbUpPin,
+    tbDownPin,
+    tbLeftPin,
+    tbRightPin,
+    tbPressPin
+};
+*/
 
 extern std::map<configNames, int> settingsMap;
-extern std::map<configNames, std::string> settingsStrings;
 extern std::ofstream traceFile;
 extern Ch341Hal *ch341Hal;
 int initGPIOPin(int pinNum, std::string gpioChipname, int line);
@@ -133,11 +140,221 @@ void getMacAddr(uint8_t *dmac);
 bool MAC_from_string(std::string mac_str, uint8_t *dmac);
 std::string exec(const char *cmd);
 
+struct pinMapping {
+    int pin;
+    int gpiochip;
+    int line;
+    bool enabled = false;
+};
+
 extern struct portduino_config_struct {
+    // Lora
+    std::map<lora_module_enum, std::string> loraModules = {
+        {use_simradio, "sim"},  {use_autoconf, "auto"}, {use_rf95, "RF95"},     {use_sx1262, "sx1262"}, {use_sx1268, "sx1268"},
+        {use_sx1280, "sx1280"}, {use_lr1110, "lr1110"}, {use_lr1120, "lr1120"}, {use_lr1121, "lr1121"}, {use_llcc68, "LLCC68"}};
+
+    lora_module_enum lora_module;
     bool has_rfswitch_table = false;
     uint32_t rfswitch_dio_pins[5] = {RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC};
     Module::RfSwitchMode_t rfswitch_table[8];
     bool force_simradio = false;
     bool has_device_id = false;
     uint8_t device_id[16] = {0};
+    std::string lora_spi_dev = "";
+    std::string lora_usb_serial_num = "";
+    int lora_spi_dev_int = 0;
+    int lora_default_gpiochip = 0;
+
+    // I2C
+    std::string i2cdev = "";
+
+    // Display
+    std::string display_spi_dev = "";
+    int display_spi_dev_int = 0;
+
+    // Touchscreen
+    std::string touchscreen_spi_dev = "";
+    int touchscreen_spi_dev_int = 0;
+
+    // Input
+    std::string keyboardDevice = "";
+    std::string pointerDevice = "";
+
+    // Logging
+    portduino_log_level logoutputlevel = level_debug;
+    std::string traceFilename;
+    bool ascii_logs = !isatty(1);
+    bool ascii_logs_explicit = false;
+
+    // Webserver
+    std::string webserver_root_path = "";
+    std::string webserver_ssl_key_path = "/etc/meshtasticd/ssl/private_key.pem";
+    std::string webserver_ssl_cert_path = "/etc/meshtasticd/ssl/certificate.pem";
+
+    // HostMetrics
+    std::string hostMetrics_user_command = "";
+
+    // General
+    std::string mac_address = "";
+    bool mac_address_explicit = false;
+    std::string mac_address_source = "";
+    std::string config_directory = "";
+    std::string available_directory = "/etc/meshtasticd/available.d/";
+
+    std::string emit_yaml()
+    {
+        YAML::Emitter out;
+        out << YAML::BeginMap;
+        out << YAML::Key << "Lora" << YAML::Value << YAML::BeginMap;
+
+        out << YAML::Key << "Module" << YAML::Value << loraModules[lora_module];
+
+        out << YAML::Key << "rfswitch_table" << YAML::Value << YAML::BeginMap;
+
+        out << YAML::Key << "pins";
+        out << YAML::Value << YAML::Flow << YAML::BeginSeq;
+
+        for (int i = 0; i < 5; i++) {
+            // set up the pin array first
+            if (rfswitch_dio_pins[i] == RADIOLIB_LR11X0_DIO5)
+                out << "DIO5";
+            if (rfswitch_dio_pins[i] == RADIOLIB_LR11X0_DIO6)
+                out << "DIO6";
+            if (rfswitch_dio_pins[i] == RADIOLIB_LR11X0_DIO7)
+                out << "DIO7";
+            if (rfswitch_dio_pins[i] == RADIOLIB_LR11X0_DIO8)
+                out << "DIO8";
+            if (rfswitch_dio_pins[i] == RADIOLIB_LR11X0_DIO10)
+                out << "DIO10";
+        }
+        out << YAML::EndSeq;
+
+        for (int i = 0; i < 7; i++) {
+            switch (i) {
+            case 0:
+                out << YAML::Key << "MODE_STBY";
+                break;
+            case 1:
+                out << YAML::Key << "MODE_RX";
+                break;
+            case 2:
+                out << YAML::Key << "MODE_TX";
+                break;
+            case 3:
+                out << YAML::Key << "MODE_TX_HP";
+                break;
+            case 4:
+                out << YAML::Key << "MODE_TX_HF";
+                break;
+            case 5:
+                out << YAML::Key << "MODE_GNSS";
+                break;
+            case 6:
+                out << YAML::Key << "MODE_WIFI";
+                break;
+            }
+
+            out << YAML::Value << YAML::Flow << YAML::BeginSeq;
+            for (int j = 0; j < 5; j++) {
+                if (rfswitch_table[i].values[j] == HIGH) {
+                    out << "HIGH";
+                } else {
+                    out << "LOW";
+                }
+            }
+            out << YAML::EndSeq;
+        }
+
+        out << YAML::EndMap; // rfswitch_table
+        if (lora_spi_dev != "")
+            out << YAML::Key << "spidev" << YAML::Value << lora_spi_dev;
+        if (lora_usb_serial_num != "")
+            out << YAML::Key << "USB_Serialnum" << YAML::Value << lora_usb_serial_num;
+        out << YAML::EndMap; // Lora
+
+        if (i2cdev != "") {
+            out << YAML::Key << "I2C" << YAML::Value << YAML::BeginMap;
+            out << YAML::Key << "I2CDevice" << YAML::Value << i2cdev;
+            out << YAML::EndMap; // I2C
+        }
+
+        // Display
+        if (display_spi_dev != "") {
+            out << YAML::Key << "Display" << YAML::Value << YAML::BeginMap;
+            out << YAML::Key << "spidev" << YAML::Value << display_spi_dev;
+            out << YAML::EndMap; // Display
+        }
+
+        // Touchscreen
+        if (touchscreen_spi_dev != "") {
+            out << YAML::Key << "Touchscreen" << YAML::Value << YAML::BeginMap;
+            out << YAML::Key << "spidev" << YAML::Value << touchscreen_spi_dev;
+            out << YAML::EndMap; // Touchscreen
+        }
+
+        // Input
+        if (keyboardDevice != "" || pointerDevice != "") {
+            out << YAML::Key << "Input" << YAML::Value << YAML::BeginMap;
+            if (keyboardDevice != "")
+                out << YAML::Key << "KeyboardDevice" << YAML::Value << keyboardDevice;
+            if (pointerDevice != "")
+                out << YAML::Key << "PointerDevice" << YAML::Value << pointerDevice;
+            out << YAML::EndMap; // Input
+        }
+
+        out << YAML::Key << "Logging" << YAML::Value << YAML::BeginMap;
+        out << YAML::Key << "LogLevel" << YAML::Value;
+        switch (logoutputlevel) {
+        case level_error:
+            out << "error";
+            break;
+        case level_warn:
+            out << "warn";
+            break;
+        case level_info:
+            out << "info";
+            break;
+        case level_debug:
+            out << "debug";
+            break;
+        case level_trace:
+            out << "trace";
+            break;
+        }
+        if (traceFilename != "")
+            out << YAML::Key << "TraceFile" << YAML::Value << traceFilename;
+        if (ascii_logs_explicit) {
+            out << YAML::Key << "AsciiLogs" << YAML::Value << ascii_logs;
+        }
+        out << YAML::EndMap; // Logging
+
+        // Webserver
+        if (webserver_root_path != "") {
+            out << YAML::Key << "Webserver" << YAML::Value << YAML::BeginMap;
+            out << YAML::Key << "RootPath" << YAML::Value << webserver_root_path;
+            out << YAML::Key << "SSLKey" << YAML::Value << webserver_ssl_key_path;
+            out << YAML::Key << "SSLCert" << YAML::Value << webserver_ssl_cert_path;
+            out << YAML::EndMap; // Webserver
+        }
+
+        // HostMetrics
+        if (hostMetrics_user_command != "") {
+            out << YAML::Key << "HostMetrics" << YAML::Value << YAML::BeginMap;
+            out << YAML::Key << "UserStringCommand" << YAML::Value << hostMetrics_user_command;
+
+            out << YAML::EndMap; // HostMetrics
+        }
+
+        out << YAML::Key << "General" << YAML::Value << YAML::BeginMap;
+        if (config_directory != "")
+            out << YAML::Key << "ConfigDirectory" << YAML::Value << config_directory;
+        if (mac_address_explicit)
+            out << YAML::Key << "MACAddress" << YAML::Value << mac_address;
+        if (mac_address_source != "")
+            out << YAML::Key << "MACAddressSource" << YAML::Value << mac_address_source;
+        if (available_directory != "")
+            out << YAML::Key << "AvailableDirectory" << YAML::Value << available_directory;
+        out << YAML::EndMap; // General
+        return out.c_str();
+    }
 } portduino_config;

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -43,7 +43,6 @@ struct pinMapping {
     int gpiochip;
     int line;
     bool enabled = false;
-
 };
 
 extern std::ofstream traceFile;
@@ -116,11 +115,11 @@ extern struct portduino_config_struct {
     bool displayInvert = false;
     int displayOffsetX = 0;
     int displayOffsetY = 0;
-    pinMapping displayDC = {"Display","DC"};
-    pinMapping displayCS = {"Display","CS"};
-    pinMapping displayBacklight = {"Display","Backlight"};
-    pinMapping displayBacklightPWMChannel = {"Display","BacklightPWMChannel"};
-    pinMapping displayReset = {"Display","Reset"};
+    pinMapping displayDC = {"Display", "DC"};
+    pinMapping displayCS = {"Display", "CS"};
+    pinMapping displayBacklight = {"Display", "Backlight"};
+    pinMapping displayBacklightPWMChannel = {"Display", "BacklightPWMChannel"};
+    pinMapping displayReset = {"Display", "Reset"};
 
     // Touchscreen
     std::string touchscreen_spi_dev = "";
@@ -129,19 +128,19 @@ extern struct portduino_config_struct {
     int touchscreenI2CAddr = -1;
     int touchscreenBusFrequency = 1000000;
     int touchscreenRotate = -1;
-    pinMapping touchscreenCS = {"Touchscreen","CS"};
-    pinMapping touchscreenIRQ = {"Touchscreen","IRQ"};
+    pinMapping touchscreenCS = {"Touchscreen", "CS"};
+    pinMapping touchscreenIRQ = {"Touchscreen", "IRQ"};
 
     // Input
     std::string keyboardDevice = "";
     std::string pointerDevice = "";
     int tbDirection;
-    pinMapping userButtonPin = {"Input","User"};
-    pinMapping tbUpPin = {"Input","TrackballUp"};
-    pinMapping tbDownPin = {"Input","TrackballDown"};
-    pinMapping tbLeftPin = {"Input","TrackballLwft"};
-    pinMapping tbRightPin = {"Input","TrackballRight"};
-    pinMapping tbPressPin = {"Input","TrackballPress"};
+    pinMapping userButtonPin = {"Input", "User"};
+    pinMapping tbUpPin = {"Input", "TrackballUp"};
+    pinMapping tbDownPin = {"Input", "TrackballDown"};
+    pinMapping tbLeftPin = {"Input", "TrackballLwft"};
+    pinMapping tbRightPin = {"Input", "TrackballRight"};
+    pinMapping tbPressPin = {"Input", "TrackballPress"};
 
     // Logging
     portduino_log_level logoutputlevel = level_debug;
@@ -173,10 +172,26 @@ extern struct portduino_config_struct {
     int maxtophone = 100;
     int MaxNodes = 200;
 
-    pinMapping *all_pins[20] = {&lora_cs_pin, &lora_irq_pin, &lora_busy_pin, &lora_reset_pin, &lora_txen_pin, &lora_rxen_pin, &lora_sx126x_ant_sw_pin,
-                              &displayDC, &displayCS, &displayBacklight, &displayBacklightPWMChannel, &displayReset,
-                              &touchscreenCS, &touchscreenIRQ,
-                              &userButtonPin, &tbUpPin, &tbDownPin, &tbLeftPin, &tbRightPin, &tbPressPin};
+    pinMapping *all_pins[20] = {&lora_cs_pin,
+                                &lora_irq_pin,
+                                &lora_busy_pin,
+                                &lora_reset_pin,
+                                &lora_txen_pin,
+                                &lora_rxen_pin,
+                                &lora_sx126x_ant_sw_pin,
+                                &displayDC,
+                                &displayCS,
+                                &displayBacklight,
+                                &displayBacklightPWMChannel,
+                                &displayReset,
+                                &touchscreenCS,
+                                &touchscreenIRQ,
+                                &userButtonPin,
+                                &tbUpPin,
+                                &tbDownPin,
+                                &tbLeftPin,
+                                &tbRightPin,
+                                &tbPressPin};
 
     std::string emit_yaml()
     {

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -96,7 +96,7 @@ enum gpio_pins {
 };
 
 struct pinMapping {
-    int pin;
+    int pin = RADIOLIB_NC;
     int gpiochip;
     int line;
     bool enabled = false;
@@ -118,6 +118,16 @@ extern struct portduino_config_struct {
     std::map<lora_module_enum, std::string> loraModules = {
         {use_simradio, "sim"},  {use_autoconf, "auto"}, {use_rf95, "RF95"},     {use_sx1262, "sx1262"}, {use_sx1268, "sx1268"},
         {use_sx1280, "sx1280"}, {use_lr1110, "lr1110"}, {use_lr1120, "lr1120"}, {use_lr1121, "lr1121"}, {use_llcc68, "LLCC68"}};
+
+    std::map<gpio_pins, std::string> lora_pins = {
+        {cs_pin, "CS"},
+        {irq_pin, "IRQ"},
+        {busy_pin, "Busy"},
+        {reset_pin, "Reset"},
+        {txen_pin, "TXen"},
+        {rxen_pin, "RXen"},
+        {sx126x_ant_sw_pin, "SX126X_ANT_SW"},
+    };
 
     std::map<gpio_pins, pinMapping> pinMappings;
     lora_module_enum lora_module;
@@ -175,6 +185,16 @@ extern struct portduino_config_struct {
         out << YAML::Key << "Lora" << YAML::Value << YAML::BeginMap;
 
         out << YAML::Key << "Module" << YAML::Value << loraModules[lora_module];
+
+        for (auto &lora_pin : lora_pins) {
+            if (pinMappings[lora_pin.first].enabled) {
+                out << YAML::Key << lora_pin.second << YAML::Value << YAML::BeginMap;
+                out << YAML::Key << "pin" << YAML::Value << pinMappings[lora_pin.first].pin;
+                out << YAML::Key << "line" << YAML::Value << pinMappings[lora_pin.first].line;
+                out << YAML::Key << "gpiochip" << YAML::Value << pinMappings[lora_pin.first].gpiochip;
+                out << YAML::EndMap; // User
+            }
+        }
 
         out << YAML::Key << "rfswitch_table" << YAML::Value << YAML::BeginMap;
 

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -109,15 +109,15 @@ extern struct portduino_config_struct {
     std::string lora_usb_serial_num = "";
     int lora_spi_dev_int = 0;
     int lora_default_gpiochip = 0;
-    int sx126x_max_power = 0;
-    int sx128x_max_power = 0;
-    int lr1110_max_power = 0;
-    int lr1120_max_power = 0;
-    int rf95_max_power = 0;
+    int sx126x_max_power = 22;
+    int sx128x_max_power = 13;
+    int lr1110_max_power = 22;
+    int lr1120_max_power = 13;
+    int rf95_max_power = 20;
     bool dio2_as_rf_switch = false;
     int dio3_tcxo_voltage = 0;
-    int lora_usb_pid = 0;
-    int lora_usb_vid = 0;
+    int lora_usb_pid = 0x5512;
+    int lora_usb_vid = 0x1A86;
     int spiSpeed = 2000000;
 
     // GPS
@@ -202,87 +202,86 @@ extern struct portduino_config_struct {
             }
         }
 
-        // TODO: don't output these when default
-        if (sx126x_max_power != 0)
+        if (sx126x_max_power != 22)
             out << YAML::Key << "SX126X_MAX_POWER" << YAML::Value << sx126x_max_power;
-        if (sx128x_max_power != 0)
+        if (sx128x_max_power != 13)
             out << YAML::Key << "SX128X_MAX_POWER" << YAML::Value << sx128x_max_power;
-        if (lr1110_max_power != 0)
+        if (lr1110_max_power != 22)
             out << YAML::Key << "LR1110_MAX_POWER" << YAML::Value << lr1110_max_power;
-        if (lr1120_max_power != 0)
+        if (lr1120_max_power != 13)
             out << YAML::Key << "LR1120_MAX_POWER" << YAML::Value << lr1120_max_power;
-        if (rf95_max_power != 0)
+        if (rf95_max_power != 20)
             out << YAML::Key << "RF95_MAX_POWER" << YAML::Value << rf95_max_power;
         out << YAML::Key << "DIO2_AS_RF_SWITCH" << YAML::Value << dio2_as_rf_switch;
         if (dio3_tcxo_voltage != 0)
             out << YAML::Key << "DIO3_TCXO_VOLTAGE" << YAML::Value << dio3_tcxo_voltage;
-        if (lora_usb_pid)
-            out << YAML::Key << "USB_PID" << YAML::Value << lora_usb_pid;
-        if (lora_usb_vid)
-            out << YAML::Key << "USB_VID" << YAML::Value << lora_usb_vid;
+        if (lora_usb_pid != 0x5512)
+            out << YAML::Key << "USB_PID" << YAML::Value << YAML::Hex << lora_usb_pid;
+        if (lora_usb_vid != 0x1A86)
+            out << YAML::Key << "USB_VID" << YAML::Value << YAML::Hex << lora_usb_vid;
         if (lora_spi_dev != "")
             out << YAML::Key << "spidev" << YAML::Value << lora_spi_dev;
         if (lora_usb_serial_num != "")
             out << YAML::Key << "USB_Serialnum" << YAML::Value << lora_usb_serial_num;
         out << YAML::Key << "spiSpeed" << YAML::Value << spiSpeed;
+        if (rfswitch_dio_pins[0] != RADIOLIB_NC) {
+            out << YAML::Key << "rfswitch_table" << YAML::Value << YAML::BeginMap;
 
-        out << YAML::Key << "rfswitch_table" << YAML::Value << YAML::BeginMap;
-
-        out << YAML::Key << "pins";
-        out << YAML::Value << YAML::Flow << YAML::BeginSeq;
-
-        for (int i = 0; i < 5; i++) {
-            // set up the pin array first
-            if (rfswitch_dio_pins[i] == RADIOLIB_LR11X0_DIO5)
-                out << "DIO5";
-            if (rfswitch_dio_pins[i] == RADIOLIB_LR11X0_DIO6)
-                out << "DIO6";
-            if (rfswitch_dio_pins[i] == RADIOLIB_LR11X0_DIO7)
-                out << "DIO7";
-            if (rfswitch_dio_pins[i] == RADIOLIB_LR11X0_DIO8)
-                out << "DIO8";
-            if (rfswitch_dio_pins[i] == RADIOLIB_LR11X0_DIO10)
-                out << "DIO10";
-        }
-        out << YAML::EndSeq;
-
-        for (int i = 0; i < 7; i++) {
-            switch (i) {
-            case 0:
-                out << YAML::Key << "MODE_STBY";
-                break;
-            case 1:
-                out << YAML::Key << "MODE_RX";
-                break;
-            case 2:
-                out << YAML::Key << "MODE_TX";
-                break;
-            case 3:
-                out << YAML::Key << "MODE_TX_HP";
-                break;
-            case 4:
-                out << YAML::Key << "MODE_TX_HF";
-                break;
-            case 5:
-                out << YAML::Key << "MODE_GNSS";
-                break;
-            case 6:
-                out << YAML::Key << "MODE_WIFI";
-                break;
-            }
-
+            out << YAML::Key << "pins";
             out << YAML::Value << YAML::Flow << YAML::BeginSeq;
-            for (int j = 0; j < 5; j++) {
-                if (rfswitch_table[i].values[j] == HIGH) {
-                    out << "HIGH";
-                } else {
-                    out << "LOW";
-                }
+
+            for (int i = 0; i < 5; i++) {
+                // set up the pin array first
+                if (rfswitch_dio_pins[i] == RADIOLIB_LR11X0_DIO5)
+                    out << "DIO5";
+                if (rfswitch_dio_pins[i] == RADIOLIB_LR11X0_DIO6)
+                    out << "DIO6";
+                if (rfswitch_dio_pins[i] == RADIOLIB_LR11X0_DIO7)
+                    out << "DIO7";
+                if (rfswitch_dio_pins[i] == RADIOLIB_LR11X0_DIO8)
+                    out << "DIO8";
+                if (rfswitch_dio_pins[i] == RADIOLIB_LR11X0_DIO10)
+                    out << "DIO10";
             }
             out << YAML::EndSeq;
-        }
 
-        out << YAML::EndMap; // rfswitch_table
+            for (int i = 0; i < 7; i++) {
+                switch (i) {
+                case 0:
+                    out << YAML::Key << "MODE_STBY";
+                    break;
+                case 1:
+                    out << YAML::Key << "MODE_RX";
+                    break;
+                case 2:
+                    out << YAML::Key << "MODE_TX";
+                    break;
+                case 3:
+                    out << YAML::Key << "MODE_TX_HP";
+                    break;
+                case 4:
+                    out << YAML::Key << "MODE_TX_HF";
+                    break;
+                case 5:
+                    out << YAML::Key << "MODE_GNSS";
+                    break;
+                case 6:
+                    out << YAML::Key << "MODE_WIFI";
+                    break;
+                }
+
+                out << YAML::Value << YAML::Flow << YAML::BeginSeq;
+                for (int j = 0; j < 5; j++) {
+                    if (rfswitch_table[i].values[j] == HIGH) {
+                        out << "HIGH";
+                    } else {
+                        out << "LOW";
+                    }
+                }
+                out << YAML::EndSeq;
+            }
+            out << YAML::EndMap; // rfswitch_table
+        }
         out << YAML::EndMap; // Lora
 
         if (i2cdev != "") {

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -92,19 +92,10 @@ extern struct portduino_config_struct {
         {sx126x_ant_sw_pin, "SX126X_ANT_SW"},
     };
 
-    std::map<screen_modules, std::string> screen_names = {
-        {x11, "X11"},
-        {fb, "FB"},
-        {st7789, "ST7789"},
-        {st7735, "ST7735"},
-        {st7735s, "ST7735S"},
-        {st7796, "ST7796"},
-        {ili9341, "ILI9341"},
-        {ili9342, "ILI9342"},
-        {ili9486, "ILI9486"},
-        {ili9488, "ILI9488"},
-        {hx8357d, "HX8357D"}
-    };
+    std::map<screen_modules, std::string> screen_names = {{x11, "X11"},         {fb, "FB"},           {st7789, "ST7789"},
+                                                          {st7735, "ST7735"},   {st7735s, "ST7735S"}, {st7796, "ST7796"},
+                                                          {ili9341, "ILI9341"}, {ili9342, "ILI9342"}, {ili9486, "ILI9486"},
+                                                          {ili9488, "ILI9488"}, {hx8357d, "HX8357D"}};
 
     std::map<gpio_pins, pinMapping> pinMappings;
     lora_module_enum lora_module;
@@ -131,7 +122,6 @@ extern struct portduino_config_struct {
 
     // GPS
     bool has_gps = false;
-
 
     // I2C
     std::string i2cdev = "";
@@ -236,7 +226,6 @@ extern struct portduino_config_struct {
             out << YAML::Key << "USB_Serialnum" << YAML::Value << lora_usb_serial_num;
         out << YAML::Key << "spiSpeed" << YAML::Value << spiSpeed;
 
-
         out << YAML::Key << "rfswitch_table" << YAML::Value << YAML::BeginMap;
 
         out << YAML::Key << "pins";
@@ -307,7 +296,7 @@ extern struct portduino_config_struct {
             out << YAML::Key << "Display" << YAML::Value << YAML::BeginMap;
             for (auto &screen_name : screen_names) {
                 if (displayPanel == screen_name.first)
-                out << YAML::Key << "Module" << YAML::Value << screen_name.second;
+                    out << YAML::Key << "Module" << YAML::Value << screen_name.second;
             }
             out << YAML::Key << "spidev" << YAML::Value << display_spi_dev;
             out << YAML::Key << "BusFrequency" << YAML::Value << displayBusFrequency;
@@ -327,8 +316,7 @@ extern struct portduino_config_struct {
                 out << YAML::Key << "OffsetX" << YAML::Value << displayOffsetX;
             if (displayOffsetY)
                 out << YAML::Key << "OffsetY" << YAML::Value << displayOffsetY;
-                
-                
+
             out << YAML::Key << "OffsetRotate" << YAML::Value << displayOffsetRotate;
 
             out << YAML::EndMap; // Display
@@ -340,14 +328,14 @@ extern struct portduino_config_struct {
             out << YAML::Key << "spidev" << YAML::Value << touchscreen_spi_dev;
             out << YAML::Key << "BusFrequency" << YAML::Value << touchscreenBusFrequency;
             switch (touchscreenModule) {
-                case xpt2046:
-                    out << YAML::Key << "Module" << YAML::Value << "XPT2046";
-                case stmpe610:
-                    out << YAML::Key << "Module" << YAML::Value << "STMPE610";
-                case gt911:
-                    out << YAML::Key << "Module" << YAML::Value << "GT911";
-                case ft5x06:
-                    out << YAML::Key << "Module" << YAML::Value << "FT5x06";
+            case xpt2046:
+                out << YAML::Key << "Module" << YAML::Value << "XPT2046";
+            case stmpe610:
+                out << YAML::Key << "Module" << YAML::Value << "STMPE610";
+            case gt911:
+                out << YAML::Key << "Module" << YAML::Value << "GT911";
+            case ft5x06:
+                out << YAML::Key << "Module" << YAML::Value << "FT5x06";
             }
             if (touchscreenRotate != -1)
                 out << YAML::Key << "Rotate" << YAML::Value << touchscreenRotate;
@@ -460,17 +448,15 @@ extern struct portduino_config_struct {
         if (has_configDisplayMode) {
             out << YAML::Key << "Config" << YAML::Value << YAML::BeginMap;
             switch (configDisplayMode) {
-                case meshtastic_Config_DisplayConfig_DisplayMode_TWOCOLOR:
-                    out << YAML::Key << "DisplayMode" << YAML::Value << "TWOCOLOR";
-                case meshtastic_Config_DisplayConfig_DisplayMode_INVERTED:
-                    out << YAML::Key << "DisplayMode" << YAML::Value << "INVERTED";
-                case meshtastic_Config_DisplayConfig_DisplayMode_COLOR:
-                    out << YAML::Key << "DisplayMode" << YAML::Value << "COLOR";
-                case meshtastic_Config_DisplayConfig_DisplayMode_DEFAULT:
-                    out << YAML::Key << "DisplayMode" << YAML::Value << "DEFAULT";
+            case meshtastic_Config_DisplayConfig_DisplayMode_TWOCOLOR:
+                out << YAML::Key << "DisplayMode" << YAML::Value << "TWOCOLOR";
+            case meshtastic_Config_DisplayConfig_DisplayMode_INVERTED:
+                out << YAML::Key << "DisplayMode" << YAML::Value << "INVERTED";
+            case meshtastic_Config_DisplayConfig_DisplayMode_COLOR:
+                out << YAML::Key << "DisplayMode" << YAML::Value << "COLOR";
+            case meshtastic_Config_DisplayConfig_DisplayMode_DEFAULT:
+                out << YAML::Key << "DisplayMode" << YAML::Value << "DEFAULT";
             }
-            
-
 
             out << YAML::EndMap; // Config
         }

--- a/src/platform/portduino/architecture.h
+++ b/src/platform/portduino/architecture.h
@@ -28,9 +28,9 @@
 #endif
 #ifndef HAS_TRACKBALL
 #define HAS_TRACKBALL 1
-#define TB_DOWN (uint8_t) portduino_config.pinMappings[tbDownPin].pin
-#define TB_UP (uint8_t) portduino_config.pinMappings[tbUpPin].pin
-#define TB_LEFT (uint8_t) portduino_config.pinMappings[tbLeftPin].pin
-#define TB_RIGHT (uint8_t) portduino_config.pinMappings[tbRightPin].pin
-#define TB_PRESS (uint8_t) portduino_config.pinMappings[tbPressPin].pin
+#define TB_DOWN (uint8_t) portduino_config.tbDownPin.pin
+#define TB_UP (uint8_t) portduino_config.tbUpPin.pin
+#define TB_LEFT (uint8_t) portduino_config.tbLeftPin.pin
+#define TB_RIGHT (uint8_t) portduino_config.tbRightPin.pin
+#define TB_PRESS (uint8_t) portduino_config.tbPressPin.pin
 #endif

--- a/src/platform/portduino/architecture.h
+++ b/src/platform/portduino/architecture.h
@@ -28,9 +28,9 @@
 #endif
 #ifndef HAS_TRACKBALL
 #define HAS_TRACKBALL 1
-#define TB_DOWN (uint8_t) settingsMap[tbDownPin]
-#define TB_UP (uint8_t) settingsMap[tbUpPin]
-#define TB_LEFT (uint8_t) settingsMap[tbLeftPin]
-#define TB_RIGHT (uint8_t) settingsMap[tbRightPin]
-#define TB_PRESS (uint8_t) settingsMap[tbPressPin]
+#define TB_DOWN (uint8_t) portduino_config.pinMappings[tbDownPin].pin
+#define TB_UP (uint8_t) portduino_config.pinMappings[tbUpPin].pin
+#define TB_LEFT (uint8_t) portduino_config.pinMappings[tbLeftPin].pin
+#define TB_RIGHT (uint8_t) portduino_config.pinMappings[tbRightPin].pin
+#define TB_PRESS (uint8_t) portduino_config.pinMappings[tbPressPin].pin
 #endif

--- a/variants/native/portduino-buildroot/variant.h
+++ b/variants/native/portduino-buildroot/variant.h
@@ -1,5 +1,5 @@
 #define HAS_SCREEN 1
 #define CANNED_MESSAGE_MODULE_ENABLE 1
 #define HAS_GPS 1
-#define MAX_RX_TOPHONE settingsMap[maxtophone]
-#define MAX_NUM_NODES settingsMap[maxnodes]
+#define MAX_RX_TOPHONE portduino_config.maxtophone
+#define MAX_NUM_NODES portduino_config.MaxNodes

--- a/variants/native/portduino/variant.h
+++ b/variants/native/portduino/variant.h
@@ -3,5 +3,5 @@
 #endif
 #define CANNED_MESSAGE_MODULE_ENABLE 1
 #define HAS_GPS 1
-#define MAX_RX_TOPHONE settingsMap[maxtophone]
-#define MAX_NUM_NODES settingsMap[maxnodes]
+#define MAX_RX_TOPHONE portduino_config.maxtophone
+#define MAX_NUM_NODES portduino_config.MaxNodes


### PR DESCRIPTION
Get rid of the raw settings maps, move everything to the portduino_config struct
Add the -y flag to print out the resulting yaml config
move all gpio to the pin/gpiochip/line scheme