### PR TITLE
Fix audio availability and ESP32-S2 build

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@
 #include "main.h"
 #include "mesh/generated/meshtastic/config.pb.h"
 #include "meshUtils.h"
+#include "modules/ModuleAvailability.h"
 #include "modules/Modules.h"
 #include "sleep.h"
 #include "target_specific.h"
@@ -1176,9 +1177,9 @@ extern meshtastic_DeviceMetadata getDeviceMetadata()
 #if MESHTASTIC_EXCLUDE_REMOTEHARDWARE
     deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_REMOTEHARDWARE_CONFIG;
 #endif
-#if MESHTASTIC_EXCLUDE_AUDIO
-    deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_AUDIO_CONFIG;
-#endif
+    if (!isAudioModuleAvailableForRegion(config.lora.region)) {
+        deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_AUDIO_CONFIG;
+    }
 // Option to explicitly include canned messages for edge cases, e.g. niche graphics
 #if ((!HAS_SCREEN || NO_EXT_GPIO) || MESHTASTIC_EXCLUDE_CANNEDMESSAGES) && !defined(MESHTASTIC_INCLUDE_NICHE_GRAPHICS)
     deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_CANNEDMSG_CONFIG;

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -38,6 +38,7 @@
 #if !MESHTASTIC_EXCLUDE_BEACON
 #include "modules/MeshBeaconModule.h"
 #endif
+#include "modules/ModuleAvailability.h"
 
 #if !MESHTASTIC_EXCLUDE_MQTT
 #include "mqtt/MQTT.h"
