### PR TITLE
InkHUD: persist incoming broadcasts on all channels

### DIFF
--- a/src/graphics/niche/InkHUD/Applets/User/ThreadedMessage/ThreadedMessageApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/User/ThreadedMessage/ThreadedMessageApplet.cpp
@@ -190,12 +190,17 @@ ProcessMessage InkHUD::ThreadedMessageApplet::handleReceived(const meshtastic_Me
     if (mp.to != NODENUM_BROADCAST)
         return ProcessMessage::CONTINUE;
 
-    // Store in the global messageStore - this handles sender, timestamp, channel, text, and ack status
-    messageStore.addFromPacket(mp);
-
-    // If this was an incoming message, suggest that our applet becomes foreground, if permitted
-    if (getFrom(&mp) != nodeDB->getNodeNum())
+    // Incoming broadcasts are stored centrally by Events::onReceiveTextMessage (for every
+    // channel, regardless of which applets exist). Only store our own outgoing/loopback
+    // messages here - Events short-circuits outgoing - to avoid double-storing incoming
+    // broadcasts on channels 0/1.
+    if (getFrom(&mp) == nodeDB->getNodeNum()) {
+        // Outgoing (e.g. canned messages generated on this node)
+        messageStore.addFromPacket(mp);
+    } else {
+        // Incoming: suggest that our applet becomes foreground, if permitted
         requestAutoshow();
+    }
 
     // Redraw the applet, perhaps.
     requestUpdate(); // Want to update display, if applet is foreground

--- a/src/graphics/niche/InkHUD/Events.cpp
+++ b/src/graphics/niche/InkHUD/Events.cpp
@@ -541,9 +541,13 @@ int InkHUD::Events::onReceiveTextMessage(const meshtastic_MeshPacket *packet)
         // DMs never pass through ThreadedMessageApplet, so add them to the global store here
         // so they survive reboots. Derive the latestMessage cache entry from the stored result.
         inkhud->persistence->latestMessage.dm = messageStore.addFromPacket(*packet);
+    } else if (packet->decoded.portnum == meshtastic_PortNum_TEXT_MESSAGE_APP) {
+        // Persist incoming text broadcasts for every channel; ThreadedMessageApplet stores
+        // outgoing only, so no double-store (outgoing on applet-less channels stays a known gap).
+        inkhud->persistence->latestMessage.broadcast = messageStore.addFromPacket(*packet);
     } else {
-        // Broadcasts are added to the global store by ThreadedMessageApplet::handleReceived().
-        // Here we only update the latestMessage cache used by AllMessageApplet / NotificationApplet.
+        // Non-text broadcasts (detection/alert/range test, see isTextPayload) update only the
+        // transient cache, never persistent history - avoids range-test traffic evicting messages.
         StoredMessage &sm = inkhud->persistence->latestMessage.broadcast;
         sm.sender = packet->from;
         sm.timestamp = getValidTime(RTCQuality::RTCQualityDevice, true);

--- a/src/graphics/niche/InkHUD/docs/README.md
+++ b/src/graphics/niche/InkHUD/docs/README.md
@@ -496,8 +496,10 @@ We keep this separate latest-message cache for this purpose, because:
 
 Broadcasts and DMs take different paths into `messageStore`:
 
-- **Broadcasts** - `ThreadedMessageApplet::handleReceived()` calls `messageStore.addFromPacket()`. `Events::onReceiveTextMessage()` then updates `latestMessage.broadcast` separately for fast access by `AllMessageApplet` and `NotificationApplet`.
-- **DMs** - `ThreadedMessageApplet` skips DMs entirely. `Events::onReceiveTextMessage()` calls `messageStore.addFromPacket()` directly and stores the result in `latestMessage.dm`.
+Storage is partitioned by **direction**, so each message is added to `messageStore` exactly once:
+
+- **Incoming text (DMs and broadcasts)** - stored centrally by `Events::onReceiveTextMessage()` via `messageStore.addFromPacket()`, for *every* channel (not just the channels that happen to have a `ThreadedMessageApplet`). The result is also cached in `latestMessage.dm` / `latestMessage.broadcast` for fast access by `AllMessageApplet` and `NotificationApplet`. Non-text broadcasts that reach this observer (detection sensor, alert, range test - see `MeshService::isTextPayload`) update only the transient cache and are deliberately *not* persisted.
+- **Outgoing / loopback broadcasts** (e.g. canned messages generated on this node) - `Events` short-circuits outgoing messages, so these are stored by `ThreadedMessageApplet::handleReceived()` instead. `ThreadedMessageApplet` only stores outgoing text (incoming is owned by `Events`), which keeps incoming broadcasts on channels 0/1 from being double-stored.
 
 #### Saving / Loading
 
@@ -610,7 +612,7 @@ Applets themselves do also listen separately for various events, but for the pur
 
 #### Text Messages
 
-`Events::onReceiveTextMessage()` is the central handler for all incoming text messages. It updates the `LatestMessage` cache and, for DMs, also adds the message to `messageStore` (since `ThreadedMessageApplet` only handles broadcasts). See `Persistence::LatestMessage` for details on how the two message types are stored.
+`Events::onReceiveTextMessage()` is the central handler for all incoming text messages. It updates the `LatestMessage` cache and adds incoming text messages (both DMs and broadcasts, on every channel) to `messageStore`. `ThreadedMessageApplet` handles only our own outgoing/loopback broadcasts, so nothing is double-stored. See `Persistence::LatestMessage` for details on how the two message types are stored.
 
 #### Buttons
 


### PR DESCRIPTION
## Summary

InkHUD instantiates a `ThreadedMessageApplet` only for channels 0 and 1 (hardcoded in every `variants/*/nicheGraphics.h`), and those applets were the only path storing **incoming broadcasts** into the shared global `messageStore`. As a result, broadcasts on any other channel (2–7), or on channel 1 while its applet is inactive (`defaultActive=false`, or disabled via the menu), were never persisted — they existed only in the transient `latestMessage` cache and were lost on reboot / absent from message history. DMs were unaffected (already stored directly by `Events::onReceiveTextMessage`).

## Fix

Move persistent storage of incoming **text** broadcasts into `Events::onReceiveTextMessage` — the single InkHUD text-message observer, which is invoked for every channel regardless of which applets exist — mirroring how DMs are already stored there. `ThreadedMessageApplet::handleReceived` now stores only our own **outgoing/loopback** messages (which `Events` short-circuits at the top), so incoming broadcasts on channels 0/1 are not double-stored.

Storage is now partitioned by **direction** (Events = incoming, applet = outgoing), which are disjoint sets, so exactly one `addFromPacket` runs per message.

Only `TEXT_MESSAGE_APP` broadcasts are persisted. Other ports that also reach the text observer via `MeshService::isTextPayload` (detection sensor, alert, range test) continue to update only the transient cache, so periodic range-test traffic can't evict real message history.

Docs (`src/graphics/niche/InkHUD/docs/README.md`) updated to match the direction-partitioned flow.

**Changed files**
- `src/graphics/niche/InkHUD/Events.cpp`
- `src/graphics/niche/InkHUD/Applets/User/ThreadedMessage/ThreadedMessageApplet.cpp`
- `src/graphics/niche/InkHUD/docs/README.md`

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)

