### PR TITLE
Remove ARIAL24 large font on NRF52 platforms (Leave it on ESP32 where we can afford flash)

### DIFF
--- a/src/graphics/ScreenFonts.h
+++ b/src/graphics/ScreenFonts.h
@@ -88,24 +88,56 @@
 #endif
 #endif
 
+// ---------------------------------------------------------------------------
+// Flash budget: nRF52 boards drop the 24pt glyph (~9.6 KB) and substitute the
+// 16pt one. Other architectures (ESP32, RP2040, Portduino, STM32) always keep
+// 24pt. Any nRF52 variant that wants 24pt back can set
+// MESHTASTIC_LARGE_FONT_24PT=1 in its build flags.
+// ---------------------------------------------------------------------------
+#if defined(ARCH_NRF52) && !defined(MESHTASTIC_LARGE_FONT_24PT)
+#define MESHTASTIC_DROP_24PT_FONT
+#endif
+
+// ---------------------------------------------------------------------------
+// Display tier → pick FONT_SMALL/MEDIUM/LARGE.
+//   BIG     — eInk panel / TFT / Hackaday Communicator.
+//   TINY    — M5STACK_UNITC6L only.
+//   default — 128x64 SSD1306 / SH1106 small OLED.
+// DISPLAY_FORCE_SMALL_FONTS opts a big-screen variant out of BIG (rarely used).
+// ---------------------------------------------------------------------------
 #if (defined(USE_EINK) || defined(ILI9341_DRIVER) || defined(ILI9342_DRIVER) || defined(ST7701_CS) || defined(ST7735_CS) ||      \
      defined(ST7789_CS) || defined(USE_ST7789) || defined(HX8357_CS) || defined(ILI9488_CS) || defined(ST7796_CS) ||             \
      defined(USE_ST7796) || defined(HACKADAY_COMMUNICATOR)) &&                                                                   \
     !defined(DISPLAY_FORCE_SMALL_FONTS)
-// The screen is bigger so use bigger fonts
-#define FONT_SMALL FONT_MEDIUM_LOCAL // Height: 19
-#define FONT_MEDIUM FONT_LARGE_LOCAL // Height: 28
-#define FONT_LARGE FONT_LARGE_LOCAL  // Height: 28
-#elif defined(M5STACK_UNITC6L)
-#define FONT_SMALL FONT_SMALL_LOCAL  // Height: 13
-#define FONT_MEDIUM FONT_SMALL_LOCAL // Height: 13
-#define FONT_LARGE FONT_SMALL_LOCAL  // Height: 13
+// Tier BIG. SMALL is 16pt; MEDIUM/LARGE normally 24pt.
+#define FONT_SMALL FONT_MEDIUM_LOCAL // 16pt
+#if defined(MESHTASTIC_DROP_24PT_FONT) && defined(USE_EINK)
+// Flash-tight nRF52 eInk: collapse MEDIUM/LARGE to 16pt too.
+#define FONT_MEDIUM FONT_MEDIUM_LOCAL // 16pt
+#define FONT_LARGE FONT_MEDIUM_LOCAL  // 16pt
 #else
-#define FONT_SMALL FONT_SMALL_LOCAL   // Height: 13
-#define FONT_MEDIUM FONT_MEDIUM_LOCAL // Height: 19
-#define FONT_LARGE FONT_LARGE_LOCAL   // Height: 28
+#define FONT_MEDIUM FONT_LARGE_LOCAL // 24pt
+#define FONT_LARGE FONT_LARGE_LOCAL  // 24pt
+#endif
+#elif defined(M5STACK_UNITC6L)
+// Tier TINY — 10pt everywhere.
+#define FONT_SMALL FONT_SMALL_LOCAL  // 10pt
+#define FONT_MEDIUM FONT_SMALL_LOCAL // 10pt
+#define FONT_LARGE FONT_SMALL_LOCAL  // 10pt
+#else
+// Default tier — small OLED.
+#define FONT_SMALL FONT_SMALL_LOCAL   // 10pt
+#define FONT_MEDIUM FONT_MEDIUM_LOCAL // 16pt
+#if defined(MESHTASTIC_DROP_24PT_FONT)
+// Flash-tight nRF52 small-OLED: substitute 16pt for 24pt. Only the BLE PIN
+// screen and one audio-module screen use FONT_LARGE on this tier.
+#define FONT_LARGE FONT_MEDIUM_LOCAL // 16pt
+#else
+#define FONT_LARGE FONT_LARGE_LOCAL // 24pt
+#endif
 #endif
 
+// CrowPanel-S3 / T5-S3 ePaper override everything with their own 30pt font.
 #if defined(CROWPANEL_ESP32S3_5_EPAPER) || defined(T5_S3_EPAPER_PRO)
 #undef FONT_SMALL
 #undef FONT_MEDIUM

--- a/src/graphics/ScreenFonts.h
+++ b/src/graphics/ScreenFonts.h
@@ -88,56 +88,33 @@
 #endif
 #endif
 
-// ---------------------------------------------------------------------------
-// Flash budget: nRF52 boards drop the 24pt glyph (~9.6 KB) and substitute the
-// 16pt one. Other architectures (ESP32, RP2040, Portduino, STM32) always keep
-// 24pt. Any nRF52 variant that wants 24pt back can set
-// MESHTASTIC_LARGE_FONT_24PT=1 in its build flags.
-// ---------------------------------------------------------------------------
+// nRF52 flash optimization: re-route FONT_LARGE_LOCAL to the 16pt glyph so
+// the display-tier dispatch below picks up 16pt everywhere it would have used
+// 24pt. Drops the ~9.6 KB ArialMT_Plain_24 table from the linked binary.
+// Set MESHTASTIC_LARGE_FONT_24PT=1 in build_flags to opt out per variant.
 #if defined(ARCH_NRF52) && !defined(MESHTASTIC_LARGE_FONT_24PT)
