### PR TITLE
Fix spiLock deadlock in MessageStore::clearAllMessages()

### DIFF
--- a/src/MessageStore.cpp
+++ b/src/MessageStore.cpp
@@ -360,10 +360,16 @@ void MessageStore::clearAllMessages()
     resetMessagePool();
 
 #ifdef FSCom
-    concurrency::LockGuard guard(spiLock);
     SafeFile f(filename.c_str(), false);
     uint8_t count = 0;
-    f.write(&count, 1); // write "0 messages"
+
+    // SafeFile already does its own spiLock in its constructor and close().
+    // Avoid nesting spiLocks, as this will hang until watchdog reset!
+    {
+        concurrency::LockGuard guard(spiLock);
+        f.write(&count, 1); // write "0 messages"
+    }
+
     f.close();
 #endif
 


### PR DESCRIPTION
## Summary

Avoid nested spiLock acquisition in `MessageStore::clearAllMessages()` by only holding the lock during the write() call. SafeFile's constructor and close() methods already handle their own spiLock acquisition, so nesting the guard around the entire operation causes a deadlock until the watchdog timer triggers a reset.

This is the MessageStore-only fix extracted from PR #10809 (which also fixes the same issue in WarmNodeStore).

## Related

- PR #10809: Fix spiLock deadlocks / frequent watchdog restarts in WarmNodeStore::save()