### PR TITLE
Reset noise floor samples after frequency changes

### DIFF
--- a/src/mesh/RadioInterface.h
+++ b/src/mesh/RadioInterface.h
@@ -240,8 +240,8 @@ class RadioInterface
   protected:
     int8_t power = 17; // Set by applyModemConfig()
 
-    float savedFreq;
-    uint32_t savedChannelNum;
+    float savedFreq = 0.0f;
+    uint32_t savedChannelNum = 0;
 
     /***
      * given a packet set sendingPacket and decode the protobufs into radiobuf.  Returns # of bytes to send (including the

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -54,6 +54,12 @@ RadioLibInterface::RadioLibInterface(LockingArduinoHal *hal, RADIOLIB_PIN_TYPE c
 #endif
 }
 
+static bool radioFrequencyChanged(float previousFreq, float currentFreq)
+{
+    const float delta = currentFreq - previousFreq;
+    return delta > 0.000001f || delta < -0.000001f;
+}
+
 #ifdef ARCH_ESP32
 // ESP32 doesn't use that flag
 #define YIELD_FROM_ISR(x) portYIELD_FROM_ISR()
@@ -228,6 +234,16 @@ bool RadioLibInterface::canSleep()
     return res;
 }
 
+bool RadioLibInterface::reconfigure()
+{
+    const float previousFreq = getFreq();
+    bool result = RadioInterface::reconfigure();
+    if (result && radioFrequencyChanged(previousFreq, getFreq())) {
+        resetNoiseFloor();
+    }
+    return result;
+}
+
 /** Allow other firmware components to ask whether we are currently sending a packet
 Initially implemented to protect T-Echo's capacitive touch button from spurious presses during tx
 */
@@ -331,6 +347,7 @@ void RadioLibInterface::resetNoiseFloor()
 {
     currentSampleIndex = 0;
     isNoiseFloorBufferFull = false;
+    lastNoiseFloorUpdate = 0;
     currentNoiseFloor = NOISE_FLOOR_DEFAULT;
     LOG_INFO("Noise floor reset - rolling window collection will restart");
 }

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -167,6 +167,8 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
     RadioLibInterface(LockingArduinoHal *hal, RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst,
                       RADIOLIB_PIN_TYPE busy, PhysicalLayer *iface = NULL);
 
