### PR TITLE
Revert "Automated version bumps (#10667)"

### DIFF
--- a/bin/org.meshtastic.meshtasticd.metainfo.xml
+++ b/bin/org.meshtastic.meshtasticd.metainfo.xml
@@ -87,12 +87,6 @@
   </screenshots>
 
   <releases>
-    <release version="2.7.26" date="2026-06-10">
-      <url type="details">https://github.com/meshtastic/firmware/releases?q=tag%3Av2.7.26</url>
-    </release>
-    <release version="2.7.25" date="2026-05-23">
-      <url type="details">https://github.com/meshtastic/firmware/releases?q=tag%3Av2.7.25</url>
-    </release>
     <release version="2.7.24" date="2026-05-08">
       <url type="details">https://github.com/meshtastic/firmware/releases?q=tag%3Av2.7.24</url>
     </release>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,15 +1,3 @@
-meshtasticd (2.7.26.0) unstable; urgency=medium
-
-  * Version 2.7.26
-
- -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Wed, 10 Jun 2026 00:19:23 +0000
-
-meshtasticd (2.7.25.0) unstable; urgency=medium
-
-  * Version 2.7.25
-
- -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Sat, 23 May 2026 01:16:20 +0000
-
 meshtasticd (2.7.24.0) unstable; urgency=medium
 
   * Version 2.7.24

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 [VERSION]  
 major = 2
-minor = 7
-build = 26
+minor = 8
+build = 0


### PR DESCRIPTION
This reverts commit abef0d85a26bc60c53bcfe50c0775c1039a28ac4.

## 🙏 Thank you for sending in a pull request, here's some tips to get started!

### ❌ (Please delete all these tips and replace them with your text) ❌

- Before starting on some new big chunk of code, it it is optional but highly recommended to open an issue first
  to say "Hey, I think this idea X should be implemented and I'm starting work on it. My general plan is Y, any feedback
  is appreciated." This will allow other devs to potentially save you time by not accidentally duplicating work etc...
- Please do not check in files that don't have real changes
- Please do not reformat lines that you didn't have to change the code on
- We recommend using the [Visual Studio Code](https://platformio.org/install/ide?install=vscode) editor along with the ['Trunk Check' extension](https://marketplace.visualstudio.com/items?itemName=trunk.io) (In beta for windows, WSL2 for the Linux version),
  because it automatically follows our indentation rules and its auto reformatting will not cause spurious changes to lines.
- If your PR fixes a bug, mention "fixes #bugnum" somewhere in your pull request description.
- If your other co-developers have comments on your PR please tweak as needed.
- Please also enable "Allow edits by maintainers".
- Please do not submit untested code.
- If you do not have the affected hardware to test your code changes adequately against regressions, please indicate this, so that contributors and community members can help test your changes.
- If your PR gets accepted you can request a "Contributor" role in the Meshtastic Discord

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
