### PR TITLE
feat(stm32wl): add reboot-to-bootloader support via enter_dfu_mode_request

### DIFF
--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -480,7 +480,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
 #if HAS_SCREEN
         IF_SCREEN(screen->showSimpleBanner("Device is rebooting\ninto DFU mode.", 0));
 #endif
-#if defined(ARCH_NRF52) || defined(ARCH_RP2040)
+#if defined(ARCH_NRF52) || defined(ARCH_RP2040) || defined(ARCH_STM32WL)
         enterDfuMode();
 #endif
         break;

--- a/src/platform/stm32wl/main-stm32wl.cpp
+++ b/src/platform/stm32wl/main-stm32wl.cpp
@@ -4,6 +4,57 @@
 #include <stm32wle5xx.h>
 #include <stm32wlxx_hal.h>
 
+// ─── Bootloader redirect ──────────────────────────────────────────────────────
+//
+// Why .noinit + constructor instead of TAMP backup registers:
+//
+//   The STM32duino startup sequence initialises clocks which may call
+//   __HAL_RCC_BACKUPRESET_FORCE/RELEASE when configuring the LSE oscillator,
+//   wiping the entire backup domain (including TAMP->BKP0R) before setup()
+//   ever runs. The backup-register approach therefore cannot reliably survive
+//   a soft reset in this toolchain.
+//
+//   Solution: store the magic in a .noinit SRAM variable.
+//   - NVIC_SystemReset() does NOT clear SRAM.
+//   - The linker script skips zero-init for .noinit sections.
+//   - __attribute__((constructor)) fires before main()/HAL_Init(), so we can
+//     intercept and jump before anything disturbs peripheral state.
+
+#define BOOTLOADER_MAGIC 0xD00DB007UL
+#define SYS_MEM_BASE 0x1FFF0000UL
+
+// Placed in .noinit — not zeroed at startup, survives NVIC_SystemReset().
+__attribute__((section(".noinit"), used)) volatile uint32_t g_bootloaderMagic;
+
+// Fires before main() / HAL_Init(). Must use only core Cortex-M registers.
+__attribute__((constructor(101), used)) static void earlyBootCheck(void)
+{
+    if (g_bootloaderMagic != BOOTLOADER_MAGIC)
+        return;
+    g_bootloaderMagic = 0;
+
+    SysTick->CTRL = 0;
+    SysTick->LOAD = 0;
+    SysTick->VAL = 0;
+    for (int i = 0; i < 8; i++) {
+        NVIC->ICER[i] = 0xFFFFFFFF;
+        NVIC->ICPR[i] = 0xFFFFFFFF;
+    }
+    __DSB();
+    __ISB();
+    SCB->VTOR = SYS_MEM_BASE;
+    __set_MSP(*(volatile uint32_t *)SYS_MEM_BASE);
+    ((void (*)(void))(*(volatile uint32_t *)(SYS_MEM_BASE + 4)))();
+    while (1)
+        ;
+}
+
+void enterDfuMode()
+{
+    g_bootloaderMagic = BOOTLOADER_MAGIC;
+    HAL_NVIC_SystemReset();
+}
+
 void setBluetoothEnable(bool enable) {}
 
 void playStartMelody() {}


### PR DESCRIPTION
## Summary

Adds support for rebooting STM32WLE5-based devices into the ROM bootloader via the existing `enter_dfu_mode_request` admin message, bringing STM32WL into parity with NRF52 and RP2040.

### How it works

Similar in spirit to NRF52's `GPREGRET` magic-word approach: a magic value is written to a variable in `.noinit` SRAM (a region the linker does not zero on startup) so it survives the reset. On the next boot, a constructor running before `main()` detects the magic and jumps directly to the STM32WL ROM bootloader, which provides UART/SPI/I2C DFU interfaces.

The magic is cleared before jumping to the bootloader, so any subsequent reset from within the bootloader results in a normal boot — no bootloader loop is possible. Cold/power-on resets are also safe as random SRAM is astronomically unlikely to match the 32-bit magic value.

TAMP backup registers are an alternative approach but are not safe — LSE/RTC initialisation can wipe the backup domain before `setup()` runs.

### Changes

- `src/platform/stm32wl/main-stm32wl.cpp` — `.noinit` magic variable, early-boot check constructor, and `enterDfuMode()` implementation
- `src/modules/AdminModule.cpp` — add `ARCH_STM32WL` to the `enter_dfu_mode_request` gate alongside `ARCH_NRF52`/`ARCH_RP2040`

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other — RAK3172 (STM32WLE5CCU6), tested via `meshtastic --enter-dfu` (Python CLI); device successfully entered ROM bootloader