### PR TITLE
Set GAT562 GPS pins from board defaults

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1222,9 +1222,11 @@ void GPS::setPowerState(GPSPowerState newState, uint32_t sleepTime)
 void GPS::writePinEN(bool on)
 {
     // Abort: if conflict with Canned Messages when using Wisblock(?)
+#if !defined(GAT562)
     if ((HW_VENDOR == meshtastic_HardwareModel_RAK4631 || HW_VENDOR == meshtastic_HardwareModel_WISMESH_TAP) &&
         (rotaryEncoderInterruptImpl1 || upDownInterruptImpl1))
         return;
+#endif
 
     // Write and log
     enablePin->set(on);

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -638,6 +638,34 @@ NodeDB::NodeDB()
         config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_ENABLED;
         config.position.gps_enabled = 0;
     }
+#if defined(GAT562)
+#if defined(GPS_RX_PIN)
+    if (config.position.rx_gpio != GPS_RX_PIN) {
+        config.position.rx_gpio = GPS_RX_PIN;
+        if (!configDecodeFailed)
+            saveWhat |= SEGMENT_CONFIG;
+    }
+#endif
+#if defined(GPS_TX_PIN)
+    if (config.position.tx_gpio != GPS_TX_PIN) {
+        config.position.tx_gpio = GPS_TX_PIN;
+        if (!configDecodeFailed)
+            saveWhat |= SEGMENT_CONFIG;
+    }
+#endif
+#if defined(PIN_GPS_EN)
+    if (config.position.gps_en_gpio != PIN_GPS_EN) {
+        config.position.gps_en_gpio = PIN_GPS_EN;
+        if (!configDecodeFailed)
+            saveWhat |= SEGMENT_CONFIG;
+    }
+#endif
+    if (config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_NOT_PRESENT) {
+        config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_ENABLED;
+        if (!configDecodeFailed)
+            saveWhat |= SEGMENT_CONFIG;
+    }
+#endif
 #ifdef USERPREFS_FIRMWARE_EDITION
     myNodeInfo.firmware_edition = USERPREFS_FIRMWARE_EDITION;
 #endif

--- a/variants/nrf52840/gat562_mesh_trial_tracker/variant.h
+++ b/variants/nrf52840/gat562_mesh_trial_tracker/variant.h
@@ -231,7 +231,8 @@ SO GPIO 39/TXEN MAY NOT BE DEFINED FOR SUCCESSFUL OPERATION OF THE SX1262 - TG
 // Therefore must be 1 to keep peripherals powered
 // Power is on the controllable 3V3_S rail
 // #define PIN_GPS_RESET (34)
-// #define PIN_GPS_EN PIN_3V3_EN
+#define PIN_GPS_EN PIN_3V3_EN
+#define GPS_EN_ACTIVE 1
 #define PIN_GPS_PPS (17) // Pulse per second input from the GPS
 
 #define GPS_BAUDRATE 9600


### PR DESCRIPTION
## Summary

Sets the GAT562 GPS enable pin and GPS UART pins from the board definition, and migrates existing saved configs that still have missing or stale GPS pin values.

GAT562 uses the controllable 3V3 rail on GPIO 34 for GPS power. If `gps_en_gpio` remains unset in saved config, GPS can be reported as present but not actually powered as expected. This change:

- defines `PIN_GPS_EN` as `PIN_3V3_EN` for the GAT562 variant
- marks the GPS enable pin active high
- restores GAT562 GPS RX/TX/EN config from board defaults at boot when needed
- avoids applying the WisBlock canned-message EN-pin conflict guard to GAT562

## Validation

Built successfully with:

```bash
python -m platformio run -e gat562_mesh_trial_tracker
```

Result: `SUCCESS`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPS hardware handling so the GPS power/control pin now works correctly on the affected device variant.
  * Ensured GPS-related settings are automatically corrected during startup when needed, and saved for future boots.
  * Allowed GPS pin control to proceed on the supported hardware even when certain interrupt features are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->