### PR TITLE
NodeDB: clear only the slots removeNodeByNum() vacates

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1603,8 +1603,10 @@ void NodeDB::removeNodeByNum(NodeNum nodeNum)
         const size_t first = numMeshNodes;
         const size_t last = std::min(first + removed, nodeDatabase.nodes.size());
         std::fill(nodeDatabase.nodes.begin() + first, nodeDatabase.nodes.begin() + last, meshtastic_NodeInfoLite());
-        eraseNodeSatellites(nodeNum);
     }
+    // Drop the node's satellite stores and warm-tier copy regardless of which tier it lived in, so
+    // an explicit removal fully forgets it.
+    eraseNodeSatellites(nodeNum);
 #if WARM_NODE_COUNT > 0
     // Explicit user removal: don't let the warm tier resurrect the node
     warmStore.remove(nodeNum);

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1597,10 +1597,14 @@ void NodeDB::removeNodeByNum(NodeNum nodeNum)
             removed++;
     }
     numMeshNodes -= removed;
-    std::fill(nodeDatabase.nodes.begin() + numMeshNodes, nodeDatabase.nodes.begin() + numMeshNodes + 1,
-              meshtastic_NodeInfoLite());
-    if (removed)
+    if (removed) {
+        // Clear exactly the slots compaction vacated. Sizing this from `removed` (rather than a
+        // fixed one) keeps it inside the vector when nothing matched and the store is full.
+        const size_t first = numMeshNodes;
+        const size_t last = std::min(first + removed, nodeDatabase.nodes.size());
+        std::fill(nodeDatabase.nodes.begin() + first, nodeDatabase.nodes.begin() + last, meshtastic_NodeInfoLite());
         eraseNodeSatellites(nodeNum);
+    }
 #if WARM_NODE_COUNT > 0
     // Explicit user removal: don't let the warm tier resurrect the node
     warmStore.remove(nodeNum);

--- a/test/test_nodedb_blocked/test_main.cpp
+++ b/test/test_nodedb_blocked/test_main.cpp
@@ -197,6 +197,39 @@ static void test_protectedCap_refusesBeyondLimit(void)
     TEST_ASSERT_TRUE(db->setProtectedFlag(already, NODEINFO_BITFIELD_IS_IGNORED_MASK, true));
 }
 
+// removeNodeByNum() compacts survivors down and clears the slots that leaves free. A full
+// store with no matching node frees none, so there is nothing past the last node to clear.
+static void test_removeNodeByNum_absentNodeOnFullDb(void)
+{
+    db->seedSelf();
+    for (int i = 1; i < MAX_NUM_NODES; i++) // fill to MAX_NUM_NODES total (incl. self)
+        db->push(8000 + i, /*last_heard=*/i, false, false, /*withUser=*/true, /*withKey=*/true);
+    TEST_ASSERT_EQUAL_INT(MAX_NUM_NODES, (int)db->getNumMeshNodes());
+
+    db->removeNodeByNum(0xDEADBEEF); // absent; ASan flags a write past the last slot
+
+    TEST_ASSERT_EQUAL_INT(MAX_NUM_NODES, (int)db->getNumMeshNodes()); // nothing removed
+    TEST_ASSERT_NOT_NULL(db->getMeshNode(0x0BADF00D));                // self intact
+    TEST_ASSERT_NOT_NULL(db->getMeshNode(8000 + 1));
+    TEST_ASSERT_NOT_NULL(db->getMeshNode(8000 + MAX_NUM_NODES - 1)); // last slot intact
+}
+
+// Control for the above: a matching node on a full store is still removed, the survivors
+// compact down, and the freed tail slot is cleared.
+static void test_removeNodeByNum_presentNodeOnFullDb(void)
+{
+    db->seedSelf();
+    for (int i = 1; i < MAX_NUM_NODES; i++)
+        db->push(8000 + i, /*last_heard=*/i, false, false, /*withUser=*/true, /*withKey=*/true);
+
+    db->removeNodeByNum(8000 + 5);
+
+    TEST_ASSERT_EQUAL_INT(MAX_NUM_NODES - 1, (int)db->getNumMeshNodes());
+    TEST_ASSERT_NULL(db->getMeshNode(8000 + 5));
+    TEST_ASSERT_NOT_NULL(db->getMeshNode(8000 + 4));
+    TEST_ASSERT_NOT_NULL(db->getMeshNode(8000 + MAX_NUM_NODES - 1)); // survivors kept
+}
+
 NDB_TEST_ENTRY void setup()
 {
     initializeTestEnvironment();
@@ -209,6 +242,8 @@ NDB_TEST_ENTRY void setup()
     RUN_TEST(test_eviction_preservesFavorite);
     RUN_TEST(test_ignored_survivesEvictionAndCleanup);
     RUN_TEST(test_protectedCap_refusesBeyondLimit);
+    RUN_TEST(test_removeNodeByNum_absentNodeOnFullDb);
+    RUN_TEST(test_removeNodeByNum_presentNodeOnFullDb);
     exit(UNITY_END());
 }
 NDB_TEST_ENTRY void loop() {}


### PR DESCRIPTION
`removeNodeByNum()` compacts the survivors down and then clears the slot the compaction
left free. It always cleared exactly one, whether or not anything was removed:

```c
numMeshNodes -= removed;
std::fill(nodeDatabase.nodes.begin() + numMeshNodes,
          nodeDatabase.nodes.begin() + numMeshNodes + 1, meshtastic_NodeInfoLite());
```

`nodeDatabase.nodes` is sized to MAX_NUM_NODES, so when the requested node is not present
`numMeshNodes` is unchanged, and on a full store that clear lands one entry past the last
slot. It was also short in the other direction: removing several nodes with the same num
vacated `removed` slots but only ever cleared one, leaving stale copies behind.

Size the clear from `removed` instead, so nothing is written when nothing was removed, all
vacated slots are cleared when they are, and the range is clamped to the vector.

The sibling clear in `cleanupMeshDB()` is already correct and is left alone: its range ends
at `numMeshNodes + removed`, which is the pre-compaction count and therefore never past the
end.

Tests: removal of an absent node from a full store (the coverage env builds with ASan, so a
write past the last slot fails the run), plus a control removing a present node from a full
store to show compaction still works.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node removal and table compaction to correctly clear all freed slots, including edge cases at maximum capacity.
  * Prevented accidental overwrite of entries when removing a missing node.
  * Ensured satellite data tied to removed nodes is always cleaned up after compaction.

* **Tests**
  * Added new coverage for `removeNodeByNum()` when the database is full: handling both present and absent node IDs, verifying correct compaction and tail cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->