### PR TITLE
Add support for VDDHDIV5 voltage measurement

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -333,7 +333,11 @@ class AnalogBatteryLevel : public HasBatteryLevel
             scaled *= operativeAdcMultiplier;
 #else // block for all other platforms
             for (uint32_t i = 0; i < BATTERY_SENSE_SAMPLES; i++) {
+#if (BATTERY_PIN == -1)
+                raw += analogReadVDDHDIV5();
+#else
                 raw += analogRead(BATTERY_PIN);
+#endif
             }
             raw = raw / BATTERY_SENSE_SAMPLES;
             scaled = operativeAdcMultiplier * ((1000 * AREF_VOLTAGE) / pow(2, BATTERY_SENSE_RESOLUTION_BITS)) * raw;


### PR DESCRIPTION
Allow a NRF52 variant, like the DIY Promicro NRF52 development boards which power the NRF52 directly via the VDDH pin to obtain battery voltage directly from this pin using VDDHDIV5.  This can simplify DIY builds by avoiding the need to connect voltage divider resistors to an analog pin.  This method also avoids the small current drain of the voltage divider.  Note however, that a tradeoff in some cases is that this method may not allow monitoring battery voltage while charging via USB since some designs, including the Promicro boards, supply USB voltage to VDDH when USB is connected.

Note that there are a couple of NRF52 variants which are already defining BATTERY_PIN to -1; presumably to indicate the absence of a battery sense pin.  It is not immediately obvious to me if these variants might happen to have battery voltage connected to VDDH and would thus benefit from this feature, but I don't expect these variants to suffer any issues do to this change.

If, however, it is preferred to have a new #DEFINE rather than overload BATTERY_PIN, please suggest a new symbol name, and I'll update this PR.

I would like to take advantage of this in the future to simplify my "Easy E22" build instructions: https://github.com/brad112358/easy_E22 

See also #7579 

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
  Tested on DIY NRF52 Promicro E22 board