### PR TITLE
Rescan I2C on AQ module init

### DIFF
--- a/src/modules/Telemetry/AirQualityTelemetry.cpp
+++ b/src/modules/Telemetry/AirQualityTelemetry.cpp
@@ -142,9 +142,11 @@ int32_t AirQualityTelemetryModule::runOnce()
         if (moduleConfig.telemetry.air_quality_enabled) {
             LOG_INFO("Air quality Telemetry: init");
 
+#if !MESHTASTIC_EXCLUDE_I2C
             // Re-scan I2C bus
             auto i2cScanner = std::unique_ptr<ScanI2CTwoWire>(new ScanI2CTwoWire());
             i2cScanFinished(i2cScanner.get());
+#endif
 
             // check if we have at least one sensor
             if (!sensors.empty()) {

--- a/src/modules/Telemetry/AirQualityTelemetry.cpp
+++ b/src/modules/Telemetry/AirQualityTelemetry.cpp
@@ -13,6 +13,7 @@
 #include "Router.h"
 #include "TransmitHistory.h"
 #include "UnitConversions.h"
+#include "detect/ScanI2CTwoWire.h"
 #include "graphics/ScreenFonts.h"
 #include "graphics/SharedUIDisplay.h"
 #include "graphics/images.h"
@@ -41,18 +42,65 @@ void AirQualityTelemetryModule::i2cScanFinished(ScanI2C *i2cScanner)
     if (!moduleConfig.telemetry.air_quality_enabled && !AIR_QUALITY_TELEMETRY_MODULE_ENABLE) {
         return;
     }
+
     LOG_INFO("Air Quality Telemetry adding I2C devices...");
 
     /*
         Uncomment the preferences below if you want to use the module
         without having to configure it from the PythonAPI or WebUI.
-        Note: this was previously on runOnce, which didnt take effect
+        Note: this was previously on runOnce, which didn't take effect
         as other modules already had already been initialized (screen)
     */
 
     // moduleConfig.telemetry.air_quality_enabled = 1;
     // moduleConfig.telemetry.air_quality_screen_enabled = 1;
     // moduleConfig.telemetry.air_quality_interval = 15;
+
+    // Add here supported sensors in the Air Quality module
+    // These sensors will be scanned twice, once in the first scan,
+    // and secondly in the first run of the module
+    if (!supportedSensors.count(PMSA003I_ADDR))
+        supportedSensors[PMSA003I_ADDR] = ScanI2C::DeviceType::PMSA003I;
+    if (!supportedSensors.count(SEN5X_ADDR))
+        supportedSensors[SEN5X_ADDR] = ScanI2C::DeviceType::SEN5X;
+#if __has_include(<SensirionI2cScd4x.h>)
+    if (!supportedSensors.count(SCD4X_ADDR))
+        supportedSensors[SCD4X_ADDR] = ScanI2C::DeviceType::SCD4X;
+#endif
+#if __has_include(<SensirionI2cSfa3x.h>)
+    if (!supportedSensors.count(SFA30_ADDR))
+        supportedSensors[SFA30_ADDR] = ScanI2C::DeviceType::SFA30;
+#endif
+#if __has_include(<SensirionI2cScd30.h>)
+    if (!supportedSensors.count(SCD30_ADDR))
+        supportedSensors[SCD30_ADDR] = ScanI2C::DeviceType::SCD30;
+#endif
+
+    if (!firstTime) {
+        // Re-scan for late comming sensors
+        LOG_INFO("Re-scanning supported sensors...");
+
+        for (const auto &[address, type] : supportedSensors) {
+
+            if (!i2cScanner->exists(type)) {
+                LOG_INFO("Re-scanning on address 0x%x", address);
+                uint8_t array_address[1] = {address};
+#if defined(I2C_SDA1) || (defined(NRF52840_XXAA) && (WIRE_INTERFACES_COUNT == 2))
+                i2cScanner->scanPort(ScanI2C::I2CPort::WIRE1, array_address, sizeof(array_address));
+#endif
+
+#if defined(I2C_SDA)
+                i2cScanner->scanPort(ScanI2C::I2CPort::WIRE, array_address, sizeof(array_address));
+#elif defined(ARCH_PORTDUINO)
+                if (portduino_config.i2cdev != "") {
+                    i2cScanner->scanPort(ScanI2C::I2CPort::WIRE, array_address, sizeof(array_address));
+                }
+#elif HAS_WIRE
+                i2cScanner->scanPort(ScanI2C::I2CPort::WIRE, array_address, sizeof(array_address));
+#endif
+            }
+        }
+    }
 
     // order by priority of metrics/values (low top, high bottom)
     addSensor<PMSA003ISensor>(i2cScanner, ScanI2C::DeviceType::PMSA003I);
@@ -93,6 +141,10 @@ int32_t AirQualityTelemetryModule::runOnce()
 
         if (moduleConfig.telemetry.air_quality_enabled) {
             LOG_INFO("Air quality Telemetry: init");
+
+            // Re-scan I2C bus
+            auto i2cScanner = std::unique_ptr<ScanI2CTwoWire>(new ScanI2CTwoWire());
+            i2cScanFinished(i2cScanner.get());
 
             // check if we have at least one sensor
             if (!sensors.empty()) {

--- a/src/modules/Telemetry/AirQualityTelemetry.h
+++ b/src/modules/Telemetry/AirQualityTelemetry.h
@@ -3,8 +3,8 @@
 #if !MESHTASTIC_EXCLUDE_AIR_QUALITY_SENSOR
 
 #pragma once
-
 #include "BaseTelemetryModule.h"
+#include <map>
 
 #ifndef AIR_QUALITY_TELEMETRY_MODULE_ENABLE
 #define AIR_QUALITY_TELEMETRY_MODULE_ENABLE 0
@@ -13,6 +13,7 @@
 #include "../mesh/generated/meshtastic/telemetry.pb.h"
 #include "NodeDB.h"
 #include "ProtobufModule.h"
+#include "detect/ScanI2C.h"
 #include "detect/ScanI2CConsumer.h"
 #include <OLEDDisplay.h>
 #include <OLEDDisplayUi.h>
@@ -69,6 +70,9 @@ class AirQualityTelemetryModule : private concurrency::OSThread,
     uint32_t sendToPhoneIntervalMs = SECONDS_IN_MINUTE * 1000; // Send to phone every minute
     // uint32_t sendToPhoneIntervalMs = 1000; // Send to phone every minute
     uint32_t lastSentToPhone = 0;
+
+    // Map for supported sensors to re-scan
+    std::map<uint8_t, ScanI2C::DeviceType> supportedSensors;
 };
 
 #endif

--- a/src/modules/Telemetry/Sensor/AddI2CSensorTemplate.h
+++ b/src/modules/Telemetry/Sensor/AddI2CSensorTemplate.h
@@ -13,7 +13,7 @@ template <typename T> void addSensor(const ScanI2C *i2cScanner, ScanI2C::DeviceT
     ScanI2C::FoundDevice dev = i2cScanner->find(type);
     // Avoid adding the same device twice
     if (dev.type != ScanI2C::DeviceType::NONE) {
-        for (TelemetrySensor *_sensor : sensors) {
+        for (const TelemetrySensor *_sensor : sensors) {
             if ((_sensor->_address == dev.address.address) && (_sensor->_port == dev.address.port)) {
                 return;
             }

--- a/src/modules/Telemetry/Sensor/AddI2CSensorTemplate.h
+++ b/src/modules/Telemetry/Sensor/AddI2CSensorTemplate.h
@@ -11,6 +11,15 @@ static std::forward_list<TelemetrySensor *> sensors;
 template <typename T> void addSensor(const ScanI2C *i2cScanner, ScanI2C::DeviceType type)
 {
     ScanI2C::FoundDevice dev = i2cScanner->find(type);
+    // Avoid adding the same device twice
+    if (dev.type != ScanI2C::DeviceType::NONE) {
+        for (TelemetrySensor *_sensor : sensors) {
+            if ((_sensor->_address == dev.address.address) && (_sensor->_port == dev.address.port)) {
+                return;
+            }
+        }
+    }
+
     if (dev.type != ScanI2C::DeviceType::NONE || type == ScanI2C::DeviceType::NONE) {
         TelemetrySensor *sensor = new T();
 #if WIRE_INTERFACES_COUNT > 1

--- a/src/modules/Telemetry/Sensor/PMSA003ISensor.h
+++ b/src/modules/Telemetry/Sensor/PMSA003ISensor.h
@@ -34,10 +34,7 @@ class PMSA003ISensor : public TelemetrySensor
     uint32_t pmMeasureStarted = 0;
 
     uint8_t buffer[PMSA003I_FRAME_LENGTH]{};
-    TwoWire *_bus{};
-    uint8_t _address{};
 #ifdef PMSA003I_I2C_CLOCK_SPEED
-    ScanI2C::I2CPort _port = ScanI2C::I2CPort::NO_I2C;
     ReClockI2C reClockI2C;
 #endif
 };

--- a/src/modules/Telemetry/Sensor/SCD30Sensor.h
+++ b/src/modules/Telemetry/Sensor/SCD30Sensor.h
@@ -13,10 +13,7 @@ class SCD30Sensor : public TelemetrySensor
 {
   private:
     SensirionI2cScd30 scd30;
-    TwoWire *_bus{};
-    uint8_t _address{};
 #ifdef SCD30_I2C_CLOCK_SPEED
-    ScanI2C::I2CPort _port = ScanI2C::I2CPort::NO_I2C;
     ReClockI2C reClockI2C;
 #endif
 

--- a/src/modules/Telemetry/Sensor/SCD4XSensor.h
+++ b/src/modules/Telemetry/Sensor/SCD4XSensor.h
@@ -16,10 +16,7 @@ class SCD4XSensor : public TelemetrySensor
 {
   private:
     SensirionI2cScd4x scd4x;
-    TwoWire *_bus{};
-    uint8_t _address{};
 #ifdef SCD4X_I2C_CLOCK_SPEED
-    ScanI2C::I2CPort _port = ScanI2C::I2CPort::NO_I2C;
     ReClockI2C reClockI2C;
 #endif
 

--- a/src/modules/Telemetry/Sensor/SEN5XSensor.h
+++ b/src/modules/Telemetry/Sensor/SEN5XSensor.h
@@ -61,10 +61,7 @@ struct _SEN5XMeasurements {
 class SEN5XSensor : public TelemetrySensor
 {
   private:
-    TwoWire *_bus{};
-    uint8_t _address{};
 #ifdef SEN5X_I2C_CLOCK_SPEED
-    ScanI2C::I2CPort _port = ScanI2C::I2CPort::NO_I2C;
     ReClockI2C reClockI2C;
 #endif
 

--- a/src/modules/Telemetry/Sensor/SFA30Sensor.h
+++ b/src/modules/Telemetry/Sensor/SFA30Sensor.h
@@ -20,10 +20,7 @@ class SFA30Sensor : public TelemetrySensor
     uint32_t measureStarted = 0;
 
     SensirionI2cSfa3x sfa30;
-    TwoWire *_bus{};
-    uint8_t _address{};
 #ifdef SFA30_I2C_CLOCK_SPEED
-    ScanI2C::I2CPort _port = ScanI2C::I2CPort::NO_I2C;
     ReClockI2C reClockI2C;
 #endif
 

--- a/src/modules/Telemetry/Sensor/SHTXXSensor.h
+++ b/src/modules/Telemetry/Sensor/SHTXXSensor.h
@@ -10,8 +10,6 @@ class SHTXXSensor : public TelemetrySensor
 {
   private:
     SHTSensor sht;
-    TwoWire *_bus{};
-    uint8_t _address{};
     SHTSensor::SHTAccuracy accuracy{};
     bool setAccuracy(SHTSensor::SHTAccuracy newAccuracy);
 

--- a/src/modules/Telemetry/Sensor/TelemetrySensor.h
+++ b/src/modules/Telemetry/Sensor/TelemetrySensor.h
@@ -56,6 +56,11 @@ class TelemetrySensor
     }
 
     const char *sensorName;
+    // TODO: Rename?
+    uint8_t _address = 0;
+    TwoWire *_bus{};
+    ScanI2C::I2CPort _port = ScanI2C::I2CPort::NO_I2C;
+
     // TODO: delete after migration
     bool hasSensor() { return nodeTelemetrySensorsMap[sensorType].first > 0; }
 


### PR DESCRIPTION
This PR adds a re-scan for late coming sensors on the `AirQualityTelemetry` module. This could be easily exported to other modules. The idea is to keep the first scan as-is, through the use of the existing i2cscanner and adding it to the Telemetry Sensor list, but to trigger a re-scan on the first run of runOnce of the TelemetryModule in question.

The PR also avoids adding the same sensor twice to the sensor `forward_list`. 

> [!CAUTION]
> Rebased onto #9898.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for several new hardware variants and radio configurations.
  * Introduced haptic feedback support for touch interactions on compatible devices.
  * Added charger/power detection support and improved sensor I2C handling.

* **Bug Fixes**
  * Improved GPS, RTC, filesystem, and radio behavior for better reliability.
  * Updated UI rendering and node list display behavior.
  * Factory reset now clears stored message history.

* **Chores**
  * Updated build and CI tooling versions across workflows and project dependencies.
  * Bumped app/package version and release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->