### PR TITLE
Remove the unused OCV_ARRAYs and move one to a variant.h

### DIFF
--- a/src/power.h
+++ b/src/power.h
@@ -15,19 +15,7 @@
 
 // Device specific curves go in variant.h
 #ifndef OCV_ARRAY
-#ifdef CELL_TYPE_LIFEPO4
-#define OCV_ARRAY 3400, 3350, 3320, 3290, 3270, 3260, 3250, 3230, 3200, 3120, 3000
-#elif defined(CELL_TYPE_LEADACID)
-#define OCV_ARRAY 2120, 2090, 2070, 2050, 2030, 2010, 1990, 1980, 1970, 1960, 1950
-#elif defined(CELL_TYPE_ALKALINE)
-#define OCV_ARRAY 1580, 1400, 1350, 1300, 1280, 1250, 1230, 1190, 1150, 1100, 1000
-#elif defined(CELL_TYPE_NIMH)
-#define OCV_ARRAY 1400, 1300, 1280, 1270, 1260, 1250, 1240, 1230, 1210, 1150, 1000
-#elif defined(CELL_TYPE_LTO)
-#define OCV_ARRAY 2700, 2560, 2540, 2520, 2500, 2460, 2420, 2400, 2380, 2320, 1500
-#else // LiIon
 #define OCV_ARRAY 4190, 4050, 3990, 3890, 3800, 3720, 3630, 3530, 3420, 3300, 3100
-#endif
 #endif
 
 /*Note: 12V lead acid is 6 cells, most board accept only 1 cell LiIon/LiPo*/

--- a/variants/esp32/chatter2/variant.h
+++ b/variants/esp32/chatter2/variant.h
@@ -79,7 +79,7 @@
                            // lower dB for lower voltage rnage
 #define ADC_MULTIPLIER 5.0 // VBATT---10k--pin34---2.5K---GND
 // Chatter2 uses 3 AAA cells
-#define CELL_TYPE_ALKALINE
+#define OCV_ARRAY 1580, 1400, 1350, 1300, 1280, 1250, 1230, 1190, 1150, 1100, 1000
 #define NUM_CELLS 3
 #undef EXT_PWR_DETECT
 


### PR DESCRIPTION
Most of the OCV_ARRAY entries were completely unused. Remove these, and move the one non-default to its proper variant.h
Custom hardware should define this string in variant.h