### PR TITLE
Channels: fix off-by-one bound in decryptForHash

### DIFF
--- a/src/mesh/Channels.cpp
+++ b/src/mesh/Channels.cpp
@@ -516,7 +516,7 @@ bool Channels::hasDefaultChannel()
  */
 bool Channels::decryptForHash(ChannelIndex chIndex, ChannelHash channelHash)
 {
-    if (chIndex > getNumChannels() || getHash(chIndex) != channelHash) {
+    if (chIndex >= getNumChannels() || getHash(chIndex) != channelHash) {
         // LOG_DEBUG("Skip channel %d (hash %x) due to invalid hash/index, want=%x", chIndex, getHash(chIndex),
         // channelHash);
         return false;


### PR DESCRIPTION
`decryptForHash` guarded the channel index with `chIndex > getNumChannels()`, which lets `chIndex == getNumChannels()` through to `getHash(chIndex)`. That reads one element past `hashes[MAX_NUM_CHANNELS]` when all channel slots are in use. Use `>=` so an out-of-range index is rejected before the array access.

Not reachable from the current caller; defensive tightening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed channel validation to correctly reject out-of-range channel indexes during decryption.
  - Prevented invalid channel access when the index equals the total number of available channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->