### PR TITLE
chore(deps): forward-port LovyanGFX + audio-driver renovate bumps from master

### DIFF
--- a/variants/esp32/chatter2/platformio.ini
+++ b/variants/esp32/chatter2/platformio.ini
@@ -12,4 +12,4 @@ build_flags =
 lib_deps =
   ${esp32_base.lib_deps}
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
-  lovyan03/LovyanGFX@1.2.21
+  lovyan03/LovyanGFX@1.2.24

--- a/variants/esp32/m5stack_core/platformio.ini
+++ b/variants/esp32/m5stack_core/platformio.ini
@@ -35,4 +35,4 @@ lib_ignore =
 lib_deps = 
   ${esp32_base.lib_deps}
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
-  lovyan03/LovyanGFX@1.2.21
+  lovyan03/LovyanGFX@1.2.24

--- a/variants/esp32/wiphone/platformio.ini
+++ b/variants/esp32/wiphone/platformio.ini
@@ -11,7 +11,7 @@ build_flags =
 lib_deps = 
   ${esp32_base.lib_deps}
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
-  lovyan03/LovyanGFX@1.2.21
+  lovyan03/LovyanGFX@1.2.24
   # renovate: datasource=custom.pio depName=SX1509 IO Expander packageName=sparkfun/library/SX1509 IO Expander
   sparkfun/SX1509 IO Expander@3.0.6
   # renovate: datasource=custom.pio depName=APA102 packageName=pololu/library/APA102

--- a/variants/esp32s3/heltec_v4/platformio.ini
+++ b/variants/esp32s3/heltec_v4/platformio.ini
@@ -134,6 +134,6 @@ build_flags =
 lib_deps = ${heltec_v4_base.lib_deps}
   ${device-ui_base.lib_deps}
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
-  lovyan03/LovyanGFX@1.2.21
+  lovyan03/LovyanGFX@1.2.24
   # renovate: datasource=git-refs depName=Quency-D_chsc6x packageName=https://github.com/Quency-D/chsc6x gitBranch=master
   https://github.com/Quency-D/chsc6x/archive/5cbead829d6b432a8d621ed1aafd4eb474fd4f27.zip

--- a/variants/esp32s3/heltec_v4_r8/platformio.ini
+++ b/variants/esp32s3/heltec_v4_r8/platformio.ini
@@ -140,6 +140,6 @@ build_flags =
 lib_deps = ${heltec_v4_r8_base.lib_deps}
   ${device-ui_base.lib_deps}
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
-  lovyan03/LovyanGFX@1.2.21
+  lovyan03/LovyanGFX@1.2.24
   # renovate: datasource=git-refs depName=Quency-D_chsc6x packageName=https://github.com/Quency-D/chsc6x gitBranch=master
   https://github.com/Quency-D/chsc6x/archive/3b2b6cebf3177b3e2c33d06e07909b0b10159516.zip

--- a/variants/esp32s3/heltec_wireless_tracker/platformio.ini
+++ b/variants/esp32s3/heltec_wireless_tracker/platformio.ini
@@ -26,4 +26,4 @@ build_flags =
 lib_deps =
   ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
-  lovyan03/LovyanGFX@1.2.21
+  lovyan03/LovyanGFX@1.2.24

--- a/variants/esp32s3/heltec_wireless_tracker_V1_0/platformio.ini
+++ b/variants/esp32s3/heltec_wireless_tracker_V1_0/platformio.ini
@@ -22,4 +22,4 @@ build_flags =
 lib_deps =
   ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
-  lovyan03/LovyanGFX@1.2.21
+  lovyan03/LovyanGFX@1.2.24

--- a/variants/esp32s3/heltec_wireless_tracker_v2/platformio.ini
+++ b/variants/esp32s3/heltec_wireless_tracker_v2/platformio.ini
@@ -21,4 +21,4 @@ build_flags =
 lib_deps =
   ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
-  lovyan03/LovyanGFX@1.2.21
+  lovyan03/LovyanGFX@1.2.24

--- a/variants/esp32s3/m5stack_cardputer_adv/platformio.ini
+++ b/variants/esp32s3/m5stack_cardputer_adv/platformio.ini
@@ -15,7 +15,7 @@ lib_deps =
   # renovate: datasource=git-refs depName=meshtastic-st7789 packageName=https://github.com/meshtastic/st7789 gitBranch=main
   https://github.com/meshtastic/st7789/archive/5180423ae2dbf5885168a8bfb308c7fb7eff6930.zip
   # renovate: datasource=github-tags depName=pschatzmann_arduino-audio-driver packageName=pschatzmann/arduino-audio-driver
