### PR TITLE
Actions: Update trunk-io/trunk-action to v1.3.1

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,13 +17,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Trunk Check
-        uses: trunk-io/trunk-action@v1
+        uses: trunk-io/trunk-action@v1.3.1
         with:
           trunk-token: ${{ secrets.TRUNK_TOKEN }}
 
   trunk_upgrade:
     if: github.repository == 'meshtastic/firmware'
-    # See: https://github.com/trunk-io/trunk-action/blob/v1/readme.md#automatic-upgrades
+    # See: https://github.com/trunk-io/trunk-action/blob/main/readme.md#automatic-upgrades
     name: Trunk Upgrade (PR)
     runs-on: ubuntu-24.04
     permissions:
@@ -34,6 +34,6 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Trunk Upgrade
-        uses: trunk-io/trunk-action/upgrade@v1
+        uses: trunk-io/trunk-action/upgrade@v1.3.1
         with:
           base: master

--- a/.github/workflows/trunk_annotate_pr.yml
+++ b/.github/workflows/trunk_annotate_pr.yml
@@ -1,5 +1,5 @@
 name: Annotate PR with trunk issues
-# See: https://github.com/trunk-io/trunk-action/blob/v1/readme.md#getting-inline-annotations-for-fork-prs
+# See: https://github.com/trunk-io/trunk-action/blob/main/readme.md#getting-inline-annotations-for-fork-prs
 
 on:
   workflow_run:
@@ -21,6 +21,6 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Trunk Check
-        uses: trunk-io/trunk-action@v1
+        uses: trunk-io/trunk-action@v1.3.1
         with:
           post-annotations: true

--- a/.github/workflows/trunk_check.yml
+++ b/.github/workflows/trunk_check.yml
@@ -19,6 +19,6 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Trunk Check
-        uses: trunk-io/trunk-action@v1
+        uses: trunk-io/trunk-action@v1.3.1
         with:
           save-annotations: true


### PR DESCRIPTION
Trunk isn't properly updating the `v1` tag in-place. Switch to specific tags and let renovate handle the rest. Maybe this will fix some issues with annotations? 🙏