### PR TITLE
feat(stm32): Add LilyGo T3-STM32 + supporting changes

### DIFF
--- a/boards/lilygo_t3_stm32_v1.json
+++ b/boards/lilygo_t3_stm32_v1.json
@@ -1,0 +1,32 @@
+{
+  "build": {
+    "arduino": {
+      "variant_h": "variant_generic.h"
+    },
+    "core": "stm32",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32WL -DSTM32WLxx -DSTM32WLE5xx",
+    "f_cpu": "48000000L",
+    "framework_extra_flags": {
+      "arduino": "-DUSE_CM4_STARTUP_FILE -DARDUINO_GENERIC_WLE5CCUX"
+    },
+    "mcu": "stm32wle5ccu7",
+    "product_line": "STM32WLE5xx",
+    "variant": "STM32WLxx/WL54CCU_WL55CCU_WLE4C(8-B-C)U_WLE5C(8-B-C)U"
+  },
+  "debug": {
+    "jlink_device": "STM32WLE5JC",
+    "openocd_target": "stm32wlx",
+    "svd_path": "STM32WLE5_CM4.svd"
+  },
+  "frameworks": ["arduino", "zephyr"],
+  "name": "LilyGo T3-STM32",
+  "upload": {
+    "maximum_ram_size": 65536,
+    "maximum_size": 262144,
+    "protocol": "serial",
+    "protocols": ["serial", "stlink", "jlink"]
+  },
+  "url": "https://github.com/Xinyuan-LilyGO/T3-STM32",
+  "vendor": "LilyGo"
+}

--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -330,6 +330,14 @@ class AnalogBatteryLevel : public HasBatteryLevel
             raw = espAdcRead();
             scaled = esp_adc_cal_raw_to_voltage(raw, adc_characs);
             scaled *= operativeAdcMultiplier;