-  https://github.com/pschatzmann/arduino-audio-driver/archive/v0.2.1.zip
+  https://github.com/pschatzmann/arduino-audio-driver/archive/v0.3.0.zip
   # renovate: datasource=git-refs depName=ESP8266Audio packageName=https://github.com/meshtastic/ESP8266Audio gitBranch=meshtastic-2.0.0-dacfix
   https://github.com/meshtastic/ESP8266Audio/archive/343024632ee78d6216907b2353fc943a62422d80.zip
   # renovate: datasource=custom.pio depName=ESP8266SAM packageName=earlephilhower/library/ESP8266SAM

--- a/variants/esp32s3/mesh-tab/platformio.ini
+++ b/variants/esp32s3/mesh-tab/platformio.ini
@@ -55,7 +55,7 @@ lib_deps =
   ${esp32s3_base.lib_deps}
   ${device-ui_base.lib_deps}
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
-  lovyan03/LovyanGFX@1.2.21
+  lovyan03/LovyanGFX@1.2.24
 
 [mesh_tab_xpt2046]
 extends = mesh_tab_base

--- a/variants/esp32s3/picomputer-s3/platformio.ini
+++ b/variants/esp32s3/picomputer-s3/platformio.ini
@@ -25,7 +25,7 @@ build_flags =
 lib_deps = 
   ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
-  lovyan03/LovyanGFX@1.2.21
+  lovyan03/LovyanGFX@1.2.24
 
 build_src_filter =
   ${esp32s3_base.build_src_filter}

--- a/variants/esp32s3/rak_wismesh_tap_v2/platformio.ini
+++ b/variants/esp32s3/rak_wismesh_tap_v2/platformio.ini
@@ -37,7 +37,7 @@ build_flags =
 lib_deps =
   ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
-  lovyan03/LovyanGFX@1.2.21
+  lovyan03/LovyanGFX@1.2.24
 
 [env:rak_wismesh_tap_v2-tft]
 extends = env:rak_wismesh_tap_v2

--- a/variants/esp32s3/t-deck/platformio.ini
+++ b/variants/esp32s3/t-deck/platformio.ini
@@ -29,7 +29,7 @@ build_flags = ${esp32s3_base.build_flags}
 
 lib_deps = ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
-  lovyan03/LovyanGFX@1.2.21
+  lovyan03/LovyanGFX@1.2.24
   # renovate: datasource=git-refs depName=ESP8266Audio packageName=https://github.com/meshtastic/ESP8266Audio gitBranch=meshtastic-2.0.0-dacfix
   https://github.com/meshtastic/ESP8266Audio/archive/343024632ee78d6216907b2353fc943a62422d80.zip
   # renovate: datasource=custom.pio depName=ESP8266SAM packageName=earlephilhower/library/ESP8266SAM

--- a/variants/esp32s3/t-watch-s3/platformio.ini
+++ b/variants/esp32s3/t-watch-s3/platformio.ini
@@ -22,7 +22,7 @@ build_flags = ${esp32s3_base.build_flags}
 
 lib_deps = ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
-  lovyan03/LovyanGFX@1.2.21
+  lovyan03/LovyanGFX@1.2.24
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
   lewisxhe/SensorLib@0.3.4
   # renovate: datasource=custom.pio depName=Adafruit DRV2605 packageName=adafruit/library/Adafruit DRV2605 Library

--- a/variants/esp32s3/tlora-pager/platformio.ini
+++ b/variants/esp32s3/tlora-pager/platformio.ini
@@ -33,7 +33,7 @@ build_flags = ${esp32s3_base.build_flags}
 
 lib_deps = ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
-  lovyan03/LovyanGFX@1.2.21
+  lovyan03/LovyanGFX@1.2.24
   # renovate: datasource=git-refs depName=ESP8266Audio packageName=https://github.com/meshtastic/ESP8266Audio gitBranch=meshtastic-2.0.0-dacfix
   https://github.com/meshtastic/ESP8266Audio/archive/343024632ee78d6216907b2353fc943a62422d80.zip
   # renovate: datasource=custom.pio depName=ESP8266SAM packageName=earlephilhower/library/ESP8266SAM
