### PR TITLE
Use `sh` in debhelper scripts

### DIFF
--- a/debian/meshtasticd.postinst
+++ b/debian/meshtasticd.postinst
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # postinst script for meshtasticd
 #
 # see: dh_installdeb(1)

--- a/debian/meshtasticd.postrm
+++ b/debian/meshtasticd.postrm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # postrm script for meshtasticd
 #
 # see: dh_installdeb(1)


### PR DESCRIPTION
Reverts unnecessary changes made to Debian debhelper scripts in #7514

These debhelper scripts work fine in `sh` which is **always** included even in the most minimal Debian installations.