### PR TITLE
Docker-Alpine: Align version between build/main stages

### DIFF
--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -3,7 +3,8 @@
 # trunk-ignore-all(hadolint/DL3018): Do not pin apk package versions
 # trunk-ignore-all(hadolint/DL3013): Do not pin pip package versions
 
-FROM python:3.14-alpine3.22 AS builder
+# Ensure the Alpine version is updated in both stages of the container!
+FROM python:3.14-alpine3.23 AS builder
 ARG PIO_ENV=native
 ENV PIP_ROOT_USER_ACTION=ignore
 


### PR DESCRIPTION
```
FROM python:3.14-alpine3.23 AS builder
FROM alpine:3.23
```
The `alpine` version needs to match in both stages 😅