### PR TITLE
fix a long-running CI bug that overran a lot

### DIFF
--- a/.github/workflows/test_native.yml
+++ b/.github/workflows/test_native.yml
@@ -44,6 +44,7 @@ jobs:
         run: |
           .pio/build/coverage/meshtasticd -s &
           PID=$!
+          trap 'kill "$PID" 2>/dev/null || true' EXIT
           timeout 20 bash -c "until ls -al /proc/$PID/fd | grep socket; do sleep 1; done"
           echo "Simulator started, launching python test..."
           python3 -c 'from meshtastic.test import testSimulator; testSimulator()'

--- a/.github/workflows/test_native.yml
+++ b/.github/workflows/test_native.yml
@@ -37,13 +37,32 @@ jobs:
           sed -i -e "s#${PWD}#.#" coverage_base.info # Make paths relative.
 
       - name: Integration test
+        # Cap the whole step: if the simulator ever fails to exit (e.g. the
+        # exit_simulator admin path regresses again) the job must fail fast,
+        # not run to GitHub's 6-hour limit.
+        timeout-minutes: 5
         run: |
           .pio/build/coverage/meshtasticd -s &
           PID=$!
           timeout 20 bash -c "until ls -al /proc/$PID/fd | grep socket; do sleep 1; done"
           echo "Simulator started, launching python test..."
           python3 -c 'from meshtastic.test import testSimulator; testSimulator()'
-          wait
+          # The Python harness sends exit_simulator and exits; the simulator is
+          # expected to terminate on its own. Give it a moment, then verify.
+          # If it is still alive the exit handshake is broken — fail loudly and
+          # do NOT fall through to `wait`, which would otherwise block until the
+          # job's hard timeout.
+          for i in $(seq 1 10); do
+            kill -0 "$PID" 2>/dev/null || break
+            sleep 1
+          done
+          if kill -0 "$PID" 2>/dev/null; then
+            echo "::error title=Simulator did not exit::meshtasticd ignored exit_simulator and is still running after the integration test. The exit_simulator admin path is broken (see AdminModule::handleReceivedProtobuf, ARCH_PORTDUINO bypass). Killing it to avoid a 6-hour CI overrun."
+            kill -9 "$PID" 2>/dev/null || true
+            wait "$PID" 2>/dev/null || true
+            exit 1
+          fi
+          wait "$PID" 2>/dev/null || true
 
       - name: Capture coverage information
         if: always() # run this step even if previous step failed

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -19,6 +19,7 @@
 #include "main.h"
 #endif
 #ifdef ARCH_PORTDUINO
+#include "PortduinoGlue.h"
 #include "unistd.h"
 #endif
 
@@ -106,6 +107,17 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
     if (mp.which_payload_variant != meshtastic_MeshPacket_decoded_tag) {
         return handled;
     }
+#ifdef ARCH_PORTDUINO
+    // Simulator only: honor exit_simulator from the local client (from==0). The test harness flags
+    // admin pki_encrypted but the sim has no PKI key, so the PKC gate below would reject it and the
+    // daemon would never exit (6-hour CI overrun). Local-origin + force_simradio only.
+    // TODO: should a local client bypass admin auth at all? Fenced to the simulator for now.
+    if (portduino_config.force_simradio && mp.from == 0 &&
+        r->which_payload_variant == meshtastic_AdminMessage_exit_simulator_tag) {
+        LOG_INFO("Exiting simulator");
+        exit(0);
+    }
+#endif
     meshtastic_Channel *ch = &channels.getByIndex(mp.channel);
     // Could tighten this up further by tracking the last public_key we went an AdminMessage request to
     // and only allowing responses from that remote.

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -108,9 +108,11 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         return handled;
     }
 #ifdef ARCH_PORTDUINO
-    // Simulator only: honor exit_simulator from the local client (from==0). The test harness flags
-    // admin pki_encrypted but the sim has no PKI key, so the PKC gate below would reject it and the
-    // daemon would never exit (6-hour CI overrun). Local-origin + force_simradio only.
+    // Simulator only: honor exit_simulator from the local client (from==0). The test harness sets
+    // pki_encrypted=true on all admin payloads; that causes the from==0 plain-admin branch below
+    // (which requires !pki_encrypted) to be skipped, routing into the PKC key-check instead. The
+    // simulator has no PKI key (region is UNSET so keygen never runs), so the PKC check rejects it
+    // and the daemon never exits — producing a 6-hour CI overrun. Local-origin + force_simradio only.
     // TODO: should a local client bypass admin auth at all? Fenced to the simulator for now.
     if (portduino_config.force_simradio && mp.from == 0 &&
         r->which_payload_variant == meshtastic_AdminMessage_exit_simulator_tag) {

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -108,11 +108,10 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         return handled;
     }
 #ifdef ARCH_PORTDUINO
-    // Simulator only: honor exit_simulator from the local client (from==0). The test harness sets
-    // pki_encrypted=true on all admin payloads; that causes the from==0 plain-admin branch below
-    // (which requires !pki_encrypted) to be skipped, routing into the PKC key-check instead. The
-    // simulator has no PKI key (region is UNSET so keygen never runs), so the PKC check rejects it
-    // and the daemon never exits — producing a 6-hour CI overrun. Local-origin + force_simradio only.
+    // Simulator only: honor exit_simulator unconditionally for the local client (from==0).
+    // The from==0 branch below now covers pki_encrypted local packets too, but is_managed
+    // can still block it. Rather than threading simulator awareness through the auth gates,
+    // intercept here before any auth logic runs. Local-origin + force_simradio only.
     // TODO: should a local client bypass admin auth at all? Fenced to the simulator for now.
     if (portduino_config.force_simradio && mp.from == 0 &&
         r->which_payload_variant == meshtastic_AdminMessage_exit_simulator_tag) {


### PR DESCRIPTION
fix CI massive overrun...

## What was actually wrong
Not HopScaling — I disproved that empirically (rebuilt with HAS_VARIABLE_HOPS=0; the simulator hung identically). The integration test succeeds (testSimulator() connects, reads info, sends exit_simulator, exits 0), but meshtasticd never terminated, so the CI wait blocked until GitHub's 6-hour limit.

The real cause: the meshtastic Python harness flags all admin payloads pki_encrypted=true, but the simulator has no PKI key (region is UNSET, so keygen never runs). Debug output confirmed ourkeysize=0 mpkeysize=0 — there's no key on either side. So exit_simulator fell into AdminModule's PKC branch and was rejected with err=37, never reaching the handler. (This also corrected my mid-investigation theory about a self-key match — there's simply no key to match.)

## The fix (two parts)
Firmware — [AdminModule.cpp](vscode-webview://0dbvt177jn5mbrdmfl8ban1v86fppkusv0ca5a976crtdeqmbieb/src/modules/AdminModule.cpp): honor exit_simulator from a local client (from==0) before the auth gate, fenced to ARCH_PORTDUINO + force_simradio. Local-origin only, so no remote mesh peer can kill a real portduino daemon. Includes the TODO you asked for, questioning whether a local client should bypass admin auth at all.

CI — [test_native.yml](vscode-webview://0dbvt177jn5mbrdmfl8ban1v86fppkusv0ca5a976crtdeqmbieb/.github/workflows/test_native.yml): timeout-minutes: 5, and after the python test, poll the PID and — if the sim is still alive — emit a loud ::error annotation, kill it, and exit 1 instead of falling through to wait. Defense-in-depth so any future regression of the exit handshake fails fast and noisily rather than burning 6 hours.

Human here: TLDR: small fix, big impact.
