### PR TITLE
I2S: Fix silent RTTTL regression

### DIFF
--- a/src/AudioThread.h
+++ b/src/AudioThread.h
@@ -26,6 +26,7 @@ class AudioThread : public concurrency::OSThread
         i2sRtttl->begin(rtttlFile, audioOut);
     }
 
+    // Also handles actually playing the RTTTL, needs to be called in loop
     bool isPlaying()
     {
         if (i2sRtttl != nullptr) {


### PR DESCRIPTION
- RTTTL plays correctly on I2S again, fixing regression from #8101
- Actually feels like it plays better than before? It felt stuttery before, sounds better now

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] T-Lora Pager
