### PR TITLE
replace std::unique_ptr<T>(new T()) with std::make_unique

### DIFF
--- a/src/AudioThread.h
+++ b/src/AudioThread.h
@@ -30,8 +30,8 @@ class AudioThread : public concurrency::OSThread
         io.digitalWrite(EXPANDS_AMP_EN, HIGH);
 #endif
         setCPUFast(true);
-        rtttlFile = std::unique_ptr<AudioFileSourcePROGMEM>(new AudioFileSourcePROGMEM(data, len));
-        i2sRtttl = std::unique_ptr<AudioGeneratorRTTTL>(new AudioGeneratorRTTTL());
+        rtttlFile = std::make_unique<AudioFileSourcePROGMEM>(data, len);
+        i2sRtttl = std::make_unique<AudioGeneratorRTTTL>();
         i2sRtttl->begin(rtttlFile.get(), audioOut.get());
     }
 
@@ -69,7 +69,7 @@ class AudioThread : public concurrency::OSThread
 #ifdef T_LORA_PAGER
         io.digitalWrite(EXPANDS_AMP_EN, HIGH);
 #endif
-        auto sam = std::unique_ptr<ESP8266SAM>(new ESP8266SAM);
+        auto sam = std::make_unique<ESP8266SAM>();
         sam->Say(audioOut.get(), text);
         setCPUFast(false);
 #ifdef T_LORA_PAGER
@@ -91,7 +91,7 @@ class AudioThread : public concurrency::OSThread
   private:
     void initOutput()
     {
-        audioOut = std::unique_ptr<AudioOutputI2S>(new AudioOutputI2S(1, AudioOutputI2S::EXTERNAL_I2S));
+        audioOut = std::make_unique<AudioOutputI2S>(1, AudioOutputI2S::EXTERNAL_I2S);
         audioOut->SetPinout(DAC_I2S_BCK, DAC_I2S_WS, DAC_I2S_DOUT, DAC_I2S_MCLK);
         audioOut->SetGain(0.2);
     };

--- a/src/input/cardKbI2cImpl.cpp
+++ b/src/input/cardKbI2cImpl.cpp
@@ -18,7 +18,7 @@ void CardKbI2cImpl::init()
 #else
         uint8_t i2caddr_asize = 5;
 #endif
-        auto i2cScanner = std::unique_ptr<ScanI2CTwoWire>(new ScanI2CTwoWire());
+        auto i2cScanner = std::make_unique<ScanI2CTwoWire>();
 
 #if WIRE_INTERFACES_COUNT == 2
         i2cScanner->scanPort(ScanI2C::I2CPort::WIRE1, i2caddr_scan, i2caddr_asize);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -522,7 +522,7 @@ void setup()
 #if !MESHTASTIC_EXCLUDE_I2C
     // We need to scan here to decide if we have a screen for nodeDB.init() and because power has been applied to
     // accessories
-    auto i2cScanner = std::unique_ptr<ScanI2CTwoWire>(new ScanI2CTwoWire());
+    auto i2cScanner = std::make_unique<ScanI2CTwoWire>();
 #if HAS_WIRE
     LOG_INFO("Scan for i2c devices");
 #endif

--- a/src/mesh/CryptoEngine.cpp
+++ b/src/mesh/CryptoEngine.cpp
@@ -172,7 +172,7 @@ void CryptoEngine::aesSetKey(const uint8_t *key_bytes, size_t key_len)
 {
     aes = nullptr;
     if (key_len != 0) {
-        aes = std::unique_ptr<AESSmall256>(new AESSmall256());
+        aes = std::make_unique<AESSmall256>();
         aes->setKey(key_bytes, key_len);
     }
 }
