### PR TITLE
2.7: Update protobufs and classes

### DIFF
--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -329,6 +329,10 @@ typedef enum _meshtastic_HardwareModel {
     meshtastic_HardwareModel_SEEED_WIO_TRACKER_L2 = 137,
     /* Elecrow CrowPanel Advance P4 models, ESP32-P4 and TFT with SX1262 radio plugin */
     meshtastic_HardwareModel_CROWPANEL_P4 = 138,
+    /* Heltec Mesh Tower V2 */
+    meshtastic_HardwareModel_HELTEC_MESH_TOWER_V2 = 139,
+    /* Meshnology W10 */
+    meshtastic_HardwareModel_MESHNOLOGY_W10 = 140,
     /* ------------------------------------------------------------------------------------------------------------------------------------------
  Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.
  ------------------------------------------------------------------------------------------------------------------------------------------ */

--- a/src/mesh/generated/meshtastic/telemetry.pb.h
+++ b/src/mesh/generated/meshtastic/telemetry.pb.h
@@ -121,7 +121,9 @@ typedef enum _meshtastic_TelemetrySensorType {
     /* ICM-42607-P 6‑Axis IMU */
     meshtastic_TelemetrySensorType_ICM42607P = 53,
     /* SPA06 pressure and temperature */
-    meshtastic_TelemetrySensorType_SPA06 = 54
+    meshtastic_TelemetrySensorType_SPA06 = 54,
+    /* HM330X PM SENSOR */
+    meshtastic_TelemetrySensorType_HM330X = 55
 } meshtastic_TelemetrySensorType;
 
 /* Struct definitions */
@@ -502,8 +504,8 @@ extern "C" {
 
 /* Helper constants for enums */
 #define _meshtastic_TelemetrySensorType_MIN meshtastic_TelemetrySensorType_SENSOR_UNSET
-#define _meshtastic_TelemetrySensorType_MAX meshtastic_TelemetrySensorType_SPA06
-#define _meshtastic_TelemetrySensorType_ARRAYSIZE ((meshtastic_TelemetrySensorType)(meshtastic_TelemetrySensorType_SPA06+1))
+#define _meshtastic_TelemetrySensorType_MAX meshtastic_TelemetrySensorType_HM330X
+#define _meshtastic_TelemetrySensorType_ARRAYSIZE ((meshtastic_TelemetrySensorType)(meshtastic_TelemetrySensorType_HM330X+1))
 
 
 


### PR DESCRIPTION
Regen protobufs for `master` branch based on the protobuf `2.7` branch.
https://github.com/meshtastic/protobufs/tree/2.7

Includes `HM330X` sensor support for FAB26