### PR TITLE
New extra variant: Xiao ESP32c3

### DIFF
--- a/variants/esp32c3/seeed_xiao_c3/pins_arduino.h
+++ b/variants/esp32c3/seeed_xiao_c3/pins_arduino.h
@@ -1,0 +1,33 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+static const uint8_t TX = 21;
+static const uint8_t RX = 20;
+
+static const uint8_t SDA = 6;
+static const uint8_t SCL = 7;
+
+static const uint8_t SS = 20;
+static const uint8_t MOSI = 10;
+static const uint8_t MISO = 9;
+static const uint8_t SCK = 8;
+
+static const uint8_t A0 = 2;
+static const uint8_t A1 = 3;
+static const uint8_t A2 = 4;
+
+static const uint8_t D0 = 2;
+static const uint8_t D1 = 3;
+static const uint8_t D2 = 4;
+static const uint8_t D3 = 5;
+static const uint8_t D4 = 6;
+static const uint8_t D5 = 7;
+static const uint8_t D6 = 21;
+static const uint8_t D7 = 20;
+static const uint8_t D8 = 8;
+static const uint8_t D9 = 9;
+static const uint8_t D10 = 10;
+
+#endif /* Pins_Arduino_h */

--- a/variants/esp32c3/seeed_xiao_c3/platformio.ini
+++ b/variants/esp32c3/seeed_xiao_c3/platformio.ini
@@ -1,0 +1,22 @@
+[seeed-xiao-c3_base]
+extends = esp32c3_base
+board = seeed_xiao_esp32c3
+board_level = extra
+build_flags = 
+  ${esp32c3_base.build_flags}
+  -D PRIVATE_HW
+  -I variants/esp32c3/seeed_xiao_c3
+
+[env:seeed-xiao-c3_loraS3]
+# Radio from https://wiki.seeedstudio.com/wio_sx1262_with_xiao_esp32s3_kit/#hardware-overview
+extends = seeed-xiao-c3_base
+build_flags = 
+  ${seeed-xiao-c3_base.build_flags}
+  -D XIAO_C3_loraS3
+
+[env:seeed-xiao-c3_loraNRF52]
+# Radio from https://wiki.seeedstudio.com/xiao_nrf52840&_wio_SX1262_kit_for_meshtastic/#pinout
+extends = seeed-xiao-c3_base
+build_flags = 
+  ${seeed-xiao-c3_base.build_flags}
+  -D XIAO_C3_loraNRF52

--- a/variants/esp32c3/seeed_xiao_c3/variant.h
+++ b/variants/esp32c3/seeed_xiao_c3/variant.h
@@ -1,0 +1,50 @@
+// Seeed Xiao ESP32c3 variant
+//
+// This MCU is not bundled with a LoRa radio.
+// Instead, it includes definitions for the radio included with the "ESP32-S3 LoRa" kit,
+// and the radio included with the "Xiao nRF52840 LoRa" kit.
+
+// #define BUTTON_PIN 9 // TODO (this varies based on the radio 'hat')
+// #define LED_PIN 2    // TODO
+// #define LED_STATE_ON 1
+
+#define HAS_SCREEN 0
+#define HAS_GPS 0
+#undef GPS_RX_PIN
+#undef GPS_TX_PIN
+
+#define USE_SX1262
+
+// https://files.seeedstudio.com/wiki/XIAO_ESP32S3_for_Meshtastic_LoRa/10.png
+#ifdef XIAO_C3_loraS3
+#define LORA_MOSI 10
+#define LORA_MISO 9
+#define LORA_SCK 8
+#define LORA_DIO1 2
+#define LORA_BUSY 3
+#define LORA_RESET 4
+#define LORA_CS 5
+#define LORA_DIO2 6
+#endif
+
+// https://media-cdn.seeedstudio.com/media/wysiwyg/upload/image_Wio-SX1262_-1.png
+#ifdef XIAO_C3_loraNRF52
+#define LORA_MOSI 10
+#define LORA_MISO 9
+#define LORA_SCK 8
+#define LORA_DIO1 3
+#define LORA_BUSY 5
+#define LORA_RESET 4
+#define LORA_CS 6
+#define LORA_DIO2 7
+#endif
+
+#define LORA_DIO0 RADIOLIB_NC
+#define SX126X_CS LORA_CS
+#define SX126X_DIO1 LORA_DIO1
+#define SX126X_BUSY LORA_BUSY
+#define SX126X_RESET LORA_RESET
+#define SX126X_DIO2_AS_RF_SWITCH
+#define SX126X_RXEN LORA_DIO2
+#define SX126X_TXEN RADIOLIB_NC
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8


### PR DESCRIPTION
Adds new variant(s) for the [Seeed Xiao ESP32-C3](https://wiki.seeedstudio.com/XIAO_ESP32C3_Getting_Started/).

This MCU is not sold in a bundle with a LoRa radio.
Definitions have been provided to build a firmware that is compatible with either the "ESP32-S3" Xiao LoRa radio or the "NRF52840" Xiao LoRa radio (they use different pinouts).