### PR TITLE
Fix ESP32 NimBLE include paths on Windows builds

### DIFF
--- a/variants/esp32/esp32.ini
+++ b/variants/esp32/esp32.ini
@@ -22,16 +22,17 @@ build_flags =
   -DMESHTASTIC_EXCLUDE_RANGETEST=1
   ; HACK HACK HACK this is just a proof of concept ESP32+NimBLE but these
   ; includes need to be done properly somehow
-  -I${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/nimble/host/include
-  -I${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/nimble/include
-  -I${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/porting/nimble/include
-  -I${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/port/include
-  -I${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/porting/npl/freertos/include
-  -I${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/nimble/transport/include
-  -I${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/nimble/host/services/gap/include
-  -I${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/esp-hci/include
-  -I${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/nimble/host/services/gatt/include
-  -I${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/nimble/host/util/include
+  ; Quotes keep Windows packages_dir backslashes intact through POSIX flag parsing
+  -I"${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/nimble/host/include"
+  -I"${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/nimble/include"
+  -I"${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/porting/nimble/include"
+  -I"${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/port/include"
+  -I"${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/porting/npl/freertos/include"
+  -I"${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/nimble/transport/include"
+  -I"${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/nimble/host/services/gap/include"
+  -I"${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/esp-hci/include"
+  -I"${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/nimble/host/services/gatt/include"
+  -I"${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/nimble/host/util/include"
 
 custom_sdkconfig =
   ${esp32_common.custom_sdkconfig}


### PR DESCRIPTION
On Windows, ${platformio.packages_dir} interpolates to a backslash path (e.g. C:\Users\name\.platformio\packages). PlatformIO parses build_flags with POSIX shell rules, which treat backslashes as escape characters. The NimBLE include flags in variants/esp32/esp32.ini therefore end up as broken drive-relative paths (c:usersname.platformiopackages/...) anchored at the platform builder directory, and every Windows native build of an ESP32 target fails with:

    src/nimble/NimbleBluetooth.cpp:23:10: fatal error: host/ble_gap.h: No such file or directory

Wrapping the -I flags in double quotes preserves the backslashes through flag parsing. No behavior change on Linux/macOS.

Verified on Windows 11 with pioarduino platform 55.03.39: radiomaster targets fail before the change and build successfully after it. CPPPATH resolution checked with pio run -t envdump in both states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ESP32 build configuration compatibility on Windows by preserving package path formatting during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->