### PR TITLE
Avoid setting HeaderBackground for transparent backgrounds

### DIFF
--- a/src/graphics/SharedUIDisplay.cpp
+++ b/src/graphics/SharedUIDisplay.cpp
@@ -147,7 +147,8 @@ void drawCommonHeader(OLEDDisplay *display, int16_t x, int16_t y, const char *ti
             // Transparent clock headers should inherit whatever body off-color is
             // already active under the header (important for light/inverted themes).
             const uint16_t transparentBgColor = resolveTFTOffColorAt(0, headerHeight + 1, getThemeBodyBg());
-            // Intentionally skip the HeaderBackground region, as small screens draw the clock in the unused space in this region, and the transparent call was erasing segments from the clock
+            // Intentionally skip the HeaderBackground region, as small screens draw the clock in the unused space in this region,
+            // and the transparent call was erasing segments from the clock
             setTFTColorRole(TFTColorRole::HeaderTitle, headerTitleColorForRole, transparentBgColor);
             setTFTColorRole(TFTColorRole::HeaderStatus, headerStatusColor, transparentBgColor);
         } else if (useInvertedHeaderStyle) {

--- a/src/graphics/SharedUIDisplay.cpp
+++ b/src/graphics/SharedUIDisplay.cpp
@@ -147,8 +147,7 @@ void drawCommonHeader(OLEDDisplay *display, int16_t x, int16_t y, const char *ti
             // Transparent clock headers should inherit whatever body off-color is
             // already active under the header (important for light/inverted themes).
             const uint16_t transparentBgColor = resolveTFTOffColorAt(0, headerHeight + 1, getThemeBodyBg());
-            setAndRegisterTFTColorRole(TFTColorRole::HeaderBackground, transparentBgColor, transparentBgColor, 0, 0, screenW,
-                                       headerHeight);
+            // Intentionally skip the HeaderBackground region, as small screens draw the clock in the unused space in this region, and the transparent call was erasing segments from the clock
             setTFTColorRole(TFTColorRole::HeaderTitle, headerTitleColorForRole, transparentBgColor);
             setTFTColorRole(TFTColorRole::HeaderStatus, headerStatusColor, transparentBgColor);
         } else if (useInvertedHeaderStyle) {


### PR DESCRIPTION
Skip setting HeaderBackground for small screens to prevent erasing clock segments.

Tested on a 128x64 color screen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transparent clock headers on small screens to prevent clock segments from being unintentionally erased.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->