### PR TITLE
fix(tap_v2): disable Bluetooth by default on TFT device

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1024,7 +1024,7 @@ void NodeDB::installDefaultConfig(bool preserveKey = false)
     strncpy(config.network.ntp_server, "meshtastic.pool.ntp.org", 32);
 
 #if (defined(T_DECK) || defined(T_WATCH_S3) || defined(UNPHONE) || defined(PICOMPUTER_S3) || defined(SENSECAP_INDICATOR) ||      \
-     defined(ELECROW_PANEL) || defined(HELTEC_V4_TFT) || defined(HELTEC_V4_R8_TFT)) &&                                           \
+     defined(ELECROW_PANEL) || defined(HELTEC_V4_TFT) || defined(HELTEC_V4_R8_TFT) || defined(RAK_WISMESH_TAP_V2)) &&           \
     HAS_TFT
     // switch BT off by default; use TFT programming mode or hotkey to enable
     config.bluetooth.enabled = false;


### PR DESCRIPTION
## Summary

Add `RAK_WISMESH_TAP_V2` to the list of TFT devices that default Bluetooth to OFF in `installDefaultConfig()`.

## Motivation

RAK WisMesh Tap V2 is a TFT-based ESP32-S3 device. Like T-Deck, T-Watch S3, HELTEC_V4_TFT, and other TFT devices, it should default Bluetooth to disabled to:

- Reduce power consumption
- Avoid unwanted BLE connections
- Match the convention of all other TFT-based devices in the codebase

Users can re-enable Bluetooth via the TFT settings menu when needed.

## Changes

- **`src/mesh/NodeDB.cpp`** — Add `RAK_WISMESH_TAP_V2` to the `#if defined(...)` preprocessor guard that sets `config.bluetooth.enabled = false` for TFT devices.

## Testing

- [ ] Verify TAP V2 builds with `rak_wismesh_tap_v2-tft` env
- [ ] Confirm Bluetooth defaults to OFF after factory reset
- [ ] Confirm Bluetooth can be re-enabled via TFT settings menu
