### PR TITLE
fix(PortduinoGlue): spi_dev_int packing

### DIFF
--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -678,7 +678,7 @@ bool loadConfig(const char *configPath)
                     // Pretty sure this is always true
                     if (x >= 0 && x < 10 && y >= 0 && y < 10) {
                         // I believe this bit of weirdness is specifically for the new GUI
-                        portduino_config.lora_spi_dev_int = x + y << 4;
+                        portduino_config.lora_spi_dev_int = x + (y << 4);
                         portduino_config.display_spi_dev_int = portduino_config.lora_spi_dev_int;
                         portduino_config.touchscreen_spi_dev_int = portduino_config.lora_spi_dev_int;
                     }
@@ -777,7 +777,7 @@ bool loadConfig(const char *configPath)
                     int x = portduino_config.display_spi_dev.at(11) - '0';
                     int y = portduino_config.display_spi_dev.at(13) - '0';
                     if (x >= 0 && x < 10 && y >= 0 && y < 10) {
-                        portduino_config.display_spi_dev_int = x + y << 4;
+                        portduino_config.display_spi_dev_int = x + (y << 4);
                         portduino_config.touchscreen_spi_dev_int = portduino_config.display_spi_dev_int;
                     }
                 }
@@ -805,7 +805,7 @@ bool loadConfig(const char *configPath)
                     int x = portduino_config.touchscreen_spi_dev.at(11) - '0';
                     int y = portduino_config.touchscreen_spi_dev.at(13) - '0';
                     if (x >= 0 && x < 10 && y >= 0 && y < 10) {
-                        portduino_config.touchscreen_spi_dev_int = x + y << 4;
+                        portduino_config.touchscreen_spi_dev_int = x + (y << 4);
                     }
                 }
             }


### PR DESCRIPTION
Operator precedence dictates that the addition will occur before the left shift unless we persuade the compiler to do otherwise.

Fixes: 45c1b46bd ("Move native to spi_host to indicate spidev for LovyanGFX")

See the following unpacking logic for more information:
https://github.com/meshtastic/framework-portduino/blob/master/cores/portduino/linux/LinuxHardwareSPI.cpp#L84-L91