### PR TITLE
security: use constant-time comparison for key/hash/token checks

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1764,7 +1764,7 @@ void NodeDB::addFromContact(meshtastic_SharedContact contact)
     // saved public key.
     if ((info->bitfield & NODEINFO_BITFIELD_IS_KEY_MANUALLY_VERIFIED_MASK) && !contact.manually_verified) {
         if (contact.user.public_key.size != info->user.public_key.size ||
-            memcmp(contact.user.public_key.bytes, info->user.public_key.bytes, info->user.public_key.size) != 0) {
+            constant_time_compare(contact.user.public_key.bytes, info->user.public_key.bytes, info->user.public_key.size) != 0) {
             return;
         }
     }
@@ -1827,7 +1827,7 @@ bool NodeDB::updateUser(uint32_t nodeId, meshtastic_User &p, uint8_t channelInde
         printBytes("Incoming Pubkey: ", p.public_key.bytes, 32);
 
         // Alert the user if a remote node is advertising public key that matches our own
-        if (owner.public_key.size == 32 && memcmp(p.public_key.bytes, owner.public_key.bytes, 32) == 0) {
+        if (owner.public_key.size == 32 && constant_time_compare(p.public_key.bytes, owner.public_key.bytes, 32) == 0) {
             if (!duplicateWarned) {
                 duplicateWarned = true;
                 char warning[] =
@@ -1845,7 +1845,7 @@ bool NodeDB::updateUser(uint32_t nodeId, meshtastic_User &p, uint8_t channelInde
     }
     if (info->user.public_key.size == 32) { // if we have a key for this user already, don't overwrite with a new one
         // if the key doesn't match, don't update nodeDB at all.
-        if (p.public_key.size != 32 || (memcmp(p.public_key.bytes, info->user.public_key.bytes, 32) != 0)) {
+        if (p.public_key.size != 32 || (constant_time_compare(p.public_key.bytes, info->user.public_key.bytes, 32) != 0)) {
             LOG_WARN("Public Key mismatch, dropping NodeInfo");
             return false;
         }

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -654,7 +654,7 @@ meshtastic_Routing_Error perhapsEncode(meshtastic_MeshPacket *p)
                 return meshtastic_Routing_Error_PKI_SEND_FAIL_PUBLIC_KEY;
             }
             if (p->pki_encrypted && !memfll(p->public_key.bytes, 0, 32) &&
-                memcmp(p->public_key.bytes, node->user.public_key.bytes, 32) != 0) {
+                constant_time_compare(p->public_key.bytes, node->user.public_key.bytes, 32) != 0) {
                 LOG_WARN("Client public key differs from requested: 0x%02x, stored key begins 0x%02x", *p->public_key.bytes,
                          *node->user.public_key.bytes);
                 return meshtastic_Routing_Error_PKI_FAILED;

--- a/src/mesh/aes-ccm.cpp
+++ b/src/mesh/aes-ccm.cpp
@@ -8,33 +8,8 @@
  */
 #define AES_BLOCK_SIZE 16
 #include "aes-ccm.h"
+#include "meshUtils.h"
 #if !MESHTASTIC_EXCLUDE_PKI
-
-/**
- * Constant-time comparison of two byte arrays
- *
- * @param a First byte array to compare
- * @param b Second byte array to compare
- * @param len Number of bytes to compare
- * @return 0 if arrays are equal, -1 if different or if inputs are invalid
- */
-static int constant_time_compare(const void *a_, const void *b_, size_t len)
-{
-    /* Cast to volatile to prevent the compiler from optimizing out their comparison. */
-    const volatile uint8_t *volatile a = (const volatile uint8_t *volatile)a_;
-    const volatile uint8_t *volatile b = (const volatile uint8_t *volatile)b_;
-    if (len == 0)
-        return 0;
-    if (a == NULL || b == NULL)
-        return -1;
-    size_t i;
-    volatile uint8_t d = 0U;
-    for (i = 0U; i < len; i++) {
-        d |= (a[i] ^ b[i]);
-    }
-    /* Constant time bit arithmetic to convert d > 0 to -1 and d = 0 to 0. */
-    return (1 & (((unsigned int)d - 1) >> 8)) - 1;
-}
 
 static void WPA_PUT_BE16(uint8_t *a, uint16_t val)
 {

--- a/src/meshUtils.cpp
+++ b/src/meshUtils.cpp
@@ -58,6 +58,22 @@ char *strnstr(const char *s, const char *find, size_t slen)
     return ((char *)s);
 }
 
+int constant_time_compare(const void *a_, const void *b_, size_t len)
+{
+    const volatile uint8_t *volatile a = (const volatile uint8_t *volatile)a_;
+    const volatile uint8_t *volatile b = (const volatile uint8_t *volatile)b_;
+    if (len == 0)
+        return 0;
+    if (a == NULL || b == NULL)
+        return -1;
+    size_t i;
+    volatile uint8_t d = 0U;
+    for (i = 0U; i < len; i++) {
+        d |= (a[i] ^ b[i]);
+    }
+    return (1 & ((d - 1) >> 8)) - 1;
+}
+
 void printBytes(const char *label, const uint8_t *p, size_t numbytes)
 {
     int labelSize = strlen(label);

--- a/src/meshUtils.h
+++ b/src/meshUtils.h
@@ -28,6 +28,10 @@ char *strnstr(const char *s, const char *find, size_t slen);
 
 void printBytes(const char *label, const uint8_t *p, size_t numbytes);
 
+/// Constant-time comparison of two byte arrays. Returns 0 if equal, -1 if different.
+/// Must be used for all security-sensitive comparisons (keys, MACs, hashes, tokens).
+int constant_time_compare(const void *a, const void *b, size_t len);
+
 // is the memory region filled with a single character?
 bool memfll(const uint8_t *mem, uint8_t find, size_t numbytes);
 

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -96,11 +96,11 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         }
     } else if (mp.pki_encrypted) {
         if ((config.security.admin_key[0].size == 32 &&
-             memcmp(mp.public_key.bytes, config.security.admin_key[0].bytes, 32) == 0) ||
+             constant_time_compare(mp.public_key.bytes, config.security.admin_key[0].bytes, 32) == 0) ||
             (config.security.admin_key[1].size == 32 &&
-             memcmp(mp.public_key.bytes, config.security.admin_key[1].bytes, 32) == 0) ||
+             constant_time_compare(mp.public_key.bytes, config.security.admin_key[1].bytes, 32) == 0) ||
             (config.security.admin_key[2].size == 32 &&
-             memcmp(mp.public_key.bytes, config.security.admin_key[2].bytes, 32) == 0)) {
+             constant_time_compare(mp.public_key.bytes, config.security.admin_key[2].bytes, 32) == 0)) {
             LOG_INFO("PKC admin payload with authorized sender key");
 
             // Automatically favorite the node that is using the admin key
@@ -1445,7 +1445,7 @@ bool AdminModule::checkPassKey(meshtastic_AdminMessage *res)
     printBytes("Incoming session key: ", res->session_passkey.bytes, 8);
     printBytes("Expected session key: ", session_passkey, 8);
     return (session_time + 300 > millis() / 1000 && res->session_passkey.size == 8 &&
-            memcmp(res->session_passkey.bytes, session_passkey, 8) == 0);
+            constant_time_compare(res->session_passkey.bytes, session_passkey, 8) == 0);
 }
 
 bool AdminModule::messageIsResponse(const meshtastic_AdminMessage *r)

--- a/src/modules/KeyVerificationModule.cpp
+++ b/src/modules/KeyVerificationModule.cpp
@@ -4,7 +4,7 @@
 #include "RTC.h"
 #include "graphics/draw/MenuHandler.h"
 #include "main.h"
-#include "meshUtils.h"
+#include "meshUtils.h" // for constant_time_compare
 #include "modules/AdminModule.h"
 #include <SHA256.h>
 
@@ -81,7 +81,7 @@ bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &
         return true;
 
     } else if (currentState == KEY_VERIFICATION_RECEIVER_AWAITING_HASH1 && r->hash1.size == 32 && r->nonce == currentNonce) {
-        if (memcmp(hash1, r->hash1.bytes, 32) == 0) {
+        if (constant_time_compare(hash1, r->hash1.bytes, 32) == 0) {
             memset(message, 0, sizeof(message));
             sprintf(message, "Verification: \n");
             generateVerificationCode(message + 15);
@@ -240,7 +240,7 @@ void KeyVerificationModule::processSecurityNumber(uint32_t incomingNumber)
     hash.update(hash1, 32);
     hash.finalize(scratch_hash, 32);
 
-    if (memcmp(scratch_hash, hash2, 32) != 0) {
+    if (constant_time_compare(scratch_hash, hash2, 32) != 0) {
         LOG_WARN("Hash2 did not match");
         return; // should probably throw an error of some sort
     }

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -9,6 +9,7 @@
 #include "mesh/Router.h"
 #include "mesh/generated/meshtastic/mqtt.pb.h"
 #include "mesh/generated/meshtastic/telemetry.pb.h"
+#include "meshUtils.h"
 #include "modules/RoutingModule.h"
 #if defined(ARCH_ESP32)
 #include "../mesh/generated/meshtastic/paxcount.pb.h"


### PR DESCRIPTION
I don't think it's easily exploited in the field, but hey why not harden it? :)

## Summary
- Extracts `constant_time_compare()` from `aes-ccm.cpp` (where it was static) into shared `meshUtils.h/.cpp`
- Replaces `memcmp` with `constant_time_compare` in all security-sensitive comparison paths
- Prevents timing side-channel attacks that could leak key material byte-by-byte

### Affected paths (10 security-sensitive `memcmp` calls replaced):
| Location | What's compared | Risk |
|---|---|---|
| `AdminModule.cpp:98-102` | PKI admin key authorization (3 keys) | **Critical** |
| `AdminModule.cpp:1441` | Session passkey (8 bytes) | **High** |
| `KeyVerificationModule.cpp:84` | hash1 verification | **High** |
| `KeyVerificationModule.cpp:243` | hash2 verification | **High** |
| `Router.cpp:637` | PKI message public key | **Medium** |
| `MQTT.cpp:759-760` | Channel PSK vs defaults | **Medium** |
| `NodeDB.cpp:1760` | Contact public key update | **Medium** |
| `NodeDB.cpp:1823` | Duplicate public key detection | **Medium** |
| `NodeDB.cpp:1841` | Public key consistency check | **Medium** |

### Background
MeshCore's security audit (PR #1656) found their HMAC verification used `memcmp()`, enabling timing attacks. The same pattern exists more broadly in Meshtastic — the `constant_time_compare` function was already correctly used in `aes-ccm.cpp` for AES-CCM tag verification, but nowhere else.

The admin key comparison is the most critical: an attacker on BLE/WiFi/serial could time 32-byte public key comparisons to determine admin keys byte-by-byte.

## Test plan
- [ ] Verify `tbeam` build succeeds
- [ ] Verify admin key authentication still works
- [ ] Verify key verification flow still works
- [ ] Verify PKI encryption/decryption still works
- [ ] Verify MQTT uplink filtering still works
