### PR TITLE
Fix message scroll being reset every frame on E-Ink displays

### DIFF
--- a/src/graphics/draw/MessageRenderer.cpp
+++ b/src/graphics/draw/MessageRenderer.cpp
@@ -717,8 +717,9 @@ void drawTextMessageFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16
         scrollY = 0;
     }
 #else
-    // E-Ink: disable autoscroll
-    scrollY = 0.0f;
+    // E-Ink: disable automatic idle autoscroll, but preserve manual scroll position
+    if (!manualScrolling)
+        scrollY = 0.0f;
     waitingToReset = false;
     scrollStarted = false;
     lastTime = millis();


### PR DESCRIPTION
## What changed

On E-Ink boards (`USE_EINK`), `drawTextMessageFrame()` in `src/graphics/draw/MessageRenderer.cpp` unconditionally reset `scrollY` to `0` on every redraw. This was meant to disable the idle auto-scroll animation (which doesn't make sense on E-Ink), but it also wiped out the scroll position set by manual `scrollUp()`/`scrollDown()` calls from button input, before the frame even rendered.

The practical effect: on E-Ink devices, pressing up/down on the messages screen had no visible effect — the message list appeared permanently stuck, since any scroll offset was zeroed out immediately after being set.

The fix guards the reset with `if (!manualScrolling)`, so the idle auto-scroll animation stays disabled on E-Ink, but a user's manual scroll input is preserved.

## Testing

Reproduced and confirmed fixed on a Heltec Vision Master E290 (physical hardware): built and flashed the `heltec-vision-master-e290` environment, populated a message thread long enough to overflow the screen, and confirmed the up/down buttons now scroll the message list instead of staying stuck.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)

Tested only on Heltec Vision Master E290. This code path is shared by all `USE_EINK` boards, but I don't have other E-Ink hardware on hand to test regressions against — happy for community members with other E-Ink devices to help verify.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved E-Ink scrolling behavior in message views so manual scroll positions are preserved instead of being reset automatically.
  * Automatic idle autoscroll is now disabled only when the user is not actively scrolling, resulting in smoother and more predictable reading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->