### PR TITLE
[codex] Fix ESP32 Paxcounter startup with Bluetooth disabled

### DIFF
--- a/src/modules/esp32/PaxcounterModule.cpp
+++ b/src/modules/esp32/PaxcounterModule.cpp
@@ -7,6 +7,34 @@
 #include "graphics/SharedUIDisplay.h"
 #include "graphics/images.h"
 #include <assert.h>
+#include <esp_event.h>
+#include <freertos/timers.h>
+
+// Arduino WiFi has a wifiscan.h too, so declare the libpax scanner hooks here.
+void set_wifi_channels(uint16_t channels_map);
+void wifi_sniffer_init(uint16_t wifi_channel_switch_interval);
+void switchWifiChannel(TimerHandle_t xTimer);
+extern TimerHandle_t WifiChanTimer;
+
+static void startWifiChannelTimer(uint16_t wifi_channel_switch_interval)
+{
+    if (wifi_channel_switch_interval == 0) {
+        return;
+    }
+
+    WifiChanTimer =
+        xTimerCreate("WifiChannelTimer", pdMS_TO_TICKS(wifi_channel_switch_interval * 10), pdTRUE, (void *)0, switchWifiChannel);
+    assert(WifiChanTimer);
+    xTimerStart(WifiChanTimer, 0);
+}
+
+static void ensureDefaultEventLoop()
+{
+    esp_err_t result = esp_event_loop_create_default();
+    if (result != ESP_OK && result != ESP_ERR_INVALID_STATE) {
+        LOG_WARN("Paxcounter could not create ESP event loop: %d", result);
+    }
+}
 
 PaxcounterModule *paxcounterModule;
 
@@ -90,8 +118,8 @@ int32_t PaxcounterModule::runOnce()
             configuration.blecounter = 1;
             configuration.blescantime = 0; // infinite
             configuration.wificounter = 1;
-            // configuration.wifi_channel_map = WIFI_CHANNEL_ALL;
-            // configuration.wifi_channel_switch_interval = 50;
+            configuration.LIBPAX_WIFI_CHANNEL_map = LIBPAX_WIFI_CHANNEL_ALL;
+            configuration.LIBPAX_WIFI_CHANNEL_switch_interval = 50;
             configuration.wifi_rssi_threshold = Default::getConfiguredOrDefault(moduleConfig.paxcounter.wifi_threshold, -80);
             configuration.ble_rssi_threshold = Default::getConfiguredOrDefault(moduleConfig.paxcounter.ble_threshold, -80);
             libpax_update_config(&configuration);
@@ -101,7 +129,12 @@ int32_t PaxcounterModule::runOnce()
                                 Default::getConfiguredOrDefault(moduleConfig.paxcounter.paxcounter_update_interval,
                                                                 default_telemetry_broadcast_interval_secs),
                                 0);
+            // libpax sets the WiFi country in counter_start(), so start channel rotation after that.
+            ensureDefaultEventLoop();
+            set_wifi_channels(configuration.LIBPAX_WIFI_CHANNEL_map);
+            wifi_sniffer_init(0);
             libpax_counter_start();
+            startWifiChannelTimer(configuration.LIBPAX_WIFI_CHANNEL_switch_interval);
         } else {
             sendInfo(NODENUM_BROADCAST);
         }

--- a/src/modules/esp32/PaxcounterModule.cpp
+++ b/src/modules/esp32/PaxcounterModule.cpp
@@ -6,7 +6,6 @@
 #include "graphics/ScreenFonts.h"
 #include "graphics/SharedUIDisplay.h"
 #include "graphics/images.h"
-#include <assert.h>
 #include <esp_event.h>
 #include <freertos/timers.h>
 
@@ -24,7 +23,10 @@ static void startWifiChannelTimer(uint16_t wifi_channel_switch_interval)
 
     WifiChanTimer =
         xTimerCreate("WifiChannelTimer", pdMS_TO_TICKS(wifi_channel_switch_interval * 10), pdTRUE, (void *)0, switchWifiChannel);
