### PR TITLE
fixed tlora-v2-1-1_16 led heartbeat not blinking and stuck at single s…

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -348,6 +348,12 @@ void setup()
     // initialize power HAL layer as early as possible
     powerHAL_init();
 
+#if defined(ARCH_ESP32) && defined(LED_HEARTBEAT)
+    pinMode(LED_HEARTBEAT, OUTPUT);
+    digitalWrite(LED_HEARTBEAT, LED_STATE_ON);
+#endif
+
+
 #ifdef LED_POWER
     pinMode(LED_POWER, OUTPUT);
     digitalWrite(LED_POWER, LED_STATE_ON);

--- a/src/modules/StatusLEDModule.cpp
+++ b/src/modules/StatusLEDModule.cpp
@@ -140,7 +140,11 @@ int32_t StatusLEDModule::runOnce()
     }
 // If we want a LED to be dedicated to the simple hearbeat, we can use that instead of the charge LED
 #if defined(LED_HEARTBEAT)
+    #ifndef USE_HEARTBEAT_REGARDLESS_POWER_STATE
     if (power_state != charging && power_state != charged && !doing_fast_blink && !config.device.led_heartbeat_disabled) {
+    #else
+    if (!config.device.led_heartbeat_disabled) {
+    #endif
         if (HEARTBEAT_LED_state == LED_STATE_ON) {
             HEARTBEAT_LED_state = LED_STATE_OFF;
             my_interval = 999;

--- a/variants/esp32/tlora_v2_1_16/platformio.ini
+++ b/variants/esp32/tlora_v2_1_16/platformio.ini
@@ -21,5 +21,4 @@ board_level = extra
 build_flags =
   ${env:tlora-v2-1-1_6.build_flags}
   -DBUTTON_PIN=0
-  -DPIN_BUZZER=25
   -DLED_POWER=-1

--- a/variants/esp32/tlora_v2_1_16/variant.h
+++ b/variants/esp32/tlora_v2_1_16/variant.h
@@ -14,6 +14,13 @@
 #define LED_POWER 25 // If defined we will blink this LED
 #endif
 
+#if defined(LED_POWER) // remove LED_POWER - they caused a LED to stuck at single state
+#undef LED_POWER
+#endif
+#define LED_HEARTBEAT 25 // use LED_HEARTBEAT instead
+#define USE_HEARTBEAT_REGARDLESS_POWER_STATE
+
+
 #define USE_RF95
 #define LORA_DIO0 26 // a No connect on the SX1262 module
 #define LORA_RESET 23


### PR DESCRIPTION
since I hate waste and trash old hardware (which could still works) I am still using tlora-v2-1-1_16 usb powered
formware for tlora-v2-1-1_16 has a bug that caused the status LED to not blinking,
conflict setup LED_POWER for blinking and power status caused that.

fixed by using LED_HEARTBEAT instead of LED_POWER and force blinking regardless power status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled the heartbeat status LED by default for the ESP32 build, with early startup GPIO initialization.
* **Bug Fixes**
  * Updated heartbeat LED behavior so it can toggle independently of power/charging states on supported builds, based on a build-time setting and the user’s “heartbeat disabled” option.
* **Configuration**
  * Updated the ESP32 variant LED/buzzer build settings: heartbeat LED now uses pin 25 (and the prior LED_POWER pin assignment is removed), and the buzzer pin definition was removed for the affected environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->