### PR TITLE
fix(mesh): null-check getMeshNode in handleFromRadio

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -94,8 +94,9 @@ int MeshService::handleFromRadio(const meshtastic_MeshPacket *mp)
         mp->decoded.portnum == meshtastic_PortNum_TELEMETRY_APP && mp->decoded.request_id > 0) {
         LOG_DEBUG("Received telemetry response. Skip sending our NodeInfo");
         //  ignore our request for its NodeInfo
-    } else if (mp->which_payload_variant == meshtastic_MeshPacket_decoded_tag && !nodeDB->getMeshNode(mp->from)->has_user &&
-               nodeInfoModule && !isPreferredRebroadcaster && !nodeDB->isFull()) {
+    } else if (auto *senderNode = (mp->which_payload_variant == meshtastic_MeshPacket_decoded_tag) ? nodeDB->getMeshNode(mp->from)
+                                                                                                  : nullptr;
+               senderNode && !senderNode->has_user && nodeInfoModule && !isPreferredRebroadcaster && !nodeDB->isFull()) {
         if (airTime->isTxAllowedChannelUtil(true)) {
             const int8_t hopsUsed = getHopsAway(*mp, config.lora.hop_limit);
             if (hopsUsed > (int32_t)(config.lora.hop_limit + 2)) {


### PR DESCRIPTION
NodeDB::getMeshNode returns nullptr legitimately under heap pressure
(see NodeDB::isFull and updateFrom early-out paths). The condition at
MeshService.cpp:97 dereferenced the result directly to read has_user,
so every received decoded packet from a new node could crash on a
device near pool exhaustion. Restructure with an init-statement so the
node is fetched once and the rest of the predicate short-circuits on
null.

Split out from #10424 per @thebentern's request — single-concern PR.

## Build verification
`pio run -e t-deck-tft` succeeds, no new warnings.

## Attestations
- [x] I have tested that my proposed changes behave as described — review/static-analysis only, not on-air.
- [ ] On-hardware testing requested from community: build-verified `t-deck-tft` only.