### PR TITLE
Reduce heap usage on ST7789 display targets with reduced-memory mode

### DIFF
--- a/variants/esp32s3/heltec_vision_master_t190/platformio.ini
+++ b/variants/esp32s3/heltec_vision_master_t190/platformio.ini
@@ -17,6 +17,7 @@ build_flags =
   ${esp32s3_base.build_flags} 
   -I variants/esp32s3/heltec_vision_master_t190
   -D HELTEC_VISION_MASTER_T190
+  -DOLEDDISPLAY_REDUCE_MEMORY
 lib_deps =
   ${esp32s3_base.lib_deps}
   # renovate: datasource=git-refs depName=meshtastic-st7789 packageName=https://github.com/meshtastic/st7789 gitBranch=main

--- a/variants/esp32s3/m5stack_cardputer_adv/platformio.ini
+++ b/variants/esp32s3/m5stack_cardputer_adv/platformio.ini
@@ -10,6 +10,7 @@ build_flags =
   -D M5STACK_CARDPUTER_ADV
   -D ARDUINO_USB_CDC_ON_BOOT=1
   -I variants/esp32s3/m5stack_cardputer_adv
+  -DOLEDDISPLAY_REDUCE_MEMORY
 lib_deps =
   ${esp32s3_base.lib_deps}
   # renovate: datasource=git-refs depName=meshtastic-st7789 packageName=https://github.com/meshtastic/st7789 gitBranch=main

--- a/variants/nrf52840/heltec_mesh_node_t114/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_node_t114/platformio.ini
@@ -18,6 +18,7 @@ debug_tool = jlink
 build_flags = ${nrf52840_base.build_flags}
   -Ivariants/nrf52840/heltec_mesh_node_t114
   -DHELTEC_T114
+  -DOLEDDISPLAY_REDUCE_MEMORY
 
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/heltec_mesh_node_t114>
 lib_deps = 

--- a/variants/nrf52840/heltec_mesh_solar/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_solar/platformio.ini
@@ -107,6 +107,7 @@ extends = heltec_mesh_solar_base
 build_flags = ${heltec_mesh_solar_base.build_flags}
   -DHELTEC_MESH_SOLAR_TFT
   -DSPI_INTERFACES_COUNT=2
+  -DOLEDDISPLAY_REDUCE_MEMORY
   -DHAS_SPI_TFT=1
   -DUSE_ST7789
   -DST7789_NSS=41


### PR DESCRIPTION
## Summary

This PR enables the `meshtastic-st7789` driver's reduced-memory mode on the ST7789-based targets that use it today:

- `heltec-mesh-node-t114`
- `heltec-vision-master-t190`
- `m5stack-cardputer-adv`
- `heltec-mesh-solar-tft`

The change is limited to PlatformIO env flags:

- `-DOLEDDISPLAY_REDUCE_MEMORY`

## Why

Runtime heap usage on larger ST7789 displays is heavily impacted by the driver's display buffering. On the T114, the display path was the main reason heap usage was so high.

These targets all use the same `meshtastic-st7789` driver, which already supports a lower-memory mode. 

## Expected impact

This should reduce runtime heap by removing the extra ST7789 backbuffer used by these targets.

Approximate savings by panel size:

- `320x240`: about `9.6 KB`
- `320x170`: about `7.0 KB`
- `240x135`: about `4.1 KB`

No intended UI or feature changes beyond using less heap.

## Testing

Verified locally:

- `platformio run -e heltec-mesh-node-t114`

The other targets were updated in the same way because they use the same ST7789 driver path and reduced-memory flag.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled lower-memory display handling on several device variants, helping firmware run more efficiently on supported OLED-based builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->