### PR TITLE
Re-enable wantresponse and other fields in simradio when on the decoded path

### DIFF
--- a/src/platform/portduino/SimRadio.cpp
+++ b/src/platform/portduino/SimRadio.cpp
@@ -252,7 +252,17 @@ void SimRadio::startSend(meshtastic_MeshPacket *txp)
 
     // pb_encode_to_bytes writes into decoded.payload, which aliases `encrypted` in the union, so all
     // reads of p->encrypted above must be complete before this point.
-    p->decoded = meshtastic_Data_init_zero;
+    if (carryEncrypted) {
+        // On the encrypted path, `decoded` aliases the ciphertext we just copied into c.data;
+        // the remaining `Data` fields hold ciphertext bytes that would serialize as spurious
+        // wire fields. Clear the whole struct before reusing `decoded.payload.bytes` for the
+        // Compressed wrapper.
+        p->decoded = meshtastic_Data_init_zero;
+    }
+    // On the decoded path, `p->decoded` is already a valid Data from perhapsDecode(); only
+    // `payload` and `portnum` need replacing. The remaining fields (want_response, request_id,
+    // reply_id, bitfield, ...) must be preserved — they travel on the outer MeshPacket through
+    // the sim loopback and are NOT restored by unpackAndReceive() on the far end.
     p->which_payload_variant = meshtastic_MeshPacket_decoded_tag;
     p->decoded.payload.size =
         pb_encode_to_bytes(p->decoded.payload.bytes, sizeof(p->decoded.payload.bytes), &meshtastic_Compressed_msg, &c);

--- a/src/platform/portduino/SimRadio.cpp
+++ b/src/platform/portduino/SimRadio.cpp
@@ -255,14 +255,11 @@ void SimRadio::startSend(meshtastic_MeshPacket *txp)
     if (carryEncrypted) {
         // On the encrypted path, `decoded` aliases the ciphertext we just copied into c.data;
         // the remaining `Data` fields hold ciphertext bytes that would serialize as spurious
-        // wire fields. Clear the whole struct before reusing `decoded.payload.bytes` for the
-        // Compressed wrapper.
+        // wire fields, so clear the struct.
         p->decoded = meshtastic_Data_init_zero;
     }
-    // On the decoded path, `p->decoded` is already a valid Data from perhapsDecode(); only
-    // `payload` and `portnum` need replacing. The remaining fields (want_response, request_id,
-    // reply_id, bitfield, ...) must be preserved — they travel on the outer MeshPacket through
-    // the sim loopback and are NOT restored by unpackAndReceive() on the far end.
+    // On the decoded path, `p->decoded` is already a valid Data from perhapsDecode(),
+    // so retain the existing fields (want_response, request_id, bitfield, etc.)
     p->which_payload_variant = meshtastic_MeshPacket_decoded_tag;
     p->decoded.payload.size =
         pb_encode_to_bytes(p->decoded.payload.bytes, sizeof(p->decoded.payload.bytes), &meshtastic_Compressed_msg, &c);


### PR DESCRIPTION
This was regressed by Copilot due to https://github.com/meshtastic/firmware/pull/10730/changes/c92e69df63f0d912e91066a89bdce41dcbcef5fe#r3420608957

My machine's assessment suggests that this change was & is correct on the `carryEncrypted` branch added by that PR (https://github.com/meshtastic/firmware/pull/10730) generally, but on the existing side it clears out all the fields on the SIMULATOR_APP packet that are needed -- want_response is the one that mattered for my testing (running traceroutes over a simulated network) but other fields are also cleared by it.

Let me know if the machine has been too verbose in the commenting, heh.

Found due to work on https://github.com/meshtastic/python/pull/946

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Portduino (native-tft)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed simulator loopback so decoded packet details are only cleared for encrypted transmissions; non-encrypted sends now preserve previously decoded fields instead of unintentionally resetting them.
  * Improved consistency of how simulator packets are prepared before receive handling, resulting in more accurate message fields during simulation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->