### PR TITLE
fix: INA226 sensor detection

### DIFF
--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -442,15 +442,17 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
                         type = INA260;
                     }
                 }
+                if (type == NONE) {
 #if HAS_TELEMETRY && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
-                if (type == NONE && detectSHT21SerialNumber(i2cBus, (uint8_t)addr.address)) {
-                    logFoundDevice("SHTXX (SHT2X)", (uint8_t)addr.address);
-                    type = SHTXX;
-                }
+                    if (detectSHT21SerialNumber(i2cBus, (uint8_t)addr.address)) {
+                        logFoundDevice("SHTXX (SHT2X)", (uint8_t)addr.address);
+                        type = SHTXX;
+                    } else
 #endif
-                else { // Assume INA219 if none of the above ones are found
-                    logFoundDevice("INA219", (uint8_t)addr.address);
-                    type = INA219;
+                    { // Assume INA219 if none of the above ones are found
+                        logFoundDevice("INA219", (uint8_t)addr.address);
+                        type = INA219;
+                    }
                 }
                 break;
             }


### PR DESCRIPTION
## Problem
The firmware attempted to read data from an INA226 power sensor as if it were an INA219. Due to an incorrect conditional, any supported INA* sensor was incorrectly identified as an INA219.

Related logs:
```
INFO  | ??:??:?? 0 Scan for i2c devices
DEBUG | ??:??:?? 0 Scan for I2C devices on port 1
DEBUG | ??:??:?? 0 Register value from 0x40: 0x5449
DEBUG | ??:??:?? 0 Register MFG_UID: 0x5449
DEBUG | ??:??:?? 0 Register value from 0x40: 0x2260
DEBUG | ??:??:?? 0 Register DIE_UID: 0x2260
INFO  | ??:??:?? 0 INA226 found at address 0x40
INFO  | ??:??:?? 0 INA219 found at address 0x40
INFO  | ??:??:?? 0 Device found at address 0x47 was not able to be enumerated
INFO  | ??:??:?? 0 1 I2C devices found
```
## Fix
Fixed the incorrect conditional used for sensor detection.

## Hardware
ESP32-C6 + E22900M30S + INA226 + BMP580