### PR TITLE
Report on-chip temperature as environment telemetry

### DIFF
--- a/src/mesh/LR11x0Interface.h
+++ b/src/mesh/LR11x0Interface.h
@@ -6,6 +6,15 @@
  * \brief Adapter for LR11x0 radio family. Implements common logic for child classes.
  * \tparam T RadioLib module type for LR11x0: SX1262, SX1268.
  */
+// RadioLib keeps getTemp() protected; this exposes it only inside the Meshtastic adapter.
+template <class T> class TemperatureReadableLR11x0 : public T
+{
+  public:
+    explicit TemperatureReadableLR11x0(Module *mod) : T(mod) {}
+
+    bool readChipTemperature(float &temperature) { return this->getTemp(&temperature) == RADIOLIB_ERR_NONE; }
+};
+
 template <class T> class LR11x0Interface : public RadioLibInterface
 {
   public:
@@ -27,6 +36,15 @@ template <class T> class LR11x0Interface : public RadioLibInterface
 
     bool isIRQPending() override { return lora.getIrqFlags() != 0; }
 
+    bool getChipTemperature(float &temperature) override
+    {
+        if (isSending() || isReceiving) {
+            return false;
+        }
+
+        return lora.readChipTemperature(temperature);
+    }
+
 #ifdef LR11X0_AGC_RESET
     void resetAGC() override;
 #endif
@@ -35,7 +53,7 @@ template <class T> class LR11x0Interface : public RadioLibInterface
     /**
      * Specific module instance
      */
-    T lora;
+    TemperatureReadableLR11x0<T> lora;
 
     int16_t getCurrentRSSI() override;
 

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -238,6 +238,11 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
      */
     bool randomBytes(uint8_t *buffer, size_t length);
 
+    /**
+     * Read radio die temperature in Celsius, if the active modem exposes a calibrated reading.
+     */
+    virtual bool getChipTemperature(float &temperature) { return false; }
+
   private:
     uint8_t getNoiseFloorSampleCountInternal() const;
     int32_t getAverageNoiseFloorInternal() const;

--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -22,6 +22,10 @@
 #include "target_specific.h"
 #include <OLEDDisplay.h>
 
+#if MESHTASTIC_ENABLE_ONCHIP_TEMPERATURE_SENSOR
+#include "Sensor/OnChipTemperatureSensor.h"
+#endif
+
 #if !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR_EXTERNAL
 
 // Sensors
@@ -157,6 +161,11 @@ void EnvironmentTelemetryModule::i2cScanFinished(ScanI2C *i2cScanner)
     // moduleConfig.telemetry.environment_update_interval = 15;
 
     // order by priority of metrics/values (low top, high bottom)
+
+#if MESHTASTIC_ENABLE_ONCHIP_TEMPERATURE_SENSOR
+    // Detected sensors push_front later, so the fallback remains last and only fills missing temperature.
+    sensors.push_front(new OnChipTemperatureSensor());
+#endif
 
 #if !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
 #ifdef T1000X_SENSOR_EN

--- a/src/modules/Telemetry/EnvironmentTelemetry.h
+++ b/src/modules/Telemetry/EnvironmentTelemetry.h
@@ -10,6 +10,10 @@
 #define ENVIRONMENTAL_TELEMETRY_MODULE_ENABLE 0
 #endif
 
+#ifndef MESHTASTIC_ENABLE_ONCHIP_TEMPERATURE_SENSOR
+#define MESHTASTIC_ENABLE_ONCHIP_TEMPERATURE_SENSOR 1
+#endif
+
 #include "../mesh/generated/meshtastic/telemetry.pb.h"
 #include "NodeDB.h"
 #include "ProtobufModule.h"

--- a/src/modules/Telemetry/Sensor/OnChipTemperatureSensor.cpp
+++ b/src/modules/Telemetry/Sensor/OnChipTemperatureSensor.cpp
@@ -1,0 +1,102 @@
+#include "configuration.h"
+
+#ifndef MESHTASTIC_ENABLE_ONCHIP_TEMPERATURE_SENSOR
+#define MESHTASTIC_ENABLE_ONCHIP_TEMPERATURE_SENSOR 1
+#endif
+
+#if !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR && MESHTASTIC_ENABLE_ONCHIP_TEMPERATURE_SENSOR
+
+#include "../mesh/generated/meshtastic/telemetry.pb.h"
+#include "OnChipTemperatureSensor.h"
+#include "RadioLibInterface.h"
+#include <math.h>
+
+#if defined(ARCH_NRF52)
+#include "nrf_soc.h"
+#endif
+
+static bool isPlausibleChipTemperature(float temperature)
+{
+    return isfinite(temperature) && temperature > -45.0f && temperature < 130.0f;
+}
+
+OnChipTemperatureSensor::OnChipTemperatureSensor()
+    : TelemetrySensor(meshtastic_TelemetrySensorType_SENSOR_UNSET, "On-chip temperature")
+{
+    initialized = true;
+}
+
+bool OnChipTemperatureSensor::getMetrics(meshtastic_Telemetry *measurement)
+{
+    float temperature = 0;
+
+    if (!readMcuTemperature(temperature) && !readRadioTemperature(temperature)) {
+        return false;
+    }
+
+    if (!isPlausibleChipTemperature(temperature)) {
+        LOG_WARN("Reject implausible on-chip temperature: %.2f", temperature);
+        return false;
+    }
+
+    if (measurement->variant.environment_metrics.has_temperature) {
+        return false;
+    }
+
+    measurement->variant.environment_metrics.has_temperature = true;
+    measurement->variant.environment_metrics.temperature = temperature;
+    LOG_DEBUG("On-chip temperature getMetrics: %.1f", temperature);
+    return true;
+}
+
+bool OnChipTemperatureSensor::readMcuTemperature(float &temperature)
+{
+#if defined(ARCH_ESP32)
+    float sum = 0.0f;
+    float raw = NAN;
+    uint8_t count = 0;
+
+    for (uint8_t i = 0; i < 5; i++) {
+        float sample = temperatureRead();
+        raw = sample;
+        if (isPlausibleChipTemperature(sample)) {
+            sum += sample;
+            count++;
+        }
+        yield();
+    }
+
+    if (count < 3) {
+        return false;
+    }
+
+    temperature = sum / count;
+    LOG_DEBUG("On-chip temperature source=mcu raw=%.3f accepted=%.2f samples=%u/5", raw, temperature, count);
+    return true;
+#elif defined(ARCH_NRF52)
+    int32_t quarterDegrees = 0;
+    if (sd_temp_get(&quarterDegrees) == NRF_SUCCESS) {
+        temperature = quarterDegrees / 4.0f;
+        LOG_DEBUG("On-chip temperature source=mcu raw=%.3f accepted=%.2f", temperature, temperature);
+        return true;
+    }
+#elif defined(ARCH_RP2040)
+    temperature = analogReadTemp();
+    LOG_DEBUG("On-chip temperature source=mcu raw=%.3f accepted=%.2f", temperature, temperature);
+    return true;
+#endif
+
+    return false;
+}
+
+bool OnChipTemperatureSensor::readRadioTemperature(float &temperature)
+{
+    if (RadioLibInterface::instance && RadioLibInterface::instance->getChipTemperature(temperature)) {
+        LOG_DEBUG("On-chip temperature source=radio raw=%.3f accepted=%.2f", temperature, temperature);
+        return true;
+    }
+
+    return false;
+}
+
+#endif

--- a/src/modules/Telemetry/Sensor/OnChipTemperatureSensor.h
+++ b/src/modules/Telemetry/Sensor/OnChipTemperatureSensor.h
@@ -1,0 +1,25 @@
+#include "configuration.h"
+
+#ifndef MESHTASTIC_ENABLE_ONCHIP_TEMPERATURE_SENSOR
+#define MESHTASTIC_ENABLE_ONCHIP_TEMPERATURE_SENSOR 1
+#endif
+
+#if !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR && MESHTASTIC_ENABLE_ONCHIP_TEMPERATURE_SENSOR
+
+#pragma once
+
+#include "../mesh/generated/meshtastic/telemetry.pb.h"
+#include "TelemetrySensor.h"
+
+class OnChipTemperatureSensor : public TelemetrySensor
+{
+  public:
+    OnChipTemperatureSensor();
+    virtual bool getMetrics(meshtastic_Telemetry *measurement) override;
+
+  private:
+    bool readMcuTemperature(float &temperature);
+    bool readRadioTemperature(float &temperature);
+};
+
+#endif


### PR DESCRIPTION
## Summary

- Adds an on-chip temperature telemetry sensor that reports die temperature through the existing environment telemetry temperature field.
- Enables the provider by default at compile time with `MESHTASTIC_ENABLE_ONCHIP_TEMPERATURE_SENSOR=0` available for builds that want to remove it.
- Runs the on-chip provider after detected external environmental sensors so it only fills the temperature field when no real ambient-temperature sensor already did.
- Supports MCU die-temperature reads on ESP32, nRF52, and RP2040/RP2350, plus LR11xx radio die-temperature reads through the Meshtastic `RadioLibInterface` adapter.
- Rejects implausible chip-temperature readings outside `(-45, 130)` C or non-finite values; ESP32 reads use five quick samples, require at least three plausible samples, and yield between samples instead of using timed sleeps.
- Emits debug logs with the raw on-chip reading, accepted telemetry value, and ESP32 accepted sample count.

## Chip coverage

Implemented MCU paths:

- ESP32-family Arduino `temperatureRead()`
- nRF52 SoftDevice `sd_temp_get()`
- RP2040/RP2350 Arduino-Pico `analogReadTemp()`

Implemented modem path:

- LR11xx `getTemp()` via a Meshtastic-side wrapper because RadioLib keeps the calibrated accessor protected.

Not reported from this PR:

- SX127x/RF95 raw temperature, because RadioLib exposes only an uncalibrated raw read that changes radio operating mode.
- SX126x/SX128x/LLCC68, because the pinned RadioLib and Semtech SX126x driver APIs do not expose a calibrated temperature accessor for them.

## Validation

- Head `d762e9707`
- `git diff --check`
- `/home/kom/.platformio/penv/bin/platformio run -e coverage`
- `/home/kom/.platformio/penv/bin/platformio run -e heltec-v3`
- Flashed only the `heltec-v3` app partition to an attached Heltec V3 without erasing config/NVS/filesystem.
- Confirmed the flashed Heltec V3 booted `2.8.0.5bd5969`/`heltec-v3` with environment telemetry still enabled after app-only flashing.
- Heltec V3, USB powered, local environment telemetry request loop:
  - idle/stable baseline: 10/10 replies, MCU die temperature reported `52.3`, `51.9`, `52.9`, `52.9`, `52.9`, `52.9`, `53.3`, `53.3`, `53.7`, `53.9` C.
  - response/activity window: 14/14 replies, value moved from the stable `53.9` C plateau to `54.7` C and then `54.9` C.
  - cooldown/recovery window after a quiet delay: 8/8 replies, value came down from `55.7` C to the `54.9`-`55.1` C band.
  - after replacing ESP32 inter-sample timed sleeps with scheduler yields: 5/5 replies, all `53.9` C.
- Inspected the installed ESP32 Arduino core for `temperatureRead()` failure behavior and reject non-finite readings.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
