### PR TITLE
NextHopRouter: fix 49.7-day millis() rollover in retransmission timing

### DIFF
--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -291,8 +291,10 @@ int32_t NextHopRouter::doRetransmissions()
 
         bool stillValid = true; // assume we'll keep this record around
 
-        // FIXME, handle 51 day rolloever here!!!
-        if (p.nextTxMsec <= now) {
+        // Use signed-difference comparison so retransmission timing stays correct across the
+        // ~49.7 day millis() wraparound (previously this FIXME would stall all retx for the
+        // duration of the wrap or fire them all at once immediately after).
+        if ((int32_t)(p.nextTxMsec - now) <= 0) {
             if (p.numRetransmissions == 0) {
                 if (isFromUs(p.packet)) {
                     LOG_DEBUG("Reliable send failed, returning a nak for fr=0x%x,to=0x%x,id=0x%x", p.packet->from, p.packet->to,

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -405,10 +405,16 @@ int32_t NextHopRouter::doRetransmissions()
 
         bool stillValid = true; // assume we'll keep this record around
 
-        // Use signed-difference comparison so retransmission timing stays correct across the
+        // Use unsigned half-range comparison so retransmission timing stays correct across the
         // ~49.7 day millis() wraparound (previously this FIXME would stall all retx for the
         // duration of the wrap or fire them all at once immediately after).
-        if ((int32_t)(p.nextTxMsec - now) <= 0) {
+        //
+        // Casting an unsigned difference to int32_t for a "time passed" test is
+        // implementation-defined in C++ when the value exceeds INT32_MAX. The unsigned
+        // half-range form below is fully well-defined: nextTxMsec is in the past (or is now)
+        // iff (now - nextTxMsec) has not wrapped past 2^31 ms. Anything further in the
+        // future wraps into the top half and reads as "not yet."
+        if ((uint32_t)(now - p.nextTxMsec) < 0x80000000u) {
             if (p.numRetransmissions == 0) {
                 if (isFromUs(p.packet)) {
                     LOG_DEBUG("Reliable send failed, returning a nak for fr=0x%08x,to=0x%08x,id=0x%08x", p.packet->from,

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -405,8 +405,10 @@ int32_t NextHopRouter::doRetransmissions()
 
         bool stillValid = true; // assume we'll keep this record around
 
-        // FIXME, handle 51 day rolloever here!!!
-        if (p.nextTxMsec <= now) {
+        // Use signed-difference comparison so retransmission timing stays correct across the
+        // ~49.7 day millis() wraparound (previously this FIXME would stall all retx for the
+        // duration of the wrap or fire them all at once immediately after).
+        if ((int32_t)(p.nextTxMsec - now) <= 0) {
             if (p.numRetransmissions == 0) {
                 if (isFromUs(p.packet)) {
                     LOG_DEBUG("Reliable send failed, returning a nak for fr=0x%08x,to=0x%08x,id=0x%08x", p.packet->from,


### PR DESCRIPTION
## Summary

Fix the `// FIXME, handle 51 day rolloever here!!!` in `NextHopRouter::doRetransmissions()` by switching the retransmission-due check to a signed-difference comparison.

## Problem

```cpp
// FIXME, handle 51 day rolloever here!!!
if (p.nextTxMsec <= now) {
```

`millis()` wraps every ~49.7 days (2^32 ms). Both `p.nextTxMsec` and `now` are `uint32_t`. When `now` wraps past the stored `nextTxMsec`, the plain `<=` comparison silently does the wrong thing in two ways:

1. Just before rollover (large `nextTxMsec`, small `now`): all pending retransmissions stall until `now` catches up — minutes to days depending on how close to the wrap the packets were queued.
2. Just after rollover (small `nextTxMsec`, large `now` before wrap): the entire retransmission queue becomes due simultaneously, causing a burst of airtime at the rollover boundary.

The packet-retransmission table is long-lived on routers and infrastructure nodes that stay up for weeks, so this FIXME is reachable in normal operation.

## Fix

Standard Arduino/embedded idiom for rollover-safe "deadline has passed" checks — subtract first, then compare as signed:

```cpp
if ((int32_t)(p.nextTxMsec - now) <= 0) {
```

`(p.nextTxMsec - now)` is computed in `uint32_t` and yields a value whose two's-complement interpretation as `int32_t` is the true signed time delta, provided the actual delta is within ±2^31 ms (~24.8 days). Retransmission deadlines are milliseconds to tens of seconds in the future, so this is always satisfied.

This is the same pattern used elsewhere in the Arduino ecosystem for rollover-safe timing (e.g. `(long)(millis() - target) >= 0`).

## Testing

- Builds cleanly against `develop`.
- Running on a 4-node fleet (RAK4631 / Station G2 / T114 / Heltec V3). Reliable-DM retransmissions continue to behave correctly under normal millis() values; the rollover case is by construction impossible to exercise in a reasonable test window but the replacement expression is a drop-in for the classic Arduino rollover-safe compare.

## Risk

Minimal. One-line change. On non-rollover timelines `(int32_t)(future - now)` is positive and `<= 0` is false exactly when `nextTxMsec <= now` was false — identical behavior. Difference only manifests across the wrap boundary, which is the bug being fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message retransmission timing across system clock rollover.
  * Prevented retransmissions from firing prematurely or becoming delayed when the timer wraps around.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->