### PR TITLE
Fix GAT562 mesh time sync before GPS lock

### DIFF
--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -149,12 +149,21 @@ bool PositionModule::hasQualityTimesource()
 {
     bool setFromPhoneOrNtpToday =
         lastSetFromPhoneNtpOrGps == 0 ? false : Throttle::isWithinTimespanMs(lastSetFromPhoneNtpOrGps, SEC_PER_DAY * 1000UL);
+#if defined(GAT562)
+    // A connected GAT562 GPS means the UART module is present, not that it has
+    // provided valid time yet. Let mesh position packets seed RTC until this
+    // device actually has a valid clock from mesh, phone/NTP, RTC, or GPS.
+    bool hasRtcQuality = getRTCQuality() >= RTCQualityFromNet;
+    bool hasHardwareRtc = (rtc_found.address != ScanI2C::ADDRESS_NONE.address);
+    return hasRtcQuality || hasHardwareRtc || setFromPhoneOrNtpToday;
+#else
 #if MESHTASTIC_EXCLUDE_GPS
     bool hasGpsOrRtc = (rtc_found.address != ScanI2C::ADDRESS_NONE.address);
 #else
     bool hasGpsOrRtc = hasGPS() || (rtc_found.address != ScanI2C::ADDRESS_NONE.address);
 #endif
     return hasGpsOrRtc || setFromPhoneOrNtpToday;
+#endif
 }
 
 bool PositionModule::hasGPS()


### PR DESCRIPTION
## Summary

Fixes GAT562 time sync behavior when the GPS module is connected but has not provided valid RTC time yet.

On GAT562, `hasGPS()` can be true as soon as the GPS UART module is detected. `PositionModule::hasQualityTimesource()` then treats the device as already having a quality time source and ignores time from mesh position packets. This prevents the terminal from syncing time over the mesh before GPS lock.

This change keeps the existing behavior for other targets, and for GAT562 only treats the device as having a quality time source once RTC quality is actually at least `RTCQualityFromNet`, or a hardware RTC / recent phone-NTP source is available.

## Validation

Built successfully with:

```bash
python -m platformio run -e gat562_mesh_trial_tracker
```

Result: `SUCCESS`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time source detection on supported devices, making it more likely the app recognizes a valid clock source when mesh quality, hardware RTC, or recent phone/NTP time is available.
  * Preserved existing time source behavior on other builds, including configurations that exclude GPS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->