### PR TITLE
Renovate: Change base branch from 'master' to 'develop'

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
     "replacements:all",
     "workarounds:all"
   ],
-  "baseBranchPatterns": ["master"],
+  "baseBranchPatterns": ["develop"],
   "forkProcessing": "enabled",
   "ignoreDeps": [
     "protobufs"


### PR DESCRIPTION
Let's target `develop` with renovate for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated dependency update configuration to use `develop` as the target branch instead of `master`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->