### PR TITLE
Hold for 20s after GPS lock

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1116,7 +1116,7 @@ int32_t GPS::runOnce()
         shouldPublish = true;
     }
 
-    bool prev_fixQual = fixQual;
+    uint8_t prev_fixQual = fixQual;
     bool gotLoc = lookForLocation();
     if (gotLoc && !hasValidLocation) { // declare that we have location ASAP
         LOG_DEBUG("hasValidLocation RISING EDGE");

--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1137,7 +1137,6 @@ int32_t GPS::runOnce()
 
     // Once we get a location we no longer desperately want an update
     if ((gotLoc && gotTime) || tooLong) {
-
         if (tooLong && !gotLoc) {
             // we didn't get a location during this ack window, therefore declare loss of lock
             if (hasValidLocation) {
@@ -1150,8 +1149,10 @@ int32_t GPS::runOnce()
             shouldPublish = true; // publish our update at the end of the lock hold
             publishUpdate();
             down();
+#ifdef GPS_DEBUG
         } else {
             LOG_DEBUG("Holding for GPS data download: %d ms (numSats=%d)", fixHoldEnds - millis(), p.sats_in_view);
+#endif
         }
     }
 

--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1123,15 +1123,11 @@ int32_t GPS::runOnce()
         hasValidLocation = true;
         shouldPublish = true;
         // Hold for 20secs after getting a lock to download ephemeris etc
-        lastFixStartMsec = millis();
-        fixHoldEnds = lastFixStartMsec + 20000;
+        fixHoldEnds = millis() + 20000;
     }
 
-    if (gotLoc && prev_fixQual == 0) { // we've moved from no lock to lock
-        LOG_DEBUG("Probably just got a lock after turning back on.");
-        // Hold for 20secs after getting a lock to download ephemeris etc
-        lastFixStartMsec = millis();
-        fixHoldEnds = lastFixStartMsec + 20000;
+    if (gotLoc && prev_fixQual == 0) { // just got a lock after turning back on.
+        fixHoldEnds = millis() + 20000;
         shouldPublish = true; // Publish immediately, since next publish is at end of hold
     }
 

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -159,7 +159,7 @@ class GPS : private concurrency::OSThread
     uint8_t fixType = 0;      // fix type from GPGSA
 #endif
 
-    uint32_t lastFixStartMsec = 0, fixHoldEnds = 0;
+    uint32_t fixHoldEnds = 0;
     uint32_t rx_gpio = 0;
     uint32_t tx_gpio = 0;
 

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -159,7 +159,7 @@ class GPS : private concurrency::OSThread
     uint8_t fixType = 0;      // fix type from GPGSA
 #endif
 
-    uint32_t lastWakeStartMsec = 0, lastSleepStartMsec = 0, lastFixStartMsec = 0;
+    uint32_t lastFixStartMsec = 0, fixHoldEnds = 0;
     uint32_t rx_gpio = 0;
     uint32_t tx_gpio = 0;
 

--- a/variants/nrf52840/tracker-t1000-e/variant.h
+++ b/variants/nrf52840/tracker-t1000-e/variant.h
@@ -124,8 +124,7 @@ extern "C" {
 #define GPS_RTC_INT (0 + 15)     // P0.15, normal is LOW, wake by HIGH
 #define GPS_RESETB_OUT (32 + 14) // P1.14, always input pull_up
 
-#define GPS_FIX_HOLD_TIME 15000 // ms
-#define BATTERY_PIN 2           // P0.02/AIN0, BAT_ADC
+#define BATTERY_PIN 2 // P0.02/AIN0, BAT_ADC
 #define BATTERY_IMMUTABLE
 #define ADC_MULTIPLIER (2.0F)
 // P0.04/AIN2 is VCC_ADC, P0.05/AIN3 is CHARGER_DET, P1.03 is CHARGE_STA, P1.04 is CHARGE_DONE

--- a/variants/nrf52840/wio-t1000-s/variant.h
+++ b/variants/nrf52840/wio-t1000-s/variant.h
@@ -123,7 +123,6 @@ extern "C" {
 #define GPS_RESETB_OUT (32 + 14) // P1.14, awlays input pull_up
 
 // #define GPS_THREAD_INTERVAL 50
-#define GPS_FIX_HOLD_TIME 15000 // ms
 
 #define BATTERY_PIN 2
 // #define ADC_CHANNEL ADC1_GPIO2_CHANNEL


### PR DESCRIPTION
GPS chips are designed to stay locked for a while to download some data and save it. This data is important for speeding up future locks, and making them higher quality. Our present configuration could make every lock perform similar to first lock.

This patch sets a hold of 20s after lock is acquired. This should allow the GPS to finish its work before we turn it off.

Fixes https://github.com/meshtastic/firmware/issues/7466

Co-Authored-By: @Quency-D 

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
GPS testing list:
- [x] Seeed Tracker WM1110 w/ Air530 (L76K)
- [x] Seeed 1000e w/ AG3335
- [ ] Heltec T114 with AGTM3332D
- [ ] Heltec T114 with Ublox 10 (BE180)
- [ ] Heltec T114 with Ublox 9
- [ ] Heltec T114 with Ublox 7 (BK-122)
- [ ] Heltec T114 with Ublox 6
- [x] Heltec Wireless Tracker with UC6580
- [x] LilyGo TBeam with Ublox 6
- [x] RAK4631