### PR TITLE
Allow label enforcement job to run on self-hosted runners

### DIFF
--- a/.github/workflows/pr_enforce_labels.yml
+++ b/.github/workflows/pr_enforce_labels.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   check-label:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check for PR labels
         uses: actions/github-script@v8


### PR DESCRIPTION
Previously, this check would only run on github-provided runners.