### PR TITLE
fix: mbed TLS crash in Arduino 3.x (pioarduino)

### DIFF
--- a/variants/esp32/esp32-common.ini
+++ b/variants/esp32/esp32-common.ini
@@ -205,10 +205,13 @@ custom_sdkconfig =
   CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_MAX_CERTS=1
   ; #shame
   CONFIG_MBEDTLS_ALLOW_WEAK_CERTIFICATE_VERIFICATION=y
-  CONFIG_MBEDTLS_SSL_RENEGOTIATION=n
-  CONFIG_MBEDTLS_SSL_PROTO_DTLS=n
-  CONFIG_MBEDTLS_CLIENT_SSL_SESSION_TICKETS=n
-  CONFIG_MBEDTLS_SERVER_SSL_SESSION_TICKETS=n
+  ; These four options must match the precompiled framework-arduinoespressif32-libs
+  ; which was built with all four enabled. Disabling them changes mbedtls_ssl_context
+  ; struct layout, causing an ABI mismatch and a crash in mbedtls_ssl_set_hostname.
+  CONFIG_MBEDTLS_SSL_RENEGOTIATION=y
+  CONFIG_MBEDTLS_SSL_PROTO_DTLS=y
+  CONFIG_MBEDTLS_CLIENT_SSL_SESSION_TICKETS=y
+  CONFIG_MBEDTLS_SERVER_SSL_SESSION_TICKETS=y
   CONFIG_MBEDTLS_PKCS7_C=n
   CONFIG_MBEDTLS_CAMELLIA_C=n
   CONFIG_MBEDTLS_CCM_C=n

--- a/variants/esp32/esp32-common.ini
+++ b/variants/esp32/esp32-common.ini
@@ -195,7 +195,7 @@ custom_sdkconfig =
   ;
   ; MBEDTLS
   ;
-  CONFIG_MBEDTLS_SSL_MAX_CONTENT_LEN=8192
+   and =16384 ; do not change, affects buffer allocation and 
   CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=n
   CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN=y
   ; Switch to custom CA bundle (for Meshtastic MQTT/etc) in the future

--- a/variants/esp32/esp32-common.ini
+++ b/variants/esp32/esp32-common.ini
@@ -195,7 +195,7 @@ custom_sdkconfig =
   ;
   ; MBEDTLS
   ;
-   and =16384 ; do not change, affects buffer allocation and 
+  CONFIG_MBEDTLS_SSL_MAX_CONTENT_LEN=16384 ; do not change, affects buffer allocation (PR10535)
   CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=n
   CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN=y
   ; Switch to custom CA bundle (for Meshtastic MQTT/etc) in the future
@@ -205,13 +205,15 @@ custom_sdkconfig =
   CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_MAX_CERTS=1
   ; #shame
   CONFIG_MBEDTLS_ALLOW_WEAK_CERTIFICATE_VERIFICATION=y
-  ; These four options must match the precompiled framework-arduinoespressif32-libs
-  ; which was built with all four enabled. Disabling them changes mbedtls_ssl_context
+  ; These six options must match the precompiled framework-arduinoespressif32-libs
+  ; which was built with all six enabled. Disabling them changes mbedtls_ssl_context
   ; struct layout, causing an ABI mismatch and a crash in mbedtls_ssl_set_hostname.
   CONFIG_MBEDTLS_SSL_RENEGOTIATION=y
   CONFIG_MBEDTLS_SSL_PROTO_DTLS=y
   CONFIG_MBEDTLS_CLIENT_SSL_SESSION_TICKETS=y
   CONFIG_MBEDTLS_SERVER_SSL_SESSION_TICKETS=y
+  CONFIG_MBEDTLS_SSL_KEEP_PEER_CERTIFICATE=y
+  CONFIG_MBEDTLS_SSL_ALPN=y
   CONFIG_MBEDTLS_PKCS7_C=n
   CONFIG_MBEDTLS_CAMELLIA_C=n
   CONFIG_MBEDTLS_CCM_C=n


### PR DESCRIPTION
This PR fixes an mbedTLS crash e.g. when starting an HTTP client in a remote connection:

