### PR TITLE
add configs for FrameTastic and PiTastic

### DIFF
--- a/bin/config.d/lora-FrameTastic-1262.yaml
+++ b/bin/config.d/lora-FrameTastic-1262.yaml
@@ -1,0 +1,20 @@
+#copy of lora-meshstick-1262.yaml data changed to match FrameTastic 1262 board
+
+Meta:
+  name: FrameTastic 1262
+  support: community
+  compatible:
+    - usb
+
+
+Lora:
+  Module: sx1262
+  CS: 0
+  IRQ: 6
+  Reset: 2
+  Busy: 4
+  spidev: ch341
+  DIO3_TCXO_VOLTAGE: true
+#  USB_Serialnum: 12345678
+  USB_PID: 0x5512
+  USB_VID: 0x1A86

--- a/bin/config.d/lora-PiTastic-1W.yaml
+++ b/bin/config.d/lora-PiTastic-1W.yaml
@@ -1,0 +1,20 @@
+#Board uses wehoopers zebra hat config # https://github.com/wehooper4/Meshtastic-Hardware/tree/main/ZebraHAT
+
+Meta:
+  name: PiTastic 1W
+  support: community
+  compatible:
+    - raspberry-pi
+
+Lora:
+  Module: sx1262
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+  SX126X_MAX_POWER: 18 
+  CS: 24
+  IRQ: 22
+  Busy: 27
+  Reset: 17
+
+I2C:
+  I2CDevice: /dev/i2c-1


### PR DESCRIPTION
adds configs for FrameTastic (framework lora module, https://github.com/valzzu/meshtastic-pcbs/tree/main/FrameTastic) and PiTastic (rasperrypi hat, https://github.com/valzzu/meshtastic-pcbs/tree/main/PiTastic)


not sure if i did this correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two new hardware board configurations: **FrameTastic 1262** and **PiTastic 1W**.
  * Included radio, GPIO, SPI, I2C, USB, and platform settings so these boards can be recognized and used more easily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->