### PR TITLE
fix(power): replace assert(0) on stuck preflight with controlled restart

### DIFF
--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -195,7 +195,26 @@ static void waitEnterSleep(bool skipPreflight = false)
             if (!Throttle::isWithinTimespanMs(now,
                                               THIRTY_SECONDS_MS)) { // If we wait too long just report an error and go to sleep
                 RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_SLEEP_ENTER_WAIT);
-                assert(0); // FIXME - for now we just restart, need to fix bug #167
+                // FIXME issue #167: a misbehaving observer can veto sleep forever.
+                // Restart cleanly rather than panicking — same effective recovery,
+                // no core-dump pollution, and the firmware can come back up with a
+                // working state machine instead of triggering the panic handler.
+                LOG_ERROR("Preflight sleep wait exceeded 30s, restarting");
+                // Notify reboot observers (e.g. InkHUD) so they can persist /
+                // shut down cleanly, matching Power::reboot's contract.
+                notifyReboot.notifyObservers(NULL);
+                console->flush();
+#if defined(ARCH_ESP32)
+                ESP.restart();
+#elif defined(ARCH_NRF52)
+                NVIC_SystemReset();
+#elif defined(ARCH_RP2040)
+                rp2040.reboot();
+#elif defined(ARCH_STM32WL)
+                HAL_NVIC_SystemReset();
+#else
+                assert(0); // fallback for archs without a clean restart primitive
+#endif
                 break;
             }
         }

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -212,6 +212,8 @@ static void waitEnterSleep(bool skipPreflight = false)
                 rp2040.reboot();
 #elif defined(ARCH_STM32WL)
                 HAL_NVIC_SystemReset();
+#elif defined(ARCH_PORTDUINO)
+                ::reboot();
 #else
                 assert(0); // fallback for archs without a clean restart primitive
 #endif


### PR DESCRIPTION
waitEnterSleep panicked with assert(0) when an observer vetoed sleep
for >30s (FIXME #167). On a field device that turns into a noisy
crash log every 30s rather than a clean reboot. Use the same
per-arch restart primitives Power::reboot uses, fall back to assert
only for archs we don't have a primitive for.

Split out from #10425 — single-concern PR.

## Build verification
`pio run -e t-deck-tft` succeeds, no new warnings.

## Attestations
- [x] I have tested that my proposed changes behave as described — review/static-analysis only, not on-air.
- [ ] On-hardware testing requested from community: build-verified `t-deck-tft` only.