### PR TITLE
LR2021 radio on NRF_Promicro

### DIFF
--- a/src/detect/LoRaRadioType.h
+++ b/src/detect/LoRaRadioType.h
@@ -11,7 +11,8 @@ enum LoRaRadioType {
     SX1280_RADIO,
     LR1110_RADIO,
     LR1120_RADIO,
-    LR1121_RADIO
+    LR1121_RADIO,
+    LR2021_RADIO
 };
 
 extern LoRaRadioType radioType;

--- a/src/mesh/InterfacesTemplates.cpp
+++ b/src/mesh/InterfacesTemplates.cpp
@@ -1,3 +1,5 @@
+#include "configuration.h"
+
 #include "LR11x0Interface.cpp"
 #include "LR11x0Interface.h"
 #include "LR20x0Interface.cpp"
@@ -23,7 +25,7 @@ template class LR11x0Interface<LR1110>;
 template class LR11x0Interface<LR1120>;
 template class LR11x0Interface<LR1121>;
 #endif
-#if RADIOLIB_EXCLUDE_LR2021 != 1
+#if defined(USE_LR2021) && RADIOLIB_EXCLUDE_LR2021 != 1
 template class LR20x0Interface<LR2021>;
 #endif
 #ifdef ARCH_STM32WL

--- a/src/mesh/InterfacesTemplates.cpp
+++ b/src/mesh/InterfacesTemplates.cpp
@@ -1,5 +1,7 @@
 #include "LR11x0Interface.cpp"
 #include "LR11x0Interface.h"
+#include "LR20x0Interface.cpp"
+#include "LR20x0Interface.h"
 #include "SX126xInterface.cpp"
 #include "SX126xInterface.h"
 #include "SX128xInterface.cpp"
@@ -20,6 +22,9 @@ template class SX128xInterface<SX1280>;
 template class LR11x0Interface<LR1110>;
 template class LR11x0Interface<LR1120>;
 template class LR11x0Interface<LR1121>;
+#endif
+#if RADIOLIB_EXCLUDE_LR2021 != 1
+template class LR20x0Interface<LR2021>;
 #endif
 #ifdef ARCH_STM32WL
 template class SX126xInterface<STM32WLx>;

--- a/src/mesh/LR2021Interface.cpp
+++ b/src/mesh/LR2021Interface.cpp
@@ -1,7 +1,8 @@
-#if RADIOLIB_EXCLUDE_LR2021 != 1
+#include "configuration.h"
+
+#if defined(USE_LR2021) && RADIOLIB_EXCLUDE_LR2021 != 1
 
 #include "LR2021Interface.h"
