### PR TITLE
fix: first set pinMode, then write to pin

### DIFF
--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -52,8 +52,8 @@ template <typename T> bool SX126xInterface<T>::init()
 
 #ifdef SX126X_POWER_EN // Perhaps add RADIOLIB_NC check, and beforehand define as such if it is undefined, but it is not commonly
                        // used and not part of the 'default' set of pin definitions.
-    digitalWrite(SX126X_POWER_EN, HIGH);
     pinMode(SX126X_POWER_EN, OUTPUT);
+    digitalWrite(SX126X_POWER_EN, HIGH);
 #endif
 
 #if HAS_LORA_FEM
@@ -65,8 +65,8 @@ template <typename T> bool SX126xInterface<T>::init()
 #endif
 
 #ifdef RF95_FAN_EN
-    digitalWrite(RF95_FAN_EN, HIGH);
     pinMode(RF95_FAN_EN, OUTPUT);
+    digitalWrite(RF95_FAN_EN, HIGH);
 #endif
 
 #if ARCH_PORTDUINO


### PR DESCRIPTION
Simple fix of rarely used functions (EN pin of SX1262 and EN pin of fan), detected on my brand new LilyGo T-Beam 1W. 

Before that fix there was a Critical Error 3.

```
[  5858][E][esp32-hal-gpio.c:181] __digitalWrite(): IO 40 is not set as GPIO. Execute digitalMode(40, OUTPUT) first.
[  5870][E][esp32-hal-gpio.c:181] __digitalWrite(): IO 41 is not set as GPIO. Execute digitalMode(41, OUTPUT) first.
```
