### PR TITLE
Debian: Correctly fail upon failure

### DIFF
--- a/debian/ci_pack_sdeb.sh
+++ b/debian/ci_pack_sdeb.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/bash
+set -e
 export DEBEMAIL="jbennett@incomsystems.biz"
 export PLATFORMIO_LIBDEPS_DIR=pio/libdeps
 export PLATFORMIO_PACKAGES_DIR=pio/packages


### PR DESCRIPTION
Fake success is BS! We should fail when we fail.
Fixes issues with Debian sourcedebs silently failing to build ocassionally (due to github 502s, etc).