### PR TITLE
Add low bandwidth conversions to MeshRadio

### DIFF
--- a/src/mesh/MeshRadio.h
+++ b/src/mesh/MeshRadio.h
@@ -123,8 +123,18 @@ static inline float clampBandwidthKHz(float bwKHz)
 
 static inline float bwCodeToKHz(uint16_t bwCode)
 {
+    if (bwCode == 8)
+        return 7.8f;
+    if (bwCode == 10)
+        return 10.4f;
+    if (bwCode == 16)
+        return 15.6f;
+    if (bwCode == 21)
+        return 20.8f;
     if (bwCode == 31)
         return 31.25f;
+    if (bwCode == 42)
+        return 41.7f;
     if (bwCode == 62)
         return 62.5f;
     if (bwCode == 200)
@@ -140,8 +150,18 @@ static inline float bwCodeToKHz(uint16_t bwCode)
 
 static inline uint16_t bwKHzToCode(float bwKHz)
 {
+    if (bwKHz > 7.7f && bwKHz < 7.9f)
+        return 8;
+    if (bwKHz > 10.3f && bwKHz < 10.5f)
+        return 10;
+    if (bwKHz > 15.5f && bwKHz < 15.7f)
+        return 16;
+    if (bwKHz > 20.7f && bwKHz < 20.9f)
+        return 21;
     if (bwKHz > 31.24f && bwKHz < 31.26f)
         return 31;
+    if (bwKHz > 41.6f && bwKHz < 41.8f)
+        return 42;
     if (bwKHz > 62.49f && bwKHz < 62.51f)
         return 62;
     if (bwKHz > 203.12f && bwKHz < 203.13f)

--- a/test/test_radio/test_main.cpp
+++ b/test/test_radio/test_main.cpp
@@ -33,7 +33,12 @@ class TestableRadioInterface : public RadioInterface
 
 static void test_bwCodeToKHz_specialMappings()
 {
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 7.8f, bwCodeToKHz(8));
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 10.4f, bwCodeToKHz(10));
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 15.6f, bwCodeToKHz(16));
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 20.8f, bwCodeToKHz(21));
     TEST_ASSERT_FLOAT_WITHIN(0.0001f, 31.25f, bwCodeToKHz(31));
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 41.7f, bwCodeToKHz(42));
     TEST_ASSERT_FLOAT_WITHIN(0.0001f, 62.5f, bwCodeToKHz(62));
     TEST_ASSERT_FLOAT_WITHIN(0.0001f, 203.125f, bwCodeToKHz(200));
     TEST_ASSERT_FLOAT_WITHIN(0.0001f, 406.25f, bwCodeToKHz(400));
@@ -45,6 +50,18 @@ static void test_bwCodeToKHz_passthrough()
 {
     TEST_ASSERT_FLOAT_WITHIN(0.0001f, 125.0f, bwCodeToKHz(125));
     TEST_ASSERT_FLOAT_WITHIN(0.0001f, 250.0f, bwCodeToKHz(250));
+}
+
+static void test_bwCodeToKHz_roundTrip()
+{
+    // Round-trip: bwKHzToCode(bwCodeToKHz(code)) should return the original code
+    uint16_t codes[] = {8, 10, 16, 21, 31, 42, 62, 200, 400, 800, 1600};
+    for (size_t i = 0; i < sizeof(codes) / sizeof(codes[0]); i++) {
+        uint16_t code = codes[i];
+        float khz = bwCodeToKHz(code);
+        uint16_t result = bwKHzToCode(khz);
+        TEST_ASSERT_EQUAL_UINT16(code, result);
+    }
 }
 
 static void test_validateConfigLora_noopWhenUsePresetFalse()
@@ -213,6 +230,7 @@ void setup()
     UNITY_BEGIN();
     RUN_TEST(test_bwCodeToKHz_specialMappings);
     RUN_TEST(test_bwCodeToKHz_passthrough);
+    RUN_TEST(test_bwCodeToKHz_roundTrip);
     RUN_TEST(test_validateConfigLora_noopWhenUsePresetFalse);
     RUN_TEST(test_validateConfigLora_validPreset_nonWideRegion);
     RUN_TEST(test_validateConfigLora_validPreset_wideRegion);


### PR DESCRIPTION
Adds support for low bandwidth LoRa conversion codes (7.8 kHz, 10.4 kHz, 15.6 kHz, 20.8 kHz, 41.7 kHz) in `bwCodeToKHz` and `bwKHzToCode` functions in `MeshRadio.h`.

## Changes Made

- Added bandwidth code mappings for codes 8, 10, 16, 21, and 42 in `bwCodeToKHz()`
- Added corresponding reverse mappings in `bwKHzToCode()`
- Added test cases for all new bandwidth codes in `test_bwCodeToKHz_specialMappings`
- Added round-trip test `test_bwCodeToKHz_roundTrip` verifying `bwKHzToCode(bwCodeToKHz(code)) == code` for all special codes to prevent regressions

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)