### PR TITLE
fix(Router): localize p_encrypted to prevent recursive-overwrite leak

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -736,9 +736,13 @@ void Router::handleReceived(meshtastic_MeshPacket *p, RxSource src)
     // Also, we should set the time from the ISR and it should have msec level resolution
     p->rx_time = getValidTime(RTCQualityFromNet); // store the arrival timestamp for the phone
 
-    // Store a copy of encrypted packet for MQTT
+    // Store a copy of the encrypted packet for MQTT.
+    // Local, not a class member: handleReceived re-enters itself when a module
+    // reply broadcast goes through MeshService::sendToMesh -> Router::sendLocal,
+    // and a member would be silently overwritten without release on the inner
+    // call. Each invocation now owns its own copy (issue #9632, #10101, #8729).
     DEBUG_HEAP_BEFORE;
-    p_encrypted = packetPool.allocCopy(*p);
+    meshtastic_MeshPacket *p_encrypted = packetPool.allocCopy(*p);
     DEBUG_HEAP_AFTER("Router::handleReceived", p_encrypted);
 
     // Take those raw bytes and convert them back into a well structured protobuf we can understand
@@ -832,8 +836,7 @@ void Router::handleReceived(meshtastic_MeshPacket *p, RxSource src)
 #endif
     }
 
-    packetPool.release(p_encrypted); // Release the encrypted packet
-    p_encrypted = nullptr;
+    packetPool.release(p_encrypted); // Release the encrypted packet (release() handles nullptr)
 }
 
 void Router::perhapsHandleReceived(meshtastic_MeshPacket *p)

--- a/src/mesh/Router.h
+++ b/src/mesh/Router.h
@@ -92,9 +92,6 @@ class Router : protected concurrency::OSThread, protected PacketHistory
         before us */
     uint32_t rxDupe = 0, txRelayCanceled = 0;
 
-    // pointer to the encrypted packet
-    meshtastic_MeshPacket *p_encrypted = nullptr;
-
   protected:
     friend class RoutingModule;
 


### PR DESCRIPTION
### What this changes

Promotes `Router::p_encrypted` from a class member to a function-local in `handleReceived()`, so each invocation owns its own decrypt copy for its full lifetime. ~5 lines of functional change; no behavioral change on the non-recursive path.

### Why

`Router::handleReceived()` re-enters itself: `callModules()` invokes module replies that go back through `MeshService::sendToMesh -> Router::sendLocal`, and on a broadcast reply that recursively calls `handleReceived()`. The inner call writes its own `packetPool.allocCopy(*p)` into `this->p_encrypted`, dropping the outer call's pointer with the allocation still live. The inner call also nulls the member on its way out, so when the outer call reaches `packetPool.release(p_encrypted)` it releases `nullptr`. The outer's allocation is permanently leaked. ~381 B per recursion event.

Copilot's review of #8999 (the original introduction of the member) flagged this exact pattern at merge time:

> Storing `p_encrypted` as a class member can cause issues with recursive or concurrent calls to `handleReceived()` since each call would overwrite the previous packet pointer.

The historical justification — a pending S&F path needing to retain the encrypted copy across calls — was satisfied differently by #9799 (ServerAPI converted to `std::unique_ptr` + cleanup on connection close), so the member is no longer load-bearing.

### How this fits with active issues

The recursion-overwrite is one mechanism behind:

- #9632 — Heltec V4 heap leak when MeshMonitor enabled
- #10101 — Station G2 TCP drops repeatedly when MeshMonitor connected (`ROUTER_LATE` 2.7.20)
- #8729 — LILYGO unreachable after wifi config (`errno: 11 EAGAIN` task-handle exhaustion during ServerAPI dump → `abort()`)

All three share the trigger shape: persistent client + stale-connection timeout reconnects fire while a prior dump is still in flight. This PR closes one path on which that retry storm leaks; it does not claim to close all of them.

### Reproduction and evidence

Two Station G2 devices on the same WiFi LAN. Each hammered with a slow-client TCP-API retry storm (open `:4403`, send `want_config_id`, read 2.5 s of the ServerAPI dump, close mid-stream, repeat at ~0.6/s). Pure TCP, no LoRa traffic. This is the trigger pattern that #9632 / #10101 attribute to MeshMonitor's `STALE_CONNECTION_TIMEOUT=5min` reconnect loop.

| Build | heapFree drift over ~9 min | rebootCount delta |
| --- | --- | --- |
| this patch | -1.5 KB (≈390 B/min, noise floor) | 0 |
| stock 2.7.13 | **-73 KB (8.1 KB/min)** | **+1 (OOM-class crash at t≈9 min)** |

Stock's `heapTotal` also contracted by ~11 KB during the test (allocator pool itself shrinking) — characteristic of a leak the heap can't reclaim. The patched build's `heapTotal` was stable to within 80 B.

The bench A/B without retry-storm trigger (~4,000 broadcast text sends each, with and without MQTT bridge re-injection) shows no drift on either build — consistent with the corpus, since the recursion window closes when the client is fast.

### Why the diff is small

This matches the merge pattern of the recently landed leak fixes (#9799, #9693, #5901, #5328, #9781). Deliberately not bundled with any allocator restructure or other concerns.

### Risk

Minimal. Lifetime of the function-local is identical to the prior member usage *inside* `handleReceived` (allocated at entry, released before return). All references to `p_encrypted` were already confined to that function body — verified by grep across `src/`. No subclass, friend class, or external module accesses the field. The pre-existing null-check at the MQTT publish site (added by #9136 as a workaround) stays in place because `allocCopy` can still legitimately return `nullptr` on `packetPool` exhaustion.