### PR TITLE
RTC: PCF85063 support, port to SensorLib 0.3.1

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -29,8 +29,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if __has_include("Melopero_RV3028.h")
 #include "Melopero_RV3028.h"
 #endif
-#if __has_include("pcf8563.h")
-#include "pcf8563.h"
+#if __has_include("SensorPCF8563.hpp")
+#include "SensorPCF8563.hpp"
+#endif
+#if __has_include("SensorPCF85063.hpp")
+#include "SensorPCF85063.hpp"
 #endif
 
 // -----------------------------------------------------------------------------

--- a/src/detect/ScanI2C.cpp
+++ b/src/detect/ScanI2C.cpp
@@ -25,8 +25,8 @@ ScanI2C::FoundDevice ScanI2C::firstScreen() const
 
 ScanI2C::FoundDevice ScanI2C::firstRTC() const
 {
-    ScanI2C::DeviceType types[] = {RTC_RV3028, RTC_PCF8563};
-    return firstOfOrNONE(2, types);
+    ScanI2C::DeviceType types[] = {RTC_RV3028, RTC_PCF8563, RTC_PCF85063};
+    return firstOfOrNONE(3, types);
 }
 
 ScanI2C::FoundDevice ScanI2C::firstKeyboard() const

--- a/src/detect/ScanI2C.h
+++ b/src/detect/ScanI2C.h
@@ -14,6 +14,7 @@ class ScanI2C
         SCREEN_ST7567,
         RTC_RV3028,
         RTC_PCF8563,
+        RTC_PCF85063,
         CARDKB,
         TDECKKB,
         BBQ10KB,

--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -198,6 +198,10 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
                 SCAN_SIMPLE_CASE(PCF8563_RTC, RTC_PCF8563, "PCF8563", (uint8_t)addr.address)
 #endif
 
+#ifdef PCF85063_RTC
+                SCAN_SIMPLE_CASE(PCF85063_RTC, RTC_PCF85063, "PCF85063", (uint8_t)addr.address)
+#endif
+
             case CARDKB_ADDR:
                 // Do we have the RAK14006 instead?
                 registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x04), 1);

--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -66,26 +66,22 @@ RTCSetResult readFromRTC()
             currentQuality = RTCQualityDevice;
         }
         return RTCSetResultSuccess;
+    } else {
+        LOG_WARN("RV3028_RTC mismatch (0x%02X)", rtc_found.address);
     }
 #elif defined(PCF8563_RTC)
     if (rtc_found.address == PCF8563_RTC) {
         uint32_t now = millis();
-        PCF8563_Class rtc;
+        SensorPCF8563 rtc;
 
 #if WIRE_INTERFACES_COUNT == 2
         rtc.begin(rtc_found.port == ScanI2C::I2CPort::WIRE1 ? Wire1 : Wire);
 #else
-        rtc.begin();
+        rtc.begin(Wire);
 #endif
 
-        auto tc = rtc.getDateTime();
-        tm t;
-        t.tm_year = tc.year - 1900;
-        t.tm_mon = tc.month - 1;
-        t.tm_mday = tc.day;
-        t.tm_hour = tc.hour;
-        t.tm_min = tc.minute;
-        t.tm_sec = tc.second;
+        RTC_DateTime datetime = rtc.getDateTime();
+        tm t = datetime.toUnixTime();
         tv.tv_sec = gm_mktime(&t);
         tv.tv_usec = 0;
         uint32_t printableEpoch = tv.tv_sec; // Print lib only supports 32 bit but time_t can be 64 bit on some platforms
@@ -108,6 +104,46 @@ RTCSetResult readFromRTC()
             currentQuality = RTCQualityDevice;
         }
         return RTCSetResultSuccess;
