### PR TITLE
PPA: Enable Ubuntu 25.10 (questing)

### DIFF
--- a/.github/workflows/daily_packaging.yml
+++ b/.github/workflows/daily_packaging.yml
@@ -31,8 +31,8 @@ jobs:
       fail-fast: false
       matrix:
         series:
-          - jammy # 22.04
-          - noble # 24.04
+          - jammy # 22.04 LTS
+          - noble # 24.04 LTS
           - plucky # 25.04
           - questing # 25.10
     uses: ./.github/workflows/package_ppa.yml

--- a/.github/workflows/release_channels.yml
+++ b/.github/workflows/release_channels.yml
@@ -21,10 +21,10 @@ jobs:
       fail-fast: false
       matrix:
         series:
-          - jammy # 22.04
-          - noble # 24.04
+          - jammy # 22.04 LTS
+          - noble # 24.04 LTS
           - plucky # 25.04
-          # - questing # 25.10
+          - questing # 25.10
     uses: ./.github/workflows/package_ppa.yml
     with:
       ppa_repo: |-


### PR DESCRIPTION
Enable Ubuntu 25.10 `questing` for PPA builds in the lead up to it's Beta release.

Ubuntu 25.10 reached Feature Freeze status on August 14, 2025, and builds are already working great in meshtasticd `Daily` releases :+1: 