### PR TITLE
Add a way to have MQTT uplinks uplink multiple copies of packets

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -88,6 +88,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MESHTASTIC_PREHOP_DROP 1
 #endif
 
+// When enabled, uplink every seen packet copy to MQTT, including duplicates.
+#ifndef USERPREFS_MQTT_UPLINK_ALL_SEEN
+#define USERPREFS_MQTT_UPLINK_ALL_SEEN 0
+#endif
+
 /// Convert a preprocessor name into a quoted string
 #define xstr(s) ystr(s)
 #define ystr(s) #s

--- a/src/mesh/FloodingRouter.cpp
+++ b/src/mesh/FloodingRouter.cpp
@@ -34,7 +34,7 @@ bool FloodingRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
     // Handle hop_limit upgrade scenario for rebroadcasters
     if (wasUpgraded && perhapsHandleUpgradedPacket(p)) {
 #if USERPREFS_MQTT_UPLINK_ALL_SEEN
-        publishReceivedToMqtt(const_cast<meshtastic_MeshPacket *>(p), DecodeState::DECODE_FAILURE);
+        publishReceivedToMqtt(p, DecodeState::DECODE_FAILURE);
 #endif
         return true; // we handled it, so stop processing
     }
@@ -62,7 +62,7 @@ bool FloodingRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
         }
 
 #if USERPREFS_MQTT_UPLINK_ALL_SEEN
-        publishReceivedToMqtt(const_cast<meshtastic_MeshPacket *>(p), DecodeState::DECODE_FAILURE);
+        publishReceivedToMqtt(p, DecodeState::DECODE_FAILURE);
 #endif
         return true;
     }

--- a/src/mesh/FloodingRouter.cpp
+++ b/src/mesh/FloodingRouter.cpp
@@ -33,6 +33,9 @@ bool FloodingRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
 
     // Handle hop_limit upgrade scenario for rebroadcasters
     if (wasUpgraded && perhapsHandleUpgradedPacket(p)) {
+#if USERPREFS_MQTT_UPLINK_ALL_SEEN
+        publishReceivedToMqtt(const_cast<meshtastic_MeshPacket *>(p), DecodeState::DECODE_FAILURE);
+#endif
         return true; // we handled it, so stop processing
     }
 
@@ -58,6 +61,9 @@ bool FloodingRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
             perhapsCancelDupe(p);
         }
 
+#if USERPREFS_MQTT_UPLINK_ALL_SEEN
+        publishReceivedToMqtt(const_cast<meshtastic_MeshPacket *>(p), DecodeState::DECODE_FAILURE);
+#endif
         return true;
     }
 

--- a/src/mesh/FloodingRouter.cpp
+++ b/src/mesh/FloodingRouter.cpp
@@ -33,7 +33,7 @@ bool FloodingRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
 
     // Handle hop_limit upgrade scenario for rebroadcasters
     if (wasUpgraded && perhapsHandleUpgradedPacket(p)) {
-#if USERPREFS_MQTT_UPLINK_ALL_SEEN
+#if USERPREFS_MQTT_UPLINK_ALL_SEEN && !MESHTASTIC_EXCLUDE_MQTT
         publishReceivedToMqtt(p, DecodeState::DECODE_FAILURE);
 #endif
         return true; // we handled it, so stop processing
@@ -61,7 +61,7 @@ bool FloodingRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
             perhapsCancelDupe(p);
         }
 
-#if USERPREFS_MQTT_UPLINK_ALL_SEEN
+#if USERPREFS_MQTT_UPLINK_ALL_SEEN && !MESHTASTIC_EXCLUDE_MQTT
         publishReceivedToMqtt(p, DecodeState::DECODE_FAILURE);
 #endif
         return true;

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -47,6 +47,9 @@ bool NextHopRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
 
     // Handle hop_limit upgrade scenario for rebroadcasters
     if (wasUpgraded && perhapsHandleUpgradedPacket(p)) {
+#if USERPREFS_MQTT_UPLINK_ALL_SEEN
+        publishReceivedToMqtt(const_cast<meshtastic_MeshPacket *>(p), DecodeState::DECODE_FAILURE);
+#endif
         return true; // we handled it, so stop processing
     }
 
