### PR TITLE
Short circuit invalid nodenum check in ham mode.

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1542,6 +1542,8 @@ void NodeDB::pickNewNodeNum()
 
     // Identity check via public key (or "empty slot?" when no keys yet);
     // macaddr no longer lives on the slim header.
+    // This check does not work when is_licensed=true since we don't store a public key.
+    // Revisit with XEdDSA signing.
     auto isOurOwnEntry = [&](const meshtastic_NodeInfoLite *n) -> bool {
         if (!n)
             return false;
@@ -1550,13 +1552,16 @@ void NodeDB::pickNewNodeNum()
         return !nodeInfoLiteHasUser(n);
     };
 
-    meshtastic_NodeInfoLite *found;
-    while (((found = getMeshNode(nodeNum)) && !isOurOwnEntry(found)) ||
-           (nodeNum == NODENUM_BROADCAST || nodeNum < NUM_RESERVED)) {
-        NodeNum candidate = random(NUM_RESERVED, LONG_MAX); // try a new random choice
-        if (found)
-            LOG_WARN("NOTE! Our desired nodenum 0x%x is invalid or in use, picking 0x%x", nodeNum, candidate);
-        nodeNum = candidate;
+    // Short circuit the check for licensed devices since they do not have public keys to compare against the nodeDB.
+    if (!owner.is_licensed) {
+        meshtastic_NodeInfoLite *found;
+        while (((found = getMeshNode(nodeNum)) && !isOurOwnEntry(found)) ||
+               (nodeNum == NODENUM_BROADCAST || nodeNum < NUM_RESERVED)) {
+            NodeNum candidate = random(NUM_RESERVED, LONG_MAX); // try a new random choice
+            if (found)
+                LOG_WARN("NOTE! Our desired nodenum 0x%x is invalid or in use, picking 0x%x", nodeNum, candidate);
+            nodeNum = candidate;
+        }
     }
     LOG_DEBUG("Use nodenum 0x%x ", nodeNum);
 


### PR DESCRIPTION
Currently when ham_mode is enabled, the nodenum is declared invalid and regenerated upon every reboot because `isOurOwnEntry` uses the publicKey (which doesn't exist in ham mode).

This PR short circuits the invalid nodenum check when ham mode is enabled. Until signing #10478 is implemented, this will prevent the nodenum from being regenerated upon each reboot.


## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] `tbeam-s3-core` 144mhz
