### PR TITLE
Update native to exit when configured with an unknown module

### DIFF
--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -784,11 +784,18 @@ bool loadConfig(const char *configPath)
         if (yamlConfig["Lora"]) {
 
             if (yamlConfig["Lora"]["Module"]) {
+                const std::string moduleName = yamlConfig["Lora"]["Module"].as<std::string>("");
+                bool found = false;
                 for (const auto &loraModule : portduino_config.loraModules) {
-                    if (yamlConfig["Lora"]["Module"].as<std::string>("") == loraModule.second) {
+                    if (moduleName == loraModule.second) {
                         portduino_config.lora_module = loraModule.first;
+                        found = true;
                         break;
                     }
+                }
+                if (!found) {
+                    std::cerr << "Unknown Lora.Module: " << moduleName << std::endl;
+                    exit(EXIT_FAILURE);
                 }
             }
             if (yamlConfig["Lora"]["SX126X_MAX_POWER"])


### PR DESCRIPTION
Update native to exit when configured with an unknown module instead of going in to sim mode.  If a lora module is set in config.yaml and that module isn't one recognized by meshtasticd, meshtasticd will now exit with an error instead of going in to sim mode. This will prevent confusion by not going in to sim mode when a radio is explicitly confined by the user.  Sim mode can still be entered by command line option, or by setting the module to sim.

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [X] Other (please specify below)
    - [X] Linux native, code change only effects code used in native.