### PR TITLE
Enable bmx160 on native

### DIFF
--- a/arch/portduino/portduino.ini
+++ b/arch/portduino/portduino.ini
@@ -31,6 +31,8 @@ lib_deps =
   https://github.com/pine64/libch341-spi-userspace/archive/af9bc27c9c30fa90772279925b7c5913dff789b4.zip
   # renovate: datasource=custom.pio depName=adafruit/Adafruit seesaw Library packageName=adafruit/library/Adafruit seesaw Library
 	adafruit/Adafruit seesaw Library@1.7.9
+  # renovate: datasource=git-refs depName=RAK12034-BMX160 packageName=https://github.com/RAKWireless/RAK12034-BMX160 gitBranch=main
+  https://github.com/RAKWireless/RAK12034-BMX160/archive/dcead07ffa267d3c906e9ca4a1330ab989e957e2.zip
 
 build_flags =
   ${arduino_base.build_flags}

--- a/src/motion/BMX160Sensor.h
+++ b/src/motion/BMX160Sensor.h
@@ -7,7 +7,7 @@
 
 #if !defined(ARCH_STM32WL) && !MESHTASTIC_EXCLUDE_I2C
 
-#if defined(RAK_4631) && !defined(RAK2560) && __has_include(<Rak_BMX160.h>)
+#if !defined(RAK2560) && __has_include(<Rak_BMX160.h>)
 
 #include "Fusion/Fusion.h"
 #include <Rak_BMX160.h>

--- a/variants/nrf52840/rak4631/platformio.ini
+++ b/variants/nrf52840/rak4631/platformio.ini
@@ -22,6 +22,7 @@ lib_deps =
   https://github.com/RAKWireless/RAK13800-W5100S/archive/1.0.2.zip
   rakwireless/RAKwireless NCP5623 RGB LED library@^1.0.2
   beegee-tokyo/RAK12035_SoilMoisture@^1.0.4
+  # renovate: datasource=git-refs depName=RAK12034-BMX160 packageName=https://github.com/RAKWireless/RAK12034-BMX160 gitBranch=main
   https://github.com/RAKWireless/RAK12034-BMX160/archive/dcead07ffa267d3c906e9ca4a1330ab989e957e2.zip
 
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)

--- a/variants/nrf52840/rak4631_eth_gw/platformio.ini
+++ b/variants/nrf52840/rak4631_eth_gw/platformio.ini
@@ -31,7 +31,8 @@ lib_deps =
   melopero/Melopero RV3028@^1.1.0
   https://github.com/RAKWireless/RAK13800-W5100S/archive/1.0.2.zip
   rakwireless/RAKwireless NCP5623 RGB LED library@^1.0.2
-  https://github.com/meshtastic/RAK12034-BMX160/archive/4821355fb10390ba8557dc43ca29a023bcfbb9d9.zip
+  # renovate: datasource=git-refs depName=RAK12034-BMX160 packageName=https://github.com/RAKWireless/RAK12034-BMX160 gitBranch=main
+  https://github.com/RAKWireless/RAK12034-BMX160/archive/dcead07ffa267d3c906e9ca4a1330ab989e957e2.zip
   bblanchon/ArduinoJson @ 6.21.4
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
 ; Note: as of 6/2013 the serial/bootloader based programming takes approximately 30 seconds


### PR DESCRIPTION
Move all the RAK12034-BMX160 libs to point to the same upstream lib, and enable on Native.