### PR TITLE
feat: Add Russell, an STM32WL balloon-optimized node

### DIFF
--- a/variants/stm32/russell/platformio.ini
+++ b/variants/stm32/russell/platformio.ini
@@ -1,0 +1,21 @@
+; Russell is a board designed to mount on an ER34615/IFR32700 cell and go Up! on a balloon
+; Hardware repository: https://github.com/Meshtastic-Malaysia/russell
+; - RAK3172 STM32WLE5CCU6 MCU + integrated SX1262 LoRa
+; - CDtop CD-PA1010D GPS
+; - Bosch Sensortec BME280 sensor
+; - Consonance CN3158 LiFePO4 solar charger
+[env:russell]
+extends = stm32_base
+board = wiscore_rak3172
+board_level = extra
+board_upload.maximum_size = 233472 ; reserve the last 28KB for filesystem
+build_flags =
+  ${stm32_base.build_flags}
+  -Ivariants/stm32/russell
+  -DPRIVATE_HW
+lib_deps =
+  ${stm32_base.lib_deps}
+	# renovate: datasource=custom.pio depName=Adafruit BME280 packageName=adafruit/library/Adafruit BME280 Library
+	adafruit/Adafruit BME280 Library@2.3.0
+
+upload_port = stlink

--- a/variants/stm32/russell/rfswitch.h
+++ b/variants/stm32/russell/rfswitch.h
@@ -1,0 +1,7 @@
+// Pins from https://forum.rakwireless.com/t/rak3172-internal-schematic/4557/2
+// PB8, PC13
+
+static const RADIOLIB_PIN_TYPE rfswitch_pins[5] = {PB8, PC13, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC};
+
+static const Module::RfSwitchMode_t rfswitch_table[4] = {
+    {STM32WLx::MODE_IDLE, {LOW, LOW}}, {STM32WLx::MODE_RX, {HIGH, LOW}}, {STM32WLx::MODE_TX_HP, {LOW, HIGH}}, END_OF_MODE_TABLE};

--- a/variants/stm32/russell/variant.h
+++ b/variants/stm32/russell/variant.h
@@ -1,0 +1,41 @@
+#ifndef _VARIANT_RUSSELL_
+#define _VARIANT_RUSSELL_
+
+#define USE_STM32WLx
+
+// I/O
+#define LED_PIN PA0 // Red LED
+#define LED_STATE_ON 1
+#define BUTTON_PIN PH3 // Shared with BOOT0
+#define BUTTON_NEED_PULLUP
+// Charger IC charge/standby pins are open-drain with no hardware pull-up:
+// Internal pull-up is needed on STM32 (TODO)
+// #define EXT_CHRG_DETECT PA5
+// #define EXT_PWR_DETECT PA4
+
+// Bosch Sensortec BME280
+#define HAS_SENSOR 1
+
+// CDtop CD-PA1010D
+#define ENABLE_HWSERIAL1
+#define PIN_SERIAL1_RX PB7
+#define PIN_SERIAL1_TX PB6
+#define HAS_GPS 1
+#define PIN_GPS_STANDBY PA15
+#define GPS_RX_PIN PB7
+#define GPS_TX_PIN PB6
+
+// LoRa
+/*
+ * RAK3172   (-20–85°C) -> No TCXO
+ * RAK3172-T (-40–85°C) -> 3.0V TCXO
+ * https://github.com/RAKWireless/RAK-STM32-RUI/blob/e5a28be8fab1a492bd9223dd425ca33a8a297d90/variants/WisDuo_RAK3172-T_Board/radio_conf.h#L91
+ */
+#define TCXO_OPTIONAL
+#define SX126X_DIO3_TCXO_VOLTAGE 3.0
+
+// Required to avoid Serial1 conflicts due to board definition here:
+// https://github.com/stm32duino/Arduino_Core_STM32/blob/main/variants/STM32WLxx/WL54CCU_WL55CCU_WLE4C(8-B-C)U_WLE5C(8-B-C)U/variant_RAK3172_MODULE.h
+#define RAK3172
+
+#endif


### PR DESCRIPTION
Russell is a board designed to mount on an ER34615/IFR32700 cell and go Up! on a balloon

Hardware repository: https://github.com/Meshtastic-Malaysia/russell
- RAK3172 STM32WLE5CCU6 MCU + integrated SX1262 LoRa
- CDtop CD-PA1010D GPS (GPS does not sleep correctly until this PR is merged: #9078)
- Bosch Sensortec BME280 sensor (BME680 can be substituted in-place but requires bsec2 `lib_deps` that currently throws a build error on STM32)
- Consonance CN3158 LiFePO4 solar charger

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] Russell