### PR TITLE
Add Module configuration for RAK6421 Slot 2 yamls

### DIFF
--- a/bin/config.d/lora-RAK6421-13300-slot2.yaml
+++ b/bin/config.d/lora-RAK6421-13300-slot2.yaml
@@ -6,6 +6,7 @@ Meta:
 
 Lora:
   ### RAK13300 in Slot 2 pins
+  Module: sx1262
   IRQ: 18 #IO6
   Reset: 24 # IO4
   Busy: 19 # IO5

--- a/bin/config.d/lora-RAK6421-13302-slot2.yaml
+++ b/bin/config.d/lora-RAK6421-13302-slot2.yaml
@@ -6,6 +6,7 @@ Meta:
 
 Lora:
   ### RAK13302 in Slot 2 pins
+  Module: sx1262
   IRQ: 18 #IO6
   Reset: 24 # IO4
   Busy: 19 # IO5


### PR DESCRIPTION
The RAK 13300 and 13302 Slot 2 config yamls are missing the Module definition.  This PR adds them.

The image below compares the slot1 to slot2 yaml:
<img width="1470" height="664" alt="image" src="https://github.com/user-attachments/assets/41a4b938-b432-4f35-890d-b8ae48a74c2a" />
