### PR TITLE
PR3 Next Hop improvements

### DIFF
--- a/docs/nexthop-routing-reliability.md
+++ b/docs/nexthop-routing-reliability.md
@@ -1,0 +1,456 @@
+# NextHop direct-message reliability on dense meshes — findings & plan
+
+**Status:** Proposal / design doc for branch handoff (no code changes yet)
+**Date:** 2026-06-13
+**Area:** `src/mesh` router stack (`NextHopRouter`, `ReliableRouter`, `FloodingRouter`, `Router`, `NodeDB`, `PacketHistory`)
+**Constraint:** No over-the-air / wire-format changes — `next_hop` and `relay_node` stay 1 byte, no `PacketHeader` changes, no breaking protobuf changes. All new state is RAM-only.
+
+This document captures the analysis and the proposed mitigations so the work can be
+continued on this branch by anyone. It is intentionally code-grounded (file:line
+references throughout) and standalone — you should not need the original investigation
+context to pick it up.
+
+---
+
+## TL;DR
+
+NextHop routing for direct messages (DMs) is unreliable on dense meshes. The headline
+cause is the **birthday problem**: `next_hop` and `relay_node` are each a single byte
+(the last byte of a 32-bit node number), so on a mesh of N nodes the probability that
+two share the same byte hits ~50% at **~19 nodes** and is near-certain by 50–100. But
+there are **other, equally important issues**: that single byte is trusted blindly at
+five different code sites, learned routes **never decay**, routes are learned from the
+**reverse (ACK) path** (asymmetric-link hazard), and collision-driven spurious
+rebroadcasts **amplify congestion** exactly when the mesh is busy.
+
+Because we can't widen the on-wire field, the fix is **interpretation-side** ("don't
+trust a byte that doesn't map to a unique reachable neighbor — flood instead") plus
+**recovery-side** ("decay stale/failing routes so they get re-discovered"). Four
+mitigations, M1–M4, all RAM-only. The net behavioral change: on dense/mobile meshes a
+DM that today silently misroutes or black-holes instead falls back to managed flooding
+(which still delivers) and re-learns a fresh route quickly. Sparse-mesh happy paths are
+unchanged.
+
+---
+
+## How NextHop routing works today (mechanics)
+
+Inheritance chain: `Router` → `FloodingRouter` → `NextHopRouter` → `ReliableRouter`.
+
+**The single-byte identifiers.** Both routing bytes come from one helper:
+
+```cpp
+// src/mesh/NodeDB.h:255
+uint8_t getLastByteOfNodeNum(NodeNum num) { return (uint8_t)((num & 0xFF) ? (num & 0xFF) : 0xFF); }
+```
+
+It projects a 32-bit node number onto 255 values (`0x00` is remapped to `0xFF` so it
+never collides with the `0`-valued sentinels `NO_NEXT_HOP_PREFERENCE` / `NO_RELAY_NODE`,
+`src/mesh/MeshTypes.h:44-46`). `next_hop` and `relay_node` in the packet header are
+`uint8_t` (`src/mesh/mesh.pb.h`, comments "Last byte of the node number…"). The learned
+route stored per destination, `meshtastic_NodeInfoLite::next_hop`, is also a single byte
+(`src/mesh/generated/meshtastic/deviceonly.pb.h:83`).
+
+**Sending a DM** — `NextHopRouter::send` (`src/mesh/NextHopRouter.cpp:23`):
+
+1. `p->relay_node = getLastByteOfNodeNum(getNodeNum())` (mark ourselves as relayer).
+2. `p->next_hop = getNextHop(p->to, p->relay_node)` (`src/mesh/NextHopRouter.cpp:192`):
+   look up `nodeDB->getMeshNode(to)->next_hop`; return it unless it equals the relayer
+   byte; otherwise `NO_NEXT_HOP_PREFERENCE` (→ flood).
+
+**Relaying** — `NextHopRouter::perhapsRebroadcast` (`src/mesh/NextHopRouter.cpp:133`):
+rebroadcast iff `next_hop == NO_NEXT_HOP_PREFERENCE` (flood) **or**
+`next_hop == getLastByteOfNodeNum(getNodeNum())` (we are the addressed next hop)
+(`:147`). Each node only ever compares against **its own** byte.
+
+**Learning** — `NextHopRouter::sniffReceived` (`src/mesh/NextHopRouter.cpp:89`): on an
+ACK/reply (`request_id`/`reply_id` set), if the relayer of the ACK was also a relayer of
+the original packet (validated via `PacketHistory::checkRelayers`), set
+`origTx->next_hop = p->relay_node` (`:114`). I.e. the **forward** next-hop is learned
+from the **reverse** path's relayer.
+
+**Retransmission / fallback** — `NextHopRouter::doRetransmissions`
+(`src/mesh/NextHopRouter.cpp:284`). Budgets: `NUM_RELIABLE_RETX=3` (originator: initial
+
+- 2 retries), `NUM_INTERMEDIATE_RETX=2` (relayer: 1 retry). On the **last** retry
+  (`numRetransmissions==1`) it resets `next_hop` to `NO_NEXT_HOP_PREFERENCE` on the packet
+  **and** clears `sentTo->next_hop` in NodeDB, then floods (`:313-321`). Retransmit timing
+  comes from `iface->getRetransmissionMsec`, whose contention window **grows with channel
+  utilization** (`src/mesh/RadioInterface.cpp` `getTxDelayMsec`/`getTxDelayMsecWeighted`).
+
+**Dedup / relayer history** — `PacketHistory` (`src/mesh/PacketHistory.cpp`): a bounded
+ring (`PACKETHISTORY_MAX = max(MAX_NUM_NODES*2, 100)`, 20 B/record) keyed by
+`(sender,id)`, tracking up to `NUM_RELAYERS=6` relayer **bytes** per packet in
+`relayed_by[]`. `wasRelayer` (`:490`) and `checkRelayers` (`:517`) match bytes against
+that array.
+
+---
+
+## Root-cause analysis
+
+### 1. The single byte is trusted blindly at five sites (the birthday problem)
+
+| #   | Site                             | File:line                   | Failure on collision                                                                                                      |
+| --- | -------------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Rebroadcast self-check           | `NextHopRouter.cpp:147`     | A remote "impostor" node sharing the intended next-hop's byte also rebroadcasts → wasted airtime / congestion.            |
+| 2   | Route learning                   | `NextHopRouter.cpp:111-114` | Stores an ambiguous byte as the route; later resolves to the wrong physical node.                                         |
+| 3   | Relayer validation               | `PacketHistory.cpp:490-538` | `wasRelayer(byte)` returns true for the wrong node → mis-validated ACK / mis-learn.                                       |
+| 4   | Favorite-router hop preservation | `Router.cpp:120-145`        | **First** NodeDB node whose last byte matches wins — non-deterministic; can preserve hops for the wrong relay (hop leak). |
+| 5   | Send-path lookup                 | `NextHopRouter.cpp:192-207` | Emits a byte that may address the wrong node; no check it still maps to a reachable neighbor.                             |
+
+Collision math (uniform last byte over 255 buckets): P(collision) ≈ 50% at ~19 nodes,
+
+> 99% by ~75 nodes. Dense meshes are squarely in the "always colliding" regime.
+
+### 2. Stale routes never decay
+
+The learned `next_hop` byte is cleared only on the **current DM's** last retry
+(`NextHopRouter.cpp:313-321`). A route learned hours ago that has since gone dead is
+still trusted on the **next** DM's first attempt — which on a congested mesh is also the
+slowest attempt. Result: silent black-hole at a dead hop until the retransmission budget
+drains, then a late flood. Intermediate nodes hold stale routes indefinitely.
+
+### 3. Reverse-path (asymmetric-link) learning
+
+`origTx->next_hop` is learned from the ACK's relayer (`NextHopRouter.cpp:110-114`) — the
+**reverse** direction. RF links are frequently asymmetric, so the best reverse relay can
+be a poor forward relay. Worse, the next reverse ACK immediately re-learns the same bad
+hop, so the route **flaps** back to the bad value even after a failure reset.
+
+### 4. Congestion amplification
+
+Collision-driven impostor rebroadcasts (issue 1) add airtime; the contention window
+grows with channel utilization, so retransmit intervals **lengthen** exactly when the
+mesh is busy. The 3-try reliable budget can then expire before delivery. On dense
+meshes, efficiency _is_ reliability.
+
+### Note: pubkey-derived node numbers (develop / 2.8) — does not change the plan
+
+develop derives the node number from the public key:
+`my_node_num = crc32Buffer(public_key)` (`src/mesh/NodeDB.cpp:481`), re-derived on key
+change in `createNewIdentity()` (`src/mesh/NodeDB.cpp:3113`). This **reinforces** the
+plan rather than changing it:
+
+- **Birthday problem unchanged and now textbook-exact.** CRC32 mixes well → the last
+  byte is uniformly distributed over 256 values. Derivation adds no wire bits.
+- **Node numbers are now immutable / identity-bound.** Pre-2.8 `pickNewNodeNum()` could
+  renumber a node to dodge a conflict; now the number is fixed by the key, so a last-byte
+  collision **cannot be resolved operationally by renumbering** → M1/M2/M3 become _more_
+  necessary.
+- **Resolver gets cleaner inputs.** Stable node numbers keep a learned byte bound to one
+  identity (good for M3 freshness). `createNewIdentity()` retires the old entry by marking
+  it **ignored** and clearing its pubkey (`src/mesh/NodeDB.cpp:3123-3125`), which M1's
+  candidate gate already skips — so key rotation can't pollute resolution.
+- **No wire-free disambiguation unlocked.** A receiver still gets only 1 byte and cannot
+  recover which full node number a colliding value meant — so "detect ambiguity → flood"
+  remains the correct strategy.
+
+---
+
+## Proposed mitigations
+
+Key insight for all of M1/M2: **a 1-byte ID only needs to be unique among a node's
+direct neighbors / plausible relays, not the whole mesh.** That candidate set is small
+(typically 5–15), so a byte usually resolves unambiguously there; when it doesn't, fall
+back to the _safe_ behavior (flood / decrement / don't-learn).
+
+### M1 — Ambiguity-aware last-byte resolution (new NodeDB primitive)
+
+New types + methods in `src/mesh/NodeDB.h` (near line 255) / `src/mesh/NodeDB.cpp`
+(near `getMeshNode`, ~2936):
+
+```cpp
+enum class LastByteResolution : uint8_t { None, Unique, Ambiguous };
+struct ResolvedNode { LastByteResolution status = LastByteResolution::None; NodeNum num = 0; };
+
+// Resolve a single on-wire last-byte to a unique full NodeNum among relevant candidates.
+ResolvedNode resolveLastByte(uint8_t lastByte, bool requireDirectNeighbor);
+// Convenience: true iff exactly one relevant candidate (Ambiguous and None both -> false = SAFE).
+bool resolveUniqueLastByte(uint8_t lastByte, bool requireDirectNeighbor, NodeNum *outNum = nullptr);
+```
+
+- **One linear pass** over `meshNodes`, reusing `getNumMeshNodes()`/`getMeshNodeByIndex()`,
+  the bitfield helpers (`nodeInfoLiteIsFavorite/HasUser/IsIgnored`), `sinceLastSeen()`,
+  and `getLastByteOfNodeNum()`. **Early-exit** on the 2nd match (return `Ambiguous`).
+- **Guard:** `if (lastByte == 0) return {None, 0};` (covers `NO_RELAY_NODE` / MQTT-invalid).
+- **Candidate gate** (skip): `num == getNodeNum()` (never resolve to ourselves), `num == 0`,
+  `num == NODENUM_BROADCAST`, `nodeInfoLiteIsIgnored`. Then match
+  `getLastByteOfNodeNum(node->num) == lastByte` (cheapest test last, mirroring `Router.cpp:119`).
+- **Relevance gate:**
+  - `requireDirectNeighbor == true` (strict, for SEND): `has_hops_away && hops_away == 0`
+    **and** `sinceLastSeen(node) < NEXTHOP_NEIGHBOR_FRESH_SECS`.
+  - `requireDirectNeighbor == false` (lenient, for learn / hop-preserve): accept if direct
+    neighbor **or** `nodeInfoLiteIsFavorite` **or** role ∈ {ROUTER, ROUTER_LATE, CLIENT_BASE}.
+- **No tie-break.** A collision must return `Ambiguous` — picking "best SNR" would
+  resurrect the silent-misroute bug. (Deliberate non-goal; document in code.)
+
+New constant in `src/mesh/MeshTypes.h` (near line 44):
+`#define NEXTHOP_NEIGHBOR_FRESH_SECS (60 * 60 * 2)` (mirrors `NUM_ONLINE_SECS`).
+
+### M2 — Only route on bytes that resolve to a unique, reachable neighbor
+
+In `getNextHop` (`src/mesh/NextHopRouter.cpp:192-207`), after the existing split-horizon
+check (`node->next_hop != relay_node`), require the stored byte to resolve to a **unique,
+currently-fresh direct neighbor**; else flood:
+
+```cpp
+if (node->next_hop != relay_node) {
+    ResolvedNode r = nodeDB->resolveLastByte(node->next_hop, /*requireDirectNeighbor=*/true);
+    if (r.status == LastByteResolution::Unique) return node->next_hop;
+    LOG_WARN("Next hop 0x%x for 0x%x %s -> flood", node->next_hop, to,
+             r.status == LastByteResolution::Ambiguous ? "ambiguous among neighbors" : "no longer a neighbor");
+    return std::nullopt;
+}
+```
+
+This self-heals when a neighbor goes away (unicast-into-a-void becomes a flood). It
+applies to originating, relaying, and retrying, since all route through `getNextHop`.
+
+Apply M1's safe fallback at the other sites:
+
+- **Learning** (`NextHopRouter.cpp:111-114`): gate `origTx->next_hop = p->relay_node` on
+  `resolveUniqueLastByte(p->relay_node, /*direct=*/false)`. Ambiguous/unknown → don't
+  learn (leave route unset → flood).
+- **Favorite-router preservation** (`Router.cpp:120-145`): replace the "first match wins"
+  loop with `resolveUniqueLastByte(p->relay_node, /*direct=*/false)` + a re-check that the
+  resolved node is favorite/has_user/router. Ambiguous/none/not-favorite → **decrement**
+  (safe). Net: removes one full DB scan, adds one resolver scan (wash).
+
+**Left unchanged, by design (document why in code):**
+
+- **Site 1** rebroadcast self-check (`NextHopRouter.cpp:147`) and self-identity checks
+  (`ReliableRouter.cpp:127`): a node matches its **own** byte — no DB resolution helps. A
+  remote impostor sharing the intended next-hop's byte will still rebroadcast. M1/M2
+  shrink the blast radius by reducing how often an ambiguous byte is ever stored or
+  originated; a true fix needs a wider field (out of scope). **This is the one residual
+  the plan cannot fully close.**
+- **Site 3** `wasRelayer`/`checkRelayers` (`PacketHistory.cpp:490-538`): intentionally
+  byte-domain (both sides are on-wire bytes); the consumer (learning) is now hardened.
+  Add a one-line comment; do not change.
+
+### M3 — Route freshness / failure memory (RAM table on NextHopRouter)
+
+A bounded, LRU-evicted table keyed by destination, mirroring `PacketHistory`'s
+reuse-oldest discipline (not an unbounded map) to cap RAM.
+
+`src/mesh/NextHopRouter.h` (near `pending`, line 99):
+
+```cpp
+struct RouteHealth {
+    NodeNum dest = 0;                  // 0 == empty slot
+    uint32_t learnedAtMsec = 0;        // millis() at last (re)learn; rollover-aware
+    uint8_t consecutiveFailures = 0;
+    uint8_t lastNextHop = NO_NEXT_HOP_PREFERENCE; // byte this health refers to
+};
+static constexpr uint8_t ROUTE_HEALTH_MAX = 32;   // ~384B; drop to 16 if RAM-tight
+RouteHealth routeHealth[ROUTE_HEALTH_MAX] = {};
+// Helpers take `now` (pure/testable): findRouteHealth, getOrAllocRouteHealth,
+// noteRouteLearned, noteRouteSuccess, noteRouteFailure, isRouteStale, clearRouteHealth
+```
+
+Policy:
+
+| Constant                  | Value  | Rationale                                                                                                                                              |
+| ------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ROUTE_TTL_MSEC`          | 30 min | Survives a normal conversation; re-discovers a moved node within a telemetry interval.                                                                 |
+| `ROUTE_FAILURE_THRESHOLD` | 3      | 1–2 consecutive failures are transient LoRa collisions; 3 to the same hop = dead. Accumulates **across** DMs (independent of the per-DM 3-try budget). |
+
+`isRouteStale(h, now)` = `(now - h.learnedAtMsec) >= ROUTE_TTL_MSEC || h.consecutiveFailures >= ROUTE_FAILURE_THRESHOLD`.
+All age math uses **unsigned subtraction** (rollover-safe, matching
+`PacketHistory.cpp:364`); treat `learnedAtMsec == 0` as "set now".
+
+Wiring (as built — `src/mesh/NextHopRouter.cpp`, `src/mesh/ReliableRouter.cpp`):
+
+- `getNextHop`: if a health record matches the stored byte and `isRouteStale`, clear
+  `node->next_hop` (NodeDB) **and** `clearRouteHealth`, return `nullopt` (flood). No
+  record yet (cold path, first DM after boot) → trust NodeDB, but the M2 strict-neighbor
+  gate still applies.
+- `sniffReceived` learn: gate the write through `resolveUniqueLastByte` (M2), then
+  `noteRouteLearned(p->from, p->relay_node, millis())` — resets `consecutiveFailures`
+  **only if the hop changed** (anti-flap for asymmetric re-learn); otherwise just refreshes
+  `learnedAtMsec`. (No success signal is taken on the intermediate reverse-pass: an ACK
+  merely passing through us is not proof that _we_ delivered, and resetting failures there
+  would reintroduce the asymmetric flap.)
+- `doRetransmissions`: on the last-retransmission branch (`numRetransmissions == 1`, the
+  point a directed delivery has gone un-ACKed for both originator and intermediate) →
+  `noteRouteFailure(to)`, then the existing NodeDB `next_hop` reset + flood. We deliberately
+  do **not** `clearRouteHealth` here: keeping the record is what lets the failure count
+  accumulate across DMs so a flapping reverse-path-relearned dead hop eventually ages out.
+- `ReliableRouter::sniffReceived` ACK path → `noteRouteSuccess(getFrom(p), millis())`
+  (an end-to-end ACK addressed to us is genuine forward-delivery proof; clears failures and
+  refreshes freshness). `noteRouteSuccess`/`noteRouteFailure` are no-ops when no record
+  exists, so flood-only destinations never pollute the table.
+
+**Reconciliation (no double-handling):** `doRetransmissions` owns _in-flight_ failure of
+the current DM (reset NodeDB `next_hop` + flood, and bump the cross-DM failure counter);
+`getNextHop` owns _between-DM_ staleness (TTL or failure-threshold → flood + clear). The
+only place that erases a health record is the `getNextHop` decay path; the retransmission
+path leaves it intact so the counter survives a reverse-path re-learn.
+
+### M4 — Earlier flood for unverified routes (gated, off by default)
+
+Compile-gated so healthy sparse meshes are untouched. **Default is off** — the define
+lives in `NextHopRouter.h` and must be flipped to measure:
+`#define NEXTHOP_EARLY_FLOOD_ON_UNVERIFIED 1`.
+
+In `doRetransmissions`, the directed-retry `else` branch: if the route is **not verified**
+(`!findRouteHealth(to) || consecutiveFailures > 0 || isRouteStale`), reset `next_hop` and
+flood on this attempt instead of spending another directed try. A **verified** route
+(record present, `consecutiveFailures == 0`, within TTL — i.e. recently ACKed) takes the
+unchanged directed-retry path, so the sparse-mesh happy path is untouched. Trade-off:
+airtime ↔ latency; the gate ensures we never pay the flood cost on a proven route, only on
+one we already distrust. Off by default precisely so it can be A/B-measured on the
+simulator before broad enable.
+
+---
+
+## Files to modify
+
+| File                                        | Change                                                                                                                                               |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/mesh/MeshTypes.h`                      | `NEXTHOP_NEIGHBOR_FRESH_SECS`, `ROUTE_TTL_MSEC`, `ROUTE_FAILURE_THRESHOLD`, `NEXTHOP_EARLY_FLOOD_ON_UNVERIFIED`                                      |
+| `src/mesh/NodeDB.h` / `src/mesh/NodeDB.cpp` | `LastByteResolution`, `ResolvedNode`, `resolveLastByte`, `resolveUniqueLastByte`                                                                     |
+| `src/mesh/NextHopRouter.h`                  | `RouteHealth` + array + helpers; `#ifdef PIO_UNIT_TESTING public:` for helpers and `getNextHop`                                                      |
+| `src/mesh/NextHopRouter.cpp`                | `getNextHop` (M2 gate + M3 decay); `sniffReceived` (learn gate + health seed + success); `doRetransmissions` (failure counting + M4); comment site 1 |
+| `src/mesh/Router.cpp`                       | `shouldDecrementHopLimit` → resolver + favorite/router re-check                                                                                      |
+| `src/mesh/ReliableRouter.cpp`               | ACK path → `noteRouteSuccess`                                                                                                                        |
+| `test/test_nexthop_routing/test_main.cpp`   | **new** unit suite (auto-built under `[env:native]`)                                                                                                 |
+
+**Reuse, don't reinvent:** `getLastByteOfNodeNum`, `sinceLastSeen`, the bitfield helpers,
+`getMeshNodeByIndex`/`getNumMeshNodes`, PacketHistory's reuse-oldest eviction shape, and
+`MockNodeDB::addTestNode` (from `test/test_hop_scaling/test_main.cpp`).
+
+---
+
+## Edge cases
+
+- **`0x00`↔`0xFF` projection:** the resolver compares via `getLastByteOfNodeNum` on both
+  sides, so a `…00` node and a `…FF` node correctly collide on `0xFF` → `Ambiguous`. Test
+  explicitly.
+- **MQTT packets:** `relay_node`/`next_hop` are forced invalid when `hop_start == 0`
+  (`src/mesh/RadioLibInterface.cpp:603-605`) → byte 0 → resolver `None` → don't learn
+  (correct).
+- **`has_hops_away == false`** nodes are excluded from the strict gate (never fabricate a
+  Unique neighbor for M2); admitted to the lenient gate only via favorite/router role.
+  Safe; self-corrects once `hops_away` is learned.
+- **Self / broadcast:** the resolver skips `getNodeNum()` and `NODENUM_BROADCAST`;
+  `getNextHop` already early-returns for broadcast.
+- **Perf:** M2 adds one O(N) resolver scan per directed send/relay (early-exit on the 2nd
+  match), cheaper than the crypto already on that path; site-4 is a wash. If ever hot, a
+  future 256-entry last-byte index is the optimization (not now — RAM).
+
+---
+
+## Verification (all tiers)
+
+### 1. Native unit tests — new `test/test_nexthop_routing/test_main.cpp`
+
+`pio test -e native -f test_nexthop_routing`; on macOS `./bin/test-native-docker.sh -f test_nexthop_routing`.
+Design the RouteHealth helpers to take `now` as a parameter so the 30-min TTL logic is
+testable without a clock mock.
+
+- **Resolver:** None / Unique / **Ambiguous (birthday collision)** / strict-excludes-stale /
+  strict-excludes-far / lenient-includes-favorite-router / lenient-collision / skips-self /
+  skips-ignored / **`0x00`↔`0xFF` collision** / early-exit.
+- **`getNextHop`:** unique→byte, **ambiguous→nullopt**, stale-neighbor→nullopt,
+  split-horizon (relay==next_hop)→nullopt, broadcast→nullopt.
+- **RouteHealth:** TTL boundary, **rollover** (learn near `0xFFFFFFFF`, check after wrap),
+  failure threshold, success-resets, **re-learn-same-hop keeps fails (anti-flap)**,
+  re-learn-new-hop resets, LRU eviction bound, clear.
+- **Site-4:** preserve on unique favorite router; **decrement on two colliding favorites**;
+  decrement when the resolved node is not a favorite.
+- **Sparse-mesh regression:** all-distinct last bytes → every resolve Unique, `getNextHop`
+  returns the stored byte unchanged (proves no happy-path change).
+- Re-run `test_packet_history` and `test_hop_scaling` for no regression.
+
+### 2. portduino SimRadio simulator
+
+`pio run -e native && ./bin/test-simulator.sh`. Best vehicle for the **intermediate-node**
+path the 2-device bench can't reach. Line topology A — B — C: establish A→C (B learns a
+directed route), stop B relaying that dest, confirm A re-discovers via flood within
+`ROUTE_FAILURE_THRESHOLD` and that B's `noteRouteFailure`/`clearRouteHealth` fires (visible
+via the `LOG_INFO "Route to … stale"` / "Resetting next hop" lines). Use this to A/B M4
+(attempts-to-delivery, total airtime).
+
+### 3. Hardware via meshtastic MCP (auto-detect; 3+ devices for a real hop)
+
+- `mcp-server/tests/mesh/test_nexthop_multihop_recovery.py` — **the multi-hop validator
+  for this work** (added on this branch). Self-discovers an A — relay — C line, asserts a
+  directed DM is delivered across the relay (next_hop + M1/M2/M3 engaged), and asserts
+  delivery recovers after the relay is power-cycled (M3). Skips unless the bench is a true
+  multi-hop line (≥3 roles via `--hub-profile`, endpoints out of direct RF range).
+- `mcp-server/tests/mesh/test_direct_with_ack.py` — happy-path regression: a fresh/unique
+  route still delivers a want_ack DM on the first/second try (M4's gate must keep this
+  green).
+- `mcp-server/tests/mesh/test_peer_offline_recovery.py` — 2-device recovery validator: peer
+  off mid-conversation then back. Must stay green and ideally recover in fewer attempts.
+
+### 4. Build / format sanity
+
+native-macos **and** Docker both ways; trunk clang-format@16.0.3; a release `pio run` to
+confirm the `#ifdef PIO_UNIT_TESTING` visibility widening does **not** leak into
+production; sanity-check RAM headroom on the smallest nRF52 build for the ~384 B table.
+
+---
+
+## Verification status (as built on `nexthop-redux`)
+
+| Tier                             | What ran                                                                            | Result              |
+| -------------------------------- | ----------------------------------------------------------------------------------- | ------------------- |
+| Unit (native-macos)              | `test_nexthop_routing` (31 cases)                                                   | ✅ 31/31            |
+| Unit (Docker / Linux, CI parity) | `test_nexthop_routing`                                                              | ✅ 31/31            |
+| Regression                       | `test_packet_history`, `test_hop_scaling`, `test_mqtt`, `test_traffic_management`   | ✅ 105/105          |
+| Build                            | `pio run -e native-macos` (M4 off) and with `-DNEXTHOP_EARLY_FLOOD_ON_UNVERIFIED=1` | ✅ both link        |
+| Format                           | trunk `clang-format@16.0.3`                                                         | ✅ no issues        |
+| Simulator (CI `simulator-tests`) | `meshtasticd -s` + `meshtastic.test.testSimulator()` on native-macos                | ✅ exit 0, no crash |
+
+**Pending (environment-blocked, not yet run):**
+
+- **Multi-hop A–B–C recovery sim** — the `simulator/` broker hub is **not git-tracked**
+  (only stale local `.pyc`), and two `meshtasticd -s` instances can't hear each other
+  without it. The intermediate-node failure-count path and the M4 A/B therefore have unit
+  coverage of their logic but no end-to-end multi-node run yet.
+- **Hardware / multi-hop tier** — a committable bench test now exists:
+  `mcp-server/tests/mesh/test_nexthop_multihop_recovery.py`. It self-discovers a real
+  multi-hop pair (A — relay — C), asserts a directed DM is delivered across the relay, and
+  asserts delivery recovers after the relay is power-cycled (the M3 path). It
+  `pytest.skip`s cleanly unless the bench is a true line with endpoints out of direct RF
+  range (≥3 roles via `--hub-profile`), so it's safe to commit and only asserts when the
+  NextHop path is genuinely exercised. Collected + verified to skip without hardware;
+  not yet run on a bench. `test_direct_with_ack.py` / `test_peer_offline_recovery.py`
+  remain the 2-device happy-path/recovery regressions.
+
+---
+
+## Risks & limitations
+
+- **Site-1 impostor rebroadcast** is unfixable without a wider field — documented; M1/M2
+  only shrink its frequency.
+- **Dense meshes flood DMs more often** — intended (a flooded DM arrives; a mis-unicast one
+  black-holes). Call out in the PR so reviewers expect a slightly higher DM flood rate on
+  very dense meshes.
+- **M4 airtime** if the gate is too loose → default conservative + compile-gated +
+  simulator A/B before broad enable.
+- **RAM** ~384 B (32 slots); 16 slots (~192 B) with graceful LRU degradation if tight.
+- **Asymmetric flap** not fully closed (a _new_ bad hop resets the counter); the TTL
+  backstop bounds it. Per-hop failure history is future work (more RAM).
+
+---
+
+## How to continue this work (commit sequencing)
+
+Each step is independently testable; land them as separate commits.
+
+1. **M1 resolver + unit tests** — `NodeDB` only; no behavior change until wired. Lands the
+   `resolveLastByte`/`resolveUniqueLastByte` primitive and its full unit-test matrix.
+2. **M2 + wiring + tests** — `getNextHop` strict gate, learning gate, favorite-router
+   preservation rewrite. Adds the `getNextHop` and site-4 tests.
+3. **M3 health table + decay + tests** — RAM `RouteHealth` table, decay-on-read, failure/
+   success accounting, reconciliation with the existing last-retry reset. Adds the
+   route-health unit tests and the simulator recovery check.
+4. **M4 gated tuning** — early-flood-on-unverified behind the compile flag; simulator A/B
+   and hardware regression.
+
+Reference plan (with the same content) was developed at
+`~/.claude/plans/nexthop-routing-for-direct-lexical-shell.md` on the author's machine; this
+in-repo doc is the canonical handoff copy.

--- a/docs/nexthop-routing-reliability.md
+++ b/docs/nexthop-routing-reliability.md
@@ -1,6 +1,6 @@
 # NextHop direct-message reliability on dense meshes — findings & plan
 
-**Status:** Proposal / design doc for branch handoff (no code changes yet)
+**Status:** Implemented — mitigations and tests in `PR3-tmm-nexthop`
 **Date:** 2026-06-13
 **Area:** `src/mesh` router stack (`NextHopRouter`, `ReliableRouter`, `FloodingRouter`, `Router`, `NodeDB`, `PacketHistory`)
 **Constraint:** No over-the-air / wire-format changes — `next_hop` and `relay_node` stay 1 byte, no `PacketHeader` changes, no breaking protobuf changes. All new state is RAM-only.

--- a/mcp-server/tests/mesh/test_nexthop_multihop_recovery.py
+++ b/mcp-server/tests/mesh/test_nexthop_multihop_recovery.py
@@ -1,0 +1,347 @@
+"""Multi-hop NextHop directed-message delivery + relay-recovery (bench test).
+
+This is the hardware/tier-3 validator for the NextHop DM reliability work
+(see `docs/nexthop-routing-reliability.md`). The unit suite
+`test/test_nexthop_routing` covers the routing *logic* exhaustively; this test
+covers the *end-to-end* multi-hop behavior that only a real (or RF-separated)
+mesh exercises:
+
+  * a directed DM that must traverse a relay is delivered (next_hop routing +
+    the M1/M2 ambiguity gate + M3 route learning all engage), and
+  * when the established relay drops and returns, delivery recovers rather than
+    black-holing (the M3 stale-route decay / re-learn path).
+
+TOPOLOGY REQUIREMENT — why this usually SKIPS:
+  A NextHop relay only happens when the two endpoints are NOT direct neighbors.
+  Three co-located radios all hear each other, so A→C is a single direct hop and
+  next_hop never engages. To run this test the bench must be a *line* — A — B — C
+  — with the endpoints out of each other's direct RF range (physical distance or
+  attenuators). The `multihop_topology` fixture detects this automatically: it
+  warms the mesh, looks for a pair that is ≥1 hop apart, confirms the relay via
+  traceroute, and `pytest.skip`s cleanly when the bench is all-direct. So this
+  file is safe to commit and run anywhere — it only *asserts* when the topology
+  genuinely requires a relay.
+
+REQUIREMENTS:
+  * ≥3 baked devices. The default hub profile is 2 roles (nrf52, esp32s3); add a
+    third via `--hub-profile=path/to/hub.yaml` (see conftest `hub_profile`).
+  * The relay-recovery test additionally needs uhubctl + a power-controllable
+    relay port (same gate the other power tests use).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+from meshtastic_mcp.connection import connect
+from tests import _power
+from tests._port_discovery import resolve_port_by_role
+
+from ._receive import ReceiveCollector, nudge_nodeinfo, nudge_nodeinfo_port
+
+
+def _hops_away(rec: dict[str, Any]) -> int | None:
+    """Read a node's hop distance from a `nodesByNum` entry, tolerating either
+    the camelCase (`hopsAway`) or snake_case (`hops_away`) spelling depending on
+    the meshtastic-python version."""
+    for key in ("hopsAway", "hops_away"):
+        val = rec.get(key)
+        if isinstance(val, int):
+            return val
+    return None
+
+
+def _warm_mesh(ports: list[str], rounds: int = 2, settle: float = 6.0) -> None:
+    """Flood a fresh NodeInfo from every node so the whole mesh (including
+    multi-hop pairs, reached via relayed broadcasts) populates pubkeys and hop
+    distances. Best-effort — a single node failing to nudge shouldn't abort."""
+    for _ in range(rounds):
+        for port in ports:
+            try:
+                nudge_nodeinfo_port(port)
+            except Exception:  # noqa: BLE001 — warmup is best-effort
+                pass
+            time.sleep(0.5)
+        time.sleep(settle)
+
+
+def _wait_for_pubkey(
+    tx_iface: Any, rx_num: int, rx_port: str, deadline_s: float = 90.0
+) -> bool:
+    """Block until `tx_iface` holds `rx_num`'s public key (directed PKI sends
+    NAK without it). Re-nudges both sides periodically; multi-hop warmup is
+    slower than the 2-device case because NodeInfo must be relayed, hence the
+    longer default deadline."""
+    deadline = time.monotonic() + deadline_s
+    last_nudge = time.monotonic()
+    while time.monotonic() < deadline:
+        rec = (tx_iface.nodesByNum or {}).get(rx_num, {})
+        if rec.get("user", {}).get("publicKey"):
+            return True
+        if time.monotonic() - last_nudge > 20.0:
+            nudge_nodeinfo_port(rx_port)
+            nudge_nodeinfo(tx_iface)
+            last_nudge = time.monotonic()
+        time.sleep(1.0)
+    return False
+
+
+def _traceroute_route(tx_port: str, rx_num: int, rx_port: str) -> list[int] | None:
+    """Run a traceroute TX→RX and return the forward `route` (list of relay node
+    numbers), or None if it couldn't be obtained. Mirrors test_traceroute's
+    request/PKI/retry pattern."""
+    from meshtastic.mesh_interface import MeshInterface
+
+    with ReceiveCollector(tx_port, topic="meshtastic.receive.traceroute") as tx:
+        nudge_nodeinfo_port(rx_port)
+        tx.broadcast_nodeinfo_ping()
+        if not _wait_for_pubkey(tx._iface, rx_num, rx_port, 60.0):
+            return None
+        for _attempt in range(2):
+            try:
+                tx._iface.sendTraceRoute(dest=rx_num, hopLimit=5)
+                break
+            except MeshInterface.MeshInterfaceError:
+                time.sleep(5.0)
+        else:
+            return None
+        pkt = tx.wait_for(lambda p: p.get("from") == rx_num, timeout=8.0)
+        if pkt is None:
+            return None
+        tr = (pkt.get("decoded", {}) or {}).get("traceroute") or {}
+        return [int(n) for n in (tr.get("route") or [])]
+
+
+@pytest.fixture(scope="session")
+def multihop_topology(baked_mesh: dict[str, Any]) -> dict[str, Any]:
+    """Discover a real multi-hop pier (tx → relay → rx) on the bench, or skip.
+
+    Returns {tx_role, tx_port, rx_role, rx_port, rx_num, relay_role, relay_num}.
+    """
+    roles = sorted(baked_mesh)
+    if len(roles) < 3:
+        pytest.skip(
+            "multi-hop NextHop test needs ≥3 baked devices arranged as a line "
+            "(endpoints out of direct RF range). Add a third role via "
+            f"--hub-profile. Detected roles: {roles}"
+        )
+
+    by_role = {r: (baked_mesh[r]["port"], baked_mesh[r]["my_node_num"]) for r in roles}
+    if any(num is None for _, num in by_role.values()):
+        pytest.skip("a baked device is missing my_node_num; can't map the topology")
+
+    _warm_mesh([port for port, _ in by_role.values()])
+
+    # Find an ordered pair that is ≥1 hop apart, using each node's own nodeDB
+    # (cheap — no traceroute yet). On an all-direct bench nothing qualifies.
+    multihop_pair: tuple[str, str] | None = None
+    for a_role in roles:
+        a_port, _ = by_role[a_role]
+        try:
+            with connect(port=a_port) as a_iface:
+                nodes = a_iface.nodesByNum or {}
+        except Exception:  # noqa: BLE001
+            continue
+        for c_role in roles:
+            if c_role == a_role:
+                continue
+            _, c_num = by_role[c_role]
+            hops = _hops_away(nodes.get(c_num, {}))
+            if hops is not None and hops >= 1:
+                multihop_pair = (a_role, c_role)
+                break
+        if multihop_pair:
+            break
+
+    if not multihop_pair:
+        pytest.skip(
+            "no multi-hop pair found — every device appears to be a direct "
+            "neighbor. Arrange the bench as a line (A — B — C) with the "
+            "endpoints out of direct RF range (distance or attenuators) so a "
+            "relay is actually required, then re-run."
+        )
+
+    a_role, c_role = multihop_pair
+    a_port, _ = by_role[a_role]
+    c_port, c_num = by_role[c_role]
+
+    route = _traceroute_route(a_port, c_num, c_port)
+    if not route:
+        pytest.skip(
+            f"{a_role}→{c_role} looked multi-hop but traceroute returned no "
+            "intermediate relay; can't identify the relay node to drive the "
+            "recovery test"
+        )
+
+    relay_num = route[0]
+    relay_role = next((r for r in roles if by_role[r][1] == relay_num), None)
+    return {
+        "tx_role": a_role,
+        "tx_port": a_port,
+        "rx_role": c_role,
+        "rx_port": c_port,
+        "rx_num": c_num,
+        "relay_role": relay_role,
+        "relay_num": relay_num,
+    }
+
+
+@pytest.mark.timeout(300)
+def test_multihop_dm_delivers(multihop_topology: dict[str, Any]) -> None:
+    """A directed wantAck DM that must traverse the relay is delivered.
+
+    Exercises the NextHop routing path end-to-end: TX picks a next hop toward
+    RX (M2 gate), the relay resolves the next_hop byte and forwards (M1), and
+    the route is learned from the returning ACK (M3). Retries absorb transient
+    LoRa loss; the assertion is on eventual delivery.
+    """
+    tx_port = multihop_topology["tx_port"]
+    rx_port = multihop_topology["rx_port"]
+    rx_num = multihop_topology["rx_num"]
+    tx_role = multihop_topology["tx_role"]
+    rx_role = multihop_topology["rx_role"]
+    relay_role = multihop_topology["relay_role"]
+
+    unique = f"nexthop-mh-{tx_role}-to-{rx_role}-{int(time.time())}"
+
+    with ReceiveCollector(rx_port, topic="meshtastic.receive.text") as rx:
+        rx.broadcast_nodeinfo_ping()
+        with connect(port=tx_port) as tx_iface:
+            nudge_nodeinfo(tx_iface)
+            if not _wait_for_pubkey(tx_iface, rx_num, rx_port, 90.0):
+                pytest.skip(
+                    f"{tx_role} never learned {rx_role}'s pubkey over the relay; "
+                    "multi-hop PKI warmup didn't complete"
+                )
+            got = None
+            for _attempt in range(3):
+                pkt = tx_iface.sendText(unique, destinationId=rx_num, wantAck=True)
+                assert pkt is not None
+                got = rx.wait_for(
+                    lambda p: p.get("decoded", {}).get("text") == unique,
+                    timeout=45,
+                )
+                if got is not None:
+                    break
+                rx.broadcast_nodeinfo_ping()
+                nudge_nodeinfo(tx_iface)
+                time.sleep(5.0)
+
+    assert got is not None, (
+        f"multi-hop directed DM {tx_role}→{rx_role} via relay "
+        f"{relay_role!r} never landed — NextHop multi-hop delivery is broken"
+    )
+
+
+@pytest.mark.timeout(600)
+def test_multihop_relay_recovery(
+    multihop_topology: dict[str, Any],
+    power_cycle,  # noqa: ARG001 — forces the uhubctl-availability skip
+) -> None:
+    """Delivery recovers after the established relay drops and returns.
+
+    Establishes a baseline DM (route via relay learned), powers the relay OFF
+    (confirming TX survives sending across a downed relay), then powers it back
+    ON and asserts directed delivery resumes — the M3 stale-route decay /
+    re-learn path. With a strict A — B — C line there is no path while B is down,
+    so we only assert TX doesn't crash during the outage; the delivery assertion
+    is after B returns.
+    """
+    relay_role = multihop_topology["relay_role"]
+    if not relay_role:
+        pytest.skip(
+            "relay node isn't one of the baked hub roles, so it can't be "
+            "power-cycled; recovery test needs a controllable relay"
+        )
+
+    tx_port = multihop_topology["tx_port"]
+    rx_port = multihop_topology["rx_port"]
+    rx_num = multihop_topology["rx_num"]
+    tx_role = multihop_topology["tx_role"]
+    rx_role = multihop_topology["rx_role"]
+
+    base = f"mh-recover-base-{int(time.time())}"
+    post = f"mh-recover-post-{int(time.time())}"
+
+    # Baseline: confirm delivery works (so the route via the relay is learned)
+    # before we perturb anything — otherwise a later failure is ambiguous.
+    with ReceiveCollector(rx_port, topic="meshtastic.receive.text") as rx:
+        rx.broadcast_nodeinfo_ping()
+        with connect(port=tx_port) as tx_iface:
+            nudge_nodeinfo(tx_iface)
+            if not _wait_for_pubkey(tx_iface, rx_num, rx_port, 90.0):
+                pytest.skip("multi-hop PKI warmup failed; can't run recovery test")
+            tx_iface.sendText(base, destinationId=rx_num, wantAck=True)
+            assert (
+                rx.wait_for(
+                    lambda p: p.get("decoded", {}).get("text") == base, timeout=45
+                )
+                is not None
+            ), "baseline multi-hop delivery failed — skipping recovery to avoid a false result"
+
+    # Power the relay OFF.
+    try:
+        _power.power_off(relay_role)
+        _power.wait_for_absence(relay_role, timeout_s=15.0)
+    except Exception as exc:  # noqa: BLE001
+        try:
+            _power.power_on(relay_role)
+            resolve_port_by_role(relay_role, timeout_s=30.0)
+        except Exception:  # noqa: BLE001
+            pass
+        pytest.skip(f"can't power-control relay {relay_role!r}: {exc}")
+
+    # With the only relay down there's no path; we just confirm TX accepts the
+    # send and survives its internal retries (it must not crash / wedge).
+    try:
+        with connect(port=tx_port) as tx_iface:
+            pkt = tx_iface.sendText(
+                f"mh-while-down-{int(time.time())}",
+                destinationId=rx_num,
+                wantAck=True,
+            )
+            assert pkt is not None
+            time.sleep(8.0)  # let retransmissions + route decay run
+    except Exception as exc:  # noqa: BLE001 — restore bench state before failing
+        _power.power_on(relay_role)
+        resolve_port_by_role(relay_role, timeout_s=30.0)
+        raise AssertionError(
+            f"TX crashed sending across a downed relay: {exc}"
+        ) from exc
+
+    # Power the relay back ON and let it re-enumerate + boot.
+    _power.power_on(relay_role)
+    time.sleep(0.5)
+    try:
+        resolve_port_by_role(relay_role, timeout_s=30.0)
+    except Exception:  # noqa: BLE001 — relay port isn't one we connect to directly
+        pass
+    time.sleep(8.0)
+    _warm_mesh([tx_port, rx_port], rounds=1)  # re-flood so the relay re-learns
+
+    # Delivery should resume once the relay is back (M3 re-learn / decay path).
+    got = None
+    with ReceiveCollector(rx_port, topic="meshtastic.receive.text") as rx:
+        rx.broadcast_nodeinfo_ping()
+        with connect(port=tx_port) as tx_iface:
+            nudge_nodeinfo(tx_iface)
+            _wait_for_pubkey(tx_iface, rx_num, rx_port, 90.0)
+            for _attempt in range(4):
+                pkt = tx_iface.sendText(post, destinationId=rx_num, wantAck=True)
+                assert pkt is not None
+                got = rx.wait_for(
+                    lambda p: p.get("decoded", {}).get("text") == post,
+                    timeout=45,
+                )
+                if got is not None:
+                    break
+                rx.broadcast_nodeinfo_ping()
+                nudge_nodeinfo(tx_iface)
+                time.sleep(6.0)
+
+    assert got is not None, (
+        f"after relay {relay_role!r} returned, multi-hop DM {tx_role}→{rx_role} "
+        "never resumed — stale-route recovery (M3) may be broken"
+    )

--- a/src/mesh/Channels.cpp
+++ b/src/mesh/Channels.cpp
@@ -440,15 +440,22 @@ bool Channels::usesPublicKey(ChannelIndex chIndex)
     return (psk.size == sizeof(defaultpsk) && memcmp(psk.bytes, defaultpsk, sizeof(defaultpsk) - 1) == 0);
 }
 
-bool Channels::isPublicChannel(ChannelIndex chIndex)
+bool Channels::isWellKnownChannel(ChannelIndex chIndex)
 {
     const auto &ch = getByIndex(chIndex);
+    // Absent (unencrypted) or single-byte PSK — all the well-known key indexes
     if (ch.settings.psk.size > 1)
         return false;
+
     const char *name = getName(chIndex);
-    const char *presetName =
-        DisplayFormatters::getModemPresetDisplayName(config.lora.modem_preset, false, config.lora.use_preset);
-    return strcmp(name, presetName) == 0;
+    for (int p = _meshtastic_Config_LoRaConfig_ModemPreset_MIN; p <= _meshtastic_Config_LoRaConfig_ModemPreset_MAX; p++) {
+        const char *presetName =
+            DisplayFormatters::getModemPresetDisplayName(static_cast<meshtastic_Config_LoRaConfig_ModemPreset>(p), false, true);
+        // Presets without a display name fall through to "Invalid" — never a match
+        if (strcmp(presetName, "Invalid") != 0 && strcmp(name, presetName) == 0)
+            return true;
+    }
+    return false;
 }
 
 bool Channels::hasDefaultChannel()

--- a/src/mesh/Channels.cpp
+++ b/src/mesh/Channels.cpp
@@ -440,6 +440,17 @@ bool Channels::usesPublicKey(ChannelIndex chIndex)
     return (psk.size == sizeof(defaultpsk) && memcmp(psk.bytes, defaultpsk, sizeof(defaultpsk) - 1) == 0);
 }
 
+bool Channels::isPublicChannel(ChannelIndex chIndex)
+{
+    const auto &ch = getByIndex(chIndex);
+    if (ch.settings.psk.size > 1)
+        return false;
+    const char *name = getName(chIndex);
+    const char *presetName =
+        DisplayFormatters::getModemPresetDisplayName(config.lora.modem_preset, false, config.lora.use_preset);
+    return strcmp(name, presetName) == 0;
+}
+
 bool Channels::hasDefaultChannel()
 {
     // If we don't use a preset or the default frequency slot, or we override the frequency, we don't have a default channel

--- a/src/mesh/Channels.h
+++ b/src/mesh/Channels.h
@@ -88,6 +88,9 @@ class Channels
 
     // Returns true if this channel's effective key is publicly decryptable (open or well-known/default PSK).
     bool usesPublicKey(ChannelIndex chIndex);
+    // Returns true if the channel is public: PSK is 0 or 1 bytes (no key or a well-known
+    // default-index shorthand) AND the name matches the modem-preset name.
+    bool isPublicChannel(ChannelIndex chIndex);
 
     // Returns true if we can be reached via a channel with the default settings given a region and modem preset
     bool hasDefaultChannel();

--- a/src/mesh/Channels.h
+++ b/src/mesh/Channels.h
@@ -88,9 +88,12 @@ class Channels
 
     // Returns true if this channel's effective key is publicly decryptable (open or well-known/default PSK).
     bool usesPublicKey(ChannelIndex chIndex);
-    // Returns true if the channel is public: PSK is 0 or 1 bytes (no key or a well-known
-    // default-index shorthand) AND the name matches the modem-preset name.
-    bool isPublicChannel(ChannelIndex chIndex);
+    // Returns true if the channel is "well known": its PSK is absent or a
+    // single-byte well-known key index, AND its name is any modem-preset
+    // display name (e.g. a channel named "LongFast" counts even while the
+    // radio runs MediumFast). Broader than isDefaultChannel, which only
+    // matches the current preset's name and PSK byte 1.
+    bool isWellKnownChannel(ChannelIndex chIndex);
 
     // Returns true if we can be reached via a channel with the default settings given a region and modem preset
     bool hasDefaultChannel();

--- a/src/mesh/Default.cpp
+++ b/src/mesh/Default.cpp
@@ -97,3 +97,25 @@ uint8_t Default::getConfiguredOrDefaultHopLimit(uint8_t configured)
     return (configured >= HOP_MAX) ? HOP_MAX : config.lora.hop_limit;
 #endif
 }
+
+uint8_t Default::hopTrimGrace(meshtastic_Config_DeviceConfig_Role role, meshtastic_PortNum portnum)
+{
+    const uint8_t base = default_traffic_mgmt_hop_trim_grace_base;
+
+    // Deprecated roles get one below base (nudge operators off them).
+    if (IS_ONE_OF(role, meshtastic_Config_DeviceConfig_Role_REPEATER, meshtastic_Config_DeviceConfig_Role_ROUTER_CLIENT))
+        return base > 0 ? static_cast<uint8_t>(base - 1) : 0;
+
+    // Infrastructure roles, and a role's specialty broadcast, get one above base.
+    if (IS_ONE_OF(role, meshtastic_Config_DeviceConfig_Role_ROUTER, meshtastic_Config_DeviceConfig_Role_ROUTER_LATE,
+                  meshtastic_Config_DeviceConfig_Role_CLIENT_BASE))
+        return static_cast<uint8_t>(base + 1);
+    if (role == meshtastic_Config_DeviceConfig_Role_SENSOR && portnum == meshtastic_PortNum_TELEMETRY_APP)
+        return static_cast<uint8_t>(base + 1);
+    if (IS_ONE_OF(role, meshtastic_Config_DeviceConfig_Role_TRACKER, meshtastic_Config_DeviceConfig_Role_TAK_TRACKER,
+                  meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND) &&
+        portnum == meshtastic_PortNum_POSITION_APP)
+        return static_cast<uint8_t>(base + 1);
+
+    return base;
+}

--- a/src/mesh/Default.cpp
+++ b/src/mesh/Default.cpp
@@ -100,7 +100,11 @@ uint8_t Default::getConfiguredOrDefaultHopLimit(uint8_t configured)
 
 uint8_t Default::hopTrimGrace(meshtastic_Config_DeviceConfig_Role role, meshtastic_PortNum portnum)
 {
-    const uint8_t base = default_traffic_mgmt_hop_trim_grace_base;
+    return hopTrimGrace(role, portnum, default_traffic_mgmt_hop_trim_grace_base);
+}
+
+uint8_t Default::hopTrimGrace(meshtastic_Config_DeviceConfig_Role role, meshtastic_PortNum portnum, uint8_t base)
+{
 
     // Deprecated roles get one below base (nudge operators off them).
     if (IS_ONE_OF(role, meshtastic_Config_DeviceConfig_Role_REPEATER, meshtastic_Config_DeviceConfig_Role_ROUTER_CLIENT))

--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -34,7 +34,7 @@
 enum class TrafficType { POSITION, TELEMETRY };
 
 // Traffic management defaults
-#define default_traffic_mgmt_position_precision_bits 24               // ~10m grid cells
+#define default_traffic_mgmt_position_precision_bits 19               // ~90m grid cells (±45m)
 #define default_traffic_mgmt_position_min_interval_secs (ONE_DAY / 2) // 12 hours between identical positions
 
 // Hop scaling defaults

--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -39,6 +39,8 @@ enum class TrafficType { POSITION, TELEMETRY };
 // Traffic management defaults
 #define default_traffic_mgmt_position_precision_bits 19                // ~90m grid cells (±45m)
 #define default_traffic_mgmt_position_min_interval_secs (11 * 60 * 60) // 11 hours between identical positions
+// Role cap: tracker-role origins may refresh a duplicate position this often (vs the 11h default).
+#define default_traffic_mgmt_tracker_position_min_interval_secs (60 * 60) // 1 hour
 
 // Hop scaling defaults
 #define default_hop_scaling_min_target_nodes 40          // walk threshold: first hop reaching this cumulative count

--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -42,6 +42,14 @@ enum class TrafficType { POSITION, TELEMETRY };
 // Role cap: tracker-role origins may refresh a duplicate position this often (vs the 11h default).
 #define default_traffic_mgmt_tracker_position_min_interval_secs (60 * 60) // 1 hour
 
+// Base hop grace for hop-trimming; the only tunable. Infra/specialty senders derive +1,
+// deprecated roles -1 (see Default::hopTrimGrace).
+#ifdef USERPREFS_TMM_HOP_TRIM_GRACE_BASE
+#define default_traffic_mgmt_hop_trim_grace_base USERPREFS_TMM_HOP_TRIM_GRACE_BASE
+#else
+#define default_traffic_mgmt_hop_trim_grace_base 2
+#endif
+
 // Hop scaling defaults
 #define default_hop_scaling_min_target_nodes 40          // walk threshold: first hop reaching this cumulative count
 #define default_hop_scaling_max_target_nodes 80          // generous extension ceiling (2 × min)
@@ -81,6 +89,9 @@ class Default
                                                    TrafficType type);
     static uint8_t getConfiguredOrDefaultHopLimit(uint8_t configured);
     static uint32_t getConfiguredOrMinimumValue(uint32_t configured, uint32_t minValue);
+    // Hops of grace a relayed broadcast gets over the local hop-scaling cap before its reach is
+    // clamped. Keyed on the sender's role and the packet portnum; derived from the base grace.
+    static uint8_t hopTrimGrace(meshtastic_Config_DeviceConfig_Role role, meshtastic_PortNum portnum);
 
   private:
     // Note: Kept as uint32_t to match the public API parameter type

--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -34,8 +34,8 @@
 enum class TrafficType { POSITION, TELEMETRY };
 
 // Traffic management defaults
-#define default_traffic_mgmt_position_precision_bits 19               // ~90m grid cells (±45m)
-#define default_traffic_mgmt_position_min_interval_secs (ONE_DAY / 2) // 12 hours between identical positions
+#define default_traffic_mgmt_position_precision_bits 19                // ~90m grid cells (±45m)
+#define default_traffic_mgmt_position_min_interval_secs (11 * 60 * 60) // 11 hours between identical positions
 
 // Hop scaling defaults
 #define default_hop_scaling_min_target_nodes 40          // walk threshold: first hop reaching this cumulative count

--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -18,6 +18,9 @@
 #define default_telemetry_broadcast_interval_secs IF_ROUTER(ONE_DAY / 2, 60 * 60)
 #define default_broadcast_interval_secs IF_ROUTER(ONE_DAY / 2, 60 * 60)
 #define default_broadcast_smart_minimum_interval_secs 5 * 60
+// Floor for our own position broadcasts when stationary (unchanged beyond the broadcast
+// precision) or fixed_position: identical positions get deduped by traffic management anyway.
+#define default_position_stationary_broadcast_secs (12 * 60 * 60)
 #define min_default_broadcast_interval_secs IF_ROUTER(ONE_DAY / 2, 60 * 60)
 #define min_default_broadcast_smart_minimum_interval_secs 5 * 60
 #define default_wait_bluetooth_secs IF_ROUTER(1, 60)

--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -92,6 +92,7 @@ class Default
     // Hops of grace a relayed broadcast gets over the local hop-scaling cap before its reach is
     // clamped. Keyed on the sender's role and the packet portnum; derived from the base grace.
     static uint8_t hopTrimGrace(meshtastic_Config_DeviceConfig_Role role, meshtastic_PortNum portnum);
+    static uint8_t hopTrimGrace(meshtastic_Config_DeviceConfig_Role role, meshtastic_PortNum portnum, uint8_t base);
 
   private:
     // Note: Kept as uint32_t to match the public API parameter type

--- a/src/mesh/FloodingRouter.cpp
+++ b/src/mesh/FloodingRouter.cpp
@@ -8,6 +8,9 @@
 #if !MESHTASTIC_EXCLUDE_TRACEROUTE
 #include "modules/TraceRouteModule.h"
 #endif
+#if HAS_TRAFFIC_MANAGEMENT
+#include "modules/TrafficManagementModule.h"
+#endif
 
 FloodingRouter::FloodingRouter() {}
 
@@ -68,6 +71,16 @@ bool FloodingRouter::perhapsHandleUpgradedPacket(const meshtastic_MeshPacket *p)
 {
     // isRebroadcaster() is duplicated in perhapsRebroadcast(), but this avoids confusing log messages
     if (isRebroadcaster() && iface && p->hop_limit > 0) {
+#if HAS_TRAFFIC_MANAGEMENT
+        // Hop-trimming refuses this "higher-hopcount wins" upgrade: it raises hop_limit and bypasses
+        // the alterReceived clamp, silently undoing the trim. For a trim-eligible packet, keep our
+        // already-trimmed queued copy and consume the fatter dupe rather than rebroadcasting it.
+        if (trafficManagementModule && trafficManagementModule->wouldHopTrim(*p)) {
+            LOG_DEBUG("Hop-trim: refusing higher-hopcount upgrade for 0x%08x (keeping trimmed copy)", p->id);
+            rxDupe++;
+            return true;
+        }
+#endif
         // If we overhear a duplicate copy of the packet with more hops left than the one we are waiting to
         // rebroadcast, then remove the packet currently sitting in the TX queue and use this one instead.
         uint8_t dropThreshold = p->hop_limit; // remove queued packets that have fewer hops remaining

--- a/src/mesh/MeshTypes.h
+++ b/src/mesh/MeshTypes.h
@@ -45,6 +45,11 @@ enum RxSource {
 // For old firmware there is no relay node set
 #define NO_RELAY_NODE 0
 
+// How recently we must have heard a direct neighbor for its single-byte relay id to be trusted as a
+// unique next hop. Mirrors NUM_ONLINE_SECS (NodeDB.cpp). Used by NodeDB::resolveLastByte() to scope
+// last-byte collision resolution to currently-reachable neighbors.
+#define NEXTHOP_NEIGHBOR_FRESH_SECS (60 * 60 * 2) // 2 hrs
+
 typedef int ErrorCode;
 
 /// Alloc and free packets to our global, ISR safe pool

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -204,7 +204,7 @@ std::optional<uint8_t> NextHopRouter::getNextHop(NodeNum to, uint8_t relay_node)
     if (node && node->next_hop) {
         // We are careful not to return the relay node as the next hop
         if (node->next_hop != relay_node) {
-            // LOG_DEBUG("Next hop for 0x%x is 0x%x", to, node->next_hop);
+            LOG_DEBUG("Next hop for 0x%x is 0x%x", to, node->next_hop);
             return node->next_hop;
         } else
             LOG_WARN("Next hop for 0x%x is 0x%x, same as relayer; set no pref", to, node->next_hop);
@@ -216,7 +216,7 @@ std::optional<uint8_t> NextHopRouter::getNextHop(NodeNum to, uint8_t relay_node)
     if (trafficManagementModule) {
         uint8_t hint = trafficManagementModule->getNextHopHint(to);
         if (hint && hint != relay_node) {
-            // LOG_DEBUG("Next hop for 0x%x is 0x%x (TMM cache)", to, hint);
+            LOG_DEBUG("Next hop for 0x%x is 0x%x (TMM cache)", to, hint);
             return hint;
         }
     }

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -98,22 +98,27 @@ void NextHopRouter::sniffReceived(const meshtastic_MeshPacket *p, const meshtast
         // destination
         if (p->from != 0) {
             meshtastic_NodeInfoLite *origTx = nodeDB->getMeshNode(p->from);
-            if (origTx) {
-                // Either relayer of ACK was also a relayer of the packet, or we were the *only* relayer and the ACK came
-                // directly from the destination
-                // Single lookup for both relayer checks on the same (request_id, to) pair
-                bool wasAlreadyRelayer = false;
-                bool weWereSoleRelayer = false;
-                bool weWereRelayer = false;
-                checkRelayers(p->relay_node, ourRelayID, p->decoded.request_id, p->to, &wasAlreadyRelayer, &weWereRelayer,
-                              &weWereSoleRelayer);
-                if ((weWereRelayer && wasAlreadyRelayer) || (getHopsAway(*p) == 0 && weWereSoleRelayer)) {
-                    if (origTx->next_hop != p->relay_node) { // Not already set
-                        LOG_INFO("Update next hop of 0x%x to 0x%x based on ACK/reply (was relayer %d we were sole %d)", p->from,
-                                 p->relay_node, wasAlreadyRelayer, weWereSoleRelayer);
-                        origTx->next_hop = p->relay_node;
-                    }
+            // Either relayer of ACK was also a relayer of the packet, or we were the *only* relayer and the ACK came
+            // directly from the destination. checkRelayers is read-only on PacketHistory and O(1), so we run it even
+            // when origTx is absent — that lets us still capture the confirmed hop into the TMM overflow cache below.
+            // Single lookup for both relayer checks on the same (request_id, to) pair
+            bool wasAlreadyRelayer = false;
+            bool weWereSoleRelayer = false;
+            bool weWereRelayer = false;
+            checkRelayers(p->relay_node, ourRelayID, p->decoded.request_id, p->to, &wasAlreadyRelayer, &weWereRelayer,
+                          &weWereSoleRelayer);
+            if ((weWereRelayer && wasAlreadyRelayer) || (getHopsAway(*p) == 0 && weWereSoleRelayer)) {
+                if (origTx && origTx->next_hop != p->relay_node) { // Not already set
+                    LOG_INFO("Update next hop of 0x%x to 0x%x based on ACK/reply (was relayer %d we were sole %d)", p->from,
+                             p->relay_node, wasAlreadyRelayer, weWereSoleRelayer);
+                    origTx->next_hop = p->relay_node;
                 }
+#if HAS_TRAFFIC_MANAGEMENT
+                // Mirror the confirmed hop into the TMM overflow cache so it survives even when the source
+                // isn't (or is no longer) in the hot NodeDB. Same bidirectional confirmation gate as above.
+                if (trafficManagementModule)
+                    trafficManagementModule->setNextHop(p->from, p->relay_node);
+#endif
             }
         }
         if (!isToUs(p)) {
@@ -194,6 +199,7 @@ std::optional<uint8_t> NextHopRouter::getNextHop(NodeNum to, uint8_t relay_node)
     if (isBroadcast(to))
         return std::nullopt;
 
+    // Hot store first: a direct array hit on the live NodeDB entry.
     meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(to);
     if (node && node->next_hop) {
         // We are careful not to return the relay node as the next hop
@@ -203,6 +209,19 @@ std::optional<uint8_t> NextHopRouter::getNextHop(NodeNum to, uint8_t relay_node)
         } else
             LOG_WARN("Next hop for 0x%x is 0x%x, same as relayer; set no pref", to, node->next_hop);
     }
+
+#if HAS_TRAFFIC_MANAGEMENT
+    // Fallback: TMM overflow cache holds confirmed hops for nodes that have aged
+    // out of the hot store. Same byte source/confidence as NodeInfoLite.next_hop.
+    if (trafficManagementModule) {
+        uint8_t hint = trafficManagementModule->getNextHopHint(to);
+        if (hint && hint != relay_node) {
+            // LOG_DEBUG("Next hop for 0x%x is 0x%x (TMM cache)", to, hint);
+            return hint;
+        }
+    }
+#endif
+
     return std::nullopt;
 }
 

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -392,6 +392,11 @@ int32_t NextHopRouter::doRetransmissions()
                             LOG_INFO("Resetting next hop for packet with dest 0x%x\n", p.packet->to);
                             sentTo->next_hop = NO_NEXT_HOP_PREFERENCE;
                         }
+#if HAS_TRAFFIC_MANAGEMENT
+                        if (trafficManagementModule) {
+                            trafficManagementModule->clearNextHop(p.packet->to);
+                        }
+#endif
                         FloodingRouter::send(packetPool.allocCopy(*p.packet));
                     } else {
 #if NEXTHOP_EARLY_FLOOD_ON_UNVERIFIED

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -108,17 +108,29 @@ void NextHopRouter::sniffReceived(const meshtastic_MeshPacket *p, const meshtast
             checkRelayers(p->relay_node, ourRelayID, p->decoded.request_id, p->to, &wasAlreadyRelayer, &weWereRelayer,
                           &weWereSoleRelayer);
             if ((weWereRelayer && wasAlreadyRelayer) || (getHopsAway(*p) == 0 && weWereSoleRelayer)) {
-                if (origTx && origTx->next_hop != p->relay_node) { // Not already set
-                    LOG_INFO("Update next hop of 0x%x to 0x%x based on ACK/reply (was relayer %d we were sole %d)", p->from,
-                             p->relay_node, wasAlreadyRelayer, weWereSoleRelayer);
-                    origTx->next_hop = p->relay_node;
-                }
+                // M1/M2: only learn a next hop whose last byte maps to a single plausible relay. On a dense
+                // mesh the byte may be ambiguous; storing it would aim future DMs at the wrong node. This gate
+                // now protects BOTH the hot-store route (NodeInfoLite.next_hop) AND the TMM overflow cache —
+                // the overflow cache deliberately holds many more next-hop bytes (long-tail nodes), so it is
+                // even more collision-prone and must never store an ambiguous byte either. Ambiguous/unknown
+                // -> store nothing and keep flooding (safe).
+                if (nodeDB->resolveUniqueLastByte(p->relay_node, /*requireDirectNeighbor=*/false)) {
+                    if (origTx && origTx->next_hop != p->relay_node) { // Not already set
+                        LOG_INFO("Update next hop of 0x%x to 0x%x based on ACK/reply (was relayer %d we were sole %d)", p->from,
+                                 p->relay_node, wasAlreadyRelayer, weWereSoleRelayer);
+                        origTx->next_hop = p->relay_node;
+                    }
+                    noteRouteLearned(p->from, p->relay_node, millis()); // M3: anchor freshness (hot or overflow route)
 #if HAS_TRAFFIC_MANAGEMENT
-                // Mirror the confirmed hop into the TMM overflow cache so it survives even when the source
-                // isn't (or is no longer) in the hot NodeDB. Same bidirectional confirmation gate as above.
-                if (trafficManagementModule)
-                    trafficManagementModule->setNextHop(p->from, p->relay_node);
+                    // Mirror the confirmed (and now unique-resolved) hop into the TMM overflow cache so it
+                    // survives even when the source isn't (or is no longer) in the hot NodeDB.
+                    if (trafficManagementModule)
+                        trafficManagementModule->setNextHop(p->from, p->relay_node);
 #endif
+                } else {
+                    LOG_DEBUG("Not learning next hop for 0x%x: relay byte 0x%x ambiguous/unknown; keep flooding", p->from,
+                              p->relay_node);
+                }
             }
         }
         if (!isToUs(p)) {
@@ -149,6 +161,11 @@ bool NextHopRouter::perhapsRebroadcast(const meshtastic_MeshPacket *p)
     if (!isToUs(p) && !isFromUs(p) && (p->hop_limit > 0 || exhaustHops)) {
         if (p->id != 0) {
             if (isRebroadcaster()) {
+                // NOTE: this is a self-identity match (is the addressed next_hop OUR last byte?), so it
+                // cannot be hardened with resolveLastByte() — a remote node that legitimately shares our
+                // last byte will also match here and rebroadcast. That residual collision needs a wider
+                // on-wire field to fix. M1/M2 instead shrink the blast radius by reducing how often an
+                // ambiguous next_hop byte is ever learned (sniffReceived) or originated (getNextHop).
                 if (p->next_hop == NO_NEXT_HOP_PREFERENCE || p->next_hop == nodeDB->getLastByteOfNodeNum(getNodeNum())) {
                     meshtastic_MeshPacket *tosend = packetPool.allocCopy(*p); // keep a copy because we will be sending it
                     LOG_INFO("Rebroadcast received message coming from %x", p->relay_node);
@@ -202,22 +219,56 @@ std::optional<uint8_t> NextHopRouter::getNextHop(NodeNum to, uint8_t relay_node)
     // Hot store first: a direct array hit on the live NodeDB entry.
     meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(to);
     if (node && node->next_hop) {
+        // M3: proactively decay a stale or repeatedly-failing route back to flooding, so a dead hop
+        // isn't trusted on the next DM's first (and on dense meshes, slowest) attempt. We only act on
+        // a health record that still matches the stored byte; a next_hop set by another path (e.g.
+        // TraceRouteModule) with no matching record is left authoritative.
+        RouteHealth *h = findRouteHealth(to);
+        if (h && h->lastNextHop == node->next_hop && isRouteStale(*h, millis())) {
+            LOG_INFO("Next hop 0x%x for 0x%x is stale (age/fails); flood and clear", node->next_hop, to);
+            node->next_hop = NO_NEXT_HOP_PREFERENCE; // clear persisted route
+            clearRouteHealth(to);                    // clear RAM health
+            return std::nullopt;
+        }
+
         // We are careful not to return the relay node as the next hop
         if (node->next_hop != relay_node) {
-            LOG_DEBUG("Next hop for 0x%x is 0x%x", to, node->next_hop);
-            return node->next_hop;
+            // M1/M2: only emit a stored next_hop if its last byte still maps to a UNIQUE, currently
+            // reachable direct neighbor. On a dense mesh the last byte collides, so an ambiguous byte
+            // would unicast a hint toward the wrong physical node; if the neighbor has gone away we'd
+            // unicast into a void. In both cases flood instead (managed flooding still delivers).
+            ResolvedNode r = nodeDB->resolveLastByte(node->next_hop, /*requireDirectNeighbor=*/true);
+            if (r.status == LastByteResolution::Unique)
+                return node->next_hop;
+            LOG_WARN("Next hop 0x%x for 0x%x %s; set no pref", node->next_hop, to,
+                     r.status == LastByteResolution::Ambiguous ? "ambiguous among neighbors" : "not a known neighbor");
         } else
             LOG_WARN("Next hop for 0x%x is 0x%x, same as relayer; set no pref", to, node->next_hop);
     }
 
 #if HAS_TRAFFIC_MANAGEMENT
-    // Fallback: TMM overflow cache holds confirmed hops for nodes that have aged
-    // out of the hot store. Same byte source/confidence as NodeInfoLite.next_hop.
+    // Fallback: TMM overflow cache holds confirmed hops for nodes that have aged out of the hot store.
+    // It is the same byte source/confidence as NodeInfoLite.next_hop, so it gets the same M1/M2/M3
+    // protection: decay a stale/failing route, then only emit a byte that still resolves to a unique
+    // reachable neighbor. Without this the overflow cache (which holds MORE bytes for MORE nodes) would
+    // reintroduce exactly the silent-misroute that M1/M2 closes on the hot path.
     if (trafficManagementModule) {
         uint8_t hint = trafficManagementModule->getNextHopHint(to);
         if (hint && hint != relay_node) {
-            LOG_DEBUG("Next hop for 0x%x is 0x%x (TMM cache)", to, hint);
-            return hint;
+            RouteHealth *h = findRouteHealth(to);
+            if (h && h->lastNextHop == hint && isRouteStale(*h, millis())) {
+                LOG_INFO("TMM next hop 0x%x for 0x%x is stale (age/fails); flood and clear", hint, to);
+                trafficManagementModule->clearNextHop(to); // clear overflow route (setNextHop won't store 0)
+                clearRouteHealth(to);                      // clear RAM health
+                return std::nullopt;
+            }
+            ResolvedNode r = nodeDB->resolveLastByte(hint, /*requireDirectNeighbor=*/true);
+            if (r.status == LastByteResolution::Unique) {
+                LOG_DEBUG("Next hop for 0x%x is 0x%x (TMM cache)", to, hint);
+                return hint;
+            }
+            LOG_WARN("TMM next hop 0x%x for 0x%x %s; set no pref", hint, to,
+                     r.status == LastByteResolution::Ambiguous ? "ambiguous among neighbors" : "not a known neighbor");
         }
     }
 #endif
@@ -330,7 +381,10 @@ int32_t NextHopRouter::doRetransmissions()
 
                 if (!isBroadcast(p.packet->to)) {
                     if (p.numRetransmissions == 1) {
-                        // Last retransmission, reset next_hop (fallback to FloodingRouter)
+                        // Last retransmission: this directed delivery went un-ACKed. Record the failure
+                        // (M3 — accumulates across DMs to age out a flapping/dead route) and reset
+                        // next_hop so the final try falls back to FloodingRouter.
+                        noteRouteFailure(p.packet->to);
                         p.packet->next_hop = NO_NEXT_HOP_PREFERENCE;
                         // Also reset it in the nodeDB
                         meshtastic_NodeInfoLite *sentTo = nodeDB->getMeshNode(p.packet->to);
@@ -340,7 +394,25 @@ int32_t NextHopRouter::doRetransmissions()
                         }
                         FloodingRouter::send(packetPool.allocCopy(*p.packet));
                     } else {
+#if NEXTHOP_EARLY_FLOOD_ON_UNVERIFIED
+                        // M4 (gated): if the route isn't proven healthy, don't spend a second directed
+                        // attempt — start flooding one retry sooner to cut recovery latency. A verified
+                        // route (fresh, zero recent failures) keeps the unchanged directed-retry path so
+                        // the sparse-mesh happy path is untouched.
+                        RouteHealth *h = findRouteHealth(p.packet->to);
+                        bool verified = h && h->consecutiveFailures == 0 && !isRouteStale(*h, now);
+                        if (!verified) {
+                            p.packet->next_hop = NO_NEXT_HOP_PREFERENCE;
+                            meshtastic_NodeInfoLite *sentTo = nodeDB->getMeshNode(p.packet->to);
+                            if (sentTo)
+                                sentTo->next_hop = NO_NEXT_HOP_PREFERENCE;
+                            FloodingRouter::send(packetPool.allocCopy(*p.packet));
+                        } else {
+                            NextHopRouter::send(packetPool.allocCopy(*p.packet));
+                        }
+#else
                         NextHopRouter::send(packetPool.allocCopy(*p.packet));
+#endif
                     }
                 } else {
                     // Note: we call the superclass version because we don't want to have our version of send() add a new
@@ -373,4 +445,97 @@ void NextHopRouter::setNextTx(PendingPacket *pending)
     LOG_DEBUG("Setting next retransmission in %u msecs: ", d);
     printPacket("", pending->packet);
     setReceivedMessage(); // Run ASAP, so we can figure out our correct sleep time
+}
+
+// ---------------------------------------------------------------------------
+// M3: RAM route-health table. Bounded array with reuse-oldest eviction (same discipline as
+// PacketHistory). All age comparisons use unsigned subtraction so they survive the 49.7-day millis()
+// rollover. dest == 0 marks an empty slot; learnedAtMsec is normalized to 1 on write so an occupied
+// slot is never read as infinitely old.
+// ---------------------------------------------------------------------------
+
+RouteHealth *NextHopRouter::findRouteHealth(NodeNum dest)
+{
+    if (dest == 0)
+        return nullptr;
+    for (auto &h : routeHealth)
+        if (h.dest == dest)
+            return &h;
+    return nullptr;
+}
+
+RouteHealth *NextHopRouter::getOrAllocRouteHealth(NodeNum dest, uint32_t now)
+{
+    if (dest == 0)
+        return nullptr;
+
+    RouteHealth *oldest = &routeHealth[0];
+    RouteHealth *freeSlot = nullptr;
+    for (auto &h : routeHealth) {
+        if (h.dest == dest)
+            return &h; // existing record
+        if (h.dest == 0) {
+            if (!freeSlot)
+                freeSlot = &h; // remember the first free slot; prefer it over evicting
+            continue;
+        }
+        // Track the oldest occupied slot in case the table is full (rollover-safe).
+        if ((uint32_t)(now - h.learnedAtMsec) > (uint32_t)(now - oldest->learnedAtMsec))
+            oldest = &h;
+    }
+    // Claim the free slot if there is one, else reuse the oldest. Reset before use and stamp the dest
+    // so the record is findable.
+    RouteHealth *slot = freeSlot ? freeSlot : oldest;
+    *slot = RouteHealth{};
+    slot->dest = dest;
+    return slot;
+}
+
+void NextHopRouter::noteRouteLearned(NodeNum dest, uint8_t nextHop, uint32_t now)
+{
+    if (dest == 0 || nextHop == NO_NEXT_HOP_PREFERENCE)
+        return;
+    RouteHealth *h = getOrAllocRouteHealth(dest, now);
+    if (!h)
+        return;
+    // A genuinely new next hop earns a clean slate; re-learning the SAME hop keeps the accumulated
+    // failure count so an asymmetric reverse path that keeps re-teaching a dead forward hop still ages
+    // out instead of resetting the counter every time.
+    if (h->lastNextHop != nextHop) {
+        h->lastNextHop = nextHop;
+        h->consecutiveFailures = 0;
+    }
+    h->learnedAtMsec = now ? now : 1;
+}
+
+void NextHopRouter::noteRouteSuccess(NodeNum dest, uint32_t now)
+{
+    RouteHealth *h = findRouteHealth(dest);
+    if (!h)
+        return; // only routes we actually learned have health to refresh
+    h->consecutiveFailures = 0;
+    h->learnedAtMsec = now ? now : 1;
+}
+
+void NextHopRouter::noteRouteFailure(NodeNum dest)
+{
+    RouteHealth *h = findRouteHealth(dest);
+    if (!h)
+        return; // nothing to penalize (we were flooding, or never learned a route here)
+    if (h->consecutiveFailures < 255)
+        h->consecutiveFailures++;
+}
+
+bool NextHopRouter::isRouteStale(const RouteHealth &h, uint32_t now) const
+{
+    if (h.consecutiveFailures >= ROUTE_FAILURE_THRESHOLD)
+        return true;
+    return (uint32_t)(now - h.learnedAtMsec) >= ROUTE_TTL_MSEC;
+}
+
+void NextHopRouter::clearRouteHealth(NodeNum dest)
+{
+    RouteHealth *h = findRouteHealth(dest);
+    if (h)
+        *h = RouteHealth{};
 }

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -223,7 +223,7 @@ std::optional<uint8_t> NextHopRouter::getNextHop(NodeNum to, uint8_t relay_node)
         // isn't trusted on the next DM's first (and on dense meshes, slowest) attempt. We only act on
         // a health record that still matches the stored byte; a next_hop set by another path (e.g.
         // TraceRouteModule) with no matching record is left authoritative.
-        RouteHealth *h = findRouteHealth(to);
+        const RouteHealth *h = findRouteHealth(to);
         if (h && h->lastNextHop == node->next_hop && isRouteStale(*h, millis())) {
             LOG_INFO("Next hop 0x%x for 0x%x is stale (age/fails); flood and clear", node->next_hop, to);
             node->next_hop = NO_NEXT_HOP_PREFERENCE; // clear persisted route
@@ -255,7 +255,7 @@ std::optional<uint8_t> NextHopRouter::getNextHop(NodeNum to, uint8_t relay_node)
     if (trafficManagementModule) {
         uint8_t hint = trafficManagementModule->getNextHopHint(to);
         if (hint && hint != relay_node) {
-            RouteHealth *h = findRouteHealth(to);
+            const RouteHealth *h = findRouteHealth(to);
             if (h && h->lastNextHop == hint && isRouteStale(*h, millis())) {
                 LOG_INFO("TMM next hop 0x%x for 0x%x is stale (age/fails); flood and clear", hint, to);
                 trafficManagementModule->clearNextHop(to); // clear overflow route (setNextHop won't store 0)

--- a/src/mesh/NextHopRouter.h
+++ b/src/mesh/NextHopRouter.h
@@ -43,6 +43,28 @@ struct PendingPacket {
     explicit PendingPacket(meshtastic_MeshPacket *p, uint8_t numRetransmissions);
 };
 
+/**
+ * RAM-only per-destination route health. Tracks how fresh a learned next_hop is and how many
+ * consecutive directed deliveries to it have failed, so getNextHop() can proactively decay a stale or
+ * repeatedly-failing route back to flooding instead of trusting a dead hop on the next (and on dense
+ * meshes, slowest) attempt. Not persisted: the learned next_hop itself lives in NodeInfoLite; this is
+ * just freshness/failure metadata.
+ */
+struct RouteHealth {
+    NodeNum dest = 0;                             ///< destination this record describes; 0 == empty slot
+    uint32_t learnedAtMsec = 0;                   ///< millis() when next_hop was last (re)learned (rollover-aware)
+    uint8_t consecutiveFailures = 0;              ///< directed deliveries to `dest` that went un-ACKed
+    uint8_t lastNextHop = NO_NEXT_HOP_PREFERENCE; ///< the relay byte this health refers to
+};
+
+// M4 (optional, off by default): when a route is not proven healthy, fall back to flooding one retry
+// earlier instead of spending a second directed attempt. Trades airtime for recovery latency on dense
+// meshes; leaves the sparse-mesh happy path (fresh, verified routes) unchanged. Measure on the
+// simulator before enabling broadly.
+#ifndef NEXTHOP_EARLY_FLOOD_ON_UNVERIFIED
+#define NEXTHOP_EARLY_FLOOD_ON_UNVERIFIED 0
+#endif
+
 class GlobalPacketIdHashFunction
 {
   public:
@@ -92,11 +114,21 @@ class NextHopRouter : public FloodingRouter
     // The number of retransmissions the original sender will do
     constexpr static uint8_t NUM_RELIABLE_RETX = 3;
 
+    // M3: bounded RAM route-health table (reuse-oldest eviction, like PacketHistory)
+    constexpr static uint8_t ROUTE_HEALTH_MAX = 32;              // ~12B/slot -> ~384B
+    constexpr static uint32_t ROUTE_TTL_MSEC = 30UL * 60 * 1000; // re-discover a route unconfirmed for 30 min
+    constexpr static uint8_t ROUTE_FAILURE_THRESHOLD = 3;        // consecutive un-ACKed directed deliveries -> dead
+
   protected:
     /**
      * Pending retransmissions
      */
     std::unordered_map<GlobalPacketId, PendingPacket, GlobalPacketIdHashFunction> pending;
+
+    /**
+     * Per-destination route health (M3). Bounded array, reuse-oldest eviction. RAM-only.
+     */
+    RouteHealth routeHealth[ROUTE_HEALTH_MAX] = {};
 
     /**
      * Should this incoming filter be dropped?
@@ -142,13 +174,38 @@ class NextHopRouter : public FloodingRouter
 
     void setNextTx(PendingPacket *pending);
 
+    // --- M3 route-health helpers (RAM-only). Protected so ReliableRouter (a subclass) can record
+    // delivery success, and so the unit-test shim can reach them via `using`. All take `now` where
+    // time matters so the decay logic is pure and testable without a clock mock. ---
+
+    /// @return the health record for `dest`, or nullptr if we hold none.
+    RouteHealth *findRouteHealth(NodeNum dest);
+    /// @return an existing record for `dest`, else a freshly claimed slot (reuse-oldest on overflow).
+    RouteHealth *getOrAllocRouteHealth(NodeNum dest, uint32_t now);
+    /// Record that we (re)learned `nextHop` for `dest`. Resets the failure count only when the hop
+    /// changed (so a flapping reverse-path re-learn of the same dead hop still ages out).
+    void noteRouteLearned(NodeNum dest, uint8_t nextHop, uint32_t now);
+    /// Record an end-to-end delivery success to `dest` (clears failures, refreshes freshness).
+    void noteRouteSuccess(NodeNum dest, uint32_t now);
+    /// Record that a directed delivery to `dest` went un-ACKed (no-op if we hold no record).
+    void noteRouteFailure(NodeNum dest);
+    /// @return true if the route is too old (TTL) or has failed too many times in a row.
+    bool isRouteStale(const RouteHealth &h, uint32_t now) const;
+    /// Forget any health record for `dest`.
+    void clearRouteHealth(NodeNum dest);
+
+#ifdef PIO_UNIT_TESTING
+  public: // expose getNextHop to the test shim without widening production visibility
+#else
   private:
+#endif
     /**
      * Get the next hop for a destination, given the relay node
      * @return the node number of the next hop, 0 if no preference (fallback to FloodingRouter)
      */
     std::optional<uint8_t> getNextHop(NodeNum to, uint8_t relay_node);
 
+  private:
     /** Check if we should be rebroadcasting this packet if so, do so.
      *  @return true if we did rebroadcast */
     bool perhapsRebroadcast(const meshtastic_MeshPacket *p) override;

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -2992,10 +2992,12 @@ void NodeDB::addFromContact(meshtastic_SharedContact contact)
         // Block the contact and drop its rich satellite data, but keep the
         // public key copied above — an ignored peer keeps a usable identity
         // (a verifiable target) rather than a bare node number.
-        if (!setProtectedFlag(info, NODEINFO_BITFIELD_IS_IGNORED_MASK, true))
+        if (setProtectedFlag(info, NODEINFO_BITFIELD_IS_IGNORED_MASK, true)) {
+            nodeInfoLiteSetBit(info, NODEINFO_BITFIELD_IS_FAVORITE_MASK, false);
+            eraseNodeSatellites(contact.node_num);
+        } else {
             LOG_WARN(PROTECTED_CAP_WARN_FMT, "ignore", contact.node_num, MAX_NUM_NODES - 2);
-        nodeInfoLiteSetBit(info, NODEINFO_BITFIELD_IS_FAVORITE_MASK, false);
-        eraseNodeSatellites(contact.node_num);
+        }
     } else {
         /* Clients are sending add_contact before every text message DM (because clients may hold a larger node database with
          * public keys than the radio holds). However, we don't want to update last_heard just because we sent someone a DM!

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1145,6 +1145,20 @@ void NodeDB::initConfigIntervals()
 #endif
 }
 
+// Always-on traffic management defaults. Only booleans are written; every
+// numeric field stays 0 and resolves to its default_traffic_mgmt_* macro at
+// use (e.g. position dedup precision/interval), so fork-wide tuning changes
+// take effect without another migration. Rate limiting and the features that
+// exhaust or reshape relayed traffic (exhaust_hop_*, drop_unknown_enabled,
+// nodeinfo_direct_response) stay opt-in.
+static void installTrafficManagementDefaults(meshtastic_LocalModuleConfig &mc)
+{
+    mc.has_traffic_management = true;
+    mc.traffic_management = meshtastic_ModuleConfig_TrafficManagementConfig_init_zero;
+    mc.traffic_management.enabled = true;
+    mc.traffic_management.position_dedup_enabled = true;
+}
+
 void NodeDB::installDefaultModuleConfig()
 {
     LOG_INFO("Install default ModuleConfig");
@@ -1261,6 +1275,8 @@ void NodeDB::installDefaultModuleConfig()
 
     moduleConfig.has_neighbor_info = true;
     moduleConfig.neighbor_info.enabled = false;
+
+    installTrafficManagementDefaults(moduleConfig);
 
     moduleConfig.has_detection_sensor = true;
     moduleConfig.detection_sensor.enabled = false;
@@ -2224,6 +2240,16 @@ void NodeDB::loadFromDisk()
         } else {
             LOG_INFO("Loaded saved moduleConfig version %d", moduleConfig.version);
         }
+    }
+
+    // Always-on traffic management: a device that has NEVER configured TMM
+    // (has_traffic_management false — AdminModule always sets the has_ flag on
+    // write, even when disabling) gets the fork defaults. Explicitly configured
+    // devices keep their exact settings.
+    if (!moduleConfig.has_traffic_management) {
+        LOG_INFO("Traffic management never configured, installing always-on defaults");
+        installTrafficManagementDefaults(moduleConfig);
+        saveToDisk(SEGMENT_MODULECONFIG);
     }
 
     state = loadProto(channelFileName, meshtastic_ChannelFile_size, sizeof(meshtastic_ChannelFile), &meshtastic_ChannelFile_msg,

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -3570,6 +3570,8 @@ bool NodeDB::createNewIdentity()
     myNodeInfo.my_node_num = newNodeNum;
 
     meshtastic_NodeInfoLite *info = getOrCreateMeshNode(getNodeNum());
+    if (!info)
+        return false;
     TypeConversions::CopyUserToNodeInfoLite(info, owner);
 
     return true;

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -3323,6 +3323,73 @@ meshtastic_NodeInfoLite *NodeDB::getMeshNode(NodeNum n)
     return NULL;
 }
 
+ResolvedNode NodeDB::resolveLastByte(uint8_t lastByte, bool requireDirectNeighbor)
+{
+    ResolvedNode result; // defaults to {None, 0}
+
+    // 0 is the NO_RELAY_NODE / NO_NEXT_HOP_PREFERENCE sentinel (also what MQTT-sourced packets carry
+    // when hop_start==0). getLastByteOfNodeNum() never yields 0, so nothing can legitimately match.
+    if (lastByte == 0)
+        return result;
+
+    const NodeNum self = getNodeNum();
+    NodeNum firstMatch = 0;
+    uint8_t matches = 0;
+
+    for (size_t i = 0; i < numMeshNodes; i++) {
+        const meshtastic_NodeInfoLite *node = &meshNodes->at(i);
+
+        // Candidate gate: never resolve to ourselves, the sentinels, or an ignored node.
+        if (node->num == self || node->num == 0 || node->num == NODENUM_BROADCAST)
+            continue;
+        if (nodeInfoLiteIsIgnored(node))
+            continue;
+        if (getLastByteOfNodeNum(node->num) != lastByte) // cheapest discriminator last
+            continue;
+
+        // Relevance gate: is this node a plausible relay for the requested scope?
+        bool relevant;
+        if (requireDirectNeighbor) {
+            relevant = node->has_hops_away && node->hops_away == 0 && sinceLastSeen(node) < NEXTHOP_NEIGHBOR_FRESH_SECS;
+        } else {
+            const bool directNeighbor = node->has_hops_away && node->hops_away == 0;
+            const bool routerRole =
+                IS_ONE_OF(node->role, meshtastic_Config_DeviceConfig_Role_ROUTER, meshtastic_Config_DeviceConfig_Role_ROUTER_LATE,
+                          meshtastic_Config_DeviceConfig_Role_CLIENT_BASE);
+            relevant = directNeighbor || nodeInfoLiteIsFavorite(node) || routerRole;
+        }
+        if (!relevant)
+            continue;
+
+        if (++matches == 1) {
+            firstMatch = node->num;
+        } else {
+            // A second relevant candidate shares this byte: ambiguous. No further scanning can
+            // change that, so stop early and report the collision.
+            result.status = LastByteResolution::Ambiguous;
+            result.num = 0;
+            return result;
+        }
+    }
+
+    if (matches == 1) {
+        result.status = LastByteResolution::Unique;
+        result.num = firstMatch;
+    }
+    return result;
+}
+
+bool NodeDB::resolveUniqueLastByte(uint8_t lastByte, bool requireDirectNeighbor, NodeNum *outNum)
+{
+    ResolvedNode r = resolveLastByte(lastByte, requireDirectNeighbor);
+    if (r.status == LastByteResolution::Unique) {
+        if (outNum)
+            *outNum = r.num;
+        return true;
+    }
+    return false;
+}
+
 // returns true if the maximum number of nodes is reached or we are running low on memory
 bool NodeDB::isFull()
 {

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -115,6 +115,20 @@ uint32_t sinceLastSeen(const meshtastic_NodeInfoLite *n);
 /// Given a packet, return how many seconds in the past (vs now) it was received
 uint32_t sinceReceived(const meshtastic_MeshPacket *p);
 
+/// Outcome of mapping a single on-wire last-byte (next_hop / relay_node) back to a full NodeNum.
+/// Because the wire only carries the last byte of a 32-bit node number, the mapping is ambiguous on
+/// dense meshes (the "birthday problem"). Callers must treat Ambiguous and None as "don't trust it".
+enum class LastByteResolution : uint8_t {
+    None,      ///< no relevant candidate node has this last byte
+    Unique,    ///< exactly one relevant candidate -> `num` is valid
+    Ambiguous, ///< two or more relevant candidates collide on this byte
+};
+
+struct ResolvedNode {
+    LastByteResolution status = LastByteResolution::None;
+    NodeNum num = 0; ///< valid only when status == Unique
+};
+
 /// Given a packet, return the number of hops used to reach this node.
 /// Returns defaultIfUnknown if the number of hops couldn't be determined.
 int8_t getHopsAway(const meshtastic_MeshPacket &p, int8_t defaultIfUnknown = -1);
@@ -330,6 +344,23 @@ class NodeDB
     /// last_heard of a hot-store node, or 0 if absent. Plain scan of meshNodes
     /// with no allocation side effects (unlike getOrCreateMeshNode).
     uint32_t hotNodeLastHeard(NodeNum n) const;
+
+    /**
+     * Resolve a single on-wire last-byte (e.g. next_hop / relay_node) back to a unique full NodeNum,
+     * detecting last-byte collisions instead of silently picking the first match. A 1-byte id only
+     * needs to be unique among a node's plausible relays, not the whole mesh, so we scope the search:
+     *  - requireDirectNeighbor == true  : candidates are direct neighbors (hops_away==0) heard within
+     *                                     NEXTHOP_NEIGHBOR_FRESH_SECS. Use on the SEND path.
+     *  - requireDirectNeighbor == false : also accept favorites and router-role nodes (unknown hop
+     *                                     distance allowed). Use when learning / preserving hops.
+     * Ignored nodes, our own node, and the broadcast/0 sentinels are never candidates. On a tie the
+     * result is Ambiguous (no tie-break) so callers fall back to flooding rather than misroute.
+     */
+    ResolvedNode resolveLastByte(uint8_t lastByte, bool requireDirectNeighbor);
+
+    /// Convenience wrapper around resolveLastByte(): true iff exactly one relevant candidate matches.
+    /// Ambiguous and None both return false (the safe answer for learning / hop preservation).
+    bool resolveUniqueLastByte(uint8_t lastByte, bool requireDirectNeighbor, NodeNum *outNum = nullptr);
 
     // Thread-safe satellite-map accessors. Return false if absent or the
     // corresponding DB is compiled out.

--- a/src/mesh/PacketHistory.cpp
+++ b/src/mesh/PacketHistory.cpp
@@ -486,7 +486,11 @@ bool PacketHistory::wasRelayer(const uint8_t relayer, const uint32_t id, const N
 }
 
 /* Check if a certain node was a relayer of a packet in the history given iterator
- * @return true if node was indeed a relayer, false if not */
+ * @return true if node was indeed a relayer, false if not
+ * NOTE: intentionally byte-domain. Both `relayer` and relayed_by[] are on-wire last bytes, so this
+ * answers "did a relayer with this byte touch the packet" — correct without resolving to a NodeNum.
+ * The collision risk is neutralized where the result is consumed (route learning in
+ * NextHopRouter::sniffReceived now gates the write through NodeDB::resolveUniqueLastByte). */
 bool PacketHistory::wasRelayer(const uint8_t relayer, const PacketRecord &r, bool *wasSole)
 {
     bool found = false;

--- a/src/mesh/PositionPrecision.cpp
+++ b/src/mesh/PositionPrecision.cpp
@@ -28,8 +28,11 @@ uint32_t getPositionPrecisionForChannel(uint8_t channelIndex)
     return precision;
 }
 
-static int32_t truncateCoordinate(int32_t coordinate, uint32_t precision)
+int32_t truncateCoordinate(int32_t coordinate, uint32_t precision)
 {
+    if (precision == 0 || precision >= 32)
+        return coordinate;
+
     uint32_t coordinateBits = static_cast<uint32_t>(coordinate);
     uint32_t truncated = coordinateBits & (UINT32_MAX << (32 - precision));
 
@@ -37,6 +40,11 @@ static int32_t truncateCoordinate(int32_t coordinate, uint32_t precision)
     truncated += (1UL << (31 - precision));
 
     return static_cast<int32_t>(truncated);
+}
+
+int32_t truncateCoordinate(int32_t coordinate, uint8_t precision)
+{
+    return truncateCoordinate(coordinate, static_cast<uint32_t>(precision));
 }
 
 void applyPositionPrecision(meshtastic_Position &position, uint32_t precision)

--- a/src/mesh/PositionPrecision.h
+++ b/src/mesh/PositionPrecision.h
@@ -15,6 +15,12 @@ uint32_t getPositionPrecisionForChannel(const meshtastic_Channel &channel);
 
 // Configured precision, clamped to MAX_POSITION_PRECISION_PUBLIC_KEY when the channel's effective key is publicly decryptable.
 uint32_t getPositionPrecisionForChannel(uint8_t channelIndex);
+
+// Truncate a single latitude_i/longitude_i to `precision` significant bits, centered in the
+// resulting grid cell (stable under GPS jitter). precision 0 or >=32 returns the value unchanged.
+// The return is the coordinate (int32_t); the uint8_t overload only narrows the precision arg.
+int32_t truncateCoordinate(int32_t coordinate, uint32_t precision);
+int32_t truncateCoordinate(int32_t coordinate, uint8_t precision);
 void applyPositionPrecision(meshtastic_Position &position, uint32_t precision);
 bool applyPositionPrecision(meshtastic_MeshPacket &packet, uint32_t precision);
 bool applyPositionPrecisionForChannel(meshtastic_MeshPacket &packet, uint8_t channelIndex);

--- a/src/mesh/ReliableRouter.cpp
+++ b/src/mesh/ReliableRouter.cpp
@@ -151,6 +151,10 @@ void ReliableRouter::sniffReceived(const meshtastic_MeshPacket *p, const meshtas
             LOG_DEBUG("Received a %s for 0x%x, stopping retransmissions", ackId ? "ACK" : "NAK", ackId);
             if (ackId) {
                 stopRetransmission(p->to, ackId);
+                // M3: an end-to-end ACK proves the directed route to the ACK's sender currently works,
+                // so clear its failure count and refresh freshness (keeps a good route pinned).
+                if (!isBroadcast(getFrom(p)))
+                    noteRouteSuccess(getFrom(p), millis());
             } else {
                 stopRetransmission(p->to, nakId);
             }

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -114,37 +114,24 @@ bool Router::shouldDecrementHopLimit(const meshtastic_MeshPacket *p)
     }
 #endif
 
-    // For subsequent hops, check if previous relay is a favorite router
-    // Optimized search for favorite routers with matching last byte
-    // Check ordering optimized for IoT devices (cheapest checks first)
-    for (size_t i = 0; i < nodeDB->getNumMeshNodes(); i++) {
-        meshtastic_NodeInfoLite *node = nodeDB->getMeshNodeByIndex(i);
-        if (!node)
-            continue;
-
-        // Check 1: is_favorite (cheapest - single bit test)
-        if (!nodeInfoLiteIsFavorite(node))
-            continue;
-
-        // Check 2: has_user (cheap - single bit test)
-        if (!nodeInfoLiteHasUser(node))
-            continue;
-
-        // Check 3: role check (moderate cost - multiple comparisons)
-        if (!IS_ONE_OF(node->role, meshtastic_Config_DeviceConfig_Role_ROUTER, meshtastic_Config_DeviceConfig_Role_ROUTER_LATE,
-                       meshtastic_Config_DeviceConfig_Role_CLIENT_BASE)) {
-            continue;
-        }
-
-        // Check 4: last byte extraction and comparison (most expensive)
-        if (nodeDB->getLastByteOfNodeNum(node->num) == p->relay_node) {
-            // Found a favorite router match
-            LOG_DEBUG("Identified favorite relay router 0x%x from last byte 0x%x", node->num, p->relay_node);
+    // For subsequent hops, preserve hop_limit only when the previous relay is UNAMBIGUOUSLY a favorite
+    // router. The relay_node byte is just the last byte of a 32-bit node number, so on a dense mesh it
+    // collides; the old "first matching node wins" scan could preserve hops for the wrong node
+    // (non-deterministic, depends on NodeDB order). resolveLastByte() reports a collision instead, and
+    // we re-check the favorite/router predicate on the single resolved node. On ambiguity/none we
+    // decrement (the safe default).
+    NodeNum resolved = 0;
+    if (nodeDB->resolveUniqueLastByte(p->relay_node, /*requireDirectNeighbor=*/false, &resolved)) {
+        meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(resolved);
+        if (node && nodeInfoLiteIsFavorite(node) && nodeInfoLiteHasUser(node) &&
+            IS_ONE_OF(node->role, meshtastic_Config_DeviceConfig_Role_ROUTER, meshtastic_Config_DeviceConfig_Role_ROUTER_LATE,
+                      meshtastic_Config_DeviceConfig_Role_CLIENT_BASE)) {
+            LOG_DEBUG("Identified unique favorite relay router 0x%x from last byte 0x%x", resolved, p->relay_node);
             return false; // Don't decrement hop_limit
         }
     }
 
-    // No favorite router match found, decrement hop_limit
+    // No unambiguous favorite router match found, decrement hop_limit
     return true;
 }
 

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -122,7 +122,7 @@ bool Router::shouldDecrementHopLimit(const meshtastic_MeshPacket *p)
     // decrement (the safe default).
     NodeNum resolved = 0;
     if (nodeDB->resolveUniqueLastByte(p->relay_node, /*requireDirectNeighbor=*/false, &resolved)) {
-        meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(resolved);
+        const meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(resolved);
         if (node && nodeInfoLiteIsFavorite(node) && nodeInfoLiteHasUser(node) &&
             IS_ONE_OF(node->role, meshtastic_Config_DeviceConfig_Role_ROUTER, meshtastic_Config_DeviceConfig_Role_ROUTER_LATE,
                       meshtastic_Config_DeviceConfig_Role_CLIENT_BASE)) {

--- a/src/mesh/generated/meshtastic/deviceonly.pb.h
+++ b/src/mesh/generated/meshtastic/deviceonly.pb.h
@@ -452,7 +452,7 @@ extern const pb_msgdesc_t meshtastic_BackupPreferences_msg;
 /* Maximum encoded size of messages (where known) */
 /* meshtastic_NodeDatabase_size depends on runtime parameters */
 #define MESHTASTIC_MESHTASTIC_DEVICEONLY_PB_H_MAX_SIZE meshtastic_BackupPreferences_size
-#define meshtastic_BackupPreferences_size        2432
+#define meshtastic_BackupPreferences_size        2444
 #define meshtastic_ChannelFile_size              718
 #define meshtastic_DeviceState_size              1944
 #define meshtastic_NodeEnvironmentEntry_size     170

--- a/src/mesh/generated/meshtastic/localonly.pb.h
+++ b/src/mesh/generated/meshtastic/localonly.pb.h
@@ -206,7 +206,7 @@ extern const pb_msgdesc_t meshtastic_LocalModuleConfig_msg;
 /* Maximum encoded size of messages (where known) */
 #define MESHTASTIC_MESHTASTIC_LOCALONLY_PB_H_MAX_SIZE meshtastic_LocalModuleConfig_size
 #define meshtastic_LocalConfig_size              757
-#define meshtastic_LocalModuleConfig_size        820
+#define meshtastic_LocalModuleConfig_size        832
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/mesh/generated/meshtastic/module_config.pb.h
+++ b/src/mesh/generated/meshtastic/module_config.pb.h
@@ -260,6 +260,18 @@ typedef struct _meshtastic_ModuleConfig_TrafficManagementConfig {
     bool exhaust_hop_position;
     /* Preserve hop_limit for router-to-router traffic */
     bool router_preserve_hops;
+    /* Enable hop-trimming of relayed broadcasts to the local hop-scaling cap plus grace.
+ When enabled, packets relayed on public (or private with apply_to_private_channels)
+ channels have their hop_limit clamped so they travel no further than the local mesh
+ requires. Default true (disable by setting hop_trim_disabled = true). */
+    bool hop_trim_disabled;
+    /* Base extra-hop grace budget added on top of the local hop-scaling cap before
+ hop-trimming engages. Infra/specialty senders receive an additional +1.
+ 0 = use firmware default (2). */
+    uint32_t hop_trim_grace;
+    /* Extend position dedup, precision clamping, and hop-trimming to private
+ (non-well-known-key) channels. Default false (well-known public channels only). */
+    bool apply_to_private_channels;
 } meshtastic_ModuleConfig_TrafficManagementConfig;
 
 /* Serial Config */
@@ -588,7 +600,7 @@ extern "C" {
 #define meshtastic_ModuleConfig_DetectionSensorConfig_init_default {0, 0, 0, 0, "", 0, _meshtastic_ModuleConfig_DetectionSensorConfig_TriggerType_MIN, 0}
 #define meshtastic_ModuleConfig_AudioConfig_init_default {0, 0, _meshtastic_ModuleConfig_AudioConfig_Audio_Baud_MIN, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_PaxcounterConfig_init_default {0, 0, 0, 0}
-#define meshtastic_ModuleConfig_TrafficManagementConfig_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+#define meshtastic_ModuleConfig_TrafficManagementConfig_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_SerialConfig_init_default {0, 0, 0, 0, _meshtastic_ModuleConfig_SerialConfig_Serial_Baud_MIN, 0, _meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MIN, 0}
 #define meshtastic_ModuleConfig_ExternalNotificationConfig_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_StoreForwardConfig_init_default {0, 0, 0, 0, 0, 0}
@@ -607,7 +619,7 @@ extern "C" {
 #define meshtastic_ModuleConfig_DetectionSensorConfig_init_zero {0, 0, 0, 0, "", 0, _meshtastic_ModuleConfig_DetectionSensorConfig_TriggerType_MIN, 0}
 #define meshtastic_ModuleConfig_AudioConfig_init_zero {0, 0, _meshtastic_ModuleConfig_AudioConfig_Audio_Baud_MIN, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_PaxcounterConfig_init_zero {0, 0, 0, 0}
-#define meshtastic_ModuleConfig_TrafficManagementConfig_init_zero {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+#define meshtastic_ModuleConfig_TrafficManagementConfig_init_zero {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_SerialConfig_init_zero {0, 0, 0, 0, _meshtastic_ModuleConfig_SerialConfig_Serial_Baud_MIN, 0, _meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MIN, 0}
 #define meshtastic_ModuleConfig_ExternalNotificationConfig_init_zero {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_StoreForwardConfig_init_zero {0, 0, 0, 0, 0, 0}
@@ -670,6 +682,9 @@ extern "C" {
 #define meshtastic_ModuleConfig_TrafficManagementConfig_exhaust_hop_telemetry_tag 12
 #define meshtastic_ModuleConfig_TrafficManagementConfig_exhaust_hop_position_tag 13
 #define meshtastic_ModuleConfig_TrafficManagementConfig_router_preserve_hops_tag 14
+#define meshtastic_ModuleConfig_TrafficManagementConfig_hop_trim_disabled_tag 15
+#define meshtastic_ModuleConfig_TrafficManagementConfig_hop_trim_grace_tag 16
+#define meshtastic_ModuleConfig_TrafficManagementConfig_apply_to_private_channels_tag 17
 #define meshtastic_ModuleConfig_SerialConfig_enabled_tag 1
 #define meshtastic_ModuleConfig_SerialConfig_echo_tag 2
 #define meshtastic_ModuleConfig_SerialConfig_rxd_tag 3
@@ -880,7 +895,10 @@ X(a, STATIC,   SINGULAR, BOOL,     drop_unknown_enabled,  10) \
 X(a, STATIC,   SINGULAR, UINT32,   unknown_packet_threshold,  11) \
 X(a, STATIC,   SINGULAR, BOOL,     exhaust_hop_telemetry,  12) \
 X(a, STATIC,   SINGULAR, BOOL,     exhaust_hop_position,  13) \
-X(a, STATIC,   SINGULAR, BOOL,     router_preserve_hops,  14)
+X(a, STATIC,   SINGULAR, BOOL,     router_preserve_hops,  14) \
+X(a, STATIC,   SINGULAR, BOOL,     hop_trim_disabled,  15) \
+X(a, STATIC,   SINGULAR, UINT32,   hop_trim_grace,   16) \
+X(a, STATIC,   SINGULAR, BOOL,     apply_to_private_channels,  17)
 #define meshtastic_ModuleConfig_TrafficManagementConfig_CALLBACK NULL
 #define meshtastic_ModuleConfig_TrafficManagementConfig_DEFAULT NULL
 
@@ -1053,7 +1071,7 @@ extern const pb_msgdesc_t meshtastic_RemoteHardwarePin_msg;
 #define meshtastic_ModuleConfig_StoreForwardConfig_size 24
 #define meshtastic_ModuleConfig_TAKConfig_size   4
 #define meshtastic_ModuleConfig_TelemetryConfig_size 50
-#define meshtastic_ModuleConfig_TrafficManagementConfig_size 52
+#define meshtastic_ModuleConfig_TrafficManagementConfig_size 64
 #define meshtastic_ModuleConfig_size             227
 #define meshtastic_RemoteHardwarePin_size        21
 

--- a/src/mesh/mesh-pb-constants.h
+++ b/src/mesh/mesh-pb-constants.h
@@ -140,7 +140,7 @@ static inline int get_max_num_nodes()
 // Traffic Management module configuration
 // Enable per-variant by defining HAS_TRAFFIC_MANAGEMENT=1 in variant.h
 #ifndef HAS_TRAFFIC_MANAGEMENT
-#define HAS_TRAFFIC_MANAGEMENT 0
+#define HAS_TRAFFIC_MANAGEMENT 1
 #endif
 
 // HopScalingModule - variable hop module: dynamically adjusts broadcast hop_limit based on mesh density

--- a/src/mesh/mesh-pb-constants.h
+++ b/src/mesh/mesh-pb-constants.h
@@ -152,14 +152,20 @@ static inline int get_max_num_nodes()
 #define HAS_VARIABLE_HOPS 1
 #endif
 
-// Cache size for traffic management (number of nodes to track)
-// Can be overridden per-variant based on available memory
+// Cache size for traffic management (number of nodes to track).
+// Sized to match each platform's node-store tier; can be overridden per-variant.
 #ifndef TRAFFIC_MANAGEMENT_CACHE_SIZE
-#if HAS_TRAFFIC_MANAGEMENT
-#define TRAFFIC_MANAGEMENT_CACHE_SIZE 1000
-#else
+#if !HAS_TRAFFIC_MANAGEMENT
 #define TRAFFIC_MANAGEMENT_CACHE_SIZE 0
-#endif // HAS_TRAFFIC_MANAGEMENT
+#elif defined(ARCH_STM32WL)
+#define TRAFFIC_MANAGEMENT_CACHE_SIZE 0 // STM32WL is flash/RAM-constrained; TMM disabled
+#elif defined(NRF52840_XXAA)
+#define TRAFFIC_MANAGEMENT_CACHE_SIZE 200 // ~8 KB; matches WARM_NODE_COUNT; MAX_NUM_NODES=120
+#elif defined(CONFIG_IDF_TARGET_ESP32S3) || defined(ARCH_PORTDUINO)
+#define TRAFFIC_MANAGEMENT_CACHE_SIZE 2000 // PSRAM/host; matches WARM_NODE_COUNT
+#else
+#define TRAFFIC_MANAGEMENT_CACHE_SIZE 1000 // generic ESP32 and others
+#endif
 #endif // TRAFFIC_MANAGEMENT_CACHE_SIZE
 
 /// helper function for encoding a record as a protobuf, any failures to encode are fatal and we will panic

--- a/src/mesh/mesh-pb-constants.h
+++ b/src/mesh/mesh-pb-constants.h
@@ -138,7 +138,7 @@ static inline int get_max_num_nodes()
 #define MAX_NUM_CHANNELS (member_size(meshtastic_ChannelFile, channels) / member_size(meshtastic_ChannelFile, channels[0]))
 
 // Traffic Management module configuration
-// Enable per-variant by defining HAS_TRAFFIC_MANAGEMENT=1 in variant.h
+// Enabled by default on all platforms; disable per-variant by defining HAS_TRAFFIC_MANAGEMENT=0 in variant.h
 #ifndef HAS_TRAFFIC_MANAGEMENT
 #define HAS_TRAFFIC_MANAGEMENT 1
 #endif

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -481,6 +481,8 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
                     screen->setFrames(graphics::Screen::FOCUS_PRESERVE); // <-- Rebuild screens
             } else if (mp.from == 0) { // local request from the phone — tell the user why it didn't take
                 sendWarning(NodeDB::PROTECTED_CAP_WARN_FMT, "favorite", r->set_favorite_node, MAX_NUM_NODES - 2);
+            } else {
+                LOG_WARN("Remote set_favorite_node for 0x%x refused: protected-node cap", r->set_favorite_node);
             }
         }
         break;
@@ -508,6 +510,8 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
                 saveChanges(SEGMENT_NODEDATABASE, false);
             } else if (mp.from == 0) { // local request from the phone — tell the user why it didn't take
                 sendWarning(NodeDB::PROTECTED_CAP_WARN_FMT, "ignore", r->set_ignored_node, MAX_NUM_NODES - 2);
+            } else {
+                LOG_WARN("Remote set_ignored_node for 0x%x refused: protected-node cap", r->set_ignored_node);
             }
         }
         break;

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -432,6 +432,33 @@ void PositionModule::sendOurPosition(NodeNum dest, bool wantReplies, uint8_t cha
 
 #define RUNONCE_INTERVAL 5000;
 
+bool PositionModule::positionUnchangedSinceLastSend(const meshtastic_PositionLite &selfPos)
+{
+    if (lastGpsLatitude == 0 && lastGpsLongitude == 0)
+        return false; // no prior broadcast to compare against
+
+    // Precision is whichever broadcast channel sendOurPosition() would pick (first non-zero),
+    // clamped to the channel maximum -- the same resolution the on-wire position is truncated to.
+    uint32_t precisionBits = 0;
+    for (uint8_t ch = 0; ch < 8; ch++) {
+        precisionBits = getPositionPrecisionForChannel(ch);
+        if (precisionBits != 0)
+            break;
+    }
+    if (precisionBits == 0 || precisionBits >= 32)
+        return false; // sharing disabled or full precision: don't suppress
+
+    meshtastic_Position cur = meshtastic_Position_init_default;
+    cur.latitude_i = selfPos.latitude_i;
+    cur.longitude_i = selfPos.longitude_i;
+    meshtastic_Position prev = meshtastic_Position_init_default;
+    prev.latitude_i = lastGpsLatitude;
+    prev.longitude_i = lastGpsLongitude;
+    applyPositionPrecision(cur, precisionBits);
+    applyPositionPrecision(prev, precisionBits);
+    return cur.latitude_i == prev.latitude_i && cur.longitude_i == prev.longitude_i;
+}
+
 int32_t PositionModule::runOnce()
 {
     if (sleepOnNextExecution == true) {
@@ -458,7 +485,25 @@ int32_t PositionModule::runOnce()
 
     bool waitingForFreshPosition = (lastGpsSend == 0) && !config.position.fixed_position && !nodeDB->hasLocalPositionSinceBoot();
 
-    if (lastGpsSend == 0 || msSinceLastSend >= intervalMs) {
+    // Hold to the stationary floor when fixed_position is set (any role) or our position hasn't
+    // moved beyond the broadcast precision since the last send. A real move still goes out early
+    // via the smart-broadcast branch below; the floor only governs the keepalive cadence.
+    uint32_t effectiveIntervalMs = intervalMs;
+    {
+        bool stationary = config.position.fixed_position;
+        if (!stationary && nodeDB->hasValidPosition(node)) {
+            meshtastic_PositionLite selfPos;
+            if (nodeDB->copyNodePosition(node->num, selfPos))
+                stationary = positionUnchangedSinceLastSend(selfPos);
+        }
+        if (stationary) {
+            const uint32_t floorMs = (uint32_t)default_position_stationary_broadcast_secs * 1000UL;
+            if (floorMs > effectiveIntervalMs)
+                effectiveIntervalMs = floorMs;
+        }
+    }
+
+    if (lastGpsSend == 0 || msSinceLastSend >= effectiveIntervalMs) {
         if (waitingForFreshPosition) {
 #ifdef GPS_DEBUG
             LOG_DEBUG("Skip initial position send; no fresh position since boot");

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -448,15 +448,8 @@ bool PositionModule::positionUnchangedSinceLastSend(const meshtastic_PositionLit
     if (precisionBits == 0 || precisionBits >= 32)
         return false; // sharing disabled or full precision: don't suppress
 
-    meshtastic_Position cur = meshtastic_Position_init_default;
-    cur.latitude_i = selfPos.latitude_i;
-    cur.longitude_i = selfPos.longitude_i;
-    meshtastic_Position prev = meshtastic_Position_init_default;
-    prev.latitude_i = lastGpsLatitude;
-    prev.longitude_i = lastGpsLongitude;
-    applyPositionPrecision(cur, precisionBits);
-    applyPositionPrecision(prev, precisionBits);
-    return cur.latitude_i == prev.latitude_i && cur.longitude_i == prev.longitude_i;
+    return truncateCoordinate(selfPos.latitude_i, precisionBits) == truncateCoordinate(lastGpsLatitude, precisionBits) &&
+           truncateCoordinate(selfPos.longitude_i, precisionBits) == truncateCoordinate(lastGpsLongitude, precisionBits);
 }
 
 int32_t PositionModule::runOnce()

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -445,11 +445,24 @@ bool PositionModule::positionUnchangedSinceLastSend(const meshtastic_PositionLit
         if (precisionBits != 0)
             break;
     }
-    if (precisionBits == 0 || precisionBits >= 32)
-        return false; // sharing disabled or full precision: don't suppress
 
-    return truncateCoordinate(selfPos.latitude_i, precisionBits) == truncateCoordinate(lastGpsLatitude, precisionBits) &&
-           truncateCoordinate(selfPos.longitude_i, precisionBits) == truncateCoordinate(lastGpsLongitude, precisionBits);
+    return positionWithinPrecisionCell(selfPos.latitude_i, selfPos.longitude_i, lastGpsLatitude, lastGpsLongitude, precisionBits);
+}
+
+bool PositionModule::positionWithinPrecisionCell(int32_t aLat, int32_t aLon, int32_t bLat, int32_t bLon, uint32_t precision)
+{
+    if (precision == 0 || precision >= 32)
+        return false; // sharing disabled or full precision: no coarse cell to hold within
+
+    return truncateCoordinate(aLat, precision) == truncateCoordinate(bLat, precision) &&
+           truncateCoordinate(aLon, precision) == truncateCoordinate(bLon, precision);
+}
+
+uint32_t PositionModule::effectiveBroadcastIntervalMs(uint32_t configuredIntervalMs, bool stationary, uint32_t stationaryFloorMs)
+{
+    if (stationary && stationaryFloorMs > configuredIntervalMs)
+        return stationaryFloorMs;
+    return configuredIntervalMs;
 }
 
 int32_t PositionModule::runOnce()
@@ -481,20 +494,14 @@ int32_t PositionModule::runOnce()
     // Hold to the stationary floor when fixed_position is set (any role) or our position hasn't
     // moved beyond the broadcast precision since the last send. A real move still goes out early
     // via the smart-broadcast branch below; the floor only governs the keepalive cadence.
-    uint32_t effectiveIntervalMs = intervalMs;
-    {
-        bool stationary = config.position.fixed_position;
-        if (!stationary && nodeDB->hasValidPosition(node)) {
-            meshtastic_PositionLite selfPos;
-            if (nodeDB->copyNodePosition(node->num, selfPos))
-                stationary = positionUnchangedSinceLastSend(selfPos);
-        }
-        if (stationary) {
-            const uint32_t floorMs = (uint32_t)default_position_stationary_broadcast_secs * 1000UL;
-            if (floorMs > effectiveIntervalMs)
-                effectiveIntervalMs = floorMs;
-        }
+    bool stationary = config.position.fixed_position;
+    if (!stationary && nodeDB->hasValidPosition(node)) {
+        meshtastic_PositionLite selfPos;
+        if (nodeDB->copyNodePosition(node->num, selfPos))
+            stationary = positionUnchangedSinceLastSend(selfPos);
     }
+    uint32_t effectiveIntervalMs =
+        effectiveBroadcastIntervalMs(intervalMs, stationary, (uint32_t)default_position_stationary_broadcast_secs * 1000UL);
 
     if (lastGpsSend == 0 || msSinceLastSend >= effectiveIntervalMs) {
         if (waitingForFreshPosition) {

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -434,7 +434,7 @@ void PositionModule::sendOurPosition(NodeNum dest, bool wantReplies, uint8_t cha
 
 bool PositionModule::positionUnchangedSinceLastSend(const meshtastic_PositionLite &selfPos, bool useConfiguredPrecision)
 {
-    if (lastGpsLatitude == 0 && lastGpsLongitude == 0)
+    if (lastGpsSend == 0)
         return false; // no prior broadcast to compare against
 
     // Broadcast channel = the one sendOurPosition() would pick (first with non-zero on-wire

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -432,7 +432,7 @@ void PositionModule::sendOurPosition(NodeNum dest, bool wantReplies, uint8_t cha
 
 #define RUNONCE_INTERVAL 5000;
 
-bool PositionModule::positionUnchangedSinceLastSend(const meshtastic_PositionLite &selfPos)
+bool PositionModule::positionUnchangedSinceLastSend(const meshtastic_PositionLite &selfPos, bool useConfiguredPrecision)
 {
     if (lastGpsLatitude == 0 && lastGpsLongitude == 0)
         return false; // no prior broadcast to compare against
@@ -497,7 +497,7 @@ int32_t PositionModule::runOnce()
     // Hold to the 12h floor when fixed_position (every role: pinning yourself forfeits the
     // exception) or when stationary. A real move still goes out early via smart-broadcast below.
     // Not-fixed exceptions: lost-and-found broadcasts freely; trackers judge movement at their
-    // own (unclamped) precision rather than the on-wire one.
+    // own (unclamped) precision rather than the on-wire one (useConfiguredPrecision).
     const auto role = config.device.role;
     bool stationary = config.position.fixed_position;
     if (!stationary && role != meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND && nodeDB->hasValidPosition(node)) {

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -437,13 +437,16 @@ bool PositionModule::positionUnchangedSinceLastSend(const meshtastic_PositionLit
     if (lastGpsLatitude == 0 && lastGpsLongitude == 0)
         return false; // no prior broadcast to compare against
 
-    // Precision is whichever broadcast channel sendOurPosition() would pick (first non-zero),
-    // clamped to the channel maximum -- the same resolution the on-wire position is truncated to.
+    // Broadcast channel = the one sendOurPosition() would pick (first with non-zero on-wire
+    // precision). Default nodes gauge movement at that on-wire (public-clamped) resolution;
+    // trackers use their own configured (unclamped) precision so finer moves still count.
     uint32_t precisionBits = 0;
     for (uint8_t ch = 0; ch < 8; ch++) {
-        precisionBits = getPositionPrecisionForChannel(ch);
-        if (precisionBits != 0)
-            break;
+        if (getPositionPrecisionForChannel(ch) == 0)
+            continue;
+        precisionBits =
+            useConfiguredPrecision ? getPositionPrecisionForChannel(channels.getByIndex(ch)) : getPositionPrecisionForChannel(ch);
+        break;
     }
 
     return positionWithinPrecisionCell(selfPos.latitude_i, selfPos.longitude_i, lastGpsLatitude, lastGpsLongitude, precisionBits);
@@ -491,14 +494,18 @@ int32_t PositionModule::runOnce()
 
     bool waitingForFreshPosition = (lastGpsSend == 0) && !config.position.fixed_position && !nodeDB->hasLocalPositionSinceBoot();
 
-    // Hold to the stationary floor when fixed_position is set (any role) or our position hasn't
-    // moved beyond the broadcast precision since the last send. A real move still goes out early
-    // via the smart-broadcast branch below; the floor only governs the keepalive cadence.
+    // Hold to the 12h floor when fixed_position (every role: pinning yourself forfeits the
+    // exception) or when stationary. A real move still goes out early via smart-broadcast below.
+    // Not-fixed exceptions: lost-and-found broadcasts freely; trackers judge movement at their
+    // own (unclamped) precision rather than the on-wire one.
+    const auto role = config.device.role;
     bool stationary = config.position.fixed_position;
-    if (!stationary && nodeDB->hasValidPosition(node)) {
+    if (!stationary && role != meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND && nodeDB->hasValidPosition(node)) {
+        const bool isTracker =
+            IS_ONE_OF(role, meshtastic_Config_DeviceConfig_Role_TRACKER, meshtastic_Config_DeviceConfig_Role_TAK_TRACKER);
         meshtastic_PositionLite selfPos;
         if (nodeDB->copyNodePosition(node->num, selfPos))
-            stationary = positionUnchangedSinceLastSend(selfPos);
+            stationary = positionUnchangedSinceLastSend(selfPos, /*useConfiguredPrecision=*/isTracker);
     }
     uint32_t effectiveIntervalMs =
         effectiveBroadcastIntervalMs(intervalMs, stationary, (uint32_t)default_position_stationary_broadcast_secs * 1000UL);

--- a/src/modules/PositionModule.h
+++ b/src/modules/PositionModule.h
@@ -66,9 +66,11 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
     meshtastic_MeshPacket *allocPositionPacket();
     struct SmartPosition getDistanceTraveledSinceLastSend(meshtastic_PositionLite currentPosition);
     // True when our position is unchanged since the last broadcast: it truncates to the same
-    // precision grid cell on the broadcast channel, so re-sending would be a duplicate that
-    // traffic management dedups downstream anyway. Used to hold stationary broadcasts to a 12h floor.
-    bool positionUnchangedSinceLastSend(const meshtastic_PositionLite &selfPos);
+    // precision grid cell, so re-sending would be a duplicate that traffic management dedups
+    // downstream anyway. Used to hold stationary broadcasts to a 12h floor. useConfiguredPrecision
+    // gauges movement at our own configured (unclamped) precision rather than the on-wire
+    // (public-clamped) precision — trackers report finer movement.
+    bool positionUnchangedSinceLastSend(const meshtastic_PositionLite &selfPos, bool useConfiguredPrecision);
     meshtastic_MeshPacket *allocAtakPli();
     void trySetRtc(meshtastic_Position p, bool isLocal, bool forceUpdate = false);
     uint32_t precision;

--- a/src/modules/PositionModule.h
+++ b/src/modules/PositionModule.h
@@ -38,6 +38,14 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
 
     void handleNewPosition();
 
+    // Pure broadcast-policy helpers, split out so they're unit-testable without the module.
+    // True when two coordinates truncate to the same precision cell (so a re-broadcast would be a
+    // duplicate). precision 0 or >=32 returns false: no coarse cell to hold within, never suppress.
+    static bool positionWithinPrecisionCell(int32_t aLat, int32_t aLon, int32_t bLat, int32_t bLon, uint32_t precision);
+    // Effective min interval: stationary positions are held to stationaryFloorMs (when that is the
+    // longer of the two); otherwise the normal configured interval.
+    static uint32_t effectiveBroadcastIntervalMs(uint32_t configuredIntervalMs, bool stationary, uint32_t stationaryFloorMs);
+
   protected:
     /** Called to handle a particular incoming message
 

--- a/src/modules/PositionModule.h
+++ b/src/modules/PositionModule.h
@@ -57,6 +57,10 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
   private:
     meshtastic_MeshPacket *allocPositionPacket();
     struct SmartPosition getDistanceTraveledSinceLastSend(meshtastic_PositionLite currentPosition);
+    // True when our position is unchanged since the last broadcast: it truncates to the same
+    // precision grid cell on the broadcast channel, so re-sending would be a duplicate that
+    // traffic management dedups downstream anyway. Used to hold stationary broadcasts to a 12h floor.
+    bool positionUnchangedSinceLastSend(const meshtastic_PositionLite &selfPos);
     meshtastic_MeshPacket *allocAtakPli();
     void trySetRtc(meshtastic_Position p, bool isLocal, bool forceUpdate = false);
     uint32_t precision;

--- a/src/modules/TraceRouteModule.cpp
+++ b/src/modules/TraceRouteModule.cpp
@@ -8,6 +8,10 @@
 #include "meshUtils.h"
 #include <vector>
 
+#if HAS_TRAFFIC_MANAGEMENT
+#include "modules/TrafficManagementModule.h"
+#endif
+
 extern graphics::Screen *screen;
 
 TraceRouteModule *traceRouteModule;
@@ -323,6 +327,14 @@ void TraceRouteModule::maybeSetNextHop(NodeNum target, uint8_t nextHopByte)
         LOG_INFO("Updating next-hop for 0x%08x to 0x%02x based on traceroute", target, nextHopByte);
         node->next_hop = nextHopByte;
     }
+
+#if HAS_TRAFFIC_MANAGEMENT
+    // Mirror into the TMM overflow cache. Traceroute is the highest-confidence
+    // source (full known route), and this captures the target even when it isn't
+    // in the hot NodeDB — same rationale as the ACK-confirmed path in NextHopRouter.
+    if (trafficManagementModule)
+        trafficManagementModule->setNextHop(target, nextHopByte);
+#endif
 }
 
 void TraceRouteModule::processUpgradedPacket(const meshtastic_MeshPacket &mp)

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -565,7 +565,7 @@ void TrafficManagementModule::preloadNextHopsFromNodeDB()
     concurrency::LockGuard guard(&cacheLock);
     const size_t count = nodeDB->getNumMeshNodes();
     for (size_t i = 0; i < count; i++) {
-        meshtastic_NodeInfoLite *node = nodeDB->getMeshNodeByIndex(i);
+        const meshtastic_NodeInfoLite *node = nodeDB->getMeshNodeByIndex(i);
         if (!node || node->num == 0 || node->next_hop == 0)
             continue;
 

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -2,6 +2,7 @@
 
 #if HAS_TRAFFIC_MANAGEMENT
 
+#include "Channels.h"
 #include "Default.h"
 #include "MeshService.h"
 #include "NodeDB.h"
@@ -761,7 +762,8 @@ ProcessMessage TrafficManagementModule::handleReceived(const meshtastic_MeshPack
     // GPS jitter within the configured precision.
 
     if (!isFromUs(&mp) && !isToUs(&mp)) {
-        if (cfg.position_dedup_enabled && mp.decoded.portnum == meshtastic_PortNum_POSITION_APP) {
+        if (cfg.position_dedup_enabled && channels.isPublicChannel(mp.channel) &&
+            mp.decoded.portnum == meshtastic_PortNum_POSITION_APP) {
             meshtastic_Position pos = meshtastic_Position_init_zero;
             if (pb_decode_from_bytes(mp.decoded.payload.bytes, mp.decoded.payload.size, &meshtastic_Position_msg, &pos)) {
                 if (shouldDropPosition(&mp, &pos, nowMs)) {

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -28,7 +28,6 @@ namespace
 
 constexpr uint32_t kMaintenanceIntervalMs = 60 * 1000UL; // Cache cleanup interval
 constexpr uint32_t kUnknownResetMs = 60 * 1000UL;        // Unknown packet window
-constexpr uint8_t kMaxCuckooKicks = 16;                  // Max displacement chain length
 
 // NodeInfo direct response: enforced maximum hops by device role
 // Both use maxHops logic (respond when hopsAway <= threshold)
@@ -74,6 +73,21 @@ bool isWithinWindow(uint32_t nowMs, uint32_t startMs, uint32_t intervalMs)
     if (intervalMs == 0 || startMs == 0)
         return false;
     return (nowMs - startMs) < intervalMs;
+}
+
+/**
+ * Slide an 8-bit relative timestamp back by a wall-clock slab during epoch rebase.
+ *
+ * Entries older than the slab clamp to 0 (then reclaimed by the maintenance sweep);
+ * live entries keep their reconstructed age minus a sub-tick remainder. Each field
+ * slides by its own resolution's worth of ticks, so a single slab covers all three.
+ */
+inline void slideRelativeTime(uint8_t &ticks, uint32_t slabMs, uint16_t resolutionSecs)
+{
+    if (ticks == 0 || resolutionSecs == 0)
+        return;
+    uint32_t dec = slabMs / (static_cast<uint32_t>(resolutionSecs) * 1000UL);
+    ticks = (ticks > dec) ? static_cast<uint8_t>(ticks - dec) : 0;
 }
 
 /**
@@ -203,27 +217,16 @@ TrafficManagementModule::TrafficManagementModule() : MeshModule("TrafficManageme
 #endif // TRAFFIC_MANAGEMENT_CACHE_SIZE > 0
 
 #if defined(ARCH_ESP32) && defined(BOARD_HAS_PSRAM)
-    TM_LOG_INFO("Allocating NodeInfo cache: target=%u occupancy=%u%% payload=%u bytes (PSRAM) tags=%u bytes (%u-bit, %u slots, "
-                "%u buckets x %u)",
-                static_cast<unsigned>(nodeInfoTargetEntries()), static_cast<unsigned>(nodeInfoTargetOccupancyPercent()),
-                static_cast<unsigned>(nodeInfoTargetEntries() * sizeof(NodeInfoPayloadEntry)),
-                static_cast<unsigned>(nodeInfoIndexMetadataBudgetBytes()), static_cast<unsigned>(nodeInfoTagBits()),
-                static_cast<unsigned>(nodeInfoIndexSlots()), static_cast<unsigned>(nodeInfoBucketCount()),
-                static_cast<unsigned>(nodeInfoBucketSize()));
+    TM_LOG_INFO("Allocating NodeInfo cache: %u entries, %u bytes (PSRAM flat array)",
+                static_cast<unsigned>(nodeInfoTargetEntries()),
+                static_cast<unsigned>(nodeInfoTargetEntries() * sizeof(NodeInfoPayloadEntry)));
 
-    nodeInfoIndex = static_cast<uint8_t *>(calloc(nodeInfoIndexMetadataBudgetBytes(), sizeof(uint8_t)));
-    if (!nodeInfoIndex) {
-        TM_LOG_WARN("NodeInfo index allocation failed; direct responses will fall back to NodeDB");
+    nodeInfoPayload = static_cast<NodeInfoPayloadEntry *>(ps_calloc(nodeInfoTargetEntries(), sizeof(NodeInfoPayloadEntry)));
+    if (nodeInfoPayload) {
+        nodeInfoPayloadFromPsram = true;
+        TM_LOG_INFO("NodeInfo PSRAM cache ready");
     } else {
-        nodeInfoPayload = static_cast<NodeInfoPayloadEntry *>(ps_calloc(nodeInfoTargetEntries(), sizeof(NodeInfoPayloadEntry)));
-        if (nodeInfoPayload) {
-            nodeInfoPayloadFromPsram = true;
-            TM_LOG_INFO("NodeInfo bucketed cuckoo cache ready");
-        } else {
-            TM_LOG_WARN("NodeInfo PSRAM payload allocation failed; direct responses will fall back to NodeDB");
-            free(nodeInfoIndex);
-            nodeInfoIndex = nullptr;
-        }
+        TM_LOG_WARN("NodeInfo PSRAM payload allocation failed; direct responses will fall back to NodeDB");
     }
 #else
     TM_LOG_DEBUG("NodeInfo PSRAM cache not available on this target");
@@ -254,11 +257,6 @@ TrafficManagementModule::~TrafficManagementModule()
         else
             delete[] nodeInfoPayload;
         nodeInfoPayload = nullptr;
-    }
-
-    if (nodeInfoIndex) {
-        free(nodeInfoIndex);
-        nodeInfoIndex = nullptr;
     }
 }
 
@@ -292,17 +290,11 @@ void TrafficManagementModule::incrementStat(uint32_t *field)
 }
 
 // =============================================================================
-// Cuckoo Hash Table Operations
+// Flat Unified Cache Operations
 // =============================================================================
 
 /**
- * Find an existing entry for the given node.
- *
- * Cuckoo hashing guarantees that if an entry exists, it's in one of exactly
- * two locations: hash1(node) or hash2(node). This provides O(1) lookup.
- *
- * @param node NodeNum to search for
- * @return     Pointer to entry if found, nullptr otherwise
+ * Find an existing entry for the given node (linear scan).
  */
 TrafficManagementModule::UnifiedCacheEntry *TrafficManagementModule::findEntry(NodeNum node)
 {
@@ -313,35 +305,26 @@ TrafficManagementModule::UnifiedCacheEntry *TrafficManagementModule::findEntry(N
     if (!cache || node == 0)
         return nullptr;
 
-    // Check primary location
-    uint16_t h1 = cuckooHash1(node);
-    if (cache[h1].node == node)
-        return &cache[h1];
-
-    // Check alternate location
-    uint16_t h2 = cuckooHash2(node);
-    if (cache[h2].node == node)
-        return &cache[h2];
-
+    for (uint16_t i = 0; i < cacheSize(); i++) {
+        if (cache[i].node == node)
+            return &cache[i];
+    }
     return nullptr;
 #endif
 }
 
 /**
- * Find or create an entry for the given node using cuckoo hashing.
+ * Find or create an entry for the given node.
  *
- * If the node exists, returns the existing entry. Otherwise, attempts to
- * insert a new entry using cuckoo displacement:
- *
- * 1. Try to insert at h1(node) - if empty, done
- * 2. Try to insert at h2(node) - if empty, done
- * 3. Kick existing entry from h1 to its alternate location
- * 4. Repeat up to kMaxCuckooKicks times
- * 5. If cycle detected or max kicks exceeded, evict oldest entry
+ * One linear pass tracks the match, the first empty slot, and the eviction
+ * victim. When the cache is full, the victim is the stalest entry (largest
+ * of its three relative timestamps is smallest), preferring entries without
+ * a next_hop hint — those hints are the long-tail routing state the cache
+ * exists to keep, and the maintenance sweep never ages them out.
  *
  * @param node  NodeNum to find or create
  * @param isNew Set to true if a new entry was created
- * @return      Pointer to entry, or nullptr if allocation failed
+ * @return      Pointer to entry, or nullptr if the cache is unavailable
  */
 TrafficManagementModule::UnifiedCacheEntry *TrafficManagementModule::findOrCreateEntry(NodeNum node, bool *isNew)
 {
@@ -351,304 +334,76 @@ TrafficManagementModule::UnifiedCacheEntry *TrafficManagementModule::findOrCreat
         *isNew = false;
     return nullptr;
 #else
-    if (!cache || node == 0) {
-        if (isNew)
-            *isNew = false;
+    if (isNew)
+        *isNew = false;
+    if (!cache || node == 0)
         return nullptr;
-    }
 
-    // Check if entry already exists (O(1) lookup)
-    uint16_t h1 = cuckooHash1(node);
-    if (cache[h1].node == node) {
-        if (isNew)
-            *isNew = false;
-        return &cache[h1];
-    }
+    UnifiedCacheEntry *empty = nullptr;
+    UnifiedCacheEntry *victim = nullptr;
+    bool victimHasHop = true;
+    uint8_t victimRecency = UINT8_MAX;
 
-    uint16_t h2 = cuckooHash2(node);
-    if (cache[h2].node == node) {
-        if (isNew)
-            *isNew = false;
-        return &cache[h2];
-    }
-
-    // Entry doesn't exist - try to insert
-
-    // Prefer empty slot at h1
-    if (cache[h1].node == 0) {
-        memset(&cache[h1], 0, sizeof(UnifiedCacheEntry));
-        cache[h1].node = node;
-        if (isNew)
-            *isNew = true;
-        return &cache[h1];
-    }
-
-    // Try empty slot at h2
-    if (cache[h2].node == 0) {
-        memset(&cache[h2], 0, sizeof(UnifiedCacheEntry));
-        cache[h2].node = node;
-        if (isNew)
-            *isNew = true;
-        return &cache[h2];
-    }
-
-    // Both slots occupied - perform cuckoo displacement
-    // Start by kicking entry at h1 to its alternate location
-    UnifiedCacheEntry displaced = cache[h1];
-    memset(&cache[h1], 0, sizeof(UnifiedCacheEntry));
-    cache[h1].node = node;
-
-    for (uint8_t kicks = 0; kicks < kMaxCuckooKicks; kicks++) {
-        // Find alternate location for displaced entry
-        uint16_t altH1 = cuckooHash1(displaced.node);
-        uint16_t altH2 = cuckooHash2(displaced.node);
-        uint16_t altSlot = (altH1 == h1) ? altH2 : altH1;
-
-        if (cache[altSlot].node == 0) {
-            // Found empty slot - insert displaced entry
-            cache[altSlot] = displaced;
-            if (isNew)
-                *isNew = true;
-            return &cache[h1];
+    for (uint16_t i = 0; i < cacheSize(); i++) {
+        UnifiedCacheEntry &e = cache[i];
+        if (e.node == node)
+            return &e;
+        if (e.node == 0) {
+            if (!empty)
+                empty = &e;
+            continue;
         }
-
-        // Kick entry from alternate slot
-        UnifiedCacheEntry temp = cache[altSlot];
-        cache[altSlot] = displaced;
-        displaced = temp;
-        h1 = altSlot;
+        if (empty)
+            continue; // an empty slot beats any victim; stop scoring
+        const bool hasHop = e.next_hop != 0;
+        uint8_t recency = e.pos_time;
+        if (e.rate_time > recency)
+            recency = e.rate_time;
+        if (e.unknown_time > recency)
+            recency = e.unknown_time;
+        if (!victim || (hasHop == victimHasHop ? recency < victimRecency : !hasHop)) {
+            victim = &e;
+            victimHasHop = hasHop;
+            victimRecency = recency;
+        }
     }
 
-    // Cuckoo cycle detected or max kicks exceeded.
-    // The displaced entry has no valid cuckoo slot — drop it to preserve cache integrity.
-    // Placing it at an arbitrary slot would make it unreachable by findEntry().
-    TM_LOG_DEBUG("Cuckoo cycle, evicting node 0x%08x", displaced.node);
-
+    UnifiedCacheEntry *slot = empty ? empty : victim;
+    if (!slot)
+        return nullptr;
+    if (!empty)
+        TM_LOG_DEBUG("Unified cache full, evicting node 0x%08x", slot->node);
+    memset(slot, 0, sizeof(UnifiedCacheEntry));
+    slot->node = node;
     if (isNew)
         *isNew = true;
-    return &cache[cuckooHash1(node)];
+    return slot;
 #endif
 }
 
 const TrafficManagementModule::NodeInfoPayloadEntry *TrafficManagementModule::findNodeInfoEntry(NodeNum node) const
 {
 #if defined(ARCH_ESP32) && defined(BOARD_HAS_PSRAM)
-    if (!nodeInfoPayload || !nodeInfoIndex || node == 0)
+    if (!nodeInfoPayload || node == 0)
         return nullptr;
 
-    uint16_t payloadIndex = findNodeInfoPayloadIndex(node);
-    if (payloadIndex >= nodeInfoTargetEntries())
-        return nullptr;
-
-    return &nodeInfoPayload[payloadIndex];
+    for (uint16_t i = 0; i < nodeInfoTargetEntries(); i++) {
+        if (nodeInfoPayload[i].node == node)
+            return &nodeInfoPayload[i];
+    }
+    return nullptr;
 #else
     (void)node;
     return nullptr;
 #endif
 }
 
-uint16_t TrafficManagementModule::encodeNodeInfoTag(uint16_t payloadIndex) const
-{
-    if (payloadIndex >= nodeInfoTargetEntries())
-        return 0;
-    return static_cast<uint16_t>(payloadIndex + 1u);
-}
-
-uint16_t TrafficManagementModule::decodeNodeInfoPayloadIndex(uint16_t tag) const
-{
-    if (tag == 0 || tag > nodeInfoTargetEntries())
-        return UINT16_MAX;
-    return static_cast<uint16_t>(tag - 1u);
-}
-
-uint16_t TrafficManagementModule::getNodeInfoTag(uint16_t slot) const
-{
-#if defined(ARCH_ESP32) && defined(BOARD_HAS_PSRAM)
-    if (!nodeInfoIndex || slot >= nodeInfoIndexSlots())
-        return 0;
-
-    const uint32_t bitOffset = static_cast<uint32_t>(slot) * nodeInfoTagBits();
-    const uint16_t byteOffset = static_cast<uint16_t>(bitOffset >> 3);
-    const uint8_t shift = static_cast<uint8_t>(bitOffset & 7u);
-    uint32_t packed = 0;
-
-    if (byteOffset < nodeInfoIndexMetadataBudgetBytes())
-        packed |= static_cast<uint32_t>(nodeInfoIndex[byteOffset]);
-    if (static_cast<uint16_t>(byteOffset + 1u) < nodeInfoIndexMetadataBudgetBytes())
-        packed |= static_cast<uint32_t>(nodeInfoIndex[byteOffset + 1u]) << 8;
-    if (static_cast<uint16_t>(byteOffset + 2u) < nodeInfoIndexMetadataBudgetBytes())
-        packed |= static_cast<uint32_t>(nodeInfoIndex[byteOffset + 2u]) << 16;
-
-    return static_cast<uint16_t>((packed >> shift) & nodeInfoTagMask());
-#else
-    (void)slot;
-    return 0;
-#endif
-}
-
-void TrafficManagementModule::setNodeInfoTag(uint16_t slot, uint16_t tag)
-{
-#if defined(ARCH_ESP32) && defined(BOARD_HAS_PSRAM)
-    if (!nodeInfoIndex || slot >= nodeInfoIndexSlots())
-        return;
-
-    const uint16_t normalizedTag = static_cast<uint16_t>(tag & nodeInfoTagMask());
-    const uint32_t bitOffset = static_cast<uint32_t>(slot) * nodeInfoTagBits();
-    const uint16_t byteOffset = static_cast<uint16_t>(bitOffset >> 3);
-    const uint8_t shift = static_cast<uint8_t>(bitOffset & 7u);
-    uint32_t packed = 0;
-
-    if (byteOffset < nodeInfoIndexMetadataBudgetBytes())
-        packed |= static_cast<uint32_t>(nodeInfoIndex[byteOffset]);
-    if (static_cast<uint16_t>(byteOffset + 1u) < nodeInfoIndexMetadataBudgetBytes())
-        packed |= static_cast<uint32_t>(nodeInfoIndex[byteOffset + 1u]) << 8;
-    if (static_cast<uint16_t>(byteOffset + 2u) < nodeInfoIndexMetadataBudgetBytes())
-        packed |= static_cast<uint32_t>(nodeInfoIndex[byteOffset + 2u]) << 16;
-
-    const uint32_t mask = static_cast<uint32_t>(nodeInfoTagMask()) << shift;
-    packed = (packed & ~mask) | ((static_cast<uint32_t>(normalizedTag) << shift) & mask);
-
-    if (byteOffset < nodeInfoIndexMetadataBudgetBytes())
-        nodeInfoIndex[byteOffset] = static_cast<uint8_t>(packed & 0xFFu);
-    if (static_cast<uint16_t>(byteOffset + 1u) < nodeInfoIndexMetadataBudgetBytes())
-        nodeInfoIndex[byteOffset + 1u] = static_cast<uint8_t>((packed >> 8) & 0xFFu);
-    if (static_cast<uint16_t>(byteOffset + 2u) < nodeInfoIndexMetadataBudgetBytes())
-        nodeInfoIndex[byteOffset + 2u] = static_cast<uint8_t>((packed >> 16) & 0xFFu);
-#else
-    (void)slot;
-    (void)tag;
-#endif
-}
-
-uint16_t TrafficManagementModule::findNodeInfoPayloadIndex(NodeNum node) const
-{
-#if defined(ARCH_ESP32) && defined(BOARD_HAS_PSRAM)
-    if (!nodeInfoPayload || !nodeInfoIndex || node == 0)
-        return UINT16_MAX;
-
-    const uint16_t buckets[2] = {nodeInfoHash1(node), nodeInfoHash2(node)};
-
-    for (uint8_t b = 0; b < 2; b++) {
-        const uint16_t base = static_cast<uint16_t>(buckets[b] * nodeInfoBucketSize());
-        for (uint8_t slot = 0; slot < nodeInfoBucketSize(); slot++) {
-            uint16_t tag = getNodeInfoTag(static_cast<uint16_t>(base + slot));
-            if (tag == 0)
-                continue;
-
-            uint16_t payloadIndex = decodeNodeInfoPayloadIndex(tag);
-            if (payloadIndex >= nodeInfoTargetEntries())
-                continue;
-
-            if (nodeInfoPayload[payloadIndex].node == node)
-                return payloadIndex;
-        }
-    }
-
-    return UINT16_MAX;
-#else
-    (void)node;
-    return UINT16_MAX;
-#endif
-}
-
-bool TrafficManagementModule::removeNodeInfoIndexEntry(NodeNum node, uint16_t payloadIndex)
-{
-#if defined(ARCH_ESP32) && defined(BOARD_HAS_PSRAM)
-    if (!nodeInfoIndex || node == 0 || payloadIndex >= nodeInfoTargetEntries())
-        return false;
-
-    const uint16_t payloadTag = encodeNodeInfoTag(payloadIndex);
-    if (payloadTag == 0)
-        return false;
-    const uint16_t buckets[2] = {nodeInfoHash1(node), nodeInfoHash2(node)};
-
-    for (uint8_t b = 0; b < 2; b++) {
-        const uint16_t base = static_cast<uint16_t>(buckets[b] * nodeInfoBucketSize());
-        for (uint8_t slot = 0; slot < nodeInfoBucketSize(); slot++) {
-            const uint16_t indexSlot = static_cast<uint16_t>(base + slot);
-            if (getNodeInfoTag(indexSlot) == payloadTag) {
-                setNodeInfoTag(indexSlot, 0);
-                return true;
-            }
-        }
-    }
-
-    return false;
-#else
-    (void)node;
-    (void)payloadIndex;
-    return false;
-#endif
-}
-
-uint16_t TrafficManagementModule::allocateNodeInfoPayloadSlot()
-{
-#if defined(ARCH_ESP32) && defined(BOARD_HAS_PSRAM)
-    if (!nodeInfoPayload)
-        return UINT16_MAX;
-
-    for (uint16_t tries = 0; tries < nodeInfoTargetEntries(); tries++) {
-        uint16_t idx = static_cast<uint16_t>((nodeInfoAllocHint + tries) % nodeInfoTargetEntries());
-        if (nodeInfoPayload[idx].node == 0) {
-            nodeInfoAllocHint = static_cast<uint16_t>((idx + 1u) % nodeInfoTargetEntries());
-            return idx;
-        }
-    }
-#endif
-    return UINT16_MAX;
-}
-
-uint16_t TrafficManagementModule::evictNodeInfoPayloadSlot()
-{
-#if defined(ARCH_ESP32) && defined(BOARD_HAS_PSRAM)
-    if (!nodeInfoPayload || !nodeInfoIndex)
-        return UINT16_MAX;
-
-    for (uint16_t tries = 0; tries < nodeInfoTargetEntries(); tries++) {
-        uint16_t idx = static_cast<uint16_t>(nodeInfoEvictCursor % nodeInfoTargetEntries());
-        nodeInfoEvictCursor = static_cast<uint16_t>((nodeInfoEvictCursor + 1u) % nodeInfoTargetEntries());
-
-        NodeNum oldNode = nodeInfoPayload[idx].node;
-        if (oldNode == 0)
-            continue;
-
-        removeNodeInfoIndexEntry(oldNode, idx); // best effort; cache tolerates occasional stale miss
-        nodeInfoPayload[idx].node = 0;
-        return idx;
-    }
-#endif
-    return UINT16_MAX;
-}
-
-bool TrafficManagementModule::tryInsertNodeInfoEntryInBucket(uint16_t bucket, uint16_t tag)
-{
-#if defined(ARCH_ESP32) && defined(BOARD_HAS_PSRAM)
-    if (!nodeInfoIndex || !nodeInfoPayload || bucket >= nodeInfoBucketCount() || tag == 0)
-        return false;
-
-    const uint16_t base = static_cast<uint16_t>(bucket * nodeInfoBucketSize());
-    for (uint8_t slot = 0; slot < nodeInfoBucketSize(); slot++) {
-        const uint16_t indexSlot = static_cast<uint16_t>(base + slot);
-        const uint16_t existingTag = getNodeInfoTag(indexSlot);
-        if (existingTag == 0) {
-            setNodeInfoTag(indexSlot, tag);
-            return true;
-        }
-
-        // Opportunistically reuse stale tags that point at empty/invalid payload slots.
-        const uint16_t payloadIndex = decodeNodeInfoPayloadIndex(existingTag);
-        if (payloadIndex >= nodeInfoTargetEntries() || nodeInfoPayload[payloadIndex].node == 0) {
-            setNodeInfoTag(indexSlot, tag);
-            return true;
-        }
-    }
-#else
-    (void)bucket;
-    (void)tag;
-#endif
-    return false;
-}
-
+/**
+ * Find or create a NodeInfo payload entry (linear scan of the flat PSRAM
+ * array). One pass tracks the match, the first empty slot, and the LRU
+ * victim by lastObservedMs (wrap-safe age). NodeInfo traffic is low-rate,
+ * so the O(n) scan is negligible.
+ */
 TrafficManagementModule::NodeInfoPayloadEntry *TrafficManagementModule::findOrCreateNodeInfoEntry(NodeNum node,
                                                                                                   bool *usedEmptySlot)
 {
@@ -656,88 +411,40 @@ TrafficManagementModule::NodeInfoPayloadEntry *TrafficManagementModule::findOrCr
         *usedEmptySlot = false;
 
 #if defined(ARCH_ESP32) && defined(BOARD_HAS_PSRAM)
-    if (!nodeInfoPayload || !nodeInfoIndex || node == 0)
+    if (!nodeInfoPayload || node == 0)
         return nullptr;
 
-    uint16_t existing = findNodeInfoPayloadIndex(node);
-    if (existing < nodeInfoTargetEntries())
-        return &nodeInfoPayload[existing];
+    NodeInfoPayloadEntry *empty = nullptr;
+    NodeInfoPayloadEntry *lru = nullptr;
+    uint32_t lruAge = 0;
+    const uint32_t now = millis();
 
-    const uint16_t beforeCount = countNodeInfoEntriesLocked();
-
-    uint16_t payloadIndex = allocateNodeInfoPayloadSlot();
-    if (payloadIndex == UINT16_MAX) {
-        payloadIndex = evictNodeInfoPayloadSlot();
-        if (payloadIndex == UINT16_MAX)
-            return nullptr;
-    }
-
-    nodeInfoPayload[payloadIndex].node = node;
-
-    // 4-way bucketed cuckoo insertion mirrors Cuckoo Filter practice from
-    // Fan et al. (CoNEXT 2014): high occupancy with short relocation chains.
-    uint16_t pending = encodeNodeInfoTag(payloadIndex);
-    uint16_t h1 = nodeInfoHash1(node);
-    uint16_t h2 = nodeInfoHash2(node);
-
-    if (!tryInsertNodeInfoEntryInBucket(h1, pending) && !tryInsertNodeInfoEntryInBucket(h2, pending)) {
-        uint16_t currentBucket = h1;
-        for (uint8_t kicks = 0; kicks < kMaxCuckooKicks; kicks++) {
-            const uint16_t base = static_cast<uint16_t>(currentBucket * nodeInfoBucketSize());
-            const uint16_t kickSlot = static_cast<uint16_t>((node + kicks) & (nodeInfoBucketSize() - 1u));
-            const uint16_t pos = static_cast<uint16_t>(base + kickSlot);
-
-            uint16_t displaced = getNodeInfoTag(pos);
-            setNodeInfoTag(pos, pending);
-            pending = displaced;
-
-            uint16_t displacedPayload = decodeNodeInfoPayloadIndex(pending);
-            if (displacedPayload >= nodeInfoTargetEntries()) {
-                pending = 0;
-                break;
-            }
-
-            NodeNum displacedNode = nodeInfoPayload[displacedPayload].node;
-            if (displacedNode == 0) {
-                pending = 0;
-                break;
-            }
-
-            uint16_t altH1 = nodeInfoHash1(displacedNode);
-            uint16_t altH2 = nodeInfoHash2(displacedNode);
-            uint16_t altBucket = (altH1 == currentBucket) ? altH2 : altH1;
-
-            if (tryInsertNodeInfoEntryInBucket(altBucket, pending)) {
-                pending = 0;
-                break;
-            }
-
-            currentBucket = altBucket;
+    for (uint16_t i = 0; i < nodeInfoTargetEntries(); i++) {
+        NodeInfoPayloadEntry &e = nodeInfoPayload[i];
+        if (e.node == node)
+            return &e;
+        if (e.node == 0) {
+            if (!empty)
+                empty = &e;
+            continue;
         }
-
-        if (pending != 0) {
-            uint16_t droppedPayload = decodeNodeInfoPayloadIndex(pending);
-            if (droppedPayload < nodeInfoTargetEntries())
-                nodeInfoPayload[droppedPayload].node = 0;
-            TM_LOG_DEBUG("NodeInfo bucketed cuckoo overflow, dropped payload idx=%u",
-                         static_cast<unsigned>(droppedPayload < nodeInfoTargetEntries() ? droppedPayload : UINT16_MAX));
+        if (empty)
+            continue;                                // an empty slot beats any victim; stop scoring
+        const uint32_t age = now - e.lastObservedMs; // unsigned subtraction is wrap-safe
+        if (!lru || age > lruAge) {
+            lru = &e;
+            lruAge = age;
         }
     }
 
-    uint16_t finalIndex = findNodeInfoPayloadIndex(node);
-    if (finalIndex >= nodeInfoTargetEntries()) {
-        // New entry did not survive insertion chain.
-        if (payloadIndex < nodeInfoTargetEntries() && nodeInfoPayload[payloadIndex].node == node)
-            nodeInfoPayload[payloadIndex].node = 0;
+    NodeInfoPayloadEntry *slot = empty ? empty : lru;
+    if (!slot)
         return nullptr;
-    }
-
-    if (usedEmptySlot) {
-        const uint16_t afterCount = countNodeInfoEntriesLocked();
-        *usedEmptySlot = afterCount > beforeCount;
-    }
-
-    return &nodeInfoPayload[finalIndex];
+    memset(slot, 0, sizeof(NodeInfoPayloadEntry));
+    slot->node = node;
+    if (usedEmptySlot)
+        *usedEmptySlot = (slot == empty);
+    return slot;
 #else
     (void)node;
     return nullptr;
@@ -747,12 +454,12 @@ TrafficManagementModule::NodeInfoPayloadEntry *TrafficManagementModule::findOrCr
 uint16_t TrafficManagementModule::countNodeInfoEntriesLocked() const
 {
 #if defined(ARCH_ESP32) && defined(BOARD_HAS_PSRAM)
-    if (!nodeInfoIndex)
+    if (!nodeInfoPayload)
         return 0;
 
     uint16_t count = 0;
-    for (uint16_t i = 0; i < nodeInfoIndexSlots(); i++) {
-        if (getNodeInfoTag(i) != 0)
+    for (uint16_t i = 0; i < nodeInfoTargetEntries(); i++) {
+        if (nodeInfoPayload[i].node != 0)
             count++;
     }
     return count;
@@ -764,7 +471,7 @@ uint16_t TrafficManagementModule::countNodeInfoEntriesLocked() const
 void TrafficManagementModule::cacheNodeInfoPacket(const meshtastic_MeshPacket &mp)
 {
 #if defined(ARCH_ESP32) && defined(BOARD_HAS_PSRAM)
-    if (!nodeInfoPayload || !nodeInfoIndex || mp.decoded.payload.size == 0)
+    if (!nodeInfoPayload || mp.decoded.payload.size == 0)
         return;
 
     meshtastic_User user = meshtastic_User_init_zero;
@@ -797,13 +504,81 @@ void TrafficManagementModule::cacheNodeInfoPacket(const meshtastic_MeshPacket &m
     }
 
     if (usedEmptySlot) {
-        TM_LOG_INFO("NodeInfo PSRAM cache entries: %u/%u target (%u packed slots, %u-bit tags, %u-byte DRAM index)",
-                    static_cast<unsigned>(cachedCount), static_cast<unsigned>(nodeInfoTargetEntries()),
-                    static_cast<unsigned>(nodeInfoIndexSlots()), static_cast<unsigned>(nodeInfoTagBits()),
-                    static_cast<unsigned>(nodeInfoIndexMetadataBudgetBytes()));
+        TM_LOG_INFO("NodeInfo PSRAM cache entries: %u/%u", static_cast<unsigned>(cachedCount),
+                    static_cast<unsigned>(nodeInfoTargetEntries()));
     }
 #else
     (void)mp;
+#endif
+}
+
+// =============================================================================
+// Next-Hop Overflow Cache
+// =============================================================================
+//
+// A routing hint store. The byte is the last byte of the NodeNum to use as next
+// hop to reach `dest`. It is written ONLY from NextHopRouter's ACK-confirmed
+// decision (a bidirectionally-verified relay) — never inferred one-way from
+// relayed traffic. The TMM cache holds confirmed next-hops that have aged out of
+// the hot NodeDB (NodeInfoLite), and NextHopRouter::getNextHop() consults it as a
+// fallback after the hot store.
+
+void TrafficManagementModule::setNextHop(NodeNum dest, uint8_t nextHopByte)
+{
+#if TRAFFIC_MANAGEMENT_CACHE_SIZE > 0
+    if (!cache || dest == 0 || nextHopByte == 0)
+        return;
+
+    concurrency::LockGuard guard(&cacheLock);
+    bool isNew = false;
+    UnifiedCacheEntry *entry = findOrCreateEntry(dest, &isNew);
+    if (entry)
+        entry->next_hop = nextHopByte; // last-write-wins; only confirmed bytes reach here
+#else
+    (void)dest;
+    (void)nextHopByte;
+#endif
+}
+
+uint8_t TrafficManagementModule::getNextHopHint(NodeNum dest)
+{
+#if TRAFFIC_MANAGEMENT_CACHE_SIZE > 0
+    if (!cache || dest == 0)
+        return 0;
+
+    concurrency::LockGuard guard(&cacheLock);
+    UnifiedCacheEntry *entry = findEntry(dest);
+    return entry ? entry->next_hop : 0;
+#else
+    (void)dest;
+    return 0;
+#endif
+}
+
+void TrafficManagementModule::preloadNextHopsFromNodeDB()
+{
+#if TRAFFIC_MANAGEMENT_CACHE_SIZE > 0
+    if (!cache || !nodeDB)
+        return;
+
+    uint16_t seeded = 0;
+    concurrency::LockGuard guard(&cacheLock);
+    const size_t count = nodeDB->getNumMeshNodes();
+    for (size_t i = 0; i < count; i++) {
+        meshtastic_NodeInfoLite *node = nodeDB->getMeshNodeByIndex(i);
+        if (!node || node->num == 0 || node->next_hop == 0)
+            continue;
+
+        bool isNew = false;
+        UnifiedCacheEntry *entry = findOrCreateEntry(node->num, &isNew);
+        // Don't clobber a freshly-learned confirmed hop with a (possibly stale) persisted one.
+        if (entry && entry->next_hop == 0) {
+            entry->next_hop = node->next_hop;
+            seeded++;
+        }
+    }
+
+    TM_LOG_INFO("Preloaded %u next-hop hints from NodeDB", static_cast<unsigned>(seeded));
 #endif
 }
 
@@ -825,6 +600,43 @@ void TrafficManagementModule::resetEpoch(uint32_t nowMs)
 
     // Full flush avoids stale dedup identity/counters surviving epoch rollover.
     memset(cache, 0, static_cast<size_t>(cacheSize()) * sizeof(UnifiedCacheEntry));
+#else
+    (void)nowMs;
+#endif
+}
+
+/**
+ * Sliding-epoch rebase — preserve cached state past the 8-bit timestamp horizon.
+ *
+ * Instead of flushing the whole cache when offsets approach overflow, advance the
+ * epoch by a fixed slab and shift every live entry's relative timestamps back by
+ * the same wall-clock amount. A valid entry's window is only a handful of ticks
+ * wide (TTL auto-scales with resolution), so live entries comfortably survive;
+ * already-expired entries clamp to 0 and are reclaimed by the maintenance sweep in
+ * the same locked pass. Reconstructed absolute time is preserved (minus a sub-tick
+ * remainder), so in-flight TTL checks remain correct across the rebase.
+ *
+ * Caller must hold cacheLock.
+ */
+void TrafficManagementModule::rebaseEpoch(uint32_t nowMs)
+{
+#if TRAFFIC_MANAGEMENT_CACHE_SIZE > 0
+    (void)nowMs;
+
+    // Slab stays well below the 200-tick reset threshold so a single rebase drops
+    // the offset back into range (~200 -> ~72 ticks) while live entries survive.
+    const uint32_t slabMs = 128UL * maxResolution() * 1000UL;
+    cacheEpochMs += slabMs;
+
+    TM_LOG_DEBUG("Rebasing cache epoch by %lus", static_cast<unsigned long>(slabMs / 1000UL));
+
+    for (uint16_t i = 0; i < cacheSize(); i++) {
+        if (cache[i].node == 0)
+            continue;
+        slideRelativeTime(cache[i].pos_time, slabMs, posTimeResolution);
+        slideRelativeTime(cache[i].rate_time, slabMs, rateTimeResolution);
+        slideRelativeTime(cache[i].unknown_time, slabMs, unknownTimeResolution);
+    }
 #else
     (void)nowMs;
 #endif
@@ -1042,11 +854,12 @@ int32_t TrafficManagementModule::runOnce()
 #if TRAFFIC_MANAGEMENT_CACHE_SIZE > 0
     const uint32_t nowMs = millis();
 
-    // Check if epoch reset needed (~3.5 hours approaching 8-bit minute overflow)
-    if (needsEpochReset(nowMs)) {
-        concurrency::LockGuard guard(&cacheLock);
-        resetEpoch(nowMs);
-        return kMaintenanceIntervalMs;
+    // Warm-start the next-hop cache from persisted NodeInfoLite hints once nodeDB
+    // is populated. Done here (not in the constructor) so nodeDB has finished
+    // loading. Takes its own lock, so call before acquiring the sweep guard below.
+    if (!nextHopPreloaded) {
+        preloadNextHopsFromNodeDB();
+        nextHopPreloaded = true;
     }
 
     // Calculate TTLs for cache expiration
@@ -1065,6 +878,13 @@ int32_t TrafficManagementModule::runOnce()
     const uint32_t sweepStartMs = millis();
 
     concurrency::LockGuard guard(&cacheLock);
+
+    // Slide the epoch instead of flushing when offsets approach 8-bit overflow.
+    // Rebase preserves live entries; only already-expired ones clamp to 0 and are
+    // reclaimed by the sweep below in this same locked pass.
+    if (needsEpochReset(nowMs))
+        rebaseEpoch(nowMs);
+
     for (uint16_t i = 0; i < cacheSize(); i++) {
         if (cache[i].node == 0)
             continue;
@@ -1104,6 +924,11 @@ int32_t TrafficManagementModule::runOnce()
             }
         }
 
+        // A confirmed next-hop hint has no TTL of its own and keeps the slot alive,
+        // so an aged-out routing hint outlives the dedup/rate/unknown state.
+        if (cache[i].next_hop != 0)
+            anyValid = true;
+
         // If all data expired, free the slot entirely
         if (!anyValid) {
             memset(&cache[i], 0, sizeof(UnifiedCacheEntry));
@@ -1118,11 +943,9 @@ int32_t TrafficManagementModule::runOnce()
                  static_cast<unsigned long>(millis() - sweepStartMs));
 
 #if defined(ARCH_ESP32) && defined(BOARD_HAS_PSRAM)
-    if (nodeInfoPayload && nodeInfoIndex) {
-        TM_LOG_DEBUG("NodeInfo PSRAM cache: %u/%u target (%u packed slots, %u buckets, %u-bit tags, %u-byte index)",
-                     static_cast<unsigned>(countNodeInfoEntriesLocked()), static_cast<unsigned>(nodeInfoTargetEntries()),
-                     static_cast<unsigned>(nodeInfoIndexSlots()), static_cast<unsigned>(nodeInfoBucketCount()),
-                     static_cast<unsigned>(nodeInfoTagBits()), static_cast<unsigned>(nodeInfoIndexMetadataBudgetBytes()));
+    if (nodeInfoPayload) {
+        TM_LOG_DEBUG("NodeInfo PSRAM cache: %u/%u", static_cast<unsigned>(countNodeInfoEntriesLocked()),
+                     static_cast<unsigned>(nodeInfoTargetEntries()));
     }
 #endif
 
@@ -1153,8 +976,11 @@ bool TrafficManagementModule::shouldDropPosition(const meshtastic_MeshPacket *p,
     const int32_t lat_truncated = truncateLatLon(pos->latitude_i, precision);
     const int32_t lon_truncated = truncateLatLon(pos->longitude_i, precision);
     const uint8_t fingerprint = computePositionFingerprint(lat_truncated, lon_truncated, precision);
-    const uint32_t minIntervalMs = secsToMs(Default::getConfiguredOrDefault(
-        moduleConfig.traffic_management.position_min_interval_secs, default_traffic_mgmt_position_min_interval_secs));
+    // Drop gate uses the RAW configured interval: 0 means "dedup disabled" (the
+    // contract documented below). The 12h default is only for resolution/TTL
+    // sizing (constructor / runOnce), not for deciding whether to drop — feeding
+    // the default here would silently turn the 0-disables-dedup contract off.
+    const uint32_t minIntervalMs = secsToMs(moduleConfig.traffic_management.position_min_interval_secs);
 
     bool isNew = false;
     concurrency::LockGuard guard(&cacheLock);
@@ -1218,7 +1044,7 @@ bool TrafficManagementModule::shouldRespondToNodeInfo(const meshtastic_MeshPacke
         // If the PSRAM cache exists but misses, we intentionally do not fall back
         // to the node-wide table. This keeps the PSRAM direct-reply path separate
         // from NodeInfoModule/NodeDB behavior when PSRAM is available.
-        if (nodeInfoPayload && nodeInfoIndex) {
+        if (nodeInfoPayload) {
             TM_LOG_DEBUG("NodeInfo PSRAM cache miss for node=0x%08x", p->to);
             return false;
         }
@@ -1378,7 +1204,9 @@ bool TrafficManagementModule::shouldDropUnknown(const meshtastic_MeshPacket *p, 
         entry->unknown_count = 0;
     }
 
-    // Increment counter (saturates at 255)
+    // Increment counter (saturates at 255). Same saturation handling as
+    // isRateLimited: without it, a clamped threshold of 255 can never fire.
+    const bool alreadySaturated = (entry->unknown_count == UINT8_MAX);
     saturatingIncrement(entry->unknown_count);
 
     // Check against threshold
@@ -1386,7 +1214,7 @@ bool TrafficManagementModule::shouldDropUnknown(const meshtastic_MeshPacket *p, 
     if (threshold > 255)
         threshold = 255;
 
-    bool drop = entry->unknown_count > threshold;
+    bool drop = entry->unknown_count > threshold || (alreadySaturated && threshold == 255);
     if (drop || entry->unknown_count == threshold) {
         TM_LOG_DEBUG("Unknown packets 0x%08x: count=%u threshold=%u -> %s", p->from, entry->unknown_count, threshold,
                      drop ? "DROP" : "at-limit");

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -6,6 +6,7 @@
 #include "Default.h"
 #include "MeshService.h"
 #include "NodeDB.h"
+#include "PositionPrecision.h"
 #include "Router.h"
 #include "TypeConversions.h"
 #include "airtime.h"
@@ -14,6 +15,7 @@
 #include "mesh-pb-constants.h"
 #include "meshUtils.h"
 #include <Arduino.h>
+#include <algorithm>
 #include <cstring>
 
 #define TM_LOG_DEBUG(fmt, ...) LOG_DEBUG("[TM] " fmt, ##__VA_ARGS__)
@@ -28,7 +30,6 @@ namespace
 {
 
 constexpr uint32_t kMaintenanceIntervalMs = 60 * 1000UL; // Cache cleanup interval
-constexpr uint32_t kUnknownResetMs = 60 * 1000UL;        // Unknown packet window
 
 // NodeInfo direct response: enforced maximum hops by device role
 // Both use maxHops logic (respond when hopsAway <= threshold)
@@ -63,32 +64,6 @@ uint8_t sanitizePositionPrecision(uint8_t precision)
 
     // Someone done messed up if we reach here
     return 32;
-}
-
-/**
- * Check if a timestamp is within a time window.
- * Handles wrap-around correctly using unsigned subtraction.
- */
-bool isWithinWindow(uint32_t nowMs, uint32_t startMs, uint32_t intervalMs)
-{
-    if (intervalMs == 0 || startMs == 0)
-        return false;
-    return (nowMs - startMs) < intervalMs;
-}
-
-/**
- * Slide an 8-bit relative timestamp back by a wall-clock slab during epoch rebase.
- *
- * Entries older than the slab clamp to 0 (then reclaimed by the maintenance sweep);
- * live entries keep their reconstructed age minus a sub-tick remainder. Each field
- * slides by its own resolution's worth of ticks, so a single slab covers all three.
- */
-inline void slideRelativeTime(uint8_t &ticks, uint32_t slabMs, uint16_t resolutionSecs)
-{
-    if (ticks == 0 || resolutionSecs == 0)
-        return;
-    uint32_t dec = slabMs / (static_cast<uint32_t>(resolutionSecs) * 1000UL);
-    ticks = (ticks > dec) ? static_cast<uint8_t>(ticks - dec) : 0;
 }
 
 /**
@@ -177,23 +152,11 @@ TrafficManagementModule::TrafficManagementModule() : MeshModule("TrafficManageme
     encryptedOk = true;   // Can process encrypted packets
     stats = meshtastic_TrafficManagementStats_init_zero;
 
-    // Initialize rolling epoch for relative timestamps
-    cacheEpochMs = millis();
-
-    // Calculate adaptive time resolutions from config (config changes require reboot)
-    // Resolution = max(60, min(339, interval/2)) for ~24 hour range with good precision
-    posTimeResolution = calcTimeResolution(Default::getConfiguredOrDefault(
-        moduleConfig.traffic_management.position_min_interval_secs, default_traffic_mgmt_position_min_interval_secs));
-    rateTimeResolution = calcTimeResolution(moduleConfig.traffic_management.rate_limit_window_secs);
-    unknownTimeResolution = calcTimeResolution(kUnknownResetMs / 1000); // ~5 min default
-
     const auto &cfg = moduleConfig.traffic_management;
     TM_LOG_INFO("Enabled: pos_dedup=%d nodeinfo_resp=%d rate_limit=%d drop_unknown=%d exhaust_telem=%d exhaust_pos=%d "
                 "preserve_hops=%d",
                 cfg.position_dedup_enabled, cfg.nodeinfo_direct_response, cfg.rate_limit_enabled, cfg.drop_unknown_enabled,
                 cfg.exhaust_hop_telemetry, cfg.exhaust_hop_position, cfg.router_preserve_hops);
-    TM_LOG_DEBUG("Time resolutions: pos=%us, rate=%us, unknown=%us", posTimeResolution, rateTimeResolution,
-                 unknownTimeResolution);
 
 // Allocate unified cache (10 bytes/entry for all platforms)
 #if TRAFFIC_MANAGEMENT_CACHE_SIZE > 0
@@ -357,11 +320,20 @@ TrafficManagementModule::UnifiedCacheEntry *TrafficManagementModule::findOrCreat
         if (empty)
             continue; // an empty slot beats any victim; stop scoring
         const bool hasHop = e.next_hop != 0;
-        uint8_t recency = e.pos_time;
-        if (e.rate_time > recency)
-            recency = e.rate_time;
-        if (e.unknown_time > recency)
-            recency = e.unknown_time;
+        // Age in pos-ticks (8-bit modular, wraps correctly). Entries with no
+        // pos state (pos_time==0) score as maximally old (age=currentPosTick()).
+        const uint8_t nowPosTick = currentPosTick();
+        const uint8_t posAge = static_cast<uint8_t>(nowPosTick - e.pos_time);
+        // Blend in rate/unknown ages scaled to pos-tick units (coarser = conservative).
+        const uint8_t rateAgePosScale =
+            static_cast<uint8_t>(static_cast<uint8_t>((currentRateTick() - e.getRateTime()) & 0x0F) * 5 / 3);
+        const uint8_t unknownAgePosScale =
+            static_cast<uint8_t>(static_cast<uint8_t>((currentUnknownTick() - e.getUnknownTime()) & 0x0F) / 6);
+        uint8_t recency = posAge;
+        if (e.rate_count != 0 && rateAgePosScale > recency)
+            recency = rateAgePosScale;
+        if (e.unknown_count != 0 && unknownAgePosScale > recency)
+            recency = unknownAgePosScale;
         if (!victim || (hasHop == victimHasHop ? recency < victimRecency : !hasHop)) {
             victim = &e;
             victimHasHop = hasHop;
@@ -587,59 +559,11 @@ void TrafficManagementModule::preloadNextHopsFromNodeDB()
 // Epoch Management
 // =============================================================================
 
-/**
- * Reset the timestamp epoch when relative offsets approach overflow.
- *
- * Called when epoch age exceeds ~19 hours (approaching 8-bit minute overflow).
- * Invalidates all cached per-node traffic state.
- */
-void TrafficManagementModule::resetEpoch(uint32_t nowMs)
+void TrafficManagementModule::flushCache()
 {
 #if TRAFFIC_MANAGEMENT_CACHE_SIZE > 0
-    TM_LOG_DEBUG("Resetting cache epoch");
-    cacheEpochMs = nowMs;
-
-    // Full flush avoids stale dedup identity/counters surviving epoch rollover.
+    TM_LOG_DEBUG("Flushing cache");
     memset(cache, 0, static_cast<size_t>(cacheSize()) * sizeof(UnifiedCacheEntry));
-#else
-    (void)nowMs;
-#endif
-}
-
-/**
- * Sliding-epoch rebase — preserve cached state past the 8-bit timestamp horizon.
- *
- * Instead of flushing the whole cache when offsets approach overflow, advance the
- * epoch by a fixed slab and shift every live entry's relative timestamps back by
- * the same wall-clock amount. A valid entry's window is only a handful of ticks
- * wide (TTL auto-scales with resolution), so live entries comfortably survive;
- * already-expired entries clamp to 0 and are reclaimed by the maintenance sweep in
- * the same locked pass. Reconstructed absolute time is preserved (minus a sub-tick
- * remainder), so in-flight TTL checks remain correct across the rebase.
- *
- * Caller must hold cacheLock.
- */
-void TrafficManagementModule::rebaseEpoch(uint32_t nowMs)
-{
-#if TRAFFIC_MANAGEMENT_CACHE_SIZE > 0
-    (void)nowMs;
-
-    // Slab stays well below the 200-tick reset threshold so a single rebase drops
-    // the offset back into range (~200 -> ~72 ticks) while live entries survive.
-    const uint32_t slabMs = 128UL * maxResolution() * 1000UL;
-    cacheEpochMs += slabMs;
-
-    TM_LOG_DEBUG("Rebasing cache epoch by %lus", static_cast<unsigned long>(slabMs / 1000UL));
-
-    for (uint16_t i = 0; i < cacheSize(); i++) {
-        if (cache[i].node == 0)
-            continue;
-        slideRelativeTime(cache[i].pos_time, slabMs, posTimeResolution);
-        slideRelativeTime(cache[i].rate_time, slabMs, rateTimeResolution);
-        slideRelativeTime(cache[i].unknown_time, slabMs, unknownTimeResolution);
-    }
-#else
-    (void)nowMs;
 #endif
 }
 
@@ -822,6 +746,39 @@ void TrafficManagementModule::alterReceived(meshtastic_MeshPacket &mp)
     const bool shouldExhaust =
         ((channelBusy && isTelemetry && cfg.exhaust_hop_telemetry) || (isPosition && cfg.exhaust_hop_position));
 
+    // -------------------------------------------------------------------------
+    // Relayed Position Precision Clamp
+    // -------------------------------------------------------------------------
+    // Clamp relayed position broadcasts to the channel's configured precision
+    // ceiling. Guards against forwarding more-precise coordinates than the
+    // channel is intended to carry (e.g. a LongFast channel set to 13-bit /
+    // ~1.5 km). chanPrec==0 means position sharing is disabled on the channel;
+    // skip — not our job to zero positions on relay.
+    // Ham mode (owner.is_licensed) is exempt.
+    // Compile USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS to extend to private channels.
+    if (!owner.is_licensed && isPosition && isBroadcast(mp.to)) {
+#ifdef USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS
+        const bool shouldClamp = true;
+#else
+        const bool shouldClamp = channels.isWellKnownChannel(mp.channel);
+#endif
+        if (shouldClamp) {
+            const uint32_t chanPrec = getPositionPrecisionForChannel(mp.channel);
+            if (chanPrec > 0) {
+                meshtastic_Position pos = meshtastic_Position_init_default;
+                if (pb_decode_from_bytes(mp.decoded.payload.bytes, mp.decoded.payload.size, &meshtastic_Position_msg, &pos)) {
+                    const uint32_t packetPrec = pos.precision_bits > 0 ? pos.precision_bits : 32u;
+                    if (packetPrec > chanPrec) {
+                        applyPositionPrecision(pos, chanPrec);
+                        mp.decoded.payload.size = pb_encode_to_bytes(mp.decoded.payload.bytes, sizeof(mp.decoded.payload.bytes),
+                                                                     &meshtastic_Position_msg, &pos);
+                        logAction("clamp", &mp, "precision");
+                    }
+                }
+            }
+        }
+    }
+
     if (!shouldExhaust || !isBroadcast(mp.to))
         return;
 
@@ -864,28 +821,32 @@ int32_t TrafficManagementModule::runOnce()
         nextHopPreloaded = true;
     }
 
-    // Calculate TTLs for cache expiration
+    // Free-running tick counters (no epoch needed).
+    // TTL expressed in ticks: pos 4× interval (default 44 ticks ≈ 4.4h),
+    // rate 2× window (default 24 ticks = 2h), unknown fixed 12 ticks (12 min).
     const uint32_t positionIntervalMs = secsToMs(Default::getConfiguredOrDefault(
         moduleConfig.traffic_management.position_min_interval_secs, default_traffic_mgmt_position_min_interval_secs));
-    const uint32_t positionTtlMs = positionIntervalMs * 4;
+    const uint8_t posTtlTicks =
+        static_cast<uint8_t>(std::min(static_cast<uint32_t>(255), (positionIntervalMs * 4) / kPosTimeTickMs));
 
-    const uint32_t rateIntervalMs = secsToMs(moduleConfig.traffic_management.rate_limit_window_secs);
-    const uint32_t rateTtlMs = (rateIntervalMs > 0) ? rateIntervalMs * 2 : (10 * 60 * 1000UL);
+    const uint32_t rateWindowMs = secsToMs(moduleConfig.traffic_management.rate_limit_window_secs);
+    const uint8_t rateTtlTicks = static_cast<uint8_t>(
+        std::min(static_cast<uint32_t>(15), (rateWindowMs > 0 ? rateWindowMs * 2 : 24 * kRateTimeTickMs) / kRateTimeTickMs));
 
-    const uint32_t unknownTtlMs = kUnknownResetMs * 5;
+    // unknown: fixed 12-tick TTL (12 min — 4 ticks past the 5-min default window)
+    const uint8_t unknownTtlTicks = 12;
+
+    const uint8_t nowPosTick = currentPosTick();
+    const uint8_t nowRateTick = currentRateTick();
+    const uint8_t nowUnknownTick = currentUnknownTick();
 
     // Sweep cache and clear expired entries
     uint16_t activeEntries = 0;
     uint16_t expiredEntries = 0;
     const uint32_t sweepStartMs = millis();
 
+    const auto &cfg = moduleConfig.traffic_management;
     concurrency::LockGuard guard(&cacheLock);
-
-    // Slide the epoch instead of flushing when offsets approach 8-bit overflow.
-    // Rebase preserves live entries; only already-expired ones clamp to 0 and are
-    // reclaimed by the sweep below in this same locked pass.
-    if (needsEpochReset(nowMs))
-        rebaseEpoch(nowMs);
 
     for (uint16_t i = 0; i < cacheSize(); i++) {
         if (cache[i].node == 0)
@@ -893,10 +854,9 @@ int32_t TrafficManagementModule::runOnce()
 
         bool anyValid = false;
 
-        // Check and clear expired position data
-        if (cache[i].pos_time != 0) {
-            uint32_t posTimeMs = fromRelativePosTime(cache[i].pos_time);
-            if (!isWithinWindow(nowMs, posTimeMs, positionTtlMs)) {
+        // Check and clear expired position data (presence: pos_fingerprint != 0)
+        if (cache[i].pos_fingerprint != 0) {
+            if (static_cast<uint8_t>(nowPosTick - cache[i].pos_time) >= posTtlTicks) {
                 cache[i].pos_fingerprint = 0;
                 cache[i].pos_time = 0;
             } else {
@@ -904,23 +864,21 @@ int32_t TrafficManagementModule::runOnce()
             }
         }
 
-        // Check and clear expired rate limit data
-        if (cache[i].rate_time != 0) {
-            uint32_t rateTimeMs = fromRelativeRateTime(cache[i].rate_time);
-            if (!isWithinWindow(nowMs, rateTimeMs, rateTtlMs)) {
+        // Check and clear expired rate limit data (gated on feature; presence: rate_count != 0)
+        if (cfg.rate_limit_enabled && cache[i].rate_count != 0) {
+            if ((static_cast<uint8_t>(nowRateTick - cache[i].getRateTime()) & 0x0F) >= rateTtlTicks) {
                 cache[i].rate_count = 0;
-                cache[i].rate_time = 0;
+                cache[i].setRateTime(0);
             } else {
                 anyValid = true;
             }
         }
 
-        // Check and clear expired unknown tracking data
-        if (cache[i].unknown_time != 0) {
-            uint32_t unknownTimeMs = fromRelativeUnknownTime(cache[i].unknown_time);
-            if (!isWithinWindow(nowMs, unknownTimeMs, unknownTtlMs)) {
+        // Check and clear expired unknown tracking data (gated on feature; presence: unknown_count != 0)
+        if (cfg.drop_unknown_enabled && cache[i].unknown_count != 0) {
+            if ((static_cast<uint8_t>(nowUnknownTick - cache[i].getUnknownTime()) & 0x0F) >= unknownTtlTicks) {
                 cache[i].unknown_count = 0;
-                cache[i].unknown_time = 0;
+                cache[i].setUnknownTime(0);
             } else {
                 anyValid = true;
             }
@@ -990,19 +948,26 @@ bool TrafficManagementModule::shouldDropPosition(const meshtastic_MeshPacket *p,
     if (!entry)
         return false;
 
-    // Compare fingerprint and check time window
-    // When minIntervalMs == 0, deduplication is disabled (withinInterval = false means never drop)
-    const bool hasPositionState = !isNew && entry->pos_time != 0;
+    // Compare fingerprint and check time window.
+    // When minIntervalMs == 0, deduplication is disabled (withinInterval = false means never drop).
+    // Presence: pos_fingerprint != 0 (zero fingerprint from real coordinates is astronomically unlikely).
+    const bool hasPositionState = !isNew && entry->pos_fingerprint != 0;
     const bool samePosition = hasPositionState && entry->pos_fingerprint == fingerprint;
+    const uint8_t nowPosTick = currentPosTick();
+    // Clamp to [1, 255]: intervals shorter than one tick still dedup within the same tick.
+    const uint8_t windowTicks =
+        (minIntervalMs == 0) ? 0
+                             : static_cast<uint8_t>(std::min(static_cast<uint32_t>(UINT8_MAX),
+                                                             std::max(static_cast<uint32_t>(1), minIntervalMs / kPosTimeTickMs)));
     const bool withinInterval =
-        hasPositionState && (minIntervalMs != 0) && isWithinWindow(nowMs, fromRelativePosTime(entry->pos_time), minIntervalMs);
+        hasPositionState && (windowTicks != 0) && (static_cast<uint8_t>(nowPosTick - entry->pos_time) < windowTicks);
 
     TM_LOG_DEBUG("Position dedup 0x%08x: fp=0x%02x prev=0x%02x same=%d within=%d new=%d", p->from, fingerprint,
                  entry->pos_fingerprint, samePosition, withinInterval, isNew);
 
-    // Update cache entry
+    // Update cache entry (raw tick; 0 is a valid tick value)
     entry->pos_fingerprint = fingerprint;
-    entry->pos_time = toRelativePosTime(nowMs);
+    entry->pos_time = nowPosTick;
 
     // Drop only if same position AND within the minimum interval
     return samePosition && withinInterval;
@@ -1156,9 +1121,14 @@ bool TrafficManagementModule::isRateLimited(NodeNum from, uint32_t nowMs)
     if (!entry)
         return false;
 
-    // Check if window has expired
-    if (isNew || !isWithinWindow(nowMs, fromRelativeRateTime(entry->rate_time), windowMs)) {
-        entry->rate_time = toRelativeRateTime(nowMs);
+    // Window ticks: clamp to [1,15] so zero windowMs (config error) opens a new window.
+    const uint8_t windowTicks = static_cast<uint8_t>(std::min(static_cast<uint32_t>(15), windowMs / kRateTimeTickMs));
+    const uint8_t nowRateTick = currentRateTick();
+    const bool windowExpired =
+        isNew || entry->rate_count == 0 ||
+        ((static_cast<uint8_t>(nowRateTick - entry->getRateTime()) & 0x0F) >= std::max(static_cast<uint8_t>(1), windowTicks));
+    if (windowExpired) {
+        entry->setRateTime(nowRateTick);
         entry->rate_count = 1;
         return false;
     }
@@ -1190,9 +1160,8 @@ bool TrafficManagementModule::shouldDropUnknown(const meshtastic_MeshPacket *p, 
     if (!moduleConfig.traffic_management.drop_unknown_enabled || moduleConfig.traffic_management.unknown_packet_threshold == 0)
         return false;
 
-    uint32_t windowMs = kUnknownResetMs;
-    if (moduleConfig.traffic_management.rate_limit_window_secs > 0)
-        windowMs = secsToMs(moduleConfig.traffic_management.rate_limit_window_secs);
+    // Fixed 5-tick (5 min) unknown window; capped at 12 ticks (12 min max).
+    static constexpr uint8_t kUnknownWindowTicks = 5;
 
     bool isNew = false;
     concurrency::LockGuard guard(&cacheLock);
@@ -1200,9 +1169,12 @@ bool TrafficManagementModule::shouldDropUnknown(const meshtastic_MeshPacket *p, 
     if (!entry)
         return false;
 
-    // Check if window has expired
-    if (isNew || !isWithinWindow(nowMs, fromRelativeUnknownTime(entry->unknown_time), windowMs)) {
-        entry->unknown_time = toRelativeUnknownTime(nowMs);
+    // Check if window has expired (presence: unknown_count != 0)
+    const uint8_t nowUnknownTick = currentUnknownTick();
+    const bool windowExpired = isNew || entry->unknown_count == 0 ||
+                               ((static_cast<uint8_t>(nowUnknownTick - entry->getUnknownTime()) & 0x0F) >= kUnknownWindowTicks);
+    if (windowExpired) {
+        entry->setUnknownTime(nowUnknownTick);
         entry->unknown_count = 0;
     }
 

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -18,6 +18,19 @@
 #include <algorithm>
 #include <cstring>
 
+#if HAS_VARIABLE_HOPS
+#include "HopScalingModule.h"
+#endif
+
+// Hop-trimming: clamp a relayed broadcast's reach to the local hop-scaling cap + role grace.
+// ON by default; needs HAS_VARIABLE_HOPS (the histogram source) and is killed by defining
+// USERPREFS_TMM_HOP_TRIM_DISABLE.
+#if HAS_VARIABLE_HOPS && !defined(USERPREFS_TMM_HOP_TRIM_DISABLE)
+#define TMM_HOP_TRIM_ENABLED 1
+#else
+#define TMM_HOP_TRIM_ENABLED 0
+#endif
+
 #define TM_LOG_DEBUG(fmt, ...) LOG_DEBUG("[TM] " fmt, ##__VA_ARGS__)
 #define TM_LOG_INFO(fmt, ...) LOG_INFO("[TM] " fmt, ##__VA_ARGS__)
 #define TM_LOG_WARN(fmt, ...) LOG_WARN("[TM] " fmt, ##__VA_ARGS__)
@@ -37,6 +50,14 @@ constexpr uint32_t kMaintenanceIntervalMs = 60 * 1000UL; // Cache cleanup interv
 // Note: nodeinfo_direct_response must also be enabled for this to take effect
 constexpr uint32_t kRouterDefaultMaxHops = 3; // Routers: max 3 hops (can set lower via config)
 constexpr uint32_t kClientDefaultMaxHops = 0; // Clients: direct only (cannot increase)
+
+#if TMM_HOP_TRIM_ENABLED
+// Relayed broadcasts subject to hop-trimming: the high-volume routine position/telemetry traffic.
+constexpr bool hopTrimEligiblePort(meshtastic_PortNum portnum)
+{
+    return portnum == meshtastic_PortNum_POSITION_APP || portnum == meshtastic_PortNum_TELEMETRY_APP;
+}
+#endif
 
 /**
  * Convert seconds to milliseconds with overflow protection.
@@ -715,6 +736,39 @@ ProcessMessage TrafficManagementModule::handleReceived(const meshtastic_MeshPack
     return ProcessMessage::CONTINUE;
 }
 
+bool TrafficManagementModule::wouldHopTrim(const meshtastic_MeshPacket &p) const
+{
+#if TMM_HOP_TRIM_ENABLED
+    if (!moduleConfig.has_traffic_management || !moduleConfig.traffic_management.enabled)
+        return false;
+    // Decryptable broadcasts only; never our own (we scale those at Router::send).
+    if (p.which_payload_variant != meshtastic_MeshPacket_decoded_tag || isFromUs(&p) || !isBroadcast(p.to))
+        return false;
+    if (!hopTrimEligiblePort(p.decoded.portnum))
+        return false;
+    // Self-gating: getLastRequiredHop() is HOP_MAX until the histogram warms, so this engages
+    // only on a busy enough mesh for hop-scaling to be in effect.
+    if (!hopScalingModule || hopScalingModule->getLastRequiredHop() >= HOP_MAX)
+        return false;
+        // Channel gate, mirroring the precision clamp: well-known channels only unless opted in.
+#ifndef USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS
+    if (!channels.isWellKnownChannel(p.channel))
+        return false;
+#endif
+    // router_preserve_hops wins for infra: if we're a router deliberately preserving hops on
+    // non-position/telemetry traffic, don't trim it either (those keep full reach by operator choice).
+    if (moduleConfig.traffic_management.router_preserve_hops &&
+        IS_ONE_OF(config.device.role, meshtastic_Config_DeviceConfig_Role_ROUTER, meshtastic_Config_DeviceConfig_Role_ROUTER_LATE,
+                  meshtastic_Config_DeviceConfig_Role_CLIENT_BASE) &&
+        p.decoded.portnum != meshtastic_PortNum_POSITION_APP && p.decoded.portnum != meshtastic_PortNum_TELEMETRY_APP)
+        return false;
+    return true;
+#else
+    (void)p;
+    return false;
+#endif
+}
+
 void TrafficManagementModule::alterReceived(meshtastic_MeshPacket &mp)
 {
     if (!moduleConfig.has_traffic_management || !moduleConfig.traffic_management.enabled)
@@ -774,6 +828,27 @@ void TrafficManagementModule::alterReceived(meshtastic_MeshPacket &mp)
             }
         }
     }
+
+    // Hop-trimming — clamp relayed broadcast reach to budget = localCap + role grace. allowedForward
+    // decays with distance (budget - hopsAway); at 0 the packet is not rebroadcast (hop_limit=0, no
+    // exhaustRequested = no final hop). hop_start drops by the same delta so hopsAway stays honest.
+#if TMM_HOP_TRIM_ENABLED
+    if (wouldHopTrim(mp)) {
+        const uint8_t localCap = hopScalingModule->getLastRequiredHop();
+        const meshtastic_NodeInfoLite *sender = nodeDB->getMeshNode(getFrom(&mp));
+        const meshtastic_Config_DeviceConfig_Role senderRole = sender ? sender->role : meshtastic_Config_DeviceConfig_Role_CLIENT;
+        const uint8_t budget = static_cast<uint8_t>(localCap + Default::hopTrimGrace(senderRole, mp.decoded.portnum));
+        const uint8_t hopsAway = (mp.hop_start >= mp.hop_limit) ? static_cast<uint8_t>(mp.hop_start - mp.hop_limit) : 0;
+        const uint8_t allowedForward = budget > hopsAway ? static_cast<uint8_t>(budget - hopsAway) : 0;
+        if (mp.hop_limit > allowedForward) {
+            logAction("trim", &mp, allowedForward ? "hop-trim" : "hop-trim-stop");
+            mp.hop_start = static_cast<uint8_t>(mp.hop_start - (mp.hop_limit - allowedForward));
+            mp.hop_limit = allowedForward;
+            if (allowedForward == 0)
+                incrementStat(&stats.hop_exhausted_packets); // trim-to-0 is, in effect, a hop exhaust
+        }
+    }
+#endif
 
     if (!shouldExhaust || !isBroadcast(mp.to))
         return;

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -536,6 +536,21 @@ uint8_t TrafficManagementModule::getNextHopHint(NodeNum dest)
 #endif
 }
 
+void TrafficManagementModule::clearNextHop(NodeNum dest)
+{
+#if TRAFFIC_MANAGEMENT_CACHE_SIZE > 0
+    if (!cache || dest == 0)
+        return;
+
+    concurrency::LockGuard guard(&cacheLock);
+    UnifiedCacheEntry *entry = findEntry(dest);
+    if (entry)
+        entry->next_hop = 0; // keep the entry (other stats), just drop the routing hint
+#else
+    (void)dest;
+#endif
+}
+
 bool TrafficManagementModule::preloadNextHopsFromNodeDB()
 {
 #if TRAFFIC_MANAGEMENT_CACHE_SIZE > 0

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -702,11 +702,11 @@ ProcessMessage TrafficManagementModule::handleReceived(const meshtastic_MeshPack
     // GPS jitter within the configured precision.
 
     if (!isFromUs(&mp) && !isToUs(&mp)) {
-        const bool dedupChannelOk = cfg.apply_to_private_channels
 #ifdef USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS
-                                    || true
+        const bool dedupChannelOk = true;
+#else
+        const bool dedupChannelOk = cfg.apply_to_private_channels || channels.isWellKnownChannel(mp.channel);
 #endif
-                                    || channels.isWellKnownChannel(mp.channel);
         if (cfg.position_dedup_enabled && dedupChannelOk && mp.decoded.portnum == meshtastic_PortNum_POSITION_APP) {
             meshtastic_Position pos = meshtastic_Position_init_zero;
             if (pb_decode_from_bytes(mp.decoded.payload.bytes, mp.decoded.payload.size, &meshtastic_Position_msg, &pos)) {
@@ -757,22 +757,11 @@ bool TrafficManagementModule::wouldHopTrim(const meshtastic_MeshPacket &p) const
     // only on a busy enough mesh for hop-scaling to be in effect.
     if (!hopScalingModule || hopScalingModule->getLastRequiredHop() >= HOP_MAX)
         return false;
-    // Channel gate: well-known channels only unless opted in via proto or compile flag.
-    if (!moduleConfig.traffic_management.apply_to_private_channels
-#ifdef USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS
-        && false // compile flag overrides proto
-#endif
-    ) {
-        if (!channels.isWellKnownChannel(p.channel))
-            return false;
-    }
-    // router_preserve_hops wins for infra: if we're a router deliberately preserving hops on
-    // non-position/telemetry traffic, don't trim it either (those keep full reach by operator choice).
-    if (moduleConfig.traffic_management.router_preserve_hops &&
-        IS_ONE_OF(config.device.role, meshtastic_Config_DeviceConfig_Role_ROUTER, meshtastic_Config_DeviceConfig_Role_ROUTER_LATE,
-                  meshtastic_Config_DeviceConfig_Role_CLIENT_BASE) &&
-        p.decoded.portnum != meshtastic_PortNum_POSITION_APP && p.decoded.portnum != meshtastic_PortNum_TELEMETRY_APP)
+        // Channel gate: well-known channels only unless opted in via proto or compile flag.
+#ifndef USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS
+    if (!moduleConfig.traffic_management.apply_to_private_channels && !channels.isWellKnownChannel(p.channel))
         return false;
+#endif
     return true;
 #else
     (void)p;
@@ -818,11 +807,11 @@ void TrafficManagementModule::alterReceived(meshtastic_MeshPacket &mp)
     // Set apply_to_private_channels (proto) or USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS to extend to private channels.
     if (!owner.is_licensed && isPosition && isBroadcast(mp.to) &&
         originRole(mp.from) != meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND) {
-        const bool shouldClamp = cfg.apply_to_private_channels
 #ifdef USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS
-                                 || true
+        const bool shouldClamp = true;
+#else
+        const bool shouldClamp = cfg.apply_to_private_channels || channels.isWellKnownChannel(mp.channel);
 #endif
-                                 || channels.isWellKnownChannel(mp.channel);
         if (shouldClamp) {
             const uint32_t chanPrec = getPositionPrecisionForChannel(mp.channel);
             if (chanPrec > 0) {
@@ -831,9 +820,12 @@ void TrafficManagementModule::alterReceived(meshtastic_MeshPacket &mp)
                     const uint32_t packetPrec = pos.precision_bits > 0 ? pos.precision_bits : 32u;
                     if (packetPrec > chanPrec) {
                         applyPositionPrecision(pos, chanPrec);
-                        mp.decoded.payload.size = pb_encode_to_bytes(mp.decoded.payload.bytes, sizeof(mp.decoded.payload.bytes),
-                                                                     &meshtastic_Position_msg, &pos);
-                        logAction("clamp", &mp, "precision");
+                        const size_t encodedSize = pb_encode_to_bytes(mp.decoded.payload.bytes, sizeof(mp.decoded.payload.bytes),
+                                                                      &meshtastic_Position_msg, &pos);
+                        if (encodedSize > 0) {
+                            mp.decoded.payload.size = encodedSize;
+                            logAction("clamp", &mp, "precision");
+                        }
                     }
                 }
             }

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -67,31 +67,6 @@ uint8_t sanitizePositionPrecision(uint8_t precision)
 }
 
 /**
- * Truncate lat/lon to specified precision for position deduplication.
- *
- * The truncation works by masking off lower bits and rounding to the center
- * of the resulting grid cell. This creates a stable truncated value even
- * when GPS jitter causes small coordinate changes.
- *
- * @param value     Raw latitude_i or longitude_i from position
- * @param precision Number of significant bits to keep (0-32)
- * @return          Truncated and centered coordinate value
- */
-int32_t truncateLatLon(int32_t value, uint8_t precision)
-{
-    if (precision == 0 || precision >= 32)
-        return value;
-
-    // Create mask to zero out lower bits
-    uint32_t mask = UINT32_MAX << (32 - precision);
-    uint32_t truncated = static_cast<uint32_t>(value) & mask;
-
-    // Add half the truncation step to center in the grid cell
-    truncated += (1u << (31 - precision));
-    return static_cast<int32_t>(truncated);
-}
-
-/**
  * Saturating increment for uint8_t counters.
  * Prevents overflow by capping at UINT8_MAX (255).
  */
@@ -941,8 +916,8 @@ bool TrafficManagementModule::shouldDropPosition(const meshtastic_MeshPacket *p,
                                                         default_traffic_mgmt_position_precision_bits);
     precision = sanitizePositionPrecision(precision);
 
-    const int32_t lat_truncated = truncateLatLon(pos->latitude_i, precision);
-    const int32_t lon_truncated = truncateLatLon(pos->longitude_i, precision);
+    const int32_t lat_truncated = truncateCoordinate(pos->latitude_i, precision);
+    const int32_t lon_truncated = truncateCoordinate(pos->longitude_i, precision);
     const uint8_t fingerprint = computePositionFingerprint(lat_truncated, lon_truncated, precision);
     // Drop gate uses the RAW configured interval: 0 means "dedup disabled" (the
     // contract documented below). The 12h default is only for resolution/TTL

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -390,7 +390,7 @@ TrafficManagementModule::NodeInfoPayloadEntry *TrafficManagementModule::findOrCr
     NodeInfoPayloadEntry *empty = nullptr;
     NodeInfoPayloadEntry *lru = nullptr;
     uint32_t lruAge = 0;
-    const uint32_t now = millis();
+    const uint32_t now = clockMs();
 
     for (uint16_t i = 0; i < nodeInfoTargetEntries(); i++) {
         NodeInfoPayloadEntry &e = nodeInfoPayload[i];
@@ -466,7 +466,7 @@ void TrafficManagementModule::cacheNodeInfoPacket(const meshtastic_MeshPacket &m
         // richer context than "just the user protobuf" when PSRAM is present.
         // This path is intentionally independent from NodeInfoModule/NodeDB.
         entry->user = user;
-        entry->lastObservedMs = millis();
+        entry->lastObservedMs = clockMs();
         entry->lastObservedRxTime = mp.rx_time;
         entry->sourceChannel = mp.channel;
         entry->hasDecodedBitfield = mp.decoded.has_bitfield;
@@ -528,11 +528,11 @@ uint8_t TrafficManagementModule::getNextHopHint(NodeNum dest)
 #endif
 }
 
-void TrafficManagementModule::preloadNextHopsFromNodeDB()
+bool TrafficManagementModule::preloadNextHopsFromNodeDB()
 {
 #if TRAFFIC_MANAGEMENT_CACHE_SIZE > 0
     if (!cache || !nodeDB)
-        return;
+        return false; // prerequisites not ready yet — caller should retry on a later pass
 
     uint16_t seeded = 0;
     concurrency::LockGuard guard(&cacheLock);
@@ -552,6 +552,9 @@ void TrafficManagementModule::preloadNextHopsFromNodeDB()
     }
 
     TM_LOG_INFO("Preloaded %u next-hop hints from NodeDB", static_cast<unsigned>(seeded));
+    return true;
+#else
+    return true; // nothing to preload on a cache-less build; don't keep retrying
 #endif
 }
 
@@ -607,7 +610,12 @@ uint8_t TrafficManagementModule::computePositionFingerprint(int32_t lat_truncate
     uint8_t latBits = (static_cast<uint32_t>(lat_truncated) >> shift) & ((1u << bitsToTake) - 1);
     uint8_t lonBits = (static_cast<uint32_t>(lon_truncated) >> shift) & ((1u << bitsToTake) - 1);
 
-    return static_cast<uint8_t>((latBits << 4) | lonBits);
+    const uint8_t fp = static_cast<uint8_t>((latBits << 4) | lonBits);
+    // 0 is the "no position seen" sentinel for pos_fingerprint, so a real position that happens to
+    // hash to 0 must not collide with it (otherwise its duplicates would never dedup). Remap 0 -> 0xFF,
+    // mirroring NodeDB::getLastByteOfNodeNum()'s 0 -> 0xFF idiom. Cost: the 0x00 bucket merges into
+    // 0xFF (one extra collision in 256 — negligible; the fingerprint already collides every 16 cells).
+    return fp ? fp : 0xFF;
 }
 
 // =============================================================================
@@ -632,7 +640,7 @@ ProcessMessage TrafficManagementModule::handleReceived(const meshtastic_MeshPack
     incrementStat(&stats.packets_inspected);
 
     const auto &cfg = moduleConfig.traffic_management;
-    const uint32_t nowMs = millis();
+    const uint32_t nowMs = TrafficManagementModule::clockMs();
 
     // -------------------------------------------------------------------------
     // Undecoded Packet Handling
@@ -811,15 +819,15 @@ int32_t TrafficManagementModule::runOnce()
         return INT32_MAX;
 
 #if TRAFFIC_MANAGEMENT_CACHE_SIZE > 0
-    const uint32_t nowMs = millis();
+    const uint32_t nowMs = TrafficManagementModule::clockMs();
 
     // Warm-start the next-hop cache from persisted NodeInfoLite hints once nodeDB
     // is populated. Done here (not in the constructor) so nodeDB has finished
     // loading. Takes its own lock, so call before acquiring the sweep guard below.
-    if (!nextHopPreloaded) {
-        preloadNextHopsFromNodeDB();
+    // Only latch the one-shot guard once the preload actually ran; if nodeDB wasn't
+    // ready yet, retry on the next maintenance pass instead of skipping it forever.
+    if (!nextHopPreloaded && preloadNextHopsFromNodeDB())
         nextHopPreloaded = true;
-    }
 
     // Free-running tick counters (no epoch needed).
     // TTL expressed in ticks: pos 4× interval (default 44 ticks ≈ 4.4h),
@@ -843,7 +851,7 @@ int32_t TrafficManagementModule::runOnce()
     // Sweep cache and clear expired entries
     uint16_t activeEntries = 0;
     uint16_t expiredEntries = 0;
-    const uint32_t sweepStartMs = millis();
+    const uint32_t sweepStartMs = TrafficManagementModule::clockMs();
 
     const auto &cfg = moduleConfig.traffic_management;
     concurrency::LockGuard guard(&cacheLock);
@@ -900,7 +908,7 @@ int32_t TrafficManagementModule::runOnce()
 
     TM_LOG_DEBUG("Maintenance: %u active, %u expired, %u/%u slots, %lums elapsed", activeEntries, expiredEntries,
                  static_cast<unsigned>(activeEntries), static_cast<unsigned>(cacheSize()),
-                 static_cast<unsigned long>(millis() - sweepStartMs));
+                 static_cast<unsigned long>(TrafficManagementModule::clockMs() - sweepStartMs));
 
 #if defined(ARCH_ESP32) && defined(BOARD_HAS_PSRAM)
     if (nodeInfoPayload) {
@@ -1056,7 +1064,7 @@ bool TrafficManagementModule::shouldRespondToNodeInfo(const meshtastic_MeshPacke
         reply->decoded.bitfield |= BITFIELD_OK_TO_MQTT_MASK;
 
     if (hasCachedUser && cachedLastObservedMs != 0) {
-        uint32_t ageMs = millis() - cachedLastObservedMs;
+        uint32_t ageMs = clockMs() - cachedLastObservedMs;
         TM_LOG_DEBUG("NodeInfo PSRAM hit node=0x%08x age=%lu ms src_ch=%u req_ch=%u rx_time=%lu", p->to,
                      static_cast<unsigned long>(ageMs), static_cast<unsigned>(cachedSourceChannel),
                      static_cast<unsigned>(p->channel), static_cast<unsigned long>(cachedLastObservedRxTime));

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -49,6 +49,17 @@ uint32_t secsToMs(uint32_t secs)
     return static_cast<uint32_t>(ms);
 }
 
+// Advertised role of the originating node (from NodeDB), or CLIENT (no exception) if unknown.
+// Position filtering grants two role exceptions: trackers may refresh duplicates hourly, and
+// lost-and-found is throttled only to the shortest tick window with no precision clamp.
+meshtastic_Config_DeviceConfig_Role originRole(NodeNum from)
+{
+    const meshtastic_NodeInfoLite *n = nodeDB ? nodeDB->getMeshNode(from) : nullptr;
+    if (n && n->has_user)
+        return n->user.role;
+    return meshtastic_Config_DeviceConfig_Role_CLIENT;
+}
+
 /**
  * Clamp precision to a valid dedup range.
  * Invalid values use the module default precision.
@@ -737,9 +748,10 @@ void TrafficManagementModule::alterReceived(meshtastic_MeshPacket &mp)
     // channel is intended to carry (e.g. a LongFast channel set to 13-bit /
     // ~1.5 km). chanPrec==0 means position sharing is disabled on the channel;
     // skip — not our job to zero positions on relay.
-    // Ham mode (owner.is_licensed) is exempt.
+    // Ham mode (owner.is_licensed) is exempt, as is a lost-and-found origin (no anti-dox).
     // Compile USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS to extend to private channels.
-    if (!owner.is_licensed && isPosition && isBroadcast(mp.to)) {
+    if (!owner.is_licensed && isPosition && isBroadcast(mp.to) &&
+        originRole(mp.from) != meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND) {
 #ifdef USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS
         const bool shouldClamp = true;
 #else
@@ -923,7 +935,21 @@ bool TrafficManagementModule::shouldDropPosition(const meshtastic_MeshPacket *p,
     // contract documented below). The 12h default is only for resolution/TTL
     // sizing (constructor / runOnce), not for deciding whether to drop — feeding
     // the default here would silently turn the 0-disables-dedup contract off.
-    const uint32_t minIntervalMs = secsToMs(moduleConfig.traffic_management.position_min_interval_secs);
+    uint32_t minIntervalMs = secsToMs(moduleConfig.traffic_management.position_min_interval_secs);
+
+    // Role exceptions keyed on the originating node's advertised role.
+    const meshtastic_Config_DeviceConfig_Role role = originRole(p->from);
+    if (role == meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND) {
+        // Lost-and-found: let it announce as fast as the tick system allows (one tick).
+        // Only when dedup is active — never tighten past an operator who disabled it (0).
+        if (minIntervalMs != 0)
+            minIntervalMs = kPosTimeTickMs;
+    } else if (role == meshtastic_Config_DeviceConfig_Role_TRACKER || role == meshtastic_Config_DeviceConfig_Role_TAK_TRACKER) {
+        // Trackers may refresh a duplicate position as often as hourly (cap, never lengthens).
+        const uint32_t trackerCapMs = secsToMs(default_traffic_mgmt_tracker_position_min_interval_secs);
+        if (minIntervalMs > trackerCapMs)
+            minIntervalMs = trackerCapMs;
+    }
 
     bool isNew = false;
     concurrency::LockGuard guard(&cacheLock);

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -838,11 +838,12 @@ void TrafficManagementModule::alterReceived(meshtastic_MeshPacket &mp)
         const meshtastic_NodeInfoLite *sender = nodeDB->getMeshNode(getFrom(&mp));
         const meshtastic_Config_DeviceConfig_Role senderRole = sender ? sender->role : meshtastic_Config_DeviceConfig_Role_CLIENT;
         const uint8_t budget = static_cast<uint8_t>(localCap + Default::hopTrimGrace(senderRole, mp.decoded.portnum));
-        const uint8_t hopsAway = (mp.hop_start >= mp.hop_limit) ? static_cast<uint8_t>(mp.hop_start - mp.hop_limit) : 0;
+        const bool hopStartValid = (mp.hop_start >= mp.hop_limit);
+        const uint8_t hopsAway = hopStartValid ? static_cast<uint8_t>(mp.hop_start - mp.hop_limit) : 0;
         const uint8_t allowedForward = budget > hopsAway ? static_cast<uint8_t>(budget - hopsAway) : 0;
         if (mp.hop_limit > allowedForward) {
             logAction("trim", &mp, allowedForward ? "hop-trim" : "hop-trim-stop");
-            mp.hop_start = static_cast<uint8_t>(mp.hop_start - (mp.hop_limit - allowedForward));
+            mp.hop_start = hopStartValid ? static_cast<uint8_t>(hopsAway + allowedForward) : allowedForward;
             mp.hop_limit = allowedForward;
             if (allowedForward == 0)
                 incrementStat(&stats.hop_exhausted_packets); // trim-to-0 is, in effect, a hop exhaust

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -55,8 +55,8 @@ uint32_t secsToMs(uint32_t secs)
 meshtastic_Config_DeviceConfig_Role originRole(NodeNum from)
 {
     const meshtastic_NodeInfoLite *n = nodeDB ? nodeDB->getMeshNode(from) : nullptr;
-    if (n && n->has_user)
-        return n->user.role;
+    if (nodeInfoLiteHasUser(n))
+        return n->role;
     return meshtastic_Config_DeviceConfig_Role_CLIENT;
 }
 

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -702,11 +702,11 @@ ProcessMessage TrafficManagementModule::handleReceived(const meshtastic_MeshPack
     // GPS jitter within the configured precision.
 
     if (!isFromUs(&mp) && !isToUs(&mp)) {
+        const bool dedupChannelOk = cfg.apply_to_private_channels
 #ifdef USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS
-        const bool dedupChannelOk = true;
-#else
-        const bool dedupChannelOk = channels.isWellKnownChannel(mp.channel);
+                                    || true
 #endif
+                                    || channels.isWellKnownChannel(mp.channel);
         if (cfg.position_dedup_enabled && dedupChannelOk && mp.decoded.portnum == meshtastic_PortNum_POSITION_APP) {
             meshtastic_Position pos = meshtastic_Position_init_zero;
             if (pb_decode_from_bytes(mp.decoded.payload.bytes, mp.decoded.payload.size, &meshtastic_Position_msg, &pos)) {
@@ -745,6 +745,9 @@ bool TrafficManagementModule::wouldHopTrim(const meshtastic_MeshPacket &p) const
 #if TMM_HOP_TRIM_ENABLED
     if (!moduleConfig.has_traffic_management || !moduleConfig.traffic_management.enabled)
         return false;
+    // Runtime disable via proto field (or compile-time USERPREFS_TMM_HOP_TRIM_DISABLE).
+    if (moduleConfig.traffic_management.hop_trim_disabled)
+        return false;
     // Decryptable broadcasts only; never our own (we scale those at Router::send).
     if (p.which_payload_variant != meshtastic_MeshPacket_decoded_tag || isFromUs(&p) || !isBroadcast(p.to))
         return false;
@@ -754,11 +757,15 @@ bool TrafficManagementModule::wouldHopTrim(const meshtastic_MeshPacket &p) const
     // only on a busy enough mesh for hop-scaling to be in effect.
     if (!hopScalingModule || hopScalingModule->getLastRequiredHop() >= HOP_MAX)
         return false;
-        // Channel gate, mirroring the precision clamp: well-known channels only unless opted in.
-#ifndef USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS
-    if (!channels.isWellKnownChannel(p.channel))
-        return false;
+    // Channel gate: well-known channels only unless opted in via proto or compile flag.
+    if (!moduleConfig.traffic_management.apply_to_private_channels
+#ifdef USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS
+        && false // compile flag overrides proto
 #endif
+    ) {
+        if (!channels.isWellKnownChannel(p.channel))
+            return false;
+    }
     // router_preserve_hops wins for infra: if we're a router deliberately preserving hops on
     // non-position/telemetry traffic, don't trim it either (those keep full reach by operator choice).
     if (moduleConfig.traffic_management.router_preserve_hops &&
@@ -808,14 +815,14 @@ void TrafficManagementModule::alterReceived(meshtastic_MeshPacket &mp)
     // ~1.5 km). chanPrec==0 means position sharing is disabled on the channel;
     // skip — not our job to zero positions on relay.
     // Ham mode (owner.is_licensed) is exempt, as is a lost-and-found origin (no anti-dox).
-    // Compile USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS to extend to private channels.
+    // Set apply_to_private_channels (proto) or USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS to extend to private channels.
     if (!owner.is_licensed && isPosition && isBroadcast(mp.to) &&
         originRole(mp.from) != meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND) {
+        const bool shouldClamp = cfg.apply_to_private_channels
 #ifdef USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS
-        const bool shouldClamp = true;
-#else
-        const bool shouldClamp = channels.isWellKnownChannel(mp.channel);
+                                 || true
 #endif
+                                 || channels.isWellKnownChannel(mp.channel);
         if (shouldClamp) {
             const uint32_t chanPrec = getPositionPrecisionForChannel(mp.channel);
             if (chanPrec > 0) {
@@ -841,7 +848,9 @@ void TrafficManagementModule::alterReceived(meshtastic_MeshPacket &mp)
         const uint8_t localCap = hopScalingModule->getLastRequiredHop();
         const meshtastic_NodeInfoLite *sender = nodeDB->getMeshNode(getFrom(&mp));
         const meshtastic_Config_DeviceConfig_Role senderRole = sender ? sender->role : meshtastic_Config_DeviceConfig_Role_CLIENT;
-        const uint8_t budget = static_cast<uint8_t>(localCap + Default::hopTrimGrace(senderRole, mp.decoded.portnum));
+        const uint8_t graceBase = cfg.hop_trim_grace > 0 ? static_cast<uint8_t>(cfg.hop_trim_grace)
+                                                         : static_cast<uint8_t>(default_traffic_mgmt_hop_trim_grace_base);
+        const uint8_t budget = static_cast<uint8_t>(localCap + Default::hopTrimGrace(senderRole, mp.decoded.portnum, graceBase));
         const bool hopStartValid = (mp.hop_start >= mp.hop_limit);
         const uint8_t hopsAway = hopStartValid ? static_cast<uint8_t>(mp.hop_start - mp.hop_limit) : 0;
         const uint8_t allowedForward = budget > hopsAway ? static_cast<uint8_t>(budget - hopsAway) : 0;

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -762,7 +762,7 @@ ProcessMessage TrafficManagementModule::handleReceived(const meshtastic_MeshPack
     // GPS jitter within the configured precision.
 
     if (!isFromUs(&mp) && !isToUs(&mp)) {
-        if (cfg.position_dedup_enabled && channels.isPublicChannel(mp.channel) &&
+        if (cfg.position_dedup_enabled && channels.isWellKnownChannel(mp.channel) &&
             mp.decoded.portnum == meshtastic_PortNum_POSITION_APP) {
             meshtastic_Position pos = meshtastic_Position_init_zero;
             if (pb_decode_from_bytes(mp.decoded.payload.bytes, mp.decoded.payload.size, &meshtastic_Position_msg, &pos)) {

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -962,7 +962,7 @@ bool TrafficManagementModule::shouldDropPosition(const meshtastic_MeshPacket *p,
 
     // Compare fingerprint and check time window.
     // When minIntervalMs == 0, deduplication is disabled (withinInterval = false means never drop).
-    // Presence: pos_fingerprint != 0 (zero fingerprint from real coordinates is astronomically unlikely).
+    // Presence: pos_fingerprint != 0; computePositionFingerprint() remaps 0 -> 0xFF so zero means unseen.
     const bool hasPositionState = !isNew && entry->pos_fingerprint != 0;
     const bool samePosition = hasPositionState && entry->pos_fingerprint == fingerprint;
     const uint8_t nowPosTick = currentPosTick();

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -315,11 +315,12 @@ TrafficManagementModule::UnifiedCacheEntry *TrafficManagementModule::findOrCreat
             static_cast<uint8_t>(static_cast<uint8_t>((currentRateTick() - e.getRateTime()) & 0x0F) * 5 / 3);
         const uint8_t unknownAgePosScale =
             static_cast<uint8_t>(static_cast<uint8_t>((currentUnknownTick() - e.getUnknownTime()) & 0x0F) / 6);
-        uint8_t recency = posAge;
-        if (e.rate_count != 0 && rateAgePosScale > recency)
-            recency = rateAgePosScale;
-        if (e.unknown_count != 0 && unknownAgePosScale > recency)
-            recency = unknownAgePosScale;
+        uint8_t recencyAge = posAge;
+        if (e.rate_count != 0 && rateAgePosScale > recencyAge)
+            recencyAge = rateAgePosScale;
+        if (e.unknown_count != 0 && unknownAgePosScale > recencyAge)
+            recencyAge = unknownAgePosScale;
+        const uint8_t recency = static_cast<uint8_t>(UINT8_MAX - recencyAge);
         if (!victim || (hasHop == victimHasHop ? recency < victimRecency : !hasHop)) {
             victim = &e;
             victimHasHop = hasHop;
@@ -817,8 +818,10 @@ int32_t TrafficManagementModule::runOnce()
         nextHopPreloaded = true;
 
     // Free-running tick counters (no epoch needed).
-    // TTL expressed in ticks: pos 4× interval (default 44 ticks ≈ 4.4h),
-    // rate 2× window (default 24 ticks = 2h), unknown fixed 12 ticks (12 min).
+    // TTL expressed in ticks:
+    // pos: 4× position_min_interval_secs (clamped to 255 ticks @ 6 min/tick)
+    // rate: 2× rate_limit_window_secs (clamped to 15 ticks @ 5 min/tick; only relevant when rate_limit_enabled)
+    // unknown: fixed 12 ticks @ 1 min/tick (only relevant when drop_unknown_enabled)
     const uint32_t positionIntervalMs = secsToMs(Default::getConfiguredOrDefault(
         moduleConfig.traffic_management.position_min_interval_secs, default_traffic_mgmt_position_min_interval_secs));
     const uint8_t posTtlTicks =

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -702,8 +702,12 @@ ProcessMessage TrafficManagementModule::handleReceived(const meshtastic_MeshPack
     // GPS jitter within the configured precision.
 
     if (!isFromUs(&mp) && !isToUs(&mp)) {
-        if (cfg.position_dedup_enabled && channels.isWellKnownChannel(mp.channel) &&
-            mp.decoded.portnum == meshtastic_PortNum_POSITION_APP) {
+#ifdef USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS
+        const bool dedupChannelOk = true;
+#else
+        const bool dedupChannelOk = channels.isWellKnownChannel(mp.channel);
+#endif
+        if (cfg.position_dedup_enabled && dedupChannelOk && mp.decoded.portnum == meshtastic_PortNum_POSITION_APP) {
             meshtastic_Position pos = meshtastic_Position_init_zero;
             if (pb_decode_from_bytes(mp.decoded.payload.bytes, mp.decoded.payload.size, &meshtastic_Position_msg, &pos)) {
                 if (shouldDropPosition(&mp, &pos, nowMs)) {

--- a/src/modules/TrafficManagementModule.h
+++ b/src/modules/TrafficManagementModule.h
@@ -20,9 +20,11 @@
  * - Router hop preservation (maintain hop_limit for router-to-router traffic)
  *
  * Memory Optimization:
- * Uses a unified cache with cuckoo hashing for O(1) lookups and 56% memory reduction
- * compared to separate per-feature caches. Timestamps are stored as 8-bit relative
- * offsets from a rolling epoch to further reduce memory footprint.
+ * Uses one flat unified cache (plain array, linear scan) shared by all
+ * per-node features instead of separate per-feature caches. Timestamps are
+ * stored as 8-bit relative offsets from a rolling epoch to further reduce
+ * memory footprint. LoRa packet rates are low enough that an O(n) scan of
+ * ~1000 11-byte entries is negligible next to packet processing.
  */
 class TrafficManagementModule : public MeshModule, private concurrency::OSThread
 {
@@ -37,6 +39,19 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     meshtastic_TrafficManagementStats getStats() const;
     void resetStats();
     void recordRouterHopPreserved();
+
+    // Next-hop overflow cache (routing hint).
+    // setNextHop: store a confirmed last-byte next hop for `dest`. Called by
+    //   NextHopRouter from its ACK-confirmed decision (see sniffReceived). The
+    //   byte must come from a bidirectionally-verified relay, not one-way inference.
+    // getNextHopHint: return the cached next-hop byte for `dest`, 0 if unknown.
+    void setNextHop(NodeNum dest, uint8_t nextHopByte);
+    uint8_t getNextHopHint(NodeNum dest);
+
+    // Warm-start the next-hop cache from persisted NodeInfoLite hints so confirmed
+    // hops survive later hot-store (NodeDB) eviction. Idempotent; runs once after
+    // nodeDB is populated (lazily on first maintenance pass).
+    void preloadNextHopsFromNodeDB();
 
     /**
      * Check if this packet should have its hops exhausted.
@@ -55,14 +70,18 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     int32_t runOnce() override;
     // Protected so test shims can force epoch rollover behavior.
     void resetEpoch(uint32_t nowMs);
+    // Sliding-epoch rebase: advance the epoch and shift live entries back by the
+    // same wall-clock amount instead of flushing, so cached state survives past the
+    // ~19h horizon. Caller must hold cacheLock.
+    void rebaseEpoch(uint32_t nowMs);
 
   private:
     // =========================================================================
-    // Unified Cache Entry (10 bytes) - Same for ALL platforms
+    // Unified Cache Entry (11 bytes) - Same for ALL platforms
     // =========================================================================
     //
     // A single compact structure used across ESP32, NRF52, and all other platforms.
-    // Memory: 10 bytes × 2048 entries = 20KB
+    // Memory: 11 bytes × 2048 entries = 22KB
     //
     // Position Fingerprinting:
     //   Instead of storing full coordinates (8 bytes) or a computed hash,
@@ -90,6 +109,16 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     //   [7]     pos_time        - Position timestamp (1 byte, adaptive resolution)
     //   [8]     rate_time       - Rate window start (1 byte, adaptive resolution)
     //   [9]     unknown_time    - Unknown tracking start (1 byte, adaptive resolution)
+    //   [10]    next_hop        - Last-byte relay to reach `node` (1 byte, 0 = none)
+    //
+    // next_hop semantics:
+    //   A routing hint: the last byte of the NodeNum to use as next hop to reach
+    //   `node`. Written ONLY from NextHopRouter's ACK-confirmed decision (a
+    //   bidirectionally-verified relay), never inferred one-way from relayed
+    //   traffic. The TMM cache acts as an overflow store for confirmed next-hops
+    //   that have aged out of the hot NodeDB (NodeInfoLite). Unlike the other
+    //   fields it has no TTL of its own — it keeps its slot alive (see runOnce)
+    //   and is refreshed only on the next confirmed exchange.
     //
     struct __attribute__((packed)) UnifiedCacheEntry {
         NodeNum node;            // 4 bytes - Node identifier (0 = empty slot)
@@ -99,66 +128,27 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
         uint8_t pos_time;        // 1 byte  - Position timestamp (adaptive resolution)
         uint8_t rate_time;       // 1 byte  - Rate window start (adaptive resolution)
         uint8_t unknown_time;    // 1 byte  - Unknown tracking start (adaptive resolution)
+        uint8_t next_hop;        // 1 byte  - Last-byte relay to reach `node` (0 = none). See note below.
     };
-    static_assert(sizeof(UnifiedCacheEntry) == 10, "UnifiedCacheEntry should be 10 bytes");
+    static_assert(sizeof(UnifiedCacheEntry) == 11, "UnifiedCacheEntry should be 11 bytes");
 
     // =========================================================================
-    // Cuckoo Hash Table Implementation
+    // Flat unified cache
     // =========================================================================
     //
-    // Cuckoo hashing provides O(1) worst-case lookup time using two hash functions.
-    // Each key can be in one of two possible locations (h1 or h2). On collision,
-    // the existing entry is "kicked" to its alternate location.
+    // Plain array, linear scan (same idiom as WarmNodeStore). A lookup walks at
+    // most cacheSize() × 11 B — microseconds at LoRa packet rates, not worth a
+    // hash table. Insertion on a full cache evicts the stalest entry,
+    // preferring entries without a next_hop hint (those are the long-tail
+    // routing state this cache exists to keep).
     //
-    // Benefits over linear scan:
-    // - O(1) lookup vs O(n) - critical at packet processing rates
-    // - O(1) insertion (amortized) with simple eviction on cycles
-    // - ~95% load factor achievable
-    //
-    // Cache size rounds to power-of-2 for fast modulo via bitmask.
-    // TRAFFIC_MANAGEMENT_CACHE_SIZE=2000 → cacheSize()=2048
-    //
-    static constexpr uint16_t cacheSize();
-    static constexpr uint16_t cacheMask();
+    static constexpr uint16_t cacheSize() { return TRAFFIC_MANAGEMENT_CACHE_SIZE; }
 
-    // Hash functions for cuckoo hashing
-    inline uint16_t cuckooHash1(NodeNum node) const { return node & cacheMask(); }
-    inline uint16_t cuckooHash2(NodeNum node) const { return ((node * 2654435769u) >> (32 - cuckooHashBits())) & cacheMask(); }
-    static constexpr uint8_t cuckooHashBits();
-
-    // NodeInfo cache configuration (PSRAM path):
-    // - Payload lives in PSRAM
-    // - DRAM keeps packed 12-bit tags with 4-way bucketed cuckoo hashing
-    //   (Fan et al., CoNEXT 2014). Tag value 0 is reserved as "empty".
-    static constexpr uint16_t kNodeInfoIndexMetadataBudgetBytes = 3072; // 3KB DRAM tag store
-    static constexpr uint8_t kNodeInfoTargetOccupancyPercent = 95;
-    static constexpr uint8_t kNodeInfoBucketSize = 4;
-    static constexpr uint8_t kNodeInfoTagBits = 12;
-    static constexpr uint16_t kNodeInfoTagMask = static_cast<uint16_t>((1u << kNodeInfoTagBits) - 1u);
-    static constexpr uint16_t kNodeInfoIndexSlotsRaw =
-        static_cast<uint16_t>((kNodeInfoIndexMetadataBudgetBytes * 8u) / kNodeInfoTagBits);
-    static constexpr uint16_t kNodeInfoIndexSlots =
-        static_cast<uint16_t>(kNodeInfoIndexSlotsRaw - (kNodeInfoIndexSlotsRaw % kNodeInfoBucketSize));
-    static constexpr uint16_t kNodeInfoTargetEntries =
-        static_cast<uint16_t>((kNodeInfoIndexSlots * kNodeInfoTargetOccupancyPercent) / 100u);
-    static_assert((kNodeInfoIndexSlots % kNodeInfoBucketSize) == 0, "NodeInfo slot count must align to bucket size");
-    static_assert(kNodeInfoTargetEntries < (1u << kNodeInfoTagBits), "NodeInfo tag bits must encode payload index");
-
-    static constexpr uint16_t nodeInfoTargetEntries();
-    static constexpr uint16_t nodeInfoIndexMetadataBudgetBytes();
-    static constexpr uint8_t nodeInfoTargetOccupancyPercent();
-    static constexpr uint8_t nodeInfoBucketSize();
-    static constexpr uint8_t nodeInfoTagBits();
-    static constexpr uint16_t nodeInfoTagMask();
-    static constexpr uint16_t nodeInfoIndexSlots();
-    static constexpr uint16_t nodeInfoBucketCount();
-    static constexpr uint16_t nodeInfoBucketMask();
-    static constexpr uint8_t nodeInfoBucketHashBits();
-    inline uint16_t nodeInfoHash1(NodeNum node) const { return node & nodeInfoBucketMask(); }
-    inline uint16_t nodeInfoHash2(NodeNum node) const
-    {
-        return ((node * 2246822519u) >> (32 - nodeInfoBucketHashBits())) & nodeInfoBucketMask();
-    }
+    // NodeInfo cache configuration (PSRAM path): a flat PSRAM array of payload
+    // entries, linear scan keyed by `node`, LRU eviction by lastObservedMs.
+    // NodeInfo traffic is low-rate, so a full scan per lookup/insert is fine.
+    static constexpr uint16_t kNodeInfoCacheEntries = 2000;
+    static constexpr uint16_t nodeInfoTargetEntries() { return kNodeInfoCacheEntries; }
 
     // =========================================================================
     // Adaptive Timestamp Resolution
@@ -192,18 +182,28 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
         return static_cast<uint16_t>(res);
     }
 
-    // Convert to/from 8-bit relative timestamps with given resolution
+    // Convert to/from 8-bit relative timestamps with given resolution.
+    //
+    // All stored timestamps carry a uniform +1 "presence" offset: a value of 0 is
+    // reserved for "no timestamp recorded" (which is also the zero-initialized
+    // state), and stored values 1..255 encode raw ticks 0..254. This keeps the
+    // 0-means-empty sentinel consistent with memset/calloc zeroing across every
+    // sub-store, so the maintenance sweep's `_time != 0` presence checks are
+    // unambiguous (a timestamp recorded in the first tick after the epoch is no
+    // longer mistaken for an empty slot). The offset is applied here and removed
+    // on read, so it cancels out in all window math.
     uint8_t toRelativeTime(uint32_t nowMs, uint16_t resolutionSecs) const
     {
         uint32_t ticks = (nowMs - cacheEpochMs) / (resolutionSecs * 1000UL);
-        return (ticks > UINT8_MAX) ? UINT8_MAX : static_cast<uint8_t>(ticks);
+        return (ticks >= UINT8_MAX) ? UINT8_MAX : static_cast<uint8_t>(ticks + 1);
     }
     uint32_t fromRelativeTime(uint8_t ticks, uint16_t resolutionSecs) const
     {
-        return cacheEpochMs + (static_cast<uint32_t>(ticks) * resolutionSecs * 1000UL);
+        return (ticks == 0) ? cacheEpochMs : cacheEpochMs + (static_cast<uint32_t>(ticks - 1) * resolutionSecs * 1000UL);
     }
 
-    // Convenience wrappers for each timestamp type
+    // Convenience wrappers for each timestamp type (the +1 presence offset lives
+    // in the shared converters above, so these are plain pass-throughs).
     uint8_t toRelativePosTime(uint32_t nowMs) const { return toRelativeTime(nowMs, posTimeResolution); }
     uint32_t fromRelativePosTime(uint8_t t) const { return fromRelativeTime(t, posTimeResolution); }
 
@@ -213,17 +213,20 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     uint8_t toRelativeUnknownTime(uint32_t nowMs) const { return toRelativeTime(nowMs, unknownTimeResolution); }
     uint32_t fromRelativeUnknownTime(uint8_t t) const { return fromRelativeTime(t, unknownTimeResolution); }
 
-    // Epoch reset when any timestamp approaches overflow
-    // With max resolution of 339 sec, 200 ticks = ~19 hours (safe margin for 24h max)
-    bool needsEpochReset(uint32_t nowMs) const
+    // Coarsest of the per-feature resolutions (seconds per tick).
+    uint16_t maxResolution() const
     {
         uint16_t maxRes = posTimeResolution;
         if (rateTimeResolution > maxRes)
             maxRes = rateTimeResolution;
         if (unknownTimeResolution > maxRes)
             maxRes = unknownTimeResolution;
-        return (nowMs - cacheEpochMs) > (200UL * maxRes * 1000UL);
+        return maxRes;
     }
+
+    // True when relative offsets approach 8-bit overflow.
+    // With max resolution of 339 sec, 200 ticks = ~19 hours (safe margin for 24h max).
+    bool needsEpochReset(uint32_t nowMs) const { return (nowMs - cacheEpochMs) > (200UL * maxResolution() * 1000UL); }
     // =========================================================================
     // Position Fingerprint
     // =========================================================================
@@ -246,7 +249,7 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     // =========================================================================
 
     mutable concurrency::Lock cacheLock; // Protects all cache access
-    UnifiedCacheEntry *cache = nullptr;  // Cuckoo hash table (unified for all platforms)
+    UnifiedCacheEntry *cache = nullptr;  // Flat unified cache (linear scan; all platforms)
     bool cacheFromPsram = false;         // Tracks allocator for correct deallocation
 
     struct NodeInfoPayloadEntry {
@@ -278,11 +281,8 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
         uint8_t decodedBitfield;
     };
 
-    NodeInfoPayloadEntry *nodeInfoPayload = nullptr; // NodeInfo payloads in PSRAM
+    NodeInfoPayloadEntry *nodeInfoPayload = nullptr; // NodeInfo payloads in PSRAM (flat array, linear scan)
     bool nodeInfoPayloadFromPsram = false;           // Tracks allocator for correct deallocation
-    uint8_t *nodeInfoIndex = nullptr;                // Packed 12-bit NodeInfo tags in DRAM
-    uint16_t nodeInfoAllocHint = 0;
-    uint16_t nodeInfoEvictCursor = 0;
 
     meshtastic_TrafficManagementStats stats;
 
@@ -293,29 +293,22 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     NodeNum exhaustRequestedFrom = 0;
     PacketId exhaustRequestedId = 0;
 
+    // One-shot guard: warm-start next-hop cache from NodeDB on first maintenance pass.
+    bool nextHopPreloaded = false;
+
     // =========================================================================
     // Cache Operations
     // =========================================================================
 
-    // Find or create entry for node using cuckoo hashing
-    // Returns nullptr if cache is full and eviction fails
+    // Find or create entry for node (linear scan; stalest-first eviction when full)
     UnifiedCacheEntry *findOrCreateEntry(NodeNum node, bool *isNew);
 
     // Find existing entry (no creation)
     UnifiedCacheEntry *findEntry(NodeNum node);
 
-    // NodeInfo cache operations (bucketed cuckoo index + PSRAM payloads)
+    // NodeInfo cache operations (flat PSRAM payload array, linear scan)
     const NodeInfoPayloadEntry *findNodeInfoEntry(NodeNum node) const;
     NodeInfoPayloadEntry *findOrCreateNodeInfoEntry(NodeNum node, bool *usedEmptySlot);
-    uint16_t findNodeInfoPayloadIndex(NodeNum node) const;
-    bool removeNodeInfoIndexEntry(NodeNum node, uint16_t payloadIndex);
-    uint16_t allocateNodeInfoPayloadSlot();
-    uint16_t evictNodeInfoPayloadSlot();
-    bool tryInsertNodeInfoEntryInBucket(uint16_t bucket, uint16_t tag);
-    uint16_t encodeNodeInfoTag(uint16_t payloadIndex) const;
-    uint16_t decodeNodeInfoPayloadIndex(uint16_t tag) const;
-    uint16_t getNodeInfoTag(uint16_t slot) const;
-    void setNodeInfoTag(uint16_t slot, uint16_t tag);
     uint16_t countNodeInfoEntriesLocked() const;
     void cacheNodeInfoPacket(const meshtastic_MeshPacket &mp);
 
@@ -333,101 +326,7 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     void incrementStat(uint32_t *field);
 };
 
-// =========================================================================
-// Compile-time Cache Size Calculations
-// =========================================================================
-//
-// Round TRAFFIC_MANAGEMENT_CACHE_SIZE up to next power of 2 for efficient
-// cuckoo hash indexing (allows bitmask instead of modulo).
-//
-// These use C++11-compatible constexpr (single return statement).
-//
-
-namespace detail
-{
-// Helper: round up to next power of 2 using bit manipulation
-constexpr uint16_t nextPow2(uint16_t n)
-{
-    return n == 0 ? 0 : (((n - 1) | ((n - 1) >> 1) | ((n - 1) >> 2) | ((n - 1) >> 4) | ((n - 1) >> 8)) + 1);
-}
-
-// Helper: floor(log2(n)) for n >= 0, C++11-compatible constexpr.
-constexpr uint8_t log2Floor(uint16_t n)
-{
-    return n <= 1 ? 0 : static_cast<uint8_t>(1 + log2Floor(static_cast<uint16_t>(n >> 1)));
-}
-
-// Helper: ceil(log2(n)) for n >= 1, C++11-compatible constexpr.
-constexpr uint8_t log2Ceil(uint16_t n)
-{
-    return n <= 1 ? 0 : static_cast<uint8_t>(1 + log2Floor(static_cast<uint16_t>(n - 1)));
-}
-} // namespace detail
-
-constexpr uint16_t TrafficManagementModule::cacheSize()
-{
-    return detail::nextPow2(TRAFFIC_MANAGEMENT_CACHE_SIZE);
-}
-
-constexpr uint16_t TrafficManagementModule::cacheMask()
-{
-    return cacheSize() > 0 ? cacheSize() - 1 : 0;
-}
-
-constexpr uint8_t TrafficManagementModule::cuckooHashBits()
-{
-    return detail::log2Floor(cacheSize());
-}
-
-constexpr uint16_t TrafficManagementModule::nodeInfoTargetEntries()
-{
-    return kNodeInfoTargetEntries;
-}
-
-constexpr uint16_t TrafficManagementModule::nodeInfoIndexMetadataBudgetBytes()
-{
-    return kNodeInfoIndexMetadataBudgetBytes;
-}
-
-constexpr uint8_t TrafficManagementModule::nodeInfoTargetOccupancyPercent()
-{
-    return kNodeInfoTargetOccupancyPercent;
-}
-
-constexpr uint8_t TrafficManagementModule::nodeInfoBucketSize()
-{
-    return kNodeInfoBucketSize;
-}
-
-constexpr uint8_t TrafficManagementModule::nodeInfoTagBits()
-{
-    return kNodeInfoTagBits;
-}
-
-constexpr uint16_t TrafficManagementModule::nodeInfoTagMask()
-{
-    return kNodeInfoTagMask;
-}
-
-constexpr uint16_t TrafficManagementModule::nodeInfoIndexSlots()
-{
-    return kNodeInfoIndexSlots;
-}
-
-constexpr uint16_t TrafficManagementModule::nodeInfoBucketCount()
-{
-    return static_cast<uint16_t>(nodeInfoIndexSlots() / nodeInfoBucketSize());
-}
-
-constexpr uint16_t TrafficManagementModule::nodeInfoBucketMask()
-{
-    return nodeInfoBucketCount() > 0 ? nodeInfoBucketCount() - 1 : 0;
-}
-
-constexpr uint8_t TrafficManagementModule::nodeInfoBucketHashBits()
-{
-    return detail::log2Floor(nodeInfoBucketCount());
-}
+static_assert(TRAFFIC_MANAGEMENT_CACHE_SIZE <= UINT16_MAX, "cacheSize() returns uint16_t");
 
 extern TrafficManagementModule *trafficManagementModule;
 

--- a/src/modules/TrafficManagementModule.h
+++ b/src/modules/TrafficManagementModule.h
@@ -51,8 +51,11 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     //   NextHopRouter from its ACK-confirmed decision (see sniffReceived). The
     //   byte must come from a bidirectionally-verified relay, not one-way inference.
     // getNextHopHint: return the cached next-hop byte for `dest`, 0 if unknown.
+    // clearNextHop: forget any cached next hop for `dest` (setNextHop refuses to store
+    //   0, so this is the way NextHopRouter decays a stale/failing overflow route).
     void setNextHop(NodeNum dest, uint8_t nextHopByte);
     uint8_t getNextHopHint(NodeNum dest);
+    void clearNextHop(NodeNum dest);
 
     // Warm-start the next-hop cache from persisted NodeInfoLite hints so confirmed
     // hops survive later hot-store (NodeDB) eviction. Idempotent; runs once after

--- a/src/modules/TrafficManagementModule.h
+++ b/src/modules/TrafficManagementModule.h
@@ -52,7 +52,9 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     // Warm-start the next-hop cache from persisted NodeInfoLite hints so confirmed
     // hops survive later hot-store (NodeDB) eviction. Idempotent; runs once after
     // nodeDB is populated (lazily on first maintenance pass).
-    void preloadNextHopsFromNodeDB();
+    // @return true if it actually ran (prereqs met / nothing to do); false if
+    //   prerequisites (cache, nodeDB) weren't ready yet, so the caller should retry.
+    bool preloadNextHopsFromNodeDB();
 
     /**
      * Check if this packet should have its hops exhausted.
@@ -63,6 +65,17 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     {
         return exhaustRequested && exhaustRequestedFrom == getFrom(&mp) && exhaustRequestedId == mp.id;
     }
+
+    // Injectable monotonic clock (ms). All TMM time reads go through clockMs() so unit tests can
+    // advance a virtual timebase instead of sleeping real seconds across the 6 min/360 s tick.
+    // Mirrors HopScalingModule::s_testNowMs. Writable from tests as TrafficManagementModule::s_testNowMs;
+    // ignored in production (clockMs() returns millis()).
+    inline static uint32_t s_testNowMs = 0;
+#ifdef PIO_UNIT_TESTING
+    static uint32_t clockMs() { return s_testNowMs; }
+#else
+    static uint32_t clockMs() { return millis(); }
+#endif
 
   protected:
     ProcessMessage handleReceived(const meshtastic_MeshPacket &mp) override;
@@ -149,9 +162,9 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     static constexpr uint32_t kRateTimeTickMs = 300'000UL;   // 5 min/tick
     static constexpr uint32_t kUnknownTimeTickMs = 60'000UL; // 1 min/tick
 
-    static uint8_t currentPosTick() { return static_cast<uint8_t>(millis() / kPosTimeTickMs); }
-    static uint8_t currentRateTick() { return static_cast<uint8_t>((millis() / kRateTimeTickMs) & 0x0F); }
-    static uint8_t currentUnknownTick() { return static_cast<uint8_t>((millis() / kUnknownTimeTickMs) & 0x0F); }
+    static uint8_t currentPosTick() { return static_cast<uint8_t>(clockMs() / kPosTimeTickMs); }
+    static uint8_t currentRateTick() { return static_cast<uint8_t>((clockMs() / kRateTimeTickMs) & 0x0F); }
+    static uint8_t currentUnknownTick() { return static_cast<uint8_t>((clockMs() / kUnknownTimeTickMs) & 0x0F); }
     // =========================================================================
     // Position Fingerprint
     // =========================================================================

--- a/src/modules/TrafficManagementModule.h
+++ b/src/modules/TrafficManagementModule.h
@@ -22,9 +22,10 @@
  * Memory Optimization:
  * Uses one flat unified cache (plain array, linear scan) shared by all
  * per-node features instead of separate per-feature caches. Timestamps are
- * stored as 8-bit relative offsets from a rolling epoch to further reduce
- * memory footprint. LoRa packet rates are low enough that an O(n) scan of
- * ~1000 11-byte entries is negligible next to packet processing.
+ * stored as free-running modular tick counters (pos: 8-bit 360 s/tick;
+ * rate+unknown: paired 4-bit nibbles in one byte) for a 10-byte entry.
+ * LoRa packet rates are low enough that an O(n) scan of ~1000 entries is
+ * negligible next to packet processing.
  */
 class TrafficManagementModule : public MeshModule, private concurrency::OSThread
 {
@@ -68,69 +69,46 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     bool wantPacket(const meshtastic_MeshPacket *p) override { return true; }
     void alterReceived(meshtastic_MeshPacket &mp) override;
     int32_t runOnce() override;
-    // Protected so test shims can force epoch rollover behavior.
-    void resetEpoch(uint32_t nowMs);
-    // Sliding-epoch rebase: advance the epoch and shift live entries back by the
-    // same wall-clock amount instead of flushing, so cached state survives past the
-    // ~19h horizon. Caller must hold cacheLock.
-    void rebaseEpoch(uint32_t nowMs);
+    // Protected so test shims can flush per-node traffic state.
+    void flushCache();
 
   private:
     // =========================================================================
-    // Unified Cache Entry (11 bytes) - Same for ALL platforms
+    // Unified Cache Entry (10 bytes) - Same for ALL platforms
     // =========================================================================
     //
-    // A single compact structure used across ESP32, NRF52, and all other platforms.
-    // Memory: 11 bytes × 2048 entries = 22KB
-    //
-    // Position Fingerprinting:
-    //   Instead of storing full coordinates (8 bytes) or a computed hash,
-    //   we store an 8-bit fingerprint derived deterministically from the
-    //   truncated lat/lon. This extracts the lower 4 significant bits from
-    //   each coordinate: fingerprint = (lat_low4 << 4) | lon_low4
-    //
-    //   Benefits over hash:
-    //   - Adjacent grid cells have sequential fingerprints (no collision)
-    //   - Two positions only collide if 16+ grid cells apart in BOTH dimensions
-    //   - Deterministic: same input always produces same output
-    //
-    // Adaptive Timestamp Resolution:
-    //   All timestamps use 8-bit values with adaptive resolution calculated
-    //   from config at startup. Resolution = max(60, min(339, interval/2)).
-    //   - Min 60 seconds ensures reasonable precision
-    //   - Max 339 seconds allows ~24 hour range (255 * 339 = 86445 sec)
-    //   - interval/2 ensures at least 2 ticks per configured interval
-    //
     // Layout:
-    //   [0-3]   node            - NodeNum (4 bytes)
-    //   [4]     pos_fingerprint - 4 bits lat + 4 bits lon (1 byte)
-    //   [5]     rate_count      - Packets in current window (1 byte)
-    //   [6]     unknown_count   - Unknown packets count (1 byte)
-    //   [7]     pos_time        - Position timestamp (1 byte, adaptive resolution)
-    //   [8]     rate_time       - Rate window start (1 byte, adaptive resolution)
-    //   [9]     unknown_time    - Unknown tracking start (1 byte, adaptive resolution)
-    //   [10]    next_hop        - Last-byte relay to reach `node` (1 byte, 0 = none)
+    //   [0-3]   node               - NodeNum (4 bytes, 0 = empty slot)
+    //   [4]     pos_fingerprint    - 4 bits lat + 4 bits lon (0 = no position seen)
+    //   [5]     rate_count         - Packets in current rate window (0 = no window active)
+    //   [6]     unknown_count      - Unknown packets in window (0 = no window active)
+    //   [7]     pos_time           - Position tick (uint8, free-running 360 s/tick)
+    //   [8]     rate_unknown_time  - [7:4] rate nibble (300 s/tick) | [3:0] unknown nibble (60 s/tick)
+    //   [9]     next_hop           - Last-byte relay to reach `node` (0 = none)
     //
-    // next_hop semantics:
-    //   A routing hint: the last byte of the NodeNum to use as next hop to reach
-    //   `node`. Written ONLY from NextHopRouter's ACK-confirmed decision (a
-    //   bidirectionally-verified relay), never inferred one-way from relayed
-    //   traffic. The TMM cache acts as an overflow store for confirmed next-hops
-    //   that have aged out of the hot NodeDB (NodeInfoLite). Unlike the other
-    //   fields it has no TTL of its own — it keeps its slot alive (see runOnce)
-    //   and is refreshed only on the next confirmed exchange.
+    // Presence sentinels (no epoch, no +1 offset needed):
+    //   pos active:     pos_fingerprint != 0
+    //   rate active:    rate_count != 0
+    //   unknown active: unknown_count != 0
+    //
+    // next_hop: routing hint written only from ACK-confirmed NextHopRouter decisions.
+    // No TTL — keeps the slot alive across maintenance sweeps.
     //
     struct __attribute__((packed)) UnifiedCacheEntry {
-        NodeNum node;            // 4 bytes - Node identifier (0 = empty slot)
-        uint8_t pos_fingerprint; // 1 byte  - Lower 4 bits of lat + lon
-        uint8_t rate_count;      // 1 byte  - Packet count (saturates at 255)
-        uint8_t unknown_count;   // 1 byte  - Unknown packet count (saturates at 255)
-        uint8_t pos_time;        // 1 byte  - Position timestamp (adaptive resolution)
-        uint8_t rate_time;       // 1 byte  - Rate window start (adaptive resolution)
-        uint8_t unknown_time;    // 1 byte  - Unknown tracking start (adaptive resolution)
-        uint8_t next_hop;        // 1 byte  - Last-byte relay to reach `node` (0 = none). See note below.
+        NodeNum node;
+        uint8_t pos_fingerprint;
+        uint8_t rate_count;
+        uint8_t unknown_count;
+        uint8_t pos_time;
+        uint8_t rate_unknown_time;
+        uint8_t next_hop;
+
+        uint8_t getRateTime() const { return (rate_unknown_time >> 4) & 0x0F; }
+        uint8_t getUnknownTime() const { return rate_unknown_time & 0x0F; }
+        void setRateTime(uint8_t t) { rate_unknown_time = static_cast<uint8_t>((rate_unknown_time & 0x0F) | ((t & 0x0F) << 4)); }
+        void setUnknownTime(uint8_t t) { rate_unknown_time = static_cast<uint8_t>((rate_unknown_time & 0xF0) | (t & 0x0F)); }
     };
-    static_assert(sizeof(UnifiedCacheEntry) == 11, "UnifiedCacheEntry should be 11 bytes");
+    static_assert(sizeof(UnifiedCacheEntry) == 10, "UnifiedCacheEntry should be 10 bytes");
 
     // =========================================================================
     // Flat unified cache
@@ -151,82 +129,29 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     static constexpr uint16_t nodeInfoTargetEntries() { return kNodeInfoCacheEntries; }
 
     // =========================================================================
-    // Adaptive Timestamp Resolution
+    // Free-Running Tick Counters
     // =========================================================================
     //
-    // All timestamps use 8-bit values with adaptive resolution calculated from
-    // config at startup. This allows ~24 hour range while maintaining precision.
+    // Timestamps are stored as free-running modular tick counters derived from
+    // millis(). No epoch anchor needed: modular subtraction gives correct age
+    // as long as the true age stays below the counter period.
     //
-    // Resolution formula: max(60, min(339, interval/2))
-    //   - 60 sec minimum ensures reasonable precision
-    //   - 339 sec maximum allows 24 hour range (255 * 339 ≈ 86400 sec)
-    //   - interval/2 ensures at least 2 ticks per configured interval
+    //   pos_time  : uint8  (256 ticks × 360 s = 25.6 h period; max window 12 h = 120 ticks)
+    //   rate_time : nibble (16 ticks × 300 s = 80 min period; max window 1 h = 12 ticks)
+    //   unknown_time: nibble (16 ticks × 60 s = 16 min period; max window 12 min = 12 ticks)
     //
-    // Since config changes require reboot, resolution is calculated once.
+    // Presence sentinels (no +1 offset needed; count fields serve as guards):
+    //   pos active:     pos_fingerprint != 0  (zero fingerprint astronomically unlikely)
+    //   rate active:    rate_count != 0
+    //   unknown active: unknown_count != 0
     //
-    uint32_t cacheEpochMs = 0;
-    uint16_t posTimeResolution = 60;     // Seconds per tick for position
-    uint16_t rateTimeResolution = 60;    // Seconds per tick for rate limiting
-    uint16_t unknownTimeResolution = 60; // Seconds per tick for unknown tracking
+    static constexpr uint32_t kPosTimeTickMs = 360'000UL;    // 6 min/tick
+    static constexpr uint32_t kRateTimeTickMs = 300'000UL;   // 5 min/tick
+    static constexpr uint32_t kUnknownTimeTickMs = 60'000UL; // 1 min/tick
 
-    // Calculate resolution from configured interval (called once at startup)
-    static uint16_t calcTimeResolution(uint32_t intervalSecs)
-    {
-        // Resolution = interval/2 to ensure at least 2 ticks per interval
-        // Clamped to [60, 339] for min precision and max 24h range
-        uint32_t res = (intervalSecs > 0) ? (intervalSecs / 2) : 60;
-        if (res < 60)
-            res = 60;
-        if (res > 339)
-            res = 339;
-        return static_cast<uint16_t>(res);
-    }
-
-    // Convert to/from 8-bit relative timestamps with given resolution.
-    //
-    // All stored timestamps carry a uniform +1 "presence" offset: a value of 0 is
-    // reserved for "no timestamp recorded" (which is also the zero-initialized
-    // state), and stored values 1..255 encode raw ticks 0..254. This keeps the
-    // 0-means-empty sentinel consistent with memset/calloc zeroing across every
-    // sub-store, so the maintenance sweep's `_time != 0` presence checks are
-    // unambiguous (a timestamp recorded in the first tick after the epoch is no
-    // longer mistaken for an empty slot). The offset is applied here and removed
-    // on read, so it cancels out in all window math.
-    uint8_t toRelativeTime(uint32_t nowMs, uint16_t resolutionSecs) const
-    {
-        uint32_t ticks = (nowMs - cacheEpochMs) / (resolutionSecs * 1000UL);
-        return (ticks >= UINT8_MAX) ? UINT8_MAX : static_cast<uint8_t>(ticks + 1);
-    }
-    uint32_t fromRelativeTime(uint8_t ticks, uint16_t resolutionSecs) const
-    {
-        return (ticks == 0) ? cacheEpochMs : cacheEpochMs + (static_cast<uint32_t>(ticks - 1) * resolutionSecs * 1000UL);
-    }
-
-    // Convenience wrappers for each timestamp type (the +1 presence offset lives
-    // in the shared converters above, so these are plain pass-throughs).
-    uint8_t toRelativePosTime(uint32_t nowMs) const { return toRelativeTime(nowMs, posTimeResolution); }
-    uint32_t fromRelativePosTime(uint8_t t) const { return fromRelativeTime(t, posTimeResolution); }
-
-    uint8_t toRelativeRateTime(uint32_t nowMs) const { return toRelativeTime(nowMs, rateTimeResolution); }
-    uint32_t fromRelativeRateTime(uint8_t t) const { return fromRelativeTime(t, rateTimeResolution); }
-
-    uint8_t toRelativeUnknownTime(uint32_t nowMs) const { return toRelativeTime(nowMs, unknownTimeResolution); }
-    uint32_t fromRelativeUnknownTime(uint8_t t) const { return fromRelativeTime(t, unknownTimeResolution); }
-
-    // Coarsest of the per-feature resolutions (seconds per tick).
-    uint16_t maxResolution() const
-    {
-        uint16_t maxRes = posTimeResolution;
-        if (rateTimeResolution > maxRes)
-            maxRes = rateTimeResolution;
-        if (unknownTimeResolution > maxRes)
-            maxRes = unknownTimeResolution;
-        return maxRes;
-    }
-
-    // True when relative offsets approach 8-bit overflow.
-    // With max resolution of 339 sec, 200 ticks = ~19 hours (safe margin for 24h max).
-    bool needsEpochReset(uint32_t nowMs) const { return (nowMs - cacheEpochMs) > (200UL * maxResolution() * 1000UL); }
+    static uint8_t currentPosTick() { return static_cast<uint8_t>(millis() / kPosTimeTickMs); }
+    static uint8_t currentRateTick() { return static_cast<uint8_t>((millis() / kRateTimeTickMs) & 0x0F); }
+    static uint8_t currentUnknownTick() { return static_cast<uint8_t>((millis() / kUnknownTimeTickMs) & 0x0F); }
     // =========================================================================
     // Position Fingerprint
     // =========================================================================

--- a/src/modules/TrafficManagementModule.h
+++ b/src/modules/TrafficManagementModule.h
@@ -41,6 +41,11 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     void resetStats();
     void recordRouterHopPreserved();
 
+    // True if this relayed broadcast is subject to hop-trimming (no mutation). Drives the clamp in
+    // alterReceived and lets FloodingRouter refuse the higher-hopcount upgrade that would undo it.
+    // Always false when the feature is compiled out.
+    bool wouldHopTrim(const meshtastic_MeshPacket &p) const;
+
     // Next-hop overflow cache (routing hint).
     // setNextHop: store a confirmed last-byte next hop for `dest`. Called by
     //   NextHopRouter from its ACK-confirmed decision (see sniffReceived). The

--- a/test/test_nexthop_routing/test_main.cpp
+++ b/test/test_nexthop_routing/test_main.cpp
@@ -1,0 +1,465 @@
+// Unit tests for NextHop direct-message reliability mitigations (see docs/nexthop-routing-reliability.md):
+//   M1 - NodeDB::resolveLastByte / resolveUniqueLastByte (ambiguity-aware last-byte resolution)
+//   M2 - NextHopRouter::getNextHop strict-neighbor gate + Router::shouldDecrementHopLimit favorite check
+//   M3 - NextHopRouter route-health freshness / failure decay
+//
+// Time handling: the route-health helpers take `now` as a parameter so the 30-minute TTL logic is
+// pure and testable without a clock mock. getNextHop()/sinceLastSeen() use the real native clock;
+// we back-date timestamps relative to it, and the unsigned-subtraction age math is rollover-safe.
+
+#include "MeshTypes.h" // before TestUtil.h: provides NodeNum etc.
+#include "TestUtil.h"
+#include <unity.h>
+
+#include "configuration.h"
+#include "gps/RTC.h"
+#include "mesh/NextHopRouter.h"
+#include "mesh/NodeDB.h"
+#include <cstdio>
+#include <cstring>
+#include <memory>
+
+#define MSG_BUF_LEN 200
+#define TEST_MSG_FMT(fmt, ...)                                                                                                   \
+    do {                                                                                                                         \
+        char _buf[MSG_BUF_LEN];                                                                                                  \
+        snprintf(_buf, sizeof(_buf), fmt, __VA_ARGS__);                                                                          \
+        TEST_MESSAGE(_buf);                                                                                                      \
+    } while (0)
+
+static constexpr NodeNum kLocalNode = 0x11111111; // last byte 0x11
+
+// ---------------------------------------------------------------------------
+// MockNodeDB — inject nodes with controlled last byte, hop distance, age, role, favorite flag.
+// ---------------------------------------------------------------------------
+class MockNodeDB : public NodeDB
+{
+  public:
+    void clearTestNodes()
+    {
+        testNodes.clear();
+        meshNodes = &testNodes;
+        numMeshNodes = 0;
+    }
+
+    // ageSecs is how long ago we last heard the node; getTime() returns a large Unix timestamp on
+    // native, so getTime()-ageSecs does not underflow for the ranges used here.
+    void addNode(NodeNum num, uint8_t hopsAway, bool hasHops, uint32_t ageSecs,
+                 meshtastic_Config_DeviceConfig_Role role = meshtastic_Config_DeviceConfig_Role_CLIENT, bool favorite = false,
+                 bool ignored = false, uint8_t nextHop = NO_NEXT_HOP_PREFERENCE)
+    {
+        meshtastic_NodeInfoLite node = meshtastic_NodeInfoLite_init_zero;
+        node.num = num;
+        node.has_hops_away = hasHops;
+        node.hops_away = hopsAway;
+        node.role = role;
+        node.next_hop = nextHop;
+        node.last_heard = getTime() - ageSecs;
+        nodeInfoLiteSetBit(&node, NODEINFO_BITFIELD_IS_FAVORITE_MASK, favorite);
+        nodeInfoLiteSetBit(&node, NODEINFO_BITFIELD_IS_IGNORED_MASK, ignored);
+        nodeInfoLiteSetBit(&node, NODEINFO_BITFIELD_HAS_USER_MASK, true);
+        testNodes.push_back(node);
+        meshNodes = &testNodes;
+        numMeshNodes = testNodes.size();
+    }
+
+    std::vector<meshtastic_NodeInfoLite> testNodes;
+};
+
+// ---------------------------------------------------------------------------
+// Test shim — expose getNextHop and the route-health helpers; reset health between tests.
+// Nulls cryptLock so the Router base can be (re)constructed (same pattern as test_mqtt MockRouter).
+// ---------------------------------------------------------------------------
+class NextHopRouterTestShim : public NextHopRouter
+{
+  public:
+    NextHopRouterTestShim() : NextHopRouter()
+    {
+        delete cryptLock;
+        cryptLock = nullptr;
+    }
+
+    using NextHopRouter::clearRouteHealth;
+    using NextHopRouter::findRouteHealth;
+    using NextHopRouter::getNextHop;
+    using NextHopRouter::getOrAllocRouteHealth;
+    using NextHopRouter::isRouteStale;
+    using NextHopRouter::noteRouteFailure;
+    using NextHopRouter::noteRouteLearned;
+    using NextHopRouter::noteRouteSuccess;
+    using Router::shouldDecrementHopLimit; // protected in Router
+
+    void resetRouteHealthForTest()
+    {
+        for (auto &h : routeHealth)
+            h = RouteHealth{};
+    }
+};
+
+static MockNodeDB *mockNodeDB = nullptr;
+static NextHopRouterTestShim *shim = nullptr;
+
+static constexpr uint32_t TTL = NextHopRouter::ROUTE_TTL_MSEC;
+static constexpr uint8_t THRESH = NextHopRouter::ROUTE_FAILURE_THRESHOLD;
+static constexpr uint8_t HEALTH_MAX = NextHopRouter::ROUTE_HEALTH_MAX;
+
+// Helper: a decoded packet whose hops-away is `hopsAway`, relayed by last byte `relay`.
+static meshtastic_MeshPacket makeRelayedPacket(uint8_t relay, uint8_t hopsAway)
+{
+    meshtastic_MeshPacket p = meshtastic_MeshPacket_init_zero;
+    p.which_payload_variant = meshtastic_MeshPacket_decoded_tag;
+    p.relay_node = relay;
+    p.hop_start = 4;
+    p.hop_limit = 4 - hopsAway; // getHopsAway() == hop_start - hop_limit
+    return p;
+}
+
+void setUp(void)
+{
+    myNodeInfo.my_node_num = kLocalNode;
+    config.device.role = meshtastic_Config_DeviceConfig_Role_CLIENT;
+    mockNodeDB->clearTestNodes();
+    shim->resetRouteHealthForTest();
+}
+
+void tearDown(void) {}
+
+// ===========================================================================
+// Group 1 — resolveLastByte (M1)
+// ===========================================================================
+
+void test_resolve_none_when_empty(void)
+{
+    ResolvedNode r = mockNodeDB->resolveLastByte(0xAB, true);
+    TEST_ASSERT_EQUAL(LastByteResolution::None, r.status);
+}
+
+void test_resolve_zero_byte_is_none(void)
+{
+    // 0 is the NO_RELAY_NODE / NO_NEXT_HOP_PREFERENCE sentinel — never resolves.
+    mockNodeDB->addNode(0x22222200, 0, true, 60); // last byte maps to 0xFF, not 0
+    TEST_ASSERT_EQUAL(LastByteResolution::None, mockNodeDB->resolveLastByte(0x00, true).status);
+    TEST_ASSERT_EQUAL(LastByteResolution::None, mockNodeDB->resolveLastByte(0x00, false).status);
+}
+
+void test_resolve_unique_neighbor(void)
+{
+    mockNodeDB->addNode(0x000005AB, 0, true, 60); // direct, fresh, last byte 0xAB
+    ResolvedNode r = mockNodeDB->resolveLastByte(0xAB, true);
+    TEST_ASSERT_EQUAL(LastByteResolution::Unique, r.status);
+    TEST_ASSERT_EQUAL_HEX32(0x000005AB, r.num);
+}
+
+void test_resolve_collision_is_ambiguous(void)
+{
+    // Birthday collision: two fresh direct neighbors share last byte 0xAB.
+    mockNodeDB->addNode(0x000005AB, 0, true, 60);
+    mockNodeDB->addNode(0x000006AB, 0, true, 60);
+    ResolvedNode r = mockNodeDB->resolveLastByte(0xAB, true);
+    TEST_ASSERT_EQUAL(LastByteResolution::Ambiguous, r.status);
+    TEST_ASSERT_EQUAL_HEX32(0, r.num); // never silently picks one
+}
+
+void test_resolve_strict_excludes_stale(void)
+{
+    mockNodeDB->addNode(0x000005AB, 0, true, 60);                                // fresh
+    mockNodeDB->addNode(0x000006AB, 0, true, NEXTHOP_NEIGHBOR_FRESH_SECS + 100); // stale
+    ResolvedNode r = mockNodeDB->resolveLastByte(0xAB, true);
+    TEST_ASSERT_EQUAL(LastByteResolution::Unique, r.status);
+    TEST_ASSERT_EQUAL_HEX32(0x000005AB, r.num);
+}
+
+void test_resolve_strict_excludes_far(void)
+{
+    mockNodeDB->addNode(0x000005AB, 0, true, 60); // direct neighbor
+    mockNodeDB->addNode(0x000006AB, 2, true, 60); // 2 hops away -> not a direct neighbor
+    ResolvedNode r = mockNodeDB->resolveLastByte(0xAB, true);
+    TEST_ASSERT_EQUAL(LastByteResolution::Unique, r.status);
+    TEST_ASSERT_EQUAL_HEX32(0x000005AB, r.num);
+}
+
+void test_resolve_lenient_includes_favorite_router(void)
+{
+    // Unknown hop distance, but a favorite ROUTER: lenient gate accepts, strict gate does not.
+    mockNodeDB->addNode(0x000007AB, 0, false, 60, meshtastic_Config_DeviceConfig_Role_ROUTER, /*favorite=*/true);
+    TEST_ASSERT_EQUAL(LastByteResolution::Unique, mockNodeDB->resolveLastByte(0xAB, false).status);
+    TEST_ASSERT_EQUAL(LastByteResolution::None, mockNodeDB->resolveLastByte(0xAB, true).status);
+}
+
+void test_resolve_lenient_collision_favorite_plus_neighbor(void)
+{
+    mockNodeDB->addNode(0x000007AB, 0, false, 60, meshtastic_Config_DeviceConfig_Role_ROUTER, /*favorite=*/true);
+    mockNodeDB->addNode(0x000005AB, 0, true, 60); // direct neighbor, same byte
+    TEST_ASSERT_EQUAL(LastByteResolution::Ambiguous, mockNodeDB->resolveLastByte(0xAB, false).status);
+}
+
+void test_resolve_skips_self(void)
+{
+    // A node equal to us (last byte 0x11) must never resolve to ourselves.
+    mockNodeDB->addNode(kLocalNode, 0, true, 60);
+    TEST_ASSERT_EQUAL(LastByteResolution::None, mockNodeDB->resolveLastByte(0x11, true).status);
+}
+
+void test_resolve_skips_ignored(void)
+{
+    mockNodeDB->addNode(0x000005AB, 0, true, 60, meshtastic_Config_DeviceConfig_Role_CLIENT, false, /*ignored=*/true);
+    TEST_ASSERT_EQUAL(LastByteResolution::None, mockNodeDB->resolveLastByte(0xAB, true).status);
+}
+
+void test_resolve_0x00_maps_to_0xFF_and_collides(void)
+{
+    // getLastByteOfNodeNum() maps ...00 -> 0xFF, so a ...00 node and a ...FF node collide on 0xFF.
+    TEST_ASSERT_EQUAL_HEX8(0xFF, mockNodeDB->getLastByteOfNodeNum(0x11111100));
+    mockNodeDB->addNode(0x11111100, 0, true, 60); // last byte 0xFF (remapped)
+    TEST_ASSERT_EQUAL(LastByteResolution::Unique, mockNodeDB->resolveLastByte(0xFF, true).status);
+    mockNodeDB->addNode(0x222222FF, 0, true, 60); // genuine ...FF
+    TEST_ASSERT_EQUAL(LastByteResolution::Ambiguous, mockNodeDB->resolveLastByte(0xFF, true).status);
+}
+
+void test_resolve_unique_helper(void)
+{
+    mockNodeDB->addNode(0x000005AB, 0, true, 60);
+    NodeNum out = 0;
+    TEST_ASSERT_TRUE(mockNodeDB->resolveUniqueLastByte(0xAB, true, &out));
+    TEST_ASSERT_EQUAL_HEX32(0x000005AB, out);
+    mockNodeDB->addNode(0x000006AB, 0, true, 60); // create collision
+    TEST_ASSERT_FALSE(mockNodeDB->resolveUniqueLastByte(0xAB, true));
+}
+
+// ===========================================================================
+// Group 2 — getNextHop (M2 send-path gate + M3 decay)
+// ===========================================================================
+
+static constexpr NodeNum DEST = 0x000000B0; // DM destination (last byte 0xB0, distinct from 0xAB)
+
+void test_getnexthop_unique_returns_byte(void)
+{
+    mockNodeDB->addNode(DEST, 2, true, 60, meshtastic_Config_DeviceConfig_Role_CLIENT, false, false, /*nextHop=*/0xAB);
+    mockNodeDB->addNode(0x000005AB, 0, true, 60); // unique fresh neighbor with byte 0xAB
+    auto nh = shim->getNextHop(DEST, /*relay=*/0x11);
+    TEST_ASSERT_TRUE(nh.has_value());
+    TEST_ASSERT_EQUAL_HEX8(0xAB, nh.value());
+}
+
+void test_getnexthop_ambiguous_floods(void)
+{
+    mockNodeDB->addNode(DEST, 2, true, 60, meshtastic_Config_DeviceConfig_Role_CLIENT, false, false, /*nextHop=*/0xAB);
+    mockNodeDB->addNode(0x000005AB, 0, true, 60);
+    mockNodeDB->addNode(0x000006AB, 0, true, 60); // collision -> ambiguous
+    TEST_ASSERT_FALSE(shim->getNextHop(DEST, 0x11).has_value());
+}
+
+void test_getnexthop_vanished_neighbor_floods(void)
+{
+    mockNodeDB->addNode(DEST, 2, true, 60, meshtastic_Config_DeviceConfig_Role_CLIENT, false, false, /*nextHop=*/0xAB);
+    // The only 0xAB node is stale -> strict gate yields None -> flood.
+    mockNodeDB->addNode(0x000005AB, 0, true, NEXTHOP_NEIGHBOR_FRESH_SECS + 100);
+    TEST_ASSERT_FALSE(shim->getNextHop(DEST, 0x11).has_value());
+}
+
+void test_getnexthop_split_horizon_floods(void)
+{
+    mockNodeDB->addNode(DEST, 2, true, 60, meshtastic_Config_DeviceConfig_Role_CLIENT, false, false, /*nextHop=*/0xAB);
+    mockNodeDB->addNode(0x000005AB, 0, true, 60);
+    // relay_node == stored next_hop -> don't send it back the way it came.
+    TEST_ASSERT_FALSE(shim->getNextHop(DEST, /*relay=*/0xAB).has_value());
+}
+
+void test_getnexthop_broadcast_is_nullopt(void)
+{
+    TEST_ASSERT_FALSE(shim->getNextHop(NODENUM_BROADCAST, 0x11).has_value());
+}
+
+void test_getnexthop_decays_stale_route(void)
+{
+    mockNodeDB->addNode(DEST, 2, true, 60, meshtastic_Config_DeviceConfig_Role_CLIENT, false, false, /*nextHop=*/0xAB);
+    mockNodeDB->addNode(0x000005AB, 0, true, 60); // a valid unique neighbor exists...
+    // ...but the health record is older than the TTL, so the route should decay to flooding.
+    shim->noteRouteLearned(DEST, 0xAB, millis() - (TTL + 5000));
+    TEST_ASSERT_FALSE(shim->getNextHop(DEST, 0x11).has_value());
+    // Decay also clears the persisted next_hop and the RAM health record.
+    TEST_ASSERT_EQUAL_HEX8(NO_NEXT_HOP_PREFERENCE, mockNodeDB->getMeshNode(DEST)->next_hop);
+    TEST_ASSERT_NULL(shim->findRouteHealth(DEST));
+}
+
+// ===========================================================================
+// Group 3 — route-health helpers (M3)
+// ===========================================================================
+
+void test_health_fresh_not_stale(void)
+{
+    shim->noteRouteLearned(DEST, 0xAB, 1000);
+    RouteHealth *h = shim->findRouteHealth(DEST);
+    TEST_ASSERT_NOT_NULL(h);
+    TEST_ASSERT_FALSE(shim->isRouteStale(*h, 1000 + TTL - 1));
+}
+
+void test_health_ttl_expiry(void)
+{
+    shim->noteRouteLearned(DEST, 0xAB, 1000);
+    RouteHealth *h = shim->findRouteHealth(DEST);
+    TEST_ASSERT_TRUE(shim->isRouteStale(*h, 1000 + TTL)); // boundary is inclusive (>=)
+}
+
+void test_health_ttl_rollover_safe(void)
+{
+    const uint32_t learnAt = 0xFFFFFFFFu - 1000; // learned just before the millis() rollover
+    shim->noteRouteLearned(DEST, 0xAB, learnAt);
+    RouteHealth *h = shim->findRouteHealth(DEST);
+    // 1500 ms later (wrapped to now=500): unsigned subtraction yields ~1500 ms, not "stale".
+    TEST_ASSERT_FALSE(shim->isRouteStale(*h, 500));
+}
+
+void test_health_failure_threshold(void)
+{
+    shim->noteRouteLearned(DEST, 0xAB, 1000);
+    for (uint8_t i = 1; i < THRESH; i++)
+        shim->noteRouteFailure(DEST);
+    TEST_ASSERT_FALSE(shim->isRouteStale(*shim->findRouteHealth(DEST), 1000)); // THRESH-1 failures: ok
+    shim->noteRouteFailure(DEST);
+    TEST_ASSERT_TRUE(shim->isRouteStale(*shim->findRouteHealth(DEST), 1000)); // THRESH failures: stale
+}
+
+void test_health_success_resets_failures(void)
+{
+    shim->noteRouteLearned(DEST, 0xAB, 1000);
+    shim->noteRouteFailure(DEST);
+    shim->noteRouteFailure(DEST);
+    shim->noteRouteSuccess(DEST, 2000);
+    RouteHealth *h = shim->findRouteHealth(DEST);
+    TEST_ASSERT_EQUAL_UINT8(0, h->consecutiveFailures);
+    TEST_ASSERT_FALSE(shim->isRouteStale(*h, 2000));
+}
+
+void test_health_relearn_same_hop_keeps_failures(void)
+{
+    // Anti-flap: an asymmetric reverse path re-teaching the same dead hop must not reset failures.
+    shim->noteRouteLearned(DEST, 0xAB, 1000);
+    shim->noteRouteFailure(DEST);
+    shim->noteRouteFailure(DEST);
+    shim->noteRouteLearned(DEST, 0xAB, 2000); // same hop
+    TEST_ASSERT_EQUAL_UINT8(2, shim->findRouteHealth(DEST)->consecutiveFailures);
+}
+
+void test_health_relearn_new_hop_resets_failures(void)
+{
+    shim->noteRouteLearned(DEST, 0xAB, 1000);
+    shim->noteRouteFailure(DEST);
+    shim->noteRouteFailure(DEST);
+    shim->noteRouteLearned(DEST, 0xCD, 2000); // genuinely new hop -> clean slate
+    RouteHealth *h = shim->findRouteHealth(DEST);
+    TEST_ASSERT_EQUAL_UINT8(0, h->consecutiveFailures);
+    TEST_ASSERT_EQUAL_HEX8(0xCD, h->lastNextHop);
+}
+
+void test_health_failure_without_record_is_noop(void)
+{
+    shim->noteRouteFailure(DEST); // no record yet
+    TEST_ASSERT_NULL(shim->findRouteHealth(DEST));
+}
+
+void test_health_clear(void)
+{
+    shim->noteRouteLearned(DEST, 0xAB, 1000);
+    TEST_ASSERT_NOT_NULL(shim->findRouteHealth(DEST));
+    shim->clearRouteHealth(DEST);
+    TEST_ASSERT_NULL(shim->findRouteHealth(DEST));
+}
+
+void test_health_lru_eviction_bounds_table(void)
+{
+    // Fill every slot with increasing learn times, then add one more: the oldest must be evicted.
+    for (uint8_t i = 0; i < HEALTH_MAX; i++)
+        shim->noteRouteLearned(0x1000 + i, 0xAB, 1000 + (uint32_t)i * 1000);
+    NodeNum oldest = 0x1000;
+    TEST_ASSERT_NOT_NULL(shim->findRouteHealth(oldest));
+    shim->noteRouteLearned(0x2000, 0xAB, 1000 + (uint32_t)HEALTH_MAX * 1000); // overflow
+    TEST_ASSERT_NULL(shim->findRouteHealth(oldest));                          // evicted
+    TEST_ASSERT_NOT_NULL(shim->findRouteHealth(0x2000));                      // newest present
+}
+
+// ===========================================================================
+// Group 4 — shouldDecrementHopLimit favorite-router resolution (M2, site 4)
+// ===========================================================================
+
+void test_hoplimit_preserve_unique_favorite_router(void)
+{
+    config.device.role = meshtastic_Config_DeviceConfig_Role_ROUTER;
+    mockNodeDB->addNode(0x000007AB, 0, true, 60, meshtastic_Config_DeviceConfig_Role_ROUTER, /*favorite=*/true);
+    meshtastic_MeshPacket p = makeRelayedPacket(/*relay=*/0xAB, /*hopsAway=*/1);
+    TEST_ASSERT_FALSE(shim->shouldDecrementHopLimit(&p)); // preserve
+}
+
+void test_hoplimit_decrement_on_colliding_favorites(void)
+{
+    // Headline regression: two favorite routers share the relay byte -> ambiguous -> decrement
+    // (the old "first NodeDB match wins" scan would non-deterministically preserve).
+    config.device.role = meshtastic_Config_DeviceConfig_Role_ROUTER;
+    mockNodeDB->addNode(0x000007AB, 0, true, 60, meshtastic_Config_DeviceConfig_Role_ROUTER, /*favorite=*/true);
+    mockNodeDB->addNode(0x000008AB, 0, true, 60, meshtastic_Config_DeviceConfig_Role_ROUTER, /*favorite=*/true);
+    meshtastic_MeshPacket p = makeRelayedPacket(0xAB, 1);
+    TEST_ASSERT_TRUE(shim->shouldDecrementHopLimit(&p)); // decrement
+}
+
+void test_hoplimit_decrement_when_resolved_not_favorite(void)
+{
+    config.device.role = meshtastic_Config_DeviceConfig_Role_ROUTER;
+    mockNodeDB->addNode(0x000007AB, 0, true, 60, meshtastic_Config_DeviceConfig_Role_ROUTER, /*favorite=*/false);
+    meshtastic_MeshPacket p = makeRelayedPacket(0xAB, 1);
+    TEST_ASSERT_TRUE(shim->shouldDecrementHopLimit(&p)); // unique but not a favorite -> decrement
+}
+
+// ===========================================================================
+
+void setup()
+{
+    initializeTestEnvironment();
+    UNITY_BEGIN();
+
+    mockNodeDB = new MockNodeDB();
+    shim = new NextHopRouterTestShim();
+    nodeDB = mockNodeDB;
+
+    printf("\n=== resolveLastByte (M1) ===\n");
+    RUN_TEST(test_resolve_none_when_empty);
+    RUN_TEST(test_resolve_zero_byte_is_none);
+    RUN_TEST(test_resolve_unique_neighbor);
+    RUN_TEST(test_resolve_collision_is_ambiguous);
+    RUN_TEST(test_resolve_strict_excludes_stale);
+    RUN_TEST(test_resolve_strict_excludes_far);
+    RUN_TEST(test_resolve_lenient_includes_favorite_router);
+    RUN_TEST(test_resolve_lenient_collision_favorite_plus_neighbor);
+    RUN_TEST(test_resolve_skips_self);
+    RUN_TEST(test_resolve_skips_ignored);
+    RUN_TEST(test_resolve_0x00_maps_to_0xFF_and_collides);
+    RUN_TEST(test_resolve_unique_helper);
+
+    printf("\n=== getNextHop (M2 + M3 decay) ===\n");
+    RUN_TEST(test_getnexthop_unique_returns_byte);
+    RUN_TEST(test_getnexthop_ambiguous_floods);
+    RUN_TEST(test_getnexthop_vanished_neighbor_floods);
+    RUN_TEST(test_getnexthop_split_horizon_floods);
+    RUN_TEST(test_getnexthop_broadcast_is_nullopt);
+    RUN_TEST(test_getnexthop_decays_stale_route);
+
+    printf("\n=== route-health helpers (M3) ===\n");
+    RUN_TEST(test_health_fresh_not_stale);
+    RUN_TEST(test_health_ttl_expiry);
+    RUN_TEST(test_health_ttl_rollover_safe);
+    RUN_TEST(test_health_failure_threshold);
+    RUN_TEST(test_health_success_resets_failures);
+    RUN_TEST(test_health_relearn_same_hop_keeps_failures);
+    RUN_TEST(test_health_relearn_new_hop_resets_failures);
+    RUN_TEST(test_health_failure_without_record_is_noop);
+    RUN_TEST(test_health_clear);
+    RUN_TEST(test_health_lru_eviction_bounds_table);
+
+    printf("\n=== shouldDecrementHopLimit (M2 site 4) ===\n");
+    RUN_TEST(test_hoplimit_preserve_unique_favorite_router);
+    RUN_TEST(test_hoplimit_decrement_on_colliding_favorites);
+    RUN_TEST(test_hoplimit_decrement_when_resolved_not_favorite);
+
+    exit(UNITY_END());
+}
+
+void loop() {}

--- a/test/test_position_module/test_main.cpp
+++ b/test/test_position_module/test_main.cpp
@@ -1,5 +1,5 @@
-#include "PositionModule.h"
 #include "TestUtil.h"
+#include "modules/PositionModule.h"
 #include <unity.h>
 
 // These exercise PositionModule's pure broadcast-policy helpers (stationary detection and the

--- a/test/test_position_module/test_main.cpp
+++ b/test/test_position_module/test_main.cpp
@@ -1,0 +1,81 @@
+#include "PositionModule.h"
+#include "TestUtil.h"
+#include <unity.h>
+
+// These exercise PositionModule's pure broadcast-policy helpers (stationary detection and the
+// interval floor). They take plain values, so no device globals or fake clock are needed.
+
+// Coordinates sharing the top `precision` bits land in the same grid cell.
+static void test_withinPrecisionCell_jitterStaysInCell()
+{
+    // At precision 16 the top 16 bits define the cell; the low 16 bits are GPS jitter.
+    TEST_ASSERT_TRUE(PositionModule::positionWithinPrecisionCell(0x12340000, 0x22340000, 0x1234ABCD, 0x2234EF01, 16));
+}
+
+static void test_withinPrecisionCell_movingLatLeavesCell()
+{
+    TEST_ASSERT_FALSE(PositionModule::positionWithinPrecisionCell(0x12340000, 0x22340000, 0x12350000, 0x22340000, 16));
+}
+
+static void test_withinPrecisionCell_movingLonLeavesCell()
+{
+    TEST_ASSERT_FALSE(PositionModule::positionWithinPrecisionCell(0x12340000, 0x22340000, 0x12340000, 0x22350000, 16));
+}
+
+// precision 0 means position sharing is off — never treat as stationary/suppressible.
+static void test_withinPrecisionCell_zeroPrecisionNeverSuppresses()
+{
+    TEST_ASSERT_FALSE(PositionModule::positionWithinPrecisionCell(0x12340000, 0x22340000, 0x12340000, 0x22340000, 0));
+}
+
+// Full precision (>=32): any difference matters, and identical full-precision coords still aren't
+// "stationary" because there's no coarse cell to hold within.
+static void test_withinPrecisionCell_fullPrecisionNeverSuppresses()
+{
+    TEST_ASSERT_FALSE(PositionModule::positionWithinPrecisionCell(0x12340000, 0x22340000, 0x12340000, 0x22340000, 32));
+}
+
+static void test_effectiveInterval_stationaryRaisesToFloor()
+{
+    TEST_ASSERT_EQUAL_UINT32(43200000U, PositionModule::effectiveBroadcastIntervalMs(60000U, true, 43200000U));
+}
+
+static void test_effectiveInterval_movingKeepsConfigured()
+{
+    TEST_ASSERT_EQUAL_UINT32(60000U, PositionModule::effectiveBroadcastIntervalMs(60000U, false, 43200000U));
+}
+
+// A configured interval already longer than the floor is never shortened.
+static void test_effectiveInterval_longConfiguredWinsOverFloor()
+{
+    TEST_ASSERT_EQUAL_UINT32(50000000U, PositionModule::effectiveBroadcastIntervalMs(50000000U, true, 43200000U));
+}
+
+static void test_effectiveInterval_zeroFloorIsNoOp()
+{
+    TEST_ASSERT_EQUAL_UINT32(60000U, PositionModule::effectiveBroadcastIntervalMs(60000U, true, 0U));
+}
+
+void setUp(void) {}
+
+void tearDown(void) {}
+
+extern "C" {
+void setup()
+{
+    initializeTestEnvironment();
+    UNITY_BEGIN();
+    RUN_TEST(test_withinPrecisionCell_jitterStaysInCell);
+    RUN_TEST(test_withinPrecisionCell_movingLatLeavesCell);
+    RUN_TEST(test_withinPrecisionCell_movingLonLeavesCell);
+    RUN_TEST(test_withinPrecisionCell_zeroPrecisionNeverSuppresses);
+    RUN_TEST(test_withinPrecisionCell_fullPrecisionNeverSuppresses);
+    RUN_TEST(test_effectiveInterval_stationaryRaisesToFloor);
+    RUN_TEST(test_effectiveInterval_movingKeepsConfigured);
+    RUN_TEST(test_effectiveInterval_longConfiguredWinsOverFloor);
+    RUN_TEST(test_effectiveInterval_zeroFloorIsNoOp);
+    exit(UNITY_END());
+}
+
+void loop() {}
+}

--- a/test/test_traffic_management/test_main.cpp
+++ b/test/test_traffic_management/test_main.cpp
@@ -1,3 +1,4 @@
+#include "MeshTypes.h" // Include BEFORE TestUtil.h — provides HAS_TRAFFIC_MANAGEMENT (via mesh-pb-constants.h)
 #include "TestUtil.h"
 #include <cstdlib>
 #include <unity.h>
@@ -10,6 +11,9 @@
 
 #if HAS_TRAFFIC_MANAGEMENT
 
+#include "airtime.h"
+#if HAS_VARIABLE_HOPS
+#endif
 #include "mesh/CryptoEngine.h"
 #include "mesh/MeshService.h"
 #include "mesh/NodeDB.h"
@@ -27,6 +31,25 @@ namespace
 constexpr NodeNum kLocalNode = 0x11111111;
 constexpr NodeNum kRemoteNode = 0x22222222;
 constexpr NodeNum kTargetNode = 0x33333333;
+
+// Telemetry hop exhaustion is gated on channel congestion (alterReceived checks
+// airTime->isTxAllowedChannelUtil/isTxAllowedAirUtil). Installs a global
+// airTime reporting 100% channel utilization for the enclosing scope.
+class ScopedBusyAirTime
+{
+  public:
+    ScopedBusyAirTime() : previous(airTime)
+    {
+        for (uint32_t i = 0; i < CHANNEL_UTILIZATION_PERIODS; i++)
+            busy.channelUtilization[i] = 10000; // 10 s of airtime per 10 s period
+        airTime = &busy;
+    }
+    ~ScopedBusyAirTime() { airTime = previous; }
+
+  private:
+    AirTime busy;
+    AirTime *previous;
+};
 
 class MockNodeDB : public NodeDB
 {
@@ -52,6 +75,32 @@ class MockNodeDB : public NodeDB
         cachedNodeNum = n;
         cachedNode.num = n;
         cachedNode.bitfield |= NODEINFO_BITFIELD_HAS_USER_MASK;
+    }
+
+    // Role the TMM should see for the cached node (sender-role-aware throttles).
+    void setCachedNodeRole(meshtastic_Config_DeviceConfig_Role role) { cachedNode.role = role; }
+
+    // Seed a node into the hot-store buffer at index 1 (index 0 is reserved for
+    // "self"). Respects the fixed-buffer invariant: `meshNodes` is a buffer of
+    // MAX_NUM_NODES slots with `numMeshNodes` as the logical count — we grow the
+    // buffer if needed and bump the count, never clear()/push_back() (which would
+    // shrink it and break NodeDB::resetNodes()'s begin()+1..end() fill).
+    void setHotNode(NodeNum n, uint8_t nextHop)
+    {
+        if (meshNodes->size() < 2)
+            meshNodes->resize(2);
+        (*meshNodes)[1] = meshtastic_NodeInfoLite_init_zero;
+        (*meshNodes)[1].num = n;
+        (*meshNodes)[1].next_hop = nextHop;
+        numMeshNodes = 2;
+    }
+
+    // Evict everything but "self" — simulates the hot DB rolling over. Logical
+    // count only; the buffer is left intact so the invariant holds.
+    void rollHotStore()
+    {
+        numMeshNodes = 1;
+        clearCachedNode();
     }
 
   private:
@@ -121,6 +170,9 @@ static void resetTrafficConfig()
     config = meshtastic_LocalConfig_init_zero;
     config.device.role = meshtastic_Config_DeviceConfig_Role_CLIENT;
 
+    channelFile = meshtastic_ChannelFile_init_zero;
+    owner.is_licensed = false;
+
     myNodeInfo.my_node_num = kLocalNode;
 
     router = nullptr;
@@ -173,6 +225,42 @@ static meshtastic_MeshPacket makePositionPacket(NodeNum from, int32_t lat, int32
     packet.decoded.payload.size =
         pb_encode_to_bytes(packet.decoded.payload.bytes, sizeof(packet.decoded.payload.bytes), &meshtastic_Position_msg, &pos);
     return packet;
+}
+
+static meshtastic_MeshPacket makePositionPacketWithPrecision(NodeNum from, int32_t lat, int32_t lon, uint32_t precisionBits)
+{
+    meshtastic_MeshPacket packet = makeDecodedPacket(meshtastic_PortNum_POSITION_APP, from, NODENUM_BROADCAST);
+    meshtastic_Position pos = meshtastic_Position_init_zero;
+    pos.has_latitude_i = true;
+    pos.has_longitude_i = true;
+    pos.latitude_i = lat;
+    pos.longitude_i = lon;
+    pos.precision_bits = precisionBits;
+
+    packet.decoded.payload.size =
+        pb_encode_to_bytes(packet.decoded.payload.bytes, sizeof(packet.decoded.payload.bytes), &meshtastic_Position_msg, &pos);
+    return packet;
+}
+
+static bool decodePositionPayload(const meshtastic_MeshPacket &packet, meshtastic_Position &out)
+{
+    out = meshtastic_Position_init_zero;
+    return pb_decode_from_bytes(packet.decoded.payload.bytes, packet.decoded.payload.size, &meshtastic_Position_msg, &out);
+}
+
+// Primary channel with a well-known single-byte PSK and the (empty -> preset)
+// default name, so Channels::isWellKnownChannel(0) is true.
+static void installWellKnownPrimaryChannel()
+{
+    channelFile = meshtastic_ChannelFile_init_zero;
+    channelFile.channels_count = 1;
+    channelFile.channels[0].index = 0;
+    channelFile.channels[0].has_settings = true;
+    channelFile.channels[0].role = meshtastic_Channel_Role_PRIMARY;
+    channelFile.channels[0].settings.psk.size = 1;
+    channelFile.channels[0].settings.psk.bytes[0] = 1;
+    config.lora.use_preset = true;
+    config.lora.modem_preset = meshtastic_Config_LoRaConfig_ModemPreset_LONG_FAST;
 }
 
 static meshtastic_MeshPacket makeNodeInfoPacket(NodeNum from, const char *longName, const char *shortName)
@@ -290,7 +378,7 @@ static void test_tm_rateLimit_dropsOnlyAfterThreshold(void)
     moduleConfig.traffic_management.rate_limit_window_secs = 60;
     moduleConfig.traffic_management.rate_limit_max_packets = 3;
     TrafficManagementModuleTestShim module;
-    meshtastic_MeshPacket packet = makeDecodedPacket(meshtastic_PortNum_TEXT_MESSAGE_APP, kRemoteNode);
+    meshtastic_MeshPacket packet = makeDecodedPacket(meshtastic_PortNum_TELEMETRY_APP, kRemoteNode);
 
     ProcessMessage r1 = module.handleReceived(packet);
     ProcessMessage r2 = module.handleReceived(packet);
@@ -305,31 +393,6 @@ static void test_tm_rateLimit_dropsOnlyAfterThreshold(void)
     TEST_ASSERT_EQUAL_UINT32(1, stats.rate_limit_drops);
     TEST_ASSERT_TRUE(module.ignoreRequestFlag());
 }
-
-/**
- * Verify routing/admin traffic is exempt from rate limiting.
- * Important because throttling control traffic can destabilize the mesh.
- */
-static void test_tm_rateLimit_skipsRoutingAndAdminPorts(void)
-{
-    moduleConfig.traffic_management.rate_limit_enabled = true;
-    moduleConfig.traffic_management.rate_limit_window_secs = 60;
-    moduleConfig.traffic_management.rate_limit_max_packets = 1;
-    TrafficManagementModuleTestShim module;
-    meshtastic_MeshPacket routingPacket = makeDecodedPacket(meshtastic_PortNum_ROUTING_APP, kRemoteNode);
-    meshtastic_MeshPacket adminPacket = makeDecodedPacket(meshtastic_PortNum_ADMIN_APP, kRemoteNode);
-
-    for (int i = 0; i < 4; i++) {
-        ProcessMessage rr = module.handleReceived(routingPacket);
-        ProcessMessage ar = module.handleReceived(adminPacket);
-        TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::CONTINUE), static_cast<int>(rr));
-        TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::CONTINUE), static_cast<int>(ar));
-    }
-
-    meshtastic_TrafficManagementStats stats = module.getStats();
-    TEST_ASSERT_EQUAL_UINT32(0, stats.rate_limit_drops);
-}
-
 /**
  * Verify packets sourced from this node bypass dedup and rate limiting.
  * Important so local transmissions are not accidentally self-throttled.
@@ -650,12 +713,15 @@ static void test_tm_nodeinfo_directResponse_psramMissDoesNotFallbackToNodeDb(voi
 #endif
 
 /**
- * Verify relayed telemetry broadcasts are hop-exhausted when enabled.
+ * Verify relayed telemetry broadcasts are hop-exhausted when enabled AND the
+ * channel is congested (telemetry exhaustion is gated on channel utilization,
+ * unlike position exhaustion).
  * Important to prevent further mesh propagation while still allowing one relay step.
  */
 static void test_tm_alterReceived_exhaustsRelayedTelemetryBroadcast(void)
 {
     moduleConfig.traffic_management.exhaust_hop_telemetry = true;
+    ScopedBusyAirTime busyChannel;
     TrafficManagementModuleTestShim module;
     meshtastic_MeshPacket packet = makeDecodedPacket(meshtastic_PortNum_TELEMETRY_APP, kRemoteNode, NODENUM_BROADCAST);
     packet.hop_start = 5;
@@ -670,6 +736,8 @@ static void test_tm_alterReceived_exhaustsRelayedTelemetryBroadcast(void)
     TEST_ASSERT_EQUAL_UINT32(1, stats.hop_exhausted_packets);
 }
 
+#if HAS_VARIABLE_HOPS
+#endif // HAS_VARIABLE_HOPS
 /**
  * Verify hop exhaustion skips unicast and local-origin packets.
  * Important to avoid mutating traffic that should retain normal forwarding behavior.
@@ -677,6 +745,7 @@ static void test_tm_alterReceived_exhaustsRelayedTelemetryBroadcast(void)
 static void test_tm_alterReceived_skipsLocalAndUnicast(void)
 {
     moduleConfig.traffic_management.exhaust_hop_telemetry = true;
+    ScopedBusyAirTime busyChannel; // congestion satisfied, so only the skip conditions are under test
     TrafficManagementModuleTestShim module;
 
     meshtastic_MeshPacket unicast = makeDecodedPacket(meshtastic_PortNum_TELEMETRY_APP, kRemoteNode, kTargetNode);
@@ -794,8 +863,11 @@ static void test_tm_positionDedup_precision32_allowsDistinctPositions(void)
 }
 
 /**
- * Verify invalid precision=0 is treated as full precision.
- * Important so invalid config does not collapse all positions into one fingerprint.
+ * Verify precision=0 falls back to the default precision (same contract as
+ * >32: getConfiguredOrDefault + sanitizePositionPrecision treat 0 as unset).
+ * Important so invalid config does not collapse all positions into one
+ * fingerprint — positions in different default-precision grid cells must
+ * still be distinct.
  */
 static void test_tm_positionDedup_precisionZero_allowsDistinctPositions(void)
 {
@@ -805,7 +877,7 @@ static void test_tm_positionDedup_precisionZero_allowsDistinctPositions(void)
     TrafficManagementModuleTestShim module;
 
     meshtastic_MeshPacket first = makePositionPacket(kRemoteNode, 374221234, -1220845678);
-    meshtastic_MeshPacket second = makePositionPacket(kRemoteNode, 374221235, -1220845677);
+    meshtastic_MeshPacket second = makePositionPacket(kRemoteNode, 384221234, -1210845678);
 
     ProcessMessage r1 = module.handleReceived(first);
     ProcessMessage r2 = module.handleReceived(second);
@@ -857,11 +929,11 @@ static void test_tm_positionDedup_priorRateState_doesNotDropFirstFingerprintZero
     moduleConfig.traffic_management.rate_limit_max_packets = 10;
     TrafficManagementModuleTestShim module;
 
-    meshtastic_MeshPacket text = makeDecodedPacket(meshtastic_PortNum_TEXT_MESSAGE_APP, kRemoteNode);
+    meshtastic_MeshPacket telemetry = makeDecodedPacket(meshtastic_PortNum_TELEMETRY_APP, kRemoteNode);
     meshtastic_MeshPacket first = makePositionPacket(kRemoteNode, 0x12300000, 0x45600000);
     meshtastic_MeshPacket duplicate = makePositionPacket(kRemoteNode, 0x12300000, 0x45600000);
 
-    ProcessMessage seeded = module.handleReceived(text);
+    ProcessMessage seeded = module.handleReceived(telemetry);
     ProcessMessage r1 = module.handleReceived(first);
     ProcessMessage r2 = module.handleReceived(duplicate);
     meshtastic_TrafficManagementStats stats = module.getStats();
@@ -882,7 +954,7 @@ static void test_tm_rateLimit_resetsAfterWindowExpires(void)
     moduleConfig.traffic_management.rate_limit_window_secs = 1;
     moduleConfig.traffic_management.rate_limit_max_packets = 1;
     TrafficManagementModuleTestShim module;
-    meshtastic_MeshPacket packet = makeDecodedPacket(meshtastic_PortNum_TEXT_MESSAGE_APP, kRemoteNode);
+    meshtastic_MeshPacket packet = makeDecodedPacket(meshtastic_PortNum_TELEMETRY_APP, kRemoteNode);
 
     ProcessMessage r1 = module.handleReceived(packet);
     ProcessMessage r2 = module.handleReceived(packet);
@@ -895,30 +967,6 @@ static void test_tm_rateLimit_resetsAfterWindowExpires(void)
     TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::CONTINUE), static_cast<int>(r3));
     TEST_ASSERT_EQUAL_UINT32(1, stats.rate_limit_drops);
 }
-
-/**
- * Verify rate-limit thresholds above 255 effectively clamp to 255.
- * Important because counters are uint8_t and must not overflow behavior.
- */
-static void test_tm_rateLimit_thresholdAbove255_clamps(void)
-{
-    moduleConfig.traffic_management.rate_limit_enabled = true;
-    moduleConfig.traffic_management.rate_limit_window_secs = 60;
-    moduleConfig.traffic_management.rate_limit_max_packets = 300;
-    TrafficManagementModuleTestShim module;
-    meshtastic_MeshPacket packet = makeDecodedPacket(meshtastic_PortNum_TEXT_MESSAGE_APP, kRemoteNode);
-
-    for (int i = 0; i < 255; i++) {
-        ProcessMessage result = module.handleReceived(packet);
-        TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::CONTINUE), static_cast<int>(result));
-    }
-    ProcessMessage dropped = module.handleReceived(packet);
-    meshtastic_TrafficManagementStats stats = module.getStats();
-
-    TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::STOP), static_cast<int>(dropped));
-    TEST_ASSERT_EQUAL_UINT32(1, stats.rate_limit_drops);
-}
-
 /**
  * Verify unknown-packet tracking resets after its active window expires.
  * Important so old unknown traffic does not trigger delayed drops.
@@ -966,12 +1014,14 @@ static void test_tm_unknownPackets_thresholdAbove255_clamps(void)
 }
 
 /**
- * Verify relayed position broadcasts can also be hop-exhausted.
+ * Verify relayed position broadcasts can also be hop-exhausted — under the
+ * same pressure gate as telemetry (here: channel congestion).
  * Important because telemetry and position use separate exhaust flags.
  */
 static void test_tm_alterReceived_exhaustsRelayedPositionBroadcast(void)
 {
     moduleConfig.traffic_management.exhaust_hop_position = true;
+    ScopedBusyAirTime busyChannel;
     TrafficManagementModuleTestShim module;
     meshtastic_MeshPacket packet = makePositionPacket(kRemoteNode, 374221234, -1220845678, NODENUM_BROADCAST);
     packet.hop_start = 5;
@@ -985,7 +1035,6 @@ static void test_tm_alterReceived_exhaustsRelayedPositionBroadcast(void)
     TEST_ASSERT_TRUE(module.shouldExhaustHops(packet));
     TEST_ASSERT_EQUAL_UINT32(1, stats.hop_exhausted_packets);
 }
-
 /**
  * Verify hop exhaustion ignores undecoded/encrypted packets.
  * Important so we never mutate packets that were not decoded by this module.
@@ -993,6 +1042,7 @@ static void test_tm_alterReceived_exhaustsRelayedPositionBroadcast(void)
 static void test_tm_alterReceived_skipsUndecodedPackets(void)
 {
     moduleConfig.traffic_management.exhaust_hop_telemetry = true;
+    ScopedBusyAirTime busyChannel; // congestion satisfied, so only the undecoded skip is under test
     TrafficManagementModuleTestShim module;
     meshtastic_MeshPacket packet = makeUnknownPacket(kRemoteNode, NODENUM_BROADCAST);
     packet.hop_start = 5;
@@ -1014,6 +1064,7 @@ static void test_tm_alterReceived_skipsUndecodedPackets(void)
 static void test_tm_alterReceived_resetExhaustFlagOnNextPacket(void)
 {
     moduleConfig.traffic_management.exhaust_hop_telemetry = true;
+    ScopedBusyAirTime busyChannel; // telemetry exhaust only fires under congestion
     TrafficManagementModuleTestShim module;
 
     meshtastic_MeshPacket telemetry = makeDecodedPacket(meshtastic_PortNum_TELEMETRY_APP, kRemoteNode, NODENUM_BROADCAST);
@@ -1039,6 +1090,7 @@ static void test_tm_alterReceived_resetExhaustFlagOnNextPacket(void)
 static void test_tm_alterReceived_exhaustFlag_isPacketScoped(void)
 {
     moduleConfig.traffic_management.exhaust_hop_telemetry = true;
+    ScopedBusyAirTime busyChannel; // telemetry exhaust only fires under congestion
     TrafficManagementModuleTestShim module;
 
     meshtastic_MeshPacket exhausted = makeDecodedPacket(meshtastic_PortNum_TELEMETRY_APP, kRemoteNode, NODENUM_BROADCAST);
@@ -1083,6 +1135,95 @@ static void test_tm_runOnce_enabledReturnsMaintenanceInterval(void)
     TEST_ASSERT_EQUAL_INT32(60 * 1000, interval);
 }
 
+// ---------------------------------------------------------------------------
+// Next-hop overflow cache
+// ---------------------------------------------------------------------------
+
+/**
+ * Round-trip set/get of a confirmed next hop, plus the input guards.
+ */
+static void test_tm_nextHop_setAndGetRoundTrip(void)
+{
+    TrafficManagementModuleTestShim module;
+
+    // Unknown node yields no hint.
+    TEST_ASSERT_EQUAL_UINT8(0, module.getNextHopHint(kTargetNode));
+
+    // Store a confirmed hop and read it back.
+    module.setNextHop(kTargetNode, 0x42);
+    TEST_ASSERT_EQUAL_UINT8(0x42, module.getNextHopHint(kTargetNode));
+
+    // Zero dest and zero byte are rejected (no spurious entry created).
+    module.setNextHop(0, 0x42);
+    module.setNextHop(kRemoteNode, 0);
+    TEST_ASSERT_EQUAL_UINT8(0, module.getNextHopHint(kRemoteNode));
+
+    // Last-write-wins on re-confirmation.
+    module.setNextHop(kTargetNode, 0x99);
+    TEST_ASSERT_EQUAL_UINT8(0x99, module.getNextHopHint(kTargetNode));
+}
+
+/**
+ * The headline scenario: a node carrying a next hop in the hot NodeInfoLite DB
+ * is warm-loaded into the TMM cache, then the hot DB is "rolled" (the node ages
+ * out entirely). The hint must still be served — now exclusively from TMM.
+ */
+static void test_tm_nextHop_servedAfterNodeDbRoll(void)
+{
+    TrafficManagementModuleTestShim module;
+
+    // Seed the hot NodeInfoLite DB with a node that has a confirmed next hop.
+    mockNodeDB->setHotNode(kTargetNode, 0x42);
+
+    // Warm-start the overflow cache from the hot DB.
+    module.preloadNextHopsFromNodeDB();
+    TEST_ASSERT_EQUAL_UINT8(0x42, module.getNextHopHint(kTargetNode));
+
+    // Roll the main NodeInfoLite DB: the node is evicted from the hot store.
+    mockNodeDB->rollHotStore();
+    TEST_ASSERT_NULL(nodeDB->getMeshNode(kTargetNode)); // gone from the hot store
+
+    // Hit is still served — proving it now comes from the TMM overflow cache.
+    TEST_ASSERT_EQUAL_UINT8(0x42, module.getNextHopHint(kTargetNode));
+}
+
+/**
+ * Preload must not clobber a freshly-learned (confirmed) hop with a possibly
+ * stale persisted one from NodeInfoLite.
+ */
+static void test_tm_nextHop_preloadDoesNotClobberLearned(void)
+{
+    TrafficManagementModuleTestShim module;
+
+    // A fresher confirmed hop is already cached.
+    module.setNextHop(kTargetNode, 0x99);
+
+    // The hot DB carries an older next hop for the same node.
+    mockNodeDB->setHotNode(kTargetNode, 0x42);
+
+    module.preloadNextHopsFromNodeDB();
+
+    // The freshly-learned hop survives.
+    TEST_ASSERT_EQUAL_UINT8(0x99, module.getNextHopHint(kTargetNode));
+}
+
+/**
+ * A pure routing hint (no dedup/rate/unknown state) must survive the maintenance
+ * sweep — next_hop != 0 keeps the slot alive even though it has no TTL.
+ */
+static void test_tm_nextHop_keptAliveAcrossMaintenanceSweep(void)
+{
+    TrafficManagementModuleTestShim module;
+
+    module.setNextHop(kTargetNode, 0x42);
+
+    // The sweep frees slots whose sub-stores are all empty; next_hop must veto that.
+    module.runOnce();
+
+    TEST_ASSERT_EQUAL_UINT8(0x42, module.getNextHopHint(kTargetNode));
+}
+#if HAS_VARIABLE_HOPS
+#endif // HAS_VARIABLE_HOPS
 } // namespace
 
 void setUp(void)
@@ -1106,7 +1247,6 @@ TM_TEST_ENTRY void setup()
     RUN_TEST(test_tm_positionDedup_dropsDuplicateWithinWindow);
     RUN_TEST(test_tm_positionDedup_allowsMovedPosition);
     RUN_TEST(test_tm_rateLimit_dropsOnlyAfterThreshold);
-    RUN_TEST(test_tm_rateLimit_skipsRoutingAndAdminPorts);
     RUN_TEST(test_tm_fromUs_bypassesPositionAndRateFilters);
     RUN_TEST(test_tm_localDestination_bypassesTransitFilters);
     RUN_TEST(test_tm_nodeinfo_routerClamp_skipsWhenTooManyHops);
@@ -1121,6 +1261,8 @@ TM_TEST_ENTRY void setup()
     RUN_TEST(test_tm_nodeinfo_directResponse_psramMissDoesNotFallbackToNodeDb);
 #endif
     RUN_TEST(test_tm_alterReceived_exhaustsRelayedTelemetryBroadcast);
+#if HAS_VARIABLE_HOPS
+#endif
     RUN_TEST(test_tm_alterReceived_skipsLocalAndUnicast);
     RUN_TEST(test_tm_positionDedup_allowsDuplicateAfterIntervalExpires);
     RUN_TEST(test_tm_positionDedup_intervalZero_neverDrops);
@@ -1130,7 +1272,6 @@ TM_TEST_ENTRY void setup()
     RUN_TEST(test_tm_positionDedup_epochReset_doesNotDropFirstPacketAfterReset);
     RUN_TEST(test_tm_positionDedup_priorRateState_doesNotDropFirstFingerprintZero);
     RUN_TEST(test_tm_rateLimit_resetsAfterWindowExpires);
-    RUN_TEST(test_tm_rateLimit_thresholdAbove255_clamps);
     RUN_TEST(test_tm_unknownPackets_resetAfterWindowExpires);
     RUN_TEST(test_tm_unknownPackets_thresholdAbove255_clamps);
     RUN_TEST(test_tm_alterReceived_exhaustsRelayedPositionBroadcast);
@@ -1139,6 +1280,12 @@ TM_TEST_ENTRY void setup()
     RUN_TEST(test_tm_alterReceived_exhaustFlag_isPacketScoped);
     RUN_TEST(test_tm_runOnce_disabledReturnsMaxInterval);
     RUN_TEST(test_tm_runOnce_enabledReturnsMaintenanceInterval);
+    RUN_TEST(test_tm_nextHop_setAndGetRoundTrip);
+    RUN_TEST(test_tm_nextHop_servedAfterNodeDbRoll);
+    RUN_TEST(test_tm_nextHop_preloadDoesNotClobberLearned);
+    RUN_TEST(test_tm_nextHop_keptAliveAcrossMaintenanceSweep);
+#if HAS_VARIABLE_HOPS
+#endif
     exit(UNITY_END());
 }
 

--- a/test/test_traffic_management/test_main.cpp
+++ b/test/test_traffic_management/test_main.cpp
@@ -13,6 +13,7 @@
 
 #include "airtime.h"
 #include "mesh/CryptoEngine.h"
+#include "mesh/Default.h"
 #include "mesh/MeshService.h"
 #include "mesh/NodeDB.h"
 #include "mesh/Router.h"
@@ -77,6 +78,13 @@ class MockNodeDB : public NodeDB
 
     // Role the TMM should see for the cached node (sender-role-aware throttles).
     void setCachedNodeRole(meshtastic_Config_DeviceConfig_Role role) { cachedNode.role = role; }
+
+    // Direct mutable access to the cached node for fine-grained bitfield manipulation in tests.
+    meshtastic_NodeInfoLite &cachedNodeForTest()
+    {
+        hasCachedNode = true;
+        return cachedNode;
+    }
 
     // Seed a node into the hot-store buffer at index 1 (index 0 is reserved for
     // "self"). Respects the fixed-buffer invariant: `meshNodes` is a buffer of
@@ -1228,6 +1236,245 @@ static void test_tm_nextHop_keptAliveAcrossMaintenanceSweep(void)
 
     TEST_ASSERT_EQUAL_UINT8(0x42, module.getNextHopHint(kTargetNode));
 }
+
+// ---------------------------------------------------------------------------
+// Role exceptions: TRACKER and LOST_AND_FOUND
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify TRACKER role caps the dedup window at 1 hour.
+ * A duplicate position that would normally be blocked for 11 h (default) must
+ * be forwarded once the 1-hour tracker cap expires.
+ */
+static void test_tm_trackerRole_capsDedupWindowAtOneHour(void)
+{
+    moduleConfig.traffic_management.position_dedup_enabled = true;
+    moduleConfig.traffic_management.position_precision_bits = 16;
+    // Operator interval is 11 h — longer than the tracker cap.
+    moduleConfig.traffic_management.position_min_interval_secs = default_traffic_mgmt_position_min_interval_secs;
+    installWellKnownPrimaryChannel();
+
+    mockNodeDB->setCachedNode(kRemoteNode);
+    mockNodeDB->setCachedNodeRole(meshtastic_Config_DeviceConfig_Role_TRACKER);
+
+    TrafficManagementModuleTestShim module;
+
+    meshtastic_MeshPacket first = makePositionPacket(kRemoteNode, 374221234, -1220845678);
+    meshtastic_MeshPacket dup = makePositionPacket(kRemoteNode, 374221234, -1220845678);
+    meshtastic_MeshPacket afterCap = makePositionPacket(kRemoteNode, 374221234, -1220845678);
+
+    ProcessMessage r1 = module.handleReceived(first);
+    ProcessMessage r2 = module.handleReceived(dup); // still within 1-hour cap
+    // Advance past 1 hour (tracker cap = 3600 s; pos-tick = 360 s → 10 ticks).
+    TrafficManagementModule::s_testNowMs += (default_traffic_mgmt_tracker_position_min_interval_secs * 1000UL) + 1;
+    ProcessMessage r3 = module.handleReceived(afterCap);
+    meshtastic_TrafficManagementStats stats = module.getStats();
+
+    TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::CONTINUE), static_cast<int>(r1));
+    TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::STOP), static_cast<int>(r2));
+    TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::CONTINUE), static_cast<int>(r3));
+    TEST_ASSERT_EQUAL_UINT32(1, stats.position_dedup_drops);
+}
+
+/**
+ * Verify TAK_TRACKER role receives the same 1-hour dedup cap as TRACKER.
+ * Both roles share the same exception branch; this guards against future divergence.
+ */
+static void test_tm_takTrackerRole_capsDedupWindowAtOneHour(void)
+{
+    moduleConfig.traffic_management.position_dedup_enabled = true;
+    moduleConfig.traffic_management.position_precision_bits = 16;
+    moduleConfig.traffic_management.position_min_interval_secs = default_traffic_mgmt_position_min_interval_secs;
+    installWellKnownPrimaryChannel();
+
+    mockNodeDB->setCachedNode(kRemoteNode);
+    mockNodeDB->setCachedNodeRole(meshtastic_Config_DeviceConfig_Role_TAK_TRACKER);
+
+    TrafficManagementModuleTestShim module;
+
+    meshtastic_MeshPacket first = makePositionPacket(kRemoteNode, 374221234, -1220845678);
+    meshtastic_MeshPacket dup = makePositionPacket(kRemoteNode, 374221234, -1220845678);
+    meshtastic_MeshPacket afterCap = makePositionPacket(kRemoteNode, 374221234, -1220845678);
+
+    ProcessMessage r1 = module.handleReceived(first);
+    ProcessMessage r2 = module.handleReceived(dup);
+    TrafficManagementModule::s_testNowMs += (default_traffic_mgmt_tracker_position_min_interval_secs * 1000UL) + 1;
+    ProcessMessage r3 = module.handleReceived(afterCap);
+    meshtastic_TrafficManagementStats stats = module.getStats();
+
+    TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::CONTINUE), static_cast<int>(r1));
+    TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::STOP), static_cast<int>(r2));
+    TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::CONTINUE), static_cast<int>(r3));
+    TEST_ASSERT_EQUAL_UINT32(1, stats.position_dedup_drops);
+}
+
+/**
+ * Verify the tracker cap never lengthens an operator-configured interval shorter
+ * than the cap default. The cap is a ceiling, not a floor.
+ */
+static void test_tm_trackerRole_doesNotLengthenShorterOperatorInterval(void)
+{
+    moduleConfig.traffic_management.position_dedup_enabled = true;
+    moduleConfig.traffic_management.position_precision_bits = 16;
+    // Operator set 5-minute interval — shorter than the 1-hour tracker cap.
+    moduleConfig.traffic_management.position_min_interval_secs = 300;
+    installWellKnownPrimaryChannel();
+
+    mockNodeDB->setCachedNode(kRemoteNode);
+    mockNodeDB->setCachedNodeRole(meshtastic_Config_DeviceConfig_Role_TRACKER);
+
+    TrafficManagementModuleTestShim module;
+
+    meshtastic_MeshPacket first = makePositionPacket(kRemoteNode, 374221234, -1220845678);
+    meshtastic_MeshPacket dup = makePositionPacket(kRemoteNode, 374221234, -1220845678);
+    meshtastic_MeshPacket afterShortInterval = makePositionPacket(kRemoteNode, 374221234, -1220845678);
+
+    ProcessMessage r1 = module.handleReceived(first);
+    ProcessMessage r2 = module.handleReceived(dup);
+    // The 300 s operator interval rounds to 1 pos-tick (360 s) — dedup is tick-granular.
+    // Advance past one full tick to verify the window is 1 tick (not the 10-tick tracker cap).
+    TrafficManagementModule::s_testNowMs += 360'000UL + 1;
+    ProcessMessage r3 = module.handleReceived(afterShortInterval);
+    meshtastic_TrafficManagementStats stats = module.getStats();
+
+    TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::CONTINUE), static_cast<int>(r1));
+    TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::STOP), static_cast<int>(r2));
+    TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::CONTINUE), static_cast<int>(r3));
+    TEST_ASSERT_EQUAL_UINT32(1, stats.position_dedup_drops);
+}
+
+/**
+ * Verify LOST_AND_FOUND role throttles duplicates to one pos-tick (360 s) only.
+ * Without the role exception, a configured 11-hour interval would drop this
+ * second packet; with it, the tick-length window expires and the packet passes.
+ */
+static void test_tm_lostAndFoundRole_throttlesToOneTick(void)
+{
+    moduleConfig.traffic_management.position_dedup_enabled = true;
+    moduleConfig.traffic_management.position_precision_bits = 16;
+    // Long interval that would normally suppress duplicates for 11 h.
+    moduleConfig.traffic_management.position_min_interval_secs = default_traffic_mgmt_position_min_interval_secs;
+    installWellKnownPrimaryChannel();
+
+    mockNodeDB->setCachedNode(kRemoteNode);
+    mockNodeDB->setCachedNodeRole(meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND);
+
+    TrafficManagementModuleTestShim module;
+
+    meshtastic_MeshPacket first = makePositionPacket(kRemoteNode, 374221234, -1220845678);
+    meshtastic_MeshPacket dup = makePositionPacket(kRemoteNode, 374221234, -1220845678);
+    meshtastic_MeshPacket afterTick = makePositionPacket(kRemoteNode, 374221234, -1220845678);
+
+    ProcessMessage r1 = module.handleReceived(first);
+    ProcessMessage r2 = module.handleReceived(dup); // within the one tick (< 360 s elapsed)
+    // Advance past exactly one pos-tick (360 s = kPosTimeTickMs, kept as a literal
+    // because the constant is private to TrafficManagementModule).
+    TrafficManagementModule::s_testNowMs += 360'000UL + 1;
+    ProcessMessage r3 = module.handleReceived(afterTick);
+    meshtastic_TrafficManagementStats stats = module.getStats();
+
+    TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::CONTINUE), static_cast<int>(r1));
+    TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::STOP), static_cast<int>(r2));
+    TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::CONTINUE), static_cast<int>(r3));
+    TEST_ASSERT_EQUAL_UINT32(1, stats.position_dedup_drops);
+}
+
+/**
+ * Verify a node with unknown role (absent from NodeDB) is not granted any role
+ * exception: the full configured interval applies, so a duplicate inside that
+ * window is dropped exactly as for an ordinary CLIENT.
+ */
+static void test_tm_unknownRole_noDbEntry_appliesFullInterval(void)
+{
+    moduleConfig.traffic_management.position_dedup_enabled = true;
+    moduleConfig.traffic_management.position_precision_bits = 16;
+    moduleConfig.traffic_management.position_min_interval_secs = 300;
+    installWellKnownPrimaryChannel();
+
+    // No cached node — getMeshNode returns nullptr for kRemoteNode.
+    mockNodeDB->clearCachedNode();
+
+    TrafficManagementModuleTestShim module;
+
+    meshtastic_MeshPacket first = makePositionPacket(kRemoteNode, 374221234, -1220845678);
+    meshtastic_MeshPacket dup = makePositionPacket(kRemoteNode, 374221234, -1220845678);
+    meshtastic_MeshPacket afterShort = makePositionPacket(kRemoteNode, 374221234, -1220845678);
+
+    ProcessMessage r1 = module.handleReceived(first);
+    ProcessMessage r2 = module.handleReceived(dup); // within 300-s window — must drop
+    // The 300 s operator interval rounds to 1 pos-tick (360 s) — dedup is tick-granular.
+    // Advance past one full tick to confirm the packet passes without any tracker exception.
+    TrafficManagementModule::s_testNowMs += 360'000UL + 1;
+    ProcessMessage r3 = module.handleReceived(afterShort);
+    meshtastic_TrafficManagementStats stats = module.getStats();
+
+    TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::CONTINUE), static_cast<int>(r1));
+    TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::STOP), static_cast<int>(r2));
+    TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::CONTINUE), static_cast<int>(r3));
+    TEST_ASSERT_EQUAL_UINT32(1, stats.position_dedup_drops);
+}
+
+/**
+ * Verify a node present in NodeDB but without user info (HAS_USER bit clear)
+ * is not granted a role exception: it falls back to CLIENT and the full
+ * configured interval applies.
+ */
+static void test_tm_unknownRole_noUserBit_appliesFullInterval(void)
+{
+    moduleConfig.traffic_management.position_dedup_enabled = true;
+    moduleConfig.traffic_management.position_precision_bits = 16;
+    moduleConfig.traffic_management.position_min_interval_secs = 300;
+    installWellKnownPrimaryChannel();
+
+    // Node is in NodeDB but the HAS_USER bit is NOT set — role must be ignored.
+    mockNodeDB->setCachedNode(kRemoteNode);
+    // Clear the HAS_USER bit that setCachedNode sets, leaving role at CLIENT default.
+    mockNodeDB->cachedNodeForTest().bitfield &= ~NODEINFO_BITFIELD_HAS_USER_MASK;
+    mockNodeDB->cachedNodeForTest().role = meshtastic_Config_DeviceConfig_Role_TRACKER;
+
+    TrafficManagementModuleTestShim module;
+
+    meshtastic_MeshPacket first = makePositionPacket(kRemoteNode, 374221234, -1220845678);
+    meshtastic_MeshPacket dup = makePositionPacket(kRemoteNode, 374221234, -1220845678);
+
+    ProcessMessage r1 = module.handleReceived(first);
+    ProcessMessage r2 = module.handleReceived(dup); // within 300-s window — must drop
+    meshtastic_TrafficManagementStats stats = module.getStats();
+
+    TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::CONTINUE), static_cast<int>(r1));
+    TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::STOP), static_cast<int>(r2));
+    TEST_ASSERT_EQUAL_UINT32(1, stats.position_dedup_drops);
+}
+
+/**
+ * Verify LOST_AND_FOUND origin skips the precision clamp in alterReceived
+ * (no anti-dox). A relayed position with precision higher than the channel
+ * setting must pass through unmodified.
+ */
+static void test_tm_lostAndFoundRole_skipsAlterReceivedPrecisionClamp(void)
+{
+    installWellKnownPrimaryChannel();
+    // Channel precision set to 16 bits (~1.5 km grid) via the default route.
+    moduleConfig.traffic_management.position_precision_bits = 16;
+
+    mockNodeDB->setCachedNode(kRemoteNode);
+    mockNodeDB->setCachedNodeRole(meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND);
+
+    TrafficManagementModuleTestShim module;
+
+    // Full-precision packet — 32 bits — exceeds the channel cap of 16 bits.
+    const uint32_t fullPrecision = 32;
+    meshtastic_MeshPacket packet = makePositionPacketWithPrecision(kRemoteNode, 374221234, -1220845678, fullPrecision);
+    packet.hop_start = 3;
+    packet.hop_limit = 2; // relayed (hop_limit < hop_start) so clamp logic applies
+
+    module.alterReceived(packet);
+
+    meshtastic_Position out;
+    TEST_ASSERT_TRUE(decodePositionPayload(packet, out));
+    // Precision must be unchanged — the clamp was skipped for LOST_AND_FOUND.
+    TEST_ASSERT_EQUAL_UINT32(fullPrecision, out.precision_bits);
+}
 } // namespace
 
 void setUp(void)
@@ -1286,6 +1533,13 @@ TM_TEST_ENTRY void setup()
     RUN_TEST(test_tm_nextHop_servedAfterNodeDbRoll);
     RUN_TEST(test_tm_nextHop_preloadDoesNotClobberLearned);
     RUN_TEST(test_tm_nextHop_keptAliveAcrossMaintenanceSweep);
+    RUN_TEST(test_tm_trackerRole_capsDedupWindowAtOneHour);
+    RUN_TEST(test_tm_takTrackerRole_capsDedupWindowAtOneHour);
+    RUN_TEST(test_tm_trackerRole_doesNotLengthenShorterOperatorInterval);
+    RUN_TEST(test_tm_lostAndFoundRole_throttlesToOneTick);
+    RUN_TEST(test_tm_lostAndFoundRole_skipsAlterReceivedPrecisionClamp);
+    RUN_TEST(test_tm_unknownRole_noDbEntry_appliesFullInterval);
+    RUN_TEST(test_tm_unknownRole_noUserBit_appliesFullInterval);
     exit(UNITY_END());
 }
 

--- a/test/test_traffic_management/test_main.cpp
+++ b/test/test_traffic_management/test_main.cpp
@@ -329,6 +329,7 @@ static void test_tm_positionDedup_dropsDuplicateWithinWindow(void)
     moduleConfig.traffic_management.position_dedup_enabled = true;
     moduleConfig.traffic_management.position_precision_bits = 16;
     moduleConfig.traffic_management.position_min_interval_secs = 300;
+    installWellKnownPrimaryChannel(); // dedup only runs on a well-known channel (gate in handleReceived)
     TrafficManagementModuleTestShim module;
 
     meshtastic_MeshPacket first = makePositionPacket(kRemoteNode, 374221234, -1220845678);
@@ -354,6 +355,7 @@ static void test_tm_positionDedup_allowsMovedPosition(void)
     moduleConfig.traffic_management.position_dedup_enabled = true;
     moduleConfig.traffic_management.position_precision_bits = 16;
     moduleConfig.traffic_management.position_min_interval_secs = 300;
+    installWellKnownPrimaryChannel(); // dedup only runs on a well-known channel (gate in handleReceived)
     TrafficManagementModuleTestShim module;
 
     meshtastic_MeshPacket first = makePositionPacket(kRemoteNode, 374221234, -1220845678);

--- a/test/test_traffic_management/test_main.cpp
+++ b/test/test_traffic_management/test_main.cpp
@@ -18,11 +18,29 @@
 #include "mesh/NodeDB.h"
 #include "mesh/Router.h"
 #include "modules/TrafficManagementModule.h"
+#if HAS_VARIABLE_HOPS
+#include "modules/HopScalingModule.h"
+#endif
 #include <climits>
 #include <cstring>
 #include <memory>
 #include <pb_encode.h>
 #include <vector>
+
+#if HAS_VARIABLE_HOPS
+// Must be at global scope and named exactly HopScalingTestShim: HopScalingModule befriends
+// `::HopScalingTestShim` under PIO_UNIT_TESTING to expose the private rollHour() (mirrors the
+// shim in test_hop_scaling). Used to warm getLastRequiredHop() via fake time.
+class HopScalingTestShim : public HopScalingModule
+{
+  public:
+    using HopScalingModule::getLastRequiredHop;
+    using HopScalingModule::runOnce;
+    using HopScalingModule::samplePacketForHistogram;
+    void rollHourTest() { rollHour(); }
+    void setDenom(uint8_t d) { setSamplingDenominator(d); }
+};
+#endif
 
 namespace
 {
@@ -187,6 +205,13 @@ static void resetTrafficConfig()
     mockNodeDB->resetNodes();
     mockNodeDB->clearCachedNode();
     nodeDB = mockNodeDB;
+
+#if HAS_VARIABLE_HOPS
+    // Hop-trimming reads the global hopScalingModule; default to none so the existing tests
+    // (which don't warm a histogram) see wouldHopTrim()==false and are unaffected.
+    hopScalingModule = nullptr;
+    HopScalingModule::s_testNowMs = 3600000;
+#endif
 
     // Virtual clock base (1 h in, so tick subtraction never underflows). Tests advance time by
     // bumping TrafficManagementModule::s_testNowMs instead of sleeping real seconds across a tick.
@@ -1475,6 +1500,222 @@ static void test_tm_lostAndFoundRole_skipsAlterReceivedPrecisionClamp(void)
     // Precision must be unchanged — the clamp was skipped for LOST_AND_FOUND.
     TEST_ASSERT_EQUAL_UINT32(fullPrecision, out.precision_bits);
 }
+
+#if HAS_VARIABLE_HOPS
+// ---------------------------------------------------------------------------
+// Hop-trimming (clamp relayed broadcast total reach to the local hop-scaling budget)
+// ---------------------------------------------------------------------------
+// We warm a real HopScalingModule histogram via fake time + sampled traffic so
+// getLastRequiredHop() converges below HOP_MAX, exactly like test_hop_scaling. The TMM clamp
+// reads the *global* hopScalingModule, so we point it at the shim. Because the histogram->hop
+// map is a threshold (not an exact cap), each test reads the warmed `cap` back and computes its
+// expectations relative to it (budget = cap + grace).
+
+// Warm with a dense-local distribution; cap settles low (< HOP_MAX). Returns the resulting cap.
+static uint8_t warmHopScalingCap(HopScalingTestShim &shim)
+{
+    static constexpr uint32_t HOUR_MS = 3600UL * 1000UL;
+    const uint16_t denseLocal[HOP_MAX + 1] = {25, 30, 15, 5, 10, 15, 10, 0};
+    shim.setDenom(HopScalingModule::DENOM_MIN);
+    for (uint8_t roll = 0; roll < 16; ++roll) {
+        HopScalingModule::s_testNowMs += HOUR_MS;
+        uint16_t ordinal = 0;
+        for (uint8_t hop = 0; hop <= HOP_MAX; ++hop)
+            for (uint16_t n = 0; n < denseLocal[hop]; ++n)
+                shim.samplePacketForHistogram(0xABCD0000u + (ordinal++) * 33u, hop);
+        shim.rollHourTest();
+    }
+    shim.runOnce();
+    return shim.getLastRequiredHop();
+}
+
+// Relayed broadcast from kRemoteNode with explicit hop fields; optionally seed the sender role.
+static meshtastic_MeshPacket makeRelayed(meshtastic_PortNum port, uint32_t hopStart, uint32_t hopLimit,
+                                         meshtastic_Config_DeviceConfig_Role senderRole, bool knownSender = true)
+{
+    installWellKnownPrimaryChannel();
+    mockNodeDB->clearCachedNode();
+    if (knownSender) {
+        mockNodeDB->setCachedNode(kRemoteNode);
+        mockNodeDB->setCachedNodeRole(senderRole);
+    }
+    meshtastic_MeshPacket p = makeDecodedPacket(port, kRemoteNode, NODENUM_BROADCAST);
+    p.hop_start = hopStart;
+    p.hop_limit = hopLimit;
+    return p;
+}
+
+// Run the clamp on an over-budget packet (hopsAway=0, hop_limit far above any budget) for the
+// given sender role/port, and return the resulting hop_limit (== budget = cap + grace).
+static uint32_t trimmedReachForRole(HopScalingTestShim &shim, uint8_t cap, meshtastic_PortNum port,
+                                    meshtastic_Config_DeviceConfig_Role role, bool knownSender)
+{
+    hopScalingModule = &shim;
+    meshtastic_MeshPacket p = makeRelayed(port, cap + 5, cap + 5, role, knownSender);
+    TrafficManagementModuleTestShim module;
+    module.alterReceived(p);
+    return p.hop_limit;
+}
+
+static void test_tm_hopTrim_clampsNearSenderPreservingHopsAway(void)
+{
+    HopScalingTestShim shim;
+    const uint8_t cap = warmHopScalingCap(shim);
+    hopScalingModule = &shim;
+    TEST_ASSERT_TRUE(cap < HOP_MAX); // histogram warmed -> feature engages
+
+    const uint8_t grace = 2; // CLIENT baseline
+    const uint8_t budget = cap + grace;
+    const uint32_t hopsAway = 1;
+    // hop_limit above budget; allowedForward = budget - hopsAway.
+    meshtastic_MeshPacket p = makeRelayed(meshtastic_PortNum_TELEMETRY_APP, budget + 2 + hopsAway, budget + 2,
+                                          meshtastic_Config_DeviceConfig_Role_CLIENT);
+    TrafficManagementModuleTestShim module;
+    module.alterReceived(p);
+
+    TEST_ASSERT_EQUAL_UINT32(budget - hopsAway, p.hop_limit);      // trimmed to allowedForward
+    TEST_ASSERT_EQUAL_UINT32(hopsAway, p.hop_start - p.hop_limit); // hopsAway preserved (hop_start pulled down)
+    hopScalingModule = nullptr;
+}
+
+static void test_tm_hopTrim_fullGraceNearOrigin(void)
+{
+    HopScalingTestShim shim;
+    const uint8_t cap = warmHopScalingCap(shim);
+    hopScalingModule = &shim;
+    const uint8_t budget = cap + 2; // CLIENT
+
+    // hopsAway = 0, fat hop_limit -> trimmed down to the full budget.
+    meshtastic_MeshPacket p =
+        makeRelayed(meshtastic_PortNum_POSITION_APP, budget + 3, budget + 3, meshtastic_Config_DeviceConfig_Role_CLIENT);
+    TrafficManagementModuleTestShim module;
+    module.alterReceived(p);
+
+    TEST_ASSERT_EQUAL_UINT32(budget, p.hop_limit);
+    TEST_ASSERT_EQUAL_UINT32(0, p.hop_start - p.hop_limit);
+    hopScalingModule = nullptr;
+}
+
+static void test_tm_hopTrim_underBudgetUntouched(void)
+{
+    HopScalingTestShim shim;
+    (void)warmHopScalingCap(shim);
+    hopScalingModule = &shim;
+
+    // Remaining (1) is at/under allowedForward, so the min() never lowers it.
+    meshtastic_MeshPacket p = makeRelayed(meshtastic_PortNum_TELEMETRY_APP, 2, 1, meshtastic_Config_DeviceConfig_Role_CLIENT);
+    TrafficManagementModuleTestShim module;
+    module.alterReceived(p);
+
+    TEST_ASSERT_EQUAL_UINT32(1, p.hop_limit);
+    TEST_ASSERT_EQUAL_UINT32(2, p.hop_start);
+    hopScalingModule = nullptr;
+}
+
+static void test_tm_hopTrim_farPacketStopsWithoutFinalHop(void)
+{
+    HopScalingTestShim shim;
+    const uint8_t cap = warmHopScalingCap(shim);
+    hopScalingModule = &shim;
+    const uint8_t budget = cap + 2;       // CLIENT
+    const uint32_t hopsAway = budget + 1; // already past the budget
+
+    meshtastic_MeshPacket p =
+        makeRelayed(meshtastic_PortNum_TELEMETRY_APP, hopsAway + 2, 2, meshtastic_Config_DeviceConfig_Role_CLIENT);
+    TrafficManagementModuleTestShim module;
+    module.alterReceived(p);
+
+    TEST_ASSERT_EQUAL_UINT32(0, p.hop_limit);       // not rebroadcast
+    TEST_ASSERT_FALSE(module.shouldExhaustHops(p)); // crucially: NO final hop (unlike exhaust_hop_*)
+    hopScalingModule = nullptr;
+}
+
+static void test_tm_hopTrim_graceByRoleAndPort(void)
+{
+    HopScalingTestShim shim;
+    const uint8_t cap = warmHopScalingCap(shim);
+
+    const auto TEL = meshtastic_PortNum_TELEMETRY_APP;
+    const auto POS = meshtastic_PortNum_POSITION_APP;
+
+    // Infra / specialty -> +3
+    TEST_ASSERT_EQUAL_UINT32(cap + 3, trimmedReachForRole(shim, cap, TEL, meshtastic_Config_DeviceConfig_Role_ROUTER, true));
+    TEST_ASSERT_EQUAL_UINT32(cap + 3, trimmedReachForRole(shim, cap, TEL, meshtastic_Config_DeviceConfig_Role_CLIENT_BASE, true));
+    TEST_ASSERT_EQUAL_UINT32(
+        cap + 3, trimmedReachForRole(shim, cap, TEL, meshtastic_Config_DeviceConfig_Role_SENSOR, true)); // sensor telem
+    TEST_ASSERT_EQUAL_UINT32(
+        cap + 3, trimmedReachForRole(shim, cap, POS, meshtastic_Config_DeviceConfig_Role_TRACKER, true)); // tracker pos
+    // Sensor OFF its specialty (position) -> baseline +2
+    TEST_ASSERT_EQUAL_UINT32(cap + 2, trimmedReachForRole(shim, cap, POS, meshtastic_Config_DeviceConfig_Role_SENSOR, true));
+    // Deprecated -> +1 (below baseline)
+    TEST_ASSERT_EQUAL_UINT32(cap + 1, trimmedReachForRole(shim, cap, TEL, meshtastic_Config_DeviceConfig_Role_REPEATER, true));
+    TEST_ASSERT_EQUAL_UINT32(cap + 1,
+                             trimmedReachForRole(shim, cap, TEL, meshtastic_Config_DeviceConfig_Role_ROUTER_CLIENT, true));
+    // Unknown sender (no NodeDB entry) -> baseline +2
+    TEST_ASSERT_EQUAL_UINT32(cap + 2, trimmedReachForRole(shim, cap, TEL, meshtastic_Config_DeviceConfig_Role_CLIENT, false));
+    hopScalingModule = nullptr;
+}
+
+static void test_tm_hopTrim_coldMeshNoOp(void)
+{
+    HopScalingTestShim shim; // unwarmed -> getLastRequiredHop() == HOP_MAX
+    TEST_ASSERT_EQUAL_UINT8(HOP_MAX, shim.getLastRequiredHop());
+    hopScalingModule = &shim;
+
+    meshtastic_MeshPacket p = makeRelayed(meshtastic_PortNum_TELEMETRY_APP, 7, 7, meshtastic_Config_DeviceConfig_Role_CLIENT);
+    TrafficManagementModuleTestShim module;
+    module.alterReceived(p);
+
+    TEST_ASSERT_EQUAL_UINT32(7, p.hop_limit); // no trim on a cold/quiet mesh
+    hopScalingModule = nullptr;
+}
+
+static void test_tm_hopTrim_neverRaisesOnReclamp(void)
+{
+    HopScalingTestShim shim;
+    const uint8_t cap = warmHopScalingCap(shim);
+    hopScalingModule = &shim;
+    const uint8_t budget = cap + 2;
+
+    meshtastic_MeshPacket p =
+        makeRelayed(meshtastic_PortNum_TELEMETRY_APP, budget + 3, budget + 3, meshtastic_Config_DeviceConfig_Role_CLIENT);
+    TrafficManagementModuleTestShim module;
+    module.alterReceived(p);
+    const uint32_t afterFirst = p.hop_limit;
+    module.alterReceived(p); // re-clamp must not raise it
+    TEST_ASSERT_EQUAL_UINT32(afterFirst, p.hop_limit);
+    hopScalingModule = nullptr;
+}
+
+static void test_tm_hopTrim_wouldHopTrimGatesUpgradeSuppression(void)
+{
+    HopScalingTestShim shim;
+    (void)warmHopScalingCap(shim);
+    hopScalingModule = &shim;
+    TrafficManagementModuleTestShim module;
+
+    // Eligible: decoded telemetry broadcast on a well-known channel, warm mesh.
+    meshtastic_MeshPacket eligible =
+        makeRelayed(meshtastic_PortNum_TELEMETRY_APP, 6, 6, meshtastic_Config_DeviceConfig_Role_CLIENT);
+    TEST_ASSERT_TRUE(module.wouldHopTrim(eligible));
+
+    // Unicast -> not reach-amplified -> not trimmed.
+    meshtastic_MeshPacket unicast = eligible;
+    unicast.to = kTargetNode;
+    TEST_ASSERT_FALSE(module.wouldHopTrim(unicast));
+
+    // Ineligible portnum (text) -> not trimmed.
+    meshtastic_MeshPacket text =
+        makeRelayed(meshtastic_PortNum_TEXT_MESSAGE_APP, 6, 6, meshtastic_Config_DeviceConfig_Role_CLIENT);
+    TEST_ASSERT_FALSE(module.wouldHopTrim(text));
+
+    // Cold mesh -> not trimmed.
+    HopScalingTestShim cold;
+    hopScalingModule = &cold;
+    TEST_ASSERT_FALSE(module.wouldHopTrim(eligible));
+    hopScalingModule = nullptr;
+}
+#endif // HAS_VARIABLE_HOPS
 } // namespace
 
 void setUp(void)
@@ -1540,6 +1781,16 @@ TM_TEST_ENTRY void setup()
     RUN_TEST(test_tm_lostAndFoundRole_skipsAlterReceivedPrecisionClamp);
     RUN_TEST(test_tm_unknownRole_noDbEntry_appliesFullInterval);
     RUN_TEST(test_tm_unknownRole_noUserBit_appliesFullInterval);
+#if HAS_VARIABLE_HOPS
+    RUN_TEST(test_tm_hopTrim_clampsNearSenderPreservingHopsAway);
+    RUN_TEST(test_tm_hopTrim_fullGraceNearOrigin);
+    RUN_TEST(test_tm_hopTrim_underBudgetUntouched);
+    RUN_TEST(test_tm_hopTrim_farPacketStopsWithoutFinalHop);
+    RUN_TEST(test_tm_hopTrim_graceByRoleAndPort);
+    RUN_TEST(test_tm_hopTrim_coldMeshNoOp);
+    RUN_TEST(test_tm_hopTrim_neverRaisesOnReclamp);
+    RUN_TEST(test_tm_hopTrim_wouldHopTrimGatesUpgradeSuppression);
+#endif
     exit(UNITY_END());
 }
 

--- a/test/test_traffic_management/test_main.cpp
+++ b/test/test_traffic_management/test_main.cpp
@@ -12,8 +12,6 @@
 #if HAS_TRAFFIC_MANAGEMENT
 
 #include "airtime.h"
-#if HAS_VARIABLE_HOPS
-#endif
 #include "mesh/CryptoEngine.h"
 #include "mesh/MeshService.h"
 #include "mesh/NodeDB.h"
@@ -181,6 +179,10 @@ static void resetTrafficConfig()
     mockNodeDB->resetNodes();
     mockNodeDB->clearCachedNode();
     nodeDB = mockNodeDB;
+
+    // Virtual clock base (1 h in, so tick subtraction never underflows). Tests advance time by
+    // bumping TrafficManagementModule::s_testNowMs instead of sleeping real seconds across a tick.
+    TrafficManagementModule::s_testNowMs = 3600000;
 }
 
 static meshtastic_MeshPacket makeDecodedPacket(meshtastic_PortNum port, NodeNum from, NodeNum to = NODENUM_BROADCAST)
@@ -738,8 +740,6 @@ static void test_tm_alterReceived_exhaustsRelayedTelemetryBroadcast(void)
     TEST_ASSERT_EQUAL_UINT32(1, stats.hop_exhausted_packets);
 }
 
-#if HAS_VARIABLE_HOPS
-#endif // HAS_VARIABLE_HOPS
 /**
  * Verify hop exhaustion skips unicast and local-origin packets.
  * Important to avoid mutating traffic that should retain normal forwarding behavior.
@@ -776,8 +776,9 @@ static void test_tm_positionDedup_allowsDuplicateAfterIntervalExpires(void)
 {
     moduleConfig.traffic_management.position_dedup_enabled = true;
     moduleConfig.traffic_management.position_precision_bits = 16;
-    // 360 s = 1 pos-tick (kPosTimeTickMs); testDelay advances past one tick period.
+    // 360 s = 1 pos-tick (kPosTimeTickMs); advance the virtual clock past one tick period.
     moduleConfig.traffic_management.position_min_interval_secs = 360;
+    installWellKnownPrimaryChannel(); // dedup only runs on a well-known channel (gate in handleReceived)
     TrafficManagementModuleTestShim module;
 
     meshtastic_MeshPacket first = makePositionPacket(kRemoteNode, 374221234, -1220845678);
@@ -786,7 +787,7 @@ static void test_tm_positionDedup_allowsDuplicateAfterIntervalExpires(void)
 
     ProcessMessage r1 = module.handleReceived(first);
     ProcessMessage r2 = module.handleReceived(second);
-    testDelay(360001); // advance past one 6-min pos-tick
+    TrafficManagementModule::s_testNowMs += 360001; // advance past one 6-min pos-tick (virtual clock)
     ProcessMessage r3 = module.handleReceived(third);
     meshtastic_TrafficManagementStats stats = module.getStats();
 
@@ -900,6 +901,7 @@ static void test_tm_positionDedup_cacheFlush_doesNotDropFirstPacketAfterFlush(vo
     moduleConfig.traffic_management.position_dedup_enabled = true;
     moduleConfig.traffic_management.position_precision_bits = 16;
     moduleConfig.traffic_management.position_min_interval_secs = 300;
+    installWellKnownPrimaryChannel(); // dedup only runs on a well-known channel (gate in handleReceived)
     TrafficManagementModuleTestShim module;
 
     meshtastic_MeshPacket first = makePositionPacket(kRemoteNode, 374221234, -1220845678);
@@ -930,6 +932,7 @@ static void test_tm_positionDedup_priorRateState_doesNotDropFirstFingerprintZero
     moduleConfig.traffic_management.rate_limit_enabled = true;
     moduleConfig.traffic_management.rate_limit_window_secs = 60;
     moduleConfig.traffic_management.rate_limit_max_packets = 10;
+    installWellKnownPrimaryChannel(); // dedup only runs on a well-known channel (gate in handleReceived)
     TrafficManagementModuleTestShim module;
 
     meshtastic_MeshPacket telemetry = makeDecodedPacket(meshtastic_PortNum_TELEMETRY_APP, kRemoteNode);
@@ -954,7 +957,7 @@ static void test_tm_positionDedup_priorRateState_doesNotDropFirstFingerprintZero
 static void test_tm_rateLimit_resetsAfterWindowExpires(void)
 {
     moduleConfig.traffic_management.rate_limit_enabled = true;
-    // 300 s = 1 rate-tick (kRateTimeTickMs); testDelay advances past one tick period.
+    // 300 s = 1 rate-tick (kRateTimeTickMs); advance the virtual clock past one tick period.
     moduleConfig.traffic_management.rate_limit_window_secs = 300;
     moduleConfig.traffic_management.rate_limit_max_packets = 1;
     TrafficManagementModuleTestShim module;
@@ -962,7 +965,7 @@ static void test_tm_rateLimit_resetsAfterWindowExpires(void)
 
     ProcessMessage r1 = module.handleReceived(packet);
     ProcessMessage r2 = module.handleReceived(packet);
-    testDelay(300001); // advance past one 5-min rate-tick
+    TrafficManagementModule::s_testNowMs += 300001; // advance past one 5-min rate-tick (virtual clock)
     ProcessMessage r3 = module.handleReceived(packet);
     meshtastic_TrafficManagementStats stats = module.getStats();
 
@@ -984,7 +987,7 @@ static void test_tm_unknownPackets_resetAfterWindowExpires(void)
 
     ProcessMessage r1 = module.handleReceived(packet);
     ProcessMessage r2 = module.handleReceived(packet);
-    testDelay(300001); // advance past 5 unknown-ticks (kUnknownWindowTicks=5 × 60s)
+    TrafficManagementModule::s_testNowMs += 300001; // advance past 5 unknown-ticks (5 × 60s) (virtual clock)
     ProcessMessage r3 = module.handleReceived(packet);
     meshtastic_TrafficManagementStats stats = module.getStats();
 
@@ -1225,8 +1228,6 @@ static void test_tm_nextHop_keptAliveAcrossMaintenanceSweep(void)
 
     TEST_ASSERT_EQUAL_UINT8(0x42, module.getNextHopHint(kTargetNode));
 }
-#if HAS_VARIABLE_HOPS
-#endif // HAS_VARIABLE_HOPS
 } // namespace
 
 void setUp(void)
@@ -1264,8 +1265,6 @@ TM_TEST_ENTRY void setup()
     RUN_TEST(test_tm_nodeinfo_directResponse_psramMissDoesNotFallbackToNodeDb);
 #endif
     RUN_TEST(test_tm_alterReceived_exhaustsRelayedTelemetryBroadcast);
-#if HAS_VARIABLE_HOPS
-#endif
     RUN_TEST(test_tm_alterReceived_skipsLocalAndUnicast);
     RUN_TEST(test_tm_positionDedup_allowsDuplicateAfterIntervalExpires);
     RUN_TEST(test_tm_positionDedup_intervalZero_neverDrops);
@@ -1287,8 +1286,6 @@ TM_TEST_ENTRY void setup()
     RUN_TEST(test_tm_nextHop_servedAfterNodeDbRoll);
     RUN_TEST(test_tm_nextHop_preloadDoesNotClobberLearned);
     RUN_TEST(test_tm_nextHop_keptAliveAcrossMaintenanceSweep);
-#if HAS_VARIABLE_HOPS
-#endif
     exit(UNITY_END());
 }
 

--- a/test/test_traffic_management/test_main.cpp
+++ b/test/test_traffic_management/test_main.cpp
@@ -151,8 +151,8 @@ class TrafficManagementModuleTestShim : public TrafficManagementModule
 {
   public:
     using TrafficManagementModule::alterReceived;
+    using TrafficManagementModule::flushCache;
     using TrafficManagementModule::handleReceived;
-    using TrafficManagementModule::resetEpoch;
     using TrafficManagementModule::runOnce;
 
     bool ignoreRequestFlag() const { return ignoreRequest; }
@@ -774,7 +774,8 @@ static void test_tm_positionDedup_allowsDuplicateAfterIntervalExpires(void)
 {
     moduleConfig.traffic_management.position_dedup_enabled = true;
     moduleConfig.traffic_management.position_precision_bits = 16;
-    moduleConfig.traffic_management.position_min_interval_secs = 1;
+    // 360 s = 1 pos-tick (kPosTimeTickMs); testDelay advances past one tick period.
+    moduleConfig.traffic_management.position_min_interval_secs = 360;
     TrafficManagementModuleTestShim module;
 
     meshtastic_MeshPacket first = makePositionPacket(kRemoteNode, 374221234, -1220845678);
@@ -783,7 +784,7 @@ static void test_tm_positionDedup_allowsDuplicateAfterIntervalExpires(void)
 
     ProcessMessage r1 = module.handleReceived(first);
     ProcessMessage r2 = module.handleReceived(second);
-    testDelay(1200);
+    testDelay(360001); // advance past one 6-min pos-tick
     ProcessMessage r3 = module.handleReceived(third);
     meshtastic_TrafficManagementStats stats = module.getStats();
 
@@ -892,7 +893,7 @@ static void test_tm_positionDedup_precisionZero_allowsDistinctPositions(void)
  * Verify epoch reset invalidates stale position identity for dedup.
  * Important so reset paths cannot leak prior packet identity into new windows.
  */
-static void test_tm_positionDedup_epochReset_doesNotDropFirstPacketAfterReset(void)
+static void test_tm_positionDedup_cacheFlush_doesNotDropFirstPacketAfterFlush(void)
 {
     moduleConfig.traffic_management.position_dedup_enabled = true;
     moduleConfig.traffic_management.position_precision_bits = 16;
@@ -900,12 +901,12 @@ static void test_tm_positionDedup_epochReset_doesNotDropFirstPacketAfterReset(vo
     TrafficManagementModuleTestShim module;
 
     meshtastic_MeshPacket first = makePositionPacket(kRemoteNode, 374221234, -1220845678);
-    meshtastic_MeshPacket afterReset = makePositionPacket(kRemoteNode, 374221234, -1220845678);
+    meshtastic_MeshPacket afterFlush = makePositionPacket(kRemoteNode, 374221234, -1220845678);
     meshtastic_MeshPacket duplicate = makePositionPacket(kRemoteNode, 374221234, -1220845678);
 
     ProcessMessage r1 = module.handleReceived(first);
-    module.resetEpoch(millis());
-    ProcessMessage r2 = module.handleReceived(afterReset);
+    module.flushCache();
+    ProcessMessage r2 = module.handleReceived(afterFlush);
     ProcessMessage r3 = module.handleReceived(duplicate);
     meshtastic_TrafficManagementStats stats = module.getStats();
 
@@ -951,14 +952,15 @@ static void test_tm_positionDedup_priorRateState_doesNotDropFirstFingerprintZero
 static void test_tm_rateLimit_resetsAfterWindowExpires(void)
 {
     moduleConfig.traffic_management.rate_limit_enabled = true;
-    moduleConfig.traffic_management.rate_limit_window_secs = 1;
+    // 300 s = 1 rate-tick (kRateTimeTickMs); testDelay advances past one tick period.
+    moduleConfig.traffic_management.rate_limit_window_secs = 300;
     moduleConfig.traffic_management.rate_limit_max_packets = 1;
     TrafficManagementModuleTestShim module;
     meshtastic_MeshPacket packet = makeDecodedPacket(meshtastic_PortNum_TELEMETRY_APP, kRemoteNode);
 
     ProcessMessage r1 = module.handleReceived(packet);
     ProcessMessage r2 = module.handleReceived(packet);
-    testDelay(1200);
+    testDelay(300001); // advance past one 5-min rate-tick
     ProcessMessage r3 = module.handleReceived(packet);
     meshtastic_TrafficManagementStats stats = module.getStats();
 
@@ -975,13 +977,12 @@ static void test_tm_unknownPackets_resetAfterWindowExpires(void)
 {
     moduleConfig.traffic_management.drop_unknown_enabled = true;
     moduleConfig.traffic_management.unknown_packet_threshold = 1;
-    moduleConfig.traffic_management.rate_limit_window_secs = 1;
     TrafficManagementModuleTestShim module;
     meshtastic_MeshPacket packet = makeUnknownPacket(kRemoteNode);
 
     ProcessMessage r1 = module.handleReceived(packet);
     ProcessMessage r2 = module.handleReceived(packet);
-    testDelay(1200);
+    testDelay(300001); // advance past 5 unknown-ticks (kUnknownWindowTicks=5 × 60s)
     ProcessMessage r3 = module.handleReceived(packet);
     meshtastic_TrafficManagementStats stats = module.getStats();
 
@@ -1269,7 +1270,7 @@ TM_TEST_ENTRY void setup()
     RUN_TEST(test_tm_positionDedup_precisionAbove32_usesDefaultPrecision);
     RUN_TEST(test_tm_positionDedup_precision32_allowsDistinctPositions);
     RUN_TEST(test_tm_positionDedup_precisionZero_allowsDistinctPositions);
-    RUN_TEST(test_tm_positionDedup_epochReset_doesNotDropFirstPacketAfterReset);
+    RUN_TEST(test_tm_positionDedup_cacheFlush_doesNotDropFirstPacketAfterFlush);
     RUN_TEST(test_tm_positionDedup_priorRateState_doesNotDropFirstFingerprintZero);
     RUN_TEST(test_tm_rateLimit_resetsAfterWindowExpires);
     RUN_TEST(test_tm_unknownPackets_resetAfterWindowExpires);

--- a/userPrefs.jsonc
+++ b/userPrefs.jsonc
@@ -24,6 +24,7 @@
   // "USERPREFS_CONFIG_OWNER_SHORT_NAME": "MLN",
   // "USERPREFS_CONFIG_DEVICE_ROLE": "meshtastic_Config_DeviceConfig_Role_CLIENT", // Defaults to CLIENT. ROUTER*, and LOST AND FOUND roles are restricted.
   // "USERPREFS_EVENT_MODE": "1",
+  // "USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS": "1", // Extend TMM position dedup and precision clamping to private/custom-key channels (default: well-known channels only)
   // "USERPREFS_FIRMWARE_EDITION": "meshtastic_FirmwareEdition_BURNING_MAN",
   // "USERPREFS_FIXED_BLUETOOTH": "121212",
   // "USERPREFS_FIXED_GPS": "",

--- a/userPrefs.jsonc
+++ b/userPrefs.jsonc
@@ -25,6 +25,8 @@
   // "USERPREFS_CONFIG_DEVICE_ROLE": "meshtastic_Config_DeviceConfig_Role_CLIENT", // Defaults to CLIENT. ROUTER*, and LOST AND FOUND roles are restricted.
   // "USERPREFS_EVENT_MODE": "1",
   // "USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS": "1", // Extend TMM position dedup and precision clamping to private/custom-key channels (default: well-known channels only)
+  // "USERPREFS_TMM_HOP_TRIM_DISABLE": "1", // Compile out TMM hop-trimming (ON by default): clamps a relayed broadcast's reach to the local hop-scaling cap + grace
+  // "USERPREFS_TMM_HOP_TRIM_GRACE_BASE": "2", // Base hop grace (default 2); infra/specialty senders get +1, deprecated roles -1
   // "USERPREFS_FIRMWARE_EDITION": "meshtastic_FirmwareEdition_BURNING_MAN",
   // "USERPREFS_FIXED_BLUETOOTH": "121212",
   // "USERPREFS_FIXED_GPS": "",

--- a/userPrefs.jsonc
+++ b/userPrefs.jsonc
@@ -24,9 +24,9 @@
   // "USERPREFS_CONFIG_OWNER_SHORT_NAME": "MLN",
   // "USERPREFS_CONFIG_DEVICE_ROLE": "meshtastic_Config_DeviceConfig_Role_CLIENT", // Defaults to CLIENT. ROUTER*, and LOST AND FOUND roles are restricted.
   // "USERPREFS_EVENT_MODE": "1",
-  // "USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS": "1", // Extend TMM position dedup, precision clamping, and hop-trimming to private/custom-key channels (default: well-known channels only)
-  // "USERPREFS_TMM_HOP_TRIM_DISABLE": "1", // Compile out TMM hop-trimming (ON by default): clamps a relayed broadcast's reach to the local hop-scaling cap + grace
-  // "USERPREFS_TMM_HOP_TRIM_GRACE_BASE": "2", // Base hop grace (default 2); infra/specialty senders get +1, deprecated roles -1
+  // "USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS": "1", // Compile-time override: extend TMM to private channels (prefer runtime proto field apply_to_private_channels in TrafficManagementConfig)
+  // "USERPREFS_TMM_HOP_TRIM_DISABLE": "1",           // Compile-time override: compile out TMM hop-trimming (prefer runtime proto field hop_trim_disabled in TrafficManagementConfig)
+  // "USERPREFS_TMM_HOP_TRIM_GRACE_BASE": "2",        // Compile-time override: base hop grace (prefer runtime proto field hop_trim_grace in TrafficManagementConfig)
   // "USERPREFS_FIRMWARE_EDITION": "meshtastic_FirmwareEdition_BURNING_MAN",
   // "USERPREFS_FIXED_BLUETOOTH": "121212",
   // "USERPREFS_FIXED_GPS": "",

--- a/userPrefs.jsonc
+++ b/userPrefs.jsonc
@@ -24,7 +24,7 @@
   // "USERPREFS_CONFIG_OWNER_SHORT_NAME": "MLN",
   // "USERPREFS_CONFIG_DEVICE_ROLE": "meshtastic_Config_DeviceConfig_Role_CLIENT", // Defaults to CLIENT. ROUTER*, and LOST AND FOUND roles are restricted.
   // "USERPREFS_EVENT_MODE": "1",
-  // "USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS": "1", // Extend TMM position dedup and precision clamping to private/custom-key channels (default: well-known channels only)
+  // "USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS": "1", // Extend TMM position dedup, precision clamping, and hop-trimming to private/custom-key channels (default: well-known channels only)
   // "USERPREFS_TMM_HOP_TRIM_DISABLE": "1", // Compile out TMM hop-trimming (ON by default): clamps a relayed broadcast's reach to the local hop-scaling cap + grace
   // "USERPREFS_TMM_HOP_TRIM_GRACE_BASE": "2", // Base hop grace (default 2); infra/specialty senders get +1, deprecated roles -1
   // "USERPREFS_FIRMWARE_EDITION": "meshtastic_FirmwareEdition_BURNING_MAN",


### PR DESCRIPTION
This pull request introduces several improvements and a robust multi-hop relay system.

It is built on top of https://github.com/meshtastic/firmware/pull/10719 and requires the inherited requirements from there.

**Testing and validation:**

* Introduced a comprehensive hardware-level test (`test_nexthop_multihop_recovery.py`) for multi-hop NextHop directed-message delivery and relay-recovery. This test ensures that messages traverse relays correctly and that delivery recovers after relay outages, only running when a suitable topology is detected.


## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
