### PR TITLE
Router: drop OTA packets with hop_start=0 & hop_limit>0 (cross-node anti-spoof)

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -869,6 +869,31 @@ void Router::perhapsHandleReceived(meshtastic_MeshPacket *p)
     }
 #endif
 
+    // Correctly-constructed origination packets have hop_start==hop_limit
+    // (stamped at the sender via isFromUs() in Router::send()). A spoofer
+    // who writes p->from to another node's nodeNum bypasses that stamp
+    // because isFromUs() returns false at the attacker's Router::send(),
+    // leaving hop_start==0. Empirical validation against the local
+    // meshlogger corpus (670 legit OTA packets, hop_start range 1..7)
+    // showed hop_start==0 was produced only by forged packets.
+    //
+    // Dropping these packets at every receiving node stops forgery from
+    // propagating across the mesh — the check is cross-node, not limited
+    // to the impersonated victim.
+    //
+    // Can be disabled via -DMESHTASTIC_DISABLE_SPOOF_HOPSTART_DROP=1 for
+    // research / debug builds or for compatibility with any hypothetical
+    // legacy firmware that does not stamp hop_start. Default ON.
+#if !defined(MESHTASTIC_DISABLE_SPOOF_HOPSTART_DROP)
+    if (p->hop_start == 0 && p->hop_limit > 0) {
+        spoofHopStartDrop++;
+        LOG_WARN("SPOOF: dropped hop_start=0 packet from=0x%08x id=0x%x hop_limit=%d rssi=%d",
+                 p->from, p->id, p->hop_limit, p->rx_rssi);
+        packetPool.release(p);
+        return;
+    }
+#endif
+
     // assert(radioConfig.has_preferences);
     if (is_in_repeated(config.lora.ignore_incoming, p->from)) {
         LOG_DEBUG("Ignore msg, 0x%x is in our ignore list", p->from);

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -849,6 +849,26 @@ void Router::perhapsHandleReceived(meshtastic_MeshPacket *p)
         LOG_TRACE("%s", MeshPacketSerializer::JsonSerializeEncrypted(p).c_str());
     }
 #endif
+    // A packet received over the air that claims `from == our own nodeNum`
+    // is physically impossible for legitimate traffic: a radio cannot hear
+    // its own transmission. Such a packet must therefore be a forgery by
+    // someone who holds the channel PSK. Drop it with zero false positives
+    // (the only way to reach this path with isFromUs(p) is OTA reception
+    // — Router::sendLocal's broadcast loopback calls handleReceived, not
+    // perhapsHandleReceived, so locally-originated packets never arrive here).
+    //
+    // Can be disabled via -DMESHTASTIC_DISABLE_SPOOF_SELF_RX_DROP=1 for
+    // research / debug builds. Default ON.
+#if !defined(MESHTASTIC_DISABLE_SPOOF_SELF_RX_DROP)
+    if (isFromUs(p)) {
+        spoofSelfRxDrop++;
+        LOG_WARN("SPOOF: dropped OTA packet claiming from=0x%08x (=our nodeNum); id=0x%x rssi=%d snr=%f",
+                 p->from, p->id, p->rx_rssi, p->rx_snr);
+        packetPool.release(p);
+        return;
+    }
+#endif
+
     // assert(radioConfig.has_preferences);
     if (is_in_repeated(config.lora.ignore_incoming, p->from)) {
         LOG_DEBUG("Ignore msg, 0x%x is in our ignore list", p->from);

--- a/src/mesh/Router.h
+++ b/src/mesh/Router.h
@@ -92,6 +92,12 @@ class Router : protected concurrency::OSThread, protected PacketHistory
         before us */
     uint32_t rxDupe = 0, txRelayCanceled = 0;
 
+    /* Count of OTA-received packets dropped because they claimed `from` equal
+       to our own nodeNum. These are physically impossible for legitimate
+       traffic (a radio cannot receive its own transmission) and therefore
+       indicate a spoof attempt by someone on the shared channel PSK. */
+    uint32_t spoofSelfRxDrop = 0;
+
     // pointer to the encrypted packet
     meshtastic_MeshPacket *p_encrypted = nullptr;
 

--- a/src/mesh/Router.h
+++ b/src/mesh/Router.h
@@ -98,6 +98,15 @@ class Router : protected concurrency::OSThread, protected PacketHistory
        indicate a spoof attempt by someone on the shared channel PSK. */
     uint32_t spoofSelfRxDrop = 0;
 
+    /* Count of OTA-received packets dropped because they arrived with
+       hop_start==0 but hop_limit>0 — a shape that correctly-constructed
+       origination packets cannot have. Router::send() stamps hop_start
+       with hop_limit only when isFromUs(p), so a spoofer who forges
+       p->from leaves hop_start==0. This signal is cross-node: every
+       receiver can detect it, which blocks mesh-wide propagation of the
+       forgery even if the impersonated node is not online. */
+    uint32_t spoofHopStartDrop = 0;
+
     // pointer to the encrypted packet
     meshtastic_MeshPacket *p_encrypted = nullptr;
 


### PR DESCRIPTION
Correctly-constructed origination packets always have `hop_start == hop_limit`
— the sender's `Router::send()` stamps them equal via an `isFromUs(p)` check
at `src/mesh/Router.cpp`:

    if (isFromUs(p))
        p->hop_start = p->hop_limit;

A spoofer who writes `p->from` to another node's nodeNum bypasses that stamp
because `isFromUs()` returns false at the attacker's own `Router::send()`,
leaving `hop_start = 0` in the transmitted packet.

Legit relayed packets keep the original sender's hop_start unchanged (only
hop_limit decrements on each hop), so hop_start > 0 at every hop. Therefore
`hop_start == 0 AND hop_limit > 0` is shape-impossible for a legitimate
origination and only appears in forged packets.

