### PR TITLE
fix(range-test): fix early newline in CSV export, reorder columns

### DIFF
--- a/src/modules/RangeTestModule.cpp
+++ b/src/modules/RangeTestModule.cpp
@@ -235,8 +235,7 @@ bool RangeTestModuleRadio::appendFile(const meshtastic_MeshPacket &mp)
         }
 
         // Print the CSV header
-        if (fileToWrite.println("time,from,sender name,sender lat,sender long,rx lat,rx long,rx elevation,rx "
-                                "snr,distance,hop limit,payload,rx rssi")) {
+        if (fileToWrite.println("time,payload,from,sender name,sender lat,sender long,rx lat,rx long,rx elevation,distance,rx snr,rx rssi,hop limit")) {
             LOG_INFO("File was written");
         } else {
             LOG_ERROR("File write failed");
@@ -268,6 +267,9 @@ bool RangeTestModuleRadio::appendFile(const meshtastic_MeshPacket &mp)
         fileToAppend.printf("??:??:??,"); // Time
     }
 
+    // TODO: If quotes are found in the payload, it has to be escaped.
+    fileToAppend.printf("\"%s\",", p.payload.bytes);   // Payload
+
     fileToAppend.printf("%d,", getFrom(&mp));          // From
     fileToAppend.printf("%s,", n ? n->long_name : ""); // Long Name
     meshtastic_PositionLite senderPos;
@@ -294,8 +296,6 @@ bool RangeTestModuleRadio::appendFile(const meshtastic_MeshPacket &mp)
         }
     }
 
-    fileToAppend.printf("%f,", mp.rx_snr); // RX SNR
-
     if (haveSenderPos && senderPos.latitude_i && senderPos.longitude_i && gpsStatus->getLatitude() && gpsStatus->getLongitude()) {
         float distance = GeoCoord::latLongToMeter(senderPos.latitude_i * 1e-7, senderPos.longitude_i * 1e-7,
                                                   gpsStatus->getLatitude() * 1e-7, gpsStatus->getLongitude() * 1e-7);
@@ -304,11 +304,9 @@ bool RangeTestModuleRadio::appendFile(const meshtastic_MeshPacket &mp)
         fileToAppend.printf("0,");
     }
 
-    fileToAppend.printf("%d,", mp.hop_limit); // Packet Hop Limit
-
-    // TODO: If quotes are found in the payload, it has to be escaped.
-    fileToAppend.printf("\"%s\"\n", p.payload.bytes);
-    fileToAppend.printf("%i,", mp.rx_rssi); // RX RSSI
+    fileToAppend.printf("%f,", mp.rx_snr);     // RX SNR
+    fileToAppend.printf("%i,", mp.rx_rssi);    // RX RSSI
+    fileToAppend.printf("%d\n", mp.hop_limit); // Packet Hop Limit
 
     fileToAppend.flush();
     fileToAppend.close();


### PR DESCRIPTION
## Summary

- `rx_rssi` was written after the row-terminating `\n`, orphaning it on the next line of every exported CSV row. Fixed by moving `\n` to the end of the final field.
- Reordered CSV columns to a more logical layout: `payload` surfaces early (after `time`), RF metrics (`distance`, `rx snr`, `rx rssi`) are grouped together, and `hop limit` closes the row.

**New column order:**
```
time, payload, from, sender name, sender lat, sender long, rx lat, rx long, rx elevation, distance, rx snr, rx rssi, hop limit
```

## Test plan
- [ ] Flash to an ESP32 device with `range_test.save = true`
- [ ] Receive a range test packet and download `/static/rangetest.csv`
- [ ] Verify each row has the correct number of columns with no stray newlines
- [ ] Verify column order matches the header