### PR TITLE
[draft] pioarduino: fix tbeam (ESP32 original) support

### DIFF
--- a/variants/esp32/esp32.ini
+++ b/variants/esp32/esp32.ini
@@ -17,11 +17,26 @@ build_flags =
   -DMESHTASTIC_EXCLUDE_PAXCOUNTER=1
   -DMESHTASTIC_EXCLUDE_WEBSERVER=1
   -DMESHTASTIC_EXCLUDE_RANGETEST=1
+  ; HACK HACK HACK this is just a proof of concept ESP32+NimBLE but these
+  ; includes need to be done properly somehow
+  -I${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/nimble/host/include
+  -I${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/nimble/include
+  -I${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/porting/nimble/include
+  -I${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/port/include
+  -I${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/porting/npl/freertos/include
+  -I${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/nimble/transport/include
+  -I${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/nimble/host/services/gap/include
+  -I${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/esp-hci/include
+  -I${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/nimble/host/services/gatt/include
+  -I${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/nimble/host/util/include
 
 custom_sdkconfig =
   ${esp32_common.custom_sdkconfig}
+  CONFIG_BTDM_CTRL_MODE_BLE_ONLY=y
   '# CONFIG_BTDM_CTRL_MODE_BR_EDR_ONLY is not set'
   '# CONFIG_BTDM_CTRL_MODE_BTDM is not set'
+  '# CONFIG_BT_BLUEDROID_ENABLED is not set'
+  CONFIG_BT_NIMBLE_ENABLED=y
 
 ; Override lib_deps to use environmental_extra_no_bsec instead of environmental_extra
 ; BSEC library uses ~3.5KB DRAM which causes overflow on original ESP32 targets


### PR DESCRIPTION
DRAFT ONLY

Current state of pioarduino branch: https://github.com/meshtastic/firmware/actions/runs/24730901810/job/72346464441

As expected: https://github.com/meshtastic/firmware/pull/9122#issuecomment-4241813349

We asked why ESP32 original still uses Bluedroid: https://github.com/espressif/esp32-arduino-lib-builder/pull/296#issuecomment-4292724957 answer is there.

Let's try to handle ESP32 original with external NimBLE-Arduino on Meshtastic side.

State after this PR (still many build errors):

```
src/nimble/NimbleBluetooth.cpp: In member function 'void BluetoothPhoneAPI::runOnceHandleFromPhoneQueue()':
src/nimble/NimbleBluetooth.cpp:327:35: error: invalid conversion from 'char*' to 'const uint8_t*' {aka 'const unsigned char*'} [-fpermissive]
  327 |             handleToRadio(val.data(), val.size());
      |                           ~~~~~~~~^~
      |                                   |
      |                                   char*
In file included from src/mesh/StreamAPI.h:3,
                 from src/SerialConsole.h:4,
                 from src/DebugConfiguration.h:34,
                 from src/configuration.h:560,
                 from src/nimble/NimbleBluetooth.cpp:1:
src/mesh/PhoneAPI.h:116:47: note:   initializing argument 1 of 'virtual bool PhoneAPI::handleToRadio(const uint8_t*, size_t)'
  116 |     virtual bool handleToRadio(const uint8_t *buf, size_t len);
      |                                ~~~~~~~~~~~~~~~^~~
src/nimble/NimbleBluetooth.cpp: At global scope:
src/nimble/NimbleBluetooth.cpp:415:10: error: 'void NimbleBluetoothToRadioCallback::onWrite(NimBLECharacteristic*)' marked 'override', but does not override
  415 |     void onWrite(BLECharacteristic *pCharacteristic) override
      |          ^~~~~~~
In file included from .pio/libdeps/tbeam/NimBLE-Arduino/src/NimBLEService.h:28,
                 from .pio/libdeps/tbeam/NimBLE-Arduino/src/NimBLEDevice.h:294,
                 from src/nimble/NimbleBluetooth.cpp:16:
.pio/libdeps/tbeam/NimBLE-Arduino/src/NimBLECharacteristic.h:300:18: warning: 'virtual void NimBLECharacteristicCallbacks::onWrite(NimBLECharacteristic*, NimBLEConnInfo&)' was hidden [-Woverloaded-virtual=]
  300 |     virtual void onWrite(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo);
      |                  ^~~~~~~
src/nimble/NimbleBluetooth.cpp:415:10: note:   by 'void NimbleBluetoothToRadioCallback::onWrite(NimBLECharacteristic*)'
  415 |     void onWrite(BLECharacteristic *pCharacteristic) override
      |          ^~~~~~~
src/nimble/NimbleBluetooth.cpp: In member function 'void NimbleBluetoothToRadioCallback::onWrite(NimBLECharacteristic*)':
src/nimble/NimbleBluetooth.cpp:433:30: error: 'class NimBLECharacteristic' has no member named 'data'
  433 |             pCharacteristic->data(), pCharacteristic->size());
      |                              ^~~~
src/nimble/NimbleBluetooth.cpp:433:55: error: 'class NimBLECharacteristic' has no member named 'size'
  433 |             pCharacteristic->data(), pCharacteristic->size());
      |                                                       ^~~~
src/nimble/NimbleBluetooth.cpp: At global scope:
src/nimble/NimbleBluetooth.cpp:472:10: error: 'void NimbleBluetoothFromRadioCallback::onRead(NimBLECharacteristic*)' marked 'override', but does not override
  472 |     void onRead(BLECharacteristic *pCharacteristic) override
      |          ^~~~~~
.pio/libdeps/tbeam/NimBLE-Arduino/src/NimBLECharacteristic.h:299:18: warning: 'virtual void NimBLECharacteristicCallbacks::onRead(NimBLECharacteristic*, NimBLEConnInfo&)' was hidden [-Woverloaded-virtual=]
  299 |     virtual void onRead(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo);
      |                  ^~~~~~
src/nimble/NimbleBluetooth.cpp:472:10: note:   by 'void NimbleBluetoothFromRadioCallback::onRead(NimBLECharacteristic*)'
  472 |     void onRead(BLECharacteristic *pCharacteristic) override
      |          ^~~~~~
src/nimble/NimbleBluetooth.cpp:582:1: error: expected class-name before '{' token
  582 | {
      | ^
src/nimble/NimbleBluetooth.cpp:583:10: error: 'void NimbleBluetoothSecurityCallback::onPassKeyNotify(uint32_t)' marked 'override', but does not override
  583 |     void onPassKeyNotify(uint32_t passkey) override
      |          ^~~~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:620:10: error: 'void NimbleBluetoothSecurityCallback::onAuthenticationComplete(ble_gap_conn_desc*)' marked 'override', but does not override
  620 |     void onAuthenticationComplete(ble_gap_conn_desc *desc) override
      |          ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from .pio/libdeps/tbeam/NimBLE-Arduino/src/NimBLEDevice.h:293:
.pio/libdeps/tbeam/NimBLE-Arduino/src/NimBLEServer.h:167:18: warning: 'virtual void NimBLEServerCallbacks::onDisconnect(NimBLEServer*, NimBLEConnInfo&, int)' was hidden [-Woverloaded-virtual=]
  167 |     virtual void onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason);
      |                  ^~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:664:10: note:   by 'void NimbleBluetoothServerCallback::onDisconnect(NimBLEServer*, ble_gap_conn_desc*)'
  664 |     void onDisconnect(BLEServer *pServer, struct ble_gap_conn_desc *desc)
      |          ^~~~~~~~~~~~
.pio/libdeps/tbeam/NimBLE-Arduino/src/NimBLEServer.h:157:18: warning: 'virtual void NimBLEServerCallbacks::onConnect(NimBLEServer*, NimBLEConnInfo&)' was hidden [-Woverloaded-virtual=]
  157 |     virtual void onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo);
      |                  ^~~~~~~~~
src/nimble/NimbleBluetooth.cpp:640:10: note:   by 'void NimbleBluetoothServerCallback::onConnect(NimBLEServer*, ble_gap_conn_desc*)'
  640 |     void onConnect(BLEServer *pServer, struct ble_gap_conn_desc *desc)
      |          ^~~~~~~~~
src/nimble/NimbleBluetooth.cpp: In member function 'void NimbleBluetooth::startAdvertising()':
src/nimble/NimbleBluetooth.cpp:718:19: error: 'class NimBLEAdvertising' has no member named 'setMinPreferred'
  718 |     pAdvertising->setMinPreferred(0x06); // functions that help with iPhone connections issue
      |                   ^~~~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:719:19: error: 'class NimBLEAdvertising' has no member named 'setMaxPreferred'
  719 |     pAdvertising->setMaxPreferred(0x12);
      |                   ^~~~~~~~~~~~~~~
Compiling .pio/build/tbeam/FrameworkArduino/base64.cpp.o
src/nimble/NimbleBluetooth.cpp: In member function 'virtual void NimbleBluetooth::setup()':
src/nimble/NimbleBluetooth.cpp:810:5: error: 'BLESecurity' was not declared in this scope
  810 |     BLESecurity *pSecurity = new BLESecurity();
      |     ^~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:810:18: error: 'pSecurity' was not declared in this scope
  810 |     BLESecurity *pSecurity = new BLESecurity();
      |                  ^~~~~~~~~
src/nimble/NimbleBluetooth.cpp:810:34: error: expected type-specifier before 'BLESecurity'
  810 |     BLESecurity *pSecurity = new BLESecurity();
      |                                  ^~~~~~~~~~~
Compiling .pio/build/tbeam/FrameworkArduino/cbuf.cpp.o
src/nimble/NimbleBluetooth.cpp:811:37: error: 'ESP_BLE_ENC_KEY_MASK' was not declared in this scope
  811 |     pSecurity->setInitEncryptionKey(ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK);
      |                                     ^~~~~~~~~~~~~~~~~~~~
Compiling .pio/build/tbeam/FrameworkArduino/chip-debug-report.cpp.o
Compiling .pio/build/tbeam/FrameworkArduino/esp32-hal-adc.c.o
src/nimble/NimbleBluetooth.cpp:811:60: error: 'ESP_BLE_ID_KEY_MASK' was not declared in this scope
  811 |     pSecurity->setInitEncryptionKey(ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK);
      |                                                            ^~~~~~~~~~~~~~~~~~~
Compiling .pio/build/tbeam/FrameworkArduino/esp32-hal-bt.c.o
src/nimble/NimbleBluetooth.cpp:815:34: error: 'ESP_IO_CAP_OUT' was not declared in this scope
  815 |         pSecurity->setCapability(ESP_IO_CAP_OUT);
      |                                  ^~~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:831:34: error: 'ESP_IO_CAP_NONE' was not declared in this scope; did you mean 'ESP_LOG_NONE'?
  831 |         pSecurity->setCapability(ESP_IO_CAP_NONE);
      |                                  ^~~~~~~~~~~~~~~
      |                                  ESP_LOG_NONE
src/nimble/NimbleBluetooth.cpp:836:16: error: 'setSecurityCallbacks' is not a member of 'NimBLEDevice'
  836 |     BLEDevice::setSecurityCallbacks(new NimbleBluetoothSecurityCallback());
      |                ^~~~~~~~~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:841:57: error: 'getDeviceName' is not a member of 'NimBLEDevice'
  841 |     int nameRc = ble_svc_gap_device_name_set(BLEDevice::getDeviceName().c_str());
      |                                                         ^~~~~~~~~~~~~
Compiling .pio/build/tbeam/FrameworkArduino/esp32-hal-cpu.c.o
Compiling .pio/build/tbeam/FrameworkArduino/esp32-hal-dac.c.o
src/nimble/NimbleBluetooth.cpp:841:18: error: 'ble_svc_gap_device_name_set' was not declared in this scope
  841 |     int nameRc = ble_svc_gap_device_name_set(BLEDevice::getDeviceName().c_str());
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp: In member function 'void NimbleBluetooth::setupService()':
src/nimble/NimbleBluetooth.cpp:858:99: error: 'PROPERTY_WRITE' is not a member of 'NimBLECharacteristic'
  858 |         ToRadioCharacteristic = bleService->createCharacteristic(TORADIO_UUID, BLECharacteristic::PROPERTY_WRITE);
      |                                                                                                   ^~~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:860:103: error: 'PROPERTY_READ' is not a member of 'NimBLECharacteristic'
  860 |         FromRadioCharacteristic = bleService->createCharacteristic(FROMRADIO_UUID, BLECharacteristic::PROPERTY_READ);
      |                                                                                                       ^~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:862:79: error: 'PROPERTY_NOTIFY' is not a member of 'NimBLECharacteristic'
  862 |             bleService->createCharacteristic(FROMNUM_UUID, BLECharacteristic::PROPERTY_NOTIFY | BLECharacteristic::PROPERTY_READ);
      |                                                                               ^~~~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:862:116: error: 'PROPERTY_READ' is not a member of 'NimBLECharacteristic'
  862 |             bleService->createCharacteristic(FROMNUM_UUID, BLECharacteristic::PROPERTY_NOTIFY | BLECharacteristic::PROPERTY_READ);
      |                                                                                                                    ^~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:863:101: error: 'PROPERTY_NOTIFY' is not a member of 'NimBLECharacteristic'
  863 |         logRadioCharacteristic = bleService->createCharacteristic(LOGRADIO_UUID, BLECharacteristic::PROPERTY_NOTIFY |
      |                                                                                                     ^~~~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:864:105: error: 'PROPERTY_READ' is not a member of 'NimBLECharacteristic'
  864 |                                                                                      BLECharacteristic::PROPERTY_READ);
      |                                                                                                         ^~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:866:99: error: 'PROPERTY_WRITE' is not a member of 'NimBLECharacteristic'
  866 |         ToRadioCharacteristic = bleService->createCharacteristic(TORADIO_UUID, BLECharacteristic::PROPERTY_WRITE |
      |                                                                                                   ^~~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:867:103: error: 'PROPERTY_WRITE_AUTHEN' is not a member of 'NimBLECharacteristic'
  867 |                                                                                    BLECharacteristic::PROPERTY_WRITE_AUTHEN |
      |                                                                                                       ^~~~~~~~~~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:868:103: error: 'PROPERTY_WRITE_ENC' is not a member of 'NimBLECharacteristic'
  868 |                                                                                    BLECharacteristic::PROPERTY_WRITE_ENC);
      |                                                                                                       ^~~~~~~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:869:103: error: 'PROPERTY_READ' is not a member of 'NimBLECharacteristic'
  869 |         FromRadioCharacteristic = bleService->createCharacteristic(FROMRADIO_UUID, BLECharacteristic::PROPERTY_READ |
      |                                                                                                       ^~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:870:107: error: 'PROPERTY_READ_AUTHEN' is not a member of 'NimBLECharacteristic'
  870 |                                                                                        BLECharacteristic::PROPERTY_READ_AUTHEN |
      |                                                                                                           ^~~~~~~~~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:871:107: error: 'PROPERTY_READ_ENC' is not a member of 'NimBLECharacteristic'
  871 |                                                                                        BLECharacteristic::PROPERTY_READ_ENC);
      |                                                                                                           ^~~~~~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:873:46: error: 'PROPERTY_NOTIFY' is not a member of 'NimBLECharacteristic'
  873 |             FROMNUM_UUID, BLECharacteristic::PROPERTY_NOTIFY | BLECharacteristic::PROPERTY_READ |
      |                                              ^~~~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:873:83: error: 'PROPERTY_READ' is not a member of 'NimBLECharacteristic'
  873 |             FROMNUM_UUID, BLECharacteristic::PROPERTY_NOTIFY | BLECharacteristic::PROPERTY_READ |
      |                                                                                   ^~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:874:50: error: 'PROPERTY_READ_AUTHEN' is not a member of 'NimBLECharacteristic'
  874 |                               BLECharacteristic::PROPERTY_READ_AUTHEN | BLECharacteristic::PROPERTY_READ_ENC);
      |                                                  ^~~~~~~~~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:874:92: error: 'PROPERTY_READ_ENC' is not a member of 'NimBLECharacteristic'
  874 |                               BLECharacteristic::PROPERTY_READ_AUTHEN | BLECharacteristic::PROPERTY_READ_ENC);
      |                                                                                            ^~~~~~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:876:47: error: 'PROPERTY_NOTIFY' is not a member of 'NimBLECharacteristic'
  876 |             LOGRADIO_UUID, BLECharacteristic::PROPERTY_NOTIFY | BLECharacteristic::PROPERTY_READ |
      |                                               ^~~~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:876:84: error: 'PROPERTY_READ' is not a member of 'NimBLECharacteristic'
  876 |             LOGRADIO_UUID, BLECharacteristic::PROPERTY_NOTIFY | BLECharacteristic::PROPERTY_READ |
      |                                                                                    ^~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:877:51: error: 'PROPERTY_READ_AUTHEN' is not a member of 'NimBLECharacteristic'
  877 |                                BLECharacteristic::PROPERTY_READ_AUTHEN | BLECharacteristic::PROPERTY_READ_ENC);
      |                                                   ^~~~~~~~~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:877:93: error: 'PROPERTY_READ_ENC' is not a member of 'NimBLECharacteristic'
  877 |                                BLECharacteristic::PROPERTY_READ_AUTHEN | BLECharacteristic::PROPERTY_READ_ENC);
      |                                                                                             ^~~~~~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:896:46: error: 'PROPERTY_READ' is not a member of 'NimBLECharacteristic'
  896 |         (uint16_t)0x2a19, BLECharacteristic::PROPERTY_READ | BLECharacteristic::PROPERTY_NOTIFY);
      |                                              ^~~~~~~~~~~~~
src/nimble/NimbleBluetooth.cpp:896:81: error: 'PROPERTY_NOTIFY' is not a member of 'NimBLECharacteristic'
  896 |         (uint16_t)0x2a19, BLECharacteristic::PROPERTY_READ | BLECharacteristic::PROPERTY_NOTIFY);
      |                                                                                 ^~~~~~~~~~~~~~~
```

- does NOT build tbeam yet (but getting closer)
- NOT build tested on other devices (like Heltec v3) to check they are still buildling
- NOT intended for merging - just a draft to show my current work and allow others to add to it