### PR TITLE
fix(tracker-x1): silence the buzzer during init

### DIFF
--- a/variants/nrf52840/seeed_mesh_tracker_X1/variant.cpp
+++ b/variants/nrf52840/seeed_mesh_tracker_X1/variant.cpp
@@ -68,4 +68,6 @@ void initVariant()
 
     pinMode(GPS_RTC_INT, OUTPUT);
     digitalWrite(GPS_RTC_INT, LOW);
+
+    pinMode(PIN_BUZZER, INPUT_PULLDOWN);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the buzzer’s default state during device startup to help prevent unintended activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->