### PR TITLE
chore(deps): forward-port un-backmerged renovate updates from master

### DIFF
--- a/.github/actions/build-variant/action.yml
+++ b/.github/actions/build-variant/action.yml
@@ -76,7 +76,7 @@ runs:
         done
 
     - name: PlatformIO ${{ inputs.arch }} download cache
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: ~/.platformio/.cache
         key: pio-cache-${{ inputs.arch }}-${{ hashFiles('.github/actions/**', '**.ini') }}

--- a/.github/actions/setup-base/action.yml
+++ b/.github/actions/setup-base/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         submodules: recursive
 

--- a/.github/workflows/build_debian_src.yml
+++ b/.github/workflows/build_debian_src.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
           path: meshtasticd

--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       artifact-id: ${{ steps.upload-firmware.outputs.artifact-id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/build_macos_bin.yml
+++ b/.github/workflows/build_macos_bin.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-${{ inputs.macos_ver }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/build_one_target.yml
+++ b/.github/workflows/build_one_target.yml
@@ -34,7 +34,7 @@ jobs:
           - all
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: 3.x
@@ -78,7 +78,7 @@ jobs:
     if: ${{ inputs.target != '' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Get release version string
         run: |
           echo "long=$(./bin/buildinfo.py long)" >> $GITHUB_OUTPUT
@@ -107,7 +107,7 @@ jobs:
     needs: [version, build]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}

--- a/.github/workflows/build_portduino_wasm.yml
+++ b/.github/workflows/build_portduino_wasm.yml
@@ -19,7 +19,7 @@ jobs:
     name: Build PortDuino WASM
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/docker_manifest.yml
+++ b/.github/workflows/docker_manifest.yml
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/firmware-size-comment.yml
+++ b/.github/workflows/firmware-size-comment.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Post or update PR comment
         if: steps.download.outcome == 'success'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/flasher-link-comment.yml
+++ b/.github/workflows/flasher-link-comment.yml
@@ -31,7 +31,7 @@ jobs:
           merge-multiple: true
 
       - name: Post or update web flasher link comment
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const marker = '<!-- web-flasher-link -->';

--- a/.github/workflows/flasher-link-placeholder.yml
+++ b/.github/workflows/flasher-link-placeholder.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post web flasher build-in-progress placeholder
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const marker = '<!-- web-flasher-link -->';

--- a/.github/workflows/hook_copr.yml
+++ b/.github/workflows/hook_copr.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -40,7 +40,7 @@ jobs:
           - check
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: 3.x
@@ -64,7 +64,7 @@ jobs:
   version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Get release version string
         run: |
           echo "long=$(./bin/buildinfo.py long)" >> $GITHUB_OUTPUT
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'workflow_dispatch' && github.repository == 'meshtastic/firmware' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Check ${{ matrix.check.board }}
@@ -198,7 +198,7 @@ jobs:
     needs: [version, build]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - uses: actions/download-artifact@v8
         with:
@@ -263,7 +263,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Download current manifests
         uses: actions/download-artifact@v8
@@ -391,7 +391,7 @@ jobs:
       # - MacOS
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -492,7 +492,7 @@ jobs:
     needs: [release-artifacts, version]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -547,7 +547,7 @@ jobs:
         esp32,esp32s3,esp32c3,esp32c6,nrf52840,rp2040,rp2350,stm32
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1
@@ -31,7 +31,7 @@ jobs:
       pull-requests: write # For trunk to create PRs
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Trunk Upgrade
         uses: trunk-io/trunk-action/upgrade@v1

--- a/.github/workflows/package_obs.yml
+++ b/.github/workflows/package_obs.yml
@@ -33,7 +33,7 @@ jobs:
     needs: build-debian-src
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
           path: meshtasticd

--- a/.github/workflows/package_pio_deps.yml
+++ b/.github/workflows/package_pio_deps.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/package_ppa.yml
+++ b/.github/workflows/package_ppa.yml
@@ -34,7 +34,7 @@ jobs:
     needs: build-debian-src
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
           path: meshtasticd

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -40,7 +40,7 @@ jobs:
       checks: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/release_channels.yml
+++ b/.github/workflows/release_channels.yml
@@ -91,7 +91,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # Always use master branch for version bumps
           ref: master

--- a/.github/workflows/sec_sast_semgrep_cron.yml
+++ b/.github/workflows/sec_sast_semgrep_cron.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       # step 1
       - name: clone application source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # step 2
       - name: full scan

--- a/.github/workflows/sec_sast_semgrep_pull.yml
+++ b/.github/workflows/sec_sast_semgrep_pull.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       # step 1
       - name: clone application source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Stale PR+Issues
-        uses: actions/stale@v10.2.0
+        uses: actions/stale@v10.3.0
         with:
           days-before-stale: 45
           stale-issue-message: This issue has not had any comment or update in the last month. If it is still relevant, please post update comments. If no comments are made, this issue will be closed automagically in 7 days.

--- a/.github/workflows/test_native.yml
+++ b/.github/workflows/test_native.yml
@@ -14,7 +14,7 @@ jobs:
     name: Native Simulator Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -88,7 +88,7 @@ jobs:
     name: Native PlatformIO Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -149,7 +149,7 @@ jobs:
       - platformio-tests
     if: always()
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Get release version string
         run: echo "long=$(./bin/buildinfo.py long)" >> $GITHUB_OUTPUT

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: test-runner
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # - uses: actions/setup-python@v6
       #   with:

--- a/.github/workflows/trunk_annotate_pr.yml
+++ b/.github/workflows/trunk_annotate_pr.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1

--- a/.github/workflows/trunk_check.yml
+++ b/.github/workflows/trunk_check.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1

--- a/.github/workflows/update_protobufs.yml
+++ b/.github/workflows/update_protobufs.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: true
 

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -4,7 +4,7 @@
 # trunk-ignore-all(hadolint/DL3013): Do not pin pip package versions
 
 # Ensure the Alpine version is updated in both stages of the container!
-FROM alpine:3.23 AS builder
+FROM alpine:3.24 AS builder
 ARG PIO_ENV=native
 
 # Enable Alpine community repository (for 'py3-grpcio-tools')
@@ -35,7 +35,7 @@ RUN bash ./bin/build-native.sh "$PIO_ENV" && \
 
 # ##### PRODUCTION BUILD #############
 
-FROM alpine:3.23
+FROM alpine:3.24
 LABEL org.opencontainers.image.title="Meshtastic" \
       org.opencontainers.image.description="Alpine Meshtastic daemon" \
       org.opencontainers.image.url="https://meshtastic.org" \

--- a/platformio.ini
+++ b/platformio.ini
@@ -69,7 +69,7 @@ monitor_speed = 115200
 monitor_filters = direct
 lib_deps =
 	# renovate: datasource=git-refs depName=meshtastic-esp8266-oled-ssd1306 packageName=https://github.com/meshtastic/esp8266-oled-ssd1306 gitBranch=master
-	https://github.com/meshtastic/esp8266-oled-ssd1306/archive/6bfd1f135e1ebe37afd6050bb4b9964cea3fcfda.zip
+	https://github.com/meshtastic/esp8266-oled-ssd1306/archive/2e26010040e028baee72e2093402fa7b3c59e430.zip
 	# renovate: datasource=git-refs depName=meshtastic-OneButton packageName=https://github.com/meshtastic/OneButton gitBranch=master
 	https://github.com/meshtastic/OneButton/archive/fa352d668c53f290cfa480a5f79ad422cd828c70.zip
 	# renovate: datasource=git-refs depName=meshtastic-arduino-fsm packageName=https://github.com/meshtastic/arduino-fsm gitBranch=master
@@ -141,7 +141,7 @@ lib_deps =
 	# renovate: datasource=github-tags depName=NeoPixel packageName=adafruit/Adafruit_NeoPixel
 	https://github.com/adafruit/Adafruit_NeoPixel/archive/1.15.5.zip
 	# renovate: datasource=github-tags depName=Adafruit SSD1306 packageName=adafruit/Adafruit_SSD1306
-	https://github.com/adafruit/Adafruit_SSD1306/archive/refs/tags/2.5.16.zip
+	https://github.com/adafruit/Adafruit_SSD1306/archive/2.5.17.zip
 	# renovate: datasource=github-tags depName=Adafruit BMP280 packageName=adafruit/Adafruit_BMP280_Library
 	https://github.com/adafruit/Adafruit_BMP280_Library/archive/refs/tags/3.0.0.zip
 	# renovate: datasource=github-tags depName=Adafruit BMP085 packageName=adafruit/Adafruit-BMP085-Library
@@ -195,7 +195,7 @@ lib_deps =
 	# renovate: datasource=github-tags depName=DFRobot_BMM150 packageName=dfrobot/DFRobot_BMM150
 	https://github.com/DFRobot/DFRobot_BMM150/archive/refs/tags/V1.0.0.zip
 	# renovate: datasource=github-tags depName=SparkFun MMC5983MA Magnetometer packageName=sparkfun/SparkFun_MMC5983MA_Magnetometer_Arduino_Library
-	https://github.com/sparkfun/SparkFun_MMC5983MA_Magnetometer_Arduino_Library/archive/refs/tags/v1.1.4.zip
+	https://github.com/sparkfun/SparkFun_MMC5983MA_Magnetometer_Arduino_Library/archive/v1.1.5.zip
 	# renovate: datasource=github-tags depName=Adafruit_TSL2561 packageName=adafruit/Adafruit_TSL2561
 	https://github.com/adafruit/Adafruit_TSL2561/archive/refs/tags/1.1.3.zip
 	# renovate: datasource=github-tags depName=BH1750_WE packageName=wollewald/BH1750_WE
@@ -207,7 +207,7 @@ lib_deps =
 	# renovate: datasource=github-tags depName=Sensirion I2C SFA3x packageName=sensirion/arduino-i2c-sfa3x
 	https://github.com/Sensirion/arduino-i2c-sfa3x/archive/refs/tags/1.0.0.zip
 	# renovate: datasource=github-tags depName=Sensirion I2C SCD30 packageName=sensirion/arduino-i2c-scd30
-	https://github.com/Sensirion/arduino-i2c-scd30/archive/refs/tags/1.0.0.zip
+	https://github.com/Sensirion/arduino-i2c-scd30/archive/1.1.1.zip
 	# renovate: datasource=github-tags depName=arduino-sht packageName=sensirion/arduino-sht
 	https://github.com/Sensirion/arduino-sht/archive/refs/tags/v1.2.6.zip
 

--- a/variants/nrf52840/nrf52.ini
+++ b/variants/nrf52840/nrf52.ini
@@ -2,7 +2,7 @@
 ; Instead of the standard nordicnrf52 platform, we use our fork which has our added variant files
 platform =
   # renovate: datasource=custom.pio depName=platformio/nordicnrf52 packageName=platformio/platform/nordicnrf52
-  platformio/nordicnrf52@10.11.0
+  platformio/nordicnrf52@10.12.0
 extends = arduino_base
 platform_packages =
   ; our custom Git version with C++17 support in platform.txt

--- a/variants/stm32/stm32.ini
+++ b/variants/stm32/stm32.ini
@@ -2,7 +2,7 @@
 extends = arduino_base
 platform =
   # renovate: datasource=custom.pio depName=platformio/ststm32 packageName=platformio/platform/ststm32
-  platformio/ststm32@19.5.0
+  platformio/ststm32@19.7.0
 platform_packages =
   # renovate: datasource=github-tags depName=Arduino_Core_STM32 packageName=stm32duino/Arduino_Core_STM32
   platformio/framework-arduinoststm32@https://github.com/stm32duino/Arduino_Core_STM32/archive/2.10.1.zip


### PR DESCRIPTION
## What

Catches `develop` up to `master`'s (2.7) renovate dependency updates that were never back-merged, so the **develop → master 2.8 promotion** ([#10777](https://github.com/meshtastic/firmware/pull/10777)) doesn't regress them.

Done as a **value reconcile, not a cherry-pick.** The 19 renovate commits on master collapse to ~14 distinct deps (5 device-ui digest bumps + 2 ststm32 bumps are superseded), and develop runs its own renovate — so cherry-picking would replay superseded intermediate values and conflict on every digest. Each dep is instead set to master's latest value (taking the newer of the two).

> Note: develop's library URLs used the stale `archive/refs/tags/<ver>.zip` form, which the renovate regex (`archive/(?<currentValue>.+?).zip`) parses as version `refs/tags/<ver>` — invalid, which is **why develop lagged**. This PR moves them to the `archive/<ver>.zip` form so renovate can track them going forward.

### GitHub Actions
- `actions/checkout` v6 → v7 (35 refs)
- `actions/cache` v5 → v6
- `actions/github-script` v8 → v9 (3 refs)
- `actions/stale` v10.2.0 → v10.3.0

### Build / platform
- `alpine` 3.23 → 3.24 (`alpine.Dockerfile`, both stages)
- `platformio/ststm32` 19.5.0 → 19.7.0
- `platformio/nordicnrf52` 10.11.0 → 10.12.0

### Libraries
- Adafruit SSD1306 2.5.16 → 2.5.17
- SparkFun MMC5983MA v1.1.4 → v1.1.5
- Sensirion I2C SCD30 1.0.0 → 1.1.1
- meshtastic esp8266-oled-ssd1306 `6bfd1f1` → `2e26010`

## Deliberately excluded
- **meshtastic/device-ui digest** (`4bf593a8` → `1c45ebc`): coupled to the firmware protobuf/API surface, and develop has diverged hard (NodeDB v25). Left for a separate maintainer bump + on-device visual check.
- **libpax**: develop uses the `mverch67` fork (pinned by the Arduino-3.x migration [#9122](https://github.com/meshtastic/firmware/pull/9122)); master uses `dbinfrago`. That's a fork divergence, **not** a version bump — reconciling would break develop's ESP32 build.
- **platform-native digest**: develop is already at `61067ac` (equal to master).

## Verification
None of these are exercised by the native test suite (they're STM32 / nRF52 / Docker / TFT-OLED specific and were already validated on master). **Build validation is left to this PR's CI matrix** — pay attention to the STM32, nRF52, Docker/alpine, and SSD1306-OLED targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated many CI workflows and shared GitHub Actions to newer versions for repository checkout and comment automation.
  * Refreshed the Alpine base image used in container builds.
  * Bumped several PlatformIO package and platform versions for embedded builds.
* **Bug Fixes**
  * No user-facing bug fixes were included; this release focuses on keeping build and release tooling current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->