### PR TITLE
fix(phone-api): skip manifest scan for node-info-only config requests

### DIFF
--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -101,6 +101,7 @@ bool renameFile(const char *pathFrom, const char *pathTo)
 
 #include <cstring>
 #include <new>
+#include <stdexcept>
 #include <vector>
 
 #ifdef FSCom
@@ -108,13 +109,36 @@ namespace
 {
 bool pathEndsWithDot(const char *path)
 {
+    if (!path)
+        return false;
+
     size_t length = strlen(path);
     return length > 0 && path[length - 1] == '.';
+}
+
+bool copyFilePath(char *dest, size_t destSize, const char *path, bool *wasLimited)
+{
+    if (!path || destSize == 0) {
+        if (wasLimited)
+            *wasLimited = true;
+        return false;
+    }
+
+    if (strlcpy(dest, path, destSize) >= destSize) {
+        if (wasLimited)
+            *wasLimited = true;
+        return false;
+    }
+
+    return true;
 }
 
 void collectFiles(const char *dirname, uint8_t levels, size_t maxCount, std::vector<meshtastic_FileInfo> &filenames,
                   bool *wasLimited)
 {
+    if (!dirname)
+        return;
+
     File root = FSCom.open(dirname, FILE_O_READ);
     if (!root)
         return;
@@ -131,25 +155,30 @@ void collectFiles(const char *dirname, uint8_t levels, size_t maxCount, std::vec
             file.close();
             break;
         }
-        if (file.isDirectory() && !pathEndsWithDot(file.name())) {
-            if (levels) {
+        const char *fileName = file.name();
+        if (file.isDirectory() && !pathEndsWithDot(fileName)) {
+            char pathBuffer[sizeof(meshtastic_FileInfo::file_name)] = {};
 #ifdef ARCH_ESP32
-                collectFiles(file.path(), levels - 1, maxCount, filenames, wasLimited);
+            const char *subDirPath = file.path();
 #else
-                collectFiles(file.name(), levels - 1, maxCount, filenames, wasLimited);
+            const char *subDirPath = fileName;
 #endif
+            bool hasSubDirPath = copyFilePath(pathBuffer, sizeof(pathBuffer), subDirPath, wasLimited);
+            file.close();
+
+            if (levels && hasSubDirPath) {
+                collectFiles(pathBuffer, levels - 1, maxCount, filenames, wasLimited);
             } else if (wasLimited) {
                 *wasLimited = true;
             }
-            file.close();
         } else {
             meshtastic_FileInfo fileInfo = {"", static_cast<uint32_t>(file.size())};
 #ifdef ARCH_ESP32
-            strlcpy(fileInfo.file_name, file.path(), sizeof(fileInfo.file_name));
+            bool hasFilePath = copyFilePath(fileInfo.file_name, sizeof(fileInfo.file_name), file.path(), wasLimited);
 #else
-            strlcpy(fileInfo.file_name, file.name(), sizeof(fileInfo.file_name));
+            bool hasFilePath = copyFilePath(fileInfo.file_name, sizeof(fileInfo.file_name), file.name(), wasLimited);
 #endif
-            if (!pathEndsWithDot(fileInfo.file_name)) {
+            if (hasFilePath && !pathEndsWithDot(fileInfo.file_name)) {
                 filenames.push_back(fileInfo);
             }
             file.close();
@@ -161,18 +190,7 @@ void collectFiles(const char *dirname, uint8_t levels, size_t maxCount, std::vec
 } // namespace
 #endif
 
-/**
- * @brief Get the list of files in a directory.
- *
- * This function returns a list of files in a directory. The list includes the full path of each file.
- * We can't use SPILOCK here because of recursion. Callers of this function should use SPILOCK.
- *
- * @param dirname The name of the directory.
- * @param levels The number of levels of subdirectories to list.
- * @param maxCount The maximum number of file entries to return.
- * @param wasLimited Set to true if maxCount or levels prevented a complete recursive listing.
- * @return A vector of file metadata containing the full path of each file in the directory.
- */
+// Callers must hold the SPI lock; recursion prevents taking it here.
 std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels, size_t maxCount, bool *wasLimited)
 {
     std::vector<meshtastic_FileInfo> filenames = {};
@@ -186,6 +204,8 @@ std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels, s
             filenames.reserve(reservedCount);
             break;
         } catch (const std::bad_alloc &) {
+            reservedCount /= 2;
+        } catch (const std::length_error &) {
             reservedCount /= 2;
         }
     }

--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -99,7 +99,67 @@ bool renameFile(const char *pathFrom, const char *pathTo)
 #endif
 }
 
+#include <cstring>
+#include <new>
 #include <vector>
+
+#ifdef FSCom
+namespace
+{
+bool pathEndsWithDot(const char *path)
+{
+    size_t length = strlen(path);
+    return length > 0 && path[length - 1] == '.';
+}
+
+void collectFiles(const char *dirname, uint8_t levels, size_t maxCount, std::vector<meshtastic_FileInfo> &filenames,
+                  bool *wasLimited)
+{
+    File root = FSCom.open(dirname, FILE_O_READ);
+    if (!root)
+        return;
+    if (!root.isDirectory()) {
+        root.close();
+        return;
+    }
+
+    File file = root.openNextFile();
+    while (file) {
+        if (filenames.size() >= maxCount) {
+            if (wasLimited)
+                *wasLimited = true;
+            file.close();
+            break;
+        }
+        if (file.isDirectory() && !pathEndsWithDot(file.name())) {
+            if (levels) {
+#ifdef ARCH_ESP32
+                collectFiles(file.path(), levels - 1, maxCount, filenames, wasLimited);
+#else
+                collectFiles(file.name(), levels - 1, maxCount, filenames, wasLimited);
+#endif
+            } else if (wasLimited) {
+                *wasLimited = true;
+            }
+            file.close();
+        } else {
+            meshtastic_FileInfo fileInfo = {"", static_cast<uint32_t>(file.size())};
+#ifdef ARCH_ESP32
+            strlcpy(fileInfo.file_name, file.path(), sizeof(fileInfo.file_name));
+#else
+            strlcpy(fileInfo.file_name, file.name(), sizeof(fileInfo.file_name));
+#endif
+            if (!pathEndsWithDot(fileInfo.file_name)) {
+                filenames.push_back(fileInfo);
+            }
+            file.close();
+        }
+        file = root.openNextFile();
+    }
+    root.close();
+}
+} // namespace
+#endif
 
 /**
  * @brief Get the list of files in a directory.
@@ -109,45 +169,38 @@ bool renameFile(const char *pathFrom, const char *pathTo)
  *
  * @param dirname The name of the directory.
  * @param levels The number of levels of subdirectories to list.
- * @return A vector of strings containing the full path of each file in the directory.
+ * @param maxCount The maximum number of file entries to return.
+ * @param wasLimited Set to true if maxCount or levels prevented a complete recursive listing.
+ * @return A vector of file metadata containing the full path of each file in the directory.
  */
-std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels)
+std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels, size_t maxCount, bool *wasLimited)
 {
     std::vector<meshtastic_FileInfo> filenames = {};
+    if (wasLimited)
+        *wasLimited = false;
 #ifdef FSCom
-    File root = FSCom.open(dirname, FILE_O_READ);
-    if (!root)
-        return filenames;
-    if (!root.isDirectory())
-        return filenames;
-
-    File file = root.openNextFile();
-    while (file) {
-        if (file.isDirectory() && !String(file.name()).endsWith(".")) {
-            if (levels) {
-#ifdef ARCH_ESP32
-                std::vector<meshtastic_FileInfo> subDirFilenames = getFiles(file.path(), levels - 1);
-#else
-                std::vector<meshtastic_FileInfo> subDirFilenames = getFiles(file.name(), levels - 1);
-#endif
-                filenames.insert(filenames.end(), subDirFilenames.begin(), subDirFilenames.end());
-                file.close();
-            }
-        } else {
-            meshtastic_FileInfo fileInfo = {"", static_cast<uint32_t>(file.size())};
-#ifdef ARCH_ESP32
-            strcpy(fileInfo.file_name, file.path());
-#else
-            strcpy(fileInfo.file_name, file.name());
-#endif
-            if (!String(fileInfo.file_name).endsWith(".")) {
-                filenames.push_back(fileInfo);
-            }
-            file.close();
+#if defined(__cpp_exceptions) || defined(__EXCEPTIONS)
+    size_t reservedCount = maxCount;
+    while (reservedCount > 0) {
+        try {
+            filenames.reserve(reservedCount);
+            break;
+        } catch (const std::bad_alloc &) {
+            reservedCount /= 2;
         }
-        file = root.openNextFile();
     }
-    root.close();
+    if (reservedCount == 0) {
+        if (wasLimited)
+            *wasLimited = true;
+        return filenames;
+    }
+    if (reservedCount < maxCount) {
+        if (wasLimited)
+            *wasLimited = true;
+        maxCount = reservedCount;
+    }
+#endif
+    collectFiles(dirname, levels, maxCount, filenames, wasLimited);
 #endif
     return filenames;
 }

--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -157,7 +157,7 @@ void collectFiles(const char *dirname, uint8_t levels, size_t maxCount, std::vec
         }
         const char *fileName = file.name();
         if (file.isDirectory() && !pathEndsWithDot(fileName)) {
-            char pathBuffer[sizeof(meshtastic_FileInfo::file_name)] = {};
+            char pathBuffer[sizeof(((meshtastic_FileInfo *)nullptr)->file_name)] = {};
 #ifdef ARCH_ESP32
             const char *subDirPath = file.path();
 #else

--- a/src/FSCommon.h
+++ b/src/FSCommon.h
@@ -52,7 +52,7 @@ void fsInit();
 void fsListFiles();
 bool copyFile(const char *from, const char *to);
 bool renameFile(const char *pathFrom, const char *pathTo);
-std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels);
+std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels, size_t maxCount = 64, bool *wasLimited = nullptr);
 void listDir(const char *dirname, uint8_t levels, bool del = false);
 void rmDir(const char *dirname);
 void setupSDCard();

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -38,8 +38,8 @@ bool heartbeatReceived = false;
 
 namespace
 {
-constexpr uint8_t kFilesManifestLevels = 3;
-constexpr size_t kFilesManifestMaxCount = 64;
+constexpr uint8_t FILES_MANIFEST_LEVELS = 3;
+constexpr size_t FILES_MANIFEST_MAX_COUNT = 64;
 
 void releaseFilesManifest(std::vector<meshtastic_FileInfo> &filesManifest)
 {
@@ -87,11 +87,11 @@ void PhoneAPI::handleStartConfig()
         bool filesManifestLimited = false;
         {
             concurrency::LockGuard guard(spiLock);
-            filesManifest = getFiles("/", kFilesManifestLevels, kFilesManifestMaxCount, &filesManifestLimited);
+            filesManifest = getFiles("/", FILES_MANIFEST_LEVELS, FILES_MANIFEST_MAX_COUNT, &filesManifestLimited);
         }
         if (filesManifestLimited) {
-            LOG_WARN("Got %zu files in manifest (limited to %zu entries/depth %u)", filesManifest.size(), kFilesManifestMaxCount,
-                     static_cast<unsigned>(kFilesManifestLevels));
+            LOG_WARN("Got %zu files in manifest (limited to %zu entries/depth %u)", filesManifest.size(),
+                     FILES_MANIFEST_MAX_COUNT, static_cast<unsigned>(FILES_MANIFEST_LEVELS));
         } else {
             LOG_DEBUG("Got %zu files in manifest", filesManifest.size());
         }

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -36,6 +36,17 @@
 // Flag to indicate a heartbeat was received and we should send queue status
 bool heartbeatReceived = false;
 
+namespace
+{
+constexpr uint8_t kFilesManifestLevels = 3;
+constexpr size_t kFilesManifestMaxCount = 64;
+
+void releaseFilesManifest(std::vector<meshtastic_FileInfo> &filesManifest)
+{
+    std::vector<meshtastic_FileInfo>().swap(filesManifest);
+}
+} // namespace
+
 PhoneAPI::PhoneAPI()
 {
     lastContactMsec = millis();
@@ -70,10 +81,23 @@ void PhoneAPI::handleStartConfig()
         state = STATE_SEND_MY_INFO;
     }
     pauseBluetoothLogging = true;
-    spiLock->lock();
-    filesManifest = getFiles("/", 10);
-    spiLock->unlock();
-    LOG_DEBUG("Got %d files in manifest", filesManifest.size());
+    // Manifest is never read on the node-info-only path (STATE_SEND_FILEMANIFEST
+    // short-circuits to sendConfigComplete), so skip the SPI lock + FS walk.
+    if (config_nonce != SPECIAL_NONCE_ONLY_NODES) {
+        bool filesManifestLimited = false;
+        {
+            concurrency::LockGuard guard(spiLock);
+            filesManifest = getFiles("/", kFilesManifestLevels, kFilesManifestMaxCount, &filesManifestLimited);
+        }
+        if (filesManifestLimited) {
+            LOG_WARN("Got %zu files in manifest (limited to %zu entries/depth %u)", filesManifest.size(), kFilesManifestMaxCount,
+                     static_cast<unsigned>(kFilesManifestLevels));
+        } else {
+            LOG_DEBUG("Got %zu files in manifest", filesManifest.size());
+        }
+    } else {
+        releaseFilesManifest(filesManifest);
+    }
 
     LOG_INFO("Start API client config millis=%u", millis());
     // Protect against concurrent BLE callbacks: they run in NimBLE's FreeRTOS task and also touch nodeInfoQueue.
@@ -122,8 +146,7 @@ void PhoneAPI::close()
             nodeInfoQueue.clear();
         }
         packetForPhone = NULL;
-        filesManifest.clear();
-        filesManifest.shrink_to_fit();
+        releaseFilesManifest(filesManifest);
         lastPortNumToRadio.clear();
         fromRadioNum = 0;
         config_nonce = 0;
@@ -532,7 +555,7 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
         if (config_state == filesManifest.size() ||
             config_nonce == SPECIAL_NONCE_ONLY_NODES) { // also handles an empty filesManifest
             config_state = 0;
-            filesManifest.clear();
+            releaseFilesManifest(filesManifest);
             // Skip to complete packet
             sendConfigComplete();
         } else {


### PR DESCRIPTION
## Overview

This change fixes a firmware crash I hit while testing the Android WiFi/TCP handshake recovery work that landed in meshtastic/Meshtastic-Android#5856.

During Android Stage 2, the app sends a node-info-only config request. On my tbeam running `v2.7.25.104df5f`, the firmware logged that the client only wanted node info, then crashed/rebooted before completing the node-info response.

The main fix is to skip filesystem manifest loading entirely for the `SPECIAL_NONCE_ONLY_NODES` path. That path does not use the file manifest, so avoiding the SPI lock and filesystem walk removes unnecessary memory pressure during node-info-only config starts.

This also hardens filesystem manifest enumeration by making it bounded and less allocation-heavy.

## Key Changes

**PhoneAPI**
- Skips filesystem manifest loading for `SPECIAL_NONCE_ONLY_NODES`.
- Releases any existing manifest data when starting the node-info-only path.
- Keeps the node-info-only flow intact: send node info, then send config complete.
- Uses explicit manifest scan limits for normal config requests:
  - depth: `3`
  - max entries: `64`
- Logs when manifest enumeration was limited.

**Filesystem Enumeration**
- Extends `getFiles()` with optional `maxCount` and `wasLimited` parameters.
- Defaults `getFiles()` to at most 64 entries.
- Adds bounded recursive traversal so enumeration stops once enough entries are collected.
- Uses one accumulator vector instead of building temporary vectors for recursive calls.
- Uses `strlcpy` instead of `strcpy` for file names.
- Avoids temporary `String` allocation for dot-suffix filtering.
- Compile-gates the `std::bad_alloc` / `std::length_error` reserve fallback so no-exception targets still build.

## Validation

Firmware built from `86f062657c95a988492d35979e972ed8d3a4a350` has been running well for about two days across multiple tbeam, rak4631, and T1000-E devices.

With that firmware, Android can connect without triggering the crash/reboot loop I was seeing before.

The latest branch includes a few additional review-suggested filesystem traversal hardening changes, which I am loading up for more testing now.

This was tested together with the latest Android-side WiFi/TCP recovery changes in meshtastic/Meshtastic-Android#5856.

## Review Notes

This patch deserves careful maintainer review. I have done the best I can to review the C/C++ side with AI tooling and device testing, but I do not have much experience with C yet.

The main behavior change to call out is that `getFiles()` now limits results to 64 entries by default. Existing callers still compile because the new parameters have defaults, but callers that need a larger or complete listing should pass a larger `maxCount` and can use `wasLimited` to detect truncation.

## Breaking Changes / Migration

`getFiles()` now limits results by default to at most 64 entries.

Existing callers continue to compile due to default arguments, but they may now receive a truncated listing. Callers that require more entries should pass a larger `maxCount` and optionally check `wasLimited`.

## Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [x] LilyGo T-Beam
  - [x] RAK WisBlock 4631
  - [x] Seeed Studio T-1000E tracker card
  - [ ] Other