### PR TITLE
(resubmission) Manual GitHub actions to allow building one target or arch

### DIFF
--- a/.github/workflows/build_one_arch.yml
+++ b/.github/workflows/build_one_arch.yml
@@ -1,37 +1,11 @@
-name: CI
-concurrency:
-  group: ci-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+name: Build One Arch
+
 on:
-  # # Triggers the workflow on push but only for the master branch
-  push:
-    branches:
-      - master
-      - develop
-      - event/*
-    paths-ignore:
-      - "**.md"
-      - version.properties
-
-  # # Note: This is different from "pull_request". Need to specify ref when doing checkouts.
-  pull_request_target:
-    branches:
-      - master
-      - develop
-      - event/*
-    paths-ignore:
-      - "**.md"
-    #  - "**.yml"
-
   workflow_dispatch:
-
-jobs:
-  setup:
-    if: github.repository == 'meshtastic/firmware'
-    strategy:
-      fail-fast: false
-      matrix:
-        arch:
+    inputs:
+      arch:
+        type: choice
+        options:
           - esp32
           - esp32s3
           - esp32c3
@@ -40,7 +14,12 @@ jobs:
           - rp2040
           - rp2350
           - stm32
-          - check
+          - native
+
+jobs:
+  setup:
+    strategy:
+      fail-fast: false
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -53,12 +32,12 @@ jobs:
         id: jsonStep
         run: |
           if [[ "$GITHUB_HEAD_REF" == "" ]]; then
-            TARGETS=$(./bin/generate_ci_matrix.py ${{matrix.arch}})
+            TARGETS=$(./bin/generate_ci_matrix.py ${{inputs.arch}} extra)
           else  
-            TARGETS=$(./bin/generate_ci_matrix.py ${{matrix.arch}} pr)
+            TARGETS=$(./bin/generate_ci_matrix.py ${{inputs.arch}} pr)
           fi
           echo "Name: $GITHUB_REF_NAME Base: $GITHUB_BASE_REF Ref: $GITHUB_REF Targets: $TARGETS"
-          echo "${{matrix.arch}}=$(jq -cn --argjson environments "$TARGETS" '{board: $environments}')" >> $GITHUB_OUTPUT
+          echo "${{inputs.arch}}=$(jq -cn --argjson environments "$TARGETS" '{board: $environments}')" >> $GITHUB_OUTPUT
     outputs:
       esp32: ${{ steps.jsonStep.outputs.esp32 }}
       esp32s3: ${{ steps.jsonStep.outputs.esp32s3 }}
@@ -71,7 +50,6 @@ jobs:
       check: ${{ steps.jsonStep.outputs.check }}
 
   version:
-    if: github.repository == 'meshtastic/firmware'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -86,23 +64,8 @@ jobs:
       long: ${{ steps.version.outputs.long }}
       deb: ${{ steps.version.outputs.deb }}
 
-  check:
-    needs: setup
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.setup.outputs.check) }}
-
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'workflow_dispatch' && github.repository == 'meshtastic/firmware' }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build base
-        id: base
-        uses: ./.github/actions/setup-base
-      - name: Check ${{ matrix.board }}
-        run: bin/check-all.sh ${{ matrix.board }}
-
   build-esp32:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.arch == 'esp32'}}
     needs: [setup, version]
     strategy:
       fail-fast: false
@@ -114,6 +77,7 @@ jobs:
       platform: esp32
 
   build-esp32s3:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.arch == 'esp32s3'}}
     needs: [setup, version]
     strategy:
       fail-fast: false
@@ -125,6 +89,7 @@ jobs:
       platform: esp32s3
 
   build-esp32c3:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.arch == 'esp32c3'}}
     needs: [setup, version]
     strategy:
       fail-fast: false
@@ -136,6 +101,7 @@ jobs:
       platform: esp32c3
 
   build-esp32c6:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.arch == 'esp32c6'}}
     needs: [setup, version]
     strategy:
       fail-fast: false
@@ -147,6 +113,7 @@ jobs:
       platform: esp32c6
 
   build-nrf52840:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.arch == 'nrf52840'}}
     needs: [setup, version]
     strategy:
       fail-fast: false
@@ -158,6 +125,7 @@ jobs:
       platform: nrf52840
 
   build-rp2040:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.arch == 'rp2040'}}
     needs: [setup, version]
     strategy:
       fail-fast: false
@@ -169,6 +137,7 @@ jobs:
       platform: rp2040
 
   build-rp2350:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.arch == 'rp2350'}}
     needs: [setup, version]
     strategy:
       fail-fast: false
@@ -180,6 +149,7 @@ jobs:
       platform: rp2350
 
   build-stm32:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.arch == 'stm32' }}
     needs: [setup, version]
     strategy:
       fail-fast: false
@@ -191,7 +161,7 @@ jobs:
       platform: stm32
 
   build-debian-src:
-    if: github.repository == 'meshtastic/firmware'
+    if: ${{ github.repository == 'meshtastic/firmware' && github.event_name != 'workflow_dispatch' || inputs.arch == 'native' }}
     uses: ./.github/workflows/build_debian_src.yml
     with:
       series: UNRELEASED
@@ -199,18 +169,18 @@ jobs:
     secrets: inherit
 
   package-pio-deps-native-tft:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ inputs.arch == 'native' }}
     uses: ./.github/workflows/package_pio_deps.yml
     with:
       pio_env: native-tft
     secrets: inherit
 
   test-native:
-    if: ${{ !contains(github.ref_name, 'event/') && github.repository == 'meshtastic/firmware' }}
+    if: ${{ !contains(github.ref_name, 'event/') && github.event_name != 'workflow_dispatch' ||  !contains(github.ref_name, 'event/') && inputs.arch == 'native' }}
     uses: ./.github/workflows/test_native.yml
 
   docker-deb-amd64:
-    if: github.repository == 'meshtastic/firmware'
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.arch == 'native' }}
     uses: ./.github/workflows/docker_build.yml
     with:
       distro: debian
@@ -219,7 +189,7 @@ jobs:
       push: false
 
   docker-deb-amd64-tft:
-    if: github.repository == 'meshtastic/firmware'
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.arch == 'native' }}
     uses: ./.github/workflows/docker_build.yml
     with:
       distro: debian
@@ -229,7 +199,7 @@ jobs:
       pio_env: native-tft
 
   docker-alp-amd64:
-    if: github.repository == 'meshtastic/firmware'
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.arch == 'native' }}
     uses: ./.github/workflows/docker_build.yml
     with:
       distro: alpine
@@ -238,7 +208,7 @@ jobs:
       push: false
 
   docker-alp-amd64-tft:
-    if: github.repository == 'meshtastic/firmware'
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.arch == 'native' }}
     uses: ./.github/workflows/docker_build.yml
     with:
       distro: alpine
@@ -248,7 +218,7 @@ jobs:
       pio_env: native-tft
 
   docker-deb-arm64:
-    if: github.repository == 'meshtastic/firmware'
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.arch == 'native' }}
     uses: ./.github/workflows/docker_build.yml
     with:
       distro: debian
@@ -257,7 +227,7 @@ jobs:
       push: false
 
   docker-deb-armv7:
-    if: github.repository == 'meshtastic/firmware'
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.arch == 'native' }}
     uses: ./.github/workflows/docker_build.yml
     with:
       distro: debian
@@ -266,7 +236,6 @@ jobs:
       push: false
 
   gather-artifacts:
-    if: github.repository == 'meshtastic/firmware'
     permissions:
       contents: write
       pull-requests: write
@@ -305,7 +274,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: ./
-          pattern: firmware-${{matrix.arch}}-*
+          pattern: firmware-${{inputs.arch}}-*
           merge-multiple: true
 
       - name: Display structure of downloaded files
@@ -317,7 +286,7 @@ jobs:
       - name: Repackage in single firmware zip
         uses: actions/upload-artifact@v4
         with:
-          name: firmware-${{matrix.arch}}-${{ needs.version.outputs.long }}
+          name: firmware-${{inputs.arch}}-${{ needs.version.outputs.long }}
           overwrite: true
           path: |
             ./firmware-*.bin
@@ -333,7 +302,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: firmware-${{matrix.arch}}-${{ needs.version.outputs.long }}
+          name: firmware-${{inputs.arch}}-${{ needs.version.outputs.long }}
           merge-multiple: true
           path: ./output
 
@@ -347,12 +316,12 @@ jobs:
           chmod +x ./output/device-update.sh
 
       - name: Zip firmware
-        run: zip -j -9 -r ./firmware-${{matrix.arch}}-${{ needs.version.outputs.long }}.zip ./output
+        run: zip -j -9 -r ./firmware-${{inputs.arch}}-${{ needs.version.outputs.long }}.zip ./output
 
       - name: Repackage in single elfs zip
         uses: actions/upload-artifact@v4
         with:
-          name: debug-elfs-${{matrix.arch}}-${{ needs.version.outputs.long }}.zip
+          name: debug-elfs-${{inputs.arch}}-${{ needs.version.outputs.long }}.zip
           overwrite: true
           path: ./*.elf
           retention-days: 30
@@ -360,13 +329,13 @@ jobs:
       - uses: scruplelesswizard/comment-artifact@main
         if: ${{ github.event_name == 'pull_request' }}
         with:
-          name: firmware-${{matrix.arch}}-${{ needs.version.outputs.long }}
-          description: "Download firmware-${{matrix.arch}}-${{ needs.version.outputs.long }}.zip. This artifact will be available for 90 days from creation"
+          name: firmware-${{inputs.arch}}-${{ needs.version.outputs.long }}
+          description: "Download firmware-${{inputs.arch}}-${{ needs.version.outputs.long }}.zip. This artifact will be available for 90 days from creation"
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   release-artifacts:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' && github.repository == 'meshtastic/firmware' }}
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     needs:
@@ -441,7 +410,7 @@ jobs:
           - rp2350
           - stm32
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' && github.repository == 'meshtastic/firmware'}}
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     needs: [release-artifacts, version]
     steps:
       - name: Checkout
@@ -454,7 +423,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          pattern: firmware-${{matrix.arch}}-${{ needs.version.outputs.long }}
+          pattern: firmware-${{inputs.arch}}-${{ needs.version.outputs.long }}
           merge-multiple: true
           path: ./output
 
@@ -467,16 +436,16 @@ jobs:
           chmod +x ./output/device-update.sh
 
       - name: Zip firmware
-        run: zip -j -9 -r ./firmware-${{matrix.arch}}-${{ needs.version.outputs.long }}.zip ./output
+        run: zip -j -9 -r ./firmware-${{inputs.arch}}-${{ needs.version.outputs.long }}.zip ./output
 
       - uses: actions/download-artifact@v4
         with:
-          name: debug-elfs-${{matrix.arch}}-${{ needs.version.outputs.long }}.zip
+          name: debug-elfs-${{inputs.arch}}-${{ needs.version.outputs.long }}.zip
           merge-multiple: true
           path: ./elfs
 
       - name: Zip debug elfs
-        run: zip -j -9 -r ./debug-elfs-${{matrix.arch}}-${{ needs.version.outputs.long }}.zip ./elfs
+        run: zip -j -9 -r ./debug-elfs-${{inputs.arch}}-${{ needs.version.outputs.long }}.zip ./elfs
 
       # For diagnostics
       - name: Display structure of downloaded files
@@ -486,8 +455,8 @@ jobs:
         # Only run when targeting master branch with workflow_dispatch
         if: ${{ github.ref_name == 'master' }}
         run: |
-          gh release upload v${{ needs.version.outputs.long }} ./firmware-${{matrix.arch}}-${{ needs.version.outputs.long }}.zip
-          gh release upload v${{ needs.version.outputs.long }} ./debug-elfs-${{matrix.arch}}-${{ needs.version.outputs.long }}.zip
+          gh release upload v${{ needs.version.outputs.long }} ./firmware-${{inputs.arch}}-${{ needs.version.outputs.long }}.zip
+          gh release upload v${{ needs.version.outputs.long }} ./debug-elfs-${{inputs.arch}}-${{ needs.version.outputs.long }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build_one_target.yml
+++ b/.github/workflows/build_one_target.yml
@@ -1,33 +1,32 @@
-name: CI
-concurrency:
-  group: ci-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+name: Build One Target
+
 on:
-  # # Triggers the workflow on push but only for the master branch
-  push:
-    branches:
-      - master
-      - develop
-      - event/*
-    paths-ignore:
-      - "**.md"
-      - version.properties
-
-  # # Note: This is different from "pull_request". Need to specify ref when doing checkouts.
-  pull_request_target:
-    branches:
-      - master
-      - develop
-      - event/*
-    paths-ignore:
-      - "**.md"
-    #  - "**.yml"
-
   workflow_dispatch:
+    inputs:
+      arch:
+        type: choice
+        options:
+          - esp32
+          - esp32s3
+          - esp32c3
+          - esp32c6
+          - nrf52840
+          - rp2040
+          - rp2350
+          - stm32
+          - native
+      target:
+        type: string
+        required: false
+        description: 'choose the target board, e.g. nrf52_promicro_diy_tcxo. If blank, will find available targets.'
 
+      # find-target:
+      #   type: boolean
+      #   default: true
+      #   description: 'Find the available targets'
 jobs:
-  setup:
-    if: github.repository == 'meshtastic/firmware'
+  find-targets:
+    if: ${{ inputs.target == '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -40,7 +39,7 @@ jobs:
           - rp2040
           - rp2350
           - stm32
-          - check
+
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -52,26 +51,20 @@ jobs:
       - name: Generate matrix
         id: jsonStep
         run: |
-          if [[ "$GITHUB_HEAD_REF" == "" ]]; then
-            TARGETS=$(./bin/generate_ci_matrix.py ${{matrix.arch}})
-          else  
-            TARGETS=$(./bin/generate_ci_matrix.py ${{matrix.arch}} pr)
-          fi
-          echo "Name: $GITHUB_REF_NAME Base: $GITHUB_BASE_REF Ref: $GITHUB_REF Targets: $TARGETS"
-          echo "${{matrix.arch}}=$(jq -cn --argjson environments "$TARGETS" '{board: $environments}')" >> $GITHUB_OUTPUT
-    outputs:
-      esp32: ${{ steps.jsonStep.outputs.esp32 }}
-      esp32s3: ${{ steps.jsonStep.outputs.esp32s3 }}
-      esp32c3: ${{ steps.jsonStep.outputs.esp32c3 }}
-      esp32c6: ${{ steps.jsonStep.outputs.esp32c6 }}
-      nrf52840: ${{ steps.jsonStep.outputs.nrf52840 }}
-      rp2040: ${{ steps.jsonStep.outputs.rp2040 }}
-      rp2350: ${{ steps.jsonStep.outputs.rp2350 }}
-      stm32: ${{ steps.jsonStep.outputs.stm32 }}
-      check: ${{ steps.jsonStep.outputs.check }}
+          TARGETS=$(./bin/generate_ci_matrix.py ${{matrix.arch}} extra)
+          echo "Name: $GITHUB_REF_NAME" >> $GITHUB_STEP_SUMMARY
+          echo "Base: $GITHUB_BASE_REF" >> $GITHUB_STEP_SUMMARY
+          echo "Arch: ${{matrix.arch}}" >> $GITHUB_STEP_SUMMARY
+          echo "Ref: $GITHUB_REF" >> $GITHUB_STEP_SUMMARY
+          echo "Targets:" >> $GITHUB_STEP_SUMMARY
+          echo $TARGETS | sed 's/[][]//g; s/", "/\n- /g; s/"//g; s/^/- /' >> $GITHUB_STEP_SUMMARY
+
+
+
+
 
   version:
-    if: github.repository == 'meshtastic/firmware'
+    if: ${{ inputs.target != '' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -86,112 +79,19 @@ jobs:
       long: ${{ steps.version.outputs.long }}
       deb: ${{ steps.version.outputs.deb }}
 
-  check:
-    needs: setup
+  build-arch:
+    if: ${{ inputs.target != '' && inputs.arch != 'native' }}
+    needs: [version]
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.setup.outputs.check) }}
-
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'workflow_dispatch' && github.repository == 'meshtastic/firmware' }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build base
-        id: base
-        uses: ./.github/actions/setup-base
-      - name: Check ${{ matrix.board }}
-        run: bin/check-all.sh ${{ matrix.board }}
-
-  build-esp32:
-    needs: [setup, version]
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.setup.outputs.esp32) }}
     uses: ./.github/workflows/build_firmware.yml
     with:
       version: ${{ needs.version.outputs.long }}
-      pio_env: ${{ matrix.board }}
-      platform: esp32
-
-  build-esp32s3:
-    needs: [setup, version]
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.setup.outputs.esp32s3) }}
-    uses: ./.github/workflows/build_firmware.yml
-    with:
-      version: ${{ needs.version.outputs.long }}
-      pio_env: ${{ matrix.board }}
-      platform: esp32s3
-
-  build-esp32c3:
-    needs: [setup, version]
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.setup.outputs.esp32c3) }}
-    uses: ./.github/workflows/build_firmware.yml
-    with:
-      version: ${{ needs.version.outputs.long }}
-      pio_env: ${{ matrix.board }}
-      platform: esp32c3
-
-  build-esp32c6:
-    needs: [setup, version]
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.setup.outputs.esp32c6) }}
-    uses: ./.github/workflows/build_firmware.yml
-    with:
-      version: ${{ needs.version.outputs.long }}
-      pio_env: ${{ matrix.board }}
-      platform: esp32c6
-
-  build-nrf52840:
-    needs: [setup, version]
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.setup.outputs.nrf52840) }}
-    uses: ./.github/workflows/build_firmware.yml
-    with:
-      version: ${{ needs.version.outputs.long }}
-      pio_env: ${{ matrix.board }}
-      platform: nrf52840
-
-  build-rp2040:
-    needs: [setup, version]
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.setup.outputs.rp2040) }}
-    uses: ./.github/workflows/build_firmware.yml
-    with:
-      version: ${{ needs.version.outputs.long }}
-      pio_env: ${{ matrix.board }}
-      platform: rp2040
-
-  build-rp2350:
-    needs: [setup, version]
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.setup.outputs.rp2350) }}
-    uses: ./.github/workflows/build_firmware.yml
-    with:
-      version: ${{ needs.version.outputs.long }}
-      pio_env: ${{ matrix.board }}
-      platform: rp2350
-
-  build-stm32:
-    needs: [setup, version]
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.setup.outputs.stm32) }}
-    uses: ./.github/workflows/build_firmware.yml
-    with:
-      version: ${{ needs.version.outputs.long }}
-      pio_env: ${{ matrix.board }}
-      platform: stm32
+      pio_env: ${{ inputs.target }}
+      platform: ${{ inputs.arch }}
 
   build-debian-src:
-    if: github.repository == 'meshtastic/firmware'
+    if: ${{ github.repository == 'meshtastic/firmware' && inputs.arch == 'native' }}
     uses: ./.github/workflows/build_debian_src.yml
     with:
       series: UNRELEASED
@@ -199,18 +99,18 @@ jobs:
     secrets: inherit
 
   package-pio-deps-native-tft:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ inputs.arch == 'native' }}
     uses: ./.github/workflows/package_pio_deps.yml
     with:
       pio_env: native-tft
     secrets: inherit
 
   test-native:
-    if: ${{ !contains(github.ref_name, 'event/') && github.repository == 'meshtastic/firmware' }}
+    if: ${{ !contains(github.ref_name, 'event/') && github.event_name != 'workflow_dispatch' ||  !contains(github.ref_name, 'event/') && inputs.arch == 'native' && inputs.target != '' }}
     uses: ./.github/workflows/test_native.yml
 
   docker-deb-amd64:
-    if: github.repository == 'meshtastic/firmware'
+    if: ${{ inputs.target != '' && inputs.arch ==  'native' }}
     uses: ./.github/workflows/docker_build.yml
     with:
       distro: debian
@@ -219,7 +119,7 @@ jobs:
       push: false
 
   docker-deb-amd64-tft:
-    if: github.repository == 'meshtastic/firmware'
+    if: ${{ inputs.target != '' && inputs.arch ==  'native' }}
     uses: ./.github/workflows/docker_build.yml
     with:
       distro: debian
@@ -229,7 +129,7 @@ jobs:
       pio_env: native-tft
 
   docker-alp-amd64:
-    if: github.repository == 'meshtastic/firmware'
+    if: ${{ inputs.target != '' && inputs.arch ==  'native' }}
     uses: ./.github/workflows/docker_build.yml
     with:
       distro: alpine
@@ -238,7 +138,7 @@ jobs:
       push: false
 
   docker-alp-amd64-tft:
-    if: github.repository == 'meshtastic/firmware'
+    if: ${{ inputs.target != '' && inputs.arch ==  'native' }}
     uses: ./.github/workflows/docker_build.yml
     with:
       distro: alpine
@@ -248,7 +148,7 @@ jobs:
       pio_env: native-tft
 
   docker-deb-arm64:
-    if: github.repository == 'meshtastic/firmware'
+    if: ${{ inputs.target != '' && inputs.arch ==  'native' }}
     uses: ./.github/workflows/docker_build.yml
     with:
       distro: debian
@@ -257,7 +157,7 @@ jobs:
       push: false
 
   docker-deb-armv7:
-    if: github.repository == 'meshtastic/firmware'
+    if: ${{ inputs.target != '' && inputs.arch ==  'native' }}
     uses: ./.github/workflows/docker_build.yml
     with:
       distro: debian
@@ -266,34 +166,16 @@ jobs:
       push: false
 
   gather-artifacts:
-    if: github.repository == 'meshtastic/firmware'
     permissions:
       contents: write
       pull-requests: write
     strategy:
       fail-fast: false
-      matrix:
-        arch:
-          - esp32
-          - esp32s3
-          - esp32c3
-          - esp32c6
-          - nrf52840
-          - rp2040
-          - rp2350
-          - stm32
     runs-on: ubuntu-latest
     needs:
       [
         version,
-        build-esp32,
-        build-esp32s3,
-        build-esp32c3,
-        build-esp32c6,
-        build-nrf52840,
-        build-rp2040,
-        build-rp2350,
-        build-stm32,
+        build-arch,
       ]
     steps:
       - name: Checkout code
@@ -305,7 +187,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: ./
-          pattern: firmware-${{matrix.arch}}-*
+          pattern: firmware-*-*
           merge-multiple: true
 
       - name: Display structure of downloaded files
@@ -317,7 +199,7 @@ jobs:
       - name: Repackage in single firmware zip
         uses: actions/upload-artifact@v4
         with:
-          name: firmware-${{matrix.arch}}-${{ needs.version.outputs.long }}
+          name: firmware-${{inputs.target}}-${{ needs.version.outputs.long }}
           overwrite: true
           path: |
             ./firmware-*.bin
@@ -333,7 +215,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: firmware-${{matrix.arch}}-${{ needs.version.outputs.long }}
+          pattern: firmware-*-${{ needs.version.outputs.long }}
           merge-multiple: true
           path: ./output
 
@@ -347,12 +229,12 @@ jobs:
           chmod +x ./output/device-update.sh
 
       - name: Zip firmware
-        run: zip -j -9 -r ./firmware-${{matrix.arch}}-${{ needs.version.outputs.long }}.zip ./output
+        run: zip -j -9 -r ./firmware-${{inputs.target}}-${{ needs.version.outputs.long }}.zip ./output
 
       - name: Repackage in single elfs zip
         uses: actions/upload-artifact@v4
         with:
-          name: debug-elfs-${{matrix.arch}}-${{ needs.version.outputs.long }}.zip
+          name: debug-elfs-${{inputs.target}}-${{ needs.version.outputs.long }}.zip
           overwrite: true
           path: ./*.elf
           retention-days: 30
@@ -360,13 +242,13 @@ jobs:
       - uses: scruplelesswizard/comment-artifact@main
         if: ${{ github.event_name == 'pull_request' }}
         with:
-          name: firmware-${{matrix.arch}}-${{ needs.version.outputs.long }}
-          description: "Download firmware-${{matrix.arch}}-${{ needs.version.outputs.long }}.zip. This artifact will be available for 90 days from creation"
+          name: firmware-${{inputs.target}}-${{ needs.version.outputs.long }}
+          description: "Download firmware-${{inputs.target}}-${{ needs.version.outputs.long }}.zip. This artifact will be available for 90 days from creation"
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   release-artifacts:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' && github.repository == 'meshtastic/firmware' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.target != ''}}
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     needs:
@@ -430,18 +312,8 @@ jobs:
   release-firmware:
     strategy:
       fail-fast: false
-      matrix:
-        arch:
-          - esp32
-          - esp32s3
-          - esp32c3
-          - esp32c6
-          - nrf52840
-          - rp2040
-          - rp2350
-          - stm32
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' && github.repository == 'meshtastic/firmware'}}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.target != ''}}
     needs: [release-artifacts, version]
     steps:
       - name: Checkout
@@ -454,7 +326,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          pattern: firmware-${{matrix.arch}}-${{ needs.version.outputs.long }}
+          pattern: firmware-*-${{ needs.version.outputs.long }}
           merge-multiple: true
           path: ./output
 
@@ -467,16 +339,16 @@ jobs:
           chmod +x ./output/device-update.sh
 
       - name: Zip firmware
-        run: zip -j -9 -r ./firmware-${{matrix.arch}}-${{ needs.version.outputs.long }}.zip ./output
+        run: zip -j -9 -r ./firmware-${{inputs.target}}-${{ needs.version.outputs.long }}.zip ./output
 
       - uses: actions/download-artifact@v4
         with:
-          name: debug-elfs-${{matrix.arch}}-${{ needs.version.outputs.long }}.zip
+          pattern: debug-elfs-*-${{ needs.version.outputs.long }}.zip
           merge-multiple: true
           path: ./elfs
 
       - name: Zip debug elfs
-        run: zip -j -9 -r ./debug-elfs-${{matrix.arch}}-${{ needs.version.outputs.long }}.zip ./elfs
+        run: zip -j -9 -r ./debug-elfs-${{inputs.target}}-${{ needs.version.outputs.long }}.zip ./elfs
 
       # For diagnostics
       - name: Display structure of downloaded files
@@ -486,14 +358,14 @@ jobs:
         # Only run when targeting master branch with workflow_dispatch
         if: ${{ github.ref_name == 'master' }}
         run: |
-          gh release upload v${{ needs.version.outputs.long }} ./firmware-${{matrix.arch}}-${{ needs.version.outputs.long }}.zip
-          gh release upload v${{ needs.version.outputs.long }} ./debug-elfs-${{matrix.arch}}-${{ needs.version.outputs.long }}.zip
+          gh release upload v${{ needs.version.outputs.long }} ./firmware-${{inputs.target}}-${{ needs.version.outputs.long }}.zip
+          gh release upload v${{ needs.version.outputs.long }} ./debug-elfs-${{inputs.target}}-${{ needs.version.outputs.long }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-firmware:
     runs-on: ubuntu-24.04
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && github.repository == 'meshtastic/firmware' && inputs.target != '' }}
     needs: [release-firmware, version]
     env:
       targets: |-

--- a/.github/workflows/daily_packaging.yml
+++ b/.github/workflows/daily_packaging.yml
@@ -21,18 +21,20 @@ permissions:
 
 jobs:
   docker-multiarch:
+    if: github.repository == 'meshtastic/firmware'
     uses: ./.github/workflows/docker_manifest.yml
     with:
       release_channel: daily
     secrets: inherit
 
   package-ppa:
+    if: github.repository == 'meshtastic/firmware'
     strategy:
       fail-fast: false
       matrix:
         series:
-          - jammy # 22.04 LTS
-          - noble # 24.04 LTS
+          - jammy # 22.04
+          - noble # 24.04
           - plucky # 25.04
           - questing # 25.10
     uses: ./.github/workflows/package_ppa.yml
@@ -42,6 +44,7 @@ jobs:
     secrets: inherit
 
   package-obs:
+    if: github.repository == 'meshtastic/firmware'
     uses: ./.github/workflows/package_obs.yml
     with:
       obs_project: network:Meshtastic:daily
@@ -49,6 +52,7 @@ jobs:
     secrets: inherit
 
   hook-copr:
+    if: github.repository == 'meshtastic/firmware'
     uses: ./.github/workflows/hook_copr.yml
     with:
       copr_project: daily


### PR DESCRIPTION
Re-submitting because I deleted the previous one (#7530) in error. Yes, I'm a doof.

Added 2 new workflows:

Build One Arch - builds everything in a particular arch
Build One Target - generates a list of targets if no target defined, or accepts a build target and builds it.

I've also added another conditional to two of the workflows to stop them running automatically on a fork.

## 🤝 Attestations

- [Tick] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
