### PR TITLE
fix(stm32wl): add TCXO-optional support and fix hardcoded TCXO voltage

### DIFF
--- a/src/mesh/STM32WLE5JCInterface.cpp
+++ b/src/mesh/STM32WLE5JCInterface.cpp
@@ -19,8 +19,8 @@ bool STM32WLE5JCInterface::init()
     RadioLibInterface::init();
 
 // https://github.com/Seeed-Studio/LoRaWan-E5-Node/blob/main/Middlewares/Third_Party/SubGHz_Phy/stm32_radio_driver/radio_driver.c
-#if (!defined(_VARIANT_RAK3172_))
-    setTCXOVoltage(1.7);
+#if defined(SX126X_DIO3_TCXO_VOLTAGE)
+    setTCXOVoltage(SX126X_DIO3_TCXO_VOLTAGE);
 #endif
 
     lora.setRfSwitchTable(rfswitch_pins, rfswitch_table);
@@ -28,6 +28,17 @@ bool STM32WLE5JCInterface::init()
     limitPower(STM32WLx_MAX_POWER);
 
     int res = lora.begin(getFreq(), bw, sf, cr, syncWord, power, preambleLength, tcxoVoltage);
+
+#if defined(TCXO_OPTIONAL)
+    // If a TCXO was requested but isn't actually populated (e.g. non-T RAK3172), retry on XTAL
+    if (res != RADIOLIB_ERR_NONE && res != RADIOLIB_ERR_CHIP_NOT_FOUND && tcxoVoltage > 0) {
+        LOG_WARN("STM32WLx init failed with TCXO Vref %fV (err %d), retrying without TCXO", tcxoVoltage, res);
+        setTCXOVoltage(0);
+        res = lora.begin(getFreq(), bw, sf, cr, syncWord, power, preambleLength, tcxoVoltage);
+        if (res == RADIOLIB_ERR_NONE)
+            LOG_INFO("STM32WLx init success without TCXO (XTAL mode)");
+    }
+#endif
 
     LOG_INFO("STM32WLx init result %d", res);
 

--- a/variants/stm32/CDEBYTE_E77-MBL/variant.h
+++ b/variants/stm32/CDEBYTE_E77-MBL/variant.h
@@ -24,12 +24,8 @@ Do not expect a working Meshtastic device with this target.
 #define EBYTE_E77_MBL
 
 // LoRa
-/*
- * EByte silently changed the E77-MBL hardware around early 2024: modules with serial number
- * >= 3202995 have a (better) TCXO; older modules have a ceramic crystal oscillator (XTAL) instead.
- * Since both are in the field under the same module name, treat the TCXO voltage as optional here.
- * https://github.com/olliw42/mLRS-docu/blob/main/docs/EBYTE_E77_MBL.md
- */
+// Hardware varies by unit: SN >= 3202995 has a TCXO, older units have XTAL only -
+// https://github.com/olliw42/mLRS-docu/blob/main/docs/EBYTE_E77_MBL.md
 #define TCXO_OPTIONAL
 #define SX126X_DIO3_TCXO_VOLTAGE 1.7
 

--- a/variants/stm32/CDEBYTE_E77-MBL/variant.h
+++ b/variants/stm32/CDEBYTE_E77-MBL/variant.h
@@ -22,4 +22,15 @@ Do not expect a working Meshtastic device with this target.
 #define SERIAL_PRINT_PORT 1
 
 #define EBYTE_E77_MBL
+
+// LoRa
+/*
+ * EByte silently changed the E77-MBL hardware around early 2024: modules with serial number
+ * >= 3202995 have a (better) TCXO; older modules have a ceramic crystal oscillator (XTAL) instead.
+ * Since both are in the field under the same module name, treat the TCXO voltage as optional here.
+ * https://github.com/olliw42/mLRS-docu/blob/main/docs/EBYTE_E77_MBL.md
+ */
+#define TCXO_OPTIONAL
+#define SX126X_DIO3_TCXO_VOLTAGE 1.7
+
 #endif

--- a/variants/stm32/rak3172/variant.h
+++ b/variants/stm32/rak3172/variant.h
@@ -28,11 +28,8 @@ Do not expect a working Meshtastic device with this target.
 #define STM32WL_LSE_DRIVE RCC_LSEDRIVE_LOW
 
 // LoRa
