### PR TITLE
Develop Warning Clean-up

### DIFF
--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -400,6 +400,7 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
                     if (type == DPS310) {
                         break;
                     }
+                    [[fallthrough]];
                 default:
                     registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x00), 1); // GET_ID
                     switch (registerValue) {

--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -672,12 +672,15 @@ bool GPS::verifyCachedProbePresence()
         break;
     case GNSS_MODEL_MTK_L76B:
         cachedProbeModelName = "L76B";
+        [[fallthrough]];
     case GNSS_MODEL_MTK_PA1010D:
         if (cachedProbeModel == GNSS_MODEL_MTK_PA1010D)
             cachedProbeModelName = "PA1010D";
+        [[fallthrough]];
     case GNSS_MODEL_MTK_PA1616S:
         if (cachedProbeModel == GNSS_MODEL_MTK_PA1616S)
             cachedProbeModelName = "PA1616S";
+        [[fallthrough]];
     case GNSS_MODEL_LS20031:
         if (cachedProbeModel == GNSS_MODEL_LS20031)
             cachedProbeModelName = "LS20031";
@@ -686,6 +689,7 @@ bool GPS::verifyCachedProbePresence()
         break;
     case GNSS_MODEL_AG3335:
         cachedProbeModelName = "AG3335";
+        [[fallthrough]];
     case GNSS_MODEL_AG3352:
         if (cachedProbeModel == GNSS_MODEL_AG3352)
             cachedProbeModelName = "AG3352";

--- a/src/graphics/draw/UIRenderer.cpp
+++ b/src/graphics/draw/UIRenderer.cpp
@@ -1275,7 +1275,7 @@ void UIRenderer::drawDeviceFocused(OLEDDisplay *display, OLEDDisplayUiState *sta
     int nameX = 0;
     int yOffset = (currentResolution == ScreenResolution::High) ? 0 : 5;
     const char *longName = (nodeInfoLiteHasUser(ourNode) && ourNode->long_name[0]) ? ourNode->long_name : "";
-    const char *shortName = owner.short_name ? owner.short_name : "";
+    const char *shortName = owner.short_name[0] ? owner.short_name : "";
     char combinedName[96];
     if (longName[0] && shortName[0]) {
         snprintf(combinedName, sizeof(combinedName), "%s (%s)", longName, shortName);
@@ -1527,7 +1527,7 @@ void UIRenderer::drawIconScreen(const char *upperMsg, OLEDDisplay *display, OLED
     if (gBootSplashBoldPass) {
         display->drawString(versionX + 1, y + 5, version);
     }
-    if (owner.short_name && owner.short_name[0]) {
+    if (owner.short_name[0]) {
         const char *shortName = owner.short_name;
         int shortNameW = UIRenderer::measureStringWithEmotes(display, shortName);
         int shortNameX = x + SCREEN_WIDTH - shortNameW - 5;

--- a/src/mesh/aes-ccm.cpp
+++ b/src/mesh/aes-ccm.cpp
@@ -21,8 +21,8 @@
 static int constant_time_compare(const void *a_, const void *b_, size_t len)
 {
     /* Cast to volatile to prevent the compiler from optimizing out their comparison. */
-    const volatile uint8_t *volatile a = (const volatile uint8_t *volatile)a_;
-    const volatile uint8_t *volatile b = (const volatile uint8_t *volatile)b_;
+    const volatile uint8_t *volatile a = (const volatile uint8_t *)a_;
+    const volatile uint8_t *volatile b = (const volatile uint8_t *)b_;
     if (len == 0)
         return 0;
     if (a == NULL || b == NULL)

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -2063,9 +2063,8 @@ void CannedMessageModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *st
             bool _highlight = (msgIdx == currentMessageIndex);
 
             // Vertically center based on rowHeight
-            int textYOffset = (rowHeight - FONT_HEIGHT_SMALL) / 2;
-
 #ifdef USE_EINK
+            int textYOffset = (rowHeight - FONT_HEIGHT_SMALL) / 2;
             int nextX = x + (_highlight ? 12 : 0);
             if (_highlight)
                 display->drawString(x + 0, lineY + textYOffset, ">");
@@ -2239,19 +2238,19 @@ ProcessMessage CannedMessageModule::handleReceived(const meshtastic_MeshPacket &
                         snprintf(buf, sizeof(buf), "Message sent to\n#%s\n\nSignal: %s",
                                  (channelName && channelName[0]) ? channelName : "unknown", qualityLabel);
                     } else {
-                        snprintf(buf, sizeof(buf), "DM sent to\n@%s\n\nSignal: %s",
-                                 (nodeName && nodeName[0]) ? nodeName : "unknown", qualityLabel);
+                        snprintf(buf, sizeof(buf), "DM sent to\n@%s\n\nSignal: %s", nodeName[0] ? nodeName : "unknown",
+                                 qualityLabel);
                     }
                 } else if (isAck && !isFromDest) {
                     // Relay ACK banner
                     snprintf(buf, sizeof(buf), "DM Relayed\n(Status Unknown)\n%s\n\nSignal: %s",
-                             (nodeName && nodeName[0]) ? nodeName : "unknown", qualityLabel);
+                             nodeName[0] ? nodeName : "unknown", qualityLabel);
                 } else {
                     if (this->lastSentNode == NODENUM_BROADCAST) {
                         snprintf(buf, sizeof(buf), "Message failed to\n#%s",
                                  (channelName && channelName[0]) ? channelName : "unknown");
                     } else {
-                        snprintf(buf, sizeof(buf), "DM failed to\n@%s", (nodeName && nodeName[0]) ? nodeName : "unknown");
+                        snprintf(buf, sizeof(buf), "DM failed to\n@%s", nodeName[0] ? nodeName : "unknown");
                     }
                 }
 

--- a/src/modules/KeyVerificationModule.cpp
+++ b/src/modules/KeyVerificationModule.cpp
@@ -103,7 +103,7 @@ bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &
             // Don't try to put the array definition in the macro. Does not work with curly braces.
             // Lambda is defined outside IF_SCREEN so that [=, this] doesn't introduce a top-level
             // comma inside the single-argument macro, which would cause a preprocessor error.
-            auto kvm_acceptCallback = [=, this](int selected) {
+            auto kvm_acceptCallback = [this](int selected) {
                 if (selected == 1) {
                     auto remoteNodePtr = nodeDB->getMeshNode(currentRemoteNode);
                     if (remoteNodePtr)

--- a/src/modules/KeyVerificationModule.cpp
+++ b/src/modules/KeyVerificationModule.cpp
@@ -101,11 +101,13 @@ bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &
             LOG_INFO("Hash1 matches!");
             static const char *optionsArray[] = {"Reject", "Accept"};
             // Don't try to put the array definition in the macro. Does not work with curly braces.
-            // Lambda is defined outside IF_SCREEN so that [=, this] doesn't introduce a top-level
-            // comma inside the single-argument macro, which would cause a preprocessor error.
-            auto kvm_acceptCallback = [this](int selected) {
+            // Lambda is defined outside IF_SCREEN so that the capture list doesn't introduce a
+            // top-level comma inside the single-argument macro, which would cause a preprocessor error.
+            // currentRemoteNode is captured by value so the callback acts on the node that triggered
+            // the banner even if currentRemoteNode changes before the user makes a selection.
+            auto kvm_acceptCallback = [this, remoteNode = currentRemoteNode](int selected) {
                 if (selected == 1) {
-                    auto remoteNodePtr = nodeDB->getMeshNode(currentRemoteNode);
+                    auto remoteNodePtr = nodeDB->getMeshNode(remoteNode);
                     if (remoteNodePtr)
                         remoteNodePtr->bitfield |= NODEINFO_BITFIELD_IS_KEY_MANUALLY_VERIFIED_MASK;
                 }

--- a/src/modules/KeyVerificationModule.cpp
+++ b/src/modules/KeyVerificationModule.cpp
@@ -101,18 +101,19 @@ bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &
             LOG_INFO("Hash1 matches!");
             static const char *optionsArray[] = {"Reject", "Accept"};
             // Don't try to put the array definition in the macro. Does not work with curly braces.
+            // Lambda is defined outside IF_SCREEN so that [=, this] doesn't introduce a top-level
+            // comma inside the single-argument macro, which would cause a preprocessor error.
+            auto kvm_acceptCallback = [=, this](int selected) {
+                if (selected == 1) {
+                    auto remoteNodePtr = nodeDB->getMeshNode(currentRemoteNode);
+                    if (remoteNodePtr)
+                        remoteNodePtr->bitfield |= NODEINFO_BITFIELD_IS_KEY_MANUALLY_VERIFIED_MASK;
+                }
+            };
             IF_SCREEN(graphics::BannerOverlayOptions options; options.message = message; options.durationMs = 30000;
                       options.optionsArrayPtr = optionsArray; options.optionsCount = 2;
                       options.notificationType = graphics::notificationTypeEnum::selection_picker;
-                      options.bannerCallback =
-                          [=](int selected) {
-                              if (selected == 1) {
-                                  auto remoteNodePtr = nodeDB->getMeshNode(currentRemoteNode);
-                                  if (remoteNodePtr)
-                                      remoteNodePtr->bitfield |= NODEINFO_BITFIELD_IS_KEY_MANUALLY_VERIFIED_MASK;
-                              }
-                          };
-                      screen->showOverlayBanner(options);)
+                      options.bannerCallback = kvm_acceptCallback; screen->showOverlayBanner(options);)
             meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
             cn->level = meshtastic_LogRecord_Level_WARNING;
             sprintf(cn->message, "Final confirmation for incoming manual key verification %s", message);

--- a/src/modules/StatusLEDModule.cpp
+++ b/src/modules/StatusLEDModule.cpp
@@ -240,6 +240,7 @@ void StatusLEDModule::setPowerLED(bool LEDon)
     }
 #endif
     uint8_t ledState = LEDon ? LED_STATE_ON : LED_STATE_OFF;
+    (void)ledState; // used only under platform-specific #ifdefs below
 #ifdef PCA_LED_POWER
     io.digitalWrite(PCA_LED_POWER, ledState);
 #endif

--- a/src/nimble/NimbleBluetooth.cpp
+++ b/src/nimble/NimbleBluetooth.cpp
@@ -358,7 +358,7 @@ class BluetoothPhoneAPI : public PhoneAPI, public concurrency::OSThread
         setup. Not worth adjusting much.
         */
         LOG_INFO("BLE requestHighThroughputConnection");
-        bleServer->updateConnParams(conn_handle, 6, 12, 0, 600);
+        bleServer->requestConnParams(conn_handle, 6, 12, 0, 600);
     }
 
     void requestLowerPowerConnection(uint16_t conn_handle)
@@ -381,7 +381,7 @@ class BluetoothPhoneAPI : public PhoneAPI, public concurrency::OSThread
         per second.
         */
         LOG_INFO("BLE requestLowerPowerConnection");
-        bleServer->updateConnParams(conn_handle, 24, 40, 2, 600);
+        bleServer->requestConnParams(conn_handle, 24, 40, 2, 600);
     }
 };
 
@@ -631,7 +631,7 @@ class NimbleBluetoothServerCallback : public BLEServerCallbacks
 #endif
 
         LOG_INFO("BLE conn %u peer MTU %u (target %u)", connHandle, pServer->getPeerMTU(connHandle), kPreferredBleMtu);
-        pServer->updateConnParams(connHandle, 6, 12, 0, 200);
+        pServer->requestConnParams(connHandle, 6, 12, 0, 200);
     }
 
     void onDisconnect(BLEServer *pServer, struct ble_gap_conn_desc *desc)


### PR DESCRIPTION
Sometimes Claude finds fixes to current code

Strategy:

1. Created a build for Cardputer which generated multiple warnings
2. Exported log and iterated through Claude to see about fixing any quick wins
3. Built for TEcho, Wio Tracker L1, and T114 - provided these logs additionally to Claude to verify any more fixes to warnings
4. Reverified that logs are how much cleaner!

All logs used are attached:
[build_cardputer_finalbuild.log](https://github.com/user-attachments/files/28856892/build_cardputer_finalbuild.log)
[build_cardputer_initialbuild.txt](https://github.com/user-attachments/files/28856893/build_cardputer_initialbuild.txt)
[build_t114.log](https://github.com/user-attachments/files/28856895/build_t114.log)
[build_techo.log](https://github.com/user-attachments/files/28856896/build_techo.log)
[build_wiotrackerl1.log](https://github.com/user-attachments/files/28856897/build_wiotrackerl1.log)
[build_wismeshtag.log](https://github.com/user-attachments/files/28856898/build_wismeshtag.log)
