### PR TITLE
Standardize PMU IRQ handling and enable power button cancel on tbeam-s3

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -1000,11 +1000,8 @@ int32_t Power::runOnce()
             powerFSM.trigger(EVENT_POWER_CONNECTED);
         }
 
-#ifdef T_WATCH_S3
-        /*
-            In the T-Watch S3 this code fragment reacts to the short press of the button by switching the
-            display on and off
-        */
+#ifdef PMU_POWER_BUTTON_IS_CANCEL
+        // cancel action also turns the screen on and off.
         if (PMU->isPekeyShortPressIrq()) {
             LOG_INFO("Input: Corona Button Click");
             InputEvent event = {.inputEvent = (input_broker_event)INPUT_BROKER_CANCEL, .kbchar = 0, .touchX = 0, .touchY = 0};
@@ -1027,13 +1024,6 @@ int32_t Power::runOnce()
             LOG_DEBUG("Battery removed");
         }
         */
-#ifndef T_WATCH_S3 // FIXME - why is this triggering on the T-Watch S3?
-        if (PMU->isPekeyLongPressIrq()) {
-            LOG_DEBUG("PEK long button press");
-            if (screen)
-                screen->setOn(false);
-        }
-#endif
 
         PMU->clearIrqStatus();
     }
@@ -1102,7 +1092,7 @@ void Power::attachPowerInterrupts()
     if (PMU) {
         attachInterrupt(
             PMU_IRQ,
-            [] {
+            []() {
                 pmu_irq = true;
                 power->setIntervalFromNow(0);
                 runASAP = true;
@@ -1405,19 +1395,16 @@ bool Power::axpChipInit()
     uint64_t pmuIrqMask = 0;
 
     if (PMU->getChipModel() == XPOWERS_AXP192) {
-        pmuIrqMask = XPOWERS_AXP192_VBUS_INSERT_IRQ | XPOWERS_AXP192_BAT_INSERT_IRQ | XPOWERS_AXP192_PKEY_SHORT_IRQ;
+        pmuIrqMask = XPOWERS_AXP192_VBUS_INSERT_IRQ | XPOWERS_AXP192_VBUS_REMOVE_IRQ | XPOWERS_AXP192_PKEY_SHORT_IRQ;
     } else if (PMU->getChipModel() == XPOWERS_AXP2101) {
-        pmuIrqMask = XPOWERS_AXP2101_VBUS_INSERT_IRQ | XPOWERS_AXP2101_BAT_INSERT_IRQ | XPOWERS_AXP2101_PKEY_SHORT_IRQ;
+        pmuIrqMask = XPOWERS_AXP2101_VBUS_INSERT_IRQ | XPOWERS_AXP2101_VBUS_REMOVE_IRQ | XPOWERS_AXP2101_PKEY_SHORT_IRQ;
     }
 
     pinMode(PMU_IRQ, INPUT);
 
-    // we do not look for AXPXXX_CHARGING_FINISHED_IRQ & AXPXXX_CHARGING_IRQ
-    // because it occurs repeatedly while there is no battery also it could cause
-    // inadvertent waking from light sleep just because the battery filled we
-    // don't look for AXPXXX_BATT_REMOVED_IRQ because it occurs repeatedly while
-    // no battery installed we don't look at AXPXXX_VBUS_REMOVED_IRQ because we
-    // don't have anything hooked to vbus
+    // We wake on IRQ, so only enable the IRQs that we care about.
+    // we want USB plug and unplug to update the screen and LED status,
+    // and short press on the power button to trigger the "cancel" action in the UI (which also turns the screen on and off).
     PMU->enableIRQ(pmuIrqMask);
 
     PMU->clearIrqStatus();

--- a/variants/esp32/tbeam/variant.h
+++ b/variants/esp32/tbeam/variant.h
@@ -35,9 +35,10 @@
 // code)
 #endif
 
-// Leave undefined to disable our PMU IRQ handler.  DO NOT ENABLE THIS because the pmuirq can cause sperious interrupts
-// and waking from light sleep
-// #define PMU_IRQ 35
+// Voiding more warranties.
+#define PMU_IRQ 35
+#define PMU_POWER_BUTTON_IS_CANCEL // maps a short click of the power button to a cancel action (turning off the screen)
+
 #define HAS_AXP192
 #define GPS_UBLOX
 #define GPS_RX_PIN 34

--- a/variants/esp32s3/t-watch-s3/variant.h
+++ b/variants/esp32s3/t-watch-s3/variant.h
@@ -42,6 +42,7 @@
 #define DAC_I2S_MCLK -1
 
 #define HAS_AXP2101
+#define PMU_POWER_BUTTON_IS_CANCEL // maps a short click of the power button to a cancel action (turning off the screen)
 
 // PCF8563 RTC Module
 #define PCF8563_RTC 0x51

--- a/variants/esp32s3/tbeam-s3-core/variant.h
+++ b/variants/esp32s3/tbeam-s3-core/variant.h
@@ -46,9 +46,9 @@
 #define LR11X0_DIO_AS_RF_SWITCH
 #endif
 
-// Leave undefined to disable our PMU IRQ handler.  DO NOT ENABLE THIS because the pmuirq can cause sperious interrupts
-// and waking from light sleep
-// #define PMU_IRQ 40
+// Voiding warrenties, we're gonna try the IRQ
+#define PMU_IRQ 40
+#define PMU_POWER_BUTTON_IS_CANCEL // maps a short click of the power button to a cancel action (turning off the screen)
 #define HAS_AXP2101
 
 // PCF8563 RTC Module


### PR DESCRIPTION
Simpler PR, splitting the functional bits from the attempted cleanup.