### PR TITLE
fix(lockdown): re-lock serial console admin auth on USB link drop

### DIFF
--- a/src/SerialConsole.cpp
+++ b/src/SerialConsole.cpp
@@ -30,6 +30,16 @@
 
 SerialConsole *console;
 
+#ifdef MESHTASTIC_PHONEAPI_ACCESS_CONTROL
+// Last-seen USB-CDC host link (DTR/mount) state, sampled each runOnce() so a
+// physical unplug/replug re-locks the per-connection admin auth (see runOnce()).
+// Kept at file scope rather than as a member both because there is exactly one
+// console singleton and because adding per-instance members to the PhoneAPI
+// hierarchy has historically perturbed nRF52 USB-CDC enumeration (see PhoneAPI.h).
+// Only compiled on lockdown (nRF52) builds.
+static bool s_serialLinkUp = false;
+#endif
+
 /// Create the shared serial console once and register receive wakeups.
 void consoleInit()
 {
@@ -88,6 +98,30 @@ SerialConsole::SerialConsole() : StreamAPI(&Port), RedirectablePrint(&Port), con
 /// Service one serial API iteration and select the next polling interval.
 int32_t SerialConsole::runOnce()
 {
+#ifdef MESHTASTIC_PHONEAPI_ACCESS_CONTROL
+    // Lockdown (nRF52) builds only. The SerialConsole is a process-lifetime
+    // singleton, so its inherited PhoneAPI object - and therefore its entry in
+    // the per-connection admin-auth slot table (keyed by PhoneAPI*) - is reused
+    // for every USB/serial client for the whole boot. Nothing re-locks that slot
+    // when the operator unplugs and a different client plugs in before the
+    // 15-minute inactivity timeout fires, so a fresh client would inherit the
+    // prior operator's admin authorization. Re-lock when the physical USB-CDC link
+    // drops - the serial analog of the BLE onDisconnect() -> close() session reset.
+    //
+    // On the nRF52 TinyUSB (Adafruit) core, (bool)Port == tud_cdc_n_connected():
+    // it goes false on cable unplug or host port-close (DTR de-assert). close()
+    // frees the auth slot and resets PhoneAPI state, so whoever connects next
+    // re-locks via handleStartConfig()'s !isConnected() branch on their first
+    // want_config - the same physical-link boundary BLE enforces in onConnect().
+    // Console transports without a real DTR line (e.g. a UART USER_DEBUG_PORT) hold
+    // this constant, so no edge fires and we fall back to the existing inactivity
+    // timeout - no worse than the pre-fix behavior.
+    const bool linkUp = static_cast<bool>(Port);
+    if (s_serialLinkUp && !linkUp)
+        close();
+    s_serialLinkUp = linkUp;
+#endif
+
 #ifdef HELTEC_MESH_SOLAR
     // After enabling the mesh solar serial port module configuration, command processing is handled by the serial port module.
     if (moduleConfig.serial.enabled && moduleConfig.serial.override_console_serial_port &&


### PR DESCRIPTION
## ⚠️ Security fix — touches the lockdown auth model. Please get a security review before merging.

### The bug
On lockdown builds (`MESHTASTIC_PHONEAPI_ACCESS_CONTROL` + `MESHTASTIC_ENCRYPTED_STORAGE`, nRF52 — see `configuration.h`), per-connection admin authorization persists across serial-console client swaps.

`SerialConsole` is a process-lifetime singleton (`src/SerialConsole.cpp`, global `console`) and inherits `PhoneAPI` via `StreamAPI`, so the **same** `PhoneAPI` object services every USB/serial client for the whole boot. Admin auth lives in the file-static `g_authSlots` table keyed by the `PhoneAPI*` `this`. Because the console's `this` never changes, an operator's unlock stays latched in that slot. The only re-lock paths for the serial console were `close()` (15-min inactivity timeout / explicit disconnect) and the `!isConnected()` branch of `handleStartConfig()`.

**Impact:** an attacker who plugs into the USB/serial port before the prior authenticated session times out inherits admin authorization — the same stale-state-on-reuse class the BLE `onConnect()`/`resetBleSessionState` fix just closed, with no serial equivalent until now.

### The fix
Give the serial console a per-physical-link re-lock. Each `runOnce()` samples the USB-CDC host link state; on the link-drop edge it calls `close()`, which frees the auth slot (`clearAuthSlot_LH`) and resets `PhoneAPI` state to `STATE_SEND_NOTHING`. Whoever connects next then re-locks through the existing `!isConnected()` branch of `handleStartConfig()` on their first `want_config` — the same physical-link boundary BLE enforces in `onConnect()`.

```cpp
const bool linkUp = static_cast<bool>(Port);
if (s_serialLinkUp && !linkUp)
    close();
s_serialLinkUp = linkUp;
```

On the nRF52 TinyUSB (Adafruit) core, `(bool)Port == tud_cdc_n_connected()`: true while a host holds the CDC port open with DTR asserted, false on cable unplug or host port-close.

### Design notes
- **Entirely `#ifdef MESHTASTIC_PHONEAPI_ACCESS_CONTROL`-gated** (nRF52-only). Non-lockdown builds compile byte-identically; when access control is off, `getAdminAuthorized()` returns `true` unconditionally so the gates are already no-ops.
- **Link-drop edge + `close()` only.** `close()` already clears the slot *and* resets state, so a rising-edge `setAdminAuthorized(false)` would be redundant. (`setAdminAuthorized` is also declared under the access-control `#ifdef`, and in this TU `PhoneAPI.h` is parsed before `configuration.h` defines the macro — `close()` is unconditionally declared and is the right primitive here.)
- **File-scope `static`, not a member** — per the note at `PhoneAPI.h` that per-instance members on the PhoneAPI hierarchy have perturbed nRF52 USB-CDC enumeration. Safe because `console` is a singleton.
- **Structural asymmetry vs BLE (intentional, analyzed):** serial has no `onConnect` event, so it relies on the disconnect edge + the new client's `handleStartConfig` re-lock rather than an unconditional connect-time clear. Reaching an un-cleared authorized slot requires the passphrase (every `setAdminAuthorized(true)` path is passphrase-gated) and the next client re-locks before any config is emitted, so the gap isn't exploitable.
- **Residuals (out of threat model, no regression):** a client that never asserts DTR falls back to the existing 15-min inactivity timeout (same as before); a machine-speed cable swap that beats the ~250 ms `runOnce` poll on a battery-powered device is beyond "reconnect before timeout."
- **Completeness:** lockdown is nRF52-only, and nRF52 has exactly two `PhoneAPI` transports — BLE (already fixed) and the serial console (this PR).

### Testing
- Builds clean on a lockdown env (`rak4631_ctf_dev`, real nRF52 toolchain): `SerialConsole.cpp` compiles + links, firmware `.hex`/OTA produced.
- `clang-format` 16.0.3 (repo config) — no changes.
- Non-lockdown / native builds unaffected by construction (all new code inside the nRF52-only `#ifdef`).
- Hardware plug/unplug re-lock verification recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USB/serial connection handling by resetting the administrative session when a physical connection is disconnected.
  * Ensured new USB/serial connections begin with a fresh authentication state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->