### PR TITLE
Fix 2.4GHz reconfiguration on LR11xx

### DIFF
--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -155,7 +155,7 @@ template <typename T> bool LR11x0Interface<T>::reconfigure()
     if (err != RADIOLIB_ERR_NONE)
         RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
 
-    err = lora.setBandwidth(bw);
+    err = lora.setBandwidth(bw, wideLora() && (getFreq() > 1000.0f));
     if (err != RADIOLIB_ERR_NONE)
         RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
 


### PR DESCRIPTION
RadioLib has a `high` parameter for `setBandwidth` on LR11xx, which should be set for 2.4GHz operation. Elsewhere internally in RadioLib it's set for LR112x if freq>1000 so I've duplicated that here.
Before this change, meshtasticd would exit when setting the region:
```
INFO  | 17:30:05 21 [Router] Set config: LoRa
INFO  | 17:30:05 21 [Router] Generate new PKI keys
DEBUG | 17:30:05 21 [Router] Generate Curve25519 keypair
INFO  | 17:30:05 21 [Router] Wanted region 13, using LORA_24
INFO  | 17:30:05 21 [Router] Save changes to disk
DEBUG | 17:30:05 21 [Router] Expand short PSK #1
INFO  | 17:30:05 21 [Router] Wanted region 13, using LORA_24
INFO  | 17:30:05 21 [Router] Radio freq=2404.469, config.lora.frequency_offset=0.000
INFO  | 17:30:05 21 [Router] Set radio: region=LORA_24, name=LongFast, config=0, ch=5, power=10
INFO  | 17:30:05 21 [Router] myRegion->freqStart -> myRegion->freqEnd: 2400.000000 -> 2483.500000 (83.500000 MHz)
INFO  | 17:30:05 21 [Router] numChannels: 102 x 812.500kHz
INFO  | 17:30:05 21 [Router] channel_num: 6
INFO  | 17:30:05 21 [Router] frequency: 2404.468750
INFO  | 17:30:05 21 [Router] Slot time: 17 msec
ERROR | 17:30:05 21 [Router] NOTE! Record critical error 7 at src/mesh/LR11x0Interface.cpp:160
ERROR | 17:30:05 21 [Router] A critical failure occurred, portduino is exiting
```

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Linux native (by @porkcube)
