### PR TITLE
fix(stm32wl): Harden LittleFS flash driver and FS layer for reliable prefs persistence

### DIFF
--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -271,8 +271,8 @@ void rmDir(const char *dirname)
 
 #if (defined(ARCH_ESP32) || defined(ARCH_RP2040) || defined(ARCH_PORTDUINO))
     listDir(dirname, 10, true);
-#elif defined(ARCH_NRF52)
-    // nRF52 implementation of LittleFS has a recursive delete function
+#elif defined(ARCH_NRF52) || defined(ARCH_STM32WL)
+    // nRF52 and STM32WL implementations of LittleFS have a recursive delete function
     FSCom.rmdir_r(dirname);
 #endif
 

--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -80,10 +80,11 @@ bool renameFile(const char *pathFrom, const char *pathTo)
 {
 #ifdef FSCom
 
-#ifdef ARCH_ESP32
+#if defined(ARCH_ESP32) || defined(ARCH_STM32WL)
     // take SPI Lock
     spiLock->lock();
-    // rename was fixed for ESP32 IDF LittleFS in April
+    // ESP32: rename was fixed for IDF LittleFS in April
+    // STM32WL: STM32_LittleFS::rename() calls lfs_rename() which is atomic
     bool result = FSCom.rename(pathFrom, pathTo);
     spiLock->unlock();
     return result;

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -2190,6 +2190,7 @@ bool NodeDB::checkLowEntropyPublicKey(const meshtastic_Config_SecurityConfig_pub
 }
 #endif
 
+#if !MESHTASTIC_EXCLUDE_BACKUP
 bool NodeDB::backupPreferences(meshtastic_AdminMessage_BackupLocation location)
 {
     bool success = false;
@@ -2277,6 +2278,7 @@ bool NodeDB::restorePreferences(meshtastic_AdminMessage_BackupLocation location,
 #endif
     return success;
 }
+#endif // !MESHTASTIC_EXCLUDE_BACKUP
 
 /// Record an error that should be reported via analytics
 void recordCriticalError(meshtastic_CriticalErrorCode code, uint32_t address, const char *filename)

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1604,7 +1604,8 @@ bool NodeDB::saveToDisk(int saveWhat)
 
     if (!success) {
         LOG_ERROR("Failed to save to disk, retrying");
-#ifdef ARCH_NRF52 // @geeksville is not ready yet to say we should do this on other platforms.  See bug #4184 discussion
+#if defined(ARCH_NRF52) ||                                                                                                       \
+    defined(ARCH_STM32WL) // @geeksville is not ready yet to say we should do this on other platforms.  See bug #4184 discussion
         spiLock->lock();
         FSCom.format();
         spiLock->unlock();

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -102,7 +102,9 @@ static constexpr const char *configFileName = "/prefs/config.proto";
 static constexpr const char *uiconfigFileName = "/prefs/uiconfig.proto";
 static constexpr const char *moduleConfigFileName = "/prefs/module.proto";
 static constexpr const char *channelFileName = "/prefs/channels.proto";
+#if !MESHTASTIC_EXCLUDE_BACKUP
 static constexpr const char *backupFileName = "/backups/backup.proto";
+#endif
 
 /// Given a node, return how many seconds in the past (vs now) that we last heard from it
 uint32_t sinceLastSeen(const meshtastic_NodeInfoLite *n);
@@ -316,9 +318,11 @@ class NodeDB
     bool checkLowEntropyPublicKey(const meshtastic_Config_SecurityConfig_public_key_t &keyToTest);
 #endif
 
+#if !MESHTASTIC_EXCLUDE_BACKUP
     bool backupPreferences(meshtastic_AdminMessage_BackupLocation location);
     bool restorePreferences(meshtastic_AdminMessage_BackupLocation location,
                             int restoreWhat = SEGMENT_CONFIG | SEGMENT_MODULECONFIG | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS);
+#endif
 
     /// Notify observers of changes to the DB
     void notifyObservers(bool forceUpdate = false)
@@ -331,9 +335,11 @@ class NodeDB
   private:
     bool duplicateWarned = false;
     bool localPositionUpdatedSinceBoot = false;
-    uint32_t lastNodeDbSave = 0;    // when we last saved our db to flash
+    uint32_t lastNodeDbSave = 0; // when we last saved our db to flash
+#if !MESHTASTIC_EXCLUDE_BACKUP
     uint32_t lastBackupAttempt = 0; // when we last tried a backup automatically or manually
-    uint32_t lastSort = 0;          // When last sorted the nodeDB
+#endif
+    uint32_t lastSort = 0; // When last sorted the nodeDB
     /// Find a node in our DB, create an empty NodeInfoLite if missing
     meshtastic_NodeInfoLite *getOrCreateMeshNode(NodeNum n);
 

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -499,6 +499,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
 #endif
         break;
     }
+#if !MESHTASTIC_EXCLUDE_BACKUP
     case meshtastic_AdminMessage_backup_preferences_tag: {
         LOG_INFO("Client requesting to backup preferences");
         if (nodeDB->backupPreferences(r->backup_preferences)) {
@@ -535,6 +536,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
 #endif
         break;
     }
+#endif // !MESHTASTIC_EXCLUDE_BACKUP
     case meshtastic_AdminMessage_send_input_event_tag: {
         LOG_INFO("Client requesting to send input event");
         handleSendInputEvent(r->send_input_event);

--- a/src/platform/stm32wl/LittleFS.cpp
+++ b/src/platform/stm32wl/LittleFS.cpp
@@ -84,30 +84,29 @@ static int _internal_flash_prog(const struct lfs_config *c, lfs_block_t block, l
     LFS_UNUSED(c);
 
     _LFS_DBG("Programming %d bytes/%d doublewords at address 0x%08x/block %d, offset %d.", size, dw_count, address, block, off);
+
+    // Validate the full write range before touching flash
+    lfs_block_t addr_end = address + (lfs_block_t)(dw_count * 8) - 1;
+    if ((address < LFS_FLASH_ADDR_BASE) || (addr_end > LFS_FLASH_ADDR_END)) {
+        _LFS_DBG("Wanted to program out of bound of FLASH: 0x%08x-0x%08x.\n", address, addr_end);
+        return LFS_ERR_INVAL;
+    }
+
     if (HAL_FLASH_Unlock() != HAL_OK) {
         return LFS_ERR_IO;
     }
     for (uint32_t i = 0; i < dw_count; i++) {
-        if ((address < LFS_FLASH_ADDR_BASE) || (address > LFS_FLASH_ADDR_END)) {
-            _LFS_DBG("Wanted to program out of bound of FLASH: 0x%08x.\n", address);
-            HAL_FLASH_Lock();
-            return LFS_ERR_INVAL;
-        }
         hal_rc = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, address, *bufp);
         if (hal_rc != HAL_OK) {
-            /* Error occurred while writing data in Flash memory.
-             * User can add here some code to deal with this error.
-             */
             _LFS_DBG("Program error at (0x%08x), 0x%X, error: 0x%08x\n", address, hal_rc, HAL_FLASH_GetError());
+            break; // Do not continue programming after a failure
         }
         address += 8;
         bufp += 1;
     }
-    if (HAL_FLASH_Lock() != HAL_OK) {
-        return LFS_ERR_IO;
-    }
+    HAL_FLASH_Lock();
 
-    return hal_rc == HAL_OK ? LFS_ERR_OK : LFS_ERR_IO; // If HAL_OK, return LFS_ERR_OK, else return LFS_ERR_IO
+    return hal_rc == HAL_OK ? LFS_ERR_OK : LFS_ERR_IO;
 }
 
 // Erase a block. A block must be erased before being programmed.

--- a/src/platform/stm32wl/LittleFS.cpp
+++ b/src/platform/stm32wl/LittleFS.cpp
@@ -83,6 +83,11 @@ static int _internal_flash_prog(const struct lfs_config *c, lfs_block_t block, l
 
     LFS_UNUSED(c);
 
+    // STM32WL HAL minimum write unit is one 64-bit doubleword (8 bytes)
+    if (size % 8 != 0) {
+        return LFS_ERR_INVAL;
+    }
+
     _LFS_DBG("Programming %d bytes/%d doublewords at address 0x%08x/block %d, offset %d.", size, dw_count, address, block, off);
 
     // Validate the full write range before touching flash

--- a/src/platform/stm32wl/LittleFS.cpp
+++ b/src/platform/stm32wl/LittleFS.cpp
@@ -95,6 +95,7 @@ static int _internal_flash_prog(const struct lfs_config *c, lfs_block_t block, l
     if (HAL_FLASH_Unlock() != HAL_OK) {
         return LFS_ERR_IO;
     }
+    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_ALL_ERRORS);
     for (uint32_t i = 0; i < dw_count; i++) {
         hal_rc = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, address, *bufp);
         if (hal_rc != HAL_OK) {
@@ -132,6 +133,7 @@ static int _internal_flash_erase(const struct lfs_config *c, lfs_block_t block)
     if (HAL_FLASH_Unlock() != HAL_OK) {
         return LFS_ERR_IO;
     }
+    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_ALL_ERRORS);
     hal_rc = HAL_FLASHEx_Erase(&EraseInitStruct, &PAGEError);
     HAL_FLASH_Lock();
 

--- a/src/platform/stm32wl/LittleFS.cpp
+++ b/src/platform/stm32wl/LittleFS.cpp
@@ -130,7 +130,9 @@ static int _internal_flash_erase(const struct lfs_config *c, lfs_block_t block)
     /* calculate the absolute page, i.e. what the ST wants */
     EraseInitStruct.Page = (address - STM32WL_FLASH_BASE) / STM32WL_PAGE_SIZE;
     _LFS_DBG("Erasing block %d at 0x%08x... ", block, address);
-    HAL_FLASH_Unlock();
+    if (HAL_FLASH_Unlock() != HAL_OK) {
+        return LFS_ERR_IO;
+    }
     hal_rc = HAL_FLASHEx_Erase(&EraseInitStruct, &PAGEError);
     HAL_FLASH_Lock();
 

--- a/variants/stm32/stm32.ini
+++ b/variants/stm32/stm32.ini
@@ -25,6 +25,7 @@ build_flags =
   -DMESHTASTIC_EXCLUDE_BLUETOOTH=1
   -DMESHTASTIC_EXCLUDE_WIFI=1
   -DMESHTASTIC_EXCLUDE_TZ=1 ; Exclude TZ to save some flash space.
+  -DMESHTASTIC_EXCLUDE_BACKUP=1 ; Backup preferences require 2 flash blocks (4 KB); not useful on a flash-constrained node.
   -DSERIAL_RX_BUFFER_SIZE=256 ; For GPS - the default of 64 is too small.
   -DHAS_SCREEN=0 ; Always disable screen for STM32, it is not supported.
   ;-DPIO_FRAMEWORK_ARDUINO_NANOLIB_FLOAT_PRINTF ; Enable this if enabling debugg logging. It is REQUIRED for at least traceroute debug prints - without it the length returned by printf ends up uninitialized.


### PR DESCRIPTION
## Summary

This PR fixes persistent configuration loss on STM32WL devices (fixes #9704) by hardening the LittleFS flash driver and correcting several missing or incorrect FS layer behaviours introduced when LittleFS support was first landed in #5987.

Changes are grouped into three layers:

---

### 1. Flash driver robustness (`src/platform/stm32wl/LittleFS.cpp`)

The original `_internal_flash_prog` and `_internal_flash_erase` implementations had four correctness issues that could silently corrupt or lose data:

| Issue | Fix |
|---|---|
| `_internal_flash_erase` discarded `HAL_FLASH_Unlock()` return, proceeding into erase even if flash remained locked | Return `LFS_ERR_IO` on failure |
| `_internal_flash_prog` loop continued writing after `HAL_FLASH_Program()` failed, touching subsequent addresses; `HAL_FLASH_Lock()` was also skipped on the early-return error path | Break on first failure; always `HAL_FLASH_Lock()` after the loop |
| Stale error flags in `FLASH->SR` from a previous failed operation cause the HAL to return `HAL_ERROR` immediately on the next operation without attempting it | Call `__HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_ALL_ERRORS)` after each successful `HAL_FLASH_Unlock()` |
| The STM32WL HAL minimum write unit is one 64-bit doubleword (8 bytes). `dw_count = size / 8` silently truncated trailing bytes when `size % 8 != 0`; LittleFS never saw the short write | Return `LFS_ERR_INVAL` early if `size % 8 != 0` |

Also moved the bounds check before the write loop (validate the full range before touching flash) rather than checking per-doubleword mid-loop.

---

### 2. FS layer completeness (`src/FSCommon.cpp`, `src/mesh/NodeDB.cpp`)

Three higher-level FS operations were missing STM32WL coverage:

**`rmDir()`** — STM32WL fell through all branches silently. Extended the existing `ARCH_NRF52` branch to `ARCH_NRF52 || ARCH_STM32WL`; `STM32_LittleFS::rmdir_r()` delegates to `lfs_remove()`.

**`saveToDisk()` format-on-retry** — The NRF52 recovery path (format + remount on a failed save, then retry) was not extended to STM32WL. Extended the `#if defined(ARCH_NRF52)` guard to include `ARCH_STM32WL`, matching existing NRF52 resilience semantics.

**`renameFile()` — atomic SafeFile close** — The non-ESP32 path implemented rename as `copyFile + remove`, costing two full block write+erase cycles per `SafeFile::close()` and, crucially, opening the destination with `FILE_O_WRITE` without truncation — the root cause of stale-byte corruption identified in #9927. Extended the `ARCH_ESP32` branch to `ARCH_ESP32 || ARCH_STM32WL` so that `STM32_LittleFS::rename()` → `lfs_rename()` is used instead: a metadata-only atomic operation with no extra flash wear and no truncation concern.

---

### 3. Flash headroom (`variants/stm32/stm32.ini`, `src/mesh/NodeDB.cpp`, `src/mesh/NodeDB.h`, `src/modules/AdminModule.cpp`)

`backup.proto` requires two LittleFS blocks (4 KB out of ~28 KB usable on the STM32WL filesystem). Backup is only written on an explicit admin command and adds no value on a flash-constrained node. Added `MESHTASTIC_EXCLUDE_BACKUP=1` to `stm32.ini` and gated the three `AdminModule` case handlers and `NodeDB` declarations/implementations behind `#if !MESHTASTIC_EXCLUDE_BACKUP`, matching the pattern used by existing `MESHTASTIC_EXCLUDE_*` flags throughout the codebase.

---

## Relationship to open PRs

### vs #9927 — `fix(STM32WL) fix LittleFS FILE_O_WRITE truncation for persistent prefs`

#9927 adds `LFS_O_TRUNC` to the `FILE_O_WRITE` open flags in the STM32WL backend to prevent stale bytes from a previous write remaining after a shorter protobuf is written over a larger one.

This PR addresses the same symptom through a more complete fix: by routing `renameFile()` through `lfs_rename()` for STM32WL, `SafeFile` writes to a `.tmp` file and atomically replaces the target via a metadata-only rename — the destination is always either the complete old version or the complete new version. The `FILE_O_WRITE` truncation issue only matters if stale bytes can survive in the *final* file; with an atomic rename the final file is the temp file's inode, so truncation of the destination never occurs. This PR's approach is a superset of #9927's fix and supersedes it.

### vs #10072 — `Remove copyFile/renameFile reimplementations, adjust STM32 SafeFile to match NRF52`

#10072 removes the `copyFile`/`renameFile` reimplementations entirely for all non-ESP32 platforms (also superseding #9927). The `renameFile` fix in this PR overlaps with #10072.

If #10072 lands first, only the `renameFile` hunk in `FSCommon.cpp` would need to be dropped; the remaining changes (flash driver hardening, `rmDir`, format-on-retry, `EXCLUDE_BACKUP`) are fully complementary and not covered by #10072.

---

## Context

The original STM32WL LittleFS implementation was contributed in #5987 and has served as the foundation, but several edge cases in the flash HAL wrapper and FS-layer integration were not discovered until devices accumulated more real-world usage. The bugs in `_internal_flash_prog` (continuing past errors, skipping lock on error path) and the missing `HAL_FLASH_Unlock()` check in `_internal_flash_erase` are the most likely root causes of flash corruption that manifest as settings reverting to defaults after reboot.

---

## Testing

Tested on Seeed Wio-E5 (STM32WLE5JC) mini dev board, RAK3172 (original variant + Russell) and Milesight GS301 (where the fixes helped to unbrick broken storage, likely due to triggering a format due to the corrupted flash - can’t confirm due to lack of logging). Configuration persistence verified across reboots with multiple setting changes (channel config, device config, module config).

Changes to `FSCommon.cpp` and `NodeDB.cpp` that aren't already guarded by `ARCH_STM32WL` follow the exact pattern of existing `ARCH_NRF52` code paths, which have been in production for some time. Non-STM32WL builds are unaffected.

Hardware help welcome for regression testing on other STM32WL variants (CDEBYTE E77, RAK3172, etc.).

---

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other:
    - [x] Seeed Wio-E5 (STM32WLE5JC) - mini dev board
    - [x] RAK3172
    - [x] Milesight GS301 (toilet sensor)