@@ -80,6 +83,9 @@ bool NextHopRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
                 perhapsCancelDupe(p); // If it's a dupe, cancel relay if we were not explicitly asked to relay
             }
         }
+#if USERPREFS_MQTT_UPLINK_ALL_SEEN
+        publishReceivedToMqtt(const_cast<meshtastic_MeshPacket *>(p), DecodeState::DECODE_FAILURE);
+#endif
         return true;
     }
 

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -47,7 +47,7 @@ bool NextHopRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
 
     // Handle hop_limit upgrade scenario for rebroadcasters
     if (wasUpgraded && perhapsHandleUpgradedPacket(p)) {
-#if USERPREFS_MQTT_UPLINK_ALL_SEEN
+#if USERPREFS_MQTT_UPLINK_ALL_SEEN && !MESHTASTIC_EXCLUDE_MQTT
         publishReceivedToMqtt(p, DecodeState::DECODE_FAILURE);
 #endif
         return true; // we handled it, so stop processing
@@ -83,7 +83,7 @@ bool NextHopRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
                 perhapsCancelDupe(p); // If it's a dupe, cancel relay if we were not explicitly asked to relay
             }
         }
-#if USERPREFS_MQTT_UPLINK_ALL_SEEN
+#if USERPREFS_MQTT_UPLINK_ALL_SEEN && !MESHTASTIC_EXCLUDE_MQTT
         publishReceivedToMqtt(p, DecodeState::DECODE_FAILURE);
 #endif
         return true;

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -48,7 +48,7 @@ bool NextHopRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
     // Handle hop_limit upgrade scenario for rebroadcasters
     if (wasUpgraded && perhapsHandleUpgradedPacket(p)) {
 #if USERPREFS_MQTT_UPLINK_ALL_SEEN
-        publishReceivedToMqtt(const_cast<meshtastic_MeshPacket *>(p), DecodeState::DECODE_FAILURE);
+        publishReceivedToMqtt(p, DecodeState::DECODE_FAILURE);
 #endif
         return true; // we handled it, so stop processing
     }
@@ -84,7 +84,7 @@ bool NextHopRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
             }
         }
 #if USERPREFS_MQTT_UPLINK_ALL_SEEN
-        publishReceivedToMqtt(const_cast<meshtastic_MeshPacket *>(p), DecodeState::DECODE_FAILURE);
+        publishReceivedToMqtt(p, DecodeState::DECODE_FAILURE);
 #endif
         return true;
     }

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -805,49 +805,78 @@ void Router::handleReceived(meshtastic_MeshPacket *p, RxSource src)
     // If this could be a spoofed packet, don't let the modules see it.
     if (!skipHandle) {
         MeshModule::callModules(*p, src);
+        publishReceivedToMqtt(p, decodedState, p_encrypted);
+    } else {
+        packetPool.release(p_encrypted);
+    }
+}
 
