### PR TITLE
Fix null pointer dereference in updateBatteryLevel function

### DIFF
--- a/src/nimble/NimbleBluetooth.cpp
+++ b/src/nimble/NimbleBluetooth.cpp
@@ -862,7 +862,7 @@ void NimbleBluetooth::setupService()
 /// Given a level between 0-100, update the BLE attribute
 void updateBatteryLevel(uint8_t level)
 {
-    if ((config.bluetooth.enabled == true) && nimbleBluetooth->isConnected()) {
+    if ((config.bluetooth.enabled == true) && nimbleBluetooth && nimbleBluetooth->isConnected()) {
         BatteryCharacteristic->setValue(&level, 1);
         BatteryCharacteristic->notify();
     }


### PR DESCRIPTION
Fixes crashes observed on T-Beam BPF at first-boot (possibly others?). Possibly caused by changes in #10390 @cpatulea 

This pull request makes a minor but important change to the Bluetooth battery level update logic. It adds a safety check to ensure that `nimbleBluetooth` is not a null pointer before accessing its methods, which helps prevent potential crashes if the object is not initialized.

- Added a null pointer check for `nimbleBluetooth` in the `updateBatteryLevel` function to prevent dereferencing a null pointer.