### PR TITLE
nrf52840: right-size the SoftDevice RAM reservation (+8 KB heap arena)

### DIFF
--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -4,6 +4,7 @@
 #include "HardwareRNG.h"
 #include "PowerFSM.h"
 #include "configuration.h"
+#include "error.h"
 #include "main.h"
 #include "mesh/PhoneAPI.h"
 #include "mesh/mesh-pb-constants.h"
@@ -275,7 +276,16 @@ void NRF52Bluetooth::setup()
     LOG_INFO("Init the Bluefruit nRF52 module");
     Bluefruit.autoConnLed(false);
     Bluefruit.configPrphBandwidth(BANDWIDTH_MAX);
-    Bluefruit.begin();
+    if (!Bluefruit.begin()) {
+        // sd_ble_enable() rejected our RAM base: the linker RAM ORIGIN
+        // (src/platform/nrf52/nrf52840_s140_v*.ld) is below what the SoftDevice needs for the
+        // current Bluefruit config. Without this check the node would silently run without BLE.
+        // Rebuild with -DCFG_DEBUG=1 to get "SoftDevice's RAM requires: 0x..." in the log, then
+        // raise the ORIGIN accordingly.
+        LOG_ERROR("Bluefruit.begin failed - SoftDevice RAM reservation too small for this config");
+        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_UNSPECIFIED);
+        return;
+    }
     // Clear existing data.
     Bluefruit.Advertising.stop();
     Bluefruit.Advertising.clearData();

--- a/src/platform/nrf52/nrf52840_s140_v6.ld
+++ b/src/platform/nrf52/nrf52840_s140_v6.ld
@@ -21,8 +21,17 @@ MEMORY
    * - Max ATT MTU
    * - Concurrent connection peripheral + central + secure links
    * - Event Len, HVN queue, Write CMD queue
+   *
+   * With our fixed Bluefruit config (1 peripheral link, BANDWIDTH_MAX / MTU 247,
+   * 0x1000 attr table) sd_ble_enable() reports a requirement well below the old
+   * 0x20006000 ORIGIN; every byte of gap is unusable RAM. 0x20004000 keeps a
+   * ~2+ KB margin over the reported base. NRF52Bluetooth::setup() now checks
+   * Bluefruit.begin() and records a critical error if the SoftDevice ever
+   * rejects this base (e.g. after an SD/Bluefruit config change) - re-measure
+   * with CFG_DEBUG=1 (Bluefruit logs "SoftDevice's RAM requires: 0x...")
+   * before raising bandwidth/MTU/link settings.
    */
-  RAM (rwx) :  ORIGIN = 0x20006000, LENGTH = 0x20040000 - 0x20006000
+  RAM (rwx) :  ORIGIN = 0x20004000, LENGTH = 0x20040000 - 0x20004000
 }
 
 SECTIONS

--- a/src/platform/nrf52/nrf52840_s140_v7.ld
+++ b/src/platform/nrf52/nrf52840_s140_v7.ld
@@ -18,8 +18,17 @@ MEMORY
    * - Max ATT MTU
    * - Concurrent connection peripheral + central + secure links
    * - Event Len, HVN queue, Write CMD queue
-   */ 
-  RAM (rwx) :  ORIGIN = 0x20006000, LENGTH = 0x20040000 - 0x20006000
+   *
+   * With our fixed Bluefruit config (1 peripheral link, BANDWIDTH_MAX / MTU 247,
+   * 0x1000 attr table) sd_ble_enable() reports a requirement well below the old
+   * 0x20006000 ORIGIN; every byte of gap is unusable RAM. 0x20004000 keeps a
+   * ~2+ KB margin over the reported base. NRF52Bluetooth::setup() now checks
+   * Bluefruit.begin() and records a critical error if the SoftDevice ever
+   * rejects this base (e.g. after an SD/Bluefruit config change) - re-measure
+   * with CFG_DEBUG=1 (Bluefruit logs "SoftDevice's RAM requires: 0x...")
+   * before raising bandwidth/MTU/link settings.
+   */
+  RAM (rwx) :  ORIGIN = 0x20004000, LENGTH = 0x20040000 - 0x20004000
 }
 
 SECTIONS


### PR DESCRIPTION
Part of the heap-recovery series (#10898, #10901, #10900, #10899, #10902).

## Problem

Both nrf52840 linker scripts hard-code the app RAM ORIGIN at `0x20006000` — a 24 KB SoftDevice reservation dating to their introduction. `sd_ble_enable()` computes the *actual* requirement from the Bluefruit configuration (one peripheral link, `BANDWIDTH_MAX`/MTU 247, `0x1000` attribute table) and it is substantially below that. The SoftDevice can't use the gap and the app is linked above it, so the difference is pure waste — on the platform where 2.8.0 field reports show the heap arena (which on this BSP is exactly the linker gap) at 99% use.

## Change

- `RAM ORIGIN 0x20006000 → 0x20004000` in both `nrf52840_s140_v6.ld` and `nrf52840_s140_v7.ld`.
- `Bluefruit.begin()`'s return value — previously discarded — is now checked: if a future SoftDevice/Bluefruit config bump raises the requirement past the reservation, the node records a **critical error with instructions** instead of silently running without BLE.

## Measured effect

**+8,192 B of heap arena on every nRF52840 board**, BT on or off:

| Build | `.heap` section | `.data` addr |
|---|---|---|
| rak4631 (S140 v6 script) develop | 124,572 B | 0x20006000 |
| rak4631 this PR | **132,764 B** | 0x20004000 |
| tracker-t1000-e (S140 v7 script) this PR | links clean | 0x20004000 |

## Hardware validation (rak4631, S140 6.1.1)

Measured the actual SoftDevice requirement via `CFG_DEBUG=1`:

```
[CFG] SoftDevice's RAM requires: 0x200038A0
```

| | Address | vs. SD floor |
|---|---|---|
| SoftDevice requirement (floor) | `0x200038A0` | — |
| Old ORIGIN | `0x20006000` | +10,080 B wasted |
| **This PR** | `0x20004000` | **+1,888 B (1.84 KB) margin** ✅ |

`0x20004000` reclaims the full +8 KB while keeping a ~1.8 KB margin for SD-version/config variance across the v6/v7 fleet. (Measurement also ruled out tightening to `0x20003800`, which would sit **below** the 0x200038A0 floor.) BLE bring-up confirmed on the new base: `Init Bluefruit → services (DIS/BAS/Mesh) → Advertise`, `Bluefruit.begin()` returns success (the new critical-error guard never fires), client reconnects over serial; a v7-script board links at the new base too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth startup reliability by detecting initialization failures early and stopping setup cleanly when Bluetooth cannot start.
  * Updated device memory settings to better match Bluetooth requirements, which should help avoid startup issues and improve available memory headroom.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->