### PR TITLE
Fix build error in rak_wismesh_tap_v2

### DIFF
--- a/variants/esp32s3/rak_wismesh_tap_v2/platformio.ini
+++ b/variants/esp32s3/rak_wismesh_tap_v2/platformio.ini
@@ -70,6 +70,7 @@ build_flags =
   ${ft5x06.build_flags}
   -D LGFX_SCREEN_WIDTH=240
   -D LGFX_SCREEN_HEIGHT=320
+  -D DISPLAY_SIZE=320x240 ; landscape mode
   -D LGFX_PANEL=ST7789
   -D LGFX_ROTATION=1
   -D LGFX_TOUCH_X_MIN=0


### PR DESCRIPTION
In the logs was:
"No screen resolution defined in build_flags. Please define DISPLAY_SIZE."

set according to similar devices.