-    assert(WifiChanTimer);
+    if (!WifiChanTimer) {
+        LOG_WARN("Paxcounter could not create WiFi channel switch timer");
+        return;
+    }
     xTimerStart(WifiChanTimer, 0);
 }
 

--- a/src/platform/esp32/main-esp32.cpp
+++ b/src/platform/esp32/main-esp32.cpp
@@ -52,8 +52,24 @@ static bool isNetworkConfiguredToDisableBluetooth()
 #endif
 }
 
+static bool isPaxcounterActiveForBoot()
+{
+#if !MESHTASTIC_EXCLUDE_PAXCOUNTER
+    return moduleConfig.has_paxcounter && moduleConfig.paxcounter.enabled && !config.bluetooth.enabled &&
+           !config.network.wifi_enabled;
+#else
+    return false;
+#endif
+}
+
 static bool shouldReleaseBluetoothMemory()
 {
+    // Paxcounter disables the Meshtastic BLE service, but libpax still needs the
+    // ESP32 BLE controller memory for scanning.
+    if (isPaxcounterActiveForBoot()) {
+        return false;
+    }
+
     // On ESP32 targets WiFi and BLE share radio resources. When WiFi is configured for this boot,
     // BLE will not be started, so its reserved memory can be returned to the heap until reboot.
     if (isNetworkConfiguredToDisableBluetooth()) {

--- a/src/platform/esp32/main-esp32.cpp
+++ b/src/platform/esp32/main-esp32.cpp
@@ -67,6 +67,7 @@ static bool shouldReleaseBluetoothMemory()
     // Paxcounter disables the Meshtastic BLE service, but libpax still needs the
     // ESP32 BLE controller memory for scanning.
     if (isPaxcounterActiveForBoot()) {
+        LOG_DEBUG("Skipping Bluetooth memory release because Paxcounter is active");
         return false;
     }
 


### PR DESCRIPTION
## Summary
- keep ESP32 Bluetooth controller memory available when Paxcounter is enabled with Meshtastic BLE disabled
- initialize libpax Wi-Fi sniffer/event-loop pieces before starting the counter
- start libpax Wi-Fi channel rotation after libpax sets Wi-Fi country data

## Root cause
On ESP32, disabling Meshtastic Bluetooth caused boot to release BTDM memory even though Paxcounter/libpax still needs BLE controller memory for scanning. After preserving that memory, libpax still expected its Wi-Fi sniffer and default event-loop setup before the counter began, otherwise startup could crash or spam Wi-Fi event-post errors.

## Validation
- `$HOME/.local/bin/trunk fmt src/modules/esp32/PaxcounterModule.cpp src/platform/esp32/main-esp32.cpp`
- `git diff --check -- src/modules/esp32/PaxcounterModule.cpp src/platform/esp32/main-esp32.cpp`
- `~/.platformio/penv/bin/pio run -e tbeam-s3-core -e t-deck`
- `~/.platformio/penv/bin/pio run -e tlora-t3s3-v1` (compiles/links but the current target image is over partition: 2,459,451 > 2,424,832)
- Hardware: T-Beam S3 Core with Paxcounter enabled, Bluetooth disabled, Wi-Fi disabled reported repeated Wi-Fi/BLE counts and no panic after reboot.
- Hardware: T-Deck with Paxcounter enabled, Bluetooth disabled, Wi-Fi disabled reported repeated Wi-Fi/BLE counts and no old crash signatures (`LoadProhibited`, `ESP_ERR_WIFI_NOT_INIT`, `IntegerDivideByZero`, Wi-Fi event-post spam).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced ESP32 Paxcounter mode startup to better manage Wi‑Fi channel rotation and enable continuous packet counting.

* **Bug Fixes**
  * Prevented Bluetooth memory from being released when running in a Paxcounter-only boot configuration, improving stability when Bluetooth and Wi‑Fi are both disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->