### PR TITLE
add an "optional" standardized private syncword (revive old meshtasti…

### DIFF
--- a/extra_scripts/syncword.py
+++ b/extra_scripts/syncword.py
@@ -7,8 +7,8 @@ Usage:
     pio run -e native -t privatesync
 
 Adds -DMESHTASTIC_SYNCWORD_0x12=1 to the build so the firmware uses
-syncWord=0x12 instead of the default 0x2b. Required when pairing with 
-some devices (with FRAME_SYNCH registers are 5-bit signed; 0x2b
+syncWord=0x12 instead of the default 0x2b. Required when pairing with an
+SX1302 concentrator gateway (FRAME_SYNCH registers are 5-bit signed; 0x2b
 overflows). Nodes built with this flag cannot communicate with stock 0x2b nodes.
 """
 

--- a/extra_scripts/syncword.py
+++ b/extra_scripts/syncword.py
@@ -7,8 +7,8 @@ Usage:
     pio run -e native -t privatesync
 
 Adds -DMESHTASTIC_SYNCWORD_0x12=1 to the build so the firmware uses
-syncWord=0x12 instead of the default 0x2b. Required when pairing with an
-SX1302 concentrator gateway (FRAME_SYNCH registers are 5-bit signed; 0x2b
+syncWord=0x12 instead of the default 0x2b. Required when pairing with 
+some devices (with FRAME_SYNCH registers are 5-bit signed; 0x2b
 overflows). Nodes built with this flag cannot communicate with stock 0x2b nodes.
 """
 

--- a/extra_scripts/syncword.py
+++ b/extra_scripts/syncword.py
@@ -1,0 +1,29 @@
+# trunk-ignore-all(ruff/F821)
+# trunk-ignore-all(flake8/F821): For SConstruct imports
+"""
+Custom PlatformIO target: privatesync
+
+Usage:
+    pio run -e native -t privatesync
+
+Adds -DMESHTASTIC_SYNCWORD_0x12=1 to the build so the firmware uses
+syncWord=0x12 instead of the default 0x2b. Required when pairing with an
+SX1302 concentrator gateway (FRAME_SYNCH registers are 5-bit signed; 0x2b
+overflows). Nodes built with this flag cannot communicate with stock 0x2b nodes.
+"""
+
+Import("env")
+
+import SCons.Script  # noqa: E402 (available after Import)
+
+if "privatesync" in SCons.Script.COMMAND_LINE_TARGETS:
+    env.Append(CPPDEFINES=["MESHTASTIC_SYNCWORD_0x12=1"])
+    print("privatesync: syncWord=0x12 enabled (SX1302 gateway mode)")
+
+env.AddCustomTarget(
+    name="privatesync",
+    dependencies=["$BUILD_DIR/${PROGNAME}${PROGSUFFIX}"],
+    actions=None,
+    title="Private Sync Word (0x12)",
+    description="Build with syncWord=0x12 for most devices  compatibility",
+)

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,6 +15,7 @@ description = Meshtastic
 [env]
 test_build_src = true
 extra_scripts =
+	pre:extra_scripts/syncword.py
 	pre:bin/platformio-pre.py
 	bin/platformio-custom.py
 	post:extra_scripts/nrf54l15_linker.py

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -81,7 +81,14 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
      * We now use 0x2b (so that someday we can possibly use NOT 2b - because that would be funny pun).  We will be staying with
      * this code for a long time.
      */
+    /* Build with -DMESHTASTIC_SYNCWORD_0x12 to use 0x12 instead of 0x2b.
+     * Required for SX1302 concentrator gateways: FRAME_SYNCH registers are 5-bit
+     * signed so 0x2b (PEAK2=22) overflows. 0x12 nodes cannot talk to stock 0x2b nodes. */
+#ifdef MESHTASTIC_SYNCWORD_0x12
+    const uint8_t syncWord = 0x12;
+#else
     const uint8_t syncWord = 0x2b;
+#endif
 
     float currentLimit = 100; // 100mA OCP - Should be acceptable for RFM95/SX127x chipset.
 


### PR DESCRIPTION
…c syncword)

## 🙏 Thank you for sending in a pull request, here's some tips to get started!

This code is not device specific but this allows other types of devices which has a limit where 0x2b syncword is not possible.

Alternatively, we provide an **opt-in** option (example: "pio run -e heltec-v4 -t privatesync -t upload") to use 0x12 (private) syncword in case they want to be compatible with devices that is not compatible with 0x2b.

Also this helps reduce costs where a single hardware can demodulate (concentrator-end can be configured for one 250kHz and multiple 125Khz bandwidth, possible one frequency with LongFast as default and some other frequencies at 125kHz presets (LongModerate, LongSlow), with different SFs (presets) simultaneously as a backhaul sink. 

Additionally, with the same syncword (LoRaWAN private + Meshtastic) and can run single-hardware Meshtastic gateways (like MQTT) and co-existing with existing LoRaWAN software (LoRaWAN + Meshtastic integration) in that single concentrator hardware.

Initially i thought of forking but it's a small change which i can add value to Meshtastic in cases where the **signed 5-bit limitation of the hardware** makes it totally not possible to use 0x2b which causes an overflow in the result syncword.

<img width="2880" height="1594" alt="image" src="https://github.com/user-attachments/assets/3878b986-481a-4f1c-95b9-e93dee97d412" />
<img width="2880" height="1594" alt="image" src="https://github.com/user-attachments/assets/8348650b-8a89-4795-94f1-71fd0695aba7" />
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/76394df0-3165-4719-bdea-76f0512eee97" />

It works, TX/RX works, no issues.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
         Semtech SX1302 Evaluation board with SX1250 frontend (meshtasticd)
         Heltec v4.3
