### PR TITLE
handleNewPosition should not do smart things if smart position is dis…

### DIFF
--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -492,7 +492,7 @@ void PositionModule::handleNewPosition()
     meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(nodeDB->getNodeNum());
     const meshtastic_NodeInfoLite *node2 = service->refreshLocalMeshNode(); // should guarantee there is now a position
     // We limit our GPS broadcasts to a max rate
-    if (nodeDB->hasValidPosition(node2)) {
+    if (config.position.position_broadcast_smart_enabled && nodeDB->hasValidPosition(node2)) {
         auto smartPosition = getDistanceTraveledSinceLastSend(node->position);
         uint32_t msSinceLastSend = millis() - lastGpsSend;
         if (smartPosition.hasTraveledOverThreshold &&


### PR DESCRIPTION
…abled

PositionModule::handleNewPosition() is called from GPS::publishUpdate, and its primary function is to send positions if they have exeecded the smart position travel threshold.

However, we did all those checks and sent positions without checking whether the user had actually enabled smart position.

Fixes https://github.com/meshtastic/firmware/issues/7911

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
