### PR TITLE
Remove memcpy

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1667,9 +1667,6 @@ bool NodeDB::updateUser(uint32_t nodeId, meshtastic_User &p, uint8_t channelInde
             return false;
         }
         LOG_INFO("Public Key set for node, not updating!");
-        // we copy the key into the incoming packet, to prevent overwrite
-        p.public_key.size = 32;
-        memcpy(p.public_key.bytes, info->user.public_key.bytes, 32);
     } else if (p.public_key.size == 32) {
         LOG_INFO("Update Node Pubkey!");
     }


### PR DESCRIPTION
After #7652 enhancement, false is returned for any key mismatches:
https://github.com/meshtastic/firmware/blob/cea9e1238bf48b766e38984f2aa326e2ce821073/src/mesh/NodeDB.cpp#L1665-L1668

Memcpy below has become obsolete by this.
The key already matches after the check so there is no need to overwrite it anymore.
I suggest to remove it.

https://github.com/meshtastic/firmware/blob/cea9e1238bf48b766e38984f2aa326e2ce821073/src/mesh/NodeDB.cpp#L1670-L1672