### PR TITLE
Add BUILD_EPOCH to latest setup step.

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -48,6 +48,10 @@ jobs:
           python-version: 3.x
           cache: pip
       - run: pip install -U platformio
+      - name: Uncomment build epoch
+        shell: bash
+        run: |
+          sed -i 's/#-DBUILD_EPOCH=$UNIX_TIME/-DBUILD_EPOCH=$UNIX_TIME/' platformio.ini
       - name: Generate matrix
         id: jsonStep
         run: |


### PR DESCRIPTION
Previously this was in setup-base. However, setup-base is no longer used by the setup job.

Fixes https://github.com/meshtastic/gh-action-firmware/issues/10 Fixes https://github.com/meshtastic/firmware/issues/7888