### PR TITLE
Update lint command path in trunk.yaml

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -63,7 +63,7 @@ lint:
         - name: lint
           output: regex
           parse_regex: (?P<path>.+):(?P<line>\d+):(?P<col>\d+):(?P<severity>\w+):(?P<message>.+):(?P<code>[a-z-]+)
-          run: bin/lint-ifdef-complexity.sh ${target}
+          run: ${workspace}/bin/lint-ifdef-complexity.sh ${target}
           success_codes: [0]
           read_output_from: stdout
   enabled:


### PR DESCRIPTION
Makes the linter work on my machine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a lint command path so checks run reliably from the correct workspace location across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->