### PR TITLE
Add support for T-Beam Supreme 144mhz variant

### DIFF
--- a/variants/esp32s3/tbeam-s3-core/variant.h
+++ b/variants/esp32s3/tbeam-s3-core/variant.h
@@ -14,12 +14,20 @@
 #define USE_SX1262
 #define USE_SX1268
 #define USE_LR1121
+#define USE_RF95
 
 #define LORA_DIO0 -1 // a No connect on the SX1262 module
 #define LORA_RESET 5
 #define LORA_DIO1 1 // SX1262 IRQ
 #define LORA_DIO2 4 // SX1262 BUSY
 #define LORA_DIO3   // Not connected on PCB, but internally on the TTGO SX1262, if DIO3 is high the TXCO is enabled
+
+// 144mhz variant uses 'RF95' (SX1278)
+#ifdef USE_RF95
+#define RF95_IRQ 2
+#define RF95_RESET LORA_RESET
+#define RF95_DIO1 LORA_DIO1
+#endif
 
 #ifdef USE_SX1262
 #define SX126X_CS 10 // FIXME - we really should define LORA_CS instead


### PR DESCRIPTION
Adds support for T-Beam-Supreme 144mhz version :meat_on_bone: 
https://github.com/Xinyuan-LilyGO/LilyGo-LoRa-Series/blob/master/docs/en/t_beam_supreme/t_beam_supreme_144_hw.md

Tested / working on `tbeam-s3-core` with SX1278 radio (~144mhz).

⚠️ Please help me test for regressions! I do not own T-Beam Supreme versions with SX1262 or LR1121.

---

This pull request adds support for the RF95 (SX1278) LoRa radio module to the `tbeam-s3-core` ESP32S3 variant. The main change is the introduction of new preprocessor definitions and pin mappings to enable and configure the RF95 hardware.

Hardware support additions:

* Added `USE_RF95` define to enable support for the RF95 (SX1278) module.
* Defined pin mappings for the RF95: `RF95_IRQ`, `RF95_RESET`, and `RF95_DIO1`, reusing existing LoRa pin assignments for compatibility.

---

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] `tbeam-s3-core` with SX1278 radio (~144mhz)
  - [ ] `tbeam-s3-core` with SX1262
  - [ ] `tbeam-s3-core` with LR1121
