### PR TITLE
exclude the variant from LTO

### DIFF
--- a/extra_scripts/nrf52_lto.py
+++ b/extra_scripts/nrf52_lto.py
@@ -51,6 +51,18 @@ USB_ISR = "Adafruit_TinyUSB_nrf"  # USBD_IRQHandler
 LIB_ISR = ("/bluefruit.cpp", "/Wire_nRF52.cpp", "/PDM.cpp", "/RotaryEncoder.cpp")
 
 
+# The active board variant file owns strong overrides of the core's weak initVariant()/
+# earlyInitVariant()/lateInitVariant() stubs (cores/nRF5/main.cpp). Same failure mode as the ISRs
+# above: whole-image LTO mis-resolves the call (made from the -fno-lto framework core) to the empty
+# WEAK stub, so the board's early hardware setup -- e.g. driving PIN_3V3_EN to power the LoRa/sensor
+# rail -- silently never runs and the radio probe finds no chip. Compiling the variant without LTO
+# lets ordinary linking pick the strong override. HW-proven on nrf52_promicro_diy_tcxo (boot-trace
+# 2026-06-30). NOTE: only the real board variant (built from /variants/...) -- NOT the guarded
+# src/platform/extra_variants/*/variant.cpp no-op stubs, which don't tolerate the -fno-lto recompile.
+def _is_board_variant(path):
+    return path.endswith("/variant.cpp") and "extra_variants" not in path
+
+
 def _no_lto(node):
     try:
         path = node.get_abspath()
@@ -63,6 +75,7 @@ def _no_lto(node):
         USB_ISR in path
         or any(s in path for s in FRAMEWORK)
         or any(s in path for s in LIB_ISR)
+        or _is_board_variant(path)
     ):
         return env.Object(
             node,

--- a/extra_scripts/nrf52_lto.py
+++ b/extra_scripts/nrf52_lto.py
@@ -33,7 +33,7 @@ Import("env")
 
 env.Append(LINKFLAGS=["-flto", "-flto-partition=1to1"])
 
-# The -fno-lto re-compiles below run with the global env, which lacks the framework's
+# The ISR -fno-lto re-compiles below run with the global env, which lacks the framework's
 # bundled-library include dirs -- and those libs cross-include each other (Wire pulls in
 # Adafruit_TinyUSB.h, which pulls in SPI.h, ...). Add every bundled-lib dir (+ its src/) so
 # the re-compiles resolve without chasing headers one at a time.
@@ -59,8 +59,42 @@ LIB_ISR = ("/bluefruit.cpp", "/Wire_nRF52.cpp", "/PDM.cpp", "/RotaryEncoder.cpp"
 # lets ordinary linking pick the strong override. HW-proven on nrf52_promicro_diy_tcxo (boot-trace
 # 2026-06-30). NOTE: only the real board variant (built from /variants/...) -- NOT the guarded
 # src/platform/extra_variants/*/variant.cpp no-op stubs, which don't tolerate the -fno-lto recompile.
+#
+# Anchor to THIS repo's variants/ tree: a board variant's abspath is
+# <PROJECT_DIR>/variants/<arch>/<board>/variant.cpp. Anchoring deliberately excludes
+#   - PlatformIO's framework-owned .../framework-arduinoadafruitnrf52/variants/*/variant.cpp
+#   - the src/platform/extra_variants/*/variant.cpp stubs (they live under src/, not variants/)
+# both of which also end in "/variant.cpp" but must NOT be recompiled here.
+_PROJECT_VARIANTS = (
+    env.subst("$PROJECT_DIR").replace("\\", "/").rstrip("/") + "/variants/"
+)
+
+
 def _is_board_variant(path):
-    return path.endswith("/variant.cpp") and "extra_variants" not in path
+    return (
+        path.endswith("/variant.cpp")
+        and path.startswith(_PROJECT_VARIANTS)
+        and "extra_variants" not in path
+    )
+
+
+# projenv is the construction env PlatformIO uses to compile project sources (src/ + the board
+# variant). Unlike the bare framework env captured above, it carries the -DAPP_VERSION... flags
+# and the generated-protobuf include path (pb.h) that bin/platformio-custom.py appends *after*
+# this pre-script's eval. It isn't exported yet at eval time, but it is by the time the build
+# middleware fires -- so fetch it lazily from SCons' export registry, falling back to env.
+_projenv_cache = []
+
+
+def _get_projenv():
+    if not _projenv_cache:
+        try:
+            from SCons.Script.SConscript import global_exports
+
+            _projenv_cache.append(global_exports.get("projenv", env))
+        except Exception:
+            _projenv_cache.append(env)
+    return _projenv_cache[0]
 
 
 def _no_lto(node):
@@ -75,12 +109,22 @@ def _no_lto(node):
         USB_ISR in path
         or any(s in path for s in FRAMEWORK)
         or any(s in path for s in LIB_ISR)
-        or _is_board_variant(path)
     ):
         return env.Object(
             node,
             CCFLAGS=env["CCFLAGS"] + ["-fno-lto"],
             CPPPATH=env["CPPPATH"] + _extra_inc,
+        )
+    if _is_board_variant(path):
+        # The board variant is a project source, not a framework object: it can #include
+        # configuration.h/sleep.h, which need the -DAPP_VERSION... define and the generated-
+        # protobuf include path (pb.h). Recompile it with projenv (which has both) -- using the
+        # bare framework env here fails with "APP_VERSION must be set" / "pb.h: No such file".
+        build_env = _get_projenv()
+        return build_env.Object(
+            node,
+            CCFLAGS=build_env["CCFLAGS"] + ["-fno-lto"],
+            CPPPATH=build_env["CPPPATH"] + _extra_inc,
         )
     return node
 


### PR DESCRIPTION
Certain NRF promicros were failing to find their radios after LTO had been improved. After several fruitless searches, bisections, intersections and a small crying fit, I remembered that the major difference between batches of promicros is whether the 3.3v rail is held on or off by a hardware cheapening resistor.

It turns out that the LTO ignores the variant.cpp. Who knew? This fixes it.

LTO exclusion improvements:

* Added the `_is_board_variant()` function to detect board variant files (`variant.cpp` in `/variants/` but not in `/extra_variants/`) that provide strong overrides for hardware initialization stubs, ensuring these files are not compiled with LTO. This prevents the linker from incorrectly resolving to weak stubs, which could cause hardware setup routines to silently fail.
* Updated the `_no_lto()` function to use `_is_board_variant()` so that board variant files are automatically excluded from LTO, ensuring correct hardware initialization during board bringup.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
promicro, my beloved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility and reliability on affected nRF52 boards by ensuring board variant sources are compiled without link-time optimization when needed.
  * Reduces startup and runtime risks that could occur due to overly aggressive optimization on certain board variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->