### PR TITLE
Audio module dev

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -852,7 +852,7 @@ void NodeDB::installDefaultModuleConfig()
 #if HAS_TFT
     if (moduleConfig.external_notification.nag_timeout == default_ringtone_nag_secs)
         moduleConfig.external_notification.nag_timeout = 0;
-#else
+#elif !defined(PIN_VIBRATION)
     moduleConfig.external_notification.nag_timeout = default_ringtone_nag_secs;
 #endif
 #endif
@@ -862,6 +862,16 @@ void NodeDB::installDefaultModuleConfig()
     moduleConfig.external_notification.output_ms = 100;
     moduleConfig.external_notification.active = true;
 #endif
+
+    // Audio module defaults
+    moduleConfig.has_audio = true;
+#ifdef USERPREFS_AUDIO_SPEAKER_GAIN
+    moduleConfig.audio.speaker_gain = USERPREFS_AUDIO_SPEAKER_GAIN;
+#endif
+#ifdef USERPREFS_AUDIO_MIC_GAIN
+    moduleConfig.audio.mic_gain = USERPREFS_AUDIO_MIC_GAIN;
+#endif
+
 #ifdef T_LORA_PAGER
     moduleConfig.canned_message.updown1_enabled = true;
     moduleConfig.canned_message.inputbroker_pin_a = ROTARY_A;

--- a/src/mesh/generated/meshtastic/module_config.pb.h
+++ b/src/mesh/generated/meshtastic/module_config.pb.h
@@ -222,6 +222,8 @@ typedef struct _meshtastic_ModuleConfig_AudioConfig {
     uint8_t mic_gain;
     /* Target node number for audio transmission. 0 = broadcast (default). */
     uint32_t audio_target;
+    /* Channel index for audio broadcast. 0 = primary channel (default). */
+    uint8_t audio_channel;
 } meshtastic_ModuleConfig_AudioConfig;
 
 /* Config for the Paxcounter Module */