+void Router::publishReceivedToMqtt(meshtastic_MeshPacket *p, DecodeState decodedState, meshtastic_MeshPacket *pEncrypted)
+{
 #if !MESHTASTIC_EXCLUDE_MQTT
-        if (p_encrypted == nullptr) {
-            LOG_WARN("p_encrypted is null, skipping MQTT publish");
-        } else {
-            // Mark as pki_encrypted if it is not yet decoded and MQTT encryption is also enabled, hash matches and it's a DM not
-            // to us (because we would be able to decrypt it)
-            if (decodedState == DecodeState::DECODE_FAILURE && moduleConfig.mqtt.encryption_enabled && p->channel == 0x00 &&
-                !isBroadcast(p->to) && !isToUs(p))
-                p_encrypted->pki_encrypted = true;
-            // After potentially altering it, publish received message to MQTT if we're not the original transmitter of the packet
-            if ((decodedState == DecodeState::DECODE_SUCCESS || p_encrypted->pki_encrypted) && moduleConfig.mqtt.enabled &&
-                !isFromUs(p) && mqtt) {
-                if (decodedState == DecodeState::DECODE_SUCCESS && p->decoded.portnum == meshtastic_PortNum_TRACEROUTE_APP &&
-                    moduleConfig.mqtt.encryption_enabled) {
-                    // For TRACEROUTE_APP packets release the original encrypted packet and encrypt a new from the changed packet
-                    // Only release the original after successful allocation to avoid losing an incomplete but valid packet
-                    auto *p_encrypted_new = packetPool.allocCopy(*p);
-                    if (p_encrypted_new) {
-                        auto encodeResult = perhapsEncode(p_encrypted_new);
-                        if (encodeResult != meshtastic_Routing_Error_NONE) {
-                            // Encryption failed, release the new packet and fall back to sending the original encrypted packet to
-                            // MQTT
-                            LOG_WARN("Encryption of new TR packet failed, sending original TR to MQTT");
-                            packetPool.release(p_encrypted_new);
-                            p_encrypted_new = nullptr;
-                        } else {
-                            // Successfully re-encrypted, release the original encrypted packet and use the new one for MQTT
-                            packetPool.release(p_encrypted);
-                            p_encrypted = p_encrypted_new;
-                        }
-                    } else {
-                        // Allocation failed, log a warning and fall back to sending the original encrypted packet to MQTT
-                        LOG_WARN("Failed to allocate new encrypted packet for TR, sending original TR to MQTT");
-                    }
-                }
-                mqtt->onSend(*p_encrypted, *p, p->channel);
-            }
-        }
-#endif
+    if (!moduleConfig.mqtt.enabled || !mqtt || isFromUs(p)) {
+        packetPool.release(pEncrypted);
+        return;
     }
 
-    packetPool.release(p_encrypted); // Release the encrypted packet (release() handles nullptr)
+    // If no encrypted copy was provided by the caller, create one from the currently-seen packet.
+    if (pEncrypted == nullptr) {
+        DEBUG_HEAP_BEFORE;
+        pEncrypted = packetPool.allocCopy(*p);
+        DEBUG_HEAP_AFTER("Router::publishReceivedToMqtt", pEncrypted);
+        if (pEncrypted == nullptr) {
+            LOG_WARN("p_encrypted is null, skipping MQTT publish");
+            return;
+        }
+    }
+
+    if (decodedState == DecodeState::DECODE_FAILURE && p->which_payload_variant != meshtastic_MeshPacket_decoded_tag) {
+        decodedState = perhapsDecode(p);
+    } else if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
+        decodedState = DecodeState::DECODE_SUCCESS;
+    }
+
+    if (decodedState == DecodeState::DECODE_FATAL) {
+        packetPool.release(pEncrypted);
+        return;
+    }
+
+    // Mark as pki_encrypted if it is not yet decoded and MQTT encryption is also enabled, hash matches and it's a DM not
+    // to us (because we would be able to decrypt it)
+    if (decodedState == DecodeState::DECODE_FAILURE && moduleConfig.mqtt.encryption_enabled && p->channel == 0x00 &&
+        !isBroadcast(p->to) && !isToUs(p)) {
+        pEncrypted->pki_encrypted = true;
+    }
+
+    // After potentially altering it, publish received message to MQTT if we're not the original transmitter of the packet.
+    if (decodedState == DecodeState::DECODE_SUCCESS || pEncrypted->pki_encrypted) {
+        if (decodedState == DecodeState::DECODE_SUCCESS && moduleConfig.mqtt.encryption_enabled &&
+            (p->decoded.portnum == meshtastic_PortNum_TRACEROUTE_APP ||
+             pEncrypted->which_payload_variant != meshtastic_MeshPacket_encrypted_tag)) {
+            // For traceroute or when we don't have an encrypted copy, encrypt a fresh copy from the current packet state.
+            auto *pEncryptedNew = packetPool.allocCopy(*p);
+            if (pEncryptedNew) {
+                auto encodeResult = perhapsEncode(pEncryptedNew);
+                if (encodeResult != meshtastic_Routing_Error_NONE) {
+                    LOG_WARN("Encryption of received packet failed, sending original packet to MQTT");
+                    packetPool.release(pEncryptedNew);
+                } else {
+                    packetPool.release(pEncrypted);
+                    pEncrypted = pEncryptedNew;
+                }
+            } else {
+                LOG_WARN("Failed to allocate new encrypted packet for MQTT publish");
+            }
+        }
+        mqtt->onSend(*pEncrypted, *p, p->channel);
+    }
+
+    packetPool.release(pEncrypted);
+#else
+    (void)p;
+    (void)decodedState;
+    (void)pEncrypted;
+#endif
 }
 
 void Router::perhapsHandleReceived(meshtastic_MeshPacket *p)

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -830,7 +830,7 @@ void Router::publishReceivedToMqtt(const meshtastic_MeshPacket *p, DecodeState d
         pEncrypted = packetPool.allocCopy(*p);
         DEBUG_HEAP_AFTER("Router::publishReceivedToMqtt", pEncrypted);
         if (pEncrypted == nullptr) {
-            LOG_WARN("p_encrypted is null, skipping MQTT publish");
+            LOG_WARN("pEncrypted is null, skipping MQTT publish");
             return;
         }
     }
