### PR TITLE
Fix ESP32-S3 USB CDC: post-disconnect task-WDT reboot from blocking console log writes

### DIFF
--- a/src/SerialConsole.cpp
+++ b/src/SerialConsole.cpp
@@ -126,11 +126,8 @@ bool SerialConsole::checkIsConnected()
 void SerialConsole::setHostDraining(bool draining)
 {
 #ifdef IS_USB_SERIAL
-    // With timeout 0, HWCDC writes never block: they drop (oldest-first ring
-    // policy) when the host isn't draining the CDC buffer. With a host attached
-    // and draining, ring space is normally available so log output still flows.
-    // A normal (blocking, 100 ms bounded) timeout is restored while an API
-    // client is connected so protobuf frames are never truncated/corrupted.
+    // Timeout 0 makes HWCDC writes drop instead of block when the host stops draining;
+    // bounded blocking is restored while an API client is connected so frames aren't truncated.
     Port.setTxTimeoutMs(draining ? 100 : 0);
 #else
     (void)draining;

--- a/src/SerialConsole.cpp
+++ b/src/SerialConsole.cpp
@@ -65,6 +65,8 @@ SerialConsole::SerialConsole() : StreamAPI(&Port), RedirectablePrint(&Port), con
     Port.setRX(SERIAL2_RX);
 #endif
     Port.begin(SERIAL_BAUD);
+    // Boot with console TX in non-blocking mode: no host is provably listening yet.
+    setHostDraining(false);
     time_t timeout = millis();
     while (!Port) {
         if (Throttle::isWithinTimespanMs(timeout, FIVE_SECONDS_MS)) {
@@ -121,6 +123,31 @@ bool SerialConsole::checkIsConnected()
     return Throttle::isWithinTimespanMs(lastContactMsec, SERIAL_CONNECTION_TIMEOUT);
 }
 
+void SerialConsole::setHostDraining(bool draining)
+{
+#ifdef IS_USB_SERIAL
+    // With timeout 0, HWCDC writes never block: they drop (oldest-first ring
+    // policy) when the host isn't draining the CDC buffer. With a host attached
+    // and draining, ring space is normally available so log output still flows.
+    // A normal (blocking, 100 ms bounded) timeout is restored while an API
+    // client is connected so protobuf frames are never truncated/corrupted.
+    Port.setTxTimeoutMs(draining ? 100 : 0);
+#else
+    (void)draining;
+#endif
+}
+
+void SerialConsole::onConnectionChanged(bool connected)
+{
+    // Order matters on disconnect: make console TX non-blocking *before* the
+    // PowerFSM/close handling below emits more log lines to a dead port.
+    if (!connected)
+        setHostDraining(false);
+    StreamAPI::onConnectionChanged(connected);
+    if (connected)
+        setHostDraining(true);
+}
+
 /**
  * we override this to notice when we've received a protobuf over the serial
  * stream.  Then we shut off debug serial output.
@@ -129,6 +156,10 @@ bool SerialConsole::handleToRadio(const uint8_t *buf, size_t len)
 {
     // only talk to the API once the configuration has been loaded and we're sure the serial port is not disabled.
     if (config.has_lora && config.security.serial_enabled) {
+        // The host just sent us bytes, so it is alive and draining the port:
+        // restore normal bounded-blocking TX before any API response is written.
+        setHostDraining(true);
+
         // Switch to protobufs for log messages
         usingProtobufs = true;
         canWrite = true;

--- a/src/SerialConsole.h
+++ b/src/SerialConsole.h
@@ -48,9 +48,8 @@ class SerialConsole : public StreamAPI, public RedirectablePrint, private concur
     virtual void log_to_serial(const char *logLevel, const char *format, va_list arg);
 
   private:
-    /// On USB CDC targets, bound console TX so a host that stopped draining the
-    /// port can never block the main loop (which starves the app task watchdog
-    /// and reboots the device with ESP_RST_TASK_WDT ~97s after every disconnect).
+    /// On USB CDC targets, keep console TX non-blocking unless a host is draining the
+    /// port, so a dead host can't stall the main loop and trip the task watchdog.
     void setHostDraining(bool draining);
 };
 

--- a/src/SerialConsole.h
+++ b/src/SerialConsole.h
@@ -40,8 +40,18 @@ class SerialConsole : public StreamAPI, public RedirectablePrint, private concur
 
     virtual void onNowHasData(uint32_t fromRadioNum) override;
 
+    /// Track serial API connect/disconnect so we can make console writes
+    /// non-blocking while no host is listening (see setHostDraining()).
+    virtual void onConnectionChanged(bool connected) override;
+
     /// Possibly switch to protobufs if we see a valid protobuf message
     virtual void log_to_serial(const char *logLevel, const char *format, va_list arg);
+
+  private:
+    /// On USB CDC targets, bound console TX so a host that stopped draining the
+    /// port can never block the main loop (which starves the app task watchdog
+    /// and reboots the device with ESP_RST_TASK_WDT ~97s after every disconnect).
+    void setHostDraining(bool draining);
 };
 
 // A simple wrapper to allow non class aware code write to the console


### PR DESCRIPTION
Fixes #10955

## Problem

On ESP32-S3 USB-Serial/JTAG CDC targets, the device reboots with `ESP_RST_TASK_WDT` ~97 s after **every** serial API client disconnect. When the host closes the port (cable still attached), it stops draining the CDC buffer while the firmware keeps writing raw-text debug logs to it. A single log write was measured blocking for **52.4 s** (8–11 ms with a host draining) — the nominal 100 ms HWCDC timeouts don't bound it because SOF tokens keep the `connected` heuristic flapping true. That blocks the Arduino loop task, which stops feeding the app task watchdog (`APP_WATCHDOG_SECS = 90`, `trigger_panic = true`), and the device reboots.

On 2.7.x (arduino-esp32 2.x / IDF 4.4) the reboot also re-enumerates USB; since the Arduino 3.x migration it is silent (USB stays enumerated), appearing as a random reboot / `reboot_count` increment ~90 s after using the CLI. Full root-cause evidence chain in #10955.

## Fix

Keep console TX in non-blocking mode (`setTxTimeoutMs(0)`, drop-oldest) whenever no API client is provably alive, and restore the normal bounded timeout while a client is connected so protobuf API frames are never truncated. Toggle points:

- constructor (boot): non-blocking — no host is listening yet
- `handleToRadio()`: host just sent bytes → restore bounded timeout *before* any API response is written
- `onConnectionChanged(false)`: switch to non-blocking *before* disconnect handling emits more log lines to the dead port; `onConnectionChanged(true)` restores

`setHostDraining()` is a no-op on non-USB-CDC targets.

## Alternatives tried and rejected

- `setTxTimeoutMs(0)` unconditionally: breaks the protobuf API ("Timed out waiting for interface config") — HWCDC's disconnected-mode ring policy (256 B, drop-oldest) corrupts frames larger than the ring during session setup.
- Gating log writes on `availableForWrite()`: ineffective — the ring reports free space while the write path stalls.
- Muting raw-text logs entirely: works but loses logs for attached readers.

## Validation (HELTEC_WIRELESS_TRACKER_V2, macOS + Linux hosts)

- Repro protocol (session open/close + 150 s unattached): `reboot_count` +1 **every cycle** before; **flat across a 10-cycle soak (15 sessions)** after.
- Max log write stall: 52,405 ms → 30 ms.
- API sessions, config download, and attached log capture unaffected.
- SIGKILL-mid-session (no `ToRadio.disconnect`): 3/3 no reboot.

## Known limitations

- An abruptly killed client leaves the bounded timeout active until `SERIAL_CONNECTION_TIMEOUT` (15 min); theoretically still vulnerable in that window, though 3/3 kill tests did not reproduce it.
- Passive readers that never send a byte (plain `cat`) get lossy logs after a session close until any byte is sent to the device. API/`--seriallog` sessions are unaffected.
- The underlying HWCDC blocking-write behavior deserves its own upstream report to espressif/arduino-esp32; this is a Meshtastic-side mitigation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serial console reliability by dynamically adjusting transmit behavior based on whether the connected host is draining data.
  * Connection changes now update host-draining state in the correct order to reduce blocking or truncation during disconnect/reconnect.
  * When the host sends data, the console switches to bounded, safer transmission to better preserve message integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->