### PR TITLE
nRF52 BLE: wait for LFXO crystal before enabling SoftDevice

### DIFF
--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -261,6 +261,12 @@ void NRF52Bluetooth::setup()
 {
     // Initialise the Bluefruit module
     LOG_INFO("Init the Bluefruit nRF52 module");
+    // Ensure LFXO crystal is fully started before enabling SoftDevice.
+    // The framework starts LFXO in init() but doesn't wait for it.
+    while (!NRF_CLOCK->EVENTS_LFCLKSTARTED) {
+        delay(1);
+    }
+
     Bluefruit.autoConnLed(false);
     Bluefruit.configPrphBandwidth(BANDWIDTH_MAX);
     Bluefruit.begin();

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -263,9 +263,18 @@ void NRF52Bluetooth::setup()
     LOG_INFO("Init the Bluefruit nRF52 module");
     // Ensure LFXO crystal is fully started before enabling SoftDevice.
     // The framework starts LFXO in init() but doesn't wait for it.
-    while (!NRF_CLOCK->EVENTS_LFCLKSTARTED) {
-        delay(1);
+#ifdef USE_LFXO
+    {
+        uint32_t lfclk_start = millis();
+        while (!NRF_CLOCK->EVENTS_LFCLKSTARTED) {
+            if (millis() - lfclk_start >= 2000) {
+                LOG_WARN("LFXO crystal did not start within 2s — check 32.768kHz crystal");
+                break;
+            }
+            delay(1);
+        }
     }
+#endif
 
     Bluefruit.autoConnLed(false);
     Bluefruit.configPrphBandwidth(BANDWIDTH_MAX);


### PR DESCRIPTION
It's not causing any issues currently by not doing this, but this ensures bluetooth is ready before we do stuff with it.

See also [this PR](https://github.com/meshcore-dev/MeshCore/pull/1939/changes)