### PR TITLE
fix: add bounds checks to PacketCache to prevent buffer overflows

### DIFF
--- a/src/mesh/PacketCache.cpp
+++ b/src/mesh/PacketCache.cpp
@@ -10,6 +10,10 @@ PacketCacheEntry *PacketCache::cache(const meshtastic_MeshPacket *p, bool preser
 {
     size_t payload_size =
         (p->which_payload_variant == meshtastic_MeshPacket_encrypted_tag) ? p->encrypted.size : p->decoded.payload.size;
+    if (payload_size > MAX_LORA_PAYLOAD_LEN) {
+        LOG_ERROR("PacketCache: payload too large (%u bytes), dropping", payload_size);
+        return NULL;
+    }
     PacketCacheEntry *e = (PacketCacheEntry *)malloc(sizeof(PacketCacheEntry) + payload_size +
                                                      (preserveMetadata ? sizeof(PacketCacheMetadata) : 0));
     if (!e) {
@@ -135,6 +139,16 @@ bool PacketCache::load(void *src, PacketCacheEntry **entries, size_t num_entries
     for (size_t i = 0; i < num_entries; i++) {
         PacketCacheEntry e{};
         memcpy(&e, pos, sizeof(PacketCacheEntry));
+        if (e.payload_len > MAX_LORA_PAYLOAD_LEN) {
+            LOG_ERROR("PacketCache load: corrupt payload_len %u at entry %u, aborting", e.payload_len, i);
+            for (size_t j = 0; j < i; j++) {
+                size -= sizeof(PacketCacheEntry) + entries[j]->payload_len +
+                        (entries[j]->has_metadata ? sizeof(PacketCacheMetadata) : 0);
+                free(entries[j]);
+                entries[j] = NULL;
+            }
+            return false;
+        }
         size_t entry_len = sizeof(PacketCacheEntry) + e.payload_len + (e.has_metadata ? sizeof(PacketCacheMetadata) : 0);
         entries[i] = (PacketCacheEntry *)malloc(entry_len);
         size += entry_len;
@@ -188,11 +202,17 @@ void PacketCache::rehydrate(const PacketCacheEntry *e, meshtastic_MeshPacket *p)
         p->priority = (meshtastic_MeshPacket_Priority)m.priority;
     }
     if (e->encrypted) {
-        memcpy(p->encrypted.bytes, payload, e->payload_len);
-        p->encrypted.size = e->payload_len;
+        size_t len = (e->payload_len <= sizeof(p->encrypted.bytes)) ? e->payload_len : sizeof(p->encrypted.bytes);
+        if (len < e->payload_len)
+            LOG_WARN("PacketCache rehydrate: truncating encrypted payload from %u to %u bytes", e->payload_len, len);
+        memcpy(p->encrypted.bytes, payload, len);
+        p->encrypted.size = len;
     } else {
-        memcpy(p->decoded.payload.bytes, payload, e->payload_len);
-        p->decoded.payload.size = e->payload_len;
+        size_t len = (e->payload_len <= sizeof(p->decoded.payload.bytes)) ? e->payload_len : sizeof(p->decoded.payload.bytes);
+        if (len < e->payload_len)
+            LOG_WARN("PacketCache rehydrate: truncating decoded payload from %u to %u bytes", e->payload_len, len);
+        memcpy(p->decoded.payload.bytes, payload, len);
+        p->decoded.payload.size = len;
         if (e->has_metadata) {
             // Decrypted-only metadata
             p->decoded.portnum = (meshtastic_PortNum)m.portnum;

--- a/src/mesh/PacketCache.cpp
+++ b/src/mesh/PacketCache.cpp
@@ -11,7 +11,7 @@ PacketCacheEntry *PacketCache::cache(const meshtastic_MeshPacket *p, bool preser
     size_t payload_size =
         (p->which_payload_variant == meshtastic_MeshPacket_encrypted_tag) ? p->encrypted.size : p->decoded.payload.size;
     if (payload_size > MAX_LORA_PAYLOAD_LEN) {
-        LOG_ERROR("PacketCache: payload too large (%u bytes), dropping", payload_size);
+        LOG_ERROR("PacketCache: payload too large (%zu bytes), dropping", payload_size);
         return NULL;
     }
     PacketCacheEntry *e = (PacketCacheEntry *)malloc(sizeof(PacketCacheEntry) + payload_size +
@@ -140,7 +140,7 @@ bool PacketCache::load(void *src, PacketCacheEntry **entries, size_t num_entries
         PacketCacheEntry e{};
         memcpy(&e, pos, sizeof(PacketCacheEntry));
         if (e.payload_len > MAX_LORA_PAYLOAD_LEN) {
-            LOG_ERROR("PacketCache load: corrupt payload_len %u at entry %u, aborting", e.payload_len, i);
+            LOG_ERROR("PacketCache load: corrupt payload_len %u at entry %zu, aborting", e.payload_len, i);
             for (size_t j = 0; j < i; j++) {
                 size -= sizeof(PacketCacheEntry) + entries[j]->payload_len +
                         (entries[j]->has_metadata ? sizeof(PacketCacheMetadata) : 0);
@@ -151,7 +151,6 @@ bool PacketCache::load(void *src, PacketCacheEntry **entries, size_t num_entries
         }
         size_t entry_len = sizeof(PacketCacheEntry) + e.payload_len + (e.has_metadata ? sizeof(PacketCacheMetadata) : 0);
         entries[i] = (PacketCacheEntry *)malloc(entry_len);
-        size += entry_len;
         if (!entries[i]) {
             LOG_ERROR("Unable to allocate memory for packet cache entry");
             for (size_t j = 0; j < i; j++) {
@@ -162,6 +161,7 @@ bool PacketCache::load(void *src, PacketCacheEntry **entries, size_t num_entries
             }
             return false;
         }
+        size += entry_len;
         memcpy(entries[i], pos, entry_len);
         pos += entry_len;
     }
@@ -204,13 +204,13 @@ void PacketCache::rehydrate(const PacketCacheEntry *e, meshtastic_MeshPacket *p)
     if (e->encrypted) {
         size_t len = (e->payload_len <= sizeof(p->encrypted.bytes)) ? e->payload_len : sizeof(p->encrypted.bytes);
         if (len < e->payload_len)
-            LOG_WARN("PacketCache rehydrate: truncating encrypted payload from %u to %u bytes", e->payload_len, len);
+            LOG_WARN("PacketCache rehydrate: truncating encrypted payload from %u to %zu bytes", e->payload_len, len);
         memcpy(p->encrypted.bytes, payload, len);
         p->encrypted.size = len;
     } else {
         size_t len = (e->payload_len <= sizeof(p->decoded.payload.bytes)) ? e->payload_len : sizeof(p->decoded.payload.bytes);
         if (len < e->payload_len)
-            LOG_WARN("PacketCache rehydrate: truncating decoded payload from %u to %u bytes", e->payload_len, len);
+            LOG_WARN("PacketCache rehydrate: truncating decoded payload from %u to %zu bytes", e->payload_len, len);
         memcpy(p->decoded.payload.bytes, payload, len);
         p->decoded.payload.size = len;
         if (e->has_metadata) {


### PR DESCRIPTION
## Summary

- Add `MAX_LORA_PAYLOAD_LEN` (255) bounds check in `cache()` before allocating memory for payload
- Add `payload_len` validation in `load()` when reading entries from flash/filesystem (untrusted source)
- Clamp `memcpy` in `rehydrate()` to destination buffer size (`encrypted.bytes` = 256B, `decoded.payload.bytes` = 233B)

## Why this matters

Three unchecked paths could overflow buffers:

1. **`cache()`**: `p->encrypted.size` or `p->decoded.payload.size` used directly for `malloc` + `memcpy` with no ceiling check. While protobuf normally limits this, a corrupted in-memory packet struct bypasses that.

2. **`load()`**: `payload_len` is read from flash/filesystem into a local struct and immediately used for `malloc` size and `memcpy` length. Corrupt stored data (filesystem corruption, flash wear, power loss during write) could set `payload_len = 65535`, causing a 64KB heap allocation and reading 64KB past the source buffer.

3. **`rehydrate()`**: `e->payload_len` from the cache entry is memcpy'd into fixed-size protobuf byte arrays without bounds checking. If `payload_len = 300` and `encrypted.bytes` is 256 bytes, the memcpy overflows by 44 bytes into adjacent struct fields (`encrypted.size`, `hop_limit`, `want_ack`, etc.), corrupting packet metadata used for routing.

## Test plan

- [x] All native test suites pass (151/151)
- [ ] Verify packet caching still works correctly on hardware
- [ ] Verify cache persistence (save/load cycle) works with bounds checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)