### PR TITLE
Give the 4MB T3-S3 boards an app partition that fits

### DIFF
--- a/bin/device-install.sh
+++ b/bin/device-install.sh
@@ -7,9 +7,9 @@ MCU=""
 # Constants
 RESET_BAUD=1200
 FIRMWARE_OFFSET=0x00
-# Default littlefs* offset.
-OFFSET=0x300000
-# Default OTA Offset
+# Fallback offsets, used only when firmware metadata carries no partition table.
+# These track partition-table.csv; boards with their own table override them below.
+SPIFFS_OFFSET=0x300000
 OTA_OFFSET=0x260000
 
 # Determine the correct esptool command to use
@@ -122,8 +122,15 @@ if [[ -f "$FILENAME" && "$FILENAME" == *.factory.bin ]]; then
         jq . "$METAFILE"
         # Extract relevant fields from metadata
         if [[ $(jq -r '.part' "$METAFILE") != "null" ]]; then
-            OTA_OFFSET=$(jq -r '.part[] | select(.subtype == "ota_1") | .offset' "$METAFILE")
-            SPIFFS_OFFSET=$(jq -r '.part[] | select(.subtype == "spiffs") | .offset' "$METAFILE")
+            META_OTA_OFFSET=$(jq -r '.part[] | select(.subtype == "ota_1") | .offset' "$METAFILE")
+            META_SPIFFS_OFFSET=$(jq -r '.part[] | select(.subtype == "spiffs") | .offset' "$METAFILE")
+            # A partition table may omit either entry; keep the built-in default then.
+            if [[ -n "$META_OTA_OFFSET" && "$META_OTA_OFFSET" != "null" ]]; then
+                OTA_OFFSET="$META_OTA_OFFSET"
+            fi
+            if [[ -n "$META_SPIFFS_OFFSET" && "$META_SPIFFS_OFFSET" != "null" ]]; then
+                SPIFFS_OFFSET="$META_SPIFFS_OFFSET"
+            fi
         fi
         MCU=$(jq -r '.mcu' "$METAFILE")
     else
@@ -154,9 +161,9 @@ if [[ -f "$FILENAME" && "$FILENAME" == *.factory.bin ]]; then
     $ESPTOOL_CMD ${ESPTOOL_ERASE_FLASH}
     $ESPTOOL_CMD ${ESPTOOL_WRITE_FLASH} $FIRMWARE_OFFSET "${FILENAME}"
     echo "Trying to flash ${OTAFILE} at offset ${OTA_OFFSET}"
-    $ESPTOOL_CMD ${ESPTOOL_WRITE_FLASH} $OTA_OFFSET "${OTAFILE}"
-    echo "Trying to flash ${SPIFFSFILE}, at offset ${OFFSET}"
-    $ESPTOOL_CMD ${ESPTOOL_WRITE_FLASH} $OFFSET "${SPIFFSFILE}"
+    $ESPTOOL_CMD ${ESPTOOL_WRITE_FLASH} "$OTA_OFFSET" "${OTAFILE}"
+    echo "Trying to flash ${SPIFFSFILE}, at offset ${SPIFFS_OFFSET}"
+    $ESPTOOL_CMD ${ESPTOOL_WRITE_FLASH} "$SPIFFS_OFFSET" "${SPIFFSFILE}"
 
 else
     show_help

--- a/partition-table-t3s3.csv
+++ b/partition-table-t3s3.csv
@@ -1,0 +1,11 @@
+# Layout for 4MB LILYGO T3-S3 boards (ESP32-S3FH4R2).
+# Reclaims 256KB from spiffs to give the app slot real headroom.
+# flashApp (ota_1) keeps its full 0xA0000 (655,360 B): the unified BLE OTA image
+# (meshtastic/esp32-unified-ota v1.0.1, mt-esp32s3-ota.bin) is 636,544 B, so this
+# slot cannot be shrunk to fund the app slot instead.
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x009000, 0x005000,
+otadata,  data, ota,     0x00e000, 0x002000,
+app,      app,  ota_0,   0x010000, 0x290000,
+flashApp, app,  ota_1,   0x2A0000, 0x0A0000,
+spiffs,   data, spiffs,  0x340000, 0x0C0000,

--- a/variants/esp32s3/tlora_t3s3_epaper/platformio.ini
+++ b/variants/esp32s3/tlora_t3s3_epaper/platformio.ini
@@ -13,9 +13,10 @@ custom_meshtastic_has_ink_hud = true
 extends = esp32s3_base
 board = tlora-t3s3-v1
 board_check = true
+board_build.partitions = partition-table-t3s3.csv
 upload_protocol = esptool
 
-build_flags = 
+build_flags =
   ${esp32s3_base.build_flags}
   -D TLORA_T3S3_EPAPER
   -I variants/esp32s3/tlora_t3s3_epaper
@@ -38,6 +39,7 @@ lib_deps =
 extends = esp32s3_base, inkhud
 board = tlora-t3s3-v1
 board_check = true
+board_build.partitions = partition-table-t3s3.csv
 upload_protocol = esptool
 build_src_filter =
   ${esp32s3_base.build_src_filter}

