### PR TITLE
Add SNR, RSSI and Hops to the Messages screen

### DIFF
--- a/src/graphics/draw/MessageRenderer.cpp
+++ b/src/graphics/draw/MessageRenderer.cpp
@@ -218,6 +218,15 @@ void drawTextMessageFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16
     }
 
     // === Header Construction ===
+    char metricsStr[64];
+    // Logic from Android app
+    int hopsAway = (mp.hop_start == 0 || mp.hop_limit > mp.hop_start) ? -1 : mp.hop_start - mp.hop_limit;
+    if(hopsAway == 0) {
+        snprintf(metricsStr, sizeof(metricsStr), "S: %.2fdB R: %ddBm", mp.rx_snr, mp.rx_rssi);
+    } else {
+        snprintf(metricsStr, sizeof(metricsStr), "H:%d S:%.2fdB R:%ddBm", hopsAway, mp.rx_snr, mp.rx_rssi);
+    }
+
     meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(getFrom(&mp));
     char headerStr[80];
     const char *sender = "???";
@@ -353,7 +362,7 @@ void drawTextMessageFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16
         LOG_INFO("Onscreen message scroll cache key needs updating: cachedKey=0x%0x, currentKey=0x%x", cachedKey, currentKey);
 
         // Cache miss - regenerate lines and heights
-        cachedLines = generateLines(display, headerStr, messageBuf, textWidth);
+        cachedLines = generateLines(display, headerStr, metricsStr, messageBuf, textWidth);
         cachedHeights = calculateLineHeights(cachedLines, emotes);
         cachedKey = currentKey;
     } else {
@@ -427,10 +436,11 @@ void drawTextMessageFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16
     graphics::drawCommonFooter(display, x, y);
 }
 
-std::vector<std::string> generateLines(OLEDDisplay *display, const char *headerStr, const char *messageBuf, int textWidth)
+std::vector<std::string> generateLines(OLEDDisplay *display, const char *headerStr, const char *metricsStr, const char *messageBuf, int textWidth)
 {
     std::vector<std::string> lines;
     lines.push_back(std::string(headerStr)); // Header line is always first
+    lines.push_back(std::string(metricsStr));
 
     std::string line, word;
     for (int i = 0; messageBuf[i]; ++i) {

--- a/src/graphics/draw/MessageRenderer.h
+++ b/src/graphics/draw/MessageRenderer.h
@@ -17,7 +17,7 @@ void drawStringWithEmotes(OLEDDisplay *display, int x, int y, const std::string 
 void drawTextMessageFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y);
 
 // Function to generate lines with word wrapping
-std::vector<std::string> generateLines(OLEDDisplay *display, const char *headerStr, const char *messageBuf, int textWidth);
+std::vector<std::string> generateLines(OLEDDisplay *display, const char *headerStr, const char *metricsStr, const char *messageBuf, int textWidth);
 
 // Function to calculate heights for each line
 std::vector<int> calculateLineHeights(const std::vector<std::string> &lines, const Emote *emotes);


### PR DESCRIPTION
Following my Feature Request in #8949, I went ahead in tried to implement it.

I  have only Heltec V3 nodes so I have tested the code only on them.

I understand that the display is small and wasting 1 line for these metrics might not be important for everyone.
If you think so, you can just ignore this PR and close it.

I have not modified the code path specific to the M5Stack C6L Unit because I could not test it.

I got the inspiration from the Android App and I have used the same logic to compute the `hopsAway` and display it if not a direct message. But I have kept the SNR and RSSI data displayed in case of hops because it is still useful for my use case using the Range Test Module.

Preview:

![IMG_20251212_185329](https://github.com/user-attachments/assets/b0f49cab-25ca-4e52-b0ca-26d9c1fb9b79)

Fixes #8949

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
