### PR TITLE
Fix intermittent busyRx on Portduino SX1262 (stale preamble IRQ)

### DIFF
--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -315,14 +315,21 @@ template <typename T> void SX126xInterface<T>::startReceive()
     setTransmitEnable(false);
     setStandby();
 
+    // On Linux-native (Portduino), use continuous receive instead of duty cycle auto-receive.
+    // The duty cycle mode causes intermittent false preamble detections due to GPIO read latency
+    // in userspace (gpiod), which leads to "Can not send yet, busyRx" errors.
+    // Power saving from duty cycle is irrelevant on mains-powered Linux devices.
+#if ARCH_PORTDUINO
+    int err = lora.startReceive(RADIOLIB_SX126X_RX_TIMEOUT_INF, MESHTASTIC_RADIOLIB_IRQ_RX_FLAGS);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("SX126X startReceive %s%d", radioLibErr, err);
+        portduino_status.LoRa_in_error = true;
+    }
+#else
     // We use a 16 bit preamble so this should save some power by letting radio sit in standby mostly.
     int err = lora.startReceiveDutyCycleAuto(preambleLength, 8, MESHTASTIC_RADIOLIB_IRQ_RX_FLAGS);
     if (err != RADIOLIB_ERR_NONE)
         LOG_ERROR("SX126X startReceiveDutyCycleAuto %s%d", radioLibErr, err);
-#ifdef ARCH_PORTDUINO
-    if (err != RADIOLIB_ERR_NONE)
-        portduino_status.LoRa_in_error = true;
-#else
     assert(err == RADIOLIB_ERR_NONE);
 #endif
 


### PR DESCRIPTION
## Summary

On Linux-native (Portduino) builds, the SX1262 radio gets stuck in RX with `Can not send yet, busyRx` / `Ignore false preamble detection` errors, blocking TX until the existing stale-flag fallback in `RadioLibInterface::receiveDetected` times out (`2 * preambleTimeMsec`). Under high radio activity I measured this on 60-80% of TX attempts; at low activity it was sporadic.

Fixes #9933. Related: #9580 (same symptoms on RPi Zero 2W), #4298 (GPIO pin issues with SX1262 on RPi 5).

## Root cause

`startReceiveDutyCycleAuto` puts the SX1262 into a sleep/CAD/sleep cycle. Every CAD pass can latch a `PREAMBLE_DETECTED` IRQ flag even when no real packet is arriving. On bare-metal MCUs those stale flags get cleared/overwritten within a few symbol times before anything sees them, because IRQ polling happens at nanosecond scale. On Linux, `gpiod` reads are microseconds each, so `getIrqFlags()` regularly catches a stale CAD-induced flag. `isActivelyReceiving()` then returns `true`, TX is gated, and we wait out the `2 * preambleTimeMsec` stale-flag fallback before unblocking — by which time `setTransmitDelay()` has already pushed the TX attempt into a new random window where the same race can recur.

## Fix

On Portduino only, replace `startReceiveDutyCycleAuto(preambleLength, 8, ...)` with `startReceive(RADIOLIB_SX126X_RX_TIMEOUT_INF, ...)`. Continuous receive has no sleep/CAD cycles, so the stale-flag source is eliminated at the root. Power saving from duty cycling is irrelevant on mains-powered Linux-class devices (Raspberry Pi, x86 gateways, femtofox).

`isActivelyReceiving()` is unchanged — the existing `receiveDetected` logic with its `2 * preambleTimeMsec` fallback remains the correct place to handle any residual stale flags on any platform.

## What this PR no longer does

An earlier revision also tried to accelerate stale-flag recovery inside `isActivelyReceiving()` on Portduino by clearing `PREAMBLE_DETECTED` and re-reading after 5 ms. That was wrong on two counts (thanks to @GUVWAF for catching it):

1. The SX1262 does not re-assert `PREAMBLE_DETECTED` later in the same reception — preamble detection is a one-shot IRQ, after which the chip moves to sync word → header → payload. If the flag was cleared mid-reception (e.g. between end-of-preamble and `HEADER_VALID`), the recheck would see "no preamble," declare the reception stale, and TX could fire into an in-progress RX.
2. The 5 ms recheck window was a constant, but preamble time scales with LoRa settings (`preambleLength * (2^sf) / bw`). LongFast is ~131 ms; LongSlow is ~524 ms. 5 ms was 25–100× too short to distinguish "real preamble, still decoding" from "stale flag."

That code is removed in the current commit. The continuous-receive change alone is sufficient on my hardware — I did not observe any residual `busyRx` after applying it.

## Behavior change

| Platform | Before | After |
| --- | --- | --- |
| Portduino SX126x | `startReceiveDutyCycleAuto(16-symbol preamble, 8-symbol RX window)` | `startReceive(RX_TIMEOUT_INF, ...)` |
| ESP32 / nRF52 / RP2040 / STM32WL SX126x | `startReceiveDutyCycleAuto(...)` | unchanged |

No change to `isActivelyReceiving` on any platform. No change on battery-powered builds.

## Test plan

Tested on Raspberry Pi 5 with SX1262 (E22-900M30S) HAT, full config (4 channels, MQTT, boosted RX gain, GPS, neighbor info, telemetry).

- [x] Before fix: `busyRx` on 60-80% of TX attempts under heavy traffic (firmware 2.7.15 and 2.7.20)
- [x] After fix: 0 `busyRx` across 10 consecutive 45-second test runs
- [x] After fix: 0 `busyRx` in a ~24 h sustained soak with mixed traffic
- [x] `Ignore false preamble detection` log no longer appears in steady state
- [x] Packet reception unchanged (NodeInfo / HostMetrics / GPS position / DeviceTelemetry all transmit and receive)
- [x] Radio init still succeeds (`SX126x init result 0`)

CLA will be signed before merge.
