### PR TITLE
Add support for Keepteen LT1 

### DIFF
--- a/boards/keepteen_lt1.json
+++ b/boards/keepteen_lt1.json
@@ -1,0 +1,79 @@
+{
+    "build": {
+      "arduino":{
+        "ldscript": "nrf52840_s140_v6.ld"
+      },
+      "core": "nRF5",
+      "cpu": "cortex-m4",
+      "extra_flags": "-DARDUINO_NRF52840_FEATHER -DNRF52840_XXAA",
+      "f_cpu": "64000000L",
+      "hwids": [
+        [
+          "0x239A",
+          "0x00B3"
+        ],
+        [
+          "0x239A",
+          "0x8029"
+        ],
+        [
+          "0x239A",
+          "0x0029"
+        ],
+        [
+          "0x239A",
+          "0x002A"
+        ],
+        [
+          "0x239A",
+          "0x802A"
+        ]
+      ],
+      "usb_product": "Keepteen LT1",
+      "mcu": "nrf52840",
+      "variant": "Keepteen LT1",
+      "variants_dir": "variants",
+      "bsp": {
+        "name": "adafruit"
+      },
+      "softdevice": {
+        "sd_flags": "-DS140",
+        "sd_name": "s140",
+        "sd_version": "6.1.1",
+        "sd_fwid": "0x00B6"
+      },
+      "bootloader": {
+        "settings_addr": "0xFF000"
+      }
+    },
+    "connectivity": [
+      "bluetooth"
+    ],
+    "debug": {
+      "jlink_device": "nRF52840_xxAA",
+      "svd_path": "nrf52840.svd",
+      "openocd_target": "nrf52.cfg"
+    },
+    "frameworks": [
+      "arduino",
+      "zephyr"
+    ],
+    "name": "Keepteen LT1",
+    "upload": {
+      "maximum_ram_size": 248832,
+      "maximum_size": 815104,
+      "speed": 115200,
+      "protocol": "nrfutil",
+      "protocols": [
+        "jlink",
+        "nrfjprog",
+        "nrfutil",
+        "stlink"
+      ],
+      "use_1200bps_touch": true,
+      "require_upload_port": true,
+      "wait_for_upload_port": true
+    },
+    "url": "http://www.keepteen.com/",
+    "vendor": "Keepteen"
+  }

--- a/variants/nrf52840/keepteen_lt1/platformio.ini
+++ b/variants/nrf52840/keepteen_lt1/platformio.ini
@@ -1,0 +1,16 @@
+[env:keepteen_lt1]
+extends = nrf52840_base
+board_level = extra
+board = keepteen_lt1
+;board_check = true
+build_flags = 
+  ${nrf52840_base.build_flags}
+  -D PRIVATE_HW
+  -DRADIOLIB_EXCLUDE_SX128X=1
+  -DRADIOLIB_EXCLUDE_SX127X=1
+  -DRADIOLIB_EXCLUDE_LR11X0=1
+  -DSERIAL_MODULE_ENABLED=0
+  -I variants/nrf52840/keepteen_lt1
+build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/keepteen_lt1>
+lib_deps =
+  ${nrf52840_base.lib_deps}

--- a/variants/nrf52840/keepteen_lt1/variant.c
+++ b/variants/nrf52840/keepteen_lt1/variant.c
@@ -1,0 +1,19 @@
+#include "variant.h"
+#include "wiring_constants.h"
+#include "wiring_digital.h"
+
+const uint32_t g_ADigitalPinMap[] = {
+  0xff, 0xff, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
+  14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+  27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+  40, 41, 42, 43, 44, 45, 46, 47
+};
+
+void initVariant()
+{
+    // init LED and button
+    pinMode(LED_PIN, OUTPUT);
+    digitalWrite(LED_PIN, LOW);
+    pinMode(BUTTON_PIN, INPUT_PULLUP);
+
+}

