### PR TITLE
fix: preserve higher-quality RTC time on system-time refresh

### DIFF
--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -41,6 +41,7 @@ RTCQuality getRTCQuality()
 static uint32_t
     timeStartMsec; // Once we have a GPS lock, this is where we hold the initial msec clock that corresponds to that time
 static uint64_t zeroOffsetSecs; // GPS based time in secs since 1970 - only updated once on initial lock
+static uint32_t lastSetMsec = 0;
 
 namespace
 {
@@ -50,7 +51,7 @@ RTCSetResult readFromSystemTimeFallback()
     if (readSystemTime(&tv)) {
         uint32_t now = millis();
         uint32_t printableEpoch = tv.tv_sec; // Print lib only supports 32 bit but time_t can be 64 bit on some platforms
-        LOG_DEBUG("Read RTC time as %ld", printableEpoch);
+        LOG_DEBUG("Read RTC time as %lu", static_cast<unsigned long>(printableEpoch));
         if (currentQuality == RTCQualityNone) {
             timeStartMsec = now;
             zeroOffsetSecs = tv.tv_sec;
@@ -63,8 +64,9 @@ RTCSetResult readFromSystemTimeFallback()
 } // namespace
 
 /**
- * Reads the current date and time from the RTC module and updates the system time.
- * @return True if the RTC was successfully read and the system time was updated, false otherwise.
+ * Reads the current date and time from the RTC or the system-time fallback.
+ * @return RTCSetResultSuccess when a time source is read successfully, even if
+ *         a higher-quality RTC source is intentionally preserved.
  */
 RTCSetResult readFromRTC()
 {
@@ -209,7 +211,6 @@ RTCSetResult readFromRTC()
  */
 RTCSetResult perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpdate)
 {
-    static uint32_t lastSetMsec = 0;
     uint32_t now = millis();
     uint32_t printableEpoch = tv->tv_sec; // Print lib only supports 32 bit but time_t can be 64 bit on some platforms
 #ifdef BUILD_EPOCH
@@ -442,8 +443,10 @@ void resetRTCStateForTests()
     currentQuality = RTCQualityNone;
     lastSetFromPhoneNtpOrGps = 0;
     lastTimeValidationWarning = 0;
+    lastSetMsec = 0;
     timeStartMsec = 0;
     zeroOffsetSecs = 0;
+    forceSystemTimeFallback = false;
     clearRTCSystemTimeForTests();
 }
 

--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -12,6 +12,25 @@ uint32_t lastSetFromPhoneNtpOrGps = 0;
 static uint32_t lastTimeValidationWarning = 0;
 static const uint32_t TIME_VALIDATION_WARNING_INTERVAL_MS = 15000; // 15 seconds
 
+namespace {
+#if defined(UNIT_TEST)
+bool hasMockSystemTime = false;
+bool forceSystemTimeFallback = false;
+struct timeval mockSystemTime = {};
+#endif
+
+bool readSystemTime(struct timeval *tv)
+{
+#if defined(UNIT_TEST)
+    if (hasMockSystemTime) {
+        *tv = mockSystemTime;
+        return true;
+    }
+#endif
+    return gettimeofday(tv, NULL) == 0;
+}
+} // namespace
+
 RTCQuality getRTCQuality()
 {
     return currentQuality;
@@ -22,12 +41,37 @@ static uint32_t
     timeStartMsec; // Once we have a GPS lock, this is where we hold the initial msec clock that corresponds to that time
 static uint64_t zeroOffsetSecs; // GPS based time in secs since 1970 - only updated once on initial lock
 
+namespace {
+RTCSetResult readFromSystemTimeFallback()
+{
+    struct timeval tv;
+    if (readSystemTime(&tv)) {
+        uint32_t now = millis();
+        uint32_t printableEpoch = tv.tv_sec; // Print lib only supports 32 bit but time_t can be 64 bit on some platforms
+        LOG_DEBUG("Read RTC time as %ld", printableEpoch);
+        if (currentQuality == RTCQualityNone) {
+            timeStartMsec = now;
+            zeroOffsetSecs = tv.tv_sec;
+        }
+        return RTCSetResultSuccess;
+    }
+
+    return RTCSetResultNotSet;
+}
+} // namespace
+
 /**
  * Reads the current date and time from the RTC module and updates the system time.
  * @return True if the RTC was successfully read and the system time was updated, false otherwise.
  */
 RTCSetResult readFromRTC()
 {
+#if defined(UNIT_TEST)
+    if (forceSystemTimeFallback) {
+        return readFromSystemTimeFallback();
+    }
+#endif
+
     struct timeval tv; /* btw settimeofday() is helpful here too*/
 #ifdef RV3028_RTC
     if (rtc_found.address == RV3028_RTC) {
@@ -147,14 +191,7 @@ RTCSetResult readFromRTC()
         }
     }
 #else
-    if (!gettimeofday(&tv, NULL)) {
-        uint32_t now = millis();
-        uint32_t printableEpoch = tv.tv_sec; // Print lib only supports 32 bit but time_t can be 64 bit on some platforms
-        LOG_DEBUG("Read RTC time as %ld", printableEpoch);
-        timeStartMsec = now;
-        zeroOffsetSecs = tv.tv_sec;
-        return RTCSetResultSuccess;
-    }
+    return readFromSystemTimeFallback();
 #endif
     return RTCSetResultNotSet;
 }
@@ -396,6 +433,40 @@ uint32_t getValidTime(RTCQuality minQuality, bool local)
 {
     return (currentQuality >= minQuality) ? getTime(local) : 0;
 }
+
+#if defined(UNIT_TEST)
+void resetRTCStateForTests()
+{
+    currentQuality = RTCQualityNone;
+    lastSetFromPhoneNtpOrGps = 0;
+    lastTimeValidationWarning = 0;
+    timeStartMsec = 0;
+    zeroOffsetSecs = 0;
+    clearRTCSystemTimeForTests();
+}
+
+void setRTCSystemTimeForTests(const struct timeval *tv)
+{
+    if (tv == NULL) {
+        clearRTCSystemTimeForTests();
+        return;
+    }
+
+    mockSystemTime = *tv;
+    hasMockSystemTime = true;
+}
+
+void clearRTCSystemTimeForTests()
+{
+    hasMockSystemTime = false;
+    mockSystemTime = {};
+}
+
+void setReadFromRTCUseSystemTimeForTests(bool enabled)
+{
+    forceSystemTimeFallback = enabled;
+}
+#endif
 
 time_t gm_mktime(const struct tm *tm)
 {

--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -12,7 +12,8 @@ uint32_t lastSetFromPhoneNtpOrGps = 0;
 static uint32_t lastTimeValidationWarning = 0;
 static const uint32_t TIME_VALIDATION_WARNING_INTERVAL_MS = 15000; // 15 seconds
 
-namespace {
+namespace
+{
 #if defined(UNIT_TEST)
 bool hasMockSystemTime = false;
 bool forceSystemTimeFallback = false;
@@ -41,7 +42,8 @@ static uint32_t
     timeStartMsec; // Once we have a GPS lock, this is where we hold the initial msec clock that corresponds to that time
 static uint64_t zeroOffsetSecs; // GPS based time in secs since 1970 - only updated once on initial lock
 
-namespace {
+namespace
+{
 RTCSetResult readFromSystemTimeFallback()
 {
     struct timeval tv;

--- a/src/gps/RTC.h
+++ b/src/gps/RTC.h
@@ -56,6 +56,13 @@ RTCSetResult readFromRTC();
 
 time_t gm_mktime(const struct tm *tm);
 
+#if defined(UNIT_TEST)
+void resetRTCStateForTests();
+void setRTCSystemTimeForTests(const struct timeval *tv);
+void clearRTCSystemTimeForTests();
+void setReadFromRTCUseSystemTimeForTests(bool enabled);
+#endif
+
 #define SEC_PER_DAY 86400
 #define SEC_PER_HOUR 3600
 #define SEC_PER_MIN 60

--- a/test/test_rtc/test_main.cpp
+++ b/test/test_rtc/test_main.cpp
@@ -1,5 +1,6 @@
 #include "TestUtil.h"
 #include "gps/RTC.h"
+#include <sys/time.h>
 #include <time.h>
 #include <unity.h>
 

--- a/test/test_rtc/test_main.cpp
+++ b/test/test_rtc/test_main.cpp
@@ -1,0 +1,73 @@
+#include "TestUtil.h"
+#include "gps/RTC.h"
+#include <time.h>
+#include <unity.h>
+
+static const time_t kUptimeTime = 21;
+static const uint32_t kAllowedDriftSeconds = 1;
+
+static time_t makeValidEpoch()
+{
+    return time(NULL) + SEC_PER_DAY;
+}
+
+void setUp(void)
+{
+    resetRTCStateForTests();
+}
+
+void tearDown(void)
+{
+    resetRTCStateForTests();
+}
+
+static void test_readFromRTC_preserves_better_network_time(void)
+{
+    resetRTCStateForTests();
+
+    const time_t networkEpoch = makeValidEpoch();
+    struct timeval networkTime;
+    networkTime.tv_sec = networkEpoch;
+    networkTime.tv_usec = 0;
+
+    TEST_ASSERT_EQUAL_INT(RTCSetResultSuccess, perhapsSetRTC(RTCQualityFromNet, &networkTime));
+
+    struct timeval uptimeTime;
+    uptimeTime.tv_sec = kUptimeTime;
+    uptimeTime.tv_usec = 0;
+    setRTCSystemTimeForTests(&uptimeTime);
+    setReadFromRTCUseSystemTimeForTests(true);
+
+    TEST_ASSERT_EQUAL_INT(RTCSetResultSuccess, readFromRTC());
+    TEST_ASSERT_EQUAL_INT(RTCQualityFromNet, getRTCQuality());
+    TEST_ASSERT_UINT32_WITHIN(kAllowedDriftSeconds, networkEpoch, getValidTime(RTCQualityFromNet));
+}
+
+static void test_readFromRTC_initializes_time_before_any_better_source(void)
+{
+    resetRTCStateForTests();
+
+    const time_t systemEpoch = makeValidEpoch();
+    struct timeval systemTime;
+    systemTime.tv_sec = systemEpoch;
+    systemTime.tv_usec = 0;
+    setRTCSystemTimeForTests(&systemTime);
+    setReadFromRTCUseSystemTimeForTests(true);
+
+    TEST_ASSERT_EQUAL_INT(RTCSetResultSuccess, readFromRTC());
+    TEST_ASSERT_EQUAL_INT(RTCQualityNone, getRTCQuality());
+    TEST_ASSERT_UINT32_WITHIN(kAllowedDriftSeconds, systemEpoch, getTime());
+}
+
+void setup()
+{
+    delay(10);
+    initializeTestEnvironment();
+
+    UNITY_BEGIN();
+    RUN_TEST(test_readFromRTC_preserves_better_network_time);
+    RUN_TEST(test_readFromRTC_initializes_time_before_any_better_source);
+    exit(UNITY_END());
+}
+
+void loop() {}


### PR DESCRIPTION
## Summary
- keep the system-time fallback in `readFromRTC()` from overwriting an already better RTC source
- factor the system-time fallback into a small helper so the no-hardware-RTC path stays aligned with the hardware RTC guards
- add focused regression tests for preserving network time and initializing time before any higher-quality source exists

Fixes #9828.

## Testing
- `./bin/test-native-docker.sh -f test_rtc`
- `./bin/test-native-docker.sh -f test_default`