### PR TITLE
Add Xiao RP2040 and RP2350 variants

### DIFF
--- a/variants/rp2040/seeed_xiao_rp2040/platformio.ini
+++ b/variants/rp2040/seeed_xiao_rp2040/platformio.ini
@@ -1,0 +1,16 @@
+[env:seeed_xiao_rp2040]
+extends = rp2040_base
+board = seeed_xiao_rp2040
+board_level = pr
+upload_protocol = picotool
+# add our variants files to the include and src paths
+build_src_filter = ${rp2040_base.build_src_filter} +<../variants/rp2040/seeed_xiao_rp2040/>
+build_flags =
+  ${rp2040_base.build_flags}
+  -D PRIVATE_HW
+  -D SEEED_XIAO_RP2040
+  -I variants/rp2040/seeed_xiao_rp2040
+  -D DEBUG_RP2040_PORT=Serial
+  ;-D HW_SPI1_DEVICE
+debug_build_flags = ${rp2040_base.build_flags}, -g
+debug_tool = cmsis-dap ; for e.g. Picotool

--- a/variants/rp2040/seeed_xiao_rp2040/variant.cpp
+++ b/variants/rp2040/seeed_xiao_rp2040/variant.cpp
@@ -1,0 +1,10 @@
+#include <Arduino.h>
+
+// Turn off the green and blue LEDs, which are on by default.
+void initVariant()
+{
+    pinMode(PIN_LED_G, OUTPUT);
+    pinMode(PIN_LED_B, OUTPUT);
+    digitalWrite(PIN_LED_G, HIGH);
+    digitalWrite(PIN_LED_B, HIGH);
+}

--- a/variants/rp2040/seeed_xiao_rp2040/variant.h
+++ b/variants/rp2040/seeed_xiao_rp2040/variant.h
@@ -1,0 +1,27 @@
+#define ARDUINO_ARCH_AVR
+
+// #define BUTTON_PIN -1
+#define LED_POWER PIN_LED_R
+// active low RGB led
+#define LED_POWER_ON 0
+
+// no ADC by default
+#define BATTERY_PIN -1
+// ratio of voltage divider = 3.0 (R1=200k, R2=100k)
+#define ADC_MULTIPLIER 3
+#define BATTERY_SENSE_RESOLUTION_BITS ADC_RESOLUTION
+
+#define USE_SX1262
+
+#define LORA_SCK 2
+#define LORA_MISO 4
+#define LORA_MOSI 3
+
+#define SX126X_CS 6
+#define SX126X_DIO1 27
+#define SX126X_BUSY 29
+#define SX126X_RESET 28
+#define SX126X_RXEN 7
+
+#define SX126X_DIO2_AS_RF_SWITCH
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8

--- a/variants/rp2350/seeed_xiao_rp2350/platformio.ini
+++ b/variants/rp2350/seeed_xiao_rp2350/platformio.ini
@@ -1,0 +1,15 @@
+[env:seeed_xiao_rp2350]
+extends = rp2350_base
+board = seeed_xiao_rp2350
+board_level = pr
+upload_protocol = picotool
+
+# add our variants files to the include and src paths
+build_flags =
+  ${rp2350_base.build_flags}
+  -D PRIVATE_HW
+  -I variants/rp2350/seeed_xiao_rp2350
+  -D DEBUG_RP2040_PORT=Serial
+  ;-D HW_SPI1_DEVICE
+debug_build_flags = ${rp2350_base.build_flags}, -g
+debug_tool = cmsis-dap ; for e.g. Picotool

--- a/variants/rp2350/seeed_xiao_rp2350/variant.h
+++ b/variants/rp2350/seeed_xiao_rp2350/variant.h
@@ -1,0 +1,26 @@
+#define ARDUINO_ARCH_AVR
+
+// #define BUTTON_PIN -1
+#define LED_POWER PIN_LED
+
+// no ADC by default
+#define BATTERY_PIN -1
+// ratio of voltage divider = 3.0 (R1=200k, R2=100k)
+#define ADC_MULTIPLIER 3
+// ADC_RESOLUTION is missing upstream, hardcode it here.
+#define BATTERY_SENSE_RESOLUTION_BITS 12
+
+#define USE_SX1262
+
+#define LORA_SCK 2
+#define LORA_MISO 4
+#define LORA_MOSI 3
+
+#define SX126X_CS 6
+#define SX126X_DIO1 27
+#define SX126X_BUSY 5
+#define SX126X_RESET 28
+#define SX126X_RXEN 7
+
+#define SX126X_DIO2_AS_RF_SWITCH
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8


### PR DESCRIPTION
A variant for https://wiki.seeedstudio.com/XIAO-RP2040/ and https://wiki.seeedstudio.com/xiao_rp2350_arduino/ , plus Wio-SX1262 for XIAO.
Seems to work with CLI/web client.
