### PR TITLE
feat(GPS): Support Softsleep with WAKE-UP pin on PA1010D

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -908,6 +908,12 @@ void GPS::writePinStandby(bool standby)
     // Write and log
     pinMode(PIN_GPS_STANDBY, OUTPUT);
     digitalWrite(PIN_GPS_STANDBY, val);
+
+    // Enter backup mode on PA1010D; TODO: may be applicable to other MTK GPS too
+    if (IS_ONE_OF(gnssModel, GNSS_MODEL_MTK_PA1010D)) {
+        _serial_gps->write("$PMTK225,4*2F\r\n");
+    }
+
 #ifdef GPS_DEBUG
     LOG_DEBUG("Pin STANDBY %s", val == HIGH ? "HI" : "LOW");
 #endif


### PR DESCRIPTION
Support softsleep by defining PIN_GPS_STANDBY on CDTop CD-PA1010D.

This differs from existing MTK GPS e.g. L76K, where pulling PIN_GPS_STANDBY (WAKE-UP pin) low is not sufficient to put the GPS module in standby.

An additional `$PMTK225,4*2F` must be sent to enter "Backup Mode" *after* the pin is brought low, which is exited by bringing PIN_GPS_STANDBY (WAKE-UP pin) high (already handled by existing code).

Refer to datasheet[0] §1.9.3 "Backup Mode".

0: https://cdn-learn.adafruit.com/assets/assets/000/084/295/original/CD_PA1010D_Datasheet_v.03.pdf

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] STM32WL

Any variants/GPS not probed as PA1010D should not be affected by this.