### PR TITLE
fix(power): use BQ25896 ADC for both battery voltage and presence

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -1668,9 +1668,14 @@ class LipoCharger : public HasBatteryLevel
     }
 
     /**
-     * The raw voltage of the battery in millivolts, or NAN if unknown
+     * The raw voltage of the battery in millivolts, or 0 if unknown.
+     * Use the BQ25896 charger ADC for both voltage and presence detection so
+     * the two readings can never disagree. The BQ27220 fuel gauge can report
+     * 0 / stale on a freshly-attached cell before its initial learn cycle
+     * finishes, which would make hasBattery=false but voltage=4.0V — the
+     * upstream PowerFSM then thinks the device is externally powered.
      */
-    virtual uint16_t getBattVoltage() override { return bq->getVoltage(); }
+    virtual uint16_t getBattVoltage() override { return PPM->getBattVoltage(); }
 
     /**
      * return true if there is a battery installed in this unit


### PR DESCRIPTION
getBattVoltage on the BQ27220+BQ25896 combo returned the fuel-gauge
reading while isBatteryConnect derived presence from the BQ25896
charger ADC. The two could disagree on a freshly-attached cell before
the fuel gauge had learned: hasBattery would say false but voltage
4.0V, and the upstream PowerFSM would treat the unit as externally
powered. Read voltage from the same source as presence so both views
move together.

Split out from #10425 — single-concern PR.

## Build verification
`pio run -e t-deck-tft` succeeds, no new warnings.

## Attestations
- [x] I have tested that my proposed changes behave as described — review/static-analysis only, not on-air.
- [ ] On-hardware testing requested from community: build-verified `t-deck-tft` only.