### PR TITLE
Auto-enable nanopb PB_NO_ERRMSG when DEBUG_MUTE is set

### DIFF
--- a/bin/platformio-custom.py
+++ b/bin/platformio-custom.py
@@ -340,6 +340,18 @@ for lb in env.GetLibBuilders():
         lb.env.Append(CPPDEFINES=[("APP_VERSION", verObj["long"])])
         break
 
+# DEBUG_MUTE already compiles every LOG_* call out entirely; nanopb's own error-message
+# strings are a separate mechanism it doesn't touch, so mirror the same intent into nanopb.
+debug_mute_defined = any(
+    d == "DEBUG_MUTE" or (isinstance(d, tuple) and d[0] == "DEBUG_MUTE") for d in env.get("CPPDEFINES", [])
+)
+if debug_mute_defined:
+    projenv.Append(CPPDEFINES=[("PB_NO_ERRMSG", 1)])
+    for lb in env.GetLibBuilders():
+        if lb.name == "Nanopb":
+            lb.env.Append(CPPDEFINES=[("PB_NO_ERRMSG", 1)])
+            break
+
 # Get the display resolution from macros
 def get_display_resolution(build_flags):
     # Check "DISPLAY_SIZE" to determine the screen resolution


### PR DESCRIPTION
## Summary

Auto-enables nanopb's `PB_NO_ERRMSG` whenever `DEBUG_MUTE` is set, by deriving it in `bin/platformio-custom.py` from the SCons build environment instead of hardcoding it per-platform.

- `wio-e5`: 1,248 bytes flash saved, 0 RAM change.

## Why

`DEBUG_MUTE` already compiles every `LOG_*` call out entirely, but nanopb's own error strings are a separate mechanism it doesn't touch — `PB_RETURN_ERROR` still embeds descriptive text in `.rodata` that can never be logged.

## What changed

`bin/platformio-custom.py`: if `DEBUG_MUTE` is in the environment's `CPPDEFINES`, append `PB_NO_ERRMSG=1` to both the main project env and the `Nanopb` LibraryBuilder's env (a plain `env.Append()` on the app env doesn't reach nanopb's own translation units). Mirrors the existing `meshtastic-device-ui` / `APP_VERSION` pattern already in the same file.

`DEBUG_MUTE` currently only appears in `variants/stm32/stm32.ini` and `variants/stm32/milesight_gs301/platformio.ini`, so today this only affects STM32WL builds, but applies automatically to any future platform that sets `DEBUG_MUTE`.

## Testing

- `pio run -e wio-e5`: 1,248 bytes flash saved, 0 RAM change, reproduced on a clean `develop` checkout.
- Grepped the `.ini` tree to confirm no other platform sets `DEBUG_MUTE` today.
- No physical hardware tested. Only affects protobuf error-message text (`PB_GET_ERROR`), not wire format.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described. (build-level only, see Testing above)
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below): none of these are affected — `DEBUG_MUTE` currently only applies to STM32WL targets


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced nanopb error-message output when debug muting is enabled.
  * Ensured the debug mute setting propagates consistently across build targets, including nanopb.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->