### PR TITLE
Router: demote cross-channel decrypt failures from ERROR to DEBUG

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -499,9 +499,9 @@ DecodeState perhapsDecode(meshtastic_MeshPacket *p)
                 meshtastic_Data decodedtmp;
                 memset(&decodedtmp, 0, sizeof(decodedtmp));
                 if (!pb_decode_from_bytes(bytes, rawSize, &meshtastic_Data_msg, &decodedtmp)) {
-                    LOG_ERROR("Invalid protobufs in received mesh packet id=0x%08x (bad psk?)!", p->id);
+                    LOG_DEBUG("Invalid protobufs in received mesh packet id=0x%08x (bad psk?)", p->id);
                 } else if (decodedtmp.portnum == meshtastic_PortNum_UNKNOWN_APP) {
-                    LOG_ERROR("Invalid portnum (bad psk?)!");
+                    LOG_DEBUG("Invalid portnum (bad psk?)");
 #if !(MESHTASTIC_EXCLUDE_PKI)
                 } else if (!owner.is_licensed && isToUs(p) && decodedtmp.portnum == meshtastic_PortNum_TEXT_MESSAGE_APP) {
                     LOG_WARN("Rejecting legacy DM");


### PR DESCRIPTION
## Summary

The \"Invalid protobufs (bad psk?)\" and \"Invalid portnum (bad psk?)\" messages in [src/mesh/Router.cpp:502-504](https://github.com/meshtastic/firmware/blob/develop/src/mesh/Router.cpp#L502-L504) fire whenever a neighbor transmits on a channel whose 8-bit hash collides with one of ours but the PSK differs. In RF environments with multiple mesh groups nearby this is **routine** — not an error.

### Why this matters

The channel hash is only 8 bits (XOR-fold of name + PSK & 0xFF), so with enough neighboring mesh groups, hash collisions are inevitable. In real-world monitoring across a single 24-hour window I counted **17 distinct cross-channel hashes** hitting the device, including SAR groups, MeshCA, Tango/Whiskey (NATO), and private community networks. Each of those that hash-collides with one of our configured channels triggers these two LOG_ERROR lines every single packet.

Effects:
- Log spam drowns actual errors
- A genuine PSK misconfiguration on your OWN channel is indistinguishable from the cross-channel noise
- ERROR-level severity is misleading — this isn't an error, it's expected behavior when the hash check yields a false positive

### Fix

Demote both to `LOG_DEBUG`. This matches how similar decrypt-failure paths are already treated — eg. the PKC \"decrypt attempted but failed\" path a few lines above uses `LOG_WARN`, and genuinely catastrophic paths (oversize packet, pb_decode fatal) use `LOG_ERROR`. Also drops the trailing \"!\" since these are expected events.

## Test plan

- [x] Grep confirms no other paths depend on these specific LOG_ERROR messages
- [ ] Build + run near neighboring mesh groups — expect log volume at INFO level to drop meaningfully
- [ ] Verify that same-channel PSK mismatch (genuine config error) still surfaces in `LOG_DEBUG` output when enabled

## Related

Part of an ongoing log-hygiene sweep. Related: #10255 (missed RX_DONE WARN→DEBUG, same spirit).