### PR TITLE
fix(modules): null-check packetPool/clientNotificationPool/mqttClientProxyMessagePool allocations

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1053,10 +1053,12 @@ void setup()
     if (nodeDB->keyIsLowEntropy && !nodeDB->hasWarned) {
         LOG_WARN(LOW_ENTROPY_WARNING);
         meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
-        cn->level = meshtastic_LogRecord_Level_WARNING;
-        cn->time = getValidTime(RTCQualityFromNet);
-        sprintf(cn->message, LOW_ENTROPY_WARNING);
-        service->sendClientNotification(cn);
+        if (cn) {
+            cn->level = meshtastic_LogRecord_Level_WARNING;
+            cn->time = getValidTime(RTCQualityFromNet);
+            sprintf(cn->message, LOW_ENTROPY_WARNING);
+            service->sendClientNotification(cn);
+        }
         nodeDB->hasWarned = true;
     }
 #endif

--- a/src/modules/KeyVerificationModule.cpp
+++ b/src/modules/KeyVerificationModule.cpp
@@ -83,7 +83,7 @@ bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &
         meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
         if (cn) {
             cn->level = meshtastic_LogRecord_Level_WARNING;
-            sprintf(cn->message, "Enter Security Number for Key Verification");
+            snprintf(cn->message, sizeof(cn->message), "Enter Security Number for Key Verification");
             cn->which_payload_variant = meshtastic_ClientNotification_key_verification_number_request_tag;
             cn->payload_variant.key_verification_number_request.nonce = currentNonce;
             copyNodeLongNameOrUnknown(cn->payload_variant.key_verification_number_request.remote_longname,
@@ -118,7 +118,7 @@ bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &
             meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
             if (cn) {
                 cn->level = meshtastic_LogRecord_Level_WARNING;
-                sprintf(cn->message, "Final confirmation for incoming manual key verification %s", message);
+                snprintf(cn->message, sizeof(cn->message), "Final confirmation for incoming manual key verification %s", message);
                 cn->which_payload_variant = meshtastic_ClientNotification_key_verification_final_tag;
                 cn->payload_variant.key_verification_final.nonce = currentNonce;
                 copyNodeLongNameOrUnknown(cn->payload_variant.key_verification_final.remote_longname,
@@ -217,8 +217,8 @@ meshtastic_MeshPacket *KeyVerificationModule::allocReply()
     meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
     if (cn) {
         cn->level = meshtastic_LogRecord_Level_WARNING;
-        sprintf(cn->message, "Incoming Key Verification.\nSecurity Number\n%03u %03u", currentSecurityNumber / 1000,
-                currentSecurityNumber % 1000);
+        snprintf(cn->message, sizeof(cn->message), "Incoming Key Verification.\nSecurity Number\n%03u %03u",
+                 currentSecurityNumber / 1000, currentSecurityNumber % 1000);
         cn->which_payload_variant = meshtastic_ClientNotification_key_verification_number_inform_tag;
         cn->payload_variant.key_verification_number_inform.nonce = currentNonce;
         copyNodeLongNameOrUnknown(cn->payload_variant.key_verification_number_inform.remote_longname,
@@ -283,7 +283,7 @@ void KeyVerificationModule::processSecurityNumber(uint32_t incomingNumber)
     meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
     if (cn) {
         cn->level = meshtastic_LogRecord_Level_WARNING;
-        sprintf(cn->message, "Final confirmation for outgoing manual key verification %s", message);
+        snprintf(cn->message, sizeof(cn->message), "Final confirmation for outgoing manual key verification %s", message);
         cn->which_payload_variant = meshtastic_ClientNotification_key_verification_final_tag;
         cn->payload_variant.key_verification_final.nonce = currentNonce;
         copyNodeLongNameOrUnknown(cn->payload_variant.key_verification_final.remote_longname,

--- a/src/modules/KeyVerificationModule.cpp
+++ b/src/modules/KeyVerificationModule.cpp
@@ -81,14 +81,16 @@ bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &
         });)
 
         meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
-        cn->level = meshtastic_LogRecord_Level_WARNING;
-        sprintf(cn->message, "Enter Security Number for Key Verification");
-        cn->which_payload_variant = meshtastic_ClientNotification_key_verification_number_request_tag;
-        cn->payload_variant.key_verification_number_request.nonce = currentNonce;
-        copyNodeLongNameOrUnknown(cn->payload_variant.key_verification_number_request.remote_longname,
-                                  sizeof(cn->payload_variant.key_verification_number_request.remote_longname),
-                                  nodeDB->getMeshNode(currentRemoteNode));
-        service->sendClientNotification(cn);
+        if (cn) {
+            cn->level = meshtastic_LogRecord_Level_WARNING;
+            sprintf(cn->message, "Enter Security Number for Key Verification");
+            cn->which_payload_variant = meshtastic_ClientNotification_key_verification_number_request_tag;
+            cn->payload_variant.key_verification_number_request.nonce = currentNonce;
+            copyNodeLongNameOrUnknown(cn->payload_variant.key_verification_number_request.remote_longname,
+                                      sizeof(cn->payload_variant.key_verification_number_request.remote_longname),
+                                      nodeDB->getMeshNode(currentRemoteNode));
+            service->sendClientNotification(cn);
+        }
         LOG_INFO("Received hash2");
         currentState = KEY_VERIFICATION_SENDER_AWAITING_NUMBER;
         return true;
@@ -114,15 +116,17 @@ bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &
                           };
                       screen->showOverlayBanner(options);)
             meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
-            cn->level = meshtastic_LogRecord_Level_WARNING;
-            sprintf(cn->message, "Final confirmation for incoming manual key verification %s", message);
-            cn->which_payload_variant = meshtastic_ClientNotification_key_verification_final_tag;
-            cn->payload_variant.key_verification_final.nonce = currentNonce;
-            copyNodeLongNameOrUnknown(cn->payload_variant.key_verification_final.remote_longname,
-                                      sizeof(cn->payload_variant.key_verification_final.remote_longname),
-                                      nodeDB->getMeshNode(currentRemoteNode));
-            cn->payload_variant.key_verification_final.isSender = false;
-            service->sendClientNotification(cn);
+            if (cn) {
+                cn->level = meshtastic_LogRecord_Level_WARNING;
+                sprintf(cn->message, "Final confirmation for incoming manual key verification %s", message);
+                cn->which_payload_variant = meshtastic_ClientNotification_key_verification_final_tag;
+                cn->payload_variant.key_verification_final.nonce = currentNonce;
+                copyNodeLongNameOrUnknown(cn->payload_variant.key_verification_final.remote_longname,
+                                          sizeof(cn->payload_variant.key_verification_final.remote_longname),
+                                          nodeDB->getMeshNode(currentRemoteNode));
+                cn->payload_variant.key_verification_final.isSender = false;
+                service->sendClientNotification(cn);
+            }
 
             currentState = KEY_VERIFICATION_RECEIVER_AWAITING_USER;
             return true;
@@ -211,16 +215,18 @@ meshtastic_MeshPacket *KeyVerificationModule::allocReply()
     IF_SCREEN(snprintf(message, 25, "Security Number \n%03u %03u", currentSecurityNumber / 1000, currentSecurityNumber % 1000);
               screen->showSimpleBanner(message, 30000); LOG_WARN("%s", message);)
     meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
-    cn->level = meshtastic_LogRecord_Level_WARNING;
-    sprintf(cn->message, "Incoming Key Verification.\nSecurity Number\n%03u %03u", currentSecurityNumber / 1000,
-            currentSecurityNumber % 1000);
-    cn->which_payload_variant = meshtastic_ClientNotification_key_verification_number_inform_tag;
-    cn->payload_variant.key_verification_number_inform.nonce = currentNonce;
-    copyNodeLongNameOrUnknown(cn->payload_variant.key_verification_number_inform.remote_longname,
-                              sizeof(cn->payload_variant.key_verification_number_inform.remote_longname),
-                              nodeDB->getMeshNode(currentRemoteNode));
-    cn->payload_variant.key_verification_number_inform.security_number = currentSecurityNumber;
-    service->sendClientNotification(cn);
+    if (cn) {
+        cn->level = meshtastic_LogRecord_Level_WARNING;
+        sprintf(cn->message, "Incoming Key Verification.\nSecurity Number\n%03u %03u", currentSecurityNumber / 1000,
+                currentSecurityNumber % 1000);
+        cn->which_payload_variant = meshtastic_ClientNotification_key_verification_number_inform_tag;
+        cn->payload_variant.key_verification_number_inform.nonce = currentNonce;
+        copyNodeLongNameOrUnknown(cn->payload_variant.key_verification_number_inform.remote_longname,
+                                  sizeof(cn->payload_variant.key_verification_number_inform.remote_longname),
+                                  nodeDB->getMeshNode(currentRemoteNode));
+        cn->payload_variant.key_verification_number_inform.security_number = currentSecurityNumber;
+        service->sendClientNotification(cn);
+    }
     LOG_WARN("Security Number %04u, nonce %llu", currentSecurityNumber, currentNonce);
     return responsePacket;
 }
@@ -275,15 +281,17 @@ void KeyVerificationModule::processSecurityNumber(uint32_t incomingNumber)
     currentState = KEY_VERIFICATION_SENDER_AWAITING_USER;
     IF_SCREEN(screen->requestMenu(graphics::menuHandler::KeyVerificationFinalPrompt);)
     meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
-    cn->level = meshtastic_LogRecord_Level_WARNING;
-    sprintf(cn->message, "Final confirmation for outgoing manual key verification %s", message);
-    cn->which_payload_variant = meshtastic_ClientNotification_key_verification_final_tag;
-    cn->payload_variant.key_verification_final.nonce = currentNonce;
-    copyNodeLongNameOrUnknown(cn->payload_variant.key_verification_final.remote_longname,
-                              sizeof(cn->payload_variant.key_verification_final.remote_longname),
-                              nodeDB->getMeshNode(currentRemoteNode));
-    cn->payload_variant.key_verification_final.isSender = true;
-    service->sendClientNotification(cn);
+    if (cn) {
+        cn->level = meshtastic_LogRecord_Level_WARNING;
+        sprintf(cn->message, "Final confirmation for outgoing manual key verification %s", message);
+        cn->which_payload_variant = meshtastic_ClientNotification_key_verification_final_tag;
+        cn->payload_variant.key_verification_final.nonce = currentNonce;
+        copyNodeLongNameOrUnknown(cn->payload_variant.key_verification_final.remote_longname,
+                                  sizeof(cn->payload_variant.key_verification_final.remote_longname),
+                                  nodeDB->getMeshNode(currentRemoteNode));
+        cn->payload_variant.key_verification_final.isSender = true;
+        service->sendClientNotification(cn);
+    }
     LOG_INFO(message);
 
     return;

--- a/src/modules/NodeInfoModule.cpp
+++ b/src/modules/NodeInfoModule.cpp
@@ -69,12 +69,13 @@ bool NodeInfoModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
     // if user has changed while packet was not for us, inform phone
     if (hasChanged && !wasBroadcast && !isToUs(&mp)) {
         auto packetCopy = packetPool.allocCopy(mp); // Keep a copy of the packet for later analysis
+        if (packetCopy) {
+            // Re-encode the user protobuf, as we have stripped out the user.id
+            packetCopy->decoded.payload.size = pb_encode_to_bytes(
+                packetCopy->decoded.payload.bytes, sizeof(packetCopy->decoded.payload.bytes), &meshtastic_User_msg, &p);
 
-        // Re-encode the user protobuf, as we have stripped out the user.id
-        packetCopy->decoded.payload.size = pb_encode_to_bytes(
-            packetCopy->decoded.payload.bytes, sizeof(packetCopy->decoded.payload.bytes), &meshtastic_User_msg, &p);
-
-        service->sendToPhone(packetCopy);
+            service->sendToPhone(packetCopy);
+        }
     }
 
     pruneLastNodeInfoCache();

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -418,12 +418,14 @@ void PositionModule::sendOurPosition(NodeNum dest, bool wantReplies, uint8_t cha
                   meshtastic_Config_DeviceConfig_Role_TAK_TRACKER) &&
         config.power.is_power_saving) {
         meshtastic_ClientNotification *notification = clientNotificationPool.allocZeroed();
-        notification->level = meshtastic_LogRecord_Level_INFO;
-        notification->time = getValidTime(RTCQualityFromNet);
-        sprintf(notification->message, "Sending position and sleeping for %us interval in a moment",
-                Default::getConfiguredOrDefaultMs(config.position.position_broadcast_secs, default_broadcast_interval_secs) /
-                    1000U);
-        service->sendClientNotification(notification);
+        if (notification) {
+            notification->level = meshtastic_LogRecord_Level_INFO;
+            notification->time = getValidTime(RTCQualityFromNet);
+            sprintf(notification->message, "Sending position and sleeping for %us interval in a moment",
+                    Default::getConfiguredOrDefaultMs(config.position.position_broadcast_secs, default_broadcast_interval_secs) /
+                        1000U);
+            service->sendClientNotification(notification);
+        }
         sleepOnNextExecution = true;
         LOG_DEBUG("Start next execution in 5s, then sleep");
         setIntervalFromNow(FIVE_SECONDS_MS);

--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -96,10 +96,12 @@ bool SerialModule::isValidConfig(const meshtastic_ModuleConfig_SerialConfig &con
         LOG_ERROR(warning);
 #ifndef PIO_UNIT_TESTING
         meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
-        cn->level = meshtastic_LogRecord_Level_ERROR;
-        cn->time = getValidTime(RTCQualityFromNet);
-        snprintf(cn->message, sizeof(cn->message), "%s", warning);
-        service->sendClientNotification(cn);
+        if (cn) {
+            cn->level = meshtastic_LogRecord_Level_ERROR;
+            cn->time = getValidTime(RTCQualityFromNet);
+            snprintf(cn->message, sizeof(cn->message), "%s", warning);
+            service->sendClientNotification(cn);
+        }
 #endif
         return false;
     }

--- a/src/modules/Telemetry/AirQualityTelemetry.cpp
+++ b/src/modules/Telemetry/AirQualityTelemetry.cpp
@@ -485,13 +485,15 @@ bool AirQualityTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
 
             if (isPowerSavingSensor()) {
                 meshtastic_ClientNotification *notification = clientNotificationPool.allocZeroed();
-                notification->level = meshtastic_LogRecord_Level_INFO;
-                notification->time = getValidTime(RTCQualityFromNet);
-                sprintf(notification->message, "Sending telemetry and sleeping for %us interval in a moment",
-                        Default::getConfiguredOrDefaultMs(moduleConfig.telemetry.air_quality_interval,
-                                                          default_telemetry_broadcast_interval_secs) /
-                            1000U);
-                service->sendClientNotification(notification);
+                if (notification) {
+                    notification->level = meshtastic_LogRecord_Level_INFO;
+                    notification->time = getValidTime(RTCQualityFromNet);
+                    sprintf(notification->message, "Sending telemetry and sleeping for %us interval in a moment",
+                            Default::getConfiguredOrDefaultMs(moduleConfig.telemetry.air_quality_interval,
+                                                              default_telemetry_broadcast_interval_secs) /
+                                1000U);
+                    service->sendClientNotification(notification);
+                }
             }
         }
     }

