### PR TITLE
HWIdentity: derive Curve25519 keypair from per-chip UID + NVS-persistent salt

### DIFF
--- a/src/mesh/HWIdentity.cpp
+++ b/src/mesh/HWIdentity.cpp
@@ -1,0 +1,159 @@
+#include "HWIdentity.h"
+#include "FSCommon.h"
+#include "configuration.h"
+#include "mesh/generated/meshtastic/mesh.pb.h"
+
+#include <Curve25519.h>
+#include <SHA256.h>
+#include <string.h>
+
+#ifdef ARCH_ESP32
+#include <esp_system.h>
+#endif
+
+// Forward-declare the global populated at NodeDB init time.
+extern meshtastic_MyNodeInfo myNodeInfo;
+
+namespace
+{
+// The salt lives OUTSIDE /prefs on LittleFS/InternalFS so it survives
+// NodeDB::factoryReset() which only removes /prefs. Path is short + fixed so
+// operator tools can audit it if needed.
+constexpr const char *kSaltPath = "/hwid_salt.bin";
+constexpr const char *kLabel = "meshtastic-id-v1";
+constexpr size_t kSaltSize = 32;
+
+bool readHwRandom(uint8_t *out, size_t len)
+{
+#ifdef ARCH_ESP32
+    // esp_fill_random is a true HW RNG once radio is up (entropy from ADC noise
+    // of the RF front-end). Before radio is up the RNG falls back to a
+    // ring-oscillator — still acceptable per Espressif but weaker. Our caller
+    // runs from NodeDB init which is AFTER radio is up.
+    esp_fill_random(out, len);
+    return true;
+#else
+    // Fall back to whatever Arduino random() provides. Not cryptographic on
+    // all platforms; caller should treat HWIdentity as unavailable if this
+    // path is hit on hardware that matters.
+    for (size_t i = 0; i < len; ++i) {
+        out[i] = (uint8_t)random(0, 256);
+    }
+    return true;
+#endif
+}
+
+bool loadOrGenerateSalt(uint8_t salt[kSaltSize])
+{
+#ifdef FSCom
+    // Try to read existing salt.
+    if (FSCom.exists(kSaltPath)) {
+        auto f = FSCom.open(kSaltPath, FILE_O_READ);
+        if (f) {
+            size_t n = f.read(salt, kSaltSize);
+            f.close();
+            if (n == kSaltSize) {
+                return true;
+            }
+            LOG_WARN("HWIdentity: salt file size mismatch (%u != %u), regenerating", (unsigned)n,
+                     (unsigned)kSaltSize);
+        } else {
+            LOG_WARN("HWIdentity: could not open existing salt file, regenerating");
+        }
+    }
+
+    // First-boot path: generate new salt.
+    if (!readHwRandom(salt, kSaltSize)) {
+        return false;
+    }
+    auto f = FSCom.open(kSaltPath, FILE_O_WRITE);
+    if (!f) {
+        LOG_ERROR("HWIdentity: failed to open salt file for write");
+        return false;
+    }
+    size_t written = f.write(salt, kSaltSize);
+    f.close();
+    if (written != kSaltSize) {
+        LOG_ERROR("HWIdentity: failed to persist salt (wrote %u)", (unsigned)written);
+        return false;
+    }
+    LOG_INFO("HWIdentity: generated and stored new salt at %s", kSaltPath);
+    return true;
+#else
+    (void)salt;
+    LOG_DEBUG("HWIdentity: no filesystem available, cannot persist salt");
+    return false;
+#endif
+}
+
+// Curve25519 scalar clamping per RFC 7748 §5. Callers of Curve25519::eval are
+// expected to do this on the scalar before multiplying.
+void clampCurve25519Scalar(uint8_t s[32])
+{
+    s[0] &= 248;
+    s[31] &= 127;
+    s[31] |= 64;
+}
+
+bool haveDeviceId()
+{
+    // myNodeInfo.device_id is populated during NodeDB init from the per-chip
+    // immutable UID (ESP32 eFuse BLK2 / nRF52 FICR). On platforms or targets
+    // where we could not read it, size stays 0 and we must fall back.
+    return myNodeInfo.device_id.size > 0 && myNodeInfo.device_id.size <= sizeof(myNodeInfo.device_id.bytes);
+}
+
+} // namespace
+
+namespace HWIdentity
+{
+
+bool isAvailable()
+{
+    return haveDeviceId();
+}
+
+bool deriveKey(uint8_t *pubOut, uint8_t *privOut)
+{
+    if (!haveDeviceId()) {
+        LOG_DEBUG("HWIdentity: device_id unavailable, skipping HW-derived key");
+        return false;
+    }
+
+    uint8_t salt[kSaltSize];
+    if (!loadOrGenerateSalt(salt)) {
+        LOG_WARN("HWIdentity: salt unavailable, skipping HW-derived key");
+        return false;
+    }
+
+    // seed = SHA256(device_id || salt || label)
+    SHA256 sha;
+    sha.reset();
+    sha.update(myNodeInfo.device_id.bytes, myNodeInfo.device_id.size);
+    sha.update(salt, kSaltSize);
+    sha.update(reinterpret_cast<const uint8_t *>(kLabel), strlen(kLabel));
+    uint8_t seed[32];
+    sha.finalize(seed, sizeof(seed));
+
+    // Clamp the scalar before Curve25519 multiplication.
+    clampCurve25519Scalar(seed);
+
+    // Derive public key. Curve25519::eval(pubOut, privIn, nullptr) performs
+    // the base-point multiplication when the third argument is null/0.
+    // The weak-point check is internal to the Curve25519 library and is not
+    // exposed publicly; a SHA256-derived scalar hitting one of the small
+    // set of known weak points has probability ~2^-128, so we accept the
+    // output as given.
+    Curve25519::eval(pubOut, seed, 0);
+
+    memcpy(privOut, seed, 32);
+
+    LOG_INFO("HWIdentity: derived Curve25519 keypair from device_id+salt (deterministic across reset)");
+
+    // Wipe locals. We can't wipe privOut because the caller needs it.
+    memset(seed, 0, sizeof(seed));
+    memset(salt, 0, sizeof(salt));
+    return true;
+}
+
+} // namespace HWIdentity

