### PR TITLE
Add regular reboot option, disabled by default

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -366,6 +366,26 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DEFAULT_REBOOT_SECONDS 7
 #endif
 
+// Allows scheduling a periodic reboot at boot-time.
+// Default is -1 (disabled).
+// Unit is whole days.
+// Effective range: 1 to 49 days.
+#ifndef DEFAULT_REGULAR_REBOOT_DAYS
+#define DEFAULT_REGULAR_REBOOT_DAYS -1
+#endif
+
+#if DEFAULT_REGULAR_REBOOT_DAYS < -1
+#error DEFAULT_REGULAR_REBOOT_DAYS must be -1 (disabled) or a positive whole number of days
+#endif
+
+#if DEFAULT_REGULAR_REBOOT_DAYS == 0
+#error DEFAULT_REGULAR_REBOOT_DAYS must be -1 (disabled) or a positive whole number of days
+#endif
+
+#if DEFAULT_REGULAR_REBOOT_DAYS > 49
+#error DEFAULT_REGULAR_REBOOT_DAYS must be 49 days or less
+#endif
+
 #ifndef DEFAULT_SHUTDOWN_SECONDS
 #define DEFAULT_SHUTDOWN_SECONDS 2
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -685,6 +685,12 @@ void setup()
 
     // Hello
     printInfo();
+#if DEFAULT_REGULAR_REBOOT_DAYS > 0 && DEFAULT_REGULAR_REBOOT_DAYS < 50
+    // Schedule a periodic reboot (build-time configured).
+    constexpr uint32_t MSEC_PER_DAY = 24UL * 60UL * 60UL * 1000UL;
+    rebootAtMsec = millis() + (uint32_t)DEFAULT_REGULAR_REBOOT_DAYS * MSEC_PER_DAY;
+    LOG_DEBUG("Periodic reboot scheduled in %u day(s)", DEFAULT_REGULAR_REBOOT_DAYS);
+#endif
 #ifdef BUILD_EPOCH
     LOG_INFO("Build timestamp: %ld", BUILD_EPOCH);
 #endif


### PR DESCRIPTION
This adds the option to enable regular reboots every `DEFAULT_REGULAR_REBOOT_DAYS` days.
Allowed range is 1 - 49 days.

Per default, this is disabled (set to -1).

For me this has proven vital to keep nodes that I connect and disconnect to via Bluetooth many times per day working for more than ~1 month without a manual reboot.

I deliberately chose whole days as the unit for this PR, to make sure and clear this is not suitable to create nodes that keep restarting so much that they hurt the mesh.

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [X] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [X] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