--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -681,13 +681,15 @@ bool EnvironmentTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
 
             if (isPowerSavingSensor()) {
                 meshtastic_ClientNotification *notification = clientNotificationPool.allocZeroed();
-                notification->level = meshtastic_LogRecord_Level_INFO;
-                notification->time = getValidTime(RTCQualityFromNet);
-                sprintf(notification->message, "Sending telemetry and sleeping for %us interval in a moment",
-                        Default::getConfiguredOrDefaultMs(moduleConfig.telemetry.environment_update_interval,
-                                                          default_telemetry_broadcast_interval_secs) /
-                            1000U);
-                service->sendClientNotification(notification);
+                if (notification) {
+                    notification->level = meshtastic_LogRecord_Level_INFO;
+                    notification->time = getValidTime(RTCQualityFromNet);
+                    sprintf(notification->message, "Sending telemetry and sleeping for %us interval in a moment",
+                            Default::getConfiguredOrDefaultMs(moduleConfig.telemetry.environment_update_interval,
+                                                              default_telemetry_broadcast_interval_secs) /
+                                1000U);
+                    service->sendClientNotification(notification);
+                }
             }
         }
     }

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -392,6 +392,8 @@ bool MQTT::publish(const char *topic, const char *payload, bool retained)
 {
     if (moduleConfig.mqtt.proxy_to_client_enabled) {
         meshtastic_MqttClientProxyMessage *msg = mqttClientProxyMessagePool.allocZeroed();
+        if (!msg)
+            return false;
         msg->which_payload_variant = meshtastic_MqttClientProxyMessage_text_tag;
         strncpy(msg->topic, topic, sizeof(msg->topic));
         msg->topic[sizeof(msg->topic) - 1] = '\0';
@@ -413,6 +415,8 @@ bool MQTT::publish(const char *topic, const uint8_t *payload, size_t length, boo
 {
     if (moduleConfig.mqtt.proxy_to_client_enabled) {
         meshtastic_MqttClientProxyMessage *msg = mqttClientProxyMessagePool.allocZeroed();
+        if (!msg)
+            return false;
         msg->which_payload_variant = meshtastic_MqttClientProxyMessage_data_tag;
         strncpy(msg->topic, topic, sizeof(msg->topic));
         msg->topic[sizeof(msg->topic) - 1] = '\0'; // Ensure null termination
@@ -595,11 +599,13 @@ bool MQTT::isValidConfig(const meshtastic_ModuleConfig_MQTTConfig &config, MQTTC
         LOG_ERROR(warning);
 #ifndef PIO_UNIT_TESTING
         meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
-        cn->level = meshtastic_LogRecord_Level_ERROR;
-        cn->time = getValidTime(RTCQualityFromNet);
-        strncpy(cn->message, warning, sizeof(cn->message) - 1);
-        cn->message[sizeof(cn->message) - 1] = '\0'; // Ensure null termination
-        service->sendClientNotification(cn);
+        if (cn) {
+            cn->level = meshtastic_LogRecord_Level_ERROR;
+            cn->time = getValidTime(RTCQualityFromNet);
+            strncpy(cn->message, warning, sizeof(cn->message) - 1);
+            cn->message[sizeof(cn->message) - 1] = '\0'; // Ensure null termination
+            service->sendClientNotification(cn);
+        }
 #endif
         return false;
 #endif
@@ -611,11 +617,13 @@ bool MQTT::isValidConfig(const meshtastic_ModuleConfig_MQTTConfig &config, MQTTC
         LOG_ERROR(warning);
 #ifndef PIO_UNIT_TESTING
         meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
-        cn->level = meshtastic_LogRecord_Level_ERROR;
-        cn->time = getValidTime(RTCQualityFromNet);
-        strncpy(cn->message, warning, sizeof(cn->message) - 1);
-        cn->message[sizeof(cn->message) - 1] = '\0'; // Ensure null termination
-        service->sendClientNotification(cn);
+        if (cn) {
+            cn->level = meshtastic_LogRecord_Level_ERROR;
+            cn->time = getValidTime(RTCQualityFromNet);
+            strncpy(cn->message, warning, sizeof(cn->message) - 1);
+            cn->message[sizeof(cn->message) - 1] = '\0'; // Ensure null termination
+            service->sendClientNotification(cn);
+        }
 #endif
         return false;
     }
@@ -746,6 +754,8 @@ void MQTT::perhapsReportToMap()
 
     // Allocate MeshPacket and fill it
     meshtastic_MeshPacket *mp = packetPool.allocZeroed();
+    if (!mp)
+        return;
     mp->which_payload_variant = meshtastic_MeshPacket_decoded_tag;
     mp->from = nodeDB->getNodeNum();
     mp->to = NODENUM_BROADCAST;

--- a/src/platform/portduino/SimRadio.cpp
+++ b/src/platform/portduino/SimRadio.cpp
@@ -209,6 +209,8 @@ void SimRadio::startSend(meshtastic_MeshPacket *txp)
     isReceiving = false;
     size_t numbytes = beginSending(txp);
     meshtastic_MeshPacket *p = packetPool.allocCopy(*txp);
+    if (!p)
+        return;
 
     // A packet we originate that's encrypted for someone else (a PKI DM, channel == 0) can't be
     // decrypted here. Attempting it only logs a spurious "no suitable channel" miss, and the
@@ -361,6 +363,8 @@ void SimRadio::handleReceiveInterrupt()
     meshtastic_MeshPacket *mp = packetPool.allocCopy(*receivingPacket); // keep a copy in packetPool
     packetPool.release(receivingPacket);                                // release the original
     receivingPacket = nullptr;
+    if (!mp)
+        return;
 
     printPacket("Lora RX", mp);
 


### PR DESCRIPTION
Follow-up to #10948, which fixed the core routing path (`Router`/`NextHopRouter`/`ReliableRouter`/`MeshService`/`RadioLibInterface`) after reproducing a HardFault on STM32WL hardware under real mesh traffic. This covers the same `allocCopy()`/`allocZeroed()` unchecked-return pattern in lower-frequency paths that were out of scope for that PR: `SimRadio.cpp` (portduino sim RX/TX), `NodeInfoModule`, the Telemetry modules' power-saving-sleep notifications, `MQTT` (map report, client-proxy messages, config-validation notifications), `PositionModule`, `SerialModule`, and `KeyVerificationModule`.

Sites where the allocation result was already read back through an existing null check downstream (e.g. Telemetry's `lastMeasurementPacket`, SimRadio's `receivingPacket`, `AdminModule::sendWarning`) were verified safe and left untouched. `Router::allocForSending()` (and everything that funnels through it, e.g. `allocDataProtobuf()`) remains unguarded and out of scope here too — it's called from 30+ sites across the codebase and needs its own audit.

**Important:** this PR alone is not a complete fix for meshpacket null-dereference crashes on memory-constrained platforms (e.g. STM32WL) — #10948 needs to land too. The two PRs cover disjoint call sites of the same unchecked-`allocCopy()`/`allocZeroed()` pattern; without #10948, the core routing/radio path (`RadioLibInterface`, `Router`, etc.) is still exposed. See the hardware soak test below, which reproduced this exact crash class on this branch without #10948 and confirmed it goes away once #10948's guard is present.

Also includes an incidental fix flagged by CodeRabbit's automated review: four `sprintf(cn->message, ...)` calls in `KeyVerificationModule.cpp` wrote into the notification's fixed-size buffer without bounds checking. Switched to `snprintf(cn->message, sizeof(cn->message), ...)`, matching the pattern already used for the same field in `SerialModule.cpp` and `MQTT.cpp` elsewhere in this PR.

## Hardware soak test (wio-e5)

wio-e5's dev-board USB-serial is not wired to the STM32WL UART bootloader, so it can only be flashed via ST-Link/SWD (`STM32_Programmer_CLI -c port=SWD -w <hex> -v -rst`), not the usual meshtastic UART DFU flow.

By default this target ships with `DEBUG_MUTE` set and no `PIO_FRAMEWORK_ARDUINO_NANOLIB_FLOAT_PRINTF`, so there's no serial log output at all — needed both flipped to get logs for this test. That pushed the build over the flash budget, so a few features wio-e5 normally ships with (GPS, I2C, environmental sensor) were also temporarily excluded to make room for the log strings + float-printf support. We also temporarily raised `MAX_NUM_NODES` from the STM32WL default of 10 to 50 to force sustained NodeDB churn/heap pressure — the default cap wasn't enough to reliably reproduce memory pressure. None of this was committed; it's local-only test-rig configuration, applied on top of this PR's commits:

```diff
diff --git a/variants/stm32/stm32.ini b/variants/stm32/stm32.ini
index 5726fd369..940d4b3d5 100644
--- a/variants/stm32/stm32.ini
+++ b/variants/stm32/stm32.ini
@@ -28,8 +28,8 @@ build_flags =
   -DMESHTASTIC_EXCLUDE_XEDDSA=1 ; The Ed25519 signing code does not fit in the 256KB flash. Packets are sent unsigned, like pre-XEdDSA firmware.
   -DSERIAL_RX_BUFFER_SIZE=256 ; For GPS - the default of 64 is too small.
   -DHAS_SCREEN=0 ; Always disable screen for STM32, it is not supported.
-  ;-DPIO_FRAMEWORK_ARDUINO_NANOLIB_FLOAT_PRINTF ; Enable this if enabling debugg logging. It is REQUIRED for at least traceroute debug prints - without it the length returned by printf ends up uninitialized.
-  -DDEBUG_MUTE ; You can #undef DEBUG_MUTE in certain source files if you need the logs.
+  -DPIO_FRAMEWORK_ARDUINO_NANOLIB_FLOAT_PRINTF ; Enable this if enabling debugg logging. It is REQUIRED for at least traceroute debug prints - without it the length returned by printf ends up uninitialized.
+  ;-DDEBUG_MUTE ; You can #undef DEBUG_MUTE in certain source files if you need the logs.
   -fmerge-all-constants
   -ffunction-sections
   -fdata-sections
diff --git a/variants/stm32/wio-e5/platformio.ini b/variants/stm32/wio-e5/platformio.ini
index 8c7579aa3..6a28325b9 100644
--- a/variants/stm32/wio-e5/platformio.ini
+++ b/variants/stm32/wio-e5/platformio.ini
@@ -18,5 +18,9 @@ build_flags =
   -DHAS_GPS=1
   -DGPS_SERIAL_PORT=Serial2
   -DMESHTASTIC_EXCLUDE_AIR_QUALITY_SENSOR=1
+  -DMESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR=1 ; TEMP: soak-test-only, freeing flash for debug logging. Do not commit.
+  -DMESHTASTIC_EXCLUDE_I2C=1 ; TEMP: soak-test-only, freeing flash for debug logging. Do not commit.
+  -DMESHTASTIC_EXCLUDE_GPS=1 ; TEMP: soak-test-only, freeing flash for debug logging. Do not commit.
+  -DMAX_NUM_NODES=50 ; TEMP: soak-test-only, intentionally raising NodeDB memory pressure. Do not commit.

 upload_port = stlink
```

(The raw serial captures aren't attached — they contain live mesh traffic from a real MQTT-bridged mesh, including other people's node names, IDs, and public keys. Only the aggregate timing/heap findings below are shared.)

#10948 should be merged together with this PR to form a complete fix for meshpacket null-dereference crashes. For this soak test, `ad0d36905` (#10948's null-check commit) was cherry-picked onto this branch to get a clean read on this PR's own changes.

With that in place: 46 minutes uptime, zero resets. NodeDB stayed pinned at the 50-node cap with as little as 3316 bytes free, continuously cycling eviction/insertion, without incident.

This confirms this PR's own changes are stable under sustained memory pressure. The soak test heavily exercised the NodeDB/Router/RadioLibInterface hot path, but the captured mesh traffic didn't specifically trigger allocation failures in the lower-frequency paths this PR actually touches (`KeyVerificationModule`, `SerialModule`, `MQTT`, `PositionModule`, `SimRadio`, `NodeInfoModule`) — those still need dedicated exercise once #10948 lands and this branch is rebased onto it.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Seeed Wio-E5 (see hardware soak test above)
  - [ ] Other (please specify below)

Compiles clean on `rak3172` and `wio-e5`. See the hardware soak test section above for wio-e5 runtime results — no regressions from this PR's own changes found, but the reset loop uncovered during testing depends on #10948 landing first. Will re-test the specific modules this PR touches once this branch is rebased onto #10948.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability across key verification, node info forwarding, position/telemetry, serial validation, MQTT publishing, and simulated radio sending/receiving.
  * Added safeguards so client notifications, proxy messages, and packet copies are only populated and sent when allocations succeed.
  * Prevented rare crashes/invalid behavior when the system is under low-memory conditions, allowing operations to fail gracefully instead of dereferencing null pointers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
