### PR TITLE
security: replace sprintf/strcpy with bounds-checked variants

### DIFF
--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -136,9 +136,11 @@ std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels)
         } else {
             meshtastic_FileInfo fileInfo = {"", static_cast<uint32_t>(file.size())};
 #ifdef ARCH_ESP32
-            strcpy(fileInfo.file_name, file.path());
+            strncpy(fileInfo.file_name, file.path(), sizeof(fileInfo.file_name) - 1);
+            fileInfo.file_name[sizeof(fileInfo.file_name) - 1] = '\0';
 #else
-            strcpy(fileInfo.file_name, file.name());
+            strncpy(fileInfo.file_name, file.name(), sizeof(fileInfo.file_name) - 1);
+            fileInfo.file_name[sizeof(fileInfo.file_name) - 1] = '\0';
 #endif
             if (!String(fileInfo.file_name).endsWith(".")) {
                 filenames.push_back(fileInfo);

--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -11,6 +11,7 @@
 #include "FSCommon.h"
 #include "SPILock.h"
 #include "configuration.h"
+#include <assert.h>
 
 // Software SPI is used by MUI so disable SD card here until it's also implemented
 #if defined(HAS_SDCARD) && !defined(SDCARD_USE_SOFT_SPI)
@@ -136,12 +137,16 @@ std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels)
         } else {
             meshtastic_FileInfo fileInfo = {"", static_cast<uint32_t>(file.size())};
 #ifdef ARCH_ESP32
-            strncpy(fileInfo.file_name, file.path(), sizeof(fileInfo.file_name) - 1);
-            fileInfo.file_name[sizeof(fileInfo.file_name) - 1] = '\0';
+            const char *fname = file.path();
 #else
-            strncpy(fileInfo.file_name, file.name(), sizeof(fileInfo.file_name) - 1);
-            fileInfo.file_name[sizeof(fileInfo.file_name) - 1] = '\0';
+            const char *fname = file.name();
 #endif
+            size_t fnameLen = strlen(fname);
+            if (fnameLen >= sizeof(fileInfo.file_name))
+                LOG_WARN("File path truncated: %s", fname);
+            assert(fnameLen < sizeof(fileInfo.file_name));
+            strncpy(fileInfo.file_name, fname, sizeof(fileInfo.file_name) - 1);
+            fileInfo.file_name[sizeof(fileInfo.file_name) - 1] = '\0';
             if (!String(fileInfo.file_name).endsWith(".")) {
                 filenames.push_back(fileInfo);
             }

--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -230,9 +230,11 @@ void RedirectablePrint::log_to_ble(const char *logLevel, const char *format, va_
             auto thread = concurrency::OSThread::currentThread;
             meshtastic_LogRecord logRecord = meshtastic_LogRecord_init_zero;
             logRecord.level = getLogLevel(logLevel);
-            vsprintf(logRecord.message, format, arg);
-            if (thread)
-                strcpy(logRecord.source, thread->ThreadName.c_str());
+            vsnprintf(logRecord.message, sizeof(logRecord.message), format, arg);
+            if (thread) {
+                strncpy(logRecord.source, thread->ThreadName.c_str(), sizeof(logRecord.source) - 1);
+                logRecord.source[sizeof(logRecord.source) - 1] = '\0';
+            }
             logRecord.time = getValidTime(RTCQuality::RTCQualityDevice, true);
 
             auto buffer = std::unique_ptr<uint8_t[]>(new uint8_t[meshtastic_LogRecord_size]);

--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -232,6 +232,7 @@ void RedirectablePrint::log_to_ble(const char *logLevel, const char *format, va_
             logRecord.level = getLogLevel(logLevel);
             vsnprintf(logRecord.message, sizeof(logRecord.message), format, arg);
             if (thread) {
+                assert(strlen(thread->ThreadName.c_str()) < sizeof(logRecord.source));
                 strncpy(logRecord.source, thread->ThreadName.c_str(), sizeof(logRecord.source) - 1);
                 logRecord.source[sizeof(logRecord.source) - 1] = '\0';
             }

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -25,6 +25,7 @@
 #include "modules/NeighborInfoModule.h"
 #include <ErriezCRC32.h>
 #include <algorithm>
+#include <assert.h>
 #include <pb_decode.h>
 #include <pb_encode.h>
 #include <power/PowerHAL.h>
@@ -1837,7 +1838,13 @@ bool NodeDB::updateUser(uint32_t nodeId, meshtastic_User &p, uint8_t channelInde
                 meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
                 cn->level = meshtastic_LogRecord_Level_WARNING;
                 cn->time = getValidTime(RTCQualityFromNet);
-                snprintf(cn->message, sizeof(cn->message), warning, p.long_name);
+                int written = snprintf(cn->message, sizeof(cn->message), warning, p.long_name);
+                if (written < 0 || (size_t)written >= sizeof(cn->message)) {
+                    LOG_ERROR("Duplicate key warning truncated (wrote %d, buf %u)", written, sizeof(cn->message));
+                    assert(false);
+                    snprintf(cn->message, sizeof(cn->message),
+                             "Remote device is advertising your public key. Possible key compromise.");
+                }
                 service->sendClientNotification(cn);
             }
             return false;

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1837,7 +1837,7 @@ bool NodeDB::updateUser(uint32_t nodeId, meshtastic_User &p, uint8_t channelInde
                 meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
                 cn->level = meshtastic_LogRecord_Level_WARNING;
                 cn->time = getValidTime(RTCQualityFromNet);
-                sprintf(cn->message, warning, p.long_name);
+                snprintf(cn->message, sizeof(cn->message), warning, p.long_name);
                 service->sendClientNotification(cn);
             }
             return false;

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -120,7 +120,7 @@ void DetectionSensorModule::sendDetectionMessage()
 {
     LOG_DEBUG("Detected event observed. Send message");
     char *message = new char[40];
-    sprintf(message, "%s detected", moduleConfig.detection_sensor.name);
+    snprintf(message, 40, "%s detected", moduleConfig.detection_sensor.name);
     meshtastic_MeshPacket *p = allocDataPacket();
     p->want_ack = false;
     p->decoded.payload.size = strlen(message);
@@ -142,7 +142,7 @@ void DetectionSensorModule::sendDetectionMessage()
 void DetectionSensorModule::sendCurrentStateMessage(bool state)
 {
     char *message = new char[40];
-    sprintf(message, "%s state: %i", moduleConfig.detection_sensor.name, state);
+    snprintf(message, 40, "%s state: %i", moduleConfig.detection_sensor.name, state);
     meshtastic_MeshPacket *p = allocDataPacket();
     p->want_ack = false;
     p->decoded.payload.size = strlen(message);

--- a/src/modules/DropzoneModule.cpp
+++ b/src/modules/DropzoneModule.cpp
@@ -32,13 +32,15 @@ ProcessMessage DropzoneModule::handleReceived(const meshtastic_MeshPacket &mp)
     auto &p = mp.decoded;
     char matchCompare[54];
     auto incomingMessage = reinterpret_cast<const char *>(p.payload.bytes);
-    snprintf(matchCompare, sizeof(matchCompare), "%s conditions", owner.short_name);
+    int written = snprintf(matchCompare, sizeof(matchCompare), "%s conditions", owner.short_name);
+    assert(written >= 0 && (size_t)written < sizeof(matchCompare)); // short_name max 4 chars + " conditions" = 15 << 54
     if (strncasecmp(incomingMessage, matchCompare, strlen(matchCompare)) == 0) {
         LOG_DEBUG("Received dropzone conditions request");
         startSendConditions = millis();
     }
 
-    snprintf(matchCompare, sizeof(matchCompare), "%s conditions", owner.long_name);
+    written = snprintf(matchCompare, sizeof(matchCompare), "%s conditions", owner.long_name);
+    assert(written >= 0 && (size_t)written < sizeof(matchCompare)); // long_name max 39 chars + " conditions" = 50 < 54
     if (strncasecmp(incomingMessage, matchCompare, strlen(matchCompare)) == 0) {
         LOG_DEBUG("Received dropzone conditions request");
         startSendConditions = millis();
@@ -70,6 +72,7 @@ meshtastic_MeshPacket *DropzoneModule::sendConditions()
     auto reply = allocDataPacket();
 
     auto node = nodeDB->getMeshNode(nodeDB->getNodeNum());
+    int written;
     if (sensor.hasSensor()) {
         meshtastic_Telemetry telemetry = meshtastic_Telemetry_init_zero;
         sensor.getMetrics(&telemetry);
@@ -77,12 +80,15 @@ meshtastic_MeshPacket *DropzoneModule::sendConditions()
         auto windDirection = telemetry.variant.environment_metrics.wind_direction;
         auto temp = telemetry.variant.environment_metrics.temperature;
         auto baro = UnitConversions::HectoPascalToInchesOfMercury(telemetry.variant.environment_metrics.barometric_pressure);
-        snprintf(replyStr, sizeof(replyStr), "%s @ %02d:%02d:%02dz\nWind %.2f kts @ %d°\nBaro %.2f inHg %.2f°C", dropzoneStatus,
-                 hour, min, sec, windSpeed, windDirection, baro, temp);
+        written = snprintf(replyStr, sizeof(replyStr), "%s @ %02d:%02d:%02dz\nWind %.2f kts @ %d°\nBaro %.2f inHg %.2f°C",
+                           dropzoneStatus, hour, min, sec, windSpeed, windDirection, baro, temp);
     } else {
         LOG_ERROR("No sensor found");
-        snprintf(replyStr, sizeof(replyStr), "%s @ %02d:%02d:%02d\nNo sensor found", dropzoneStatus, hour, min, sec);
+        written = snprintf(replyStr, sizeof(replyStr), "%s @ %02d:%02d:%02d\nNo sensor found", dropzoneStatus, hour, min, sec);
     }
+    if (written < 0 || (size_t)written >= sizeof(replyStr))
+        LOG_ERROR("replyStr truncated (wrote %d, buf %u)", written, sizeof(replyStr));
+    assert(written >= 0 && (size_t)written < sizeof(replyStr));
     LOG_DEBUG("Conditions reply: %s", replyStr);
     reply->decoded.payload.size = strlen(replyStr); // You must specify how many bytes are in the reply
     memcpy(reply->decoded.payload.bytes, replyStr, reply->decoded.payload.size);

--- a/src/modules/DropzoneModule.cpp
+++ b/src/modules/DropzoneModule.cpp
@@ -32,13 +32,13 @@ ProcessMessage DropzoneModule::handleReceived(const meshtastic_MeshPacket &mp)
     auto &p = mp.decoded;
     char matchCompare[54];
     auto incomingMessage = reinterpret_cast<const char *>(p.payload.bytes);
-    sprintf(matchCompare, "%s conditions", owner.short_name);
+    snprintf(matchCompare, sizeof(matchCompare), "%s conditions", owner.short_name);
     if (strncasecmp(incomingMessage, matchCompare, strlen(matchCompare)) == 0) {
         LOG_DEBUG("Received dropzone conditions request");
         startSendConditions = millis();
     }
 
-    sprintf(matchCompare, "%s conditions", owner.long_name);
+    snprintf(matchCompare, sizeof(matchCompare), "%s conditions", owner.long_name);
     if (strncasecmp(incomingMessage, matchCompare, strlen(matchCompare)) == 0) {
         LOG_DEBUG("Received dropzone conditions request");
         startSendConditions = millis();
@@ -77,11 +77,11 @@ meshtastic_MeshPacket *DropzoneModule::sendConditions()
         auto windDirection = telemetry.variant.environment_metrics.wind_direction;
         auto temp = telemetry.variant.environment_metrics.temperature;
         auto baro = UnitConversions::HectoPascalToInchesOfMercury(telemetry.variant.environment_metrics.barometric_pressure);
-        sprintf(replyStr, "%s @ %02d:%02d:%02dz\nWind %.2f kts @ %d°\nBaro %.2f inHg %.2f°C", dropzoneStatus, hour, min, sec,
-                windSpeed, windDirection, baro, temp);
+        snprintf(replyStr, sizeof(replyStr), "%s @ %02d:%02d:%02dz\nWind %.2f kts @ %d°\nBaro %.2f inHg %.2f°C", dropzoneStatus,
+                 hour, min, sec, windSpeed, windDirection, baro, temp);
     } else {
         LOG_ERROR("No sensor found");
-        sprintf(replyStr, "%s @ %02d:%02d:%02d\nNo sensor found", dropzoneStatus, hour, min, sec);
+        snprintf(replyStr, sizeof(replyStr), "%s @ %02d:%02d:%02d\nNo sensor found", dropzoneStatus, hour, min, sec);
     }
     LOG_DEBUG("Conditions reply: %s", replyStr);
     reply->decoded.payload.size = strlen(replyStr); // You must specify how many bytes are in the reply

--- a/src/modules/KeyVerificationModule.cpp
+++ b/src/modules/KeyVerificationModule.cpp
@@ -69,7 +69,7 @@ bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &
 
         meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
         cn->level = meshtastic_LogRecord_Level_WARNING;
-        sprintf(cn->message, "Enter Security Number for Key Verification");
+        snprintf(cn->message, sizeof(cn->message), "Enter Security Number for Key Verification");
         cn->which_payload_variant = meshtastic_ClientNotification_key_verification_number_request_tag;
         cn->payload_variant.key_verification_number_request.nonce = currentNonce;
         strncpy(cn->payload_variant.key_verification_number_request.remote_longname, // should really check for nulls, etc
@@ -83,7 +83,7 @@ bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &
     } else if (currentState == KEY_VERIFICATION_RECEIVER_AWAITING_HASH1 && r->hash1.size == 32 && r->nonce == currentNonce) {
         if (memcmp(hash1, r->hash1.bytes, 32) == 0) {
             memset(message, 0, sizeof(message));
-            sprintf(message, "Verification: \n");
+            snprintf(message, sizeof(message), "Verification: \n");
             generateVerificationCode(message + 15);
             LOG_INFO("Hash1 matches!");
             static const char *optionsArray[] = {"Reject", "Accept"};
@@ -101,7 +101,7 @@ bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &
                       screen->showOverlayBanner(options);)
             meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
             cn->level = meshtastic_LogRecord_Level_WARNING;
-            sprintf(cn->message, "Final confirmation for incoming manual key verification %s", message);
+            snprintf(cn->message, sizeof(cn->message), "Final confirmation for incoming manual key verification %s", message);
             cn->which_payload_variant = meshtastic_ClientNotification_key_verification_final_tag;
             cn->payload_variant.key_verification_final.nonce = currentNonce;
             strncpy(cn->payload_variant.key_verification_final.remote_longname, // should really check for nulls, etc
@@ -198,8 +198,8 @@ meshtastic_MeshPacket *KeyVerificationModule::allocReply()
               screen->showSimpleBanner(message, 30000); LOG_WARN("%s", message);)
     meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
     cn->level = meshtastic_LogRecord_Level_WARNING;
-    sprintf(cn->message, "Incoming Key Verification.\nSecurity Number\n%03u %03u", currentSecurityNumber / 1000,
-            currentSecurityNumber % 1000);
+    snprintf(cn->message, sizeof(cn->message), "Incoming Key Verification.\nSecurity Number\n%03u %03u",
+             currentSecurityNumber / 1000, currentSecurityNumber % 1000);
     cn->which_payload_variant = meshtastic_ClientNotification_key_verification_number_inform_tag;
     cn->payload_variant.key_verification_number_inform.nonce = currentNonce;
     strncpy(cn->payload_variant.key_verification_number_inform.remote_longname, // should really check for nulls, etc
@@ -262,7 +262,7 @@ void KeyVerificationModule::processSecurityNumber(uint32_t incomingNumber)
     IF_SCREEN(screen->requestMenu(graphics::menuHandler::KeyVerificationFinalPrompt);)
     meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
     cn->level = meshtastic_LogRecord_Level_WARNING;
-    sprintf(cn->message, "Final confirmation for outgoing manual key verification %s", message);
+    snprintf(cn->message, sizeof(cn->message), "Final confirmation for outgoing manual key verification %s", message);
     cn->which_payload_variant = meshtastic_ClientNotification_key_verification_final_tag;
     cn->payload_variant.key_verification_final.nonce = currentNonce;
     strncpy(cn->payload_variant.key_verification_final.remote_longname, // should really check for nulls, etc

--- a/src/modules/KeyVerificationModule.cpp
+++ b/src/modules/KeyVerificationModule.cpp
@@ -7,6 +7,7 @@
 #include "meshUtils.h"
 #include "modules/AdminModule.h"
 #include <SHA256.h>
+#include <assert.h>
 
 KeyVerificationModule *keyVerificationModule;
 
@@ -69,12 +70,18 @@ bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &
 
         meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
         cn->level = meshtastic_LogRecord_Level_WARNING;
-        snprintf(cn->message, sizeof(cn->message), "Enter Security Number for Key Verification");
+        int written = snprintf(cn->message, sizeof(cn->message), "Enter Security Number for Key Verification");
+        assert(written >= 0 && (size_t)written < sizeof(cn->message)); // 43 chars << 400 bytes
         cn->which_payload_variant = meshtastic_ClientNotification_key_verification_number_request_tag;
         cn->payload_variant.key_verification_number_request.nonce = currentNonce;
-        strncpy(cn->payload_variant.key_verification_number_request.remote_longname, // should really check for nulls, etc
-                nodeDB->getMeshNode(currentRemoteNode)->user.long_name,
-                sizeof(cn->payload_variant.key_verification_number_request.remote_longname));
+        auto &dst1 = cn->payload_variant.key_verification_number_request.remote_longname;
+        const char *src1 = nodeDB->getMeshNode(currentRemoteNode)->user.long_name;
+        size_t len1 = strlen(src1);
+        if (len1 >= sizeof(dst1))
+            LOG_ERROR("remote_longname truncated for number_request");
+        assert(len1 < sizeof(dst1)); // both are char[40]
+        strncpy(dst1, src1, sizeof(dst1));
+        dst1[sizeof(dst1) - 1] = '\0';
         service->sendClientNotification(cn);
         LOG_INFO("Received hash2");
         currentState = KEY_VERIFICATION_SENDER_AWAITING_NUMBER;
@@ -83,7 +90,8 @@ bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &
     } else if (currentState == KEY_VERIFICATION_RECEIVER_AWAITING_HASH1 && r->hash1.size == 32 && r->nonce == currentNonce) {
         if (memcmp(hash1, r->hash1.bytes, 32) == 0) {
             memset(message, 0, sizeof(message));
-            snprintf(message, sizeof(message), "Verification: \n");
+            int written = snprintf(message, sizeof(message), "Verification: \n");
+            assert(written >= 0 && (size_t)written < sizeof(message)); // 16 chars << 40 bytes
             generateVerificationCode(message + 15);
             LOG_INFO("Hash1 matches!");
             static const char *optionsArray[] = {"Reject", "Accept"};
@@ -101,12 +109,21 @@ bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &
                       screen->showOverlayBanner(options);)
             meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
             cn->level = meshtastic_LogRecord_Level_WARNING;
-            snprintf(cn->message, sizeof(cn->message), "Final confirmation for incoming manual key verification %s", message);
+            written =
+                snprintf(cn->message, sizeof(cn->message), "Final confirmation for incoming manual key verification %s", message);
+            if (written < 0 || (size_t)written >= sizeof(cn->message))
+                LOG_ERROR("Final confirmation message truncated");
+            assert(written >= 0 && (size_t)written < sizeof(cn->message));
             cn->which_payload_variant = meshtastic_ClientNotification_key_verification_final_tag;
             cn->payload_variant.key_verification_final.nonce = currentNonce;
-            strncpy(cn->payload_variant.key_verification_final.remote_longname, // should really check for nulls, etc
-                    nodeDB->getMeshNode(currentRemoteNode)->user.long_name,
-                    sizeof(cn->payload_variant.key_verification_final.remote_longname));
+            auto &dst2 = cn->payload_variant.key_verification_final.remote_longname;
+            const char *src2 = nodeDB->getMeshNode(currentRemoteNode)->user.long_name;
+            size_t len2 = strlen(src2);
+            if (len2 >= sizeof(dst2))
+                LOG_ERROR("remote_longname truncated for key_verification_final");
+            assert(len2 < sizeof(dst2)); // both are char[40]
+            strncpy(dst2, src2, sizeof(dst2));
+            dst2[sizeof(dst2) - 1] = '\0';
             cn->payload_variant.key_verification_final.isSender = false;
             service->sendClientNotification(cn);
 
@@ -194,17 +211,28 @@ meshtastic_MeshPacket *KeyVerificationModule::allocReply()
     responsePacket = allocDataProtobuf(response);
 
     responsePacket->pki_encrypted = true;
-    IF_SCREEN(snprintf(message, 25, "Security Number \n%03u %03u", currentSecurityNumber / 1000, currentSecurityNumber % 1000);
-              screen->showSimpleBanner(message, 30000); LOG_WARN("%s", message);)
+    IF_SCREEN({
+        int w = snprintf(message, sizeof(message), "Security Number \n%03u %03u", currentSecurityNumber / 1000,
+                         currentSecurityNumber % 1000);
+        assert(w >= 0 && (size_t)w < sizeof(message)); // 24 chars << 40 bytes
+        screen->showSimpleBanner(message, 30000);
+        LOG_WARN("%s", message);
+    })
     meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
     cn->level = meshtastic_LogRecord_Level_WARNING;
-    snprintf(cn->message, sizeof(cn->message), "Incoming Key Verification.\nSecurity Number\n%03u %03u",
-             currentSecurityNumber / 1000, currentSecurityNumber % 1000);
+    int written = snprintf(cn->message, sizeof(cn->message), "Incoming Key Verification.\nSecurity Number\n%03u %03u",
+                           currentSecurityNumber / 1000, currentSecurityNumber % 1000);
+    assert(written >= 0 && (size_t)written < sizeof(cn->message)); // ~56 chars << 400 bytes
     cn->which_payload_variant = meshtastic_ClientNotification_key_verification_number_inform_tag;
     cn->payload_variant.key_verification_number_inform.nonce = currentNonce;
-    strncpy(cn->payload_variant.key_verification_number_inform.remote_longname, // should really check for nulls, etc
-            nodeDB->getMeshNode(currentRemoteNode)->user.long_name,
-            sizeof(cn->payload_variant.key_verification_number_inform.remote_longname));
+    auto &dst = cn->payload_variant.key_verification_number_inform.remote_longname;
+    const char *src = nodeDB->getMeshNode(currentRemoteNode)->user.long_name;
+    size_t srcLen = strlen(src);
+    if (srcLen >= sizeof(dst))
+        LOG_ERROR("remote_longname truncated for number_inform");
+    assert(srcLen < sizeof(dst)); // both are char[40]
+    strncpy(dst, src, sizeof(dst));
+    dst[sizeof(dst) - 1] = '\0';
     cn->payload_variant.key_verification_number_inform.security_number = currentSecurityNumber;
     service->sendClientNotification(cn);
     LOG_WARN("Security Number %04u, nonce %llu", currentSecurityNumber, currentNonce);
@@ -262,12 +290,21 @@ void KeyVerificationModule::processSecurityNumber(uint32_t incomingNumber)
     IF_SCREEN(screen->requestMenu(graphics::menuHandler::KeyVerificationFinalPrompt);)
     meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
     cn->level = meshtastic_LogRecord_Level_WARNING;
-    snprintf(cn->message, sizeof(cn->message), "Final confirmation for outgoing manual key verification %s", message);
+    int written =
+        snprintf(cn->message, sizeof(cn->message), "Final confirmation for outgoing manual key verification %s", message);
+    if (written < 0 || (size_t)written >= sizeof(cn->message))
+        LOG_ERROR("Final confirmation message truncated");
+    assert(written >= 0 && (size_t)written < sizeof(cn->message));
     cn->which_payload_variant = meshtastic_ClientNotification_key_verification_final_tag;
     cn->payload_variant.key_verification_final.nonce = currentNonce;
-    strncpy(cn->payload_variant.key_verification_final.remote_longname, // should really check for nulls, etc
-            nodeDB->getMeshNode(currentRemoteNode)->user.long_name,
-            sizeof(cn->payload_variant.key_verification_final.remote_longname));
+    auto &dst = cn->payload_variant.key_verification_final.remote_longname;
+    const char *src = nodeDB->getMeshNode(currentRemoteNode)->user.long_name;
+    size_t srcLen = strlen(src);
+    if (srcLen >= sizeof(dst))
+        LOG_ERROR("remote_longname truncated for key_verification_final");
+    assert(srcLen < sizeof(dst)); // both are char[40]
+    strncpy(dst, src, sizeof(dst));
+    dst[sizeof(dst) - 1] = '\0';
     cn->payload_variant.key_verification_final.isSender = true;
     service->sendClientNotification(cn);
     LOG_INFO(message);

--- a/src/modules/KeyVerificationModule.cpp
+++ b/src/modules/KeyVerificationModule.cpp
@@ -74,14 +74,15 @@ bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &
         assert(written >= 0 && (size_t)written < sizeof(cn->message)); // 43 chars << 400 bytes
         cn->which_payload_variant = meshtastic_ClientNotification_key_verification_number_request_tag;
         cn->payload_variant.key_verification_number_request.nonce = currentNonce;
-        auto &dst1 = cn->payload_variant.key_verification_number_request.remote_longname;
+        char *dst1 = cn->payload_variant.key_verification_number_request.remote_longname;
+        const size_t dst1Size = sizeof(cn->payload_variant.key_verification_number_request.remote_longname);
         const char *src1 = nodeDB->getMeshNode(currentRemoteNode)->user.long_name;
         size_t len1 = strlen(src1);
-        if (len1 >= sizeof(dst1))
+        if (len1 >= dst1Size)
             LOG_ERROR("remote_longname truncated for number_request");
-        assert(len1 < sizeof(dst1)); // both are char[40]
-        strncpy(dst1, src1, sizeof(dst1));
-        dst1[sizeof(dst1) - 1] = '\0';
+        assert(len1 < dst1Size); // both are char[40]
+        strncpy(dst1, src1, dst1Size);
+        dst1[dst1Size - 1] = '\0';
         service->sendClientNotification(cn);
         LOG_INFO("Received hash2");
         currentState = KEY_VERIFICATION_SENDER_AWAITING_NUMBER;
@@ -116,14 +117,15 @@ bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &
             assert(written >= 0 && (size_t)written < sizeof(cn->message));
             cn->which_payload_variant = meshtastic_ClientNotification_key_verification_final_tag;
             cn->payload_variant.key_verification_final.nonce = currentNonce;
-            auto &dst2 = cn->payload_variant.key_verification_final.remote_longname;
+            char *dst2 = cn->payload_variant.key_verification_final.remote_longname;
+            const size_t dst2Size = sizeof(cn->payload_variant.key_verification_final.remote_longname);
             const char *src2 = nodeDB->getMeshNode(currentRemoteNode)->user.long_name;
             size_t len2 = strlen(src2);
-            if (len2 >= sizeof(dst2))
+            if (len2 >= dst2Size)
                 LOG_ERROR("remote_longname truncated for key_verification_final");
-            assert(len2 < sizeof(dst2)); // both are char[40]
-            strncpy(dst2, src2, sizeof(dst2));
-            dst2[sizeof(dst2) - 1] = '\0';
+            assert(len2 < dst2Size); // both are char[40]
+            strncpy(dst2, src2, dst2Size);
+            dst2[dst2Size - 1] = '\0';
             cn->payload_variant.key_verification_final.isSender = false;
             service->sendClientNotification(cn);
 
@@ -225,14 +227,15 @@ meshtastic_MeshPacket *KeyVerificationModule::allocReply()
     assert(written >= 0 && (size_t)written < sizeof(cn->message)); // ~56 chars << 400 bytes
     cn->which_payload_variant = meshtastic_ClientNotification_key_verification_number_inform_tag;
     cn->payload_variant.key_verification_number_inform.nonce = currentNonce;
-    auto &dst = cn->payload_variant.key_verification_number_inform.remote_longname;
+    char *dst = cn->payload_variant.key_verification_number_inform.remote_longname;
+    const size_t dstSize = sizeof(cn->payload_variant.key_verification_number_inform.remote_longname);
     const char *src = nodeDB->getMeshNode(currentRemoteNode)->user.long_name;
     size_t srcLen = strlen(src);
-    if (srcLen >= sizeof(dst))
+    if (srcLen >= dstSize)
         LOG_ERROR("remote_longname truncated for number_inform");
-    assert(srcLen < sizeof(dst)); // both are char[40]
-    strncpy(dst, src, sizeof(dst));
-    dst[sizeof(dst) - 1] = '\0';
+    assert(srcLen < dstSize); // both are char[40]
+    strncpy(dst, src, dstSize);
+    dst[dstSize - 1] = '\0';
     cn->payload_variant.key_verification_number_inform.security_number = currentSecurityNumber;
     service->sendClientNotification(cn);
     LOG_WARN("Security Number %04u, nonce %llu", currentSecurityNumber, currentNonce);
@@ -297,14 +300,15 @@ void KeyVerificationModule::processSecurityNumber(uint32_t incomingNumber)
     assert(written >= 0 && (size_t)written < sizeof(cn->message));
     cn->which_payload_variant = meshtastic_ClientNotification_key_verification_final_tag;
     cn->payload_variant.key_verification_final.nonce = currentNonce;
-    auto &dst = cn->payload_variant.key_verification_final.remote_longname;
+    char *dst = cn->payload_variant.key_verification_final.remote_longname;
+    const size_t dstSize = sizeof(cn->payload_variant.key_verification_final.remote_longname);
     const char *src = nodeDB->getMeshNode(currentRemoteNode)->user.long_name;
     size_t srcLen = strlen(src);
-    if (srcLen >= sizeof(dst))
+    if (srcLen >= dstSize)
         LOG_ERROR("remote_longname truncated for key_verification_final");
-    assert(srcLen < sizeof(dst)); // both are char[40]
-    strncpy(dst, src, sizeof(dst));
-    dst[sizeof(dst) - 1] = '\0';
+    assert(srcLen < dstSize); // both are char[40]
+    strncpy(dst, src, dstSize);
+    dst[dstSize - 1] = '\0';
     cn->payload_variant.key_verification_final.isSender = true;
     service->sendClientNotification(cn);
     LOG_INFO(message);

--- a/src/modules/KeyVerificationModule.cpp
+++ b/src/modules/KeyVerificationModule.cpp
@@ -74,15 +74,14 @@ bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &
         assert(written >= 0 && (size_t)written < sizeof(cn->message)); // 43 chars << 400 bytes
         cn->which_payload_variant = meshtastic_ClientNotification_key_verification_number_request_tag;
         cn->payload_variant.key_verification_number_request.nonce = currentNonce;
-        char *dst1 = cn->payload_variant.key_verification_number_request.remote_longname;
-        const size_t dst1Size = sizeof(cn->payload_variant.key_verification_number_request.remote_longname);
+        auto &dst1 = cn->payload_variant.key_verification_number_request.remote_longname;
         const char *src1 = nodeDB->getMeshNode(currentRemoteNode)->user.long_name;
         size_t len1 = strlen(src1);
-        if (len1 >= dst1Size)
+        if (len1 >= sizeof(dst1))
             LOG_ERROR("remote_longname truncated for number_request");
-        assert(len1 < dst1Size); // both are char[40]
-        strncpy(dst1, src1, dst1Size);
-        dst1[dst1Size - 1] = '\0';
+        assert(len1 < sizeof(dst1)); // both are char[40]
+        strncpy(dst1, src1, sizeof(dst1));
+        dst1[sizeof(dst1) - 1] = '\0';
         service->sendClientNotification(cn);
         LOG_INFO("Received hash2");
         currentState = KEY_VERIFICATION_SENDER_AWAITING_NUMBER;
@@ -117,15 +116,14 @@ bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &
             assert(written >= 0 && (size_t)written < sizeof(cn->message));
             cn->which_payload_variant = meshtastic_ClientNotification_key_verification_final_tag;
             cn->payload_variant.key_verification_final.nonce = currentNonce;
-            char *dst2 = cn->payload_variant.key_verification_final.remote_longname;
-            const size_t dst2Size = sizeof(cn->payload_variant.key_verification_final.remote_longname);
+            auto &dst2 = cn->payload_variant.key_verification_final.remote_longname;
             const char *src2 = nodeDB->getMeshNode(currentRemoteNode)->user.long_name;
             size_t len2 = strlen(src2);
-            if (len2 >= dst2Size)
+            if (len2 >= sizeof(dst2))
                 LOG_ERROR("remote_longname truncated for key_verification_final");
-            assert(len2 < dst2Size); // both are char[40]
-            strncpy(dst2, src2, dst2Size);
-            dst2[dst2Size - 1] = '\0';
+            assert(len2 < sizeof(dst2)); // both are char[40]
+            strncpy(dst2, src2, sizeof(dst2));
+            dst2[sizeof(dst2) - 1] = '\0';
             cn->payload_variant.key_verification_final.isSender = false;
             service->sendClientNotification(cn);
 
@@ -227,15 +225,14 @@ meshtastic_MeshPacket *KeyVerificationModule::allocReply()
     assert(written >= 0 && (size_t)written < sizeof(cn->message)); // ~56 chars << 400 bytes
     cn->which_payload_variant = meshtastic_ClientNotification_key_verification_number_inform_tag;
     cn->payload_variant.key_verification_number_inform.nonce = currentNonce;
-    char *dst = cn->payload_variant.key_verification_number_inform.remote_longname;
-    const size_t dstSize = sizeof(cn->payload_variant.key_verification_number_inform.remote_longname);
+    auto &dst = cn->payload_variant.key_verification_number_inform.remote_longname;
     const char *src = nodeDB->getMeshNode(currentRemoteNode)->user.long_name;
     size_t srcLen = strlen(src);
-    if (srcLen >= dstSize)
+    if (srcLen >= sizeof(dst))
         LOG_ERROR("remote_longname truncated for number_inform");
-    assert(srcLen < dstSize); // both are char[40]
-    strncpy(dst, src, dstSize);
-    dst[dstSize - 1] = '\0';
+    assert(srcLen < sizeof(dst)); // both are char[40]
+    strncpy(dst, src, sizeof(dst));
+    dst[sizeof(dst) - 1] = '\0';
     cn->payload_variant.key_verification_number_inform.security_number = currentSecurityNumber;
     service->sendClientNotification(cn);
     LOG_WARN("Security Number %04u, nonce %llu", currentSecurityNumber, currentNonce);
@@ -300,15 +297,14 @@ void KeyVerificationModule::processSecurityNumber(uint32_t incomingNumber)
     assert(written >= 0 && (size_t)written < sizeof(cn->message));
     cn->which_payload_variant = meshtastic_ClientNotification_key_verification_final_tag;
     cn->payload_variant.key_verification_final.nonce = currentNonce;
-    char *dst = cn->payload_variant.key_verification_final.remote_longname;
-    const size_t dstSize = sizeof(cn->payload_variant.key_verification_final.remote_longname);
+    auto &dst = cn->payload_variant.key_verification_final.remote_longname;
     const char *src = nodeDB->getMeshNode(currentRemoteNode)->user.long_name;
     size_t srcLen = strlen(src);
-    if (srcLen >= dstSize)
+    if (srcLen >= sizeof(dst))
         LOG_ERROR("remote_longname truncated for key_verification_final");
-    assert(srcLen < dstSize); // both are char[40]
-    strncpy(dst, src, dstSize);
-    dst[dstSize - 1] = '\0';
+    assert(srcLen < sizeof(dst)); // both are char[40]
+    strncpy(dst, src, sizeof(dst));
+    dst[sizeof(dst) - 1] = '\0';
     cn->payload_variant.key_verification_final.isSender = true;
     service->sendClientNotification(cn);
     LOG_INFO(message);

--- a/src/modules/NodeInfoModule.cpp
+++ b/src/modules/NodeInfoModule.cpp
@@ -10,6 +10,7 @@
 #include "main.h"
 #include <Throttle.h>
 #include <algorithm>
+#include <assert.h>
 
 #ifndef USERPREFS_NODEINFO_REPLY_SUPPRESS_SECS
 #define USERPREFS_NODEINFO_REPLY_SUPPRESS_SECS (12 * 60 * 60)
@@ -157,7 +158,8 @@ meshtastic_MeshPacket *NodeInfoModule::allocReply()
         // FIXME: Clear the user.id field since it should be derived from node number on the receiving end
         // u.id[0] = '\0';
 
-        // Ensure our user.id is derived correctly
+        // Ensure our user.id is derived correctly — "!%08x" = 10 chars into id[16]
+        assert(nodeDB->getNodeId().length() < sizeof(u.id));
         strncpy(u.id, nodeDB->getNodeId().c_str(), sizeof(u.id) - 1);
         u.id[sizeof(u.id) - 1] = '\0';
 

--- a/src/modules/NodeInfoModule.cpp
+++ b/src/modules/NodeInfoModule.cpp
@@ -158,7 +158,8 @@ meshtastic_MeshPacket *NodeInfoModule::allocReply()
         // u.id[0] = '\0';
 
         // Ensure our user.id is derived correctly
-        strcpy(u.id, nodeDB->getNodeId().c_str());
+        strncpy(u.id, nodeDB->getNodeId().c_str(), sizeof(u.id) - 1);
+        u.id[sizeof(u.id) - 1] = '\0';
 
         LOG_INFO("Send owner %s/%s/%s", u.id, u.long_name, u.short_name);
         if (transmitHistory)


### PR DESCRIPTION
## Summary
- Replaces unsafe `sprintf` calls with `snprintf` across multiple modules
- Replaces unsafe `strcpy` calls with `strncpy` + null termination
- Adds `assert()` for statically-bounded writes and `LOG_ERROR`/`LOG_WARN` + `assert` for runtime-dependent writes, so overflows are caught in debug and reported in release
- Refactors `DetectionSensorModule` to write directly into `payload.bytes`, eliminating a heap allocation, fixing a packet leak on the public-channel error path, and removing a bogus null-terminator write after the bell character

### Changes by file
| File | What changed |
|---|---|
| `DetectionSensorModule.cpp` | Rewrote `sendDetectionMessage` and `sendCurrentStateMessage` — `snprintf` directly into `payload.bytes`, use return value instead of `strlen`, `packetPool.release()` on error paths |
| `DropzoneModule.cpp` | `snprintf` + assert-only for bounded `matchCompare` (short/long name), `LOG_ERROR` + assert for `replyStr` formatting |
| `KeyVerificationModule.cpp` | `snprintf` + assert for all 5 notification messages, cleaned up `strncpy` of `remote_longname` with cached `strlen` and explicit null-termination, fixed `IF_SCREEN` block to use `sizeof(message)` instead of hardcoded `25` |
| `NodeDB.cpp` | `snprintf` with `LOG_ERROR` + assert + hardcoded fallback message for the duplicate-key notification |
| `RedirectablePrint.cpp` | `strncpy` + `LOG_WARN` for BLE log message truncation (non-critical), assert-only for thread name (bounded) |
| `FSCommon.cpp` | `strncpy` + `LOG_WARN` + assert for file path copies, deduplicated the ESP32/other `#ifdef` branches |
| `NodeInfoModule.cpp` | assert + `strncpy` for node ID copy (`"!%08x"` = 10 chars into 16-byte buffer) |

### Background
MeshCore's security audit flagged widespread `sprintf`/`strcpy` usage without bounds checking. The same patterns exist in Meshtastic. While most buffers are sized adequately for typical data, user-configurable fields (sensor names, node names) and mesh-received data (owner names) could exceed buffer limits. Rather than silently truncating, overflows now trigger asserts in debug builds and log errors in release builds.

## Test plan
- [ ] Verify `tbeam` build succeeds
- [ ] Verify detection sensor messages still send correctly
- [ ] Verify dropzone conditions responses format correctly
- [ ] Verify key verification UI notifications display correctly
- [ ] Verify BLE log records don't truncate normal messages