### PR TITLE
feat(gps): cache negative probe verdict — skip 76s baud scan on GPS-less boards

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -79,7 +79,7 @@ namespace
 {
 // Versioned on-disk record for persisted GPS probe results.
 constexpr uint32_t GPS_PROBE_CACHE_MAGIC = 0x47504348UL; // "GPCH"
-constexpr uint16_t GPS_PROBE_CACHE_VERSION = 1;
+constexpr uint16_t GPS_PROBE_CACHE_VERSION = 2;
 constexpr const char *GPS_PROBE_CACHE_FILE = "/prefs/gps_probe_cache.dat";
 constexpr int MIN_PLAUSIBLE_GPS_YEAR = 2020;
 constexpr int MAX_PLAUSIBLE_GPS_YEAR = 2100;
@@ -91,7 +91,8 @@ constexpr uint32_t T1000_E_AIROHA_WAKE_INTERVAL_MS = 40;
 struct GPSProbeCacheRecord {
     uint32_t magic;
     uint16_t version;
-    uint16_t reserved;
+    uint8_t reserved;
+    uint8_t negative_verdict;
     uint32_t baud;
     uint8_t model;
 };
@@ -607,7 +608,7 @@ bool GPS::loadProbeCache()
 {
 #ifdef FSCom
     // Load the last known-good GPS model/baud pair so we can avoid a full probe
-    // sweep on every boot.
+    // sweep on every boot. Also handles cached negative verdicts (GPS not detected).
     triedProbeCache = true; // Latch this boot's load attempt, even if no cache.
     GPSProbeCacheRecord record = {};
     size_t bytesRead = 0;
@@ -623,10 +624,24 @@ bool GPS::loadProbeCache()
     spiLock->unlock();
 
     const bool headerValid = (bytesRead == sizeof(record)) && (record.magic == GPS_PROBE_CACHE_MAGIC) &&
-                             (record.version == GPS_PROBE_CACHE_VERSION) && (record.reserved == 0U);
-    if (!headerValid || !isValidGnssModel(record.model) || !isValidProbeBaud(record.baud)) {
-        clearProbeCache(); // Drop corrupt/invalid cache so next boot can
-                           // recover.
+                             (record.version == GPS_PROBE_CACHE_VERSION);
+    if (!headerValid) {
+        clearProbeCache(); // Drop corrupt/invalid cache so next boot can recover.
+        return false;
+    }
+
+    // Handle negative verdict: GPS exhaustively probed but not found.
+    if (record.negative_verdict == 1) {
+        // Honor cached negative verdict to skip exhaustive baud scan.
+        // Users can re-probe by changing position config (clears cache) or manually deleting /prefs/gps_probe_cache.dat.
+        hasNegativeProbeCache = true;
+        LOG_INFO("GPS probe skipped: cached negative verdict");
+        return true; // Skip probe; GPS remains GNSS_MODEL_UNKNOWN.
+    }
+
+    // Positive verdict: cached GPS model found.
+    if (!isValidGnssModel(record.model) || !isValidProbeBaud(record.baud)) {
+        clearProbeCache(); // Drop corrupt/invalid cache so next boot can recover.
         return false;
     }
 
@@ -670,7 +685,7 @@ bool GPS::saveProbeCache() const
     FSCom.mkdir("/prefs");
     spiLock->unlock();
     GPSProbeCacheRecord record = {
-        GPS_PROBE_CACHE_MAGIC, GPS_PROBE_CACHE_VERSION, 0, static_cast<uint32_t>(detectedBaud), static_cast<uint8_t>(gnssModel),
+        GPS_PROBE_CACHE_MAGIC, GPS_PROBE_CACHE_VERSION, 0, 0, static_cast<uint32_t>(detectedBaud), static_cast<uint8_t>(gnssModel),
     };
 
     auto file = SafeFile(GPS_PROBE_CACHE_FILE, true);
@@ -680,6 +695,42 @@ bool GPS::saveProbeCache() const
     return (written == sizeof(record)) && file.close();
 #else
     return false;
+#endif
+}
+
+bool GPS::saveNegativeProbeCache() const
+{
+#ifdef FSCom
+    // Cache a negative probe verdict: GPS not detected after exhaustive baud scan.
+    // This saves ~76 seconds on every boot for GPS-less boards with HAS_GPS defined.
+    spiLock->lock();
+    FSCom.mkdir("/prefs");
+    spiLock->unlock();
+    GPSProbeCacheRecord record = {
+        GPS_PROBE_CACHE_MAGIC, GPS_PROBE_CACHE_VERSION, 0, 1, 0, static_cast<uint8_t>(GNSS_MODEL_UNKNOWN),
+    };
+
+    auto file = SafeFile(GPS_PROBE_CACHE_FILE, true);
+    spiLock->lock();
+    const size_t written = file.write(reinterpret_cast<const uint8_t *>(&record), sizeof(record));
+    spiLock->unlock();
+    LOG_INFO("GPS probe negative verdict cached — will skip probe next boot");
+    return (written == sizeof(record)) && file.close();
+#else
+    return false;
+#endif
+}
+
+void GPS::clearProbeCacheFile()
+{
+// Called by AdminModule when position config is written; invalidates cached
+// probe result so next boot will re-probe GPS.
+#ifdef FSCom
+    spiLock->lock();
+    if (FSCom.exists(GPS_PROBE_CACHE_FILE)) {
+        FSCom.remove(GPS_PROBE_CACHE_FILE);
+    }
+    spiLock->unlock();
 #endif
 }
 
@@ -810,8 +861,15 @@ bool GPS::setup()
     if (!didSerialInit) {
         int msglen = 0;
         if (tx_gpio && gnssModel == GNSS_MODEL_UNKNOWN) {
-            if (!hasProbeCache && !triedProbeCache) {
+            if (!hasProbeCache && !triedProbeCache && !hasNegativeProbeCache) {
                 (void)loadProbeCache();
+            }
+
+            // Handle negative probe verdict: skip probe entirely on this boot.
+            // (didSerialInit=true prevents re-entry on subsequent calls to setup())
+            if (hasNegativeProbeCache) {
+                didSerialInit = true; // Skip rest of GPS init; gnssModel remains UNKNOWN.
+                return true;           // Probe skipped; update() will see UNKNOWN and call disable().
             }
 
             if (hasProbeCache && !triedProbeCache) {
@@ -852,6 +910,7 @@ bool GPS::setup()
             setConnected();
             (void)saveProbeCache();
         } else {
+            (void)saveNegativeProbeCache(); // Cache that no GPS module was found.
             return false;
         }
 

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -132,6 +132,9 @@ class GPS : private concurrency::OSThread
     // Let the GPS hardware save power between updates
     void down();
 
+    // Clear on-disk probe cache file (static for AdminModule hook when position config changes).
+    static void clearProbeCacheFile();
+
   private:
     GPS() : concurrency::OSThread("GPS") {}
 
@@ -165,6 +168,8 @@ class GPS : private concurrency::OSThread
     void clearProbeCache();
     // Persist the currently detected GPS model+baud.
     bool saveProbeCache() const;
+    // Persist a negative probe verdict (GPS not found after exhaustive scan).
+    bool saveNegativeProbeCache() const;
     // Verify the cached model+baud still maps to a live GPS device.
     bool verifyCachedProbePresence();
 
@@ -198,6 +203,8 @@ class GPS : private concurrency::OSThread
     bool hasProbeCache = false;
     // Ensures cached probe is attempted once per boot.
     bool triedProbeCache = false;
+    // Negative probe verdict cached (GPS not found).
+    bool hasNegativeProbeCache = false;
 
     /**
      * hasValidLocation - indicates that the position variables contain a complete

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -846,6 +846,10 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
             saveChanges(SEGMENT_NODEDATABASE | SEGMENT_CONFIG, false);
         }
         config.position = c.payload_variant.position;
+        // User touched position config — invalidate GPS probe cache so next boot re-probes.
+#if !MESHTASTIC_EXCLUDE_GPS
+        GPS::clearProbeCacheFile();
+#endif
 
         // Save nodedb as well in case we got a fixed position packet
         break;


### PR DESCRIPTION
## Why

Boards that define `HAS_GPS` + GPS pins for an *optional* module (e.g. seeed-xiao-s3, where the L76K is an expansion board) run the full exhaustive GPS baud probe on **every boot** when no module is attached: ~76 seconds of `Set GPS Baud to X` / `Trying $PDTINFO...` / `No GNSS Module` cycles before `GPS not detected; marked not present for this boot`. This delays boot-to-usable and floods the serial console (on ESP32-S3 native USB-Serial/JTAG we observed byte-level corruption in the stream during the flood).

The probe cache (`/prefs/gps_probe_cache.dat`) already persists *positive* verdicts (model+baud) — but `saveProbeCache()` explicitly skips saving when `gnssModel == GNSS_MODEL_UNKNOWN`, so the expensive negative outcome is rediscovered every boot.

## What

- `GPSProbeCacheRecord`: split the `uint16_t reserved` into `reserved` + `negative_verdict` (same 16-byte layout), bump cache version 1→2 (old caches auto-invalidated).
- `saveNegativeProbeCache()`: after the probe exhausts all bauds with no module found, persist the negative verdict.
- `loadProbeCache()`: a valid negative verdict skips the probe entirely on subsequent boots (GPS stays `GNSS_MODEL_UNKNOWN` → disabled, same end state as today, just ~76s sooner).
- Invalidation: any **position config write via AdminModule** clears the cache file (`GPS::clearProbeCacheFile()`, guarded by `#if !MESHTASTIC_EXCLUDE_GPS` like the neighboring GPS references) — so attaching a module later just requires touching position config (which reboots anyway) or deleting the file. Version bump covers upgrades.

## Testing

- `pio run -e seeed-xiao-s3` clean.
- Flashed to a physical seeed-xiao-s3 with no GPS module: first boot ran the full probe once; every subsequent observed boot (4+, including DTR-reset boots) showed zero probe activity, firmware healthy (scheduler/modules running normally).
- Positive-verdict path untouched apart from the struct/version change.

Found while running e2e sessions against develop with an MCP-driven bench harness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPS detection outcomes are now persisted across reboots, including “no GPS detected” results.
  * Devices can avoid repeated GPS probing when a prior negative result is available.
* **Bug Fixes**
  * GPS probe cache format was updated to improve reliability, and corrupt/invalid cached data is cleared automatically to allow recovery.
  * Changing GPS-related configuration now clears the cached result so fresh detection runs on the next boot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->