-#include "configuration.h"
 #include "error.h"
 
 LR2021Interface::LR2021Interface(LockingArduinoHal *hal, RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst,

--- a/src/mesh/LR2021Interface.cpp
+++ b/src/mesh/LR2021Interface.cpp
@@ -1,0 +1,17 @@
+#if RADIOLIB_EXCLUDE_LR2021 != 1
+
+#include "LR2021Interface.h"
+#include "configuration.h"
+#include "error.h"
+
+LR2021Interface::LR2021Interface(LockingArduinoHal *hal, RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst,
+                                 RADIOLIB_PIN_TYPE busy)
+    : LR20x0Interface(hal, cs, irq, rst, busy)
+{
+}
+
+bool LR2021Interface::wideLora()
+{
+    return true;
+}
+#endif

--- a/src/mesh/LR2021Interface.h
+++ b/src/mesh/LR2021Interface.h
@@ -1,0 +1,15 @@
+#pragma once
+#if RADIOLIB_EXCLUDE_LR2021 != 1
+#include "LR20x0Interface.h"
+
+/**
+ * Our adapter for LR2021 radios
+ */
+class LR2021Interface : public LR20x0Interface<LR2021>
+{
+  public:
+    LR2021Interface(LockingArduinoHal *hal, RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst,
+                    RADIOLIB_PIN_TYPE busy);
+    bool wideLora() override;
+};
+#endif

--- a/src/mesh/LR20x0Interface.cpp
+++ b/src/mesh/LR20x0Interface.cpp
@@ -2,9 +2,7 @@
 
 #if defined(USE_LR2021) && RADIOLIB_EXCLUDE_LR2021 != 1
 #include "LR20x0Interface.h"
-#include "Throttle.h"
 #include "error.h"
-#include "mesh/NodeDB.h"
 
 // Keep LR20x0 naming while RadioLib exposes LR2021 symbols.
 #ifndef LR20x0
@@ -34,7 +32,7 @@ static const Module::RfSwitchMode_t lr20x0_rfswitch_table[] = {
 #define LR2021_MAX_POWER 22
 #endif
 
-// the 2.4G part maxes at 13dBm ???
+// the 2.4G part maxes at 12dBm
 
 #if ARCH_PORTDUINO
 #define LR2021_MAX_POWER_HF portduino_config.lr1120_max_power
@@ -67,7 +65,7 @@ template <typename T> bool LR20x0Interface<T>::init()
 #elif defined(LR2021_DIO3_TCXO_VOLTAGE)
     float tcxoVoltage = LR2021_DIO3_TCXO_VOLTAGE;
     LOG_DEBUG("LR2021_DIO3_TCXO_VOLTAGE defined, using DIO3 as TCXO reference voltage at %f V", LR2021_DIO3_TCXO_VOLTAGE);
-    // (DIO3 is not free to be used as an IRQ) ???
+    // (DIO3 is not free to be used as an IRQ)
 #elif defined(TCXO_OPTIONAL)
     float tcxoVoltage = 1.6f; // TCXO_OPTIONAL: try default 1.6 V first, fall back to XTAL on failure
     LOG_DEBUG("TCXO_OPTIONAL: no LR2021_DIO3_TCXO_VOLTAGE defined, trying default TCXO Vref 1.6 V first");
@@ -230,7 +228,7 @@ template <typename T> bool LR20x0Interface<T>::reconfigure()
 
     startReceive(); // restart receiving
 
-    return RADIOLIB_ERR_NONE;
+    return true;
 }
 
 template <typename T> void LR20x0Interface<T>::disableInterrupt()

--- a/src/mesh/LR20x0Interface.cpp
+++ b/src/mesh/LR20x0Interface.cpp
@@ -3,6 +3,7 @@
 #if defined(USE_LR2021) && RADIOLIB_EXCLUDE_LR2021 != 1
 #include "LR20x0Interface.h"
 #include "error.h"
+#include "mesh/NodeDB.h"
 
 // Keep LR20x0 naming while RadioLib exposes LR2021 symbols.
 #ifndef LR20x0
@@ -149,9 +150,14 @@ template <typename T> bool LR20x0Interface<T>::init()
     if (res == RADIOLIB_ERR_NONE)
         res = lora.setCRC(2);
 
-        // // FIXME: May want to set depending on a definition, currently all LR1110 variant files use the DC-DC regulator option
-        // if (res == RADIOLIB_ERR_NONE)
-        //     res = lora.setRegulatorDCDC();
+        // Standard DCDC ramp timing from RadioLib workarounds (register 0x00F20024)
+        // Currently requires radiolib godmode
+        // if (res == RADIOLIB_ERR_NONE) {
+        //     uint8_t rampTimes[4] = {15, 15, 15, 15}; // Standard case for all conditions
+        //     res = lora.setRegMode(RADIOLIB_LR2021_REG_MODE_SIMO_NORMAL, rampTimes);
+        //     if (res != RADIOLIB_ERR_NONE)
+        //         LOG_WARN("LR2021 setRegMode failed: %d", res);
+        // }
 
 #ifdef LR2021_DIO_AS_RF_SWITCH
     bool dioAsRfSwitch = true;

--- a/src/mesh/LR20x0Interface.cpp
+++ b/src/mesh/LR20x0Interface.cpp
@@ -26,7 +26,7 @@ static const Module::RfSwitchMode_t lr20x0_rfswitch_table[] = {
 // Particular boards might define a different max power based on what their hardware can do, default to max power output if not
 // specified (may be dangerous if using external PA and LR20x0 power config forgotten)
 #if ARCH_PORTDUINO
-#define LR2021_MAX_POWER portduino_config.lr1110_max_power
+#define LR2021_MAX_POWER portduino_config.lr2021_max_power
 #endif
 #ifndef LR2021_MAX_POWER
 #define LR2021_MAX_POWER 22
@@ -35,7 +35,7 @@ static const Module::RfSwitchMode_t lr20x0_rfswitch_table[] = {
 // the 2.4G part maxes at 12dBm
 
 #if ARCH_PORTDUINO
-#define LR2021_MAX_POWER_HF portduino_config.lr1120_max_power
+#define LR2021_MAX_POWER_HF portduino_config.lr2021_max_power_hf
 #endif
 #ifndef LR2021_MAX_POWER_HF
 #define LR2021_MAX_POWER_HF 12
@@ -296,7 +296,7 @@ template <typename T> void LR20x0Interface<T>::startReceive()
 
     RadioLibInterface::startReceive();
 
-    // Must be done AFTER starting transmit, because startTransmit clears (possibly stale) interrupt pending register bits
+    // Must be done AFTER starting receive, because startReceive clears (possibly stale) interrupt pending register bits
     enableInterrupt(isrRxLevel0);
     checkRxDoneIrqFlag();
 #endif

--- a/src/mesh/LR20x0Interface.cpp
+++ b/src/mesh/LR20x0Interface.cpp
@@ -1,94 +1,103 @@
-#if RADIOLIB_EXCLUDE_LR11X0 != 1
-#include "LR11x0Interface.h"
+#if RADIOLIB_EXCLUDE_LR2021 != 1
+#include "LR20x0Interface.h"
 #include "Throttle.h"
 #include "configuration.h"
 #include "error.h"
 #include "mesh/NodeDB.h"
-#ifdef LR11X0_DIO_AS_RF_SWITCH
+
+// Keep LR20x0 naming while RadioLib exposes LR2021 symbols.
+#ifndef LR20x0
+#define LR20x0 LR2021
+#endif
+
+#ifdef LR2021_DIO_AS_RF_SWITCH
 #include "rfswitch.h"
 #elif ARCH_PORTDUINO
 #include "PortduinoGlue.h"
-#define rfswitch_dio_pins portduino_config.rfswitch_dio_pins
-#define rfswitch_table portduino_config.rfswitch_table
+#define lr20x0_rfswitch_dio_pins portduino_config.rfswitch_dio_pins
+#define lr20x0_rfswitch_table portduino_config.rfswitch_table
 #else
-static const uint32_t rfswitch_dio_pins[] = {RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC};
-static const Module::RfSwitchMode_t rfswitch_table[] = {
-    {LR11x0::MODE_STBY, {}},  {LR11x0::MODE_RX, {}},   {LR11x0::MODE_TX, {}},   {LR11x0::MODE_TX_HP, {}},
-    {LR11x0::MODE_TX_HF, {}}, {LR11x0::MODE_GNSS, {}}, {LR11x0::MODE_WIFI, {}}, END_OF_MODE_TABLE,
+static const uint32_t lr20x0_rfswitch_dio_pins[] = {RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC};
+static const Module::RfSwitchMode_t lr20x0_rfswitch_table[] = {
+    {LR20x0::MODE_STBY, {}},  {LR20x0::MODE_RX, {}},    {LR20x0::MODE_TX, {}},
+    {LR20x0::MODE_RX_HF, {}}, {LR20x0::MODE_TX_HF, {}}, END_OF_MODE_TABLE,
 };
 #endif
 
 // Particular boards might define a different max power based on what their hardware can do, default to max power output if not
-// specified (may be dangerous if using external PA and LR11x0 power config forgotten)
+// specified (may be dangerous if using external PA and LR20x0 power config forgotten)
 #if ARCH_PORTDUINO
-#define LR1110_MAX_POWER portduino_config.lr1110_max_power
+#define LR2021_MAX_POWER portduino_config.lr1110_max_power
 #endif
-#ifndef LR1110_MAX_POWER
-#define LR1110_MAX_POWER 22
+#ifndef LR2021_MAX_POWER
+#define LR2021_MAX_POWER 22
 #endif
 
-// the 2.4G part maxes at 13dBm
+// the 2.4G part maxes at 13dBm ???
 
 #if ARCH_PORTDUINO
-#define LR1120_MAX_POWER portduino_config.lr1120_max_power
+#define LR2021_MAX_POWER_HF portduino_config.lr1120_max_power
 #endif
-#ifndef LR1120_MAX_POWER
-#define LR1120_MAX_POWER 13
+#ifndef LR2021_MAX_POWER_HF
+#define LR2021_MAX_POWER_HF 12
 #endif
 
 template <typename T>
-LR11x0Interface<T>::LR11x0Interface(LockingArduinoHal *hal, RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst,
+LR20x0Interface<T>::LR20x0Interface(LockingArduinoHal *hal, RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst,
                                     RADIOLIB_PIN_TYPE busy)
     : RadioLibInterface(hal, cs, irq, rst, busy, &lora), lora(&module)
 {
-    LOG_WARN("LR11x0Interface(cs=%d, irq=%d, rst=%d, busy=%d)", cs, irq, rst, busy);
+    LOG_WARN("LR20x0Interface(cs=%d, irq=%d, rst=%d, busy=%d)", cs, irq, rst, busy);
 }
 
 /// Initialise the Driver transport hardware and software.
 /// Make sure the Driver is properly configured before calling init().
 /// \return true if initialisation succeeded.
-template <typename T> bool LR11x0Interface<T>::init()
+template <typename T> bool LR20x0Interface<T>::init()
 {
-#ifdef LR11X0_POWER_EN
-    pinMode(LR11X0_POWER_EN, OUTPUT);
-    digitalWrite(LR11X0_POWER_EN, HIGH);
+#ifdef LR2021_POWER_EN
+    pinMode(LR2021_POWER_EN, OUTPUT);
+    digitalWrite(LR2021_POWER_EN, HIGH);
 #endif
 
 #if ARCH_PORTDUINO
     float tcxoVoltage = (float)portduino_config.dio3_tcxo_voltage / 1000;
-// FIXME: correct logic to default to not using TCXO if no voltage is specified for LR11x0_DIO3_TCXO_VOLTAGE
-#elif defined(LR11X0_DIO3_TCXO_VOLTAGE)
-    float tcxoVoltage = LR11X0_DIO3_TCXO_VOLTAGE;
-    LOG_DEBUG("LR11X0_DIO3_TCXO_VOLTAGE defined, using DIO3 as TCXO reference voltage at %f V", LR11X0_DIO3_TCXO_VOLTAGE);
-    // (DIO3 is not free to be used as an IRQ)
+// FIXME: correct logic to default to not using TCXO if no voltage is specified for LR20x0_DIO3_TCXO_VOLTAGE
+#elif defined(LR2021_DIO3_TCXO_VOLTAGE)
+    float tcxoVoltage = LR2021_DIO3_TCXO_VOLTAGE;
+    LOG_DEBUG("LR2021_DIO3_TCXO_VOLTAGE defined, using DIO3 as TCXO reference voltage at %f V", LR2021_DIO3_TCXO_VOLTAGE);
+    // (DIO3 is not free to be used as an IRQ) ???
 #elif defined(TCXO_OPTIONAL)
     float tcxoVoltage = 1.6f; // TCXO_OPTIONAL: try default 1.6 V first, fall back to XTAL on failure
-    LOG_DEBUG("TCXO_OPTIONAL: no LR11X0_DIO3_TCXO_VOLTAGE defined, trying default TCXO Vref 1.6 V first");
+    LOG_DEBUG("TCXO_OPTIONAL: no LR2021_DIO3_TCXO_VOLTAGE defined, trying default TCXO Vref 1.6 V first");
 #else
     float tcxoVoltage =
         0; // "TCXO reference voltage to be set on DIO3. Defaults to 1.6 V, set to 0 to skip." per
            // https://github.com/jgromes/RadioLib/blob/690a050ebb46e6097c5d00c371e961c1caa3b52e/src/modules/LR11x0/LR11x0.h#L471C26-L471C104
     // (DIO3 is free to be used as an IRQ)
-    LOG_DEBUG("LR11X0_DIO3_TCXO_VOLTAGE not defined, not using DIO3 as TCXO reference voltage");
+    LOG_DEBUG("LR2021_DIO3_TCXO_VOLTAGE not defined, not using DIO3 as TCXO reference voltage");
 #endif
 
     RadioLibInterface::init();
 
+    lora.irqDioNum = LR2021_IRQ_DIO_NUM;
+    LOG_DEBUG("Set irqDioNum %d", lora.irqDioNum);
+
     if (config.lora.region == meshtastic_Config_LoRaConfig_RegionCode_LORA_24) { // clamp if wide freq range
-        limitPower(LR1120_MAX_POWER);
+        limitPower(LR2021_MAX_POWER_HF);
     } else {
-        limitPower(LR1110_MAX_POWER); // default clamp for non-wide freq range
+        limitPower(LR2021_MAX_POWER); // default clamp for non-wide freq range
     }
 
-#ifdef LR11X0_RF_SWITCH_SUBGHZ
-    pinMode(LR11X0_RF_SWITCH_SUBGHZ, OUTPUT);
-    digitalWrite(LR11X0_RF_SWITCH_SUBGHZ, getFreq() < 1e9 ? HIGH : LOW);
+#ifdef LR2021_RF_SWITCH_SUBGHZ
+    pinMode(LR2021_RF_SWITCH_SUBGHZ, OUTPUT);
+    digitalWrite(LR2021_RF_SWITCH_SUBGHZ, getFreq() < 1e9 ? HIGH : LOW);
     LOG_DEBUG("Set RF0 switch to %s", getFreq() < 1e9 ? "SubGHz" : "2.4GHz");
 #endif
 
-#ifdef LR11X0_RF_SWITCH_2_4GHZ
-    pinMode(LR11X0_RF_SWITCH_2_4GHZ, OUTPUT);
-    digitalWrite(LR11X0_RF_SWITCH_2_4GHZ, getFreq() < 1e9 ? LOW : HIGH);
+#ifdef LR2021_RF_SWITCH_2_4GHZ
+    pinMode(LR2021_RF_SWITCH_2_4GHZ, OUTPUT);
+    digitalWrite(LR2021_RF_SWITCH_2_4GHZ, getFreq() < 1e9 ? LOW : HIGH);
     LOG_DEBUG("Set RF1 switch to %s", getFreq() < 1e9 ? "SubGHz" : "2.4GHz");
 #endif
 
@@ -99,7 +108,7 @@ template <typename T> bool LR11x0Interface<T>::init()
 
     // Retry if we get SPI command failed - some units need extra TCXO stabilization time
     if (res == RADIOLIB_ERR_SPI_CMD_FAILED) {
-        LOG_WARN("LR11x0 init failed with %d (SPI_CMD_FAILED), retrying after delay...", res);
+        LOG_WARN("LR20x0 init failed with %d (SPI_CMD_FAILED), retrying after delay...", res);
         delay(100);
         res = lora.begin(getFreq(), bw, sf, cr, syncWord, power, preambleLength, tcxoVoltage);
     }
@@ -107,24 +116,25 @@ template <typename T> bool LR11x0Interface<T>::init()
 #if defined(TCXO_OPTIONAL)
     // If init failed for any reason other than chip not found, retry without TCXO (XTAL mode)
     if (res != RADIOLIB_ERR_NONE && res != RADIOLIB_ERR_CHIP_NOT_FOUND && tcxoVoltage > 0) {
-        LOG_WARN("LR11x0 init failed with TCXO Vref %f V (err %d), retrying without TCXO", tcxoVoltage, res);
+        LOG_WARN("LR20x0 init failed with TCXO Vref %f V (err %d), retrying without TCXO", tcxoVoltage, res);
         tcxoVoltage = 0;
         res = lora.begin(getFreq(), bw, sf, cr, syncWord, power, preambleLength, tcxoVoltage);
         if (res == RADIOLIB_ERR_NONE)
-            LOG_INFO("LR11x0 init success without TCXO (XTAL mode)");
+            LOG_INFO("LR20x0 init success without TCXO (XTAL mode)");
     }
 #endif
 
-    // \todo Display actual typename of the adapter, not just `LR11x0`
-    LOG_INFO("LR11x0 init result %d", res);
+    // \todo Display actual typename of the adapter, not just `LR20x0`
+    LOG_INFO("LR20x0 init result %d", res);
     if (res == RADIOLIB_ERR_CHIP_NOT_FOUND || res == RADIOLIB_ERR_SPI_CMD_FAILED)
         return false;
 
-    LR11x0VersionInfo_t version;
-    res = lora.getVersionInfo(&version);
-    if (res == RADIOLIB_ERR_NONE)
-        LOG_DEBUG("LR11x0 Device %d, HW %d, FW %d.%d, WiFi %d.%d, GNSS %d.%d", version.device, version.hardware, version.fwMajor,
-                  version.fwMinor, version.fwMajorWiFi, version.fwMinorWiFi, version.fwGNSS, version.almanacGNSS);
+    // LR20x0VersionInfo_t version;
+    // res = lora.getVersionInfo(&version);
+    // if (res == RADIOLIB_ERR_NONE)
+    //     LOG_DEBUG("LR20x0 Device %d, HW %d, FW %d.%d, WiFi %d.%d, GNSS %d.%d", version.device, version.hardware,
+    //     version.fwMajor,
+    //               version.fwMinor, version.fwMajorWiFi, version.fwMinorWiFi, version.fwGNSS, version.almanacGNSS);
 
     LOG_INFO("Frequency set to %f", getFreq());
     LOG_INFO("Bandwidth set to %f", bw);
@@ -133,11 +143,11 @@ template <typename T> bool LR11x0Interface<T>::init()
     if (res == RADIOLIB_ERR_NONE)
         res = lora.setCRC(2);
 
-    // FIXME: May want to set depending on a definition, currently all LR1110 variant files use the DC-DC regulator option
-    if (res == RADIOLIB_ERR_NONE)
-        res = lora.setRegulatorDCDC();
+        // // FIXME: May want to set depending on a definition, currently all LR1110 variant files use the DC-DC regulator option
+        // if (res == RADIOLIB_ERR_NONE)
+        //     res = lora.setRegulatorDCDC();
 
-#ifdef LR11X0_DIO_AS_RF_SWITCH
+#ifdef LR2021_DIO_AS_RF_SWITCH
     bool dioAsRfSwitch = true;
 #elif defined(ARCH_PORTDUINO)
     bool dioAsRfSwitch = portduino_config.has_rfswitch_table;
@@ -146,7 +156,7 @@ template <typename T> bool LR11x0Interface<T>::init()
 #endif
 
     if (dioAsRfSwitch) {
-        lora.setRfSwitchTable(rfswitch_dio_pins, rfswitch_table);
+        lora.setRfSwitchTable(lr20x0_rfswitch_dio_pins, lr20x0_rfswitch_table);
         LOG_DEBUG("Set DIO RF switch");
     }
 
@@ -166,7 +176,7 @@ template <typename T> bool LR11x0Interface<T>::init()
     return res == RADIOLIB_ERR_NONE;
 }
 
-template <typename T> bool LR11x0Interface<T>::reconfigure()
+template <typename T> bool LR20x0Interface<T>::reconfigure()
 {
     RadioLibInterface::reconfigure();
 
@@ -178,7 +188,7 @@ template <typename T> bool LR11x0Interface<T>::reconfigure()
     if (err != RADIOLIB_ERR_NONE)
         RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
 
-    err = lora.setBandwidth(bw, wideLora() && (getFreq() > 1000.0f));
+    err = lora.setBandwidth(bw); // different form than LR11xx
     if (err != RADIOLIB_ERR_NONE)
         RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
 
@@ -190,9 +200,9 @@ template <typename T> bool LR11x0Interface<T>::reconfigure()
     assert(err == RADIOLIB_ERR_NONE);
 
     if (config.lora.region == meshtastic_Config_LoRaConfig_RegionCode_LORA_24) { // clamp if wide freq range
-        limitPower(LR1120_MAX_POWER);
+        limitPower(LR2021_MAX_POWER_HF);
     } else {
-        limitPower(LR1110_MAX_POWER); // default clamp for non-wide freq range
+        limitPower(LR2021_MAX_POWER); // default clamp for non-wide freq range
     }
 
     err = lora.setPreambleLength(preambleLength);
@@ -208,26 +218,26 @@ template <typename T> bool LR11x0Interface<T>::reconfigure()
     // Apply RX gain mode — valid in STDBY, matches resetAGC() pattern
     err = lora.setRxBoostedGainMode(config.lora.sx126x_rx_boosted_gain);
     if (err != RADIOLIB_ERR_NONE)
-        LOG_WARN("LR11x0 setRxBoostedGainMode %s%d", radioLibErr, err);
+        LOG_WARN("LR20x0 setRxBoostedGainMode %s%d", radioLibErr, err);
 
     startReceive(); // restart receiving
 
     return RADIOLIB_ERR_NONE;
 }
 
-template <typename T> void LR11x0Interface<T>::disableInterrupt()
+template <typename T> void LR20x0Interface<T>::disableInterrupt()
 {
     lora.clearIrqAction();
 }
 
-template <typename T> void LR11x0Interface<T>::setStandby()
+template <typename T> void LR20x0Interface<T>::setStandby()
 {
     checkNotification(); // handle any pending interrupts before we force standby
 
     int err = lora.standby();
 
     if (err != RADIOLIB_ERR_NONE) {
-        LOG_DEBUG("LR11x0 standby failed with error %d", err);
+        LOG_DEBUG("LR20x0 standby failed with error %d", err);
     }
 
     assert(err == RADIOLIB_ERR_NONE);
@@ -242,17 +252,18 @@ template <typename T> void LR11x0Interface<T>::setStandby()
 /**
  * Add SNR data to received messages
  */
-template <typename T> void LR11x0Interface<T>::addReceiveMetadata(meshtastic_MeshPacket *mp)
+template <typename T> void LR20x0Interface<T>::addReceiveMetadata(meshtastic_MeshPacket *mp)
 {
     // LOG_DEBUG("PacketStatus %x", lora.getPacketStatus());
     mp->rx_snr = lora.getSNR();
     mp->rx_rssi = lround(lora.getRSSI());
-    LOG_DEBUG("Corrected frequency offset: %f", lora.getFrequencyError());
+    // LOG_DEBUG("Corrected frequency offset: %f", lora.getFrequencyError()); // not implemented for LR20x0, but noop for LR11x0
+    // too(!)
 }
 
 /** We override to turn on transmitter power as needed.
  */
-template <typename T> void LR11x0Interface<T>::configHardwareForSend()
+template <typename T> void LR20x0Interface<T>::configHardwareForSend()
 {
     RadioLibInterface::configHardwareForSend();
 }
@@ -260,7 +271,7 @@ template <typename T> void LR11x0Interface<T>::configHardwareForSend()
 // For power draw measurements, helpful to force radio to stay sleeping
 // #define SLEEP_ONLY
 
-template <typename T> void LR11x0Interface<T>::startReceive()
+template <typename T> void LR20x0Interface<T>::startReceive()
 {
 #ifdef SLEEP_ONLY
     sleep();
@@ -272,27 +283,27 @@ template <typename T> void LR11x0Interface<T>::startReceive()
 
     // We use a 16 bit preamble so this should save some power by letting radio sit in standby mostly.
     int err =
-        lora.startReceive(RADIOLIB_LR11X0_RX_TIMEOUT_INF, MESHTASTIC_RADIOLIB_IRQ_RX_FLAGS, RADIOLIB_IRQ_RX_DEFAULT_MASK, 0);
+        lora.startReceive(RADIOLIB_LR2021_RX_TIMEOUT_INF, MESHTASTIC_RADIOLIB_IRQ_RX_FLAGS, RADIOLIB_IRQ_RX_DEFAULT_MASK, 0);
     if (err)
         LOG_ERROR("StartReceive error: %d", err);
     assert(err == RADIOLIB_ERR_NONE);
 
     RadioLibInterface::startReceive();
 
-    // Must be done AFTER, starting transmit, because startTransmit clears (possibly stale) interrupt pending register bits
+    // Must be done AFTER starting transmit, because startTransmit clears (possibly stale) interrupt pending register bits
     enableInterrupt(isrRxLevel0);
     checkRxDoneIrqFlag();
 #endif
 }
 
 /** Is the channel currently active? */
-template <typename T> bool LR11x0Interface<T>::isChannelActive()
+template <typename T> bool LR20x0Interface<T>::isChannelActive()
 {
     // check if we can detect a LoRa preamble on the current channel
     ChannelScanConfig_t cfg = {.cad = {.symNum = NUM_SYM_CAD,
-                                       .detPeak = RADIOLIB_LR11X0_CAD_PARAM_DEFAULT,
-                                       .detMin = RADIOLIB_LR11X0_CAD_PARAM_DEFAULT,
-                                       .exitMode = RADIOLIB_LR11X0_CAD_PARAM_DEFAULT,
+                                       .detPeak = RADIOLIB_LR2021_CAD_PARAM_DEFAULT,
+                                       .detMin = RADIOLIB_LR2021_CAD_PARAM_DEFAULT,
+                                       .exitMode = RADIOLIB_LR2021_CAD_PARAM_DEFAULT,
                                        .timeout = 0,
                                        .irqFlags = RADIOLIB_IRQ_CAD_DEFAULT_FLAGS,
                                        .irqMask = RADIOLIB_IRQ_CAD_DEFAULT_MASK}};
@@ -309,33 +320,32 @@ template <typename T> bool LR11x0Interface<T>::isChannelActive()
 }
 
 /** Could we send right now (i.e. either not actively receiving or transmitting)? */
-template <typename T> bool LR11x0Interface<T>::isActivelyReceiving()
+template <typename T> bool LR20x0Interface<T>::isActivelyReceiving()
 {
     // The IRQ status will be cleared when we start our read operation. Check if we've started a header, but haven't yet
     // received and handled the interrupt for reading the packet/handling errors.
-    return receiveDetected(lora.getIrqStatus(), RADIOLIB_LR11X0_IRQ_SYNC_WORD_HEADER_VALID,
-                           RADIOLIB_LR11X0_IRQ_PREAMBLE_DETECTED);
+    return receiveDetected(lora.getIrqStatus(), RADIOLIB_LR2021_IRQ_LORA_HEADER_VALID, RADIOLIB_LR2021_IRQ_PREAMBLE_DETECTED);
 }
 
-#ifdef LR11X0_AGC_RESET
-template <typename T> void LR11x0Interface<T>::resetAGC()
+#ifdef LR20X0_AGC_RESET
+template <typename T> void LR20x0Interface<T>::resetAGC()
 {
     // Safety: don't reset mid-packet
     if (sendingPacket != NULL || (isReceiving && isActivelyReceiving()))
         return;
 
-    LOG_DEBUG("LR11x0 AGC reset: warm sleep + Calibrate(0x3F)");
+    LOG_DEBUG("LR20x0 AGC reset: warm sleep + Calibrate(0x3F)");
 
     // 1. Warm sleep — powers down the analog frontend, resetting AGC state
     lora.sleep(true, 0);
 
     // 2. Wake to RC standby for stable calibration
-    lora.standby(RADIOLIB_LR11X0_STANDBY_RC, true);
+    lora.standby(RADIOLIB_LR20X0_STANDBY_RC, true);
 
     // 3. Calibrate all blocks (PLL, ADC, image, RC oscillators)
-    //    calibrate() is protected on LR11x0, so use raw SPI (same as internal implementation)
-    uint8_t calData = RADIOLIB_LR11X0_CALIBRATE_ALL;
-    module.SPIwriteStream(RADIOLIB_LR11X0_CMD_CALIBRATE, &calData, 1, true, true);
+    //    calibrate() is protected on LR20x0, so use raw SPI (same as internal implementation)
+    uint8_t calData = RADIOLIB_LR20X0_CALIBRATE_ALL;
+    module.SPIwriteStream(RADIOLIB_LR20X0_CMD_CALIBRATE, &calData, 1, true, true);
 
     // 4. Re-calibrate image rejection for actual operating frequency
     //    Calibrate(0x3F) defaults to 902-928 MHz which is wrong for other regions.
@@ -349,10 +359,10 @@ template <typename T> void LR11x0Interface<T>::resetAGC()
 }
 #endif
 
-template <typename T> bool LR11x0Interface<T>::sleep()
+template <typename T> bool LR20x0Interface<T>::sleep()
 {
-    // \todo Display actual typename of the adapter, not just `LR11x0`
-    LOG_DEBUG("LR11x0 entering sleep mode");
+    // \todo Display actual typename of the adapter, not just `LR20x0`
+    LOG_DEBUG("LR20x0 entering sleep mode");
     setStandby(); // Stop any pending operations
 
     // turn off TCXO if it was powered
@@ -362,8 +372,8 @@ template <typename T> bool LR11x0Interface<T>::sleep()
     bool keepConfig = false;
     lora.sleep(keepConfig, 0); // Note: we do not keep the config, full reinit will be needed
 
-#ifdef LR11X0_POWER_EN
-    digitalWrite(LR11X0_POWER_EN, LOW);
+#ifdef LR2021_POWER_EN
+    digitalWrite(LR2021_POWER_EN, LOW);
 #endif
 
     return true;

--- a/src/mesh/LR20x0Interface.cpp
+++ b/src/mesh/LR20x0Interface.cpp
@@ -136,12 +136,16 @@ template <typename T> bool LR20x0Interface<T>::init()
     if (res == RADIOLIB_ERR_CHIP_NOT_FOUND || res == RADIOLIB_ERR_SPI_CMD_FAILED)
         return false;
 
-    // LR20x0VersionInfo_t version;
-    // res = lora.getVersionInfo(&version);
-    // if (res == RADIOLIB_ERR_NONE)
-    //     LOG_DEBUG("LR20x0 Device %d, HW %d, FW %d.%d, WiFi %d.%d, GNSS %d.%d", version.device, version.hardware,
-    //     version.fwMajor,
-    //               version.fwMinor, version.fwMajorWiFi, version.fwMinorWiFi, version.fwGNSS, version.almanacGNSS);
+        // Some basic info about the module's explicit firmware version - no other info available
+        // Currently requires radiolib godmode
+
+#if RADIOLIB_GODMODE
+    uint8_t fwMajor = 0;
+    uint8_t fwMinor = 0;
+    int versionRes = lora.getVersion(&fwMajor, &fwMinor);
+    if (versionRes == RADIOLIB_ERR_NONE)
+        LOG_DEBUG("LR20x0 FW %d.%d", fwMajor, fwMinor);
+#endif
 
     LOG_INFO("Frequency set to %f", getFreq());
     LOG_INFO("Bandwidth set to %f", bw);
@@ -152,12 +156,14 @@ template <typename T> bool LR20x0Interface<T>::init()
 
         // Standard DCDC ramp timing from RadioLib workarounds (register 0x00F20024)
         // Currently requires radiolib godmode
-        // if (res == RADIOLIB_ERR_NONE) {
-        //     uint8_t rampTimes[4] = {15, 15, 15, 15}; // Standard case for all conditions
-        //     res = lora.setRegMode(RADIOLIB_LR2021_REG_MODE_SIMO_NORMAL, rampTimes);
-        //     if (res != RADIOLIB_ERR_NONE)
-        //         LOG_WARN("LR2021 setRegMode failed: %d", res);
-        // }
+#if RADIOLIB_GODMODE
+    if (res == RADIOLIB_ERR_NONE) {
+        uint8_t rampTimes[4] = {15, 15, 15, 15}; // Standard case for all conditions
+        res = lora.setRegMode(RADIOLIB_LR2021_REG_MODE_SIMO_NORMAL, rampTimes);
+        if (res != RADIOLIB_ERR_NONE)
+            LOG_WARN("LR2021 setRegMode failed: %d", res);
+    }
+#endif
 
 #ifdef LR2021_DIO_AS_RF_SWITCH
     bool dioAsRfSwitch = true;

--- a/src/mesh/LR20x0Interface.cpp
+++ b/src/mesh/LR20x0Interface.cpp
@@ -1,7 +1,8 @@
-#if RADIOLIB_EXCLUDE_LR2021 != 1
+#include "configuration.h"
+
+#if defined(USE_LR2021) && RADIOLIB_EXCLUDE_LR2021 != 1
 #include "LR20x0Interface.h"
 #include "Throttle.h"
-#include "configuration.h"
 #include "error.h"
 #include "mesh/NodeDB.h"
 
@@ -80,8 +81,15 @@ template <typename T> bool LR20x0Interface<T>::init()
 
     RadioLibInterface::init();
 
+#ifdef LR2021_IRQ_DIO_NUM
     lora.irqDioNum = LR2021_IRQ_DIO_NUM;
     LOG_DEBUG("Set irqDioNum %d", lora.irqDioNum);
+#elif defined(IRQ_DIO_NUM)
+    lora.irqDioNum = IRQ_DIO_NUM;
+    LOG_DEBUG("Set irqDioNum %d", lora.irqDioNum);
+#else
+    LOG_DEBUG("Use default irqDioNum %d", lora.irqDioNum);
+#endif
 
     if (config.lora.region == meshtastic_Config_LoRaConfig_RegionCode_LORA_24) { // clamp if wide freq range
         limitPower(LR2021_MAX_POWER_HF);

--- a/src/mesh/LR20x0Interface.h
+++ b/src/mesh/LR20x0Interface.h
@@ -4,7 +4,7 @@
 
 /**
  * \brief Adapter for LR20x0 radio family. Implements common logic for child classes.
- * \tparam T RadioLib module type for LR20x0: SX1262, SX1268.
+ * \tparam T RadioLib module type for LR20x0, e.g. LR2021.
  */
 template <class T> class LR20x0Interface : public RadioLibInterface
 {

--- a/src/mesh/LR20x0Interface.h
+++ b/src/mesh/LR20x0Interface.h
@@ -1,0 +1,75 @@
+#pragma once
+#if RADIOLIB_EXCLUDE_LR2021 != 1
+#include "RadioLibInterface.h"
+
+/**
+ * \brief Adapter for LR20x0 radio family. Implements common logic for child classes.
+ * \tparam T RadioLib module type for LR20x0: SX1262, SX1268.
+ */
+template <class T> class LR20x0Interface : public RadioLibInterface
+{
+  public:
+    LR20x0Interface(LockingArduinoHal *hal, RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst,
+                    RADIOLIB_PIN_TYPE busy);
+
+    /// Initialise the Driver transport hardware and software.
+    /// Make sure the Driver is properly configured before calling init().
+    /// \return true if initialisation succeeded.
+    virtual bool init() override;
+
+    /// Apply any radio provisioning changes
+    /// Make sure the Driver is properly configured before calling init().
+    /// \return true if initialisation succeeded.
+    virtual bool reconfigure() override;
+
+    /// Prepare hardware for sleep.  Call this _only_ for deep sleep, not needed for light sleep.
+    virtual bool sleep() override;
+
+    bool isIRQPending() override { return lora.getIrqFlags() != 0; }
+
+#ifdef LR20X0_AGC_RESET
+    void resetAGC() override;
+#endif
+
+  protected:
+    /**
+     * Specific module instance
+     */
+    T lora;
+
+    /**
+     * Glue functions called from ISR land
+     */
+    virtual void disableInterrupt() override;
+
+    /**
+     * Enable a particular ISR callback glue function
+     */
+    virtual void enableInterrupt(void (*callback)()) { lora.setIrqAction(callback); }
+
+    /** can we detect a LoRa preamble on the current channel? */
+    virtual bool isChannelActive() override;
+
+    /** are we actively receiving a packet (only called during receiving state) */
+    virtual bool isActivelyReceiving() override;
+
+    /**
+     * Start waiting to receive a message
+     */
+    virtual void startReceive() override;
+
+    /**
+     *  We override to turn on transmitter power as needed.
+     */
+    virtual void configHardwareForSend() override;
+
+    /**
+     * Add SNR data to received messages
+     */
+    virtual void addReceiveMetadata(meshtastic_MeshPacket *mp) override;
+
+    virtual void setStandby() override;
+
+    uint32_t getPacketTime(uint32_t pl, bool received) override { return computePacketTime(lora, pl, received); }
+};
+#endif

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -5,6 +5,7 @@
 #include "LR1110Interface.h"
 #include "LR1120Interface.h"
 #include "LR1121Interface.h"
+#include "LR2021Interface.h"
 #include "MeshRadio.h"
 #include "MeshService.h"
 #include "NodeDB.h"
@@ -474,6 +475,21 @@ std::unique_ptr<RadioInterface> initLoRa()
         } else {
             LOG_INFO("LR1121 init success");
             radioType = LR1121_RADIO;
+        }
+    }
+#endif
+
+#if defined(USE_LR2021) && RADIOLIB_EXCLUDE_LR2021 != 1
+    if (!rIf) {
+        rIf = std::unique_ptr<LR2021Interface>(
+            new LR2021Interface(loraHal, LR2021_SPI_NSS_PIN, LR2021_IRQ_PIN, LR2021_NRESET_PIN, LR2021_BUSY_PIN));
+        if (!rIf->init()) {
+            LOG_WARN("No LR2021 radio");
+            rIf = nullptr;
+            RadioLibInterface::instance = NULL;
+        } else {
+            LOG_INFO("LR2021 init success");
+            radioType = LR2021_RADIO;
         }
     }
 #endif

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -486,7 +486,6 @@ std::unique_ptr<RadioInterface> initLoRa()
         if (!rIf->init()) {
             LOG_WARN("No LR2021 radio");
             rIf = nullptr;
-            RadioLibInterface::instance = NULL;
         } else {
             LOG_INFO("LR2021 init success");
             radioType = LR2021_RADIO;

--- a/test/test_radio/test_main.cpp
+++ b/test/test_radio/test_main.cpp
@@ -4,7 +4,6 @@
 #include "TestUtil.h"
 #include <unity.h>
 
-#include "detect/LoRaRadioType.h"
 #include "meshtastic/config.pb.h"
 
 class MockMeshService : public MeshService
@@ -184,19 +183,6 @@ static void test_applyModemConfig_customCodingRateLowerThanPreset()
     TEST_ASSERT_EQUAL_UINT8(8, testRadio->getCr());
 }
 
-// -----------------------------------------------------------------------
-// LR2021 radio type detection tests
-// -----------------------------------------------------------------------
-
-static void test_loraRadioType_LR2021_enumExists()
-{
-    // Verify that LR2021_RADIO enum value exists and is distinct from other radio types
-    TEST_ASSERT_NOT_EQUAL(NO_RADIO, LR2021_RADIO);
-    TEST_ASSERT_NOT_EQUAL(SX1262_RADIO, LR2021_RADIO);
-    TEST_ASSERT_NOT_EQUAL(LR1110_RADIO, LR2021_RADIO);
-    TEST_ASSERT_NOT_EQUAL(LR1120_RADIO, LR2021_RADIO);
-}
-
 void setUp(void)
 {
     mockMeshService = new MockMeshService();
@@ -237,7 +223,6 @@ void setup()
     RUN_TEST(test_applyModemConfig_codingRateMatchesPreset);
     RUN_TEST(test_applyModemConfig_customCodingRateHigherThanPreset);
     RUN_TEST(test_applyModemConfig_customCodingRateLowerThanPreset);
-    RUN_TEST(test_loraRadioType_LR2021_enumExists);
     exit(UNITY_END());
 }
 

--- a/test/test_radio/test_main.cpp
+++ b/test/test_radio/test_main.cpp
@@ -4,6 +4,7 @@
 #include "TestUtil.h"
 #include <unity.h>
 
+#include "detect/LoRaRadioType.h"
 #include "meshtastic/config.pb.h"
 
 class MockMeshService : public MeshService
@@ -183,6 +184,19 @@ static void test_applyModemConfig_customCodingRateLowerThanPreset()
     TEST_ASSERT_EQUAL_UINT8(8, testRadio->getCr());
 }
 
+// -----------------------------------------------------------------------
+// LR2021 radio type detection tests
+// -----------------------------------------------------------------------
+
+static void test_loraRadioType_LR2021_enumExists()
+{
+    // Verify that LR2021_RADIO enum value exists and is distinct from other radio types
+    TEST_ASSERT_NOT_EQUAL(NO_RADIO, LR2021_RADIO);
+    TEST_ASSERT_NOT_EQUAL(SX1262_RADIO, LR2021_RADIO);
+    TEST_ASSERT_NOT_EQUAL(LR1110_RADIO, LR2021_RADIO);
+    TEST_ASSERT_NOT_EQUAL(LR1120_RADIO, LR2021_RADIO);
+}
+
 void setUp(void)
 {
     mockMeshService = new MockMeshService();
@@ -223,6 +237,7 @@ void setup()
     RUN_TEST(test_applyModemConfig_codingRateMatchesPreset);
     RUN_TEST(test_applyModemConfig_customCodingRateHigherThanPreset);
     RUN_TEST(test_applyModemConfig_customCodingRateLowerThanPreset);
+    RUN_TEST(test_loraRadioType_LR2021_enumExists);
     exit(UNITY_END());
 }
 

--- a/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/platformio.ini
+++ b/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/platformio.ini
@@ -15,6 +15,7 @@ board = promicro-nrf52840
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/diy/nrf52_promicro_diy_tcxo
   -D NRF52_PROMICRO_DIY
+  ; -D RADIOLIB_GODMODE=1 ; needed for some LR2021 items, but not enabled by default.
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/diy/nrf52_promicro_diy_tcxo>
 debug_tool = jlink
 

--- a/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/rfswitch.h
+++ b/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/rfswitch.h
@@ -1,4 +1,10 @@
+#pragma once
 #include "RadioLib.h"
+
+// Keep LR20x0 naming while RadioLib exposes LR2021 symbols.
+#ifndef LR20x0
+#define LR20x0 LR2021
+#endif
 
 // This is rewritten to match the requirements of the E80-900M2213S
 // The E80 does not conform to the reference Semtech switches(!) and therefore needs a custom matrix.
@@ -13,14 +19,35 @@ static const uint32_t rfswitch_dio_pins[] = {RADIOLIB_LR11X0_DIO5, RADIOLIB_LR11
 
 static const Module::RfSwitchMode_t rfswitch_table[] = {
     // clang-format off
-    // mode            DIO5  DIO6  DIO7
-    {LR11x0::MODE_STBY, {LOW, LOW, LOW}},
-    {LR11x0::MODE_RX, {LOW, HIGH, LOW}},
-    {LR11x0::MODE_TX, {HIGH, HIGH, LOW}},
-    {LR11x0::MODE_TX_HP, {HIGH, LOW, LOW}},
-    {LR11x0::MODE_TX_HF, {LOW, LOW, LOW}},
-    {LR11x0::MODE_GNSS, {LOW, LOW, HIGH}},
-    {LR11x0::MODE_WIFI, {LOW, LOW, LOW}},
+    // mode              DIO5  DIO6  DIO7
+    {LR11x0::MODE_STBY,  {LOW,  LOW,  LOW}},
+    {LR11x0::MODE_RX,    {LOW,  HIGH, LOW}},
+    {LR11x0::MODE_TX,    {HIGH, HIGH, LOW}},
+    {LR11x0::MODE_TX_HP, {HIGH, LOW,  LOW}},
+    {LR11x0::MODE_TX_HF, {LOW,  LOW,  LOW}},
+    {LR11x0::MODE_GNSS,  {LOW,  LOW,  HIGH}},
+    {LR11x0::MODE_WIFI,  {LOW,  LOW,  LOW}},
+    END_OF_MODE_TABLE,
+    // clang-format on
+};
+
+// LR2021 RF switch matrix following the standard Semtech / Seeed T1000-E reference topology.
+// DIO5 -> antenna path select (HIGH = sub-GHz LF)
+// DIO6 -> TX enable / HP PA select
+// DIO7 -> not connected (no GNSS on LR2021)
+// DIO8 -> RF front-end power enable
+
+static const uint32_t lr20x0_rfswitch_dio_pins[] = {RADIOLIB_LR2021_DIO5, RADIOLIB_LR2021_DIO6, RADIOLIB_LR2021_DIO7,
+                                                    RADIOLIB_LR2021_DIO8, RADIOLIB_NC};
+
+static const Module::RfSwitchMode_t lr20x0_rfswitch_table[] = {
+    // clang-format off
+    // mode               DIO5  DIO6  DIO7  DIO8
+    {LR20x0::MODE_STBY,   {LOW,  LOW,  LOW,  LOW}},
+    {LR20x0::MODE_RX,     {HIGH, LOW,  LOW,  HIGH}},
+    {LR20x0::MODE_TX,     {HIGH, HIGH, LOW,  HIGH}},
+    {LR20x0::MODE_RX_HF,  {LOW,  LOW,  LOW,  LOW}},
+    {LR20x0::MODE_TX_HF,  {LOW,  LOW,  LOW,  LOW}},
     END_OF_MODE_TABLE,
     // clang-format on
 };

--- a/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/variant.h
+++ b/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/variant.h
@@ -155,6 +155,16 @@ NRF52 PRO MICRO PIN ASSIGNMENT
 #define LR11X0_DIO_AS_RF_SWITCH
 #endif
 
+// LR2021
+#define USE_LR2021
+#define LR2021_IRQ_PIN (0 + 10)      // P0.10 IRQ
+#define LR2021_NRESET_PIN LORA_RESET // P0.09 NRST
+#define LR2021_BUSY_PIN (0 + 29)     // P0.29 BUSY
+#define LR2021_SPI_NSS_PIN LORA_CS   // P1.13
+#define LR2021_DIO3_TCXO_VOLTAGE 1.8
+#define LR2021_DIO_AS_RF_SWITCH
+#define LR2021_IRQ_DIO_NUM 9 // DIO9 → P0.10
+
 // #define SX126X_MAX_POWER 8 set this if using a high-power board!
 
 /*

--- a/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/variant.h
+++ b/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/variant.h
@@ -1,6 +1,9 @@
 #ifndef _VARIANT_PROMICRO_DIY_
 #define _VARIANT_PROMICRO_DIY_
 
+// #undef RADIOLIB_GODMODE
+// #define RADIOLIB_GODMODE 1
+
 /** Master clock frequency */
 #define VARIANT_MCK (64000000ul)
 

--- a/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/variant.h
+++ b/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/variant.h
@@ -1,9 +1,6 @@
 #ifndef _VARIANT_PROMICRO_DIY_
 #define _VARIANT_PROMICRO_DIY_
 
-// #undef RADIOLIB_GODMODE
-// #define RADIOLIB_GODMODE 1
-
 /** Master clock frequency */
 #define VARIANT_MCK (64000000ul)
 


### PR DESCRIPTION
This pull request adds support for the LR2021 radio chipset, introducing a new `LR2021Interface` and a generic `LR20x0Interface` base class, based on the LR11x0 and LR1110.

**LR2021 radio support:**

* Added `LR2021_RADIO` to the `LoRaRadioType` enum and updated radio detection logic to instantiate and initialize `LR2021Interface` when appropriate. [[1]](diffhunk://#diff-d1ba735d815f635321eba3c5db8a06f8b6d0895ddb3937121a83705b147d4f42L14-R15) [[2]](diffhunk://#diff-ad55475cca6c487a8b020a5f8036f160cd1fc92cce2ea887bfe83f284a6fc855R482-R496)
* Added and implemented `LR2021Interface` and generic `LR20x0Interface` classes for LR2021 radio support, including initialization, configuration, and runtime methods. [[1]](diffhunk://#diff-91d47153dacad14a3f94052b064120dbac7a816068a1096e7f0836a99699ce42R1-R17) [[2]](diffhunk://#diff-ec6a64f75dc17b35988c85ddd1df8c45b718d1fdc49ab2769119c93c0a82515dR1-R15) [[3]](diffhunk://#diff-e277e25860d272402102115b1dd5c82ea69df1d2f7b5394109b4177e2be460bfR1-R75) [[4]](diffhunk://#diff-f10fb3492f1ccf65f44c09d8723b0d6bb691186864a20df9ce0b4275e87c83d5R1-R381)
* Integrated LR2021 interface into build system and template instantiations, including necessary includes in source files. [[1]](diffhunk://#diff-93922d13b20758873efd32f4ebb5ba7c63cbc5a058460911af3f55ecc88d59d1R3-R4) [[2]](diffhunk://#diff-93922d13b20758873efd32f4ebb5ba7c63cbc5a058460911af3f55ecc88d59d1R26-R28) [[3]](diffhunk://#diff-ad55475cca6c487a8b020a5f8036f160cd1fc92cce2ea887bfe83f284a6fc855R8)

**Radio initialization and configuration improvements:**

* Implemented robust TCXO voltage selection and fallback logic for both LR11x0 and LR20x0/LR2021 radios, including retry without TCXO if initialization fails and improved debug logging. [[1]](diffhunk://#diff-fe32ebabfc0b032dfa11210a6822b29996b2a53074f3a8e5e2c1242396bf5415L60-L69) [[2]](diffhunk://#diff-fe32ebabfc0b032dfa11210a6822b29996b2a53074f3a8e5e2c1242396bf5415R107-R117) [[3]](diffhunk://#diff-f10fb3492f1ccf65f44c09d8723b0d6bb691186864a20df9ce0b4275e87c83d5R1-R381)
* Added board-specific and region-specific power clamping, RF switch handling, and RX gain mode logic for LR2021, improving hardware compatibility and runtime reliability. [[1]](diffhunk://#diff-f10fb3492f1ccf65f44c09d8723b0d6bb691186864a20df9ce0b4275e87c83d5R1-R381) [[2]](diffhunk://#diff-0e683f73878eed4984f9677e4a99b11c7644bc2196008da09d60fe5c5275a2d6R1-R8)

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
NRF promicro