### PR TITLE
Give ThinkNode-m4 a heartbeat

### DIFF
--- a/src/modules/StatusLEDModule.cpp
+++ b/src/modules/StatusLEDModule.cpp
@@ -106,6 +106,19 @@ int32_t StatusLEDModule::runOnce()
         }
     }
 
+// If we want a LED to be dedicated to the simple hearbeat, we can use that instead of the charge LED
+#if defined(LED_HEARTBEAT)
+    if (!config.device.led_heartbeat_disabled) {
+        if (HEARTBEAT_LED_state == LED_STATE_ON) {
+            HEARTBEAT_LED_state = LED_STATE_OFF;
+            my_interval = 999;
+        } else {
+            HEARTBEAT_LED_state = LED_STATE_ON;
+            my_interval = 1;
+        }
+        digitalWrite(LED_HEARTBEAT, HEARTBEAT_LED_state);
+    }
+#endif
     if (!config.bluetooth.enabled || PAIRING_LED_starttime + 30 * 1000 < millis() || doing_fast_blink) {
         PAIRING_LED_state = LED_STATE_OFF;
     } else if (ble_state == unpaired) {

--- a/src/modules/StatusLEDModule.h
+++ b/src/modules/StatusLEDModule.h
@@ -43,6 +43,9 @@ class StatusLEDModule : private concurrency::OSThread
   private:
     bool CHARGE_LED_state = LED_STATE_OFF;
     bool PAIRING_LED_state = LED_STATE_OFF;
+#if defined(LED_HEARTBEAT)
+    bool HEARTBEAT_LED_state = LED_STATE_OFF;
+#endif
 
     uint32_t PAIRING_LED_starttime = 0;
     uint32_t lastUserbuttonTime = 0;

--- a/variants/nrf52840/ELECROW-ThinkNode-M4/variant.cpp
+++ b/variants/nrf52840/ELECROW-ThinkNode-M4/variant.cpp
@@ -35,6 +35,9 @@ void initVariant()
     pinMode(LED_PAIRING, OUTPUT);
     ledOff(LED_PAIRING);
 
+    pinMode(LED_HEARTBEAT, OUTPUT);
+    ledOff(LED_HEARTBEAT);
+
     pinMode(Battery_LED_1, OUTPUT);
     ledOff(Battery_LED_1);
     pinMode(Battery_LED_2, OUTPUT);

--- a/variants/nrf52840/ELECROW-ThinkNode-M4/variant.h
+++ b/variants/nrf52840/ELECROW-ThinkNode-M4/variant.h
@@ -41,7 +41,8 @@ extern "C" {
 
 // LEDs
 #define LED_BLUE -1
-#define LED_NOTIFICATION (32 + 9)
+// #define LED_NOTIFICATION (32 + 9)
+#define LED_HEARTBEAT (32 + 9)
 #define LED_PAIRING (13)
 
 #define Battery_LED_1 (15)


### PR DESCRIPTION
The M4 doesn't have a heartbeat at all when running normally, so re-tooling the red LED as a dedicated heartbeat LED.