```
Guru Meditation Error: Core  0 panic'ed (LoadProhibited). Exception was unhandled.

Core  0 register dump:
PC      : 0x400556d5  PS      : 0x00060730  A0      : 0x821ab850  A1      : 0x3fcc31a0  
A2      : 0x00010100  A3      : 0x000100fc  A4      : 0x000000ff  A5      : 0x0000ff00  
A6      : 0x00ff0000  A7      : 0xff000000  A8      : 0x00000000  A9      : 0x0000c064  
A10     : 0x3fcc2fec  A11     : 0x00000000  A12     : 0x00000180  A13     : 0x3fcc316c  
A14     : 0xaaa43b47  A15     : 0x00000018  SAR     : 0x00000010  EXCCAUSE: 0x0000001c  
EXCVADDR: 0x00010100  LBEG    : 0x400556d5  LEND    : 0x400556e5  LCOUNT  : 0xffffffff  

0x400556d2: ?? ??:0
0x421ab84d: mbedtls_ssl_free_hostname at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/mbedtls/mbedtls/library/ssl_tls.c:2819
0x421abced: mbedtls_ssl_set_hostname at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/mbedtls/mbedtls/library/ssl_tls.c:2841
0x4201a235: start_ssl_client(sslclient_context*, IPAddress const&, unsigned long, char const*, int, char const*, bool, char const*, char const*, char const*, char const*, bool, char const**) at /home/manuel/.platformio/packages/framework-arduinoespressif32/libraries/NetworkClientSecure/src/ssl_client.cpp:296 (discriminator 8)
0x4201aaeb: NetworkClientSecure::connect(IPAddress, unsigned short, char const*, char const*, char const*, char const*) at /home/manuel/.platformio/packages/framework-arduinoespressif32/libraries/NetworkClientSecure/src/NetworkClientSecure.cpp:148 (discriminator 1)
0x4201d38d: NetworkClientSecure::connect(char const*, unsigned short, char const*, char const*, char const*) at /home/manuel/.platformio/packages/framework-arduinoespressif32/libraries/NetworkClientSecure/src/NetworkClientSecure.cpp:144 (discriminator 2)
 (inlined by) NetworkClientSecure::connect(char const*, unsigned short) at /home/manuel/.platformio/packages/framework-arduinoespressif32/libraries/NetworkClientSecure/src/NetworkClientSecure.cpp:126 (discriminator 2)
 (inlined by) NetworkClientSecure::connect(char const*, unsigned short) at /home/manuel/.platformio/packages/framework-arduinoespressif32/libraries/NetworkClientSecure/src/NetworkClientSecure.cpp:122 (discriminator 2)
0x42017c95: NetworkClientSecure::connect(char const*, unsigned short, long) at /home/manuel/.platformio/packages/framework-arduinoespressif32/libraries/NetworkClientSecure/src/NetworkClientSecure.cpp:131
0x420936c9: HTTPClient::connect() at /home/manuel/.platformio/packages/framework-arduinoespressif32/libraries/HTTPClient/src/HTTPClient.cpp:1109 (discriminator 1)
 (inlined by) HTTPClient::sendRequest(char const*, unsigned char*, unsigned int) at /home/manuel/.platformio/packages/framework-arduinoespressif32/libraries/HTTPClient/src/HTTPClient.cpp:577 (discriminator 1)
 (inlined by) HTTPClient::GET() at /home/manuel/.platformio/packages/framework-arduinoespressif32/libraries/HTTPClient/src/HTTPClient.cpp:497 (discriminator 1)
 (inlined by) URLService::load(char const*, void*) at /home/manuel/Documents/PlatformIO/Projects/device-ui-master/source/graphics/map/URLService.cpp:46 (discriminator 1)
0x4208ae9f: TileService::load(char const*, void*) at /home/manuel/Documents/PlatformIO/Projects/device-ui-master/include/graphics/map/TileService.h:38 (discriminator 1)
```

The reason for the crash is the `sdkconfig` (_.platformio/packages/framework-arduinoespressif32-libs/sdkconfig_) that is used to generate the pre-compiled framework libs. It must match the actual `custom_sdkconfig` for some macros **used in structures** otherwise size and initialisation of these structures do not match between application and pre-compiled libs, e.g.

<img width="840" height="307" alt="image" src="https://github.com/user-attachments/assets/afe83cb8-4f4e-49a7-b305-60f5469f8dab" />
 
Here, `MBEDTLS_SSL_RENEGOTIATION` changes the definition and size of a structure so the `custom_sdkconfig` must not use different config values than the framework libs. Thus, the following CONFIGs are required and fix the mbedTLS crash.
```
  CONFIG_MBEDTLS_SSL_RENEGOTIATION=y
  CONFIG_MBEDTLS_SSL_PROTO_DTLS=y
  CONFIG_MBEDTLS_CLIENT_SSL_SESSION_TICKETS=y
  CONFIG_MBEDTLS_SERVER_SSL_SESSION_TICKETS=y
```

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [X] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
