### PR TITLE
Actions: Fix tagging upon release.

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -333,6 +333,7 @@ jobs:
           prerelease: true
           name: Meshtastic Firmware ${{ needs.version.outputs.long }} Alpha
           tag_name: v${{ needs.version.outputs.long }}
+          target_commitish: ${{ github.sha }}
           body: ${{ steps.release_notes.outputs.notes }}
 
       - name: Download source deb


### PR DESCRIPTION
Current release tags are actually based upon the latest state of `develop` branch currently 😬... Specify target_commitish to always use the commit that triggered the build

Targetted at `develop` since it's the default branch. Should be cherrypicked to `master` immediately.