### PR TITLE
fix(telemetry): stop emitting -0.001V sentinel when battery unavailable (#7958)

### DIFF
--- a/src/modules/Telemetry/DeviceTelemetry.cpp
+++ b/src/modules/Telemetry/DeviceTelemetry.cpp
@@ -99,17 +99,21 @@ meshtastic_Telemetry DeviceTelemetryModule::getDeviceTelemetry()
     t.variant.device_metrics.has_air_util_tx = true;
     t.variant.device_metrics.has_battery_level = true;
     t.variant.device_metrics.has_channel_utilization = true;
-    t.variant.device_metrics.has_voltage = true;
     t.variant.device_metrics.has_uptime_seconds = true;
-
     t.variant.device_metrics.air_util_tx = airTime->utilizationTXPercent();
     t.variant.device_metrics.battery_level = (!powerStatus->getHasBattery() || powerStatus->getIsCharging())
                                                  ? MAGIC_USB_BATTERY_LEVEL
                                                  : powerStatus->getBatteryChargePercent();
     t.variant.device_metrics.channel_utilization = airTime->channelUtilizationPercent();
-    t.variant.device_metrics.voltage = powerStatus->getBatteryVoltageMv() / 1000.0;
+    // Only populate voltage when we actually have a battery reading. Previously this assigned
+    // -0.001 (from -1 mV / 1000) whenever the ADC returned -1, leaking a sentinel onto the wire
+    // that clients then displayed as a real negative voltage. See GH #7958.
+    uint16_t batteryMv = powerStatus->getBatteryVoltageMv();
+    if (powerStatus->getHasBattery() && batteryMv > 0) {
+        t.variant.device_metrics.has_voltage = true;
+        t.variant.device_metrics.voltage = batteryMv / 1000.0f;
+    }
     t.variant.device_metrics.uptime_seconds = getUptimeSeconds();
-
     return t;
 }
 

--- a/src/modules/Telemetry/DeviceTelemetry.cpp
+++ b/src/modules/Telemetry/DeviceTelemetry.cpp
@@ -108,7 +108,7 @@ meshtastic_Telemetry DeviceTelemetryModule::getDeviceTelemetry()
     // Only populate voltage when we actually have a battery reading. Previously this assigned
     // -0.001 (from -1 mV / 1000) whenever the ADC returned -1, leaking a sentinel onto the wire
     // that clients then displayed as a real negative voltage. See GH #7958.
-    uint16_t batteryMv = powerStatus->getBatteryVoltageMv();
+    int32_t batteryMv = powerStatus->getBatteryVoltageMv();
     if (powerStatus->getHasBattery() && batteryMv > 0) {
         t.variant.device_metrics.has_voltage = true;
         t.variant.device_metrics.voltage = batteryMv / 1000.0f;


### PR DESCRIPTION
## Summary

Fixes #7958.

Device telemetry packets currently emit `voltage = -0.0010000000474974513` for
nodes without a valid battery reading. That oddly-specific number is exactly the
`double` printout of the `float` literal `-0.001f` — a sentinel value that was
leaking onto the wire and being displayed to users as a real (negative) voltage.

Reporters confirmed this on TBEAM, HELTEC V2/V3, XIAO S3, XIAO NRF52, and
RAK4631 — identical bit pattern across wildly different hardware, which rules
out any measurement or hardware-specific cause.

## Root cause

In `getDeviceTelemetry()`:

- `has_voltage = true` was set unconditionally, on every telemetry packet.
- `voltage = powerStatus->getBatteryVoltageMv() / 1000.0` was assigned
  unconditionally. When `getBatteryVoltageMv()` returned `-1` through any
  signed path, dividing by 1000 produced `-0.001f`.

Because `has_voltage` was stamped `true` regardless, nanopb dutifully shipped
the sentinel over LoRa / BLE / MQTT. Downstream consumers (web client, Python
CLI, iOS/Android apps) had no way to know it meant "no reading" and rendered
it as a real voltage.

## Fix

Only set `has_voltage = true` and assign a value when we actually have a
battery and a non-zero reading. This matches the existing pattern used by
`MAX17048Sensor::getMetrics()` elsewhere in the tree, and `DeviceMetrics.voltage`
is already defined as an optional field in the protobuf, so absence is a
valid wire state.

```diff
-    t.variant.device_metrics.has_voltage = true;
     t.variant.device_metrics.has_uptime_seconds = true;
     ...
-    t.variant.device_metrics.voltage = powerStatus->getBatteryVoltageMv() / 1000.0;
+    uint16_t batteryMv = powerStatus->getBatteryVoltageMv();
+    if (powerStatus->getHasBattery() && batteryMv > 0) {
+        t.variant.device_metrics.has_voltage = true;
+        t.variant.device_metrics.voltage = batteryMv / 1000.0f;
+    }
```

Also switched the divisor to `1000.0f` (single-precision) to match the `float`
destination and avoid a pointless double round-trip.

## Related cleanups (not in this PR — deliberately keeping scope small)

- `src/graphics/draw/UIRenderer.cpp:661` has a defensive `voltage > 0.001f`
  check that's a workaround for this exact bug. Worth leaving as-is for now —
  it defends against older-firmware peers on the mesh still sending `-0.001`,
  which will persist in the wild for a while. Can be simplified to just
  `has_voltage` in a later cleanup PR.
- `MeshPacketSerializer.cpp` and `MeshPacketSerializer_nRF52.cpp` currently
  always serialize `voltage` into JSON/MQTT output regardless of `has_voltage`.
  Those sites should probably gate on the flag too, so MQTT subscribers stop
  seeing `"voltage": 0.0` for nodes with no battery. Separate PR.

## Testing

- Not built locally — submitting for CI verification.
- Change is mechanical: removes an unconditional `has_voltage = true` and
  gates the existing assignment behind `getHasBattery() && batteryMv > 0`,
  matching the pattern already used in `MAX17048Sensor::getMetrics()`.
- Happy to iterate if a maintainer flags anything on a specific platform.

## Backward compatibility

Older clients that don't check `has_voltage` will see `voltage == 0.0` (the
default for an unset `float` in zero-initialized nanopb structs) instead of
`-0.001`. This is strictly better: no client rendered `-0.001V` correctly,
whereas `0.0` is either shown as "0.0V" (acceptable) or filtered out.
Recent first-party clients already read `has_voltage` correctly.