### PR TITLE
Update variant.h to force small icons for Heltec Wireless Tracker  V1.1

### DIFF
--- a/variants/esp32s3/heltec_wireless_tracker/variant.h
+++ b/variants/esp32s3/heltec_wireless_tracker/variant.h
@@ -27,6 +27,7 @@
 #define TFT_OFFSET_Y -1
 #define SCREEN_TRANSITION_FRAMERATE 3 // fps
 #define DISPLAY_FORCE_SMALL_FONTS
+#define FORCE_LOW_RES 1
 #define USE_TFTDISPLAY 1
 
 // pin 3 is Vext on v1.1 - HIGH enables LDO for Vext rail which goes to:


### PR DESCRIPTION
Force small icons for Heltec Wireless Tracker  V1.1
Default icons are too big for that screen


- [x] I have tested that my proposed changes behave as described.

