### PR TITLE
fix: extend retransmission timeout for ROUTER_LATE broadcast window

### DIFF
--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -250,10 +250,11 @@ uint32_t RadioInterface::getRetransmissionMsec(const meshtastic_MeshPacket *p)
     uint32_t packetAirtime = getPacketTime(numbytes + sizeof(PacketHeader));
     // Make sure enough time has elapsed for this packet to be sent and an ACK is received.
     // LOG_DEBUG("Waiting for flooding message with airtime %d and slotTime is %d", packetAirtime, slotTimeMsec);
-    float channelUtil = airTime->channelUtilizationPercent();
-    uint8_t CWsize = map(channelUtil, 0, 100, CWmin, CWmax);
-    // Assuming we pick max. of CWsize and there will be a client with SNR at half the range
-    return 2 * packetAirtime + (pow_of_2(CWsize) + 2 * CWmax + pow_of_2(int((CWmax + CWmin) / 2))) * slotTimeMsec +
+    // Account for worst-case ROUTER_LATE delay: (2 * CWmax + pow_of_2(CWmax)) * slotTimeMsec
+    // ROUTER_LATE uses SNR-based CWsize independent of channel util, so we must assume CWmax for both terms
+    // to ensure timeout is always longer than the maximum possible ROUTER_LATE rebroadcast delay.
+    // This prevents MAX_RETRANSMIT errors when ROUTER_LATE nodes successfully rebroadcast but with delay.
+    return 2 * packetAirtime + (2 * pow_of_2(CWmax) + 2 * CWmax) * slotTimeMsec +
            PROCESSING_TIME_MSEC;
 }
 


### PR DESCRIPTION
ROUTER_LATE nodes intentionally delay rebroadcasts to provide coverage. This delay can be up to ~7 seconds (using `getTxDelayMsecWeightedWorst` with `pow_of_2(CWmax) * slotTimeMsec`).

The retransmission timeout was previously ~5-6 seconds, causing the sender to hit MAX_RETRANSMIT and report failure before ROUTER_LATE nodes could rebroadcast. This resulted in false negative acknowledgments where messages successfully propagated but the sender incorrectly reported delivery failure.

Extended the timeout calculation to account for worst-case ROUTER_LATE delay by changing from `pow_of_2((CWmax+CWmin)/2) ` to `pow_of_2(CWmax)`, adding approximately 4.5-11 seconds depending on modem preset.

This prevents clients from implementing unnecessary retry logic that creates duplicate messages on the mesh.

Closes #9185 

## 🤝 Attestations

- [ x ] I have tested that my proposed changes behave as described.
- [ x ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ x ] Other (please specify below)
  
  Rak Wismesh Tag, Seeed Solar Node
