### PR TITLE
esp32: fix NimBLE use-after-free crash when disabling bluetooth while connected

### DIFF
--- a/src/nimble/NimbleBluetooth.cpp
+++ b/src/nimble/NimbleBluetooth.cpp
@@ -801,13 +801,32 @@ void NimbleBluetooth::deinit()
 {
 #ifdef ARCH_ESP32
     LOG_INFO("Disable bluetooth until reboot");
+
+    // BLEDevice::deinit() deletes the BLEServer before nimble_port_stop(); doing that with a live
+    // connection dispatches synthesized unsubscribe events into the freed server (LoadProhibited),
+    // so disconnect cleanly first. deinit() runs on the main task; the waits below are bounded.
+    if (bluetoothPhoneAPI)
+        bluetoothPhoneAPI->onReadCallbackIsWaitingForData = false; // release any in-flight onRead
+
+    // isDeInit must stay false here, else onDisconnect early-returns without clearing the handle.
+    uint16_t connHandle = nimbleBluetoothConnHandle.load();
+    if (connHandle != BLE_HS_CONN_HANDLE_NONE && bleServer) {
+        bleServer->disconnect(connHandle);
+        uint32_t start = millis();
+        while (nimbleBluetoothConnHandle.load() != BLE_HS_CONN_HANDLE_NONE && millis() - start < 2000)
+            delay(10);
+        delay(50);
+    }
+
     isDeInit = true;
+    pendingStartAdvertising = false; // stack is going away; don't let runOnce retry the adv restart
 
 #ifdef BLE_LED
     digitalWrite(BLE_LED, LED_STATE_OFF);
 #endif
 
     BLEDevice::deinit(true);
+    bleServer = nullptr;             // deleted by deinit(); clear the dangling copy
     BatteryCharacteristic = nullptr; // freed by deinit; clear so updateBatteryLevel() won't touch it
     lastBatteryLevel = -1;
 #endif

--- a/src/nimble/NimbleBluetooth.cpp
+++ b/src/nimble/NimbleBluetooth.cpp
@@ -881,6 +881,12 @@ void NimbleBluetooth::setup()
 
     LOG_INFO("Init the NimBLE bluetooth module");
 
+    // deinit() latches these teardown guards; clear them so a re-init on the same boot (e.g. an
+    // admin disable-bluetooth followed by re-enable) doesn't leave onRead stuck draining or
+    // onDisconnect early-returning without clearing the connection handle.
+    bleDraining = false;
+    isDeInit = false;
+
 #ifdef ARCH_ESP32
     // Runs before BLEDevice::init() reads the bond store, but logs after the "Init" line above so
     // any bond-cleanup output doesn't appear to precede the module init.

--- a/src/nimble/NimbleBluetooth.cpp
+++ b/src/nimble/NimbleBluetooth.cpp
@@ -8,6 +8,7 @@
 #include "concurrency/OSThread.h"
 #include "main.h"
 #include "mesh/PhoneAPI.h"
+#include "mesh/Throttle.h"
 #include "mesh/mesh-pb-constants.h"
 #include "sleep.h"
 #include <BLE2904.h>
@@ -106,6 +107,10 @@ static std::atomic<uint16_t> nimbleBluetoothConnHandle{BLE_HS_CONN_HANDLE_NONE};
 // triggers a MIC failure + NimBLE host reset; re-entering ble_gap_adv_* from the disconnect
 // callback while the host is mid-reset crashes (LoadProhibited), so the main task does it instead.
 static std::atomic<bool> pendingStartAdvertising{false};
+
+// Set by deinit() before it disconnects. Makes onRead bail immediately instead of arming the
+// up-to-20s wait, so a read arriving mid-teardown can't pin the NimBLE task and stall the disconnect.
+static std::atomic<bool> bleDraining{false};
 
 static void clearPairingDisplay()
 {
@@ -541,14 +546,18 @@ class NimbleBluetoothFromRadioCallback : public BLECharacteristicCallbacks
 #ifdef DEBUG_NIMBLE_ON_READ_TIMING
             LOG_DEBUG("BLE onRead(%d): packet already waiting, no need to set onReadCallbackIsWaitingForData", currentReadCount);
 #endif
-        } else {
+        } else if (!bleDraining) {
+            // (If deinit() is tearing the stack down, skip the wait entirely and just return a 0-size
+            // response below - arming the wait here could pin this NimBLE task for ~20s and stall teardown.)
+
             // Tell the main task that we'd like a packet.
             bluetoothPhoneAPI->onReadCallbackIsWaitingForData = true;
 
             // Wait for the main task to produce a packet for us, up to about 20 seconds.
             // It normally takes just a few milliseconds, but at initial startup, etc, the main task can get blocked for longer
             // doing various setup tasks.
-            while (bluetoothPhoneAPI->onReadCallbackIsWaitingForData && tries < 4000) {
+            // bleDraining lets deinit() release an in-flight wait immediately.
+            while (bluetoothPhoneAPI->onReadCallbackIsWaitingForData && !bleDraining && tries < 4000) {
                 // Schedule the main task runOnce to run ASAP.
                 bluetoothPhoneAPI->setIntervalFromNow(0);
                 concurrency::mainDelay.interrupt(); // wake up main loop if sleeping
@@ -805,6 +814,9 @@ void NimbleBluetooth::deinit()
     // BLEDevice::deinit() deletes the BLEServer before nimble_port_stop(); doing that with a live
     // connection dispatches synthesized unsubscribe events into the freed server (LoadProhibited),
     // so disconnect cleanly first. deinit() runs on the main task; the waits below are bounded.
+    // bleDraining must be set before we clear the flag / disconnect, so a read arriving now bails
+    // instead of re-arming the ~20s wait and re-pinning the NimBLE task through the whole teardown.
+    bleDraining = true;
     if (bluetoothPhoneAPI)
         bluetoothPhoneAPI->onReadCallbackIsWaitingForData = false; // release any in-flight onRead
 
@@ -813,7 +825,7 @@ void NimbleBluetooth::deinit()
     if (connHandle != BLE_HS_CONN_HANDLE_NONE && bleServer) {
         bleServer->disconnect(connHandle);
         uint32_t start = millis();
-        while (nimbleBluetoothConnHandle.load() != BLE_HS_CONN_HANDLE_NONE && millis() - start < 2000)
+        while (nimbleBluetoothConnHandle.load() != BLE_HS_CONN_HANDLE_NONE && Throttle::isWithinTimespanMs(start, 2000))
             delay(10);
         delay(50);
     }


### PR DESCRIPTION
## Symptom

ESP32-S3 / NimBLE devices `Guru Meditation Error: LoadProhibited` when a config that disables Bluetooth is saved **over BLE while the phone is connected**. Reproduced on a Heltec Wireless Tracker V2 (develop) by saving MQTT module config from the connected app.

```
19:22:27  [Router] Set module config: MQTT
19:22:27  [Router] Disable bluetooth until reboot
19:22:47  [Router] BLE onRead(79): timeout waiting for data after 19920 ms, 4000 tries, giving up
          subscribe event; attr_handle=8, subscribed: false
          Guru Meditation Error: Core 0 panic'ed (LoadProhibited)
  #0 BLEServer::handleGATTServerEvent(ble_gap_event*, void*)
  #4 ble_gatts_subscribe_event  #5 ble_gatts_connection_broken
  #6 ble_gap_conn_broken         #7 ble_gap_rx_disconn_complete
```

## Root cause

`disableBluetooth()` → `NimbleBluetooth::deinit()` called `BLEDevice::deinit(true)` immediately, and the arduino-esp32 BLE wrapper `delete`s the `BLEServer` **before** `nimble_port_stop()`. Stopping the NimBLE port with a live connection makes the host synthesize *unsubscribe* events through `ble_gatts_connection_broken()` and dispatch them into the freed `BLEServer` — the crash is `handleGATTServerEvent` iterating `server->m_notifyChrVec` on freed memory.

It was amplified by our own onRead callback: it pins the NimBLE **host task** in a ≤20 s polling loop waiting for the main task to produce a packet (the `timeout after 19920 ms` line), so the host task couldn't process the teardown until well after the objects beneath it were freed.

## Fix — drain before demolition

`NimbleBluetooth::deinit()` now, before `BLEDevice::deinit(true)`:
1. clears `onReadCallbackIsWaitingForData` so any in-flight onRead returns immediately and the host task is free to run;
2. disconnects the peer and waits (bounded, ~2 s) for the host task to run `onDisconnect` (which clears `nimbleBluetoothConnHandle`), so the unsubscribe/GATT-broken teardown lands on the **still-live** server;
3. only then tears the stack down.

Details that matter: `isDeInit` is raised *after* the drain (`onDisconnect` early-returns when it's set and would otherwise never clear the handle); the deferred advertising restart (`pendingStartAdvertising`) is dropped since the stack is going away (post-deinit `ble_hs_synced()` never returns true and `runOnce` would retry forever); and the now-dangling `bleServer` pointer is nulled so `isActive()` stays honest and a re-entrant `deinit()` can't deref freed memory.

`deinit()` runs on the main task (admin/PowerFSM/menu/sleep; phone writes are queued to the main task, not run on the host task), so waiting on the host task's callbacks is safe — and every wait is bounded regardless.

## Notes
- **Upstream:** the `delete BLEServer` before `nimble_port_stop()` ordering in arduino-esp32 is the underlying bug; I'll file that with espressif/arduino-esp32 separately. This change makes Meshtastic robust against it.
- Scoped entirely to `#ifdef ARCH_ESP32`; no change to the non-ESP32 `shutdown()` path.

## Verification
- `heltec-wireless-tracker-v2` builds green.
- Hardware repro pending on the same unit: connect, save MQTT config while connected → expect a clean disconnect + BLE off until reboot, no Guru Meditation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth shutdown reliability by coordinating teardown with the ongoing read/poll loop to prevent crashes and stalls.
  * Added a “draining” safeguard so read handling won’t pause for extended periods during deinitialization.
  * Enhanced shutdown behavior by cleanly terminating any active connection with a bounded wait, then fully deinitializing so the service no longer appears active after restart/shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->