### PR TITLE
Leave src/platform out of the build filter by default

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -103,7 +103,7 @@ build_unflags =
 	-std=gnu++11
 build_flags = ${env.build_flags} -Os
 	-std=gnu++17
-build_src_filter = ${env.build_src_filter} -<platform/portduino/> -<graphics/niche/>
+build_src_filter = ${env.build_src_filter} -<platform/> +<platform/extra-variants/> -<graphics/niche/>
 
 ; Common libs for communicating over TCP/IP networks such as MQTT
 [networking_base]

--- a/platformio.ini
+++ b/platformio.ini
@@ -103,7 +103,7 @@ build_unflags =
 	-std=gnu++11
 build_flags = ${env.build_flags} -Os
 	-std=gnu++17
-build_src_filter = ${env.build_src_filter} -<platform/> +<platform/extra-variants/> -<graphics/niche/>
+build_src_filter = ${env.build_src_filter} -<platform/> +<platform/extra_variants/> -<graphics/niche/>
 
 ; Common libs for communicating over TCP/IP networks such as MQTT
 [networking_base]

--- a/variants/esp32/esp32-common.ini
+++ b/variants/esp32/esp32-common.ini
@@ -17,7 +17,7 @@ extra_scripts =
   extra_scripts/esp32_extra.py
 
 build_src_filter = 
-  ${arduino_base.build_src_filter} -<platform/nrf52/> -<platform/nrf54l15/> -<platform/stm32wl> -<platform/rp2xx0> -<mesh/eth/> -<mesh/raspihttp>
+  ${arduino_base.build_src_filter} +<platform/esp32/> -<mesh/eth/> -<mesh/raspihttp>
 
 upload_speed = 921600
 debug_init_break = tbreak setup

--- a/variants/esp32p4/esp32p4.ini
+++ b/variants/esp32p4/esp32p4.ini
@@ -13,7 +13,7 @@ build_flags =
   -DMESHTASTIC_EXCLUDE_PAXCOUNTER=1
 
 build_src_filter = 
-  ${esp32_common.build_src_filter} -<libpax/> -<platform/stm32wl> -<nimble> -<mesh/http/> -<platform/rp2xx0> -<mesh/raspihttp> -<serialization/>
+  ${esp32_common.build_src_filter} -<libpax/> +<platform/esp32> -<mesh/raspihttp> -<serialization/>
 
 extra_scripts =
   ${esp32_common.extra_scripts}

--- a/variants/native/portduino.ini
+++ b/variants/native/portduino.ini
@@ -6,13 +6,10 @@ platform =
 framework = arduino
 
 build_src_filter = 
-  ${env.build_src_filter} 
-  -<platform/esp32/> 
+  ${env.build_src_filter}
+  -<platform/>
+  +<platform/portduino>
   -<nimble/> 
-  -<platform/nrf52/>
-  -<platform/nrf54l15/>
-  -<platform/stm32wl/>
-  -<platform/rp2xx0>
   -<mesh/wifi/>
   -<mesh/http/>
   +<mesh/raspihttp/>

--- a/variants/nrf52840/nrf52.ini
+++ b/variants/nrf52840/nrf52.ini
@@ -43,7 +43,7 @@ build_unflags =
   -std=gnu++11
 
 build_src_filter = 
-  ${arduino_base.build_src_filter} -<platform/esp32/> -<platform/nrf54l15/> -<platform/stm32wl> -<nimble/> -<mesh/wifi/> -<mesh/api/> -<mesh/http/> -<modules/esp32> -<platform/rp2xx0> -<mesh/eth/> -<mesh/raspihttp> -<serialization/>
+  ${arduino_base.build_src_filter} +<platform/nrf52/> -<nimble/> -<mesh/wifi/> -<mesh/api/> -<mesh/http/> -<modules/esp32> -<mesh/eth/> -<mesh/raspihttp> -<serialization/>
 
 lib_deps=
   ${arduino_base.lib_deps}

--- a/variants/nrf54l15/nrf54l15.ini
+++ b/variants/nrf54l15/nrf54l15.ini
@@ -32,10 +32,6 @@ build_flags =
 
 build_src_filter =
   ${arduino_base.build_src_filter}
-  -<platform/esp32/>
-  -<platform/stm32wl>
-  -<platform/nrf52/>
-  -<platform/rp2xx0>
   -<nimble/>
   -<mesh/wifi/>
   -<mesh/api/>

--- a/variants/rp2040/rp2040.ini
+++ b/variants/rp2040/rp2040.ini
@@ -20,7 +20,7 @@ build_flags =
   -D__FREERTOS=1
 #  -D _POSIX_THREADS
 build_src_filter = 
-  ${arduino_base.build_src_filter} -<platform/esp32/> -<nimble/> -<modules/esp32> -<platform/nrf52/> -<platform/nrf54l15/> -<platform/stm32wl> -<mesh/eth/> -<mesh/wifi/> -<mesh/http/> -<mesh/raspihttp>
+  ${arduino_base.build_src_filter} +<platform/rp2xx0/> -<nimble/> -<modules/esp32> -<mesh/eth/> -<mesh/wifi/> -<mesh/http/> -<mesh/raspihttp>
 
 lib_ignore =
   BluetoothOTA

--- a/variants/rp2350/rp2350.ini
+++ b/variants/rp2350/rp2350.ini
@@ -17,7 +17,7 @@ build_flags =
   -D__PLAT_RP2350__
   -D__FREERTOS=1
 build_src_filter =
-  ${arduino_base.build_src_filter} -<platform/esp32/> -<nimble/> -<modules/esp32> -<platform/nrf52/> -<platform/nrf54l15/> -<platform/stm32wl> -<mesh/eth/> -<mesh/wifi/> -<mesh/http/> -<mesh/raspihttp> -<platform/rp2xx0/pico_sleep> -<platform/rp2xx0/hardware_rosc>
+  ${arduino_base.build_src_filter} +<platform/rp2xx0/> -<nimble/> -<modules/esp32> -<mesh/eth/> -<mesh/wifi/> -<mesh/http/> -<mesh/raspihttp> -<platform/rp2xx0/pico_sleep> -<platform/rp2xx0/hardware_rosc>
 
 lib_ignore =
   BluetoothOTA

--- a/variants/stm32/stm32.ini
+++ b/variants/stm32/stm32.ini
@@ -45,7 +45,7 @@ build_flags =
   -Wl,--wrap=_tzset_unlocked_r
 
 build_src_filter =
-  ${arduino_base.build_src_filter} -<platform/esp32/> -<nimble/> -<mesh/api/> -<mesh/wifi/> -<mesh/http/> -<modules/esp32> -<mesh/eth/> -<input> -<buzz> -<modules/RemoteHardwareModule.cpp> -<platform/nrf52> -<platform/nrf54l15/> -<platform/portduino> -<platform/rp2xx0> -<mesh/raspihttp>
+  ${arduino_base.build_src_filter} +<platform/stm32wl/> -<nimble/> -<mesh/api/> -<mesh/wifi/> -<mesh/http/> -<modules/esp32> -<mesh/eth/> -<input> -<buzz> -<modules/RemoteHardwareModule.cpp> -<mesh/raspihttp>
 
 board_upload.offset_address = 0x08000000
 upload_protocol = stlink


### PR DESCRIPTION
src/platform contains files for various builds. We've been including it by default, and excluding what isn't needed. This has reached a point of being unwieldy. So this change discludes the whole folder by default, re-includes the extra_variants folder, and then just adds each additional folder in builds that need it.