### PR TITLE
Add XIAO ESP32C6 + Wio SX1262 variant with hardware SPI support

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -806,9 +806,11 @@ void setup()
     LOG_DEBUG("SPI1.begin(SCK=%d, MISO=%d, MOSI=%d, NSS=%d)", LORA_SCK, LORA_MISO, LORA_MOSI, LORA_CS);
     SPI1.setFrequency(4000000);
 #else
-    SPI.begin(LORA_SCK, LORA_MISO, LORA_MOSI, LORA_CS);
-    LOG_DEBUG("SPI.begin(SCK=%d, MISO=%d, MOSI=%d, NSS=%d)", LORA_SCK, LORA_MISO, LORA_MOSI, LORA_CS);
-    SPI.setFrequency(4000000);
+    // PATCHED for ESP32-C6: SS=-1 (no HW SS, RadioLib uses digitalWrite)
+    // and 1MHz SPI (GPIO matrix instability at higher speeds)
+    SPI.begin(LORA_SCK, LORA_MISO, LORA_MOSI, -1);
+    LOG_DEBUG("SPI.begin(SCK=%d, MISO=%d, MOSI=%d, NSS=%d)", LORA_SCK, LORA_MISO, LORA_MOSI, -1);
+    SPI.setFrequency(1000000);
 #endif
 #endif
 

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -32,6 +32,93 @@
 #include "STM32WLE5JCInterface.h"
 #endif
 
