### PR TITLE
Fix telemetry config save ordering before BLE deinit

### DIFF
--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -941,8 +941,9 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
     bool shouldReboot = true;
     // If we are in an open transaction or configuring MQTT or Serial (which have validation), defer disabling Bluetooth
     // Otherwise, disable Bluetooth to prevent the phone from interfering with the config
-    if (!hasOpenEditTransaction && !IS_ONE_OF(c.which_payload_variant, meshtastic_ModuleConfig_mqtt_tag,
-                                              meshtastic_ModuleConfig_serial_tag, meshtastic_ModuleConfig_statusmessage_tag)) {
+    if (!hasOpenEditTransaction &&
+        !IS_ONE_OF(c.which_payload_variant, meshtastic_ModuleConfig_mqtt_tag, meshtastic_ModuleConfig_serial_tag,
+                   meshtastic_ModuleConfig_statusmessage_tag, meshtastic_ModuleConfig_telemetry_tag)) {
         disableBluetooth();
     }
 
@@ -1047,6 +1048,9 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
         break;
     }
     saveChanges(SEGMENT_MODULECONFIG, shouldReboot);
+    if (!hasOpenEditTransaction && c.which_payload_variant == meshtastic_ModuleConfig_telemetry_tag) {
+        disableBluetooth();
+    }
     return true;
 }
 


### PR DESCRIPTION
## Summary

Fix telemetry module config save ordering on ESP32-class devices by deferring BLE deinit until after telemetry config is saved.

fixes #10548

## What changed

In `AdminModule::handleSetModuleConfig()`:

- exclude `meshtastic_ModuleConfig_telemetry_tag` from the early `disableBluetooth()` path
- call `disableBluetooth()` for telemetry only after `saveChanges(SEGMENT_MODULECONFIG, shouldReboot)`

## Why

On affected devices, telemetry settings enabled from the app could revert after reboot because BLE was being torn down before the module config had been persisted to `/prefs/module.proto`.

In failing logs, the config flow reached:

- `Client set module config`
- `Disable bluetooth until reboot`

but did not reliably complete the telemetry save path first.

This change keeps the existing reboot behavior but moves BLE teardown later for telemetry config updates so the config is saved before reboot.

## Scope

This PR is intentionally narrow:
- telemetry module config only
- no change to MQTT / Serial / StatusMessage handling
- no change to telemetry runtime logic

## Testing

Tested on:
- Arduino Nesso N1 / ESP32-C6

Observed:
- before this change, some devices reverted telemetry to disabled after reboot
- after this change, telemetry remained enabled after reboot

Build tested:
- `pio run -e arduino-nesso-n1`
