### PR TITLE
build(native-macos): enable UDP multicast mesh

### DIFF
--- a/variants/native/portduino/platformio.ini
+++ b/variants/native/portduino/platformio.ini
@@ -194,6 +194,12 @@ build_flags = ${portduino_base.build_flags_common}
   -L/opt/homebrew/opt/yaml-cpp/lib
   -largp
   -DPORTDUINO_DARWIN
+  ; UDP multicast mesh-over-LAN. Linux native gets this via
+  ; portduino_base.build_flags, but native-macos only pulls build_flags_common,
+  ; so enable it explicitly here. Requires the Darwin INADDR_ANY multicast-bind
+  ; fix in framework-portduino (meshtastic/framework-portduino#75) to actually
+  ; mesh between sibling processes on macOS.
+  -DHAS_UDP_MULTICAST=1
   ; Headless build - variants/native/portduino/variant.h would otherwise
   ; default HAS_SCREEN to 1 and pull in screen-renderer source that uses
   ; VLA-with-initializer (a GNU/GCC extension Apple Clang rejects).


### PR DESCRIPTION
## Summary

`native-macos` only pulls `portduino_base.build_flags_common`, which omits `-DHAS_UDP_MULTICAST=1` (that flag lives in `portduino_base.build_flags`, inherited by Linux native via `native_base`). So macOS native builds shipped with no UDP multicast, and two local `meshtasticd` nodes couldn't mesh over `224.0.0.69:4403`.

This adds `-DHAS_UDP_MULTICAST=1` to the `native-macos` build flags (also inherited by `native-macos-debug`).

## Dependency

> **Blocked on [meshtastic/framework-portduino#75](https://github.com/meshtastic/framework-portduino/pull/75)** and a subsequent `platform-native` bump that bundles it.

Without the Darwin multicast-bind fix in that PR, the socket binds the multicast group address and never loops back on macOS, so enabling the flag alone yields a non-functional listener on Darwin. Opening as a draft until the framework fix is in the resolved `platform-native` bundle.

## Test plan

- `pio run -e native-macos` builds with the flag (no manual `PLATFORMIO_BUILD_FLAGS` override).
- With framework-portduino#75 applied, two `native-macos` nodes mesh over `224.0.0.69:4403` — both node DBs cross-populate and a text message is delivered.
- Linux native (`-e native`) unaffected — it already had the flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled UDP multicast mesh support for macOS native builds.
  * Improved macOS build configuration clarity with supporting comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->