@@ -45,7 +45,7 @@ lib_deps = ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
   lewisxhe/SensorLib@0.3.4
   # renovate: datasource=github-tags depName=pschatzmann_arduino-audio-driver packageName=pschatzmann/arduino-audio-driver
-  https://github.com/pschatzmann/arduino-audio-driver/archive/v0.2.1.zip
+  https://github.com/pschatzmann/arduino-audio-driver/archive/v0.3.0.zip
   # TODO renovate
   https://github.com/mverch67/BQ27220/archive/07d92be846abd8a0258a50c23198dac0858b22ed.zip
   # TODO renovate

--- a/variants/esp32s3/tracksenger/platformio.ini
+++ b/variants/esp32s3/tracksenger/platformio.ini
@@ -22,7 +22,7 @@ build_flags =
 lib_deps =
   ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
-  lovyan03/LovyanGFX@1.2.21
+  lovyan03/LovyanGFX@1.2.24
 
 [env:tracksenger-lcd]
 custom_meshtastic_hw_model = 48
@@ -48,7 +48,7 @@ build_flags =
 lib_deps =
   ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
-  lovyan03/LovyanGFX@1.2.21
+  lovyan03/LovyanGFX@1.2.24
 
 [env:tracksenger-oled]
 custom_meshtastic_hw_model = 48

--- a/variants/esp32s3/unphone/platformio.ini
+++ b/variants/esp32s3/unphone/platformio.ini
@@ -36,7 +36,7 @@ build_src_filter =
 
 lib_deps = ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
-  lovyan03/LovyanGFX@1.2.21
+  lovyan03/LovyanGFX@1.2.24
   # TODO renovate https://gitlab.com/hamishcunningham/unphonelibrary#meshtastic@9.0.0
   https://gitlab.com/hamishcunningham/unphonelibrary/-/archive/meshtastic/unphonelibrary-meshtastic.zip
 

--- a/variants/native/portduino.ini
+++ b/variants/native/portduino.ini
@@ -26,7 +26,7 @@ lib_deps =
   # renovate: datasource=git-refs depName=meshtastic/Crypto packageName=https://github.com/meshtastic/Crypto gitBranch=master
   https://github.com/meshtastic/Crypto/archive/1aa30eb536bd52a576fde6dfa393bf7349cf102d.zip
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
-  lovyan03/LovyanGFX@1.2.21
+  lovyan03/LovyanGFX@1.2.24
   ; # renovate: datasource=git-refs depName=libch341-spi-userspace packageName=https://github.com/pine64/libch341-spi-userspace gitBranch=main
   https://github.com/pine64/libch341-spi-userspace/archive/2e5ff751d0c39667993df672cb683740ed5c9394.zip
   # renovate: datasource=custom.pio depName=adafruit/Adafruit seesaw Library packageName=adafruit/library/Adafruit seesaw Library


### PR DESCRIPTION
## What

Two more renovate updates landed on master (2.7) after [#10824](https://github.com/meshtastic/firmware/pull/10824), not yet on develop. Same **value-reconcile** approach.

- **LovyanGFX** `1.2.21` → `1.2.24` ([#10783](https://github.com/meshtastic/firmware/pull/10783)) — 18 `lovyan03` custom.pio pins
- **pschatzmann arduino-audio-driver** `v0.2.1` → `v0.3.0` ([#10770](https://github.com/meshtastic/firmware/pull/10770)) — `tlora-pager`, `tracksenger`

## Deliberately left untouched (develop-only pins; master's renovate didn't bump these either)
- `lovyan03/LovyanGFX@1.2.19` — single deliberate variant pin
- `mverch67/LovyanGFX` fork — `seeed-sensecap-indicator` variant (a fork divergence, like libpax — not a version bump)

## Verification
- Native Docker suite: **501/501 passed**; log confirms `LovyanGFX@1.2.24` installed and built on the native/portduino path (the historically native-fragile dep).
- audio-driver is ESP32-only (`tlora-pager`/`tracksenger`) — not exercised by the native suite; left to this PR's CI matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the graphics library across multiple device variants to a newer version.
  * Upgraded the audio driver library on supported board configurations.
  * Kept native and ESP32/ESP32-S3 build setups aligned with the latest dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->