### PR TITLE
Fix MQTT reconnect handling on SPI Ethernet builds

### DIFF
--- a/src/mesh/udp/UdpMulticastHandler.h
+++ b/src/mesh/udp/UdpMulticastHandler.h
@@ -33,6 +33,8 @@ class UdpMulticastHandler final
 #if defined(ARCH_NRF52) || defined(ARCH_PORTDUINO)
             LOG_DEBUG("UDP Listening on IP: %u.%u.%u.%u:%u", udpIpAddress[0], udpIpAddress[1], udpIpAddress[2], udpIpAddress[3],
                       UDP_MULTICAST_DEFAUL_PORT);
+#elif defined(USE_WS5500) || defined(USE_CH390D)
+            LOG_DEBUG("UDP Listening on IP: %s", ETH.localIP().toString().c_str());
 #else
             LOG_DEBUG("UDP Listening on IP: %s", WiFi.localIP().toString().c_str());
 #endif
@@ -96,6 +98,10 @@ class UdpMulticastHandler final
         }
 #if defined(ARCH_NRF52)
         if (!isEthernetAvailable()) {
+            return false;
+        }
+#elif defined(USE_WS5500) || defined(USE_CH390D)
+        if (!ETH.connected()) {
             return false;
         }
 #elif !defined(ARCH_PORTDUINO)

--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -563,6 +563,11 @@ static void WiFiEvent(WiFiEvent_t event)
         break;
     case ARDUINO_EVENT_ETH_DISCONNECTED:
         syslog.disable();
+#if HAS_UDP_MULTICAST
+        if (udpHandler) {
+            udpHandler->stop();
+        }
+#endif
         LOG_INFO("Ethernet disconnected");
         break;
     case ARDUINO_EVENT_ETH_GOT_IP:

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -470,8 +470,16 @@ void MQTT::reconnect()
             reconnectCount++;
             LOG_ERROR("Failed to contact MQTT server directly (%d/%d)", reconnectCount, reconnectMax);
             if (reconnectCount >= reconnectMax) {
+#if defined(USE_WS5500) || defined(USE_CH390D)
+                LOG_WARN("MQTT connect failed repeatedly; waiting for Ethernet reconnect");
+#else
                 needReconnect = true;
-                wifiReconnect->setIntervalFromNow(0);
+                if (wifiReconnect) {
+                    wifiReconnect->setIntervalFromNow(0);
+                } else {
+                    LOG_WARN("MQTT connect failed repeatedly, but WiFi reconnect is unavailable");
+                }
+#endif
                 reconnectCount = 0;
             }
 #endif


### PR DESCRIPTION
## Summary

This PR fixes Ethernet-specific MQTT reconnect handling for SPI Ethernet builds (`USE_WS5500` / `USE_CH390D`).

When the direct MQTT connection failed repeatedly, the MQTT reconnect path always triggered the WiFi reconnect scheduler after `reconnectMax` failures. That behavior makes sense for WiFi builds, but it is wrong for Ethernet-only or SPI Ethernet boards: there is no WiFi link to recover, and forcing the WiFi reconnect path can destabilize the network stack instead of waiting for Ethernet link recovery.

The change keeps the existing WiFi behavior intact, but for W5500/CH390 Ethernet builds it stops trying to recover MQTT by scheduling WiFi reconnects. Instead, MQTT logs that it is waiting for Ethernet recovery.

## Problem

On an ESP32-S3 + W5500 gateway, MQTT failures could lead to Ethernet instability and repeated spontaneous reboots. The observed chain was:
- MQTT direct connection starts failing
- firmware reaches repeated `Failed to contact MQTT server directly` retries
- generic reconnect handling schedules a WiFi reconnect path
- on an Ethernet build this is not the correct recovery mechanism
- the node eventually drops Ethernet/MQTT activity and may reboot

This is related to older WiFi/MQTT reports where MQTT failures trigger network reconnect behavior:
- Refs #2796
- Refs #3029
- Refs #5198
- Refs #3031

Those reports are WiFi-focused, so this PR does not claim to fix them directly. It fixes the Ethernet-specific case where that same MQTT failure path should not schedule WiFi reconnects.

This may also be relevant to Ethernet gateway reports like:

- May help with #10335, but that issue still needs logs to confirm the exact failure mode.

## Changes

- Avoid scheduling `wifiReconnect` after repeated MQTT connection failures on W5500/CH390 Ethernet builds.
- Keep the existing WiFi reconnect behavior for WiFi builds.
- Add a null guard around `wifiReconnect` for non-Ethernet builds.
- Stop the UDP multicast handler when Ethernet disconnects.
- Use Ethernet link state for UDP multicast send checks on W5500/CH390 builds.
- Log the Ethernet IP address for UDP multicast startup instead of using the WiFi IP on SPI Ethernet builds.

## Testing

Tested on a custom ESP32-S3 + E22 + W5500 gateway.

Validation performed:
- Built and flashed the firmware successfully.
- Monitored serial logs after the fix.
- Ran a 30 minute stability check after flashing.
- Ran an additional 1 hour serial monitoring session.

Results:
- No `Guru Meditation`
- No panic/assert/watchdog/brownout
- No spontaneous reboot observed during the final 1 hour run
- No `Failed to contact MQTT server directly` during the final 1 hour run
- No `Ethernet disconnected` during the final 1 hour run
- MQTT continued publishing packets
- Device uptime continued increasing normally

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other: custom ESP32-S3 + E22 + W5500 Ethernet gateway


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multicast and MQTT connection handling on Ethernet-based builds, reducing failed sends and reconnect loops when the network link is down.
  * Multicast listening now reports the correct interface IP on supported Ethernet hardware.
  * Ethernet disconnects now stop multicast activity more reliably when enabled.
  * MQTT reconnect behavior now better reflects whether Ethernet or Wi‑Fi recovery is actually available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->