### PR TITLE
fix(mqtt): coarsen public position uplinks

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -58,16 +58,17 @@ static bool isConnected = false;
 
 static uint32_t lastPositionUnavailableWarning = 0;
 static const uint32_t POSITION_UNAVAILABLE_WARNING_INTERVAL_MS = 15000; // 15 seconds
+static constexpr uint32_t PUBLIC_MQTT_MAX_POSITION_PRECISION_BITS = 15;
 
-uint32_t getPublicMqttPositionPrecision()
+static uint32_t getPublicMqttPositionPrecision()
 {
-    // Public MQTT map reports currently accept precision bits up to 15.
+    // Public MQTT map reports currently accept precision bits up to PUBLIC_MQTT_MAX_POSITION_PRECISION_BITS.
     // Forwarded LoRa positions use that most precise public value as a cap so
     // an already-coarser source packet keeps its original privacy boundary.
-    return 15;
+    return PUBLIC_MQTT_MAX_POSITION_PRECISION_BITS;
 }
 
-bool makePublicMqttPositionPacket(meshtastic_MeshPacket &mqttPacket, const meshtastic_MeshPacket &sourcePacket)
+static bool makePublicMqttPositionPacket(meshtastic_MeshPacket &mqttPacket, const meshtastic_MeshPacket &sourcePacket)
 {
     if (sourcePacket.which_payload_variant != meshtastic_MeshPacket_decoded_tag ||
         sourcePacket.decoded.portnum != meshtastic_PortNum_POSITION_APP)
@@ -90,11 +91,18 @@ bool makePublicMqttPositionPacket(meshtastic_MeshPacket &mqttPacket, const mesht
     position.precision_bits = precision;
 
     mqttPacket = sourcePacket;
+    // Use a fresh id so downstream id-based MQTT consumers can receive the public-safe copy
+    // even when they already cached or deduplicated the precise source packet.
     mqttPacket.id = generatePacketId();
-    mqttPacket.decoded.payload.size =
+    const size_t positionSize =
         pb_encode_to_bytes(mqttPacket.decoded.payload.bytes, sizeof(mqttPacket.decoded.payload.bytes), &meshtastic_Position_msg,
                            &position);
-    return mqttPacket.decoded.payload.size > 0;
+    if (positionSize == 0) {
+        mqttPacket = meshtastic_MeshPacket_init_default;
+        return false;
+    }
+    mqttPacket.decoded.payload.size = positionSize;
+    return true;
 }
 
 inline void onReceiveProto(char *topic, byte *payload, size_t length)
@@ -846,14 +854,14 @@ void MQTT::onSend(const meshtastic_MeshPacket &mp_encrypted, const meshtastic_Me
     meshtastic_MeshPacket mqttPositionPacket = meshtastic_MeshPacket_init_default;
     const meshtastic_MeshPacket *publicMqttPositionPacket = nullptr;
     const meshtastic_MeshPacket *p;
+    if (isConfiguredForDefaultServer && !isMqttServerAddressPrivate &&
+        makePublicMqttPositionPacket(mqttPositionPacket, mp_decoded))
+        publicMqttPositionPacket = &mqttPositionPacket;
     if (moduleConfig.mqtt.encryption_enabled) {
         p = &mp_encrypted;
         LOG_DEBUG("encrypted message");
     } else if (mp_decoded.which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
         p = &mp_decoded;
-        if (isConfiguredForDefaultServer && !isMqttServerAddressPrivate &&
-            makePublicMqttPositionPacket(mqttPositionPacket, mp_decoded))
-            publicMqttPositionPacket = &mqttPositionPacket;
         LOG_DEBUG("portnum %i message", mp_decoded.decoded.portnum);
     } else {
         LOG_DEBUG("nothing, pkt not decrypted");
@@ -875,7 +883,7 @@ void MQTT::onSend(const meshtastic_MeshPacket &mp_encrypted, const meshtastic_Me
 
 #if !defined(ARCH_NRF52) ||                                                                                                      \
     defined(NRF52_USE_JSON) // JSON is not supported on nRF52, see issue #2804 ### Fixed by using ArduinoJson ###
-            if (moduleConfig.mqtt.json_enabled) {
+            if (moduleConfig.mqtt.json_enabled && jsonPacket != nullptr) {
                 auto jsonString = MeshPacketSerializer::JsonSerialize(jsonPacket);
                 if (jsonString.length() != 0) {
                     std::string topicJson = jsonTopic + channelId + "/" + nodeId;
@@ -906,13 +914,16 @@ void MQTT::onSend(const meshtastic_MeshPacket &mp_encrypted, const meshtastic_Me
     // current filter accepts a location update, then preserve the original packet for brokers that accept it. When offline
     // and short on queue space, keep the public-usable copy instead of immediately evicting it with the precise original.
     const bool willQueuePacket = !(moduleConfig.mqtt.proxy_to_client_enabled || this->isConnectedDirectly());
-    if (publicMqttPositionPacket != nullptr && willQueuePacket && mqttQueue.numFree() < 2) {
+    const bool shouldDualPublishPublicPosition = publicMqttPositionPacket != nullptr && !moduleConfig.mqtt.encryption_enabled;
+    if (shouldDualPublishPublicPosition && willQueuePacket && mqttQueue.numFree() < 2) {
         publishPacket(publicMqttPositionPacket, publicMqttPositionPacket);
         return;
     }
-    if (publicMqttPositionPacket != nullptr)
+    if (shouldDualPublishPublicPosition)
         publishPacket(publicMqttPositionPacket, publicMqttPositionPacket);
-    publishPacket(p, &mp_decoded);
+    const meshtastic_MeshPacket *jsonPacket =
+        publicMqttPositionPacket != nullptr ? (moduleConfig.mqtt.encryption_enabled ? publicMqttPositionPacket : nullptr) : &mp_decoded;
+    publishPacket(p, jsonPacket);
 }
 
 void MQTT::perhapsReportToMap()
@@ -923,7 +934,7 @@ void MQTT::perhapsReportToMap()
 
     // Coerce the map position precision to be within the valid range
     // This removes obtusely large radius and privacy problematic ones from the map
-    if (map_position_precision < 12 || map_position_precision > 15) {
+    if (map_position_precision < 12 || map_position_precision > PUBLIC_MQTT_MAX_POSITION_PRECISION_BITS) {
         LOG_WARN("MQTT Map report position precision %u is out of range, using default %u", map_position_precision,
                  default_map_position_precision);
         map_position_precision = default_map_position_precision;

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -94,9 +94,8 @@ static bool makePublicMqttPositionPacket(meshtastic_MeshPacket &mqttPacket, cons
     // Use a fresh id so downstream id-based MQTT consumers can receive the public-safe copy
     // even when they already cached or deduplicated the precise source packet.
     mqttPacket.id = generatePacketId();
-    const size_t positionSize =
-        pb_encode_to_bytes(mqttPacket.decoded.payload.bytes, sizeof(mqttPacket.decoded.payload.bytes), &meshtastic_Position_msg,
-                           &position);
+    const size_t positionSize = pb_encode_to_bytes(mqttPacket.decoded.payload.bytes, sizeof(mqttPacket.decoded.payload.bytes),
+                                                   &meshtastic_Position_msg, &position);
     if (positionSize == 0) {
         mqttPacket = meshtastic_MeshPacket_init_default;
         return false;
@@ -788,16 +787,12 @@ void MQTT::publishQueuedMessages()
 
 #if !defined(ARCH_NRF52) ||                                                                                                      \
     defined(NRF52_USE_JSON) // JSON is not supported on nRF52, see issue #2804 ### Fixed by using ArduinoJson ###
-    if (!moduleConfig.mqtt.json_enabled)
+    if (!moduleConfig.mqtt.json_enabled || entry->jsonPayload.empty())
         return;
 
     // handle json topic
     const DecodedServiceEnvelope env(entry->envBytes.data(), entry->envBytes.size());
     if (!env.validDecode || env.packet == NULL || env.channel_id == NULL)
-        return;
-
-    auto jsonString = MeshPacketSerializer::JsonSerialize(env.packet);
-    if (jsonString.length() == 0)
         return;
 
     // Generate node ID from nodenum for topic
@@ -809,8 +804,9 @@ void MQTT::publishQueuedMessages()
     } else {
         topicJson = jsonTopic + env.channel_id + "/" + nodeId;
     }
-    LOG_INFO("JSON publish message to %s, %u bytes: %s", topicJson.c_str(), jsonString.length(), jsonString.c_str());
-    publish(topicJson.c_str(), jsonString.c_str(), false);
+    LOG_INFO("JSON publish message to %s, %u bytes: %s", topicJson.c_str(), entry->jsonPayload.length(),
+             entry->jsonPayload.c_str());
+    publish(topicJson.c_str(), entry->jsonPayload.c_str(), false);
 #endif // ARCH_NRF52 NRF52_USE_JSON
 }
 
@@ -887,7 +883,8 @@ void MQTT::onSend(const meshtastic_MeshPacket &mp_encrypted, const meshtastic_Me
                 auto jsonString = MeshPacketSerializer::JsonSerialize(jsonPacket);
                 if (jsonString.length() != 0) {
                     std::string topicJson = jsonTopic + channelId + "/" + nodeId;
-                    LOG_INFO("JSON publish message to %s, %u bytes: %s", topicJson.c_str(), jsonString.length(), jsonString.c_str());
+                    LOG_INFO("JSON publish message to %s, %u bytes: %s", topicJson.c_str(), jsonString.length(),
+                             jsonString.c_str());
                     publish(topicJson.c_str(), jsonString.c_str(), false);
                 }
             }
@@ -903,6 +900,12 @@ void MQTT::onSend(const meshtastic_MeshPacket &mp_encrypted, const meshtastic_Me
             }
             entry->topic = topic;
             entry->envBytes.assign(bytes, numBytes);
+            entry->jsonPayload.clear();
+#if !defined(ARCH_NRF52) ||                                                                                                      \
+    defined(NRF52_USE_JSON) // JSON is not supported on nRF52, see issue #2804 ### Fixed by using ArduinoJson ###
+            if (moduleConfig.mqtt.json_enabled && jsonPacket != nullptr)
+                entry->jsonPayload = MeshPacketSerializer::JsonSerialize(jsonPacket);
+#endif // ARCH_NRF52 NRF52_USE_JSON
             if (mqttQueue.enqueue(entry, 0) == false) {
                 LOG_CRIT("Failed to add a message to mqttQueue!");
                 abort();
@@ -921,8 +924,9 @@ void MQTT::onSend(const meshtastic_MeshPacket &mp_encrypted, const meshtastic_Me
     }
     if (shouldDualPublishPublicPosition)
         publishPacket(publicMqttPositionPacket, publicMqttPositionPacket);
-    const meshtastic_MeshPacket *jsonPacket =
-        publicMqttPositionPacket != nullptr ? (moduleConfig.mqtt.encryption_enabled ? publicMqttPositionPacket : nullptr) : &mp_decoded;
+    const meshtastic_MeshPacket *jsonPacket = publicMqttPositionPacket != nullptr
+                                                  ? (moduleConfig.mqtt.encryption_enabled ? publicMqttPositionPacket : nullptr)
+                                                  : &mp_decoded;
     publishPacket(p, jsonPacket);
 }
 

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -59,6 +59,44 @@ static bool isConnected = false;
 static uint32_t lastPositionUnavailableWarning = 0;
 static const uint32_t POSITION_UNAVAILABLE_WARNING_INTERVAL_MS = 15000; // 15 seconds
 
+uint32_t getPublicMqttPositionPrecision()
+{
+    // Public MQTT map reports currently accept precision bits up to 15.
+    // Forwarded LoRa positions use that most precise public value as a cap so
+    // an already-coarser source packet keeps its original privacy boundary.
+    return 15;
+}
+
+bool makePublicMqttPositionPacket(meshtastic_MeshPacket &mqttPacket, const meshtastic_MeshPacket &sourcePacket)
+{
+    if (sourcePacket.which_payload_variant != meshtastic_MeshPacket_decoded_tag ||
+        sourcePacket.decoded.portnum != meshtastic_PortNum_POSITION_APP)
+        return false;
+
+    meshtastic_Position position = meshtastic_Position_init_default;
+    if (!pb_decode_from_bytes(sourcePacket.decoded.payload.bytes, sourcePacket.decoded.payload.size, &meshtastic_Position_msg,
+                              &position))
+        return false;
+    if (!position.has_latitude_i || !position.has_longitude_i)
+        return false;
+
+    uint32_t precision = getPublicMqttPositionPrecision();
+    if (position.precision_bits > 0 && position.precision_bits < precision)
+        precision = position.precision_bits;
+    position.latitude_i = position.latitude_i & (UINT32_MAX << (32 - precision));
+    position.longitude_i = position.longitude_i & (UINT32_MAX << (32 - precision));
+    position.latitude_i += (1 << (31 - precision));
+    position.longitude_i += (1 << (31 - precision));
+    position.precision_bits = precision;
+
+    mqttPacket = sourcePacket;
+    mqttPacket.id = generatePacketId();
+    mqttPacket.decoded.payload.size =
+        pb_encode_to_bytes(mqttPacket.decoded.payload.bytes, sizeof(mqttPacket.decoded.payload.bytes), &meshtastic_Position_msg,
+                           &position);
+    return mqttPacket.decoded.payload.size > 0;
+}
+
 inline void onReceiveProto(char *topic, byte *payload, size_t length)
 {
     const DecodedServiceEnvelope e(payload, length);
@@ -805,12 +843,17 @@ void MQTT::onSend(const meshtastic_MeshPacket &mp_encrypted, const meshtastic_Me
     const char *channelId = isPKIEncrypted ? "PKI" : channels.getGlobalId(chIndex);
 
     LOG_DEBUG("MQTT onSend - Publish ");
+    meshtastic_MeshPacket mqttPositionPacket = meshtastic_MeshPacket_init_default;
+    const meshtastic_MeshPacket *publicMqttPositionPacket = nullptr;
     const meshtastic_MeshPacket *p;
     if (moduleConfig.mqtt.encryption_enabled) {
         p = &mp_encrypted;
         LOG_DEBUG("encrypted message");
     } else if (mp_decoded.which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
         p = &mp_decoded;
+        if (isConfiguredForDefaultServer && !isMqttServerAddressPrivate &&
+            makePublicMqttPositionPacket(mqttPositionPacket, mp_decoded))
+            publicMqttPositionPacket = &mqttPositionPacket;
         LOG_DEBUG("portnum %i message", mp_decoded.decoded.portnum);
     } else {
         LOG_DEBUG("nothing, pkt not decrypted");
@@ -819,47 +862,57 @@ void MQTT::onSend(const meshtastic_MeshPacket &mp_encrypted, const meshtastic_Me
 
     // Generate node ID from nodenum for service envelope
     std::string nodeId = nodeDB->getNodeId();
-
-    const meshtastic_ServiceEnvelope env = {.packet = const_cast<meshtastic_MeshPacket *>(p),
-                                            .channel_id = const_cast<char *>(channelId),
-                                            .gateway_id = const_cast<char *>(nodeId.c_str())};
-    size_t numBytes = pb_encode_to_bytes(bytes, sizeof(bytes), &meshtastic_ServiceEnvelope_msg, &env);
     std::string topic = cryptTopic + channelId + "/" + nodeId;
+    auto publishPacket = [&](const meshtastic_MeshPacket *packet, const meshtastic_MeshPacket *jsonPacket) {
+        const meshtastic_ServiceEnvelope env = {.packet = const_cast<meshtastic_MeshPacket *>(packet),
+                                                .channel_id = const_cast<char *>(channelId),
+                                                .gateway_id = const_cast<char *>(nodeId.c_str())};
+        size_t numBytes = pb_encode_to_bytes(bytes, sizeof(bytes), &meshtastic_ServiceEnvelope_msg, &env);
 
-    if (moduleConfig.mqtt.proxy_to_client_enabled || this->isConnectedDirectly()) {
-        LOG_DEBUG("MQTT Publish %s, %u bytes", topic.c_str(), numBytes);
-        publish(topic.c_str(), bytes, numBytes, false);
+        if (moduleConfig.mqtt.proxy_to_client_enabled || this->isConnectedDirectly()) {
+            LOG_DEBUG("MQTT Publish %s, %u bytes", topic.c_str(), numBytes);
+            publish(topic.c_str(), bytes, numBytes, false);
 
 #if !defined(ARCH_NRF52) ||                                                                                                      \
     defined(NRF52_USE_JSON) // JSON is not supported on nRF52, see issue #2804 ### Fixed by using ArduinoJson ###
-        if (!moduleConfig.mqtt.json_enabled)
-            return;
-        // handle json topic
-        auto jsonString = MeshPacketSerializer::JsonSerialize(&mp_decoded);
-        if (jsonString.length() == 0)
-            return;
-        // Generate node ID from nodenum for JSON topic
-        std::string nodeIdForJson = nodeDB->getNodeId();
-        std::string topicJson = jsonTopic + channelId + "/" + nodeIdForJson;
-        LOG_INFO("JSON publish message to %s, %u bytes: %s", topicJson.c_str(), jsonString.length(), jsonString.c_str());
-        publish(topicJson.c_str(), jsonString.c_str(), false);
+            if (moduleConfig.mqtt.json_enabled) {
+                auto jsonString = MeshPacketSerializer::JsonSerialize(jsonPacket);
+                if (jsonString.length() != 0) {
+                    std::string topicJson = jsonTopic + channelId + "/" + nodeId;
+                    LOG_INFO("JSON publish message to %s, %u bytes: %s", topicJson.c_str(), jsonString.length(), jsonString.c_str());
+                    publish(topicJson.c_str(), jsonString.c_str(), false);
+                }
+            }
 #endif // ARCH_NRF52 NRF52_USE_JSON
-    } else {
-        LOG_INFO("MQTT not connected, queue packet");
-        QueueEntry *entry;
-        if (mqttQueue.numFree() == 0) {
-            LOG_WARN("MQTT queue is full, discard oldest");
-            entry = mqttQueue.dequeuePtr(0);
         } else {
-            entry = new QueueEntry;
+            LOG_INFO("MQTT not connected, queue packet");
+            QueueEntry *entry;
+            if (mqttQueue.numFree() == 0) {
+                LOG_WARN("MQTT queue is full, discard oldest");
+                entry = mqttQueue.dequeuePtr(0);
+            } else {
+                entry = new QueueEntry;
+            }
+            entry->topic = topic;
+            entry->envBytes.assign(bytes, numBytes);
+            if (mqttQueue.enqueue(entry, 0) == false) {
+                LOG_CRIT("Failed to add a message to mqttQueue!");
+                abort();
+            }
         }
-        entry->topic = std::move(topic);
-        entry->envBytes.assign(bytes, numBytes);
-        if (mqttQueue.enqueue(entry, 0) == false) {
-            LOG_CRIT("Failed to add a message to mqttQueue!");
-            abort();
-        }
+    };
+
+    // The public broker currently filters precise POSITION_APP packets. Publish a generated imprecise packet first so the
+    // current filter accepts a location update, then preserve the original packet for brokers that accept it. When offline
+    // and short on queue space, keep the public-usable copy instead of immediately evicting it with the precise original.
+    const bool willQueuePacket = !(moduleConfig.mqtt.proxy_to_client_enabled || this->isConnectedDirectly());
+    if (publicMqttPositionPacket != nullptr && willQueuePacket && mqttQueue.numFree() < 2) {
+        publishPacket(publicMqttPositionPacket, publicMqttPositionPacket);
+        return;
     }
+    if (publicMqttPositionPacket != nullptr)
+        publishPacket(publicMqttPositionPacket, publicMqttPositionPacket);
+    publishPacket(p, &mp_decoded);
 }
 
 void MQTT::perhapsReportToMap()

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -91,9 +91,9 @@ static bool makePublicMqttPositionPacket(meshtastic_MeshPacket &mqttPacket, cons
     position.precision_bits = precision;
 
     mqttPacket = sourcePacket;
-    // Use a fresh id so downstream id-based MQTT consumers can receive the public-safe copy
-    // even when they already cached or deduplicated the precise source packet.
-    mqttPacket.id = generatePacketId();
+    // Keep the original packet id so downstream consumers can correlate this
+    // public-safe copy with the precise packet it was derived from.
+    mqttPacket.id = sourcePacket.id;
     const size_t positionSize = pb_encode_to_bytes(mqttPacket.decoded.payload.bytes, sizeof(mqttPacket.decoded.payload.bytes),
                                                    &meshtastic_Position_msg, &position);
     if (positionSize == 0) {

--- a/src/mqtt/MQTT.h
+++ b/src/mqtt/MQTT.h
@@ -68,6 +68,7 @@ class MQTT : private concurrency::OSThread
     struct QueueEntry {
         std::string topic;
         std::basic_string<uint8_t> envBytes; // binary/pb_encode_to_bytes ServiceEnvelope
+        std::string jsonPayload;
     };
     PointerQueue<QueueEntry> mqttQueue;
 

--- a/test/test_mqtt/MQTT.cpp
+++ b/test/test_mqtt/MQTT.cpp
@@ -566,6 +566,125 @@ void test_sendJsonPositionToPublicServerIsImpreciseThenOriginal(void)
     TEST_ASSERT_EQUAL(32, originalPosition.precision_bits);
 }
 
+// Queued public MQTT positions should not publish precise JSON after reconnect.
+void test_sendQueuedJsonPositionToPublicServerKeepsOriginalOutOfJson(void)
+{
+    constexpr uint32_t precision = 15;
+    constexpr uint32_t latitude = 416213022;
+    constexpr uint32_t longitude = 415906392;
+    moduleConfig.mqtt.json_enabled = true;
+    MQTTUnitTest::restart();
+    pubsub->connected_ = false;
+    pubsub->refuseConnection_ = true;
+    TEST_ASSERT_TRUE(loopUntil([] { return !unitTest->getPubSub().connected(); }));
+
+    meshtastic_MeshPacket positionPacket = makePositionPacket(latitude, longitude);
+    mqtt->onSend(encrypted, positionPacket, 0);
+
+    TEST_ASSERT_EQUAL(2, unitTest->queueSize());
+    TEST_ASSERT_TRUE(pubsub->published_.empty());
+
+    pubsub->refuseConnection_ = false;
+    unitTest->reconnect();
+    unitTest->drainQueue();
+
+    TEST_ASSERT_EQUAL(3, pubsub->published_.size());
+    size_t jsonPositionCount = 0;
+    for (const auto &[topic, payload] : pubsub->published_) {
+        if (topic.find("/json/") == std::string::npos)
+            continue;
+
+        jsonPositionCount++;
+        const std::string &json = std::get<std::string>(payload);
+        std::stringstream expectedLatitude;
+        expectedLatitude << "\"latitude_i\":" << makeImpreciseCoordinate(latitude, precision);
+        std::stringstream expectedLongitude;
+        expectedLongitude << "\"longitude_i\":" << makeImpreciseCoordinate(longitude, precision);
+        TEST_ASSERT_TRUE(json.find(expectedLatitude.str()) != std::string::npos);
+        TEST_ASSERT_TRUE(json.find(expectedLongitude.str()) != std::string::npos);
+        TEST_ASSERT_TRUE(json.find("\"precision_bits\":15") != std::string::npos);
+        TEST_ASSERT_TRUE(json.find("\"latitude_i\":416213022") == std::string::npos);
+        TEST_ASSERT_TRUE(json.find("\"longitude_i\":415906392") == std::string::npos);
+    }
+    TEST_ASSERT_EQUAL(1, jsonPositionCount);
+}
+
+// Queued encrypted public MQTT positions should publish imprecise JSON after reconnect.
+void test_sendQueuedEncryptedJsonPositionUsesImprecisePublicPacket(void)
+{
+    constexpr uint32_t precision = 15;
+    constexpr uint32_t latitude = 416213022;
+    constexpr uint32_t longitude = 415906392;
+    moduleConfig.mqtt.encryption_enabled = true;
+    moduleConfig.mqtt.json_enabled = true;
+    MQTTUnitTest::restart();
+    pubsub->connected_ = false;
+    pubsub->refuseConnection_ = true;
+    TEST_ASSERT_TRUE(loopUntil([] { return !unitTest->getPubSub().connected(); }));
+
+    meshtastic_MeshPacket positionPacket = makePositionPacket(latitude, longitude);
+    mqtt->onSend(encrypted, positionPacket, 0);
+
+    TEST_ASSERT_EQUAL(1, unitTest->queueSize());
+    TEST_ASSERT_TRUE(pubsub->published_.empty());
+
+    pubsub->refuseConnection_ = false;
+    unitTest->reconnect();
+    unitTest->drainQueue();
+
+    TEST_ASSERT_EQUAL(2, pubsub->published_.size());
+    auto published = pubsub->published_.begin();
+    const auto &[protoTopic, protoPayload] = *published++;
+    const DecodedServiceEnvelope &env = std::get<DecodedServiceEnvelope>(protoPayload);
+    TEST_ASSERT_EQUAL_STRING("msh/2/e/test/!12345678", protoTopic.c_str());
+    TEST_ASSERT_TRUE(env.validDecode);
+    TEST_ASSERT_EQUAL(meshtastic_MeshPacket_encrypted_tag, env.packet->which_payload_variant);
+
+    const auto &[jsonTopic, jsonPayload] = *published;
+    TEST_ASSERT_EQUAL_STRING("msh/2/json/test/!12345678", jsonTopic.c_str());
+    const std::string &json = std::get<std::string>(jsonPayload);
+    std::stringstream expectedLatitude;
+    expectedLatitude << "\"latitude_i\":" << makeImpreciseCoordinate(latitude, precision);
+    std::stringstream expectedLongitude;
+    expectedLongitude << "\"longitude_i\":" << makeImpreciseCoordinate(longitude, precision);
+    TEST_ASSERT_TRUE(json.find(expectedLatitude.str()) != std::string::npos);
+    TEST_ASSERT_TRUE(json.find(expectedLongitude.str()) != std::string::npos);
+    TEST_ASSERT_TRUE(json.find("\"precision_bits\":15") != std::string::npos);
+    TEST_ASSERT_TRUE(json.find("\"latitude_i\":416213022") == std::string::npos);
+    TEST_ASSERT_TRUE(json.find("\"longitude_i\":415906392") == std::string::npos);
+}
+
+// Reused queue entries should not carry stale JSON from an evicted packet.
+void test_sendQueuedOverflowClearsStaleJsonPayload(void)
+{
+    moduleConfig.mqtt.json_enabled = true;
+    MQTTUnitTest::restart();
+    pubsub->connected_ = false;
+    pubsub->refuseConnection_ = true;
+    TEST_ASSERT_TRUE(loopUntil([] { return !unitTest->getPubSub().connected(); }));
+
+    for (int i = 0; i < MAX_MQTT_QUEUE; i++)
+        mqtt->onSend(encrypted, decoded, 0);
+    TEST_ASSERT_EQUAL(MAX_MQTT_QUEUE, unitTest->queueSize());
+
+    moduleConfig.mqtt.json_enabled = false;
+    mqtt->onSend(encrypted, decoded, 0);
+    TEST_ASSERT_EQUAL(MAX_MQTT_QUEUE, unitTest->queueSize());
+    TEST_ASSERT_TRUE(pubsub->published_.empty());
+
+    moduleConfig.mqtt.json_enabled = true;
+    pubsub->refuseConnection_ = false;
+    unitTest->reconnect();
+    unitTest->drainQueue();
+
+    size_t jsonPublishCount = 0;
+    for (const auto &[topic, payload] : pubsub->published_) {
+        if (topic.find("/json/") != std::string::npos)
+            jsonPublishCount++;
+    }
+    TEST_ASSERT_EQUAL(MAX_MQTT_QUEUE - 1, jsonPublishCount);
+}
+
 // Encrypted MQTT should continue to publish the encrypted packet, not a decoded position.
 void test_sendEncryptedPositionToPublicServerStaysEncrypted(void)
 {
@@ -1165,6 +1284,9 @@ void setup()
     RUN_TEST(test_sendCoarserPositionToPublicServerPreservesPrecision);
     RUN_TEST(test_sendPositionWithoutCoordinatesDoesNotCreateImpreciseCopy);
     RUN_TEST(test_sendJsonPositionToPublicServerIsImpreciseThenOriginal);
+    RUN_TEST(test_sendQueuedJsonPositionToPublicServerKeepsOriginalOutOfJson);
+    RUN_TEST(test_sendQueuedEncryptedJsonPositionUsesImprecisePublicPacket);
+    RUN_TEST(test_sendQueuedOverflowClearsStaleJsonPayload);
     RUN_TEST(test_sendEncryptedPositionToPublicServerStaysEncrypted);
     RUN_TEST(test_sendEncryptedJsonPositionUsesImprecisePublicPacket);
     RUN_TEST(test_proxyToMeshServiceDecoded);

--- a/test/test_mqtt/MQTT.cpp
+++ b/test/test_mqtt/MQTT.cpp
@@ -469,7 +469,7 @@ void test_sendPositionToPublicServerIsImpreciseThenOriginal(void)
     TEST_ASSERT_EQUAL_STRING("msh/2/e/test/!12345678", impreciseTopic.c_str());
     TEST_ASSERT_TRUE(impreciseEnv.validDecode);
     TEST_ASSERT_EQUAL(meshtastic_PortNum_POSITION_APP, impreciseEnv.packet->decoded.portnum);
-    TEST_ASSERT_NOT_EQUAL(positionPacket.id, impreciseEnv.packet->id);
+    TEST_ASSERT_EQUAL(positionPacket.id, impreciseEnv.packet->id);
 
     const meshtastic_Position imprecisePosition = decodePositionPacket(*impreciseEnv.packet);
     TEST_ASSERT_EQUAL(makeImpreciseCoordinate(latitude, precision), imprecisePosition.latitude_i);

--- a/test/test_mqtt/MQTT.cpp
+++ b/test/test_mqtt/MQTT.cpp
@@ -144,13 +144,26 @@ class MockPubSubServer : public WiFiClient
     size_t write(const uint8_t *buf, size_t size) override
     {
         command_ += std::string(reinterpret_cast<const char *>(buf), size);
-        if (command_.size() < 2)
-            return size;
-        const int len = (uint8_t)command_[1] + 2;
-        if (command_.size() < len)
-            return size;
-        handleCommand(command_[0], command_.substr(2, len));
-        command_ = command_.substr(len, command_.size());
+        while (command_.size() >= 2) {
+            size_t multiplier = 1;
+            size_t messageSize = 0;
+            size_t cursor = 1;
+            uint8_t encodedByte;
+            do {
+                if (cursor >= command_.size())
+                    return size;
+                encodedByte = static_cast<uint8_t>(command_[cursor++]);
+                messageSize += (encodedByte & 0x7f) * multiplier;
+                multiplier *= 128;
+            } while ((encodedByte & 0x80) != 0);
+
+            const size_t commandSize = cursor + messageSize;
+            if (command_.size() < commandSize)
+                return size;
+
+            handleCommand(command_[0], std::string_view(command_).substr(cursor, messageSize));
+            command_.erase(0, commandSize);
+        }
         return size;
     }
 
@@ -198,7 +211,7 @@ class MockPubSubServer : public WiFiClient
             std::string topic(message.data(), topicSize);
             message.remove_prefix(topicSize);
 
-            if (topic == kTextTopic) {
+            if (topic == kTextTopic || topic.find("/json/") != std::string::npos) {
                 published_.emplace_back(std::move(topic), std::string(message.data(), message.size()));
             } else {
                 published_.emplace_back(
@@ -262,6 +275,11 @@ class MQTTUnitTest : public MQTT
     using MQTT::isValidConfig;
     using MQTT::reconnect;
     int queueSize() { return mqttQueue.numUsed(); }
+    void drainQueue()
+    {
+        while (queueSize() > 0)
+            publishQueuedMessages();
+    }
     void reportToMap(std::optional<uint32_t> precision = std::nullopt)
     {
         if (precision.has_value())
@@ -325,6 +343,47 @@ const meshtastic_MeshPacket encrypted = {
     .encrypted = {.size = 0},
     .id = 3,
 };
+
+uint32_t makeImpreciseCoordinate(uint32_t coordinate, uint32_t precision)
+{
+    return (coordinate & (UINT32_MAX << (32 - precision))) + (1 << (31 - precision));
+}
+
+meshtastic_MeshPacket makePositionPacket(uint32_t latitude, uint32_t longitude, uint32_t precisionBits = 32)
+{
+    meshtastic_Position position = meshtastic_Position_init_default;
+    position.has_latitude_i = true;
+    position.latitude_i = latitude;
+    position.has_longitude_i = true;
+    position.longitude_i = longitude;
+    position.precision_bits = precisionBits;
+
+    meshtastic_MeshPacket packet = decoded;
+    packet.decoded.portnum = meshtastic_PortNum_POSITION_APP;
+    packet.decoded.payload.size = pb_encode_to_bytes(packet.decoded.payload.bytes, sizeof(packet.decoded.payload.bytes),
+                                                     &meshtastic_Position_msg, &position);
+    return packet;
+}
+
+meshtastic_MeshPacket makePositionPacketWithoutCoordinates()
+{
+    meshtastic_Position position = meshtastic_Position_init_default;
+    position.time = 1234;
+
+    meshtastic_MeshPacket packet = decoded;
+    packet.decoded.portnum = meshtastic_PortNum_POSITION_APP;
+    packet.decoded.payload.size = pb_encode_to_bytes(packet.decoded.payload.bytes, sizeof(packet.decoded.payload.bytes),
+                                                     &meshtastic_Position_msg, &position);
+    return packet;
+}
+
+meshtastic_Position decodePositionPacket(const meshtastic_MeshPacket &packet)
+{
+    meshtastic_Position position = meshtastic_Position_init_default;
+    TEST_ASSERT_TRUE(
+        pb_decode_from_bytes(packet.decoded.payload.bytes, packet.decoded.payload.size, &meshtastic_Position_msg, &position));
+    return position;
+}
 } // namespace
 
 // Initialize mocks and configuration before running each test.
@@ -391,6 +450,164 @@ void test_sendDirectlyConnectedEncrypted(void)
     TEST_ASSERT_EQUAL_STRING("msh/2/e/test/!12345678", topic.c_str());
     TEST_ASSERT_TRUE(env.validDecode);
     TEST_ASSERT_EQUAL(encrypted.id, env.packet->id);
+}
+
+// Position packets decoded for the public MQTT server should publish an imprecise copy before the original.
+void test_sendPositionToPublicServerIsImpreciseThenOriginal(void)
+{
+    constexpr uint32_t precision = 15;
+    constexpr uint32_t latitude = 416213022;
+    constexpr uint32_t longitude = 415906392;
+    meshtastic_MeshPacket positionPacket = makePositionPacket(latitude, longitude);
+
+    mqtt->onSend(encrypted, positionPacket, 0);
+
+    TEST_ASSERT_EQUAL(2, pubsub->published_.size());
+    auto published = pubsub->published_.begin();
+    const auto &[impreciseTopic, imprecisePayload] = *published++;
+    const DecodedServiceEnvelope &impreciseEnv = std::get<DecodedServiceEnvelope>(imprecisePayload);
+    TEST_ASSERT_EQUAL_STRING("msh/2/e/test/!12345678", impreciseTopic.c_str());
+    TEST_ASSERT_TRUE(impreciseEnv.validDecode);
+    TEST_ASSERT_EQUAL(meshtastic_PortNum_POSITION_APP, impreciseEnv.packet->decoded.portnum);
+    TEST_ASSERT_NOT_EQUAL(positionPacket.id, impreciseEnv.packet->id);
+
+    const meshtastic_Position imprecisePosition = decodePositionPacket(*impreciseEnv.packet);
+    TEST_ASSERT_EQUAL(makeImpreciseCoordinate(latitude, precision), imprecisePosition.latitude_i);
+    TEST_ASSERT_EQUAL(makeImpreciseCoordinate(longitude, precision), imprecisePosition.longitude_i);
+    TEST_ASSERT_EQUAL(precision, imprecisePosition.precision_bits);
+
+    const auto &[originalTopic, originalPayload] = *published;
+    const DecodedServiceEnvelope &originalEnv = std::get<DecodedServiceEnvelope>(originalPayload);
+    TEST_ASSERT_EQUAL_STRING("msh/2/e/test/!12345678", originalTopic.c_str());
+    TEST_ASSERT_TRUE(originalEnv.validDecode);
+    TEST_ASSERT_EQUAL(meshtastic_PortNum_POSITION_APP, originalEnv.packet->decoded.portnum);
+    TEST_ASSERT_EQUAL(positionPacket.id, originalEnv.packet->id);
+
+    const meshtastic_Position originalPosition = decodePositionPacket(*originalEnv.packet);
+    TEST_ASSERT_EQUAL(latitude, originalPosition.latitude_i);
+    TEST_ASSERT_EQUAL(longitude, originalPosition.longitude_i);
+    TEST_ASSERT_EQUAL(32, originalPosition.precision_bits);
+}
+
+// A source packet that is already coarser than the public MQTT cap should stay coarser.
+void test_sendCoarserPositionToPublicServerPreservesPrecision(void)
+{
+    constexpr uint32_t precision = 12;
+    constexpr uint32_t latitude = 416213022;
+    constexpr uint32_t longitude = 415906392;
+    meshtastic_MeshPacket positionPacket = makePositionPacket(latitude, longitude, precision);
+
+    mqtt->onSend(encrypted, positionPacket, 0);
+
+    TEST_ASSERT_EQUAL(2, pubsub->published_.size());
+    const auto &[impreciseTopic, imprecisePayload] = pubsub->published_.front();
+    const DecodedServiceEnvelope &impreciseEnv = std::get<DecodedServiceEnvelope>(imprecisePayload);
+    TEST_ASSERT_EQUAL_STRING("msh/2/e/test/!12345678", impreciseTopic.c_str());
+    TEST_ASSERT_TRUE(impreciseEnv.validDecode);
+
+    const meshtastic_Position imprecisePosition = decodePositionPacket(*impreciseEnv.packet);
+    TEST_ASSERT_EQUAL(makeImpreciseCoordinate(latitude, precision), imprecisePosition.latitude_i);
+    TEST_ASSERT_EQUAL(makeImpreciseCoordinate(longitude, precision), imprecisePosition.longitude_i);
+    TEST_ASSERT_EQUAL(precision, imprecisePosition.precision_bits);
+}
+
+// Position packets without coordinates should not get a synthetic public MQTT coordinate.
+void test_sendPositionWithoutCoordinatesDoesNotCreateImpreciseCopy(void)
+{
+    meshtastic_MeshPacket positionPacket = makePositionPacketWithoutCoordinates();
+
+    mqtt->onSend(encrypted, positionPacket, 0);
+
+    TEST_ASSERT_EQUAL(1, pubsub->published_.size());
+    const auto &[topic, payload] = pubsub->published_.front();
+    const DecodedServiceEnvelope &env = std::get<DecodedServiceEnvelope>(payload);
+    TEST_ASSERT_EQUAL_STRING("msh/2/e/test/!12345678", topic.c_str());
+    TEST_ASSERT_TRUE(env.validDecode);
+
+    const meshtastic_Position originalPosition = decodePositionPacket(*env.packet);
+    TEST_ASSERT_FALSE(originalPosition.has_latitude_i);
+    TEST_ASSERT_FALSE(originalPosition.has_longitude_i);
+}
+
+// JSON position packets should follow the same imprecise-then-original order as protobuf MQTT.
+void test_sendJsonPositionToPublicServerIsImpreciseThenOriginal(void)
+{
+    constexpr uint32_t precision = 15;
+    constexpr uint32_t latitude = 416213022;
+    constexpr uint32_t longitude = 415906392;
+    moduleConfig.mqtt.json_enabled = true;
+    MQTTUnitTest::restart();
+    meshtastic_MeshPacket positionPacket = makePositionPacket(latitude, longitude);
+
+    mqtt->onSend(encrypted, positionPacket, 0);
+
+    TEST_ASSERT_EQUAL(4, pubsub->published_.size());
+    auto published = pubsub->published_.begin();
+    ++published; // imprecise protobuf
+    const auto &[impreciseTopic, imprecisePayload] = *published++;
+    TEST_ASSERT_EQUAL_STRING("msh/2/json/test/!12345678", impreciseTopic.c_str());
+
+    const std::string &json = std::get<std::string>(imprecisePayload);
+    std::stringstream expectedLatitude;
+    expectedLatitude << "\"latitude_i\":" << makeImpreciseCoordinate(latitude, precision);
+    std::stringstream expectedLongitude;
+    expectedLongitude << "\"longitude_i\":" << makeImpreciseCoordinate(longitude, precision);
+    TEST_ASSERT_TRUE(json.find(expectedLatitude.str()) != std::string::npos);
+    TEST_ASSERT_TRUE(json.find(expectedLongitude.str()) != std::string::npos);
+    TEST_ASSERT_TRUE(json.find("\"precision_bits\":15") != std::string::npos);
+
+    ++published; // original protobuf
+    const auto &[originalTopic, originalPayload] = *published;
+    TEST_ASSERT_EQUAL_STRING("msh/2/json/test/!12345678", originalTopic.c_str());
+    const std::string &originalJson = std::get<std::string>(originalPayload);
+    TEST_ASSERT_TRUE(originalJson.find("\"latitude_i\":416213022") != std::string::npos);
+    TEST_ASSERT_TRUE(originalJson.find("\"longitude_i\":415906392") != std::string::npos);
+    TEST_ASSERT_TRUE(originalJson.find("\"precision_bits\":32") != std::string::npos);
+}
+
+// Encrypted MQTT should continue to publish the encrypted packet, not a decoded position.
+void test_sendEncryptedPositionToPublicServerStaysEncrypted(void)
+{
+    moduleConfig.mqtt.encryption_enabled = true;
+    meshtastic_MeshPacket positionPacket = makePositionPacket(416213022, 415906392);
+
+    mqtt->onSend(encrypted, positionPacket, 0);
+
+    TEST_ASSERT_EQUAL(1, pubsub->published_.size());
+    const auto &[topic, payload] = pubsub->published_.front();
+    const DecodedServiceEnvelope &env = std::get<DecodedServiceEnvelope>(payload);
+    TEST_ASSERT_EQUAL_STRING("msh/2/e/test/!12345678", topic.c_str());
+    TEST_ASSERT_TRUE(env.validDecode);
+    TEST_ASSERT_EQUAL(meshtastic_MeshPacket_encrypted_tag, env.packet->which_payload_variant);
+    TEST_ASSERT_EQUAL(encrypted.id, env.packet->id);
+}
+
+// Encrypted protobuf MQTT should still publish decoded JSON when JSON is enabled.
+void test_sendEncryptedJsonPositionUsesDecodedPacket(void)
+{
+    constexpr uint32_t latitude = 416213022;
+    constexpr uint32_t longitude = 415906392;
+    moduleConfig.mqtt.encryption_enabled = true;
+    moduleConfig.mqtt.json_enabled = true;
+    MQTTUnitTest::restart();
+    meshtastic_MeshPacket positionPacket = makePositionPacket(latitude, longitude);
+
+    mqtt->onSend(encrypted, positionPacket, 0);
+
+    TEST_ASSERT_EQUAL(2, pubsub->published_.size());
+    auto published = pubsub->published_.begin();
+    const auto &[protoTopic, protoPayload] = *published++;
+    const DecodedServiceEnvelope &env = std::get<DecodedServiceEnvelope>(protoPayload);
+    TEST_ASSERT_EQUAL_STRING("msh/2/e/test/!12345678", protoTopic.c_str());
+    TEST_ASSERT_TRUE(env.validDecode);
+    TEST_ASSERT_EQUAL(meshtastic_MeshPacket_encrypted_tag, env.packet->which_payload_variant);
+
+    const auto &[jsonTopic, jsonPayload] = *published;
+    TEST_ASSERT_EQUAL_STRING("msh/2/json/test/!12345678", jsonTopic.c_str());
+    const std::string &json = std::get<std::string>(jsonPayload);
+    TEST_ASSERT_TRUE(json.find("\"type\":\"position\"") != std::string::npos);
+    TEST_ASSERT_TRUE(json.find("\"latitude_i\":416213022") != std::string::npos);
+    TEST_ASSERT_TRUE(json.find("\"longitude_i\":415906392") != std::string::npos);
 }
 
 // Verify that the decoded MeshPacket is proxied through the MeshService when encryption_enabled = false.
@@ -511,6 +728,49 @@ void test_sendQueued(void)
     TEST_ASSERT_EQUAL_STRING("msh/2/e/test/!12345678", topic.c_str());
     TEST_ASSERT_TRUE(env.validDecode);
     TEST_ASSERT_EQUAL(decoded.id, env.packet->id);
+}
+
+// If the offline queue has room for only one more packet, keep the public-usable imprecise position.
+void test_sendQueuedPublicPositionKeepsImpreciseWhenQueueAlmostFull(void)
+{
+    // Cause a disconnect.
+    pubsub->connected_ = false;
+    pubsub->refuseConnection_ = true;
+    TEST_ASSERT_TRUE(loopUntil([] { return !unitTest->getPubSub().connected(); }));
+
+    for (int i = 0; i < MAX_MQTT_QUEUE - 1; i++)
+        mqtt->onSend(encrypted, decoded, 0);
+
+    constexpr uint32_t precision = 15;
+    constexpr uint32_t latitude = 416213022;
+    constexpr uint32_t longitude = 415906392;
+    meshtastic_MeshPacket positionPacket = makePositionPacket(latitude, longitude);
+    mqtt->onSend(encrypted, positionPacket, 0);
+
+    TEST_ASSERT_EQUAL(MAX_MQTT_QUEUE, unitTest->queueSize());
+    TEST_ASSERT_TRUE(pubsub->published_.empty());
+
+    // Allow reconnect to happen and drain the queued packets.
+    pubsub->refuseConnection_ = false;
+    unitTest->reconnect();
+    unitTest->drainQueue();
+    TEST_ASSERT_EQUAL(0, unitTest->queueSize());
+
+    size_t positionPacketCount = 0;
+    meshtastic_Position queuedPosition = meshtastic_Position_init_default;
+    for (const auto &[topic, payload] : pubsub->published_) {
+        const DecodedServiceEnvelope &env = std::get<DecodedServiceEnvelope>(payload);
+        if (env.packet->decoded.portnum != meshtastic_PortNum_POSITION_APP)
+            continue;
+
+        positionPacketCount++;
+        queuedPosition = decodePositionPacket(*env.packet);
+    }
+
+    TEST_ASSERT_EQUAL(1, positionPacketCount);
+    TEST_ASSERT_EQUAL(makeImpreciseCoordinate(latitude, precision), queuedPosition.latitude_i);
+    TEST_ASSERT_EQUAL(makeImpreciseCoordinate(longitude, precision), queuedPosition.longitude_i);
+    TEST_ASSERT_EQUAL(precision, queuedPosition.precision_bits);
 }
 
 // Verify reconnecting with the proxy enabled does not reconnect to a MQTT server.
@@ -892,6 +1152,12 @@ void setup()
     UNITY_BEGIN();
     RUN_TEST(test_sendDirectlyConnectedDecoded);
     RUN_TEST(test_sendDirectlyConnectedEncrypted);
+    RUN_TEST(test_sendPositionToPublicServerIsImpreciseThenOriginal);
+    RUN_TEST(test_sendCoarserPositionToPublicServerPreservesPrecision);
+    RUN_TEST(test_sendPositionWithoutCoordinatesDoesNotCreateImpreciseCopy);
+    RUN_TEST(test_sendJsonPositionToPublicServerIsImpreciseThenOriginal);
+    RUN_TEST(test_sendEncryptedPositionToPublicServerStaysEncrypted);
+    RUN_TEST(test_sendEncryptedJsonPositionUsesDecodedPacket);
     RUN_TEST(test_proxyToMeshServiceDecoded);
     RUN_TEST(test_proxyToMeshServiceEncrypted);
     RUN_TEST(test_dontMqttMeOnPublicServer);
@@ -899,6 +1165,7 @@ void setup()
     RUN_TEST(test_noRangeTestAppOnDefaultServer);
     RUN_TEST(test_noDetectionSensorAppOnDefaultServer);
     RUN_TEST(test_sendQueued);
+    RUN_TEST(test_sendQueuedPublicPositionKeepsImpreciseWhenQueueAlmostFull);
     RUN_TEST(test_reconnectProxyDoesNotReconnectMqtt);
     RUN_TEST(test_receiveEmptyMeshPacket);
     RUN_TEST(test_receiveDecodedProto);

--- a/test/test_mqtt/MQTT.cpp
+++ b/test/test_mqtt/MQTT.cpp
@@ -529,7 +529,7 @@ void test_sendPositionWithoutCoordinatesDoesNotCreateImpreciseCopy(void)
     TEST_ASSERT_FALSE(originalPosition.has_longitude_i);
 }
 
-// JSON position packets should follow the same imprecise-then-original order as protobuf MQTT.
+// JSON position packets should publish imprecise JSON only, while protobuf still preserves the original second publish.
 void test_sendJsonPositionToPublicServerIsImpreciseThenOriginal(void)
 {
     constexpr uint32_t precision = 15;
@@ -541,7 +541,7 @@ void test_sendJsonPositionToPublicServerIsImpreciseThenOriginal(void)
 
     mqtt->onSend(encrypted, positionPacket, 0);
 
-    TEST_ASSERT_EQUAL(4, pubsub->published_.size());
+    TEST_ASSERT_EQUAL(3, pubsub->published_.size());
     auto published = pubsub->published_.begin();
     ++published; // imprecise protobuf
     const auto &[impreciseTopic, imprecisePayload] = *published++;
@@ -556,13 +556,14 @@ void test_sendJsonPositionToPublicServerIsImpreciseThenOriginal(void)
     TEST_ASSERT_TRUE(json.find(expectedLongitude.str()) != std::string::npos);
     TEST_ASSERT_TRUE(json.find("\"precision_bits\":15") != std::string::npos);
 
-    ++published; // original protobuf
     const auto &[originalTopic, originalPayload] = *published;
-    TEST_ASSERT_EQUAL_STRING("msh/2/json/test/!12345678", originalTopic.c_str());
-    const std::string &originalJson = std::get<std::string>(originalPayload);
-    TEST_ASSERT_TRUE(originalJson.find("\"latitude_i\":416213022") != std::string::npos);
-    TEST_ASSERT_TRUE(originalJson.find("\"longitude_i\":415906392") != std::string::npos);
-    TEST_ASSERT_TRUE(originalJson.find("\"precision_bits\":32") != std::string::npos);
+    TEST_ASSERT_EQUAL_STRING("msh/2/e/test/!12345678", originalTopic.c_str());
+    const DecodedServiceEnvelope &originalEnv = std::get<DecodedServiceEnvelope>(originalPayload);
+    TEST_ASSERT_TRUE(originalEnv.validDecode);
+    const meshtastic_Position originalPosition = decodePositionPacket(*originalEnv.packet);
+    TEST_ASSERT_EQUAL(latitude, originalPosition.latitude_i);
+    TEST_ASSERT_EQUAL(longitude, originalPosition.longitude_i);
+    TEST_ASSERT_EQUAL(32, originalPosition.precision_bits);
 }
 
 // Encrypted MQTT should continue to publish the encrypted packet, not a decoded position.
@@ -582,9 +583,10 @@ void test_sendEncryptedPositionToPublicServerStaysEncrypted(void)
     TEST_ASSERT_EQUAL(encrypted.id, env.packet->id);
 }
 
-// Encrypted protobuf MQTT should still publish decoded JSON when JSON is enabled.
-void test_sendEncryptedJsonPositionUsesDecodedPacket(void)
+// Encrypted protobuf MQTT should only expose the imprecise public-safe decoded position through JSON.
+void test_sendEncryptedJsonPositionUsesImprecisePublicPacket(void)
 {
+    constexpr uint32_t precision = 15;
     constexpr uint32_t latitude = 416213022;
     constexpr uint32_t longitude = 415906392;
     moduleConfig.mqtt.encryption_enabled = true;
@@ -606,8 +608,15 @@ void test_sendEncryptedJsonPositionUsesDecodedPacket(void)
     TEST_ASSERT_EQUAL_STRING("msh/2/json/test/!12345678", jsonTopic.c_str());
     const std::string &json = std::get<std::string>(jsonPayload);
     TEST_ASSERT_TRUE(json.find("\"type\":\"position\"") != std::string::npos);
-    TEST_ASSERT_TRUE(json.find("\"latitude_i\":416213022") != std::string::npos);
-    TEST_ASSERT_TRUE(json.find("\"longitude_i\":415906392") != std::string::npos);
+    std::stringstream expectedLatitude;
+    expectedLatitude << "\"latitude_i\":" << makeImpreciseCoordinate(latitude, precision);
+    std::stringstream expectedLongitude;
+    expectedLongitude << "\"longitude_i\":" << makeImpreciseCoordinate(longitude, precision);
+    TEST_ASSERT_TRUE(json.find(expectedLatitude.str()) != std::string::npos);
+    TEST_ASSERT_TRUE(json.find(expectedLongitude.str()) != std::string::npos);
+    TEST_ASSERT_TRUE(json.find("\"precision_bits\":15") != std::string::npos);
+    TEST_ASSERT_TRUE(json.find("\"latitude_i\":416213022") == std::string::npos);
+    TEST_ASSERT_TRUE(json.find("\"longitude_i\":415906392") == std::string::npos);
 }
 
 // Verify that the decoded MeshPacket is proxied through the MeshService when encryption_enabled = false.
@@ -1157,7 +1166,7 @@ void setup()
     RUN_TEST(test_sendPositionWithoutCoordinatesDoesNotCreateImpreciseCopy);
     RUN_TEST(test_sendJsonPositionToPublicServerIsImpreciseThenOriginal);
     RUN_TEST(test_sendEncryptedPositionToPublicServerStaysEncrypted);
-    RUN_TEST(test_sendEncryptedJsonPositionUsesDecodedPacket);
+    RUN_TEST(test_sendEncryptedJsonPositionUsesImprecisePublicPacket);
     RUN_TEST(test_proxyToMeshServiceDecoded);
     RUN_TEST(test_proxyToMeshServiceEncrypted);
     RUN_TEST(test_dontMqttMeOnPublicServer);


### PR DESCRIPTION
## Summary
- dual-publish decoded POSITION_APP packets to the default public MQTT server
- publish a generated coarse packet first with `precision_bits = 15`, then publish the original packet unchanged
- apply the same ordering to JSON MQTT output when JSON is enabled

## Why
The public MQTT broker currently filters precise position packets. Publishing the coarse packet first lets current public consumers receive a location update, while publishing the original second preserves current behavior for private/custom brokers and for any future public-broker policy that accepts more precise positions.

## Notes
- Only decoded `POSITION_APP` packets sent to the default public MQTT server are duplicated/coarsened.
- Encrypted uplinks remain unchanged.
- The generated coarse packet keeps the same mesh metadata but masks latitude/longitude to the public precision bucket.

## Tests
- Added/updated `test_mqtt` coverage for protobuf dual publish, JSON dual publish, and encrypted-position behavior.
- Built `heltec-v3` successfully with PlatformIO.