--- a/variants/nrf52840/keepteen_lt1/variant.h
+++ b/variants/nrf52840/keepteen_lt1/variant.h
@@ -1,0 +1,97 @@
+#ifndef _VARIANT_KEEPTEEN_LT1_
+#define _VARIANT_KEEPTEEN_LT1_
+
+#define VARIANT_MCK             (64000000ul)
+#define USE_LFRC 
+
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+
+#define PINS_COUNT  48
+#define NUM_DIGITAL_PINS    48
+#define NUM_ANALOG_INPUTS   1
+#define NUM_ANALOG_OUTPUTS  0
+
+
+#define LED_PIN 15
+#define LED_BUILTIN LED_PIN
+#define LED_STATE_ON 1 
+#define LED_BLUE -1 // disabled
+
+// OLED display i2c configuration
+#define WIRE_INTERFACES_COUNT 1
+#define HAS_SCREEN 1
+#define USE_SSD1306
+#define SDA_OLED 34
+#define SCL_OLED 36
+#define RST_OLED -1 // nc
+#define RESET_OLED RST_OLED
+#define PIN_WIRE_SDA SDA_OLED
+#define PIN_WIRE_SCL SCL_OLED
+
+// we only have a single button, connected at pin 32
+#define BUTTON_PIN  32
+
+// ADC settings for battery monitoring
+#define BATTERY_PIN 31
+#define ADC_MULTIPLIER 1.73F
+#undef AREF_VOLTAGE
+#define AREF_VOLTAGE 3.6F
+#define BATTERY_SENSE_RESOLUTION_BITS 12
+
+// serial interface used for GPS
+#define PIN_SERIAL1_RX 22
+#define PIN_SERIAL1_TX 20
+
+// gps itself
+#define GPS_BAUDRATE 9600
+#define GPS_RX_PIN PIN_SERIAL1_RX
+#define GPS_TX_PIN PIN_SERIAL1_TX
+#define PIN_GPS_EN 24
+
+// LoRa module: sx1262
+#define SPI_INTERFACES_COUNT 1
+#define USE_SX1262
+#define LORA_DIO0 -1 // a No connect on the SX1262 module
+#define LORA_RESET 9
+#define LORA_DIO1 10 // SX1262 IRQ
+#define LORA_DIO2 29 // SX1262 BUSY
+#define LORA_DIO3   
+#define LORA_NSS 45
+#define LORA_SCK 43
+#define LORA_MISO 2
+#define LORA_MOSI 38
+#define LORA_CS 8
+#define PIN_SPI_MISO LORA_MISO
+#define PIN_SPI_MOSI LORA_MOSI
+#define PIN_SPI_SCK LORA_SCK
+
+#define SX126X_CS LORA_NSS
+#define SX126X_DIO1 LORA_DIO1
+#define SX126X_BUSY LORA_DIO2
+#define SX126X_RESET LORA_RESET
+#define SX126X_RXEN RADIOLIB_NC
+#define SX126X_TXEN RADIOLIB_NC
+
+#define SX126X_DIO2_AS_RF_SWITCH true
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8f
+
+
+// hacks and crap to make it compile
+#define PIN_SERIAL2_RX -1
+#define PIN_SERIAL2_TX -1
+
+#ifdef __cplusplus
+}
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#endif // _VARIANT_KEEPTEEN_LT1_


### PR DESCRIPTION
Adds support for the [Keepteen LT1 Pocket Meshtastic Tracker](https://www.keepteen.com/GAT562-Pocket-Lora-Node-Radio-for-Meshtastic-Meshcore-Mesh-Tracker-with-SX1262-NRF53840-L76K-GPS-p6556031.html).

Out of the box these ship with a custom build of 2.7.2 of which the source code is unfortunately not shared. Trust me, I've tried.

As I own three of these I wanted to get a newer firmware version installed. Due to the double pin rows on the HT-RA61 module I was unable to beep out the correct pinouts but thankfully the manufacturer recently published a patch to [add support to MeshCore](https://github.com/meshcore-dev/MeshCore/pull/1106) under the BSD license which meant I could get the relevant information there without breaching any licenses. 

There's probably some weird and unnecessary stuff in this PR as I just really wanted to get it to compile and run properly, so feel free to clean up so I can learn more about how this codebase works :) 
 

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