@@ -865,7 +865,9 @@ void Router::publishReceivedToMqtt(const meshtastic_MeshPacket *p, DecodeState d
         pEncrypted->pki_encrypted = true;
     }
 
-    // After potentially altering it, publish received message to MQTT if we're not the original transmitter of the packet.
+    // After potentially altering it, publish received message to MQTT.
+    // Note: packets originating from us are only suppressed when callerProvided=true (the handleReceived path);
+    // on the dupe-filter path (callerProvided=false) we intentionally uplink relayed copies of our own packets.
     if (decodedState == DecodeState::DECODE_SUCCESS || pEncrypted->pki_encrypted) {
         if (decodedState == DecodeState::DECODE_SUCCESS && moduleConfig.mqtt.encryption_enabled &&
             (decodedPacket->decoded.portnum == meshtastic_PortNum_TRACEROUTE_APP ||

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -811,7 +811,7 @@ void Router::handleReceived(meshtastic_MeshPacket *p, RxSource src)
     }
 }
 
-void Router::publishReceivedToMqtt(meshtastic_MeshPacket *p, DecodeState decodedState, meshtastic_MeshPacket *pEncrypted)
+void Router::publishReceivedToMqtt(const meshtastic_MeshPacket *p, DecodeState decodedState, meshtastic_MeshPacket *pEncrypted)
 {
 #if !MESHTASTIC_EXCLUDE_MQTT
     if (!moduleConfig.mqtt.enabled || !mqtt || isFromUs(p)) {
@@ -830,13 +830,24 @@ void Router::publishReceivedToMqtt(meshtastic_MeshPacket *p, DecodeState decoded
         }
     }
 
+    const meshtastic_MeshPacket *decodedPacket = p;
+    meshtastic_MeshPacket *decodedCopy = nullptr;
     if (decodedState == DecodeState::DECODE_FAILURE && p->which_payload_variant != meshtastic_MeshPacket_decoded_tag) {
-        decodedState = perhapsDecode(p);
+        decodedCopy = packetPool.allocCopy(*p);
+        if (decodedCopy == nullptr) {
+            LOG_WARN("Failed to allocate packet copy for MQTT decode");
+            packetPool.release(pEncrypted);
+            return;
+        }
+        decodedState = perhapsDecode(decodedCopy);
+        if (decodedState == DecodeState::DECODE_SUCCESS)
+            decodedPacket = decodedCopy;
     } else if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
         decodedState = DecodeState::DECODE_SUCCESS;
     }
 
     if (decodedState == DecodeState::DECODE_FATAL) {
+        packetPool.release(decodedCopy);
         packetPool.release(pEncrypted);
         return;
     }
@@ -851,26 +862,33 @@ void Router::publishReceivedToMqtt(meshtastic_MeshPacket *p, DecodeState decoded
     // After potentially altering it, publish received message to MQTT if we're not the original transmitter of the packet.
     if (decodedState == DecodeState::DECODE_SUCCESS || pEncrypted->pki_encrypted) {
         if (decodedState == DecodeState::DECODE_SUCCESS && moduleConfig.mqtt.encryption_enabled &&
-            (p->decoded.portnum == meshtastic_PortNum_TRACEROUTE_APP ||
+            (decodedPacket->decoded.portnum == meshtastic_PortNum_TRACEROUTE_APP ||
              pEncrypted->which_payload_variant != meshtastic_MeshPacket_encrypted_tag)) {
             // For traceroute or when we don't have an encrypted copy, encrypt a fresh copy from the current packet state.
-            auto *pEncryptedNew = packetPool.allocCopy(*p);
+            auto *pEncryptedNew = packetPool.allocCopy(*decodedPacket);
             if (pEncryptedNew) {
                 auto encodeResult = perhapsEncode(pEncryptedNew);
                 if (encodeResult != meshtastic_Routing_Error_NONE) {
-                    LOG_WARN("Encryption of received packet failed, sending original packet to MQTT");
+                    LOG_WARN("Encryption of received packet failed, skipping MQTT publish");
                     packetPool.release(pEncryptedNew);
+                    packetPool.release(decodedCopy);
+                    packetPool.release(pEncrypted);
+                    return;
                 } else {
                     packetPool.release(pEncrypted);
                     pEncrypted = pEncryptedNew;
                 }
             } else {
                 LOG_WARN("Failed to allocate new encrypted packet for MQTT publish");
+                packetPool.release(decodedCopy);
+                packetPool.release(pEncrypted);
+                return;
             }
         }
-        mqtt->onSend(*pEncrypted, *p, p->channel);
+        mqtt->onSend(*pEncrypted, *decodedPacket, p->channel);
     }
 
+    packetPool.release(decodedCopy);
     packetPool.release(pEncrypted);
 #else
     (void)p;

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -819,7 +819,7 @@ void Router::handleReceived(meshtastic_MeshPacket *p, RxSource src)
 void Router::publishReceivedToMqtt(const meshtastic_MeshPacket *p, DecodeState decodedState, meshtastic_MeshPacket *pEncrypted)
 {
     bool callerProvided = (pEncrypted != nullptr);
-    if (!moduleConfig.mqtt.enabled || !mqtt || isFromUs(p)) {
+    if (!moduleConfig.mqtt.enabled || !mqtt || (isFromUs(p) && callerProvided)) {
         packetPool.release(pEncrypted);
         return;
     }

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -885,7 +885,7 @@ void Router::publishReceivedToMqtt(const meshtastic_MeshPacket *p, DecodeState d
                 return;
             }
         }
-        mqtt->onSend(*pEncrypted, *decodedPacket, p->channel);
+        mqtt->onSend(*pEncrypted, *decodedPacket, decodedPacket->channel);
     }
 
     packetPool.release(decodedCopy);
@@ -893,7 +893,7 @@ void Router::publishReceivedToMqtt(const meshtastic_MeshPacket *p, DecodeState d
 #else
     (void)p;
     (void)decodedState;
-    (void)pEncrypted;
+    packetPool.release(pEncrypted);
 #endif
 }
 

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -805,15 +805,20 @@ void Router::handleReceived(meshtastic_MeshPacket *p, RxSource src)
     // If this could be a spoofed packet, don't let the modules see it.
     if (!skipHandle) {
         MeshModule::callModules(*p, src);
+#if !MESHTASTIC_EXCLUDE_MQTT
         publishReceivedToMqtt(p, decodedState, p_encrypted);
+#else
+        packetPool.release(p_encrypted);
+#endif
     } else {
         packetPool.release(p_encrypted);
     }
 }
 
+#if !MESHTASTIC_EXCLUDE_MQTT
 void Router::publishReceivedToMqtt(const meshtastic_MeshPacket *p, DecodeState decodedState, meshtastic_MeshPacket *pEncrypted)
 {
-#if !MESHTASTIC_EXCLUDE_MQTT
+    bool callerProvided = (pEncrypted != nullptr);
     if (!moduleConfig.mqtt.enabled || !mqtt || isFromUs(p)) {
         packetPool.release(pEncrypted);
         return;
@@ -832,7 +837,8 @@ void Router::publishReceivedToMqtt(const meshtastic_MeshPacket *p, DecodeState d
 
     const meshtastic_MeshPacket *decodedPacket = p;
     meshtastic_MeshPacket *decodedCopy = nullptr;
-    if (decodedState == DecodeState::DECODE_FAILURE && p->which_payload_variant != meshtastic_MeshPacket_decoded_tag) {
+    if (decodedState == DecodeState::DECODE_FAILURE && !callerProvided &&
+        p->which_payload_variant != meshtastic_MeshPacket_decoded_tag) {
         decodedCopy = packetPool.allocCopy(*p);
         if (decodedCopy == nullptr) {
             LOG_WARN("Failed to allocate packet copy for MQTT decode");
@@ -890,12 +896,8 @@ void Router::publishReceivedToMqtt(const meshtastic_MeshPacket *p, DecodeState d
 
     packetPool.release(decodedCopy);
     packetPool.release(pEncrypted);
-#else
-    (void)p;
-    (void)decodedState;
-    packetPool.release(pEncrypted);
-#endif
 }
+#endif
 
 void Router::perhapsHandleReceived(meshtastic_MeshPacket *p)
 {

--- a/src/mesh/Router.h
+++ b/src/mesh/Router.h
@@ -10,6 +10,8 @@
 #include "concurrency/OSThread.h"
 #include <memory>
 
+enum DecodeState : int;
+
 /**
  * A mesh aware router that supports multiple interfaces.
  */
@@ -129,6 +131,10 @@ class Router : protected concurrency::OSThread, protected PacketHistory
     void sendAckNak(meshtastic_Routing_Error err, NodeNum to, PacketId idFrom, ChannelIndex chIndex, uint8_t hopLimit = 0,
                     bool ackWantsAck = false);
 
+    /** Publish a received packet to MQTT using the same receive-side publish rules as handleReceived(). */
+    void publishReceivedToMqtt(meshtastic_MeshPacket *p, DecodeState decodedState,
+                               meshtastic_MeshPacket *pEncrypted = nullptr);
+
   private:
     /**
      * Called from loop()
@@ -154,7 +160,7 @@ class Router : protected concurrency::OSThread, protected PacketHistory
     void abortSendAndNak(meshtastic_Routing_Error err, meshtastic_MeshPacket *p);
 };
 
-enum DecodeState { DECODE_SUCCESS, DECODE_FAILURE, DECODE_FATAL };
+enum DecodeState : int { DECODE_SUCCESS, DECODE_FAILURE, DECODE_FATAL };
 
 /** FIXME - move this into a mesh packet class
  * Remove any encryption and decode the protobufs inside this packet (if necessary).

--- a/src/mesh/Router.h
+++ b/src/mesh/Router.h
@@ -132,8 +132,7 @@ class Router : protected concurrency::OSThread, protected PacketHistory
                     bool ackWantsAck = false);
 
     /** Publish a received packet to MQTT using the same receive-side publish rules as handleReceived(). */
-    void publishReceivedToMqtt(meshtastic_MeshPacket *p, DecodeState decodedState,
-                               meshtastic_MeshPacket *pEncrypted = nullptr);
+    void publishReceivedToMqtt(meshtastic_MeshPacket *p, DecodeState decodedState, meshtastic_MeshPacket *pEncrypted = nullptr);
 
   private:
     /**

--- a/src/mesh/Router.h
+++ b/src/mesh/Router.h
@@ -131,12 +131,14 @@ class Router : protected concurrency::OSThread, protected PacketHistory
     void sendAckNak(meshtastic_Routing_Error err, NodeNum to, PacketId idFrom, ChannelIndex chIndex, uint8_t hopLimit = 0,
                     bool ackWantsAck = false);
 
+#if !MESHTASTIC_EXCLUDE_MQTT
     /**
      * Publish a received packet to MQTT using the same receive-side publish rules as handleReceived().
      * Takes ownership of pEncrypted when provided (and always releases it before returning).
      */
     void publishReceivedToMqtt(const meshtastic_MeshPacket *p, DecodeState decodedState,
                                meshtastic_MeshPacket *pEncrypted = nullptr);
+#endif
 
   private:
     /**

--- a/src/mesh/Router.h
+++ b/src/mesh/Router.h
@@ -131,8 +131,12 @@ class Router : protected concurrency::OSThread, protected PacketHistory
     void sendAckNak(meshtastic_Routing_Error err, NodeNum to, PacketId idFrom, ChannelIndex chIndex, uint8_t hopLimit = 0,
                     bool ackWantsAck = false);
 
-    /** Publish a received packet to MQTT using the same receive-side publish rules as handleReceived(). */
-    void publishReceivedToMqtt(meshtastic_MeshPacket *p, DecodeState decodedState, meshtastic_MeshPacket *pEncrypted = nullptr);
+    /**
+     * Publish a received packet to MQTT using the same receive-side publish rules as handleReceived().
+     * Takes ownership of pEncrypted when provided (and always releases it before returning).
+     */
+    void publishReceivedToMqtt(const meshtastic_MeshPacket *p, DecodeState decodedState,
+                               meshtastic_MeshPacket *pEncrypted = nullptr);
 
   private:
     /**

--- a/userPrefs.jsonc
+++ b/userPrefs.jsonc
@@ -57,6 +57,7 @@
   // "USERPREFS_MQTT_ENCRYPTION_ENABLED": "true",
   // "USERPREFS_MQTT_TLS_ENABLED": "false",
   // "USERPREFS_MQTT_ROOT_TOPIC": "event/REPLACEME",
+  // "USERPREFS_MQTT_UPLINK_ALL_SEEN": "1",
   // "USERPREFS_RINGTONE_NAG_SECS": "60",
   // "USERPREFS_NODEINFO_REPLY_SUPPRESS_SECS": "43200",
   // "USERPREFS_UI_TEST_LOG": "true", // Test-only: emits `Screen: frame N/M name=... reason=...` log per UI transition (for the mcp-server ui test tier); off in release builds.


### PR DESCRIPTION
... when they're heard multiple times (hidden behind compile flag + userPrefs)

This is entirely for MQTT-based analytics. Uplinking packets multiple times means analytics tools and users can see SNRs for rebroadcasts after the first heard by each uplink, and it's especially useful for traceroutes, where entire paths that might otherwise not appear can come by way of later-heard copies of the packet.

My experience level with C++ is not amazing so I'm suspecting there are things here that aren't needed, despite my best efforts to rein in the generated code. The primary parts of this PR are just moving MQTT uplink logic into a dedicated `Router::publishReceivedToMqtt` and then calling it from a variety of places to catch packets that otherwise wouldn't make it to the regular uplink location.

Some specific question areas are the necessity of lines 870-874 in Router.cpp, serving as a dummy implementation I guess, and whether the gate on MQTT being enabled at all should be moved to live outside the newly created function. I'll try to test it on a few more devices, but it's also not a huge change and it works on at least one esp32 and nrf52, so I'm not too worried it'll turn up issues.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [x] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below) (LilyGo t3s3 v1)
