### PR TITLE
Added Last Coordinate counter to Position screen

### DIFF
--- a/src/GPSStatus.h
+++ b/src/GPSStatus.h
@@ -22,6 +22,9 @@ class GPSStatus : public Status
 
     meshtastic_Position p = meshtastic_Position_init_default;
 
+    /// Time of last valid GPS fix (millis since boot)
+    uint32_t lastFixMillis = 0;
+
   public:
     GPSStatus() { statusType = STATUS_TYPE_GPS; }
 
@@ -83,6 +86,9 @@ class GPSStatus : public Status
 
     uint32_t getNumSatellites() const { return p.sats_in_view; }
 
+    /// Return millis() when the last GPS fix occurred (0 = never)
+    uint32_t getLastFixMillis() const { return lastFixMillis; }
+
     bool matches(const GPSStatus *newStatus) const
     {
 #ifdef GPS_DEBUG
@@ -114,6 +120,9 @@ class GPSStatus : public Status
 
         if (isDirty) {
             if (hasLock) {
+                // Record time of last valid GPS fix
+                lastFixMillis = millis();
+
                 // In debug logs, identify position by @timestamp:stage (stage 3 = notify)
                 LOG_DEBUG("New GPS pos@%x:3 lat=%f lon=%f alt=%d pdop=%.2f track=%.2f speed=%.2f sats=%d", p.timestamp,
                           p.latitude_i * 1e-7, p.longitude_i * 1e-7, p.altitude, p.PDOP * 1e-2, p.ground_track * 1e-5,

--- a/src/graphics/draw/UIRenderer.cpp
+++ b/src/graphics/draw/UIRenderer.cpp
@@ -922,15 +922,52 @@ void UIRenderer::drawCompassAndLocationScreen(OLEDDisplay *display, OLEDDisplayU
 
     // If GPS is off, no need to display these parts
     if (strcmp(displayLine, "GPS off") != 0 && strcmp(displayLine, "No GPS") != 0) {
+        /* MUST BE MOVED TO CLOCK SCREEN
+            // === Second Row: Date ===
+            uint32_t rtc_sec = getValidTime(RTCQuality::RTCQualityDevice, true);
+            char datetimeStr[25];
+            bool showTime = false; // set to true for full datetime
+            UIRenderer::formatDateTime(datetimeStr, sizeof(datetimeStr), rtc_sec, display, showTime);
+            char fullLine[40];
+            snprintf(fullLine, sizeof(fullLine), " Date: %s", datetimeStr);
+            display->drawString(0, getTextPositions(display)[line++], fullLine);
+        */
 
-        // === Second Row: Date ===
-        uint32_t rtc_sec = getValidTime(RTCQuality::RTCQualityDevice, true);
-        char datetimeStr[25];
-        bool showTime = false; // set to true for full datetime
-        UIRenderer::formatDateTime(datetimeStr, sizeof(datetimeStr), rtc_sec, display, showTime);
-        char fullLine[40];
-        snprintf(fullLine, sizeof(fullLine), " Date: %s", datetimeStr);
-        display->drawString(0, getTextPositions(display)[line++], fullLine);
+        // === Second Row: Last GPS Fix ===
+        if (gpsStatus->getLastFixMillis() > 0) {
+            uint32_t delta = (millis() - gpsStatus->getLastFixMillis()) / 1000; // seconds since last fix
+            uint32_t days = delta / 86400;
+            uint32_t hours = (delta % 86400) / 3600;
+            uint32_t mins = (delta % 3600) / 60;
+            uint32_t secs = delta % 60;
+
+            char buf[32];
+#if defined(USE_EINK)
+            // E-Ink: skip seconds, show only days/hours/mins
+            if (days > 0) {
+                snprintf(buf, sizeof(buf), " Last: %ud %uh", days, hours);
+            } else if (hours > 0) {
+                snprintf(buf, sizeof(buf), " Last: %uh %um", hours, mins);
+            } else {
+                snprintf(buf, sizeof(buf), " Last: %um", mins);
+            }
+#else
+            // Non E-Ink: include seconds where useful
+            if (days > 0) {
+                snprintf(buf, sizeof(buf), " Last: %ud %uh", days, hours);
+            } else if (hours > 0) {
+                snprintf(buf, sizeof(buf), " Last: %uh %um", hours, mins);
+            } else if (mins > 0) {
+                snprintf(buf, sizeof(buf), " Last: %um %us", mins, secs);
+            } else {
+                snprintf(buf, sizeof(buf), " Last: %us", secs);
+            }
+#endif
+
+            display->drawString(0, getTextPositions(display)[line++], buf);
+        } else {
+            display->drawString(0, getTextPositions(display)[line++], " Last: ?");
+        }
 
         // === Third Row: Latitude ===
         char latStr[32];


### PR DESCRIPTION
Adding a counter to show the last time a GPS coordinate was detected to ensure the user is aware how long since the coordinate updated or to identify any errors. I commented out the date so that it can be moved to the Clock screen that is more fitting since it's related data.

Will display like this format
Under 1 hour → 20m 59s
Under 24 hours → 19h 20m
24h+ → 2d 5h

Eink will not have a second counter to prevent unnecessary refreshes, it will start counting from the first minute.
