### PR TITLE
Enhance TFTDisplay with board-specific driver support

### DIFF
--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -1142,8 +1142,17 @@ class LGFX : public lgfx::LGFX_Device
 
 static LGFX *tft = nullptr;
 
-#endif
+#elif defined(VARIANT_DISPLAY_DRIVER)
+// Board-specific framebuffer backends (class LGFX) can livee in the
+// variant files — variant_display.h (declaration) and
+// variant_display.cpp (bodies) — so this shared
+// file isn't inflated for a single board. It exposes the same surface TFTDisplay
+// drives, so the generic `tft = new LGFX;` in connect() works.
+#include "variant_display.h"
 
+static LGFX *tft = nullptr;
+
+#endif
 #include "SPILock.h"
 #include "TFTColorRegions.h"
 #include "TFTDisplay.h"


### PR DESCRIPTION
Added conditional inclusion for board-specific framebuffer backends and updated comments for clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an alternate display-driver path for specific hardware variants, improving compatibility with different screens.
  * Kept the existing default display behavior unchanged for other builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->