### PR TITLE
Add dropped packet count to LocalStats

### DIFF
--- a/src/mesh/MeshPacketQueue.cpp
+++ b/src/mesh/MeshPacketQueue.cpp
@@ -65,7 +65,7 @@ void fixPriority(meshtastic_MeshPacket *p)
 }
 
 /** enqueue a packet, return false if full */
-bool MeshPacketQueue::enqueue(meshtastic_MeshPacket *p)
+bool MeshPacketQueue::enqueue(meshtastic_MeshPacket *p, bool *dropped)
 {
     // no space - try to replace a lower priority packet in the queue
     if (queue.size() >= maxLen) {
@@ -73,7 +73,14 @@ bool MeshPacketQueue::enqueue(meshtastic_MeshPacket *p)
         if (!replaced) {
             LOG_WARN("TX queue is full, and there is no lower-priority packet available to evict in favour of 0x%08x", p->id);
         }
+        if (dropped) {
+            *dropped = true;
+        }
         return replaced;
+    }
+
+    if (dropped) {
+        *dropped = false;
     }
 
     // Find the correct position using upper_bound to maintain a stable order

--- a/src/mesh/MeshPacketQueue.h
+++ b/src/mesh/MeshPacketQueue.h
@@ -19,8 +19,10 @@ class MeshPacketQueue
   public:
     explicit MeshPacketQueue(size_t _maxLen);
 
-    /** enqueue a packet, return false if full */
-    bool enqueue(meshtastic_MeshPacket *p);
+    /** enqueue a packet, return false if full
+     * @param dropped Optional pointer to a bool that will be set to true if a packet was dropped
+     */
+    bool enqueue(meshtastic_MeshPacket *p, bool *dropped = nullptr);
 
     /** return true if the queue is empty */
     bool empty();

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -116,6 +116,7 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
      * Debugging counts
      */
     uint32_t rxBad = 0, rxGood = 0, txGood = 0, txRelay = 0;
+    uint16_t txDrop = 0;
 
   public:
     RadioLibInterface(LockingArduinoHal *hal, RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst,

--- a/src/modules/Telemetry/DeviceTelemetry.cpp
+++ b/src/modules/Telemetry/DeviceTelemetry.cpp
@@ -121,6 +121,7 @@ meshtastic_Telemetry DeviceTelemetryModule::getLocalStatsTelemetry()
         telemetry.variant.local_stats.num_packets_rx = RadioLibInterface::instance->rxGood + RadioLibInterface::instance->rxBad;
         telemetry.variant.local_stats.num_packets_rx_bad = RadioLibInterface::instance->rxBad;
         telemetry.variant.local_stats.num_tx_relay = RadioLibInterface::instance->txRelay;
+        telemetry.variant.local_stats.num_tx_dropped = RadioLibInterface::instance->txDrop;
     }
 #ifdef ARCH_PORTDUINO
     if (SimRadio::instance) {
@@ -128,6 +129,7 @@ meshtastic_Telemetry DeviceTelemetryModule::getLocalStatsTelemetry()
         telemetry.variant.local_stats.num_packets_rx = SimRadio::instance->rxGood + SimRadio::instance->rxBad;
         telemetry.variant.local_stats.num_packets_rx_bad = SimRadio::instance->rxBad;
         telemetry.variant.local_stats.num_tx_relay = SimRadio::instance->txRelay;
+        telemetry.variant.local_stats.num_tx_dropped = SimRadio::instance->txDrop;
     }
 #else
     telemetry.variant.local_stats.heap_total_bytes = memGet.getHeapSize();

--- a/src/platform/portduino/SimRadio.cpp
+++ b/src/platform/portduino/SimRadio.cpp
@@ -13,7 +13,12 @@ ErrorCode SimRadio::send(meshtastic_MeshPacket *p)
 {
     printPacket("enqueuing for send", p);
 
-    ErrorCode res = txQueue.enqueue(p) ? ERRNO_OK : ERRNO_UNKNOWN;
+    bool dropped = false;
+    ErrorCode res = txQueue.enqueue(p, &dropped) ? ERRNO_OK : ERRNO_UNKNOWN;
+
+    if (dropped) {
+        txDrop++;
+    }
 
     if (res != ERRNO_OK) { // we weren't able to queue it, so we must drop it to prevent leaks
         packetPool.release(p);

--- a/src/platform/portduino/SimRadio.h
+++ b/src/platform/portduino/SimRadio.h
@@ -52,6 +52,7 @@ class SimRadio : public RadioInterface, protected concurrency::NotifiedWorkerThr
      * Debugging counts
      */
     uint32_t rxBad = 0, rxGood = 0, txGood = 0, txRelay = 0;
+    uint16_t txDrop = 0;
 
   protected:
     /// are _trying_ to receive a packet currently (note - we might just be waiting for one)

--- a/variants/nrf52840/t-echo-lite/variant.h
+++ b/variants/nrf52840/t-echo-lite/variant.h
@@ -145,7 +145,7 @@ static const uint8_t A0 = PIN_A0;
 #define PIN_GPS_STANDBY (32 + 13) // wakeup pin
 #define PIN_GPS_PPS (32 + 15)
 #define GPS_TX_PIN (32 + 10) // L76K module RX PIN
-#define GPS_RX_PIN (0 + 29) // L76K module TX PIN
+#define GPS_RX_PIN (0 + 29)  // L76K module TX PIN
 
 #define GPS_THREAD_INTERVAL 50
 


### PR DESCRIPTION
Dropping may happen if the transmit queue is full while we're trying to enqueue another packet. Even if we replaced a lower-priority packet, we count that dropped packet.

Closes #8056.