### PR TITLE
Actions: CI docker with a fancy matrix

### DIFF
--- a/.github/workflows/build_one_arch.yml
+++ b/.github/workflows/build_one_arch.yml
@@ -88,62 +88,6 @@ jobs:
     if: ${{ !contains(github.ref_name, 'event/') && github.event_name != 'workflow_dispatch' ||  !contains(github.ref_name, 'event/') && inputs.arch == 'native' }}
     uses: ./.github/workflows/test_native.yml
 
-  docker-deb-amd64:
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.arch == 'native' }}
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      distro: debian
-      platform: linux/amd64
-      runs-on: ubuntu-24.04
-      push: false
-
-  docker-deb-amd64-tft:
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.arch == 'native' }}
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      distro: debian
-      platform: linux/amd64
-      runs-on: ubuntu-24.04
-      push: false
-      pio_env: native-tft
-
-  docker-alp-amd64:
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.arch == 'native' }}
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      distro: alpine
-      platform: linux/amd64
-      runs-on: ubuntu-24.04
-      push: false
-
-  docker-alp-amd64-tft:
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.arch == 'native' }}
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      distro: alpine
-      platform: linux/amd64
-      runs-on: ubuntu-24.04
-      push: false
-      pio_env: native-tft
-
-  docker-deb-arm64:
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.arch == 'native' }}
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      distro: debian
-      platform: linux/arm64
-      runs-on: ubuntu-24.04-arm
-      push: false
-
-  docker-deb-armv7:
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.arch == 'native' }}
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      distro: debian
-      platform: linux/arm/v7
-      runs-on: ubuntu-24.04-arm
-      push: false
-
   gather-artifacts:
     permissions:
       contents: write

--- a/.github/workflows/build_one_target.yml
+++ b/.github/workflows/build_one_target.yml
@@ -106,62 +106,6 @@ jobs:
     if: ${{ !contains(github.ref_name, 'event/') && github.event_name != 'workflow_dispatch' ||  !contains(github.ref_name, 'event/') && inputs.arch == 'native' && inputs.target != '' }}
     uses: ./.github/workflows/test_native.yml
 
-  docker-deb-amd64:
-    if: ${{ inputs.target != '' && inputs.arch ==  'native' }}
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      distro: debian
-      platform: linux/amd64
-      runs-on: ubuntu-24.04
-      push: false
-
-  docker-deb-amd64-tft:
-    if: ${{ inputs.target != '' && inputs.arch ==  'native' }}
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      distro: debian
-      platform: linux/amd64
-      runs-on: ubuntu-24.04
-      push: false
-      pio_env: native-tft
-
-  docker-alp-amd64:
-    if: ${{ inputs.target != '' && inputs.arch ==  'native' }}
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      distro: alpine
-      platform: linux/amd64
-      runs-on: ubuntu-24.04
-      push: false
-
-  docker-alp-amd64-tft:
-    if: ${{ inputs.target != '' && inputs.arch ==  'native' }}
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      distro: alpine
-      platform: linux/amd64
-      runs-on: ubuntu-24.04
-      push: false
-      pio_env: native-tft
-
-  docker-deb-arm64:
-    if: ${{ inputs.target != '' && inputs.arch ==  'native' }}
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      distro: debian
-      platform: linux/arm64
-      runs-on: ubuntu-24.04-arm
-      push: false
-
-  docker-deb-armv7:
-    if: ${{ inputs.target != '' && inputs.arch ==  'native' }}
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      distro: debian
-      platform: linux/arm/v7
-      runs-on: ubuntu-24.04-arm
-      push: false
-
   gather-artifacts:
     permissions:
       contents: write

--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -27,7 +27,6 @@ on:
 
 jobs:
   setup:
-    if: github.repository == 'meshtastic/firmware'
     strategy:
       fail-fast: true
       matrix:
@@ -42,10 +41,6 @@ jobs:
           python-version: 3.x
           cache: pip
       - run: pip install -U platformio
-      - name: Uncomment build epoch
-        shell: bash
-        run: |
-          sed -i 's/#-DBUILD_EPOCH=$UNIX_TIME/-DBUILD_EPOCH=$UNIX_TIME/' platformio.ini
       - name: Generate matrix
         id: jsonStep
         run: |
@@ -62,7 +57,6 @@ jobs:
       check: ${{ steps.jsonStep.outputs.check }}
 
   version:
