### PR TITLE
feat(power): automatic WiFi disable when running on battery

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -30,7 +30,7 @@
 #include "input/LinuxInputImpl.h"
 #endif
 
-#if HAS_WIFI
+#if HAS_WIFI && !defined(ARCH_PORTDUINO)
 #include "mesh/wifi/WiFiAPClient.h"
 #endif
 
@@ -54,7 +54,7 @@
 #endif
 
 // WiFi power management state
-#if HAS_WIFI
+#if HAS_WIFI && !defined(ARCH_PORTDUINO)
 static uint32_t wifiPowerLossTimerStart = 0;
 static bool wifiPowerLossTimerActive = false;
 static bool wifiWasDisabledByPowerLoss = false;
@@ -967,7 +967,7 @@ void Power::readPowerStatus()
     }
 }
 
-#if HAS_WIFI
+#if HAS_WIFI && !defined(ARCH_PORTDUINO)
 /**
  * Handle automatic WiFi enable/disable based on power source.
  * When wifi_on_external_power_only is enabled:
@@ -1022,13 +1022,13 @@ void Power::handleWifiPowerManagement()
         }
     }
 }
-#endif // HAS_WIFI
+#endif // HAS_WIFI && !defined(ARCH_PORTDUINO)
 
 int32_t Power::runOnce()
 {
     readPowerStatus();
 
-#if HAS_WIFI
+#if HAS_WIFI && !defined(ARCH_PORTDUINO)
     handleWifiPowerManagement();
 #endif
 

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -743,6 +743,10 @@ void NodeDB::installDefaultConfig(bool preserveKey = false)
     config.network.ipv6_enabled = default_network_ipv6_enabled;
 #endif
 
+    // WiFi power management defaults
+    config.network.wifi_on_external_power_only = false;
+    config.network.wifi_power_loss_timeout_secs = 30;
+
 #ifdef DISPLAY_FLIP_SCREEN
     config.display.flip_screen = true;
 #endif

--- a/src/mesh/generated/meshtastic/config.pb.h
+++ b/src/mesh/generated/meshtastic/config.pb.h
@@ -469,6 +469,14 @@ typedef struct _meshtastic_Config_NetworkConfig {
     uint32_t enabled_protocols;
     /* Enable/Disable ipv6 support */
     bool ipv6_enabled;
+    /* Only enable WiFi when connected to external power (USB).
+     WiFi will be automatically disabled when running on battery
+     after wifi_power_loss_timeout_secs delay. */
+    bool wifi_on_external_power_only;
+    /* Delay in seconds before disabling WiFi after external power is lost.
+     This allows for brief power interruptions without toggling WiFi.
+     Default: 30 seconds. Set to 0 for immediate disable. */
+    uint32_t wifi_power_loss_timeout_secs;
 } meshtastic_Config_NetworkConfig;
 
 /* Display Config */
