### PR TITLE
Bound payload.bytes prints by payload.size

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -753,7 +753,7 @@ meshtastic_Routing_Error perhapsEncode(meshtastic_MeshPacket *p)
 
             LOG_DEBUG("Original length - %d ", p->decoded.payload.size);
             LOG_DEBUG("Compressed length - %d ", compressed_len);
-            LOG_DEBUG("Original message - %s ", p->decoded.payload.bytes);
+            LOG_DEBUG("Original message - %.*s ", (int)p->decoded.payload.size, p->decoded.payload.bytes);
 
             // If the compressed length is greater than or equal to the original size, don't use the compressed form
             if (compressed_len >= p->decoded.payload.size) {

--- a/src/modules/RangeTestModule.cpp
+++ b/src/modules/RangeTestModule.cpp
@@ -154,7 +154,7 @@ ProcessMessage RangeTestModuleRadio::handleReceived(const meshtastic_MeshPacket 
             NodeInfoLite *n = nodeDB->getMeshNode(getFrom(&mp));
 
             LOG_DEBUG("-----------------------------------------");
-            LOG_DEBUG("p.payload.bytes  \"%s\"", p.payload.bytes);
+            LOG_DEBUG("p.payload.bytes  \"%.*s\"", (int)p.payload.size, p.payload.bytes);
             LOG_DEBUG("p.payload.size   %d", p.payload.size);
             LOG_DEBUG("---- Received Packet:");
             LOG_DEBUG("mp.from          %d", mp.from);
@@ -192,7 +192,7 @@ bool RangeTestModuleRadio::appendFile(const meshtastic_MeshPacket &mp)
     meshtastic_NodeInfoLite *n = nodeDB->getMeshNode(getFrom(&mp));
     /*
         LOG_DEBUG("-----------------------------------------");
-        LOG_DEBUG("p.payload.bytes  \"%s\"", p.payload.bytes);
+        LOG_DEBUG("p.payload.bytes  \"%.*s\"", (int)p.payload.size, p.payload.bytes);
         LOG_DEBUG("p.payload.size   %d", p.payload.size);
         LOG_DEBUG("---- Received Packet:");
         LOG_DEBUG("mp.from          %d", mp.from);
@@ -307,7 +307,7 @@ bool RangeTestModuleRadio::appendFile(const meshtastic_MeshPacket &mp)
     fileToAppend.printf("%d,", mp.hop_limit); // Packet Hop Limit
 
     // TODO: If quotes are found in the payload, it has to be escaped.
-    fileToAppend.printf("\"%s\"\n", p.payload.bytes);
+    fileToAppend.printf("\"%.*s\"\n", (int)p.payload.size, p.payload.bytes);
     fileToAppend.printf("%i,", mp.rx_rssi); // RX RSSI
 
     fileToAppend.flush();

--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -396,7 +396,7 @@ ProcessMessage SerialModuleRadio::handleReceived(const meshtastic_MeshPacket &mp
                     lastRxID = mp.id;
                     // LOG_DEBUG("* * Message came this device");
                     // serialPrint->println("* * Message came this device");
-                    serialPrint->printf("%s", p.payload.bytes);
+                    serialPrint->printf("%.*s", (int)p.payload.size, p.payload.bytes);
                 }
             }
         } else {
@@ -408,7 +408,7 @@ ProcessMessage SerialModuleRadio::handleReceived(const meshtastic_MeshPacket &mp
                 meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(getFrom(&mp));
                 const char *sender = nodeInfoLiteHasUser(node) ? node->short_name : "???";
                 serialPrint->println();
-                serialPrint->printf("%s: %s", sender, p.payload.bytes);
+                serialPrint->printf("%s: %.*s", sender, (int)p.payload.size, p.payload.bytes);
                 serialPrint->println();
             } else if ((moduleConfig.serial.mode == meshtastic_ModuleConfig_SerialConfig_Serial_Mode_NMEA ||
                         moduleConfig.serial.mode == meshtastic_ModuleConfig_SerialConfig_Serial_Mode_CALTOPO) &&


### PR DESCRIPTION
`decoded.payload.bytes` is a fixed 233-byte protobuf bytes field and is not
NUL-terminated. A few sites print it with a plain `"%s"`, which reads until it finds a
NUL; a full-length payload with no NUL byte makes that read run off the end of the field.

Fixed to `"%.*s"` bounded by `payload.size`, which is the form
`SerialModule` already uses for the raw `write(bytes, size)` case a few lines up.

Live sites:
- `RangeTestModule.cpp` `appendFile()` - writes received text to the range-test CSV
- `SerialModule.cpp` - PROTO/TEXTMSG serial output of received messages

The same change is applied to three currently commented-out debug lines
(`RangeTestModule` x2, `Router.cpp` compression block) so the pattern stays correct if
they are ever re-enabled; those are not live today.

Swept the tree for every other `payload.bytes` used as a C string. The rest are already
safe: `pb_decode`/`pb_encode`/`memcpy` with an explicit size, `strnlen(payload, 219)`
(under the 233-byte field) in `MessageStore`, a `payload.size`-bounded alert-scan loop in
`MessageRenderer`, an explicit clamped length in the InkHUD store path, and a
`strncasecmp` bounded by a 54-byte local buffer in `DropzoneModule`. Many call sites
already use the `"%.*s"` form; this brings the stragglers in line.

No unit test: the two live sites are inline writes to a Stream and to the filesystem, so a
targeted repro needs serial/FS mocking for what is a mechanical format-string bound with no
behavior change for valid input. The coverage env builds with ASan, which guards the
broader decode paths the suite already exercises.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of received payloads that are not null-terminated or contain binary data.
  * Serial echo and text output now consistently display the recorded payload length.
  * Debug logs and CSV exports now preserve payload content more reliably without relying on null-termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->