### PR TITLE
[feat] Skip MQTT allocation when disabled

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -409,6 +409,9 @@ void MQTT::onReceive(char *topic, byte *payload, size_t length)
 
 void mqttInit()
 {
+    if (!moduleConfig.mqtt.enabled)
+        return;
+
     new MQTT();
 }
 

--- a/test/test_mqtt/MQTT.cpp
+++ b/test/test_mqtt/MQTT.cpp
@@ -800,6 +800,17 @@ void test_disabled(void)
     TEST_ASSERT_FALSE(mqtt->isEnabled());
 }
 
+void test_mqttInitSkipsAllocationWhenDisabled(void)
+{
+    delete unitTest;
+    mqtt = unitTest = NULL;
+
+    moduleConfig.mqtt.enabled = false;
+    mqttInit();
+
+    TEST_ASSERT_NULL(mqtt);
+}
+
 // Subscriptions contain the moduleConfig.mqtt.root prefix.
 void test_customMqttRoot(void)
 {
@@ -912,6 +923,7 @@ void setup()
     RUN_TEST(test_usingCustomServer);
     RUN_TEST(test_enabled);
     RUN_TEST(test_disabled);
+    RUN_TEST(test_mqttInitSkipsAllocationWhenDisabled);
     RUN_TEST(test_customMqttRoot);
     RUN_TEST(test_configEmptyIsValid);
     RUN_TEST(test_configEnabledEmptyIsValid);


### PR DESCRIPTION
# MQTT init heap validation

## AI Warning
This one was developed using AI, including this most of this PR text. Reviewed by fallible human. Savings are real and not simulated or hallucinated. This warning text, however is written by a human. No robots were harmed in the making of this PR.

## Summary

When MQTT is disabled, `mqttInit()` now returns before allocating the `MQTT` singleton. This avoids constructing the MQTT thread, queue, client, and PubSubClient objects for nodes that do not use MQTT.

The measured heap improvement on an attached Heltec v3 was 3396 bytes.

## Change

- `src/mqtt/MQTT.cpp`: `mqttInit()` exits early when `moduleConfig.mqtt.enabled` is false.
- `test/test_mqtt/MQTT.cpp`: adds coverage that `mqttInit()` leaves the global `mqtt` pointer null when MQTT is disabled.

Enabled MQTT behavior is unchanged because `mqttInit()` still constructs `MQTT` when `moduleConfig.mqtt.enabled` is true.

## Hardware validation

Device:

- Board: Heltec v3
- Port: `/dev/cu.usbserial-0001`
- Config state: `mqtt.enabled: False`
- Firmware baseline: `develop` at `cdc47a2aeaa564732382d9a7d539abeda9da6b49`
- Branch: `codex/mqtt-init-enabled-heap`

Method:

1. Built and flashed the `develop` baseline with `pio run -e heltec-v3 -t upload --upload-port /dev/cu.usbserial-0001`.
2. Reset the device under serial capture and recorded the boot-time `Free heap` log line after LoRa init.
3. Built and flashed this branch with the same command.
4. Reset the device under serial capture and recorded the same boot-time `Free heap` log line.

Results:

| Build | Boot free heap |
| --- | ---: |
| `develop` baseline | 121944 bytes |
| This branch | 125340 bytes |
| Delta | +3396 bytes |

The result matches the expected heap reduction from skipping `new MQTT()` when MQTT is disabled.

## Checks

- `trunk fmt src/mqtt/MQTT.cpp test/test_mqtt/MQTT.cpp`
- `git diff --check -- src/mqtt/MQTT.cpp test/test_mqtt/MQTT.cpp`
- `pio run -e heltec-v3 -t upload --upload-port /dev/cu.usbserial-0001`
## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [X] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
