### PR TITLE
Update PhoneAPI.cpp to reduce chattiness

### DIFF
--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -522,11 +522,6 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
             // LOG_INFO("nodeinfo: num=0x%x, lastseen=%u, id=%s, name=%s", nodeInfoForPhone.num, nodeInfoForPhone.last_heard,
             // nodeInfoForPhone.user.id, nodeInfoForPhone.user.long_name);
 
-            // Occasional progress logging. (readIndex==2 will be true for the first non-us node)
-            if (readIndex == 2 || readIndex % 20 == 0) {
-                LOG_DEBUG("nodeinfo: %d/%d", readIndex, nodeDB->getNumMeshNodes());
-            }
-
             fromRadioScratch.which_payload_variant = meshtastic_FromRadio_node_info_tag;
             fromRadioScratch.node_info = infoToSend;
             prefetchNodeInfos();
@@ -657,9 +652,11 @@ void PhoneAPI::releaseQueueStatusPhonePacket()
 void PhoneAPI::prefetchNodeInfos()
 {
     bool added = false;
+    bool wasEmpty = false;
     // Keep the queue topped up so BLE reads stay responsive even if DB fetches take a moment.
     {
         concurrency::LockGuard guard(&nodeInfoMutex);
+        wasEmpty = nodeInfoQueue.empty();
         while (nodeInfoQueue.size() < kNodePrefetchDepth) {
             auto nextNode = nodeDB->readNextMeshNode(readIndex);
             if (!nextNode)
@@ -673,11 +670,15 @@ void PhoneAPI::prefetchNodeInfos()
             info.via_mqtt = isUs ? false : info.via_mqtt;
             info.is_favorite = info.is_favorite || isUs;
             nodeInfoQueue.push_back(info);
+            // Log progress here (at fetch time) so readIndex is accurate and each value logs only once.
+            if (readIndex == 2 || readIndex % 20 == 0) {
+                LOG_DEBUG("nodeinfo: %d/%d", readIndex, nodeDB->getNumMeshNodes());
+            }
             added = true;
         }
     }
 
-    if (added)
+    if (added && wasEmpty)
         onNowHasData(0);
 }
 


### PR DESCRIPTION
Update PhoneAPI.cpp to reduce chattiness, this fixes an excessive number of "INFO  | 21:01:05 13 BLE notify fromNum" lines and improves initial connection by roughly 2.5 seconds.

PR'd against develop as it's hard to test if this has created a regression anywhere.

**Before:**
DEBUG | 21:01:05 13 Send My NodeInfo
INFO  | 21:01:05 13 BLE notify fromNum
...
INFO  | 21:01:06 14 BLE notify fromNum
DEBUG | 21:01:06 14 nodeinfo: 20/80
INFO  | 21:01:06 14 BLE notify fromNum
...
INFO  | 21:01:07 15 BLE notify fromNum
DEBUG | 21:01:07 15 nodeinfo: 40/80
INFO  | 21:01:07 15 BLE notify fromNum
...INFO  | 21:01:09 17 BLE notify fromNum
DEBUG | 21:01:09 17 nodeinfo: 60/80
INFO  | 21:01:09 17 BLE notify fromNum
...
INFO  | 21:01:10 18 BLE notify fromNum
DEBUG | 21:01:10 18 nodeinfo: 80/80
DEBUG | 21:01:10 18 nodeinfo: 80/80
DEBUG | 21:01:10 18 nodeinfo: 80/80
DEBUG | 21:01:10 18 nodeinfo: 80/80
DEBUG | 21:01:10 18 Done sending 80 of 80 nodeinfos millis=18884

**After:**
DEBUG | 21:10:09 11 Send My NodeInfo
INFO  | 21:10:09 11 BLE notify fromNum
DEBUG | 21:10:09 11 nodeinfo: 2/80
INFO  | 21:10:09 11 BLE notify fromNum
DEBUG | 21:10:10 12 nodeinfo: 20/80
DEBUG | 21:10:11 13 nodeinfo: 40/80
DEBUG | 21:10:12 14 nodeinfo: 60/80
DEBUG | 21:10:13 15 nodeinfo: 80/80
DEBUG | 21:10:14 16 Done sending 80 of 80 nodeinfos millis=16307