@@ -730,7 +738,7 @@ extern "C" {
 #define meshtastic_Config_DeviceConfig_init_default {_meshtastic_Config_DeviceConfig_Role_MIN, 0, 0, 0, _meshtastic_Config_DeviceConfig_RebroadcastMode_MIN, 0, 0, 0, 0, "", 0, _meshtastic_Config_DeviceConfig_BuzzerMode_MIN}
 #define meshtastic_Config_PositionConfig_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, _meshtastic_Config_PositionConfig_GpsMode_MIN}
 #define meshtastic_Config_PowerConfig_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0}
-#define meshtastic_Config_NetworkConfig_init_default {0, "", "", "", 0, _meshtastic_Config_NetworkConfig_AddressMode_MIN, false, meshtastic_Config_NetworkConfig_IpV4Config_init_default, "", 0, 0}
+#define meshtastic_Config_NetworkConfig_init_default {0, "", "", "", 0, _meshtastic_Config_NetworkConfig_AddressMode_MIN, false, meshtastic_Config_NetworkConfig_IpV4Config_init_default, "", 0, 0, 0, 0}
 #define meshtastic_Config_NetworkConfig_IpV4Config_init_default {0, 0, 0, 0}
 #define meshtastic_Config_DisplayConfig_init_default {0, _meshtastic_Config_DisplayConfig_DeprecatedGpsCoordinateFormat_MIN, 0, 0, 0, _meshtastic_Config_DisplayConfig_DisplayUnits_MIN, _meshtastic_Config_DisplayConfig_OledType_MIN, _meshtastic_Config_DisplayConfig_DisplayMode_MIN, 0, 0, _meshtastic_Config_DisplayConfig_CompassOrientation_MIN, 0, 0}
 #define meshtastic_Config_LoRaConfig_init_default {0, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, 0, 0, 0, 0, _meshtastic_Config_LoRaConfig_RegionCode_MIN, 0, 0, 0, 0, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0}
@@ -741,7 +749,7 @@ extern "C" {
 #define meshtastic_Config_DeviceConfig_init_zero {_meshtastic_Config_DeviceConfig_Role_MIN, 0, 0, 0, _meshtastic_Config_DeviceConfig_RebroadcastMode_MIN, 0, 0, 0, 0, "", 0, _meshtastic_Config_DeviceConfig_BuzzerMode_MIN}
 #define meshtastic_Config_PositionConfig_init_zero {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, _meshtastic_Config_PositionConfig_GpsMode_MIN}
 #define meshtastic_Config_PowerConfig_init_zero  {0, 0, 0, 0, 0, 0, 0, 0, 0}
-#define meshtastic_Config_NetworkConfig_init_zero {0, "", "", "", 0, _meshtastic_Config_NetworkConfig_AddressMode_MIN, false, meshtastic_Config_NetworkConfig_IpV4Config_init_zero, "", 0, 0}
+#define meshtastic_Config_NetworkConfig_init_zero {0, "", "", "", 0, _meshtastic_Config_NetworkConfig_AddressMode_MIN, false, meshtastic_Config_NetworkConfig_IpV4Config_init_zero, "", 0, 0, 0, 0}
 #define meshtastic_Config_NetworkConfig_IpV4Config_init_zero {0, 0, 0, 0}
 #define meshtastic_Config_DisplayConfig_init_zero {0, _meshtastic_Config_DisplayConfig_DeprecatedGpsCoordinateFormat_MIN, 0, 0, 0, _meshtastic_Config_DisplayConfig_DisplayUnits_MIN, _meshtastic_Config_DisplayConfig_OledType_MIN, _meshtastic_Config_DisplayConfig_DisplayMode_MIN, 0, 0, _meshtastic_Config_DisplayConfig_CompassOrientation_MIN, 0, 0}
 #define meshtastic_Config_LoRaConfig_init_zero   {0, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, 0, 0, 0, 0, _meshtastic_Config_LoRaConfig_RegionCode_MIN, 0, 0, 0, 0, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0}
@@ -798,6 +806,8 @@ extern "C" {
 #define meshtastic_Config_NetworkConfig_rsyslog_server_tag 9
 #define meshtastic_Config_NetworkConfig_enabled_protocols_tag 10
 #define meshtastic_Config_NetworkConfig_ipv6_enabled_tag 11
+#define meshtastic_Config_NetworkConfig_wifi_on_external_power_only_tag 12
+#define meshtastic_Config_NetworkConfig_wifi_power_loss_timeout_secs_tag 13
 #define meshtastic_Config_DisplayConfig_screen_on_secs_tag 1
 #define meshtastic_Config_DisplayConfig_gps_format_tag 2
 #define meshtastic_Config_DisplayConfig_auto_screen_carousel_secs_tag 3
@@ -1038,7 +1048,7 @@ extern const pb_msgdesc_t meshtastic_Config_SessionkeyConfig_msg;
 #define meshtastic_Config_DisplayConfig_size     34
 #define meshtastic_Config_LoRaConfig_size        85
 #define meshtastic_Config_NetworkConfig_IpV4Config_size 20
-#define meshtastic_Config_NetworkConfig_size     204
+#define meshtastic_Config_NetworkConfig_size     212
 #define meshtastic_Config_PositionConfig_size    62
 #define meshtastic_Config_PowerConfig_size       52
 #define meshtastic_Config_SecurityConfig_size    178

--- a/src/mesh/http/WebServer.cpp
+++ b/src/mesh/http/WebServer.cpp
@@ -247,4 +247,24 @@ void initWebServer()
         LOG_ERROR("Web Servers Failed! ;-( ");
     }
 }
+
+void deinitWebServer()
+{
+    LOG_DEBUG("Deinit Web Server");
+    isWebServerReady = false;
+
+    if (secureServer) {
+        secureServer->stop();
+        delete secureServer;
+        secureServer = nullptr;
+    }
+
+    if (insecureServer) {
+        insecureServer->stop();
+        delete insecureServer;
+        insecureServer = nullptr;
+    }
+
+    LOG_INFO("Web Servers Stopped");
+}
 #endif

--- a/src/mesh/http/WebServer.h
+++ b/src/mesh/http/WebServer.h
@@ -6,6 +6,7 @@
 #include <functional>
 
 void initWebServer();
+void deinitWebServer();
 void createSSLCert();
 
 class WebServerThread : private concurrency::OSThread

--- a/src/mesh/udp/UdpMulticastHandler.h
+++ b/src/mesh/udp/UdpMulticastHandler.h
@@ -42,7 +42,9 @@ class UdpMulticastHandler final
     void stop()
     {
         LOG_DEBUG("Stopping UDP Multicast");
+#ifdef ARCH_ESP32
         udp.close();
+#endif
     }
 
     void onReceive(AsyncUDPPacket packet)

--- a/src/mesh/udp/UdpMulticastHandler.h
+++ b/src/mesh/udp/UdpMulticastHandler.h
@@ -39,6 +39,12 @@ class UdpMulticastHandler final
         }
     }
 
