### PR TITLE
feat(mesh): Shift mobile roles contention window to lower priority (10687)

### DIFF
--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -707,9 +707,18 @@ uint32_t RadioInterface::getTxDelayMsecWeighted(meshtastic_MeshPacket *p)
     if (shouldRebroadcastEarlyLikeRouter(p)) {
         delay = random(0, 2 * CWsize) * slotTimeMsec;
         LOG_DEBUG("rx_snr found in packet. Router: setting tx delay:%d", delay);
+    } else if (config.device.role == meshtastic_Config_DeviceConfig_Role_CLIENT_BASE) {
+        delay = (2 * CWmax * slotTimeMsec) + random(0, pow_of_2(CWsize)) * slotTimeMsec;
+        LOG_DEBUG("rx_snr found in packet. Client_base: setting tx delay:%d", delay);
     } else {
         // offset the maximum delay for routers: (2 * CWmax * slotTimeMsec)
-        delay = (2 * CWmax * slotTimeMsec) + random(0, pow_of_2(CWsize)) * slotTimeMsec;
+        // plus another 8*CWmax to cede priority to client_base
+        uint8_t routerWindow = 2 * CWmax;
+        delay = (8 * CWmax) + random(0, pow_of_2(CWsize));
+        delay = delay > pow_of_2(CWmax) ? pow_of_2(CWmax) : delay;
+        delay += routerWindow;
+
+        delay *= slotTimeMsec;
         LOG_DEBUG("rx_snr found in packet. Setting tx delay:%d", delay);
     }
 


### PR DESCRIPTION
This is the proposed code for issue [10687](https://github.com/meshtastic/firmware/issues/10687).

It shifts all non infrastructure role's contention window to a later frame. This should allow infrastructure to have priority and reduce client retransmissions in dense meshes. 

I tried a couple of other approaches but settled on this. It provides a predictable behavior with no (theoretical) impact on the existing retry logic.

- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
- [X] Heltec (Lora32) V3
- [X] Other (please specify below)
    Muzi R1 Neo    

Using the serial debug output I was able to confirm that the expected wait times were upheld even at extreme SNRs. With an SDR I was able to confirm that retransmissions still happen. Finally I have been using the modified code on my daily driven R1 Neo with no obvious problems.