### PR TITLE
fix(mesh): drop oversized RX packets instead of asserting

### DIFF
--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -530,7 +530,16 @@ void RadioLibInterface::handleReceiveInterrupt()
 
             mp->which_payload_variant =
                 meshtastic_MeshPacket_encrypted_tag; // Mark that the payload is still encrypted at this point
-            assert(((uint32_t)payloadLen) <= sizeof(mp->encrypted.bytes));
+            if ((uint32_t)payloadLen > sizeof(mp->encrypted.bytes)) {
+                LOG_WARN("Drop oversized RX packet (%d > %u)", payloadLen, (unsigned)sizeof(mp->encrypted.bytes));
+                packetPool.release(mp);
+                // The outer else branch already incremented rxGood for this packet;
+                // undo that and reclassify as rxBad so num_packets_rx isn't double-counted.
+                rxGood--;
+                rxBad++;
+                airTime->logAirtime(RX_ALL_LOG, rxMsec);
+                return;
+            }
             memcpy(mp->encrypted.bytes, radioBuffer.payload, payloadLen);
             mp->encrypted.size = payloadLen;
 


### PR DESCRIPTION
handleReceiveInterrupt bounded the encrypted-payload memcpy with an
assert, which a future modem with a longer max payload would turn into
a panic-reset on a malformed (or simply larger) air packet. Replace
with a runtime length check that releases the pool entry, bumps rxBad,
and returns. assert() also vanishes in NDEBUG builds, so there was no
actual bound check in release.

Split out from #10424 per @thebentern's request — single-concern PR.

## Build verification
`pio run -e t-deck-tft` succeeds, no new warnings.

## Attestations
- [x] I have tested that my proposed changes behave as described — review/static-analysis only, not on-air.
- [ ] On-hardware testing requested from community: build-verified `t-deck-tft` only.