### PR TITLE
fix: preserve established NodeNum across 2.7→2.8 upgrade (gate createNewIdentity)

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -485,13 +485,12 @@ NodeDB::NodeDB()
     if (!configDecodeFailed)
         generateCryptoKeyPair(nullptr);
 #elif !(MESHTASTIC_EXCLUDE_PKI)
-    // Calculate Curve25519 public and private keys
+    // No keygen here: just load the existing keypair for DH. Don't re-derive my_node_num from it - that
+    // would migrate an established NodeNum on boot (see PR #10820).
     if (config.security.private_key.size == 32 && config.security.public_key.size == 32) {
         owner.public_key.size = config.security.public_key.size;
         memcpy(owner.public_key.bytes, config.security.public_key.bytes, config.security.public_key.size);
         crypto->setDHPrivateKey(config.security.private_key.bytes);
-        // Set my node num uint32 value to bytes from the new public key
-        myNodeInfo.my_node_num = crc32Buffer(config.security.public_key.bytes, config.security.public_key.size);
     }
 #endif
     // Identity is now established, so run the self-care pass on the store
@@ -3795,6 +3794,9 @@ bool NodeDB::generateCryptoKeyPair(const uint8_t *privateKey)
     }
 
     bool keygenSuccess = false;
+    // Only a new/imported keypair may adopt the key-derived NodeNum; regenerating an unchanged key on a
+    // normal boot must not (it would migrate established legacy NodeNums - see PR #10820).
+    bool freshKeypair = false;
     // Record whether the stored key is a known compromised/low-entropy key so main.cpp can warn the
     // user. A detected low-entropy key is regenerated below, but the flag stays set so the
     // "Compromised keys were detected and regenerated" notification still fires.
@@ -3810,12 +3812,13 @@ bool NodeDB::generateCryptoKeyPair(const uint8_t *privateKey)
         // Generate public key from the provided private key
         if (crypto->regeneratePublicKey(config.security.public_key.bytes, config.security.private_key.bytes)) {
             keygenSuccess = true;
+            freshKeypair = true; // an explicitly imported key establishes a (possibly new) identity
         } else {
             LOG_ERROR("Failed to generate public key from provided private key");
             return false;
         }
     }
-    // Try to regenerate public key from existing private key if it's valid and not low entropy
+    // Existing key regenerated on a normal boot: unchanged, so leave freshKeypair false to preserve the NodeNum.
     else if (config.security.private_key.size == 32 && !keyIsLowEntropy) {
         config.security.public_key.size = 32;
         LOG_DEBUG("Regenerate PKI public key from existing private key");
@@ -3829,6 +3832,7 @@ bool NodeDB::generateCryptoKeyPair(const uint8_t *privateKey)
         config.security.private_key.size = 32;
         crypto->generateKeyPair(config.security.public_key.bytes, config.security.private_key.bytes);
         keygenSuccess = true;
+        freshKeypair = true; // a brand-new keypair gets a fresh key-derived identity
     }
 
     // Update sizes and copy to owner if successful
@@ -3840,8 +3844,10 @@ bool NodeDB::generateCryptoKeyPair(const uint8_t *privateKey)
         LOG_DEBUG("Set DH private key for crypto operations");
         crypto->setDHPrivateKey(config.security.private_key.bytes);
 
-        // Conditionally create new identity based on parameter
-        createNewIdentity();
+        // Adopt the key-derived NodeNum only for a new/imported keypair, never on an unchanged-key boot.
+        if (freshKeypair) {
+            createNewIdentity();
+        }
     }
     return keygenSuccess;
 #else

--- a/test/test_nodedb_blocked/test_main.cpp
+++ b/test/test_nodedb_blocked/test_main.cpp
@@ -13,6 +13,7 @@
 // The migration demotes overflow into the warm tier, so these tests need it.
 #if WARM_NODE_COUNT > 0
 
+#include "mesh/CryptoEngine.h"
 #include "mesh/NodeDB.h"
 #include <cstring>
 
@@ -197,6 +198,30 @@ static void test_protectedCap_refusesBeyondLimit(void)
     TEST_ASSERT_TRUE(db->setProtectedFlag(already, NODEINFO_BITFIELD_IS_IGNORED_MASK, true));
 }
 
