### PR TITLE
VSCode: Prepare for pioarduino transition

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,17 +8,21 @@
   "features": {
     "ghcr.io/devcontainers/features/python:1": {
       "installTools": true,
-      "version": "3.14"
+      "version": "3.13"
     }
   },
   "customizations": {
     "vscode": {
       "extensions": [
         "ms-vscode.cpptools",
-        "platformio.platformio-ide",
+        "Jason2866.esp-decoder",
+        "pioarduino.pioarduino-ide",
         "Trunk.io"
       ],
-      "unwantedRecommendations": ["ms-azuretools.vscode-docker"],
+      "unwantedRecommendations": [
+        "ms-azuretools.vscode-docker",
+        "platformio.platformio-ide"
+      ],
       "settings": {
         "extensions.ignoreRecommendations": true
       }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,10 +1,10 @@
 {
-    // See http://go.microsoft.com/fwlink/?LinkId=827846
-    // for the documentation about the extensions.json format
     "recommendations": [
-        "platformio.platformio-ide"
+        "Jason2866.esp-decoder",
+        "pioarduino.pioarduino-ide"
     ],
     "unwantedRecommendations": [
-        "ms-vscode.cpptools-extension-pack"
+        "ms-vscode.cpptools-extension-pack",
+        "platformio.platformio-ide"
     ]
 }


### PR DESCRIPTION
Start recommending the pioarduino VS Code extension instead of the PlatformIO extension.

pioarduino-based builds cannot complete correctly using the platformio extension. Normal platformio builds (nrf52, stm32) are unaffected//still work correctly.

Devs may need to delete their `~.platformio` and `.pio` directories once after install in order to build properly.


This is intentionally targetting `master` (should be backmerged to `develop`)