### PR TITLE
Use UDP as roof node <---> indoor nodes backchannel

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -394,7 +394,12 @@ ErrorCode Router::send(meshtastic_MeshPacket *p)
 
 #if HAS_UDP_MULTICAST
     if (udpHandler && config.network.enabled_protocols & meshtastic_Config_NetworkConfig_ProtocolFlags_UDP_BROADCAST) {
-        udpHandler->onSend(const_cast<meshtastic_MeshPacket *>(p));
+        bool res = udpHandler->onSend(const_cast<meshtastic_MeshPacket *>(p));
+        if (res && config.device.role == meshtastic_Config_DeviceConfig_Role_CLIENT_MUTE) {
+            LOG_DEBUG("Packet successfully sent via UDP, skipping LoRa");
+            packetPool.release(p);
+            return ERRNO_OK;
+        }
     }
 #endif
 

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -830,6 +830,23 @@ void Router::handleReceived(meshtastic_MeshPacket *p, RxSource src)
             }
         }
 #endif
+#if HAS_UDP_MULTICAST
+        if (config.device.role == meshtastic_Config_DeviceConfig_Role_CLIENT_BASE && udpHandler &&
+            p->transport_mechanism != meshtastic_MeshPacket_TransportMechanism_TRANSPORT_MULTICAST_UDP &&
+            config.network.enabled_protocols & meshtastic_Config_NetworkConfig_ProtocolFlags_UDP_BROADCAST && !isFromUs(p)) {
+#if MESHTASTIC_EXCLUDE_MQTT
+            if (decodedState == DecodeState::DECODE_FAILURE && p->channel == 0x00 && !isBroadcast(p->to) && !isToUs(p)) {
+                p_encrypted->pki_encrypted = true;
+            }
+#endif
+            if (decodedState == DecodeState::DECODE_SUCCESS || p_encrypted->pki_encrypted) {
+                LOG_DEBUG("Rebroadcasting incoming packet via UDP too");
+                if (!udpHandler->onSend(const_cast<meshtastic_MeshPacket *>(p_encrypted))) {
+                    LOG_WARN("Rebroadcast via UDP failed");
+                }
+            }
+        }
+#endif
     }
 
     packetPool.release(p_encrypted); // Release the encrypted packet


### PR DESCRIPTION
For deployments with a roof node and one or more indoor nodes, having the latter to reliably receive broadcast messages from the Mesh is a challenge. CLIENT_BASE now behaves as ROUTER_LATE, but only for packets having one of the indoor nodes as source or final destination (assuming they have been configured as favourites). This has prompted some users to configure their roof nodes as ROUTER_LATE, which can degrade the Mesh.

This PR promotes the use of UDP broadcast as the backchannel between the roof and the indoor nodes, increasing the reliability by which broadcast packets arrive to the latter while also decreasing the overall LoRa traffic. This is achieved by slightly changing the behaviour of CLIENT_MUTE and CLIENT_BASE when UDP broadcast in enabled:

- CLIENT_MUTE: for locally generated packets, if there's an active `udpHandler` and sending the packet via UDP has succeeded, LoRa broadcasting is skipped.
- CLIENT_BASE: if there's an active `udpHandler`, incoming packets are also rebroadcasted via UDP.

## Open questions

- Should this behaviour be gated behind a configuration option? Since AFAIK the UDP broadcast feature is not yet stable, I've assumed it's safe to change the behaviour of CLIENT_MUTE and CLIENT_BASE when it's enabled without the burden of maintaining an additional configuration option, but can be done if deemed necessary. 
- Should going through the roof node via UDP count as a hop? This PR doesn't implement a special treatment for packets coming from the UDP transport, meaning it does count as a hop. If people think it's better to not count as a hop, we can implement the exception either here or in a future PR (TBH, I'd prefer the latter). 
- Is UDP broadcast reliable on arbitrary consumer-grade WiFi equipment? I have my doubts about it, so if people like this approach and this PR goes in, I'll try to implement a UDP unicast option with a configurable list of IPs in another PR.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
  - [x] RAK 3112