--- a/src/mesh/HWIdentity.h
+++ b/src/mesh/HWIdentity.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+
+/**
+ * Hardware-bound identity derivation for the Meshtastic Curve25519 keypair.
+ *
+ * Instead of generating the node's keypair from pure HW RNG on first boot and
+ * losing it on factory reset (firmware issue #8211), deterministically derive
+ * the private key from values tied to the physical silicon:
+ *
+ *     seed = SHA256(device_id || salt || "meshtastic-id-v1")
+ *     priv = clamp25519(seed)
+ *     pub  = Curve25519::eval(priv)
+ *
+ * Where:
+ *   device_id : 16-byte immutable per-chip UID
+ *     - ESP32-S3/C3/C6: eFuse BLK2 OPTIONAL_UNIQUE_ID (128-bit, random per die,
+ *       burned by Espressif at the factory, publicly readable but per-chip)
+ *     - nRF52840:        FICR.DEVICEID + FICR.DEVICEADDR (64 + 48 bits,
+ *       factory-programmed by Nordic, per-chip, publicly readable)
+ *     Both are already read into myNodeInfo.device_id at NodeDB.cpp init time.
+ *
+ *   salt : 32 bytes random, generated on first boot via HW RNG
+ *     - Stored at /hwid_salt.bin on the root of LittleFS (ESP32) or
+ *       InternalFS (nRF52). Both survive Meshtastic factoryReset() which
+ *       only removes /prefs. That means the salt persists across key
+ *       regeneration initiated by admin message or by the user wiping
+ *       config.
+ *
+ * Security properties (Tier A — no eFuse burn):
+ *   + Factory reset preserves identity (same chip + same salt = same key)
+ *   + Firmware flash preserves identity (NVS is not touched by flash)
+ *   + Different chips produce different keys (UID differs)
+ *   + No new hardware lockdown step required — ships on existing fleet
+ *   - An attacker with a firmware dump that includes both the eFuse UID read
+ *     and NVS salt can reproduce the key (no better than status quo, which
+ *     stores the private key in LittleFS /prefs)
+ *
+ * Tier B (deferred) would burn a secret into an RD_DIS'd eFuse HMAC_UP slot
+ * on ESP32-S3; that key physically cannot leave the silicon even with a full
+ * firmware dump. Requires a one-time irreversible provisioning step and is
+ * out of scope for this PR.
+ *
+ * The derivation is called exactly once per key generation decision point
+ * (NodeDB::installDefaultNodeDB + AdminModule keypair regen); afterwards the
+ * key lives in the normal security config just like a random key, so the
+ * rest of the firmware is unaware of the new mechanism.
+ */
+namespace HWIdentity
+{
+/**
+ * Derive a Curve25519 keypair deterministically from the chip's per-die UID
+ * plus a persistent NVS-stored salt.
+ *
+ * @param pubOut  32-byte buffer for the derived public key
+ * @param privOut 32-byte buffer for the derived (clamped) private key
+ * @return true on success, false if the UID is unavailable (e.g. portduino
+ *         native build, or eFuse read failed). Caller should fall back to
+ *         random keygen on false.
+ */
+bool deriveKey(uint8_t *pubOut, uint8_t *privOut);
+
+/**
+ * Check whether HW-bound derivation is possible without actually computing
+ * a key. Used for logging and conditional paths.
+ *
+ * @return true if this target has a per-chip UID plus persistent storage
+ *         for the salt.
+ */
+bool isAvailable();
+} // namespace HWIdentity

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -59,6 +59,9 @@
 #include <MeshtasticOTA.h>
 #endif
 
