### PR TITLE
fix(nrf52): enable USB/charge detection on Seeed Wio Tracker L1

### DIFF
--- a/variants/nrf52840/seeed_wio_tracker_L1/variant.h
+++ b/variants/nrf52840/seeed_wio_tracker_L1/variant.h
@@ -112,6 +112,8 @@ static const uint8_t SCL = PIN_WIRE_SCL;
 #define ADC_MULTIPLIER 2.0
 #define BATTERY_PIN PIN_VBAT // PIN_A7
 #define AREF_VOLTAGE 3.6
+// We rely on the nrf52840 USB controller to tell us if we are hooked to a power supply
+#define NRF_APM
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 //  GPS L76KB
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### PR DESCRIPTION
`isCharging()`/`getHasUSB()` are hard-compiled to always return `false` on the Seeed Wio Tracker L1: the `nrfx_power_usbstatus_get()` detection block in `Power.cpp` is gated behind `#ifdef NRF_APM`, and this board's `variant.h` never defined it — unlike `tracker-t1000-e` and `wio-tracker-wm1110`, which do.

Same gap as #4367, fixed for those two boards in #4376 (which also fixed a deeper bug where `PowerStatus` notifications were gated behind a battery-level null check — that part is already fixed generically in `Power.cpp` today, so this board only needed the define). Looks like an oversight from when this board was added, since it's newer than the two boards #4376 touched.

Confirmed on hardware, with a battery attached and connected to USB, isolated from any other change (built and flashed from this branch alone, on top of `develop`):
- Before this change: `Battery: usbPower=0, isCharging=0, batMv=..., batPct=...` regardless of actual power state.
- After: `Battery: usbPower=1, isCharging=1, batMv=4159, batPct=97` while genuinely on USB power.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other: hardware flash+boot on **Seeed Wio Tracker L1** (the board this PR touches) — boots clean, no regressions, and confirms the fix end-to-end (see above).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved power-detection behavior for the Seeed Wio Tracker L1 on nRF52840 boards, helping the device better recognize when it is connected to external power.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->