### PR TITLE
Fix `spiLock` deadlocks / frequent watchdog restarts in `WarmNodeStore::save()`

### DIFF
--- a/src/MessageStore.cpp
+++ b/src/MessageStore.cpp
@@ -354,10 +354,16 @@ void MessageStore::clearAllMessages()
     resetMessagePool();
 
 #ifdef FSCom
-    concurrency::LockGuard guard(spiLock);
     SafeFile f(filename.c_str(), false);
     uint8_t count = 0;
-    f.write(&count, 1); // write "0 messages"
+
+    // SafeFile already does its own spiLock in its constructor and close().
+    // Avoid nesting spiLocks, as this will hang until watchdog reset!
+    {
+        concurrency::LockGuard guard(spiLock);
+        f.write(&count, 1); // write "0 messages"
+    }
+
     f.close();
 #endif
 

--- a/src/mesh/WarmNodeStore.cpp
+++ b/src/mesh/WarmNodeStore.cpp
@@ -589,12 +589,22 @@ bool WarmNodeStore::save()
     h.entrySize = sizeof(WarmNodeEntry);
     h.crc = crc32Buffer(packed.data(), h.count * sizeof(WarmNodeEntry));
 
-    concurrency::LockGuard g(spiLock);
-    FSCom.mkdir("/prefs");
+    // SafeFile already does its own spiLock in its constructor and close().
+    // Avoid nesting spiLocks, as this will hang until watchdog reset!
+
+    {
+        concurrency::LockGuard g(spiLock);
+        FSCom.mkdir("/prefs");
+    }
 
     auto f = SafeFile(warmFileName, false);
-    f.write((const uint8_t *)&h, sizeof(h));
-    f.write((const uint8_t *)packed.data(), h.count * sizeof(WarmNodeEntry));
+
+    {
+        concurrency::LockGuard g(spiLock);
+        f.write((const uint8_t *)&h, sizeof(h));
+        f.write((const uint8_t *)packed.data(), h.count * sizeof(WarmNodeEntry));
+    }
+
     bool ok = f.close();
     if (!ok)
         LOG_ERROR("WarmStore: can't write %s", warmFileName);


### PR DESCRIPTION
Fixes frequent watchdog restarts on platforms with `FSCom`.

I was seeing frequent (every few minutes to tens of minutes) hangs and then watchdog reboots. I tracked it down to `WarmNodeStore::save()` which holds `spiLock` while calling `SafeFile f(filename.c_str(), false);`. The constructor for `SafeFile` itself tries to grab `spiLock`, which is already held, so this causes a deadlock, until the watchdog timer kicks in and reboots.

This PR makes it so `WarmNodeStore::save()` adds locking **only** around the calls that aren't already covered by an `spiLock`: the `mkdir` and the `write` calls.

(Also found and fixed similar in `MessageStore::clearAllMessages`, but that's not very commonly used.)

It appears that this logic was introduced about two weeks ago in https://github.com/meshtastic/firmware/pull/10705/changes#diff-fd0d79c004a2b4611b3eee806f16eef5d803bebd2e1a13f7b891e6b4bc312b2dR523-R534 @NomDeTom @thebentern 

My logs looked like:

```
DEBUG | 16:07:05 264 [Router] Saved Pubkey:  ...
DEBUG | 16:07:05 264 [Router] Update changed=1 user Redacted/RDCT, id=0x12345678, channel=1
DEBUG | 16:07:06 264 [Router] Node status update: 78 online, 250 total
DEBUG | 16:07:06 264 [Router] Save to disk 16
DEBUG | 16:07:06 264 [Router] Opening /prefs/nodes.proto, fullAtomic=0
INFO  | 16:07:06 264 [Router] Save /prefs/nodes.proto
E (355189) task_wdt: Task watchdog got triggered. The following tasks/users did not reset the watchdog in time:
E (355189) task_wdt:  - loopTask (CPU 1)
E (355190) task_wdt: Tasks currently running:
E (355190) task_wdt: CPU 0: IDLE0
E (355190) task_wdt: CPU 1: IDLE1
E (355190) task_wdt: Aborting.
E (355210) task_wdt: Print CPU 1 (current core) backtrace
...
```

## 🤝 Attestations

Testing is in progress; would appreciate other testers!