### PR TITLE
Implement SD card backup/restore of preferences; add SD support for Cardputer Advanced

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -2179,23 +2179,52 @@ bool NodeDB::checkLowEntropyPublicKey(const meshtastic_Config_SecurityConfig_pub
 }
 #endif
 
+#ifdef FSCom
+// Shared by the FLASH and SD backup locations so the two paths can't drift apart
+static meshtastic_BackupPreferences buildBackupPreferences()
+{
+    meshtastic_BackupPreferences backup = meshtastic_BackupPreferences_init_zero;
+    backup.version = DEVICESTATE_CUR_VER;
+    backup.timestamp = getValidTime(RTCQuality::RTCQualityDevice, false);
+    backup.has_config = true;
+    backup.config = config;
+    backup.has_module_config = true;
+    backup.module_config = moduleConfig;
+    backup.has_channels = true;
+    backup.channels = channelFile;
+    backup.has_owner = true;
+    backup.owner = owner;
+    return backup;
+}
+
+static void applyRestoredPreferences(const meshtastic_BackupPreferences &backup, int restoreWhat)
+{
+    if (restoreWhat & SEGMENT_CONFIG) {
+        config = backup.config;
+        LOG_DEBUG("Restored config");
+    }
+    if (restoreWhat & SEGMENT_MODULECONFIG) {
+        moduleConfig = backup.module_config;
+        LOG_DEBUG("Restored module config");
+    }
+    if (restoreWhat & SEGMENT_DEVICESTATE) {
+        devicestate.owner = backup.owner;
+        LOG_DEBUG("Restored device state");
+    }
+    if (restoreWhat & SEGMENT_CHANNELS) {
+        channelFile = backup.channels;
+        LOG_DEBUG("Restored channels");
+    }
+}
+#endif
+
 bool NodeDB::backupPreferences(meshtastic_AdminMessage_BackupLocation location)
 {
     bool success = false;
     lastBackupAttempt = millis();
 #ifdef FSCom
     if (location == meshtastic_AdminMessage_BackupLocation_FLASH) {
-        meshtastic_BackupPreferences backup = meshtastic_BackupPreferences_init_zero;
-        backup.version = DEVICESTATE_CUR_VER;
-        backup.timestamp = getValidTime(RTCQuality::RTCQualityDevice, false);
-        backup.has_config = true;
-        backup.config = config;
-        backup.has_module_config = true;
-        backup.module_config = moduleConfig;
-        backup.has_channels = true;
-        backup.channels = channelFile;
-        backup.has_owner = true;
-        backup.owner = owner;
+        meshtastic_BackupPreferences backup = buildBackupPreferences();
 
         size_t backupSize;
         pb_get_encoded_size(&backupSize, meshtastic_BackupPreferences_fields, &backup);
@@ -2212,17 +2241,7 @@ bool NodeDB::backupPreferences(meshtastic_AdminMessage_BackupLocation location)
         }
     } else if (location == meshtastic_AdminMessage_BackupLocation_SD) {
 #if defined(HAS_SDCARD) && !defined(SDCARD_USE_SOFT_SPI)
-        meshtastic_BackupPreferences backup = meshtastic_BackupPreferences_init_zero;
-        backup.version = DEVICESTATE_CUR_VER;
-        backup.timestamp = getValidTime(RTCQuality::RTCQualityDevice, false);
-        backup.has_config = true;
-        backup.config = config;
-        backup.has_module_config = true;
-        backup.module_config = moduleConfig;
-        backup.has_channels = true;
-        backup.channels = channelFile;
-        backup.has_owner = true;
-        backup.owner = owner;
+        meshtastic_BackupPreferences backup = buildBackupPreferences();
 
         std::vector<uint8_t> buffer(meshtastic_BackupPreferences_size);
         pb_ostream_t stream = pb_ostream_from_buffer(buffer.data(), buffer.size());
@@ -2270,22 +2289,7 @@ bool NodeDB::restorePreferences(meshtastic_AdminMessage_BackupLocation location,
         success = loadProto(backupFileName, meshtastic_BackupPreferences_size, sizeof(meshtastic_BackupPreferences),
                             &meshtastic_BackupPreferences_msg, &backup);
         if (success) {
-            if (restoreWhat & SEGMENT_CONFIG) {
-                config = backup.config;
-                LOG_DEBUG("Restored config");
-            }
-            if (restoreWhat & SEGMENT_MODULECONFIG) {
-                moduleConfig = backup.module_config;
-                LOG_DEBUG("Restored module config");
-            }
-            if (restoreWhat & SEGMENT_DEVICESTATE) {
-                devicestate.owner = backup.owner;
-                LOG_DEBUG("Restored device state");
-            }
-            if (restoreWhat & SEGMENT_CHANNELS) {
-                channelFile = backup.channels;
-                LOG_DEBUG("Restored channels");
-            }
+            applyRestoredPreferences(backup, restoreWhat);
 
             success = saveToDisk(restoreWhat);
             if (success) {
@@ -2327,22 +2331,7 @@ bool NodeDB::restorePreferences(meshtastic_AdminMessage_BackupLocation location,
             LOG_ERROR("Failed to decode backup preferences from SD card");
             return false;
         }
-        if (restoreWhat & SEGMENT_CONFIG) {
-            config = backup.config;
-            LOG_DEBUG("Restored config");
-        }
-        if (restoreWhat & SEGMENT_MODULECONFIG) {
-            moduleConfig = backup.module_config;
-            LOG_DEBUG("Restored module config");
-        }
-        if (restoreWhat & SEGMENT_DEVICESTATE) {
-            devicestate.owner = backup.owner;
-            LOG_DEBUG("Restored device state");
-        }
-        if (restoreWhat & SEGMENT_CHANNELS) {
-            channelFile = backup.channels;
-            LOG_DEBUG("Restored channels");
-        }
+        applyRestoredPreferences(backup, restoreWhat);
         success = saveToDisk(restoreWhat);
         if (success) {
             LOG_INFO("Restored preferences from SD card backup");

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -7,6 +7,9 @@
 #include "CryptoEngine.h"
 #include "Default.h"
 #include "FSCommon.h"
+#if defined(HAS_SDCARD) && !defined(SDCARD_USE_SOFT_SPI)
+#include <SD.h>
+#endif
 #include "MeshRadio.h"
 #include "MeshService.h"
 #include "MessageStore.h"
@@ -2208,7 +2211,43 @@ bool NodeDB::backupPreferences(meshtastic_AdminMessage_BackupLocation location)
             LOG_ERROR("Failed to save backup preferences to file");
         }
     } else if (location == meshtastic_AdminMessage_BackupLocation_SD) {
-        // TODO: After more mainline SD card support
+#if defined(HAS_SDCARD) && !defined(SDCARD_USE_SOFT_SPI)
+        meshtastic_BackupPreferences backup = meshtastic_BackupPreferences_init_zero;
+        backup.version = DEVICESTATE_CUR_VER;
+        backup.timestamp = getValidTime(RTCQuality::RTCQualityDevice, false);
+        backup.has_config = true;
+        backup.config = config;
+        backup.has_module_config = true;
+        backup.module_config = moduleConfig;
+        backup.has_channels = true;
+        backup.channels = channelFile;
+        backup.has_owner = true;
+        backup.owner = owner;
+
+        std::vector<uint8_t> buffer(meshtastic_BackupPreferences_size);
+        pb_ostream_t stream = pb_ostream_from_buffer(buffer.data(), buffer.size());
+        if (!pb_encode(&stream, &meshtastic_BackupPreferences_msg, &backup)) {
+            LOG_ERROR("Failed to encode backup preferences");
+            return false;
+        }
+
+        concurrency::LockGuard g(spiLock);
+        SD.mkdir("/backups");
+        File file = SD.open(backupFileName, FILE_WRITE);
+        if (!file) {
+            LOG_ERROR("Failed to open %s on SD card (no card inserted?)", backupFileName);
+            return false;
+        }
+        success = file.write(buffer.data(), stream.bytes_written) == stream.bytes_written;
+        file.close();
+        if (success) {
+            LOG_INFO("Saved backup preferences to SD card");
+        } else {
+            LOG_ERROR("Failed to save backup preferences to SD card");
+        }
+#else
+        LOG_ERROR("SD card backup requested, but this device has no SD card support");
+#endif
     }
 #endif
     return success;
@@ -2258,7 +2297,61 @@ bool NodeDB::restorePreferences(meshtastic_AdminMessage_BackupLocation location,
             LOG_ERROR("Failed to restore preferences from backup file");
         }
     } else if (location == meshtastic_AdminMessage_BackupLocation_SD) {
-        // TODO: After more mainline SD card support
+#if defined(HAS_SDCARD) && !defined(SDCARD_USE_SOFT_SPI)
+        std::vector<uint8_t> buffer;
+        {
+            concurrency::LockGuard g(spiLock);
+            File file = SD.open(backupFileName, FILE_READ);
+            if (!file) {
+                LOG_WARN("Could not restore. No backup file found on SD card");
+                return false;
+            }
+            size_t fileSize = file.size();
+            if (fileSize == 0 || fileSize > meshtastic_BackupPreferences_size + 256) {
+                file.close();
+                LOG_ERROR("Could not restore. Backup file on SD card has implausible size %u", (unsigned)fileSize);
+                return false;
+            }
+            buffer.resize(fileSize);
+            if ((size_t)file.read(buffer.data(), fileSize) != fileSize) {
+                file.close();
+                LOG_ERROR("Could not restore. Failed to read backup file from SD card");
+                return false;
+            }
+            file.close();
+        }
+        meshtastic_BackupPreferences backup = meshtastic_BackupPreferences_init_zero;
+        pb_istream_t stream = pb_istream_from_buffer(buffer.data(), buffer.size());
+        success = pb_decode(&stream, &meshtastic_BackupPreferences_msg, &backup);
+        if (!success) {
+            LOG_ERROR("Failed to decode backup preferences from SD card");
+            return false;
+        }
+        if (restoreWhat & SEGMENT_CONFIG) {
+            config = backup.config;
+            LOG_DEBUG("Restored config");
+        }
+        if (restoreWhat & SEGMENT_MODULECONFIG) {
+            moduleConfig = backup.module_config;
+            LOG_DEBUG("Restored module config");
+        }
+        if (restoreWhat & SEGMENT_DEVICESTATE) {
+            devicestate.owner = backup.owner;
+            LOG_DEBUG("Restored device state");
+        }
+        if (restoreWhat & SEGMENT_CHANNELS) {
+            channelFile = backup.channels;
+            LOG_DEBUG("Restored channels");
+        }
+        success = saveToDisk(restoreWhat);
+        if (success) {
+            LOG_INFO("Restored preferences from SD card backup");
+        } else {
+            LOG_ERROR("Failed to save restored preferences to flash");
+        }
+#else
+        LOG_ERROR("SD card restore requested, but this device has no SD card support");
+#endif
     }
 #endif
     return success;

--- a/variants/esp32s3/m5stack_cardputer_adv/variant.h
+++ b/variants/esp32s3/m5stack_cardputer_adv/variant.h
@@ -59,6 +59,14 @@
 #define SX126X_DIO3_TCXO_VOLTAGE 1.8
 #define TCXO_OPTIONAL
 
+// SD card slot — shares the SPI bus with the LoRa radio (separate chip select).
+// The default SPI instance is used; spiLock arbitrates access between radio and SD.
+#define HAS_SDCARD
+#define SPI_SCK 40
+#define SPI_MISO 39
+#define SPI_MOSI 14
+#define SDCARD_CS 12
+
 #undef GPS_RX_PIN
 #undef GPS_TX_PIN
 #define GPS_RX_PIN 15


### PR DESCRIPTION
Implements the two `// TODO: After more mainline SD card support` stubs in `NodeDB::backupPreferences` / `NodeDB::restorePreferences`, so the existing `backup_preferences` / `restore_preferences` admin messages work with `BackupLocation_SD`, and wires up the SD card slot on the M5Stack Cardputer Advanced (which has a physical slot the firmware previously didn't use).

## Why

Flash-location backups don't survive reflashes or flash repartitioning. Devices with an SD slot can keep the same `BackupPreferences` proto on removable storage, which makes full config recovery (including channels and security keys) possible after a wipe — particularly useful on multi-firmware devices (e.g. Cardputer users switching firmwares via a boot launcher).

## What

- `NodeDB.cpp`: SD branches for backup and restore, mirroring the FLASH implementation. Same proto, same `/backups/backup.proto` path on the card. Guarded by `HAS_SDCARD && !SDCARD_USE_SOFT_SPI` (same condition as `FSCommon`'s SD support); devices without SD support now log an explicit error instead of silently returning false. SD access is wrapped in `spiLock` like other filesystem/radio bus users.
- `variants/esp32s3/m5stack_cardputer_adv/variant.h`: SD pin definitions (`SPI_SCK 40 / SPI_MISO 39 / SPI_MOSI 14 / SDCARD_CS 12`). The slot shares the SPI bus with the SX1262 (separate CS); pins match the working configuration used by community firmware that drives this slot (M5Launcher).

## Testing

- **Hardware-tested on two M5Stack Cardputer Advanced units** with this code backported onto v2.7.26: SD card mounts at boot (SDHC, correct size), backup writes verified (`Saved backup preferences to SD card`, ~600-700 bytes), restore verified end-to-end (config + module config + channels/PSKs + owner all applied and persisted; node identity/keys recovered after a full flash wipe). LoRa RX/TX confirmed unaffected by the shared SPI bus (messages exchanged with other mesh nodes after restore).
- This branch compiles clean for `m5stack-cardputer-adv` against current master.
- **Not tested**: master on hardware (our devices run the 2.7.26 backport of this exact code), and other `HAS_SDCARD` devices (e.g. T-Deck) — the code paths only execute when a client explicitly requests the SD location, which previously no-op'd, but community testing on other SD-equipped boards would be welcome.

## Transparency

This contribution was developed with substantial AI assistance (Anthropic's Claude, in an agentic coding session), with a human directing the work and performing all hardware testing. Please review accordingly. It is offered as-is under the project's license, without warranty of any kind — we're sharing it because it filled a real gap for us and may help others, and we're happy to revise per maintainer feedback.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described. (On M5Stack Cardputer Advanced, via a v2.7.26 backport of this exact code — see Testing above.)
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)

Regression testing done on: M5Stack Cardputer Advanced (×2). No other hardware available to us; the changed code paths are compile-gated to `HAS_SDCARD` builds and runtime-gated to explicit `BackupLocation_SD` requests, so regression surface elsewhere should be minimal — but independent verification on T-Deck (which also defines an SD card) would be valuable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SD card support for backing up and restoring device preferences on supported hardware.
  * Enabled SD card configuration for a supported device variant.

* **Bug Fixes**
  * Improved reliability of backup and restore operations with better error handling and file validation.
  * Restores now apply settings more completely and save them back safely after recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->