### PR TITLE
fix(mesh): poll TX_DONE and stuck-TX timeout from main loop

### DIFF
--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -555,6 +555,17 @@ void RadioLibInterface::pollMissedIrqs()
     if (isReceiving) {
         checkRxDoneIrqFlag();
     }
+    if (sendingPacket != NULL) {
+        checkTxDoneIrqFlag();
+        // The stuck-TX guard in canSendImmediately only runs when the queue
+        // gets new packets. If the queue is empty, a wedged radio sits
+        // forever — fire the same reboot path here so it always trips.
+        if (!Throttle::isWithinTimespanMs(lastTxStart, 60000) && rebootAtMsec == 0) {
+            LOG_ERROR("Hardware Failure! TX stuck for more than 60s (poll)");
+            RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_TRANSMIT_FAILED);
+            rebootAtMsec = lastTxStart + 65000;
+        }
+    }
 }
 
 void RadioLibInterface::resetAGC()
@@ -567,6 +578,14 @@ void RadioLibInterface::checkRxDoneIrqFlag()
     if (iface->checkIrq(RADIOLIB_IRQ_RX_DONE)) {
         LOG_WARN("caught missed RX_DONE");
         notify(ISR_RX, true);
+    }
+}
+
+void RadioLibInterface::checkTxDoneIrqFlag()
+{
+    if (iface->checkIrq(RADIOLIB_IRQ_TX_DONE)) {
+        LOG_WARN("caught missed TX_DONE");
+        notify(ISR_TX, true);
     }
 }
 

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -293,4 +293,5 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
     bool removePendingTXPacket(NodeNum from, PacketId id, uint32_t hop_limit_lt) override;
 
     void checkRxDoneIrqFlag();
+    void checkTxDoneIrqFlag();
 };


### PR DESCRIPTION
The 60s stuck-TX detector in canSendImmediately only fires when more
packets enter the TX queue, because that's the only path that calls it.
If the queue empties after the radio wedges, no IRQ ever fires, no
poll runs, and the device sits in busyTx forever. pollMissedIrqs is
already invoked unconditionally from the main loop — extend it to
poll TX_DONE when sendingPacket is set, and trip the same reboot
path independently of queue activity.

Split out from #10424 per @thebentern's request — single-concern PR.

## Build verification
`pio run -e t-deck-tft` succeeds, no new warnings.

## Attestations
- [x] I have tested that my proposed changes behave as described — review/static-analysis only, not on-air.
- [ ] On-hardware testing requested from community: build-verified `t-deck-tft` only.