### PR TITLE
FSCommon::copyFile: close source file on destination-open failure

### DIFF
--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -53,6 +53,7 @@ bool copyFile(const char *from, const char *to)
     File f2 = FSCom.open(to, FILE_O_WRITE);
     if (!f2) {
         LOG_ERROR("Failed to open destination file %s", to);
+        f1.close();
         return false;
     }
 


### PR DESCRIPTION
## Problem

In `src/FSCommon.cpp::copyFile()`, if opening the destination file fails, the function returns without closing the already-opened source file handle:

```cpp
File f1 = FSCom.open(from, FILE_O_READ);
if (!f1) {
    LOG_ERROR("Failed to open source file %s", from);
    return false;
}

File f2 = FSCom.open(to, FILE_O_WRITE);
if (!f2) {
    LOG_ERROR("Failed to open destination file %s", to);
    return false;    // <-- f1 leaks here
}
```

The leak compounds every time `copyFile()` is retried with a failing destination (destination FS full, read-only, permission denied, etc.) until the node runs out of file descriptors.

## Fix

Add `f1.close()` before the early return on destination-open failure, matching the cleanup that already happens on the success path (lines 65-66 before the patch).

## Risk

Minimal. One-line change, closes an already-opened handle that would otherwise leak. No behavior change on the success path.

## Testing

I've had this patch in a fleet local build for several weeks with no issues. Builds cleanly against `develop`.