### PR TITLE
PhoneAPI: rate-limit handleStartConfig to prevent reconnect-storm heap fragmentation

### DIFF
--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -47,8 +47,28 @@ PhoneAPI::~PhoneAPI()
     close();
 }
 
+uint32_t PhoneAPI::lastStartConfigMs = 0;
+
+// Minimum interval between full config-dump handshakes, shared across all PhoneAPI
+// transports (BLE, WiFi/TCP, Serial, HTTP, Ethernet). Chosen to be just longer than
+// a nominal config dump takes to complete (~1.5-2 seconds on a 250-node DB), so
+// legitimate reconnect-after-disconnect flows still work but a flapping client
+// can't drive one handshake per second and exhaust internal SRAM.
+static constexpr uint32_t MIN_CONFIG_HANDSHAKE_INTERVAL_MS = 2000;
+
 void PhoneAPI::handleStartConfig()
 {
+    // Rate-limit full config dumps. Each dump exercises the protobuf encode path for
+    // all channels, configs, the entire NodeDB, and a full filesystem walk — back-to-back
+    // dumps fragment the internal SRAM heap and can wedge the device on static-pool
+    // allocators. Well-behaved clients only issue one want_config_id per reconnect.
+    if (lastStartConfigMs != 0 && (millis() - lastStartConfigMs) < MIN_CONFIG_HANDSHAKE_INTERVAL_MS) {
+        LOG_WARN("Config handshake throttled (last one %u ms ago, min interval %u ms)",
+                 (unsigned)(millis() - lastStartConfigMs), (unsigned)MIN_CONFIG_HANDSHAKE_INTERVAL_MS);
+        return;
+    }
+    lastStartConfigMs = millis();
+
     // Must be before setting state (because state is how we know !connected)
     if (!isConnected()) {
         onConnectionChanged(true);

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -55,6 +55,9 @@ std::atomic<uint32_t> PhoneAPI::lastStartConfigMs{0};
 // legitimate reconnect-after-disconnect flows still work but a flapping client
 // can't drive one handshake per second and exhaust internal SRAM.
 static constexpr uint32_t MIN_CONFIG_HANDSHAKE_INTERVAL_MS = 2000;
+// Rate-limit the throttled-handshake WARN itself so a flapping client can't turn this
+// defensive code into its own log-flood problem.
+static constexpr uint32_t HANDSHAKE_THROTTLE_LOG_INTERVAL_MS = 5000;
 
 void PhoneAPI::handleStartConfig(uint32_t newConfigNonce)
 {
@@ -69,17 +72,26 @@ void PhoneAPI::handleStartConfig(uint32_t newConfigNonce)
     // The new nonce is only committed to config_nonce AFTER the throttle check passes — so
     // an in-flight dump (triggered by an earlier accepted handshake) keeps its nonce and
     // sendConfigComplete matches what the client asked for.
-    const uint32_t now = millis();
     uint32_t last = lastStartConfigMs.load(std::memory_order_relaxed);
     while (true) {
+        // Re-read `now` on every iteration. If a concurrent task CASed lastStartConfigMs
+        // between our load and our CAS, the weak-CAS failure path updates `last` to the
+        // newer timestamp — if we then reused a stale `now` (captured before the race)
+        // our next CAS could commit a backwards-in-time value, breaking the rate limit
+        // for the next arriving handshake.
+        const uint32_t now = millis();
         if (last != 0 && (now - last) < MIN_CONFIG_HANDSHAKE_INTERVAL_MS) {
-            LOG_WARN("Config handshake throttled (last one %u ms ago, min interval %u ms)",
-                     (unsigned)(now - last), (unsigned)MIN_CONFIG_HANDSHAKE_INTERVAL_MS);
+            static uint32_t lastThrottleLogMs = 0;
+            if (!Throttle::isWithinTimespanMs(lastThrottleLogMs, HANDSHAKE_THROTTLE_LOG_INTERVAL_MS)) {
+                lastThrottleLogMs = now;
+                LOG_WARN("Config handshake throttled (last one %u ms ago, min interval %u ms)",
+                         (unsigned)(now - last), (unsigned)MIN_CONFIG_HANDSHAKE_INTERVAL_MS);
+            }
             return;
         }
         if (lastStartConfigMs.compare_exchange_weak(last, now, std::memory_order_acq_rel, std::memory_order_relaxed))
             break;
-        // another task raced us — re-check the (possibly updated) `last` value
+        // another task raced us — loop re-reads `now` and re-checks the updated `last`
     }
 
     // Throttle passed — safe to advance state. Commit the new nonce so sendConfigComplete

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -62,12 +62,13 @@ void PhoneAPI::handleStartConfig()
     // all channels, configs, the entire NodeDB, and a full filesystem walk — back-to-back
     // dumps fragment the internal SRAM heap and can wedge the device on static-pool
     // allocators. Well-behaved clients only issue one want_config_id per reconnect.
-    if (lastStartConfigMs != 0 && (millis() - lastStartConfigMs) < MIN_CONFIG_HANDSHAKE_INTERVAL_MS) {
+    const uint32_t now = millis();
+    if (lastStartConfigMs != 0 && (now - lastStartConfigMs) < MIN_CONFIG_HANDSHAKE_INTERVAL_MS) {
         LOG_WARN("Config handshake throttled (last one %u ms ago, min interval %u ms)",
-                 (unsigned)(millis() - lastStartConfigMs), (unsigned)MIN_CONFIG_HANDSHAKE_INTERVAL_MS);
+                 (unsigned)(now - lastStartConfigMs), (unsigned)MIN_CONFIG_HANDSHAKE_INTERVAL_MS);
         return;
     }
-    lastStartConfigMs = millis();
+    lastStartConfigMs = now;
 
     // Must be before setting state (because state is how we know !connected)
     if (!isConnected()) {

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -47,7 +47,7 @@ PhoneAPI::~PhoneAPI()
     close();
 }
 
-uint32_t PhoneAPI::lastStartConfigMs = 0;
+std::atomic<uint32_t> PhoneAPI::lastStartConfigMs{0};
 
 // Minimum interval between full config-dump handshakes, shared across all PhoneAPI
 // transports (BLE, WiFi/TCP, Serial, HTTP, Ethernet). Chosen to be just longer than
@@ -56,19 +56,35 @@ uint32_t PhoneAPI::lastStartConfigMs = 0;
 // can't drive one handshake per second and exhaust internal SRAM.
 static constexpr uint32_t MIN_CONFIG_HANDSHAKE_INTERVAL_MS = 2000;
 
-void PhoneAPI::handleStartConfig()
+void PhoneAPI::handleStartConfig(uint32_t newConfigNonce)
 {
     // Rate-limit full config dumps. Each dump exercises the protobuf encode path for
     // all channels, configs, the entire NodeDB, and a full filesystem walk — back-to-back
     // dumps fragment the internal SRAM heap and can wedge the device on static-pool
     // allocators. Well-behaved clients only issue one want_config_id per reconnect.
+    //
+    // Use atomic load/compare_exchange so concurrent handshakes across transports (BLE
+    // callback task vs WiFi/Eth OSThread vs serial-console task) can't both pass the check.
+    //
+    // The new nonce is only committed to config_nonce AFTER the throttle check passes — so
+    // an in-flight dump (triggered by an earlier accepted handshake) keeps its nonce and
+    // sendConfigComplete matches what the client asked for.
     const uint32_t now = millis();
-    if (lastStartConfigMs != 0 && (now - lastStartConfigMs) < MIN_CONFIG_HANDSHAKE_INTERVAL_MS) {
-        LOG_WARN("Config handshake throttled (last one %u ms ago, min interval %u ms)",
-                 (unsigned)(now - lastStartConfigMs), (unsigned)MIN_CONFIG_HANDSHAKE_INTERVAL_MS);
-        return;
+    uint32_t last = lastStartConfigMs.load(std::memory_order_relaxed);
+    while (true) {
+        if (last != 0 && (now - last) < MIN_CONFIG_HANDSHAKE_INTERVAL_MS) {
+            LOG_WARN("Config handshake throttled (last one %u ms ago, min interval %u ms)",
+                     (unsigned)(now - last), (unsigned)MIN_CONFIG_HANDSHAKE_INTERVAL_MS);
+            return;
+        }
+        if (lastStartConfigMs.compare_exchange_weak(last, now, std::memory_order_acq_rel, std::memory_order_relaxed))
+            break;
+        // another task raced us — re-check the (possibly updated) `last` value
     }
-    lastStartConfigMs = now;
+
+    // Throttle passed — safe to advance state. Commit the new nonce so sendConfigComplete
+    // returns it back to the client that asked for it.
+    config_nonce = newConfigNonce;
 
     // Must be before setting state (because state is how we know !connected)
     if (!isConnected()) {
@@ -181,9 +197,8 @@ bool PhoneAPI::handleToRadio(const uint8_t *buf, size_t bufLength)
         case meshtastic_ToRadio_packet_tag:
             return handleToRadioPacket(toRadioScratch.packet);
         case meshtastic_ToRadio_want_config_id_tag:
-            config_nonce = toRadioScratch.want_config_id;
-            LOG_INFO("Client wants config, nonce=%u", config_nonce);
-            handleStartConfig();
+            LOG_INFO("Client wants config, nonce=%u", toRadioScratch.want_config_id);
+            handleStartConfig(toRadioScratch.want_config_id);
             break;
         case meshtastic_ToRadio_disconnect_tag:
             LOG_INFO("Disconnect from phone");

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -80,12 +80,25 @@ void PhoneAPI::handleStartConfig(uint32_t newConfigNonce)
         // our next CAS could commit a backwards-in-time value, breaking the rate limit
         // for the next arriving handshake.
         const uint32_t now = millis();
-        if (last != 0 && (now - last) < MIN_CONFIG_HANDSHAKE_INTERVAL_MS) {
+        // Only enforce the throttle when we're actually mid-dump
+        // (state in [STATE_SEND_UIDATA..STATE_SEND_COMPLETE_ID]). The throttle's purpose
+        // is preventing concurrent overlapping dumps from fragmenting the heap; it must
+        // NOT block legitimate fresh-client handshakes (state == STATE_SEND_NOTHING) or
+        // post-dump re-handshake requests (state == STATE_SEND_PACKETS, the steady state
+        // after a successful dump). Without this gate the static lastStartConfigMs across
+        // transports causes legitimate cross-transport reconnects (e.g. BLE → TCP) to
+        // silently early-return without advancing state, leaving the client stuck on
+        // "reading config" forever. Hardware-confirmed on Heltec V4 TFT 2026-04-27:
+        // first handshake passed (state was 0), Android closed and re-issued want_config
+        // ~570ms later when state was 11 (POST_DUMP), and the original throttle blocked
+        // the second handshake — Android stalled.
+        const bool dumpInFlight = (state >= STATE_SEND_UIDATA && state <= STATE_SEND_COMPLETE_ID);
+        if (dumpInFlight && last != 0 && (now - last) < MIN_CONFIG_HANDSHAKE_INTERVAL_MS) {
             static uint32_t lastThrottleLogMs = 0;
             if (!Throttle::isWithinTimespanMs(lastThrottleLogMs, HANDSHAKE_THROTTLE_LOG_INTERVAL_MS)) {
                 lastThrottleLogMs = now;
-                LOG_WARN("Config handshake throttled (last one %u ms ago, min interval %u ms)",
-                         (unsigned)(now - last), (unsigned)MIN_CONFIG_HANDSHAKE_INTERVAL_MS);
+                LOG_WARN("Config handshake throttled (last one %u ms ago, min interval %u ms, state=%d)",
+                         (unsigned)(now - last), (unsigned)MIN_CONFIG_HANDSHAKE_INTERVAL_MS, (int)state);
             }
             return;
         }

--- a/src/mesh/PhoneAPI.h
+++ b/src/mesh/PhoneAPI.h
@@ -145,6 +145,15 @@ class PhoneAPI
     /** the last msec we heard from the client on the other side of this link */
     uint32_t lastContactMsec = 0;
 
+    /**
+     * Shared across all PhoneAPI instances — prevents a misbehaving client (or flapping TCP
+     * reconnect loop) from driving back-to-back full config handshakes. Every handshake
+     * exercises the protobuf encode path for MY_INFO, OWN_NODEINFO, METADATA, all channels,
+     * all configs, the entire NodeDB, and a filesystem walk — each cycle costs heap that
+     * takes time to recover, and high-rate repetition fragments the internal SRAM heap.
+     */
+    static uint32_t lastStartConfigMs;
+
     /// Hookable to find out when connection changes
     virtual void onConnectionChanged(bool connected) {}
 

--- a/src/mesh/PhoneAPI.h
+++ b/src/mesh/PhoneAPI.h
@@ -4,6 +4,7 @@
 #include "concurrency/Lock.h"
 #include "mesh-pb-constants.h"
 #include "meshtastic/portnums.pb.h"
+#include <atomic>
 #include <deque>
 #include <iterator>
 #include <string>
@@ -151,8 +152,12 @@ class PhoneAPI
      * exercises the protobuf encode path for MY_INFO, OWN_NODEINFO, METADATA, all channels,
      * all configs, the entire NodeDB, and a filesystem walk — each cycle costs heap that
      * takes time to recover, and high-rate repetition fragments the internal SRAM heap.
+     *
+     * Atomic because PhoneAPI subclasses run on different FreeRTOS tasks (NimBLE callback
+     * for BLE, APIServerPort OSThread for WiFi/HTTP/Ethernet, the serial-console task for
+     * USB) — concurrent reads/writes across transports are possible.
      */
-    static uint32_t lastStartConfigMs;
+    static std::atomic<uint32_t> lastStartConfigMs;
 
     /// Hookable to find out when connection changes
     virtual void onConnectionChanged(bool connected) {}
@@ -173,8 +178,11 @@ class PhoneAPI
     virtual void onConfigStart() {}
     virtual void onConfigComplete() {}
 
-    /// begin a new connection
-    void handleStartConfig();
+    /// begin a new connection. If the request is throttled (see lastStartConfigMs),
+    /// the member `config_nonce` is NOT updated from `newConfigNonce` — so an already
+    /// in-flight config dump keeps its original nonce and the caller's nonce is silently
+    /// dropped. Well-behaved clients retry on timeout.
+    void handleStartConfig(uint32_t newConfigNonce);
 
     enum APIType {
         TYPE_NONE, // Initial state, don't send anything until the client starts asking for config

--- a/src/mesh/api/PacketAPI.cpp
+++ b/src/mesh/api/PacketAPI.cpp
@@ -66,9 +66,8 @@ bool PacketAPI::receivePacket(void)
             break;
         }
         case meshtastic_ToRadio_want_config_id_tag: {
-            uint32_t config_nonce = mr->want_config_id;
-            LOG_INFO("Screen wants config, nonce=%u", config_nonce);
-            handleStartConfig();
+            LOG_INFO("Screen wants config, nonce=%u", mr->want_config_id);
+            handleStartConfig(mr->want_config_id);
             break;
         }
         case meshtastic_ToRadio_heartbeat_tag:


### PR DESCRIPTION
## Summary

Add a 2000 ms minimum interval between full config-dump handshakes in [PhoneAPI::handleStartConfig](https://github.com/meshtastic/firmware/blob/develop/src/mesh/PhoneAPI.cpp#L50). A misbehaving or flapping client that reconnects faster than a config dump can complete is currently able to exhaust the internal SRAM heap via fragmentation.

## Evidence

Measured on a Station G2 (ESP32-S3, 248 KB internal SRAM heap, 8 MB PSRAM) running `2.7.23.ef4693d` with full DEBUG_HEAP instrumentation:

- Meshtastic-python \`TCPInterface\` client with a reader thread that gets \`Connection reset by peer\` from a remote under heap pressure → Python side tears down and reconnects → full \`want_config_id\` re-issued → new \`handleStartConfig\` every ~1 s.
- **466 complete reconnect cycles over 85 minutes.**
- **Net heap loss: 108 KB** (avg 232 B / median 192 B per cycle).
- \`heap_free\` trajectory: 150 KB → 50 KB over the 85 min, crashed into reboot.
- Post-reboot with the storm stopped: heap rock-stable at 145 KB for 11 hours (no continued leak).

Stage-by-stage heap delta per cycle (from log parse over 398 cycles):

| Segment | Avg Δ | Median Δ |
|---|---|---|
| \`wants_config → got_files\` | +2,815 | +2,052 |
| \`force_close → incoming_api\` | +1,472 | +1,164 |
| \`send_myinfo → send_metadata\` | **-3,556** | **-3,692** |
| \`send_cfg_device → send_cfg_sec\` | -501 | -568 |

Most of the loss is heap fragmentation from the repeated alloc/free of mid-sized protobuf encode buffers (MY_INFO, OWN_NODEINFO, METADATA, NodeDB entries) interleaved with longer-lived queue entries. Once the storm stops, the free total does not recover until reboot.

## Fix

Add \`PhoneAPI::lastStartConfigMs\` as a static member (shared across all transport subclasses — BLE, WiFi/TCP, Serial, HTTP, Ethernet) and reject handshakes within 2000 ms of the previous one:

- 2000 ms chosen to be just longer than a full config dump takes to complete on a saturated (250-node) NodeDB, so legitimate reconnect-after-disconnect flows still work.
- Well-behaved clients only issue one \`want_config_id\` per reconnect so are unaffected.
- The throttled path returns early *before* touching state, observers, or \`getFiles\` — no resources are leaked per throttled call.
- The client either waits and retries or times out and recovers naturally.

## Test plan

- [x] Builds clean on heltec-v4 (ESP32-S3) — local verification
- [ ] CI build across all targets
- [ ] Repro: run a meshtastic-python TCP reconnect loop against a Station G2, confirm heap_free no longer bleeds out

## Related work

The underlying fragmentation vulnerability is an architectural issue — large per-session protobuf buffers land in internal SRAM even on boards with 8 MB of idle PSRAM. Separately scoping a PSRAM-routing change for the large allocators; this PR is the narrow defensive fix.