### PR TITLE
promicro doesn't need limiting

### DIFF
--- a/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/platformio.ini
+++ b/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/platformio.ini
@@ -5,8 +5,6 @@ board = promicro-nrf52840
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/diy/nrf52_promicro_diy_tcxo
   -D NRF52_PROMICRO_DIY
-  -DRADIOLIB_EXCLUDE_SX128X=1
-  -DRADIOLIB_EXCLUDE_SX127X=1
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/diy/nrf52_promicro_diy_tcxo>
 lib_deps = 
   ${nrf52840_base.lib_deps}
@@ -22,8 +20,6 @@ build_flags =
   ${inkhud.build_flags}
   -I variants/nrf52840/diy/nrf52_promicro_diy_tcxo
   -D NRF52_PROMICRO_DIY
-  -DRADIOLIB_EXCLUDE_SX128X=1
-  -DRADIOLIB_EXCLUDE_SX127X=1
 build_src_filter =
   ${nrf52_base.build_src_filter}
   ${inkhud.build_src_filter}


### PR DESCRIPTION
PR https://github.com/meshtastic/firmware/pull/8854 seems to have included some unnecessary limitations on the promicro DIY target. I've taken them back out.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
