### PR TITLE
Power airtime monotonic windows due to light sleep. 

### DIFF
--- a/src/airtime.cpp
+++ b/src/airtime.cpp
@@ -12,6 +12,8 @@ uint32_t air_period_rx[PERIODS_TO_LOG];
 
 void AirTime::logAirtime(reportTypes reportType, uint32_t airtime_ms)
 {
+    // A packet may be logged immediately after waking from light sleep. Sync first so
+    // the packet is counted in the current wall-time bucket, not a stale awake-time bucket.
     syncNow();
 
     if (reportType == TX_LOG) {
@@ -50,11 +52,14 @@ uint8_t AirTime::getPeriodUtilHour()
 
 void AirTime::airtimeRotatePeriod()
 {
+    // Preserve the public helper while keeping all rotation logic in one monotonic-time path.
     syncNow();
 }
 
 void AirTime::syncNow()
 {
+    // Use monotonic uptime rather than RTC/network time; user, GPS, or NTP clock changes
+    // must not move airtime accounting backward or forward.
     uint32_t nowMsec = millis();
 
     if (firstTime) {
@@ -67,6 +72,7 @@ void AirTime::syncNow()
         memset(air_period_rx, 0, sizeof(air_period_rx));
 
         this->secSinceBoot = nowMsec / 1000;
+        // Keep the checkpoint on a whole-second boundary so elapsedSecs advances predictably.
         this->lastSyncMsec = nowMsec - (nowMsec % 1000);
         this->lastUtilPeriod = this->getPeriodUtilMinute();
         this->lastUtilPeriodTX = this->getPeriodUtilHour();
@@ -85,6 +91,8 @@ void AirTime::syncNow()
     this->secSinceBoot += elapsedSecs;
     this->lastSyncMsec += elapsedSecs * 1000;
 
+    // Historical airtime reports use 1-hour buckets. If multiple hours elapsed while
+    // asleep, rotate each crossed bucket or clear the whole report window.
     uint32_t elapsedAirtimePeriods = (this->secSinceBoot / SECONDS_PER_PERIOD) - (oldSecSinceBoot / SECONDS_PER_PERIOD);
     if (elapsedAirtimePeriods >= PERIODS_TO_LOG) {
         memset(this->airtimes.periodTX, 0, sizeof(this->airtimes.periodTX));
@@ -112,6 +120,8 @@ void AirTime::syncNow()
     }
     this->airtimes.lastPeriodIndex = this->currentPeriodIndex();
 
+    // Channel utilization is a rolling 60-second view split into six 10-second buckets.
+    // Clear every bucket crossed while asleep so old airtime decays by real elapsed time.
     uint32_t elapsedUtilPeriods = (this->secSinceBoot / 10) - (oldSecSinceBoot / 10);
     if (elapsedUtilPeriods >= CHANNEL_UTILIZATION_PERIODS) {
         memset(this->channelUtilization, 0, sizeof(this->channelUtilization));
@@ -122,6 +132,7 @@ void AirTime::syncNow()
     }
     this->lastUtilPeriod = this->getPeriodUtilMinute();
 
+    // TX utilization is a rolling 60-minute view used by duty-cycle checks.
     uint32_t elapsedUtilTXPeriods = (this->secSinceBoot / 60) - (oldSecSinceBoot / 60);
     if (elapsedUtilTXPeriods >= MINUTES_IN_HOUR) {
         memset(this->utilizationTX, 0, sizeof(this->utilizationTX));
@@ -135,6 +146,7 @@ void AirTime::syncNow()
 
 uint32_t *AirTime::airtimeReport(reportTypes reportType)
 {
+    // Reports may be requested before runOnce() executes after wake.
     syncNow();
 
     if (reportType == TX_LOG) {
@@ -159,12 +171,14 @@ uint32_t AirTime::getSecondsPerPeriod()
 
 uint32_t AirTime::getSecondsSinceBoot()
 {
+    // Keep HTTP/debug reporting aligned with the same monotonic clock used by the buckets.
     syncNow();
     return this->secSinceBoot;
 }
 
 float AirTime::channelUtilizationPercent()
 {
+    // Gate decisions should see buckets that have decayed across light-sleep time.
     syncNow();
 
     uint32_t sum = 0;
@@ -177,6 +191,7 @@ float AirTime::channelUtilizationPercent()
 
 float AirTime::utilizationTXPercent()
 {
+    // Duty-cycle checks use this value, so keep it current even outside the periodic thread.
     syncNow();
 
     uint32_t sum = 0;

--- a/src/airtime.cpp
+++ b/src/airtime.cpp
@@ -1,6 +1,7 @@
 #include "airtime.h"
 #include "NodeDB.h"
 #include "configuration.h"
+#include <string.h>
 
 AirTime *airTime = NULL;
 
@@ -11,6 +12,7 @@ uint32_t air_period_rx[PERIODS_TO_LOG];
 
 void AirTime::logAirtime(reportTypes reportType, uint32_t airtime_ms)
 {
+    syncNow();
 
     if (reportType == TX_LOG) {
         LOG_DEBUG("Packet TX: %ums", airtime_ms);
@@ -33,47 +35,107 @@ void AirTime::logAirtime(reportTypes reportType, uint32_t airtime_ms)
 
 uint8_t AirTime::currentPeriodIndex()
 {
-    return ((getSecondsSinceBoot() / SECONDS_PER_PERIOD) % PERIODS_TO_LOG);
+    return ((secSinceBoot / SECONDS_PER_PERIOD) % PERIODS_TO_LOG);
 }
 
 uint8_t AirTime::getPeriodUtilMinute()
 {
-    return (getSecondsSinceBoot() / 10) % CHANNEL_UTILIZATION_PERIODS;
+    return (secSinceBoot / 10) % CHANNEL_UTILIZATION_PERIODS;
 }
 
 uint8_t AirTime::getPeriodUtilHour()
 {
-    return (getSecondsSinceBoot() / 60) % MINUTES_IN_HOUR;
+    return (secSinceBoot / 60) % MINUTES_IN_HOUR;
 }
 
 void AirTime::airtimeRotatePeriod()
 {
+    syncNow();
+}
 
-    if (this->airtimes.lastPeriodIndex != this->currentPeriodIndex()) {
-        LOG_DEBUG("Rotate airtimes to a new period = %u", this->currentPeriodIndex());
+void AirTime::syncNow()
+{
+    uint32_t nowMsec = millis();
 
-        for (int i = PERIODS_TO_LOG - 2; i >= 0; --i) {
-            this->airtimes.periodTX[i + 1] = this->airtimes.periodTX[i];
-            this->airtimes.periodRX[i + 1] = this->airtimes.periodRX[i];
-            this->airtimes.periodRX_ALL[i + 1] = this->airtimes.periodRX_ALL[i];
+    if (firstTime) {
+        memset(this->utilizationTX, 0, sizeof(this->utilizationTX));
+        memset(this->channelUtilization, 0, sizeof(this->channelUtilization));
+        memset(this->airtimes.periodTX, 0, sizeof(this->airtimes.periodTX));
+        memset(this->airtimes.periodRX, 0, sizeof(this->airtimes.periodRX));
+        memset(this->airtimes.periodRX_ALL, 0, sizeof(this->airtimes.periodRX_ALL));
+        memset(air_period_tx, 0, sizeof(air_period_tx));
+        memset(air_period_rx, 0, sizeof(air_period_rx));
 
-            air_period_tx[i + 1] = this->airtimes.periodTX[i];
-            air_period_rx[i + 1] = this->airtimes.periodRX[i];
-        }
-
-        this->airtimes.periodTX[0] = 0;
-        this->airtimes.periodRX[0] = 0;
-        this->airtimes.periodRX_ALL[0] = 0;
-
-        air_period_tx[0] = 0;
-        air_period_rx[0] = 0;
-
+        this->secSinceBoot = nowMsec / 1000;
+        this->lastSyncMsec = nowMsec - (nowMsec % 1000);
+        this->lastUtilPeriod = this->getPeriodUtilMinute();
+        this->lastUtilPeriodTX = this->getPeriodUtilHour();
         this->airtimes.lastPeriodIndex = this->currentPeriodIndex();
+        firstTime = false;
+        return;
     }
+
+    uint32_t elapsedMsec = nowMsec - this->lastSyncMsec;
+    uint32_t elapsedSecs = elapsedMsec / 1000;
+    if (elapsedSecs == 0) {
+        return;
+    }
+
+    uint32_t oldSecSinceBoot = this->secSinceBoot;
+    this->secSinceBoot += elapsedSecs;
+    this->lastSyncMsec += elapsedSecs * 1000;
+
+    uint32_t elapsedAirtimePeriods = (this->secSinceBoot / SECONDS_PER_PERIOD) - (oldSecSinceBoot / SECONDS_PER_PERIOD);
+    if (elapsedAirtimePeriods >= PERIODS_TO_LOG) {
+        memset(this->airtimes.periodTX, 0, sizeof(this->airtimes.periodTX));
+        memset(this->airtimes.periodRX, 0, sizeof(this->airtimes.periodRX));
+        memset(this->airtimes.periodRX_ALL, 0, sizeof(this->airtimes.periodRX_ALL));
+        memset(air_period_tx, 0, sizeof(air_period_tx));
+        memset(air_period_rx, 0, sizeof(air_period_rx));
+    } else {
+        while (elapsedAirtimePeriods-- > 0) {
+            LOG_DEBUG("Rotate airtimes to a new period = %u", this->currentPeriodIndex());
+            for (int i = PERIODS_TO_LOG - 2; i >= 0; --i) {
+                this->airtimes.periodTX[i + 1] = this->airtimes.periodTX[i];
+                this->airtimes.periodRX[i + 1] = this->airtimes.periodRX[i];
+                this->airtimes.periodRX_ALL[i + 1] = this->airtimes.periodRX_ALL[i];
+                air_period_tx[i + 1] = this->airtimes.periodTX[i];
+                air_period_rx[i + 1] = this->airtimes.periodRX[i];
+            }
+
+            this->airtimes.periodTX[0] = 0;
+            this->airtimes.periodRX[0] = 0;
+            this->airtimes.periodRX_ALL[0] = 0;
+            air_period_tx[0] = 0;
+            air_period_rx[0] = 0;
+        }
+    }
+    this->airtimes.lastPeriodIndex = this->currentPeriodIndex();
+
+    uint32_t elapsedUtilPeriods = (this->secSinceBoot / 10) - (oldSecSinceBoot / 10);
+    if (elapsedUtilPeriods >= CHANNEL_UTILIZATION_PERIODS) {
+        memset(this->channelUtilization, 0, sizeof(this->channelUtilization));
+    } else {
+        for (uint32_t i = 1; i <= elapsedUtilPeriods; i++) {
+            this->channelUtilization[((oldSecSinceBoot / 10) + i) % CHANNEL_UTILIZATION_PERIODS] = 0;
+        }
+    }
+    this->lastUtilPeriod = this->getPeriodUtilMinute();
+
+    uint32_t elapsedUtilTXPeriods = (this->secSinceBoot / 60) - (oldSecSinceBoot / 60);
+    if (elapsedUtilTXPeriods >= MINUTES_IN_HOUR) {
+        memset(this->utilizationTX, 0, sizeof(this->utilizationTX));
+    } else {
+        for (uint32_t i = 1; i <= elapsedUtilTXPeriods; i++) {
+            this->utilizationTX[((oldSecSinceBoot / 60) + i) % MINUTES_IN_HOUR] = 0;
+        }
+    }
+    this->lastUtilPeriodTX = this->getPeriodUtilHour();
 }
 
 uint32_t *AirTime::airtimeReport(reportTypes reportType)
 {
+    syncNow();
 
     if (reportType == TX_LOG) {
         return this->airtimes.periodTX;
@@ -97,11 +159,14 @@ uint32_t AirTime::getSecondsPerPeriod()
 
 uint32_t AirTime::getSecondsSinceBoot()
 {
+    syncNow();
     return this->secSinceBoot;
 }
 
 float AirTime::channelUtilizationPercent()
 {
+    syncNow();
+
     uint32_t sum = 0;
     for (uint32_t i = 0; i < CHANNEL_UTILIZATION_PERIODS; i++) {
         sum += this->channelUtilization[i];
@@ -112,6 +177,8 @@ float AirTime::channelUtilizationPercent()
 
 float AirTime::utilizationTXPercent()
 {
+    syncNow();
+
     uint32_t sum = 0;
     for (uint32_t i = 0; i < MINUTES_IN_HOUR; i++) {
         sum += this->utilizationTX[i];
@@ -162,50 +229,6 @@ AirTime::AirTime() : concurrency::OSThread("AirTime"), airtimes({}) {}
 
 int32_t AirTime::runOnce()
 {
-    secSinceBoot++;
-
-    uint8_t utilPeriod = this->getPeriodUtilMinute();
-    uint8_t utilPeriodTX = this->getPeriodUtilHour();
-
-    if (firstTime) {
-
-        // Init utilizationTX window to all 0
-        for (uint32_t i = 0; i < MINUTES_IN_HOUR; i++) {
-            this->utilizationTX[i] = 0;
-        }
-
-        // Init channelUtilization window to all 0
-        for (uint32_t i = 0; i < CHANNEL_UTILIZATION_PERIODS; i++) {
-            this->channelUtilization[i] = 0;
-        }
-
-        // Init airtime windows to all 0
-        for (int i = 0; i < PERIODS_TO_LOG; i++) {
-            this->airtimes.periodTX[i] = 0;
-            this->airtimes.periodRX[i] = 0;
-            this->airtimes.periodRX_ALL[i] = 0;
-
-            // air_period_tx[i] = 0;
-            // air_period_rx[i] = 0;
-        }
-
-        firstTime = false;
-        lastUtilPeriod = utilPeriod;
-    } else {
-        this->airtimeRotatePeriod();
-
-        // Reset the channelUtilization window when we roll over
-        if (lastUtilPeriod != utilPeriod) {
-            lastUtilPeriod = utilPeriod;
-
-            this->channelUtilization[utilPeriod] = 0;
-        }
-
-        if (lastUtilPeriodTX != utilPeriodTX) {
-            lastUtilPeriodTX = utilPeriodTX;
-
-            this->utilizationTX[utilPeriodTX] = 0;
-        }
-    }
+    syncNow();
     return (1000 * 1);
 }

--- a/src/airtime.h
+++ b/src/airtime.h
@@ -66,6 +66,7 @@ class AirTime : private concurrency::OSThread
     bool firstTime = true;
     uint8_t lastUtilPeriod = 0;
     uint8_t lastUtilPeriodTX = 0;
+    uint32_t lastSyncMsec = 0;
     uint32_t secSinceBoot = 0;
     uint8_t max_channel_util_percent = 40;
     uint8_t polite_channel_util_percent = 25;
@@ -81,6 +82,7 @@ class AirTime : private concurrency::OSThread
     uint8_t getPeriodUtilMinute();
     uint8_t getPeriodUtilHour();
     uint8_t currentPeriodIndex();
+    void syncNow();
 
   protected:
     virtual int32_t runOnce() override;

--- a/src/airtime.h
+++ b/src/airtime.h
@@ -66,6 +66,7 @@ class AirTime : private concurrency::OSThread
     bool firstTime = true;
     uint8_t lastUtilPeriod = 0;
     uint8_t lastUtilPeriodTX = 0;
+    // Monotonic uptime checkpoint used to rotate airtime windows even if the scheduler was paused by light sleep.
     uint32_t lastSyncMsec = 0;
     uint32_t secSinceBoot = 0;
     uint8_t max_channel_util_percent = 40;
@@ -82,6 +83,7 @@ class AirTime : private concurrency::OSThread
     uint8_t getPeriodUtilMinute();
     uint8_t getPeriodUtilHour();
     uint8_t currentPeriodIndex();
+    // Advance rolling airtime windows from millis(), not from runOnce() calls.
     void syncNow();
 
   protected:


### PR DESCRIPTION
# Power Airtime Monotonic Windows

## Summary

This change updates airtime accounting to advance from monotonic uptime instead of the `AirTime` thread's once-per-second scheduler tick.

Before this change, `AirTime::runOnce()` incremented an internal `secSinceBoot` counter by one each time the thread ran. On devices using light sleep, the scheduler can be paused while real time continues. That means the channel-utilization and TX-utilization windows could decay according to awake scheduler time, not elapsed wall time.

After this change, airtime windows are synchronized from `millis()` before airtime is logged or read. Packets observed after wake are counted in the current elapsed-time bucket, and buckets crossed during sleep are cleared or rotated immediately.

## Motivation

The power-saving work makes ESP32 nodes enter light sleep quickly after packet processing. That exposed a mismatch in airtime accounting:

- Channel utilization is intended to be a rolling 60-second view.
- TX utilization is intended to be a rolling 60-minute view.
- Historical airtime reports are intended to use hour-sized periods.
- The old implementation advanced those windows only when the `AirTime` thread ran.

When a node slept frequently, old airtime could remain in the active channel-utilization window for longer than 60 real seconds. This could make the channel appear busy after the channel had actually been quiet from the node's point of view.

## Code Changes

The change is isolated to:

- `src/airtime.cpp`
- `src/airtime.h`

The new private helper is:

```cpp
void AirTime::syncNow();
```

`syncNow()` uses `millis()` as the time source. It intentionally does not use RTC, GPS, NTP, or mesh time, because wall-clock time can move backward or forward. Airtime windows should be based on monotonic uptime.

The helper is called from:

- `logAirtime()`
- `airtimeReport()`
- `getSecondsSinceBoot()`
- `channelUtilizationPercent()`
- `utilizationTXPercent()`
- `runOnce()`
- `airtimeRotatePeriod()`

Calling it from both readers and writers matters because a node may wake, receive a packet, or make a send-gating decision before the periodic `AirTime` thread runs again.

## Window Behavior

Channel utilization keeps the existing six 10-second buckets:

```cpp
#define CHANNEL_UTILIZATION_PERIODS 6
```
If one or more 10-second boundaries were crossed while the scheduler was paused, `syncNow()` clears each crossed bucket. If the elapsed time is large enough to cover the full 60-second window, it clears the whole channel-utilization window.
TX utilization keeps the existing 60 one-minute buckets:
```cpp
#define MINUTES_IN_HOUR 60
```

If one or more minute boundaries were crossed, `syncNow()` clears those buckets. If the elapsed time covers the full hour, it clears the full TX-utilization window.

Historical airtime reports keep the existing hour-sized periods:

```cpp
#define SECONDS_PER_PERIOD 3600
#define PERIODS_TO_LOG 8
```
If one or more hour boundaries were crossed, `syncNow()` rotates the report periods. If the elapsed time covers all retained periods, it clears the full report window.
## Expected Runtime Impact
The main behavioral change is that channel utilization and TX utilization decay according to elapsed monotonic uptime, including time spent in light sleep.
This can affect send-gating decisions that use:
```cpp
airTime->isTxAllowedChannelUtil(...)
airTime->isTxAllowedAirUtil()
```
## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
Heltec v4.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved airtime tracking accuracy after light sleep or other scheduling pauses.
  * Ensured transmitted and received packets are attributed to the correct current time period.
  * Updated airtime and utilization reporting to consistently reflect elapsed time.
  * Added reliable catch-up behavior for rolling airtime/utilization windows after extended inactivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->