### PR TITLE
Flatpak: rename Meshtastic -> MeshtasticD

### DIFF
--- a/bin/org.meshtastic.meshtasticd.desktop
+++ b/bin/org.meshtastic.meshtasticd.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
-Name=Meshtastic
-Comment=Meshtastic App
+Name=MeshtasticD
+Comment=Meshtastic Daemon + MUI
 Exec=meshtasticd
 Icon=org.meshtastic.meshtasticd
 Terminal=true

--- a/bin/org.meshtastic.meshtasticd.metainfo.xml
+++ b/bin/org.meshtastic.meshtasticd.metainfo.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
   <id>org.meshtastic.meshtasticd</id>
 
-  <name>Meshtastic</name>
+  <name>MeshtasticD</name>
   <summary>Decentralized mesh communication</summary>
 
   <metadata_license>CC-BY-4.0</metadata_license>
@@ -13,6 +13,9 @@
   </developer>
 
   <description>
+    <p>
+      MeshtasticD is an app that allows you to use your Linux computer as a Meshtastic node (using a CH341 USB LoRa radio).
+    </p>
     <p>
       Meshtastic is an open source project for creating off-grid, affordable, and resilient communication with LoRa mesh networks.
     </p>


### PR DESCRIPTION
This PR renames the Flatpak package from "Meshtastic" to "MeshtasticD".
With the introduction of "Meshtastic Desktop" on FlatHub, the meshtasticd flatpak could use a rename to be a bit less confusing.


This should also be cherrypicked to `develop`.