### PR TITLE
Router: drop OTA packets that claim from=ourNodeNum (self-RX anti-spoof)

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -849,6 +849,26 @@ void Router::perhapsHandleReceived(meshtastic_MeshPacket *p)
         LOG_TRACE("%s", MeshPacketSerializer::JsonSerializeEncrypted(p).c_str());
     }
 #endif
+    // A packet received over the air that claims `from == our own nodeNum`
+    // is physically impossible for legitimate traffic: a radio cannot hear
+    // its own transmission. Such a packet must therefore be a forgery by
+    // someone who holds the channel PSK. Drop it with zero false positives
+    // (the only way to reach this path with isFromUs(p) is OTA reception
+    // — Router::sendLocal's broadcast loopback calls handleReceived, not
+    // perhapsHandleReceived, so locally-originated packets never arrive here).
+    //
+    // Can be disabled via -DMESHTASTIC_DISABLE_SPOOF_SELF_RX_DROP=1 for
+    // research / debug builds. Default ON.
+#if !defined(MESHTASTIC_DISABLE_SPOOF_SELF_RX_DROP)
+    if (isFromUs(p)) {
+        spoofSelfRxDrop++;
+        LOG_WARN("SPOOF: dropped OTA packet claiming from=0x%08x (=our nodeNum); id=0x%x rssi=%d snr=%f",
+                 p->from, p->id, p->rx_rssi, p->rx_snr);
+        packetPool.release(p);
+        return;
+    }
+#endif
+
     // assert(radioConfig.has_preferences);
     if (is_in_repeated(config.lora.ignore_incoming, p->from)) {
         LOG_DEBUG("Ignore msg, 0x%x is in our ignore list", p->from);

--- a/src/mesh/Router.h
+++ b/src/mesh/Router.h
@@ -92,6 +92,12 @@ class Router : protected concurrency::OSThread, protected PacketHistory
         before us */
     uint32_t rxDupe = 0, txRelayCanceled = 0;
 
+    /* Count of OTA-received packets dropped because they claimed `from` equal
+       to our own nodeNum. These are physically impossible for legitimate
+       traffic (a radio cannot receive its own transmission) and therefore
+       indicate a spoof attempt by someone on the shared channel PSK. */
+    uint32_t spoofSelfRxDrop = 0;
+
     // pointer to the encrypted packet
     meshtastic_MeshPacket *p_encrypted = nullptr;
 


### PR DESCRIPTION
A packet received over the air whose `from` field equals our own nodeNum is
physically impossible for legitimate traffic: a radio cannot hear its own
transmission. Such a packet must therefore be a forgery by someone who holds
the channel PSK (which is trivially the case on the default `AQ==` channel
shared across the global public mesh) and is transmitting with our nodeNum in
the `from` field.

Drop these packets with zero false positives. The only way to reach
`perhapsHandleReceived()` with `isFromUs(p) == true` is OTA reception, because
`Router::sendLocal`'s broadcast loopback calls `handleReceived()` rather than
`perhapsHandleReceived()` for locally-originated packets.

Counter `Router::spoofSelfRxDrop` exposed for observability alongside the
existing `rxDupe` / `txRelayCanceled` stats.

Defense can be compiled out with `-DMESHTASTIC_DISABLE_SPOOF_SELF_RX_DROP=1`
for research / debug builds that want to see all inbound traffic.

## Attack context

This is one of two shape-detection defenses I tested against the attack class
behind:
- **MKE mesh bot** (ongoing Discord complaints about node impersonation)
- **CVE-2025-55292** (the DEF CON 33 "🥷" NodeInfo-forge incident)
- **GHSA-45vg-3f35-7ch2** (Cezar Lungu Feb-2026 disclosure, HAM-mode-flag downgrade)

This specific PR catches the **self-spoof** variant where the attacker forges
`from = victim's nodeNum` and the victim receives the packet itself. It
complements the hop_start-anomaly defense in the companion PR.

## Testing

**Corpus analysis.** Ran the candidate check against 670 real OTA packets from
a multi-day meshlogger capture of local-mesh activity. Zero false positives
on legit traffic.

**Live attack test.** Authorized two-node fleet:
- Attacker board flashed with a local `SpoofTestModule` that forges
  `from = victim's nodeNum` using the standard `meshtastic-python`-equivalent
  attack path.
- Victim board running this patch.
- Attacker fires 10 broadcast text packets at 60 s intervals.

Result: **21 SPOOF drops** in the victim's serial log (one per reception
including retransmissions), **10/10 unique packet IDs dropped**, zero false
positives on 4 concurrent legit packets from other mesh nodes during the
attack window.

Same attack against an undefended node in the same RF neighborhood resulted
in all 10 spoofs being accepted into the phone API. A/B cross-match rules
out RF coincidence.

Full evidence: https://github.com/nightjoker7/meshtastic-spoof-research/blob/main/evidence/phase_1/SUMMARY.md

## Log output format

```
SPOOF: dropped OTA packet claiming from=0x%08x (=our nodeNum); id=0x%x rssi=%d snr=%f
```

The log is WARN-level so operators can grep it. Counter is `uint32_t`.

## What this does NOT claim

- Does not catch spoofs where the attacker forges **someone else's** nodeNum
  (that's what my companion hop_start-anomaly PR catches).
- Does not replace XEdDSA signing (upstream #7602 + #9610). This is a
  shape-detection layer that ships today and works even before signing is
  widely deployed.

## Diff summary

- `src/mesh/Router.h` — add `uint32_t spoofSelfRxDrop = 0;` counter beside
  existing stats.
- `src/mesh/Router.cpp` — 10-LOC check at the top of `perhapsHandleReceived()`
  before other drop paths. Guarded by `#if !defined(MESHTASTIC_DISABLE_SPOOF_SELF_RX_DROP)`.

Happy to iterate on log level, opt-out flag naming, counter placement, or
comment wording.
