### PR TITLE
RadioLibInterface: clear static `instance` on destruction to prevent UAF

### DIFF
--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -46,6 +46,16 @@ RadioLibInterface::RadioLibInterface(LockingArduinoHal *hal, RADIOLIB_PIN_TYPE c
 #endif
 }
 
+RadioLibInterface::~RadioLibInterface()
+{
+    // If the static `instance` pointer still references us, clear it.
+    // A later successful init() may have replaced `instance` with a newer
+    // interface — don't clobber that case.
+    if (instance == this) {
+        instance = nullptr;
+    }
+}
+
 #ifdef ARCH_ESP32
 // ESP32 doesn't use that flag
 #define YIELD_FROM_ISR(x) portYIELD_FROM_ISR()

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -136,6 +136,13 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
     RadioLibInterface(LockingArduinoHal *hal, RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst,
                       RADIOLIB_PIN_TYPE busy, PhysicalLayer *iface = NULL);
 
+    /**
+     * Clear the static `instance` pointer if it still points at us, so callers
+     * that check `RadioLibInterface::instance != nullptr` don't dereference a
+     * freed object after a failed init() + unique_ptr reset.
+     */
+    virtual ~RadioLibInterface();
+
     virtual ErrorCode send(meshtastic_MeshPacket *p) override;
 
     /**


### PR DESCRIPTION
Fixes #9880.

## Problem

The `RadioLibInterface` constructor sets the static `instance = this` immediately, before `init()` runs:

```cpp
RadioLibInterface::RadioLibInterface(...)
    : NotifiedWorkerThread("RadioIf"), module(hal, cs, irq, rst, busy), iface(_iface)
{
    instance = this;   // <-- set before init() has a chance to fail
    ...
}
```

`initLoRa()` in `RadioInterface.cpp` constructs each radio variant and then calls `init()`:

```cpp
rIf = std::unique_ptr<SX1262Interface>(new SX1262Interface(...));
if (!rIf->init()) {
    LOG_WARN("No SX1262 radio");
    rIf = nullptr;   // <-- destroys the object; but `instance` still points at freed memory
}
```

`main.cpp` then checks `RadioLibInterface::instance != nullptr` every loop and calls methods on it:

```cpp
if (RadioLibInterface::instance != nullptr) {
    ...
    RadioLibInterface::instance->pollMissedIrqs();  // <-- UAF
    ...
    RadioLibInterface::instance->resetAGC();         // <-- UAF
}
```

On hardware where `init()` always fails (e.g., an ESP32-S3 dev board with no radio attached, per #9880), this hard-faults with `Guru Meditation Error: Core 1 panic'ed (IllegalInstruction)` pointing at freed memory.

## Fix

Add a virtual destructor to `RadioLibInterface` that clears the static pointer iff it still refers to this object:

```cpp
RadioLibInterface::~RadioLibInterface()
{
    if (instance == this) {
        instance = nullptr;
    }
}
```

The `instance == this` guard is important: `initLoRa()` has multiple fallback paths (try TCXO first, then XTAL, then bare retry) — each constructs a new interface that sets `instance = this`. If an earlier attempt succeeded but the destructor of a later-constructed-then-destroyed interface fires, we mustn't clobber the successful `instance` pointer.

## Risk

Minimal. Adds a destructor that was implicitly compiler-generated before (no explicit base destructor to worry about) and does nothing on the happy path where init succeeded and the object lives until shutdown. Addresses the reported UAF pattern directly.

## Testing

Can't directly reproduce without a radio-less ESP32-S3 board, but the logic is straightforward and the fix pattern is standard RAII. Would appreciate @duraseb confirming on the affected hardware.

Also: this hardens any other path where an interface might be destroyed — not just the init-failure path reported in #9880. Anything that destroys a `RadioLibInterface` (e.g., future reconfiguration / dynamic reinit / test fixtures) will now correctly clear the static pointer.