### PR TITLE
stm32wl(rak3172): implement cpuDeepSleep()/shutdown() via STM32LowPower

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -906,7 +906,7 @@ void Power::shutdown()
 #if HAS_SCREEN
     messageStore.saveToFlash();
 #endif
-#if defined(ARCH_NRF52) || defined(ARCH_ESP32) || defined(ARCH_RP2040)
+#if defined(ARCH_NRF52) || defined(ARCH_ESP32) || defined(ARCH_RP2040) || defined(ARCH_STM32WL)
 #ifdef PIN_LED1
     ledOff(PIN_LED1);
 #endif

--- a/src/platform/stm32wl/main-stm32wl.cpp
+++ b/src/platform/stm32wl/main-stm32wl.cpp
@@ -7,6 +7,7 @@
 #include <stm32wlxx_hal.h>
 
 #if HAS_LSE
+#include <STM32LowPower.h>
 #include <STM32RTC.h>
 
 // LSEDRV is a 2-bit RCC_BDCR field where every combination is a legal drive level, so this covers all 4 values.
@@ -120,6 +121,7 @@ void stm32wlSetup()
         rtc.setClockSource(STM32RTC::LSE_CLOCK);
         rtc.begin();
         stm32wlRtcValid = true;
+        LowPower.begin();
         LOG_INFO("STM32WL: LSE locked, hardware RTC available");
     } else {
         // Don't leave a failed oscillator burning current.
@@ -138,7 +140,24 @@ bool stm32wlRtcAvailable()
 void stm32wlSetup() {}
 #endif
 
-void cpuDeepSleep(uint32_t msecToWake) {}
+void cpuDeepSleep(uint32_t msecToWake)
+{
+#if HAS_LSE
+    if (!stm32wlRtcAvailable())
+        return;
+
+    if (Serial)
+        Serial.end();
+
+    if (msecToWake != portMAX_DELAY) {
+        LowPower.shutdown(msecToWake);
+    } else {
+        LowPower.shutdown();
+    }
+    // RTC wakes from shutdown into MCU reset, so this code should never be reached
+    HAL_NVIC_SystemReset();
+#endif
+}
 
 // Hacks to force more code and data out.
 

--- a/src/platform/stm32wl/main-stm32wl.cpp
+++ b/src/platform/stm32wl/main-stm32wl.cpp
@@ -143,11 +143,21 @@ void stm32wlSetup() {}
 void cpuDeepSleep(uint32_t msecToWake)
 {
 #if HAS_LSE
-    if (!stm32wlRtcAvailable())
-        return;
+    if (!stm32wlRtcAvailable()) {
+        // Hardware can't shutdown, but firmware has already prepared itself for shutdown
+        // Do not leave the device unresponsive, reset instead
+        LOG_WARN("STM32WL: hardware RTC failed, cannot deep sleep/shutdown");
+        if (Serial) {
+            Serial.flush();
+            Serial.end();
+        }
+        HAL_NVIC_SystemReset();
+    }
 
-    if (Serial)
+    if (Serial) {
+        Serial.flush();
         Serial.end();
+    }
 
     if (msecToWake != portMAX_DELAY) {
         LowPower.shutdown(msecToWake);

--- a/variants/stm32/rak3172/platformio.ini
+++ b/variants/stm32/rak3172/platformio.ini
@@ -20,5 +20,7 @@ lib_deps =
   ${stm32_base.lib_deps}
   # renovate: datasource=github-tags depName=STM32RTC packageName=stm32duino/STM32RTC
   https://github.com/stm32duino/STM32RTC/archive/refs/tags/1.9.0.zip
+  # renovate: datasource=github-tags depName=STM32LowPower packageName=stm32duino/STM32LowPower
+  https://github.com/stm32duino/STM32LowPower/archive/refs/tags/1.5.0.zip
 
 upload_port = stlink


### PR DESCRIPTION
## Summary

Implements deep-sleep/shutdown for STM32WL (`rak3172`) using the `STM32LowPower` Arduino library, building on #10961's `HAS_LSE`/`STM32RTC` infrastructure.

- `cpuDeepSleep()` (`src/platform/stm32wl/main-stm32wl.cpp`) was an empty stub, so the SDS deep-sleep PowerFSM state and low-battery shutdown never actually slept.
- `Power::shutdown()` didn't include STM32WL in its arch list, so an explicit shutdown command just logged a FIXME warning.

Both gaps are closed for `rak3172`, gated behind the existing `HAS_LSE` flag (default 0, only set for `rak3172`). The main reason to only implement it in RAK3172 is because the remaining FLASH memory is too tight on other variants, including the RTC and LowPower libraries overflow on most other STM32WL variants.

In future, this can (and should) be rolled out to all STM32WL variants that have a hardware LSE crystal (most of them, it seems).

## Dependency

This PR is based on #10961 (open, not yet merged). `stm32wl-hardware-rtc` (its head branch) only exists on the `mesh-malaysia` fork, not upstream, so this PR targets `develop` directly — the diff currently includes #10961's commits too, until #10961 merges.

## Implementation

Both `cpuDeepSleep()` paths use `LowPower.shutdown()` (Standby mode) — with an RTC alarm for a finite wake (SDS/low-battery), without one for a forever shutdown (`Power::shutdown()`).

## Flash budget

| | Flash |
|---|---|
| `rak3172` before | 76.7% (190,100 / 247,808) |
| `rak3172` after | 77.1% (191,452 / 247,808) |
| `wio-e5` before/after | 96.8%, byte-identical |

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)

Tested on a RAK3172-T unit, with PR #10964's TCXO fixes cherry-picked in for that testing session (not included in this PR — a RAK3172-T needs #10964 to boot at all, but a base RAK3172 does not, and this PR's changes don't depend on it). Confirmed on hardware:
- Explicit shutdown (`Power::shutdown()`, Standby mode, no alarm): device saves state, sleeps the radio, enters Standby, and stays silent until manually reset.
- Low-battery deep sleep (Standby mode with RTC alarm, finite wake): `low_voltage_counter` debounce fires `EVENT_LOW_BATTERY`, device enters deep sleep, then resets and rejoins the mesh on its own once `sds_secs` elapses.

Build-verified no regression on `wio-e5`, `russell`, `CDEBYTE_E77-MBL` (`HAS_LSE` defaults to `0`, all new code compiled out). `milesight_gs301` fails to build on `develop` independent of this PR (pre-existing `NANOLIB_FLOAT_PRINTF`/debug-print config issue, confirmed via a clean checkout).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reliable deep-sleep support for STM32WL devices with hardware RTC availability checks.
  * STM32WL devices now support timed wake-up and indefinite deep sleep.
* **Bug Fixes**
  * Shutdown now consistently turns off indicator LEDs before entering deep sleep on supported STM32WL hardware.
  * Added safeguards to reset the device if deep-sleep recovery does not complete as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->