-    if: github.repository == 'meshtastic/firmware'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -125,60 +119,26 @@ jobs:
     if: ${{ !contains(github.ref_name, 'event/') && github.repository == 'meshtastic/firmware' }}
     uses: ./.github/workflows/test_native.yml
 
-  docker-deb-amd64:
-    if: github.repository == 'meshtastic/firmware'
+  docker:
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [debian, alpine]
+        platform: [linux/amd64, linux/arm64, linux/arm/v7]
+        pio_env: [native, native-tft]
+        exclude:
+          - distro: alpine
+            platform: linux/arm/v7
+          - pio_env: native-tft
+            platform: linux/arm64
+          - pio_env: native-tft
+            platform: linux/arm/v7
     uses: ./.github/workflows/docker_build.yml
     with:
-      distro: debian
-      platform: linux/amd64
-      runs-on: ubuntu-24.04
-      push: false
-
-  docker-deb-amd64-tft:
-    if: github.repository == 'meshtastic/firmware'
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      distro: debian
-      platform: linux/amd64
-      runs-on: ubuntu-24.04
-      push: false
-      pio_env: native-tft
-
-  docker-alp-amd64:
-    if: github.repository == 'meshtastic/firmware'
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      distro: alpine
-      platform: linux/amd64
-      runs-on: ubuntu-24.04
-      push: false
-
-  docker-alp-amd64-tft:
-    if: github.repository == 'meshtastic/firmware'
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      distro: alpine
-      platform: linux/amd64
-      runs-on: ubuntu-24.04
-      push: false
-      pio_env: native-tft
-
-  docker-deb-arm64:
-    if: github.repository == 'meshtastic/firmware'
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      distro: debian
-      platform: linux/arm64
-      runs-on: ubuntu-24.04-arm
-      push: false
-
-  docker-deb-armv7:
-    if: github.repository == 'meshtastic/firmware'
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      distro: debian
-      platform: linux/arm/v7
-      runs-on: ubuntu-24.04-arm
+      distro: ${{ matrix.distro }}
+      platform: ${{ matrix.platform }}
+      runs-on: ${{ contains(matrix.platform, 'arm') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+      pio_env: ${{ matrix.pio_env }}
       push: false
 
   gather-artifacts:

--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -99,54 +99,26 @@ jobs:
     if: ${{ !contains(github.ref_name, 'event/') }}
     uses: ./.github/workflows/test_native.yml
 
-  docker-deb-amd64:
+  docker:
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [debian, alpine]
+        platform: [linux/amd64, linux/arm64, linux/arm/v7]
+        pio_env: [native, native-tft]
+        exclude:
+          - distro: alpine
+            platform: linux/arm/v7
+          - pio_env: native-tft
+            platform: linux/arm64
+          - pio_env: native-tft
+            platform: linux/arm/v7
     uses: ./.github/workflows/docker_build.yml
     with:
-      distro: debian
-      platform: linux/amd64
-      runs-on: ubuntu-24.04
-      push: false
-
-  docker-deb-amd64-tft:
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      distro: debian
-      platform: linux/amd64
-      runs-on: ubuntu-24.04
-      push: false
-      pio_env: native-tft
-
-  docker-alp-amd64:
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      distro: alpine
-      platform: linux/amd64
-      runs-on: ubuntu-24.04
-      push: false
-
-  docker-alp-amd64-tft:
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      distro: alpine
-      platform: linux/amd64
-      runs-on: ubuntu-24.04
-      push: false
-      pio_env: native-tft
-
-  docker-deb-arm64:
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      distro: debian
-      platform: linux/arm64
-      runs-on: ubuntu-24.04-arm
-      push: false
-
-  docker-deb-armv7:
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      distro: debian
-      platform: linux/arm/v7
-      runs-on: ubuntu-24.04-arm
+      distro: ${{ matrix.distro }}
+      platform: ${{ matrix.platform }}
+      runs-on: ${{ contains(matrix.platform, 'arm') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+      pio_env: ${{ matrix.pio_env }}
       push: false
 
   gather-artifacts:


### PR DESCRIPTION
- Simplify matrix for docker builds
- Rip out all the docker builds in `build_one_*` -- they aren't published anywhere or used for testing, it's just a waste of electricity! :zap: 

Tested in my fork :+1: 