**Testing status — please read:** I do not currently have an InkHUD e-ink device, so per the contributing guidance I'm flagging this for community testing rather than claiming hardware verification. What has been done:

- **Compile-verified**: builds clean for `t-echo-inkhud` (nRF52840), no errors/warnings on the changed files.
- **Logic-reviewed**: traced all four `addFromPacket` call sites and the observer/module wiring to confirm no double-store and no new missing-store, and that non-text ports (detection sensor / alert / range test) are excluded from persistence.
- I could not run `trunk fmt` locally (tooling unavailable in my environment); happy to push a formatting fixup if CI flags anything.

Testing help on any InkHUD e-ink variant (t-echo, Heltec Vision Master E213, T114-InkHUD, etc.) would be appreciated — specifically:
1. Send a broadcast on a channel with index ≥ 2, reboot, and confirm it now appears in message history.
2. Confirm channel 0/1 broadcasts are **not** duplicated.
3. Confirm detection-sensor / alert / range-test broadcasts do **not** flood the stored message history.

Allow edits by maintainers is enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate broadcast entries by changing what gets added to message history.
  * Text messages are now persisted through the main receive path, while other broadcast types update only the transient latest-message state.
  * Kept auto-show and notification behavior consistent for incoming messages.

* **Documentation**
  * Updated the InkHUD README to describe the new direction-partitioned persistence flow for outgoing/loopback versus incoming text and non-text broadcasts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->