+    void stop()
+    {
+        LOG_DEBUG("Stopping UDP Multicast");
+        udp.close();
+    }
+
     void onReceive(AsyncUDPPacket packet)
     {
         size_t packetLength = packet.length();

--- a/src/power.h
+++ b/src/power.h
@@ -103,6 +103,9 @@ class Power : private concurrency::OSThread
 
     void powerCommandsCheck();
     void readPowerStatus();
+#if HAS_WIFI
+    void handleWifiPowerManagement();
+#endif
     virtual bool setup();
     virtual int32_t runOnce() override;
     void setStatusHandler(meshtastic::PowerStatus *handler) { statusHandler = handler; }

--- a/src/power.h
+++ b/src/power.h
@@ -103,7 +103,7 @@ class Power : private concurrency::OSThread
 
     void powerCommandsCheck();
     void readPowerStatus();
-#if HAS_WIFI
+#if HAS_WIFI && !defined(ARCH_PORTDUINO)
     void handleWifiPowerManagement();
 #endif
     virtual bool setup();


### PR DESCRIPTION
## Summary

Implement automatic WiFi management based on power source. When enabled, WiFi is automatically disabled when running on battery and re-enabled when external power is connected.

- Add `wifi_on_external_power_only` config option to enable feature
- Add `wifi_power_loss_timeout_secs` config option for delay before disabling WiFi (default: 30s)
- Implement proper WiFi hot toggle without device reboot

## Use Case

**Docked mode (at home, charging):**
- Node connected to USB power
- WiFi enabled for web UI access from PC, MQTT, remote management

**Portable mode (on the go):**
- Node running on battery
- WiFi not needed — phone connects via BLE
- WiFi wastes ~100-150mA for no benefit

## Implementation

### WiFi Service Cleanup (hot toggle support)
- Add `deinitWebServer()` to stop HTTPS/HTTP servers
- Add `stop()` method to `UdpMulticastHandler`
- Add `deinitWifiServices()` to properly shutdown all WiFi-dependent services (mDNS, NTP, Syslog, WebServer, API Server)
- Reset `APStartupComplete` flag to allow service reinitialization on reconnect

### Power-Based WiFi Control
- `handleWifiPowerManagement()` in `Power.cpp` monitors USB power state
- Timer-based approach prevents WiFi toggle on brief power interruptions
- WiFi automatically re-enables when external power is restored

## Dependencies

- Protobufs PR: https://github.com/meshtastic/protobufs/pull/851

## Test Plan

- [ ] Build for ESP32-S3 target
- [ ] Verify WiFi connects normally with external power
- [ ] Disconnect USB, wait 30s — verify WiFi disabled
- [ ] Reconnect USB — verify WiFi re-enables
- [ ] Test "accidental unplug" — disconnect and reconnect within 30s — WiFi should stay on
- [ ] Monitor heap usage for memory leaks

## Platforms

- [x] ESP32 (tested build: seeed-xiao-s3)
- [ ] RP2040 (untested, should work)
- [ ] Linux Native (untested, should work)

Closes: https://github.com/meshtastic/firmware/issues/9427