### PR TITLE
Fix GPS `gm_mktime` memory leak

### DIFF
--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -324,14 +324,40 @@ uint32_t getValidTime(RTCQuality minQuality, bool local)
 time_t gm_mktime(struct tm *tm)
 {
 #if !MESHTASTIC_EXCLUDE_TZ
-    setenv("TZ", "GMT0", 1);
-    time_t res = mktime(tm);
-    if (*config.device.tzdef) {
-        setenv("TZ", config.device.tzdef, 1);
-    } else {
-        setenv("TZ", "UTC0", 1);
+    time_t result = 0;
+
+    // First, get us to the start of tm->year, by calcuating the number of days since the Unix epoch.
+    int year = 1900 + tm->tm_year; // tm_year is years since 1900
+    int year_minus_one = year - 1;
+    int days_before_this_year = 0;
+    days_before_this_year += year_minus_one * 365;
+    // leap days: every 4 years, except 100s, but including 400s.
+    days_before_this_year += year_minus_one / 4 - year_minus_one / 100 + year_minus_one / 400;
+    // subtract from 1970-01-01 to get days since epoch
+    days_before_this_year -= 719162; // (1969 * 365 + 1969 / 4 - 1969 / 100 + 1969 / 400);
+
+    // Now, within this tm->year, compute the days *before* this tm->month starts.
+    int days_before_month[12] = {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334}; // non-leap year
+    int days_this_year_before_this_month = days_before_month[tm->tm_mon];                // tm->tm_mon is 0..11
+
+    // If this is a leap year, and we're past February, add a day:
+    if (tm->tm_mon >= 2 && (year % 4) == 0 && ((year % 100) != 0 || (year % 400) == 0)) {
+        days_this_year_before_this_month += 1;
     }
-    return res;
+
+    // And within this month:
+    int days_this_month_before_today = tm->tm_mday - 1; // tm->tm_mday is 1..31
+
+    // Now combine them all together, and convert days to seconds:
+    result += (days_before_this_year + days_this_year_before_this_month + days_this_month_before_today);
+    result *= 86400L;
+
+    // Finally, add in the hours, minutes, and seconds of today:
+    result += tm->tm_hour * 3600;
+    result += tm->tm_min * 60;
+    result += tm->tm_sec;
+
+    return result;
 #else
     return mktime(tm);
 #endif


### PR DESCRIPTION
I have a Heltec V3 with a GY-NEO6MV2 GPS module. I've noticed heap usage growing steadily and causing reboots after just a few hours, and eventually noticed it only happened when there was a GPS lock.

After much hunting, enabling `-D DEBUG_HEAP`, and adding a ton of `LOG_DEBUG` lines, I finally found the issue in `src/gps/RTC.cpp`:

https://github.com/meshtastic/firmware/blob/de3a65579dd0d31d36a6e764563c4fb4dde413a4/src/gps/RTC.cpp#L324-L338

The `setenv` and/or the libc loading of the new timezone data leaks memory: 60 bytes per `gm_mktime` call. This stacks up fast.

<img width="720" height="841" alt="GPS_Memory_Leak" src="https://github.com/user-attachments/assets/87cede5b-2307-4b97-a2fb-791d14fc0e08" />

In the attached `GPS_Memory_Leak_Log.txt`, you'll see 11 leak iterations (660 bytes total) in just 10 seconds. 😮 

-----

## The Fix

The fix is to implement `gm_mktime` (converting a `struct tm` which is `{year,month,day,hour,minute,second}`, assumed to be in UTC, to the number of seconds since unix epoch)  without using `setenv`.

I've implemented this in this PR.

To test the logic, I've attached a `test-gmtime.c` program which you can run as `gcc -o test-gmtime test-gmtime.c && TZ=UTC ./test-gmtime`. By setting `TZ=UTC`, it's able to compare `mktime` to this new implementation of `gm_mktime`, and compares that the results are the same day-by-day from 1970 to the year 2500.

-----

## Post Fix

No more memory leak highlighted by `-D DEBUG_HEAP`. No more drop when calling `gm_mktime`.

<img width="691" height="830" alt="GPS_Memory_Leak_Fixed" src="https://github.com/user-attachments/assets/b7175e7f-88ab-4b19-b571-dbf82358e21b" />

The attached `GPS_Memory_Leak_Fixed_Log.txt` shows about 10 seconds with tons of calls to `gm_mktime`, but stable heap usage.

On my device, I no longer see heap % growing like crazy.

-----

## Attachments

[test-gmtime.c](https://github.com/user-attachments/files/22318270/test-gmtime.c)

[GPS_Memory_Leak_Log.txt](https://github.com/user-attachments/files/22318260/GPS_Memory_Leak_Log.txt)

[GPS_Memory_Leak_Fixed_Log.txt](https://github.com/user-attachments/files/22318261/GPS_Memory_Leak_Fixed_Log.txt)

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [X] Heltec (Lora32) V3
