### PR TITLE
Update next-hops based on traceroute result

### DIFF
--- a/src/modules/TraceRouteModule.cpp
+++ b/src/modules/TraceRouteModule.cpp
@@ -212,7 +212,7 @@ void TraceRouteModule::maybeSetNextHop(NodeNum target, uint8_t nextHopByte)
 
     meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(target);
     if (node && node->next_hop != nextHopByte) {
-        LOG_INFO("Updating next-hop for 0x%08x to 0x%08x based on traceroute", target, nextHopByte);
+        LOG_INFO("Updating next-hop for 0x%08x to 0x%02x based on traceroute", target, nextHopByte);
         node->next_hop = nextHopByte;
     }
 }

--- a/src/modules/TraceRouteModule.h
+++ b/src/modules/TraceRouteModule.h
@@ -55,6 +55,12 @@ class TraceRouteModule : public ProtobufModule<meshtastic_RouteDiscovery>,
     // Call to add your ID to the route array of a RouteDiscovery message
     void appendMyIDandSNR(meshtastic_RouteDiscovery *r, float snr, bool isTowardsDestination, bool SNRonly);
 
+    // Update next-hops in the routing table based on the returned route
+    void updateNextHops(meshtastic_MeshPacket &p, meshtastic_RouteDiscovery *r);
+
+    // Helper to update next-hop for a single node
+    void maybeSetNextHop(NodeNum target, uint8_t nextHopByte);
+
     /* Call to print the route array of a RouteDiscovery message.
        Set origin to where the request came from.
        Set dest to the ID of its destination, or NODENUM_BROADCAST if it has not yet arrived there. */


### PR DESCRIPTION
This updates next-hops for nodes in the original route towards a certain destination when the traceroute result came back. Brought up by @mihvoi (https://github.com/meshtastic/firmware/issues/7839#issuecomment-3250917220).

E.g., if the route is A->B->C->D and we are B, we can set C as next-hop for C and D. Similarly, if we are C, we can set D as next-hop for D. Lastly if we are A, we can set B as next-hop for B, C and D.

Tested with the interactive simulator, e.g. for the original sender:

```
INFO  | 14:39:44 80 [Router] Route traced:
0x10 --> 0x11 (-9.25dB) --> 0x12 (-7.25dB) --> 0x13 (-4.50dB)
(-9.25dB) 0x10 <-- (-7.25dB) 0x11 <-- (-4.50dB) 0x12 <-- 0x13
INFO  | 14:39:44 80 [Router] Updating next-hop for 0x00000011 to 0x00000011 based on traceroute
INFO  | 14:39:44 80 [Router] Updating next-hop for 0x00000012 to 0x00000011 based on traceroute
INFO  | 14:39:44 80 [Router] Updating next-hop for 0x00000013 to 0x00000011 based on traceroute
```

And for the last node in the route:
```
INFO  | 14:39:31 67 [Router] Route traced:
0x10 --> 0x11 (-9.25dB) --> 0x12 (-7.25dB) --> 0x13 (-4.50dB)
...(-4.50dB) 0x12 <-- 0x13
INFO  | 14:39:31 67 [Router] Updating next-hop for 0x00000013 to 0x00000013 based on traceroute
```