### PR TITLE
Fixed pin state setup when SX126X_ANT_SW is defined

### DIFF
--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -46,8 +46,8 @@ template <typename T> bool SX126xInterface<T>::init()
 // means this workaround is not necessary.
 #ifdef SX126X_ANT_SW // Perhaps add RADIOLIB_NC check, and beforehand define as such if it is undefined, but it is not commonly
                      // used and not part of the 'default' set of pin definitions.
-    digitalWrite(SX126X_ANT_SW, HIGH);
     pinMode(SX126X_ANT_SW, OUTPUT);
+    digitalWrite(SX126X_ANT_SW, HIGH);
 #endif
 
 #ifdef SX126X_POWER_EN // Perhaps add RADIOLIB_NC check, and beforehand define as such if it is undefined, but it is not commonly

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -72,8 +72,8 @@ template <typename T> bool SX126xInterface<T>::init()
 #if ARCH_PORTDUINO
     tcxoVoltage = (float)portduino_config.dio3_tcxo_voltage / 1000;
     if (portduino_config.lora_sx126x_ant_sw_pin.pin != RADIOLIB_NC) {
-        digitalWrite(portduino_config.lora_sx126x_ant_sw_pin.pin, HIGH);
         pinMode(portduino_config.lora_sx126x_ant_sw_pin.pin, OUTPUT);
+        digitalWrite(portduino_config.lora_sx126x_ant_sw_pin.pin, HIGH);
     }
 #endif
     if (tcxoVoltage == 0.0)


### PR DESCRIPTION
Fixed the order of pinMode and digitalWrite calls if SX126X_ANT_SW is defined.

## 🤝 Attestations

- [V] I have tested that my proposed changes behave as described.
- [V] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
  - Wio-SX1262 for XIAO LoRa Module with the Waweshare ESP32-S3-Zero as the MCU
  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SX126x startup reliability by configuring the antenna switch GPIO correctly before enabling it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->