### PR TITLE
FSCommon: close File handle on directory-listing early returns

### DIFF
--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -118,8 +118,10 @@ std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels)
     File root = FSCom.open(dirname, FILE_O_READ);
     if (!root)
         return filenames;
-    if (!root.isDirectory())
+    if (!root.isDirectory()) {
+        root.close();
         return filenames;
+    }
 
     File file = root.openNextFile();
     while (file) {
@@ -131,8 +133,8 @@ std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels)
                 std::vector<meshtastic_FileInfo> subDirFilenames = getFiles(file.name(), levels - 1);
 #endif
                 filenames.insert(filenames.end(), subDirFilenames.begin(), subDirFilenames.end());
-                file.close();
             }
+            file.close();
         } else {
             meshtastic_FileInfo fileInfo = {"", static_cast<uint32_t>(file.size())};
 #ifdef ARCH_ESP32
@@ -171,6 +173,7 @@ void listDir(const char *dirname, uint8_t levels, bool del)
         return;
     }
     if (!root.isDirectory()) {
+        root.close();
         return;
     }
 
@@ -205,6 +208,8 @@ void listDir(const char *dirname, uint8_t levels, bool del)
                 listDir(file.name(), levels - 1, del);
                 file.close();
 #endif
+            } else {
+                file.close();
             }
         } else {
 #ifdef ARCH_ESP32


### PR DESCRIPTION
## Summary

Three file-descriptor leaks in the directory-enumeration helpers in [src/FSCommon.cpp](https://github.com/meshtastic/firmware/blob/develop/src/FSCommon.cpp):

1. **getFiles() line 122** — early return when root was opened but is not a directory, without closing root.
2. **getFiles() lines 126-134** — directory entries encountered when \`levels == 0\` were never closed. \`file.close()\` was nested inside \`if (levels) { ... }\` so it only ran when we recursed into the subdirectory. When the caller passed \`levels == 0\` (or the deepest level of recursion), each subdirectory entry leaked its File handle through the loop until \`openNextFile\` returned false.
3. **listDir() lines 173 + 211** — same two patterns as above in the sibling function.

On LittleFS each File handle holds a per-file cache buffer (~256 bytes on ESP32, larger on nRF52). Repeated enumeration under FS pressure can exhaust the concurrent-open limit and cause later \`FSCom.open()\` calls to fail silently. This is the same bug class as the FSCommon::copyFile FD leak fixed in #10249.

## Fix

- Add \`root.close()\` before both early-returns.
- Move \`file.close()\` out of the \`if (levels)\` block in both functions so every directory entry is closed, regardless of recursion depth.

## Test plan

- [x] Verified all three paths via grep — no other early-returns in these loops
- [ ] Call \`getFiles(\"/prefs\", 0)\` (levels=0) on a device with subdirectories under /prefs and confirm no \"too many open files\" errors after repeated calls
- [ ] Call \`listDir\` on a non-directory path and confirm the subsequent FS ops still work

Related: #10249 (same bug class in FSCommon::copyFile).