### PR TITLE
move HTTP contentTypes to Flash - saves 768 Bytes of RAM

### DIFF
--- a/src/mesh/http/ContentHandler.cpp
+++ b/src/mesh/http/ContentHandler.cpp
@@ -55,12 +55,12 @@ HTTPClient httpClient;
 
 // We need to specify some content-type mapping, so the resources get delivered with the
 // right content type and are displayed correctly in the browser
-char contentTypes[][2][32] = {{".txt", "text/plain"},     {".html", "text/html"},
-                              {".js", "text/javascript"}, {".png", "image/png"},
-                              {".jpg", "image/jpg"},      {".gz", "application/gzip"},
-                              {".gif", "image/gif"},      {".json", "application/json"},
-                              {".css", "text/css"},       {".ico", "image/vnd.microsoft.icon"},
-                              {".svg", "image/svg+xml"},  {"", ""}};
+char const *contentTypes[][2] = {{".txt", "text/plain"},     {".html", "text/html"},
+                                 {".js", "text/javascript"}, {".png", "image/png"},
+                                 {".jpg", "image/jpg"},      {".gz", "application/gzip"},
+                                 {".gif", "image/gif"},      {".json", "application/json"},
+                                 {".css", "text/css"},       {".ico", "image/vnd.microsoft.icon"},
+                                 {".svg", "image/svg+xml"},  {"", ""}};
 
 // const char *certificate = NULL; // change this as needed, leave as is for no TLS check (yolo security)
 


### PR DESCRIPTION
move HTTP contentTypes to Flash - saves 768 Bytes of RAM

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