-/*
- * RAK3172   (-20-85°C) -> No TCXO
- * RAK3172-T (-40-85°C) -> 3.0V TCXO
- * https://github.com/RAKWireless/RAK-STM32-RUI/blob/e5a28be8fab1a492bd9223dd425ca33a8a297d90/variants/WisDuo_RAK3172-T_Board/radio_conf.h#L91
- */
+// RAK3172: no TCXO, RAK3172-T: 3.0V TCXO -
+// https://github.com/RAKWireless/RAK-STM32-RUI/blob/e5a28be8fab1a492bd9223dd425ca33a8a297d90/variants/WisDuo_RAK3172-T_Board/radio_conf.h#L91
 #define TCXO_OPTIONAL
 #define SX126X_DIO3_TCXO_VOLTAGE 3.0
 

--- a/variants/stm32/rak3172/variant.h
+++ b/variants/stm32/rak3172/variant.h
@@ -27,4 +27,13 @@ Do not expect a working Meshtastic device with this target.
 #define HAS_LSE 1
 #define STM32WL_LSE_DRIVE RCC_LSEDRIVE_LOW
 
+// LoRa
+/*
+ * RAK3172   (-20-85°C) -> No TCXO
+ * RAK3172-T (-40-85°C) -> 3.0V TCXO
+ * https://github.com/RAKWireless/RAK-STM32-RUI/blob/e5a28be8fab1a492bd9223dd425ca33a8a297d90/variants/WisDuo_RAK3172-T_Board/radio_conf.h#L91
+ */
+#define TCXO_OPTIONAL
+#define SX126X_DIO3_TCXO_VOLTAGE 3.0
+
 #endif

--- a/variants/stm32/wio-e5/variant.h
+++ b/variants/stm32/wio-e5/variant.h
@@ -19,4 +19,8 @@ Do not expect a working Meshtastic device with this target.
 
 #define WIO_E5
 
+// LoRa
+// https://github.com/Seeed-Studio/LoRaWan-E5-Node/blob/163c05379b1805dd8f2c061d4557a69985acc953/Middlewares/Third_Party/SubGHz_Phy/stm32_radio_driver/radio_driver.c#L94
+#define SX126X_DIO3_TCXO_VOLTAGE 1.7
+
 #endif


### PR DESCRIPTION
## Summary

Adds TCXO-optional support to the STM32WL radio path (`STM32WLE5JCInterface`), so one `rak3172` build works on both non-T RAK3172 (XTAL) and RAK3172-T (3.0V TCXO). Also fixes a bug that silently ignored any STM32WL variant's declared TCXO voltage, hardware-confirmed on `wio-e5`.

## Problem

1. **Hardcoded 1.7V, ignoring `SX126X_DIO3_TCXO_VOLTAGE`.** Every variant except `rak3172` got `setTCXOVoltage(1.7)` unconditionally. `russell` declares `SX126X_DIO3_TCXO_VOLTAGE 3.0`, but it was silently overridden to 1.7V.
2. **`rak3172` configured no TCXO at all.** RAK3172-T (populated 3.0V TCXO) failed radio init outright.

Confirmed on TCXO-equivalent test hardware: RadioLib error `-707` (`RADIOLIB_ERR_SPI_CMD_FAILED`) on stock `develop`. RAK's own [`radio_conf.h`](https://github.com/RAKWireless/RAK-STM32-RUI/blob/e5a28be8fab1a492bd9223dd425ca33a8a297d90/variants/WisDuo_RAK3172-T_Board/radio_conf.h#L91) confirms RAK3172-T needs 3.0V.

```mermaid
flowchart TD
    A["STM32WLE5JCInterface::init()"] --> B{"_VARIANT_RAK3172_ defined?"}
    B -- "yes (rak3172)" --> C["No TCXO configured"]
    B -- "no (every other variant)" --> D["setTCXOVoltage(1.7), hardcoded"]
    D -.-> N["russell/milesight_gs301 declare 3.0V,\nget 1.7V instead — outcome unverified"]
    C --> E["lora.begin()"]
    D --> E
    E --> F{"Success?"}
    F -- "yes" --> G["Radio up"]
    F -- "no" --> H["Fails, no retry.\nRAK3172-T: confirmed fails (-707)"]
```

## Fix

