### PR TITLE
Fix WiFi TCP/HTTP services not starting without USB serial connected

### DIFF
--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -291,9 +291,7 @@ static int32_t reconnectWiFi()
 #endif
         return 1000; // check once per second
     } else {
-#ifdef ARCH_RP2040
-        onNetworkConnected(); // will only do anything once
-#endif
+        onNetworkConnected(); // will only do anything once (guarded by APStartupComplete)
         return 300000; // every 5 minutes
     }
 }
@@ -343,9 +341,6 @@ bool initWifi()
         const char *wifiPsw = config.network.wifi_psk;
 
 #ifndef ARCH_RP2040
-#if !MESHTASTIC_EXCLUDE_WEBSERVER
-        createSSLCert(); // For WebServer
-#endif
         WiFi.persistent(false); // Disable flash storage for WiFi credentials
 #endif
         if (!*wifiPsw) // Treat empty password as no password
@@ -370,6 +365,9 @@ bool initWifi()
 #endif
             }
 #ifdef ARCH_ESP32
+            // Register WiFi event handler BEFORE createSSLCert() to prevent race condition:
+            // Without this, WiFi can auto-reconnect during cert generation and fire GOT_IP
+            // before the handler is registered, causing onNetworkConnected() to never run.
             WiFi.onEvent(WiFiEvent);
             WiFi.setAutoReconnect(true);
             WiFi.setSleep(false);
@@ -391,6 +389,12 @@ bool initWifi()
                     wifiDisconnectReason = info.wifi_sta_disconnected.reason;
                 },
                 WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
+#endif
+
+#ifndef ARCH_RP2040
+#if !MESHTASTIC_EXCLUDE_WEBSERVER
+            createSSLCert(); // For WebServer - called after WiFi.onEvent() to avoid race condition
+#endif
 #endif
             LOG_DEBUG("JOINING WIFI soon: ssid=%s", wifiName);
             wifiReconnect = new Periodic("WifiConnect", reconnectWiFi);


### PR DESCRIPTION
Fixes a race condition in `initWifi()` that prevents `onNetworkConnected()` from ever being called when the device boots without a USB serial connection. This causes the TCP API server (port 4403) and HTTP API handlers to never initialize, even though WiFi connects successfully.

In `initWifi()`, `WiFi.onEvent(WiFiEvent)` is registered after `createSSLCert()`. The `createSSLCert()` function blocks with `yield()` calls while generating/loading the SSL certificate.

Without USB serial, the `SerialConsole` constructor delays boot by up to 5 seconds (`while (!Port)` timeout). By the time `initWifi()` runs, the ESP32 WiFi subsystem has had time to auto-reconnect using credentials stored in NVS. During `createSSLCert()`'s `yield()` calls, WiFi fires `ARDUINO_EVENT_WIFI_STA_GOT_IP`, but the event handler isn't registered yet, so the event is lost. `onNetworkConnected()` never runs, and the web/TCP services never start.

With USB serial connected, the serial port becomes ready immediately (no 5-second timeout), so `initWifi()` runs earlier and `WiFi.onEvent()` is registered before WiFi can auto-reconnect.

Two changes in `WiFiAPClient.cpp`:

1. Move `WiFi.onEvent(WiFiEvent)` before `createSSLCert()` so the event handler is ready before any blocking call that could allow WiFi to reconnect.

2. Call `onNetworkConnected()` from `reconnectWiFi()` on all platforms (not just RP2040) as a safety net. The function is already guarded by `APStartupComplete` so it only runs once.

Tested on Heltec V3 (ESP32-S3) with firmware 2.7.23:
- 3 consecutive reboots without USB serial: TCP 4403 open on all
- Web API returns correct JSON responses
- MeshMonitor (TCP client) reconnects successfully after each reboot
- Heap stable at ~58100 bytes across reboots

## Possibly related issues

Reports describing the same end-user symptom (WiFi connects and the device gets an IP, but no client can connect because TCP/HTTP services never come up) that this PR may fix. I do not own these specific boards, so confirmation from affected users would be appreciated:

- May fix #8729 (LILYGO T-LoRa V2.1-1.6: node unreachable for clients after configuring WiFi)
- May fix #9622 (T-Deck: app sees the device but tapping connect does nothing)

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)