### PR TITLE
update build-* to also output binaries to *-update.bin/uf2

### DIFF
--- a/bin/build-nrf52.sh
+++ b/bin/build-nrf52.sh
@@ -47,6 +47,8 @@ else
 	cp bin/*.uf2 $OUTDIR
 fi
 
+cp $OUTDIR/$basename.uf2 $OUTDIR/$basename-update.uf2
+
 if (echo $1 | grep -q "rak4631"); then
 	echo "Copying hex file"
 	cp .pio/build/$1/firmware.hex $OUTDIR/$basename.hex

--- a/bin/build-rp2xx0.sh
+++ b/bin/build-rp2xx0.sh
@@ -29,5 +29,7 @@ echo "Copying uf2 file"
 SRCBIN=.pio/build/$1/firmware.uf2
 cp $SRCBIN $OUTDIR/$basename.uf2
 
+cp $OUTDIR/$basename.uf2 $OUTDIR/$basename-update.uf2
+
 cp bin/device-install.* $OUTDIR
 cp bin/device-update.* $OUTDIR

--- a/bin/build-stm32wl.sh
+++ b/bin/build-stm32wl.sh
@@ -27,3 +27,5 @@ cp $SRCELF $OUTDIR/$basename.elf
 
 SRCBIN=.pio/build/$1/firmware.bin
 cp $SRCBIN $OUTDIR/$basename.bin
+
+cp $OUTDIR/$basename.bin $OUTDIR/$basename-update.bin


### PR DESCRIPTION
This is in preparation for supporting the factory reset firmware for non-esp32 targets.