### PR TITLE
esp32-common: Do not remove `network-provisioning` component

### DIFF
--- a/variants/esp32/esp32-common.ini
+++ b/variants/esp32/esp32-common.ini
@@ -126,7 +126,7 @@ custom_component_remove =
   espressif/esp_diagnostics
   espressif/esp_rainmaker
   espressif/rmaker_common
-  espressif/network_provisioning
+  ; espressif/network_provisioning
   chmorgan/esp-libhelix-mp3
   espressif/esp-tflite-micro
   espressif/esp-sr


### PR DESCRIPTION
Removing the `espressif/network-provisioning` component is breaking builds. This should be safe to keep (even if we aren't using it).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the `network_provisioning` component in ESP32 builds by no longer removing it during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->