### PR TITLE
Debian: Correctly build without signing (for forks)

### DIFF
--- a/debian/ci_pack_sdeb.sh
+++ b/debian/ci_pack_sdeb.sh
@@ -33,5 +33,5 @@ if [[ -n $GPG_KEY_ID ]]; then
 	debuild -S -nc -k"$GPG_KEY_ID"
 else
 	# Build the source deb without signing (forks)
-	debuild -S -nc
+	debuild -S -nc -us -uc
 fi


### PR DESCRIPTION
This pull request makes a minor update to the Debian packaging script to clarify the behavior when building unsigned source packages. Specifically, it ensures that when no GPG key is provided, the build process explicitly disables signing.

- Packaging script update:
  * [`debian/ci_pack_sdeb.sh`](diffhunk://#diff-9ce6f41f62767494f5f80e054b5d0bc1d93616e5d45b6c6476e6cd5fca383bf1L36-R36): Added `-us -uc` flags to the `debuild` command to explicitly disable signing when no GPG key is provided.