### PR TITLE
Fix: use `lora.use_preset` config to get name

### DIFF
--- a/src/mesh/Channels.cpp
+++ b/src/mesh/Channels.cpp
@@ -428,8 +428,8 @@ bool Channels::setDefaultPresetCryptoForHash(ChannelHash channelHash)
     // Iterate all known presets
     for (int preset = _meshtastic_Config_LoRaConfig_ModemPreset_MIN; preset <= _meshtastic_Config_LoRaConfig_ModemPreset_MAX;
          ++preset) {
-        const char *name =
-            DisplayFormatters::getModemPresetDisplayName((meshtastic_Config_LoRaConfig_ModemPreset)preset, false, false);
+        const char *name = DisplayFormatters::getModemPresetDisplayName((meshtastic_Config_LoRaConfig_ModemPreset)preset, false,
+                                                                        config.lora.use_preset);
         if (!name)
             continue;
         if (strcmp(name, "Invalid") == 0)


### PR DESCRIPTION
Possibly related to #8039.
