### PR TITLE
Add `sent_at` member to packet history

### DIFF
--- a/src/modules/StoreForwardModule.cpp
+++ b/src/modules/StoreForwardModule.cpp
@@ -193,6 +193,7 @@ void StoreForwardModule::historyAdd(const meshtastic_MeshPacket &mp)
     }
 
     this->packetHistory[this->packetHistoryTotalCount].time = getTime();
+    this->packetHistory[this->packetHistoryTotalCount].sent_at = mp.sent_at;
     this->packetHistory[this->packetHistoryTotalCount].to = mp.to;
     this->packetHistory[this->packetHistoryTotalCount].channel = mp.channel;
     this->packetHistory[this->packetHistoryTotalCount].from = getFrom(&mp);
@@ -254,7 +255,7 @@ meshtastic_MeshPacket *StoreForwardModule::preparePayload(NodeNum dest, uint32_t
                 p->id = this->packetHistory[i].id;
                 p->channel = this->packetHistory[i].channel;
                 p->decoded.reply_id = this->packetHistory[i].reply_id;
-                p->rx_time = this->packetHistory[i].time;
+                p->rx_time = this->packetHistory[i].sent_at;
                 p->decoded.emoji = (uint32_t)this->packetHistory[i].emoji;
                 p->rx_rssi = this->packetHistory[i].rx_rssi;
                 p->rx_snr = this->packetHistory[i].rx_snr;
@@ -308,6 +309,7 @@ void StoreForwardModule::sendMessage(NodeNum dest, const meshtastic_StoreAndForw
     p->to = dest;
 
     p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
+    p.sent_at = getTime();
 
     // Let's assume that if the server received the S&F request that the client is in range.
     //   TODO: Make this configurable.

--- a/src/modules/StoreForwardModule.h
+++ b/src/modules/StoreForwardModule.h
@@ -11,6 +11,7 @@
 
 struct PacketHistoryStruct {
     uint32_t time;
+    uint32_t sent_at;
     uint32_t to;
     uint32_t from;
     uint32_t id;


### PR DESCRIPTION
This new member is assigned when the packet is sent and will be used to display messages chronologically in conversation.

Fix for #4166, I don't have the hardware to test it.