### PR TITLE
Null-check pool.allocZeroed() at 13 sites across 9 files

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -909,8 +909,8 @@ void setup()
     if (nodeDB->keyIsLowEntropy && !nodeDB->hasWarned) {
         LOG_WARN(LOW_ENTROPY_WARNING);
         // Mark as warned unconditionally — the LOG_WARN above has already fired the user-visible
-        // notice; if the ClientNotification pool is exhausted we'd otherwise spin every tick
-        // retrying + spamming LOG_WARN.
+        // notice. `hasWarned` persists in NodeDB, so this also suppresses the same warning on
+        // subsequent boots regardless of whether the ClientNotification pool had room this time.
         nodeDB->hasWarned = true;
         meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
         if (cn) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -908,13 +908,16 @@ void setup()
     // warn the user about a low entropy key
     if (nodeDB->keyIsLowEntropy && !nodeDB->hasWarned) {
         LOG_WARN(LOW_ENTROPY_WARNING);
+        // Mark as warned unconditionally — the LOG_WARN above has already fired the user-visible
+        // notice; if the ClientNotification pool is exhausted we'd otherwise spin every tick
+        // retrying + spamming LOG_WARN.
+        nodeDB->hasWarned = true;
         meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
         if (cn) {
             cn->level = meshtastic_LogRecord_Level_WARNING;
             cn->time = getValidTime(RTCQualityFromNet);
             sprintf(cn->message, LOW_ENTROPY_WARNING);
             service->sendClientNotification(cn);
-            nodeDB->hasWarned = true;
         }
     }
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -909,11 +909,13 @@ void setup()
     if (nodeDB->keyIsLowEntropy && !nodeDB->hasWarned) {
         LOG_WARN(LOW_ENTROPY_WARNING);
         meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
-        cn->level = meshtastic_LogRecord_Level_WARNING;
-        cn->time = getValidTime(RTCQualityFromNet);
-        sprintf(cn->message, LOW_ENTROPY_WARNING);
-        service->sendClientNotification(cn);
-        nodeDB->hasWarned = true;
+        if (cn) {
+            cn->level = meshtastic_LogRecord_Level_WARNING;
+            cn->time = getValidTime(RTCQualityFromNet);
+            sprintf(cn->message, LOW_ENTROPY_WARNING);
+            service->sendClientNotification(cn);
+            nodeDB->hasWarned = true;
+        }
     }
 #endif
 #if !MESHTASTIC_EXCLUDE_INPUTBROKER

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1884,7 +1884,9 @@ bool NodeDB::updateUser(uint32_t nodeId, meshtastic_User &p, uint8_t channelInde
                 if (cn) {
                     cn->level = meshtastic_LogRecord_Level_WARNING;
                     cn->time = getValidTime(RTCQualityFromNet);
-                    sprintf(cn->message, warning, p.long_name);
+                    // snprintf because p.long_name is remote-controlled up to 40 bytes and the
+                    // warning format itself is ~150 bytes — sprintf could overflow cn->message.
+                    snprintf(cn->message, sizeof(cn->message), warning, p.long_name);
                     service->sendClientNotification(cn);
                 }
             }

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1881,10 +1881,12 @@ bool NodeDB::updateUser(uint32_t nodeId, meshtastic_User &p, uint8_t channelInde
                     "to regenerate your public keys.";
                 LOG_WARN(warning, p.long_name);
                 meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
-                cn->level = meshtastic_LogRecord_Level_WARNING;
-                cn->time = getValidTime(RTCQualityFromNet);
-                sprintf(cn->message, warning, p.long_name);
-                service->sendClientNotification(cn);
+                if (cn) {
+                    cn->level = meshtastic_LogRecord_Level_WARNING;
+                    cn->time = getValidTime(RTCQualityFromNet);
+                    sprintf(cn->message, warning, p.long_name);
+                    service->sendClientNotification(cn);
+                }
             }
             return false;
         }

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -774,9 +774,10 @@ void PhoneAPI::sendNotification(meshtastic_LogRecord_Level level, uint32_t reply
         return;
     cn->has_reply_id = true;
     cn->reply_id = replyId;
-    cn->level = meshtastic_LogRecord_Level_WARNING;
+    cn->level = level;
     cn->time = getValidTime(RTCQualityFromNet);
-    strncpy(cn->message, message, sizeof(cn->message));
+    strncpy(cn->message, message, sizeof(cn->message) - 1);
+    cn->message[sizeof(cn->message) - 1] = '\0';
     service->sendClientNotification(cn);
 }
 

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -765,6 +765,8 @@ bool PhoneAPI::available()
 void PhoneAPI::sendNotification(meshtastic_LogRecord_Level level, uint32_t replyId, const char *message)
 {
     meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
+    if (!cn)
+        return;
     cn->has_reply_id = true;
     cn->reply_id = replyId;
     cn->level = meshtastic_LogRecord_Level_WARNING;

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -325,12 +325,14 @@ ErrorCode Router::send(meshtastic_MeshPacket *p)
             LOG_WARN("Duty cycle limit exceeded. Aborting send for now, you can send again in %d mins", silentMinutes);
 
             meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
-            cn->has_reply_id = true;
-            cn->reply_id = p->id;
-            cn->level = meshtastic_LogRecord_Level_WARNING;
-            cn->time = getValidTime(RTCQualityFromNet);
-            sprintf(cn->message, "Duty cycle limit exceeded. You can send again in %d mins", silentMinutes);
-            service->sendClientNotification(cn);
+            if (cn) {
+                cn->has_reply_id = true;
+                cn->reply_id = p->id;
+                cn->level = meshtastic_LogRecord_Level_WARNING;
+                cn->time = getValidTime(RTCQualityFromNet);
+                sprintf(cn->message, "Duty cycle limit exceeded. You can send again in %d mins", silentMinutes);
+                service->sendClientNotification(cn);
+            }
 
             meshtastic_Routing_Error err = meshtastic_Routing_Error_DUTY_CYCLE_LIMIT;
             if (isFromUs(p)) { // only send NAK to API, not to the mesh

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -397,12 +397,14 @@ void PositionModule::sendOurPosition(NodeNum dest, bool wantReplies, uint8_t cha
                   meshtastic_Config_DeviceConfig_Role_TAK_TRACKER) &&
         config.power.is_power_saving) {
         meshtastic_ClientNotification *notification = clientNotificationPool.allocZeroed();
-        notification->level = meshtastic_LogRecord_Level_INFO;
-        notification->time = getValidTime(RTCQualityFromNet);
-        sprintf(notification->message, "Sending position and sleeping for %us interval in a moment",
-                Default::getConfiguredOrDefaultMs(config.position.position_broadcast_secs, default_broadcast_interval_secs) /
-                    1000U);
-        service->sendClientNotification(notification);
+        if (notification) {
+            notification->level = meshtastic_LogRecord_Level_INFO;
+            notification->time = getValidTime(RTCQualityFromNet);
+            sprintf(notification->message, "Sending position and sleeping for %us interval in a moment",
+                    Default::getConfiguredOrDefaultMs(config.position.position_broadcast_secs, default_broadcast_interval_secs) /
+                        1000U);
+            service->sendClientNotification(notification);
+        }
         sleepOnNextExecution = true;
         LOG_DEBUG("Start next execution in 5s, then sleep");
         setIntervalFromNow(FIVE_SECONDS_MS);

--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -96,10 +96,12 @@ bool SerialModule::isValidConfig(const meshtastic_ModuleConfig_SerialConfig &con
         LOG_ERROR(warning);
 #if !IS_RUNNING_TESTS
         meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
-        cn->level = meshtastic_LogRecord_Level_ERROR;
-        cn->time = getValidTime(RTCQualityFromNet);
-        snprintf(cn->message, sizeof(cn->message), "%s", warning);
-        service->sendClientNotification(cn);
+        if (cn) {
+            cn->level = meshtastic_LogRecord_Level_ERROR;
+            cn->time = getValidTime(RTCQualityFromNet);
+            snprintf(cn->message, sizeof(cn->message), "%s", warning);
+            service->sendClientNotification(cn);
+        }
 #endif
         return false;
     }

--- a/src/modules/Telemetry/AirQualityTelemetry.cpp
+++ b/src/modules/Telemetry/AirQualityTelemetry.cpp
@@ -416,13 +416,15 @@ bool AirQualityTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
 
             if (config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR && config.power.is_power_saving) {
                 meshtastic_ClientNotification *notification = clientNotificationPool.allocZeroed();
-                notification->level = meshtastic_LogRecord_Level_INFO;
-                notification->time = getValidTime(RTCQualityFromNet);
-                sprintf(notification->message, "Sending telemetry and sleeping for %us interval in a moment",
-                        Default::getConfiguredOrDefaultMs(moduleConfig.telemetry.air_quality_interval,
-                                                          default_telemetry_broadcast_interval_secs) /
-                            1000U);
-                service->sendClientNotification(notification);
+                if (notification) {
+                    notification->level = meshtastic_LogRecord_Level_INFO;
+                    notification->time = getValidTime(RTCQualityFromNet);
+                    sprintf(notification->message, "Sending telemetry and sleeping for %us interval in a moment",
+                            Default::getConfiguredOrDefaultMs(moduleConfig.telemetry.air_quality_interval,
+                                                              default_telemetry_broadcast_interval_secs) /
+                                1000U);
+                    service->sendClientNotification(notification);
+                }
                 sleepOnNextExecution = true;
                 LOG_DEBUG("Start next execution in 5s, then sleep");
                 setIntervalFromNow(FIVE_SECONDS_MS);
@@ -430,13 +432,15 @@ bool AirQualityTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
 
             if (config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR && config.power.is_power_saving) {
                 meshtastic_ClientNotification *notification = clientNotificationPool.allocZeroed();
-                notification->level = meshtastic_LogRecord_Level_INFO;
-                notification->time = getValidTime(RTCQualityFromNet);
-                sprintf(notification->message, "Sending telemetry and sleeping for %us interval in a moment",
-                        Default::getConfiguredOrDefaultMs(moduleConfig.telemetry.air_quality_interval,
-                                                          default_telemetry_broadcast_interval_secs) /
-                            1000U);
-                service->sendClientNotification(notification);
+                if (notification) {
+                    notification->level = meshtastic_LogRecord_Level_INFO;
+                    notification->time = getValidTime(RTCQualityFromNet);
+                    sprintf(notification->message, "Sending telemetry and sleeping for %us interval in a moment",
+                            Default::getConfiguredOrDefaultMs(moduleConfig.telemetry.air_quality_interval,
+                                                              default_telemetry_broadcast_interval_secs) /
+                                1000U);
+                    service->sendClientNotification(notification);
+                }
                 sleepOnNextExecution = true;
                 LOG_DEBUG("Start next execution in 5s, then sleep");
                 setIntervalFromNow(FIVE_SECONDS_MS);

--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -644,13 +644,15 @@ bool EnvironmentTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
 
             if (config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR && config.power.is_power_saving) {
                 meshtastic_ClientNotification *notification = clientNotificationPool.allocZeroed();
-                notification->level = meshtastic_LogRecord_Level_INFO;
-                notification->time = getValidTime(RTCQualityFromNet);
-                sprintf(notification->message, "Sending telemetry and sleeping for %us interval in a moment",
-                        Default::getConfiguredOrDefaultMs(moduleConfig.telemetry.environment_update_interval,
-                                                          default_telemetry_broadcast_interval_secs) /
-                            1000U);
-                service->sendClientNotification(notification);
+                if (notification) {
+                    notification->level = meshtastic_LogRecord_Level_INFO;
+                    notification->time = getValidTime(RTCQualityFromNet);
+                    sprintf(notification->message, "Sending telemetry and sleeping for %us interval in a moment",
+                            Default::getConfiguredOrDefaultMs(moduleConfig.telemetry.environment_update_interval,
+                                                              default_telemetry_broadcast_interval_secs) /
+                                1000U);
+                    service->sendClientNotification(notification);
+                }
                 sleepOnNextExecution = true;
                 LOG_DEBUG("Start next execution in 5s, then sleep");
                 setIntervalFromNow(FIVE_SECONDS_MS);

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -482,8 +482,10 @@ bool MQTT::publish(const char *topic, const char *payload, bool retained)
 {
     if (moduleConfig.mqtt.proxy_to_client_enabled) {
         meshtastic_MqttClientProxyMessage *msg = mqttClientProxyMessagePool.allocZeroed();
-        if (!msg)
+        if (!msg) {
+            LOG_WARN("MQTT proxy publish skipped: message pool exhausted");
             return false;
+        }
         msg->which_payload_variant = meshtastic_MqttClientProxyMessage_text_tag;
         strncpy(msg->topic, topic, sizeof(msg->topic));
         msg->topic[sizeof(msg->topic) - 1] = '\0';
@@ -505,8 +507,10 @@ bool MQTT::publish(const char *topic, const uint8_t *payload, size_t length, boo
 {
     if (moduleConfig.mqtt.proxy_to_client_enabled) {
         meshtastic_MqttClientProxyMessage *msg = mqttClientProxyMessagePool.allocZeroed();
-        if (!msg)
+        if (!msg) {
+            LOG_WARN("MQTT proxy publish skipped: message pool exhausted");
             return false;
+        }
         msg->which_payload_variant = meshtastic_MqttClientProxyMessage_data_tag;
         strncpy(msg->topic, topic, sizeof(msg->topic));
         msg->topic[sizeof(msg->topic) - 1] = '\0'; // Ensure null termination
@@ -887,7 +891,7 @@ void MQTT::perhapsReportToMap()
     // Allocate MeshPacket and fill it
     meshtastic_MeshPacket *mp = packetPool.allocZeroed();
     if (!mp) {
-        LOG_WARN("MQTT Map report: packet pool exhausted");
+        LOG_ERROR("MQTT Map report: packet pool exhausted");
         return;
     }
     mp->which_payload_variant = meshtastic_MeshPacket_decoded_tag;

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -483,7 +483,7 @@ bool MQTT::publish(const char *topic, const char *payload, bool retained)
     if (moduleConfig.mqtt.proxy_to_client_enabled) {
         meshtastic_MqttClientProxyMessage *msg = mqttClientProxyMessagePool.allocZeroed();
         if (!msg) {
-            LOG_WARN("MQTT proxy publish skipped: message pool exhausted");
+            // MemoryPool::alloc already LOG_WARNs on exhaustion; don't double-log here.
             return false;
         }
         msg->which_payload_variant = meshtastic_MqttClientProxyMessage_text_tag;
@@ -508,7 +508,7 @@ bool MQTT::publish(const char *topic, const uint8_t *payload, size_t length, boo
     if (moduleConfig.mqtt.proxy_to_client_enabled) {
         meshtastic_MqttClientProxyMessage *msg = mqttClientProxyMessagePool.allocZeroed();
         if (!msg) {
-            LOG_WARN("MQTT proxy publish skipped: message pool exhausted");
+            // MemoryPool::alloc already LOG_WARNs on exhaustion; don't double-log here.
             return false;
         }
         msg->which_payload_variant = meshtastic_MqttClientProxyMessage_data_tag;
@@ -891,7 +891,12 @@ void MQTT::perhapsReportToMap()
     // Allocate MeshPacket and fill it
     meshtastic_MeshPacket *mp = packetPool.allocZeroed();
     if (!mp) {
+        // Back off to the configured publish interval on pool exhaustion. Without this,
+        // perhapsReportToMap() would be called on every runOnce() (20–200 ms) until the
+        // pool recovers, and each call would retry the log + early return — turning
+        // sustained pool pressure into a log-flood instead of a throttled failure.
         LOG_ERROR("MQTT Map report: packet pool exhausted");
+        last_report_to_map = millis();
         return;
     }
     mp->which_payload_variant = meshtastic_MeshPacket_decoded_tag;

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -482,6 +482,8 @@ bool MQTT::publish(const char *topic, const char *payload, bool retained)
 {
     if (moduleConfig.mqtt.proxy_to_client_enabled) {
         meshtastic_MqttClientProxyMessage *msg = mqttClientProxyMessagePool.allocZeroed();
+        if (!msg)
+            return false;
         msg->which_payload_variant = meshtastic_MqttClientProxyMessage_text_tag;
         strncpy(msg->topic, topic, sizeof(msg->topic));
         msg->topic[sizeof(msg->topic) - 1] = '\0';
@@ -503,6 +505,8 @@ bool MQTT::publish(const char *topic, const uint8_t *payload, size_t length, boo
 {
     if (moduleConfig.mqtt.proxy_to_client_enabled) {
         meshtastic_MqttClientProxyMessage *msg = mqttClientProxyMessagePool.allocZeroed();
+        if (!msg)
+            return false;
         msg->which_payload_variant = meshtastic_MqttClientProxyMessage_data_tag;
         strncpy(msg->topic, topic, sizeof(msg->topic));
         msg->topic[sizeof(msg->topic) - 1] = '\0'; // Ensure null termination
@@ -685,11 +689,13 @@ bool MQTT::isValidConfig(const meshtastic_ModuleConfig_MQTTConfig &config, MQTTC
         LOG_ERROR(warning);
 #if !IS_RUNNING_TESTS
         meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
-        cn->level = meshtastic_LogRecord_Level_ERROR;
-        cn->time = getValidTime(RTCQualityFromNet);
-        strncpy(cn->message, warning, sizeof(cn->message) - 1);
-        cn->message[sizeof(cn->message) - 1] = '\0'; // Ensure null termination
-        service->sendClientNotification(cn);
+        if (cn) {
+            cn->level = meshtastic_LogRecord_Level_ERROR;
+            cn->time = getValidTime(RTCQualityFromNet);
+            strncpy(cn->message, warning, sizeof(cn->message) - 1);
+            cn->message[sizeof(cn->message) - 1] = '\0'; // Ensure null termination
+            service->sendClientNotification(cn);
+        }
 #endif
         return false;
 #endif
@@ -701,11 +707,13 @@ bool MQTT::isValidConfig(const meshtastic_ModuleConfig_MQTTConfig &config, MQTTC
         LOG_ERROR(warning);
 #if !IS_RUNNING_TESTS
         meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
-        cn->level = meshtastic_LogRecord_Level_ERROR;
-        cn->time = getValidTime(RTCQualityFromNet);
-        strncpy(cn->message, warning, sizeof(cn->message) - 1);
-        cn->message[sizeof(cn->message) - 1] = '\0'; // Ensure null termination
-        service->sendClientNotification(cn);
+        if (cn) {
+            cn->level = meshtastic_LogRecord_Level_ERROR;
+            cn->time = getValidTime(RTCQualityFromNet);
+            strncpy(cn->message, warning, sizeof(cn->message) - 1);
+            cn->message[sizeof(cn->message) - 1] = '\0'; // Ensure null termination
+            service->sendClientNotification(cn);
+        }
 #endif
         return false;
     }
@@ -878,6 +886,10 @@ void MQTT::perhapsReportToMap()
 
     // Allocate MeshPacket and fill it
     meshtastic_MeshPacket *mp = packetPool.allocZeroed();
+    if (!mp) {
+        LOG_WARN("MQTT Map report: packet pool exhausted");
+        return;
+    }
     mp->which_payload_variant = meshtastic_MeshPacket_decoded_tag;
     mp->from = nodeDB->getNodeNum();
     mp->to = NODENUM_BROADCAST;


### PR DESCRIPTION
## Summary

13 sites across 9 files called \`pool.allocZeroed()\` and immediately dereferenced the result without null-checking. When the static MemoryPool is exhausted, \`allocZeroed()\` returns nullptr (with a LOG_WARN in Allocator::allocZeroed) — every dereference that follows is a crash.

From [MemoryPool.h:149-160](https://github.com/meshtastic/firmware/blob/develop/src/mesh/MemoryPool.h#L149-L160): static pools return nullptr when no free slot is available. That's a real failure mode under burst load.

## Sites fixed

| File | Line | Pool | Trigger |
|---|---|---|---|
| \`main.cpp\` | 911 | clientNotification | Low-entropy key warning on boot |
| \`mesh/NodeDB.cpp\` | 1883 | clientNotification | Duplicate public key warning |
| \`mesh/PhoneAPI.cpp\` | 767 | clientNotification | \`sendNotification()\` helper |
| \`mesh/Router.cpp\` | 327 | clientNotification | Duty-cycle-exceeded notification |
| \`modules/PositionModule.cpp\` | 399 | clientNotification | Tracker role power-save notify |
| \`modules/SerialModule.cpp\` | 98 | clientNotification | Invalid serial config |
| \`modules/Telemetry/AirQualityTelemetry.cpp\` | 418, 432 | clientNotification | Sensor role power-save notify (2 sites) |
| \`modules/Telemetry/EnvironmentTelemetry.cpp\` | 646 | clientNotification | Sensor role power-save notify |
| \`mqtt/MQTT.cpp\` | 484, 505 | mqttClientProxyMessage | MQTT publish proxy (2 sites) |
| \`mqtt/MQTT.cpp\` | 687, 703 | clientNotification | Invalid-config notifications (2 sites) |
| \`mqtt/MQTT.cpp\` | 888 | packet | Map report MeshPacket alloc |

## Style

Matches the existing pattern used in already-null-checked sites:
- [AdminModule::sendWarning](https://github.com/meshtastic/firmware/blob/develop/src/modules/AdminModule.cpp#L1553-L1555): \`if (!cn) return;\`
- [RadioInterface::sendErrorNotification](https://github.com/meshtastic/firmware/blob/develop/src/mesh/RadioInterface.cpp#L773-L775): \`if (!cn) return;\`
- [MQTT.cpp:671-678](https://github.com/meshtastic/firmware/blob/develop/src/mqtt/MQTT.cpp#L671-L678): \`if (cn) { ... }\`

Used \`if (!cn) return;\` for single-exit contexts and \`if (cn) { ... }\` where the surrounding code needs to run regardless (eg. \`sleepOnNextExecution = true;\` still happens in the telemetry modules even when the notification can't be sent).

## Related

- #10261 — same bug class in \`Router::allocForSending\` (separate PR, narrower scope)
- #10252 — same bug class in \`RadioLibInterface\` RX path (already filed)