### PR TITLE
Disable web server on Picomputer so firmware can fit in flash again

### DIFF
--- a/variants/esp32s3/picomputer-s3/platformio.ini
+++ b/variants/esp32s3/picomputer-s3/platformio.ini
@@ -26,6 +26,7 @@ extends = env:picomputer-s3
 
 build_flags =
   ${env:picomputer-s3.build_flags}
+  -D MESHTASTIC_EXCLUDE_WEBSERVER=1
   -D INPUTDRIVER_MATRIX_TYPE=1
   -D USE_PIN_BUZZER=PIN_BUZZER
   -D USE_SX127x


### PR DESCRIPTION
Meshtastic no longer fits on the flash of the Picomputer.

Since this is a handheld, portable device, it's unlikely that people are connecting to it via the webserver. So, disable the webserver and it fits again:

```
Checking size .pio/build/picomputer-s3-tft/firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [===       ]  32.4% (used 106056 bytes from 327680 bytes)
Flash: [==========]  99.1% (used 3313913 bytes from 3342336 bytes)
```

Fixes: https://github.com/meshtastic/firmware/issues/7906