### PR TITLE
Draft: Restore XEdDSA material in keygen-excluded identity loads

### DIFF
--- a/src/mesh/CryptoEngine.cpp
+++ b/src/mesh/CryptoEngine.cpp
@@ -289,6 +289,9 @@ bool CryptoEngine::decryptCurve25519(uint32_t fromNode, meshtastic_NodeInfoLite_
 void CryptoEngine::setDHPrivateKey(uint8_t *_private_key)
 {
     memcpy(private_key, _private_key, 32);
+#if !(MESHTASTIC_EXCLUDE_XEDDSA)
+    XEdDSA::priv_curve_to_ed_keys(private_key, xeddsa_private_key, xeddsa_public_key);
+#endif
 }
 
 /**

--- a/src/mesh/CryptoEngine.cpp
+++ b/src/mesh/CryptoEngine.cpp
@@ -290,6 +290,11 @@ void CryptoEngine::setDHPrivateKey(uint8_t *_private_key)
 {
     memcpy(private_key, _private_key, 32);
 #if !(MESHTASTIC_EXCLUDE_XEDDSA)
+    if (memfll(private_key, 0, sizeof(private_key))) {
+        memset(xeddsa_private_key, 0, sizeof(xeddsa_private_key));
+        memset(xeddsa_public_key, 0, sizeof(xeddsa_public_key));
+        return;
+    }
     XEdDSA::priv_curve_to_ed_keys(private_key, xeddsa_private_key, xeddsa_public_key);
 #endif
 }

--- a/test/test_crypto/test_main.cpp
+++ b/test/test_crypto/test_main.cpp
@@ -307,6 +307,22 @@ void test_XEdDSA_persisted_private_key_reload(void)
     TEST_ASSERT_TRUE(secondLoad.xeddsa_verify(curvePublic, 0x12345678, 0xABCDEF01, 1, payload, sizeof(payload), signature));
 }
 
+void test_XEdDSA_zero_private_key_reload_clears_signing_material(void)
+{
+    uint8_t curvePublic[32], privateKey[32], zeroKey[32] = {0};
+    uint8_t signature[XEDDSA_SIGNATURE_SIZE];
+    const uint8_t payload[] = "zero persisted identity";
+
+    crypto->generateKeyPair(curvePublic, privateKey);
+    crypto->setDHPrivateKey(privateKey);
+    TEST_ASSERT_TRUE(crypto->xeddsa_sign(0x1, 0x2, 1, payload, sizeof(payload), signature));
+
+    crypto->setDHPrivateKey(zeroKey);
+    TEST_ASSERT_EQUAL_MEMORY(zeroKey, crypto->xeddsa_private_key, sizeof(zeroKey));
+    TEST_ASSERT_EQUAL_MEMORY(zeroKey, crypto->xeddsa_public_key, sizeof(zeroKey));
+    TEST_ASSERT_FALSE(crypto->xeddsa_sign(0x1, 0x2, 1, payload, sizeof(payload), signature));
+}
+
 void test_AES_CTR(void)
 {
     uint8_t expected[32];
@@ -354,6 +370,7 @@ void setup()
     RUN_TEST(test_XEdDSA_max_payload);
     RUN_TEST(test_XEdDSA_repeated_sign_is_randomized);
     RUN_TEST(test_XEdDSA_persisted_private_key_reload);
+    RUN_TEST(test_XEdDSA_zero_private_key_reload_clears_signing_material);
     exit(UNITY_END()); // stop unit testing
 }
 

--- a/test/test_crypto/test_main.cpp
+++ b/test/test_crypto/test_main.cpp
@@ -284,6 +284,29 @@ void test_XEdDSA_repeated_sign_is_randomized(void)
     TEST_ASSERT_TRUE(crypto->xeddsa_verify(pub, fromNode, packetId, portnum, message, sizeof(message), sig2));
 }
 
+void test_XEdDSA_persisted_private_key_reload(void)
+{
+    uint8_t curvePublic[32], persistedPrivate[32];
+    uint8_t expectedEdPrivate[32], expectedEdPublic[32];
+    crypto->generateKeyPair(curvePublic, persistedPrivate);
+    XEdDSA::priv_curve_to_ed_keys(persistedPrivate, expectedEdPrivate, expectedEdPublic);
+
+    CryptoEngine firstLoad;
+    CryptoEngine secondLoad;
+    firstLoad.setDHPrivateKey(persistedPrivate);
+    secondLoad.setDHPrivateKey(persistedPrivate);
+
+    TEST_ASSERT_EQUAL_MEMORY(expectedEdPrivate, firstLoad.xeddsa_private_key, sizeof(expectedEdPrivate));
+    TEST_ASSERT_EQUAL_MEMORY(expectedEdPublic, firstLoad.xeddsa_public_key, sizeof(expectedEdPublic));
+    TEST_ASSERT_EQUAL_MEMORY(firstLoad.xeddsa_private_key, secondLoad.xeddsa_private_key, sizeof(expectedEdPrivate));
+    TEST_ASSERT_EQUAL_MEMORY(firstLoad.xeddsa_public_key, secondLoad.xeddsa_public_key, sizeof(expectedEdPublic));
+
+    const uint8_t payload[] = "persisted identity";
+    uint8_t signature[XEDDSA_SIGNATURE_SIZE];
+    TEST_ASSERT_TRUE(firstLoad.xeddsa_sign(0x12345678, 0xABCDEF01, 1, payload, sizeof(payload), signature));
+    TEST_ASSERT_TRUE(secondLoad.xeddsa_verify(curvePublic, 0x12345678, 0xABCDEF01, 1, payload, sizeof(payload), signature));
+}
+
 void test_AES_CTR(void)
 {
     uint8_t expected[32];
@@ -330,6 +353,7 @@ void setup()
     RUN_TEST(test_XEdDSA_curve_to_ed_cache);
     RUN_TEST(test_XEdDSA_max_payload);
     RUN_TEST(test_XEdDSA_repeated_sign_is_randomized);
+    RUN_TEST(test_XEdDSA_persisted_private_key_reload);
     exit(UNITY_END()); // stop unit testing
 }
 


### PR DESCRIPTION
Refs #10982

Related: #10966
Design: meshtastic/design#122

## Summary

- rebuild the in-memory XEdDSA private/public material when a valid persisted Curve25519 identity is installed through the keygen-excluded boot restore path;
- use the same guarded deterministic conversion already used during key generation and public-key regeneration;
- leave normal Curve25519 PKI behavior and XEdDSA-excluded targets unchanged;
- add a regression that loads one persisted identity into two fresh crypto engines, compares the exact derived XEdDSA material, then signs with one instance and verifies with the other.

Normal keygen-capable builds already call `regeneratePublicKey()` before installing the private key. This draft is intentionally limited to deciding and covering behavior for `MESHTASTIC_EXCLUDE_PKI_KEYGEN` builds that restore an existing PKI identity.

## Validation

- native macOS crypto suite: 12/12 passed;
- native macOS packet-signing suite: 29/29 passed;
- T-Echo XEdDSA-enabled build: passed, 37.5% RAM, 92.6% flash, 46 KiB warm-region clearance;
- Wio-E5 with `MESHTASTIC_EXCLUDE_XEDDSA=1`: passed, 40.7% RAM, 96.8% flash;
- independent dedicated security review approved exact head `521c62015d39ca57b8180cf7e78e62ae48a2184b`;
- Trunk and `git diff --check`: clean.

The regression fails on the pre-fix baseline because a fresh engine has no reconstructed XEdDSA material after loading a persisted Curve private key, and passes with this change.

## Draft / decision status

Keep this PR draft pending maintainer direction on whether XEdDSA signing is intended for the keygen-excluded restore path. No internal bench logs or captures are included.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described within the validation limits above.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (build-only validation on T-Echo and Wio-E5)
