### PR TITLE
Add RAK WisMesh Pocket V3 variant

### DIFF
--- a/variants/nrf52840/rak4631/platformio.ini
+++ b/variants/nrf52840/rak4631/platformio.ini
@@ -56,6 +56,21 @@ build_flags =
   -DSAFE_VDD_VOLTAGE_THRESHOLD_MV=2900
   -DSAFE_VDD_VOLTAGE_THRESHOLD_HYST_MV=100
 
+; RAK WisMesh Pocket V3 - rak4631 pin map + OLED; no ethernet (unlike env:rak4631)
+[env:rak_wismesh_pocket]
+extends = env:rak4631
+custom_meshtastic_display_name = RAK WisMesh Pocket V3
+custom_meshtastic_images = rak4631.svg
+build_flags =
+  ${env:rak4631.build_flags}
+  -D WISMESH_POCKET
+  -DLOW_VDD_SYSTEMOFF_DELAY_MS=5000
+  -DSAFE_VDD_VOLTAGE_THRESHOLD_MV=2900
+  -DSAFE_VDD_VOLTAGE_THRESHOLD_HYST_MV=100
+build_src_filter = ${env:rak4631.build_src_filter}
+  -<mesh/eth/>
+  -<mesh/api/>
+
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
 ; Note: as of 6/2013 the serial/bootloader based programming takes approximately 30 seconds
 ;upload_protocol = jlink

--- a/variants/nrf52840/rak4631/variant.h
+++ b/variants/nrf52840/rak4631/variant.h
@@ -231,6 +231,11 @@ SO GPIO 39/TXEN MAY NOT BE DEFINED FOR SUCCESSFUL OPERATION OF THE SX1262 - TG
 #define PIN_3V3_EN (34)
 #define WB_IO2 PIN_3V3_EN
 
+#if defined(WISMESH_POCKET)
+// Pocket v3: P1.02 (GPIO 34) = GPS_PWR_EN
+#define PIN_GPS_EN PIN_3V3_EN
+#endif
+
 // RAK1910 GPS module
 // If using the wisblock GPS module and pluged into Port A on WisBlock base
 // IO1 is hooked to PPS (pin 12 on header) = gpio 17
@@ -253,9 +258,11 @@ SO GPIO 39/TXEN MAY NOT BE DEFINED FOR SUCCESSFUL OPERATION OF THE SX1262 - TG
 #define PIN_BUZZER 21 // IO3 is PWM2
 // NEW: set this via protobuf instead!
 
-// RAK4631 custom ringtone
+// RAK4631 custom ringtone (but not for Pocket - it uses the default ringtone)
+#ifndef WISMESH_POCKET
 #undef USERPREFS_RINGTONE_RTTTL
 #define USERPREFS_RINGTONE_RTTTL "Rak:d=32,o=5,b=200:b7,p,b7,4p,p"
+#endif
 
 // Battery
 // The battery sense is hooked to pin A0 (5)
@@ -282,7 +289,11 @@ SO GPIO 39/TXEN MAY NOT BE DEFINED FOR SUCCESSFUL OPERATION OF THE SX1262 - TG
 // VDD=3.3V AIN3=6/8*VDD=2.47V VBAT=1.66*AIN3=4.1V
 #define BATTERY_LPCOMP_THRESHOLD NRF_LPCOMP_REF_SUPPLY_11_16
 
+#if defined(WISMESH_POCKET)
+#define HAS_ETHERNET 0
+#else
 #define HAS_ETHERNET 1
+#endif
 
 #define RAK_4631 1
 


### PR DESCRIPTION
## Summary

- Add **`rak_wismesh_pocket`** build env for **RAK WisMesh Pocket V3** (RAK4631 + OLED).
- Pocket-specific pin/config via `WISMESH_POCKET` in `rak4631/variant.h`:
  - `PIN_GPS_EN` on GPIO 34 (`GPS_PWR_EN` per schematic)
  - `HAS_ETHERNET 0` (no Ethernet)
  - Default ringtone (not RAK4631 custom RTTTL)
- Env excludes Ethernet/API mesh code (`build_src_filter`: `mesh/eth`, `mesh/api`).
- MQTT is **enabled** (Client Proxy MQTT on phones).
- Reuses low-VDD System OFF + LPCOMP wake behavior from `rak4631` via `LOW_VDD_SYSTEMOFF_DELAY_MS` (infrastructure from #10918).

## Depends on

- #10918 — `variant_enableBatteryLpcompWake()` in `main-nrf52.cpp` and low-VDD hook in `rak4631/variant.cpp` must land first (or be included in the same release baseline).

## Files changed

| Area | Change |
|------|--------|
| `rak4631/platformio.ini` | New `[env:rak_wismesh_pocket]` |
| `rak4631/variant.h` | `WISMESH_POCKET`: `PIN_GPS_EN`, `HAS_ETHERNET`, ringtone |

## Test plan

- [x] `pio run -e rak_wismesh_pocket`
- [x] `pio run -e rak4631` — no behavior change on base env
- [x] Hardware: GPS on/off power (~53 mA / ~23 mA with `PIN_GPS_EN`)
- [x] Hardware: basic mesh, OLED, shutdown on battery
- [ ] Low-VDD auto shutdown (battery, no USB) — same as rak4631 mini path
- [ ] User shutdown near LPCOMP threshold (battery) — inherits #10918 fix

## Notes for reviewers

- This PR is **Pocket only**.
- Pocket does not add new `variant.cpp` logic; it extends `env:rak4631` and relies on #10918 for power/LPCOMP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new firmware build option for the RAK4631 Pocket variant with Pocket-specific display settings and low-power (safe-VDD/system-off) tuning.
  * Updated Pocket variant hardware behavior, including GPS power control.

* **Bug Fixes**
  * Disabled Ethernet support for the Pocket build.
  * Updated Pocket ringtone/default audio behavior so it follows the intended variant-specific configuration.

* **Chores**
  * Reduced the Pocket build footprint by excluding networking-related components at build time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->