### PR TITLE
nrf52: fix loop-task stack overflow causing reset on BLE pairing/first-sync

### DIFF
--- a/src/platform/nrf52/main-nrf52.cpp
+++ b/src/platform/nrf52/main-nrf52.cpp
@@ -378,7 +378,11 @@ void nrf52Setup()
     pinMode(ADC_V, INPUT);
 #endif
 
-    uint32_t why = NRF_POWER->RESETREAS;
+    // The Adafruit core's init() (cores/nRF5/wiring.c) caches RESETREAS into a static and then
+    // W1C-clears the hardware register before setup() ever runs, so a raw NRF_POWER->RESETREAS
+    // read here is ALWAYS 0. Use the core's cached copy so this log line is actually meaningful
+    // (0x1 pin reset, 0x2 watchdog, 0x4 soft reset/SREQ, 0x8 CPU lockup, 0x10000 System OFF wake).
+    uint32_t why = readResetReason();
     // per
     // https://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.nrf52832.ps.v1.1%2Fpower.html
     LOG_DEBUG("Reset reason: 0x%x", why);

--- a/variants/nrf52840/nrf52.ini
+++ b/variants/nrf52840/nrf52.ini
@@ -23,6 +23,13 @@ build_flags =
   ${arduino_base.build_flags}
   -Wno-unused-variable
   -Isrc/platform/nrf52
+  ; The Arduino loop task runs the entire cooperative OSThread scheduler; the core's stock
+  ; 4 KB (1024-word) stack overflows during BLE first-sync (admin config-apply -> radio
+  ; reconfigure with XEdDSA/satmap/log frames stacked) - SWD-proven on T1000-E: SP driven
+  ; 40 B below pxStack, corrupting adjacent heap -> silent HardFault reset on phone pairing.
+  ; 2048 words = 8 KB, validated on hardware. Value is in WORDS; requires the #ifndef guard
+  ; from meshtastic/Adafruit_nRF52_Arduino#7 (harmless redefinition warning until it merges).
+  -DLOOP_STACK_SZ=2048
   -DLFS_NO_ASSERT                      ; Disable LFS assertions , see https://github.com/meshtastic/firmware/pull/3818
   -DMESHTASTIC_EXCLUDE_AUDIO=1
   -DMESHTASTIC_EXCLUDE_PAXCOUNTER=1


### PR DESCRIPTION
Fixes the 2.8 nRF52 crash where devices silently reset seconds after a phone connects/pairs (tracked in field reports as a T1000-E "bootloop on BLE connect"; also reproduced deterministically with `set_time_only` on an empty-DB node).

## Root cause — SWD-proven

The Arduino loop task runs Meshtastic's entire cooperative OSThread scheduler on the Adafruit core's stock **4 KB (1024-word) stack** (`LOOP_STACK_SZ`, previously not overridable). The 2.8 first-sync window stacks the deepest excursion:

```
AdminModule::handleSetConfig      (phone's routine config push on connect)
 └ saveChanges → configChanged → RadioInterface::reloadConfig
   └ LR11x0Interface::reconfigure → setStandby → SPIwriteStream
     └ LockingArduinoHal::spiBeginTransaction → concurrency::Lock::lock()
       └ xQueueSemaphoreTake(<corrupted handle>) → BusFault
```
…with `_vsnprintf_r` / USB-CDC logging frames interleaved on the same stack.

A hardware fault capture (RAKDAP + `pyocd vector_catch=h`, T1000-E, 100 % repro) showed:
- loop task **SP 40 bytes below its own `pxStack` base**; stack paint (`0xa5a5a5a5`) consumed to the floor
- the fatal dereference was a FreeRTOS semaphore handle overwritten by adjacent-heap corruption with **log-line text** (`0x3f3f207c` = `"| ??"`)
- `CFSR=0x8200` (precise BusFault), `BFAR = handle+0x38`

The core's HardFault handler is a bare `NVIC_SystemReset`, so in the field this is a **silent instant reboot** (log severed mid-line); when the corruption lands on task TCBs instead, it's a 30 s zombie hang ending in a supervision-timeout `0x8` disconnect. 2.7.26 is unaffected because the deep frames (XEdDSA signing, satellite-map conversion, replay engine) didn't exist yet.

## Fix

- `-DLOOP_STACK_SZ=2048` (words = **8 KB**) for all nrf52840 targets. Validated on hardware: pairing + full sync completes; stack paint shows healthy margin under live BLE load.
- **Depends on** meshtastic/Adafruit_nRF52_Arduino#7 (adds the `#ifndef` guard; merge that first — until then this flag is a harmless macro-redefinition warning with no effect).
- Drive-by fix: the boot `Reset reason:` log has always printed `0x0` because the core's `init()` caches-and-clears `RESETREAS` before `setup()` runs — switched to `readResetReason()`. (`preFSBegin()`'s `RESETREAS==0` gate is deliberately untouched; its degenerate GPREGRET-only behavior is what makes lfs recovery work today.)

RAM cost: 4 KB from the heap arena per nrf52840 device — more than covered by the +8 KB reclaimed in #10903.

## Verification
- `tracker-t1000-e` and `rak4631` build green; `mov.w r2, #2048` confirmed in both binaries
- T1000-E hardware: previously 100 %-reproducible pairing crash gone; full app sync completes and stays connected; fault trap (vector catch) stayed silent through the whole session

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reset logging so device restarts now report a more accurate reset reason.
  * Increased stability during Bluetooth pairing on the nRF52840 by raising the loop-task stack size to prevent silent crashes and unexpected resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->