Dropping these packets at every receiver stops forgery from **propagating
across the mesh** — the check is cross-node, not limited to the impersonated
victim. A ROUTER_LATE running this patch refuses to relay such packets,
breaking the router-relay flood pathway that makes MKE-bot-style attacks
mesh-wide in the first place.

## Corpus validation (empirical zero false positive)

Before deploying, I ran this check against every OTA packet in a multi-day
meshlogger capture of real local-mesh traffic:

- 670 legit OTA packets → hop_start distribution {1, 2, 3, 4, 5, 6, 7}
- 30 hop_start=0 packets → **every one** was an attack packet I generated
  myself during research (`SpoofTestModule`), verified by packet ID + payload
  length

**Zero legitimate packets would have been blocked** across the multi-day
corpus. The selectivity is empirical, not theoretical.

## Live attack test

Authorized two-node setup (attacker + defended victim) plus the local mesh
as undefended ambient witnesses:

- Attacker forges `from = a_different_node's_nodeNum` (not the receiver)
- Victim runs this patch
- 10-packet attack burst fired at 60 s intervals

Result: **20 SPOOF drops** (every direct + every relayed retransmission),
10/10 unique packet IDs dropped, zero false positives on ambient mesh
activity during the 10-minute window. An undefended witness in the same RF
neighborhood captured 9 of the same packet IDs normally.

The relay-catching behavior matters most: when another undefended node
relayed the spoof onto the mesh, the defended receiver still caught the
relayed copy because hop_start=0 propagates through relays unchanged
(only hop_limit decrements).

Full evidence (serial logs, packet IDs, cross-matched meshlogger JSONLs):
https://github.com/nightjoker7/meshtastic-spoof-research/blob/main/evidence/phase_1/MESH_PREVENTION.md

## Attack context

Addresses the same attack class as the companion self-RX-drop PR (MKE bot,
CVE-2025-55292, Cezar Lungu disclosure), but catches the **cross-node
spoof** variant where the attacker forges someone else's nodeNum and the
packet lands at a third party — which is the actual MKE-bot-style attack
happening in the wild today.

## Compatibility

All current deployed Meshtastic firmware stamps `hop_start` on origination
via the `isFromUs()` check. The corpus has zero packets from firmware that
wouldn't stamp it. If such legacy firmware did exist, the opt-out flag
`-DMESHTASTIC_DISABLE_SPOOF_HOPSTART_DROP=1` compiles the check out
per-device, so operators who discover a legacy node in their fleet can
disable it without a full rebuild.

Counter `Router::spoofHopStartDrop` exposed for observability.

## Side benefit: channel-utilization relief on congested meshes

The test burst captured 19 meshlogger events for 10 V4 transmissions — i.e.
each attack packet produced ~2× amplification via retries and relays. At
MediumFast (BW=250 kHz, SF=11), each 77-byte encrypted packet takes ~242 ms
on-air. A single low-rate attacker at one spoof per minute is already
~5-8% channel utilization on the shared default channel, before you count
NodeDB-churn traffic from TOFU-eviction attack variants.

Because this PR causes defended routers to drop spoofed packets before
rebroadcast, it cuts the per-spoof airtime cost from `hop_limit ×
packet_airtime` down to just the attacker's single TX. For a spoof at
hop_limit=3 traversing two defended routers, that saves ~1.5 s of relay
airtime per spoof packet — meaningful on meshes already running near the
40% channel-utilization threshold Meshtastic firmware warns about.

In short: the defense is a security win *and* a utility win for operators
whose busy meshes are congested by spoof propagation.

## What this does NOT claim

- A sophisticated attacker who crafts raw protobuf and manually stamps
  `hop_start = hop_limit` bypasses this check. That threat is covered by
  XEdDSA signing (upstream #9610). This PR is the shape-detection layer
  that ships today and works independently of signing.
- Catches only the construction path used by `meshtastic/python`'s
  `sendText(fromId=...)` and equivalent tooling — which is what 100% of
  the attackers we've observed in the wild actually use.

## Diff summary

- `src/mesh/Router.h` — add `uint32_t spoofHopStartDrop = 0;` counter.
- `src/mesh/Router.cpp` — 15-LOC check in `perhapsHandleReceived()`, placed
  after the self-RX drop from the companion PR. Guarded by
  `#if !defined(MESHTASTIC_DISABLE_SPOOF_HOPSTART_DROP)`.

Log format:
    SPOOF: dropped hop_start=0 packet from=0x%08x id=0x%x hop_limit=%d rssi=%d

Happy to iterate on all of the above.
