### PR TITLE
Always Zero-Hop MQTT traffic

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -108,7 +108,7 @@ inline void onReceiveProto(char *topic, byte *payload, size_t length)
     p->to = e.packet->to;
     p->id = e.packet->id;
     p->channel = e.packet->channel;
-    p->hop_limit = e.packet->hop_limit;
+    p->hop_limit = 0; // Always zero-hop MQTT traffic
     p->hop_start = e.packet->hop_start;
     p->want_ack = e.packet->want_ack;
     p->via_mqtt = true; // Mark that the packet was received via MQTT


### PR DESCRIPTION
*Always* zero hop packets that originate from MQTT (Downlink).

This allows users to continue to use MQTT *on node*, while leaving the precious airwaves alone.

Changing this behavior *should* be extremely high friction (modify and compile your own firmware, not a standard config) as it's risk for abuse (intentional or accidental) is extremely high.

The Meshtastic Public MQTT, as well as many private-mesh-group MQTT servers are Zero-Hopped for this reason (high abuse potential). Let's end this madness everywhere.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
