### PR TITLE
Update ESP32-CH390 to v1.1.0

### DIFF
--- a/variants/esp32s3/ELECROW-ThinkNode-G3/platformio.ini
+++ b/variants/esp32s3/ELECROW-ThinkNode-G3/platformio.ini
@@ -21,4 +21,4 @@ build_src_filter =
 lib_deps =
   ${esp32s3_base.lib_deps}
   # renovate: datasource=github-tags depName=ESP32-CH390 packageName=meshtastic/ESP32-CH390
-  https://github.com/meshtastic/ESP32-CH390/archive/refs/tags/v1.0.1.zip
+  https://github.com/meshtastic/ESP32-CH390/archive/v1.1.0.zip

--- a/variants/esp32s3/ELECROW-ThinkNode-M7/platformio.ini
+++ b/variants/esp32s3/ELECROW-ThinkNode-M7/platformio.ini
@@ -20,4 +20,4 @@ build_src_filter =
 lib_deps =
   ${esp32s3_base.lib_deps}
   # renovate: datasource=github-tags depName=ESP32-CH390 packageName=meshtastic/ESP32-CH390
-  https://github.com/meshtastic/ESP32-CH390/archive/refs/tags/v1.0.1.zip
+  https://github.com/meshtastic/ESP32-CH390/archive/v1.1.0.zip


### PR DESCRIPTION
Library updated for idf5 / arduino 3.x compat (should retain backwards compat with idf4 / arduino 2.x)
https://github.com/meshtastic/ESP32-CH390/pull/2