### PR TITLE
Arduino Nesso N1 support

### DIFF
--- a/variants/esp32c6/arduino_nesso_n1/pins_arduino.h
+++ b/variants/esp32c6/arduino_nesso_n1/pins_arduino.h
@@ -1,0 +1,22 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define USB_VID 0x303A
+#define USB_PID 0x1001
+
+static const uint8_t TX = -1;
+static const uint8_t RX = -1;
+
+static const uint8_t SDA = 10;
+static const uint8_t SCL = 8;
+
+// Default SPI will be mapped to Radio
+static const uint8_t MOSI = 21;
+static const uint8_t MISO = 22;
+static const uint8_t SCK = 20;
+static const uint8_t SS = 23;
+
+#endif /* Pins_Arduino_h */
+

--- a/variants/esp32c6/arduino_nesso_n1/pins_arduino.h
+++ b/variants/esp32c6/arduino_nesso_n1/pins_arduino.h
@@ -19,4 +19,3 @@ static const uint8_t SCK = 20;
 static const uint8_t SS = 23;
 
 #endif /* Pins_Arduino_h */
-

--- a/variants/esp32c6/arduino_nesso_n1/platformio.ini
+++ b/variants/esp32c6/arduino_nesso_n1/platformio.ini
@@ -1,0 +1,34 @@
+[env:arduino-nesso-n1]
+custom_meshtastic_hw_model = 255
+custom_meshtastic_hw_model_slug = ARDUINO_NESSO_N1
+custom_meshtastic_architecture = esp32-c6
+custom_meshtastic_actively_supported = false
+custom_meshtastic_display_name = Arduino Nesso N1
+custom_meshtastic_tags = DIY
+
+extends = esp32c6_base
+board = esp32-c6-devkitc-1
+board_level = extra
+board_upload.flash_size = 16MB
+board_build.partitions = default_16MB.csv
+;OpenOCD flash method
+;upload_protocol = esp-builtin
+;Normal method
+upload_protocol = esptool
+;upload_port = /dev/ttyACM2
+build_flags = 
+  ${esp32c6_base.build_flags}
+  -D PRIVATE_HW
+  -D ARDUINO_NESSO_N1
+  -D M5STACK_UNITC6L
+  -I variants/esp32c6/arduino_nesso_n1
+  -DARDUINO_USB_CDC_ON_BOOT=1
+  -DARDUINO_USB_MODE=1
+monitor_speed=115200
+build_src_filter = 
+ ${esp32c6_base.build_src_filter} +<../variants/esp32c6/arduino_nesso_n1>
+lib_deps =
+  ${esp32c6_base.lib_deps}
+  # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
+  lovyan03/LovyanGFX@1.2.21
+  https://github.com/mverch67/BQ27220/archive/07d92be846abd8a0258a50c23198dac0858b22ed.zip

--- a/variants/esp32c6/arduino_nesso_n1/platformio.ini
+++ b/variants/esp32c6/arduino_nesso_n1/platformio.ini
@@ -31,4 +31,5 @@ lib_deps =
   ${esp32c6_base.lib_deps}
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.21
+  # renovate: datasource=git-refs depName=BQ27220 packageName=https://github.com/mverch67/BQ27220 gitBranch=main
   https://github.com/mverch67/BQ27220/archive/07d92be846abd8a0258a50c23198dac0858b22ed.zip

--- a/variants/esp32c6/arduino_nesso_n1/variant.cpp
+++ b/variants/esp32c6/arduino_nesso_n1/variant.cpp
@@ -21,7 +21,7 @@
 #define setbit(x, y) x |= (0x01 << y)
 #define clrbit(x, y) x &= ~(0x01 << y)
 #define reversebit(x, y) x ^= (0x01 << y)
