### PR TITLE
fix: MQTT connection on Portduino/Linux native nodes

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -350,6 +350,8 @@ inline bool isConnectedToNetwork()
     return WiFi.isConnected();
 #elif HAS_ETHERNET
     return Ethernet.linkStatus() == LinkON;
+#elif defined(ARCH_PORTDUINO)
+    return true;
 #else
     return false;
 #endif


### PR DESCRIPTION
## Problem
When running meshtasticd as a software-only node (no radio hardware) 
on Linux/Portduino, MQTT never connects at boot despite correct 
configuration. The node shows "MQTT server on a private IP" but never 
attempts a connection.

## Root Cause
`isConnectedToNetwork()` in MQTT.cpp always returns `false` on 
ARCH_PORTDUINO because none of HAS_WIFI, HAS_ETHERNET, or USE_WS5500 
are defined for Linux native builds. This causes `wantsLink()` to 
always return `false`, which causes `runOnce()` to immediately disable 
the MQTT thread on every boot.

## Fix
Return `true` for ARCH_PORTDUINO since Linux always has network 
access available through the host OS.

## Testing
Tested on Ubuntu 24.04 running meshtasticd as a cloud-based 
software-only MQTT node. MQTT now connects automatically at boot 
without any manual intervention.