### PR TITLE
Add 1.25 Meter '125cm' amateur radio region support

### DIFF
--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -209,6 +209,7 @@ void menuHandler::LoraRegionPicker(uint32_t duration)
         {"ITU1_2M (144-146)", OptionsAction::Select, meshtastic_Config_LoRaConfig_RegionCode_ITU1_2M},
         {"ITU2_2M (144-148)", OptionsAction::Select, meshtastic_Config_LoRaConfig_RegionCode_ITU2_2M},
         {"ITU3_2M (144-148)", OptionsAction::Select, meshtastic_Config_LoRaConfig_RegionCode_ITU3_2M},
+        {"ITU2_125CM (220-225)", OptionsAction::Select, meshtastic_Config_LoRaConfig_RegionCode_ITU2_125CM},
 
     };
 

--- a/src/graphics/niche/InkHUD/Applets/System/Menu/MenuAction.h
+++ b/src/graphics/niche/InkHUD/Applets/System/Menu/MenuAction.h
@@ -69,6 +69,7 @@ enum MenuAction {
     SET_REGION_ITU1_2M,
     SET_REGION_ITU2_2M,
     SET_REGION_ITU3_2M,
+    SET_REGION_ITU2_125CM,
     // Device Roles
     SET_ROLE_CLIENT,
     SET_ROLE_CLIENT_MUTE,

--- a/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
@@ -796,6 +796,10 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         applyLoRaRegion(meshtastic_Config_LoRaConfig_RegionCode_ITU3_2M);
         break;
 
+    case SET_REGION_ITU2_125CM:
+        applyLoRaRegion(meshtastic_Config_LoRaConfig_RegionCode_ITU2_125CM);
+        break;
+
     // Roles
     case SET_ROLE_CLIENT:
         applyDeviceRole(meshtastic_Config_DeviceConfig_Role_CLIENT);
@@ -1500,6 +1504,7 @@ void InkHUD::MenuApplet::showPage(MenuPage page)
         items.push_back(MenuItem("ITU1_2M (144-146)", MenuAction::SET_REGION_ITU1_2M, MenuPage::EXIT));
         items.push_back(MenuItem("ITU2_2M (144-148)", MenuAction::SET_REGION_ITU2_2M, MenuPage::EXIT));
         items.push_back(MenuItem("ITU3_2M (144-148)", MenuAction::SET_REGION_ITU3_2M, MenuPage::EXIT));
+        items.push_back(MenuItem("ITU2_125CM (220-225)", MenuAction::SET_REGION_ITU2_125CM, MenuPage::EXIT));
         items.push_back(MenuItem("Exit", MenuPage::EXIT));
         break;
 

--- a/src/mesh/MeshRadio.h
+++ b/src/mesh/MeshRadio.h
@@ -45,6 +45,7 @@ extern const RegionProfile PROFILE_UNDEF;
 extern const RegionProfile PROFILE_LITE;
 extern const RegionProfile PROFILE_NARROW;
 extern const RegionProfile PROFILE_HAM_20KHZ;
+extern const RegionProfile PROFILE_HAM_100KHZ;
 
 // Map from old region names to new region enums
 struct RegionInfo {

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -60,6 +60,8 @@ const RegionProfile PROFILE_LITE = {PRESETS_LITE, 0.4, 0.0375f, false, false, 0,
 const RegionProfile PROFILE_NARROW = {PRESETS_NARROW, 0, 0.0104f, true, false, 0, 1, 1};
 // Ham '20kHz' profile. 15.6kHz bandwidth coerced to 20kHz via padding.
 const RegionProfile PROFILE_HAM_20KHZ = {PRESETS_TINY, 0, 0.0022f, false, true, 0, 2, 2};
+// Ham '100kHz' profile. 62.5kHz bandwidth coerced to 100kHz via padding.
+const RegionProfile PROFILE_HAM_100KHZ = {PRESETS_NARROW, 0, 0.01875f, false, true, 0, 1, 1};
 
 #define RDEF(name, freq_start, freq_end, duty_cycle, power_limit, frequency_switching, wide_lora, profile_ptr, default_preset,   \
              override_slot)                                                                                                      \
@@ -258,6 +260,16 @@ const RegionInfo regions[] = {
         https://www.wia.org.au/members/bandplans/data/documents/WIA%20Australian%20Band%20Plan%202026.pdf
     */
     RDEF(ITU3_2M, 144.0f, 148.0f, 100, 30, false, false, PROFILE_HAM_20KHZ, PRESET(TINY_FAST), 33),
+
+    /*
+        ITU Region 2 (Americas) amateur 1.25m '125cm' allocation: 220.000 - 225.000 MHz.
+        Typical admin rules (e.g. US FCC Part 97) allow well above 30 dBm for licensed operators.
+        Note: Some countries do not allocate 220-222 MHz (e.g. USA, Canada). Check local law!
+
+        Default slot: 37 (223.650 MHz)
+        https://www.arrl.org/band-plan
+    */
+    RDEF(ITU2_125CM, 220.0f, 225.0f, 100, 30, false, false, PROFILE_HAM_100KHZ, PRESET(NARROW_SLOW), 37),
 
     /*
        2.4 GHZ WLAN Band equivalent. Only for SX128x chips.


### PR DESCRIPTION
Adds new region for the 1.25 Meter (125cm) ham band.
:earth_americas:🇺🇸 ITU2_125CM: Default Slot 37 (223.650 MHz)

This band is only allocated in the :earth_americas: ITU2 (Americas) region.

Uses 62.5 kHz (NARROW) bandwidth, padded to 100kHz for clean channelization.

---

This pull request adds support for the ITU Region 2 1.25m (220-225 MHz) amateur radio band ("ITU2_125CM") to the menu system and radio region configuration, and introduces a new 100kHz amateur radio profile to support this band. The changes update both the user interface and the backend region definitions to enable configuration and use of this new region.

**Region and Profile Additions:**

* Added the `ITU2_125CM (220-225)` region to the region picker UI (`menuHandler::LoraRegionPicker`) and the region selection menu in the InkHUD applet, allowing users to select this band from the device interface. [[1]](diffhunk://#diff-42b779fbaf784d6b09c1770397a59db686044c519108888f421651113995f1a7R212) [[2]](diffhunk://#diff-b0fa850e0eff92934e7b34086843ce0e1a51dbb88cf46ac4cf98e398bb093264R1507)
* Defined a new region enum value `SET_REGION_ITU2_125CM` and handled its selection in the menu action logic, enabling the system to apply the correct configuration when chosen. [[1]](diffhunk://#diff-f897afb9f8f4157807bcd8def8e10c44ad590a8c8201dd9d0efbd753e1f1d45eR72) [[2]](diffhunk://#diff-b0fa850e0eff92934e7b34086843ce0e1a51dbb88cf46ac4cf98e398bb093264R799-R802)
* Added the `PROFILE_HAM_100KHZ` radio profile to support the wider bandwidth typical of the 1.25m band, and registered it in the region profiles. [[1]](diffhunk://#diff-76e54608113a80d1fb91dc423a3290d5cbf99201f05e9ebf363a5223e640e134R48) [[2]](diffhunk://#diff-ad55475cca6c487a8b020a5f8036f160cd1fc92cce2ea887bfe83f284a6fc855R63-R64)
* Registered the new `ITU2_125CM` region in the backend region definitions, specifying its frequency range, power limits, and default slot, and linking it to the new 100kHz profile.