### PR TITLE
Fix Heltec V3 missed button presses

### DIFF
--- a/src/input/ButtonThread.cpp
+++ b/src/input/ButtonThread.cpp
@@ -279,7 +279,7 @@ int32_t ButtonThread::runOnce()
     if (!userButton.isIdle() || waitingForLongPress) {
         return 50;
     }
-    return INT32_MAX;
+    return 100; // FIXME: Why can't we rely on interrupts and use INT32_MAX here?
 }
 
 /*


### PR DESCRIPTION
Based on my experience and others on discord, it seems like we can't reliably catch button presses on Heltec V3 and other hardware models