### PR TITLE
Draft: feat(esp32): add Bluetooth Classic variant for connectivity with legacy devices

### DIFF
--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -221,8 +221,10 @@ void RedirectablePrint::log_to_ble(const char *logLevel, const char *format, va_
 #if !MESHTASTIC_EXCLUDE_BLUETOOTH
     if (config.security.debug_log_api_enabled && !pauseBluetoothLogging) {
         bool isBleConnected = false;
-#ifdef ARCH_ESP32
+#if defined(ARCH_ESP32) && !MESHTASTIC_ENABLE_BLUETOOTHCLASSIC
         isBleConnected = nimbleBluetooth && nimbleBluetooth->isActive() && nimbleBluetooth->isConnected();
+#elif defined(ARCH_ESP32) && MESHTASTIC_ENABLE_BLUETOOTHCLASSIC
+        isBleConnected = bluetoothClassic && bluetoothClassic->isActive() && bluetoothClassic->isConnected();
 #elif defined(ARCH_NRF52)
         isBleConnected = nrf52Bluetooth != nullptr && nrf52Bluetooth->isConnected();
 #endif
@@ -237,8 +239,10 @@ void RedirectablePrint::log_to_ble(const char *logLevel, const char *format, va_
 
             auto buffer = std::unique_ptr<uint8_t[]>(new uint8_t[meshtastic_LogRecord_size]);
             size_t size = pb_encode_to_bytes(buffer.get(), meshtastic_LogRecord_size, meshtastic_LogRecord_fields, &logRecord);
-#ifdef ARCH_ESP32
+#if defined(ARCH_ESP32) && !MESHTASTIC_ENABLE_BLUETOOTHCLASSIC
             nimbleBluetooth->sendLog(buffer.get(), size);
+#elif defined(ARCH_ESP32) && MESHTASTIC_ENABLE_BLUETOOTHCLASSIC
+            bluetoothClassic->sendLog(buffer.get(), size);
 #elif defined(ARCH_NRF52)
             nrf52Bluetooth->sendLog(buffer.get(), size);
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,7 +48,10 @@
 #if !MESHTASTIC_EXCLUDE_WEBSERVER
 #include "mesh/http/WebServer.h"
 #endif
-#if !MESHTASTIC_EXCLUDE_BLUETOOTH
+#if MESHTASTIC_ENABLE_BLUETOOTHCLASSIC
+#include "modules/esp32/BluetoothClassic.h"
+BluetoothClassic *bluetoothClassic = nullptr;
+#elif !MESHTASTIC_EXCLUDE_BLUETOOTH
 #include "nimble/NimbleBluetooth.h"
 NimbleBluetooth *nimbleBluetooth = nullptr;
 #endif

--- a/src/main.h
+++ b/src/main.h
@@ -11,7 +11,10 @@
 #include "mesh/generated/meshtastic/telemetry.pb.h"
 #include <SPI.h>
 #include <map>
-#if defined(ARCH_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32S2)
+#if defined(ARCH_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32S2) && defined(MESHTASTIC_ENABLE_BLUETOOTHCLASSIC)
+#include "modules/esp32/BluetoothClassic.h"
+extern BluetoothClassic *bluetoothClassic;
+#elif defined(ARCH_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32S2)
 #include "nimble/NimbleBluetooth.h"
 extern NimbleBluetooth *nimbleBluetooth;
 #endif

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -407,7 +407,9 @@ meshtastic_NodeInfoLite *MeshService::refreshLocalMeshNode()
     position.time = getValidTime(RTCQualityFromNet);
 
     if (powerStatus->getHasBattery() == 1) {
-        updateBatteryLevel(powerStatus->getBatteryChargePercent());
+        if (!updateBatteryLevel) {
+            updateBatteryLevel(powerStatus->getBatteryChargePercent());
+        }
     }
 
     return node;

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -1335,7 +1335,12 @@ void AdminModule::handleGetDeviceConnectionStatus(const meshtastic_MeshPacket &r
 #if HAS_BLUETOOTH
     conn.has_bluetooth = true;
     conn.bluetooth.pin = config.bluetooth.fixed_pin;
-#ifdef ARCH_ESP32
+#if defined(ARCH_ESP32) && MESHTASTIC_ENABLE_BLUETOOTHCLASSIC
+    if (config.bluetooth.enabled && bluetoothClassic) {
+        conn.bluetooth.is_connected = bluetoothClassic->isConnected();
+        conn.bluetooth.rssi = bluetoothClassic->getRssi();
+    }
+#elif defined(ARCH_ESP32)
     if (config.bluetooth.enabled && nimbleBluetooth) {
         conn.bluetooth.is_connected = nimbleBluetooth->isConnected();
         conn.bluetooth.rssi = nimbleBluetooth->getRssi();
@@ -1599,8 +1604,13 @@ void disableBluetooth()
 {
 #if HAS_BLUETOOTH
 #ifdef ARCH_ESP32
+#if !MESHTASTIC_ENABLE_BLUETOOTHCLASSIC
     if (nimbleBluetooth)
         nimbleBluetooth->deinit();
+#else
+    if (bluetoothClassic)
+        bluetoothClassic->deinit();
+#endif
 #elif defined(ARCH_NRF52)
     if (nrf52Bluetooth)
         nrf52Bluetooth->shutdown();

--- a/src/modules/esp32/BluetoothClassic.cpp
+++ b/src/modules/esp32/BluetoothClassic.cpp
@@ -1,0 +1,77 @@
+
+#include "configuration.h"
+#include "DebugConfiguration.h"
+#include "BluetoothSerial.h"
+#include "BluetoothClassic.h"
+
+#if !defined(CONFIG_BT_ENABLED) || !defined(CONFIG_BLUEDROID_ENABLED)
+#error Bluetooth is not enabled! Please run `make menuconfig` to and enable it
+#endif
+
+const char *pin = "123456"; // Change this to more secure PIN.
+
+BluetoothSerial SerialBT;
+
+String message = "";
+char incomingChar;
+
+void BluetoothClassic::setup()
+{
+  // Bluetooth device name
+  // TODO use getDeviceName()
+  SerialBT.begin("meshtastic_btclassic");
+  LOG_INFO("The device started, now you can pair it with bluetooth classic!");
+  SerialBT.setPin(pin);
+  LOG_INFO("Using PIN");
+  // TODO setup callback
+}
+
+// Bluetooth Event Handler CallBack Function Definition
+void BT_EventHandler(esp_spp_cb_event_t event, esp_spp_cb_param_t *param) {
+  if (event == ESP_SPP_START_EVT) {
+    LOG_INFO("Initialized SPP");
+  }
+  else if (event == ESP_SPP_SRV_OPEN_EVT ) {
+    LOG_INFO("Client connected");
+  }
+  else if (event == ESP_SPP_CLOSE_EVT  ) {
+    LOG_INFO("Client disconnected");
+  }
+  // else if (event == ESP_SPP_DATA_IND_EVT ) {
+  //   LOG_INFO("Data received");
+  //   while (SerialBT.available()) {
+  //     int incoming = SerialBT.read();
+  //     LOG_INFO(incoming);
+  //   }
+  // }
+}
+
+void BluetoothClassic::sendLog(const uint8_t *logMessage, size_t length)
+{
+   //SerialBT.write(logMessage);
+   if (SerialBT.available()){
+    char incomingChar = SerialBT.read();
+    if (incomingChar != '\n'){
+      message += String(incomingChar);
+    }
+    else{
+      message = "";
+    }
+    //LOG_INFO(incomingChar);
+  }
+  delay(20);
+}
+
+// TODO
+void BluetoothClassic::shutdown() {}
+void BluetoothClassic::deinit() {}
+void BluetoothClassic::clearBonds() {}
+bool BluetoothClassic::isActive() {
+  return false;
+}
+bool BluetoothClassic::isConnected() {
+  return false;
+}
+int BluetoothClassic::getRssi() {
+  return 0;
+}

--- a/src/modules/esp32/BluetoothClassic.cpp
+++ b/src/modules/esp32/BluetoothClassic.cpp
@@ -1,8 +1,8 @@
 
-#include "configuration.h"
-#include "DebugConfiguration.h"
-#include "BluetoothSerial.h"
 #include "BluetoothClassic.h"
+#include "BluetoothSerial.h"
+#include "DebugConfiguration.h"
+#include "configuration.h"
 
 #if !defined(CONFIG_BT_ENABLED) || !defined(CONFIG_BLUEDROID_ENABLED)
 #error Bluetooth is not enabled! Please run `make menuconfig` to and enable it
@@ -17,61 +17,62 @@ char incomingChar;
 
 void BluetoothClassic::setup()
 {
-  // Bluetooth device name
-  // TODO use getDeviceName()
-  SerialBT.begin("meshtastic_btclassic");
-  LOG_INFO("The device started, now you can pair it with bluetooth classic!");
-  SerialBT.setPin(pin);
-  LOG_INFO("Using PIN");
-  // TODO setup callback
+    // Bluetooth device name
+    // TODO use getDeviceName()
+    SerialBT.begin("meshtastic_btclassic");
+    LOG_INFO("The device started, now you can pair it with bluetooth classic!");
+    SerialBT.setPin(pin);
+    LOG_INFO("Using PIN");
+    // TODO setup callback
 }
 
 // Bluetooth Event Handler CallBack Function Definition
-void BT_EventHandler(esp_spp_cb_event_t event, esp_spp_cb_param_t *param) {
-  if (event == ESP_SPP_START_EVT) {
-    LOG_INFO("Initialized SPP");
-  }
-  else if (event == ESP_SPP_SRV_OPEN_EVT ) {
-    LOG_INFO("Client connected");
-  }
-  else if (event == ESP_SPP_CLOSE_EVT  ) {
-    LOG_INFO("Client disconnected");
-  }
-  // else if (event == ESP_SPP_DATA_IND_EVT ) {
-  //   LOG_INFO("Data received");
-  //   while (SerialBT.available()) {
-  //     int incoming = SerialBT.read();
-  //     LOG_INFO(incoming);
-  //   }
-  // }
+void BT_EventHandler(esp_spp_cb_event_t event, esp_spp_cb_param_t *param)
+{
+    if (event == ESP_SPP_START_EVT) {
+        LOG_INFO("Initialized SPP");
+    } else if (event == ESP_SPP_SRV_OPEN_EVT) {
+        LOG_INFO("Client connected");
+    } else if (event == ESP_SPP_CLOSE_EVT) {
+        LOG_INFO("Client disconnected");
+    }
+    // else if (event == ESP_SPP_DATA_IND_EVT ) {
+    //   LOG_INFO("Data received");
+    //   while (SerialBT.available()) {
+    //     int incoming = SerialBT.read();
+    //     LOG_INFO(incoming);
+    //   }
+    // }
 }
 
 void BluetoothClassic::sendLog(const uint8_t *logMessage, size_t length)
 {
-   //SerialBT.write(logMessage);
-   if (SerialBT.available()){
-    char incomingChar = SerialBT.read();
-    if (incomingChar != '\n'){
-      message += String(incomingChar);
+    // SerialBT.write(logMessage);
+    if (SerialBT.available()) {
+        char incomingChar = SerialBT.read();
+        if (incomingChar != '\n') {
+            message += String(incomingChar);
+        } else {
+            message = "";
+        }
+        // LOG_INFO(incomingChar);
     }
-    else{
-      message = "";
-    }
-    //LOG_INFO(incomingChar);
-  }
-  delay(20);
+    delay(20);
 }
 
 // TODO
 void BluetoothClassic::shutdown() {}
 void BluetoothClassic::deinit() {}
 void BluetoothClassic::clearBonds() {}
-bool BluetoothClassic::isActive() {
-  return false;
+bool BluetoothClassic::isActive()
+{
+    return false;
 }
-bool BluetoothClassic::isConnected() {
-  return false;
+bool BluetoothClassic::isConnected()
+{
+    return false;
 }
-int BluetoothClassic::getRssi() {
-  return 0;
+int BluetoothClassic::getRssi()
+{
+    return 0;
 }

--- a/src/modules/esp32/BluetoothClassic.h
+++ b/src/modules/esp32/BluetoothClassic.h
@@ -1,0 +1,25 @@
+
+#pragma once
+#include "BluetoothCommon.h"
+#include "BluetoothSerial.h"
+
+class BluetoothClassic : BluetoothApi
+{
+  public:
+    void setup();
+    void shutdown();
+    void deinit();
+    void clearBonds();
+    bool isActive();
+    bool isConnected();
+    int getRssi();
+    void sendLog(const uint8_t *logMessage, size_t length);
+    bool isDeInit = false;
+
+  private:
+    void setupService();
+};
+
+void setBluetoothEnable(bool enable);
+
+extern BluetoothClassic *bluetoothClassic;

--- a/src/nimble/NimbleBluetooth.cpp
+++ b/src/nimble/NimbleBluetooth.cpp
@@ -1,5 +1,5 @@
 #include "configuration.h"
-#if !MESHTASTIC_EXCLUDE_BLUETOOTH
+#if !MESHTASTIC_EXCLUDE_BLUETOOTH && !MESHTASTIC_ENABLE_BLUETOOTHCLASSIC
 #include "BluetoothCommon.h"
 #include "NimbleBluetooth.h"
 #include "PowerFSM.h"

--- a/src/platform/esp32/main-esp32.cpp
+++ b/src/platform/esp32/main-esp32.cpp
@@ -4,8 +4,11 @@
 #include "esp_task_wdt.h"
 #include "main.h"
 
-#if !defined(CONFIG_IDF_TARGET_ESP32S2) && !MESHTASTIC_EXCLUDE_BLUETOOTH
+#if !defined(CONFIG_IDF_TARGET_ESP32S2) && !MESHTASTIC_EXCLUDE_BLUETOOTH && !MESHTASTIC_ENABLE_BLUETOOTHCLASSIC
 #include "nimble/NimbleBluetooth.h"
+#endif
+#if !defined(CONFIG_IDF_TARGET_ESP32S2) && !MESHTASTIC_EXCLUDE_BLUETOOTH && MESHTASTIC_ENABLE_BLUETOOTHCLASSIC
+#include "modules/esp32/BluetoothClassic.h"
 #endif
 
 #include <MeshtasticOTA.h>
@@ -39,6 +42,18 @@ void setBluetoothEnable(bool enable)
 #else
     if (config.bluetooth.enabled == true)
 #endif
+#if MESHTASTIC_ENABLE_BLUETOOTHCLASSIC
+    {
+        if (!bluetoothClassic) {
+            bluetoothClassic = new BluetoothClassic();
+        }
+        if (enable && !bluetoothClassic->isActive()) {
+            powerMon->setState(meshtastic_PowerMon_State_BT_On);
+            bluetoothClassic->setup();
+        }
+    }
+}
+#else
     {
         if (!nimbleBluetooth) {
             nimbleBluetooth = new NimbleBluetooth();
@@ -52,6 +67,7 @@ void setBluetoothEnable(bool enable)
         // For deep-sleep, shutdown hardware with nimbleBluetooth->deinit(). Requires reboot to reverse
     }
 }
+#endif
 #else
 void setBluetoothEnable(bool enable) {}
 void updateBatteryLevel(uint8_t level) {}

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -218,10 +218,13 @@ void doDeepSleep(uint32_t msecToWake, bool skipPreflight = false, bool skipSaveN
     // esp_wifi_stop();
     waitEnterSleep(skipPreflight);
 
-#if defined(ARCH_ESP32) && !MESHTASTIC_EXCLUDE_BLUETOOTH
+#if defined(ARCH_ESP32) && !MESHTASTIC_EXCLUDE_BLUETOOTH && !MESHTASTIC_ENABLE_BLUETOOTHCLASSIC
     // Full shutdown of bluetooth hardware
     if (nimbleBluetooth)
         nimbleBluetooth->deinit();
+#elif defined(ARCH_ESP32) && !MESHTASTIC_EXCLUDE_BLUETOOTH && MESHTASTIC_ENABLE_BLUETOOTHCLASSIC
+    if (bluetoothClassic)
+        bluetoothClassic->deinit();
 #endif
 
 #ifdef ARCH_ESP32

--- a/variants/esp32/diy/btclassic/platformio.ini
+++ b/variants/esp32/diy/btclassic/platformio.ini
@@ -1,0 +1,43 @@
+; Meshtastic DIY v1 by Nano VHF Schematic based on ESP32-WROOM-32 (38 pins) devkit & EBYTE E22 SX1262/SX1268 module
+[env:meshtastic-diy-btclassic]
+custom_meshtastic_hw_model = 39
+custom_meshtastic_hw_model_slug = DIY_V1
+custom_meshtastic_architecture = esp32
+custom_meshtastic_actively_supported = false
+#custom_meshtastic_support_level = 3
+custom_meshtastic_display_name = DIY btclassic
+custom_meshtastic_images = diy.svg
+custom_meshtastic_tags = DIY
+
+extends = esp32_base
+board = esp32doit-devkit-v1
+board_check = true
+#TODO remove Nimble dependency
+
+build_flags =
+  ${esp32_base.build_flags}
+  -D DIY_V1
+  -D EBYTE_E22
+  # WIP - so firmware fits in size, awaiting disable nimble
+  -DMESHTASTIC_EXCLUDE_GPS=1
+  -DMESHTASTIC_EXCLUDE_MQTT=1
+  #-D MESHTASTIC_EXCLUDE_BLUETOOTH
+  #-D CONFIG_BT_ENABLED
+  #-D CONFIG_BLUEDROID_ENABLED
+  -D MESHTASTIC_ENABLE_BLUETOOTHCLASSIC
+  -I variants/esp32/diy/btclassic
+
+lib_deps =
+  ${arduino_base.lib_deps}
+  ${networking_base.lib_deps}
+  ${networking_extra.lib_deps}
+  ${radiolib_base.lib_deps}
+  ${environmental_base.lib_deps}
+  ${environmental_extra_no_bsec.lib_deps}
+  # renovate: datasource=custom.pio depName=NimBLE-Arduino packageName=h2zero/library/NimBLE-Arduino
+  # TODO DISABLE
+  h2zero/NimBLE-Arduino@1.4.3
+  # renovate: datasource=custom.pio depName=XPowersLib packageName=lewisxhe/library/XPowersLib
+  lewisxhe/XPowersLib@0.3.3
+  # renovate: datasource=custom.pio depName=rweather/Crypto packageName=rweather/library/Crypto
+  rweather/Crypto@0.4.0

--- a/variants/esp32/diy/btclassic/variant.h
+++ b/variants/esp32/diy/btclassic/variant.h
@@ -1,0 +1,57 @@
+// For OLED LCD
+#define I2C_SDA 21
+#define I2C_SCL 22
+
+// GPS
+#undef GPS_RX_PIN
+#undef GPS_TX_PIN
+#define GPS_RX_PIN 12
+#define GPS_TX_PIN 15
+#define GPS_UBLOX
+
+#define BUTTON_PIN 39  // The middle button GPIO on the T-Beam
+#define BATTERY_PIN 35 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
+#define ADC_CHANNEL ADC1_GPIO35_CHANNEL
+#define ADC_MULTIPLIER 1.85 // (R1 = 470k, R2 = 680k)
+#define EXT_PWR_DETECT 4    // Pin to detect connected external power source for LILYGO® TTGO T-Energy T18 and other DIY boards
+#define EXT_NOTIFY_OUT 12   // Overridden default pin to use for Ext Notify Module (#975).
+#define LED_POWER 2         // add status LED (compatible with core-pcb and DIY targets)
+
+#define LORA_DIO0 26  // a No connect on the SX1262/SX1268 module
+#define LORA_RESET 23 // RST for SX1276, and for SX1262/SX1268
+#define LORA_DIO1 33  // IRQ for SX1262/SX1268
+#define LORA_DIO2 32  // BUSY for SX1262/SX1268
+#define LORA_DIO3     // Not connected on PCB, but internally on the TTGO SX1262/SX1268, if DIO3 is high the TXCO is enabled
+
+#define LORA_SCK 5
+#define LORA_MISO 19
+#define LORA_MOSI 27
+#define LORA_CS 18
+
+// supported modules list
+#define USE_RF95 // RFM95/SX127x
+#define USE_SX1262
+#define USE_SX1268
+#define USE_LLCC68
+
+// common pinouts for SX126X modules
+#define SX126X_CS 18 // NSS for SX126X
+#define SX126X_DIO1 LORA_DIO1
+#define SX126X_BUSY LORA_DIO2
+#define SX126X_RESET LORA_RESET
+#define SX126X_RXEN RADIOLIB_NC // Defining the RXEN ruins RFSwitching for the E22 900M30S in RadioLib
+#define SX126X_TXEN 13
+
+// RX/TX for RFM95/SX127x
+#define RF95_RXEN 14
+#define RF95_TXEN 13
+
+// Set lora.tx_power to 13 for Hydra or other E22 900M30S target due to PA
+#define SX126X_MAX_POWER 22
+
+#ifdef EBYTE_E22
+// Internally the TTGO module hooks the SX126x-DIO2 in to control the TX/RX switch
+// (which is the default for the sx1262interface code)
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8
+#define TCXO_OPTIONAL // make it so that the firmware can try both TCXO and XTAL
+#endif


### PR DESCRIPTION
fixes #10381

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)

ESP32-WROOM dev board
