### PR TITLE
second pass adding beacons admin

### DIFF
--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -897,6 +897,13 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_tak_tag;
             fromRadioScratch.moduleConfig.payload_variant.tak = moduleConfig.tak;
             break;
+#if !MESHTASTIC_EXCLUDE_BEACON
+        case meshtastic_ModuleConfig_mesh_beacon_tag:
+            LOG_DEBUG("Send module config: mesh beacon");
+            fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_mesh_beacon_tag;
+            fromRadioScratch.moduleConfig.payload_variant.mesh_beacon = moduleConfig.mesh_beacon;
+            break;
+#endif
         default:
             LOG_DEBUG("Unhandled module config type %d", config_state);
         }

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -901,7 +901,17 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
         case meshtastic_ModuleConfig_mesh_beacon_tag:
             LOG_DEBUG("Send module config: mesh beacon");
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_mesh_beacon_tag;
-            fromRadioScratch.moduleConfig.payload_variant.mesh_beacon = moduleConfig.mesh_beacon;
+#ifdef MESHTASTIC_PHONEAPI_ACCESS_CONTROL
+            if (!getAdminAuthorized()) {
+                // Unauthenticated: emit an empty MeshBeaconConfig (zero-init from
+                // the top-of-loop memset). The embedded ChannelSettings
+                // (broadcast_offer_channel / broadcast_on_channel) carry PSKs that
+                // must not be visible to an unauth client.
+            } else
+#endif
+            {
+                fromRadioScratch.moduleConfig.payload_variant.mesh_beacon = moduleConfig.mesh_beacon;
+            }
             break;
 #endif
         default:

--- a/src/mesh/generated/meshtastic/admin.pb.h
+++ b/src/mesh/generated/meshtastic/admin.pb.h
@@ -83,7 +83,9 @@ typedef enum _meshtastic_AdminMessage_ModuleConfigType {
     /* Traffic management module config */
     meshtastic_AdminMessage_ModuleConfigType_TRAFFICMANAGEMENT_CONFIG = 14,
     /* TAK module config */
-    meshtastic_AdminMessage_ModuleConfigType_TAK_CONFIG = 15
+    meshtastic_AdminMessage_ModuleConfigType_TAK_CONFIG = 15,
+    /* Mesh Beacon module config */
+    meshtastic_AdminMessage_ModuleConfigType_MESHBEACON_CONFIG = 16
 } meshtastic_AdminMessage_ModuleConfigType;
 
 typedef enum _meshtastic_AdminMessage_BackupLocation {
@@ -510,8 +512,8 @@ extern "C" {
 #define _meshtastic_AdminMessage_ConfigType_ARRAYSIZE ((meshtastic_AdminMessage_ConfigType)(meshtastic_AdminMessage_ConfigType_DEVICEUI_CONFIG+1))
 
 #define _meshtastic_AdminMessage_ModuleConfigType_MIN meshtastic_AdminMessage_ModuleConfigType_MQTT_CONFIG
-#define _meshtastic_AdminMessage_ModuleConfigType_MAX meshtastic_AdminMessage_ModuleConfigType_TAK_CONFIG
-#define _meshtastic_AdminMessage_ModuleConfigType_ARRAYSIZE ((meshtastic_AdminMessage_ModuleConfigType)(meshtastic_AdminMessage_ModuleConfigType_TAK_CONFIG+1))
+#define _meshtastic_AdminMessage_ModuleConfigType_MAX meshtastic_AdminMessage_ModuleConfigType_MESHBEACON_CONFIG
+#define _meshtastic_AdminMessage_ModuleConfigType_ARRAYSIZE ((meshtastic_AdminMessage_ModuleConfigType)(meshtastic_AdminMessage_ModuleConfigType_MESHBEACON_CONFIG+1))
 
 #define _meshtastic_AdminMessage_BackupLocation_MIN meshtastic_AdminMessage_BackupLocation_FLASH
 #define _meshtastic_AdminMessage_BackupLocation_MAX meshtastic_AdminMessage_BackupLocation_SD

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -1487,6 +1487,13 @@ void AdminModule::handleGetModuleConfig(const meshtastic_MeshPacket &req, const 
             res.get_module_config_response.which_payload_variant = meshtastic_ModuleConfig_traffic_management_tag;
             res.get_module_config_response.payload_variant.traffic_management = moduleConfig.traffic_management;
             break;
+#if !MESHTASTIC_EXCLUDE_BEACON
+        case meshtastic_AdminMessage_ModuleConfigType_MESHBEACON_CONFIG:
+            configName = "MeshBeacon";
+            res.get_module_config_response.which_payload_variant = meshtastic_ModuleConfig_mesh_beacon_tag;
+            res.get_module_config_response.payload_variant.mesh_beacon = moduleConfig.mesh_beacon;
+            break;
+#endif
         }
         LOG_INFO("Get module config: %s", configName);
 


### PR DESCRIPTION

* Added support for sending the `mesh_beacon` module configuration in `getFromRadio` when `MESHTASTIC_EXCLUDE_BEACON` is not defined. This ensures that the mesh beacon configuration can be communicated to clients when the feature is enabled.

@jamesarich this is the one, right here. This allows the phone to poll the status from the node.


## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for requesting and receiving the **MeshBeacon** module configuration (when beacon support is enabled).
  * Device configuration responses now include this mesh beacon setting as a dedicated configuration variant, improving configuration accuracy across compatible builds.
* **Chores**
  * Updated the protobuf definitions reference to a newer revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->