### PR TITLE
Issue: #7944 External notification module: Adjusted default nag timeout to 5s (from 60s)

### DIFF
--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -27,7 +27,7 @@
 #ifdef USERPREFS_RINGTONE_NAG_SECS
 #define default_ringtone_nag_secs USERPREFS_RINGTONE_NAG_SECS
 #else
-#define default_ringtone_nag_secs 60
+#define default_ringtone_nag_secs 5
 #endif
 
 #define default_mqtt_address "mqtt.meshtastic.org"


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/meshtastic/firmware/issues/7944). I've adjusted the default external notification nag timeout to be 5s rather than 60s.
Due to my lack of knowledge and skills i was not able to implement only notifying when receiving a DM. Help with this is greatly appreciated!

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
