### PR TITLE
Add Femtofox E22P-915M30S meshtasticd config

### DIFF
--- a/bin/config.d/lora-femtofox_E22P-915M30S.yaml
+++ b/bin/config.d/lora-femtofox_E22P-915M30S.yaml
@@ -1,0 +1,24 @@
+---
+Meta:
+  name: Femtofox E22P-915M30S
+  support: community
+  compatible:
+    - luckfox-pico-mini
+
+Lora:
+  ## Femtofox / Luckfox Pico Mini with Ebyte E22P-915M30S.
+  ## This wiring was verified stable with meshtasticd 2.7.15 on mPWRD-OS.
+  ## Unlike lora-femtofox_SX1262_TCXO.yaml, this config does not use DIO2
+  ## as the RF switch. Enabling DIO2_AS_RF_SWITCH caused hangs after setting
+  ## region US on the tested E22P-915M30S hardware.
+  Module: sx1262
+  gpiochip: 1 # subtract 32 from the gpio numbers
+  DIO2_AS_RF_SWITCH: false
+  DIO3_TCXO_VOLTAGE: true
+  CS: 16 # pin6 / GPIO48 1C0
+  IRQ: 23 # pin17 / GPIO55 1C7
+  Busy: 22 # pin16 / GPIO54 1C6
+  Reset: 25 # pin13 / GPIO57 1D1
+  RXen: 24 # pin12 / GPIO56 1D0
+  spidev: spidev0.0 # pins are CS=16, CLK=17, MOSI=18, MISO=19
+  spiSpeed: 2000000


### PR DESCRIPTION
## Summary

Adds a dedicated meshtasticd config for Femtofox / Luckfox Pico Mini with the Ebyte E22P-915M30S SX1262 module.

## Why

On tested hardware, the existing Femtofox SX1262 TCXO config hangs after setting region when `DIO2_AS_RF_SWITCH: true`.

This E22P-specific config uses:

```yaml
DIO2_AS_RF_SWITCH: false
```

## Tested

Hardware/software:

- Femtofox / Luckfox Pico Mini
- Ebyte E22P-915M30S
- mPWRD-OS
- meshtasticd native 2.7.15
- Region: US

Verified:

- meshtasticd starts
- SX1262 initializes
- region US works without hang
- RXen, TCXO, and 2 MHz SPI remain stable
- mesh RX observed

## Notes

This adds a new config instead of changing `lora-femtofox_SX1262_TCXO.yaml`, because the existing config covers multiple SX1262 TCXO modules that may rely on DIO2 RF switching.