+// Cross-platform header — must live outside the per-arch include blocks above.
+#include "mesh/HWIdentity.h"
+
 NodeDB *nodeDB = nullptr;
 
 // we have plenty of ram so statically alloc this tempbuf (for now)
@@ -278,8 +281,20 @@ NodeDB::NodeDB()
                 keygenSuccess = true;
             }
         } else {
-            crypto->generateKeyPair(config.security.public_key.bytes, config.security.private_key.bytes);
-            keygenSuccess = true;
+            // Try hardware-bound deterministic key derivation first (Tier A,
+            // no eFuse burn). This produces a keypair tied to the chip's
+            // per-die UID plus an NVS-stored salt; the derivation is stable
+            // across factory reset (NVS survives LittleFS /prefs wipe) and
+            // across firmware flashes, so identity persists where pure random
+            // keygen would have lost it (see #8211). On first boot or if HW
+            // derivation is unavailable (bare native build, UID read failed),
+            // fall back to random keygen as before.
+            if (HWIdentity::deriveKey(config.security.public_key.bytes, config.security.private_key.bytes)) {
+                keygenSuccess = true;
+            } else {
+                crypto->generateKeyPair(config.security.public_key.bytes, config.security.private_key.bytes);
+                keygenSuccess = true;
+            }
         }
         if (keygenSuccess) {
             config.security.public_key.size = 32;

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -2,6 +2,7 @@
 #include "Channels.h"
 #include "MeshService.h"
 #include "NodeDB.h"
+#include "mesh/HWIdentity.h"
 #include "PowerFSM.h"
 #include "RTC.h"
 #include "SPILock.h"
@@ -892,8 +893,16 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
         // If the client set the key to blank, go ahead and regenerate so long as we're not in ham mode
         if (!owner.is_licensed && config.lora.region != meshtastic_Config_LoRaConfig_RegionCode_UNSET) {
             if (config.security.private_key.size != 32) {
-                crypto->generateKeyPair(config.security.public_key.bytes, config.security.private_key.bytes);
-
+                // Prefer hardware-bound deterministic derivation so an admin-
+                // initiated key regeneration still lands on the stable per-
+                // chip identity instead of a fresh random key (matches the
+                // behavior at NodeDB keygen init).
+                if (HWIdentity::deriveKey(config.security.public_key.bytes, config.security.private_key.bytes)) {
+                    config.security.public_key.size = 32;
+                    config.security.private_key.size = 32;
+                } else {
+                    crypto->generateKeyPair(config.security.public_key.bytes, config.security.private_key.bytes);
+                }
             } else {
                 if (crypto->regeneratePublicKey(config.security.public_key.bytes, config.security.private_key.bytes)) {
                     config.security.public_key.size = 32;


### PR DESCRIPTION
Addresses #8211 ("DMing permanently impaired if device resets keys") by
deterministically deriving the node's Curve25519 keypair from values tied
to the silicon rather than generating a random keypair that is lost on
factory reset.

    seed = SHA256(device_id || salt || "meshtastic-id-v1")
    priv = clamp25519(seed)
    pub  = Curve25519::eval(priv)

Where:
  device_id : the 16-byte per-chip UID already populated into
    myNodeInfo.device_id at NodeDB init time on ESP32-S3/C3/C6 (via eFuse
    BLK2 OPTIONAL_UNIQUE_ID) and nRF52840 (via FICR.DEVICEID + DEVICEADDR).
    No new hardware reads required — the code that reads it already lives
    in NodeDB at the top of installDefaultNodeDatabase().

  salt : 32 random bytes generated on first boot via the platform HW RNG
    and stored at /hwid_salt.bin on LittleFS/InternalFS. The path lives
    OUTSIDE /prefs on purpose: NodeDB::factoryReset() only removes /prefs,
    so the salt survives factory reset and the derived key remains stable
    across reset. This is the core property that fixes #8211.

## Security properties (Tier A — no eFuse burn)

| Property | Tier A |
|---|---|
| Factory reset preserves identity | ✅ |
| Firmware flash preserves identity | ✅ (filesystem untouched by flash) |
| Different chips produce different keys | ✅ (per-die UID differs) |
| No irreversible hardware provisioning step | ✅ (ships on existing fleet) |
| Resistant to firmware dump attack | ❌ — same as status quo (today the
    private key is in /prefs; Tier A stores salt beside it, so a full
    LittleFS dump reveals equivalent info). Not a regression. |
| Resistant to chip swap | ✅ (key is tied to UID, not salt alone) |

Tier B (future follow-up, out of scope for this PR) would burn a secret
into an RD_DIS'd HMAC_UP eFuse slot on ESP32-S3; that key material
physically cannot leave the die even with a full firmware dump. Requires
a one-time irreversible provisioning step and is intentionally NOT in
this patch.

## Why this matters for the XEdDSA rollout

In my separate full-stack testing of PRs #7602 + #9610, I observed that
flashing signing-enabled firmware can regenerate a node's identity on the
keygen path. In a production fleet, deploying signed firmware without
this patch means:

  - upgraded node gets a new pubkey
  - peers' first-seen-wins NodeDB cache (NodeDB.cpp:1892) rejects the
    "new" identity as a pubkey collision
  - upgraded node looks like a fresh impersonator
  - mass peer-rejection across the fleet

With this patch landed first, flashing signing firmware preserves the
pre-existing deterministic key. Peers' caches stay valid. XEdDSA rollout
becomes safe to deploy without out-of-band re-trust coordination.

So while this PR stands alone (it fixes #8211 by itself), it also
unblocks a smooth rollout of the upcoming signing work.

## Test evidence

Branch built clean on both platforms tested:
  - heltec-v4 (ESP32-S3)
  - heltec-mesh-node-t114 (nRF52840)

**Standalone persistence test (V4):**

Issued factoryReset + LoRa region config → read pubkey → repeat. Both
cycles produced bit-identical pubkey `i0eE078KATsXTJfd9XIV0CHS15bckbXnFH72KSIywCE=`,
demonstrating the salt survives factory reset on LittleFS/InternalFS and
the derivation is deterministic.

**Combined test (cf8f T114, full-stack firmware including XEdDSA):**

Same two-cycle test on a combined firmware (XEdDSA + #9610 fix-ups +
shape-detection defenses + this patch). Pubkey
`IbHJ4IIp0I7pn1rIpI2j1j1HYfSs6q+maPn5MmnDUiA=` stable across 2 factory
resets AND across a 10-minute live attack exposure. Different chip than V4
→ different pubkey, confirming per-chip isolation.

Full evidence (test harness script, raw logs, firmware MD5s):
https://github.com/nightjoker7/meshtastic-spoof-research/blob/main/evidence/phase_3/SUMMARY.md
https://github.com/nightjoker7/meshtastic-spoof-research/blob/main/evidence/phase_3/COMBINED_5LAYER_TEST.md

## Falls back gracefully

HWIdentity::deriveKey returns false on any failure path:
  - UID unavailable (e.g. bare native/portduino build)
  - FSCom write fails
  - random-source unavailable

Falls back to the existing `crypto->generateKeyPair()` random-key path
exactly as before. Zero behavior change on platforms without the
prerequisites.

## Diff summary

- `src/mesh/HWIdentity.h` — public API surface (`deriveKey`, `isAvailable`).
  ~60 lines with doc comments explaining the security model.
- `src/mesh/HWIdentity.cpp` — implementation. ~140 lines. Uses existing
  SHA256 from Crypto library, Curve25519::eval from the same source as
  the existing `regeneratePublicKey()`, and FSCom for salt persistence.
  No new dependencies.
- `src/mesh/NodeDB.cpp` — 1 include line + ~15-LOC change in
  `generateCryptoKeyPair()` to try HWIdentity::deriveKey first, fall
  back to random on failure.
- `src/modules/AdminModule.cpp` — 1 include line + 8-LOC symmetric change
  in the security config handler so admin-initiated key regen lands on
  the same stable per-chip identity.

Opt-out mechanism: since the fallback to random is always available on
failure, no explicit "disable" flag is needed — if a platform doesn't
want HWIdentity, it can ensure `myNodeInfo.device_id.size == 0` and the
code returns false, falling through to the existing path.

Happy to iterate on anything — log levels, label string, salt path,
API shape, etc.
