### PR TITLE
feat: populate MyNodeInfo.device_id on all platforms

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -406,9 +406,8 @@ NodeDB::NodeDB()
     uint32_t channelFileCRC = crc32Buffer(&channelFile, sizeof(channelFile));
 
     int saveWhat = 0;
-    // Get device unique id. Derived from silicon (or the factory MAC) by the per-architecture
-    // getDeviceId() in src/platform/<arch>/. Re-read on every boot: clear any value loaded from
-    // disk first so getDeviceId() returning false leaves it unset rather than stale.
+    // Re-read the device id from silicon each boot via the per-arch getDeviceId(); clear the
+    // disk-loaded value first so a failed/empty derivation leaves it unset rather than stale.
     myNodeInfo.device_id.size = 0;
     memset(myNodeInfo.device_id.bytes, 0, sizeof(myNodeInfo.device_id.bytes));
     if (getDeviceId(myNodeInfo.device_id.bytes)) {

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -430,7 +430,10 @@ NodeDB::NodeDB()
     uint32_t channelFileCRC = crc32Buffer(&channelFile, sizeof(channelFile));
 
     int saveWhat = 0;
-    // Get device unique id
+    // Get device unique id. Re-derived from silicon on every boot: clear any value loaded
+    // from disk first so a failed read below leaves it unset rather than stale.
+    myNodeInfo.device_id.size = 0;
+    memset(myNodeInfo.device_id.bytes, 0, sizeof(myNodeInfo.device_id.bytes));
 #if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3) ||            \
     defined(CONFIG_IDF_TARGET_ESP32C6)
     uint32_t unique_id[4];
@@ -475,8 +478,8 @@ NodeDB::NodeDB()
     myNodeInfo.device_id.size = 16;
 #elif ARCH_PORTDUINO
     if (portduino_config.has_device_id) {
-        memcpy(myNodeInfo.device_id.bytes, portduino_config.device_id, 16);
-        myNodeInfo.device_id.size = 16;
+        memcpy(myNodeInfo.device_id.bytes, portduino_config.device_id, sizeof(portduino_config.device_id));
+        myNodeInfo.device_id.size = sizeof(portduino_config.device_id);
     } else {
         // Config-supplied id stays preferred: host NIC/BT MACs can be unstable (docker, multi-NIC)
         deriveDeviceIdFromMacAddr();

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -27,6 +27,7 @@
 #include "mesh/generated/meshtastic/deviceonly_legacy.pb.h"
 #include "meshUtils.h"
 #include "modules/NeighborInfoModule.h"
+#include "target_specific.h"
 #if HAS_VARIABLE_HOPS
 #include "modules/HopScalingModule.h"
 #endif
@@ -368,11 +369,7 @@ void NodeDB::disarmNodeDatabaseDecodeTargets()
  */
 uint32_t radioGeneration;
 
-// FIXME - move this somewhere else
-extern void getMacAddr(uint8_t *dmac);
-
-// Per-architecture hardware device id (see target_specific.h); implemented in src/platform/<arch>/.
-extern bool getDeviceId(uint8_t *deviceId);
+// getMacAddr() and getDeviceId() are the per-architecture hooks declared in target_specific.h.
 
 /**
  *
@@ -417,16 +414,6 @@ NodeDB::NodeDB()
     if (getDeviceId(myNodeInfo.device_id.bytes)) {
         myNodeInfo.device_id.size = sizeof(myNodeInfo.device_id.bytes);
     }
-
-    // if (myNodeInfo.device_id.size == 16) {
-    //     std::string deviceIdHex;
-    //     for (size_t i = 0; i < myNodeInfo.device_id.size; ++i) {
-    //         char buf[3];
-    //         snprintf(buf, sizeof(buf), "%02X", myNodeInfo.device_id.bytes[i]);
-    //         deviceIdHex += buf;
-    //     }
-    //     LOG_DEBUG("Device ID (HEX): %s", deviceIdHex.c_str());
-    // }
 
     // likewise - we always want the app requirements to come from the running appload
     myNodeInfo.min_app_version = 30200; // format is Mmmss (where M is 1+the numeric major number. i.e. 30200 means 2.2.00

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -408,7 +408,7 @@ static uint8_t ourMacAddr[6];
 static void deriveDeviceIdFromMacAddr()
 {
     getMacAddr(ourMacAddr);
-    uint8_t zero_mac[sizeof(ourMacAddr)] = {0};
+    const uint8_t zero_mac[sizeof(ourMacAddr)] = {0};
     if (memcmp(ourMacAddr, zero_mac, sizeof(ourMacAddr)) == 0) {
         LOG_WARN("MAC is all zeros, leaving device_id unset");
         return;

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -50,11 +50,7 @@
 #include "SPILock.h"
 #include "modules/StoreForwardModule.h"
 #include <Preferences.h>
-#include <esp_efuse.h>
-#include <esp_efuse_table.h>
 #include <nvs_flash.h>
-#include <soc/efuse_reg.h>
-#include <soc/soc.h>
 #endif
 
 #ifdef ARCH_PORTDUINO
@@ -69,11 +65,6 @@
 
 #ifdef ARCH_RP2040
 #include <hardware/watchdog.h>
-#include <pico/unique_id.h>
-#endif
-
-#ifdef ARCH_STM32WL
-#include <stm32wlxx_hal.h>
 #endif
 
 #if defined(ARCH_ESP32) && !MESHTASTIC_EXCLUDE_WIFI
@@ -380,6 +371,9 @@ uint32_t radioGeneration;
 // FIXME - move this somewhere else
 extern void getMacAddr(uint8_t *dmac);
 
+// Per-architecture hardware device id (see target_specific.h); implemented in src/platform/<arch>/.
+extern bool getDeviceId(uint8_t *deviceId);
+
 /**
  *
  * Normally userids are unique and start with +country code to look like Signal phone numbers.
@@ -403,21 +397,6 @@ uint32_t error_address = 0;
 
 static uint8_t ourMacAddr[6];
 
-// Derive device_id from the factory MAC when no better silicon source exists:
-// MAC in bytes 0-5, bytes 6-15 zero. Deterministic, survives reboots and flash erases.
-static void deriveDeviceIdFromMacAddr()
-{
-    getMacAddr(ourMacAddr);
-    const uint8_t zero_mac[sizeof(ourMacAddr)] = {0};
-    if (memcmp(ourMacAddr, zero_mac, sizeof(ourMacAddr)) == 0) {
-        LOG_WARN("MAC is all zeros, leaving device_id unset");
-        return;
-    }
-    memset(myNodeInfo.device_id.bytes, 0, sizeof(myNodeInfo.device_id.bytes));
-    memcpy(myNodeInfo.device_id.bytes, ourMacAddr, sizeof(ourMacAddr));
-    myNodeInfo.device_id.size = 16;
-}
-
 NodeDB::NodeDB()
 {
     LOG_INFO("Init NodeDB");
@@ -430,64 +409,14 @@ NodeDB::NodeDB()
     uint32_t channelFileCRC = crc32Buffer(&channelFile, sizeof(channelFile));
 
     int saveWhat = 0;
-    // Get device unique id. Re-derived from silicon on every boot: clear any value loaded
-    // from disk first so a failed read below leaves it unset rather than stale.
+    // Get device unique id. Derived from silicon (or the factory MAC) by the per-architecture
+    // getDeviceId() in src/platform/<arch>/. Re-read on every boot: clear any value loaded from
+    // disk first so getDeviceId() returning false leaves it unset rather than stale.
     myNodeInfo.device_id.size = 0;
     memset(myNodeInfo.device_id.bytes, 0, sizeof(myNodeInfo.device_id.bytes));
-#if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3) ||            \
-    defined(CONFIG_IDF_TARGET_ESP32C6)
-    uint32_t unique_id[4];
-    // ESP32 factory burns a unique id in efuse for S2+ series and evidently C3+ series
-    // This is used for HMACs in the esp-rainmaker AIOT platform and seems to be a good choice for us
-    esp_err_t err = esp_efuse_read_field_blob(ESP_EFUSE_OPTIONAL_UNIQUE_ID, unique_id, sizeof(unique_id) * 8);
-    if (err == ESP_OK) {
-        memcpy(myNodeInfo.device_id.bytes, unique_id, sizeof(unique_id));
-        myNodeInfo.device_id.size = 16;
-    } else {
-        LOG_WARN("Failed to read unique id from efuse");
+    if (getDeviceId(myNodeInfo.device_id.bytes)) {
+        myNodeInfo.device_id.size = sizeof(myNodeInfo.device_id.bytes);
     }
-#elif defined(ARCH_NRF54L15)
-    // nRF54L15: DEVICEID is under FICR->INFO sub-struct (not top-level as on nRF52)
-    uint64_t device_id_start = ((uint64_t)NRF_FICR->INFO.DEVICEID[1] << 32) | NRF_FICR->INFO.DEVICEID[0];
-    uint64_t device_id_end = ((uint64_t)NRF_FICR->DEVICEADDR[1] << 32) | NRF_FICR->DEVICEADDR[0];
-    memcpy(myNodeInfo.device_id.bytes, &device_id_start, sizeof(device_id_start));
-    memcpy(myNodeInfo.device_id.bytes + sizeof(device_id_start), &device_id_end, sizeof(device_id_end));
-    myNodeInfo.device_id.size = 16;
-#elif defined(ARCH_NRF52)
-    // Nordic applies a FIPS compliant Random ID to each chip at the factory
-    // We concatenate the device address to the Random ID to create a unique ID for now
-    // This will likely utilize a crypto module in the future
-    uint64_t device_id_start = ((uint64_t)NRF_FICR->DEVICEID[1] << 32) | NRF_FICR->DEVICEID[0];
-    uint64_t device_id_end = ((uint64_t)NRF_FICR->DEVICEADDR[1] << 32) | NRF_FICR->DEVICEADDR[0];
-    memcpy(myNodeInfo.device_id.bytes, &device_id_start, sizeof(device_id_start));
-    memcpy(myNodeInfo.device_id.bytes + sizeof(device_id_start), &device_id_end, sizeof(device_id_end));
-    myNodeInfo.device_id.size = 16;
-    // Uncomment below to print the device id
-#elif defined(ARCH_RP2040)
-    // RP2040/RP2350: 64-bit unique board id (flash serial / OTP) in bytes 0-7, bytes 8-15 zero
-    pico_unique_board_id_t board_id;
-    pico_get_unique_board_id(&board_id);
-    memcpy(myNodeInfo.device_id.bytes, board_id.id, sizeof(board_id.id));
-    memset(myNodeInfo.device_id.bytes + sizeof(board_id.id), 0, sizeof(myNodeInfo.device_id.bytes) - sizeof(board_id.id));
-    myNodeInfo.device_id.size = 16;
-#elif defined(ARCH_STM32WL)
-    // STM32WL: 96-bit factory-programmed silicon UID (words w0..w2 little-endian) in bytes 0-11, bytes 12-15 zero
-    uint32_t uid[3] = {HAL_GetUIDw0(), HAL_GetUIDw1(), HAL_GetUIDw2()};
-    memcpy(myNodeInfo.device_id.bytes, uid, sizeof(uid));
-    memset(myNodeInfo.device_id.bytes + sizeof(uid), 0, sizeof(myNodeInfo.device_id.bytes) - sizeof(uid));
-    myNodeInfo.device_id.size = 16;
-#elif ARCH_PORTDUINO
-    if (portduino_config.has_device_id) {
-        memcpy(myNodeInfo.device_id.bytes, portduino_config.device_id, sizeof(portduino_config.device_id));
-        myNodeInfo.device_id.size = sizeof(portduino_config.device_id);
-    } else {
-        // Config-supplied id stays preferred: host NIC/BT MACs can be unstable (docker, multi-NIC)
-        deriveDeviceIdFromMacAddr();
-    }
-#else
-    // No factory unique-id silicon source on this platform (classic ESP32 in particular)
-    deriveDeviceIdFromMacAddr();
-#endif
 
     // if (myNodeInfo.device_id.size == 16) {
     //     std::string deviceIdHex;

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -69,6 +69,11 @@
 
 #ifdef ARCH_RP2040
 #include <hardware/watchdog.h>
+#include <pico/unique_id.h>
+#endif
+
+#ifdef ARCH_STM32WL
+#include <stm32wlxx_hal.h>
 #endif
 
 #if defined(ARCH_ESP32) && !MESHTASTIC_EXCLUDE_WIFI
@@ -398,6 +403,21 @@ uint32_t error_address = 0;
 
 static uint8_t ourMacAddr[6];
 
+// Derive device_id from the factory MAC when no better silicon source exists:
+// MAC in bytes 0-5, bytes 6-15 zero. Deterministic, survives reboots and flash erases.
+static void deriveDeviceIdFromMacAddr()
+{
+    getMacAddr(ourMacAddr);
+    uint8_t zero_mac[sizeof(ourMacAddr)] = {0};
+    if (memcmp(ourMacAddr, zero_mac, sizeof(ourMacAddr)) == 0) {
+        LOG_WARN("MAC is all zeros, leaving device_id unset");
+        return;
+    }
+    memset(myNodeInfo.device_id.bytes, 0, sizeof(myNodeInfo.device_id.bytes));
+    memcpy(myNodeInfo.device_id.bytes, ourMacAddr, sizeof(ourMacAddr));
+    myNodeInfo.device_id.size = 16;
+}
+
 NodeDB::NodeDB()
 {
     LOG_INFO("Init NodeDB");
@@ -411,7 +431,8 @@ NodeDB::NodeDB()
 
     int saveWhat = 0;
     // Get device unique id
-#if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C6)
+#if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3) ||            \
+    defined(CONFIG_IDF_TARGET_ESP32C6)
     uint32_t unique_id[4];
     // ESP32 factory burns a unique id in efuse for S2+ series and evidently C3+ series
     // This is used for HMACs in the esp-rainmaker AIOT platform and seems to be a good choice for us
@@ -439,13 +460,30 @@ NodeDB::NodeDB()
     memcpy(myNodeInfo.device_id.bytes + sizeof(device_id_start), &device_id_end, sizeof(device_id_end));
     myNodeInfo.device_id.size = 16;
     // Uncomment below to print the device id
+#elif defined(ARCH_RP2040)
+    // RP2040/RP2350: 64-bit unique board id (flash serial / OTP) in bytes 0-7, bytes 8-15 zero
+    pico_unique_board_id_t board_id;
+    pico_get_unique_board_id(&board_id);
+    memcpy(myNodeInfo.device_id.bytes, board_id.id, sizeof(board_id.id));
+    memset(myNodeInfo.device_id.bytes + sizeof(board_id.id), 0, sizeof(myNodeInfo.device_id.bytes) - sizeof(board_id.id));
+    myNodeInfo.device_id.size = 16;
+#elif defined(ARCH_STM32WL)
+    // STM32WL: 96-bit factory-programmed silicon UID (words w0..w2 little-endian) in bytes 0-11, bytes 12-15 zero
+    uint32_t uid[3] = {HAL_GetUIDw0(), HAL_GetUIDw1(), HAL_GetUIDw2()};
+    memcpy(myNodeInfo.device_id.bytes, uid, sizeof(uid));
+    memset(myNodeInfo.device_id.bytes + sizeof(uid), 0, sizeof(myNodeInfo.device_id.bytes) - sizeof(uid));
+    myNodeInfo.device_id.size = 16;
 #elif ARCH_PORTDUINO
     if (portduino_config.has_device_id) {
         memcpy(myNodeInfo.device_id.bytes, portduino_config.device_id, 16);
         myNodeInfo.device_id.size = 16;
+    } else {
+        // Config-supplied id stays preferred: host NIC/BT MACs can be unstable (docker, multi-NIC)
+        deriveDeviceIdFromMacAddr();
     }
 #else
-    // FIXME - implement for other platforms
+    // No factory unique-id silicon source on this platform (classic ESP32 in particular)
+    deriveDeviceIdFromMacAddr();
 #endif
 
     // if (myNodeInfo.device_id.size == 16) {

--- a/src/meshUtils.cpp
+++ b/src/meshUtils.cpp
@@ -79,6 +79,22 @@ bool memfll(const uint8_t *mem, uint8_t find, size_t numbytes)
     return true;
 }
 
+// Defined per-architecture in src/platform/<arch>/; forward-declared here to avoid
+// pulling the Arduino headers of target_specific.h into this lightweight utility TU.
+extern void getMacAddr(uint8_t *dmac);
+
+bool getMacAddrDeviceId(uint8_t *deviceId)
+{
+    uint8_t mac[6];
+    getMacAddr(mac);
+    if (memfll(mac, 0, sizeof(mac))) {
+        LOG_WARN("MAC is all zeros, leaving device_id unset");
+        return false;
+    }
+    memcpy(deviceId, mac, sizeof(mac));
+    return true;
+}
+
 bool isOneOf(int item, int count, ...)
 {
     va_list args;

--- a/src/meshUtils.cpp
+++ b/src/meshUtils.cpp
@@ -1,4 +1,5 @@
 #include "meshUtils.h"
+#include "target_specific.h"
 #include <string.h>
 
 /*
@@ -79,13 +80,11 @@ bool memfll(const uint8_t *mem, uint8_t find, size_t numbytes)
     return true;
 }
 
-// Defined per-architecture in src/platform/<arch>/; forward-declared here to avoid
-// pulling the Arduino headers of target_specific.h into this lightweight utility TU.
-extern void getMacAddr(uint8_t *dmac);
-
 bool getMacAddrDeviceId(uint8_t *deviceId)
 {
-    uint8_t mac[6];
+    // Zero-initialized: getMacAddr() may return without writing (e.g. Portduino with no MAC
+    // source), and we want that no-write case to hit the all-zeros guard below, not read garbage.
+    uint8_t mac[6] = {0};
     getMacAddr(mac);
     if (memfll(mac, 0, sizeof(mac))) {
         LOG_WARN("MAC is all zeros, leaving device_id unset");

--- a/src/meshUtils.h
+++ b/src/meshUtils.h
@@ -49,6 +49,13 @@ void printBytes(const char *label, const uint8_t *p, size_t numbytes);
 // is the memory region filled with a single character?
 bool memfll(const uint8_t *mem, uint8_t find, size_t numbytes);
 
+// Fallback device_id derivation for platforms without dedicated unique-id silicon:
+// copies the 6-byte factory MAC into the caller's (pre-zeroed) deviceId buffer. Returns
+// true, or false when the MAC is all zeros (so two blank devices can't collide on an
+// all-zero id, and the caller leaves device_id unset). Deterministic; survives reboots
+// and flash erases. See getDeviceId() in target_specific.h.
+bool getMacAddrDeviceId(uint8_t *deviceId);
+
 bool isOneOf(int item, int count, ...);
 
 const std::string vformat(const char *const zcFormat, ...);

--- a/src/meshUtils.h
+++ b/src/meshUtils.h
@@ -49,11 +49,9 @@ void printBytes(const char *label, const uint8_t *p, size_t numbytes);
 // is the memory region filled with a single character?
 bool memfll(const uint8_t *mem, uint8_t find, size_t numbytes);
 
-// Fallback device_id derivation for platforms without dedicated unique-id silicon:
-// copies the 6-byte factory MAC into the caller's (pre-zeroed) deviceId buffer. Returns
-// true, or false when the MAC is all zeros (so two blank devices can't collide on an
-// all-zero id, and the caller leaves device_id unset). Deterministic; survives reboots
-// and flash erases. See getDeviceId() in target_specific.h.
+// getDeviceId() fallback (see target_specific.h) for platforms without a dedicated unique-id:
+// copies the 6-byte factory MAC, or returns false on an all-zero MAC so two blank devices don't
+// collide on an all-zero id.
 bool getMacAddrDeviceId(uint8_t *deviceId);
 
 bool isOneOf(int item, int count, ...);

--- a/src/meshUtils.h
+++ b/src/meshUtils.h
@@ -49,9 +49,8 @@ void printBytes(const char *label, const uint8_t *p, size_t numbytes);
 // is the memory region filled with a single character?
 bool memfll(const uint8_t *mem, uint8_t find, size_t numbytes);
 
-// getDeviceId() fallback (see target_specific.h) for platforms without a dedicated unique-id:
-// copies the 6-byte factory MAC, or returns false on an all-zero MAC so two blank devices don't
-// collide on an all-zero id.
+// getDeviceId() fallback (see target_specific.h): copies the 6-byte factory MAC, or returns false
+// on an all-zero MAC so two blank devices don't collide on an all-zero id.
 bool getMacAddrDeviceId(uint8_t *deviceId);
 
 bool isOneOf(int item, int count, ...);

--- a/src/platform/esp32/main-esp32.cpp
+++ b/src/platform/esp32/main-esp32.cpp
@@ -27,6 +27,8 @@
 #include "target_specific.h"
 #include <Preferences.h>
 #include <driver/rtc_io.h>
+#include <esp_efuse.h>
+#include <esp_efuse_table.h>
 #include <nvs.h>
 #include <nvs_flash.h>
 
@@ -155,6 +157,26 @@ void getMacAddr(uint8_t *dmac)
 #else
     auto res = esp_efuse_mac_get_default(dmac);
     assert(res == ESP_OK);
+#endif
+}
+
+bool getDeviceId(uint8_t *deviceId)
+{
+#if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3) ||            \
+    defined(CONFIG_IDF_TARGET_ESP32C6)
+    // ESP32 factory burns a 128-bit unique id in efuse for S2+ and C3+ series (used for HMACs
+    // in the esp-rainmaker AIOT platform); a good stable hardware anchor for us too.
+    uint32_t unique_id[4];
+    esp_err_t err = esp_efuse_read_field_blob(ESP_EFUSE_OPTIONAL_UNIQUE_ID, unique_id, sizeof(unique_id) * 8);
+    if (err != ESP_OK) {
+        LOG_WARN("Failed to read unique id from efuse");
+        return false;
+    }
+    memcpy(deviceId, unique_id, sizeof(unique_id));
+    return true;
+#else
+    // Classic ESP32 has no OPTIONAL_UNIQUE_ID efuse: fall back to the factory-burned MAC.
+    return getMacAddrDeviceId(deviceId);
 #endif
 }
 

--- a/src/platform/nrf52/main-nrf52.cpp
+++ b/src/platform/nrf52/main-nrf52.cpp
@@ -186,6 +186,17 @@ void getMacAddr(uint8_t *dmac)
     dmac[0] = src[5] | 0xc0; // MSB high two bits get set elsewhere in the bluetooth stack
 }
 
+bool getDeviceId(uint8_t *deviceId)
+{
+    // Nordic burns a FIPS-compliant random id into each chip at the factory. We concatenate
+    // the device address to that random id to form the 16-byte hardware identifier.
+    uint64_t device_id_start = ((uint64_t)NRF_FICR->DEVICEID[1] << 32) | NRF_FICR->DEVICEID[0];
+    uint64_t device_id_end = ((uint64_t)NRF_FICR->DEVICEADDR[1] << 32) | NRF_FICR->DEVICEADDR[0];
+    memcpy(deviceId, &device_id_start, sizeof(device_id_start));
+    memcpy(deviceId + sizeof(device_id_start), &device_id_end, sizeof(device_id_end));
+    return true;
+}
+
 #if !MESHTASTIC_EXCLUDE_BLUETOOTH
 void setBluetoothEnable(bool enable)
 {

--- a/src/platform/nrf54l15/main-nrf54l15.cpp
+++ b/src/platform/nrf54l15/main-nrf54l15.cpp
@@ -100,9 +100,8 @@ void getMacAddr(uint8_t *dmac)
 
 bool getDeviceId(uint8_t *deviceId)
 {
-    // nRF54L15: DEVICEID lives under the FICR->INFO sub-struct (not top-level as on nRF52).
-    // Read unconditionally: if a future build lacks NRF_FICR we want a loud compile error, not a
-    // silent fallback to getMacAddr()'s placeholder MAC (which would give every unit the same id).
+    // nRF54L15: DEVICEID under the FICR->INFO sub-struct. Read unconditionally so a future build
+    // lacking NRF_FICR fails loudly rather than silently sharing getMacAddr()'s placeholder MAC.
     uint64_t device_id_start = ((uint64_t)NRF_FICR->INFO.DEVICEID[1] << 32) | NRF_FICR->INFO.DEVICEID[0];
     uint64_t device_id_end = ((uint64_t)NRF_FICR->DEVICEADDR[1] << 32) | NRF_FICR->DEVICEADDR[0];
     memcpy(deviceId, &device_id_start, sizeof(device_id_start));

--- a/src/platform/nrf54l15/main-nrf54l15.cpp
+++ b/src/platform/nrf54l15/main-nrf54l15.cpp
@@ -12,6 +12,7 @@
 #include <SPI.h>
 #include <Wire.h>
 #include <assert.h>
+#include <cstring>
 #include <stdio.h>
 
 #include "NodeDB.h"
@@ -94,6 +95,21 @@ void getMacAddr(uint8_t *dmac)
     dmac[3] = 0x15;
     dmac[4] = 0x00;
     dmac[5] = 0x01;
+#endif
+}
+
+bool getDeviceId(uint8_t *deviceId)
+{
+#if defined(NRF_FICR)
+    // nRF54L15: DEVICEID lives under the FICR->INFO sub-struct (not top-level as on nRF52).
+    uint64_t device_id_start = ((uint64_t)NRF_FICR->INFO.DEVICEID[1] << 32) | NRF_FICR->INFO.DEVICEID[0];
+    uint64_t device_id_end = ((uint64_t)NRF_FICR->DEVICEADDR[1] << 32) | NRF_FICR->DEVICEADDR[0];
+    memcpy(deviceId, &device_id_start, sizeof(device_id_start));
+    memcpy(deviceId + sizeof(device_id_start), &device_id_end, sizeof(device_id_end));
+    return true;
+#else
+    // No confirmed FICR path yet: fall back to the (placeholder) MAC derivation.
+    return getMacAddrDeviceId(deviceId);
 #endif
 }
 

--- a/src/platform/nrf54l15/main-nrf54l15.cpp
+++ b/src/platform/nrf54l15/main-nrf54l15.cpp
@@ -100,17 +100,14 @@ void getMacAddr(uint8_t *dmac)
 
 bool getDeviceId(uint8_t *deviceId)
 {
-#if defined(NRF_FICR)
     // nRF54L15: DEVICEID lives under the FICR->INFO sub-struct (not top-level as on nRF52).
+    // Read unconditionally: if a future build lacks NRF_FICR we want a loud compile error, not a
+    // silent fallback to getMacAddr()'s placeholder MAC (which would give every unit the same id).
     uint64_t device_id_start = ((uint64_t)NRF_FICR->INFO.DEVICEID[1] << 32) | NRF_FICR->INFO.DEVICEID[0];
     uint64_t device_id_end = ((uint64_t)NRF_FICR->DEVICEADDR[1] << 32) | NRF_FICR->DEVICEADDR[0];
     memcpy(deviceId, &device_id_start, sizeof(device_id_start));
     memcpy(deviceId + sizeof(device_id_start), &device_id_end, sizeof(device_id_end));
     return true;
-#else
-    // No confirmed FICR path yet: fall back to the (placeholder) MAC derivation.
-    return getMacAddrDeviceId(deviceId);
-#endif
 }
 
 // ── Bluetooth ─────────────────────────────────────────────────────────────────

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -201,6 +201,16 @@ void getMacAddr(uint8_t *dmac)
     }
 }
 
+bool getDeviceId(uint8_t *deviceId)
+{
+    if (portduino_config.has_device_id) {
+        memcpy(deviceId, portduino_config.device_id, sizeof(portduino_config.device_id));
+        return true;
+    }
+    // Config-supplied id stays preferred: host NIC/BT MACs can be unstable (docker, multi-NIC).
+    return getMacAddrDeviceId(deviceId);
+}
+
 std::string cleanupNameForAutoconf(std::string name)
 {
     // Convert spaces -> dashes, lowercase

--- a/src/platform/rp2xx0/main-rp2xx0.cpp
+++ b/src/platform/rp2xx0/main-rp2xx0.cpp
@@ -1,6 +1,7 @@
 #include "HardwareRNG.h"
 #include "configuration.h"
 #include "hardware/xosc.h"
+#include <cstring>
 #include <hardware/clocks.h>
 #include <hardware/pll.h>
 #include <hardware/watchdog.h>
@@ -96,6 +97,16 @@ void getMacAddr(uint8_t *dmac)
     dmac[2] = src.id[4];
     dmac[1] = src.id[3];
     dmac[0] = src.id[2];
+}
+
+bool getDeviceId(uint8_t *deviceId)
+{
+    // RP2040/RP2350: 64-bit unique board id (flash serial / OTP) in bytes 0-7; the caller
+    // pre-zeroes the buffer so bytes 8-15 stay zero.
+    pico_unique_board_id_t board_id;
+    pico_get_unique_board_id(&board_id);
+    memcpy(deviceId, board_id.id, sizeof(board_id.id));
+    return true;
 }
 
 void rp2040Setup()

--- a/src/platform/rp2xx0/main-rp2xx0.cpp
+++ b/src/platform/rp2xx0/main-rp2xx0.cpp
@@ -101,8 +101,7 @@ void getMacAddr(uint8_t *dmac)
 
 bool getDeviceId(uint8_t *deviceId)
 {
-    // RP2040/RP2350: 64-bit unique board id (flash serial / OTP) in bytes 0-7; the caller
-    // pre-zeroes the buffer so bytes 8-15 stay zero.
+    // RP2040/RP2350: 64-bit unique board id (flash serial / OTP) in bytes 0-7 (rest stay zero).
     pico_unique_board_id_t board_id;
     pico_get_unique_board_id(&board_id);
     memcpy(deviceId, board_id.id, sizeof(board_id.id));

--- a/src/platform/stm32wl/main-stm32wl.cpp
+++ b/src/platform/stm32wl/main-stm32wl.cpp
@@ -1,5 +1,6 @@
 #include "RTC.h"
 #include "configuration.h"
+#include <cstring>
 #include <stdarg.h>
 #include <stm32wle5xx.h>
 #include <stm32wlxx_hal.h>
@@ -75,6 +76,15 @@ void getMacAddr(uint8_t *dmac)
     dmac[2] = (uint8_t)(uid1 >> 8);
     dmac[1] = (uint8_t)uid2;
     dmac[0] = (uint8_t)(uid2 >> 8);
+}
+
+bool getDeviceId(uint8_t *deviceId)
+{
+    // STM32WL: 96-bit factory-programmed silicon UID (words w0..w2, little-endian) in bytes
+    // 0-11; the caller pre-zeroes the buffer so bytes 12-15 stay zero.
+    uint32_t uid[3] = {HAL_GetUIDw0(), HAL_GetUIDw1(), HAL_GetUIDw2()};
+    memcpy(deviceId, uid, sizeof(uid));
+    return true;
 }
 
 void cpuDeepSleep(uint32_t msecToWake) {}

--- a/src/platform/stm32wl/main-stm32wl.cpp
+++ b/src/platform/stm32wl/main-stm32wl.cpp
@@ -80,8 +80,7 @@ void getMacAddr(uint8_t *dmac)
 
 bool getDeviceId(uint8_t *deviceId)
 {
-    // STM32WL: 96-bit factory-programmed silicon UID (words w0..w2, little-endian) in bytes
-    // 0-11; the caller pre-zeroes the buffer so bytes 12-15 stay zero.
+    // STM32WL: 96-bit factory silicon UID (words w0..w2, little-endian) in bytes 0-11 (rest stay zero).
     uint32_t uid[3] = {HAL_GetUIDw0(), HAL_GetUIDw1(), HAL_GetUIDw2()};
     memcpy(deviceId, uid, sizeof(uid));
     return true;

--- a/src/target_specific.h
+++ b/src/target_specific.h
@@ -9,10 +9,7 @@ void setBluetoothEnable(bool enable);
 
 void getMacAddr(uint8_t *dmac);
 
-// Populate the caller-provided, zero-initialized 16-byte deviceId buffer with a stable,
-// factory/silicon-derived hardware identifier (writes only the meaningful leading bytes;
-// the caller pre-zeroes so any trailing bytes stay zero). Returns true if an id was
-// written, or false if no stable id is available on this platform (buffer left unchanged,
-// caller leaves MyNodeInfo.device_id unset). Re-read from silicon every boot, never
-// persisted. Implemented per-architecture in src/platform/<arch>/.
+// Fill deviceId (a caller-zeroed 16-byte buffer) with a stable, silicon/factory-derived id and
+// return true; return false (buffer untouched) when no stable id exists on this platform. Writes
+// only the leading meaningful bytes, so the caller must pre-zero. Implemented per src/platform/<arch>/.
 bool getDeviceId(uint8_t *deviceId);

--- a/src/target_specific.h
+++ b/src/target_specific.h
@@ -8,3 +8,11 @@
 void setBluetoothEnable(bool enable);
 
 void getMacAddr(uint8_t *dmac);
+
+// Populate the caller-provided, zero-initialized 16-byte deviceId buffer with a stable,
+// factory/silicon-derived hardware identifier (writes only the meaningful leading bytes;
+// the caller pre-zeroes so any trailing bytes stay zero). Returns true if an id was
+// written, or false if no stable id is available on this platform (buffer left unchanged,
+// caller leaves MyNodeInfo.device_id unset). Re-read from silicon every boot, never
+// persisted. Implemented per-architecture in src/platform/<arch>/.
+bool getDeviceId(uint8_t *deviceId);

--- a/src/target_specific.h
+++ b/src/target_specific.h
@@ -9,7 +9,6 @@ void setBluetoothEnable(bool enable);
 
 void getMacAddr(uint8_t *dmac);
 
-// Fill deviceId (a caller-zeroed 16-byte buffer) with a stable, silicon/factory-derived id and
-// return true; return false (buffer untouched) when no stable id exists on this platform. Writes
-// only the leading meaningful bytes, so the caller must pre-zero. Implemented per src/platform/<arch>/.
+// Fill deviceId (a caller-zeroed 16-byte buffer) with a stable silicon/factory id; return true, or
+// false (buffer untouched) if none exists here. Writes only leading bytes. Per-arch: src/platform/<arch>/.
 bool getDeviceId(uint8_t *deviceId);


### PR DESCRIPTION
## Why

Firmware 2.8 derives the node number from the node's public key (`my_node_num = crc32(public_key)`), so node numbers are no longer stable hardware identifiers: every 2.7→2.8 upgrade, flash erase, or manual key regeneration renumbers the device. Clients need a stable *hardware* anchor to reconcile their per-device local databases across those renumberings. `MyNodeInfo.device_id` (16-byte factory/silicon-derived id) is that anchor — Meshtastic-Android is shipping device-identity reconciliation that uses `device_id` as a same-hardware signal when present (and degrades gracefully when absent).

Today the field is only populated on ESP32-C3/S3/C6, nRF52, nRF54L15, and Portduino (config-supplied). Classic ESP32, ESP32-S2, RP2040/RP2350, and STM32WL report none. This PR resolves the `// FIXME - implement for other platforms` in `NodeDB.cpp`.

## What

| Platform | Source | Layout (16 bytes) |
| --- | --- | --- |
| ESP32-S2 | `ESP_EFUSE_OPTIONAL_UNIQUE_ID` — added the target to the existing efuse branch (field verified present in the IDF 5.5 efuse table for S2) | 128-bit efuse id |
| RP2040 / RP2350 | `pico_get_unique_board_id()` (flash serial / OTP) | 64-bit id in bytes 0-7, bytes 8-15 zero |
| STM32WL | 96-bit silicon UID via `HAL_GetUIDw0/1/2` | UID words (LE) in bytes 0-11, bytes 12-15 zero |
| Classic ESP32 + any future platform (`#else` fallback) | factory-burned MAC via `getMacAddr()` (`esp_efuse_mac_get_default` on ESP32 — survives erases, immune to base-MAC overrides) | MAC in bytes 0-5, bytes 6-15 zero |
| Portduino | config-supplied id still preferred; NEW: falls back to the host MAC scheme above when the config doesn't supply one (config stays preferred because host NIC/BT MACs can be unstable under docker/multi-NIC) | per source |

An all-zeros MAC leaves `device_id` unset (with a warning) rather than emitting an all-zeros id that two different devices could collide on.

## What deliberately did NOT change

- **nRF52 / nRF54L15 FICR and ESP32-S3/C3/C6 efuse derivations are untouched.** Those ids have already shipped in the field; changing their derivation would cause a one-time identity discontinuity for clients that store `device_id`.
- **No proto changes** — the field already exists.
- **No persistence changes** — `device_id` is re-read from silicon on every boot and never written to flash.
- **PhoneAPI lockdown behavior preserved** — `device_id` is still zeroed for unauthenticated clients (`PhoneAPI.cpp`).
- Every derivation is deterministic: no `random()`, no time, stable across reboots and erases.

## Alternative considered: MAC-only everywhere

From @thebentern on Discord:

> Yeah that's totally fine. OG ESP32 is basically ded these days anyway

> Always using MAC could be the easier choice though

`getMacAddr()` is implemented on every architecture, so the whole chain *could* collapse to the single MAC-derived branch. Trade-offs:

- **Pro:** one code path everywhere, no per-target code.
- **Con:** changes already-shipped `device_id`s on nRF52 and ESP32-S3-class hardware — a one-time identity discontinuity for clients that store `device_id` (Meshtastic-Android now does).
- **Con (minor):** `device_id` is one of the entropy inputs stirred into CryptoEngine's RNG seeding; a MAC has less entropy than the nRF52 FICR random id. Not load-bearing — the TRNG is the primary source — but worth stating.

This PR keeps the shipped derivations and only fills the gaps. Happy to collapse to MAC-only if that's the preferred direction.

## Testing

Builds green (no hardware needed — the id is read from silicon at boot):

- `tbeam` (classic ESP32 → MAC fallback)
- `rak11310` (RP2040), `pico2` (RP2350)
- `rak3172` (STM32WL)
- `rak4631` (nRF52 — regression, branch untouched)
- `native-macos` (Portduino — config-preferred + MAC fallback)

`nugget-s2-lora` (the only ESP32-S2 env) currently fails on **develop without this change** with `'USBSerial' was not declared` in the framework's `HardwareSerial.h` (looks like fallout from the S2 TinyUSB CDC sdkconfig change, #10799) — pre-existing and unrelated; the efuse code added for S2 is byte-for-byte the code already compiling on S3/C3/C6, and `ESP_EFUSE_OPTIONAL_UNIQUE_ID` is confirmed present in the IDF 5.5 S2 efuse table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device identification by re-deriving the device ID on every boot to avoid stale or incorrect values.
  * Enhanced unique-ID sourcing across more hardware platforms, including RP2040/RP2350 and STM32WL.
  * Expanded ESP32 support to include C3, S2, S3, and C6 variants using the most reliable identifier available.
  * Added a safe MAC-based fallback for platforms without a stable factory unique ID, while still preferring configured IDs when provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->