-#define getbit(x, y) ((x) >> (y)&0x01)
+#define getbit(x, y) ((x) >> (y) & 0x01)
 
 void i2c_read_byte(uint8_t addr, uint8_t reg, uint8_t *value)
 {

--- a/variants/esp32c6/arduino_nesso_n1/variant.cpp
+++ b/variants/esp32c6/arduino_nesso_n1/variant.cpp
@@ -1,0 +1,129 @@
+#include "driver/gpio.h"
+#include <Arduino.h>
+#include <Wire.h>
+// I2C device addr
+#define PI4IO_M_ADDR 0x43
+#define PI4IO_M_ADDR2 0x44
+
+// PI4IO registers
+#define PI4IO_REG_CHIP_RESET 0x01
+#define PI4IO_REG_IO_DIR 0x03
+#define PI4IO_REG_OUT_SET 0x05
+#define PI4IO_REG_OUT_H_IM 0x07
+#define PI4IO_REG_IN_DEF_STA 0x09
+#define PI4IO_REG_PULL_EN 0x0B
+#define PI4IO_REG_PULL_SEL 0x0D
+#define PI4IO_REG_IN_STA 0x0F
+#define PI4IO_REG_INT_MASK 0x11
+#define PI4IO_REG_IRQ_STA 0x13
+// PI4IO
+
+#define setbit(x, y) x |= (0x01 << y)
+#define clrbit(x, y) x &= ~(0x01 << y)
+#define reversebit(x, y) x ^= (0x01 << y)
+#define getbit(x, y) ((x) >> (y)&0x01)
+
+void i2c_read_byte(uint8_t addr, uint8_t reg, uint8_t *value)
+{
+    Wire.beginTransmission(addr);
+    Wire.write(reg);
+    Wire.endTransmission();
+    Wire.requestFrom(addr, 1);
+    *value = Wire.read();
+}
+
+/*******************************************************************/
+void i2c_write_byte(uint8_t addr, uint8_t reg, uint8_t value)
+{
+    Wire.beginTransmission(addr);
+    Wire.write(reg);
+    Wire.write(value);
+    Wire.endTransmission();
+}
+/*******************************************************************/
+void c6l_init()
+{
+    // P7 LoRa Reset
+    // P6 RF Switch
+    // P5 LNA Enable
+    // P1 KEY2
+    // P0 KEY1
+    // P107 LED_BUILTIN
+    // P106 LCD_BACKLIGHT
+    // P105 VIN_DETECT
+    // P102 GROVE_POWER_EN
+    // P101 LCD_RESET
+    // P100 POWEROFF
+
+    printf("pi4io_init\n");
+    uint8_t in_data;
+    i2c_write_byte(PI4IO_M_ADDR, PI4IO_REG_CHIP_RESET, 0xFF);
+    vTaskDelay(10 / portTICK_PERIOD_MS);
+    i2c_read_byte(PI4IO_M_ADDR, PI4IO_REG_CHIP_RESET, &in_data);
+    vTaskDelay(10 / portTICK_PERIOD_MS);
+    i2c_write_byte(PI4IO_M_ADDR, PI4IO_REG_IO_DIR, 0b11100000); // P5,P6,P7 as outputs
+    vTaskDelay(10 / portTICK_PERIOD_MS);
+    i2c_write_byte(PI4IO_M_ADDR, PI4IO_REG_OUT_H_IM, 0b00011100); // High-Impedance
+    vTaskDelay(10 / portTICK_PERIOD_MS);
+    i2c_write_byte(PI4IO_M_ADDR, PI4IO_REG_PULL_SEL, 0b11100011); // pull up/down select, 0 down, 1 up
+    vTaskDelay(10 / portTICK_PERIOD_MS);
+    i2c_write_byte(PI4IO_M_ADDR, PI4IO_REG_PULL_EN, 0b11100011); // pull up/down enable, 0 disable, 1 enable
+    vTaskDelay(10 / portTICK_PERIOD_MS);
+    i2c_write_byte(PI4IO_M_ADDR, PI4IO_REG_IN_DEF_STA, 0b00000011); // P0 P1 default to high level; button press triggers the interrupt
+    vTaskDelay(10 / portTICK_PERIOD_MS);
+    i2c_write_byte(PI4IO_M_ADDR, PI4IO_REG_INT_MASK, 0b11111100); // P0 P1 interrupts enabled (0 = enable, 1 = disable)
+    vTaskDelay(10 / portTICK_PERIOD_MS);
+    i2c_write_byte(PI4IO_M_ADDR, PI4IO_REG_OUT_SET, 0b10000000); // default output is 0
+    vTaskDelay(10 / portTICK_PERIOD_MS);
+    i2c_read_byte(PI4IO_M_ADDR, PI4IO_REG_IRQ_STA, &in_data); // read IRQ_STA to clear the flag
+    vTaskDelay(10 / portTICK_PERIOD_MS);
+
+    i2c_read_byte(PI4IO_M_ADDR, PI4IO_REG_OUT_SET, &in_data);
+    setbit(in_data, 6); // enable SX_ANT_SW
+    setbit(in_data, 5); // enable SX_LNA_EN
+    i2c_write_byte(PI4IO_M_ADDR, PI4IO_REG_OUT_SET, in_data);
+
+    i2c_write_byte(PI4IO_M_ADDR2, PI4IO_REG_CHIP_RESET, 0xFF);
+    vTaskDelay(10 / portTICK_PERIOD_MS);
+    i2c_read_byte(PI4IO_M_ADDR2, PI4IO_REG_CHIP_RESET, &in_data);
+    vTaskDelay(10 / portTICK_PERIOD_MS);
+    i2c_write_byte(PI4IO_M_ADDR2, PI4IO_REG_IO_DIR, 0b11000110); // 0: input 1: output
+    vTaskDelay(10 / portTICK_PERIOD_MS);
+    i2c_write_byte(PI4IO_M_ADDR2, PI4IO_REG_OUT_H_IM, 0b00111000); // Output High-Impedance, 1 high-impedance
+    vTaskDelay(10 / portTICK_PERIOD_MS);
+    i2c_write_byte(PI4IO_M_ADDR2, PI4IO_REG_PULL_SEL, 0b11000111); // pull up/down select, 0 down, 1 up
+    vTaskDelay(10 / portTICK_PERIOD_MS);
+    i2c_write_byte(PI4IO_M_ADDR2, PI4IO_REG_PULL_EN, 0b11000111); // pull up/down enable, 0 disable, 1 enable
+    vTaskDelay(10 / portTICK_PERIOD_MS);
+    i2c_write_byte(PI4IO_M_ADDR2, PI4IO_REG_IN_DEF_STA, 0b00000000); // P0 P1 Default state HIGH, interrupt when pressed
+    vTaskDelay(10 / portTICK_PERIOD_MS);
+    i2c_write_byte(PI4IO_M_ADDR2, PI4IO_REG_INT_MASK, 0b11111111); // P0 P1 Interrupt 0 enable, 1 disable
+    vTaskDelay(10 / portTICK_PERIOD_MS);
+    i2c_write_byte(PI4IO_M_ADDR2, PI4IO_REG_OUT_SET, 0b11000110); // default output to 0
+
+    // AW32001E - address 0x49
+    // charge current 256mA (default 128mA)
+    i2c_write_byte(0x49, 0x2, 0x1f);
+    // charge voltage 4.200(default)
+    // disable watch dog timer (default: 0x1f)
+    i2c_write_byte(0x49, 0x5, 0x1a);
+    // UVLO: 2.580 (default: 2.760), charge enable, disable HIZ (default: 0xac)
+    i2c_write_byte(0x49, 0x1, 0xa2);
+    // DPM 4.520 (default)
+    i2c_write_byte(0x49, 0x0, 0x8f);
+}
+
+void gpio_ext_set(uint8_t address, uint8_t pin, bool value)
+{
+    uint8_t in_data;
+    i2c_read_byte(address, PI4IO_REG_OUT_SET, &in_data);
+    value ? setbit(in_data, pin) : clrbit(in_data, pin);
+    i2c_write_byte(address, PI4IO_REG_OUT_SET, in_data);
+}
+
+uint8_t gpio_ext_get(uint8_t address, uint8_t pin)
+{
+    uint8_t in_data;
+    i2c_read_byte(address, PI4IO_REG_OUT_SET, &in_data);
+    return getbit(in_data, pin);
+}

--- a/variants/esp32c6/arduino_nesso_n1/variant.h
+++ b/variants/esp32c6/arduino_nesso_n1/variant.h
@@ -31,8 +31,8 @@ uint8_t gpio_ext_get(uint8_t address, uint8_t pin);
 #undef LORA_CS
 
 // battery charger BQ25896
-//#define HAS_PPM 1
-//#define XPOWERS_CHIP_BQ25896
+// #define HAS_PPM 1
+// #define XPOWERS_CHIP_BQ25896
 
 // battery quality management BQ27220
 #define HAS_BQ27220 1
@@ -80,7 +80,7 @@ uint8_t gpio_ext_get(uint8_t address, uint8_t pin);
 #define SCREEN_TRANSITION_FRAMERATE 5
 #define BRIGHTNESS_DEFAULT 130
 
-//#define HAS_TOUCHSCREEN 1
+// #define HAS_TOUCHSCREEN 1
 #define TOUCH_I2C_PORT 0
 #define TOUCH_SLAVE_ADDRESS 0x38
 #define SCREEN_TOUCH_INT 3

--- a/variants/esp32c6/arduino_nesso_n1/variant.h
+++ b/variants/esp32c6/arduino_nesso_n1/variant.h
@@ -1,0 +1,86 @@
+void c6l_init();
+void gpio_ext_set(uint8_t address, uint8_t pin, bool value);
+uint8_t gpio_ext_get(uint8_t address, uint8_t pin);
+
+#define HAS_GPS 0
+#define GPS_RX_PIN -1
+#define GPS_TX_PIN -1
+
+#define I2C_SDA 10
+#define I2C_SCL 8
+
+#define LCD_CS 17
+#define LCD_RS 16
+#define SYS_IRQ 3
+
+#define MOSI 21
+#define MISO 22
+#define SCK 20
+
+#define PIN_BUZZER 11
+
+#define IO_EXPANDER 0x40
+#define LCD_BACKLIGHT 0x106
+
+// #define BUTTON_PIN 9
+#define BUTTON_EXTENDER
+
+#undef LORA_SCK
+#undef LORA_MISO
+#undef LORA_MOSI
+#undef LORA_CS
+
+// battery charger BQ25896
+//#define HAS_PPM 1
+//#define XPOWERS_CHIP_BQ25896
+
+// battery quality management BQ27220
+#define HAS_BQ27220 1
+#define BQ27220_I2C_SDA I2C_SDA
+#define BQ27220_I2C_SCL I2C_SCL
+#define BQ27220_DESIGN_CAPACITY 250
+
+// WaveShare Core1262-868M OK
+// https://www.waveshare.com/wiki/Core1262-868M
+#define USE_SX1262
+
+#define LORA_MISO 22
+#define LORA_SCK 20
+#define LORA_MOSI 21
+#define LORA_CS 23
+#define LORA_RESET RADIOLIB_NC
+#define LORA_DIO1 15
+#define LORA_BUSY 19
+#define SX126X_CS LORA_CS
+#define SX126X_DIO1 LORA_DIO1
+#define SX126X_BUSY LORA_BUSY
+#define SX126X_RESET LORA_RESET
+#define SX126X_DIO2_AS_RF_SWITCH
+#define SX126X_DIO3_TCXO_VOLTAGE 3.0
+
+#define USE_TFTDISPLAY 1
+#define GRAPHICS_TFT_COLORING_ENABLED 1
+#define ST7789_DRIVER
+#define ST7789_CS 17
+#define ST7789_RS 16
+#define ST7789_SDA 21
+#define ST7789_SCK 20
+#define ST7789_RESET -1
+#define ST7789_MISO 22
+#define ST7789_BUSY -1
+#define ST7789_SPI_HOST SPI2_HOST
+#define SPI_FREQUENCY 60000000
+#define SPI_READ_FREQUENCY 16000000
+#define TFT_HEIGHT 240
+#define TFT_WIDTH 137
+#define TFT_OFFSET_X -52
+#define TFT_OFFSET_Y 40
+#define TFT_OFFSET_ROTATION 2
+#define SCREEN_ROTATE
+#define SCREEN_TRANSITION_FRAMERATE 5
+#define BRIGHTNESS_DEFAULT 130
+
+//#define HAS_TOUCHSCREEN 1
+#define TOUCH_I2C_PORT 0
+#define TOUCH_SLAVE_ADDRESS 0x38
+#define SCREEN_TOUCH_INT 3


### PR DESCRIPTION
This is resubmit of Arduino Nesso N1 support #8784

Issue: [Board]: Arduino Nesso N1 #8744

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Arduino ESP32-C6 board variant.
  * Included board setup for USB, I2C, SPI, display, radio, battery monitor, and touchscreen-related hardware.
  * Added startup configuration for onboard peripherals and external GPIO expansion.
  * Added a PlatformIO environment with board metadata, flash settings, and required dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->