### PR TITLE
Fixing RTC Clock: T-Lora Pager actually uses PCF85063 for RTC

### DIFF
--- a/src/detect/ScanI2C.cpp
+++ b/src/detect/ScanI2C.cpp
@@ -25,7 +25,7 @@ ScanI2C::FoundDevice ScanI2C::firstScreen() const
 
 ScanI2C::FoundDevice ScanI2C::firstRTC() const
 {
-    ScanI2C::DeviceType types[] = {RTC_RV3028, RTC_PCF8563};
+    ScanI2C::DeviceType types[] = {RTC_RV3028, RTC_PCF8563,RTC_PCF85063};
     return firstOfOrNONE(2, types);
 }
 

--- a/src/detect/ScanI2C.h
+++ b/src/detect/ScanI2C.h
@@ -14,6 +14,7 @@ class ScanI2C
         SCREEN_ST7567,
         RTC_RV3028,
         RTC_PCF8563,
+        RTC_PCF85063,
         CARDKB,
         TDECKKB,
         BBQ10KB,

--- a/variants/esp32s3/tlora-pager/variant.h
+++ b/variants/esp32s3/tlora-pager/variant.h
@@ -34,11 +34,11 @@
 #define GPS_TX_PIN 12
 #define PIN_GPS_PPS 13
 
-// PCF8563 RTC Module
-#if __has_include("pcf8563.h")
-#include "pcf8563.h"
+// PCF85063 RTC Module
+#if __has_include("pcf85063.h")
+#include "pcf85063.h"
 #endif
-#define PCF8563_RTC 0x51
+#define PCF85063_RTC 0x51
 #define HAS_RTC 1
 
 // Rotary

--- a/variants/esp32s3/tlora-pager/variant.h
+++ b/variants/esp32s3/tlora-pager/variant.h
@@ -34,11 +34,11 @@
 #define GPS_TX_PIN 12
 #define PIN_GPS_PPS 13
 
-// PCF85063 RTC Module
-#if __has_include("pcf85063.h")
-#include "pcf85063.h"
+// PCF8563 RTC Module
+#if __has_include("pcf8563.h")
+#include "pcf8563.h"
 #endif
-#define PCF85063_RTC 0x51
+#define PCF8563_RTC 0x51
 #define HAS_RTC 1
 
 // Rotary


### PR DESCRIPTION
PCF85063 has a different RTC masking scheme than the PCF8563. This would fix the RTC clock issue on many devices.

fixes #7885 

## 🤝 Attestations

- [ ✅] I have tested that my proposed changes behave as described.
- [ ✅] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [✅] Other (please specify below) T-Lora Pager
