### PR TITLE
feat(Power): support EXT_PWR_DETECT_MODE & EXT_PWR_DETECT_VAL, simplify EXT_PWR_DETECT

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -94,6 +94,20 @@ static const adc_atten_t atten = ADC_ATTENUATION;
 #endif
 #endif // BATTERY_PIN && ARCH_ESP32
 
+#ifdef EXT_PWR_DETECT
+#ifndef EXT_PWR_DETECT_MODE
+#define EXT_PWR_DETECT_MODE INPUT
+// If using internal pull resistors, we can infer EXT_PWR_DETECT_VALUE
+#elif EXT_PWR_DETECT_MODE == INPUT_PULLUP
+#define EXT_PWR_DETECT_VALUE LOW
+#elif EXT_PWR_DETECT_MODE == INPUT_PULLDOWN
+#define EXT_PWR_DETECT_VALUE HIGH
+#endif
+#ifndef EXT_PWR_DETECT_VALUE
+#define EXT_PWR_DETECT_VALUE HIGH
+#endif
+#endif
+
 #ifdef EXT_CHRG_DETECT
 #ifndef EXT_CHRG_DETECT_MODE
 static const uint8_t ext_chrg_detect_mode = INPUT;
@@ -469,28 +483,14 @@ class AnalogBatteryLevel : public HasBatteryLevel
     virtual bool isBatteryConnect() override { return getBatteryPercent() != -1; }
 #endif
 
-    /// If we see a battery voltage higher than physics allows - assume charger is
-    /// pumping in power On some boards we don't have the power management chip
-    /// (like AXPxxxx) so we use EXT_PWR_DETECT GPIO pin to detect external power
-    /// source
+    // Detect if an external power source is connected if we don’t have a PMIC;
+    // Firstly prefer EXT_PWR_DETECT GPIO if available,
+    // secondly try an nRF52-specific routine on some variants,
+    // lastly provide a fallback to indicate external power when fully charged.
     virtual bool isVbusIn() override
     {
 #ifdef EXT_PWR_DETECT
-#if defined(HELTEC_CAPSULE_SENSOR_V3) || defined(HELTEC_SENSOR_HUB)
-        // if external powered that pin will be pulled down
-        if (digitalRead(EXT_PWR_DETECT) == LOW) {
-            return true;
-        }
-        // if it's not LOW - check the battery
-#else
-        // if external powered that pin will be pulled up
-        if (digitalRead(EXT_PWR_DETECT) == HIGH) {
-            return true;
-        }
-        // if it's not HIGH - check the battery
-#endif
-        // If we have an EXT_PWR_DETECT pin and it indicates no external power, believe it.
-        return false;
+        return digitalRead(EXT_PWR_DETECT) == EXT_PWR_DETECT_VALUE;
 
 // technically speaking this should work for all(?) NRF52 boards
 // but needs testing across multiple devices. NRF52 USB would not even work if
@@ -646,11 +646,7 @@ Power::Power() : OSThread("Power")
 bool Power::analogInit()
 {
 #ifdef EXT_PWR_DETECT
-#if defined(HELTEC_CAPSULE_SENSOR_V3) || defined(HELTEC_SENSOR_HUB)
-    pinMode(EXT_PWR_DETECT, INPUT_PULLUP);
-#else
-    pinMode(EXT_PWR_DETECT, INPUT);
-#endif
+    pinMode(EXT_PWR_DETECT, EXT_PWR_DETECT_MODE);
 #endif
 #ifdef EXT_CHRG_DETECT
     pinMode(EXT_CHRG_DETECT, ext_chrg_detect_mode);
@@ -1837,7 +1833,7 @@ SerialBatteryLevel serialBatteryLevel;
 bool Power::serialBatteryInit()
 {
 #ifdef EXT_PWR_DETECT
-    pinMode(EXT_PWR_DETECT, INPUT);
+    pinMode(EXT_PWR_DETECT, EXT_PWR_DETECT_MODE);
 #endif
 #ifdef EXT_CHRG_DETECT
     pinMode(EXT_CHRG_DETECT, ext_chrg_detect_mode);

--- a/variants/esp32s3/heltec_capsule_sensor_v3/variant.h
+++ b/variants/esp32s3/heltec_capsule_sensor_v3/variant.h
@@ -1,6 +1,7 @@
 #define LED_POWER 33
 #define LED_POWER2 34
 #define EXT_PWR_DETECT 35
+#define EXT_PWR_DETECT_MODE INPUT_PULLUP
 
 #define BUTTON_PIN 18
 #define BUTTON_ACTIVE_LOW false

--- a/variants/esp32s3/heltec_sensor_hub/variant.h
+++ b/variants/esp32s3/heltec_sensor_hub/variant.h
@@ -1,4 +1,5 @@
 #define EXT_PWR_DETECT 20
+#define EXT_PWR_DETECT_MODE INPUT_PULLUP
 
 #define BUTTON_PIN 17
 #define BUTTON_ACTIVE_LOW false


### PR DESCRIPTION
Motivation: Simplify future variants by allowing to use internal pull-up/pull-down resistors, thus eliminating a physical resistor on the PCB.

- Also adds feature parity to EXT_CHG_DETECT which supports custom modes and high/low state already.
- Support the use of custom GPIO mode for EXT_PWR_DETECT GPIO pin, which allows the use of INPUT_PULLDOWN and INPUT_PULLUP on MCUs which have internal pull-up or pull-down resistors supported in Arduino.
- Migrate heltec_capsule_sensor_v3 and heltec_sensor_hub from inline ifdef hacks to EXT_PWR_DETECT_MODE.
- Support the use of EXT_PWR_DETECT_VAL which allows both internal or external pull-down resistors to be used for EXT_PWR_DETECT. Automatically set the appropriate EXT_PWR_DETECT_VAL if internal pull resistors are used.
- Simplified EXT_PWR_DETECT by comparing with EXT_PWR_DETECT_VAL directly and remove heltec_capsule_sensor_v3 and heltec_sensor_hub #ifdef hacks now that EXT_PWR_DETECT_VAL is used.

Clean up the comments for isVbusIn() while I am here.

Build tested on:
- heltec_capsule_sensor_v3
- heltec_sensor_hub
- heltec-v3 (as a regression test)
- russell (not in this PR, working on a bunch of enhancements seperately)

Functionality tested on:
- russell (not in this PR, working on a bunch of enhancements seperately)

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
  - Testers needed, especially heltec_capsule_sensor_v3 & heltec_sensor_hub, I don’t have these devices but they are using hacks that this PR removes in favor of proper implementation
