### PR TITLE
fix(STM32WL) fix LittleFS FILE_O_WRITE truncation for persistent prefs

### DIFF
--- a/src/platform/stm32wl/STM32_LittleFS_File.cpp
+++ b/src/platform/stm32wl/STM32_LittleFS_File.cpp
@@ -54,7 +54,7 @@ File::File(char const *filename, uint8_t mode, STM32_LittleFS &fs) : File(fs)
 
 bool File::_open_file(char const *filepath, uint8_t mode)
 {
-    int flags = (mode == FILE_O_READ) ? LFS_O_RDONLY : (mode == FILE_O_WRITE) ? (LFS_O_RDWR | LFS_O_CREAT) : 0;
+    int flags = (mode == FILE_O_READ) ? LFS_O_RDONLY : (mode == FILE_O_WRITE) ? (LFS_O_RDWR | LFS_O_CREAT | LFS_O_TRUNC) : 0;
 
     if (flags) {
         _file = (lfs_file_t *)rtos_malloc(sizeof(lfs_file_t));
@@ -71,10 +71,6 @@ bool File::_open_file(char const *filepath, uint8_t mode)
             _file = NULL;
             return false;
         }
-
-        // move to end of file
-        if (mode == FILE_O_WRITE)
-            lfs_file_seek(_fs->_getFS(), _file, 0, LFS_SEEK_END);
 
         _is_dir = false;
     }


### PR DESCRIPTION
# Fix persisted config corruption on CDEBYTE_E77-MBL. 

**Likely fixes** #9704 see Testing

STM32WL LittleFS reopened `FILE_O_WRITE` without truncation, which could leave stale bytes in rewritten protobuf files. After reboot this broke prefs loading and the node fell back to defaults.

## Fix
use `LFS_O_TRUNC` LittleFS flags for STM32WL `FILE_O_WRITE`

Only the STM32WL LittleFS backend is changed.

According to @caveman99 's littlefs implementation #5987 and @vidplace7 's report, it worked for them without this fix. I'd love to hear your feedback.

With the fix, I've got a fully functional variant for serial from E77-900m22s.

## Reproduction:
```
  meshtastic --port /dev/ttyUSB0 --set device.led_heartbeat_disabled true --timeout 20
  meshtastic --port /dev/ttyUSB0 --set display.flip_screen true --timeout 20
  meshtastic --port /dev/ttyUSB0 --set lora.hop_limit 7 --timeout 20
  meshtastic --port /dev/ttyUSB0 --reboot --wait-to-disconnect 3 --timeout 20
  sleep 12
  meshtastic --port /dev/ttyUSB0 --get device.led_heartbeat_disabled --timeout 20
  meshtastic --port /dev/ttyUSB0 --get display.flip_screen --timeout 20
  meshtastic --port /dev/ttyUSB0 --get lora.hop_limit --timeout 20
```

## Testing
I have tested only on `CDEBYTE_E77-MBL` and `heltec-v3` (for regressions). Since this only affected the STM32WL LittleFS backend, it would be a good idea to test it on other STM32WL variants, such as the wio-e5, but I don't have any of those. I'd appreciate some help with this.

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [x] CDEBYTE_E77-MBL