+    } else {
+        LOG_WARN("PCF8563_RTC mismatch (0x%02X)", rtc_found.address);
+    }
+#elif defined(PCF85063_RTC)
+    if (rtc_found.address == PCF85063_RTC) {
+        uint32_t now = millis();
+        SensorPCF85063 rtc;
+
+#if WIRE_INTERFACES_COUNT == 2
+        rtc.begin(rtc_found.port == ScanI2C::I2CPort::WIRE1 ? Wire1 : Wire);
+#else
+        rtc.begin(Wire);
+#endif
+
+        RTC_DateTime datetime = rtc.getDateTime();
+        tm t = datetime.toUnixTime();
+        tv.tv_sec = gm_mktime(&t);
+        tv.tv_usec = 0;
+        uint32_t printableEpoch = tv.tv_sec; // Print lib only supports 32 bit but time_t can be 64 bit on some platforms
+
+#ifdef BUILD_EPOCH
+        if (tv.tv_sec < BUILD_EPOCH) {
+            if (Throttle::isWithinTimespanMs(lastTimeValidationWarning, TIME_VALIDATION_WARNING_INTERVAL_MS) == false) {
+                LOG_WARN("Ignore time (%ld) before build epoch (%ld)!", printableEpoch, BUILD_EPOCH);
+                lastTimeValidationWarning = millis();
+            }
+            return RTCSetResultInvalidTime;
+        }
+#endif
+
+        LOG_DEBUG("Read RTC time from PCF85063 getDateTime as %02d-%02d-%02d %02d:%02d:%02d (%ld)", t.tm_year + 1900,
+                  t.tm_mon + 1, t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec, printableEpoch);
+        if (currentQuality == RTCQualityNone) {
+            timeStartMsec = now;
+            zeroOffsetSecs = tv.tv_sec;
+            currentQuality = RTCQualityDevice;
+        }
+        return RTCSetResultSuccess;
+    } else {
+        LOG_WARN("PCF85063_RTC mismatch (0x%02X)", rtc_found.address);
     }
 #else
     if (!gettimeofday(&tv, NULL)) {
@@ -199,20 +235,40 @@ RTCSetResult perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpd
             rtc.setTime(t->tm_year + 1900, t->tm_mon + 1, t->tm_wday, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec);
             LOG_DEBUG("RV3028_RTC setTime %02d-%02d-%02d %02d:%02d:%02d (%ld)", t->tm_year + 1900, t->tm_mon + 1, t->tm_mday,
                       t->tm_hour, t->tm_min, t->tm_sec, printableEpoch);
+        } else {
+            LOG_WARN("RV3028_RTC mismatch (0x%02X)", rtc_found.address);
         }
 #elif defined(PCF8563_RTC)
         if (rtc_found.address == PCF8563_RTC) {
-            PCF8563_Class rtc;
+            SensorPCF8563 rtc;
 
 #if WIRE_INTERFACES_COUNT == 2
             rtc.begin(rtc_found.port == ScanI2C::I2CPort::WIRE1 ? Wire1 : Wire);
 #else
-            rtc.begin();
+            rtc.begin(Wire);
 #endif
             tm *t = gmtime(&tv->tv_sec);
-            rtc.setDateTime(t->tm_year + 1900, t->tm_mon + 1, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec);
+            rtc.setDateTime(*t);
             LOG_DEBUG("PCF8563_RTC setDateTime %02d-%02d-%02d %02d:%02d:%02d (%ld)", t->tm_year + 1900, t->tm_mon + 1, t->tm_mday,
                       t->tm_hour, t->tm_min, t->tm_sec, printableEpoch);
+        } else {
+            LOG_WARN("PCF8563_RTC mismatch (0x%02X)", rtc_found.address);
+        }
+#elif defined(PCF85063_RTC)
+        if (rtc_found.address == PCF85063_RTC) {
+            SensorPCF85063 rtc;
+
+#if WIRE_INTERFACES_COUNT == 2
+            rtc.begin(rtc_found.port == ScanI2C::I2CPort::WIRE1 ? Wire1 : Wire);
+#else
+            rtc.begin(Wire);
+#endif
+            tm *t = gmtime(&tv->tv_sec);
+            rtc.setDateTime(*t);
+            LOG_DEBUG("PCF85063_RTC setDateTime %02d-%02d-%02d %02d:%02d:%02d (%ld)", t->tm_year + 1900, t->tm_mon + 1,
+                      t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec, printableEpoch);
+        } else {
+            LOG_WARN("PCF85063_RTC mismatch (0x%02X)", rtc_found.address);
         }
 #elif defined(ARCH_ESP32)
         settimeofday(tv, NULL);

--- a/src/motion/BMA423Sensor.cpp
+++ b/src/motion/BMA423Sensor.cpp
@@ -2,16 +2,14 @@
 
 #if !defined(ARCH_STM32WL) && !MESHTASTIC_EXCLUDE_I2C && defined(HAS_BMA423) && __has_include(<SensorBMA423.hpp>)
 
