### PR TITLE
fix(MQTT): Send first MapReport as soon as possible

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -845,7 +845,7 @@ void MQTT::perhapsReportToMap()
         map_position_precision = default_map_position_precision;
     }
 
-    if (Throttle::isWithinTimespanMs(last_report_to_map, map_publish_interval_msecs))
+    if (Throttle::isWithinTimespanMs(last_report_to_map, map_publish_interval_msecs) && last_report_to_map != 0)
         return;
 
     if (localPosition.latitude_i == 0 && localPosition.longitude_i == 0) {

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -848,11 +848,8 @@ void MQTT::perhapsReportToMap()
     if (Throttle::isWithinTimespanMs(last_report_to_map, map_publish_interval_msecs) && last_report_to_map != 0)
         return;
 
-    if (localPosition.latitude_i == 0 && localPosition.longitude_i == 0) {
-        last_report_to_map = millis();
-        LOG_WARN("MQTT Map report enabled, but no position available");
+    if (localPosition.latitude_i == 0 && localPosition.longitude_i == 0)
         return;
-    }
 
     // Allocate MeshPacket and fill it
     meshtastic_MeshPacket *mp = packetPool.allocZeroed();


### PR DESCRIPTION
1. fix(MQTT): First MapReport does not get sent 
   
   Throttle::isWithinTimespanMs(last_report_to_map, map_publish_interval_msecs) is used to maintain the map reporting interval, but because last_report_to_map has an initial value of 0, the map report routine does not start until the system
millis() time has passed map_publish_interval_msecs.
   
   Fix this by adding a check that last_report_to_map is not 0.
2. feat(MQTT): Send MapReporting immediately upon location fix 
   
   Do not update last_report_to_map when Map Report is attempted without a valid location, as this results in waiting up to an hour (or configured Map Report interval).
   
   That usually happens because most nodes do not keep GPS warm, so GPS usually locks after the first attempt at Map Report.
   
   This change also results in the log WARNing message getting spammed until a location is obtained, so remove the message for now.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Other: Heltec T114v2
  - [x] Other: Lilygo T3-S3
