### PR TITLE
Fix screen geometry update for SH1107 display

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -731,8 +731,15 @@ void setup()
 #elif defined(USE_SH1107_128_64)
     screen_model = meshtastic_Config_DisplayConfig_OledType_OLED_SH1107; // keep dimension of 128x64
 #else
-    if (config.display.oled != meshtastic_Config_DisplayConfig_OledType_OLED_AUTO)
+    if (config.display.oled != meshtastic_Config_DisplayConfig_OledType_OLED_AUTO) {
         screen_model = config.display.oled;
+
+        // Fix: update geometry for SH1107 128x128 selected via menu
+        if (screen_model == meshtastic_Config_DisplayConfig_OledType_OLED_SH1107_128_128) {
+            screen_geometry = GEOMETRY_128_128;
+            screen_model = meshtastic_Config_DisplayConfig_OledType_OLED_SH1107; // normalize
+        }
+    }
 #endif
 #endif
 


### PR DESCRIPTION
Added conditional block to update screen geometry for SH1107 128x128.

<details>
<summary>before</summary>
<img width="1804" height="2411" alt="WhatsApp Image 2026-05-09 at 16 45 21 (1)" src="https://github.com/user-attachments/assets/e037c76f-0058-44c3-b522-5ce80f3a9e84" />
</details>
<details>
<summary>after</summary>
<img width="1197" height="1600" alt="WhatsApp Image 2026-05-09 at 16 45 21" src="https://github.com/user-attachments/assets/3040ce5d-5a39-4b45-8142-38af81020513" />
</details>


Fix #9751

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] NRF52 Pro-micro DIY
    - [x] Seeed Xiao ESP32-S3