### PR TITLE
Fix mesh reconfigure methods to return true instead of error code

### DIFF
--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -198,7 +198,7 @@ template <typename T> bool LR11x0Interface<T>::reconfigure()
 
     startReceive(); // restart receiving
 
-    return RADIOLIB_ERR_NONE;
+    return true;
 }
 
 template <typename T> void LR11x0Interface<T>::disableInterrupt()

--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -252,7 +252,7 @@ bool RF95Interface::reconfigure()
 
     startReceive(); // restart receiving
 
-    return RADIOLIB_ERR_NONE;
+    return true;
 }
 
 /**

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -262,7 +262,7 @@ template <typename T> bool SX126xInterface<T>::reconfigure()
 
     startReceive(); // restart receiving
 
-    return RADIOLIB_ERR_NONE;
+    return true;
 }
 
 template <typename T> void SX126xInterface<T>::disableInterrupt()

--- a/src/mesh/SX128xInterface.cpp
+++ b/src/mesh/SX128xInterface.cpp
@@ -153,7 +153,7 @@ template <typename T> bool SX128xInterface<T>::reconfigure()
 
     startReceive(); // restart receiving
 
-    return RADIOLIB_ERR_NONE;
+    return true;
 }
 
 template <typename T> void SX128xInterface<T>::disableInterrupt()


### PR DESCRIPTION
This pull request updates the return values of the `reconfigure()` methods in several radio interface classes to return `true` instead of the constant `RADIOLIB_ERR_NONE`. This change standardizes the return type to a boolean, improving consistency and clarity in the codebase.

Return value standardization:

* Changed the return value of `reconfigure()` in `LR11x0Interface` (`src/mesh/LR11x0Interface.cpp`) to return `true` instead of `RADIOLIB_ERR_NONE`.
* Changed the return value of `reconfigure()` in `RF95Interface` (`src/mesh/RF95Interface.cpp`) to return `true` instead of `RADIOLIB_ERR_NONE`.
* Changed the return value of `reconfigure()` in `SX126xInterface` (`src/mesh/SX126xInterface.cpp`) to return `true` instead of `RADIOLIB_ERR_NONE`.
* Changed the return value of `reconfigure()` in `SX128xInterface` (`src/mesh/SX128xInterface.cpp`) to return `true` instead of `RADIOLIB_ERR_NONE`.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