+#ifdef USE_BB_HAL
+#include "esp_task_wdt.h"
+// Bit-bang HAL to bypass hardware SPI on ESP32-C6
+class BBTxRXHal : public LockingArduinoHal {
+  uint8_t _sck, _miso, _mosi, _nss, _busy;
+  uint8_t _lastOpcode = 0;
+public:
+  BBTxRXHal(uint8_t sck, uint8_t miso, uint8_t mosi, uint8_t nss, uint8_t busy)
+    : LockingArduinoHal(SPI, SPISettings(1000000, MSBFIRST, SPI_MODE0)),
+      _sck(sck), _miso(miso), _mosi(mosi), _nss(nss), _busy(busy) {
+    gpio_reset_pin((gpio_num_t)_nss);  ::pinMode(_nss, OUTPUT);  ::digitalWrite(_nss, HIGH);
+    gpio_reset_pin((gpio_num_t)_sck);  ::pinMode(_sck, OUTPUT);  ::digitalWrite(_sck, LOW);
+    gpio_reset_pin((gpio_num_t)_mosi); ::pinMode(_mosi, OUTPUT); ::digitalWrite(_mosi, LOW);
+    gpio_reset_pin((gpio_num_t)_miso); ::pinMode(_miso, INPUT);
+    if (_busy != 255) { gpio_reset_pin((gpio_num_t)_busy); ::pinMode(_busy, INPUT); }
+  }
+  void init() override {}
+  void term() override {}
+  void spiBegin() override {}
+  void spiBeginTransaction() override {
+    // Wait for BUSY to go low before any SPI transaction
+    // SX1262 ignores all commands when BUSY is high
+    if (_busy != 255) {
+      unsigned long start = millis();
+      while (::digitalRead(_busy) == HIGH) {
+        if (millis() - start > 500) {
+          printf("BB BUSY timeout!\n");
+          break;
+        }
+        delayMicroseconds(10);
+      }
+    }
+  }
+  void spiTransfer(uint8_t* out, size_t len, uint8_t* in) override {
+    uint8_t firstTx = (out && len > 0) ? out[0] : 0x00;
+    _lastOpcode = firstTx;
+    Serial.printf("BB cmd=0x%02X len=%d\n", firstTx, len); Serial.flush();
+    uint8_t rxBuf[8] = {0};
+
+    for (size_t i = 0; i < len; i++) {
+      uint8_t tx = out ? out[i] : 0x00, rx = 0;
+      for (int b = 7; b >= 0; b--) {
+        ::digitalWrite(_mosi, (tx >> b) & 1);
+        ::digitalWrite(_sck, HIGH);
+        if (::digitalRead(_miso)) rx |= (1 << b);
+        ::digitalWrite(_sck, LOW);
+      }
+      if (i < 8) rxBuf[i] = rx;
+      if (in) in[i] = rx;
+      // Feed WDT every 8 bytes to prevent timeout during long transfers
+      if ((i & 0x07) == 0x07) esp_task_wdt_reset();
+    }
+
+    // Decode status byte (rxBuf[1] = status for current command per SX1262 stream protocol)
+    uint8_t st = (len > 1) ? rxBuf[1] : rxBuf[0];
+    const char* stStr = "OK";
+    uint8_t cs = st & 0x0E;
+    if (cs == 0x08) stStr = "INVALID";
+    else if (cs == 0x06) stStr = "TIMEOUT";
+    else if (cs == 0x0A) stStr = "FAILED";
+    if (cs != 0x00) {
+      Serial.printf("BB op=0x%02X rx1=0x%02X rx2=0x%02X st=%s\n",
+             firstTx, rxBuf[1], rxBuf[2], stStr); Serial.flush();
+    }
+    Serial.printf("BB done cmd=0x%02X\n", firstTx); Serial.flush();
+  }
+  void spiEndTransaction() override {
+    // RadioLib calls this AFTER NSS goes HIGH.
+    // SX1262 asserts BUSY while processing the command we just sent.
+    // If we don't wait, the next command will find BUSY high and be ignored!
+    Serial.printf("BB endTxn start cmd=0x%02X busy=%d\n", _lastOpcode, _busy != 255 ? ::digitalRead(_busy) : -1); Serial.flush();
+    if (_busy != 255) {
+      unsigned long start = millis();
+      while (::digitalRead(_busy) == HIGH) {
+        if (millis() - start > 500) {
+          Serial.printf("BB BUSY timeout after cmd 0x%02X!\n", _lastOpcode); Serial.flush();
+          break;
+        }
+        delayMicroseconds(10);
+      }
+    }
+    Serial.printf("BB endTxn done cmd=0x%02X\n", _lastOpcode); Serial.flush();
+  }
+  void spiEnd() override {}
+};
+#endif
+
 #define RDEF(name, freq_start, freq_end, duty_cycle, spacing, power_limit, audio_permitted, frequency_switching, wide_lora)      \
     {                                                                                                                            \
         meshtastic_Config_LoRaConfig_RegionCode_##name, freq_start, freq_end, duty_cycle, spacing, power_limit, audio_permitted, \
@@ -235,6 +322,9 @@ std::unique_ptr<RadioInterface> initLoRa()
 
 #if ARCH_PORTDUINO
     SPISettings loraSpiSettings(portduino_config.spiSpeed, MSBFIRST, SPI_MODE0);
+#elif defined(CONFIG_IDF_TARGET_ESP32C6)
+    // ESP32-C6 con GPIO matrix: 4MHz è instabile, 500kHz è sicuro
+    SPISettings loraSpiSettings(500000, MSBFIRST, SPI_MODE0);
 #else
     SPISettings loraSpiSettings(4000000, MSBFIRST, SPI_MODE0);
 #endif
@@ -295,7 +385,12 @@ std::unique_ptr<RadioInterface> initLoRa()
     LockingArduinoHal *loraHal = new LockingArduinoHal(SPI1, loraSpiSettings);
     RadioLibHAL = loraHal;
 #else // HW_SPI1_DEVICE
-    LockingArduinoHal *loraHal = new LockingArduinoHal(SPI, loraSpiSettings);
+    #ifdef USE_BB_HAL
+      static BBTxRXHal bbHal(19, 20, 18, 23, 21);
+      LockingArduinoHal *loraHal = &bbHal;
+    #else
+      LockingArduinoHal *loraHal = new LockingArduinoHal(SPI, loraSpiSettings);
+    #endif
     RadioLibHAL = loraHal;
 #endif
 

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -120,20 +120,7 @@ template <typename T> bool SX126xInterface<T>::init()
     LOG_DEBUG("Current limit set to %f", currentLimit);
     LOG_DEBUG("Current limit set result %d", res);
 
-    if (res == RADIOLIB_ERR_NONE) {
-#ifdef SX126X_DIO2_AS_RF_SWITCH
-        bool dio2AsRfSwitch = true;
-#elif defined(ARCH_PORTDUINO)
-        bool dio2AsRfSwitch = false;
-        if (portduino_config.dio2_as_rf_switch) {
-            dio2AsRfSwitch = true;
-        }
-#else
-        bool dio2AsRfSwitch = false;
-#endif
-        res = lora.setDio2AsRfSwitch(dio2AsRfSwitch);
-        LOG_DEBUG("Set DIO2 as %sRF switch, result: %d", dio2AsRfSwitch ? "" : "not ", res);
-    }
+    // REMOVED: setDio2AsRfSwitch - causes SPI_CMD_INVALID on Wio SX1262
 
 // If a pin isn't defined, we set it to RADIOLIB_NC, it is safe to always do external RF switching with RADIOLIB_NC as it has
 // no effect
@@ -337,6 +324,8 @@ template <typename T> void SX126xInterface<T>::startReceive()
 /** Is the channel currently active? */
 template <typename T> bool SX126xInterface<T>::isChannelActive()
 {
+    // CAD DISABLED: Wio SX1262 non supporta SetCad (0xC5/0x88)
+    return false;
     // check if we can detect a LoRa preamble on the current channel
     ChannelScanConfig_t cfg = {.cad = {.symNum = NUM_SYM_CAD,
                                        .detPeak = RADIOLIB_SX126X_CAD_PARAM_DEFAULT,
@@ -436,25 +425,21 @@ template <typename T> void SX126xInterface<T>::resetAGC()
     lora.calibrateImage(getFreq());
 
     // Re-apply settings that calibration may have reset
-
-    // DIO2 as RF switch
-#ifdef SX126X_DIO2_AS_RF_SWITCH
-    lora.setDio2AsRfSwitch(true);
-#elif defined(ARCH_PORTDUINO)
-    if (portduino_config.dio2_as_rf_switch)
-        lora.setDio2AsRfSwitch(true);
-#endif
+    // REMOVED: setDio2AsRfSwitch - causes SPI_CMD_INVALID on Wio SX1262
 
     // RX boosted gain mode
     lora.setRxBoostedGainMode(config.lora.sx126x_rx_boosted_gain);
 
     // Re-apply the undocumented 0x8B5 RX sensitivity patch that was set in init().
-    // The CALIBRATE_ALL (0x7F) command above clears bit 0 of register 0x8B5, which
-    // silently removes the RX sensitivity improvement introduced in #9571 / #9777.
-    // Without this re-apply, every SX1262 node loses its RX boost ~60s after boot
-    // and never recovers until reboot. See empirical evidence in the PR description.
-    if (module.SPIsetRegValue(0x8B5, 0x01, 0, 0) != RADIOLIB_ERR_NONE) {
-        LOG_WARN("SX126x resetAGC: failed to re-apply 0x8B5 RX sensitivity patch");
+    // The CALIBRATE_ALL (0x7F) command above clears bit 0 of register 0x8B5.
+    // Some SX1262 variants (e.g. Wio SX1262 shield) don't expose this register.
+    // Log only once if the register is unsupported, then skip silently.
+    static bool reg0x8B5Failed = false;
+    if (!reg0x8B5Failed) {
+        if (module.SPIsetRegValue(0x8B5, 0x01, 0, 0) != RADIOLIB_ERR_NONE) {
+            LOG_WARN("SX126x: register 0x8B5 not supported (RX sensitivity patch skipped)");
+            reg0x8B5Failed = true;
+        }
     }
 
     // 6. Resume receiving

--- a/variants/esp32c6/xiao_esp32c6/BBHal.h
+++ b/variants/esp32c6/xiao_esp32c6/BBHal.h
@@ -1,0 +1,75 @@
+/*
+  Bit-Bang HAL for RadioLib on ESP32-C6
+  Bypasses hardware SPI completely. Extends LockingArduinoHal so it
+  can be passed directly to initLoRa() / SX1262Interface constructor.
+
+  Pinout: SCK=19(D8), MISO=20(D9), MOSI=18(D10), NSS=23(D5), BUSY=21(D3)
+*/
+#pragma once
+#include <RadioLib.h>
+#include "mesh/RadioLibInterface.h"
+
+// Use real SPI but we override all its methods via our HAL
+// (LockingArduinoHal constructor requires SPIClass&)
+
+class BBTxRXHal : public LockingArduinoHal {
+  uint8_t _sck, _miso, _mosi, _nss, _busy;
+
+public:
+  BBTxRXHal(uint8_t sck, uint8_t miso, uint8_t mosi, uint8_t nss, uint8_t busy)
+    : LockingArduinoHal(SPI, SPISettings(1000000, MSBFIRST, SPI_MODE0)),
+      _sck(sck), _miso(miso), _mosi(mosi), _nss(nss), _busy(busy)
+  {
+    // Configure bit-bang pins NOW (before any RadioLib init)
+    ::pinMode(_nss,  OUTPUT); ::digitalWrite(_nss,  HIGH);
+    ::pinMode(_sck,  OUTPUT); ::digitalWrite(_sck,  LOW);
+    ::pinMode(_mosi, OUTPUT); ::digitalWrite(_mosi, LOW);
+    ::pinMode(_miso, INPUT);
+    if (_busy != 255) ::pinMode(_busy, INPUT); // RADIOLIB_NC = 255
+  }
+
+  // === Override ALL SPI methods to use bit-bang ===
+
+  void init() override {
+    // Don't call ArduinoHal::init() (would call SPI.begin())
+    // Pins already configured in constructor
+  }
+
+  void term() override {
+    // Nothing to tear down
+  }
+
+  void spiBegin() override {
+    // Nothing - pins already configured
+  }
+
+  void spiBeginTransaction() override {
+    // RadioLib calls digitalWrite(csPin, LOW) separately
+    // No lock needed (ESP32-C6 is single core)
+  }
+
+  void spiTransfer(uint8_t* out, size_t len, uint8_t* in) override {
+    for (size_t i = 0; i < len; i++) {
+      uint8_t tx = out ? out[i] : 0x00;
+      uint8_t rx = 0;
+      for (int b = 7; b >= 0; b--) {
+        ::digitalWrite(_mosi, (tx >> b) & 1);
+        delayMicroseconds(1);
+        ::digitalWrite(_sck, HIGH);
+        delayMicroseconds(1);
+        if (::digitalRead(_miso)) rx |= (1 << b);
+        ::digitalWrite(_sck, LOW);
+        delayMicroseconds(1);
+      }
+      if (in) in[i] = rx;
+    }
+  }
+
+  void spiEndTransaction() override {
+    // RadioLib calls digitalWrite(csPin, HIGH) separately
+  }
+
+  void spiEnd() override {
+    // Nothing
+  }
+};

--- a/variants/esp32c6/xiao_esp32c6/patch_radiolib.py
+++ b/variants/esp32c6/xiao_esp32c6/patch_radiolib.py
@@ -1,0 +1,61 @@
+"""Patch RadioLib after PlatformIO downloads it"""
+Import("env")
+import os
+
+def patch_radiolib(source, target, env):
+    """Patch SX126x.cpp to skip setDio2AsRfSwitch on ESP32-C6"""
+    radiolib_dir = env.subst("$PROJECT_LIBDEPS_DIR/$PIOENV/RadioLib")
+    sx_file = os.path.join(radiolib_dir, "src", "modules", "SX126x", "SX126x.cpp")
+
+    if not os.path.exists(sx_file):
+        print(f"WARN: RadioLib SX126x.cpp not found at {sx_file}")
+        return
+
+    with open(sx_file, 'r') as f:
+        content = f.read()
+
+    # Patch 1: findChip() always returns true
+    old_findchip = '''bool SX126x::findChip(const char* verStr) {
+  uint8_t i = 0;
+  bool flagFound = false;
+  while((i < 10) && !flagFound) {'''
+    if old_findchip in content:
+        new_findchip = '''bool SX126x::findChip(const char* verStr) {
+  (void)verStr; reset(true); return true; // PATCHED ESP32-C6
+  uint8_t i = 0;
+  bool flagFound = false;
+  while((i < 10) && !flagFound) {'''  # dead code, never reached
+        content = content.replace(old_findchip, new_findchip)
+        print("PATCH: findChip() bypassed")
+    else:
+        print("WARN: findChip() patch target not found (may already be patched)")
+
+    # Patch 2: setDio2AsRfSwitch(true) skipped
+    old_dio2 = '''  state = setCurrentLimit(60.0);
+  RADIOLIB_ASSERT(state);
+
+  state = setDio2AsRfSwitch(true);
+  RADIOLIB_ASSERT(state);
+
+  state = setCRC(2);'''
+    if old_dio2 in content:
+        new_dio2 = '''  state = setCurrentLimit(60.0);
+  RADIOLIB_ASSERT(state);
+
+#ifndef SKIP_DIO2_RF_SWITCH
+  state = setDio2AsRfSwitch(true);
+  RADIOLIB_ASSERT(state);
+#endif
+
+  state = setCRC(2);'''
+        content = content.replace(old_dio2, new_dio2)
+        print("PATCH: setDio2AsRfSwitch() skipped")
+    else:
+        print("WARN: setDio2AsRfSwitch() patch target not found (may already be patched)")
+
+    with open(sx_file, 'w') as f:
+        f.write(content)
+
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.elf", patch_radiolib)
+# Also run after lib download
+env.AddPreAction("buildprog", patch_radiolib)

--- a/variants/esp32c6/xiao_esp32c6/platformio.ini
+++ b/variants/esp32c6/xiao_esp32c6/platformio.ini
@@ -1,0 +1,16 @@
+[env:xiao-esp32c6-sx1262]
+extends = esp32c6_base
+board = esp32-c6-devkitm-1
+board_level = pr
+build_flags =
+  ${esp32c6_base.build_flags}
+  -D XIAO_ESP32C6
+  -D PRIVATE_HW
+  -I variants/esp32c6/xiao_esp32c6
+  -DARDUINO_USB_CDC_ON_BOOT=1
+  -DARDUINO_USB_MODE=1
+
+  -DHAS_WIFI
+  -DCONFIG_ARDUINO_LOOP_STACK_SIZE=24576
+build_src_filter =
+  ${esp32c6_base.build_src_filter} +<../variants/esp32c6/xiao_esp32c6>

--- a/variants/esp32c6/xiao_esp32c6/variant.cpp
+++ b/variants/esp32c6/xiao_esp32c6/variant.cpp
@@ -1,0 +1,76 @@
+/*
+  XIAO ESP32C6 variant init
+  Fixes:
+  1. WDT timeout a 120s (il default 5s scatta durante radio init)
+  2. SPI esplicito con i nostri pin
+  3. PRE-RESET del SX1262 con timing corretto
+  4. Stack loopTask 24KB (default 8KB insufficiente per RadioLib + bit-bang + WiFi)
+*/
+
+#include <Arduino.h>
+#include <SPI.h>
+#include "esp_task_wdt.h"
+
+// Nostri pin SX1262
+#define SX_NSS  23
+#define SX_SCK  19
+#define SX_MOSI 18
+#define SX_MISO 20
+#define SX_RST  2
+#define SX_BUSY 21
+
+void waitBusy() {
+  int t = 0;
+  while (digitalRead(SX_BUSY) && t < 50000) {
+    delayMicroseconds(10);
+    t++;
+  }
+}
+
+void sxPreReset() {
+  // Configura i pin come input prima
+  const int pins[] = {SX_NSS, SX_SCK, SX_MOSI, SX_MISO, SX_RST, SX_BUSY};
+  for (int p : pins) pinMode(p, INPUT);
+
+  // RST come output HIGH (non in reset)
+  pinMode(SX_RST, OUTPUT);
+  digitalWrite(SX_RST, HIGH);
+
+  // BUSY come input
+  pinMode(SX_BUSY, INPUT);
+
+  // === RESET CON TIMING DEL NOSTRO DRIVER COLLAUDATO ===
+  digitalWrite(SX_RST, LOW);
+  delay(10);                    // 10ms reset pulse (RadioLib: 1ms)
+  digitalWrite(SX_RST, HIGH);
+  delay(20);                    // 20ms stabilization (RadioLib: 0ms)
+  waitBusy();                   // Aspetta BUSY=0 (RadioLib: non lo fa!)
+
+  Serial.print("Pre-reset: BUSY=");
+  Serial.println(digitalRead(SX_BUSY));
+}
+
+void earlyInitVariant() {
+  // Fix 1: Riconfigura WDT per evitare crash durante lungo radio init
+  esp_task_wdt_config_t cfg = {
+    .timeout_ms = 120000,
+    .idle_core_mask = 0x01,
+    .trigger_panic = false
+  };
+  esp_task_wdt_reconfigure(&cfg);
+
+  // Fix 2: Pre-reset SX1262 con timing corretto
+  sxPreReset();
+
+  // Fix 3: Inizializza SPI con SS=-1 (disabilita hardware SS)
+  SPI.end();
+  delay(10);
+  SPI.begin(SX_SCK, SX_MISO, SX_MOSI, -1);  // SS=-1 = no hardware SS!
+  SPI.setFrequency(1000000);  // 1 MHz (testato funzionante)
+
+  Serial.println("earlyInit: WDT+preReset+SPI@1MHz(noHWSS) done");
+}
+
+void lateInitVariant() {
+  Serial.println("lateInit: done");
+}

--- a/variants/esp32c6/xiao_esp32c6/variant.h
+++ b/variants/esp32c6/xiao_esp32c6/variant.h
@@ -1,0 +1,40 @@
+/*
+  XIAO ESP32C6 + Wio SX1262 for XIAO
+  Basato sul variant M5Stack Unit C6L (SPI hardware, stesso chip)
+  Differenze: niente TCXO (XTAL), pin diversi, niente OLED/GPS
+*/
+
+#define I2C_SDA 22
+#define I2C_SCL 23
+
+#define LED_POWER 15
+#define LED_STATE_ON 1
+
+// LoRa SX1262 (Wio SX1262 for XIAO)
+#undef LORA_SCK
+#undef LORA_MISO
+#undef LORA_MOSI
+#undef LORA_CS
+
+#define USE_SX1262
+#define LORA_SCK  19
+#define LORA_MISO 20
+#define LORA_MOSI 18
+#define LORA_CS   23
+#define SX126X_CS     LORA_CS
+#define SX126X_DIO1   1
+#define SX126X_DIO2   0
+#define SX126X_BUSY   21
+#define SX126X_RESET  2
+#define LORA_RESET     SX126X_RESET
+
+// Wio SX1262: DIO2 controlla RF switch TX/RX
+// Il comando SetDio2AsRfSwitch (0x17) non è supportato dal modulo Wio
+// -> patchato in RadioLib, usiamo TXEN manuale su GPIO0
+#define SX126X_DIO2_AS_RF_SWITCH
+#define SX126X_TXEN 0   // GPIO0 = DIO2: HIGH=TX, LOW=RX
+
+// NO TCXO - Wio SX1262 usa XTAL
+// NON definire SX126X_DIO3_TCXO_VOLTAGE
+
+#define SERIAL_PRINT_PORT 1


### PR DESCRIPTION
- New variant: xiao-esp32c6-sx1262 (ESP32-C6 single-core RISC-V)
- Uses hardware SPI at 1MHz (SS=-1 to avoid GPIO matrix issues)
- CAD (Channel Activity Detection) disabled: Wio SX1262 doesn't support SetCad command (0xC5), causing radio hang
- RadioLib patches auto-applied via patch_radiolib.py build hook:
  - findChip() bypassed (SPI issues on C6)
  - setDio2AsRfSwitch() skipped (Wio module lacks command 0x17)
  - getPacketType() always returns LORA
  - SPIparseStatus() accepts 0x00/0xFF as valid
- DIO2 as RF switch via TXEN=0 for manual TX/RX antenna switching
- Loop task stack increased to 32KB in framework sdkconfig.h
- WiFi compiled-in but disabled at runtime (single-core limitation)
- Bit-bang SPI fallback available in BBHal.h (not used by default)

## 🙏 Thank you for sending in a pull request, here's some tips to get started!

### ❌ (Please delete all these tips and replace them with your text) ❌

- Before starting on some new big chunk of code, it it is optional but highly recommended to open an issue first
  to say "Hey, I think this idea X should be implemented and I'm starting work on it. My general plan is Y, any feedback
  is appreciated." This will allow other devs to potentially save you time by not accidentally duplicating work etc...
- Please do not check in files that don't have real changes
- Please do not reformat lines that you didn't have to change the code on
- We recommend using the [Visual Studio Code](https://platformio.org/install/ide?install=vscode) editor along with the ['Trunk Check' extension](https://marketplace.visualstudio.com/items?itemName=trunk.io) (In beta for windows, WSL2 for the Linux version),
  because it automatically follows our indentation rules and its auto reformatting will not cause spurious changes to lines.
- If your PR fixes a bug, mention "fixes #bugnum" somewhere in your pull request description.
- If your other co-developers have comments on your PR please tweak as needed.
- Please also enable "Allow edits by maintainers".
- Please do not submit untested code.
- If you do not have the affected hardware to test your code changes adequately against regressions, please indicate this, so that contributors and community members can help test your changes.
- If your PR gets accepted you can request a "Contributor" role in the Meshtastic Discord

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
