### PR TITLE
MacOS: Correct pkg-config name `openssl` for ulfius.

### DIFF
--- a/.github/workflows/build_macos_bin.yml
+++ b/.github/workflows/build_macos_bin.yml
@@ -24,7 +24,7 @@ jobs:
         shell: bash
         run: |
           brew update
-          brew install platformio yaml-cpp libuv openssl@3 libusb argp-standalone pkg-config
+          brew install platformio yaml-cpp libuv openssl@3 libusb argp-standalone pkg-config ulfius
 
       - name: Get release version string
         run: |

--- a/variants/native/portduino/platformio.ini
+++ b/variants/native/portduino/platformio.ini
@@ -195,14 +195,12 @@ build_flags = ${portduino_base.build_flags_common}
   -DMESHTASTIC_EXCLUDE_SCREEN=1
   ; openssl@3 is the keg-only Homebrew formula; --cflags is required so the
   ; compiler finds <openssl/*.h> in the Homebrew prefix (not just the linker).
-  !pkg-config --cflags --libs openssl@3 --silence-errors || :
+  !pkg-config --cflags --libs openssl --silence-errors || :
   ; PiWebServer (src/mesh/raspihttp/PiWebServer.cpp) auto-engages when ulfius
   ; headers are reachable via `#if __has_include(<ulfius.h>)`. The `|| :`
   ; tail keeps the build green when the user hasn't run `brew install ulfius`
   ; — they just don't get the HTTP API in that case.
   !pkg-config --cflags --libs libulfius --silence-errors || :
-  !pkg-config --cflags --libs liborcania --silence-errors || :
-  !pkg-config --cflags --libs libyder --silence-errors || :
 ; src/input/Linux*.{cpp,h} drive evdev (`<linux/input.h>`) which doesn't exist
 ; on macOS. graphics/Panel_sdl.* and graphics/TFTDisplay.cpp pull LovyanGFX
 ; (which we lib_ignore on macOS for the <malloc.h> issue). Neither is needed


### PR DESCRIPTION
Addendum to
- #10366 

Fix openssl linker issues when building for `native-macos`