+    virtual bool reconfigure() override;
+
     virtual ErrorCode send(meshtastic_MeshPacket *p) override;
 
     /**

--- a/test/test_radio/test_main.cpp
+++ b/test/test_radio/test_main.cpp
@@ -1,9 +1,53 @@
 #include "MeshRadio.h"
+#include "MeshService.h"
+#include "NodeDB.h"
 #include "RadioInterface.h"
+#include "RadioLibInterface.h"
 #include "TestUtil.h"
+#include <SPI.h>
 #include <unity.h>
 
 #include "meshtastic/config.pb.h"
+
+class MockMeshService : public MeshService
+{
+  public:
+    void sendClientNotification(meshtastic_ClientNotification *n) override { releaseClientNotificationToPool(n); }
+};
+
+static MockMeshService *mockMeshService;
+
+static LockingArduinoHal *getTestHal()
+{
+    static LockingArduinoHal hal(SPI, SPISettings(1000000, MSBFIRST, SPI_MODE0));
+    return &hal;
+}
+
+class TestableRadioLibInterface : public RadioLibInterface
+{
+  public:
+    TestableRadioLibInterface() : RadioLibInterface(getTestHal(), RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC, nullptr) {}
+
+    void seedNoiseFloorForTest()
+    {
+        noiseFloorSamples[0] = -110;
+        currentSampleIndex = 1;
+        isNoiseFloorBufferFull = false;
+        lastNoiseFloorUpdate = 1234;
+        currentNoiseFloor = -110;
+    }
+
+    uint32_t getLastNoiseFloorUpdateForTest() const { return lastNoiseFloorUpdate; }
+
+  protected:
+    void disableInterrupt() override {}
+    void enableInterrupt(void (*)()) override {}
+    bool isChannelActive() override { return false; }
+    bool isActivelyReceiving() override { return false; }
+    void addReceiveMetadata(meshtastic_MeshPacket *) override {}
+    uint32_t getPacketTime(uint32_t, bool) override { return 0; }
+    int16_t getCurrentRSSI() override { return NOISE_FLOOR_DEFAULT; }
+};
 
 static void test_bwCodeToKHz_specialMappings()
 {
@@ -77,8 +121,59 @@ static void test_bootstrapLoRaConfigFromPreset_fallsBackIfBandwidthExceedsRegion
     TEST_ASSERT_EQUAL_UINT32(11, cfg.spread_factor);
 }
 
-void setUp(void) {}
-void tearDown(void) {}
+static void configureLongFastUs(float frequencyOffset = 0.0f)
+{
+    config.lora = meshtastic_Config_LoRaConfig_init_zero;
+    config.lora.region = meshtastic_Config_LoRaConfig_RegionCode_US;
+    config.lora.use_preset = true;
+    config.lora.modem_preset = meshtastic_Config_LoRaConfig_ModemPreset_LONG_FAST;
+    config.lora.frequency_offset = frequencyOffset;
+}
+
+static void test_radioLibReconfigureResetsNoiseFloorWhenFrequencyChanges()
+{
+    TestableRadioLibInterface testRadioLib;
+    configureLongFastUs();
+    testRadioLib.reconfigure();
+    testRadioLib.seedNoiseFloorForTest();
+
+    config.lora.frequency_offset = 0.125f;
+    testRadioLib.reconfigure();
+
+    TEST_ASSERT_FALSE(testRadioLib.hasNoiseFloorSamples());
+    TEST_ASSERT_EQUAL_INT32(-120, testRadioLib.getNoiseFloor());
+    TEST_ASSERT_EQUAL_UINT32(0, testRadioLib.getLastNoiseFloorUpdateForTest());
+}
+
+static void test_radioLibReconfigureKeepsNoiseFloorWhenFrequencyUnchanged()
+{
+    TestableRadioLibInterface testRadioLib;
+    configureLongFastUs();
+    testRadioLib.reconfigure();
+    testRadioLib.seedNoiseFloorForTest();
+
+    testRadioLib.reconfigure();
+
+    TEST_ASSERT_TRUE(testRadioLib.hasNoiseFloorSamples());
+    TEST_ASSERT_EQUAL_INT32(-110, testRadioLib.getNoiseFloor());
+    TEST_ASSERT_EQUAL_UINT32(1234, testRadioLib.getLastNoiseFloorUpdateForTest());
+}
+
+void setUp(void)
+{
+    mockMeshService = new MockMeshService();
+    service = mockMeshService;
+
+    config.lora.region = meshtastic_Config_LoRaConfig_RegionCode_US;
+    initRegion();
+}
+
+void tearDown(void)
+{
+    service = nullptr;
+    delete mockMeshService;
+    mockMeshService = nullptr;
+}
 
 void setup()
 {
@@ -94,6 +189,8 @@ void setup()
     RUN_TEST(test_bootstrapLoRaConfigFromPreset_setsDerivedFields_nonWideRegion);
     RUN_TEST(test_bootstrapLoRaConfigFromPreset_setsDerivedFields_wideRegion);
     RUN_TEST(test_bootstrapLoRaConfigFromPreset_fallsBackIfBandwidthExceedsRegionSpan);
+    RUN_TEST(test_radioLibReconfigureResetsNoiseFloorWhenFrequencyChanges);
+    RUN_TEST(test_radioLibReconfigureKeepsNoiseFloorWhenFrequencyUnchanged);
     exit(UNITY_END());
 }
 


### PR DESCRIPTION
## Summary
- Reset RadioLib noise-floor calibration when `reconfigure()` applies a different effective receiver frequency.
- Keep the change local to `RadioLibInterface`; all RadioLib chip drivers already call this base reconfigure path before applying chip-specific settings.
- Clear the noise-floor sample throttle timestamp during reset so collection can restart immediately on the new frequency.
- Add `test_radio` coverage that seeds RadioLib noise-floor state, verifies it is cleared when frequency changes, and verifies it is preserved when frequency is unchanged.

## Why this is needed
LoRa config changes do not generally reboot the node. `AdminModule::handleSetConfig()` explicitly sets `requiresReboot = false` for LoRa config, then `saveChanges()` calls `MeshService::reloadConfig()`, which notifies the radio config observer and reconfigures the radio live. Channel changes also save without reboot and flow through reloadConfig; this matters because the default frequency slot can be derived from the primary channel name.

## Testing
- `trunk fmt src/mesh/RadioInterface.h src/mesh/RadioInterface.cpp src/mesh/RadioLibInterface.h src/mesh/RadioLibInterface.cpp test/test_radio/test_main.cpp`
- `~/.platformio/penv/bin/python -m platformio test -e native-macos -f test_radio`: 17 passed
- `pio run -e heltec-v3`: SUCCESS

## Notes
- Attempted `~/.platformio/penv/bin/python -m platformio test -e native -f test_radio` on macOS, but it failed before test execution because LovyanGFX includes Linux-only `<malloc.h>`. The repo has `native-macos` for this case, and that target passed.