### PR TITLE
fix(inkhud): scale map applet markers with font size

### DIFF
--- a/src/graphics/niche/InkHUD/Applets/Bases/Map/MapApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/Bases/Map/MapApplet.cpp
@@ -43,8 +43,8 @@ void InkHUD::MapApplet::onRender(bool full)
 
         // Add white halo outline first
         constexpr int outlinePad = 1;
-        int boxSize = 11;
-        int radius = 2; // rounded corner radius
+        int boxSize = fontSmall.lineHeight() + 2; // scale with font so digit fits
+        int radius = max(2, boxSize / 6);
 
         // White halo background
         fillRoundedRect(x, y, boxSize + (outlinePad * 2), boxSize + (outlinePad * 2), radius + 1, WHITE);
@@ -143,17 +143,19 @@ void InkHUD::MapApplet::onRender(bool full)
         int16_t centerX = X(0.5) + (self.eastMeters * metersToPx);
         int16_t centerY = Y(0.5) - (self.northMeters * metersToPx);
 
+        int16_t r = fontSmall.lineHeight() / 2; // scale marker with font
+
         // White fill background + halo
-        fillCircle(centerX, centerY, 8, WHITE); // big white base
-        drawCircle(centerX, centerY, 8, WHITE); // crisp edge
+        fillCircle(centerX, centerY, r + 2, WHITE);
+        drawCircle(centerX, centerY, r + 2, WHITE);
 
         // Black bullseye on top
-        drawCircle(centerX, centerY, 6, BLACK);
-        fillCircle(centerX, centerY, 2, BLACK);
+        drawCircle(centerX, centerY, r, BLACK);
+        fillCircle(centerX, centerY, max(2, r / 4), BLACK);
 
         // Crosshairs
-        drawLine(centerX - 8, centerY, centerX + 8, centerY, BLACK);
-        drawLine(centerX, centerY - 8, centerX, centerY + 8, BLACK);
+        drawLine(centerX - r - 2, centerY, centerX + r + 2, centerY, BLACK);
+        drawLine(centerX, centerY - r - 2, centerX, centerY + r + 2, BLACK);
     }
 }
 
@@ -382,9 +384,9 @@ void InkHUD::MapApplet::drawLabeledMarker(meshtastic_NodeInfoLite *node)
 
     constexpr uint16_t paddingH = 2;
     constexpr uint16_t paddingW = 4;
-    uint16_t paddingInnerW = 2;            // Zero'd out if no text
-    constexpr uint16_t markerSizeMax = 12; // Size of cross (if marker uses a cross)
-    constexpr uint16_t markerSizeMin = 5;
+    uint16_t paddingInnerW = 2;                      // Zero'd out if no text
+    uint16_t markerSizeMax = fontSmall.lineHeight(); // Scale cross with font
+    uint16_t markerSizeMin = max(5, fontSmall.lineHeight() / 3);
 
     int16_t textX;
     int16_t textY;


### PR DESCRIPTION
The `MapApplet` (used by the Positions applet) had all marker sizes hardcoded in pixels: an 11 px hop-count box, a radius-8 own-node bullseye, and a 12 px labeled-marker cross. On displays with a small font (6 pt, ~8 px line height) these looked fine. On the LilyGo T5-S3-ePaper-Pro, which uses a 12 pt `fontSmall` (~17 px line height), the hop-count digit overflowed its box entirely and all markers appeared as tiny specks on the 960×540 panel.

All three sizes now derive from `fontSmall.lineHeight()`, so the applet scales correctly across display variants without any per-variant tuning. Before / after screenshots attached.

<img width="462" height="1000" alt="20260424_235612" src="https://github.com/user-attachments/assets/1eb641a6-506d-4c7d-91f7-38991ba41e11" />
<img width="462" height="1000" alt="20260424_235832" src="https://github.com/user-attachments/assets/7fbd8f4c-36cb-4b6e-84ee-ec27e16341aa" />

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other: LilyGo T5-S3-ePaper-Pro
