### PR TITLE
feat: DIY XIAO-esp32c6 + Wio-SX1262-for-XIAO

### DIFF
--- a/variants/esp32c6/diy/seeed-xiao-c6-wio-sx1262-for-xiao/platformio.ini
+++ b/variants/esp32c6/diy/seeed-xiao-c6-wio-sx1262-for-xiao/platformio.ini
@@ -1,0 +1,12 @@
+; Seeed XIAO C6 + XIAO Wio SX1262 DIY
+[env:seeed-xiao-c6-wio-sx1262-for-xiao]
+build_type = debug
+extends = esp32c6_base
+board = esp32-c6-devkitm-1
+board_level = extra
+build_flags = 
+  ${esp32c6_base.build_flags}
+  -Ivariants/esp32c6/diy/seeed-xiao-c6-wio-sx1262-for-xiao
+  -D PRIVATE_HW
+  -DARDUINO_USB_CDC_ON_BOOT=1
+  -DARDUINO_USB_MODE=1

--- a/variants/esp32c6/diy/seeed-xiao-c6-wio-sx1262-for-xiao/variant.h
+++ b/variants/esp32c6/diy/seeed-xiao-c6-wio-sx1262-for-xiao/variant.h
@@ -1,0 +1,43 @@
+// XIAO esp32c6: https://www.seeedstudio.com/Seeed-Studio-XIAO-ESP32C6-p-5884.html
+//
+// with
+//
+// Wio-SX1262-for-XIAO: https://www.seeedstudio.com/Wio-SX1262-for-XIAO-p-6379.html
+
+#define LED_PIN 15
+#define LED_STATE_ON 0 // LED is on
+
+#define BUTTON_PIN 21 // program button
+#define BUTTON_NEED_PULLUP
+
+// XIAO wio-SX1262 shield user button
+#define PIN_BUTTON1 0
+
+// Assume we don't have a screen
+#define HAS_SCREEN 0
+
+#define USE_SX1262
+
+#define LORA_MOSI 18
+#define LORA_MISO 20
+#define LORA_SCK 19
+#define LORA_CS 22
+
+#define LORA_RESET 2
+#define LORA_DIO1 1
+
+#define LORA_DIO2 23
+
+#define LORA_BUSY 21
+#define LORA_RF_SW LORA_DIO2
+
+#define SX126X_CS LORA_CS
+#define SX126X_DIO1 LORA_DIO1
+#define SX126X_BUSY LORA_BUSY
+#define SX126X_RESET LORA_RESET
+
+//  DIO2 controlls an antenna switch and the TCXO voltage is controlled by DIO3
+#define SX126X_DIO2_AS_RF_SWITCH
+#define SX126X_RXEN LORA_RF_SW
+#define SX126X_TXEN RADIOLIB_NC
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8


### PR DESCRIPTION
Add DIY build with [XIAO esp32c6](https://www.seeedstudio.com/Seeed-Studio-XIAO-ESP32C6-p-5884.html) + [Wio SX1262 for XIAO](https://www.seeedstudio.com/Wio-SX1262-for-XIAO-p-6379.html). From my testing everything seems to works.

The shield is compatible with the other xiao board so this pinout should also work with other xiao boards.

## 🤝 Attestations
- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