@@ -592,7 +594,7 @@ extern "C" {
 #define meshtastic_ModuleConfig_RemoteHardwareConfig_init_default {0, 0, 0, {meshtastic_RemoteHardwarePin_init_default, meshtastic_RemoteHardwarePin_init_default, meshtastic_RemoteHardwarePin_init_default, meshtastic_RemoteHardwarePin_init_default}}
 #define meshtastic_ModuleConfig_NeighborInfoConfig_init_default {0, 0, 0}
 #define meshtastic_ModuleConfig_DetectionSensorConfig_init_default {0, 0, 0, 0, "", 0, _meshtastic_ModuleConfig_DetectionSensorConfig_TriggerType_MIN, 0}
-#define meshtastic_ModuleConfig_AudioConfig_init_default {0, 0, _meshtastic_ModuleConfig_AudioConfig_Audio_Baud_MIN, 0, 0, 0, 0, 0, 0, 0}
+#define meshtastic_ModuleConfig_AudioConfig_init_default {0, 0, _meshtastic_ModuleConfig_AudioConfig_Audio_Baud_MIN, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_PaxcounterConfig_init_default {0, 0, 0, 0}
 #define meshtastic_ModuleConfig_TrafficManagementConfig_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_SerialConfig_init_default {0, 0, 0, 0, _meshtastic_ModuleConfig_SerialConfig_Serial_Baud_MIN, 0, _meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MIN, 0}
@@ -661,6 +663,7 @@ extern "C" {
 #define meshtastic_ModuleConfig_AudioConfig_speaker_gain_tag 8
 #define meshtastic_ModuleConfig_AudioConfig_mic_gain_tag 9
 #define meshtastic_ModuleConfig_AudioConfig_audio_target_tag 10
+#define meshtastic_ModuleConfig_AudioConfig_audio_channel_tag 11
 #define meshtastic_ModuleConfig_PaxcounterConfig_enabled_tag 1
 #define meshtastic_ModuleConfig_PaxcounterConfig_paxcounter_update_interval_tag 2
 #define meshtastic_ModuleConfig_PaxcounterConfig_wifi_threshold_tag 3
@@ -866,7 +869,8 @@ X(a, STATIC,   SINGULAR, UINT32,   i2s_din,           6) \
 X(a, STATIC,   SINGULAR, UINT32,   i2s_sck,           7) \
 X(a, STATIC,   SINGULAR, UINT32,   speaker_gain,      8) \
 X(a, STATIC,   SINGULAR, UINT32,   mic_gain,          9) \
-X(a, STATIC,   SINGULAR, UINT32,   audio_target,     10)
+X(a, STATIC,   SINGULAR, UINT32,   audio_target,     10) \
+X(a, STATIC,   SINGULAR, UINT32,   audio_channel,    11)
 #define meshtastic_ModuleConfig_AudioConfig_CALLBACK NULL
 #define meshtastic_ModuleConfig_AudioConfig_DEFAULT NULL
 
@@ -1050,7 +1054,7 @@ extern const pb_msgdesc_t meshtastic_RemoteHardwarePin_msg;
 /* Maximum encoded size of messages (where known) */
 #define MESHTASTIC_MESHTASTIC_MODULE_CONFIG_PB_H_MAX_SIZE meshtastic_ModuleConfig_size
 #define meshtastic_ModuleConfig_AmbientLightingConfig_size 14
-#define meshtastic_ModuleConfig_AudioConfig_size 30
+#define meshtastic_ModuleConfig_AudioConfig_size 32
 #define meshtastic_ModuleConfig_CannedMessageConfig_size 49
 #define meshtastic_ModuleConfig_DetectionSensorConfig_size 44
 #define meshtastic_ModuleConfig_ExternalNotificationConfig_size 42

--- a/src/mesh/generated/meshtastic/module_config.pb.h
+++ b/src/mesh/generated/meshtastic/module_config.pb.h
@@ -204,18 +204,24 @@ typedef struct _meshtastic_ModuleConfig_DetectionSensorConfig {
 typedef struct _meshtastic_ModuleConfig_AudioConfig {
     /* Whether Audio is enabled */
     bool codec2_enabled;
-    /* PTT Pin */
+    /* PTT Pin for codec2 audio. Can also be set at compile time via AUDIO_PTT_PIN. */
     uint8_t ptt_pin;
-    /* The audio sample rate to use for codec2 */
+    /* The codec2 bitrate to use for encoding/decoding voice */
     meshtastic_ModuleConfig_AudioConfig_Audio_Baud bitrate;
-    /* I2S Word Select */
+    /* I2S Word Select (legacy: single-I2S-bus mode only) */
     uint8_t i2s_ws;
-    /* I2S Data IN */
+    /* I2S Data IN (legacy: single-I2S-bus mode only) */
     uint8_t i2s_sd;
-    /* I2S Data OUT */
+    /* I2S Data OUT (legacy: single-I2S-bus mode only) */
     uint8_t i2s_din;
-    /* I2S Clock */
+    /* I2S Clock (legacy: single-I2S-bus mode only) */
     uint8_t i2s_sck;
+    /* Speaker output gain multiplier. 0 = firmware default. Valid range 1-30. */
+    uint8_t speaker_gain;
+    /* Microphone input gain multiplier. 0 = firmware default. Valid range 1-30. */
+    uint8_t mic_gain;
+    /* Target node number for audio transmission. 0 = broadcast (default). */
+    uint32_t audio_target;
 } meshtastic_ModuleConfig_AudioConfig;
 
 /* Config for the Paxcounter Module */
@@ -586,7 +592,7 @@ extern "C" {
 #define meshtastic_ModuleConfig_RemoteHardwareConfig_init_default {0, 0, 0, {meshtastic_RemoteHardwarePin_init_default, meshtastic_RemoteHardwarePin_init_default, meshtastic_RemoteHardwarePin_init_default, meshtastic_RemoteHardwarePin_init_default}}
 #define meshtastic_ModuleConfig_NeighborInfoConfig_init_default {0, 0, 0}
 #define meshtastic_ModuleConfig_DetectionSensorConfig_init_default {0, 0, 0, 0, "", 0, _meshtastic_ModuleConfig_DetectionSensorConfig_TriggerType_MIN, 0}
-#define meshtastic_ModuleConfig_AudioConfig_init_default {0, 0, _meshtastic_ModuleConfig_AudioConfig_Audio_Baud_MIN, 0, 0, 0, 0}
+#define meshtastic_ModuleConfig_AudioConfig_init_default {0, 0, _meshtastic_ModuleConfig_AudioConfig_Audio_Baud_MIN, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_PaxcounterConfig_init_default {0, 0, 0, 0}
 #define meshtastic_ModuleConfig_TrafficManagementConfig_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_SerialConfig_init_default {0, 0, 0, 0, _meshtastic_ModuleConfig_SerialConfig_Serial_Baud_MIN, 0, _meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MIN, 0}
@@ -605,7 +611,7 @@ extern "C" {
 #define meshtastic_ModuleConfig_RemoteHardwareConfig_init_zero {0, 0, 0, {meshtastic_RemoteHardwarePin_init_zero, meshtastic_RemoteHardwarePin_init_zero, meshtastic_RemoteHardwarePin_init_zero, meshtastic_RemoteHardwarePin_init_zero}}
 #define meshtastic_ModuleConfig_NeighborInfoConfig_init_zero {0, 0, 0}
 #define meshtastic_ModuleConfig_DetectionSensorConfig_init_zero {0, 0, 0, 0, "", 0, _meshtastic_ModuleConfig_DetectionSensorConfig_TriggerType_MIN, 0}
-#define meshtastic_ModuleConfig_AudioConfig_init_zero {0, 0, _meshtastic_ModuleConfig_AudioConfig_Audio_Baud_MIN, 0, 0, 0, 0}
+#define meshtastic_ModuleConfig_AudioConfig_init_zero {0, 0, _meshtastic_ModuleConfig_AudioConfig_Audio_Baud_MIN, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_PaxcounterConfig_init_zero {0, 0, 0, 0}
 #define meshtastic_ModuleConfig_TrafficManagementConfig_init_zero {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_SerialConfig_init_zero {0, 0, 0, 0, _meshtastic_ModuleConfig_SerialConfig_Serial_Baud_MIN, 0, _meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MIN, 0}
@@ -652,6 +658,9 @@ extern "C" {
 #define meshtastic_ModuleConfig_AudioConfig_i2s_sd_tag 5
 #define meshtastic_ModuleConfig_AudioConfig_i2s_din_tag 6
 #define meshtastic_ModuleConfig_AudioConfig_i2s_sck_tag 7
+#define meshtastic_ModuleConfig_AudioConfig_speaker_gain_tag 8
+#define meshtastic_ModuleConfig_AudioConfig_mic_gain_tag 9
+#define meshtastic_ModuleConfig_AudioConfig_audio_target_tag 10
 #define meshtastic_ModuleConfig_PaxcounterConfig_enabled_tag 1
 #define meshtastic_ModuleConfig_PaxcounterConfig_paxcounter_update_interval_tag 2
 #define meshtastic_ModuleConfig_PaxcounterConfig_wifi_threshold_tag 3
@@ -854,7 +863,10 @@ X(a, STATIC,   SINGULAR, UENUM,    bitrate,           3) \
 X(a, STATIC,   SINGULAR, UINT32,   i2s_ws,            4) \
 X(a, STATIC,   SINGULAR, UINT32,   i2s_sd,            5) \
 X(a, STATIC,   SINGULAR, UINT32,   i2s_din,           6) \
-X(a, STATIC,   SINGULAR, UINT32,   i2s_sck,           7)
+X(a, STATIC,   SINGULAR, UINT32,   i2s_sck,           7) \
+X(a, STATIC,   SINGULAR, UINT32,   speaker_gain,      8) \
+X(a, STATIC,   SINGULAR, UINT32,   mic_gain,          9) \
+X(a, STATIC,   SINGULAR, UINT32,   audio_target,     10)
 #define meshtastic_ModuleConfig_AudioConfig_CALLBACK NULL
 #define meshtastic_ModuleConfig_AudioConfig_DEFAULT NULL
 
@@ -1038,7 +1050,7 @@ extern const pb_msgdesc_t meshtastic_RemoteHardwarePin_msg;
 /* Maximum encoded size of messages (where known) */
 #define MESHTASTIC_MESHTASTIC_MODULE_CONFIG_PB_H_MAX_SIZE meshtastic_ModuleConfig_size
 #define meshtastic_ModuleConfig_AmbientLightingConfig_size 14
-#define meshtastic_ModuleConfig_AudioConfig_size 19
+#define meshtastic_ModuleConfig_AudioConfig_size 30
 #define meshtastic_ModuleConfig_CannedMessageConfig_size 49
 #define meshtastic_ModuleConfig_DetectionSensorConfig_size 44
 #define meshtastic_ModuleConfig_ExternalNotificationConfig_size 42

--- a/src/modules/esp32/AudioModule.cpp
+++ b/src/modules/esp32/AudioModule.cpp
@@ -7,6 +7,7 @@
 #include "PowerFSM.h"
 #include "RTC.h"
 #include "Router.h"
+#include "Channels.h"
 #include "graphics/Screen.h"
 #ifdef HAS_I2S
 #include "main.h" // for audioThread
@@ -38,18 +39,41 @@ ButterworthFilter hp_filter(240, 8000, ButterworthFilter::ButterworthFilter::Hig
 static int getMicGain()
 {
     uint8_t g = moduleConfig.audio.mic_gain;
-    return (g > 0 && g <= 30) ? g : AUDIO_DEFAULT_GAIN;
+    return (g > 0 && g <= 12) ? g : AUDIO_DEFAULT_GAIN;
 }
 
 static int getSpeakerGain()
 {
     uint8_t g = moduleConfig.audio.speaker_gain;
-    return (g > 0 && g <= 30) ? g : AUDIO_DEFAULT_GAIN;
+    return (g > 0 && g <= 12) ? g : AUDIO_DEFAULT_GAIN;
 }
 
 TaskHandle_t codec2HandlerTask;
 TaskHandle_t speakerTaskHandle;
 AudioModule *audioModule;
+
+// Max audio payload bytes.  Fits inside a PKI-encrypted LoRa packet:
+// MAX_LORA_PAYLOAD_LEN(255) - header(16) - PKC overhead(12) - protobuf(~6) ≈ 221;
+// we use 212 for safety headroom.
+static const int MAX_AUDIO_DATA = 212;
+
+// Human-readable codec2 rate string from the protobuf enum value.
+static const char *getCodecRateStr(uint8_t bitrate)
+{
+    if (bitrate == 0)
+        bitrate = AUDIO_MODULE_MODE; // default
+    switch (bitrate) {
+    case 1:  return "3200";
+    case 2:  return "2400";
+    case 3:  return "1600";
+    case 4:  return "1400";
+    case 5:  return "1300";
+    case 6:  return "1200";
+    case 7:  return "700";
+    case 8:  return "700B";
+    default: return "???";
+    }
+}
 
 #ifdef ARCH_ESP32
 // ESP32 doesn't use that flag
@@ -178,6 +202,7 @@ static void speaker_task(void *parameter)
             if (millis() - lastDataTime > RX_SILENCE_TIMEOUT) {
                 audioModule->rx_playback_active = false;
                 audioModule->rx_draining = false;
+                audioModule->rx_from_node = 0;
                 audioModule->i2s_reclaimed_for_codec2 = false;
                 audioModule->rx_seq_initialized = false;
                 LOG_INFO("RX playback stopped (buffer drained, no new data)");
@@ -356,12 +381,7 @@ AudioModule::AudioModule() : SinglePortModule("Audio", meshtastic_PortNum_AUDIO_
         adc_buffer_size = codec2_samples_per_frame(codec2);
 
         // Fill as much of the payload as possible for the slowest packet rate.
-        // The radio frame limit is MAX_LORA_PAYLOAD_LEN(255) - MESHTASTIC_HEADER_LENGTH(16)
-        // - MESHTASTIC_PKC_OVERHEAD(12) = 227 bytes for the protobuf-encoded Data struct.
-        // Protobuf adds ~6 bytes overhead (field tags, varint lengths), so max audio
-        // payload ≈ 227 - 6 = 221.  We use 212 as a safe max (leaves headroom and
-        // ensures PKI encryption works for direct-message audio).
-        static const int MAX_AUDIO_DATA = 212;
+        // See MAX_AUDIO_DATA definition at file scope for the size derivation.
         encode_frame_num = MAX_AUDIO_DATA / encode_codec_size;
         encode_frame_size = encode_frame_num * encode_codec_size;
         int frameDurationMs = (adc_buffer_size * 1000) / 8000;
@@ -406,47 +426,69 @@ void AudioModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int
     display->fillRect(0 + x, 0 + y, x + display->getWidth(), y + FONT_HEIGHT_SMALL);
     display->setColor(BLACK);
     if (moduleConfig.audio.audio_target) {
-        display->drawStringf(0 + x, 0 + y, buffer, "Audio DM !%08x",
-                             moduleConfig.audio.audio_target);
+        meshtastic_NodeInfoLite *tgt = nodeDB->getMeshNode(moduleConfig.audio.audio_target);
+        if (tgt && tgt->user.long_name[0]) {
+            display->drawStringf(0 + x, 0 + y, buffer, "Audio DM: %s", tgt->user.long_name);
+        } else {
+            display->drawStringf(0 + x, 0 + y, buffer, "Audio DM !%08x", moduleConfig.audio.audio_target);
+        }
     } else {
-        display->drawStringf(0 + x, 0 + y, buffer, "Codec2 Mode %d Audio",
-                             (moduleConfig.audio.bitrate ? moduleConfig.audio.bitrate : AUDIO_MODULE_MODE) - 1);
+        uint8_t ch = moduleConfig.audio.audio_channel;
+        const char *chName = channels.getName(ch);
+        display->drawStringf(0 + x, 0 + y, buffer, "Audio [%s]", chName);
     }
     display->setColor(WHITE);
     display->setFont(FONT_LARGE);
     display->setTextAlignment(TEXT_ALIGN_CENTER);
     if (radio_state == RadioState::tx) {
         display->drawString(display->getWidth() / 2 + x, (display->getHeight() - FONT_HEIGHT_SMALL) / 2 + y, "PTT");
+    } else if (rx_draining || rx_playback_active) {
+        // Audio is actively being received — show sender info
+        if (rx_is_dm) {
+            display->drawString(display->getWidth() / 2 + x, 14 + y, "RX DM");
+        } else {
+            display->setFont(FONT_MEDIUM);
+            display->drawStringf(display->getWidth() / 2 + x, 14 + y, buffer, "RX [%s]", channels.getName(rx_channel));
+        }
+        display->setFont(FONT_SMALL);
+        if (rx_from_node) {
+            meshtastic_NodeInfoLite *sender = nodeDB->getMeshNode(rx_from_node);
+            if (sender && sender->user.long_name[0]) {
+                display->drawStringf(display->getWidth() / 2 + x, 38 + y, buffer, "From: %s", sender->user.long_name);
+            } else if (sender && sender->user.short_name[0]) {
+                display->drawStringf(display->getWidth() / 2 + x, 38 + y, buffer, "From: %.4s", sender->user.short_name);
+            } else {
+                display->drawStringf(display->getWidth() / 2 + x, 38 + y, buffer, "From: !%08x", rx_from_node);
+            }
+        }
     } else {
-        // Map numeric gain to human-readable label
-        auto gainLabel = [](uint8_t g) -> const char * {
-            if (g == 0)
-                g = AUDIO_DEFAULT_GAIN;
-            if (g <= 1)
-                return "Quiet";
-            if (g <= 4)
-                return "Low";
-            if (g <= 8)
-                return "Default";
-            if (g <= 16)
-                return "High";
-            if (g <= 24)
-                return "Loud";
-            return "Max";
-        };
+        uint8_t micG = moduleConfig.audio.mic_gain;
+        uint8_t spkG = moduleConfig.audio.speaker_gain;
+        if (micG < 1 || micG > 12) micG = AUDIO_DEFAULT_GAIN;
+        if (spkG < 1 || spkG > 12) spkG = AUDIO_DEFAULT_GAIN;
 
         display->setFont(FONT_SMALL);
-        display->drawStringf(display->getWidth() / 2 + x, 16 + y, buffer, "Mic: %s   Spk: %s",
-                             gainLabel(moduleConfig.audio.mic_gain), gainLabel(moduleConfig.audio.speaker_gain));
+        display->drawStringf(display->getWidth() / 2 + x, 16 + y, buffer, "Mic: %u   Spk: %u", micG, spkG);
 
         // Target line
         if (moduleConfig.audio.audio_target) {
             meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(moduleConfig.audio.audio_target);
-            const char *name = (node && node->user.short_name[0]) ? node->user.short_name : "????";
-            display->drawStringf(display->getWidth() / 2 + x, 30 + y, buffer, "To: %.4s", name);
+            if (node && node->user.long_name[0]) {
+                display->drawStringf(display->getWidth() / 2 + x, 30 + y, buffer, "To: %s", node->user.long_name);
+            } else if (node && node->user.short_name[0]) {
+                display->drawStringf(display->getWidth() / 2 + x, 30 + y, buffer, "To: %.4s", node->user.short_name);
+            } else {
+                display->drawStringf(display->getWidth() / 2 + x, 30 + y, buffer, "To: !%08x", moduleConfig.audio.audio_target);
+            }
         } else {
-            display->drawString(display->getWidth() / 2 + x, 30 + y, "To: Broadcast");
+            uint8_t ch = moduleConfig.audio.audio_channel;
+            const char *chName = channels.getName(ch);
+            display->drawStringf(display->getWidth() / 2 + x, 30 + y, buffer, "Ch: %s", chName);
         }
+
+        // Codec rate line
+        display->drawStringf(display->getWidth() / 2 + x, 44 + y, buffer, "Rate: %s bps",
+                             getCodecRateStr(moduleConfig.audio.bitrate));
     }
 }
 
@@ -632,9 +674,18 @@ int32_t AudioModule::runOnce()
                 case 3:
                     showTargetMenu();
                     break;
+                case 4:
+                    showCodecRateMenu();
+                    break;
                 }
             }
 #endif
+            // Apply pending codec2 reinit (from codec rate menu) when idle
+            if (pendingCodecReinit && radio_state == RadioState::rx && !rx_playback_active && !rx_draining) {
+                pendingCodecReinit = false;
+                reinitCodec();
+            }
+
             // Check if PTT is pressed (active LOW). TODO hook that into Onebutton/Interrupt drive.
             if (digitalRead(moduleConfig.audio.ptt_pin ? moduleConfig.audio.ptt_pin : PTT_PIN) == LOW) {
                 if (radio_state == RadioState::rx) {
@@ -649,6 +700,7 @@ int32_t AudioModule::runOnce()
                     // Reset audio state for new TX session
                     rx_playback_active = false;
                     rx_draining = false;
+                    rx_from_node = 0;
                     i2s_reclaimed_for_codec2 = false;
                     rx_seq_initialized = false;
                     tx_seq = 0;
@@ -678,6 +730,7 @@ int32_t AudioModule::runOnce()
                     adc_buffer_index = 0;
                     rx_playback_active = false;
                     rx_draining = false;
+                    rx_from_node = 0;
                     i2s_reclaimed_for_codec2 = false;
                     rx_seq_initialized = false; // reset for next RX session
                     ring_drops = 0; // reset drop counter
@@ -714,6 +767,11 @@ void AudioModule::sendPayload(NodeNum dest, bool wantReplies)
     meshtastic_MeshPacket *p = allocReply();
     p->to = dest;
     p->decoded.want_response = wantReplies;
+
+    // Use the configured broadcast channel (only meaningful for broadcast; DMs use PKI)
+    if (dest == NODENUM_BROADCAST && moduleConfig.audio.audio_channel > 0) {
+        p->channel = moduleConfig.audio.audio_channel;
+    }
 
     p->want_ack = false;                              // Audio is shoot&forget. No need to wait for ACKs.
     p->priority = meshtastic_MeshPacket_Priority_MAX; // Audio is important, because realtime
@@ -754,6 +812,19 @@ ProcessMessage AudioModule::handleReceived(const meshtastic_MeshPacket &mp)
                 xTaskNotifyGive(codec2HandlerTask);
             }
             radio_state = RadioState::rx;
+
+            // Track who is sending audio for the display
+            rx_from_node = mp.from;
+            rx_is_dm = (mp.to != NODENUM_BROADCAST);
+            rx_channel = mp.channel;
+            rx_last_packet_ms = millis();
+
+            // Switch display to audio frame so user can see incoming audio
+            powerFSM.trigger(EVENT_INPUT);
+            requestFocus();
+            UIFrameEvent e;
+            e.action = UIFrameEvent::Action::REGENERATE_FRAMESET;
+            this->notifyObservers(&e);
         }
     }
 
@@ -798,11 +869,11 @@ void AudioModule::showAudioMenu()
 {
     if (!screen)
         return;
-    static const char *opts[] = {"Back", "Mic Gain", "Speaker Gain", "Target"};
+    static const char *opts[] = {"Back", "Mic Gain", "Speaker Gain", "Target", "Codec Rate"};
     graphics::BannerOverlayOptions banner;
     banner.message = "Audio Settings";
     banner.optionsArrayPtr = opts;
-    banner.optionsCount = 4;
+    banner.optionsCount = 5;
     banner.bannerCallback = [](int selected) {
         if (!audioModule)
             return;
@@ -817,6 +888,9 @@ void AudioModule::showAudioMenu()
         case 3:
             audioModule->pendingMenu = 3;
             break; // target
+        case 4:
+            audioModule->pendingMenu = 4;
+            break; // codec rate
         default:
             break; // Back
         }
@@ -829,21 +903,19 @@ void AudioModule::showGainMenu(bool isMic)
     if (!screen)
         return;
 
-    static const char *micOpts[] = {"Back", "1 Quiet", "4 Low", "8 Default", "16 High", "24 Loud", "30 Max"};
-    static const char *spkOpts[] = {"Back", "1 Quiet", "4 Low", "8 Default", "16 High", "24 Loud", "30 Max"};
-    static const uint8_t gainValues[] = {0, 1, 4, 8, 16, 24, 30};
+    static const char *gainOpts[] = {"Back", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"};
 
     graphics::BannerOverlayOptions banner;
     banner.message = isMic ? "Mic Gain" : "Speaker Gain";
-    banner.optionsArrayPtr = isMic ? micOpts : spkOpts;
-    banner.optionsCount = 7;
+    banner.optionsArrayPtr = gainOpts;
+    banner.optionsCount = 13;
     banner.bannerCallback = [isMic](int selected) {
         if (!audioModule)
             return;
         audioModule->suppressNextSelect = true;
         if (selected == 0)
             return; // Back
-        uint8_t gain = gainValues[selected];
+        uint8_t gain = (uint8_t)selected; // 1-12
         if (isMic)
             moduleConfig.audio.mic_gain = gain;
         else
@@ -854,14 +926,9 @@ void AudioModule::showGainMenu(bool isMic)
 
     // Pre-select the current value
     uint8_t current = isMic ? moduleConfig.audio.mic_gain : moduleConfig.audio.speaker_gain;
-    if (current == 0)
+    if (current < 1 || current > 12)
         current = AUDIO_DEFAULT_GAIN;
-    for (int i = 1; i < 7; i++) {
-        if (gainValues[i] >= current) {
-            banner.InitialSelected = i;
-            break;
-        }
-    }
+    banner.InitialSelected = current;
 
     screen->showOverlayBanner(banner);
 }
@@ -871,36 +938,57 @@ void AudioModule::showTargetMenu()
     if (!screen)
         return;
 
-    // Build a dynamic list: Back, Broadcast, then up to 5 known nodes
-    static char nodeLabels[8][20];
-    static const char *opts[8];
-    static uint32_t nodeNums[8];
+    // Combined menu: Back, broadcast channels, then DM nodes
+    static char labels[14][20];
+    static const char *opts[14];
+    static uint32_t targetNums[14];  // node num (0 = broadcast)
+    static uint8_t targetChans[14];  // channel index (broadcast entries only)
     int idx = 0;
 
-    strncpy(nodeLabels[idx], "Back", sizeof(nodeLabels[0]));
-    opts[idx] = nodeLabels[idx];
-    nodeNums[idx] = 0;
+    opts[idx] = "Back";
+    targetNums[idx] = 0;
+    targetChans[idx] = 0;
     idx++;
 
-    strncpy(nodeLabels[idx], "Broadcast", sizeof(nodeLabels[0]));
-    opts[idx] = nodeLabels[idx];
-    nodeNums[idx] = 0;
-    idx++;
+    // Broadcast entries — one per enabled channel
+    for (int i = 0; i < channels.getNumChannels() && idx < 10; i++) {
+        meshtastic_Channel ch = channels.getByIndex(i);
+        if (ch.role == meshtastic_Channel_Role_DISABLED)
+            continue;
+        const char *name = channels.getName(i);
+        snprintf(labels[idx], sizeof(labels[0]), "Bcast: %.12s", name);
+        targetNums[idx] = 0;
+        targetChans[idx] = i;
+        opts[idx] = labels[idx];
+        idx++;
+    }
 
-    // Add up to 5 known nodes (excluding self)
-    for (int i = 0; i < nodeDB->getNumMeshNodes() && idx < 7; i++) {
+    // DM entries — up to 5 known nodes (excluding self)
+    for (int i = 0; i < nodeDB->getNumMeshNodes() && idx < 14; i++) {
         meshtastic_NodeInfoLite *node = nodeDB->getMeshNodeByIndex(i);
         if (!node || node->num == nodeDB->getNodeNum())
             continue;
-        const char *shortName = node->user.short_name[0] ? node->user.short_name : "????";
-        snprintf(nodeLabels[idx], sizeof(nodeLabels[0]), "%.4s !%04x", shortName, (uint16_t)(node->num & 0xFFFF));
-        nodeNums[idx] = node->num;
-        opts[idx] = nodeLabels[idx];
+        if (node->user.long_name[0]) {
+            snprintf(labels[idx], sizeof(labels[0]), "%.19s", node->user.long_name);
+        } else if (node->user.short_name[0]) {
+            snprintf(labels[idx], sizeof(labels[0]), "%.4s !%04x", node->user.short_name, (uint16_t)(node->num & 0xFFFF));
+        } else {
+            snprintf(labels[idx], sizeof(labels[0]), "!%08x", node->num);
+        }
+        targetNums[idx] = node->num;
+        targetChans[idx] = 0;
+        opts[idx] = labels[idx];
         idx++;
     }
 
     graphics::BannerOverlayOptions banner;
-    banner.message = moduleConfig.audio.audio_target ? "Target: DM" : "Target: Bcast";
+    static char hdr[24];
+    if (moduleConfig.audio.audio_target) {
+        banner.message = "Target: DM";
+    } else {
+        snprintf(hdr, sizeof(hdr), "Target: %.15s", channels.getName(moduleConfig.audio.audio_channel));
+        banner.message = hdr;
+    }
     banner.optionsArrayPtr = opts;
     banner.optionsCount = idx;
     banner.bannerCallback = [](int selected) {
@@ -909,17 +997,30 @@ void AudioModule::showTargetMenu()
         audioModule->suppressNextSelect = true;
         if (selected == 0)
             return; // Back
-        moduleConfig.audio.audio_target = nodeNums[selected]; // 0 for Broadcast, nodeNum for DM
+        moduleConfig.audio.audio_target = targetNums[selected];
+        if (targetNums[selected] == 0) {
+            // Broadcast — also set channel
+            moduleConfig.audio.audio_channel = targetChans[selected];
+        }
         nodeDB->saveToDisk(SEGMENT_MODULECONFIG);
-        LOG_INFO("Audio target set to %s (0x%08x)",
-                 moduleConfig.audio.audio_target ? "DM" : "broadcast",
-                 moduleConfig.audio.audio_target);
+        if (targetNums[selected]) {
+            LOG_INFO("Audio target set to DM 0x%08x", targetNums[selected]);
+        } else {
+            LOG_INFO("Audio target set to broadcast ch %d", targetChans[selected]);
+        }
     };
 
-    // If a DM target is set, pre-select it in the list
+    // Pre-select current target
     if (moduleConfig.audio.audio_target) {
-        for (int i = 2; i < idx; i++) {
-            if (nodeNums[i] == moduleConfig.audio.audio_target) {
+        for (int i = 1; i < idx; i++) {
+            if (targetNums[i] == moduleConfig.audio.audio_target) {
+                banner.InitialSelected = i;
+                break;
+            }
+        }
+    } else {
+        for (int i = 1; i < idx; i++) {
+            if (targetNums[i] == 0 && targetChans[i] == moduleConfig.audio.audio_channel) {
                 banner.InitialSelected = i;
                 break;
             }
@@ -927,6 +1028,64 @@ void AudioModule::showTargetMenu()
     }
 
     screen->showOverlayBanner(banner);
+}
+
+void AudioModule::showCodecRateMenu()
+{
+    if (!screen)
+        return;
+
+    static const char *opts[] = {"Back", "3200 bps", "2400 bps", "1600 bps", "1400 bps", "1300 bps", "1200 bps", "700 bps"};
+    // Protobuf enum values: CODEC2_3200=1 .. CODEC2_700=7
+    static const uint8_t rateValues[] = {0, 1, 2, 3, 4, 5, 6, 7};
+
+    graphics::BannerOverlayOptions banner;
+    banner.message = "Codec Rate";
+    banner.optionsArrayPtr = opts;
+    banner.optionsCount = 8;
+    banner.bannerCallback = [](int selected) {
+        if (!audioModule)
+            return;
+        audioModule->suppressNextSelect = true;
+        if (selected == 0)
+            return; // Back
+        moduleConfig.audio.bitrate = (meshtastic_ModuleConfig_AudioConfig_Audio_Baud)rateValues[selected];
+        nodeDB->saveToDisk(SEGMENT_MODULECONFIG);
+        audioModule->pendingCodecReinit = true;
+        LOG_INFO("Audio codec rate set to %s bps", getCodecRateStr(rateValues[selected]));
+    };
+
+    // Pre-select the current value
+    uint8_t current = moduleConfig.audio.bitrate ? moduleConfig.audio.bitrate : AUDIO_MODULE_MODE;
+    for (int i = 1; i < 8; i++) {
+        if (rateValues[i] == current) {
+            banner.InitialSelected = i;
+            break;
+        }
+    }
+
+    screen->showOverlayBanner(banner);
+}
+
+void AudioModule::reinitCodec()
+{
+    if (codec2) {
+        codec2_destroy(codec2);
+    }
+    int mode = (moduleConfig.audio.bitrate ? moduleConfig.audio.bitrate : AUDIO_MODULE_MODE) - 1;
+    codec2 = codec2_create(mode);
+    codec2_set_lpc_post_filter(codec2, 1, 0, 0.8, 0.2);
+    encode_codec_size = (codec2_bits_per_frame(codec2) + 7) / 8;
+    adc_buffer_size = codec2_samples_per_frame(codec2);
+    encode_frame_num = MAX_AUDIO_DATA / encode_codec_size;
+    encode_frame_size = encode_frame_num * encode_codec_size;
+    tx_header.mode = mode;
+    memcpy(tx_encode_frame, &tx_header, sizeof(c2_header)); // Update wire header so receivers see the new mode
+    tx_encode_frame_index = AUDIO_HEADER_SIZE;
+    rx_encode_frame_index = 0;
+    int frameDurationMs = (adc_buffer_size * 1000) / 8000;
+    LOG_INFO("Codec2 reinit: mode %d, %d frames of %d bytes (%dms per packet)",
+             mode, encode_frame_num, encode_codec_size, encode_frame_num * frameDurationMs);
 }
 
 #endif // HAS_SCREEN

--- a/src/modules/esp32/AudioModule.cpp
+++ b/src/modules/esp32/AudioModule.cpp
@@ -357,10 +357,11 @@ AudioModule::AudioModule() : SinglePortModule("Audio", meshtastic_PortNum_AUDIO_
 
         // Fill as much of the payload as possible for the slowest packet rate.
         // The radio frame limit is MAX_LORA_PAYLOAD_LEN(255) - MESHTASTIC_HEADER_LENGTH(16)
-        // = 239 bytes for the protobuf-encoded Data struct. Protobuf adds ~6 bytes
-        // overhead (field tags, varint lengths), so max audio payload ≈ 233 - 6 = 227.
-        // We use 224 as a safe max for the codec data portion (leaves headroom).
-        static const int MAX_AUDIO_DATA = 224;
+        // - MESHTASTIC_PKC_OVERHEAD(12) = 227 bytes for the protobuf-encoded Data struct.
+        // Protobuf adds ~6 bytes overhead (field tags, varint lengths), so max audio
+        // payload ≈ 227 - 6 = 221.  We use 212 as a safe max (leaves headroom and
+        // ensures PKI encryption works for direct-message audio).
+        static const int MAX_AUDIO_DATA = 212;
         encode_frame_num = MAX_AUDIO_DATA / encode_codec_size;
         encode_frame_size = encode_frame_num * encode_codec_size;
         int frameDurationMs = (adc_buffer_size * 1000) / 8000;

--- a/src/modules/esp32/AudioModule.cpp
+++ b/src/modules/esp32/AudioModule.cpp
@@ -7,6 +7,7 @@
 #include "PowerFSM.h"
 #include "RTC.h"
 #include "Router.h"
+#include "graphics/Screen.h"
 #ifdef HAS_I2S
 #include "main.h" // for audioThread
 #endif
@@ -33,9 +34,18 @@
 
 ButterworthFilter hp_filter(240, 8000, ButterworthFilter::ButterworthFilter::Highpass, 1);
 
-// Volume gain applied to mic input and speaker output.
-// Increase to make audio louder; decrease if clipping/distortion occurs.
-static constexpr int AUDIO_GAIN = 8;
+// Runtime gain helpers — read once from config, cached in local vars
+static int getMicGain()
+{
+    uint8_t g = moduleConfig.audio.mic_gain;
+    return (g > 0 && g <= 30) ? g : AUDIO_DEFAULT_GAIN;
+}
+
+static int getSpeakerGain()
+{
+    uint8_t g = moduleConfig.audio.speaker_gain;
+    return (g > 0 && g <= 30) ? g : AUDIO_DEFAULT_GAIN;
+}
 
 TaskHandle_t codec2HandlerTask;
 TaskHandle_t speakerTaskHandle;
@@ -219,7 +229,7 @@ void run_codec2(void *parameter)
                     continue; // Partial read — try again (don't break out of TX loop!)
 
                 for (int i = 0; i < audioModule->adc_buffer_size; i++) {
-                    int32_t sample = (int32_t)hp_filter.Update((float)audioModule->speech[i]) * AUDIO_GAIN;
+                    int32_t sample = (int32_t)hp_filter.Update((float)audioModule->speech[i]) * getMicGain();
                     if (sample > 32767) sample = 32767;
                     if (sample < -32768) sample = -32768;
                     audioModule->speech[i] = (int16_t)sample;
@@ -232,7 +242,8 @@ void run_codec2(void *parameter)
                 if (audioModule->tx_encode_frame_index == (audioModule->encode_frame_size + (int)AUDIO_HEADER_SIZE)) {
                     LOG_DEBUG("Send %d codec2 bytes (seq=%u)", audioModule->encode_frame_size, audioModule->tx_seq);
                     audioModule->tx_encode_frame[sizeof(c2_header)] = audioModule->tx_seq++;
-                    audioModule->sendPayload();
+                    NodeNum dest = moduleConfig.audio.audio_target ? moduleConfig.audio.audio_target : NODENUM_BROADCAST;
+                    audioModule->sendPayload(dest);
                     audioModule->tx_encode_frame_index = AUDIO_HEADER_SIZE;
                     taskYIELD();
                 }
@@ -302,7 +313,7 @@ void run_codec2(void *parameter)
                 for (int i = AUDIO_HEADER_SIZE; i + dec_frame_bytes <= (int)pkt.size; i += dec_frame_bytes) {
                     codec2_decode(dec_codec, audioModule->output_buffer, pkt.data + i);
                     for (int j = 0; j < dec_samples; j++) {
-                        int32_t s = (int32_t)audioModule->output_buffer[j] * AUDIO_GAIN;
+                        int32_t s = (int32_t)audioModule->output_buffer[j] * getSpeakerGain();
                         if (s > 32767) s = 32767;
                         if (s < -32768) s = -32768;
                         audioModule->output_buffer[j] = (int16_t)s;
@@ -358,6 +369,9 @@ AudioModule::AudioModule() : SinglePortModule("Audio", meshtastic_PortNum_AUDIO_
                  encode_frame_num * frameDurationMs,
                  encode_frame_size, (int)AUDIO_HEADER_SIZE,
                  encode_frame_size + (int)AUDIO_HEADER_SIZE);
+        LOG_INFO("Audio gain: mic=%d speaker=%d, target=%s",
+                 getMicGain(), getSpeakerGain(),
+                 moduleConfig.audio.audio_target ? "DM" : "broadcast");
         // Speaker task: HIGHEST priority (22) on core 1.
         // Must never be starved — DMA underruns cause audible glitches.
         // Blocks on i2s_write(portMAX_DELAY) when DMA is full, freeing CPU.
@@ -375,24 +389,63 @@ AudioModule::AudioModule() : SinglePortModule("Audio", meshtastic_PortNum_AUDIO_
 
 void AudioModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y)
 {
+#if HAS_SCREEN
+    lastDrawMs = millis();
+
+    // Suppress frame content while a sub-menu is pending or the overlay
+    // banner is active.  Without this, "Receive" flashes for one frame
+    // between the main menu closing and the sub-menu opening.
+    if (pendingMenu != 0)
+        return;
+#endif
     char buffer[50];
 
     display->setTextAlignment(TEXT_ALIGN_LEFT);
     display->setFont(FONT_SMALL);
     display->fillRect(0 + x, 0 + y, x + display->getWidth(), y + FONT_HEIGHT_SMALL);
     display->setColor(BLACK);
-    display->drawStringf(0 + x, 0 + y, buffer, "Codec2 Mode %d Audio",
-                         (moduleConfig.audio.bitrate ? moduleConfig.audio.bitrate : AUDIO_MODULE_MODE) - 1);
+    if (moduleConfig.audio.audio_target) {
+        display->drawStringf(0 + x, 0 + y, buffer, "Audio DM !%08x",
+                             moduleConfig.audio.audio_target);
+    } else {
+        display->drawStringf(0 + x, 0 + y, buffer, "Codec2 Mode %d Audio",
+                             (moduleConfig.audio.bitrate ? moduleConfig.audio.bitrate : AUDIO_MODULE_MODE) - 1);
+    }
     display->setColor(WHITE);
     display->setFont(FONT_LARGE);
     display->setTextAlignment(TEXT_ALIGN_CENTER);
-    switch (radio_state) {
-    case RadioState::tx:
+    if (radio_state == RadioState::tx) {
         display->drawString(display->getWidth() / 2 + x, (display->getHeight() - FONT_HEIGHT_SMALL) / 2 + y, "PTT");
-        break;
-    default:
-        display->drawString(display->getWidth() / 2 + x, (display->getHeight() - FONT_HEIGHT_SMALL) / 2 + y, "Receive");
-        break;
+    } else {
+        // Map numeric gain to human-readable label
+        auto gainLabel = [](uint8_t g) -> const char * {
+            if (g == 0)
+                g = AUDIO_DEFAULT_GAIN;
+            if (g <= 1)
+                return "Quiet";
+            if (g <= 4)
+                return "Low";
+            if (g <= 8)
+                return "Default";
+            if (g <= 16)
+                return "High";
+            if (g <= 24)
+                return "Loud";
+            return "Max";
+        };
+
+        display->setFont(FONT_SMALL);
+        display->drawStringf(display->getWidth() / 2 + x, 16 + y, buffer, "Mic: %s   Spk: %s",
+                             gainLabel(moduleConfig.audio.mic_gain), gainLabel(moduleConfig.audio.speaker_gain));
+
+        // Target line
+        if (moduleConfig.audio.audio_target) {
+            meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(moduleConfig.audio.audio_target);
+            const char *name = (node && node->user.short_name[0]) ? node->user.short_name : "????";
+            display->drawStringf(display->getWidth() / 2 + x, 30 + y, buffer, "To: %.4s", name);
+        } else {
+            display->drawString(display->getWidth() / 2 + x, 30 + y, "To: Broadcast");
+        }
     }
 }
 
@@ -559,7 +612,28 @@ int32_t AudioModule::runOnce()
                      pttPin, initialPttState == LOW ? "LOW (PTT active!)" : "HIGH (idle)");
 
             firstTime = false;
+#if HAS_SCREEN
+            this->inputObserver.observe(inputBroker);
+#endif
         } else {
+#if HAS_SCREEN
+            // Process pending sub-menu from previous banner callback
+            if (pendingMenu != 0 && screen) {
+                uint8_t menu = pendingMenu;
+                pendingMenu = 0;
+                switch (menu) {
+                case 1:
+                    showGainMenu(true);
+                    break;
+                case 2:
+                    showGainMenu(false);
+                    break;
+                case 3:
+                    showTargetMenu();
+                    break;
+                }
+            }
+#endif
             // Check if PTT is pressed (active LOW). TODO hook that into Onebutton/Interrupt drive.
             if (digitalRead(moduleConfig.audio.ptt_pin ? moduleConfig.audio.ptt_pin : PTT_PIN) == LOW) {
                 if (radio_state == RadioState::rx) {
@@ -592,7 +666,8 @@ int32_t AudioModule::runOnce()
                         // Send the incomplete frame
                         LOG_DEBUG("Send %d codec2 bytes (incomplete, seq=%u)", tx_encode_frame_index, tx_seq);
                         tx_encode_frame[sizeof(c2_header)] = tx_seq++;
-                        sendPayload();
+                        NodeNum dest = moduleConfig.audio.audio_target ? moduleConfig.audio.audio_target : NODENUM_BROADCAST;
+                        sendPayload(dest);
                     }
                     tx_encode_frame_index = AUDIO_HEADER_SIZE;
                     // Flush stale RX audio that may have arrived during TX
@@ -630,8 +705,6 @@ meshtastic_MeshPacket *AudioModule::allocReply()
 
 bool AudioModule::shouldDraw()
 {
-    if (!moduleConfig.audio.codec2_enabled)
-        return false;
     return (radio_state == RadioState::tx);
 }
 
@@ -685,5 +758,176 @@ ProcessMessage AudioModule::handleReceived(const meshtastic_MeshPacket &mp)
 
     return ProcessMessage::CONTINUE;
 }
+
+// --- On-screen audio settings menus (long-press SELECT on audio frame) ---
+
+#if HAS_SCREEN
+
+int AudioModule::handleInputEvent(const InputEvent *event)
+{
+    if (event->inputEvent != INPUT_BROKER_SELECT)
+        return 0;
+
+    // If a banner callback just fired (e.g. user picked an option), suppress
+    // this SELECT so we don't immediately reopen the main menu.
+    if (suppressNextSelect) {
+        suppressNextSelect = false;
+        return 0;
+    }
+
+    // Only act when the audio frame was drawn recently (i.e. it's visible).
+    // Use 1000ms to cover the 500ms long-press hold time plus margin for
+    // auto-frame-advance that may stop drawFrame calls mid-press.
+    if ((millis() - lastDrawMs) > 1000)
+        return 0;
+
+    // Don't intercept while a banner overlay is already showing
+    if (screen && screen->isOverlayBannerShowing())
+        return 0;
+
+    // Don't open menu during active TX (PTT held)
+    if (radio_state == RadioState::tx)
+        return 0;
+
+    showAudioMenu();
+    return 1; // consumed — stop observer chain
+}
+
+void AudioModule::showAudioMenu()
+{
+    if (!screen)
+        return;
+    static const char *opts[] = {"Back", "Mic Gain", "Speaker Gain", "Target"};
+    graphics::BannerOverlayOptions banner;
+    banner.message = "Audio Settings";
+    banner.optionsArrayPtr = opts;
+    banner.optionsCount = 4;
+    banner.bannerCallback = [](int selected) {
+        if (!audioModule)
+            return;
+        audioModule->suppressNextSelect = true;
+        switch (selected) {
+        case 1:
+            audioModule->pendingMenu = 1;
+            break; // mic gain
+        case 2:
+            audioModule->pendingMenu = 2;
+            break; // speaker gain
+        case 3:
+            audioModule->pendingMenu = 3;
+            break; // target
+        default:
+            break; // Back
+        }
+    };
+    screen->showOverlayBanner(banner);
+}
+
+void AudioModule::showGainMenu(bool isMic)
+{
+    if (!screen)
+        return;
+
+    static const char *micOpts[] = {"Back", "1 Quiet", "4 Low", "8 Default", "16 High", "24 Loud", "30 Max"};
+    static const char *spkOpts[] = {"Back", "1 Quiet", "4 Low", "8 Default", "16 High", "24 Loud", "30 Max"};
+    static const uint8_t gainValues[] = {0, 1, 4, 8, 16, 24, 30};
+
+    graphics::BannerOverlayOptions banner;
+    banner.message = isMic ? "Mic Gain" : "Speaker Gain";
+    banner.optionsArrayPtr = isMic ? micOpts : spkOpts;
+    banner.optionsCount = 7;
+    banner.bannerCallback = [isMic](int selected) {
+        if (!audioModule)
+            return;
+        audioModule->suppressNextSelect = true;
+        if (selected == 0)
+            return; // Back
+        uint8_t gain = gainValues[selected];
+        if (isMic)
+            moduleConfig.audio.mic_gain = gain;
+        else
+            moduleConfig.audio.speaker_gain = gain;
+        nodeDB->saveToDisk(SEGMENT_MODULECONFIG);
+        LOG_INFO("Audio %s gain set to %u", isMic ? "mic" : "speaker", gain);
+    };
+
+    // Pre-select the current value
+    uint8_t current = isMic ? moduleConfig.audio.mic_gain : moduleConfig.audio.speaker_gain;
+    if (current == 0)
+        current = AUDIO_DEFAULT_GAIN;
+    for (int i = 1; i < 7; i++) {
+        if (gainValues[i] >= current) {
+            banner.InitialSelected = i;
+            break;
+        }
+    }
+
+    screen->showOverlayBanner(banner);
+}
+
+void AudioModule::showTargetMenu()
+{
+    if (!screen)
+        return;
+
+    // Build a dynamic list: Back, Broadcast, then up to 5 known nodes
+    static char nodeLabels[8][20];
+    static const char *opts[8];
+    static uint32_t nodeNums[8];
+    int idx = 0;
+
+    strncpy(nodeLabels[idx], "Back", sizeof(nodeLabels[0]));
+    opts[idx] = nodeLabels[idx];
+    nodeNums[idx] = 0;
+    idx++;
+
+    strncpy(nodeLabels[idx], "Broadcast", sizeof(nodeLabels[0]));
+    opts[idx] = nodeLabels[idx];
+    nodeNums[idx] = 0;
+    idx++;
+
+    // Add up to 5 known nodes (excluding self)
+    for (int i = 0; i < nodeDB->getNumMeshNodes() && idx < 7; i++) {
+        meshtastic_NodeInfoLite *node = nodeDB->getMeshNodeByIndex(i);
+        if (!node || node->num == nodeDB->getNodeNum())
+            continue;
+        const char *shortName = node->user.short_name[0] ? node->user.short_name : "????";
+        snprintf(nodeLabels[idx], sizeof(nodeLabels[0]), "%.4s !%04x", shortName, (uint16_t)(node->num & 0xFFFF));
+        nodeNums[idx] = node->num;
+        opts[idx] = nodeLabels[idx];
+        idx++;
+    }
+
+    graphics::BannerOverlayOptions banner;
+    banner.message = moduleConfig.audio.audio_target ? "Target: DM" : "Target: Bcast";
+    banner.optionsArrayPtr = opts;
+    banner.optionsCount = idx;
+    banner.bannerCallback = [](int selected) {
+        if (!audioModule)
+            return;
+        audioModule->suppressNextSelect = true;
+        if (selected == 0)
+            return; // Back
+        moduleConfig.audio.audio_target = nodeNums[selected]; // 0 for Broadcast, nodeNum for DM
+        nodeDB->saveToDisk(SEGMENT_MODULECONFIG);
+        LOG_INFO("Audio target set to %s (0x%08x)",
+                 moduleConfig.audio.audio_target ? "DM" : "broadcast",
+                 moduleConfig.audio.audio_target);
+    };
+
+    // If a DM target is set, pre-select it in the list
+    if (moduleConfig.audio.audio_target) {
+        for (int i = 2; i < idx; i++) {
+            if (nodeNums[i] == moduleConfig.audio.audio_target) {
+                banner.InitialSelected = i;
+                break;
+            }
+        }
+    }
+
+    screen->showOverlayBanner(banner);
+}
+
+#endif // HAS_SCREEN
 
 #endif

--- a/src/modules/esp32/AudioModule.cpp
+++ b/src/modules/esp32/AudioModule.cpp
@@ -7,6 +7,9 @@
 #include "PowerFSM.h"
 #include "RTC.h"
 #include "Router.h"
+#ifdef HAS_I2S
+#include "main.h" // for audioThread
+#endif
 
 /*
     AudioModule
@@ -35,6 +38,7 @@ ButterworthFilter hp_filter(240, 8000, ButterworthFilter::ButterworthFilter::Hig
 static constexpr int AUDIO_GAIN = 8;
 
 TaskHandle_t codec2HandlerTask;
+TaskHandle_t speakerTaskHandle;
 AudioModule *audioModule;
 
 #ifdef ARCH_ESP32
@@ -46,18 +50,174 @@ AudioModule *audioModule;
 
 #include "graphics/ScreenFonts.h"
 
+#ifdef AUDIO_I2S_DUAL
+void AudioModule::reinstallSpeakerI2S()
+{
+    // AudioOutputI2S::stop() calls i2s_driver_uninstall(), so we must
+    // reinstall the driver before codec2 can write decoded audio.
+    i2s_config_t spk_config = {.mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX),
+                               .sample_rate = 8000,
+                               .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
+                               .channel_format = I2S_CHANNEL_FMT_ONLY_LEFT,
+                               .communication_format = (i2s_comm_format_t)(I2S_COMM_FORMAT_STAND_I2S),
+                               .intr_alloc_flags = 0,
+                               .dma_buf_count = 16,
+                               .dma_buf_len = adc_buffer_size,
+                               .use_apll = false,
+                               .tx_desc_auto_clear = true,
+                               .fixed_mclk = 0};
+    esp_err_t res = i2s_driver_install(I2S_PORT_SPK, &spk_config, 0, NULL);
+    if (res == ESP_OK) {
+        const i2s_pin_config_t spk_pins = {.mck_io_num = I2S_PIN_NO_CHANGE,
+                                           .bck_io_num = AUDIO_I2S_SPK_SCK,
+                                           .ws_io_num = AUDIO_I2S_SPK_WS,
+                                           .data_out_num = AUDIO_I2S_SPK_DIN,
+                                           .data_in_num = I2S_PIN_NO_CHANGE};
+        i2s_set_pin(I2S_PORT_SPK, &spk_pins);
+        i2s_start(I2S_PORT_SPK);
+        LOG_INFO("Reinstalled speaker I2S driver after AudioThread teardown");
+    } else if (res == ESP_ERR_INVALID_STATE) {
+        // Driver still installed (RTTTL never played or stop() wasn't called) — just reset rate
+        i2s_set_sample_rates(I2S_PORT_SPK, 8000);
+    } else {
+        LOG_ERROR("Failed to reinstall speaker I2S driver: %d", res);
+    }
+}
+#endif
+
+// --- Shared ring buffer helpers (TX mic and RX jitter use the same buffer) ---
+
+uint32_t AudioModule::ringAvailable()
+{
+    uint32_t h = ring_head;
+    uint32_t t = ring_tail;
+    return (h - t) & RING_BUF_MASK;
+}
+
+void AudioModule::ringWrite(const int16_t *data, int count)
+{
+    for (int i = 0; i < count; i++) {
+        uint32_t nextHead = (ring_head + 1) & RING_BUF_MASK;
+        if (nextHead == ring_tail) {
+            // Buffer full — drop remaining samples (never modify ring_tail from writer;
+            // only the reader may advance tail to keep this a safe SPSC buffer).
+            uint32_t dropped = count - i;
+            ring_drops += dropped;
+            LOG_WARN("Ring buffer full, dropped %u samples (total drops: %u, avail: %u)",
+                     dropped, ring_drops, ringAvailable());
+            return;
+        }
+        ring_buf[ring_head] = data[i];
+        ring_head = nextHead;
+    }
+}
+
+int AudioModule::ringRead(int16_t *data, int maxCount)
+{
+    int count = 0;
+    while (count < maxCount && ring_tail != ring_head) {
+        data[count++] = ring_buf[ring_tail];
+        ring_tail = (ring_tail + 1) & RING_BUF_MASK;
+    }
+    return count;
+}
+
+void AudioModule::ringReset()
+{
+    ring_head = ring_tail = 0;
+}
+
+// === Speaker drain task ===
+// Runs independently of codec2 decode at priority 19 on core 1.
+// Continuously pulls decoded PCM from the ring buffer and writes to I2S.
+// Uses portMAX_DELAY so it blocks on the I2S DMA semaphore and wakes
+// the instant DMA space opens — natural hardware flow control.
+static void speaker_task(void *parameter)
+{
+    while (audioModule == nullptr)
+        vTaskDelay(pdMS_TO_TICKS(10));
+
+    int16_t playBuf[ADC_BUFFER_SIZE_MAX];
+    uint32_t lastDataTime = 0;
+
+    LOG_INFO("Speaker drain task started");
+
+    while (true) {
+        // Wait for playback to become active
+        if (!audioModule->rx_playback_active) {
+            // Check if jitter buffer is filled enough to start
+            if (audioModule->rx_draining && audioModule->ringAvailable() >= RX_JITTER_SAMPLES) {
+                audioModule->rx_playback_active = true;
+                lastDataTime = millis();
+                LOG_INFO("RX jitter buffer filled (%u samples), starting playback", audioModule->ringAvailable());
+            } else {
+                vTaskDelay(pdMS_TO_TICKS(5));
+                continue;
+            }
+        }
+
+        // Drain one frame to I2S (blocks until DMA accepts it)
+        if (audioModule->ringAvailable() >= (uint32_t)audioModule->adc_buffer_size) {
+            audioModule->ringRead(playBuf, audioModule->adc_buffer_size);
+            size_t bytesOut = 0;
+            i2s_write(I2S_PORT_SPK, playBuf, audioModule->adc_buffer_size * sizeof(int16_t),
+                      &bytesOut, portMAX_DELAY);
+            lastDataTime = millis();
+        } else {
+            // Ring buffer empty — check for silence timeout
+            if (millis() - lastDataTime > RX_SILENCE_TIMEOUT) {
+                audioModule->rx_playback_active = false;
+                audioModule->rx_draining = false;
+                audioModule->i2s_reclaimed_for_codec2 = false;
+                audioModule->rx_seq_initialized = false;
+                LOG_INFO("RX playback stopped (buffer drained, no new data)");
+            } else {
+                // Brief sleep while waiting for more decoded data
+                vTaskDelay(pdMS_TO_TICKS(5));
+            }
+        }
+    }
+}
+
 void run_codec2(void *parameter)
 {
-    // 4 bytes of header in each frame hex c0 de c2 plus the bitrate
+    // Wait for the global audioModule pointer to be assigned.
+    // The task is created inside the AudioModule constructor, but the global
+    // pointer isn't set until after the constructor returns (audioModule = new AudioModule()).
+    // On dual-core ESP32-S3 the task can start on core 1 immediately.
+    while (audioModule == nullptr) {
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
+
+    // 4 bytes of c2_header (magic + mode) then 1 byte sequence number
     memcpy(audioModule->tx_encode_frame, &audioModule->tx_header, sizeof(audioModule->tx_header));
+    audioModule->tx_encode_frame[sizeof(c2_header)] = 0; // initial seq = 0
 
     LOG_INFO("Start codec2 task");
 
     while (true) {
-        uint32_t tcount = ulTaskNotifyTake(pdFALSE, pdMS_TO_TICKS(10000));
+        // Block until notified by handleReceived (new packet) or PTT press.
+        // Short timeout during TX so we re-enter the mic read loop quickly
+        // if we ever exit it (e.g. partial i2s_read). Long timeout during RX
+        // since speaker_task handles playback independently.
+        bool inTx = (audioModule->radio_state == RadioState::tx);
+        uint32_t tcount = ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(inTx ? 5 : 10000));
 
-        if (tcount != 0) {
-            if (audioModule->radio_state == RadioState::tx) {
+        // === TX path: read mic I2S directly, filter, encode, send ===
+        // codec2 task runs at priority 1 (same as main loop) so that
+        // xTaskNotifyGive from the PTT handler does NOT preempt — the main
+        // loop finishes its iteration (including screen update) first.
+        // i2s_read blocks on DMA, naturally yielding CPU between frames.
+        if (audioModule->radio_state == RadioState::tx) {
+            size_t bytesIn = 0;
+            while (audioModule->radio_state == RadioState::tx) {
+                // Read one full codec2 frame directly from mic I2S
+                esp_err_t res = i2s_read(I2S_PORT_MIC, audioModule->speech,
+                                         audioModule->adc_buffer_size * sizeof(int16_t),
+                                         &bytesIn, pdMS_TO_TICKS(80));
+                if (res != ESP_OK || (int)(bytesIn / sizeof(int16_t)) < audioModule->adc_buffer_size)
+                    continue; // Partial read — try again (don't break out of TX loop!)
+
                 for (int i = 0; i < audioModule->adc_buffer_size; i++) {
                     int32_t sample = (int32_t)hp_filter.Update((float)audioModule->speech[i]) * AUDIO_GAIN;
                     if (sample > 32767) sample = 32767;
@@ -69,47 +229,100 @@ void run_codec2(void *parameter)
                               audioModule->speech);
                 audioModule->tx_encode_frame_index += audioModule->encode_codec_size;
 
-                if (audioModule->tx_encode_frame_index == (audioModule->encode_frame_size + sizeof(audioModule->tx_header))) {
-                    LOG_INFO("Send %d codec2 bytes", audioModule->encode_frame_size);
+                if (audioModule->tx_encode_frame_index == (audioModule->encode_frame_size + (int)AUDIO_HEADER_SIZE)) {
+                    LOG_DEBUG("Send %d codec2 bytes (seq=%u)", audioModule->encode_frame_size, audioModule->tx_seq);
+                    audioModule->tx_encode_frame[sizeof(c2_header)] = audioModule->tx_seq++;
                     audioModule->sendPayload();
-                    audioModule->tx_encode_frame_index = sizeof(audioModule->tx_header);
-                }
-            }
-            if (audioModule->radio_state == RadioState::rx) {
-                size_t bytesOut = 0;
-                if (memcmp(audioModule->rx_encode_frame, &audioModule->tx_header, sizeof(audioModule->tx_header)) == 0) {
-                    for (int i = 4; i < audioModule->rx_encode_frame_index; i += audioModule->encode_codec_size) {
-                        codec2_decode(audioModule->codec2, audioModule->output_buffer, audioModule->rx_encode_frame + i);
-                        for (int j = 0; j < audioModule->adc_buffer_size; j++) {
-                            int32_t s = (int32_t)audioModule->output_buffer[j] * AUDIO_GAIN;
-                            if (s > 32767) s = 32767;
-                            if (s < -32768) s = -32768;
-                            audioModule->output_buffer[j] = (int16_t)s;
-                        }
-                        i2s_write(I2S_PORT_SPK, audioModule->output_buffer,
-                                  audioModule->adc_buffer_size * sizeof(int16_t), &bytesOut, pdMS_TO_TICKS(500));
-                    }
-                } else {
-                    // if the buffer header does not match our own codec, make a temp decoding setup.
-                    CODEC2 *tmp_codec2 = codec2_create(audioModule->rx_encode_frame[3]);
-                    codec2_set_lpc_post_filter(tmp_codec2, 1, 0, 0.8, 0.2);
-                    int tmp_encode_codec_size = (codec2_bits_per_frame(tmp_codec2) + 7) / 8;
-                    int tmp_adc_buffer_size = codec2_samples_per_frame(tmp_codec2);
-                    for (int i = 4; i < audioModule->rx_encode_frame_index; i += tmp_encode_codec_size) {
-                        codec2_decode(tmp_codec2, audioModule->output_buffer, audioModule->rx_encode_frame + i);
-                        for (int j = 0; j < tmp_adc_buffer_size; j++) {
-                            int32_t s = (int32_t)audioModule->output_buffer[j] * AUDIO_GAIN;
-                            if (s > 32767) s = 32767;
-                            if (s < -32768) s = -32768;
-                            audioModule->output_buffer[j] = (int16_t)s;
-                        }
-                        i2s_write(I2S_PORT_SPK, audioModule->output_buffer,
-                                  tmp_adc_buffer_size * sizeof(int16_t), &bytesOut, pdMS_TO_TICKS(500));
-                    }
-                    codec2_destroy(tmp_codec2);
+                    audioModule->tx_encode_frame_index = AUDIO_HEADER_SIZE;
+                    taskYIELD();
                 }
             }
         }
+
+        // === RX path: decode queued packets into ring buffer ===
+        if (audioModule->radio_state != RadioState::tx && audioModule->rxPacketQueue) {
+            AudioRxPacket pkt;
+            while (xQueueReceive(audioModule->rxPacketQueue, &pkt, 0) == pdTRUE) {
+                if (pkt.size < AUDIO_HEADER_SIZE)
+                    continue;
+
+                // Extract and check sequence number (byte after c2_header)
+                uint8_t rxSeq = pkt.data[sizeof(c2_header)];
+                if (!audioModule->rx_seq_initialized) {
+                    audioModule->rx_seq_expected = rxSeq;
+                    audioModule->rx_seq_initialized = true;
+                }
+                if (rxSeq != audioModule->rx_seq_expected) {
+                    uint8_t gap = (uint8_t)(rxSeq - audioModule->rx_seq_expected);
+                    LOG_WARN("RX audio seq gap: expected %u got %u (lost %u packets)",
+                             audioModule->rx_seq_expected, rxSeq, gap);
+
+                    // Packet Loss Concealment: insert silence for each missing packet
+                    // so playback timing stays aligned. Without this, the ring buffer
+                    // drains early and the listener hears a jarring click/pop.
+                    // Cap at 3 packets to avoid flooding the ring buffer on session restart
+                    // or large sequence jumps (e.g. wrap from 255 → 0 after a gap).
+                    uint8_t plcGap = (gap > 3) ? 3 : gap;
+                    memset(audioModule->output_buffer, 0, audioModule->adc_buffer_size * sizeof(int16_t));
+                    for (uint8_t g = 0; g < plcGap; g++) {
+                        for (int f = 0; f < audioModule->encode_frame_num; f++) {
+                            audioModule->ringWrite(audioModule->output_buffer, audioModule->adc_buffer_size);
+                        }
+                    }
+                    LOG_DEBUG("PLC: inserted %d samples of silence for %u missing packets (gap=%u)",
+                              audioModule->encode_frame_num * audioModule->adc_buffer_size * plcGap, plcGap, gap);
+                }
+                audioModule->rx_seq_expected = rxSeq + 1;
+
+                // Determine codec from packet header
+                bool headerMatch = (memcmp(pkt.data, &audioModule->tx_header, sizeof(c2_header)) == 0);
+                CODEC2 *dec_codec;
+                int dec_frame_bytes, dec_samples;
+                bool tmpCodec = false;
+
+                if (headerMatch) {
+                    dec_codec = audioModule->codec2;
+                    dec_frame_bytes = audioModule->encode_codec_size;
+                    dec_samples = audioModule->adc_buffer_size;
+                } else if (memcmp(pkt.data, c2_magic, sizeof(c2_magic)) == 0) {
+                    // Mismatched codec mode — create temporary decoder
+                    dec_codec = codec2_create(pkt.data[3]);
+                    codec2_set_lpc_post_filter(dec_codec, 1, 0, 0.8, 0.2);
+                    dec_frame_bytes = (codec2_bits_per_frame(dec_codec) + 7) / 8;
+                    dec_samples = codec2_samples_per_frame(dec_codec);
+                    tmpCodec = true;
+                } else {
+                    continue; // Unknown header, skip
+                }
+
+                // Decode all frames in the packet into the ring buffer.
+                // Speaker_task is higher priority and preempts us whenever DMA
+                // needs data, so no yield needed here — just decode as fast
+                // as possible to keep the ring buffer ahead of playback.
+                for (int i = AUDIO_HEADER_SIZE; i + dec_frame_bytes <= (int)pkt.size; i += dec_frame_bytes) {
+                    codec2_decode(dec_codec, audioModule->output_buffer, pkt.data + i);
+                    for (int j = 0; j < dec_samples; j++) {
+                        int32_t s = (int32_t)audioModule->output_buffer[j] * AUDIO_GAIN;
+                        if (s > 32767) s = 32767;
+                        if (s < -32768) s = -32768;
+                        audioModule->output_buffer[j] = (int16_t)s;
+                    }
+                    audioModule->ringWrite(audioModule->output_buffer, dec_samples);
+                    // Signal speaker to start as soon as first frame is decoded,
+                    // not after the whole packet. Critical for slow codecs (700bps).
+                    audioModule->rx_draining = true;
+                }
+
+                if (tmpCodec)
+                    codec2_destroy(dec_codec);
+
+                LOG_DEBUG("RX decoded seq=%u: %d frames, ring=%u/%d samples",
+                          rxSeq, (int)(pkt.size - AUDIO_HEADER_SIZE) / dec_frame_bytes,
+                          audioModule->ringAvailable(), RING_BUF_SAMPLES);
+            }
+        }
+
+        // Nothing else to do here — speaker_task handles playback independently.
     }
 }
 
@@ -129,12 +342,32 @@ AudioModule::AudioModule() : SinglePortModule("Audio", meshtastic_PortNum_AUDIO_
         tx_header.mode = (moduleConfig.audio.bitrate ? moduleConfig.audio.bitrate : AUDIO_MODULE_MODE) - 1;
         codec2_set_lpc_post_filter(codec2, 1, 0, 0.8, 0.2);
         encode_codec_size = (codec2_bits_per_frame(codec2) + 7) / 8;
-        encode_frame_num = (meshtastic_Constants_DATA_PAYLOAD_LEN - sizeof(tx_header)) / encode_codec_size;
-        encode_frame_size = encode_frame_num * encode_codec_size; // max 233 bytes + 4 header bytes
         adc_buffer_size = codec2_samples_per_frame(codec2);
-        LOG_INFO("Use %d frames of %d bytes for a total payload length of %d bytes", encode_frame_num, encode_codec_size,
-                 encode_frame_size);
-        xTaskCreate(&run_codec2, "codec2_task", 30000, NULL, 5, &codec2HandlerTask);
+
+        // Fill as much of the payload as possible for the slowest packet rate.
+        // The radio frame limit is MAX_LORA_PAYLOAD_LEN(255) - MESHTASTIC_HEADER_LENGTH(16)
+        // = 239 bytes for the protobuf-encoded Data struct. Protobuf adds ~6 bytes
+        // overhead (field tags, varint lengths), so max audio payload ≈ 233 - 6 = 227.
+        // We use 224 as a safe max for the codec data portion (leaves headroom).
+        static const int MAX_AUDIO_DATA = 224;
+        encode_frame_num = MAX_AUDIO_DATA / encode_codec_size;
+        encode_frame_size = encode_frame_num * encode_codec_size;
+        int frameDurationMs = (adc_buffer_size * 1000) / 8000;
+        LOG_INFO("Use %d frames of %d bytes (%dms per packet, total %d+%d=%d bytes)",
+                 encode_frame_num, encode_codec_size,
+                 encode_frame_num * frameDurationMs,
+                 encode_frame_size, (int)AUDIO_HEADER_SIZE,
+                 encode_frame_size + (int)AUDIO_HEADER_SIZE);
+        // Speaker task: HIGHEST priority (22) on core 1.
+        // Must never be starved — DMA underruns cause audible glitches.
+        // Blocks on i2s_write(portMAX_DELAY) when DMA is full, freeing CPU.
+        xTaskCreatePinnedToCore(&speaker_task, "speaker_task", 8192, NULL, 2, &speakerTaskHandle, 1);
+        // Codec2 task: priority 20, core 1 — handles encode/decode only.
+        // Lower than speaker so decode bursts never starve DMA refills.
+        xTaskCreatePinnedToCore(&run_codec2, "codec2_task", 30000, NULL, 1, &codec2HandlerTask, 1);
+        rxPacketQueue = xQueueCreate(16, sizeof(AudioRxPacket));
+        if (!rxPacketQueue)
+            LOG_ERROR("Failed to create RX audio packet queue");
     } else {
         disable();
     }
@@ -182,7 +415,7 @@ int32_t AudioModule::runOnce()
                                        .channel_format = I2S_CHANNEL_FMT_ONLY_RIGHT,
                                        .communication_format = (i2s_comm_format_t)(I2S_COMM_FORMAT_STAND_I2S),
                                        .intr_alloc_flags = 0,
-                                       .dma_buf_count = 8,
+                                       .dma_buf_count = 16,
                                        .dma_buf_len = adc_buffer_size,
                                        .use_apll = false,
                                        .tx_desc_auto_clear = false,
@@ -209,7 +442,7 @@ int32_t AudioModule::runOnce()
                                        .channel_format = I2S_CHANNEL_FMT_ONLY_LEFT,
                                        .communication_format = (i2s_comm_format_t)(I2S_COMM_FORMAT_STAND_I2S),
                                        .intr_alloc_flags = 0,
-                                       .dma_buf_count = 8,
+                                       .dma_buf_count = 16,
                                        .dma_buf_len = adc_buffer_size,
                                        .use_apll = false,
                                        .tx_desc_auto_clear = false,
@@ -233,13 +466,18 @@ int32_t AudioModule::runOnce()
                 LOG_ERROR("Failed to start mic I2S: %d", res);
 
             // --- Speaker I2S (TX only) on I2S_NUM_1 ---
+            // AudioModule always installs the speaker I2S driver itself.
+            // When HAS_I2S is defined, AudioThread (ESP8266Audio) will later try to
+            // i2s_driver_install in its begin() — that call will harmlessly fail
+            // (ESP_ERR_INVALID_STATE) because the driver is already installed.
+            // AudioThread then re-uses this driver and adjusts sample rate as needed.
             i2s_config_t spk_config = {.mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX),
                                        .sample_rate = 8000,
                                        .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
                                        .channel_format = I2S_CHANNEL_FMT_ONLY_LEFT,
                                        .communication_format = (i2s_comm_format_t)(I2S_COMM_FORMAT_STAND_I2S),
                                        .intr_alloc_flags = 0,
-                                       .dma_buf_count = 8,
+                                       .dma_buf_count = 16,
                                        .dma_buf_len = adc_buffer_size,
                                        .use_apll = false,
                                        .tx_desc_auto_clear = true,
@@ -279,8 +517,8 @@ int32_t AudioModule::runOnce()
                                        .channel_format = I2S_CHANNEL_FMT_ONLY_LEFT,
                                        .communication_format = (i2s_comm_format_t)(I2S_COMM_FORMAT_STAND_I2S),
                                        .intr_alloc_flags = 0,
-                                       .dma_buf_count = 8,
-                                       .dma_buf_len = adc_buffer_size, // 320 * 2 bytes
+                                       .dma_buf_count = 16,
+                                       .dma_buf_len = adc_buffer_size,
                                        .use_apll = false,
                                        .tx_desc_auto_clear = true,
                                        .fixed_mclk = 0};
@@ -322,67 +560,63 @@ int32_t AudioModule::runOnce()
 
             firstTime = false;
         } else {
-            UIFrameEvent e;
-            // Periodic debug to verify cooperative scheduler is alive
-            static uint32_t lastAudioDebug = 0;
-            if (millis() - lastAudioDebug > 5000) {
-                lastAudioDebug = millis();
-                uint8_t pttPin = moduleConfig.audio.ptt_pin ? moduleConfig.audio.ptt_pin : PTT_PIN;
-                int pttVal = digitalRead(pttPin);
-                LOG_WARN("Audio runOnce: state=%s ptt_pin=%d val=%d",
-                         radio_state == RadioState::tx ? "TX" : "RX", pttPin, pttVal);
-            }
             // Check if PTT is pressed (active LOW). TODO hook that into Onebutton/Interrupt drive.
             if (digitalRead(moduleConfig.audio.ptt_pin ? moduleConfig.audio.ptt_pin : PTT_PIN) == LOW) {
                 if (radio_state == RadioState::rx) {
                     LOG_INFO("PTT pressed, switching to TX");
                     powerFSM.trigger(EVENT_INPUT); // Wake screen on PTT press
                     radio_state = RadioState::tx;
-                    requestFocus(); // Focus on the audio frame when PTT is pressed
-                    e.action = UIFrameEvent::Action::REGENERATE_FRAMESET; // Add audio frame + focus on it
+                    // Update screen FIRST — show "PTT" before any blocking I/O
+                    requestFocus();
+                    UIFrameEvent e;
+                    e.action = UIFrameEvent::Action::REGENERATE_FRAMESET;
                     this->notifyObservers(&e);
+                    // Reset audio state for new TX session
+                    rx_playback_active = false;
+                    rx_draining = false;
+                    i2s_reclaimed_for_codec2 = false;
+                    rx_seq_initialized = false;
+                    tx_seq = 0;
+                    ring_drops = 0;
+                    ringReset();
+                    adc_buffer_index = 0;
+                    if (rxPacketQueue)
+                        xQueueReset(rxPacketQueue);
+                    // Wake the codec2 task — it may be sleeping for up to 10s
+                    xTaskNotifyGive(codec2HandlerTask);
                 }
             } else {
                 if (radio_state == RadioState::tx) {
                     LOG_INFO("PTT released, switching to RX");
-                    if (tx_encode_frame_index > sizeof(tx_header)) {
+                    if (tx_encode_frame_index > (int)AUDIO_HEADER_SIZE) {
                         // Send the incomplete frame
-                        LOG_INFO("Send %d codec2 bytes (incomplete)", tx_encode_frame_index);
+                        LOG_DEBUG("Send %d codec2 bytes (incomplete, seq=%u)", tx_encode_frame_index, tx_seq);
+                        tx_encode_frame[sizeof(c2_header)] = tx_seq++;
                         sendPayload();
                     }
-                    tx_encode_frame_index = sizeof(tx_header);
+                    tx_encode_frame_index = AUDIO_HEADER_SIZE;
+                    // Flush stale RX audio that may have arrived during TX
+                    if (rxPacketQueue)
+                        xQueueReset(rxPacketQueue);
+                    ringReset();
+                    adc_buffer_index = 0;
+                    rx_playback_active = false;
+                    rx_draining = false;
+                    i2s_reclaimed_for_codec2 = false;
+                    rx_seq_initialized = false; // reset for next RX session
+                    ring_drops = 0; // reset drop counter
                     radio_state = RadioState::rx;
-                    e.action = UIFrameEvent::Action::REGENERATE_FRAMESET_BACKGROUND; // Remove audio frame, preserve user's position
+                    UIFrameEvent e;
+                    e.action = UIFrameEvent::Action::REGENERATE_FRAMESET_BACKGROUND;
                     this->notifyObservers(&e);
                 }
             }
             if (radio_state == RadioState::tx) {
-                // Drain all available I2S DMA data in a loop to avoid falling behind.
-                // At 8kHz/16-bit/mono = 16KB/s, each codec2 frame is 320 samples (640 bytes, 40ms).
-                // We must read faster than data arrives to avoid DMA overflow.
-                size_t bytesIn = 0;
-                int framesEncoded = 0;
-                const int maxFramesPerCall = 4; // cap to avoid blocking too long
-
-                do {
-                    size_t readSize = (adc_buffer_size - adc_buffer_index) * sizeof(uint16_t);
-                    res = i2s_read(I2S_PORT_MIC, (uint8_t *)adc_buffer + adc_buffer_index * sizeof(uint16_t), readSize, &bytesIn,
-                                   pdMS_TO_TICKS(20));
-
-                    if (res == ESP_OK && bytesIn > 0) {
-                        adc_buffer_index += bytesIn / sizeof(uint16_t);
-                        if (adc_buffer_index >= (uint16_t)adc_buffer_size) {
-                            adc_buffer_index = 0;
-                            memcpy((void *)speech, (void *)adc_buffer, adc_buffer_size * sizeof(int16_t));
-                            // Notify run_codec2 task that the buffer is ready.
-                            xTaskNotifyGive(codec2HandlerTask);
-                            framesEncoded++;
-                        }
-                    }
-                } while (res == ESP_OK && bytesIn > 0 && framesEncoded < maxFramesPerCall);
+                // Mic reading is handled by the codec2 task directly.
+                // Nothing to do here — just let runOnce cycle for PTT polling.
             }
         }
-        return 100;
+        return 50;
     } else {
         return disable();
     }
@@ -396,9 +630,8 @@ meshtastic_MeshPacket *AudioModule::allocReply()
 
 bool AudioModule::shouldDraw()
 {
-    if (!moduleConfig.audio.codec2_enabled) {
+    if (!moduleConfig.audio.codec2_enabled)
         return false;
-    }
     return (radio_state == RadioState::tx);
 }
 
@@ -422,11 +655,31 @@ ProcessMessage AudioModule::handleReceived(const meshtastic_MeshPacket &mp)
     if ((moduleConfig.audio.codec2_enabled) && (myRegion->audioPermitted)) {
         auto &p = mp.decoded;
         if (!isFromUs(&mp)) {
-            memcpy(rx_encode_frame, p.payload.bytes, p.payload.size);
+#ifdef AUDIO_I2S_DUAL
+            // Stop any RTTTL/TTS playback and reclaim the speaker I2S port,
+            // but only ONCE per audio session.  Doing this on every packet
+            // would call i2s_driver_uninstall() and destroy all DMA-buffered
+            // audio that is still playing back.
+            if (!i2s_reclaimed_for_codec2 && audioThread) {
+                audioThread->stop();
+                reinstallSpeakerI2S();
+                i2s_reclaimed_for_codec2 = true;
+            }
+#endif
+            // Queue the packet for the codec2 task to decode into the jitter buffer.
+            // This avoids blocking the mesh thread and prevents data loss if
+            // multiple packets arrive before the previous one is decoded.
+            if (rxPacketQueue) {
+                AudioRxPacket pkt;
+                memcpy(pkt.data, p.payload.bytes, p.payload.size);
+                pkt.size = p.payload.size;
+                if (xQueueSend(rxPacketQueue, &pkt, 0) != pdTRUE) {
+                    LOG_WARN("RX audio packet queue full, dropped packet");
+                }
+                // Wake codec2 task to process the queued packet
+                xTaskNotifyGive(codec2HandlerTask);
+            }
             radio_state = RadioState::rx;
-            rx_encode_frame_index = p.payload.size;
-            // Notify run_codec2 task that the buffer is ready.
-            xTaskNotifyGive(codec2HandlerTask);
         }
     }
 

--- a/src/modules/esp32/AudioModule.cpp
+++ b/src/modules/esp32/AudioModule.cpp
@@ -4,6 +4,7 @@
 #include "FSCommon.h"
 #include "MeshService.h"
 #include "NodeDB.h"
+#include "PowerFSM.h"
 #include "RTC.h"
 #include "Router.h"
 
@@ -29,6 +30,10 @@
 
 ButterworthFilter hp_filter(240, 8000, ButterworthFilter::ButterworthFilter::Highpass, 1);
 
+// Volume gain applied to mic input and speaker output.
+// Increase to make audio louder; decrease if clipping/distortion occurs.
+static constexpr int AUDIO_GAIN = 8;
+
 TaskHandle_t codec2HandlerTask;
 AudioModule *audioModule;
 
@@ -53,8 +58,12 @@ void run_codec2(void *parameter)
 
         if (tcount != 0) {
             if (audioModule->radio_state == RadioState::tx) {
-                for (int i = 0; i < audioModule->adc_buffer_size; i++)
-                    audioModule->speech[i] = (int16_t)hp_filter.Update((float)audioModule->speech[i]);
+                for (int i = 0; i < audioModule->adc_buffer_size; i++) {
+                    int32_t sample = (int32_t)hp_filter.Update((float)audioModule->speech[i]) * AUDIO_GAIN;
+                    if (sample > 32767) sample = 32767;
+                    if (sample < -32768) sample = -32768;
+                    audioModule->speech[i] = (int16_t)sample;
+                }
 
                 codec2_encode(audioModule->codec2, audioModule->tx_encode_frame + audioModule->tx_encode_frame_index,
                               audioModule->speech);
@@ -71,8 +80,14 @@ void run_codec2(void *parameter)
                 if (memcmp(audioModule->rx_encode_frame, &audioModule->tx_header, sizeof(audioModule->tx_header)) == 0) {
                     for (int i = 4; i < audioModule->rx_encode_frame_index; i += audioModule->encode_codec_size) {
                         codec2_decode(audioModule->codec2, audioModule->output_buffer, audioModule->rx_encode_frame + i);
-                        i2s_write(I2S_PORT, &audioModule->output_buffer, audioModule->adc_buffer_size, &bytesOut,
-                                  pdMS_TO_TICKS(500));
+                        for (int j = 0; j < audioModule->adc_buffer_size; j++) {
+                            int32_t s = (int32_t)audioModule->output_buffer[j] * AUDIO_GAIN;
+                            if (s > 32767) s = 32767;
+                            if (s < -32768) s = -32768;
+                            audioModule->output_buffer[j] = (int16_t)s;
+                        }
+                        i2s_write(I2S_PORT_SPK, audioModule->output_buffer,
+                                  audioModule->adc_buffer_size * sizeof(int16_t), &bytesOut, pdMS_TO_TICKS(500));
                     }
                 } else {
                     // if the buffer header does not match our own codec, make a temp decoding setup.
@@ -82,7 +97,14 @@ void run_codec2(void *parameter)
                     int tmp_adc_buffer_size = codec2_samples_per_frame(tmp_codec2);
                     for (int i = 4; i < audioModule->rx_encode_frame_index; i += tmp_encode_codec_size) {
                         codec2_decode(tmp_codec2, audioModule->output_buffer, audioModule->rx_encode_frame + i);
-                        i2s_write(I2S_PORT, &audioModule->output_buffer, tmp_adc_buffer_size, &bytesOut, pdMS_TO_TICKS(500));
+                        for (int j = 0; j < tmp_adc_buffer_size; j++) {
+                            int32_t s = (int32_t)audioModule->output_buffer[j] * AUDIO_GAIN;
+                            if (s > 32767) s = 32767;
+                            if (s < -32768) s = -32768;
+                            audioModule->output_buffer[j] = (int16_t)s;
+                        }
+                        i2s_write(I2S_PORT_SPK, audioModule->output_buffer,
+                                  tmp_adc_buffer_size * sizeof(int16_t), &bytesOut, pdMS_TO_TICKS(500));
                     }
                     codec2_destroy(tmp_codec2);
                 }
@@ -146,6 +168,107 @@ int32_t AudioModule::runOnce()
     if ((moduleConfig.audio.codec2_enabled) && (myRegion->audioPermitted)) {
         esp_err_t res;
         if (firstTime) {
+#ifdef AUDIO_I2S_DUAL
+            // ---- Dual I2S mode (e.g. MVSR board): separate buses for mic and speaker ----
+#ifdef AUDIO_I2S_MIC_PDM
+            LOG_INFO("Init dual I2S — PDM Mic CLK:%d DATA:%d EN:%d | Spk SCK:%d WS:%d DIN:%d EN:%d",
+                     AUDIO_I2S_MIC_CLK, AUDIO_I2S_MIC_DATA, AUDIO_I2S_MIC_EN,
+                     AUDIO_I2S_SPK_SCK, AUDIO_I2S_SPK_WS, AUDIO_I2S_SPK_DIN, AUDIO_I2S_SPK_EN);
+
+            // --- Microphone I2S in PDM RX mode on I2S_NUM_0 ---
+            i2s_config_t mic_config = {.mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_RX | I2S_MODE_PDM),
+                                       .sample_rate = 8000,
+                                       .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
+                                       .channel_format = I2S_CHANNEL_FMT_ONLY_RIGHT,
+                                       .communication_format = (i2s_comm_format_t)(I2S_COMM_FORMAT_STAND_I2S),
+                                       .intr_alloc_flags = 0,
+                                       .dma_buf_count = 8,
+                                       .dma_buf_len = adc_buffer_size,
+                                       .use_apll = false,
+                                       .tx_desc_auto_clear = false,
+                                       .fixed_mclk = 0};
+            res = i2s_driver_install(I2S_PORT_MIC, &mic_config, 0, NULL);
+            if (res != ESP_OK)
+                LOG_ERROR("Failed to install mic I2S PDM driver: %d", res);
+
+            // For PDM RX on ESP32-S3: CLK output is via ws_io_num, data input via data_in_num
+            const i2s_pin_config_t mic_pins = {.mck_io_num = I2S_PIN_NO_CHANGE,
+                                               .bck_io_num = I2S_PIN_NO_CHANGE,
+                                               .ws_io_num = AUDIO_I2S_MIC_CLK,
+                                               .data_out_num = I2S_PIN_NO_CHANGE,
+                                               .data_in_num = AUDIO_I2S_MIC_DATA};
+#else
+            LOG_INFO("Init dual I2S — Mic SCK:%d WS:%d SD:%d EN:%d | Spk SCK:%d WS:%d DIN:%d EN:%d",
+                     AUDIO_I2S_MIC_SCK, AUDIO_I2S_MIC_WS, AUDIO_I2S_MIC_SD, AUDIO_I2S_MIC_EN,
+                     AUDIO_I2S_SPK_SCK, AUDIO_I2S_SPK_WS, AUDIO_I2S_SPK_DIN, AUDIO_I2S_SPK_EN);
+
+            // --- Microphone I2S (standard RX) on I2S_NUM_0 ---
+            i2s_config_t mic_config = {.mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_RX),
+                                       .sample_rate = 8000,
+                                       .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
+                                       .channel_format = I2S_CHANNEL_FMT_ONLY_LEFT,
+                                       .communication_format = (i2s_comm_format_t)(I2S_COMM_FORMAT_STAND_I2S),
+                                       .intr_alloc_flags = 0,
+                                       .dma_buf_count = 8,
+                                       .dma_buf_len = adc_buffer_size,
+                                       .use_apll = false,
+                                       .tx_desc_auto_clear = false,
+                                       .fixed_mclk = 0};
+            res = i2s_driver_install(I2S_PORT_MIC, &mic_config, 0, NULL);
+            if (res != ESP_OK)
+                LOG_ERROR("Failed to install mic I2S driver: %d", res);
+
+            const i2s_pin_config_t mic_pins = {.mck_io_num = I2S_PIN_NO_CHANGE,
+                                               .bck_io_num = AUDIO_I2S_MIC_SCK,
+                                               .ws_io_num = AUDIO_I2S_MIC_WS,
+                                               .data_out_num = I2S_PIN_NO_CHANGE,
+                                               .data_in_num = AUDIO_I2S_MIC_SD};
+#endif
+            res = i2s_set_pin(I2S_PORT_MIC, &mic_pins);
+            if (res != ESP_OK)
+                LOG_ERROR("Failed to set mic I2S pins: %d", res);
+
+            res = i2s_start(I2S_PORT_MIC);
+            if (res != ESP_OK)
+                LOG_ERROR("Failed to start mic I2S: %d", res);
+
+            // --- Speaker I2S (TX only) on I2S_NUM_1 ---
+            i2s_config_t spk_config = {.mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX),
+                                       .sample_rate = 8000,
+                                       .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
+                                       .channel_format = I2S_CHANNEL_FMT_ONLY_LEFT,
+                                       .communication_format = (i2s_comm_format_t)(I2S_COMM_FORMAT_STAND_I2S),
+                                       .intr_alloc_flags = 0,
+                                       .dma_buf_count = 8,
+                                       .dma_buf_len = adc_buffer_size,
+                                       .use_apll = false,
+                                       .tx_desc_auto_clear = true,
+                                       .fixed_mclk = 0};
+            res = i2s_driver_install(I2S_PORT_SPK, &spk_config, 0, NULL);
+            if (res != ESP_OK)
+                LOG_ERROR("Failed to install speaker I2S driver: %d", res);
+
+            const i2s_pin_config_t spk_pins = {.mck_io_num = I2S_PIN_NO_CHANGE,
+                                               .bck_io_num = AUDIO_I2S_SPK_SCK,
+                                               .ws_io_num = AUDIO_I2S_SPK_WS,
+                                               .data_out_num = AUDIO_I2S_SPK_DIN,
+                                               .data_in_num = I2S_PIN_NO_CHANGE};
+            res = i2s_set_pin(I2S_PORT_SPK, &spk_pins);
+            if (res != ESP_OK)
+                LOG_ERROR("Failed to set speaker I2S pins: %d", res);
+
+            res = i2s_start(I2S_PORT_SPK);
+            if (res != ESP_OK)
+                LOG_ERROR("Failed to start speaker I2S: %d", res);
+
+            // Enable mic (active LOW) and speaker amplifier via their enable pins
+            pinMode(AUDIO_I2S_MIC_EN, OUTPUT);
+            digitalWrite(AUDIO_I2S_MIC_EN, LOW);
+            pinMode(AUDIO_I2S_SPK_EN, OUTPUT);
+            digitalWrite(AUDIO_I2S_SPK_EN, HIGH);
+
+#else
+            // ---- Single I2S mode: shared bus for mic + speaker ----
             // Set up I2S Processor configuration. This will produce 16bit samples at 8 kHz instead of 12 from the ADC
             LOG_INFO("Init I2S SD: %d DIN: %d WS: %d SCK: %d", moduleConfig.audio.i2s_sd, moduleConfig.audio.i2s_din,
                      moduleConfig.audio.i2s_ws, moduleConfig.audio.i2s_sck);
@@ -161,41 +284,62 @@ int32_t AudioModule::runOnce()
                                        .use_apll = false,
                                        .tx_desc_auto_clear = true,
                                        .fixed_mclk = 0};
-            res = i2s_driver_install(I2S_PORT, &i2s_config, 0, NULL);
+            res = i2s_driver_install(I2S_PORT_MIC, &i2s_config, 0, NULL);
             if (res != ESP_OK) {
                 LOG_ERROR("Failed to install I2S driver: %d", res);
             }
 
             const i2s_pin_config_t pin_config = {
+                .mck_io_num = I2S_PIN_NO_CHANGE,
                 .bck_io_num = moduleConfig.audio.i2s_sck,
                 .ws_io_num = moduleConfig.audio.i2s_ws,
                 .data_out_num = moduleConfig.audio.i2s_din ? moduleConfig.audio.i2s_din : I2S_PIN_NO_CHANGE,
                 .data_in_num = moduleConfig.audio.i2s_sd ? moduleConfig.audio.i2s_sd : I2S_PIN_NO_CHANGE};
-            res = i2s_set_pin(I2S_PORT, &pin_config);
+            res = i2s_set_pin(I2S_PORT_MIC, &pin_config);
             if (res != ESP_OK) {
                 LOG_ERROR("Failed to set I2S pin config: %d", res);
             }
 
-            res = i2s_start(I2S_PORT);
+            res = i2s_start(I2S_PORT_MIC);
             if (res != ESP_OK) {
                 LOG_ERROR("Failed to start I2S: %d", res);
             }
+#endif
 
             radio_state = RadioState::rx;
 
-            // Configure PTT input
-            LOG_INFO("Init PTT on Pin %u", moduleConfig.audio.ptt_pin ? moduleConfig.audio.ptt_pin : PTT_PIN);
-            pinMode(moduleConfig.audio.ptt_pin ? moduleConfig.audio.ptt_pin : PTT_PIN, INPUT);
+            // Configure PTT input with pull-up; PTT is active LOW (shorted to GND when pressed).
+            // This prevents a floating pin from causing spurious REGENERATE_FRAMESET calls
+            // that would reset the screen to frame 0 and break user button navigation.
+            uint8_t pttPin = moduleConfig.audio.ptt_pin ? moduleConfig.audio.ptt_pin : PTT_PIN;
+            LOG_INFO("Init PTT on Pin %u", pttPin);
+            pinMode(pttPin, INPUT_PULLUP);
+
+            // Log the initial PTT state to help diagnose hardware that holds the pin LOW
+            int initialPttState = digitalRead(pttPin);
+            LOG_WARN("PTT pin %u initial state after INPUT_PULLUP: %s",
+                     pttPin, initialPttState == LOW ? "LOW (PTT active!)" : "HIGH (idle)");
 
             firstTime = false;
         } else {
             UIFrameEvent e;
-            // Check if PTT is pressed. TODO hook that into Onebutton/Interrupt drive.
-            if (digitalRead(moduleConfig.audio.ptt_pin ? moduleConfig.audio.ptt_pin : PTT_PIN) == HIGH) {
+            // Periodic debug to verify cooperative scheduler is alive
+            static uint32_t lastAudioDebug = 0;
+            if (millis() - lastAudioDebug > 5000) {
+                lastAudioDebug = millis();
+                uint8_t pttPin = moduleConfig.audio.ptt_pin ? moduleConfig.audio.ptt_pin : PTT_PIN;
+                int pttVal = digitalRead(pttPin);
+                LOG_WARN("Audio runOnce: state=%s ptt_pin=%d val=%d",
+                         radio_state == RadioState::tx ? "TX" : "RX", pttPin, pttVal);
+            }
+            // Check if PTT is pressed (active LOW). TODO hook that into Onebutton/Interrupt drive.
+            if (digitalRead(moduleConfig.audio.ptt_pin ? moduleConfig.audio.ptt_pin : PTT_PIN) == LOW) {
                 if (radio_state == RadioState::rx) {
                     LOG_INFO("PTT pressed, switching to TX");
+                    powerFSM.trigger(EVENT_INPUT); // Wake screen on PTT press
                     radio_state = RadioState::tx;
-                    e.action = UIFrameEvent::Action::REGENERATE_FRAMESET; // We want to change the list of frames shown on-screen
+                    requestFocus(); // Focus on the audio frame when PTT is pressed
+                    e.action = UIFrameEvent::Action::REGENERATE_FRAMESET; // Add audio frame + focus on it
                     this->notifyObservers(&e);
                 }
             } else {
@@ -208,29 +352,34 @@ int32_t AudioModule::runOnce()
                     }
                     tx_encode_frame_index = sizeof(tx_header);
                     radio_state = RadioState::rx;
-                    e.action = UIFrameEvent::Action::REGENERATE_FRAMESET; // We want to change the list of frames shown on-screen
+                    e.action = UIFrameEvent::Action::REGENERATE_FRAMESET_BACKGROUND; // Remove audio frame, preserve user's position
                     this->notifyObservers(&e);
                 }
             }
             if (radio_state == RadioState::tx) {
-                // Get I2S data from the microphone and place in data buffer
+                // Drain all available I2S DMA data in a loop to avoid falling behind.
+                // At 8kHz/16-bit/mono = 16KB/s, each codec2 frame is 320 samples (640 bytes, 40ms).
+                // We must read faster than data arrives to avoid DMA overflow.
                 size_t bytesIn = 0;
-                res = i2s_read(I2S_PORT, adc_buffer + adc_buffer_index, adc_buffer_size - adc_buffer_index, &bytesIn,
-                               pdMS_TO_TICKS(40)); // wait 40ms for audio to arrive.
+                int framesEncoded = 0;
+                const int maxFramesPerCall = 4; // cap to avoid blocking too long
 
-                if (res == ESP_OK) {
-                    adc_buffer_index += bytesIn;
-                    if (adc_buffer_index == adc_buffer_size) {
-                        adc_buffer_index = 0;
-                        memcpy((void *)speech, (void *)adc_buffer, 2 * adc_buffer_size);
-                        // Notify run_codec2 task that the buffer is ready.
-                        radio_state = RadioState::tx;
-                        BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-                        vTaskNotifyGiveFromISR(codec2HandlerTask, &xHigherPriorityTaskWoken);
-                        if (xHigherPriorityTaskWoken == pdTRUE)
-                            YIELD_FROM_ISR(xHigherPriorityTaskWoken);
+                do {
+                    size_t readSize = (adc_buffer_size - adc_buffer_index) * sizeof(uint16_t);
+                    res = i2s_read(I2S_PORT_MIC, (uint8_t *)adc_buffer + adc_buffer_index * sizeof(uint16_t), readSize, &bytesIn,
+                                   pdMS_TO_TICKS(20));
+
+                    if (res == ESP_OK && bytesIn > 0) {
+                        adc_buffer_index += bytesIn / sizeof(uint16_t);
+                        if (adc_buffer_index >= (uint16_t)adc_buffer_size) {
+                            adc_buffer_index = 0;
+                            memcpy((void *)speech, (void *)adc_buffer, adc_buffer_size * sizeof(int16_t));
+                            // Notify run_codec2 task that the buffer is ready.
+                            xTaskNotifyGive(codec2HandlerTask);
+                            framesEncoded++;
+                        }
                     }
-                }
+                } while (res == ESP_OK && bytesIn > 0 && framesEncoded < maxFramesPerCall);
             }
         }
         return 100;
@@ -277,10 +426,7 @@ ProcessMessage AudioModule::handleReceived(const meshtastic_MeshPacket &mp)
             radio_state = RadioState::rx;
             rx_encode_frame_index = p.payload.size;
             // Notify run_codec2 task that the buffer is ready.
-            BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-            vTaskNotifyGiveFromISR(codec2HandlerTask, &xHigherPriorityTaskWoken);
-            if (xHigherPriorityTaskWoken == pdTRUE)
-                YIELD_FROM_ISR(xHigherPriorityTaskWoken);
+            xTaskNotifyGive(codec2HandlerTask);
         }
     }
 

--- a/src/modules/esp32/AudioModule.h
+++ b/src/modules/esp32/AudioModule.h
@@ -11,6 +11,7 @@
 #include <OLEDDisplayUi.h>
 #include <codec2.h>
 #include <driver/i2s.h>
+#include <freertos/queue.h>
 #include <functional>
 
 enum RadioState { standby, rx, tx };
@@ -21,6 +22,9 @@ struct c2_header {
     char magic[3];
     char mode;
 };
+
+// Wire header: 4-byte c2_header + 1-byte packet sequence number.
+#define AUDIO_HEADER_SIZE (sizeof(c2_header) + 1)
 
 #define ADC_BUFFER_SIZE_MAX 320
 
@@ -42,7 +46,21 @@ struct c2_header {
 #endif
 
 #define AUDIO_MODULE_RX_BUFFER 128
-#define AUDIO_MODULE_MODE meshtastic_ModuleConfig_AudioConfig_Audio_Baud_CODEC2_700
+#define AUDIO_MODULE_MODE meshtastic_ModuleConfig_AudioConfig_Audio_Baud_CODEC2_1600
+
+// Shared ring buffer for TX mic data and RX decoded audio.
+// Since audio is half-duplex (PTT), only one direction is active at a time,
+// so we share one large buffer for both paths.
+#define RING_BUF_SAMPLES 16384 // 2.0s at 8kHz — power-of-2 for fast bitmask modulo
+#define RING_BUF_MASK    (RING_BUF_SAMPLES - 1)
+#define RX_JITTER_SAMPLES 9600   // 1.2s pre-fill ≈ 1 full packet of decoded audio
+#define RX_SILENCE_TIMEOUT 2000  // ms of silence before stopping RX playback
+
+// Queue item for received encoded audio packets
+struct AudioRxPacket {
+    uint8_t data[meshtastic_Constants_DATA_PAYLOAD_LEN];
+    uint16_t size;
+};
 
 class AudioModule : public SinglePortModule, public Observable<const UIFrameEvent *>, private concurrency::OSThread
 {
@@ -50,19 +68,38 @@ class AudioModule : public SinglePortModule, public Observable<const UIFrameEven
     unsigned char rx_encode_frame[meshtastic_Constants_DATA_PAYLOAD_LEN] = {};
     unsigned char tx_encode_frame[meshtastic_Constants_DATA_PAYLOAD_LEN] = {};
     c2_header tx_header = {};
-    int16_t speech[ADC_BUFFER_SIZE_MAX] = {};
-    int16_t output_buffer[ADC_BUFFER_SIZE_MAX] = {};
-    uint16_t adc_buffer[ADC_BUFFER_SIZE_MAX] = {};
+    int16_t speech[ADC_BUFFER_SIZE_MAX] = {};       // scratch buffer for codec2 encode
+    int16_t output_buffer[ADC_BUFFER_SIZE_MAX] = {}; // scratch buffer for codec2 decode
+    uint16_t adc_buffer[ADC_BUFFER_SIZE_MAX] = {};   // partial I2S read accumulator
     int adc_buffer_size = 0;
     uint16_t adc_buffer_index = 0;
-    int tx_encode_frame_index = sizeof(c2_header); // leave room for header
+    int tx_encode_frame_index = AUDIO_HEADER_SIZE; // leave room for header + seq byte
     int rx_encode_frame_index = 0;
     int encode_codec_size = 0;
     int encode_frame_size = 0;
+    int encode_frame_num = 0;
+    uint8_t tx_seq = 0;           // TX packet sequence number (wraps at 255)
+    uint8_t rx_seq_expected = 0;  // next expected RX sequence number
+    bool rx_seq_initialized = false; // first packet resets expected seq
     volatile RadioState radio_state = RadioState::rx;
 
     struct CODEC2 *codec2 = NULL;
-    // int16_t sample;
+
+    // Shared ring buffer for TX mic capture and RX decoded playback.
+    // Half-duplex: only one direction active at a time, so one buffer suffices.
+    int16_t ring_buf[RING_BUF_SAMPLES] = {};
+    volatile uint32_t ring_head = 0;
+    volatile uint32_t ring_tail = 0;
+    volatile bool rx_playback_active = false;
+    volatile bool rx_draining = false;
+    volatile bool i2s_reclaimed_for_codec2 = false; // true once we've stopped audioThread & reinstalled speaker I2S
+    volatile uint32_t ring_drops = 0;  // count of samples dropped due to ring buffer overflow
+    QueueHandle_t rxPacketQueue = nullptr;
+
+    uint32_t ringAvailable();
+    void ringWrite(const int16_t *data, int count);
+    int ringRead(int16_t *data, int maxCount);
+    void ringReset();
 
     AudioModule();
 
@@ -73,8 +110,12 @@ class AudioModule : public SinglePortModule, public Observable<const UIFrameEven
      */
     void sendPayload(NodeNum dest = NODENUM_BROADCAST, bool wantReplies = false);
 
+#ifdef AUDIO_I2S_DUAL
+    /// Reinstall the speaker I2S driver (needed after AudioThread::stop() uninstalls it)
+    void reinstallSpeakerI2S();
+#endif
+
   protected:
-    int encode_frame_num = 0;
     bool firstTime = true;
 
     virtual int32_t runOnce() override;

--- a/src/modules/esp32/AudioModule.h
+++ b/src/modules/esp32/AudioModule.h
@@ -23,9 +23,23 @@ struct c2_header {
 };
 
 #define ADC_BUFFER_SIZE_MAX 320
-#define PTT_PIN 39
 
+#ifdef AUDIO_PTT_PIN
+#define PTT_PIN AUDIO_PTT_PIN
+#else
+#define PTT_PIN 39
+#endif
+
+#ifdef AUDIO_I2S_DUAL
+// Dual I2S mode: separate buses for mic (RX) and speaker (TX)
+#define I2S_PORT_MIC I2S_NUM_0
+#define I2S_PORT_SPK I2S_NUM_1
+#else
+// Single I2S mode: shared bus for both mic and speaker
 #define I2S_PORT I2S_NUM_0
+#define I2S_PORT_MIC I2S_PORT
+#define I2S_PORT_SPK I2S_PORT
+#endif
 
 #define AUDIO_MODULE_RX_BUFFER 128
 #define AUDIO_MODULE_MODE meshtastic_ModuleConfig_AudioConfig_Audio_Baud_CODEC2_700

--- a/src/modules/esp32/AudioModule.h
+++ b/src/modules/esp32/AudioModule.h
@@ -13,6 +13,7 @@
 #include <driver/i2s.h>
 #include <freertos/queue.h>
 #include <functional>
+#include "input/InputBroker.h"
 
 enum RadioState { standby, rx, tx };
 
@@ -47,6 +48,7 @@ struct c2_header {
 
 #define AUDIO_MODULE_RX_BUFFER 128
 #define AUDIO_MODULE_MODE meshtastic_ModuleConfig_AudioConfig_Audio_Baud_CODEC2_1600
+#define AUDIO_DEFAULT_GAIN 8 // Default gain multiplier when config value is 0
 
 // Shared ring buffer for TX mic data and RX decoded audio.
 // Since audio is half-duplex (PTT), only one direction is active at a time,
@@ -122,7 +124,7 @@ class AudioModule : public SinglePortModule, public Observable<const UIFrameEven
 
     virtual meshtastic_MeshPacket *allocReply() override;
 
-    virtual bool wantUIFrame() override { return this->shouldDraw(); }
+    virtual bool wantUIFrame() override { return true; }
     virtual Observable<const UIFrameEvent *> *getUIFrameObservable() override { return this; }
 #if !HAS_SCREEN
     void drawFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y);
@@ -135,6 +137,21 @@ class AudioModule : public SinglePortModule, public Observable<const UIFrameEven
      * for it
      */
     virtual ProcessMessage handleReceived(const meshtastic_MeshPacket &mp) override;
+
+#if HAS_SCREEN
+  private:
+    volatile uint32_t lastDrawMs = 0;
+    uint8_t pendingMenu = 0;       // 0=none, 1=mic gain, 2=spk gain, 3=target
+    bool suppressNextSelect = false;
+
+    int handleInputEvent(const InputEvent *event);
+    void showAudioMenu();
+    void showGainMenu(bool isMic);
+    void showTargetMenu();
+
+    CallbackObserver<AudioModule, const InputEvent *> inputObserver =
+        CallbackObserver<AudioModule, const InputEvent *>(this, &AudioModule::handleInputEvent);
+#endif
 };
 
 extern AudioModule *audioModule;

--- a/src/modules/esp32/AudioModule.h
+++ b/src/modules/esp32/AudioModule.h
@@ -47,7 +47,7 @@ struct c2_header {
 #endif
 
 #define AUDIO_MODULE_RX_BUFFER 128
-#define AUDIO_MODULE_MODE meshtastic_ModuleConfig_AudioConfig_Audio_Baud_CODEC2_1600
+#define AUDIO_MODULE_MODE meshtastic_ModuleConfig_AudioConfig_Audio_Baud_CODEC2_1200
 #define AUDIO_DEFAULT_GAIN 8 // Default gain multiplier when config value is 0
 
 // Shared ring buffer for TX mic data and RX decoded audio.
@@ -96,6 +96,10 @@ class AudioModule : public SinglePortModule, public Observable<const UIFrameEven
     volatile bool rx_draining = false;
     volatile bool i2s_reclaimed_for_codec2 = false; // true once we've stopped audioThread & reinstalled speaker I2S
     volatile uint32_t ring_drops = 0;  // count of samples dropped due to ring buffer overflow
+    volatile NodeNum rx_from_node = 0;     // node number of current audio sender
+    volatile bool rx_is_dm = false;           // true if last RX was a DM, false if broadcast
+    volatile uint8_t rx_channel = 0;          // channel index of last RX packet
+    volatile uint32_t rx_last_packet_ms = 0; // millis() of last received audio packet
     QueueHandle_t rxPacketQueue = nullptr;
 
     uint32_t ringAvailable();
@@ -141,13 +145,16 @@ class AudioModule : public SinglePortModule, public Observable<const UIFrameEven
 #if HAS_SCREEN
   private:
     volatile uint32_t lastDrawMs = 0;
-    uint8_t pendingMenu = 0;       // 0=none, 1=mic gain, 2=spk gain, 3=target
+    uint8_t pendingMenu = 0;       // 0=none, 1=mic gain, 2=spk gain, 3=target, 4=codec rate
     bool suppressNextSelect = false;
+    volatile bool pendingCodecReinit = false;
 
     int handleInputEvent(const InputEvent *event);
     void showAudioMenu();
     void showGainMenu(bool isMic);
     void showTargetMenu();
+    void showCodecRateMenu();
+    void reinitCodec();
 
     CallbackObserver<AudioModule, const InputEvent *> inputObserver =
         CallbackObserver<AudioModule, const InputEvent *>(this, &AudioModule::handleInputEvent);

--- a/variants/esp32s3/tlora_t3s3_v1_mvsr/pins_arduino.h
+++ b/variants/esp32s3/tlora_t3s3_v1_mvsr/pins_arduino.h
@@ -1,0 +1,26 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define USB_VID 0x303a
+#define USB_PID 0x1001
+
+// The default Wire will be mapped to PMU and RTC
+static const uint8_t SDA = 18;
+static const uint8_t SCL = 17;
+
+// Default SPI will be mapped to Radio
+static const uint8_t SS = 7;
+static const uint8_t MOSI = 6;
+static const uint8_t MISO = 3;
+static const uint8_t SCK = 5;
+
+#define SPI_MOSI (11)
+#define SPI_SCK (14)
+#define SPI_MISO (2)
+#define SPI_CS (13)
+
+#define SDCARD_CS SPI_CS
+
+#endif /* Pins_Arduino_h */

--- a/variants/esp32s3/tlora_t3s3_v1_mvsr/platformio.ini
+++ b/variants/esp32s3/tlora_t3s3_v1_mvsr/platformio.ini
@@ -24,3 +24,5 @@ lib_deps =
   earlephilhower/ESP8266Audio@1.9.9
   # renovate: datasource=custom.pio depName=ESP8266SAM packageName=earlephilhower/library/ESP8266SAM
   earlephilhower/ESP8266SAM@1.1.0
+  # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
+  lewisxhe/SensorLib@0.3.4

--- a/variants/esp32s3/tlora_t3s3_v1_mvsr/platformio.ini
+++ b/variants/esp32s3/tlora_t3s3_v1_mvsr/platformio.ini
@@ -17,3 +17,10 @@ build_flags =
   -D TLORA_T3S3_V1
   -D AUDIO_I2S_DUAL=1
   -I variants/esp32s3/tlora_t3s3_v1_mvsr
+
+lib_deps =
+  ${esp32s3_base.lib_deps}
+  # renovate: datasource=custom.pio depName=ESP8266Audio packageName=earlephilhower/library/ESP8266Audio
+  earlephilhower/ESP8266Audio@1.9.9
+  # renovate: datasource=custom.pio depName=ESP8266SAM packageName=earlephilhower/library/ESP8266SAM
+  earlephilhower/ESP8266SAM@1.1.0

--- a/variants/esp32s3/tlora_t3s3_v1_mvsr/platformio.ini
+++ b/variants/esp32s3/tlora_t3s3_v1_mvsr/platformio.ini
@@ -1,0 +1,19 @@
+[env:tlora-t3s3-v1-mvsr]
+custom_meshtastic_hw_model = 16
+custom_meshtastic_hw_model_slug = TLORA_T3_S3
+custom_meshtastic_architecture = esp32-s3
+custom_meshtastic_actively_supported = false
+custom_meshtastic_support_level = 2
+custom_meshtastic_display_name = LILYGO T-LoRa T3-S3 + MVSR Audio
+custom_meshtastic_tags = LilyGo, Audio
+
+extends = esp32s3_base
+board = tlora-t3s3-v1
+board_check = true
+upload_protocol = esptool
+
+build_flags =
+  ${esp32s3_base.build_flags}
+  -D TLORA_T3S3_V1
+  -D AUDIO_I2S_DUAL=1
+  -I variants/esp32s3/tlora_t3s3_v1_mvsr

--- a/variants/esp32s3/tlora_t3s3_v1_mvsr/rfswitch.h
+++ b/variants/esp32s3/tlora_t3s3_v1_mvsr/rfswitch.h
@@ -1,0 +1,11 @@
+#include "RadioLib.h"
+
+static const uint32_t rfswitch_dio_pins[] = {RADIOLIB_LR11X0_DIO5, RADIOLIB_LR11X0_DIO6, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC};
+
+static const Module::RfSwitchMode_t rfswitch_table[] = {
+    // mode                  DIO5  DIO6
+    {LR11x0::MODE_STBY, {LOW, LOW}},  {LR11x0::MODE_RX, {HIGH, LOW}},
+    {LR11x0::MODE_TX, {LOW, HIGH}},   {LR11x0::MODE_TX_HP, {LOW, HIGH}},
+    {LR11x0::MODE_TX_HF, {LOW, LOW}}, {LR11x0::MODE_GNSS, {LOW, LOW}},
+    {LR11x0::MODE_WIFI, {LOW, LOW}},  END_OF_MODE_TABLE,
+};

--- a/variants/esp32s3/tlora_t3s3_v1_mvsr/variant.h
+++ b/variants/esp32s3/tlora_t3s3_v1_mvsr/variant.h
@@ -14,8 +14,8 @@
 #define I2C_SDA 18 // I2C pins for this board
 #define I2C_SCL 17
 
-#define I2C_SDA1 43
-#define I2C_SCL1 44
+#define I2C_SDA1 42 // PCF85063A RTC
+#define I2C_SCL1 45 // PCF85063A RTC
 
 #define LED_POWER 37 // If defined we will blink this LED
 #define BUTTON_PIN 0 // If defined, this will be used for user button presses,
@@ -107,6 +107,13 @@
 #define DAC_I2S_DOUT AUDIO_I2S_SPK_DIN
 #define DAC_I2S_MCLK -1 // No MCLK pin (I2S_PIN_NO_CHANGE)
 
-// PTT button — use the T3S3 user button (GPIO 0) by default
-// Override in moduleConfig.audio.ptt_pin if using a different pin
-#define AUDIO_PTT_PIN 42
+// PCF85063A RTC on Wire1 (I2C_SDA1/I2C_SCL1)
+#define PCF85063_RTC 0x51
+#define RTC_USE_WIRE1
+#define PIN_RTC_INT 16 // RTC interrupt, active LOW
+
+// Vibration motor on GPIO 46
+#define PIN_VIBRATION 46
+
+// PTT button
+#define AUDIO_PTT_PIN 47

--- a/variants/esp32s3/tlora_t3s3_v1_mvsr/variant.h
+++ b/variants/esp32s3/tlora_t3s3_v1_mvsr/variant.h
@@ -99,6 +99,14 @@
 #define AUDIO_I2S_SPK_DIN 39  // DATA (serial data to speaker)
 #define AUDIO_I2S_SPK_EN 38   // SD_MODE / amplifier enable (active HIGH)
 
+// Enable the HAS_I2S subsystem so AudioThread handles RTTTL tones and TTS
+// through the same speaker. AudioModule codec2 audio also writes to I2S_NUM_1.
+#define HAS_I2S
+#define DAC_I2S_BCK AUDIO_I2S_SPK_SCK
+#define DAC_I2S_WS AUDIO_I2S_SPK_WS
+#define DAC_I2S_DOUT AUDIO_I2S_SPK_DIN
+#define DAC_I2S_MCLK -1 // No MCLK pin (I2S_PIN_NO_CHANGE)
+
 // PTT button — use the T3S3 user button (GPIO 0) by default
 // Override in moduleConfig.audio.ptt_pin if using a different pin
 #define AUDIO_PTT_PIN 42

--- a/variants/esp32s3/tlora_t3s3_v1_mvsr/variant.h
+++ b/variants/esp32s3/tlora_t3s3_v1_mvsr/variant.h
@@ -1,0 +1,104 @@
+// T3S3 V1 + MVSR Audio Board variant
+// Inherits all T3S3 V1 pin assignments, adds MVSR dual-I2S audio pins
+
+#define HAS_SDCARD
+#define SDCARD_USE_SPI1
+
+#define USE_SSD1306
+
+#define BATTERY_PIN 1 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
+// ratio of voltage divider = 2.0 (R42=100k, R43=100k)
+#define ADC_MULTIPLIER 2.11 // 2.0 + 10% for correction of display undervoltage.
+#define ADC_CHANNEL ADC1_GPIO1_CHANNEL
+
+#define I2C_SDA 18 // I2C pins for this board
+#define I2C_SCL 17
+
+#define I2C_SDA1 43
+#define I2C_SCL1 44
+
+#define LED_POWER 37 // If defined we will blink this LED
+#define BUTTON_PIN 0 // If defined, this will be used for user button presses,
+
+#define BUTTON_NEED_PULLUP
+
+// TTGO uses a common pinout for their SX1262 vs RF95 modules - both can be enabled and we will probe at runtime for RF95 and if
+// not found then probe for SX1262
+#define USE_RF95 // RFM95/SX127x
+#define USE_SX1262
+#define USE_SX1280
+#define USE_LR1121
+
+#define LORA_SCK 5
+#define LORA_MISO 3
+#define LORA_MOSI 6
+#define LORA_CS 7
+#define LORA_RESET 8
+
+// per SX1276_Receive_Interrupt/utilities.h
+#define LORA_DIO0 9
+#define LORA_DIO1 33 // TCXO_EN ?
+#define LORA_DIO2 34
+#define LORA_RXEN 21
+#define LORA_TXEN 10
+
+// per SX1262_Receive_Interrupt/utilities.h
+#ifdef USE_SX1262
+#define SX126X_CS LORA_CS
+#define SX126X_DIO1 33
+#define SX126X_BUSY 34
+#define SX126X_RESET LORA_RESET
+#define SX126X_DIO2_AS_RF_SWITCH
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8
+#endif
+
+// per SX128x_Receive_Interrupt/utilities.h
+#ifdef USE_SX1280
+#define SX128X_CS LORA_CS
+#define SX128X_DIO1 9
+#define SX128X_DIO2 33
+#define SX128X_DIO3 34
+#define SX128X_BUSY 36
+#define SX128X_RESET LORA_RESET
+#define SX128X_RXEN 21
+#define SX128X_TXEN 10
+#define SX128X_MAX_POWER 3
+#endif
+
+// LR1121
+#ifdef USE_LR1121
+#define LR1121_IRQ_PIN 36
+#define LR1121_NRESET_PIN LORA_RESET
+#define LR1121_BUSY_PIN LORA_DIO2
+#define LR1121_SPI_NSS_PIN LORA_CS
+#define LR1121_SPI_SCK_PIN LORA_SCK
+#define LR1121_SPI_MOSI_PIN LORA_MOSI
+#define LR1121_SPI_MISO_PIN LORA_MISO
+#define LR11X0_DIO3_TCXO_VOLTAGE 3.0
+#define LR11X0_DIO_AS_RF_SWITCH
+#endif
+
+#define HAS_SDCARD // Have SPI interface SD card slot
+#define SDCARD_USE_SPI1
+
+// -----------------------------------------------------------------------------
+// MVSR Audio Board — Dual I2S configuration
+// The MVSR uses separate I2S buses for microphone and speaker.
+// -----------------------------------------------------------------------------
+#define AUDIO_I2S_DUAL 1
+
+// Microphone (PDM) — I2S_NUM_0, RX only (PDM mode)
+#define AUDIO_I2S_MIC_PDM 1     // Use PDM mode for the microphone
+#define AUDIO_I2S_MIC_CLK 15   // PDM clock output (routed via I2S WS pin on ESP32-S3)
+#define AUDIO_I2S_MIC_DATA 48  // PDM data input
+#define AUDIO_I2S_MIC_EN 35    // Mic enable pin (active HIGH)
+
+// Speaker amplifier (MAX98357 or similar) — I2S_NUM_1, TX only
+#define AUDIO_I2S_SPK_SCK 40  // BCLK
+#define AUDIO_I2S_SPK_WS 41   // LRCLK
+#define AUDIO_I2S_SPK_DIN 39  // DATA (serial data to speaker)
+#define AUDIO_I2S_SPK_EN 38   // SD_MODE / amplifier enable (active HIGH)
+
+// PTT button — use the T3S3 user button (GPIO 0) by default
+// Override in moduleConfig.audio.ptt_pin if using a different pin
+#define AUDIO_PTT_PIN 42


### PR DESCRIPTION
This is a *significant* re-work of the audio module, explicitly to support the Lilygo T3S3 SX1280 + MVSR board. I will unabashedly admit that alot of this was done using an LLM, but I have alot of experience with I2S audio and heavily directed it's actions to properly function. 

The end result works quite well, if I may say so. I'm very pleased - and my pie-in-the-sky hope is that this enables an off-the-shelf board to work as a neato mesh walkie-talkie. 

NOTE - this did require changes to the protobuf definitions - I have submitted a secondary PR for this as well. 

## 🤝 Attestations

- [-] I have tested that my proposed changes behave as described.
- [] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [] Heltec (Lora32) V3
  - [] LilyGo T-Deck
  - [] LilyGo T-Beam
  - [] RAK WisBlock 4631
  - [] Seeed Studio T-1000E tracker card
  - [] - Other (please specify below)
