### PR TITLE
Don't use IS_ONE_OF when loading Modules

### DIFF
--- a/src/modules/Modules.cpp
+++ b/src/modules/Modules.cpp
@@ -148,7 +148,8 @@ void setupModules()
     }
 #endif
 #if !MESHTASTIC_EXCLUDE_ATAK
-    if (IS_ONE_OF(config.device.role, meshtastic_Config_DeviceConfig_Role_TAK, meshtastic_Config_DeviceConfig_Role_TAK_TRACKER)) {
+    if (config.device.role == meshtastic_Config_DeviceConfig_Role_TAK ||
+        config.device.role == meshtastic_Config_DeviceConfig_Role_TAK_TRACKER) {
         atakPluginModule = new AtakPluginModule();
     }
 #endif


### PR DESCRIPTION
`IS_ONE_OF` is a helper macro from meshUtils.h

meshUtils.h is not explicitly included (typically inherited) and is not always available (e.g. `heltec-wireless-bridge`) causing build failures on some platforms.

This PR replaces use of `IS_ONE_OF` with a simple comparison in Modules.cpp (rather than explicitly including meshUtils.h). "Keep it simple stupid" :joy: 