### PR TITLE
Fix build script failure under certain conditions for devices that use UF2 binaries 

### DIFF
--- a/bin/platformio-custom.py
+++ b/bin/platformio-custom.py
@@ -86,7 +86,7 @@ if platform.name == "espressif32":
 
 if platform.name == "nordicnrf52":
     env.AddPostAction("$BUILD_DIR/${PROGNAME}.hex",
-                      env.VerboseAction(f"\"{sys.executable}\" ./bin/uf2conv.py $BUILD_DIR/firmware.hex -c -f 0xADA52840 -o $BUILD_DIR/firmware.uf2",
+                      env.VerboseAction(f"\"{sys.executable}\" ./bin/uf2conv.py \"$BUILD_DIR/firmware.hex\" -c -f 0xADA52840 -o \"$BUILD_DIR/firmware.uf2\"",
                                         "Generating UF2 file"))
 
 Import("projenv")

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -707,20 +707,40 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c)
 #endif
         config.display = c.payload_variant.display;
         break;
-    case meshtastic_Config_lora_tag:
+
+    case meshtastic_Config_lora_tag: {
+        // Wrap the entire case in a block to scope variables and avoid crossing initialization
+        auto oldLoraConfig = config.lora;
+        auto validatedLora = c.payload_variant.lora;
+
         LOG_INFO("Set config: LoRa");
         config.has_lora = true;
+
+        if (validatedLora.coding_rate < 4 || validatedLora.coding_rate > 8) {
+            LOG_WARN("Invalid coding_rate %d, setting to 5", validatedLora.coding_rate);
+            validatedLora.coding_rate = 5;
+        }
+
+        if (validatedLora.spread_factor < 7 || validatedLora.spread_factor > 12) {
+            LOG_WARN("Invalid spread_factor %d, setting to 11", validatedLora.spread_factor);
+            validatedLora.spread_factor = 11;
+        }
+
+        if (validatedLora.bandwidth == 0) {
+            int originalBandwidth = validatedLora.bandwidth;
+            validatedLora.bandwidth = myRegion->wideLora ? 800 : 250;
+            LOG_WARN("Invalid bandwidth %d, setting to default", originalBandwidth);
+        }
+
         // If no lora radio parameters change, don't need to reboot
-        if (config.lora.use_preset == c.payload_variant.lora.use_preset && config.lora.region == c.payload_variant.lora.region &&
-            config.lora.modem_preset == c.payload_variant.lora.modem_preset &&
-            config.lora.bandwidth == c.payload_variant.lora.bandwidth &&
-            config.lora.spread_factor == c.payload_variant.lora.spread_factor &&
-            config.lora.coding_rate == c.payload_variant.lora.coding_rate &&
-            config.lora.tx_power == c.payload_variant.lora.tx_power &&
-            config.lora.frequency_offset == c.payload_variant.lora.frequency_offset &&
-            config.lora.override_frequency == c.payload_variant.lora.override_frequency &&
-            config.lora.channel_num == c.payload_variant.lora.channel_num &&
-            config.lora.sx126x_rx_boosted_gain == c.payload_variant.lora.sx126x_rx_boosted_gain) {
+        if (oldLoraConfig.use_preset == validatedLora.use_preset && oldLoraConfig.region == validatedLora.region &&
+            oldLoraConfig.modem_preset == validatedLora.modem_preset && oldLoraConfig.bandwidth == validatedLora.bandwidth &&
+            oldLoraConfig.spread_factor == validatedLora.spread_factor &&
+            oldLoraConfig.coding_rate == validatedLora.coding_rate && oldLoraConfig.tx_power == validatedLora.tx_power &&
+            oldLoraConfig.frequency_offset == validatedLora.frequency_offset &&
+            oldLoraConfig.override_frequency == validatedLora.override_frequency &&
+            oldLoraConfig.channel_num == validatedLora.channel_num &&
+            oldLoraConfig.sx126x_rx_boosted_gain == validatedLora.sx126x_rx_boosted_gain) {
             requiresReboot = false;
         }
 
@@ -739,7 +759,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c)
             digitalWrite(RF95_FAN_EN, HIGH ^ 0);
         }
 #endif
-        config.lora = c.payload_variant.lora;
+        config.lora = validatedLora;
         // If we're setting region for the first time, init the region and regenerate the keys
         if (isRegionUnset && config.lora.region > meshtastic_Config_LoRaConfig_RegionCode_UNSET) {
             if (!owner.is_licensed) {
@@ -771,6 +791,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c)
             }
         }
         break;
+    }
     case meshtastic_Config_bluetooth_tag:
         LOG_INFO("Set config: Bluetooth");
         config.has_bluetooth = true;


### PR DESCRIPTION
Previously, full file paths containing spaces in them were passed to uf2conv without being quoted. At least on Linux (untested in other OSes), this would cause an incomplete string to be passed to uf2conv, causing that step of a local build to fail. Putting the arguments being given to uf2conv in quotes resolves this and it finishes the builds as-expected.

For example, if the repository was stored in the directory `/home/kealper/meshtastic - firmware/`, without the quotes, uf2conv was thinking `/home/kealper/meshtastic`, `-`, and `firmware/[...]` were all separate arguments instead of one single argument that contained spaces.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [x] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