- `STM32WLE5JCInterface::init()` reads `SX126X_DIO3_TCXO_VOLTAGE` per variant instead of hardcoding 1.7V. No macro → no TCXO call (XTAL).
- With `TCXO_OPTIONAL` defined, a failed TCXO attempt retries once on XTAL — same pattern as `LR11x0Interface.cpp`, `LR20x0Interface.cpp`, and the SX1262/SX1268 paths in `RadioInterface.cpp`.
- `rak3172`: `TCXO_OPTIONAL` + `SX126X_DIO3_TCXO_VOLTAGE 3.0`.
- `wio-e5`: `SX126X_DIO3_TCXO_VOLTAGE 1.7` (mandatory), matching [Seeed's reference driver](https://github.com/Seeed-Studio/LoRaWan-E5-Node/blob/163c05379b1805dd8f2c061d4557a69985acc953/Middlewares/Third_Party/SubGHz_Phy/stm32_radio_driver/radio_driver.c#L94).
- `CDEBYTE_E77-MBL`: `TCXO_OPTIONAL` + `SX126X_DIO3_TCXO_VOLTAGE 1.7` — [hardware varies by unit](https://github.com/olliw42/mLRS-docu/blob/main/docs/EBYTE_E77_MBL.md).

```mermaid
flowchart TD
    A["STM32WLE5JCInterface::init()"] --> B{"SX126X_DIO3_TCXO_VOLTAGE defined?"}
    B -- "yes" --> C["setTCXOVoltage(value)"]
    B -- "no" --> D["No TCXO call, XTAL"]
    C --> E["lora.begin()"]
    D --> E
    E -.-> M["RadioLib's modSetup() retries TCXO to\nXTAL internally on oscillator-start error,\nbefore begin() returns"]
    E --> F{"Success?"}
    F -- "yes" --> G["Radio up"]
    F -- "no" --> H{"TCXO_OPTIONAL and TCXO\nwas attempted?"}
    H -- "no" --> I["Fails\n(incompatible XTAL populated instead)"]
    H -- "yes" --> J["Retry XTAL\n(rarely reached — RadioLib's fallback\nabove already resolves this)"]
    J --> K{"Success?"}
    K -- "yes" --> G
    K -- "no" --> I
```

5 commits: one per file, plus a comment-length cleanup touching `rak3172` and `CDEBYTE_E77-MBL`.

## Side effects on other variants

> [!WARNING]
> `russell` and `milesight_gs301` change behavior as a side effect (their `variant.h` wasn't touched), untested. A regression on either after merge means that board's actual TCXO voltage doesn't match its declared `SX126X_DIO3_TCXO_VOLTAGE` — check the schematic and fix the value, don't revert this PR.

| Variant | Before | After |
|---|---|---|
| `russell` | Declared 3.0V, silently got 1.7V | Declaration now honored |
| `milesight_gs301` | Declared 3.0V (mandatory), silently got 1.7V | Gets 3.0V, still mandatory |

RadioLib's `SX126x::modSetup()` has a one-shot internal TCXO→XTAL fallback on oscillator-start failure — likely why the old bug wasn't visibly broken elsewhere; doesn't help boards with no XTAL (`wio-e5`). This PR's own `TCXO_OPTIONAL` retry in `STM32WLE5JCInterface.cpp` is redundant for the RAK3172/CDEBYTE_E77-MBL case for the same reason: RadioLib recovers before `lora.begin()` returns, so the retry's `LOG_WARN`/`LOG_INFO` won't fire. Kept for parity with the existing SX1262/SX1268 `TCXO_OPTIONAL` pattern in `RadioInterface.cpp`, and as a backstop for failure modes RadioLib's internal check doesn't catch.

## Testing

- Hardware-tested:
  - `rak3172` (TCXO path): `-707` on stock `develop`, succeeds at 3.0V after this fix.
  - `wio-e5`: via ST-Link/SWD (no UART bootloader on this board). With `SX126X_DIO3_TCXO_VOLTAGE 1.7`, `meshtastic --sendtext --ack` against a live `rak3172` node returned `PKI_SEND_FAIL_PUBLIC_KEY` (unrelated — no shared public key yet) instead of `NO_INTERFACE`, and `--traceroute` round-tripped successfully.
- Not hardware-tested: genuine non-T RAK3172, `russell`, `milesight_gs301`, `CDEBYTE_E77-MBL`.
- Build-verified, all compile clean. Flash usage:
  - `rak3172`: 88.0% (218,084/247,808)
  - `wio-e5`: 93.0% (230,384/247,808)
  - `CDEBYTE_E77-MBL`: 83.3% (206,472/247,808)
  - `russell`: 94.9% (235,168/247,808)
- `./bin/run-tests.sh`: STM32WL code is `#ifdef ARCH_STM32WL`-gated, not exercised by the native suite.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described — `rak3172` TCXO path and `wio-e5`, both hardware-verified; see Testing above for what wasn't.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] RAK3172 (RAK3172-T module)
  - [x] Wio-E5
  - [x] Other (please specify below)

Not tested on: genuine non-T RAK3172, `russell`, `milesight_gs301`, `CDEBYTE_E77-MBL`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TCXO voltage support for compatible STM32 LoRa boards.
  * Added board-specific oscillator settings for EByte E77-MBL, RAK3172(-T), and Wio-E5 variants.
  * Devices with optional TCXO hardware now automatically retry startup in crystal oscillator mode when needed.
* **Bug Fixes**
  * Improved LoRa radio initialization reliability across boards with different oscillator configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
