### PR TITLE
Board support:  RAK3401+RAK13302

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -9,7 +9,7 @@ plugins:
 lint:
   enabled:
     - checkov@3.2.471
-    - renovate@41.127.2
+    - renovate@41.130.1
     - prettier@3.6.2
     - trufflehog@3.90.8
     - yamllint@1.37.1

--- a/src/graphics/SharedUIDisplay.cpp
+++ b/src/graphics/SharedUIDisplay.cpp
@@ -284,7 +284,7 @@ void drawCommonHeader(OLEDDisplay *display, int16_t x, int16_t y, const char *ti
                 int iconX = iconRightEdge - mute_symbol_big_width;
                 int iconY = textY + (FONT_HEIGHT_SMALL - mute_symbol_big_height) / 2;
 
-                if (isInverted) {
+                if (isInverted && !force_no_invert) {
                     display->setColor(WHITE);
                     display->fillRect(iconX - 1, iconY - 1, mute_symbol_big_width + 2, mute_symbol_big_height + 2);
                     display->setColor(BLACK);

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -852,24 +852,31 @@ void menuHandler::GPSFormatMenu()
     bannerOptions.bannerCallback = [](int selected) -> void {
         if (selected == 1) {
             uiconfig.gps_format = meshtastic_DeviceUIConfig_GpsCoordinateFormat_DEC;
+            saveUIConfig();
             service->reloadConfig(SEGMENT_CONFIG);
         } else if (selected == 2) {
             uiconfig.gps_format = meshtastic_DeviceUIConfig_GpsCoordinateFormat_DMS;
+            saveUIConfig();
             service->reloadConfig(SEGMENT_CONFIG);
         } else if (selected == 3) {
             uiconfig.gps_format = meshtastic_DeviceUIConfig_GpsCoordinateFormat_UTM;
+            saveUIConfig();
             service->reloadConfig(SEGMENT_CONFIG);
         } else if (selected == 4) {
             uiconfig.gps_format = meshtastic_DeviceUIConfig_GpsCoordinateFormat_MGRS;
+            saveUIConfig();
             service->reloadConfig(SEGMENT_CONFIG);
         } else if (selected == 5) {
             uiconfig.gps_format = meshtastic_DeviceUIConfig_GpsCoordinateFormat_OLC;
+            saveUIConfig();
             service->reloadConfig(SEGMENT_CONFIG);
         } else if (selected == 6) {
             uiconfig.gps_format = meshtastic_DeviceUIConfig_GpsCoordinateFormat_OSGR;
+            saveUIConfig();
             service->reloadConfig(SEGMENT_CONFIG);
         } else if (selected == 7) {
             uiconfig.gps_format = meshtastic_DeviceUIConfig_GpsCoordinateFormat_MLS;
+            saveUIConfig();
             service->reloadConfig(SEGMENT_CONFIG);
         } else {
             menuQueue = position_base_menu;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -866,7 +866,14 @@ void setup()
         SPI.begin();
     }
 #elif !defined(ARCH_ESP32) // ARCH_RP2040
+#if defined(RAK3401) || defined(RAK13302)
+    pinMode(WB_IO2, OUTPUT);
+    digitalWrite(WB_IO2, HIGH);
+    SPI1.setPins(LORA_MISO, LORA_SCK, LORA_MOSI , LORA_CS);
+    SPI1.begin();
+#else
     SPI.begin();
+#endif
 #else
         // ESP32
 #if defined(HW_SPI1_DEVICE)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -869,7 +869,7 @@ void setup()
 #if defined(RAK3401) || defined(RAK13302)
     pinMode(WB_IO2, OUTPUT);
     digitalWrite(WB_IO2, HIGH);
-    SPI1.setPins(LORA_MISO, LORA_SCK, LORA_MOSI , LORA_CS);
+    SPI1.setPins(LORA_MISO, LORA_SCK, LORA_MOSI);
     SPI1.begin();
 #else
     SPI.begin();

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -224,7 +224,7 @@ extern struct portduino_config_struct {
             out << YAML::Key << "RF95_MAX_POWER" << YAML::Value << rf95_max_power;
         out << YAML::Key << "DIO2_AS_RF_SWITCH" << YAML::Value << dio2_as_rf_switch;
         if (dio3_tcxo_voltage != 0)
-            out << YAML::Key << "DIO3_TCXO_VOLTAGE" << YAML::Value << dio3_tcxo_voltage;
+            out << YAML::Key << "DIO3_TCXO_VOLTAGE" << YAML::Value << YAML::Precision(3) << (float)dio3_tcxo_voltage / 1000;
         if (lora_usb_pid != 0x5512)
             out << YAML::Key << "USB_PID" << YAML::Value << YAML::Hex << lora_usb_pid;
         if (lora_usb_vid != 0x1A86)

--- a/variants/nrf52840/rak3401_1watt/platformio.ini
+++ b/variants/nrf52840/rak3401_1watt/platformio.ini
@@ -7,8 +7,8 @@ build_flags = ${nrf52840_base.build_flags}
   -Ivariants/nrf52840/rak3401_1watt
   -D RAK_4631
 ;   -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
-  -D RAK_3401
-  -D RAK_13302 ; RAK 1Watt Power Amplifier
+  -D RAK3401
+  -D RAK13302 ; RAK 1Watt Power Amplifier
   -DRADIOLIB_EXCLUDE_SX128X=1
   -DRADIOLIB_EXCLUDE_SX127X=1
   -DRADIOLIB_EXCLUDE_LR11X0=1

--- a/variants/nrf52840/rak3401_1watt/platformio.ini
+++ b/variants/nrf52840/rak3401_1watt/platformio.ini
@@ -1,0 +1,30 @@
+; The very slick RAK wireless RAK 4631 / 4630 board - Unified firmware for 5005/19003, with or without OLED RAK 1921
+[env:rak3401-1watt]
+extends = nrf52840_base
+board = wiscore_rak4631
+board_check = true
+build_flags = ${nrf52840_base.build_flags} 
+  -Ivariants/nrf52840/rak3401_1watt
+  -D RAK_4631
+;   -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
+  -D RAK_3401
+  -DRADIOLIB_EXCLUDE_SX128X=1
+  -DRADIOLIB_EXCLUDE_SX127X=1
+  -DRADIOLIB_EXCLUDE_LR11X0=1
+build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/rak3401_1watt> +<mesh/api/>
+lib_deps = 
+  ${nrf52840_base.lib_deps}
+  ${networking_base.lib_deps}
+  melopero/Melopero RV3028@^1.1.0
+  rakwireless/RAKwireless NCP5623 RGB LED library@^1.0.2
+  beegee-tokyo/RAK12035_SoilMoisture@^1.0.4
+  https://github.com/RAKWireless/RAK12034-BMX160/archive/dcead07ffa267d3c906e9ca4a1330ab989e957e2.zip
+
+; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
+; Note: as of 6/2013 the serial/bootloader based programming takes approximately 30 seconds
+;upload_protocol = jlink
+
+; Allows programming and debug via the RAK NanoDAP as the default debugger tool for the RAK4631 (it is only $10!)
+; programming time is about the same as the bootloader version.
+; For information on this see the meshtastic developers documentation for "Development on the NRF52"
+

--- a/variants/nrf52840/rak3401_1watt/platformio.ini
+++ b/variants/nrf52840/rak3401_1watt/platformio.ini
@@ -8,6 +8,7 @@ build_flags = ${nrf52840_base.build_flags}
   -D RAK_4631
 ;   -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
   -D RAK_3401
+  -D RAK_13302 ; RAK 1Watt Power Amplifier
   -DRADIOLIB_EXCLUDE_SX128X=1
   -DRADIOLIB_EXCLUDE_SX127X=1
   -DRADIOLIB_EXCLUDE_LR11X0=1

--- a/variants/nrf52840/rak3401_1watt/variant.cpp
+++ b/variants/nrf52840/rak3401_1watt/variant.cpp
@@ -1,0 +1,45 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  Copyright (c) 2018, Adafruit Industries (adafruit.com)
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "variant.h"
+#include "nrf.h"
+#include "wiring_constants.h"
+#include "wiring_digital.h"
+
+const uint32_t g_ADigitalPinMap[] = {
+    // P0
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+
+    // P1
+    32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47};
+
+void initVariant()
+{
+    // LED1 & LED2
+    pinMode(PIN_LED1, OUTPUT);
+    ledOff(PIN_LED1);
+
+    pinMode(PIN_LED2, OUTPUT);
+    ledOff(PIN_LED2);
+
+    // 3V3 Power Rail
+    pinMode(PIN_3V3_EN, OUTPUT);
+    digitalWrite(PIN_3V3_EN, HIGH);
+}

--- a/variants/nrf52840/rak3401_1watt/variant.h
+++ b/variants/nrf52840/rak3401_1watt/variant.h
@@ -56,16 +56,6 @@ extern "C" {
 #define LED_STATE_ON 1 // State when LED is litted
 
 /*
- * Buttons
- */
-
-// #define PIN_BUTTON1 9 // Pin for button on E-ink button module or IO expansion
-// #define BUTTON_NEED_PULLUP
-// #define PIN_BUTTON2 12
-// #define PIN_BUTTON3 24
-// #define PIN_BUTTON4 25
-
-/*
  * Analog pins
  */
 #define PIN_A0 (5)
@@ -129,19 +119,13 @@ static const uint8_t SCK = PIN_SPI_SCK;
 
 /*
  * eink display pins
- */
-
+*/
 #define PIN_EINK_CS (0 + 26)
 #define PIN_EINK_BUSY (0 + 4)
 #define PIN_EINK_DC (0 + 17)
 #define PIN_EINK_RES (-1)
 #define PIN_EINK_SCLK (0 + 3)
 #define PIN_EINK_MOSI (0 + 30) // also called SDI
-
-// #define USE_EINK
-
-// RAKRGB
-// #define HAS_NCP5623
 
 /*
  * Wire Interfaces
@@ -163,62 +147,12 @@ static const uint8_t SCK = PIN_SPI_SCK;
 #define EXTERNAL_FLASH_DEVICES IS25LP080D
 #define EXTERNAL_FLASH_USE_QSPI
 
-/* @note RAK5005-O GPIO mapping to RAK4631 GPIO ports
-   RAK5005-O <->  nRF52840
-   IO1       <->  P0.17 (Arduino GPIO number 17)
-   IO2       <->  P1.02 (Arduino GPIO number 34)
-   IO3       <->  P0.21 (Arduino GPIO number 21)
-   IO4       <->  P0.04 (Arduino GPIO number 4)
-   IO5       <->  P0.09 (Arduino GPIO number 9)
-   IO6       <->  P0.10 (Arduino GPIO number 10)
-   IO7       <->  P0.28 (Arduino GPIO number 28)
-   SW1       <->  P0.01 (Arduino GPIO number 1)
-   A0        <->  P0.04/AIN2 (Arduino Analog A2
-   A1        <->  P0.31/AIN7 (Arduino Analog A7
-   SPI_CS    <->  P0.26 (Arduino GPIO number 26)
- */
-
-// RAK4630 LoRa module
-
-/* Setup of the SX1262 LoRa module ( https://docs.rakwireless.com/Product-Categories/WisBlock/RAK4631/Datasheet/ )
-
-P1.10   NSS     SPI NSS (Arduino GPIO number 42)
-P1.11   SCK     SPI CLK (Arduino GPIO number 43)
-P1.12   MOSI    SPI MOSI (Arduino GPIO number 44)
-P1.13   MISO    SPI MISO (Arduino GPIO number 45)
-P1.14   BUSY    BUSY signal (Arduino GPIO number 46)
-P1.15   DIO1    DIO1 event interrupt (Arduino GPIO number 47)
-P1.06   NRESET  NRESET manual reset of the SX1262 (Arduino GPIO number 38)
-
-Important for successful SX1262 initialization:
-
-* Setup DIO2 to control the antenna switch
-* Setup DIO3 to control the TCXO power supply
-* Setup the SX1262 to use it's DCDC regulator and not the LDO
-* RAK4630 schematics show GPIO P1.07 connected to the antenna switch, but it should not be initialized, as DIO2 will do the
-control of the antenna switch
-
-SO GPIO 39/TXEN MAY NOT BE DEFINED FOR SUCCESSFUL OPERATION OF THE SX1262 - TG
-
-*/
-
-// configure the SET pin on the RAK12039 sensor board to disable the sensor while not reading
-// air quality telemetry.  PIN_NFC2 doesn't seem to be used anywhere else in the codebase, but if
-// you're having problems with your node behaving weirdly when a RAK12039 board isn't connected,
-// try disabling this.
-// #define PMSA003I_ENABLE_PIN PIN_NFC2
-
-// #define DETECTION_SENSOR_EN 4
-
+// 1watt sx1262 RAK13302
 #define HW_SPI1_DEVICE 1
 
-#undef LORA_SCK
-#define LORA_SCK 3
-#undef LORA_MISO
-#define LORA_MISO 29
-#undef LORA_MOSI
-#define LORA_MOSI 30
-#undef LORA_CS
+#define LORA_SCK PIN_SPI1_SCK
+#define LORA_MISO PIN_SPI1_MISO
+#define LORA_MOSI PIN_SPI1_MOSI
 #define LORA_CS 26
 
 #define USE_SX1262
@@ -226,8 +160,7 @@ SO GPIO 39/TXEN MAY NOT BE DEFINED FOR SUCCESSFUL OPERATION OF THE SX1262 - TG
 #define SX126X_DIO1 (10)
 #define SX126X_BUSY (9)
 #define SX126X_RESET (4)
-// #define SX126X_TXEN (39)
-// #define SX126X_RXEN (37)
+
 #define SX126X_POWER_EN (21)
 // DIO2 controlls an antenna switch and the TCXO voltage is controlled by DIO3
 #define SX126X_DIO2_AS_RF_SWITCH
@@ -280,14 +213,8 @@ SO GPIO 39/TXEN MAY NOT BE DEFINED FOR SUCCESSFUL OPERATION OF THE SX1262 - TG
 
 #define HAS_RTC 1
 
-// #define HAS_ETHERNET 1
-
 #define RAK_4631 1
 
-// #define PIN_ETHERNET_RESET 21
-// #define PIN_ETHERNET_SS PIN_EINK_CS
-// #define ETH_SPI_PORT SPI1
-// #define AQ_SET_PIN 10
 
 #ifdef __cplusplus
 }

--- a/variants/nrf52840/rak3401_1watt/variant.h
+++ b/variants/nrf52840/rak3401_1watt/variant.h
@@ -1,0 +1,300 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  Copyright (c) 2018, Adafruit Industries (adafruit.com)
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _VARIANT_RAK3401_
+#define _VARIANT_RAK3401_
+
+#define RAK4630
+
+/** Master clock frequency */
+#define VARIANT_MCK (64000000ul)
+
+#define USE_LFXO // Board uses 32khz crystal for LF
+// define USE_LFRC    // Board uses RC for LF
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+// Number of pins defined in PinDescription array
+#define PINS_COUNT (48)
+#define NUM_DIGITAL_PINS (48)
+#define NUM_ANALOG_INPUTS (6)
+#define NUM_ANALOG_OUTPUTS (0)
+
+// LEDs
+#define PIN_LED1 (35)
+#define PIN_LED2 (36)
+
+#define LED_BUILTIN PIN_LED1
+#define LED_CONN PIN_LED2
+
+#define LED_GREEN PIN_LED1
+#define LED_BLUE PIN_LED2
+
+#define LED_STATE_ON 1 // State when LED is litted
+
+/*
+ * Buttons
+ */
+
+// #define PIN_BUTTON1 9 // Pin for button on E-ink button module or IO expansion
+// #define BUTTON_NEED_PULLUP
+// #define PIN_BUTTON2 12
+// #define PIN_BUTTON3 24
+// #define PIN_BUTTON4 25
+
+/*
+ * Analog pins
+ */
+#define PIN_A0 (5)
+#define PIN_A1 (31)
+#define PIN_A2 (28)
+#define PIN_A3 (29)
+#define PIN_A4 (30)
+#define PIN_A5 (31)
+#define PIN_A6 (0xff)
+#define PIN_A7 (0xff)
+
+static const uint8_t A0 = PIN_A0;
+static const uint8_t A1 = PIN_A1;
+static const uint8_t A2 = PIN_A2;
+static const uint8_t A3 = PIN_A3;
+static const uint8_t A4 = PIN_A4;
+static const uint8_t A5 = PIN_A5;
+static const uint8_t A6 = PIN_A6;
+static const uint8_t A7 = PIN_A7;
+#define ADC_RESOLUTION 14
+
+// Other pins
+#define WB_I2C1_SDA (13) // SENSOR_SLOT IO_SLOT
+#define WB_I2C1_SCL (14) // SENSOR_SLOT IO_SLOT
+
+#define PIN_AREF (2)
+#define PIN_NFC1 (9)
+#define WB_IO5 PIN_NFC1
+#define WB_IO4 (4)
+#define PIN_NFC2 (10)
+
+static const uint8_t AREF = PIN_AREF;
+
+/*
+ * Serial interfaces
+ */
+#define PIN_SERIAL1_RX (15)
+#define PIN_SERIAL1_TX (16)
+
+// Connected to Jlink CDC
+#define PIN_SERIAL2_RX (8)
+#define PIN_SERIAL2_TX (6)
+
+/*
+ * SPI Interfaces
+ */
+#define SPI_INTERFACES_COUNT 2
+
+#define PIN_SPI_MISO (45)
+#define PIN_SPI_MOSI (44)
+#define PIN_SPI_SCK (43)
+
+#define PIN_SPI1_MISO (29) // (0 + 29)
+#define PIN_SPI1_MOSI (30) // (0 + 30)
+#define PIN_SPI1_SCK (3)   // (0 + 3)
+
+static const uint8_t SS = 42;
+static const uint8_t MOSI = PIN_SPI_MOSI;
+static const uint8_t MISO = PIN_SPI_MISO;
+static const uint8_t SCK = PIN_SPI_SCK;
+
+/*
+ * eink display pins
+ */
+
+#define PIN_EINK_CS (0 + 26)
+#define PIN_EINK_BUSY (0 + 4)
+#define PIN_EINK_DC (0 + 17)
+#define PIN_EINK_RES (-1)
+#define PIN_EINK_SCLK (0 + 3)
+#define PIN_EINK_MOSI (0 + 30) // also called SDI
+
+// #define USE_EINK
+
+// RAKRGB
+// #define HAS_NCP5623
+
+/*
+ * Wire Interfaces
+ */
+#define WIRE_INTERFACES_COUNT 1
+
+#define PIN_WIRE_SDA (WB_I2C1_SDA)
+#define PIN_WIRE_SCL (WB_I2C1_SCL)
+
+// QSPI Pins
+#define PIN_QSPI_SCK 3
+#define PIN_QSPI_CS 26
+#define PIN_QSPI_IO0 30
+#define PIN_QSPI_IO1 29
+#define PIN_QSPI_IO2 28
+#define PIN_QSPI_IO3 2
+
+// On-board QSPI Flash
+#define EXTERNAL_FLASH_DEVICES IS25LP080D
+#define EXTERNAL_FLASH_USE_QSPI
+
+/* @note RAK5005-O GPIO mapping to RAK4631 GPIO ports
+   RAK5005-O <->  nRF52840
+   IO1       <->  P0.17 (Arduino GPIO number 17)
+   IO2       <->  P1.02 (Arduino GPIO number 34)
+   IO3       <->  P0.21 (Arduino GPIO number 21)
+   IO4       <->  P0.04 (Arduino GPIO number 4)
+   IO5       <->  P0.09 (Arduino GPIO number 9)
+   IO6       <->  P0.10 (Arduino GPIO number 10)
+   IO7       <->  P0.28 (Arduino GPIO number 28)
+   SW1       <->  P0.01 (Arduino GPIO number 1)
+   A0        <->  P0.04/AIN2 (Arduino Analog A2
+   A1        <->  P0.31/AIN7 (Arduino Analog A7
+   SPI_CS    <->  P0.26 (Arduino GPIO number 26)
+ */
+
+// RAK4630 LoRa module
+
+/* Setup of the SX1262 LoRa module ( https://docs.rakwireless.com/Product-Categories/WisBlock/RAK4631/Datasheet/ )
+
+P1.10   NSS     SPI NSS (Arduino GPIO number 42)
+P1.11   SCK     SPI CLK (Arduino GPIO number 43)
+P1.12   MOSI    SPI MOSI (Arduino GPIO number 44)
+P1.13   MISO    SPI MISO (Arduino GPIO number 45)
+P1.14   BUSY    BUSY signal (Arduino GPIO number 46)
+P1.15   DIO1    DIO1 event interrupt (Arduino GPIO number 47)
+P1.06   NRESET  NRESET manual reset of the SX1262 (Arduino GPIO number 38)
+
+Important for successful SX1262 initialization:
+
+* Setup DIO2 to control the antenna switch
+* Setup DIO3 to control the TCXO power supply
+* Setup the SX1262 to use it's DCDC regulator and not the LDO
+* RAK4630 schematics show GPIO P1.07 connected to the antenna switch, but it should not be initialized, as DIO2 will do the
+control of the antenna switch
+
+SO GPIO 39/TXEN MAY NOT BE DEFINED FOR SUCCESSFUL OPERATION OF THE SX1262 - TG
+
+*/
+
+// configure the SET pin on the RAK12039 sensor board to disable the sensor while not reading
+// air quality telemetry.  PIN_NFC2 doesn't seem to be used anywhere else in the codebase, but if
+// you're having problems with your node behaving weirdly when a RAK12039 board isn't connected,
+// try disabling this.
+// #define PMSA003I_ENABLE_PIN PIN_NFC2
+
+// #define DETECTION_SENSOR_EN 4
+
+#define HW_SPI1_DEVICE 1
+
+#undef LORA_SCK
+#define LORA_SCK 3
+#undef LORA_MISO
+#define LORA_MISO 29
+#undef LORA_MOSI
+#define LORA_MOSI 30
+#undef LORA_CS
+#define LORA_CS 26
+
+#define USE_SX1262
+#define SX126X_CS (26)
+#define SX126X_DIO1 (10)
+#define SX126X_BUSY (9)
+#define SX126X_RESET (4)
+// #define SX126X_TXEN (39)
+// #define SX126X_RXEN (37)
+#define SX126X_POWER_EN (21)
+// DIO2 controlls an antenna switch and the TCXO voltage is controlled by DIO3
+#define SX126X_DIO2_AS_RF_SWITCH
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8
+
+// Testing USB detection
+#define NRF_APM
+// If using a power chip like the INA3221 you can override the default battery voltage channel below
+// and comment out NRF_APM to use the INA3221 instead of the USB detection for charging
+// #define INA3221_BAT_CH INA3221_CH2
+// #define INA3221_ENV_CH INA3221_CH1
+
+// enables 3.3V periphery like GPS or IO Module
+// Do not toggle this for GPS power savings
+#define PIN_3V3_EN (34)
+#define WB_IO2 PIN_3V3_EN
+
+// RAK1910 GPS module
+// If using the wisblock GPS module and pluged into Port A on WisBlock base
+// IO1 is hooked to PPS (pin 12 on header) = gpio 17
+// IO2 is hooked to GPS RESET = gpio 34, but it can not be used to this because IO2 is ALSO used to control 3V3_S power (1 is on).
+// Therefore must be 1 to keep peripherals powered
+// Power is on the controllable 3V3_S rail
+// #define PIN_GPS_RESET (34)
+// #define PIN_GPS_EN PIN_3V3_EN
+#define PIN_GPS_PPS (17) // Pulse per second input from the GPS
+
+#define GPS_RX_PIN PIN_SERIAL1_RX
+#define GPS_TX_PIN PIN_SERIAL1_TX
+
+// Define pin to enable GPS toggle (set GPIO to LOW) via user button triple press
+
+// RAK12002 RTC Module
+#define RV3028_RTC (uint8_t)0b1010010
+
+// RAK18001 Buzzer in Slot C
+// #define PIN_BUZZER 21 // IO3 is PWM2
+// NEW: set this via protobuf instead!
+
+// Battery
+// The battery sense is hooked to pin A0 (5)
+#define BATTERY_PIN PIN_A0
+// and has 12 bit resolution
+#define BATTERY_SENSE_RESOLUTION_BITS 12
+#define BATTERY_SENSE_RESOLUTION 4096.0
+#undef AREF_VOLTAGE
+#define AREF_VOLTAGE 3.0
+#define VBAT_AR_INTERNAL AR_INTERNAL_3_0
+#define ADC_MULTIPLIER 1.73
+
+#define HAS_RTC 1
+
+// #define HAS_ETHERNET 1
+
+#define RAK_4631 1
+
+// #define PIN_ETHERNET_RESET 21
+// #define PIN_ETHERNET_SS PIN_EINK_CS
+// #define ETH_SPI_PORT SPI1
+// #define AQ_SET_PIN 10
+
+#ifdef __cplusplus
+}
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#endif

--- a/variants/nrf52840/rak3401_1watt/variant.h
+++ b/variants/nrf52840/rak3401_1watt/variant.h
@@ -215,7 +215,6 @@ static const uint8_t SCK = PIN_SPI_SCK;
 
 #define RAK_4631 1
 
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This pull request introduces support for the RAK3401(nrf52840)+RAK13302 (sx1262 1-watt) variant on the nRF52840 platform, 

### RAK3401 1-watt variant support

* Added new board variant files: `variant.cpp`, `variant.h`, and `platformio.ini` for the RAK3401 1-watt configuration, defining pin mappings, hardware features, and build settings for the nRF52840-based RAK4631/RAK3401 boards. [[1]](diffhunk://#diff-b4fb2435d62afc0dd0c0cd4ba575b4d86a9b438a867ef28079962bc848f50671R1-R45) [[2]](diffhunk://#diff-62c5845a23cbe1325eaf4643a7d7fac2874bc6c617f4d72ba2d2e0b80fc2c0beR1-R226) [[3]](diffhunk://#diff-fa4cb2e5d0def4adacee435dc8a5670ba7b2a78814c571fe5643fc78f4925903R1-R31)

* Updated hardware initialization in `src/main.cpp` to correctly configure SPI pins and power enable for RAK3401/RAK13302 boards, ensuring proper startup and peripheral activation.

