### PR TITLE
When `DEBUG_HEAP` is defined, add free heap bytes to every log line in `RedirectablePrint::log_to_serial`

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -55,6 +55,7 @@ build_flags = -Wno-missing-field-initializers
 	-D MAX_THREADS=40 ; As we've split modules, we have more threads to manage
 	#-DBUILD_EPOCH=$UNIX_TIME ; set in platformio-custom.py now
 	#-D OLED_PL=1
+	#-D DEBUG_HEAP=1 ; uncomment to add free heap space / memory leak debugging logs
 
 monitor_speed = 115200
 monitor_filters = direct

--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -4,6 +4,7 @@
 #include "concurrency/OSThread.h"
 #include "configuration.h"
 #include "main.h"
+#include "memGet.h"
 #include "mesh/generated/meshtastic/mesh.pb.h"
 #include <assert.h>
 #include <cstring>
@@ -166,6 +167,16 @@ void RedirectablePrint::log_to_serial(const char *logLevel, const char *format, 
         print(thread->ThreadName);
         print("] ");
     }
+
+#ifdef DEBUG_HEAP
+    // Add heap free space bytes prefix before every log message
+#ifdef ARCH_PORTDUINO
+    ::printf("[heap %u] ", memGet.getFreeHeap());
+#else
+    printf("[heap %u] ", memGet.getFreeHeap());
+#endif
+#endif // DEBUG_HEAP
+
     r += vprintf(logLevel, format, arg);
 }
 


### PR DESCRIPTION
Adds a `[heap: 12345]` prefix before all `LOG_*` lines when `-D DEBUG_HEAP` is set.

I found this useful for hunting down memory leaks in https://github.com/meshtastic/firmware/pull/7981 https://github.com/meshtastic/firmware/pull/7964 https://github.com/meshtastic/firmware/pull/7965 because I could just add more `LOG_DEBUG` lines to bisect where heap was being allocated.

<img width="683" height="131" alt="image" src="https://github.com/user-attachments/assets/ee4ac6ef-0980-4054-bed2-7196f09f7f82" />

Suggested by @jp-bennett in Discord https://discord.com/channels/867578229534359593/931765413350613052/1417208138616147968

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [X] Heltec (Lora32) V3