### PR TITLE
Guard LR1121/LR2021 radio configs with #ifdef

### DIFF
--- a/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/rfswitch.h
+++ b/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/rfswitch.h
@@ -13,7 +13,7 @@
 // DIO5 -> RFSW0_V1
 // DIO6 -> RFSW1_V2
 // DIO7 -> not connected on E80 module - note that GNSS and Wifi scanning are not possible.
-
+#ifdef USE_LR1121
 static const uint32_t rfswitch_dio_pins[] = {RADIOLIB_LR11X0_DIO5, RADIOLIB_LR11X0_DIO6, RADIOLIB_LR11X0_DIO7, RADIOLIB_NC,
                                              RADIOLIB_NC};
 
@@ -30,13 +30,14 @@ static const Module::RfSwitchMode_t rfswitch_table[] = {
     END_OF_MODE_TABLE,
     // clang-format on
 };
+#endif
 
 // LR2021 RF switch matrix following the standard Semtech / Seeed T1000-E reference topology.
 // DIO5 -> antenna path select (HIGH = sub-GHz LF)
 // DIO6 -> TX enable / HP PA select
 // DIO7 -> not connected (no GNSS on LR2021)
 // DIO8 -> RF front-end power enable
-
+#ifdef USE_LR2021
 static const uint32_t lr20x0_rfswitch_dio_pins[] = {RADIOLIB_LR2021_DIO5, RADIOLIB_LR2021_DIO6, RADIOLIB_LR2021_DIO7,
                                                     RADIOLIB_LR2021_DIO8, RADIOLIB_NC};
 
@@ -51,3 +52,4 @@ static const Module::RfSwitchMode_t lr20x0_rfswitch_table[] = {
     END_OF_MODE_TABLE,
     // clang-format on
 };
+#endif

--- a/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/variant.h
+++ b/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/variant.h
@@ -121,9 +121,9 @@ NRF52 PRO MICRO PIN ASSIGNMENT
 #define USE_RF95
 #define USE_SX1268
 #define USE_LR1121
+#define USE_LR2021
 
 // RF95 CONFIG
-
 #define LORA_DIO0 (0 + 29) // P0.29 BUSY
 #define LORA_DIO1 (0 + 10) // P0.10 IRQ
 #define LORA_RESET (0 + 9) // P0.09 NRST
@@ -156,7 +156,7 @@ NRF52 PRO MICRO PIN ASSIGNMENT
 #endif
 
 // LR2021
-#define USE_LR2021
+#ifdef USE_LR2021
 #define LR2021_IRQ_PIN (0 + 10)      // P0.10 IRQ
 #define LR2021_NRESET_PIN LORA_RESET // P0.09 NRST
 #define LR2021_BUSY_PIN (0 + 29)     // P0.29 BUSY
@@ -164,6 +164,7 @@ NRF52 PRO MICRO PIN ASSIGNMENT
 #define LR2021_DIO3_TCXO_VOLTAGE 1.8
 #define LR2021_DIO_AS_RF_SWITCH
 #define LR2021_IRQ_DIO_NUM 9 // DIO9 → P0.10
+#endif
 
 // #define SX126X_MAX_POWER 8 set this if using a high-power board!
 


### PR DESCRIPTION
Add conditional compilation guards for LR1121 and LR2021 radio chip configurations in rfswitch.h to prevent compilation errors when these radios are not in use. Move USE_LR2021 definition to the radio section in variant.h for consistency with other radio chip definitions.

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [X] Promicro DIY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit LR2021 radio module support for the DIY nRF52 Pro Micro TCXO board.
  * Configured LR2021 pin assignments, TCXO settings, interrupt mapping, and RF switch behavior.

* **Bug Fixes**
  * Prevented LR1121 and LR2021 hardware settings from being mixed when selecting a radio module.
  * Ensured each module uses only its applicable RF switch configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->