### PR TITLE
portduino bump to fix gpiod bug

### DIFF
--- a/arch/portduino/portduino.ini
+++ b/arch/portduino/portduino.ini
@@ -2,7 +2,7 @@
 [portduino_base]
 platform =
   # renovate: datasource=git-refs depName=platform-native packageName=https://github.com/meshtastic/platform-native gitBranch=develop
-  https://github.com/meshtastic/platform-native/archive/c490bcd019e0658404088a61b96e653c9da22c45.zip
+  https://github.com/meshtastic/platform-native/archive/d3f6e339534233c7217818867368767590ce549e.zip
 framework = arduino
 
 build_src_filter = 


### PR DESCRIPTION
An earlier portduino causes problems with initializing gpiod lines. This pulls in the fix.