### PR TITLE
Add search duration check for exceeding 15 minutes

### DIFF
--- a/src/gps/GPSUpdateScheduling.cpp
+++ b/src/gps/GPSUpdateScheduling.cpp
@@ -81,6 +81,10 @@ bool GPSUpdateScheduling::searchedTooLong()
     else if (elapsedSearchMs() > maxSearchMs)
         return true;
 
+    // Anything over 15 minutes is too long. TODO: Make a smarter algorithm that backs off the search dwell time when not getting a lock.
+    else if (elapsedSearchMs() > 1000 * 60 * 15)
+        return true;
+
     // Otherwise, not too long yet!
     else
         return false;

--- a/src/gps/GPSUpdateScheduling.cpp
+++ b/src/gps/GPSUpdateScheduling.cpp
@@ -70,7 +70,8 @@ bool GPSUpdateScheduling::isUpdateDue()
 // Have we been searching for a GPS position for too long?
 bool GPSUpdateScheduling::searchedTooLong()
 {
-    constexpr uint32_t maxSearchClampMs = 1000UL * 60 * 15; // Hard cap: 15 minutes is always too long
+    constexpr uint32_t oneMinuteMs = 60UL * 1000UL;
+    constexpr uint32_t maxSearchClampMs = 15UL * oneMinuteMs; // Hard cap: 15 minutes is always too long
     uint32_t elapsed = elapsedSearchMs();
 
     // Anything over 15 minutes is too long, regardless of the broadcast interval.

--- a/src/gps/GPSUpdateScheduling.cpp
+++ b/src/gps/GPSUpdateScheduling.cpp
@@ -70,25 +70,28 @@ bool GPSUpdateScheduling::isUpdateDue()
 // Have we been searching for a GPS position for too long?
 bool GPSUpdateScheduling::searchedTooLong()
 {
+    constexpr uint32_t maxSearchClampMs = 1000UL * 60 * 15; // Hard cap: 15 minutes is always too long
+    uint32_t elapsed = elapsedSearchMs();
+
+    // Anything over 15 minutes is too long, regardless of the broadcast interval.
+    // TODO: Make a smarter algorithm that backs off the search dwell time when not getting a lock.
+    if (elapsed > maxSearchClampMs)
+        return true;
+
     uint32_t minimumOrConfiguredSecs =
         Default::getConfiguredOrMinimumValue(config.position.position_broadcast_secs, default_broadcast_interval_secs);
     uint32_t maxSearchMs = Default::getConfiguredOrDefaultMs(minimumOrConfiguredSecs, default_broadcast_interval_secs);
+
     // If broadcast interval set to max, no such thing as "too long"
     if (maxSearchMs == UINT32_MAX)
         return false;
 
     // If we've been searching longer than our position broadcast interval: that's too long
-    else if (elapsedSearchMs() > maxSearchMs)
-        return true;
-
-    // Anything over 15 minutes is too long. TODO: Make a smarter algorithm that backs off the search dwell time when not getting
-    // a lock.
-    else if (elapsedSearchMs() > 1000 * 60 * 15)
+    if (elapsed > maxSearchMs)
         return true;
 
     // Otherwise, not too long yet!
-    else
-        return false;
+    return false;
 }
 
 // Updates the predicted time-to-get-lock, by exponentially smoothing the latest observation

--- a/src/gps/GPSUpdateScheduling.cpp
+++ b/src/gps/GPSUpdateScheduling.cpp
@@ -81,7 +81,8 @@ bool GPSUpdateScheduling::searchedTooLong()
     else if (elapsedSearchMs() > maxSearchMs)
         return true;
 
-    // Anything over 15 minutes is too long. TODO: Make a smarter algorithm that backs off the search dwell time when not getting a lock.
+    // Anything over 15 minutes is too long. TODO: Make a smarter algorithm that backs off the search dwell time when not getting
+    // a lock.
     else if (elapsedSearchMs() > 1000 * 60 * 15)
         return true;
 

--- a/src/gps/GPSUpdateScheduling.cpp
+++ b/src/gps/GPSUpdateScheduling.cpp
@@ -83,10 +83,6 @@ bool GPSUpdateScheduling::searchedTooLong()
         Default::getConfiguredOrMinimumValue(config.position.position_broadcast_secs, default_broadcast_interval_secs);
     uint32_t maxSearchMs = Default::getConfiguredOrDefaultMs(minimumOrConfiguredSecs, default_broadcast_interval_secs);
 
-    // If broadcast interval set to max, no such thing as "too long"
-    if (maxSearchMs == UINT32_MAX)
-        return false;
-
     // If we've been searching longer than our position broadcast interval: that's too long
     if (elapsed > maxSearchMs)
         return true;


### PR DESCRIPTION
Added a condition to check if the search duration exceeds 15 minutes, indicating too long of a search.

Received reports that the new 60 minute default was causing battery drain problems. Simple solution is to clamp the search time to 15 minutes.