+#if !(MESHTASTIC_EXCLUDE_PKI_KEYGEN) && !(MESHTASTIC_EXCLUDE_PKI)
+// Regression (PR #10820): regenerating the public key from an unchanged private key on a normal boot must
+// preserve the NodeNum, not re-derive crc32(pubkey) and migrate a legacy NodeNum.
+static void test_generateCryptoKeyPair_regenerateKeepsExistingNodeNum(void)
+{
+    // Establish a valid existing keypair; region set so keygen isn't blocked; non-licensed.
+    crypto->generateKeyPair(config.security.public_key.bytes, config.security.private_key.bytes);
+    config.security.public_key.size = 32;
+    config.security.private_key.size = 32;
+    config.lora.region = meshtastic_Config_LoRaConfig_RegionCode_US;
+    owner.is_licensed = false;
+
+    // A legacy NodeNum that does NOT equal crc32(pubkey).
+    const uint32_t legacyNum = 0x2b873e80;
+    myNodeInfo.my_node_num = legacyNum;
+
+    // privateKey == nullptr + a valid existing 32-byte key => the "regenerate from existing key" branch.
+    // Assert it actually ran (returns true), then that identity was preserved (createNewIdentity skipped).
+    TEST_ASSERT_TRUE(db->generateCryptoKeyPair());
+
+    TEST_ASSERT_EQUAL_UINT32(legacyNum, db->getNodeNum());
+}
+#endif
+
 NDB_TEST_ENTRY void setup()
 {
     initializeTestEnvironment();
@@ -209,6 +234,9 @@ NDB_TEST_ENTRY void setup()
     RUN_TEST(test_eviction_preservesFavorite);
     RUN_TEST(test_ignored_survivesEvictionAndCleanup);
     RUN_TEST(test_protectedCap_refusesBeyondLimit);
+#if !(MESHTASTIC_EXCLUDE_PKI_KEYGEN) && !(MESHTASTIC_EXCLUDE_PKI)
+    RUN_TEST(test_generateCryptoKeyPair_regenerateKeepsExistingNodeNum);
+#endif
     exit(UNITY_END());
 }
 NDB_TEST_ENTRY void loop() {}


### PR DESCRIPTION
## Problem

Nodes upgrading from ≤2.7 to 2.8 silently get a **new NodeNum** on the first boot, orphaning them on the mesh. Confirmed from alpha-tester logs: `!2b873e80` ("cute") became `!fb2df592` on the first 2.8 boot.

This is distinct from #10808 (which fixed config-corruption key-wipe and the admin security clobber) — it's the normal-boot keygen path, with an intact, unchanged private key.

## Root cause

A node's NodeNum is `my_node_num == crc32(public_key)`, assigned by `createNewIdentity()`. Since #10478 (XEdDSA, 2.8), `generateCryptoKeyPair()` called `createNewIdentity()` after **every** keygen — including the normal-boot *"regenerate public key from existing private key"* branch, where the key is unchanged.

2.7.17 never tied the NodeNum to the pubkey — `pickNewNodeNum()` kept the stored (macaddr-derived) value. So on the first 2.8 boot, any legacy node whose stored NodeNum wasn't already `crc32(pubkey)` gets silently re-numbered.

### Downstream damage (from the logs)
`createNewIdentity()` retires the old number as an **ignored, keyless ghost**:
- Peers keep addressing the old number; the app sends admin to it and every packet NAKs:
  `Unknown public key for destination node 0x2b873e80 … Error=39` (`PKI_SEND_FAIL_PUBLIC_KEY`).
- The old entry keeps its name ("cute"), is flagged `is_ignored`, and is **eviction-protected**, so it persists and is pushed to the app's node list as a permanent ignored ghost.

## Fix

Adopt the key-derived NodeNum only when the keypair is **genuinely new or imported**, never when regenerating the same public key from an unchanged private key on a normal boot:
- a `freshKeypair` flag is set in the imported-key and generate-new-keypair branches, left false in the regenerate-from-existing branch, and `createNewIdentity()` runs only `if (freshKeypair)`.
- the equivalent unconditional re-derivation in the no-keygen (`#elif !MESHTASTIC_EXCLUDE_PKI`) load path is dropped too.

Established nodes keep their identity across upgrade; genuinely new or imported keys still adopt `crc32(pubkey)`. A low-entropy/compromised stored key still regenerates and adopts a new identity (the key actually changes).

### Note / accepted trade-off
A node provisioned **region-after-boot** mints its key via `ensurePkiKeys()` (which doesn't touch `my_node_num`), so it now **retains its macaddr-derived NodeNum** instead of adopting `crc32(pubkey)` on the next boot — matching pre-2.8 behavior. The node is fully functional; nothing requires `NodeNum == crc32(pubkey)` (XEdDSA verification keys off the peer's stored pubkey, not the local NodeNum). Re-adding `crc32` adoption at provisioning time would be a separate, optional change.

## Testing
- New regression test `test_generateCryptoKeyPair_regenerateKeepsExistingNodeNum` (`test_nodedb_blocked`): the regenerate-from-existing-key path keeps the NodeNum.
- Full native suite (Docker, CI parity): **502/502**.
- Adversarial multi-lens review: gating correct across all branches; no residual live migration path; the trade-off is functionally harmless.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserves the node’s existing identity and node number during normal startup key regeneration when the private key is unchanged.
  - Prevents unnecessary identity re-derivation during routine boot recovery scenarios.

- **Tests**
  - Added a regression test covering regeneration from an existing valid keypair, ensuring the stored node number remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->