### PR TITLE
fix(nrf52): keep BLE active during reset cleanup

### DIFF
--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -1696,16 +1696,17 @@ void menuHandler::resetNodeDBMenu()
     bannerOptions.optionsCount = 3;
     bannerOptions.bannerCallback = [](int selected) -> void {
         if (selected == 1 || selected == 2) {
-            disableBluetooth();
             screen->setFrames(Screen::FOCUS_DEFAULT);
         }
         if (selected == 1) {
             LOG_INFO("Initiate node-db reset");
             nodeDB->resetNodes();
+            disableBluetooth();
             rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
         } else if (selected == 2) {
             LOG_INFO("Initiate node-db reset but keeping favorites");
             nodeDB->resetNodes(1);
+            disableBluetooth();
             rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
         } else if (selected == 0) {
             menuQueue = NodeBaseMenu;

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -418,22 +418,22 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         break;
     }
     case meshtastic_AdminMessage_factory_reset_config_tag: {
-        disableBluetooth();
         LOG_INFO("Initiate factory config reset");
+        // Keep BLE active while reset cleanup performs nRF flash operations.
         nodeDB->factoryReset();
         LOG_INFO("Factory config reset finished, rebooting soon");
+        disableBluetooth();
         reboot(DEFAULT_REBOOT_SECONDS);
         break;
     }
     case meshtastic_AdminMessage_factory_reset_device_tag: {
-        disableBluetooth();
         LOG_INFO("Initiate full factory reset");
         nodeDB->factoryReset(true);
+        disableBluetooth();
         reboot(DEFAULT_REBOOT_SECONDS);
         break;
     }
     case meshtastic_AdminMessage_nodedb_reset_tag: {
-        disableBluetooth();
         LOG_INFO("Initiate node-db reset");
         //  CLIENT_BASE, ROUTER and ROUTER_LATE are able to preserve the remaining hop count when relaying a packet via a
         //  favorited node, so ensure that their favorites are kept on reset
@@ -441,6 +441,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
             isOneOf(config.device.role, meshtastic_Config_DeviceConfig_Role_CLIENT_BASE,
                     meshtastic_Config_DeviceConfig_Role_ROUTER, meshtastic_Config_DeviceConfig_Role_ROUTER_LATE);
         nodeDB->resetNodes(rolePreference ? rolePreference : r->nodedb_reset);
+        disableBluetooth();
         reboot(DEFAULT_REBOOT_SECONDS);
         break;
     }

--- a/src/modules/SystemCommandsModule.cpp
+++ b/src/modules/SystemCommandsModule.cpp
@@ -117,9 +117,9 @@ int SystemCommandsModule::handleInputEvent(const InputEvent *event)
         return true;
     // factory reset
     case INPUT_BROKER_FACTORY_RST:
-        disableBluetooth();
         LOG_INFO("Initiate full factory reset");
         nodeDB->factoryReset(true);
+        disableBluetooth();
         // reboot(DEFAULT_REBOOT_SECONDS);
         LOG_INFO("Reboot in %d seconds", DEFAULT_REBOOT_SECONDS);
         if (screen)


### PR DESCRIPTION
## Summary

Fixes #10851.

nRF52 factory/config reset paths were stopping Bluetooth before running reset cleanup. On current firmware that cleanup can perform flash-backed work before scheduling reboot, including the nRF52840 warm-node raw-flash erase added in #10705. Keeping BLE/SoftDevice active until after the reset cleanup lets those flash operations complete normally, then advertising is stopped immediately before the scheduled reboot.

This moves `disableBluetooth()` after the reset cleanup for:

- admin factory config reset / full factory reset / NodeDB reset
- input-broker full factory reset
- screen-menu NodeDB reset

## Hardware repro / verification

Bench target: Muzi Base nRF52840 on `/dev/cu.usbmodem31201`, `MUZI_BASE`, firmware `2.8.0.84b1af0`.

Before fix, on upstream `develop`:

- `bluetooth.enabled=false` followed by admin reboot: PASS, metadata returned immediately.
- `meshtastic --factory-reset`: FAIL, serial API timed out repeatedly for more than two minutes. USB stayed enumerated, but Meshtastic metadata never returned until bootloader/PlatformIO recovery.
- Checked the issue's proposed reset cause: `Power::reboot()` uses `NVIC_SystemReset()` in `v2.7.22.96dd647`, `v2.7.26.54e0d8d`, and current `develop`; no `sd_nvic_SystemReset()` change exists in that path.

After fix, final artifact flashed to the same Muzi Base:

- `meshtastic --factory-reset`: PASS. Poll 1 saw expected USB disconnect during reboot; poll 2 returned metadata successfully with no recovery.
- Restored bench config afterward: `bluetooth.enabled=True`, `lora.region=13`, metadata healthy.

## Tests

- `trunk fmt src/modules/AdminModule.cpp src/modules/SystemCommandsModule.cpp src/graphics/draw/MenuHandler.cpp`
- `git diff --check`
- `pio run -e muzi-base`
- `pio run -e muzi-base -t upload --upload-port /dev/cu.usbmodem31201`
- Hardware repro above on Muzi Base nRF52840

Native test note:

- `./bin/run-tests.sh` does not run on this macOS checkout because it uses GNU/bash features not available here (`mapfile`, `find -printf`).
- Raw fallback `python -m platformio test -e native` fails before tests on existing unrelated native compile errors in `src/graphics/draw/NotificationRenderer.cpp` variable-length array initializers and Linux input headers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the order of reset actions so Bluetooth is turned off only after reset steps begin or complete, helping reset flows finish more reliably.
  * Updated factory and node database reset behavior to better preserve the correct screen state during confirmation and reset actions.
  * Refined admin and system reset handling to keep reset messages and actions in a clearer, more consistent order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->