### PR TITLE
Prevent ghost nodes during onboarding

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1989,6 +1989,14 @@ bool NodeDB::saveDeviceStateToDisk()
 
 bool NodeDB::saveNodeDatabaseToDisk()
 {
+    // Don't persist the node DB until this device has a PKI keypair
+    // TODO: revisit when Licensed is signed
+#if !(MESHTASTIC_EXCLUDE_PKI_KEYGEN || MESHTASTIC_EXCLUDE_PKI)
+    if (owner.public_key.size != 32 && !owner.is_licensed) {
+        LOG_DEBUG("Skip NodeDB without key");
+        return true;
+    }
+#endif
 
     // do not try to save anything if power level is not safe. In many cases flash will be lock-protected
     // and all writes will fail anyway. Device should be sleeping at this point anyway.

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1990,7 +1990,7 @@ bool NodeDB::saveDeviceStateToDisk()
 bool NodeDB::saveNodeDatabaseToDisk()
 {
     // Don't persist the node DB until this device has a PKI keypair
-    // TODO: revisit when Licensed is signed
+    // TODO: revisit when https://github.com/meshtastic/firmware/pull/10478 lands
 #if !(MESHTASTIC_EXCLUDE_PKI_KEYGEN || MESHTASTIC_EXCLUDE_PKI)
     if (owner.public_key.size != 32 && !owner.is_licensed) {
         LOG_DEBUG("Skip NodeDB without key");


### PR DESCRIPTION
A node generates no PKI keypair until a region is configured. During that onboarding window the device still writes its own self-entry into the node DB. On the next boot pickNewNodeNum() can't recognize that keyless entry as itself, so it mints a new random nodenum and orphans the old entry. Every reboot before the region/key is set therefore leaves another "ghost" copy of the node in the DB.

Defer node-DB persistence until the device has a public key, so the keyless self is never written. Config, device state, and channels (including the security keypair) still persist normally, factory-reset keypair reclaim is unaffected, and licensed nodes and PKI-disabled builds are unchanged.
