### PR TITLE
Add support for the Challenger rp2040 lora

### DIFF
--- a/variants/rp2040/challenger_2040_lora/pins_arduino.h
+++ b/variants/rp2040/challenger_2040_lora/pins_arduino.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#define PINS_COUNT          (25u)
+#define NUM_DIGITAL_PINS    (25u)
+#define NUM_ANALOG_INPUTS   (4u)
+#define NUM_ANALOG_OUTPUTS  (0u)
+#define ADC_RESOLUTION      (12u)
+
+// LEDs
+#define PIN_LED             (24u)
+
+// Serial
+#define PIN_SERIAL1_TX      (16u)
+#define PIN_SERIAL1_RX      (17u)
+
+// SPI
+#define PIN_SPI0_MISO       (20u)
+#define PIN_SPI0_MOSI       (23u)
+#define PIN_SPI0_SCK        (22u)
+#define PIN_SPI0_SS         (21u)
+
+// Connected to LoRa module
+#define PIN_SPI1_MISO       (12u)
+#define PIN_SPI1_MOSI       (11u)
+#define PIN_SPI1_SCK        (10u)
+#define PIN_SPI1_SS         (9u)
+#define RFM95W_SS           (9u)
+#define RFM95W_DIO0         (14u)
+#define RFM95W_DIO1         (15u)
+#define RFM95W_DIO2         (18u)
+#define RFM95W_RST          (13u)
+#define RFM95W_SPI          SPI1
+
+// Wire
+#define PIN_WIRE0_SDA       (0u)
+#define PIN_WIRE0_SCL       (1u)
+
+// Not pinned out
+#define PIN_WIRE1_SDA       (31u)
+#define PIN_WIRE1_SCL       (31u)
+#define PIN_SERIAL2_RX      (31u)
+#define PIN_SERIAL2_TX      (31u)
+
+#define SERIAL_HOWMANY      (1u)
+#define SPI_HOWMANY         (2u)
+#define WIRE_HOWMANY        (1u)
+
+#define LED_BUILTIN         PIN_LED
+
+static const uint8_t D0 = (16u);
+static const uint8_t D1 = (17u);
+static const uint8_t D2 = (20u);
+static const uint8_t D3 = (23u);
+static const uint8_t D4 = (22u);
+static const uint8_t D5 = (2u);
+static const uint8_t D6 = (3u);
+static const uint8_t D7 = (0u);
+static const uint8_t D8 = (1u);
+static const uint8_t D9 = (4u);
+static const uint8_t D10 = (5u);
+static const uint8_t D11 = (6u);
+static const uint8_t D12 = (7u);
+static const uint8_t D13 = (8u);
+static const uint8_t D14 = (13u);
+static const uint8_t D15 = (14u);
+static const uint8_t D16 = (15u);
+static const uint8_t D17 = (18u);
+static const uint8_t D18 = (24u);
+
+static const uint8_t A0 = (26u);
+static const uint8_t A1 = (27u);
+static const uint8_t A2 = (28u);
+static const uint8_t A3 = (29u);
+static const uint8_t A4 = (19u);
+static const uint8_t A5 = (21u);
+
+#ifndef SS
+#define SS PIN_SPI1_SS
+#endif

--- a/variants/rp2040/challenger_2040_lora/platformio.ini
+++ b/variants/rp2040/challenger_2040_lora/platformio.ini
@@ -1,0 +1,15 @@
+[env:challenger_2040_lora]
+extends = rp2040_base
+board = challenger_2040_lora
+upload_protocol = picotool
+# add our variants files to the include and src paths
+build_flags = 
+  ${rp2040_base.build_flags} 
+  -D PRIVATE_HW
+  -I variants/rp2040/challenger_2040_lora
+  -D DEBUG_RP2040_PORT=Serial
+  -D HW_SPI1_DEVICE
+lib_deps =
+  ${rp2040_base.lib_deps}
+debug_build_flags = ${rp2040_base.build_flags}
+debug_tool = cmsis-dap ; for e.g. Picotool

--- a/variants/rp2040/challenger_2040_lora/variant.h
+++ b/variants/rp2040/challenger_2040_lora/variant.h
@@ -1,0 +1,42 @@
+// Define SS for compatibility with libraries expecting a default SPI chip select pin
+
+
+#define ARDUINO_ARCH_AVR
+
+
+#define EXT_NOTIFY_OUT 0xFFFFFFFF
+#define BUTTON_PIN 0xFFFFFFFF
+
+
+#define LED_PIN PIN_LED
+
+#define USE_RF95 // RFM95/SX127x
+
+#undef LORA_SCK
+#undef LORA_MISO
+#undef LORA_MOSI
+#undef LORA_CS
+
+// https://gitlab.com/invectorlabs/hw/challenger_rp2040_lora
+#define LORA_SCK 10   // Clock
+#define LORA_CS 9     // Chip Select
+#define LORA_MOSI 11  // Serial Data Out
+#define LORA_MISO 12  // Serial Data In
+
+#define LORA_RESET 13 // Reset 
+
+#define LORA_DIO0 14 // DIO0
+#define LORA_DIO1 15 // DIO1
+#define LORA_DIO2 18 // DIO2
+#define LORA_DIO3 0xFFFFFFFF // Not connected
+#define LORA_DIO4 0xFFFFFFFF // Not connected
+#define LORA_DIO5 0xFFFFFFFF // Not connected
+
+#ifdef USE_SX1262
+#define SX126X_CS LORA_CS
+#define SX126X_DIO1 LORA_DIO1
+#define SX126X_BUSY LORA_DIO2
+#define SX126X_RESET LORA_RESET
+#define SX126X_DIO2_AS_RF_SWITCH
+// #define SX126X_DIO3_TCXO_VOLTAGE 1.8
+#endif


### PR DESCRIPTION
This pull request adds support for the [Challenger RP2040 LoRa](https://ilabs.se/product/challenger-rp2040-lora/) hardware variant on the RP2040 platform. It introduces new configuration files that define pin mappings, hardware features, and build settings for PlatformIO. The changes are grouped as follows:

**New Hardware Variant Definitions:**

Added `variant.h` to define pin mappings and hardware features for the Challenger RP2040 LoRa module with the RFM95W radio.
Added `pins_arduino.h` to specify Arduino pin constants and USB VID/PID for the new variant.

**PlatformIO Build Configuration:**

Added a new platformio.ini file with build environments and flags tailored for the Challenger RP2040 LoRa.

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [X] Heltec (Lora32) V3
  - [X] LilyGo T-Deck
  - [X] LilyGo T-Beam
  - [X] RAK WisBlock 4631
  - [X] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
