### PR TITLE
fix: right-size warm tier for constrained platforms (#10746, #10705)

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -66,6 +66,10 @@
 #include <utility/bonding.h>
 #endif
 
+#ifdef ARCH_RP2040
+#include <hardware/watchdog.h>
+#endif
+
 #if defined(ARCH_ESP32) && !MESHTASTIC_EXCLUDE_WIFI
 #include <MeshtasticOTA.h>
 #endif
@@ -2682,6 +2686,11 @@ bool NodeDB::saveNodeDatabaseToDisk()
     nodeDatabase.status.clear();
     nodeDatabase.status.shrink_to_fit();
 #if WARM_NODE_COUNT > 0
+#ifdef ARCH_RP2040
+    // nodes.proto + warm.dat are written back-to-back without the loop running between them;
+    // reset the 8s HW watchdog so the second write gets a full budget (issue #10746).
+    watchdog_update();
+#endif
     // Same cadence as the node DB; failure is logged but must not propagate —
     // a false return from here would trigger saveToDisk()'s fsFormat() path.
     warmStore.saveIfDirty();

--- a/src/mesh/mesh-pb-constants.h
+++ b/src/mesh/mesh-pb-constants.h
@@ -128,13 +128,15 @@ static inline int get_max_num_nodes()
 // chain. Backed by the raw-flash ring below LittleFS — see WarmNodeStore.h.
 #define WARM_NODE_COUNT 200
 #elif (defined(CONFIG_IDF_TARGET_ESP32S3) && defined(BOARD_HAS_PSRAM)) || defined(ARCH_PORTDUINO)
-#define WARM_NODE_COUNT 2000 // PSRAM-equipped ESP32-S3 / native host; warm.dat ~80 KB
-#elif defined(CONFIG_IDF_TARGET_ESP32S3)
-#define WARM_NODE_COUNT 150 // ESP32-S3 without PSRAM: ~6 KB heap, keeps BLE headroom (#10705)
+#define WARM_NODE_COUNT 2000 // PSRAM-equipped ESP32-S3 / native host; warm cache in PSRAM (~80 KB)
+#elif defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32P4)
+#define WARM_NODE_COUNT 150 // 512 KB+ SRAM, no PSRAM (S3/C6/P4): ~6 KB heap (#10705)
+#elif defined(ARCH_ESP32)
+#define WARM_NODE_COUNT 100 // classic ESP32 (520 KB) / S2 (320 KB) / C3 (400 KB): tightest free heap w/ BLE+WiFi, ~4 KB (#10705)
 #elif defined(ARCH_RP2040)
-#define WARM_NODE_COUNT 150 // RP2040/RP2350: smaller warm.dat so the second flash write fits the watchdog (#10746)
+#define WARM_NODE_COUNT 150 // RP2040 (264 KB) / RP2350 (520 KB): bounded so warm.dat write fits the 8s watchdog (#10746)
 #else
-#define WARM_NODE_COUNT 320 // Generic ESP32, ESP32C3 etc.
+#define WARM_NODE_COUNT 320 // other LittleFS-backed parts
 #endif                      // platform
 #endif                      // WARM_NODE_COUNT
 
@@ -168,10 +170,12 @@ static inline int get_max_num_nodes()
 #define TRAFFIC_MANAGEMENT_CACHE_SIZE 0
 #elif (defined(CONFIG_IDF_TARGET_ESP32S3) && defined(BOARD_HAS_PSRAM)) || defined(ARCH_PORTDUINO)
 #define TRAFFIC_MANAGEMENT_CACHE_SIZE 2048 // PSRAM-equipped ESP32-S3 / native host
-#elif defined(CONFIG_IDF_TARGET_ESP32S3)
-#define TRAFFIC_MANAGEMENT_CACHE_SIZE 500 // ESP32-S3 without PSRAM: ~5 KB heap, keeps BLE headroom (#10705)
+#elif defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32P4)
+#define TRAFFIC_MANAGEMENT_CACHE_SIZE 500 // 512 KB+ SRAM, no PSRAM (S3/C6/P4): ~5 KB heap (#10705)
+#elif defined(ARCH_ESP32)
+#define TRAFFIC_MANAGEMENT_CACHE_SIZE 400 // classic ESP32 / S2 / C3: tightest free heap, ~4 KB (#10705)
 #else
-#define TRAFFIC_MANAGEMENT_CACHE_SIZE 1000 // Generic ESP32
+#define TRAFFIC_MANAGEMENT_CACHE_SIZE 1000 // RP2040 / other
 #endif
 #endif // TRAFFIC_MANAGEMENT_CACHE_SIZE
 

--- a/src/mesh/mesh-pb-constants.h
+++ b/src/mesh/mesh-pb-constants.h
@@ -129,8 +129,12 @@ static inline int get_max_num_nodes()
 #define WARM_NODE_COUNT 200
 #elif (defined(CONFIG_IDF_TARGET_ESP32S3) && defined(BOARD_HAS_PSRAM)) || defined(ARCH_PORTDUINO)
 #define WARM_NODE_COUNT 2000 // PSRAM-equipped ESP32-S3 / native host; warm.dat ~80 KB
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+#define WARM_NODE_COUNT 150 // ESP32-S3 without PSRAM: ~6 KB heap, keeps BLE headroom (#10705)
+#elif defined(ARCH_RP2040)
+#define WARM_NODE_COUNT 150 // RP2040/RP2350: smaller warm.dat so the second flash write fits the watchdog (#10746)
 #else
-#define WARM_NODE_COUNT 320 // Generic ESP32, ESP32-S3 without PSRAM, ESP32C3 etc.
+#define WARM_NODE_COUNT 320 // Generic ESP32, ESP32C3 etc.
 #endif                      // platform
 #endif                      // WARM_NODE_COUNT
 
@@ -164,8 +168,10 @@ static inline int get_max_num_nodes()
 #define TRAFFIC_MANAGEMENT_CACHE_SIZE 0
 #elif (defined(CONFIG_IDF_TARGET_ESP32S3) && defined(BOARD_HAS_PSRAM)) || defined(ARCH_PORTDUINO)
 #define TRAFFIC_MANAGEMENT_CACHE_SIZE 2048 // PSRAM-equipped ESP32-S3 / native host
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+#define TRAFFIC_MANAGEMENT_CACHE_SIZE 500 // ESP32-S3 without PSRAM: ~5 KB heap, keeps BLE headroom (#10705)
 #else
-#define TRAFFIC_MANAGEMENT_CACHE_SIZE 1000 // Generic ESP32, ESP32-S3 without PSRAM
+#define TRAFFIC_MANAGEMENT_CACHE_SIZE 1000 // Generic ESP32
 #endif
 #endif // TRAFFIC_MANAGEMENT_CACHE_SIZE
 

--- a/src/mesh/mesh-pb-constants.h
+++ b/src/mesh/mesh-pb-constants.h
@@ -136,7 +136,10 @@ static inline int get_max_num_nodes()
 #elif defined(ARCH_RP2040)
 #define WARM_NODE_COUNT 150 // RP2040 (264 KB) / RP2350 (520 KB): bounded so warm.dat write fits the 8s watchdog (#10746)
 #else
-#define WARM_NODE_COUNT 320 // other LittleFS-backed parts
+// nRF52840 is handled explicitly above (200, raw-flash ring). Any other nRF52 (non-XXAA) and any
+// future non-ESP32/non-RP LittleFS part fall through to this 320 default — flag for review if such a
+// RAM-constrained nRF52 target is ever added.
+#define WARM_NODE_COUNT 320 // other LittleFS-backed parts (e.g. non-nRF52840 nRF52)
 #endif                      // platform
 #endif                      // WARM_NODE_COUNT
 
@@ -175,7 +178,10 @@ static inline int get_max_num_nodes()
 #elif defined(ARCH_ESP32)
 #define TRAFFIC_MANAGEMENT_CACHE_SIZE 400 // classic ESP32 / S2 / C3: tightest free heap, ~4 KB (#10705)
 #else
-#define TRAFFIC_MANAGEMENT_CACHE_SIZE 1000 // RP2040 / other
+// nRF52 (incl. nRF52840) and RP2040/RP2350 fall through here — there is no nRF/RP branch above,
+// by design. These parts have no ESP32-style WiFi+BLE coexistence eating the heap, so the larger
+// 1000-entry (~10 KB) cache fits: nRF52840 is BLE-only on 256 KB RAM; RP2040/RP2350 have 264/520 KB.
+#define TRAFFIC_MANAGEMENT_CACHE_SIZE 1000 // nRF52 / RP2040 / RP2350 / other non-ESP32
 #endif
 #endif // TRAFFIC_MANAGEMENT_CACHE_SIZE
 


### PR DESCRIPTION
Constrained platforms fall into the generic `WARM_NODE_COUNT 320` catch-all, which is too large for them.

- **RP2040/RP2350 (#10746):** `nodes.proto` and `warm.dat` are written back-to-back in one blocking stretch, so the loop never feeds the 8s HW watchdog and it resets on the second write. Fix: `watchdog_update()` between the two writes, plus an explicit `ARCH_RP2040` branch (150).
- **No-PSRAM ESP32-S3 (#10705 BLE reboots):** `WARM_NODE_COUNT` 320→150 and `TRAFFIC_MANAGEMENT_CACHE_SIZE` 1000→500 (~12 KB heap recovered).

Warm tier stays enabled on all platforms; generic ESP32 unchanged.