### PR TITLE
feat(rak4631_eth_gw): advertise a DHCP hostname derived from the device name

### DIFF
--- a/src/mesh/eth/ethClient.cpp
+++ b/src/mesh/eth/ethClient.cpp
@@ -45,6 +45,33 @@ using namespace concurrency;
 
 static Periodic *ethEvent;
 
+#ifdef RAK_ETH_CUSTOM_HOSTNAME
+#include <cctype>
+
+// Advertise a DHCP hostname (option 12) derived from the Meshtastic device name.
+// getDeviceName() returns e.g. "MyNode_a1b2", but '_' is not a valid DNS label
+// character, so map every non-alphanumeric run to a single '-' and trim edges,
+// yielding a recognizable, DNS-safe hostname such as "MyNode-a1b2".
+static const char *getEthHostname()
+{
+    static char ethHostname[HOST_NAME_MAX_LENGTH + 1];
+    const char *src = getDeviceName();
+    size_t j = 0;
+    for (size_t i = 0; src[i] != '\0' && j < sizeof(ethHostname) - 1; i++) {
+        char c = src[i];
+        if (isalnum((unsigned char)c)) {
+            ethHostname[j++] = c;
+        } else if (j > 0 && ethHostname[j - 1] != '-') {
+            ethHostname[j++] = '-'; // collapse invalid chars (incl. '_') into one hyphen
+        }
+    }
+    while (j > 0 && ethHostname[j - 1] == '-') // no trailing hyphen
+        j--;
+    ethHostname[j] = '\0';
+    return ethHostname;
+}
+#endif
+
 static int32_t reconnectETH()
 {
     if (config.network.eth_enabled) {
@@ -109,6 +136,10 @@ static int32_t reconnectETH()
             ETH_SPI_PORT.begin();
 #endif
             Ethernet.init(ETH_SPI_PORT, PIN_ETHERNET_SS);
+#endif
+
+#ifdef RAK_ETH_CUSTOM_HOSTNAME
+            Ethernet.setHostname(getEthHostname()); // re-apply hostname after chip reset, before begin()
 #endif
 
             int status = 0;
@@ -266,6 +297,11 @@ bool initEthernet()
 
         getMacAddr(mac); // FIXME use the BLE MAC for now...
         mac[0] &= 0xfe;  // Make sure this is not a multicast MAC
+
+#ifdef RAK_ETH_CUSTOM_HOSTNAME
+        Ethernet.setHostname(getEthHostname()); // advertised to the DHCP server; must precede begin()
+        LOG_INFO("Ethernet hostname %s", getEthHostname());
+#endif
 
         if (config.network.address_mode == meshtastic_Config_NetworkConfig_AddressMode_DHCP) {
             LOG_INFO("Start Ethernet DHCP");

--- a/variants/nrf52840/rak4631_eth_gw/platformio.ini
+++ b/variants/nrf52840/rak4631_eth_gw/platformio.ini
@@ -7,6 +7,10 @@ build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/rak4631_eth_gw
   -D RAK_4631
   -DHAS_UDP_MULTICAST=1
+  ; Uses the gdiciocco/RAK13800-W5100S fork, which adds Ethernet.setHostname().
+  ; Gates the hostname code in mesh/eth/ethClient.cpp so other Ethernet variants
+  ; (still on upstream RAK13800-W5100S 1.0.2) keep compiling.
+  -DRAK_ETH_CUSTOM_HOSTNAME=1
   -DEINK_DISPLAY_MODEL=GxEPD2_213_BN
   -DEINK_WIDTH=250
   -DEINK_HEIGHT=122
@@ -27,8 +31,8 @@ lib_deps =
   ${networking_base.lib_deps}
   # renovate: datasource=custom.pio depName=Melopero RV3028 packageName=melopero/library/Melopero RV3028
   melopero/Melopero RV3028@1.2.0
-  # renovate: datasource=github-tags depName=RAK13800-W5100S packageName=RAKWireless/RAK13800-W5100S
-  https://github.com/RAKWireless/RAK13800-W5100S/archive/1.0.2.zip
+  # renovate: datasource=custom.pio depName=RAK13800-W5100S packageName=https://github.com/gdiciocco/RAK13800-W5100S gitBranch=feature/custom-hostname
+  https://github.com/gdiciocco/RAK13800-W5100S/archive/refs/heads/feature/custom-hostname.zip
   # renovate: datasource=custom.pio depName=RAK NCP5623 RGB LED packageName=rakwireless/library/RAKwireless NCP5623 RGB LED library
   rakwireless/RAKwireless NCP5623 RGB LED library@1.0.3
   # renovate: datasource=git-refs depName=RAK12034-BMX160 packageName=https://github.com/RAKWireless/RAK12034-BMX160 gitBranch=main


### PR DESCRIPTION
### Summary
The RAK4631 W5100S Ethernet gateway registers with DHCP without a hostname, so on the LAN it only shows up by MAC/IP — awkward to identify in multi-node deployments. This advertises a DHCP hostname (option 12) derived from Meshtastic's own device identity.

The name comes from `getDeviceName()` (e.g. `MyNode_a1b2` — the same string already used for BLE and for the syslog device hostname on this path) and is sanitized into a valid DNS label (`MyNode-a1b2`). WiFi already advertises a hostname (`Meshtastic-<mac>` in `WiFiAPClient.cpp`); this brings the Ethernet gateway to parity and additionally includes the node's short name.

### Changes
- **`variants/nrf52840/rak4631_eth_gw/platformio.ini`**
  - Points the `RAK13800-W5100S` dependency at the `gdiciocco/RAK13800-W5100S` `feature/custom-hostname` fork, which adds `Ethernet.setHostname()` and emits the name as DHCP option 12.
  - Adds `-DRAK_ETH_CUSTOM_HOSTNAME=1` to gate the new code.
- **`src/mesh/eth/ethClient.cpp`**
  - New `getEthHostname()` helper (compiled only under `RAK_ETH_CUSTOM_HOSTNAME`) that turns `getDeviceName()` into a DNS-safe label: non-alphanumeric runs — including the `_` `getDeviceName()` uses — collapse to a single `-`, no leading/trailing hyphen.
  - Calls `Ethernet.setHostname()` before `Ethernet.begin()` in both `initEthernet()` and the W5100S chip-reset recovery in `reconnectETH()`, so the hostname survives a PoE brownout re-init.

### Scope & safety
`ethClient.cpp` is shared by all Ethernet variants, but the new API calls are wrapped in `#ifdef RAK_ETH_CUSTOM_HOSTNAME`, defined **only** for `rak4631_eth_gw`. Every other Ethernet variant (rak4631, rak11310, r1-neo, rak_wismeshtap, monteops_hw1) stays on upstream `RAK13800-W5100S@1.0.2` and is unaffected. Static-IP mode has no DHCP exchange, so the call is a harmless no-op there.

### Hostname derivation
| `getDeviceName()` | advertised hostname |
| --- | --- |
| `Meshtastic_a1b2` | `Meshtastic-a1b2` |
| `MyNode_a1b2` | `MyNode-a1b2` |
| `🚀_a1b2` (emoji short name) | `a1b2` |

### Testing
- Builds clean: `pio run -e rak4631_eth_gw` — Flash 76.4%, RAM 40.7%.
- [ ] Hardware: confirm the hostname appears in the router's DHCP lease table / local DNS.

### Dependency note
`lib_deps` points at a personal fork (`gdiciocco/RAK13800-W5100S`). For a clean merge, the `setHostname()` change should be upstreamed into `RAKWireless/RAK13800-W5100S` and this reference bumped to a tagged release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ethernet-enabled devices can now use a custom DHCP hostname derived from the device name.
  * The hostname is automatically made DNS-safe, improving network identification on routers and DHCP servers.

* **Bug Fixes**
  * Ethernet reconnects now reapply the hostname after a controller reset, helping preserve consistent network naming.
  * Startup logging now includes the chosen Ethernet hostname for easier setup verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->