### PR TITLE
Add TinyFast and TinySlow presets to modem configuration

### DIFF
--- a/src/DisplayFormatters.cpp
+++ b/src/DisplayFormatters.cpp
@@ -51,6 +51,12 @@ const char *DisplayFormatters::getModemPresetDisplayName(meshtastic_Config_LoRaC
     case PRESET(NARROW_SLOW):
         return useShortName ? "NarS" : "NarrowSlow";
         break;
+    case PRESET(TINY_FAST):
+        return useShortName ? "TinyF" : "TinyFast";
+        break;
+    case PRESET(TINY_SLOW):
+        return useShortName ? "TinyS" : "TinySlow";
+        break;
     default:
         return useShortName ? "Custom" : "Invalid";
         break;

--- a/src/graphics/niche/InkHUD/Applets/System/Menu/MenuAction.h
+++ b/src/graphics/niche/InkHUD/Applets/System/Menu/MenuAction.h
@@ -84,6 +84,8 @@ enum MenuAction {
     SET_PRESET_LITE_FAST,
     SET_PRESET_NARROW_SLOW,
     SET_PRESET_NARROW_FAST,
+    SET_PRESET_TINY_SLOW,
+    SET_PRESET_TINY_FAST,
     SET_PRESET_FROM_REGION, // Dynamic: preset chosen from region-available list
     // Timezones
     SET_TZ_US_HAWAII,

--- a/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
@@ -834,6 +834,22 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         applyLoRaPreset(PRESET(SHORT_TURBO));
         break;
 
+    case SET_PRESET_NARROW_SLOW:
+        applyLoRaPreset(PRESET(NARROW_SLOW));
+        break;
+
+    case SET_PRESET_NARROW_FAST:
+        applyLoRaPreset(PRESET(NARROW_FAST));
+        break;
+
+    case SET_PRESET_TINY_SLOW:
+        applyLoRaPreset(PRESET(TINY_SLOW));
+        break;
+
+    case SET_PRESET_TINY_FAST:
+        applyLoRaPreset(PRESET(TINY_FAST));
+        break;
+
     case SET_PRESET_FROM_REGION: {
         // cursor - 1 because index 0 is "Back"
         const uint8_t index = cursor - 1;

--- a/src/mesh/MeshRadio.h
+++ b/src/mesh/MeshRadio.h
@@ -44,7 +44,7 @@ extern const RegionProfile PROFILE_EU868;
 extern const RegionProfile PROFILE_UNDEF;
 extern const RegionProfile PROFILE_LITE;
 extern const RegionProfile PROFILE_NARROW;
-// extern const RegionProfile  PROFILE_HAM;
+extern const RegionProfile PROFILE_HAM_20KHZ;
 
 // Map from old region names to new region enums
 struct RegionInfo {
@@ -128,7 +128,7 @@ static inline float bwCodeToKHz(uint16_t bwCode)
     if (bwCode == 10)
         return 10.4f;
     if (bwCode == 16)
-        return 15.6f;
+        return 15.625f;
     if (bwCode == 21)
         return 20.8f;
     if (bwCode == 31)
@@ -236,6 +236,16 @@ static inline void modemPresetToParams(meshtastic_Config_LoRaConfig_ModemPreset 
         break;
     case PRESET(NARROW_SLOW):
         bwKHz = 62.5f;
+        cr = 6;
+        sf = 8;
+        break;
+    case PRESET(TINY_FAST):
+        bwKHz = 15.625f;
+        cr = 5;
+        sf = 7;
+        break;
+    case PRESET(TINY_SLOW):
+        bwKHz = 15.625f;
         cr = 6;
         sf = 8;
         break;

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -49,6 +49,8 @@ static const meshtastic_Config_LoRaConfig_ModemPreset PRESETS_LITE[] = {PRESET(L
 static const meshtastic_Config_LoRaConfig_ModemPreset PRESETS_NARROW[] = {PRESET(NARROW_FAST), PRESET(NARROW_SLOW),
                                                                           MODEM_PRESET_END};
 
+static const meshtastic_Config_LoRaConfig_ModemPreset PRESETS_TINY[] = {PRESET(TINY_FAST), PRESET(TINY_SLOW), MODEM_PRESET_END};
+
 // Region profiles: bundle preset list + regulatory parameters shared across regions
 // presets, spacing, padding, audio, licensed, text throttle, position throttle, telemetry throttle
 const RegionProfile PROFILE_STD = {PRESETS_STD, 0, 0, true, false, 0, 1, 1};
@@ -56,6 +58,8 @@ const RegionProfile PROFILE_EU868 = {PRESETS_EU_868, 0, 0, false, false, 0, 1, 1
 const RegionProfile PROFILE_UNDEF = {PRESETS_UNDEF, 0, 0, true, false, 0, 1, 1};
 const RegionProfile PROFILE_LITE = {PRESETS_LITE, 0.4, 0.0375f, false, false, 0, 10, 10};
 const RegionProfile PROFILE_NARROW = {PRESETS_NARROW, 0, 0.0104f, true, false, 0, 1, 1};
+// Ham '20kHz' profile. 15.625kHz bandwidth coerced to 20kHz via padding.
+const RegionProfile PROFILE_HAM_20KHZ = {PRESETS_TINY, 0, 0.0021875f, false, true, 0, 2, 2};
 
 #define RDEF(name, freq_start, freq_end, duty_cycle, power_limit, frequency_switching, wide_lora, profile_ptr, default_preset,   \
              override_slot)                                                                                                      \

--- a/test/test_radio/test_main.cpp
+++ b/test/test_radio/test_main.cpp
@@ -35,7 +35,7 @@ static void test_bwCodeToKHz_specialMappings()
 {
     TEST_ASSERT_FLOAT_WITHIN(0.0001f, 7.8f, bwCodeToKHz(8));
     TEST_ASSERT_FLOAT_WITHIN(0.0001f, 10.4f, bwCodeToKHz(10));
-    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 15.6f, bwCodeToKHz(16));
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 15.625f, bwCodeToKHz(16));
     TEST_ASSERT_FLOAT_WITHIN(0.0001f, 20.8f, bwCodeToKHz(21));
     TEST_ASSERT_FLOAT_WITHIN(0.0001f, 31.25f, bwCodeToKHz(31));
     TEST_ASSERT_FLOAT_WITHIN(0.0001f, 41.7f, bwCodeToKHz(42));


### PR DESCRIPTION
This pull request adds support for new "Tiny" (15.625 kHz) modem presets and introduces a new region profile for ham radio operation with a 20kHz bandwidth. The changes include updates to display formatting, menu actions, preset parameter handling, and the addition of the new region profile.

This does not add new regions that consume these presets. Simply the presets themselves.

**Support for Tiny Modem Presets:**

* Added new modem presets `TINY_FAST` and `TINY_SLOW` to the preset parameter mapping logic, including their bandwidth, coding rate, and spreading factor values in `modemPresetToParams` (`src/mesh/MeshRadio.h`).
* Added display names for the new `TINY_FAST` and `TINY_SLOW` presets in `DisplayFormatters::getModemPresetDisplayName` (`src/DisplayFormatters.cpp`).
* Added new menu actions for selecting the Tiny presets in the system menu (`src/graphics/niche/InkHUD/Applets/System/Menu/MenuAction.h`).
* Defined a new preset array `PRESETS_TINY` containing the Tiny presets (`src/mesh/RadioInterface.cpp`).

**New Ham 20kHz Region Profile:**

* Introduced a new region profile `PROFILE_HAM_20KHZ` that uses the Tiny presets and is intended for ham radio operation with a 20kHz bandwidth (`src/mesh/RadioInterface.cpp`, `src/mesh/MeshRadio.h`). [[1]](diffhunk://#diff-ad55475cca6c487a8b020a5f8036f160cd1fc92cce2ea887bfe83f284a6fc855R52-R62) [[2]](diffhunk://#diff-76e54608113a80d1fb91dc423a3290d5cbf99201f05e9ebf363a5223e640e134R47)

---

✅ Depends on:
- Protobufs https://github.com/meshtastic/protobufs/pull/934
- Protobuf regen https://github.com/meshtastic/firmware/pull/10614
- Low-bandwidth conversions #10595