### PR TITLE
Introduce non-linear TX_GAIN_LORA

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -117,6 +117,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define SX126X_MAX_POWER 22
 #endif
 
+#ifdef HELTEC_V4
+// Power Amps are often non-linear, so we can use an array of values for the power curve
+#define NUM_PA_POINTS 22
+#define TX_GAIN_LORA 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 10, 10, 9, 9, 8, 7
+#endif
+
 // Default system gain to 0 if not defined
 #ifndef TX_GAIN_LORA
 #define TX_GAIN_LORA 0

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -674,11 +674,25 @@ void RadioInterface::limitPower(int8_t loraMaxPower)
         power = maxPower;
     }
 
+#ifndef NUM_PA_POINTS
     if (TX_GAIN_LORA > 0) {
         LOG_INFO("Requested Tx power: %d dBm; Device LoRa Tx gain: %d dB", power, TX_GAIN_LORA);
         power -= TX_GAIN_LORA;
     }
+#else
+    // we have an array of PA gain values.  Find the highest power setting that works.
+    const uint16_t tx_gain[NUM_PA_POINTS] = {TX_GAIN_LORA};
+    for (int radio_dbm = 0; radio_dbm < NUM_PA_POINTS; radio_dbm++) {
+        if (((radio_dbm + tx_gain[radio_dbm]) > power) ||
+            ((radio_dbm == (NUM_PA_POINTS - 1)) && ((radio_dbm + tx_gain[radio_dbm]) <= power))) {
+            // we've exceeded the power limit, or hit the max we can do
+            LOG_INFO("Requested Tx power: %d dBm; Device LoRa Tx gain: %d dB", power, tx_gain[radio_dbm]);
+            power -= tx_gain[radio_dbm];
+            break;
+        }
+    }
 
+#endif
     if (power > loraMaxPower) // Clamp power to maximum defined level
         power = loraMaxPower;
 


### PR DESCRIPTION
Previously, our TX_GAIN_LORA setting was a single number, intended to represent the signal gain going through a power amp (plus or minus antenna, attenuator, and other parts of the RF chain).

It turns out the relationship between the input power (i.e. from an SX1262) and total output power is often non-linear. While we fudged a 1dBm difference here and there with existing chips, the Heltec v4 has a 5dBm difference in gain depending on which end of the input power (and frequency) you are at.

To allow people to run their Heltec v4 at max power when legal, and future proof our code, this patch introduced an optional array-based TX_GAIN_LORA.

Define NUM_PA_POINTS and set TX_GAIN_LORA to gain values for a given input power in 1dBm increments, and all will work.

For linear systems, just continue to define TX_GAIN_LORA as a number.

Fixes https://github.com/meshtastic/firmware/issues/8070

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
