### PR TITLE
fix(heltec_v4): revert USB_MODE to TinyUSB OTG (regression from #8881)

### DIFF
--- a/boards/heltec_v4.json
+++ b/boards/heltec_v4.json
@@ -9,7 +9,7 @@
     "extra_flags": [
       "-DBOARD_HAS_PSRAM",
       "-DARDUINO_USB_CDC_ON_BOOT=1",
-      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_MODE=0",
       "-DARDUINO_RUNNING_CORE=1",
       "-DARDUINO_EVENT_RUNNING_CORE=1"
     ],

--- a/boards/heltec_v4_r8.json
+++ b/boards/heltec_v4_r8.json
@@ -9,7 +9,7 @@
     "extra_flags": [
       "-DBOARD_HAS_PSRAM",
       "-DARDUINO_USB_CDC_ON_BOOT=1",
-      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_MODE=0",
       "-DARDUINO_RUNNING_CORE=1",
       "-DARDUINO_EVENT_RUNNING_CORE=1"
     ],


### PR DESCRIPTION
## Summary

Reverts `ARDUINO_USB_MODE` from `1` back to `0` in `boards/heltec_v4.json` and `boards/heltec_v4_r8.json` (regression introduced by #8881). The change in #8881 swapped the application USB-CDC stack from TinyUSB OTG to the native ESP32-S3 USB-Serial-JTAG (HWCDC) controller. While that fixed `esptool` RTS/DTR auto-reset on flash, it silently broke the Meshtastic Python CLI handshake on macOS (and several Linux setups per meshtastic/python#850) — `meshtastic --info` / `--configure` hang indefinitely after capturing the boot banner.

## Reproducer

1. Flash a Heltec V4 / V4 R8 with FW `>= 2.7.22` (any build after #8881 merged on 2025-12-07).
2. Plug into a macOS host. `ls /dev/cu.usbmodem*` shows the port. ROM-mode `esptool` works fine.
3. Boot the radio. Passive listen on the serial port shows the boot banner: `S:B:110,2.7.22.<sha>,heltec-v4`.
4. Run `meshtastic --port /dev/cu.usbmodem* --info`.
5. **Observe:** the CLI hangs at `Connected to radio` and then times out after 10s. Raw `WANT_CONFIG_ID=0xCAFE` returns 0 bytes. No application-stream traffic is received over USB even though the firmware boot path is healthy.
6. Same firmware over BLE (`meshtastic --ble`) works correctly. LoRa unaffected. Confirms the regression is USB-CDC-specific.

Reproduced on two physical Heltec V4 carts in our fleet (CART002, CART003) on FW `2.7.22.96dd647` against `python-meshtastic` `2.7.8` running on macOS Sonoma 14.6 + Apple Silicon.

## Affected hardware

- `heltec-v4` (board variant `heltec_v4`, ESP32-S3 native USB) — confirmed broken.
- `heltec-v4-r8` (board variant `heltec_v4_r8`, ESP32-S3 native USB, 8 MB OPI PSRAM) — same flag set in #8881, same regression by inspection (not directly tested on real hardware in our fleet).

## Root cause

When `ARDUINO_USB_CDC_ON_BOOT=1` is paired with `ARDUINO_USB_MODE=0`, the Arduino-ESP32 framework binds `Serial` to the TinyUSB OTG CDC class (USBSerial). When `ARDUINO_USB_CDC_ON_BOOT=1` is paired with `ARDUINO_USB_MODE=1` (the state introduced by #8881), the framework binds `Serial` to the hardware USB-Serial-JTAG controller via `HWCDC`. The Meshtastic application stream protocol (`StreamAPI` in `src/mesh/api/SerialConsole.cpp`) needs the CDC class to deliver bidirectional bulk traffic reliably; on macOS (and some Linux hosts) the HWCDC path drops application bytes silently in one direction even though boot-time `Serial.println` from the firmware is observable. esptool flashing remains fine because it only needs the bootloader RTS/DTR reset path, which HWCDC does honor — that's exactly what #8881 was solving.

This split — boot banner reaches the host but `WANT_CONFIG_ID` returns 0 bytes — matches every report on meshtastic/python#850.

The majority of native-USB ESP32-S3 boards in this repo (`heltec_wireless_tracker`, `heltec_wireless_tracker_v2`, `heltec_vision_master_e213/e290/t190`, `tbeam-s3-core`, `t-deck`, etc. — 19 boards total, vs. 10 with `MODE=1`) already use `ARDUINO_USB_MODE=0` and are unaffected.

## Fix

One-line revert in each of `boards/heltec_v4.json` and `boards/heltec_v4_r8.json`:

```diff
-      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_MODE=0",
```

Restores the TinyUSB OTG CDC path, which is what the board shipped with from #7845 (initial heltec_v4 board addition, 2025-09) until #8881 landed.

## Risk assessment

The only thing #8881 added that this revert removes is automatic `esptool` chip-reset via DTR/RTS toggling on the hardware USB-Serial-JTAG controller. After this revert, users flashing firmware over USB will need to either:

1. Hold the BOOT button while plugging in (entering ROM download mode manually), exactly as the Heltec V3 / Heltec Wireless Tracker / T-Deck and most other ESP32-S3 boards in this repo already require, **or**
2. Pass `--before usb_reset --after hard_reset` to `esptool` (host-side option, no firmware change needed).

OTA firmware update via the Meshtastic app, BLE, and the web client is unaffected. LoRa, BLE, and Meshtastic admin are unaffected. The regression this PR fixes (broken Python CLI handshake) currently makes the V4 the only Heltec ESP32-S3 board in the fleet that cannot be administered over USB at all — including diagnostic recovery flows. That's a strictly larger surface than the convenience of single-button reflash that #8881 added.

We consider this trade-off net-positive because:
- USB CLI is a runtime / recovery interface; flash-reset is a one-time-per-update inconvenience.
- The boot-button-hold workflow is already the documented norm across the rest of the ESP32-S3 board family.
- `esptool --before usb_reset` solves the same problem client-side with no firmware lock-in.

## Cross-references

- Introduced regression: https://github.com/meshtastic/firmware/pull/8881 (merged 2025-12-07)
- User-facing report on the Python side: https://github.com/meshtastic/python/issues/850 (`I can repeatably replicate it with my Heltec v4`)
- Initial heltec_v4 board addition (USB_MODE=0, working state): https://github.com/meshtastic/firmware/pull/7845
- Independent fleet reproducer + RCA write-up (external project documentation): https://github.com/eric-holtzclaw/meshtastic-golf-bridge/blob/main/docs/session-2026-05-02/B42-PLATFORMIO-DIFF-RESEARCH.md

## Test plan

- [ ] Build `heltec-v4` artifact from this branch and confirm `meshtastic --port <usb> --info` succeeds on macOS host (the failing case in #850 and our fleet).
- [ ] Confirm `esptool` flash still works with `--before usb_reset` flag (or with manual BOOT-button-hold) — same workflow as other Heltec ESP32-S3 native-USB boards in the repo.
- [ ] Sanity-check BLE and LoRa unaffected on a flashed unit.
- [ ] Same checks against `heltec-v4-r8` if hardware is available (board file changed by inspection only).
