### PR TITLE
Remove undefined trunk linters (ascii-dash, too-many-defined)

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -8,8 +8,6 @@ plugins:
       uri: https://github.com/trunk-io/plugins
 lint:
   enabled:
-    - ascii-dash@SYSTEM
-    - too-many-defined@SYSTEM
     - checkov@3.3.6
     - renovate@43.251.1
     - prettier@3.9.4


### PR DESCRIPTION
## Problem

The automated trunk upgrade [#10865](https://github.com/meshtastic/firmware/pull/10865) enabled two linters in `.trunk/trunk.yaml` that have **no** `lint.definitions` entry:

```yaml
lint:
  enabled:
    - ascii-dash@SYSTEM
    - too-many-defined@SYSTEM
```

trunk rejects them as `'<name>' is not a supported linter` (`trunk/config-error`, high severity), which fails the **Trunk Check** on every open PR:

```
11:7  high  'ascii-dash' is not a supported linter        trunk/config-error
12:7  high  'too-many-defined' is not a supported linter  trunk/config-error
```

Because `trunk_check.yml` runs `on: [pull_request]` only, master's push CI never ran the check, so the broken config landed unnoticed and now surfaces on PRs via their merge ref (e.g. #10854).

## Fix

Remove the two undefined `@SYSTEM` linter entries. The rest of #10865 (the version bumps for checkov, renovate, trufflehog, trivy, etc.) is kept intact.