### PR TITLE
RadioLibInterface: drop "caught missed RX_DONE" from WARN to DEBUG

### DIFF
--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -555,7 +555,12 @@ void RadioLibInterface::resetAGC()
 void RadioLibInterface::checkRxDoneIrqFlag()
 {
     if (iface->checkIrq(RADIOLIB_IRQ_RX_DONE)) {
-        LOG_WARN("caught missed RX_DONE");
+        // This is the normal recovery path for back-to-back RX events where the
+        // second packet's DIO1 edge happens while the GPIO interrupt was still
+        // disabled (between ISR disable and the handler re-enabling it).
+        // Matches the log level used for other "compensated for a normal radio
+        // oddity" events in this file (e.g. "Ignore false preamble detection").
+        LOG_DEBUG("Caught RX_DONE via poll (ISR-missed edge, normal under dense RX)");
         notify(ISR_RX, true);
     }
 }


### PR DESCRIPTION
## Context

PR #9658 added `pollMissedIrqs()` as a 1 Hz backup to catch RX_DONE events where the GPIO edge happened while the ISR was still disabled from processing the previous packet. That's a real scenario on back-to-back receptions:

1. Packet A's edge fires DIO1 → ISR runs → `disableInterrupt()`
2. Worker thread reads + processes A via SPI (takes milliseconds)
3. **Packet B completes during step 2**; its DIO1 transition happens while our GPIO interrupt is disabled
4. Worker re-enables interrupt, but DIO1 is already high — no new edge to trigger on
5. `pollMissedIrqs()` at 1 Hz notices the RX_DONE flag is set, kicks the handler → packet B gets processed

This is the polling safety net working exactly as intended. Not a warning condition.

## Problem

Current log level is `LOG_WARN`:

```cpp
if (iface->checkIrq(RADIOLIB_IRQ_RX_DONE)) {
    LOG_WARN("caught missed RX_DONE");
    notify(ISR_RX, true);
}
```

On a Station G2 running in ROUTER_LATE in an active urban mesh, this fires ~200 times per day under sustained RX load — clustered during dense-RX bursts (e.g., phone-app reconnect storms, neighbor floods). It buries actual warnings in the log.

Same pattern as PR #10252's CRC_MISMATCH fix (same file): a normal radio recovery event logged at the wrong level.

## Fix

Drop to `LOG_DEBUG` and expand the message so it's self-documenting at DEBUG level:

```cpp
LOG_DEBUG("Caught RX_DONE via poll (ISR-missed edge, normal under dense RX)");
```

## Alignment with existing file conventions

This matches how `RadioLibInterface.cpp` logs other "we compensated for a normal radio oddity" cases:

| Line | Current level | Condition |
|---|---|---|
| 123 | `LOG_DEBUG` | "Ignore false preamble detection" (receiver timed out on PREAMBLE_DETECTED without follow-up HEADER_VALID) |
| 130 | `LOG_DEBUG` | "Ignore false header detection" (similar — HEADER_VALID but no RX_DONE follow-up) |
| 558 (was) | `LOG_WARN` | "caught missed RX_DONE" (our robustness-poll catching a back-to-back RX) |

The new level brings #558 into line with the other two.

## Risk

Minimal — log level only, no behavior change. Identical commit pattern to the CRC_MISMATCH drop in #10252.

## Observation data

On my Station G2 fleet over 24 hours, captured:

```
177 LOG_WARN "caught missed RX_DONE"
```

Clustered at high-stress periods:
- 71 events during a 17:00 UTC reconnect-storm window
- 36 during morning mesh activity
- 50 during an early-morning reconnect event

In every case the poll successfully recovered the missed IRQ and the packet was processed normally. Zero observed lost packets attributable to missed RX_DONE — the backup poll is doing its job, it just shouldn't be shouting while it does.