### PR TITLE
Fix InputEvent variable usage with out initialization (random key events while using rotery encoder)

### DIFF
--- a/src/input/ExpressLRSFiveWay.cpp
+++ b/src/input/ExpressLRSFiveWay.cpp
@@ -188,7 +188,7 @@ void ExpressLRSFiveWay::determineAction(KeyType key, PressLength length)
 // Feed input to the canned messages module
 void ExpressLRSFiveWay::sendKey(input_broker_event key)
 {
-    InputEvent e;
+    InputEvent e = {};
     e.source = inputSourceName;
     e.inputEvent = key;
     notifyObservers(&e);

--- a/src/input/LinuxInput.cpp
+++ b/src/input/LinuxInput.cpp
@@ -73,7 +73,7 @@ int32_t LinuxInput::runOnce()
         int rd = read(events[i].data.fd, ev, sizeof(ev));
         assert(rd > ((signed int)sizeof(struct input_event)));
         for (int j = 0; j < rd / ((signed int)sizeof(struct input_event)); j++) {
-            InputEvent e;
+            InputEvent e = {};
             e.inputEvent = INPUT_BROKER_NONE;
             e.source = this->_originName;
             e.kbchar = 0;

--- a/src/input/RotaryEncoderInterruptBase.cpp
+++ b/src/input/RotaryEncoderInterruptBase.cpp
@@ -45,7 +45,7 @@ void RotaryEncoderInterruptBase::init(
 
 int32_t RotaryEncoderInterruptBase::runOnce()
 {
-    InputEvent e;
+    InputEvent e = {};
     e.inputEvent = INPUT_BROKER_NONE;
     e.source = this->_originName;
     unsigned long now = millis();

--- a/src/input/SeesawRotary.cpp
+++ b/src/input/SeesawRotary.cpp
@@ -49,7 +49,7 @@ bool SeesawRotary::init()
 
 int32_t SeesawRotary::runOnce()
 {
-    InputEvent e;
+    InputEvent e = {};
     e.inputEvent = INPUT_BROKER_NONE;
     bool currentlyPressed = !ss.digitalRead(SS_SWITCH);
 

--- a/src/input/SerialKeyboard.cpp
+++ b/src/input/SerialKeyboard.cpp
@@ -29,7 +29,7 @@ SerialKeyboard::SerialKeyboard(const char *name) : concurrency::OSThread(name)
 
 void SerialKeyboard::erase()
 {
-    InputEvent e;
+    InputEvent e = {};
     e.inputEvent = INPUT_BROKER_BACK;
     e.kbchar = 0x08;
     e.source = this->_originName;
@@ -80,7 +80,7 @@ int32_t SerialKeyboard::runOnce()
 
         if (keys < prevKeys) { // a new key has been pressed (and not released), doesn't works for multiple presses at once but
                                // shouldn't be a limitation
-            InputEvent e;
+            InputEvent e = {};
             e.inputEvent = INPUT_BROKER_NONE;
             e.source = this->_originName;
             // SELECT OR SEND OR CANCEL EVENT

--- a/src/input/TouchScreenImpl1.cpp
+++ b/src/input/TouchScreenImpl1.cpp
@@ -47,7 +47,7 @@ bool TouchScreenImpl1::getTouch(int16_t &x, int16_t &y)
  */
 void TouchScreenImpl1::onEvent(const TouchEvent &event)
 {
-    InputEvent e;
+    InputEvent e = {};
     e.source = event.source;
     e.kbchar = 0;
     e.touchX = event.x;

--- a/src/input/TrackballInterruptBase.cpp
+++ b/src/input/TrackballInterruptBase.cpp
@@ -51,7 +51,7 @@ void TrackballInterruptBase::init(uint8_t pinDown, uint8_t pinUp, uint8_t pinLef
 
 int32_t TrackballInterruptBase::runOnce()
 {
-    InputEvent e;
+    InputEvent e = {};
     e.inputEvent = INPUT_BROKER_NONE;
 
     // Handle long press detection for press button

--- a/src/input/UpDownInterruptBase.cpp
+++ b/src/input/UpDownInterruptBase.cpp
@@ -48,7 +48,7 @@ void UpDownInterruptBase::init(uint8_t pinDown, uint8_t pinUp, uint8_t pinPress,
 
 int32_t UpDownInterruptBase::runOnce()
 {
-    InputEvent e;
+    InputEvent e = {};
     e.inputEvent = INPUT_BROKER_NONE;
     unsigned long now = millis();
 

--- a/src/input/kbI2cBase.cpp
+++ b/src/input/kbI2cBase.cpp
@@ -90,7 +90,7 @@ int32_t KbI2cBase::runOnce()
         while (keyCount--) {
             const BBQ10Keyboard::KeyEvent key = Q10keyboard.keyEvent();
             if ((key.key != 0x00) && (key.state == BBQ10Keyboard::StateRelease)) {
-                InputEvent e;
+                InputEvent e = {};
                 e.inputEvent = INPUT_BROKER_NONE;
                 e.source = this->_originName;
                 switch (key.key) {
@@ -187,7 +187,7 @@ int32_t KbI2cBase::runOnce()
     }
     case 0x37: { // MPR121
         MPRkeyboard.trigger();
-        InputEvent e;
+        InputEvent e = {};
 
         while (MPRkeyboard.hasEvent()) {
             char nextEvent = MPRkeyboard.dequeueEvent();
@@ -250,7 +250,7 @@ int32_t KbI2cBase::runOnce()
     }
     case 0x84: { // Adafruit TCA8418
         TCAKeyboard.trigger();
-        InputEvent e;
+        InputEvent e = {};
         while (TCAKeyboard.hasEvent()) {
             char nextEvent = TCAKeyboard.dequeueEvent();
             e.inputEvent = INPUT_BROKER_ANYKEY;
@@ -350,7 +350,7 @@ int32_t KbI2cBase::runOnce()
         }
         if (PrintDataBuf != 0) {
             LOG_DEBUG("RAK14004 key 0x%x pressed", PrintDataBuf);
-            InputEvent e;
+            InputEvent e = {};
             e.inputEvent = INPUT_BROKER_MATRIXKEY;
             e.source = this->_originName;
             e.kbchar = PrintDataBuf;
@@ -365,7 +365,7 @@ int32_t KbI2cBase::runOnce()
 
         if (i2cBus->available()) {
             char c = i2cBus->read();
-            InputEvent e;
+            InputEvent e = {};
             e.inputEvent = INPUT_BROKER_NONE;
             e.source = this->_originName;
             switch (c) {

--- a/src/input/kbMatrixBase.cpp
+++ b/src/input/kbMatrixBase.cpp
@@ -72,7 +72,7 @@ int32_t KbMatrixBase::runOnce()
             if (key != 0) {
                 LOG_DEBUG("Key 0x%x pressed", key);
                 // reset shift now that we have a keypress
-                InputEvent e;
+                InputEvent e = {};
                 e.inputEvent = INPUT_BROKER_NONE;
                 e.source = this->_originName;
                 switch (key) {


### PR DESCRIPTION
Currently the InputEvent variable in multiple code places is not initialised before usage.
This will result in events with random (what ever value is in RAM) key presses / actions.

I found this while using an rotery encoder.

before fix, see the "random" kbchar send in the event.
In my cases this resulted in notification mute / unmute actions while moving the rotery encoder.

the MUTE happens since a `kbchar` of 172 (0xAC) is mapped to MUTE.

```
DEBUG | 16:51:33 235 [rotEnc1] Rotary event CCW
INFO  | 16:51:33 235 [rotEnc1] Input event 20! kb 228
DEBUG | 16:51:33 235 [rotEnc1] Rotary event CCW
INFO  | 16:51:33 235 [rotEnc1] Input event 20! kb 4
DEBUG | 16:51:34 235 [rotEnc1] Rotary event CCW
INFO  | 16:51:34 236 [rotEnc1] Input event 20! kb 228
DEBUG | 16:51:34 236 [rotEnc1] Rotary event CCW
INFO  | 16:51:34 236 [rotEnc1] Input event 20! kb 228
DEBUG | 16:51:34 236 [rotEnc1] Rotary event CCW
INFO  | 16:51:34 236 [rotEnc1] Input event 20! kb 4
DEBUG | 16:51:34 236 [rotEnc1] Rotary event CCW
INFO  | 16:51:34 236 [rotEnc1] Input event 20! kb 228
DEBUG | 16:51:34 236 [rotEnc1] Rotary event CCW
INFO  | 16:51:34 236 [rotEnc1] Input event 20! kb 172
DEBUG | 16:51:35 237 [rotEnc1] Rotary event CCW
INFO  | 16:51:35 237 [rotEnc1] Input event 20! kb 228
```

after the fix:

```
INFO  | 17:20:11 148 [rotEnc1] Input event 20! kb 0
DEBUG | 17:20:11 148 [rotEnc1] Rotary event CCW
INFO  | 17:20:11 148 [rotEnc1] Input event 20! kb 0
DEBUG | 17:20:11 148 [rotEnc1] Rotary event CCW
INFO  | 17:20:11 148 [rotEnc1] Input event 20! kb 0
DEBUG | 17:20:12 149 [rotEnc1] Rotary event CCW
INFO  | 17:20:12 149 [rotEnc1] Input event 20! kb 0
DEBUG | 17:20:12 149 [rotEnc1] Rotary event CCW
INFO  | 17:20:12 149 [rotEnc1] Input event 20! kb 0
DEBUG | 17:20:12 149 [rotEnc1] Rotary event CCW
INFO  | 17:20:12 149 [rotEnc1] Input event 20! kb 0
DEBUG | 17:20:14 151 [rotEnc1] Rotary event CW
INFO  | 17:20:14 151 [rotEnc1] Input event 19! kb 0
```

works was expected and no more `kbchar` events for the encoder;

I fixed all places of `InputEvent` without init I did find.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
