### PR TITLE
Fix example comment in airtime.h

### DIFF
--- a/src/airtime.h
+++ b/src/airtime.h
@@ -19,8 +19,8 @@
 
   TX_LOG + RX_LOG = Total air time for a particular meshtastic channel.
 
-  TX_LOG + RX_LOG = Total air time for a particular meshtastic channel, including
-                    other lora radios.
+  TX_LOG + RX_ALL_LOG = Total air time for a particular meshtastic channel, including
+                        other lora radios.
 
   RX_ALL_LOG - RX_LOG = Other lora radios on our frequency channel.
 */


### PR DESCRIPTION
Looks like a copy'n'paste typo from the previous line. It definitely meant to be RX_ALL_LOG according to comment.
The change cannot affect any devices and doesn't need testing.

