### PR TITLE
Scale probe buffer size based on current baud rate

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1205,7 +1205,7 @@ static const char *DETECTED_MESSAGE = "%s detected";
         LOG_DEBUG(PROBE_MESSAGE, COMMAND, FAMILY_NAME);                                                                          \
         clearBuffer();                                                                                                           \
         _serial_gps->write(COMMAND "\r\n");                                                                                      \
-        GnssModel_t detectedDriver = getProbeResponse(TIMEOUT, RESPONSE_MAP);                                                    \
+        GnssModel_t detectedDriver = getProbeResponse(TIMEOUT, RESPONSE_MAP, serialSpeed);                                       \
         if (detectedDriver != GNSS_MODEL_UNKNOWN) {                                                                              \
             return detectedDriver;                                                                                               \
         }                                                                                                                        \
@@ -1367,9 +1367,18 @@ GnssModel_t GPS::probe(int serialSpeed)
     return GNSS_MODEL_UNKNOWN;
 }
 
-GnssModel_t GPS::getProbeResponse(unsigned long timeout, const std::vector<ChipInfo> &responseMap)
+GnssModel_t GPS::getProbeResponse(unsigned long timeout, const std::vector<ChipInfo> &responseMap, int serialSpeed)
 {
-    char response[256] = {0}; // Fixed buffer instead of String
+    // Calculate buffer size based on baud rate - 256 bytes for 9600 baud as baseline
+    // Higher baud rates get proportionally larger buffers to handle more data
+    int bufferSize = (serialSpeed * 256) / 9600;
+    // Clamp buffer size between reasonable limits
+    if (bufferSize < 128)
+        bufferSize = 128;
+    if (bufferSize > 2048)
+        bufferSize = 2048;
+
+    char *response = new char[bufferSize](); // Dynamically allocate based on baud rate
     uint16_t responseLen = 0;
     unsigned long start = millis();
     while (millis() - start < timeout) {
@@ -1377,7 +1386,7 @@ GnssModel_t GPS::getProbeResponse(unsigned long timeout, const std::vector<ChipI
             char c = _serial_gps->read();
 
             // Add char to buffer if there's space
-            if (responseLen < sizeof(response) - 1) {
+            if (responseLen < bufferSize - 1) {
                 response[responseLen++] = c;
                 response[responseLen] = '\0';
             }
@@ -1390,6 +1399,7 @@ GnssModel_t GPS::getProbeResponse(unsigned long timeout, const std::vector<ChipI
                 for (const auto &chipInfo : responseMap) {
                     if (strstr(response, chipInfo.detectionString.c_str()) != nullptr) {
                         LOG_INFO("%s detected", chipInfo.chipName.c_str());
+                        delete[] response; // Cleanup before return
                         return chipInfo.driver;
                     }
                 }
@@ -1404,6 +1414,7 @@ GnssModel_t GPS::getProbeResponse(unsigned long timeout, const std::vector<ChipI
 #ifdef GPS_DEBUG
     LOG_DEBUG(response);
 #endif
+    delete[] response;         // Cleanup before return
     return GNSS_MODEL_UNKNOWN; // Return unknown on timeout
 }
 

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -236,7 +236,7 @@ class GPS : private concurrency::OSThread
 
     virtual int32_t runOnce() override;
 
-    GnssModel_t getProbeResponse(unsigned long timeout, const std::vector<ChipInfo> &responseMap);
+    GnssModel_t getProbeResponse(unsigned long timeout, const std::vector<ChipInfo> &responseMap, int serialSpeed);
 
     // Get GNSS model
     GnssModel_t probe(int serialSpeed);

--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -9,6 +9,10 @@
 static RTCQuality currentQuality = RTCQualityNone;
 uint32_t lastSetFromPhoneNtpOrGps = 0;
 
+// Rate limiting for GPS time validation warnings
+static uint32_t lastTimeValidationWarning = 0;
+static const uint32_t TIME_VALIDATION_WARNING_INTERVAL_MS = 15000; // 15 seconds
+
 RTCQuality getRTCQuality()
 {
     return currentQuality;
@@ -130,11 +134,20 @@ RTCSetResult perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpd
     uint32_t printableEpoch = tv->tv_sec; // Print lib only supports 32 bit but time_t can be 64 bit on some platforms
 #ifdef BUILD_EPOCH
     if (tv->tv_sec < BUILD_EPOCH) {
-        LOG_WARN("Ignore time (%ld) before build epoch (%ld)!", printableEpoch, BUILD_EPOCH);
+        if (Throttle::isWithinTimespanMs(lastTimeValidationWarning, TIME_VALIDATION_WARNING_INTERVAL_MS) == false) {
+            LOG_WARN("Ignore time (%ld) before build epoch (%ld)!", printableEpoch, BUILD_EPOCH);
+            lastTimeValidationWarning = millis();
+        }
         return RTCSetResultInvalidTime;
-    } else if (tv->tv_sec > (BUILD_EPOCH + FORTY_YEARS)) {
-        LOG_WARN("Ignore time (%ld) too far in the future (build epoch: %ld, max allowed: %ld)!", printableEpoch, BUILD_EPOCH,
-                 BUILD_EPOCH + FORTY_YEARS);
+    } else if (tv->tv_sec > (time_t)(BUILD_EPOCH + FORTY_YEARS)) {
+        if (Throttle::isWithinTimespanMs(lastTimeValidationWarning, TIME_VALIDATION_WARNING_INTERVAL_MS) == false) {
+            // Calculate max allowed time safely to avoid overflow in logging
+            uint64_t maxAllowedTime = (uint64_t)BUILD_EPOCH + FORTY_YEARS;
+            uint32_t maxAllowedPrintable = (maxAllowedTime > UINT32_MAX) ? UINT32_MAX : (uint32_t)maxAllowedTime;
+            LOG_WARN("Ignore time (%ld) too far in the future (build epoch: %ld, max allowed: %ld)!", printableEpoch,
+                     (uint32_t)BUILD_EPOCH, maxAllowedPrintable);
+            lastTimeValidationWarning = millis();
+        }
         return RTCSetResultInvalidTime;
     }
 #endif
@@ -252,11 +265,20 @@ RTCSetResult perhapsSetRTC(RTCQuality q, struct tm &t)
     uint32_t printableEpoch = tv.tv_sec; // Print lib only supports 32 bit but time_t can be 64 bit on some platforms
 #ifdef BUILD_EPOCH
     if (tv.tv_sec < BUILD_EPOCH) {
-        LOG_WARN("Ignore time (%ld) before build epoch (%ld)!", printableEpoch, BUILD_EPOCH);
+        if (Throttle::isWithinTimespanMs(lastTimeValidationWarning, TIME_VALIDATION_WARNING_INTERVAL_MS) == false) {
+            LOG_WARN("Ignore time (%ld) before build epoch (%ld)!", printableEpoch, BUILD_EPOCH);
+            lastTimeValidationWarning = millis();
+        }
         return RTCSetResultInvalidTime;
-    } else if (tv.tv_sec > (BUILD_EPOCH + FORTY_YEARS)) {
-        LOG_WARN("Ignore time (%ld) too far in the future (build epoch: %ld, max allowed: %ld)!", printableEpoch, BUILD_EPOCH,
-                 BUILD_EPOCH + FORTY_YEARS);
+    } else if (tv.tv_sec > (time_t)(BUILD_EPOCH + FORTY_YEARS)) {
+        if (Throttle::isWithinTimespanMs(lastTimeValidationWarning, TIME_VALIDATION_WARNING_INTERVAL_MS) == false) {
+            // Calculate max allowed time safely to avoid overflow in logging
+            uint64_t maxAllowedTime = (uint64_t)BUILD_EPOCH + FORTY_YEARS;
+            uint32_t maxAllowedPrintable = (maxAllowedTime > UINT32_MAX) ? UINT32_MAX : (uint32_t)maxAllowedTime;
+            LOG_WARN("Ignore time (%ld) too far in the future (build epoch: %ld, max allowed: %ld)!", printableEpoch,
+                     (uint32_t)BUILD_EPOCH, maxAllowedPrintable);
+            lastTimeValidationWarning = millis();
+        }
         return RTCSetResultInvalidTime;
     }
 #endif

--- a/src/gps/RTC.h
+++ b/src/gps/RTC.h
@@ -56,5 +56,5 @@ time_t gm_mktime(struct tm *tm);
 #define SEC_PER_HOUR 3600
 #define SEC_PER_MIN 60
 #ifdef BUILD_EPOCH
-#define FORTY_YEARS (40UL * 365 * SEC_PER_DAY) // probably time to update your firmware
+#define FORTY_YEARS (40ULL * 365 * SEC_PER_DAY) // Use 64-bit arithmetic to prevent overflow
 #endif


### PR DESCRIPTION
Tested on a number of 9600 and 115200 baud GNSS equipped devices.
Also fixed some spam of time validation logging