@@ -233,9 +233,9 @@ void CryptoEngine::encryptAESCtr(CryptoKey _key, uint8_t *_nonce, size_t numByte
 {
     std::unique_ptr<CTRCommon> ctr;
     if (_key.length == 16)
-        ctr = std::unique_ptr<CTRCommon>(new CTR<AES128>());
+        ctr = std::make_unique<CTR<AES128>>();
     else
-        ctr = std::unique_ptr<CTRCommon>(new CTR<AES256>());
+        ctr = std::make_unique<CTR<AES256>>();
     ctr->setKey(_key.bytes, _key.length);
     static uint8_t scratch[MAX_BLOCKSIZE];
     memcpy(scratch, bytes, numBytes);

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -241,29 +241,38 @@ std::unique_ptr<RadioInterface> initLoRa()
     // as one can't use a function pointer to the class constructor:
     auto loraModuleInterface = [](LockingArduinoHal *hal, RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst,
                                   RADIOLIB_PIN_TYPE busy) {
+        std::unique_ptr<RadioInterface> r = nullptr;
         switch (portduino_config.lora_module) {
         case use_rf95:
-            return std::unique_ptr<RadioInterface>(new RF95Interface(hal, cs, irq, rst, busy));
+            r = std::make_unique<RF95Interface>(hal, cs, irq, rst, busy);
+            break;
         case use_sx1262:
-            return std::unique_ptr<RadioInterface>(new SX1262Interface(hal, cs, irq, rst, busy));
+            r = std::make_unique<SX1262Interface>(hal, cs, irq, rst, busy);
+            break;
         case use_sx1268:
-            return std::unique_ptr<RadioInterface>(new SX1268Interface(hal, cs, irq, rst, busy));
+            r = std::make_unique<SX1268Interface>(hal, cs, irq, rst, busy);
+            break;
         case use_sx1280:
-            return std::unique_ptr<RadioInterface>(new SX1280Interface(hal, cs, irq, rst, busy));
+            r = std::make_unique<SX1280Interface>(hal, cs, irq, rst, busy);
+            break;
         case use_lr1110:
-            return std::unique_ptr<RadioInterface>(new LR1110Interface(hal, cs, irq, rst, busy));
+            r = std::make_unique<LR1110Interface>(hal, cs, irq, rst, busy);
+            break;
         case use_lr1120:
-            return std::unique_ptr<RadioInterface>(new LR1120Interface(hal, cs, irq, rst, busy));
+            r = std::make_unique<LR1120Interface>(hal, cs, irq, rst, busy);
+            break;
         case use_lr1121:
-            return std::unique_ptr<RadioInterface>(new LR1121Interface(hal, cs, irq, rst, busy));
+            r = std::make_unique<LR1121Interface>(hal, cs, irq, rst, busy);
+            break;
         case use_llcc68:
-            return std::unique_ptr<RadioInterface>(new LLCC68Interface(hal, cs, irq, rst, busy));
+            r = std::make_unique<LLCC68Interface>(hal, cs, irq, rst, busy);
+            break;
         case use_simradio:
-            return std::unique_ptr<RadioInterface>(new SimRadio);
-        default:
-            assert(0); // shouldn't happen
-            return std::unique_ptr<RadioInterface>(nullptr);
+            r = std::make_unique<SimRadio>();
         }
+        if (!r)
+            assert(0); // shouldn't happen
+        return r;
     };
 
     LOG_DEBUG("Activate %s radio on SPI port %s", portduino_config.loraModules[portduino_config.lora_module].c_str(),
@@ -300,8 +309,7 @@ std::unique_ptr<RadioInterface> initLoRa()
 // radio init MUST BE AFTER service.init, so we have our radio config settings (from nodedb init)
 #if defined(USE_STM32WLx)
     if (!rIf) {
-        rIf = std::unique_ptr<STM32WLE5JCInterface>(
-            new STM32WLE5JCInterface(loraHal, SX126X_CS, SX126X_DIO1, SX126X_RESET, SX126X_BUSY));
+        rIf = std::make_unique<STM32WLE5JCInterface>(loraHal, SX126X_CS, SX126X_DIO1, SX126X_RESET, SX126X_BUSY);
         if (!rIf->init()) {
             LOG_WARN("No STM32WL radio");
             rIf = nullptr;
@@ -314,7 +322,7 @@ std::unique_ptr<RadioInterface> initLoRa()
 
 #if defined(RF95_IRQ) && RADIOLIB_EXCLUDE_SX127X != 1
     if ((!rIf) && (config.lora.region != meshtastic_Config_LoRaConfig_RegionCode_LORA_24)) {
-        rIf = std::unique_ptr<RF95Interface>(new RF95Interface(loraHal, LORA_CS, RF95_IRQ, RF95_RESET, RF95_DIO1));
+        rIf = std::make_unique<RF95Interface>(loraHal, LORA_CS, RF95_IRQ, RF95_RESET, RF95_DIO1);
         if (!rIf->init()) {
             LOG_WARN("No RF95 radio");
             rIf = nullptr;
@@ -327,8 +335,7 @@ std::unique_ptr<RadioInterface> initLoRa()
 
 #if defined(USE_SX1262) && !defined(ARCH_PORTDUINO) && !defined(TCXO_OPTIONAL) && RADIOLIB_EXCLUDE_SX126X != 1
     if ((!rIf) && (config.lora.region != meshtastic_Config_LoRaConfig_RegionCode_LORA_24)) {
-        auto sxIf =
-            std::unique_ptr<SX1262Interface>(new SX1262Interface(loraHal, SX126X_CS, SX126X_DIO1, SX126X_RESET, SX126X_BUSY));
+        auto sxIf = std::make_unique<SX1262Interface>(loraHal, SX126X_CS, SX126X_DIO1, SX126X_RESET, SX126X_BUSY);
 #ifdef SX126X_DIO3_TCXO_VOLTAGE
         sxIf->setTCXOVoltage(SX126X_DIO3_TCXO_VOLTAGE);
 #endif
@@ -346,8 +353,7 @@ std::unique_ptr<RadioInterface> initLoRa()
 #if defined(USE_SX1262) && !defined(ARCH_PORTDUINO) && defined(TCXO_OPTIONAL)
     if ((!rIf) && (config.lora.region != meshtastic_Config_LoRaConfig_RegionCode_LORA_24)) {
         // try using the specified TCXO voltage
-        auto sxIf =
-            std::unique_ptr<SX1262Interface>(new SX1262Interface(loraHal, SX126X_CS, SX126X_DIO1, SX126X_RESET, SX126X_BUSY));
+        auto sxIf = std::make_unique<SX1262Interface>(loraHal, SX126X_CS, SX126X_DIO1, SX126X_RESET, SX126X_BUSY);
         sxIf->setTCXOVoltage(SX126X_DIO3_TCXO_VOLTAGE);
         if (!sxIf->init()) {
             LOG_WARN("No SX1262 radio with TCXO, Vref %fV", SX126X_DIO3_TCXO_VOLTAGE);
@@ -361,7 +367,7 @@ std::unique_ptr<RadioInterface> initLoRa()
 
     if ((!rIf) && (config.lora.region != meshtastic_Config_LoRaConfig_RegionCode_LORA_24)) {
         // If specified TCXO voltage fails, attempt to use DIO3 as a reference instead
-        rIf = std::unique_ptr<SX1262Interface>(new SX1262Interface(loraHal, SX126X_CS, SX126X_DIO1, SX126X_RESET, SX126X_BUSY));
+        rIf = std::make_unique<SX1262Interface>(loraHal, SX126X_CS, SX126X_DIO1, SX126X_RESET, SX126X_BUSY);
         if (!rIf->init()) {
             LOG_WARN("No SX1262 radio with XTAL, Vref 0.0V");
             rIf = nullptr;
@@ -376,8 +382,7 @@ std::unique_ptr<RadioInterface> initLoRa()
 #if defined(SX126X_DIO3_TCXO_VOLTAGE) && defined(TCXO_OPTIONAL)
     if ((!rIf) && (config.lora.region != meshtastic_Config_LoRaConfig_RegionCode_LORA_24)) {
         // try using the specified TCXO voltage
-        auto sxIf =
-            std::unique_ptr<SX1268Interface>(new SX1268Interface(loraHal, SX126X_CS, SX126X_DIO1, SX126X_RESET, SX126X_BUSY));
+        auto sxIf = std::make_unique<SX1268Interface>(loraHal, SX126X_CS, SX126X_DIO1, SX126X_RESET, SX126X_BUSY);
         sxIf->setTCXOVoltage(SX126X_DIO3_TCXO_VOLTAGE);
         if (!sxIf->init()) {
             LOG_WARN("No SX1268 radio with TCXO, Vref %fV", SX126X_DIO3_TCXO_VOLTAGE);
@@ -390,7 +395,7 @@ std::unique_ptr<RadioInterface> initLoRa()
     }
 #endif
     if ((!rIf) && (config.lora.region != meshtastic_Config_LoRaConfig_RegionCode_LORA_24)) {
-        rIf = std::unique_ptr<SX1268Interface>(new SX1268Interface(loraHal, SX126X_CS, SX126X_DIO1, SX126X_RESET, SX126X_BUSY));
+        rIf = std::make_unique<SX1268Interface>(loraHal, SX126X_CS, SX126X_DIO1, SX126X_RESET, SX126X_BUSY);
         if (!rIf->init()) {
             LOG_WARN("No SX1268 radio");
             rIf = nullptr;
@@ -403,7 +408,7 @@ std::unique_ptr<RadioInterface> initLoRa()
 
 #if defined(USE_LLCC68)
     if ((!rIf) && (config.lora.region != meshtastic_Config_LoRaConfig_RegionCode_LORA_24)) {
-        rIf = std::unique_ptr<LLCC68Interface>(new LLCC68Interface(loraHal, SX126X_CS, SX126X_DIO1, SX126X_RESET, SX126X_BUSY));
+        rIf = std::make_unique<LLCC68Interface>(loraHal, SX126X_CS, SX126X_DIO1, SX126X_RESET, SX126X_BUSY);
         if (!rIf->init()) {
             LOG_WARN("No LLCC68 radio");
             rIf = nullptr;
@@ -416,8 +421,7 @@ std::unique_ptr<RadioInterface> initLoRa()
 
 #if defined(USE_LR1110) && RADIOLIB_EXCLUDE_LR11X0 != 1
     if ((!rIf) && (config.lora.region != meshtastic_Config_LoRaConfig_RegionCode_LORA_24)) {
-        rIf = std::unique_ptr<LR1110Interface>(
-            new LR1110Interface(loraHal, LR1110_SPI_NSS_PIN, LR1110_IRQ_PIN, LR1110_NRESET_PIN, LR1110_BUSY_PIN));
+        rIf = std::make_unique<LR1110Interface>(loraHal, LR1110_SPI_NSS_PIN, LR1110_IRQ_PIN, LR1110_NRESET_PIN, LR1110_BUSY_PIN);
         if (!rIf->init()) {
             LOG_WARN("No LR1110 radio");
             rIf = nullptr;
@@ -430,8 +434,7 @@ std::unique_ptr<RadioInterface> initLoRa()
 
 #if defined(USE_LR1120) && RADIOLIB_EXCLUDE_LR11X0 != 1
     if (!rIf) {
-        rIf = std::unique_ptr<LR1120Interface>(
-            new LR1120Interface(loraHal, LR1120_SPI_NSS_PIN, LR1120_IRQ_PIN, LR1120_NRESET_PIN, LR1120_BUSY_PIN));
+        rIf = std::make_unique<LR1120Interface>(loraHal, LR1120_SPI_NSS_PIN, LR1120_IRQ_PIN, LR1120_NRESET_PIN, LR1120_BUSY_PIN);
         if (!rIf->init()) {
             LOG_WARN("No LR1120 radio");
             rIf = nullptr;
@@ -444,8 +447,7 @@ std::unique_ptr<RadioInterface> initLoRa()
 
 #if defined(USE_LR1121) && RADIOLIB_EXCLUDE_LR11X0 != 1
     if (!rIf) {
-        rIf = std::unique_ptr<LR1121Interface>(
-            new LR1121Interface(loraHal, LR1121_SPI_NSS_PIN, LR1121_IRQ_PIN, LR1121_NRESET_PIN, LR1121_BUSY_PIN));
+        rIf = std::make_unique<LR1121Interface>(loraHal, LR1121_SPI_NSS_PIN, LR1121_IRQ_PIN, LR1121_NRESET_PIN, LR1121_BUSY_PIN);
         if (!rIf->init()) {
             LOG_WARN("No LR1121 radio");
             rIf = nullptr;
@@ -458,7 +460,7 @@ std::unique_ptr<RadioInterface> initLoRa()
 
 #if defined(USE_SX1280) && RADIOLIB_EXCLUDE_SX128X != 1
     if (!rIf) {
-        rIf = std::unique_ptr<SX1280Interface>(new SX1280Interface(loraHal, SX128X_CS, SX128X_DIO1, SX128X_RESET, SX128X_BUSY));
+        rIf = std::make_unique<SX1280Interface>(loraHal, SX128X_CS, SX128X_DIO1, SX128X_RESET, SX128X_BUSY);
         if (!rIf->init()) {
             LOG_WARN("No SX1280 radio");
             rIf = nullptr;

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -409,7 +409,7 @@ void mqttInit()
 }
 
 #if HAS_NETWORKING
-MQTT::MQTT() : MQTT(std::unique_ptr<MQTTClient>(new MQTTClient())) {}
+MQTT::MQTT() : MQTT(std::make_unique<MQTTClient>()) {}
 MQTT::MQTT(std::unique_ptr<MQTTClient> _mqttClient)
     : concurrency::OSThread("mqtt"), mqttQueue(MAX_MQTT_QUEUE), mqttClient(std::move(_mqttClient)), pubSub(*mqttClient)
 #else

--- a/test/test_traffic_management/test_main.cpp
+++ b/test/test_traffic_management/test_main.cpp
@@ -431,7 +431,7 @@ static void test_tm_nodeinfo_directResponse_respondsFromCache(void)
     mockNodeDB->setCachedNode(kTargetNode);
 
     MockRouter mockRouter;
-    mockRouter.addInterface(std::unique_ptr<RadioInterface>(new MockRadioInterface()));
+    mockRouter.addInterface(std::make_unique<MockRadioInterface>());
     MeshService mockService;
     router = &mockRouter;
     service = &mockService;
@@ -476,7 +476,7 @@ static void test_tm_nodeinfo_directResponse_learnsRequestorNodeInfo(void)
     mockNodeDB->setCachedNode(kTargetNode);
 
     MockRouter mockRouter;
-    mockRouter.addInterface(std::unique_ptr<RadioInterface>(new MockRadioInterface()));
+    mockRouter.addInterface(std::make_unique<MockRadioInterface>());
     MeshService mockService;
     router = &mockRouter;
     service = &mockService;
@@ -539,7 +539,7 @@ static void test_tm_nodeinfo_directResponse_withoutNodeDbEntry_skips(void)
     mockNodeDB->clearCachedNode();
 
     MockRouter mockRouter;
-    mockRouter.addInterface(std::unique_ptr<RadioInterface>(new MockRadioInterface()));
+    mockRouter.addInterface(std::make_unique<MockRadioInterface>());
     MeshService mockService;
     router = &mockRouter;
     service = &mockService;
@@ -574,7 +574,7 @@ static void test_tm_nodeinfo_directResponse_psramCacheRespondsAndPreservesBitfie
     mockNodeDB->clearCachedNode();
 
     MockRouter mockRouter;
-    mockRouter.addInterface(std::unique_ptr<RadioInterface>(new MockRadioInterface()));
+    mockRouter.addInterface(std::make_unique<MockRadioInterface>());
     MeshService mockService;
     router = &mockRouter;
     service = &mockService;
@@ -627,7 +627,7 @@ static void test_tm_nodeinfo_directResponse_psramMissDoesNotFallbackToNodeDb(voi
     mockNodeDB->setCachedNode(kTargetNode);
 
     MockRouter mockRouter;
-    mockRouter.addInterface(std::unique_ptr<RadioInterface>(new MockRadioInterface()));
+    mockRouter.addInterface(std::make_unique<MockRadioInterface>());
     MeshService mockService;
     router = &mockRouter;
     service = &mockService;

--- a/variants/esp32/esp32-common.ini
+++ b/variants/esp32/esp32-common.ini
@@ -34,7 +34,7 @@ build_flags =
   -Wall
   -Wextra
   -Isrc/platform/esp32
-  -std=c++11
+  -std=c++17
   -DLOG_LOCAL_LEVEL=ESP_LOG_DEBUG
   -DCORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_DEBUG
   -DMYNEWT_VAL_BLE_HS_LOG_LVL=LOG_LEVEL_CRITICAL

--- a/variants/esp32c6/esp32c6.ini
+++ b/variants/esp32c6/esp32c6.ini
@@ -8,7 +8,7 @@ build_flags =
   -Wall
   -Wextra
   -Isrc/platform/esp32
-  -std=c++11
+  -std=c++17
   -DESP_OPENSSL_SUPPRESS_LEGACY_WARNING
   -DSERIAL_BUFFER_SIZE=4096
   -DLIBPAX_ARDUINO


### PR DESCRIPTION
We should use make_unique in all similar cases in the future. We didn't in the past since we didn't had a C++ version high enough.

Ben fixed this in #9874