### PR TITLE
Debian: Correctly generate changelog entries

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,50 +1,109 @@
-meshtasticd (2.7.9.0) UNRELEASED; urgency=medium
+meshtasticd (2.7.9.0) unstable; urgency=medium
 
-  [ Austin Lane ]
+  * Version 2.7.9
+
+ -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Wed, 03 Sep 2025 23:39:17 +0000
+
+meshtasticd (2.7.8.0) unstable; urgency=medium
+
+  * Version 2.7.8
+
+ -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Sat, 30 Aug 2025 00:26:04 +0000
+
+meshtasticd (2.7.7.0) unstable; urgency=medium
+
+  * Version 2.7.7
+
+ -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Thu, 28 Aug 2025 10:33:25 +0000
+
+meshtasticd (2.7.6.0) unstable; urgency=medium
+
+  * Version 2.7.6
+
+ -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Tue, 12 Aug 2025 23:48:48 +0000
+
+meshtasticd (2.7.5.0) unstable; urgency=medium
+
+  * Version 2.7.5
+
+ -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Sat, 09 Aug 2025 12:46:53 +0000
+
+meshtasticd (2.7.4.0) unstable; urgency=medium
+
+  * Version 2.7.4
+
+ -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Sat, 19 Jul 2025 11:36:55 +0000
+
+meshtasticd (2.7.3.0) unstable; urgency=medium
+
+  * Version 2.7.3
+
+ -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Thu, 10 Jul 2025 16:29:27 +0000
+
+meshtasticd (2.7.2.0) unstable; urgency=medium
+
+  * Version 2.7.2
+
+ -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Fri, 04 Jul 2025 11:58:01 +0000
+
+meshtasticd (2.7.1.0) unstable; urgency=medium
+
+  * Version 2.7.1
+
+ -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Fri, 27 Jun 2025 20:12:21 +0000
+
+meshtasticd (2.6.13) unstable; urgency=medium
+
+  * Version 2.6.13
+
+ -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Mon, 16 Jun 2025 02:10:49 +0000
+
+meshtasticd (2.6.11) unstable; urgency=medium
+
+  * Version 2.6.11
+
+ -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Mon, 02 Jun 2025 20:00:55 +0000
+
+meshtasticd (2.6.10) unstable; urgency=medium
+
+  * Version 2.6.10
+
+ -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Sun, 25 May 2025 20:46:49 +0000
+
+meshtasticd (2.6.9) unstable; urgency=medium
+
+  * Version 2.6.9
+  * Run as non-root user, 'meshtasticd'
+
+ -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Thu, 15 May 2025 11:13:30 +0000
+
+meshtasticd (2.6.8) unstable; urgency=medium
+
+  * Version 2.6.8
+
+ -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Tue, 06 May 2025 01:32:49 +0000
+
+meshtasticd (2.5.22) unstable; urgency=medium
+
+  * Version 2.5.22
+
+ -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Wed, 05 Feb 2025 01:10:33 +0000
+
+meshtasticd (2.5.21) unstable; urgency=medium
+
+  * Version 2.5.21
+
+ -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Sat, 25 Jan 2025 01:39:16 +0000
+
+meshtasticd (2.5.20) unstable; urgency=medium
+
+  * Version 2.5.20
+
+ -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Mon, 13 Jan 2025 19:24:14 +0000
+
+meshtasticd (2.5.19) unstable; urgency=medium
+
   * Initial packaging
-  * GitHub Actions Automatic version bump
-  * GitHub Actions Automatic version bump
-  * GitHub Actions Automatic version bump
-  * GitHub Actions Automatic version bump
+  * Version 2.5.19
 
-  [  ]
-  * GitHub Actions Automatic version bump
-
-  [  ]
-  * GitHub Actions Automatic version bump
-
-  [  ]
-  * GitHub Actions Automatic version bump
-
-  [  ]
-  * GitHub Actions Automatic version bump
-
-  [  ]
-  * GitHub Actions Automatic version bump
-
-  [  ]
-  * GitHub Actions Automatic version bump
-
-  [  ]
-  * GitHub Actions Automatic version bump
-
-  [ Ubuntu ]
-  * GitHub Actions Automatic version bump
-
-  [  ]
-  * GitHub Actions Automatic version bump
-
-  [  ]
-  * GitHub Actions Automatic version bump
-
-  [  ]
-  * GitHub Actions Automatic version bump
-  * GitHub Actions Automatic version bump
-
-  [  ]
-  * GitHub Actions Automatic version bump
-
-  [  ]
-  * GitHub Actions Automatic version bump
-
- --  <github-actions[bot]@users.noreply.github.com>  Wed, 03 Sep 2025 23:39:17 +0000
+ -- Austin Lane <vidplace7@gmail.com>  Thu, 02 Jan 2025 12:00:00 +0000

--- a/debian/ci_changelog.sh
+++ b/debian/ci_changelog.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/bash
+export DEBFULLNAME="GitHub Actions"
 export DEBEMAIL="github-actions[bot]@users.noreply.github.com"
 PKG_VERSION=$(python3 bin/buildinfo.py short)
 
 dch --newversion "$PKG_VERSION.0" \
-	--distribution UNRELEASED \
-	"GitHub Actions Automatic version bump"
+	--distribution unstable \
+	"Version $PKG_VERSION"


### PR DESCRIPTION
Fix Debian changelogs to correctly generate new entries (not overwrite existing entries) upon version bump.

Also manually re-creates the previous release changelogs based on git history :nerd_face: 