### PR TITLE
nRF52 BLE: restore pairing passkey callback on re-enable

### DIFF
--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -369,6 +369,15 @@ void NRF52Bluetooth::setup()
 }
 void NRF52Bluetooth::resumeAdvertising()
 {
+    // shutdown() latches onUnwantedPairing to actively refuse pairing (used on the factory-reset /
+    // BT-disable teardown path). The real pairing passkey callback is installed only in setup(), but a
+    // shutdown()->resumeAdvertising() re-enable cycle skips setup() entirely (see setBluetoothEnable() in
+    // main-nrf52.cpp), so restore the correct callback here - otherwise the device silently refuses all
+    // pairing until the next reboot. Mirror the mode check in setup(): only PIN modes drive a passkey-
+    // display callback, so NO_PIN (Just Works) needs no restore.
+    if (config.bluetooth.mode != meshtastic_Config_BluetoothConfig_PairingMode_NO_PIN)
+        Bluefruit.Security.setPairPasskeyCallback(NRF52Bluetooth::onPairingPasskey);
+
     Bluefruit.Advertising.restartOnDisconnect(true);
     Bluefruit.Advertising.setInterval(32, 668); // in unit of 0.625 ms
     Bluefruit.Advertising.setFastTimeout(30);   // number of seconds in fast mode


### PR DESCRIPTION
## Summary

Fixes an nRF52 BLE pairing-callback latch: after a `shutdown()` → `resumeAdvertising()` cycle **without a reboot**, the device silently refuses all pairing until the next reboot.

`NRF52Bluetooth::shutdown()` installs `onUnwantedPairing` as the pairing passkey callback to actively refuse pairing (intended for the factory-reset / BT-disable teardown path). The correct callback, `onPairingPasskey`, is installed **only** in `setup()`. But re-enabling BLE on an already-constructed `nrf52Bluetooth` goes through `resumeAdvertising()` — not `setup()` (see `setBluetoothEnable()` in `main-nrf52.cpp`) — and `resumeAdvertising()` only re-armed advertising. It never restored the pairing callback, so the `onUnwantedPairing` refusal stayed latched.

## Fix

Restore the correct pairing passkey callback at the top of `resumeAdvertising()`, guarded by the same `config.bluetooth.mode` check `setup()` uses:

```cpp
if (config.bluetooth.mode != meshtastic_Config_BluetoothConfig_PairingMode_NO_PIN)
    Bluefruit.Security.setPairPasskeyCallback(NRF52Bluetooth::onPairingPasskey);
```

Only PIN modes drive a passkey-display callback (the callback fires solely on `BLE_GAP_EVT_PASSKEY_DISPLAY`); NO_PIN / Just Works never invokes it, so no restore is needed there — this mirrors `setup()` exactly. `shutdown()` only overwrites the passkey callback (not IOCaps/PIN/permissions), so restoring just that callback is sufficient and avoids re-running RANDOM_PIN generation (which would change the displayed PIN on every resume).

## Severity / reachability

Narrow. Normal runtime `setBluetoothEnable(false)` paths reboot, so the only non-reboot `shutdown()` → `resumeAdvertising()` reentry today is the PowerStress test module's `BT_OFF` then `BT_ON` opcodes. Low severity, but a real teardown-latches / re-enable-doesn't-restore asymmetry.

## Testing

Build-verified on `rak4631` (nRF52840) — `SUCCESS`, all nRF52 warm-region / ISR-handler / variant guards pass. No hardware needed since the change is a callback restore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PIN-based Bluetooth pairing after Bluetooth is resumed.
  * Passkeys are now displayed correctly without requiring a device reboot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->