### PR TITLE
Actions: Update protobufs using the triggering branch

### DIFF
--- a/.github/workflows/update_protobufs.yml
+++ b/.github/workflows/update_protobufs.yml
@@ -16,9 +16,14 @@ jobs:
           submodules: true
 
       - name: Update submodule
-        if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' }}
+        if: ${{ github.ref_name == 'master' || github.ref_name == 'develop' }}
+        working-directory: protobufs
+        env:
+          # Use the branch that triggered the workflow as the protobuf branch.
+          GIT_BRANCH: ${{ github.ref_name }}
         run: |
-          git submodule update --remote protobufs
+          git fetch --prune origin $GIT_BRANCH
+          git checkout origin/$GIT_BRANCH
 
       - name: Download nanopb
         run: |
@@ -33,7 +38,7 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@v8
         with:
-          branch: create-pull-request/update-protobufs
+          branch: create-pull-request/update-protobufs-${{ github.ref_name }}
           labels: submodules
           title: Update protobufs and classes
           commit-message: Update protobufs


### PR DESCRIPTION
This pull request updates the workflow for updating protobuf submodules to better handle branch references and submodule updates. The main change is switching to use `github.ref_name` instead of `github.ref` and improving how the protobuf submodule is updated. Now when the workflow is triggered in `develop` branch, `develop` branch protobufs will be used.

**Workflow improvements:**

* The condition for updating the submodule now uses `github.ref_name` for better clarity and reliability when checking if the workflow is running on `master` or `develop` branches.
* The submodule update step now sets the working directory to `protobufs`, uses an environment variable (`GIT_BRANCH`) to track the triggering branch, and replaces the previous `git submodule update` command with a `git pull` and `git checkout` to ensure the correct branch is checked out and up to date.