### PR TITLE
Fix packet-pool slot leak in canned message destination picker

### DIFF
--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -289,10 +289,6 @@ void CannedMessageModule::updateDestinationSelectionList()
         }
     }
 
-    meshtastic_MeshPacket *p = allocDataPacket();
-    p->pki_encrypted = true;
-    p->channel = 0;
-
     // Populate active channels
     std::vector<String> seenChannels;
     seenChannels.reserve(channels.getNumChannels());


### PR DESCRIPTION
## Summary

`CannedMessageModule::updateDestinationSelectionList()` allocated a `meshtastic_MeshPacket` via `allocDataPacket()` that was **never sent nor released**, permanently consuming one slot from `packetPool` on every rebuild of the destination-selection picker.

```cpp
meshtastic_MeshPacket *p = allocDataPacket();
p->pki_encrypted = true;
p->channel = 0;
// ...p is never used again, never sent, never released
```

### Impact
- **Non-PSRAM targets:** `packetPool` is a static 70-slot BSS pool (`Router.cpp:57-66`). Repeated use of the destination picker steadily drains it and eventually blocks **all** packet allocation, causing TX/RX failures.
- **PSRAM / portduino targets:** `packetPool` uses `MemoryDynamic`, so this is a true heap leak of ~424 B per rebuild.

The picker is rebuilt on entry to destination selection, on every search keystroke, and whenever the node list changes, so the leak accumulates quickly in normal use.

### Root cause
The three lines were a copy/paste artifact of the legitimate PKI setup in `sendText()` (introduced in #8182, "Multi message storage"). In `sendText()` the allocated packet is populated and handed to `service->sendToMesh()`; here it was pasted into a function that only builds a UI list and has nothing to send.

## Fix
Remove the dead allocation. No other code in the function references `p`, so there is no behavior change beyond eliminating the leak. `allocDataPacket()`'s only side effect is bumping the monotonic packet-ID counter, which is harmless to skip since nothing was ever transmitted.

## Testing
- Native test suite: **602/602 passing** (`./bin/test-native-docker.sh`)
- `trunk fmt`: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal destination-selection processing without changing observable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->