-using namespace MotionSensorI2C;
-
 BMA423Sensor::BMA423Sensor(ScanI2C::FoundDevice foundDevice) : MotionSensor::MotionSensor(foundDevice) {}
 
 bool BMA423Sensor::init()
 {
-    if (sensor.begin(deviceAddress(), &MotionSensorI2C::readRegister, &MotionSensorI2C::writeRegister)) {
+    if (sensor.begin(Wire, deviceAddress())) {
         sensor.configAccelerometer(sensor.RANGE_2G, sensor.ODR_100HZ, sensor.BW_NORMAL_AVG4, sensor.PERF_CONTINUOUS_MODE);
         sensor.enableAccelerometer();
-        sensor.configInterrupt(BMA4_LEVEL_TRIGGER, BMA4_ACTIVE_HIGH, BMA4_PUSH_PULL, BMA4_OUTPUT_ENABLE, BMA4_INPUT_DISABLE);
+        sensor.configInterrupt();
 
 #ifdef BMA423_INT
         pinMode(BMA4XX_INT, INPUT);
@@ -26,7 +24,7 @@ bool BMA423Sensor::init()
 
 #ifdef T_WATCH_S3
         // Need to raise the wrist function, need to set the correct axis
-        sensor.setReampAxes(sensor.REMAP_TOP_LAYER_RIGHT_CORNER);
+        sensor.setRemapAxes(sensor.REMAP_TOP_LAYER_RIGHT_CORNER);
 #else
         sensor.setReampAxes(sensor.REMAP_BOTTOM_LAYER_BOTTOM_LEFT_CORNER);
 #endif
@@ -50,7 +48,7 @@ bool BMA423Sensor::init()
 
 int32_t BMA423Sensor::runOnce()
 {
-    if (sensor.readIrqStatus() != DEV_WIRE_NONE) {
+    if (sensor.readIrqStatus()) {
         if (sensor.isTilt() || sensor.isDoubleTap()) {
             wakeScreen();
             return 500;

--- a/src/motion/MotionSensor.h
+++ b/src/motion/MotionSensor.h
@@ -61,32 +61,6 @@ class MotionSensor
     uint32_t endCalibrationAt = 0;
 };
 
-namespace MotionSensorI2C
-{
-
-static inline int readRegister(uint8_t address, uint8_t reg, uint8_t *data, uint8_t len)
-{
-    Wire.beginTransmission(address);
-    Wire.write(reg);
-    Wire.endTransmission();
-    Wire.requestFrom((uint8_t)address, (uint8_t)len);
-    uint8_t i = 0;
-    while (Wire.available()) {
-        data[i++] = Wire.read();
-    }
-    return 0; // Pass
-}
-
-static inline int writeRegister(uint8_t address, uint8_t reg, uint8_t *data, uint8_t len)
-{
-    Wire.beginTransmission(address);
-    Wire.write(reg);
-    Wire.write(data, len);
-    return (0 != Wire.endTransmission());
-}
-
-} // namespace MotionSensorI2C
-
 #endif
 
 #endif

--- a/variants/esp32/m5stack_coreink/platformio.ini
+++ b/variants/esp32/m5stack_coreink/platformio.ini
@@ -19,7 +19,7 @@ build_flags =
 lib_deps = 
   ${esp32_base.lib_deps}
   zinggjm/GxEPD2@^1.6.2
-  lewisxhe/PCF8563_Library@^1.0.1
+  lewisxhe/SensorLib@0.3.1
 lib_ignore =
   m5stack-coreink
 monitor_filters = esp32_exception_decoder

--- a/variants/esp32/m5stack_coreink/variant.h
+++ b/variants/esp32/m5stack_coreink/variant.h
@@ -13,7 +13,6 @@
 #define LED_STATE_ON 1 // State when LED is lit
 #define LED_PIN 10
 
-#include "pcf8563.h"
 // PCF8563 RTC Module
 #define PCF8563_RTC 0x51
 #define HAS_RTC 1

--- a/variants/esp32s3/ELECROW-ThinkNode-M2/variant.h
+++ b/variants/esp32s3/ELECROW-ThinkNode-M2/variant.h
@@ -56,10 +56,6 @@
 #define HAS_SCREEN 1
 #define USE_SH1106 1
 
-// PCF8563 RTC Module
-// #define PCF8563_RTC 0x51
-// #define PIN_RTC_INT 48 // Interrupt from the PCF8563 RTC
-#define HAS_RTC 0
 #define HAS_GPS 0
 
 #define BUTTON_PIN PIN_BUTTON1

--- a/variants/esp32s3/ELECROW-ThinkNode-M5/platformio.ini
+++ b/variants/esp32s3/ELECROW-ThinkNode-M5/platformio.ini
@@ -17,5 +17,4 @@ build_flags =
 
 lib_deps = ${esp32s3_base.lib_deps}
   https://github.com/meshtastic/GxEPD2/archive/1655054ba298e0e29fc2044741940f927f9c2a43.zip
-  lewisxhe/PCF8563_Library@^1.0.1
   maxpromer/PCA9557-arduino @ ^1.0.0

--- a/variants/esp32s3/ELECROW-ThinkNode-M5/variant.h
+++ b/variants/esp32s3/ELECROW-ThinkNode-M5/variant.h
@@ -42,9 +42,6 @@
 #define PIN_SERIAL1_RX GPS_TX_PIN
 #define PIN_SERIAL1_TX GPS_RX_PIN
 
-// PCF8563 RTC Module
-#define PCF8563_RTC 0x51
-
 #define SX126X_CS 17
 #define LORA_SCK 16
 #define LORA_MOSI 15

--- a/variants/esp32s3/heltec_vision_master_e213/platformio.ini
+++ b/variants/esp32s3/heltec_vision_master_e213/platformio.ini
@@ -18,7 +18,6 @@ build_flags =
 lib_deps =
   ${esp32s3_base.lib_deps}
   https://github.com/meshtastic/GxEPD2/archive/1655054ba298e0e29fc2044741940f927f9c2a43.zip
-  lewisxhe/PCF8563_Library@^1.0.1
 upload_speed = 115200
 
 [env:heltec-vision-master-e213-inkhud]

--- a/variants/esp32s3/heltec_vision_master_e290/platformio.ini
+++ b/variants/esp32s3/heltec_vision_master_e290/platformio.ini
@@ -21,7 +21,6 @@ build_flags =
 lib_deps =
   ${esp32s3_base.lib_deps}
   https://github.com/meshtastic/GxEPD2/archive/448c8538129fde3d02a7cb5e6fc81971ad92547f.zip
-  lewisxhe/PCF8563_Library@^1.0.1
 upload_speed = 115200
 
 [env:heltec-vision-master-e290-inkhud]

--- a/variants/esp32s3/heltec_vision_master_t190/platformio.ini
+++ b/variants/esp32s3/heltec_vision_master_t190/platformio.ini
@@ -8,6 +8,5 @@ build_flags =
   -D HELTEC_VISION_MASTER_T190
 lib_deps =
   ${esp32s3_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1
   https://github.com/meshtastic/st7789/archive/bd33ea58ddfe4a5e4a66d53300ccbd38d66ac21f.zip
 upload_speed = 921600

--- a/variants/esp32s3/heltec_wireless_paper/platformio.ini
+++ b/variants/esp32s3/heltec_wireless_paper/platformio.ini
@@ -19,7 +19,6 @@ build_flags =
 lib_deps =
   ${esp32s3_base.lib_deps}
   https://github.com/meshtastic/GxEPD2/archive/1655054ba298e0e29fc2044741940f927f9c2a43.zip
-  lewisxhe/PCF8563_Library@^1.0.1
 upload_speed = 115200
 
 [env:heltec-wireless-paper-inkhud]

--- a/variants/esp32s3/heltec_wireless_paper_v1/platformio.ini
+++ b/variants/esp32s3/heltec_wireless_paper_v1/platformio.ini
@@ -16,5 +16,4 @@ build_flags =
 lib_deps =
   ${esp32s3_base.lib_deps}
   https://github.com/meshtastic/GxEPD2/archive/55f618961db45a23eff0233546430f1e5a80f63a.zip
-  lewisxhe/PCF8563_Library@^1.0.1
 upload_speed = 115200

--- a/variants/esp32s3/t-watch-s3/platformio.ini
+++ b/variants/esp32s3/t-watch-s3/platformio.ini
@@ -14,8 +14,7 @@ build_flags = ${esp32_base.build_flags}
 
 lib_deps = ${esp32s3_base.lib_deps}
 	lovyan03/LovyanGFX@^1.2.0
-  lewisxhe/PCF8563_Library@1.0.1
+  lewisxhe/SensorLib@0.3.1
   adafruit/Adafruit DRV2605 Library@^1.2.2
   earlephilhower/ESP8266Audio@^1.9.9
   earlephilhower/ESP8266SAM@^1.0.1
-  lewisxhe/SensorLib@0.2.0

--- a/variants/esp32s3/t-watch-s3/platformio.ini
+++ b/variants/esp32s3/t-watch-s3/platformio.ini
@@ -9,8 +9,6 @@ upload_protocol = esptool
 build_flags = ${esp32_base.build_flags} 
   -DT_WATCH_S3
   -Ivariants/esp32s3/t-watch-s3
-  -DPCF8563_RTC=0x51
-  -DHAS_BMA423=1
 
 lib_deps = ${esp32s3_base.lib_deps}
 	lovyan03/LovyanGFX@^1.2.0

--- a/variants/esp32s3/t-watch-s3/variant.h
+++ b/variants/esp32s3/t-watch-s3/variant.h
@@ -40,11 +40,14 @@
 
 #define HAS_AXP2101
 
+// PCF8563 RTC Module
+#define PCF8563_RTC 0x51
 #define HAS_RTC 1
 
 #define I2C_SDA 10 // For QMC6310 sensors and screens
 #define I2C_SCL 11 // For QMC6310 sensors and screens
 
+#define HAS_BMA423 1
 #define BMA4XX_INT 14 // Interrupt for BMA_423 axis sensor
 
 #define HAS_GPS 0

--- a/variants/esp32s3/tbeam-s3-core/platformio.ini
+++ b/variants/esp32s3/tbeam-s3-core/platformio.ini
@@ -7,7 +7,7 @@ board_check = true
 
 lib_deps =
   ${esp32s3_base.lib_deps}
-  lewisxhe/PCF8563_Library@1.0.1
+  lewisxhe/SensorLib@0.3.1
 
 build_flags = 
   ${esp32s3_base.build_flags} 

--- a/variants/esp32s3/tbeam-s3-core/platformio.ini
+++ b/variants/esp32s3/tbeam-s3-core/platformio.ini
@@ -12,4 +12,3 @@ lib_deps =
 build_flags = 
   ${esp32s3_base.build_flags} 
   -I variants/esp32s3/tbeam-s3-core
-  -D PCF8563_RTC=0x51 ;Putting definitions in variant.h does not compile correctly

--- a/variants/esp32s3/tbeam-s3-core/variant.h
+++ b/variants/esp32s3/tbeam-s3-core/variant.h
@@ -39,6 +39,8 @@
 // #define PMU_IRQ 40
 #define HAS_AXP2101
 
+// PCF8563 RTC Module
+#define PCF8563_RTC 0x51
 #define HAS_RTC 1
 
 // Specify the PMU as Wire1. In the t-beam-s3 core, PCF8563 and PMU share the bus
@@ -57,9 +59,6 @@
 
 #define HAS_SDCARD // Have SPI interface SD card slot
 #define SDCARD_USE_SPI1
-
-// PCF8563 RTC Module
-// #define PCF8563_RTC 0x51         //Putting definitions in variant. h does not compile correctly
 
 // has 32768 Hz crystal
 #define HAS_32768HZ 1

--- a/variants/esp32s3/tlora-pager/platformio.ini
+++ b/variants/esp32s3/tlora-pager/platformio.ini
@@ -22,7 +22,6 @@ lib_deps = ${esp32s3_base.lib_deps}
   earlephilhower/ESP8266Audio@1.9.9
   earlephilhower/ESP8266SAM@1.0.1
   adafruit/Adafruit DRV2605 Library@1.2.4
-  lewisxhe/PCF8563_Library@1.0.1
   lewisxhe/SensorLib@0.3.1
   https://github.com/pschatzmann/arduino-audio-driver/archive/refs/tags/v0.1.3.zip
   https://github.com/mverch67/BQ27220/archive/07d92be846abd8a0258a50c23198dac0858b22ed.zip

--- a/variants/esp32s3/tlora-pager/variant.h
+++ b/variants/esp32s3/tlora-pager/variant.h
@@ -34,11 +34,8 @@
 #define GPS_TX_PIN 12
 #define PIN_GPS_PPS 13
 
-// PCF8563 RTC Module
-#if __has_include("pcf8563.h")
-#include "pcf8563.h"
-#endif
-#define PCF8563_RTC 0x51
+// PCF85063 RTC Module
+#define PCF85063_RTC 0x51
 #define HAS_RTC 1
 
 // Rotary

--- a/variants/nrf52840/ELECROW-ThinkNode-M1/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M1/platformio.ini
@@ -25,7 +25,6 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/ELECROW
 lib_deps = 
   ${nrf52840_base.lib_deps}
   https://github.com/meshtastic/GxEPD2/archive/33db3fa8ee6fc47d160bdb44f8f127c9a9203a10.zip
-  lewisxhe/PCF8563_Library@^1.0.1
   khoih-prog/nRF52_PWM@^1.0.1
 ;upload_protocol = fs
 
@@ -46,4 +45,3 @@ build_src_filter =
 lib_deps = 
   ${inkhud.lib_deps} ; InkHUD libs first, so we get GFXRoot instead of AdafruitGFX
   ${nrf52840_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1

--- a/variants/nrf52840/ELECROW-ThinkNode-M1/variant.h
+++ b/variants/nrf52840/ELECROW-ThinkNode-M1/variant.h
@@ -99,8 +99,6 @@ static const uint8_t A0 = PIN_A0;
 
 #define TP_SER_IO (0 + 11)
 
-#define PIN_RTC_INT (0 + 16) // Interrupt from the PCF8563 RTC
-
 /*
 External serial flash WP25R1635FZUIL0
 */
@@ -167,9 +165,6 @@ External serial flash WP25R1635FZUIL0
 #define PIN_SERIAL1_RX GPS_TX_PIN
 #define PIN_SERIAL1_TX GPS_RX_PIN
 
-// PCF8563 RTC Module
-#define PCF8563_RTC 0x51
-
 /*
  * SPI Interfaces
  */
@@ -196,7 +191,6 @@ External serial flash WP25R1635FZUIL0
 #define VBAT_AR_INTERNAL AR_INTERNAL_3_0
 #define ADC_MULTIPLIER (2.02F)
 
-// #define HAS_RTC 0
 // #define HAS_SCREEN 0
 
 #ifdef __cplusplus

--- a/variants/nrf52840/canaryone/platformio.ini
+++ b/variants/nrf52840/canaryone/platformio.ini
@@ -11,5 +11,4 @@ build_flags =
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/canaryone>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1
 ;upload_protocol = fs

--- a/variants/nrf52840/heltec_mesh_node_t114-inkhud/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_node_t114-inkhud/platformio.ini
@@ -14,7 +14,6 @@ build_src_filter =
 lib_deps = 
   ${inkhud.lib_deps} ; InkHUD libs first, so we get GFXRoot instead of AdafruitGFX
   ${nrf52840_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1
 extra_scripts =
   ${env.extra_scripts}
   variants/nrf52840/diy/nrf52_promicro_diy_tcxo/custom_build_tasks.py ; Add to PIO's Project Tasks pane: preset builds for common displays

--- a/variants/nrf52840/heltec_mesh_node_t114-inkhud/variant.h
+++ b/variants/nrf52840/heltec_mesh_node_t114-inkhud/variant.h
@@ -124,9 +124,6 @@ No longer populated on PCB
 #define PIN_SERIAL1_RX GPS_TX_PIN
 #define PIN_SERIAL1_TX GPS_RX_PIN
 
-// PCF8563 RTC Module
-#define PCF8563_RTC 0x51
-
 /*
  * SPI Interfaces
  */
@@ -163,7 +160,6 @@ No longer populated on PCB
 #define VBAT_AR_INTERNAL AR_INTERNAL_3_0
 #define ADC_MULTIPLIER (4.90F)
 
-#define HAS_RTC 0
 #ifdef __cplusplus
 }
 #endif

--- a/variants/nrf52840/heltec_mesh_node_t114/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_node_t114/platformio.ini
@@ -14,5 +14,4 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/heltec_mesh_node_t114>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1
   https://github.com/meshtastic/st7789/archive/bd33ea58ddfe4a5e4a66d53300ccbd38d66ac21f.zip

--- a/variants/nrf52840/heltec_mesh_node_t114/variant.h
+++ b/variants/nrf52840/heltec_mesh_node_t114/variant.h
@@ -175,9 +175,6 @@ No longer populated on PCB
 #define PIN_SERIAL1_RX GPS_TX_PIN
 #define PIN_SERIAL1_TX GPS_RX_PIN
 
-// PCF8563 RTC Module
-#define PCF8563_RTC 0x51
-
 /*
  * SPI Interfaces
  */
@@ -210,7 +207,6 @@ No longer populated on PCB
 #define VBAT_AR_INTERNAL AR_INTERNAL_3_0
 #define ADC_MULTIPLIER (4.916F)
 
-#define HAS_RTC 0
 #ifdef __cplusplus
 }
 #endif

--- a/variants/nrf52840/heltec_mesh_pocket/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_pocket/platformio.ini
@@ -25,7 +25,6 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/heltec_mesh_pocket> 
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1
   https://github.com/meshtastic/GxEPD2#b202ebfec6a4821e098cf7a625ba0f6f2400292d
 
 
@@ -71,7 +70,6 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/heltec_mesh_pocket> 
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1
   https://github.com/meshtastic/GxEPD2#b202ebfec6a4821e098cf7a625ba0f6f2400292d
 
 

--- a/variants/nrf52840/heltec_mesh_pocket/variant.h
+++ b/variants/nrf52840/heltec_mesh_pocket/variant.h
@@ -124,7 +124,6 @@ No longer populated on PCB
 
 #undef HAS_GPS
 #define HAS_GPS 0
-#define HAS_RTC 0
 #ifdef __cplusplus
 }
 #endif

--- a/variants/nrf52840/heltec_mesh_solar/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_solar/platformio.ini
@@ -15,5 +15,4 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/heltec_
 lib_deps = 
   ${nrf52840_base.lib_deps}
   https://github.com/NMIoT/meshsolar/archive/dfc5330dad443982e6cdd37a61d33fc7252f468b.zip
-  lewisxhe/PCF8563_Library@^1.0.1
   ArduinoJson@6.21.4

--- a/variants/nrf52840/heltec_mesh_solar/variant.h
+++ b/variants/nrf52840/heltec_mesh_solar/variant.h
@@ -39,16 +39,15 @@ extern "C" {
 #define NUM_ANALOG_INPUTS (1)
 #define NUM_ANALOG_OUTPUTS (0)
 
-
 #define PIN_LED1 (0 + 12) // green (confirmed on 1.0 board)
 #define LED_BLUE PIN_LED1 // fake for bluefruit library
 #define LED_GREEN PIN_LED1
 #define LED_BUILTIN LED_GREEN
-#define LED_STATE_ON 0  // State when LED is lit
+#define LED_STATE_ON 0 // State when LED is lit
 
 #define HAS_NEOPIXEL                         // Enable the use of neopixels
 #define NEOPIXEL_COUNT 1                     // How many neopixels are connected
-#define NEOPIXEL_DATA (32+15)                // gpio pin used to send data to the neopixels
+#define NEOPIXEL_DATA (32 + 15)              // gpio pin used to send data to the neopixels
 #define NEOPIXEL_TYPE (NEO_GRB + NEO_KHZ800) // type of neopixels in use
 
 /*
@@ -72,15 +71,14 @@ No longer populated on PCB
 #define WIRE_INTERFACES_COUNT 2
 
 // I2C bus 0
-// Routed to footprint for PCF8563TS RTC
 // Not populated on T114 V1, maybe in future?
-#define PIN_WIRE_SDA (0 + 6) // P0.26
+#define PIN_WIRE_SDA (0 + 6)  // P0.26
 #define PIN_WIRE_SCL (0 + 26) // P0.26
 
 // I2C bus 1
 // Available on header pins, for general use
 #define PIN_WIRE1_SDA (0 + 30) // P0.30
-#define PIN_WIRE1_SCL (0 + 5) // P0.13
+#define PIN_WIRE1_SCL (0 + 5)  // P0.13
 
 /*
  * Lora radio
@@ -89,14 +87,14 @@ No longer populated on PCB
 #define USE_SX1262
 // #define USE_SX1268
 #define SX126X_CS (0 + 24) // FIXME - we really should define LORA_CS instead
-#define LORA_CS  (0 + 24)
+#define LORA_CS (0 + 24)
 #define SX126X_DIO1 (0 + 20)
 // Note DIO2 is attached internally to the module to an analog switch for TX/RX switching
 // #define SX1262_DIO3 (0 + 21)
 // This is used as an *output* from the sx1262 and connected internally to power the tcxo, do not drive from the
 //    main
 // CPU?
-#define SX126X_BUSY  (0 + 17)
+#define SX126X_BUSY (0 + 17)
 #define SX126X_RESET (0 + 25)
 // Not really an E22 but TTGO seems to be trying to clone that
 #define SX126X_DIO2_AS_RF_SWITCH
@@ -134,18 +132,17 @@ No longer populated on PCB
 // For LORA, spi 0
 #define PIN_SPI_MISO (0 + 23)
 #define PIN_SPI_MOSI (0 + 22)
-#define PIN_SPI_SCK  (0 + 19)
+#define PIN_SPI_SCK (0 + 19)
 
 // #define PIN_PWR_EN (0 + 6)
 
 // To debug via the segger JLINK console rather than the CDC-ACM serial device
 // #define USE_SEGGER
 
-#define BQ4050_SDA_PIN                      (32+1) // I2C data line pin
-#define BQ4050_SCL_PIN                      (32+0) // I2C clock line pin
-#define BQ4050_EMERGENCY_SHUTDOWN_PIN       (32+3) // Emergency shutdown pin
+#define BQ4050_SDA_PIN (32 + 1)                // I2C data line pin
+#define BQ4050_SCL_PIN (32 + 0)                // I2C clock line pin
+#define BQ4050_EMERGENCY_SHUTDOWN_PIN (32 + 3) // Emergency shutdown pin
 
-#define HAS_RTC 0
 #ifdef __cplusplus
 }
 #endif

--- a/variants/nrf52840/nano-g2-ultra/platformio.ini
+++ b/variants/nrf52840/nano-g2-ultra/platformio.ini
@@ -10,5 +10,5 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/nano-g2-ultra>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1
+  lewisxhe/SensorLib@0.3.1
 ;upload_protocol = fs

--- a/variants/nrf52840/nano-g2-ultra/variant.h
+++ b/variants/nrf52840/nano-g2-ultra/variant.h
@@ -87,8 +87,6 @@ static const uint8_t A4 = PIN_A4;
 #define PIN_WIRE_SDA (0 + 17)
 #define PIN_WIRE_SCL (0 + 15)
 
-#define PIN_RTC_INT (0 + 14) // Interrupt from the PCF8563 RTC
-
 /*
 External serial flash W25Q16JV_IQ
 */
@@ -141,7 +139,9 @@ External serial flash W25Q16JV_IQ
 #define PIN_SERIAL1_TX PIN_GPS_RX
 
 // PCF8563 RTC Module
+#define PIN_RTC_INT (0 + 14) // Interrupt from the PCF8563 RTC
 #define PCF8563_RTC 0x51
+#define HAS_RTC 1
 
 /*
  * SPI Interfaces
@@ -168,8 +168,6 @@ External serial flash W25Q16JV_IQ
 #define AREF_VOLTAGE 3.0
 #define VBAT_AR_INTERNAL AR_INTERNAL_3_0
 #define ADC_MULTIPLIER (2.0F)
-
-#define HAS_RTC 1
 
 /**
     OLED Screen Model

--- a/variants/nrf52840/t-echo/platformio.ini
+++ b/variants/nrf52840/t-echo/platformio.ini
@@ -22,7 +22,7 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/t-echo>
 lib_deps = 
   ${nrf52840_base.lib_deps}
   https://github.com/meshtastic/GxEPD2/archive/55f618961db45a23eff0233546430f1e5a80f63a.zip
-  lewisxhe/PCF8563_Library@^1.0.1
+  lewisxhe/SensorLib@0.3.1
 ;upload_protocol = fs
 
 [env:t-echo-inkhud]
@@ -42,4 +42,4 @@ build_src_filter =
 lib_deps = 
   ${inkhud.lib_deps} ; InkHUD libs first, so we get GFXRoot instead of AdafruitGFX
   ${nrf52840_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1
+  lewisxhe/SensorLib@0.3.1

--- a/variants/nrf52840/t-echo/variant.h
+++ b/variants/nrf52840/t-echo/variant.h
@@ -108,8 +108,6 @@ No longer populated on PCB
 
 #define TP_SER_IO (0 + 11)
 
-#define PIN_RTC_INT (0 + 16) // Interrupt from the PCF8563 RTC
-
 /*
 External serial flash WP25R1635FZUIL0
 */
@@ -191,7 +189,9 @@ External serial flash WP25R1635FZUIL0
 #define PIN_SERIAL1_TX GPS_RX_PIN
 
 // PCF8563 RTC Module
+#define PIN_RTC_INT (0 + 16) // Interrupt from the PCF8563 RTC
 #define PCF8563_RTC 0x51
+#define HAS_RTC 1
 
 /*
  * SPI Interfaces
@@ -220,8 +220,6 @@ External serial flash WP25R1635FZUIL0
 #define ADC_MULTIPLIER (2.0F)
 
 // #define NO_EXT_GPIO 1
-
-#define HAS_RTC 1
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- Support for PCF85063, enables RTC on T-Lora Pager
- Supersedes #7886
- Fixes #7885
- Port all `SensorLib` usages to `0.3.1`, port `PCF8563_Library` usages to `SensorLib`
  - Notably, this fails at linking step on nRF52 platform, I have opened a bug report:
  - Could also use some testing that BMA423 on t-watch-s2 still works, API changed quiet a bit and I hope I ported it correctly
- Removes PCF8563 and related defines for devices that AFAICT do not have a PCF8563
  - Could use some help double checking I did not add any regressions as for some devices I cuold not find very detailed information on this
- Adds log warnings in case RTC address is defined but RTC was not found at runtime

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
    - [x] T-Lora Pager
