### PR TITLE
nRF54L15: fix SHT4x sensor libdep (arduino-sht, not Adafruit_SHT4X)

### DIFF
--- a/variants/nrf54l15/nrf54l15.ini
+++ b/variants/nrf54l15/nrf54l15.ini
@@ -66,7 +66,10 @@ lib_deps =
   https://github.com/adafruit/Adafruit_INA219/archive/refs/tags/1.2.3.zip
   https://github.com/RobTillaart/INA3221_RT/archive/refs/tags/0.4.2.zip
   https://github.com/RobTillaart/INA226/archive/refs/tags/0.6.6.zip
-  https://github.com/adafruit/Adafruit_SHT4X/archive/refs/tags/1.0.5.zip
+  ; SHTXXSensor gates on __has_include(<SHTSensor.h>), a header shipped by
+  ; Sensirion/arduino-sht. Adafruit_SHT4X ships Adafruit_SHT4X.h instead and
+  ; has no consumer in src/, so it left the SHT40 driver out of the build.
+  https://github.com/Sensirion/arduino-sht/archive/refs/tags/v1.2.6.zip
 
 lib_ignore =
   BluetoothOTA


### PR DESCRIPTION
## What

The nRF54L15-DK variant (added in #10193) lists `Adafruit_SHT4X` in `lib_deps`, but the SHT4x driver `SHTXXSensor` includes `<SHTSensor.h>` and is gated behind `__has_include(<SHTSensor.h>)`.

`<SHTSensor.h>` is shipped by Sensirion/arduino-sht. `Adafruit_SHT4X` ships `Adafruit_SHT4X.h` instead and has no consumer anywhere in `src/`, so the `__has_include` gate evaluates false and the SHT4x driver is silently excluded from the build — the variant cannot read an SHT4x sensor.

## Fix

Replace the dead `Adafruit_SHT4X` libdep with `arduino-sht v1.2.6`.

## Testing

Validated on an nRF54L15-DK with an SHT40-AD1B on TWIM30 (addr `0x44`): 24h soak, temperature + humidity telemetry stable end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ci: re-trigger check-label (bugfix label was applied after the initial run) -->
