### PR TITLE
Fix double free in virtual keyboard

### DIFF
--- a/src/graphics/draw/NotificationRenderer.cpp
+++ b/src/graphics/draw/NotificationRenderer.cpp
@@ -1038,10 +1038,9 @@ void NotificationRenderer::drawTextInput(OLEDDisplay *display, OLEDDisplayUiStat
             // Cancel virtual keyboard - call callback with empty string to indicate timeout
             auto callback = textInputCallback; // Store callback before clearing
 
-            // Clean up first to prevent re-entry
-            delete virtualKeyboard;
-            virtualKeyboard = nullptr;
-            textInputCallback = nullptr;
+            // Clean up first to prevent re-entry. The keyboard belongs to OnScreenKeyboardModule; only stop()
+            // may free it, and it clears virtualKeyboard/textInputCallback for us.
+            OnScreenKeyboardModule::instance().stop(false);
             resetBanner();
 
             // Call callback after cleanup
@@ -1060,9 +1059,7 @@ void NotificationRenderer::drawTextInput(OLEDDisplay *display, OLEDDisplayUiStat
             bool handled = OnScreenKeyboardModule::processVirtualKeyboardInput(inEvent, virtualKeyboard);
             if (!handled && inEvent.inputEvent == INPUT_BROKER_CANCEL) {
                 auto callback = textInputCallback;
-                delete virtualKeyboard;
-                virtualKeyboard = nullptr;
-                textInputCallback = nullptr;
+                OnScreenKeyboardModule::instance().stop(false); // sole owner of the keyboard; also clears our aliases
                 resetBanner();
                 if (callback) {
                     callback("");


### PR DESCRIPTION
Found via portduino. As there are two separate references to this pointer, they both could call free

Actual credit goes to my daughter for triggering the crash. =D

Potential backport to 2.7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual keyboard cleanup when input sessions time out or are canceled.
  * Helps prevent inconsistent keyboard state and ensures related input handling continues reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->