-#define MESHTASTIC_DROP_24PT_FONT
+#undef FONT_LARGE_LOCAL
+#define FONT_LARGE_LOCAL FONT_MEDIUM_LOCAL
 #endif
 
-// ---------------------------------------------------------------------------
-// Display tier → pick FONT_SMALL/MEDIUM/LARGE.
-//   BIG     — eInk panel / TFT / Hackaday Communicator.
-//   TINY    — M5STACK_UNITC6L only.
-//   default — 128x64 SSD1306 / SH1106 small OLED.
-// DISPLAY_FORCE_SMALL_FONTS opts a big-screen variant out of BIG (rarely used).
-// ---------------------------------------------------------------------------
 #if (defined(USE_EINK) || defined(ILI9341_DRIVER) || defined(ILI9342_DRIVER) || defined(ST7701_CS) || defined(ST7735_CS) ||      \
      defined(ST7789_CS) || defined(USE_ST7789) || defined(HX8357_CS) || defined(ILI9488_CS) || defined(ST7796_CS) ||             \
      defined(USE_ST7796) || defined(HACKADAY_COMMUNICATOR)) &&                                                                   \
     !defined(DISPLAY_FORCE_SMALL_FONTS)
-// Tier BIG. SMALL is 16pt; MEDIUM/LARGE normally 24pt.
-#define FONT_SMALL FONT_MEDIUM_LOCAL // 16pt
-#if defined(MESHTASTIC_DROP_24PT_FONT) && defined(USE_EINK)
-// Flash-tight nRF52 eInk: collapse MEDIUM/LARGE to 16pt too.
-#define FONT_MEDIUM FONT_MEDIUM_LOCAL // 16pt
-#define FONT_LARGE FONT_MEDIUM_LOCAL  // 16pt
-#else
-#define FONT_MEDIUM FONT_LARGE_LOCAL // 24pt
-#define FONT_LARGE FONT_LARGE_LOCAL  // 24pt
-#endif
+// The screen is bigger so use bigger fonts
+#define FONT_SMALL FONT_MEDIUM_LOCAL // Height: 19
+#define FONT_MEDIUM FONT_LARGE_LOCAL // Height: 28
+#define FONT_LARGE FONT_LARGE_LOCAL  // Height: 28
 #elif defined(M5STACK_UNITC6L)
-// Tier TINY — 10pt everywhere.
-#define FONT_SMALL FONT_SMALL_LOCAL  // 10pt
-#define FONT_MEDIUM FONT_SMALL_LOCAL // 10pt
-#define FONT_LARGE FONT_SMALL_LOCAL  // 10pt
+#define FONT_SMALL FONT_SMALL_LOCAL  // Height: 13
+#define FONT_MEDIUM FONT_SMALL_LOCAL // Height: 13
+#define FONT_LARGE FONT_SMALL_LOCAL  // Height: 13
 #else
-// Default tier — small OLED.
-#define FONT_SMALL FONT_SMALL_LOCAL   // 10pt
-#define FONT_MEDIUM FONT_MEDIUM_LOCAL // 16pt
-#if defined(MESHTASTIC_DROP_24PT_FONT)
-// Flash-tight nRF52 small-OLED: substitute 16pt for 24pt. Only the BLE PIN
-// screen and one audio-module screen use FONT_LARGE on this tier.
-#define FONT_LARGE FONT_MEDIUM_LOCAL // 16pt
-#else
-#define FONT_LARGE FONT_LARGE_LOCAL // 24pt
-#endif
+#define FONT_SMALL FONT_SMALL_LOCAL   // Height: 13
+#define FONT_MEDIUM FONT_MEDIUM_LOCAL // Height: 19
+#define FONT_LARGE FONT_LARGE_LOCAL   // Height: 28
 #endif
 
-// CrowPanel-S3 / T5-S3 ePaper override everything with their own 30pt font.
 #if defined(CROWPANEL_ESP32S3_5_EPAPER) || defined(T5_S3_EPAPER_PRO)
 #undef FONT_SMALL
 #undef FONT_MEDIUM

--- a/src/graphics/ScreenFonts.h
+++ b/src/graphics/ScreenFonts.h
@@ -91,8 +91,9 @@
 // nRF52 flash optimization: re-route FONT_LARGE_LOCAL to the 16pt glyph so
 // the display-tier dispatch below picks up 16pt everywhere it would have used
 // 24pt. Drops the ~9.6 KB ArialMT_Plain_24 table from the linked binary.
-// Set MESHTASTIC_LARGE_FONT_24PT=1 in build_flags to opt out per variant.
-#if defined(ARCH_NRF52) && !defined(MESHTASTIC_LARGE_FONT_24PT)
+// Set MESHTASTIC_LARGE_FONT_24PT=1 in build_flags to opt out per variant
+// (undefined or 0 keeps the optimization on).
+#if defined(ARCH_NRF52) && (!defined(MESHTASTIC_LARGE_FONT_24PT) || MESHTASTIC_LARGE_FONT_24PT == 0)
 #undef FONT_LARGE_LOCAL
 #define FONT_LARGE_LOCAL FONT_MEDIUM_LOCAL
 #endif


### PR DESCRIPTION
As far as I can tell, this only impacts BLE pin screen which is getting refactored anyway.
Savings: 9,648 bytes ≈ 9.4 KB (1.2% of the app region)