### PR TITLE
Make nRF52 lockdown support opt-in

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -576,9 +576,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // -----------------------------------------------------------------------------
 // MESHTASTIC_LOCKDOWN — runtime, client-toggleable hardening (nRF52 only)
 //
-// There is NO build flag to turn lockdown on or off. On nRF52 (CC310 hardware
-// crypto) the lockdown machinery is ALWAYS compiled in; whether it is ACTIVE
-// is decided entirely at runtime by EncryptedStorage::isLockdownActive()
+// Lockdown/protect support is opt-in at build time. Builds that need it pass
+// -DMESHTASTIC_ENABLE_LOCKDOWN=1. When enabled on nRF52 (CC310 hardware
+// crypto), whether it is ACTIVE is decided entirely at runtime by
+// EncryptedStorage::isLockdownActive()
 // (== a passphrase has been provisioned, i.e. /prefs/.dek exists). A device
 // that has never been provisioned — or that the operator disabled from the
 // client app — behaves exactly like stock firmware: plaintext storage, no
@@ -594,11 +595,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //               reboots into normal mode. APPROTECT is the one thing that
 //               does NOT revert (see below).
 //
-// MESHTASTIC_LOCKDOWN here is an INTERNAL capability marker, auto-defined for
-// nRF52. It gates the UI bits (lock screen, pairing-PIN handling). It is NOT
-// something a variant sets. Flash-constrained nRF52 variants that genuinely
-// cannot afford the ~tens-of-KB of crypto + access-control code may opt OUT
-// with -DMESHTASTIC_EXCLUDE_LOCKDOWN=1.
+// MESHTASTIC_LOCKDOWN here is an INTERNAL capability marker. It gates the UI
+// bits (lock screen, pairing-PIN handling). Flash-constrained nRF52 variants
+// that genuinely cannot afford the ~tens-of-KB of crypto + access-control code
+// may also opt out with -DMESHTASTIC_EXCLUDE_LOCKDOWN=1.
 //
 //   MESHTASTIC_PHONEAPI_ACCESS_CONTROL — per-connection auth + redaction,
 //                                        gated at runtime on isLockdownActive()
@@ -615,7 +615,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // -DMESHTASTIC_LOCKDOWN_DEBUG=1 keeps the irreversible APPROTECT burn disabled
 // even when provisioned — for development so dev boards never lose SWD.
 // -----------------------------------------------------------------------------
-#if defined(ARCH_NRF52) && !defined(MESHTASTIC_EXCLUDE_LOCKDOWN)
+#ifndef MESHTASTIC_ENABLE_LOCKDOWN
+#define MESHTASTIC_ENABLE_LOCKDOWN 0
+#endif
+
+#if !MESHTASTIC_ENABLE_LOCKDOWN
+#undef MESHTASTIC_LOCKDOWN
+#undef MESHTASTIC_PHONEAPI_ACCESS_CONTROL
+#undef MESHTASTIC_ENCRYPTED_STORAGE
+#undef MESHTASTIC_ENABLE_APPROTECT
+#ifndef MESHTASTIC_EXCLUDE_LOCKDOWN
+#define MESHTASTIC_EXCLUDE_LOCKDOWN 1
+#endif
+#endif
+
+#if defined(ARCH_NRF52) && MESHTASTIC_ENABLE_LOCKDOWN && !defined(MESHTASTIC_EXCLUDE_LOCKDOWN)
 #define MESHTASTIC_LOCKDOWN 1
 #define MESHTASTIC_PHONEAPI_ACCESS_CONTROL 1
 #define MESHTASTIC_ENCRYPTED_STORAGE 1

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -615,6 +615,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // -DMESHTASTIC_LOCKDOWN_DEBUG=1 keeps the irreversible APPROTECT burn disabled
 // even when provisioned — for development so dev boards never lose SWD.
 // -----------------------------------------------------------------------------
+#if defined(ARCH_NRF52)
 #ifndef MESHTASTIC_ENABLE_LOCKDOWN
 #define MESHTASTIC_ENABLE_LOCKDOWN 0
 #endif
@@ -629,12 +630,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 #endif
 
-#if defined(ARCH_NRF52) && MESHTASTIC_ENABLE_LOCKDOWN && !defined(MESHTASTIC_EXCLUDE_LOCKDOWN)
+#if MESHTASTIC_ENABLE_LOCKDOWN && !defined(MESHTASTIC_EXCLUDE_LOCKDOWN)
 #define MESHTASTIC_LOCKDOWN 1
 #define MESHTASTIC_PHONEAPI_ACCESS_CONTROL 1
 #define MESHTASTIC_ENCRYPTED_STORAGE 1
 #ifndef MESHTASTIC_LOCKDOWN_DEBUG
 #define MESHTASTIC_ENABLE_APPROTECT 1
+#endif
 #endif
 #endif
 

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -71,9 +71,11 @@ void onConnect(uint16_t conn_handle)
     // the (single, reused) bluetoothPhoneAPI instance, so a prior session's
     // authorization can otherwise survive a quick reconnect. handleStartConfig()
     // re-locks on every want_config too; this closes the window before that.
+#ifdef MESHTASTIC_PHONEAPI_ACCESS_CONTROL
     if (bluetoothPhoneAPI) {
         bluetoothPhoneAPI->setAdminAuthorized(false);
     }
+#endif
 
     // Notify UI (or any other interested firmware components)
     meshtastic::BluetoothStatus newStatus(meshtastic::BluetoothStatus::ConnectionState::CONNECTED);


### PR DESCRIPTION
## Summary

- Make nRF52 lockdown/protect support opt-in with `-DMESHTASTIC_ENABLE_LOCKDOWN=1`.
- Keep the existing `MESHTASTIC_EXCLUDE_LOCKDOWN` opt-out behavior.
- Guard the BLE reconnect admin-auth reset behind `MESHTASTIC_PHONEAPI_ACCESS_CONTROL`, because that method is not available when access-control is excluded.

## Why

Default firmware builds should not compile the encrypted-storage/access-control/APPROTECT capability unless the build explicitly asks for it. APPROTECT is intentionally sticky once provisioned, so making the capability opt-in avoids surprising default builds while preserving the feature for builds that enable `MESHTASTIC_ENABLE_LOCKDOWN=1`.

## Verification

- `trunk fmt src/configuration.h src/platform/nrf52/NRF52Bluetooth.cpp`
- `git diff --check`
- Default build: `pio run -e tracker-t1000-e`
  - Result: success
  - RAM: `37.2%`, `92484 / 248832` bytes
  - Flash: `59.5%`, `485112 / 815104` bytes
  - Artifact MD5s: ELF `f793cc3a616b3108bcf248dbaee81327`, UF2 `646cee5805de520efc2e5796b4942fd2`
- Opt-in build: `PLATFORMIO_BUILD_FLAGS=-DMESHTASTIC_ENABLE_LOCKDOWN=1 pio run -e tracker-t1000-e`
  - Result: success
  - RAM: `37.4%`, `93012 / 248832` bytes
  - Flash: `62.7%`, `510728 / 815104` bytes
  - Artifact MD5s: ELF `0ba865078f187c3d8cae39aeb5102e09`, UF2 `36ac0986c78485683e1ffcb7f5feb866`
