### PR TITLE
fix: replace unsafe sprintf/strcpy with bounds-checked alternatives

### DIFF
--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -282,7 +282,7 @@ void RedirectablePrint::log(const char *logLevel, const char *format, ...)
     // append \n to format
     size_t len = strlen(format);
     auto newFormat = std::unique_ptr<char[]>(new char[len + 2]);
-    strcpy(newFormat.get(), format);
+    memcpy(newFormat.get(), format, len);
     newFormat[len] = '\n';
     newFormat[len + 1] = '\0';
 
@@ -384,7 +384,7 @@ std::string RedirectablePrint::mt_sprintf(const std::string fmt_str, ...)
     va_list ap;
     while (1) {
         formatted.reset(new char[n]); /* Wrap the plain char array into the unique_ptr */
-        strcpy(&formatted[0], fmt_str.c_str());
+        memcpy(&formatted[0], fmt_str.c_str(), fmt_str.size() + 1);
         va_start(ap, fmt_str);
         int final_n = vsnprintf(&formatted[0], n, fmt_str.c_str(), ap);
         va_end(ap);

--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -230,9 +230,11 @@ void RedirectablePrint::log_to_ble(const char *logLevel, const char *format, va_
             auto thread = concurrency::OSThread::currentThread;
             meshtastic_LogRecord logRecord = meshtastic_LogRecord_init_zero;
             logRecord.level = getLogLevel(logLevel);
-            vsprintf(logRecord.message, format, arg);
-            if (thread)
-                strcpy(logRecord.source, thread->ThreadName.c_str());
+            vsnprintf(logRecord.message, sizeof(logRecord.message), format, arg);
+            if (thread) {
+                strncpy(logRecord.source, thread->ThreadName.c_str(), sizeof(logRecord.source) - 1);
+                logRecord.source[sizeof(logRecord.source) - 1] = '\0';
+            }
             logRecord.time = getValidTime(RTCQuality::RTCQualityDevice, true);
 
             auto buffer = std::unique_ptr<uint8_t[]>(new uint8_t[meshtastic_LogRecord_size]);
@@ -368,7 +370,7 @@ void RedirectablePrint::hexDump(const char *logLevel, const unsigned char *buf, 
             }
         }
         uint8_t index = i / 16;
-        sprintf(s, "%03x", index);
+        snprintf(s, 4, "%03x", index);
         s[3] = '.';
         log(logLevel, s);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -912,7 +912,7 @@ void setup()
         meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
         cn->level = meshtastic_LogRecord_Level_WARNING;
         cn->time = getValidTime(RTCQualityFromNet);
-        sprintf(cn->message, LOW_ENTROPY_WARNING);
+        snprintf(cn->message, sizeof(cn->message), "%s", LOW_ENTROPY_WARNING);
         service->sendClientNotification(cn);
         nodeDB->hasWarned = true;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -837,7 +837,8 @@ void setup()
             setenv("TZ", "GMT0", 1);
         } else {
             setenv("TZ", (const char *)slipstreamTZString, 1);
-            strcpy(config.device.tzdef, (const char *)slipstreamTZString);
+            strncpy(config.device.tzdef, (const char *)slipstreamTZString, sizeof(config.device.tzdef) - 1);
+            config.device.tzdef[sizeof(config.device.tzdef) - 1] = '\0';
         }
     }
     tzset();

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -329,7 +329,7 @@ ErrorCode Router::send(meshtastic_MeshPacket *p)
             cn->reply_id = p->id;
             cn->level = meshtastic_LogRecord_Level_WARNING;
             cn->time = getValidTime(RTCQualityFromNet);
