### PR TITLE
PR: Fix has_module_settings flag inconsistency in channel updates

### DIFF
--- a/src/mesh/Channels.cpp
+++ b/src/mesh/Channels.cpp
@@ -71,6 +71,14 @@ meshtastic_Channel &Channels::fixupChannel(ChannelIndex chIndex)
         // Convert the old string "Default" to our new short representation
         if (strcmp(meshtastic_channelSettings.name, "Default") == 0)
             *meshtastic_channelSettings.name = '\0';
+
+        // Ensure has_module_settings flag is set when any module_settings field is populated
+        if (!meshtastic_channelSettings.has_module_settings) {
+            if (meshtastic_channelSettings.module_settings.position_precision != 0 ||
+                meshtastic_channelSettings.module_settings.is_muted) {
+                meshtastic_channelSettings.has_module_settings = true;
+            }
+        }
     }
 
     hashes[chIndex] = generateHash(chIndex);
@@ -353,7 +361,21 @@ void Channels::setChannel(const meshtastic_Channel &c)
             if (channelFile.channels[i].role == meshtastic_Channel_Role_PRIMARY)
                 channelFile.channels[i].role = meshtastic_Channel_Role_SECONDARY;
 
-    old = c; // slam in the new settings/role
+    meshtastic_Channel newc = c;
+
+    if (newc.has_settings) {
+        meshtastic_ChannelSettings &meshtastic_channelSettings = newc.settings;
+
+        // Ensure has_module_settings flag is set when any module_settings field is populated
+        if (!meshtastic_channelSettings.has_module_settings) {
+            if (meshtastic_channelSettings.module_settings.position_precision != 0 ||
+                meshtastic_channelSettings.module_settings.is_muted) {
+                meshtastic_channelSettings.has_module_settings = true;
+            }
+        }
+    }
+
+    old = newc; // slam in the new settings/role
 }
 
 bool Channels::anyMqttEnabled()


### PR DESCRIPTION
### Summary

Fixes a bug where channels could be created/configured with populated `module_settings` (e.g., `position_precision`, `is_muted`) but leave `has_module_settings=false`. This caused position and mute state to be ignored by downstream code.

One consequence of this is that manual position requests on a channel configured for full-precision location would sometimes (depending on how the channel was created) return [Null Island](https://en.wikipedia.org/wiki/Null_Island).

### Root Cause
`setChannel()` was accepting incoming `meshtastic_Channel` objects without validating the `has_module_settings` flag. When a channel from an external source (phone API,  etc.) carried `module_settings` data but didn't set the flag, those settings would overwrite the stored channel while appearing disabled.

### Solution
Added normalization logic to `setChannel()` and `fixupChannel()`:
If any `module_settings` fields are non-zero (`position_precision` or `is_muted`), ensure `has_module_settings=true`.

### Testing

Idempotent: calling `setChannel()` multiple times on the same object has no side effects. `fixupChannel()` applies the same logic to stored channels at boot and on config changes (via `onConfigChanged()`).

### Impact
Risk: Low — purely additive validation; no behavior changes for well-formed channels.

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [X] Seeed Studio T-1000E tracker card
  - [X] Heltec (Lora32) V4
  - [X] Wio Tracker L1