+#elif defined(ARCH_STM32WL) // ADC block for STM32WL platforms
+#include "stm32yyxx_ll_adc.h"
+            raw = analogRead(BATTERY_PIN);
+            // Simplified from STM32duino example code at
+            // https://github.com/stm32duino/STM32Examples/blob/main/examples/Peripherals/ADC/Internal_channels/Internal_channels.ino
+            uint32_t VRef = __LL_ADC_CALC_VREFANALOG_VOLTAGE(analogRead(AVREF), LL_ADC_RESOLUTION);
+            scaled = __LL_ADC_CALC_DATA_TO_VOLTAGE(VRef, raw, LL_ADC_RESOLUTION);
+            scaled *= operativeAdcMultiplier;
 #else // block for all other platforms
             for (uint32_t i = 0; i < BATTERY_SENSE_SAMPLES; i++) {
                 raw += analogRead(BATTERY_PIN);
@@ -615,8 +623,13 @@ bool Power::analogInit()
 #ifdef BATTERY_PIN
     LOG_DEBUG("Use analog input %d for battery level", BATTERY_PIN);
 
+#ifdef ARCH_STM32WL
+    // STM32-specific analog pinmode
+    pinMode(BATTERY_PIN, INPUT_ANALOG);
+#else
     // disable any internal pullups
     pinMode(BATTERY_PIN, INPUT);
+#endif
 
 #ifndef BATTERY_SENSE_RESOLUTION_BITS
 #define BATTERY_SENSE_RESOLUTION_BITS 10

--- a/src/mesh/STM32WLE5JCInterface.cpp
+++ b/src/mesh/STM32WLE5JCInterface.cpp
@@ -18,9 +18,8 @@ bool STM32WLE5JCInterface::init()
 {
     RadioLibInterface::init();
 
-// https://github.com/Seeed-Studio/LoRaWan-E5-Node/blob/main/Middlewares/Third_Party/SubGHz_Phy/stm32_radio_driver/radio_driver.c
-#if (!defined(_VARIANT_RAK3172_))
-    setTCXOVoltage(1.7);
+#ifdef STM32WLx_TCXO_VOLTAGE
+    setTCXOVoltage(STM32WLx_TCXO_VOLTAGE);
 #endif
 
     lora.setRfSwitchTable(rfswitch_pins, rfswitch_table);

--- a/src/platform/stm32wl/architecture.h
+++ b/src/platform/stm32wl/architecture.h
@@ -17,6 +17,18 @@
 #endif
 
 //
+// ADC defaults for STM32WL
+//
+#if defined(LL_ADC_RESOLUTION_12B)
+#define LL_ADC_RESOLUTION LL_ADC_RESOLUTION_12B
+#elif defined(LL_ADC_DS_DATA_WIDTH_12_BIT)
+#define LL_ADC_RESOLUTION LL_ADC_DS_DATA_WIDTH_12_BIT
+#else
+#error "ADC resolution could not be defined!"
+#endif
+#define ADC_RANGE 4096
+
+//
 // set HW_VENDOR
 //
 #ifdef _VARIANT_WIOE5_

--- a/variants/stm32/CDEBYTE_E77-MBL/variant.h
+++ b/variants/stm32/CDEBYTE_E77-MBL/variant.h
@@ -14,6 +14,11 @@ Do not expect a working Meshtastic device with this target.
 #define _VARIANT_EBYTE_E77_
 
 #define USE_STM32WLx
+/*
+Unfortunately, E77-MBL are shipped with and without TCXO; If LoRa fails to
+initialize with "STM32WLx init result -707", try removing this definition.
+*/
+#define STM32WLx_TCXO_VOLTAGE 1.7
 
 #define LED_PIN PB4 // LED1
 // #define LED_PIN PB3 // LED2

--- a/variants/stm32/lilygo_t3_stm32_v1/platformio.ini
+++ b/variants/stm32/lilygo_t3_stm32_v1/platformio.ini
@@ -1,0 +1,20 @@
+[env:lilygo_t3_stm32_v1]
+extends = stm32_base
+board = lilygo_t3_stm32_v1
+board_level = pr
+board_upload.maximum_size = 233472 ; reserve the last 28KB for filesystem
+build_flags =
+  ${stm32_base.build_flags}
+  -Ivariants/stm32/lilygo_t3_stm32_v1
+  -DSERIAL_UART_INSTANCE=2
+  -DPIN_SERIAL_RX=PA10
+  -DPIN_SERIAL_TX=PA9
+  -DENABLE_HWSERIAL1
+  -DPIN_SERIAL1_RX=PA3
+  -DPIN_SERIAL1_TX=PA2
+  -DPIN_WIRE_SDA=PA5
+  -DPIN_WIRE_SCL=PA7
+; Serial upload will not work until PlatformIO stm32flash is updated to include this upstream commit:
+; https://sourceforge.net/p/stm32flash/code/ci/5530160c67df46c0fff9dcdeb46585b1c8512140/
+; As a workaround, flash the built .hex file using STM32CubeProgrammer (or use `upload_protocol = stlink`)
+upload_protocol = serial

--- a/variants/stm32/lilygo_t3_stm32_v1/rfswitch.h
+++ b/variants/stm32/lilygo_t3_stm32_v1/rfswitch.h
@@ -1,0 +1,8 @@
+// Pins from https://github.com/Xinyuan-LilyGO/T3-STM32/blob/master/hardware/T3_STM32%20V1.0%2024-07-30.pdf
+// RF switch: AS169-73LF SPDT, pin V1 always high, pin V2 controlled by GPIO PB2
+// Rx = PB2 high, Tx = PB2 low: https://github.com/Xinyuan-LilyGO/T3-STM32/blob/master/examples/6_SubGHz_TXRX/User/user.h
+
+static const RADIOLIB_PIN_TYPE rfswitch_pins[5] = {PB2, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC};
+
+static const Module::RfSwitchMode_t rfswitch_table[4] = {
+    {STM32WLx::MODE_IDLE, {HIGH}}, {STM32WLx::MODE_RX, {HIGH}}, {STM32WLx::MODE_TX_HP, {LOW}}, END_OF_MODE_TABLE};

--- a/variants/stm32/lilygo_t3_stm32_v1/variant.h
+++ b/variants/stm32/lilygo_t3_stm32_v1/variant.h
@@ -1,0 +1,33 @@
+#ifndef _VARIANT_LILYGO_T3_STM32_V1_
+#define _VARIANT_LILYGO_T3_STM32_V1_
+
+#define USE_STM32WLx
+
+#define LED_PIN PA0  // Green LED
+#define USER_LED PA1 // Red LED
+#define LED_STATE_ON 1
+
+#define BUTTON_PIN PH3 // BOOT
+
+#define BATTERY_PIN PB3 // BAT_DET
+// ratio of voltage divider = 2.0 (R42=100k, R43=100k)
+#define ADC_MULTIPLIER 2.11 // 2.0 + 10% for correction of display undervoltage
+
+/*
+OLED currently unsupported as it is wired in 4-wire SPI mode.
+STM32 is also presently built without OLED support.
+SPI CS#:  PB12
+SPI D/C#: PA8
+SPI SCK:  PA5
+SPI MOSI: PA7
+*/
+/*
+#ifndef HAS_SCREEN
+#define HAS_SCREEN
+#endif
+#define USE_SSD1306
+*/
+
+#define LILYGO_T3_STM32_V1
+
+#endif

--- a/variants/stm32/wio-e5/variant.h
+++ b/variants/stm32/wio-e5/variant.h
@@ -13,6 +13,7 @@ Do not expect a working Meshtastic device with this target.
 #define _VARIANT_WIOE5_
 
 #define USE_STM32WLx
+#define STM32WLx_TCXO_VOLTAGE 1.7
 
 #define LED_PIN PB5
 #define LED_STATE_ON 0


### PR DESCRIPTION
- Add LilyGo T3-STM32
- Explicitly enable TCXO voltage for wio-e5 & CDEBYTE_E77-MBL
- Add STM32 ADC support
  - Defines in src/platform/stm32wl/architecture.h
  - STM32-specific HAL calculation code in src/Power.cpp

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Seeed Wio-e5 mini dev board