@@ -1086,6 +1087,11 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
 bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
 {
     bool shouldReboot = true;
+    if (c.which_payload_variant == meshtastic_ModuleConfig_audio_tag && !isAudioModuleAvailableForRegion(config.lora.region)) {
+        LOG_WARN("Set module config: Audio module is unavailable for current radio/region");
+        return false;
+    }
+
     // If we are in an open transaction or configuring MQTT or Serial (which have validation), defer disabling Bluetooth
     // Otherwise, disable Bluetooth to prevent the phone from interfering with the config
     if (!hasOpenEditTransaction && !IS_ONE_OF(c.which_payload_variant, meshtastic_ModuleConfig_mqtt_tag,
@@ -1448,6 +1454,11 @@ void AdminModule::handleGetModuleConfig(const meshtastic_MeshPacket &req, const 
             res.get_module_config_response.payload_variant.canned_message = moduleConfig.canned_message;
             break;
         case meshtastic_AdminMessage_ModuleConfigType_AUDIO_CONFIG:
+            if (!isAudioModuleAvailableForRegion(config.lora.region)) {
+                LOG_WARN("Get module config: Audio module is unavailable for current radio/region");
+                myReply = allocErrorResponse(meshtastic_Routing_Error_BAD_REQUEST, &req);
+                return;
+            }
             configName = "Audio";
             res.get_module_config_response.which_payload_variant = meshtastic_ModuleConfig_audio_tag;
             res.get_module_config_response.payload_variant.audio = moduleConfig.audio;

--- a/src/modules/ModuleAvailability.h
+++ b/src/modules/ModuleAvailability.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "mesh/generated/meshtastic/config.pb.h"
+
+inline bool isAudioModuleAvailable(bool isEsp32, bool hasSx1280, bool audioExcluded,
+                                   meshtastic_Config_LoRaConfig_RegionCode region)
+{
+    return isEsp32 && hasSx1280 && !audioExcluded && region == meshtastic_Config_LoRaConfig_RegionCode_LORA_24;
+}
+
+inline bool isAudioModuleAvailableForRegion(meshtastic_Config_LoRaConfig_RegionCode region)
+{
+#if defined(ARCH_ESP32)
+    constexpr bool isEsp32 = true;
+#else
+    constexpr bool isEsp32 = false;
+#endif
+
+#if defined(USE_SX1280)
+    constexpr bool hasSx1280 = true;
+#else
+    constexpr bool hasSx1280 = false;
+#endif
+
+#if MESHTASTIC_EXCLUDE_AUDIO
+    constexpr bool audioExcluded = true;
+#else
+    constexpr bool audioExcluded = false;
+#endif
+
+    return isAudioModuleAvailable(isEsp32, hasSx1280, audioExcluded, region);
+}

--- a/test/test_module_availability/test_main.cpp
+++ b/test/test_module_availability/test_main.cpp
@@ -1,0 +1,46 @@
+#include "TestUtil.h"
+#include "meshtastic/config.pb.h"
+#include "modules/ModuleAvailability.h"
+#include <Arduino.h>
+#include <unity.h>
+
+static void test_audio_available_only_on_esp32_sx1280_lora24()
+{
+    TEST_ASSERT_TRUE(isAudioModuleAvailable(true, true, false, meshtastic_Config_LoRaConfig_RegionCode_LORA_24));
+}
+
+static void test_audio_excluded_when_region_is_not_lora24()
+{
+    TEST_ASSERT_FALSE(isAudioModuleAvailable(true, true, false, meshtastic_Config_LoRaConfig_RegionCode_US));
+}
+
+static void test_audio_excluded_when_radio_lacks_sx1280()
+{
+    TEST_ASSERT_FALSE(isAudioModuleAvailable(true, false, false, meshtastic_Config_LoRaConfig_RegionCode_LORA_24));
+}
+
+static void test_audio_excluded_when_build_excludes_audio()
+{
+    TEST_ASSERT_FALSE(isAudioModuleAvailable(true, true, true, meshtastic_Config_LoRaConfig_RegionCode_LORA_24));
+}
+
+void setUp(void) {}
+
+void tearDown(void) {}
+
+void setup()
+{
+    testDelay(10);
+    testDelay(2000);
+
+    initializeTestEnvironment();
+
+    UNITY_BEGIN();
+    RUN_TEST(test_audio_available_only_on_esp32_sx1280_lora24);
+    RUN_TEST(test_audio_excluded_when_region_is_not_lora24);
+    RUN_TEST(test_audio_excluded_when_radio_lacks_sx1280);
+    RUN_TEST(test_audio_excluded_when_build_excludes_audio);
+    exit(UNITY_END());
+}
+
+void loop() {}

--- a/variants/esp32s2/esp32s2.ini
+++ b/variants/esp32s2/esp32s2.ini
@@ -7,8 +7,17 @@ build_src_filter =
 
 monitor_speed = 115200
 
+board_build.extra_flags =
+  -DARDUINO_LOLIN_S2_MINI
+  -DBOARD_HAS_PSRAM
+  -DARDUINO_USB_CDC_ON_BOOT=0
+  -DARDUINO_USB_MODE=0
+
 build_flags =
   ${esp32_common.build_flags}
+  ; pioarduino's ESP32-S2 Arduino libs omit libcoexist.a, but esp_wifi still references it.
+  -L${platformio.packages_dir}/framework-espidf/components/esp_coex/lib/esp32s2
+  -lcoexist
   -DHAS_BLUETOOTH=0
   -DMESHTASTIC_EXCLUDE_PAXCOUNTER
   -DMESHTASTIC_EXCLUDE_BLUETOOTH
@@ -16,9 +25,6 @@ build_flags =
 
 custom_sdkconfig =
   ${esp32_common.custom_sdkconfig}
-  ; ESP32-S2 has no USB-Serial-JTAG peripheral (issue #10799)
- CONFIG_TINYUSB_ENABLED=y
-  CONFIG_TINYUSB_CDC_ENABLED=y
 
 lib_ignore = 
   ${esp32_common.lib_ignore}
@@ -29,4 +35,3 @@ lib_deps =
   ${esp32_common.lib_deps}
   # renovate: datasource=git-refs depName=meshtastic-ESP32_Codec2 packageName=https://github.com/meshtastic/ESP32_Codec2 gitBranch=master
   https://github.com/meshtastic/ESP32_Codec2/archive/633326c78ac251c059ab3a8c430fcdf25b41672f.zip
-  


### PR DESCRIPTION
## Summary

- Add a shared audio availability helper and use it in device metadata so Audio is excluded unless the build is ESP32 + SX1280, Audio is compiled in, and the current LoRa region is `LORA_24`.
- Reject Admin get/set of `AUDIO_CONFIG` with `BAD_REQUEST` when Audio is unavailable for the current radio/region.
- Fix `nugget-s2-lora` builds by overriding the ESP32-S2 board USB CDC-on-boot macros and linking the matching ESP-IDF S2 `libcoexist.a` archive.

Fixes #10522.
Fixes #10799.

## Root Cause

For #10522, Audio metadata was gated only by the build-time `MESHTASTIC_EXCLUDE_AUDIO` macro, so non-2.4 GHz capable radios/regions could still advertise Audio config availability.

For #10799, the `lolin_s2_mini` board defaults define `ARDUINO_USB_CDC_ON_BOOT=1`, which maps `Serial` to `USBSerial`; this S2 build does not provide that symbol. Enabling TinyUSB got past that symptom but then failed on missing TinyUSB headers. With CDC-on-boot disabled, the final link also needs `libcoexist.a`: pioarduino's ESP32-S2 Arduino libs bundle omits it, while `esp_wifi`/startup still reference the coexistence symbols. The matching ESP-IDF package already provides that archive.

## Verification

- `git diff --check`
- `/opt/homebrew/opt/llvm/bin/clang-format -style=file:.trunk/configs/.clang-format -i ...` on touched C++ files (`trunk` CLI was not on PATH locally)
- `~/.platformio/penv/bin/python -m platformio test -e native-macos -f test_module_availability` - PASS, 4/4
- `~/.platformio/penv/bin/pio run -e nugget-s2-lora -j1` - PASS
