### PR TITLE
Some fixes for xeddsa pr

### DIFF
--- a/arch/portduino/portduino.ini
+++ b/arch/portduino/portduino.ini
@@ -24,7 +24,6 @@ lib_deps =
   ${radiolib_base.lib_deps}
   ${environmental_base.lib_deps}
   # renovate: datasource=custom.pio depName=rweather/Crypto packageName=rweather/library/Crypto
-  #rweather/Crypto@0.4.0
   https://github.com/meshtastic/Crypto/archive/1aa30eb536bd52a576fde6dfa393bf7349cf102d.zip
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@^1.2.0

--- a/src/mesh/CryptoEngine.cpp
+++ b/src/mesh/CryptoEngine.cpp
@@ -100,8 +100,8 @@ bool CryptoEngine::xeddsa_sign(uint32_t fromNode, uint32_t packetId, uint32_t po
     return true;
 }
 
-bool CryptoEngine::xeddsa_verify(uint8_t *pubKey, uint32_t fromNode, uint32_t packetId, uint32_t portnum, const uint8_t *payload,
-                                 size_t payloadLen, uint8_t *signature)
+bool CryptoEngine::xeddsa_verify(const uint8_t *pubKey, uint32_t fromNode, uint32_t packetId, uint32_t portnum,
+                                 const uint8_t *payload, size_t payloadLen, const uint8_t *signature)
 {
     // Use cached Ed25519 key if the Curve25519 key matches, avoiding expensive field inversion
     if (memcmp(pubKey, cached_curve_pubkey, 32) != 0) {
@@ -115,7 +115,7 @@ bool CryptoEngine::xeddsa_verify(uint8_t *pubKey, uint32_t fromNode, uint32_t pa
     return XEdDSA::verify(signature, cached_ed_pubkey, sigBuf, sigLen);
 }
 
-void CryptoEngine::curve_to_ed_pub(uint8_t *curve_pubkey, uint8_t *ed_pubkey)
+void CryptoEngine::curve_to_ed_pub(const uint8_t *curve_pubkey, uint8_t *ed_pubkey)
 {
 
     // Apply the birational map defined in RFC 7748, section 4.1 "Curve25519" to calculate an Ed25519 public

--- a/src/mesh/CryptoEngine.h
+++ b/src/mesh/CryptoEngine.h
@@ -38,8 +38,8 @@ class CryptoEngine
     virtual bool regeneratePublicKey(uint8_t *pubKey, uint8_t *privKey);
     bool xeddsa_sign(uint32_t fromNode, uint32_t packetId, uint32_t portnum, const uint8_t *payload, size_t payloadLen,
                      uint8_t *signature);
-    bool xeddsa_verify(uint8_t *pubKey, uint32_t fromNode, uint32_t packetId, uint32_t portnum, const uint8_t *payload,
-                       size_t payloadLen, uint8_t *signature);
+    bool xeddsa_verify(const uint8_t *pubKey, uint32_t fromNode, uint32_t packetId, uint32_t portnum, const uint8_t *payload,
+                       size_t payloadLen, const uint8_t *signature);
 
 #endif
     void clearKeys();
@@ -89,7 +89,7 @@ class CryptoEngine
     uint8_t private_key[32] = {0};
     uint8_t xeddsa_public_key[32] = {0};
     uint8_t xeddsa_private_key[32] = {0};
-    void curve_to_ed_pub(uint8_t *curve_pubkey, uint8_t *ed_pubkey);
+    void curve_to_ed_pub(const uint8_t *curve_pubkey, uint8_t *ed_pubkey);
     // Single-entry cache for curve_to_ed_pub conversion (avoids expensive field inversion per packet)
     uint8_t cached_curve_pubkey[32] = {0};
     uint8_t cached_ed_pubkey[32] = {0};

--- a/src/mesh/CryptoEngine.h
+++ b/src/mesh/CryptoEngine.h
@@ -22,6 +22,7 @@ struct CryptoKey {
 
 #define MAX_BLOCKSIZE 256
 #define TEST_CURVE25519_FIELD_OPS // Exposes Curve25519::isWeakPoint() for testing keys
+#define XEDDSA_SIGNATURE_SIZE 64
 
 class CryptoEngine
 {

--- a/src/mesh/CryptoEngine.h
+++ b/src/mesh/CryptoEngine.h
@@ -35,8 +35,10 @@ class CryptoEngine
 #if !(MESHTASTIC_EXCLUDE_PKI_KEYGEN)
     virtual void generateKeyPair(uint8_t *pubKey, uint8_t *privKey);
     virtual bool regeneratePublicKey(uint8_t *pubKey, uint8_t *privKey);
-    bool xeddsa_sign(uint8_t *message, size_t len, uint8_t *signature);
-    bool xeddsa_verify(uint8_t *pubKey, uint8_t *message, size_t len, uint8_t *signature);
+    bool xeddsa_sign(uint32_t fromNode, uint32_t packetId, uint32_t portnum, const uint8_t *payload, size_t payloadLen,
+                     uint8_t *signature);
+    bool xeddsa_verify(uint8_t *pubKey, uint32_t fromNode, uint32_t packetId, uint32_t portnum, const uint8_t *payload,
+                       size_t payloadLen, uint8_t *signature);
 
 #endif
     void clearKeys();

--- a/src/mesh/CryptoEngine.h
+++ b/src/mesh/CryptoEngine.h
@@ -89,6 +89,9 @@ class CryptoEngine
     uint8_t xeddsa_public_key[32] = {0};
     uint8_t xeddsa_private_key[32] = {0};
     void curve_to_ed_pub(uint8_t *curve_pubkey, uint8_t *ed_pubkey);
+    // Single-entry cache for curve_to_ed_pub conversion (avoids expensive field inversion per packet)
+    uint8_t cached_curve_pubkey[32] = {0};
+    uint8_t cached_ed_pubkey[32] = {0};
 #endif
     /**
      * Init our 128 bit nonce for a new packet

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -817,6 +817,12 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c)
         else if (config.security.private_key.size == 32 && config.security.public_key.size == 0) {
             nodeDB->generateCryptoKeyPair(config.security.private_key.bytes);
         }
+        // User provided both keys — load them into the crypto engine
+        else {
+            owner.public_key.size = config.security.public_key.size;
+            memcpy(owner.public_key.bytes, config.security.public_key.bytes, config.security.public_key.size);
+            crypto->setDHPrivateKey(config.security.private_key.bytes);
+        }
 #endif
         if (config.security.is_managed && !(config.security.admin_key[0].size == 32 || config.security.admin_key[1].size == 32 ||
                                             config.security.admin_key[2].size == 32)) {

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -817,12 +817,6 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c)
         else if (config.security.private_key.size == 32 && config.security.public_key.size == 0) {
             nodeDB->generateCryptoKeyPair(config.security.private_key.bytes);
         }
-        // User provided both keys — load them into the crypto engine
-        else {
-            owner.public_key.size = config.security.public_key.size;
-            memcpy(owner.public_key.bytes, config.security.public_key.bytes, config.security.public_key.size);
-            crypto->setDHPrivateKey(config.security.private_key.bytes);
-        }
 #endif
         if (config.security.is_managed && !(config.security.admin_key[0].size == 32 || config.security.admin_key[1].size == 32 ||
                                             config.security.admin_key[2].size == 32)) {

--- a/src/modules/NodeInfoModule.cpp
+++ b/src/modules/NodeInfoModule.cpp
@@ -24,8 +24,10 @@ bool NodeInfoModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
     }
     NodeNum sourceNum = getFrom(&mp);
     auto node = nodeDB->getMeshNode(sourceNum);
-    if ((node->bitfield & NODEINFO_BITFIELD_HAS_XEDDSA_SIGNED_MASK) && !mp.xeddsa_signed)
+    if (node && (node->bitfield & NODEINFO_BITFIELD_HAS_XEDDSA_SIGNED_MASK) && !mp.xeddsa_signed) {
+        LOG_WARN("Dropping unsigned NodeInfo from node 0x%08x that previously signed", sourceNum);
         return true;
+    }
 
     // Coerce user.id to be derived from the node number
     snprintf(p.id, sizeof(p.id), "!%08x", getFrom(&mp));


### PR DESCRIPTION
- fix null dereference crash in NodeInfoModule when receiving NodeInfo from unknown nodes                                                                                                       
- signature verification failure didn't drop the packet — now it does
- HAS_XEDDSA_SIGNED bitfield was never set — now set on successful verification, so unsigned packets from previously-signing nodes are rejected                                             
- Signature only covered payload bytes — now covers metadata too: fromNode, packetId, and portnum to prevent replay, reattribution, and portnum redirection
- xeddsa_sign() had no key initialization check — now returns false if keys are all zeros                                                                                                   
- AdminModule didn't load keys when user provided both private and public key                                                                                                               
- curve_to_ed_pub() field inversion ran on every signed packet — now cached per sender
- createNewIdentity() ran unnecessarily on every boot when the key hadn't changed
- Hardcoded 120 byte signing limit replaced with derivation from XEDDSA_SIGNATURE_SIZE and DATA_PAYLOAD_LEN
- Added const qualifiers to input-only parameters in xeddsa_verify and curve_to_ed_pub
