### PR TITLE
ESP32: Update pioarduino to v3.3.9

### DIFF
--- a/variants/esp32/esp32-common.ini
+++ b/variants/esp32/esp32-common.ini
@@ -5,7 +5,7 @@ custom_esp32_kind =
 custom_mtjson_part =
 platform =
   # TODO renovate
-  https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
+  https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
   ; https://github.com/pioarduino/platform-espressif32.git#develop
 platform_packages =
   # renovate: datasource=custom.pio depName=platformio/tool-mklittlefs packageName=platformio/tool/tool-mklittlefs


### PR DESCRIPTION
Update pioarduino

Arduino Release v3.3.9 based on ESP-IDF v5.5.4
- https://github.com/pioarduino/platform-espressif32/releases/tag/55.03.39
- https://github.com/espressif/arduino-esp32/releases/tag/3.3.9

~May help with recent compile troubles? #10630~

Could also cause Bluetooth regressions @cpatulea 