### PR TITLE
Upon receiving ACK/reply directly, only update next-hop if we’re the *sole* relayer

### DIFF
--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -71,10 +71,11 @@ void NextHopRouter::sniffReceived(const meshtastic_MeshPacket *p, const meshtast
         if (p->from != 0) {
             meshtastic_NodeInfoLite *origTx = nodeDB->getMeshNode(p->from);
             if (origTx) {
-                // Either relayer of ACK was also a relayer of the packet, or we were the relayer and the ACK came directly from
-                // the destination
+                // Either relayer of ACK was also a relayer of the packet, or we were the *only* relayer and the ACK came directly
+                // from the destination
                 if (wasRelayer(p->relay_node, p->decoded.request_id, p->to) ||
-                    (wasRelayer(ourRelayID, p->decoded.request_id, p->to) && p->hop_start != 0 && p->hop_start == p->hop_limit)) {
+                    (p->hop_start != 0 && p->hop_start == p->hop_limit &&
+                     wasSoleRelayer(ourRelayID, p->decoded.request_id, p->to))) {
                     if (origTx->next_hop != p->relay_node) { // Not already set
                         LOG_INFO("Update next hop of 0x%x to 0x%x based on ACK/reply", p->from, p->relay_node);
                         origTx->next_hop = p->relay_node;

--- a/src/mesh/PacketHistory.h
+++ b/src/mesh/PacketHistory.h
@@ -34,8 +34,9 @@ class PacketHistory
     void insert(const PacketRecord &r); // Insert or replace a packet record in the history
 
     /* Check if a certain node was a relayer of a packet in the history given iterator
+     * If wasSole is not nullptr, it will be set to true if the relayer was the only relayer of that packet
      * @return true if node was indeed a relayer, false if not */
-    bool wasRelayer(const uint8_t relayer, const PacketRecord &r);
+    bool wasRelayer(const uint8_t relayer, const PacketRecord &r, bool *wasSole = nullptr);
 
     PacketHistory(const PacketHistory &);            // non construction-copyable
     PacketHistory &operator=(const PacketHistory &); // non copyable
@@ -54,8 +55,12 @@ class PacketHistory
                          bool *weWereNextHop = nullptr);
 
     /* Check if a certain node was a relayer of a packet in the history given an ID and sender
+     * If wasSole is not nullptr, it will be set to true if the relayer was the only relayer of that packet
      * @return true if node was indeed a relayer, false if not */
-    bool wasRelayer(const uint8_t relayer, const uint32_t id, const NodeNum sender);
+    bool wasRelayer(const uint8_t relayer, const uint32_t id, const NodeNum sender, bool *wasSole = nullptr);
+
+    // Check if a certain node was the *only* relayer of a packet in the history given an ID and sender
+    bool wasSoleRelayer(const uint8_t relayer, const uint32_t id, const NodeNum sender);
 
     // Remove a relayer from the list of relayers of a packet in the history given an ID and sender
     void removeRelayer(const uint8_t relayer, const uint32_t id, const NodeNum sender);


### PR DESCRIPTION
Fixes #7839. 

Simulated the same scenario with the [interactive simulator](https://github.com/meshtastic/Meshtasticator/blob/master/INTERACTIVE_SIM.md) and it works correctly now. 
Previously it indeed set the next-hop while it shouldn’t: 

```
INFO  | 19:44:23 12 [Router] Received traceroute from=0x12, id=0x21ceb01c, portnum=70, payloadlen=28
INFO  | 19:44:23 12 [Router] Route traced:
0x10 --> 0x11 (-7.00dB) --> 0x12 (-7.25dB)
(-12.00dB) 0x10 <-- 0x12
INFO  | 19:44:23 47 [Router] Update next hop of 0x12 to 0x12 based on ACK/reply
```

After this: 
```
INFO  | 18:43:19 56 [Router] Route traced:
0x10 --> 0x11 (-8.25dB) --> 0x12 (-8.75dB)
(-10.00dB) 0x10 <-- 0x12
INFO  | 18:43:19 56 [Router] ACK/reply for 0x12, wasRelayOrigPacket=0, wasSoleRelay=0
```
`wasSoleRelay=0` means it wasn’t the sole relayer (because 0x11 forwarded it), and the next-hop does not get set.