### PR TITLE
MUI displaymode toggle: keep Bluetooth enabled on PSRAM boards

### DIFF
--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -2020,7 +2020,14 @@ void menuHandler::switchToMUIMenu()
     bannerOptions.bannerCallback = [](int selected) -> void {
         if (selected == 1) {
             config.display.displaymode = meshtastic_Config_DisplayConfig_DisplayMode_COLOR;
+#if !defined(BOARD_HAS_PSRAM)
+            // Boards without PSRAM can't fit the LVGL framebuffer (240x320x2 = ~150KB)
+            // alongside NimBLE's GATT mempool in internal SRAM. Auto-disable BT here so
+            // entering MUI doesn't push the device into memory-pressure crashes.
+            // PSRAM boards (Heltec V4 / Station G2 / etc) have enough headroom for both;
+            // we leave BT alone there so users don't lose phone connectivity on toggle.
             config.bluetooth.enabled = false;
+#endif
             service->reloadConfig(SEGMENT_CONFIG);
             rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
         }

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -769,7 +769,14 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
             requiresReboot = false;
         } else if (config.display.displaymode != meshtastic_Config_DisplayConfig_DisplayMode_COLOR &&
                    c.payload_variant.display.displaymode == meshtastic_Config_DisplayConfig_DisplayMode_COLOR) {
+#if !defined(BOARD_HAS_PSRAM)
+            // Boards without PSRAM can't fit LVGL framebuffer + NimBLE GATT pool simultaneously
+            // in internal SRAM, so we auto-disable BT to prevent memory-pressure crashes when
+            // the phone-app pushes a switch to MUI/COLOR mode. PSRAM boards (V4, Station G2, etc)
+            // have headroom for both and shouldn't lose phone connectivity on a UI mode toggle.
+            // (Pairs with the same gate in src/graphics/draw/MenuHandler.cpp switchToMUIMenu().)
             config.bluetooth.enabled = false;
+#endif
         }
 #if !defined(ARCH_PORTDUINO) && !defined(ARCH_STM32WL) && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR &&                            \
     !MESHTASTIC_EXCLUDE_ACCELEROMETER


### PR DESCRIPTION
## Problem

Switching to MUI/COLOR display mode silently disables Bluetooth on PSRAM-equipped TFT boards (Heltec V4-TFT, T-Deck, etc). Phones can no longer connect after the toggle until the user notices and re-enables BT manually.

Two paths trigger this on the same board:

1. **On-device touchscreen menu** — `MenuHandler::switchToMUIMenu()` callback when the user accepts the "Switch to MUI?" prompt
2. **Phone-app SET_CONFIG** — `AdminModule::handleSetConfig()` when the phone app pushes a `displaymode = COLOR` config write

Both intentionally set `config.bluetooth.enabled = false` to defend against memory pressure (LVGL framebuffer + NimBLE GATT mempool fighting for internal SRAM on tight boards).

## Repro

V4-TFT, displaymode=DEFAULT, BT enabled, paired to phone. Either:
- Tap "Switch to MUI?" on the V4 touchscreen
- OR change Display → Color via the phone-app config screen

After reboot: `bluetooth.enabled=False`, phone can't see V4 over BT.

## Fix

Gate both auto-disable sites on `#if !defined(BOARD_HAS_PSRAM)`. Boards without PSRAM keep the existing defensive auto-disable. PSRAM boards have enough internal-SRAM headroom for both LVGL framebuffer and NimBLE GATT — they shouldn't lose phone connectivity on a UI-mode toggle.

```cpp
// Before
config.display.displaymode = ...COLOR;
config.bluetooth.enabled = false;

// After
config.display.displaymode = ...COLOR;
#if !defined(BOARD_HAS_PSRAM)
config.bluetooth.enabled = false;
#endif
```

Total diff: +14 / -0 across 2 files. No new code paths, no new behavior — only narrows when the existing defensive disable applies.

## Compatibility

- **PSRAM boards that use MUI/COLOR (Heltec V4-TFT, T-Deck, etc.):** auto-disable removed. Field-tested on Heltec V4-TFT.
- **PSRAM boards without TFT (e.g. Station G2 with SH1107 OLED):** unaffected in practice — they don't switch to COLOR mode. The AdminModule code path is in shared code so the gate still applies, but the behavior change is a no-op there.
- **Non-PSRAM boards:** unchanged. The original defensive disable still applies.
- **Other display modes (DEFAULT, TWOCOLOR, INVERTED):** never had this auto-disable in the first place. Untouched.

## Test plan

1. Flash a PSRAM TFT board (V4-TFT) with BT enabled and displaymode=DEFAULT
2. Pair phone via BT, confirm connection works
3. Either: tap "Switch to MUI?" on touchscreen OR change Display→Color in phone app
4. After the device reboots: `bluetooth.enabled` should still be `true`, phone should reconnect

## Notes

- Field-verified on Heltec V4-TFT for the `MenuHandler.cpp` path. The `AdminModule.cpp` path uses the identical conditional pattern; reasoning is mechanical.
- The two sites duplicate the same coupling logic. A future cleanup could consolidate via a single helper (e.g. `applyDisplayMode()`) so the next person to change this doesn't need to find both places. Out of scope for this fix, but worth flagging.
