### PR TITLE
Add Poly-Safe alert on T1000-E double press

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,45 @@ This repository is the [Meshtastic](https://meshtastic.org) firmware — a C++17
 
 **Read `.github/copilot-instructions.md` first.** That file is the canonical agent-facing document for this repo. It covers project layout, coding conventions (naming, module framework, Observer pattern, thread safety), the build system, CI/CD, the native C++ test suite, and — most importantly for automation work — the **MCP Server & Hardware Test Harness** section. Read it top-to-bottom before starting any non-trivial change.
 
+## Poly-Safe overlay instructions
+
+This repository is a fork of Meshtastic firmware used as the base for Poly-Safe devices.
+
+Poly-Safe adds safety-oriented device modes on top of Meshtastic:
+- wearable tracker with silent alarm
+- fixed emergency button
+- screen receiver / pager
+- gateway or relay device
+- LTE-M or WiFi backhaul gateway
+- battery-low alert
+- simplified display behavior for emergency use
+
+### Poly-Safe rules
+
+- Keep Poly-Safe-specific code under `src/polysafe/` when possible.
+- Avoid modifying Meshtastic core files unless necessary.
+- When Meshtastic core files must be modified, keep changes small, explicit, and guarded.
+- Guard Poly-Safe behavior with compile-time flags such as:
+  - `POLYSAFE`
+  - `POLYSAFE_TRACKER`
+  - `POLYSAFE_FIXED_BUTTON`
+  - `POLYSAFE_SCREEN_RECEIVER`
+  - `POLYSAFE_GATEWAY`
+  - `POLYSAFE_DEVICE_T1000E`
+  - `POLYSAFE_DEVICE_WIO_L1`
+- Do not remove normal Meshtastic behavior unless the change is isolated behind a Poly-Safe flag.
+- Prefer small pull requests, each focused on one feature or one device role.
+- Each Poly-Safe change must still build for the relevant Meshtastic base target.
+
+### Poly-Safe build targets
+
+Common base targets:
+
+```bash
+pio run -e tracker-t1000-e
+pio run -e seeed_wio_tracker_L1
+pio run -e rak4631
+
 This file (`AGENTS.md`) is a short pointer + quick reference for agents that don't read `.github/copilot-instructions.md` by default.
 
 ## Quick command reference

--- a/src/input/InputBroker.cpp
+++ b/src/input/InputBroker.cpp
@@ -4,6 +4,12 @@
 #include "graphics/Screen.h"
 #include "modules/ExternalNotificationModule.h"
 
+#ifdef POLYSAFE_TRACKER
+#include "mesh/MeshService.h"
+#include "mesh/MeshTypes.h"
+#include "mesh/NodeDB.h"
+#endif
+
 #if ARCH_PORTDUINO
 #include "input/LinuxInputImpl.h"
 #include "input/SeesawRotary.h"
@@ -31,6 +37,29 @@
 
 #if HAS_BUTTON || defined(ARCH_PORTDUINO)
 #include "input/ButtonThread.h"
+
+#ifdef POLYSAFE_TRACKER
+extern MeshService *service;
+extern NodeDB *nodeDB;
+
+static uint32_t polySafeLastAlertSent = 0;
+
+#ifndef POLYSAFE_ALERT_COOLDOWN_MS
+#define POLYSAFE_ALERT_COOLDOWN_MS 15000
+#endif
+
+#ifndef POLYSAFE_ALERT_PORTNUM
+#define POLYSAFE_ALERT_PORTNUM 150
+#endif
+
+#ifndef POLYSAFE_ALERT_CHANNEL
+#define POLYSAFE_ALERT_CHANNEL 0
+#endif
+
+#ifndef POLYSAFE_BUTTON_SLEEP_LONG_PRESS_MS
+#define POLYSAFE_BUTTON_SLEEP_LONG_PRESS_MS 10000
+#endif
+#endif
 
 #if defined(BUTTON_PIN_TOUCH)
 ButtonThread *TouchButtonThread = nullptr;
@@ -114,6 +143,41 @@ int InputBroker::handleInputEvent(const InputEvent *event)
         // If this turns off a notification, don't further process the event
         return 0;
     }
+    #ifdef POLYSAFE_TRACKER
+    if (event && event->inputEvent == INPUT_BROKER_SEND_PING) {
+        uint32_t now = millis();
+
+        if (now - polySafeLastAlertSent < POLYSAFE_ALERT_COOLDOWN_MS) {
+            LOG_INFO("Poly-Safe alert blocked by cooldown");
+            return 0;
+        }
+
+        meshtastic_MeshPacket *p = packetPool.allocZeroed();
+        if (!p) {
+            LOG_WARN("Poly-Safe alert failed: packet allocation failed");
+            return 0;
+        }
+
+        polySafeLastAlertSent = now;
+
+        p->to = NODENUM_BROADCAST;
+        p->from = nodeDB->getNodeNum();
+        p->want_ack = false;
+        p->hop_limit = config.lora.hop_limit;
+        p->channel = POLYSAFE_ALERT_CHANNEL;
+        p->which_payload_variant = meshtastic_MeshPacket_decoded_tag;
+        p->decoded.portnum = (meshtastic_PortNum)POLYSAFE_ALERT_PORTNUM;
+
+        uint32_t tagID = nodeDB->getNodeNum();
+        memcpy(p->decoded.payload.bytes, &tagID, sizeof(tagID));
+        p->decoded.payload.size = sizeof(tagID);
+
+        service->sendToMesh(p);
+
+        LOG_INFO("Poly-Safe alert sent | Tag %u", tagID);
+        return 0;
+    }
+#endif
 
 #if HAS_SCREEN
     if (screen && screenWasOff) {
@@ -317,6 +381,9 @@ void InputBroker::Init()
         userConfig.longPress = INPUT_BROKER_SELECT;
         userConfig.longPressTime = 500;
         userConfig.longLongPress = INPUT_BROKER_SHUTDOWN;
+        #ifdef POLYSAFE_TRACKER
+        userConfig.longLongPressTime = POLYSAFE_BUTTON_SLEEP_LONG_PRESS_MS;
+#endif
         UserButtonThread->initButton(userConfig);
     } else
 #endif
@@ -337,6 +404,9 @@ void InputBroker::Init()
         userConfigNoScreen.longPress = INPUT_BROKER_NONE;
         userConfigNoScreen.longPressTime = 500;
         userConfigNoScreen.longLongPress = INPUT_BROKER_SHUTDOWN;
+        #ifdef POLYSAFE_TRACKER
+        userConfigNoScreen.longLongPressTime = POLYSAFE_BUTTON_SLEEP_LONG_PRESS_MS;
+#endif
         userConfigNoScreen.doublePress = INPUT_BROKER_SEND_PING;
         userConfigNoScreen.triplePress = INPUT_BROKER_GPS_TOGGLE;
         UserButtonThread->initButton(userConfigNoScreen);

--- a/src/polysafe/PolySafeConfig.h
+++ b/src/polysafe/PolySafeConfig.h
@@ -1,0 +1,15 @@
+﻿#pragma once
+
+#define POLYSAFE_VERSION "0.1.0"
+
+// Roles Poly-Safe
+#define POLYSAFE_ROLE_TRACKER 1
+#define POLYSAFE_ROLE_FIXED_BUTTON 2
+#define POLYSAFE_ROLE_SCREEN_RECEIVER 3
+#define POLYSAFE_ROLE_GATEWAY 4
+
+// Seuils par défaut
+#define POLYSAFE_LOW_BATTERY_PERCENT 10
+
+// Anti-spam alerte, en millisecondes
+#define POLYSAFE_ALERT_COOLDOWN_MS 300000

--- a/variants/polysafe/platformio.ini
+++ b/variants/polysafe/platformio.ini
@@ -1,0 +1,17 @@
+[env:polysafe-t1000e]
+extends = env:tracker-t1000-e
+build_flags =
+    ${env:tracker-t1000-e.build_flags}
+    -D POLYSAFE=1
+    -D POLYSAFE_TRACKER=1
+    -D POLYSAFE_DEVICE_T1000E=1
+    -I src/polysafe
+
+[env:polysafe-wio-l1]
+extends = env:seeed_wio_tracker_L1
+build_flags =
+    ${env:seeed_wio_tracker_L1.build_flags}
+    -D POLYSAFE=1
+    -D POLYSAFE_SCREEN_RECEIVER=1
+    -D POLYSAFE_DEVICE_WIO_L1=1
+    -I src/polysafe


### PR DESCRIPTION
Adds Poly-Safe alert behavior for the T1000-E variant.

Behavior:
- intercepts INPUT_BROKER_SEND_PING when POLYSAFE_TRACKER is enabled
- sends a broadcast mesh packet on custom portnum 150
- payload contains the local node number
- adds cooldown protection to avoid alert spam
- keeps normal Meshtastic behavior unchanged outside POLYSAFE_TRACKER builds

Tested:
- pio run -e polysafe-t1000e
- pio run -e tracker-t1000-e
