### PR TITLE
Add PIN_GPS_STANDBY to Heltec Capsule Sensor

### DIFF
--- a/variants/esp32s3/heltec_capsule_sensor_v3/variant.h
+++ b/variants/esp32s3/heltec_capsule_sensor_v3/variant.h
@@ -19,6 +19,7 @@
 #define GPS_RX_PIN 5
 #define GPS_TX_PIN 4
 #define PIN_GPS_RESET 3
+#define PIN_GPS_STANDBY 2
 #define GPS_RESET_MODE LOW
 #define PIN_GPS_PPS 1
 #define PIN_GPS_EN 21


### PR DESCRIPTION
As reported by @hafis328 , the L76K in the Heltec Capsule Sensor was missing the standby pin definition. As a result, the GPS did not turn on.

This patch adds the relevant pin, bringing the board into line with others that have L76Ks.

Fixes https://github.com/meshtastic/firmware/issues/9854