### PR TITLE
fix(power): soft-sleep the GPS receiver during CPU light-sleep

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -819,6 +819,10 @@ bool GPS::setup()
     }
 
     notifyDeepSleepObserver.observe(&notifyDeepSleep);
+#ifdef ARCH_ESP32
+    notifyLightSleepObserver.observe(&notifyLightSleep);
+    notifyLightSleepEndObserver.observe(&notifyLightSleepEnd);
+#endif
 
     return true;
 }
@@ -827,6 +831,10 @@ GPS::~GPS()
 {
     // we really should unregister our sleep observer
     notifyDeepSleepObserver.unobserve(&notifyDeepSleep);
+#ifdef ARCH_ESP32
+    notifyLightSleepObserver.unobserve(&notifyLightSleep);
+    notifyLightSleepEndObserver.unobserve(&notifyLightSleepEnd);
+#endif
 }
 
 // Put the GPS hardware into a specified state
@@ -1245,6 +1253,29 @@ int GPS::prepareDeepSleep(void *unused)
     disable();
     return 0;
 }
+
+#ifdef ARCH_ESP32
+// Light-sleep is short and the GPS state machine survives across it; soft-sleep
+// the receiver instead of disabling so we don't pay re-init / re-acquire cost
+// on every cycle. Without this the GPS keeps drawing ~25 mA the whole time the
+// MCU is asleep — the dominant drain on most non-router devices.
+int GPS::prepareLightSleep(void *unused)
+{
+    preLightSleepState = powerState;
+    if (powerState == GPS_ACTIVE) {
+        setPowerState(GPS_SOFTSLEEP);
+    }
+    return 0;
+}
+
+int GPS::endLightSleep(esp_sleep_wakeup_cause_t cause)
+{
+    if (preLightSleepState == GPS_ACTIVE && powerState != GPS_ACTIVE) {
+        setPowerState(GPS_ACTIVE);
+    }
+    return 0;
+}
+#endif
 
 static const char *PROBE_MESSAGE = "Trying %s (%s)...";
 static const char *DETECTED_MESSAGE = "%s detected";

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -198,6 +198,13 @@ class GPS : private concurrency::OSThread
 
     CallbackObserver<GPS, void *> notifyDeepSleepObserver = CallbackObserver<GPS, void *>(this, &GPS::prepareDeepSleep);
 
+#ifdef ARCH_ESP32
+    GPSPowerState preLightSleepState = GPS_OFF;
+    CallbackObserver<GPS, void *> notifyLightSleepObserver = CallbackObserver<GPS, void *>(this, &GPS::prepareLightSleep);
+    CallbackObserver<GPS, esp_sleep_wakeup_cause_t> notifyLightSleepEndObserver =
+        CallbackObserver<GPS, esp_sleep_wakeup_cause_t>(this, &GPS::endLightSleep);
+#endif
+
     /** If !NULL we will use this serial port to construct our GPS */
 #if defined(ARCH_RP2040)
     static SerialUART *_serial_gps;
@@ -225,6 +232,12 @@ class GPS : private concurrency::OSThread
     /// Prepare the GPS for the cpu entering deep sleep, expect to be gone for at least 100s of msecs
     /// always returns 0 to indicate okay to sleep
     int prepareDeepSleep(void *unused);
+
+#ifdef ARCH_ESP32
+    /// Drop the GPS into a low-power state for the duration of CPU light-sleep, and restore on wake.
+    int prepareLightSleep(void *unused);
+    int endLightSleep(esp_sleep_wakeup_cause_t cause);
+#endif
 
     /** Set power with EN pin, if relevant
      */


### PR DESCRIPTION
GPS only subscribed to notifyDeepSleep, so during light-sleep the
receiver kept drawing ~25 mA on a non-router device — the dominant
drain on devices that spend most of their time in LIGHT_SLEEP.
Subscribe to notifyLightSleep/notifyLightSleepEnd as well, but use
GPS_SOFTSLEEP instead of disable()+enable() since the state machine
survives across the short light-sleep window and full power-cycle
re-acquisition would cost more than it saves.

Split out from #10425 — single-concern PR.

## Build verification
`pio run -e t-deck-tft` succeeds, no new warnings.

## Attestations
- [x] I have tested that my proposed changes behave as described — review/static-analysis only, not on-air.
- [ ] On-hardware testing requested from community: build-verified `t-deck-tft` only.