-            sprintf(cn->message, "Duty cycle limit exceeded. You can send again in %d mins", silentMinutes);
+            snprintf(cn->message, sizeof(cn->message), "Duty cycle limit exceeded. You can send again in %d mins", silentMinutes);
             service->sendClientNotification(cn);
 
             meshtastic_Routing_Error err = meshtastic_Routing_Error_DUTY_CYCLE_LIMIT;

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -823,7 +823,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
                 }
                 if (strncmp(moduleConfig.mqtt.root, default_mqtt_root, strlen(default_mqtt_root)) == 0) {
                     //  Default root is in use, so subscribe to the appropriate MQTT topic for this region
-                    sprintf(moduleConfig.mqtt.root, "%s/%s", default_mqtt_root, myRegion->name);
+                    snprintf(moduleConfig.mqtt.root, sizeof(moduleConfig.mqtt.root), "%s/%s", default_mqtt_root, myRegion->name);
                 }
                 changes = SEGMENT_CONFIG | SEGMENT_MODULECONFIG;
             } else {

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -120,7 +120,7 @@ void DetectionSensorModule::sendDetectionMessage()
 {
     LOG_DEBUG("Detected event observed. Send message");
     char *message = new char[40];
-    sprintf(message, "%s detected", moduleConfig.detection_sensor.name);
+    snprintf(message, 40, "%s detected", moduleConfig.detection_sensor.name);
     meshtastic_MeshPacket *p = allocDataPacket();
     p->want_ack = false;
     p->decoded.payload.size = strlen(message);
@@ -142,7 +142,7 @@ void DetectionSensorModule::sendDetectionMessage()
 void DetectionSensorModule::sendCurrentStateMessage(bool state)
 {
     char *message = new char[40];
-    sprintf(message, "%s state: %i", moduleConfig.detection_sensor.name, state);
+    snprintf(message, 40, "%s state: %i", moduleConfig.detection_sensor.name, state);
     meshtastic_MeshPacket *p = allocDataPacket();
     p->want_ack = false;
     p->decoded.payload.size = strlen(message);

--- a/src/modules/NodeInfoModule.cpp
+++ b/src/modules/NodeInfoModule.cpp
@@ -171,7 +171,8 @@ meshtastic_MeshPacket *NodeInfoModule::allocReply()
         // u.id[0] = '\0';
 
         // Ensure our user.id is derived correctly
-        strcpy(u.id, nodeDB->getNodeId().c_str());
+        strncpy(u.id, nodeDB->getNodeId().c_str(), sizeof(u.id) - 1);
+        u.id[sizeof(u.id) - 1] = '\0';
 
         LOG_INFO("Send owner %s/%s/%s", u.id, u.long_name, u.short_name);
         if (transmitHistory)

--- a/src/motion/MotionSensor.cpp
+++ b/src/motion/MotionSensor.cpp
@@ -44,7 +44,7 @@ void MotionSensor::drawFrameCalibration(OLEDDisplay *display, OLEDDisplayUiState
     display->drawString(x, y, "Calibrating\nCompass");
 
     uint8_t timeRemaining = (screen->getEndCalibration() - millis()) / 1000;
-    sprintf(timeRemainingBuffer, "( %02d )", timeRemaining);
+    snprintf(timeRemainingBuffer, sizeof(timeRemainingBuffer), "( %02d )", timeRemaining);
     display->setFont(FONT_SMALL);
     display->drawString(x, y + 40, timeRemainingBuffer);
 

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -497,7 +497,7 @@ void portduinoSetup()
             dmac[4] = hash[4];
             dmac[5] = hash[5];
             char macBuf[13] = {0};
-            sprintf(macBuf, "%02X%02X%02X%02X%02X%02X", dmac[0], dmac[1], dmac[2], dmac[3], dmac[4], dmac[5]);
+            snprintf(macBuf, sizeof(macBuf), "%02X%02X%02X%02X%02X%02X", dmac[0], dmac[1], dmac[2], dmac[3], dmac[4], dmac[5]);
             portduino_config.mac_address = macBuf;
         }
     }


### PR DESCRIPTION
## Summary
Replace unbounded string operations with bounds-checked alternatives in core paths (routing, config, logging, sensors, notifications):

- **`sprintf` -> `snprintf`** (9 instances): Router.cpp, AdminModule.cpp, MotionSensor.cpp, RedirectablePrint.cpp, DetectionSensorModule.cpp (x2), PortduinoGlue.cpp, main.cpp
- **`vsprintf` -> `vsnprintf`** (1 instance): RedirectablePrint.cpp BLE log path
- **`strcpy` -> `strncpy` + null termination** (2 instances): main.cpp timezone string, NodeInfoModule.cpp node ID
- **`strcpy` -> `memcpy`** (2 instances): RedirectablePrint.cpp format string copies (buffer size is known at call site, memcpy is more explicit)

**Note:** Additional sprintf/strcpy calls exist in graphics, telemetry, platform-specific, and third-party code (littlefs). Those are left for follow-up PRs to keep this change reviewable and focused on core paths where untrusted or variable-length input flows through.

## Test plan
- [ ] All 152 native tests pass (test_transmit_history has a pre-existing SIGHUP at teardown unrelated to these changes)
- [ ] Verify no functional change -- only string operation safety, with truncation on oversized inputs instead of overflow
- [ ] Spot-check MQTT root topic, detection sensor messages, BLE log output still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)