### PR TITLE
Fix RAK3401 User Button

### DIFF
--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -158,11 +158,19 @@ static void lsIdle()
 
             default:
                 // We woke for some other reason (button press, device IRQ interrupt)
-
-#ifdef BUTTON_PIN
-                bool pressed = !digitalRead(config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN);
-#else
                 bool pressed = false;
+
+#ifdef HAS_BUTTON
+                int _buttonPin = -1;
+#if defined(BUTTON_PIN)
+                _buttonPin = BUTTON_PIN;
+#endif
+                if (config.device.button_gpio) {
+                    _buttonPin = config.device.button_gpio;
+                }
+                if (_buttonPin >= 0) {
+                    pressed = !digitalRead(_buttonPin);
+                }
 #endif
                 if (pressed) { // If we woke because of press, instead generate a PRESS event.
                     powerFSM.trigger(EVENT_PRESS);

--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -160,7 +160,7 @@ static void lsIdle()
                 // We woke for some other reason (button press, device IRQ interrupt)
                 bool pressed = false;
 
-#ifdef HAS_BUTTON
+#if HAS_BUTTON
                 int _buttonPin = -1;
 #if defined(BUTTON_PIN)
                 _buttonPin = BUTTON_PIN;

--- a/src/graphics/niche/Inputs/TwoButton.cpp
+++ b/src/graphics/niche/Inputs/TwoButton.cpp
@@ -70,11 +70,6 @@ uint8_t TwoButton::getUserButtonPin()
     pin = BUTTON_PIN;
 #endif
 
-    // From userPrefs.jsonc, if set
-#ifdef USERPREFS_BUTTON_PIN
-    pin = USERPREFS_BUTTON_PIN;
-#endif
-
     // From user's override in device settings, if set
     if (config.device.button_gpio)
         pin = config.device.button_gpio;

--- a/src/graphics/niche/Inputs/TwoButtonExtended.cpp
+++ b/src/graphics/niche/Inputs/TwoButtonExtended.cpp
@@ -102,11 +102,6 @@ uint8_t TwoButtonExtended::getUserButtonPin()
     pin = BUTTON_PIN;
 #endif
 
-    // From userPrefs.jsonc, if set
-#ifdef USERPREFS_BUTTON_PIN
-    pin = USERPREFS_BUTTON_PIN;
-#endif
-
     // From user's override in device settings, if set
     if (config.device.button_gpio)
         pin = config.device.button_gpio;

--- a/src/input/InputBroker.cpp
+++ b/src/input/InputBroker.cpp
@@ -40,7 +40,7 @@ static bool touchBacklightActive = false;
 #endif
 #endif
 
-#if defined(BUTTON_PIN) || defined(ARCH_PORTDUINO)
+#if defined(HAS_BUTTON) || defined(ARCH_PORTDUINO)
 ButtonThread *UserButtonThread = nullptr;
 #endif
 
@@ -144,31 +144,42 @@ void InputBroker::pollSoonWorker(void *p)
 void InputBroker::Init()
 {
 
-#ifdef BUTTON_PIN
+#ifdef HAS_BUTTON
+    int _pinNum = -1;
+
+#if defined(BUTTON_PIN)
+    // if this is defined, do we really even want to honor the config value?
+    _pinNum = config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN;
+#else
+    _pinNum = config.device.button_gpio ? config.device.button_gpio : -1;
+#endif
+
 #ifdef ARCH_ESP32
 
+    if (_pinNum >= 0) {
 #if ESP_ARDUINO_VERSION_MAJOR >= 3
+
 #ifdef BUTTON_NEED_PULLUP
-    pinMode(config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN, INPUT_PULLUP);
+        pinMode(_pinNum, INPUT_PULLUP);
 #else
-    pinMode(config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN, INPUT); // default to BUTTON_PIN
+        pinMode(_pinNum, INPUT); // default to BUTTON_PIN
 #endif
+    }
 #else
-    pinMode(config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN, INPUT); // default to BUTTON_PIN
+        pinMode(_pinNum, INPUT); // default to BUTTON_PIN
 #ifdef BUTTON_NEED_PULLUP
-    gpio_pullup_en((gpio_num_t)(config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN));
-    delay(10);
+        gpio_pullup_en((gpio_num_t)_pinNum);
+        delay(10);
 #endif
+    }
 #ifdef BUTTON_NEED_PULLUP2
     gpio_pullup_en((gpio_num_t)BUTTON_NEED_PULLUP2);
     delay(10);
 #endif
 #endif
-#endif
-#endif
+#endif // ARCH_ESP32
 
-// buttons are now inputBroker, so have to come after setupModules
-#if HAS_BUTTON
+    // buttons are now inputBroker, so have to come after setupModules
     int pullup_sense = 0;
 #ifdef INPUT_PULLUP_SENSE
     // Some platforms (nrf52) have a SENSE variant which allows wake from sleep - override what OneButton did
@@ -283,12 +294,6 @@ void InputBroker::Init()
     BackButtonThread->initButton(backConfig);
 #endif
 
-#if defined(BUTTON_PIN)
-#if defined(USERPREFS_BUTTON_PIN)
-    int _pinNum = config.device.button_gpio ? config.device.button_gpio : USERPREFS_BUTTON_PIN;
-#else
-    int _pinNum = config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN;
-#endif
 #ifndef BUTTON_ACTIVE_LOW
 #define BUTTON_ACTIVE_LOW true
 #endif
@@ -298,51 +303,52 @@ void InputBroker::Init()
 
     // Buttons. Moved here cause we need NodeDB to be initialized
     // If your variant.h has a BUTTON_PIN defined, go ahead and define BUTTON_ACTIVE_LOW and BUTTON_ACTIVE_PULLUP
-    UserButtonThread = new ButtonThread("UserButton");
+    if (_pinNum >= 0) {
+        UserButtonThread = new ButtonThread("UserButton");
 #if !MESHTASTIC_EXCLUDE_SCREEN
-    if (screen) {
-        ButtonConfig userConfig;
-        userConfig.pinNumber = (uint8_t)_pinNum;
-        userConfig.activeLow = BUTTON_ACTIVE_LOW;
-        userConfig.activePullup = BUTTON_ACTIVE_PULLUP;
-        userConfig.pullupSense = pullup_sense;
-        userConfig.intRoutine = []() {
-            UserButtonThread->userButton.tick();
-            UserButtonThread->setIntervalFromNow(0);
-            runASAP = true;
-            BaseType_t higherWake = 0;
-            concurrency::mainDelay.interruptFromISR(&higherWake);
-        };
-        userConfig.singlePress = INPUT_BROKER_USER_PRESS;
-        userConfig.longPress = INPUT_BROKER_SELECT;
-        userConfig.longPressTime = 500;
-        userConfig.longLongPress = INPUT_BROKER_SHUTDOWN;
-        UserButtonThread->initButton(userConfig);
-    } else
+        if (screen) {
+            ButtonConfig userConfig;
+            userConfig.pinNumber = (uint8_t)_pinNum;
+            userConfig.activeLow = BUTTON_ACTIVE_LOW;
+            userConfig.activePullup = BUTTON_ACTIVE_PULLUP;
+            userConfig.pullupSense = pullup_sense;
+            userConfig.intRoutine = []() {
+                UserButtonThread->userButton.tick();
+                UserButtonThread->setIntervalFromNow(0);
+                runASAP = true;
+                BaseType_t higherWake = 0;
+                concurrency::mainDelay.interruptFromISR(&higherWake);
+            };
+            userConfig.singlePress = INPUT_BROKER_USER_PRESS;
+            userConfig.longPress = INPUT_BROKER_SELECT;
+            userConfig.longPressTime = 500;
+            userConfig.longLongPress = INPUT_BROKER_SHUTDOWN;
+            UserButtonThread->initButton(userConfig);
+        } else
 #endif
-    {
-        ButtonConfig userConfigNoScreen;
-        userConfigNoScreen.pinNumber = (uint8_t)_pinNum;
-        userConfigNoScreen.activeLow = BUTTON_ACTIVE_LOW;
-        userConfigNoScreen.activePullup = BUTTON_ACTIVE_PULLUP;
-        userConfigNoScreen.pullupSense = pullup_sense;
-        userConfigNoScreen.intRoutine = []() {
-            UserButtonThread->userButton.tick();
-            UserButtonThread->setIntervalFromNow(0);
-            runASAP = true;
-            BaseType_t higherWake = 0;
-            concurrency::mainDelay.interruptFromISR(&higherWake);
-        };
-        userConfigNoScreen.singlePress = INPUT_BROKER_USER_PRESS;
-        userConfigNoScreen.longPress = INPUT_BROKER_NONE;
-        userConfigNoScreen.longPressTime = 500;
-        userConfigNoScreen.longLongPress = INPUT_BROKER_SHUTDOWN;
-        userConfigNoScreen.doublePress = INPUT_BROKER_SEND_PING;
-        userConfigNoScreen.triplePress = INPUT_BROKER_GPS_TOGGLE;
-        UserButtonThread->initButton(userConfigNoScreen);
+        {
+            ButtonConfig userConfigNoScreen;
+            userConfigNoScreen.pinNumber = (uint8_t)_pinNum;
+            userConfigNoScreen.activeLow = BUTTON_ACTIVE_LOW;
+            userConfigNoScreen.activePullup = BUTTON_ACTIVE_PULLUP;
+            userConfigNoScreen.pullupSense = pullup_sense;
+            userConfigNoScreen.intRoutine = []() {
+                UserButtonThread->userButton.tick();
+                UserButtonThread->setIntervalFromNow(0);
+                runASAP = true;
+                BaseType_t higherWake = 0;
+                concurrency::mainDelay.interruptFromISR(&higherWake);
+            };
+            userConfigNoScreen.singlePress = INPUT_BROKER_USER_PRESS;
+            userConfigNoScreen.longPress = INPUT_BROKER_NONE;
+            userConfigNoScreen.longPressTime = 500;
+            userConfigNoScreen.longLongPress = INPUT_BROKER_SHUTDOWN;
+            userConfigNoScreen.doublePress = INPUT_BROKER_SEND_PING;
+            userConfigNoScreen.triplePress = INPUT_BROKER_GPS_TOGGLE;
+            UserButtonThread->initButton(userConfigNoScreen);
+        }
     }
-#endif
-#endif
+#endif // HAS_BUTTON
 
 #if (HAS_BUTTON || ARCH_PORTDUINO) && !MESHTASTIC_EXCLUDE_INPUTBROKER
     if (config.display.displaymode != meshtastic_Config_DisplayConfig_DisplayMode_COLOR) {

--- a/src/input/InputBroker.cpp
+++ b/src/input/InputBroker.cpp
@@ -40,7 +40,7 @@ static bool touchBacklightActive = false;
 #endif
 #endif
 
-#if defined(HAS_BUTTON) || defined(ARCH_PORTDUINO)
+#if HAS_BUTTON || defined(ARCH_PORTDUINO)
 ButtonThread *UserButtonThread = nullptr;
 #endif
 
@@ -144,7 +144,7 @@ void InputBroker::pollSoonWorker(void *p)
 void InputBroker::Init()
 {
 
-#ifdef HAS_BUTTON
+#if HAS_BUTTON
     int _pinNum = -1;
 
 #if defined(BUTTON_PIN)

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -682,6 +682,9 @@ void NodeDB::installDefaultConfig(bool preserveKey = false)
     if (config.device.role != meshtastic_Config_DeviceConfig_Role_ROUTER &&
         config.device.role != meshtastic_Config_DeviceConfig_Role_ROUTER_LATE)
         config.device.node_info_broadcast_secs = default_node_info_broadcast_secs;
+#if defined(USERPREFS_BUTTON_PIN)
+    config.device.button_gpio = USERPREFS_BUTTON_PIN;
+#endif
     config.security.serial_enabled = true;
     config.security.admin_channel_enabled = false;
     resetRadioConfig(true); // This also triggers NodeInfo/Position requests since we're fresh

--- a/src/platform/esp32/main-esp32.cpp
+++ b/src/platform/esp32/main-esp32.cpp
@@ -226,36 +226,44 @@ void cpuDeepSleep(uint32_t msecToWake)
 
         // FIXME, disable internal rtc pullups/pulldowns on the non isolated pins. for inputs that we aren't using
         // to detect wake and in normal operation the external part drives them hard.
+#if HAS_BUTTON
+    int _buttonPin = -1;
 #ifdef BUTTON_PIN
+    _buttonPin = BUTTON_PIN;
+#endif
+    if (config.device.button_gpio)
+        _buttonPin = config.device.button_gpio;
+    if (_buttonPin >= 0) {
         // Only GPIOs which are have RTC functionality can be used in this bit map: 0,2,4,12-15,25-27,32-39.
 #if SOC_RTCIO_HOLD_SUPPORTED && SOC_PM_SUPPORT_EXT_WAKEUP
-    uint64_t gpioMask = (1ULL << (config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN));
+        uint64_t gpioMask = (1ULL << (_buttonPin));
 #endif
 #ifdef ALT_BUTTON_WAKE
-    gpioMask |= (1ULL << BUTTON_PIN_ALT);
+        gpioMask |= (1ULL << BUTTON_PIN_ALT);
 #endif
 #ifdef BUTTON_NEED_PULLUP
-    gpio_pullup_en((gpio_num_t)BUTTON_PIN);
+        gpio_pullup_en((gpio_num_t)BUTTON_PIN);
 #endif
 
-    // Not needed because both of the current boards have external pullups
-    // FIXME change polarity in hw so we can wake on ANY_HIGH instead - that would allow us to use all three buttons (instead
-    // of just the first) gpio_pullup_en((gpio_num_t)BUTTON_PIN);
+        // Not needed because both of the current boards have external pullups
+        // FIXME change polarity in hw so we can wake on ANY_HIGH instead - that would allow us to use all three buttons (instead
+        // of just the first) gpio_pullup_en((gpio_num_t)BUTTON_PIN);
 
 #ifdef ESP32S3_WAKE_TYPE
-    esp_sleep_enable_ext1_wakeup(gpioMask, ESP32S3_WAKE_TYPE);
+        esp_sleep_enable_ext1_wakeup(gpioMask, ESP32S3_WAKE_TYPE);
 #else
 #if SOC_PM_SUPPORT_EXT_WAKEUP
 #ifdef CONFIG_IDF_TARGET_ESP32
-    // ESP_EXT1_WAKEUP_ALL_LOW has been deprecated since esp-idf v5.4 for any other target.
-    esp_sleep_enable_ext1_wakeup(gpioMask, ESP_EXT1_WAKEUP_ALL_LOW);
+        // ESP_EXT1_WAKEUP_ALL_LOW has been deprecated since esp-idf v5.4 for any other target.
+        esp_sleep_enable_ext1_wakeup(gpioMask, ESP_EXT1_WAKEUP_ALL_LOW);
 #else
-    esp_sleep_enable_ext1_wakeup(gpioMask, ESP_EXT1_WAKEUP_ANY_LOW);
+        esp_sleep_enable_ext1_wakeup(gpioMask, ESP_EXT1_WAKEUP_ANY_LOW);
 #endif
 #endif
 
 #endif // #end ESP32S3_WAKE_TYPE
-#endif
+    }
+#endif // HAS_BUTTON
     variant_shutdown();
 
     // We want RTC peripherals to stay on

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -286,7 +286,7 @@ void doDeepSleep(uint32_t msecToWake, bool skipPreflight = false, bool skipSaveN
     if (shouldLoraWake(msecToWake)) {
         enableLoraInterrupt();
     }
-#ifdef HAS_BUTTON
+#if HAS_BUTTON
     int _buttonPin = -1;
 #ifdef BUTTON_PIN
     _buttonPin = BUTTON_PIN;
@@ -442,7 +442,7 @@ esp_sleep_wakeup_cause_t doLightSleep(uint64_t sleepMsec) // FIXME, use a more r
     // Side-key interrupt line from PCA9535 expander (active low).
     gpio_wakeup_enable((gpio_num_t)BOARD_PCA9535_INT, GPIO_INTR_LOW_LEVEL);
 #endif
-#ifdef HAS_BUTTON
+#if HAS_BUTTON
     int _buttonPin = -1;
 #ifdef BUTTON_PIN
     _buttonPin = BUTTON_PIN;
@@ -500,63 +500,64 @@ esp_sleep_wakeup_cause_t doLightSleep(uint64_t sleepMsec) // FIXME, use a more r
 #ifdef BOARD_PCA9535_INT
     gpio_wakeup_disable((gpio_num_t)BOARD_PCA9535_INT);
 #endif
-#ifdef HAS_BUTTON
+#if HAS_BUTTON
     // Disable wake-on-button interrupt. Re-attach normal button-interrupts
     if (_buttonPin >= 0) {
         gpio_num_t pin = (gpio_num_t)(_buttonPin);
         gpio_wakeup_disable(pin);
+    }
 #endif
 #ifdef INPUTDRIVER_WAKE_BTN_PIN
-        gpio_wakeup_disable((gpio_num_t)INPUTDRIVER_WAKE_BTN_PIN);
+    gpio_wakeup_disable((gpio_num_t)INPUTDRIVER_WAKE_BTN_PIN);
 #undef INPUTDRIVER_WAKE_BTN_PIN
 #endif
 #if defined(WAKE_ON_TOUCH)
-        gpio_wakeup_disable((gpio_num_t)SCREEN_TOUCH_INT);
+    gpio_wakeup_disable((gpio_num_t)SCREEN_TOUCH_INT);
 #endif
 #if !defined(SOC_PM_SUPPORT_EXT_WAKEUP) && defined(LORA_DIO1) && (LORA_DIO1 != RADIOLIB_NC)
-        if (radioType != RF95_RADIO) {
-            gpio_wakeup_disable((gpio_num_t)LORA_DIO1);
-        }
+    if (radioType != RF95_RADIO) {
+        gpio_wakeup_disable((gpio_num_t)LORA_DIO1);
+    }
 #endif
 #if defined(RF95_IRQ) && (RF95_IRQ != RADIOLIB_NC)
-        if (radioType == RF95_RADIO) {
-            gpio_wakeup_disable((gpio_num_t)RF95_IRQ);
-        }
+    if (radioType == RF95_RADIO) {
+        gpio_wakeup_disable((gpio_num_t)RF95_IRQ);
+    }
 #endif
 
-        esp_sleep_wakeup_cause_t cause = esp_sleep_get_wakeup_cause();
-        notifyLightSleepEnd.notifyObservers(cause); // Button interrupts are reattached here
+    esp_sleep_wakeup_cause_t cause = esp_sleep_get_wakeup_cause();
+    notifyLightSleepEnd.notifyObservers(cause); // Button interrupts are reattached here
 
-        if (cause == ESP_SLEEP_WAKEUP_GPIO) {
-            LOG_INFO("Exit light sleep gpio");
-            // If we woke because of a GPIO, it's possible power needs to run to handle.
-            power->setIntervalFromNow(0);
-            runASAP = true;
-        } else {
-            LOG_INFO("Exit light sleep cause: %d", cause);
-        }
-
-        return cause;
+    if (cause == ESP_SLEEP_WAKEUP_GPIO) {
+        LOG_INFO("Exit light sleep gpio");
+        // If we woke because of a GPIO, it's possible power needs to run to handle.
+        power->setIntervalFromNow(0);
+        runASAP = true;
+    } else {
+        LOG_INFO("Exit light sleep cause: %d", cause);
     }
 
-    // not legal on the stock android ESP build
+    return cause;
+}
 
-    /**
-     * enable modem sleep mode as needed and available.  Should lower our CPU current draw to an average of about 20mA.
-     *
-     * per https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/system/power_management.html
-     *
-     * supposedly according to https://github.com/espressif/arduino-esp32/issues/475 this is already done in arduino
-     */
-    void enableModemSleep()
-    {
+// not legal on the stock android ESP build
+
+/**
+ * enable modem sleep mode as needed and available.  Should lower our CPU current draw to an average of about 20mA.
+ *
+ * per https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/system/power_management.html
+ *
+ * supposedly according to https://github.com/espressif/arduino-esp32/issues/475 this is already done in arduino
+ */
+void enableModemSleep()
+{
 #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
-        static esp_pm_config_t esp32_config; // filled with zeros because bss
+    static esp_pm_config_t esp32_config; // filled with zeros because bss
 #else
     static esp_pm_config_esp32_t esp32_config; // filled with zeros because bss
 #endif
 #if CONFIG_IDF_TARGET_ESP32S3
-        esp32_config.max_freq_mhz = CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ;
+    esp32_config.max_freq_mhz = CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ;
 #elif CONFIG_IDF_TARGET_ESP32S2
     esp32_config.max_freq_mhz = CONFIG_ESP32S2_DEFAULT_CPU_FREQ_MHZ;
 #elif CONFIG_IDF_TARGET_ESP32C6
@@ -566,42 +567,42 @@ esp_sleep_wakeup_cause_t doLightSleep(uint64_t sleepMsec) // FIXME, use a more r
 #else
     esp32_config.max_freq_mhz = CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ;
 #endif
-        esp32_config.min_freq_mhz = 20; // 10Mhz is minimum recommended
-        esp32_config.light_sleep_enable = false;
-        int rv = esp_pm_configure(&esp32_config);
-        LOG_DEBUG("Sleep request result %x", rv);
-    }
+    esp32_config.min_freq_mhz = 20; // 10Mhz is minimum recommended
+    esp32_config.light_sleep_enable = false;
+    int rv = esp_pm_configure(&esp32_config);
+    LOG_DEBUG("Sleep request result %x", rv);
+}
 
-    bool shouldLoraWake(uint32_t msecToWake)
-    {
-        return msecToWake < portMAX_DELAY && (config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER ||
-                                              config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER_LATE);
-    }
+bool shouldLoraWake(uint32_t msecToWake)
+{
+    return msecToWake < portMAX_DELAY && (config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER ||
+                                          config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER_LATE);
+}
 
-    void enableLoraInterrupt()
-    {
-        esp_err_t res;
+void enableLoraInterrupt()
+{
+    esp_err_t res;
 #if SOC_PM_SUPPORT_EXT_WAKEUP && defined(LORA_DIO1) && (LORA_DIO1 != RADIOLIB_NC)
-        res = gpio_pulldown_en((gpio_num_t)LORA_DIO1);
-        if (res != ESP_OK) {
-            LOG_ERROR("gpio_pulldown_en(LORA_DIO1) result %d", res);
-        }
+    res = gpio_pulldown_en((gpio_num_t)LORA_DIO1);
+    if (res != ESP_OK) {
+        LOG_ERROR("gpio_pulldown_en(LORA_DIO1) result %d", res);
+    }
 #if defined(LORA_RESET) && (LORA_RESET != RADIOLIB_NC)
-        res = gpio_pullup_en((gpio_num_t)LORA_RESET);
-        if (res != ESP_OK) {
-            LOG_ERROR("gpio_pullup_en(LORA_RESET) result %d", res);
-        }
+    res = gpio_pullup_en((gpio_num_t)LORA_RESET);
+    if (res != ESP_OK) {
+        LOG_ERROR("gpio_pullup_en(LORA_RESET) result %d", res);
+    }
 #endif
 #if defined(LORA_CS) && (LORA_CS != RADIOLIB_NC) && !defined(ELECROW_PANEL)
-        gpio_pullup_en((gpio_num_t)LORA_CS);
+    gpio_pullup_en((gpio_num_t)LORA_CS);
 #endif
 
 #if HAS_LORA_FEM
-        loraFEMInterface.setRxModeEnableWhenMCUSleep();
+    loraFEMInterface.setRxModeEnableWhenMCUSleep();
 #endif
 
-        LOG_INFO("setup LORA_DIO1 (GPIO%02d) with wakeup by gpio interrupt", LORA_DIO1);
-        gpio_wakeup_enable((gpio_num_t)LORA_DIO1, GPIO_INTR_HIGH_LEVEL);
+    LOG_INFO("setup LORA_DIO1 (GPIO%02d) with wakeup by gpio interrupt", LORA_DIO1);
+    gpio_wakeup_enable((gpio_num_t)LORA_DIO1, GPIO_INTR_HIGH_LEVEL);
 
 #elif defined(LORA_DIO1) && (LORA_DIO1 != RADIOLIB_NC)
     if (radioType != RF95_RADIO) {
@@ -610,10 +611,10 @@ esp_sleep_wakeup_cause_t doLightSleep(uint64_t sleepMsec) // FIXME, use a more r
     }
 #endif
 #if defined(RF95_IRQ) && (RF95_IRQ != RADIOLIB_NC)
-        if (radioType == RF95_RADIO) {
-            LOG_INFO("setup RF95_IRQ (GPIO%02d) with wakeup by gpio interrupt", RF95_IRQ);
-            gpio_wakeup_enable((gpio_num_t)RF95_IRQ, GPIO_INTR_HIGH_LEVEL); // RF95 interrupt, active high
-        }
-#endif
+    if (radioType == RF95_RADIO) {
+        LOG_INFO("setup RF95_IRQ (GPIO%02d) with wakeup by gpio interrupt", RF95_IRQ);
+        gpio_wakeup_enable((gpio_num_t)RF95_IRQ, GPIO_INTR_HIGH_LEVEL); // RF95 interrupt, active high
     }
+#endif
+}
 #endif

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -286,15 +286,23 @@ void doDeepSleep(uint32_t msecToWake, bool skipPreflight = false, bool skipSaveN
     if (shouldLoraWake(msecToWake)) {
         enableLoraInterrupt();
     }
+#ifdef HAS_BUTTON
+    int _buttonPin = -1;
 #ifdef BUTTON_PIN
-    // Avoid leakage through button pin
-    if (GPIO_IS_VALID_OUTPUT_GPIO(BUTTON_PIN)) {
-#ifdef BUTTON_NEED_PULLUP
-        pinMode(BUTTON_PIN, INPUT_PULLUP);
-#else
-        pinMode(BUTTON_PIN, INPUT);
+    _buttonPin = BUTTON_PIN;
 #endif
-        gpio_hold_en((gpio_num_t)BUTTON_PIN);
+    if (config.device.button_gpio)
+        _buttonPin = config.device.button_gpio;
+    if (_buttonPin >= 0) {
+        // Avoid leakage through button pin
+        if (GPIO_IS_VALID_OUTPUT_GPIO(_buttonPin)) {
+#ifdef BUTTON_NEED_PULLUP
+            pinMode(_buttonPin, INPUT_PULLUP);
+#else
+            pinMode(_buttonPin, INPUT);
+#endif
+            gpio_hold_en((gpio_num_t)_buttonPin);
+        }
     }
 #endif
 #ifdef SENSECAP_INDICATOR
@@ -434,9 +442,17 @@ esp_sleep_wakeup_cause_t doLightSleep(uint64_t sleepMsec) // FIXME, use a more r
     // Side-key interrupt line from PCA9535 expander (active low).
     gpio_wakeup_enable((gpio_num_t)BOARD_PCA9535_INT, GPIO_INTR_LOW_LEVEL);
 #endif
+#ifdef HAS_BUTTON
+    int _buttonPin = -1;
 #ifdef BUTTON_PIN
-    gpio_num_t pin = (gpio_num_t)(config.device.button_gpio ? config.device.button_gpio : BUTTON_PIN);
-    gpio_wakeup_enable(pin, GPIO_INTR_LOW_LEVEL);
+    _buttonPin = BUTTON_PIN;
+#endif
+    if (config.device.button_gpio)
+        _buttonPin = config.device.button_gpio;
+    if (_buttonPin >= 0) {
+        gpio_num_t pin = (gpio_num_t)(_buttonPin);
+        gpio_wakeup_enable(pin, GPIO_INTR_LOW_LEVEL);
+    }
 #endif
 #if defined(INPUTDRIVER_TWO_WAY_ROCKER_BTN) || defined(INPUTDRIVER_ENCODER_BTN)
 #if defined(INPUTDRIVER_TWO_WAY_ROCKER_BTN)
@@ -484,61 +500,63 @@ esp_sleep_wakeup_cause_t doLightSleep(uint64_t sleepMsec) // FIXME, use a more r
 #ifdef BOARD_PCA9535_INT
     gpio_wakeup_disable((gpio_num_t)BOARD_PCA9535_INT);
 #endif
-#ifdef BUTTON_PIN
+#ifdef HAS_BUTTON
     // Disable wake-on-button interrupt. Re-attach normal button-interrupts
-    gpio_wakeup_disable(pin);
+    if (_buttonPin >= 0) {
+        gpio_num_t pin = (gpio_num_t)(_buttonPin);
+        gpio_wakeup_disable(pin);
 #endif
 #ifdef INPUTDRIVER_WAKE_BTN_PIN
-    gpio_wakeup_disable((gpio_num_t)INPUTDRIVER_WAKE_BTN_PIN);
+        gpio_wakeup_disable((gpio_num_t)INPUTDRIVER_WAKE_BTN_PIN);
 #undef INPUTDRIVER_WAKE_BTN_PIN
 #endif
 #if defined(WAKE_ON_TOUCH)
-    gpio_wakeup_disable((gpio_num_t)SCREEN_TOUCH_INT);
+        gpio_wakeup_disable((gpio_num_t)SCREEN_TOUCH_INT);
 #endif
 #if !defined(SOC_PM_SUPPORT_EXT_WAKEUP) && defined(LORA_DIO1) && (LORA_DIO1 != RADIOLIB_NC)
-    if (radioType != RF95_RADIO) {
-        gpio_wakeup_disable((gpio_num_t)LORA_DIO1);
-    }
+        if (radioType != RF95_RADIO) {
+            gpio_wakeup_disable((gpio_num_t)LORA_DIO1);
+        }
 #endif
 #if defined(RF95_IRQ) && (RF95_IRQ != RADIOLIB_NC)
-    if (radioType == RF95_RADIO) {
-        gpio_wakeup_disable((gpio_num_t)RF95_IRQ);
-    }
+        if (radioType == RF95_RADIO) {
+            gpio_wakeup_disable((gpio_num_t)RF95_IRQ);
+        }
 #endif
 
-    esp_sleep_wakeup_cause_t cause = esp_sleep_get_wakeup_cause();
-    notifyLightSleepEnd.notifyObservers(cause); // Button interrupts are reattached here
+        esp_sleep_wakeup_cause_t cause = esp_sleep_get_wakeup_cause();
+        notifyLightSleepEnd.notifyObservers(cause); // Button interrupts are reattached here
 
-    if (cause == ESP_SLEEP_WAKEUP_GPIO) {
-        LOG_INFO("Exit light sleep gpio");
-        // If we woke because of a GPIO, it's possible power needs to run to handle.
-        power->setIntervalFromNow(0);
-        runASAP = true;
-    } else {
-        LOG_INFO("Exit light sleep cause: %d", cause);
+        if (cause == ESP_SLEEP_WAKEUP_GPIO) {
+            LOG_INFO("Exit light sleep gpio");
+            // If we woke because of a GPIO, it's possible power needs to run to handle.
+            power->setIntervalFromNow(0);
+            runASAP = true;
+        } else {
+            LOG_INFO("Exit light sleep cause: %d", cause);
+        }
+
+        return cause;
     }
 
-    return cause;
-}
+    // not legal on the stock android ESP build
 
-// not legal on the stock android ESP build
-
-/**
- * enable modem sleep mode as needed and available.  Should lower our CPU current draw to an average of about 20mA.
- *
- * per https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/system/power_management.html
- *
- * supposedly according to https://github.com/espressif/arduino-esp32/issues/475 this is already done in arduino
- */
-void enableModemSleep()
-{
+    /**
+     * enable modem sleep mode as needed and available.  Should lower our CPU current draw to an average of about 20mA.
+     *
+     * per https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/system/power_management.html
+     *
+     * supposedly according to https://github.com/espressif/arduino-esp32/issues/475 this is already done in arduino
+     */
+    void enableModemSleep()
+    {
 #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
-    static esp_pm_config_t esp32_config; // filled with zeros because bss
+        static esp_pm_config_t esp32_config; // filled with zeros because bss
 #else
     static esp_pm_config_esp32_t esp32_config; // filled with zeros because bss
 #endif
 #if CONFIG_IDF_TARGET_ESP32S3
-    esp32_config.max_freq_mhz = CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ;
+        esp32_config.max_freq_mhz = CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ;
 #elif CONFIG_IDF_TARGET_ESP32S2
     esp32_config.max_freq_mhz = CONFIG_ESP32S2_DEFAULT_CPU_FREQ_MHZ;
 #elif CONFIG_IDF_TARGET_ESP32C6
@@ -548,42 +566,42 @@ void enableModemSleep()
 #else
     esp32_config.max_freq_mhz = CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ;
 #endif
-    esp32_config.min_freq_mhz = 20; // 10Mhz is minimum recommended
-    esp32_config.light_sleep_enable = false;
-    int rv = esp_pm_configure(&esp32_config);
-    LOG_DEBUG("Sleep request result %x", rv);
-}
+        esp32_config.min_freq_mhz = 20; // 10Mhz is minimum recommended
+        esp32_config.light_sleep_enable = false;
+        int rv = esp_pm_configure(&esp32_config);
+        LOG_DEBUG("Sleep request result %x", rv);
+    }
 
-bool shouldLoraWake(uint32_t msecToWake)
-{
-    return msecToWake < portMAX_DELAY && (config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER ||
-                                          config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER_LATE);
-}
+    bool shouldLoraWake(uint32_t msecToWake)
+    {
+        return msecToWake < portMAX_DELAY && (config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER ||
+                                              config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER_LATE);
+    }
 
-void enableLoraInterrupt()
-{
-    esp_err_t res;
+    void enableLoraInterrupt()
+    {
+        esp_err_t res;
 #if SOC_PM_SUPPORT_EXT_WAKEUP && defined(LORA_DIO1) && (LORA_DIO1 != RADIOLIB_NC)
-    res = gpio_pulldown_en((gpio_num_t)LORA_DIO1);
-    if (res != ESP_OK) {
-        LOG_ERROR("gpio_pulldown_en(LORA_DIO1) result %d", res);
-    }
+        res = gpio_pulldown_en((gpio_num_t)LORA_DIO1);
+        if (res != ESP_OK) {
+            LOG_ERROR("gpio_pulldown_en(LORA_DIO1) result %d", res);
+        }
 #if defined(LORA_RESET) && (LORA_RESET != RADIOLIB_NC)
-    res = gpio_pullup_en((gpio_num_t)LORA_RESET);
-    if (res != ESP_OK) {
-        LOG_ERROR("gpio_pullup_en(LORA_RESET) result %d", res);
-    }
+        res = gpio_pullup_en((gpio_num_t)LORA_RESET);
+        if (res != ESP_OK) {
+            LOG_ERROR("gpio_pullup_en(LORA_RESET) result %d", res);
+        }
 #endif
 #if defined(LORA_CS) && (LORA_CS != RADIOLIB_NC) && !defined(ELECROW_PANEL)
-    gpio_pullup_en((gpio_num_t)LORA_CS);
+        gpio_pullup_en((gpio_num_t)LORA_CS);
 #endif
 
 #if HAS_LORA_FEM
-    loraFEMInterface.setRxModeEnableWhenMCUSleep();
+        loraFEMInterface.setRxModeEnableWhenMCUSleep();
 #endif
 
-    LOG_INFO("setup LORA_DIO1 (GPIO%02d) with wakeup by gpio interrupt", LORA_DIO1);
-    gpio_wakeup_enable((gpio_num_t)LORA_DIO1, GPIO_INTR_HIGH_LEVEL);
+        LOG_INFO("setup LORA_DIO1 (GPIO%02d) with wakeup by gpio interrupt", LORA_DIO1);
+        gpio_wakeup_enable((gpio_num_t)LORA_DIO1, GPIO_INTR_HIGH_LEVEL);
 
 #elif defined(LORA_DIO1) && (LORA_DIO1 != RADIOLIB_NC)
     if (radioType != RF95_RADIO) {
@@ -592,10 +610,10 @@ void enableLoraInterrupt()
     }
 #endif
 #if defined(RF95_IRQ) && (RF95_IRQ != RADIOLIB_NC)
-    if (radioType == RF95_RADIO) {
-        LOG_INFO("setup RF95_IRQ (GPIO%02d) with wakeup by gpio interrupt", RF95_IRQ);
-        gpio_wakeup_enable((gpio_num_t)RF95_IRQ, GPIO_INTR_HIGH_LEVEL); // RF95 interrupt, active high
-    }
+        if (radioType == RF95_RADIO) {
+            LOG_INFO("setup RF95_IRQ (GPIO%02d) with wakeup by gpio interrupt", RF95_IRQ);
+            gpio_wakeup_enable((gpio_num_t)RF95_IRQ, GPIO_INTR_HIGH_LEVEL); // RF95 interrupt, active high
+        }
 #endif
-}
+    }
 #endif

--- a/variants/nrf52840/rak3401_1watt/variant.h
+++ b/variants/nrf52840/rak3401_1watt/variant.h
@@ -53,6 +53,13 @@ extern "C" {
 #define LED_STATE_ON 1 // State when LED is litted
 
 /*
+ * Buttons
+ */
+
+#define PIN_BUTTON1 31
+#define BUTTON_NEED_PULLUP
+
+/*
  * Analog pins
  */
 #define PIN_A0 (5)

--- a/variants/nrf52840/rak3401_1watt/variant.h
+++ b/variants/nrf52840/rak3401_1watt/variant.h
@@ -50,14 +50,7 @@ extern "C" {
 #define LED_GREEN PIN_LED1
 #define LED_NOTIFICATION LED_BLUE
 
-#define LED_STATE_ON 1 // State when LED is litted
-
-/*
- * Buttons
- */
-
-#define PIN_BUTTON1 31
-#define BUTTON_NEED_PULLUP
+#define LED_STATE_ON 1 // State when LED is lit
 
 /*
  * Analog pins


### PR DESCRIPTION
Fixes #10337 

The user button on the RAK3401 does currently not function after following the [instructions](https://store.rokland.com/pages/adding-a-user-button-rak19007) from ROKland. This PR fixes that. I'm not a seasoned C++/embedded developer. Sorry if my changes are nonsensical.

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [X] Other (please specify below): RAK3401
