### PR TITLE
Revert "Fix thinknode_m7 esp32s3 CI build failure from missing `esp_eth_driver.h`"

### DIFF
--- a/src/platform/esp32/esp_eth_driver.h
+++ b/src/platform/esp32/esp_eth_driver.h
@@ -1,7 +1,0 @@
-#pragma once
-
-#if __has_include_next("esp_eth_driver.h")
-#include_next "esp_eth_driver.h"
-#elif __has_include("esp_eth.h")
-#include "esp_eth.h"
-#endif


### PR DESCRIPTION
Reverts meshtastic/firmware#10585 -- it didn't do anything.

Cherrypicking #10528 to `develop` (or just backmerging `master` to `develop`) doesn't fix the issue either.

Further changes are likely needed in [ESP32-CH390](https://github.com/meshtastic/ESP32-CH390)