### PR TITLE
fix(power): re-seed analog battery filter on charging-state change

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -172,6 +172,13 @@ class HasBatteryLevel
 
     virtual bool isVbusIn() { return false; }
     virtual bool isCharging() { return false; }
+
+    /**
+     * Called when the charging state changes (external power connected or
+     * disconnected), so implementations can discard smoothing state that
+     * tracks the previous power state.
+     */
+    virtual void notifyChargingStateChanged() {}
 };
 #endif
 
@@ -351,6 +358,13 @@ class AnalogBatteryLevel : public HasBatteryLevel
                 if (scaled > last_read_value)
                     last_read_value = scaled;
                 initial_read_done = true;
+            } else if (reseed_pending) {
+                // The charging state just changed, which steps the battery voltage
+                // sharply (charge voltage vs loaded/rested voltage). The previous
+                // filtered value tracks the old power state, so replace it instead
+                // of blending the step in over several reads.
+                last_read_value = scaled;
+                reseed_pending = false;
             } else {
                 // Already initialized - filter this reading
                 last_read_value += (scaled - last_read_value) * 0.5; // Virtual LPF
@@ -523,6 +537,15 @@ class AnalogBatteryLevel : public HasBatteryLevel
         return isVbusIn();
     }
 
+    /// Re-seed the smoothing filter with the next raw reading (and let that
+    /// reading happen immediately) so the reported voltage tracks the new
+    /// charging state within one poll instead of converging over several.
+    virtual void notifyChargingStateChanged() override
+    {
+        reseed_pending = true;
+        last_read_time_ms = 0;
+    }
+
   private:
     /// If we see a battery voltage higher than physics allows - assume charger is
     /// pumping in power
@@ -537,6 +560,9 @@ class AnalogBatteryLevel : public HasBatteryLevel
     // This value is over-written by the first ADC reading, it the voltage seems
     // reasonable.
     bool initial_read_done = false;
+    // Set when the charging state changes: the next ADC reading replaces the
+    // filtered value instead of being blended into it.
+    bool reseed_pending = false;
     float last_read_value = (OCV[NUM_OCV_POINTS - 1] * NUM_CELLS);
     uint32_t last_read_time_ms = 0;
 
@@ -890,6 +916,29 @@ void Power::readPowerStatus()
         isChargingNow = usbPowered = OptTrue;
 
 #endif
+
+    // A charging-state transition steps the battery voltage sharply (charge
+    // voltage vs loaded/rested voltage), but the analog reading is smoothed, so
+    // the reported voltage/SoC would otherwise keep tracking the old power state
+    // for several polls of this routine. Tell the sensor to drop its smoothing
+    // state and take a fresh reading now, so telemetry sent right after a
+    // plug/unplug reflects the new state within one poll.
+    static OptionalBool prevIsCharging = OptUnknown;
+    if (batteryLevel && hasBattery == OptTrue && isChargingNow != OptUnknown && prevIsCharging != OptUnknown &&
+        isChargingNow != prevIsCharging) {
+        LOG_INFO("Charging state changed, re-reading battery level");
+        batteryLevel->notifyChargingStateChanged();
+        batteryVoltageMv = batteryLevel->getBattVoltage();
+        int freshPercent = batteryLevel->getBatteryPercent();
+        if (freshPercent >= 0) {
+            batteryChargePercent = freshPercent;
+        } else {
+            batteryChargePercent = clamp((int)(((batteryVoltageMv - (OCV[NUM_OCV_POINTS - 1] * NUM_CELLS)) * 1e2) /
+                                               ((OCV[0] * NUM_CELLS) - (OCV[NUM_OCV_POINTS - 1] * NUM_CELLS))),
+                                         0, 100);
+        }
+    }
+    prevIsCharging = isChargingNow;
 
     // Notify any status instances that are observing us
     const PowerStatus powerStatus2 = PowerStatus(hasBattery, usbPowered, isChargingNow, batteryVoltageMv, batteryChargePercent);


### PR DESCRIPTION
## Problem

The analog battery voltage is intentionally smoothed (15-sample ADC average + a 0.5-coefficient low-pass filter in `AnalogBatteryLevel::getBattVoltage()`) to reject noise. A charging-state transition, however, steps the real voltage sharply (charge voltage vs loaded/rested voltage), and the filter blends that step in by halves per `Power::runOnce` poll (20 s) — so the reported voltage, and the SoC derived from it via the OCV table, keep tracking the previous power state for roughly 1–2 minutes after plugging or unplugging external power. Telemetry sent (or requested) shortly after a power change reports these stale values.

## Fix

- `Power::readPowerStatus()` tracks the resolved charging state across polls (checked after all detection variants, including the `NRF_APM` USB-regulator path) and, on a transition, calls a new `HasBatteryLevel::notifyChargingStateChanged()` hook, then takes an immediate fresh voltage/percent reading.
- `AnalogBatteryLevel` implements the hook by bypassing the 5 s read throttle and **replacing** the filtered value with the next raw reading instead of blending it.

No behavior change when the charging state is steady (the filter path is identical), and battery sensors with their own gauge (PMU/fuel-gauge boards) are unaffected — the base-class hook is a no-op.

## Testing

Tested on two Seeed T1000-E tracker cards (one flashed with this patch on the v2.7.26 base, plus a build from current master), with external power switched by a BLE-controlled inline USB power switch so the disconnect moment is timestamped:

- While charging: `battery_level=101`, voltage ≈ 4.02 V (charge voltage) — unchanged.
- External power removed at t=0: telemetry requested over the mesh returned a real SoC and a settled voltage that stayed **flat** across samples at t+2:02 / t+2:24 / t+2:46 (76% / 3.93 V on all three) — i.e. the reading had fully re-seeded within one poll, where the unpatched filter is still converging in that window.
- >1 h combined runtime on both devices with the patch: mesh traffic, position, telemetry all normal; no resets.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [x] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)

I don't have the other listed devices; the touched code paths are shared (`Power.cpp`), with the analog re-seed only reachable on boards using `AnalogBatteryLevel` and only on a charging-state edge.