### PR TITLE
trunk: ignore branding/ dir

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -36,6 +36,7 @@ lint:
     - linters: [ALL]
       paths:
         - bin/**
+        - branding/**
 runtimes:
   enabled:
     - python@3.14.4


### PR DESCRIPTION
Trunk loves to complain about svgs and pngs in `branding/`. Make it stop!

This should also be cherrypicked to `develop`.