### PR TITLE
feat(power): allow overriding ADC_CTRL settle delay per variant

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -314,7 +314,7 @@ void battery_adcEnable()
     digitalWrite(ADC_CTRL, ADC_CTRL_ENABLED);
 #endif
 #endif
-    delay(10);
+    delay(ADC_CTRL_SETTLE_MS);
 #endif
 }
 

--- a/src/Power.h
+++ b/src/Power.h
@@ -30,6 +30,11 @@
 #define NUM_CELLS 1
 #endif
 
+// Override in variant.h for boards with a larger BATTERY_PIN filter capacitor
+#ifndef ADC_CTRL_SETTLE_MS
+#define ADC_CTRL_SETTLE_MS 10
+#endif
+
 #if HAS_TELEMETRY && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
 #include "modules/Telemetry/Sensor/nullSensor.h"
 #if __has_include(<Adafruit_INA219.h>)


### PR DESCRIPTION
## Summary

`battery_adcEnable()` hardcodes a 10ms delay between enabling the `ADC_CTRL`-gated voltage divider and reading it, assuming every board's RC filter settles within that window. A board with a larger filter capacitor needs longer, and previously had no way to declare that — its readings would be taken before the divider settled.

Adds an opt-in `ADC_CTRL_SETTLE_MS` override, defaulting to 10ms.

## Regression scope

No functional change for any existing board — this is just turning a hardcoded constant into an overridable macro, defaulting to the same 10ms as before.

## Testing

Build-verified on every board defining `ADC_CTRL`. Hardware-verified (flash/boot/battery reading) on a new RAK3172-based board overriding this to 40ms for its 100nF filter capacitor.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other: build-only for all `ADC_CTRL`-defining boards; hardware-tested on a new RAK3172-based board.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the battery voltage reading startup delay to use a configurable settle time instead of a fixed wait.
  * Added a default settle-time setting for devices that don’t define their own value, improving compatibility across boards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->