--- a/variants/esp32s3/tlora_t3s3_v1/platformio.ini
+++ b/variants/esp32s3/tlora_t3s3_v1/platformio.ini
@@ -12,9 +12,10 @@ custom_meshtastic_requires_dfu = true
 extends = esp32s3_base
 board = tlora-t3s3-v1
 board_check = true
+board_build.partitions = partition-table-t3s3.csv
 upload_protocol = esptool
 
-build_flags = 
+build_flags =
   ${esp32s3_base.build_flags}
   -D TLORA_T3S3_V1
   -I variants/esp32s3/tlora_t3s3_v1


### PR DESCRIPTION
## Problem

`tlora-t3s3-v1` and `tlora-t3s3-epaper` have exceeded the app slot of the shared `partition-table.csv` (`ota_0 = 0x250000` = 2,424,832 B) on **every develop build since 22072c5f4** (2026-06-20). The last green build, `ca7d82629`, cleared it by 881 bytes. develop today is ~38.7 KB over:

```
Error: The program size (2,463,504 bytes) is greater than maximum allowed (2,424,832 bytes)
```

These envs have no `board_level`, so `bin/generate_ci_matrix.py --level pr` omits them — they only build in the full matrix on push to develop. That's why no PR ever caught it. The board never really had room; TMM nexthop (#10745) just tipped it.

## Fix

A dedicated `partition-table-t3s3.csv` for the 4 MB ESP32-S3FH4R2 T3-S3 boards, wired to all three t3s3 envs:

| partition | subtype | offset | size | change |
|---|---|---|---|---|
| `app` | `ota_0` | `0x010000` | `0x290000` | **+256 KB** (was `0x250000`) |
| `flashApp` | `ota_1` | `0x2A0000` | `0x0A0000` | unchanged |
| `spiffs` | — | `0x340000` | `0x0C0000` | **−256 KB** (was `0x100000`) |

The headroom comes out of `spiffs`, not `flashApp`. The unified BLE OTA image (`meshtastic/esp32-unified-ota` v1.0.1, `mt-esp32s3-ota.bin`) is **636,544 B** against a **655,360 B** slot, so `ota_1` has nothing to give. The table is contiguous, ends exactly at 4 MiB, and keeps both app partitions 64 KB-aligned.

This follows existing precedent — `partition-table-8MB.csv`, `default_8MB.csv`, and `default_16MB.csv` are already selected per-variant via `board_build.partitions`.

## Why not trim instead

Measured, not estimated:

| lever | bytes | verdict |
|---|---|---|
| `-D EXCLUDE_EMOJI` (guard already exists, unused) | −6,304 | 16% of the deficit |
| drop `espressif/network_provisioning` | −5,740 | |
| `HAS_TRAFFIC_MANAGEMENT=0` + exclude paxcounter/storeforward/rangetest/atak | −46,636 cumulative | lands at 99.7% full |

The full trim clears the cap by only 8,413 bytes — weeks of headroom at develop's observed ~38 KB/3-weeks growth — in exchange for shipping a feature-reduced board. The slot was mis-sized, not the firmware.

(For the record: `EXCLUDE_EMOJI` also cannot be enabled as-is. `numEmotes` becomes 0, the clamp at `CannedMessageModule.cpp:1835` sets `emotePickerIndex = -1`, and `:1016` then reads `emotes[-1].label`. Reachable via CardKB `fn+e`.)

## Flasher fix (first commit)

`bin/device-install.sh` read the spiffs offset from `.mt.json` into `SPIFFS_OFFSET`, then flashed littlefs at `$OFFSET` — a different variable still holding the hardcoded `0x300000`. **The metadata value was never used.** Under the new table that writes the filesystem into `flashApp`, clobbering the OTA image.

Unified on `SPIFFS_OFFSET`, guarded both metadata overrides against empty/`null` jq results, and quoted the offsets at the call site. `device-install.bat` already did all three correctly; this brings the shell script to parity.

## Verification

Docker build of all three envs against the new table:

| env | flash | usage |
|---|---|---|
| `tlora-t3s3-v1` | 2,463,504 | 91.7% |
| `tlora-t3s3-epaper` | 2,458,487 | 91.5% |
| `tlora-t3s3-epaper-inkhud` | 2,400,851 | 89.4% |

Partition table validated for contiguity, 64 KB app alignment, and exact 4 MiB end. `bash -n` + shellcheck clean on the flasher.

## ⚠️ Flash layout change

Existing T3-S3 units must be **erased and factory-flashed once** to pick up the new offsets; an OTA across the boundary would land the image at the wrong address. No working configuration regresses — these boards already cannot run a current develop build.

Downstream flashers that hardcode `0x260000`/`0x300000` for ESP32 (web flasher, mobile apps) will need the same metadata-driven offset handling that `device-install.sh`/`.bat` now use.

## Follow-up (not in this PR)

Once this is green, adding `board_level = pr` to the t3s3 envs would make PR CI catch the next overflow instead of develop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved device installation by correctly applying firmware-specific OTA and SPIFFS partition offsets.
  - Added safer handling for missing partition metadata and flashing parameters.

- **Configuration**
  - Updated ESP32-S3 builds to use the correct T3S3 partition table.
  - Applied consistent partition settings across supported T3S3 device variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->