### PR TITLE
C6l fixes

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -516,6 +516,7 @@ bool GPS::setup()
                 }
             }
             // Rare Serial Speeds
+#ifndef CONFIG_IDF_TARGET_ESP32C6
             if (probeTries == GPS_PROBETRIES) {
                 LOG_DEBUG("Probe for GPS at %d", rareSerialSpeeds[speedSelect]);
                 gnssModel = probe(rareSerialSpeeds[speedSelect]);
@@ -526,6 +527,7 @@ bool GPS::setup()
                     }
                 }
             }
+#endif
         }
 
         if (gnssModel != GNSS_MODEL_UNKNOWN) {

--- a/src/nimble/NimbleBluetooth.cpp
+++ b/src/nimble/NimbleBluetooth.cpp
@@ -231,6 +231,8 @@ class NimbleBluetoothServerCallback : public NimBLEServerCallbacks
     {
         LOG_INFO("BLE disconnect");
 #endif
+        if (ble->isDeInit)
+            return;
 
         meshtastic::BluetoothStatus newStatus(meshtastic::BluetoothStatus::ConnectionState::DISCONNECTED);
         bluetoothStatus->updateStatus(&newStatus);
@@ -270,6 +272,7 @@ void NimbleBluetooth::deinit()
 {
 #ifdef ARCH_ESP32
     LOG_INFO("Disable bluetooth until reboot");
+    isDeInit = true;
 
 #ifdef BLE_LED
 #ifdef BLE_LED_INVERTED
@@ -278,7 +281,9 @@ void NimbleBluetooth::deinit()
     digitalWrite(BLE_LED, LOW);
 #endif
 #endif
+#ifndef NIMBLE_TWO
     NimBLEDevice::deinit();
+#endif
 #endif
 }
 

--- a/src/nimble/NimbleBluetooth.cpp
+++ b/src/nimble/NimbleBluetooth.cpp
@@ -231,8 +231,10 @@ class NimbleBluetoothServerCallback : public NimBLEServerCallbacks
     {
         LOG_INFO("BLE disconnect");
 #endif
+#ifdef NIMBLE_TWO
         if (ble->isDeInit)
             return;
+#endif
 
         meshtastic::BluetoothStatus newStatus(meshtastic::BluetoothStatus::ConnectionState::DISCONNECTED);
         bluetoothStatus->updateStatus(&newStatus);

--- a/src/nimble/NimbleBluetooth.h
+++ b/src/nimble/NimbleBluetooth.h
@@ -15,6 +15,7 @@ class NimbleBluetooth : BluetoothApi
 #if defined(NIMBLE_TWO)
     void startAdvertising();
 #endif
+    bool isDeInit = false;
 
   private:
     void setupService();


### PR DESCRIPTION
Found a BLE crash upon deinit, where the nimble driver seems to internally dereference a null pointer after deinit is called.

Also fixes a GPS crash during probing. My guess is that the c6l fails to put the UART into the 4800 or 57600 baudrates, and calling _serial_gps->available() in this state causes a crash.