### PR TITLE
Add SX1262 variant my_sx1262

### DIFF
--- a/variants/my_sx1262/platformio.ini
+++ b/variants/my_sx1262/platformio.ini
@@ -1,0 +1,6 @@
+[env:my_sx1262]
+extends = arduino_base
+board = esp32dev
+build_flags = ${env.build_flags} -D PRIVATE_HW -I variants/my_sx1262
+platform_packages = ${env.platform_packages}
+lib_deps = ${env.lib_deps}


### PR DESCRIPTION
Aggiunge la variant per modulo SX1262 (DX-LR30) sotto variants/my_sx1262.

Cosa include

    variants/my_sx1262/platformio.ini con environment per ESP32.
    File di configurazione dei pin per SX1262 (SPI, NSS, RST, BUSY, DIO) — vedi variants/my_sx1262 per dettagli.
    Note su alimentazione e compatibilità hardware.

Motivazione
Permette l'uso del modulo DX-LR30 (SX1262) con il firmware, offrendo supporto per dispositivi basati su SX1262 e facilitando build e test su ESP32.

Test eseguiti

    Compilazione locale con PlatformIO per l'environment [inserire nome env] — build completata con successo.
    (Opzionale) Flash test su ESP32 con DX-LR30: [inserire risultati o "non ancora testato"].

Istruzioni per i maintainer

    Verificare che l'environment selezionato in platformio.ini corrisponda alla board usata nei CI.
    Controllare i mapping pin nel file della variant e confermare che corrispondano al modulo DX-LR30 (SPI, NSS, RST, BUSY, DIO).
    Se necessario, posso aggiornare il branch con modifiche ai pin o aggiungere istruzioni di setup specifiche per il testing.

Note sul mantenimento della privacy

    Il commit è stato creato con identità anonima per rispetto della privacy; posso associare un account riconoscibile se preferite.

Contatti / Follow-up

    Posso fornire log di build, foto dei collegamenti hardware o aiutare a testare il flash su ESP32 se richiesto.
