### PR TITLE
update SenseCAP Indicator arduino-esp32 fork to 3.3.9

### DIFF
--- a/variants/esp32s3/seeed-sensecap-indicator/platformio.ini
+++ b/variants/esp32s3/seeed-sensecap-indicator/platformio.ini
@@ -14,7 +14,7 @@ custom_meshtastic_has_mui = true
 extends = esp32s3_base
 platform_packages =
   ; Version needs to match the pioarduino version used in esp32_common.ini
-  platformio/framework-arduinoespressif32 @ https://github.com/mverch67/arduino-esp32#82aee17619ea2940de03b0db4d082d5def657771
+  platformio/framework-arduinoespressif32 @ https://github.com/mverch67/arduino-esp32#c96df236ce132368f893e4d6cbb315831ea842d7 ; 3.3.9
 
 board = seeed-sensecap-indicator
 board_check = true


### PR DESCRIPTION
see title, SenseCAP Indicator arduino-esp32 version must match esp-common.ini

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] Seeed SenseCAP Indicator


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a pinned platform framework reference to a newer revision.
  * This should help keep builds aligned with the latest supported toolchain version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->