### PR TITLE
Use hardware RNG for session passkey and PKC extra nonce

### DIFF
--- a/src/mesh/CryptoEngine.cpp
+++ b/src/mesh/CryptoEngine.cpp
@@ -224,7 +224,11 @@ bool CryptoEngine::encryptCurve25519(uint32_t toNode, uint32_t fromNode, meshtas
                                      uint64_t packetNum, size_t numBytes, const uint8_t *bytes, uint8_t *bytesOut)
 {
     uint8_t *auth;
-    long extraNonceTmp = random();
+    // The extra nonce must be unpredictable: use the hardware RNG, falling back to the
+    // seeded CSPRNG only when no hardware source is available.
+    uint32_t extraNonceTmp;
+    if (!HardwareRNG::fill((uint8_t *)&extraNonceTmp, sizeof(extraNonceTmp)))
+        CryptRNG.rand((uint8_t *)&extraNonceTmp, sizeof(extraNonceTmp));
     auth = bytesOut + numBytes;
     memcpy((uint8_t *)(auth + 8), &extraNonceTmp,
            sizeof(uint32_t)); // do not use dereference on potential non aligned pointers : *extraNonce = extraNonceTmp;

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -1789,13 +1789,13 @@ void AdminModule::setPassKey(meshtastic_AdminMessage *res)
 {
     // Regenerate once there is no session yet or the current key is older than 150s. session_time
     // holds millis(); the Throttle check is rollover-safe, unlike the previous seconds comparison.
-    if (!session_passkey_valid || !Throttle::isWithinTimespanMs(session_time, 150 * 1000UL)) {
+    if (!sessionPasskeyValid || !Throttle::isWithinTimespanMs(session_time, 150 * 1000UL)) {
         // Session passkey authenticates admin replies, so it must be unpredictable: prefer the
         // hardware RNG, falling back to the seeded CSPRNG only when no hardware source exists.
         if (!HardwareRNG::fill(session_passkey, sizeof(session_passkey)))
             CryptRNG.rand(session_passkey, sizeof(session_passkey));
         session_time = millis();
-        session_passkey_valid = true;
+        sessionPasskeyValid = true;
     }
     memcpy(res->session_passkey.bytes, session_passkey, 8);
     res->session_passkey.size = 8;
@@ -1808,8 +1808,8 @@ bool AdminModule::checkPassKey(meshtastic_AdminMessage *res)
 { // check that the key in the packet is still valid
     printBytes("Incoming session key: ", res->session_passkey.bytes, 8);
     printBytes("Expected session key: ", session_passkey, 8);
-    // Key is valid for 300s from issue; session_passkey_valid guards an unissued session.
-    return (session_passkey_valid && Throttle::isWithinTimespanMs(session_time, 300 * 1000UL) && res->session_passkey.size == 8 &&
+    // Key is valid for 300s from issue; sessionPasskeyValid guards an unissued session.
+    return (sessionPasskeyValid && Throttle::isWithinTimespanMs(session_time, 300 * 1000UL) && res->session_passkey.size == 8 &&
             memcmp(res->session_passkey.bytes, session_passkey, 8) == 0);
 }
 

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -1,6 +1,7 @@
 #include "AdminModule.h"
 #include "Channels.h"
 #include "DisplayFormatters.h"
+#include "HardwareRNG.h"
 #include "MeshService.h"
 #include "NodeDB.h"
 #include "PositionPrecision.h"
@@ -47,6 +48,8 @@
 #if !MESHTASTIC_EXCLUDE_GPS
 #include "GPS.h"
 #endif
+
+#include <RNG.h> // CryptRNG, the seeded CSPRNG used as fallback for the session passkey
 
 #if MESHTASTIC_EXCLUDE_GPS
 #include "modules/PositionModule.h"
@@ -1784,9 +1787,10 @@ AdminModule::AdminModule() : ProtobufModule("Admin", meshtastic_PortNum_ADMIN_AP
 void AdminModule::setPassKey(meshtastic_AdminMessage *res)
 {
     if (session_time == 0 || millis() / 1000 > session_time + 150) {
-        for (int i = 0; i < 8; i++) {
-            session_passkey[i] = random();
-        }
+        // Session passkey authenticates admin replies, so it must be unpredictable: prefer the
+        // hardware RNG, falling back to the seeded CSPRNG only when no hardware source exists.
+        if (!HardwareRNG::fill(session_passkey, sizeof(session_passkey)))
+            CryptRNG.rand(session_passkey, sizeof(session_passkey));
         session_time = millis() / 1000;
     }
     memcpy(res->session_passkey.bytes, session_passkey, 8);

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -49,7 +49,8 @@
 #include "GPS.h"
 #endif
 
-#include <RNG.h> // CryptRNG, the seeded CSPRNG used as fallback for the session passkey
+#include <RNG.h>      // CryptRNG, the seeded CSPRNG used as fallback for the session passkey
+#include <Throttle.h> // rollover-safe elapsed-time checks for the session passkey
 
 #if MESHTASTIC_EXCLUDE_GPS
 #include "modules/PositionModule.h"
@@ -1786,12 +1787,14 @@ AdminModule::AdminModule() : ProtobufModule("Admin", meshtastic_PortNum_ADMIN_AP
 
 void AdminModule::setPassKey(meshtastic_AdminMessage *res)
 {
-    if (session_time == 0 || millis() / 1000 > session_time + 150) {
+    // Regenerate once the current key is older than 150s. session_time holds millis(); the
+    // Throttle check is rollover-safe, unlike the previous seconds-based comparison.
+    if (session_time == 0 || !Throttle::isWithinTimespanMs(session_time, 150 * 1000UL)) {
         // Session passkey authenticates admin replies, so it must be unpredictable: prefer the
         // hardware RNG, falling back to the seeded CSPRNG only when no hardware source exists.
         if (!HardwareRNG::fill(session_passkey, sizeof(session_passkey)))
             CryptRNG.rand(session_passkey, sizeof(session_passkey));
-        session_time = millis() / 1000;
+        session_time = millis();
     }
     memcpy(res->session_passkey.bytes, session_passkey, 8);
     res->session_passkey.size = 8;
@@ -1804,7 +1807,8 @@ bool AdminModule::checkPassKey(meshtastic_AdminMessage *res)
 { // check that the key in the packet is still valid
     printBytes("Incoming session key: ", res->session_passkey.bytes, 8);
     printBytes("Expected session key: ", session_passkey, 8);
-    return (session_time + 300 > millis() / 1000 && res->session_passkey.size == 8 &&
+    // Key is valid for 300s from issue; session_time == 0 means no session yet.
+    return (session_time != 0 && Throttle::isWithinTimespanMs(session_time, 300 * 1000UL) && res->session_passkey.size == 8 &&
             memcmp(res->session_passkey.bytes, session_passkey, 8) == 0);
 }
 

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -1787,14 +1787,15 @@ AdminModule::AdminModule() : ProtobufModule("Admin", meshtastic_PortNum_ADMIN_AP
 
 void AdminModule::setPassKey(meshtastic_AdminMessage *res)
 {
-    // Regenerate once the current key is older than 150s. session_time holds millis(); the
-    // Throttle check is rollover-safe, unlike the previous seconds-based comparison.
-    if (session_time == 0 || !Throttle::isWithinTimespanMs(session_time, 150 * 1000UL)) {
+    // Regenerate once there is no session yet or the current key is older than 150s. session_time
+    // holds millis(); the Throttle check is rollover-safe, unlike the previous seconds comparison.
+    if (!session_passkey_valid || !Throttle::isWithinTimespanMs(session_time, 150 * 1000UL)) {
         // Session passkey authenticates admin replies, so it must be unpredictable: prefer the
         // hardware RNG, falling back to the seeded CSPRNG only when no hardware source exists.
         if (!HardwareRNG::fill(session_passkey, sizeof(session_passkey)))
             CryptRNG.rand(session_passkey, sizeof(session_passkey));
         session_time = millis();
+        session_passkey_valid = true;
     }
     memcpy(res->session_passkey.bytes, session_passkey, 8);
     res->session_passkey.size = 8;
@@ -1807,8 +1808,8 @@ bool AdminModule::checkPassKey(meshtastic_AdminMessage *res)
 { // check that the key in the packet is still valid
     printBytes("Incoming session key: ", res->session_passkey.bytes, 8);
     printBytes("Expected session key: ", session_passkey, 8);
-    // Key is valid for 300s from issue; session_time == 0 means no session yet.
-    return (session_time != 0 && Throttle::isWithinTimespanMs(session_time, 300 * 1000UL) && res->session_passkey.size == 8 &&
+    // Key is valid for 300s from issue; session_passkey_valid guards an unissued session.
+    return (session_passkey_valid && Throttle::isWithinTimespanMs(session_time, 300 * 1000UL) && res->session_passkey.size == 8 &&
             memcmp(res->session_passkey.bytes, session_passkey, 8) == 0);
 }
 

--- a/src/modules/AdminModule.h
+++ b/src/modules/AdminModule.h
@@ -41,7 +41,7 @@ class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Obser
     bool hasOpenEditTransaction = false;
 
     uint8_t session_passkey[8] = {0};
-    uint session_time = 0;
+    uint32_t session_time = 0; // millis() when the current session passkey was issued (0 = none)
 
     void saveChanges(int saveWhat, bool shouldReboot = true);
 

--- a/src/modules/AdminModule.h
+++ b/src/modules/AdminModule.h
@@ -41,8 +41,8 @@ class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Obser
     bool hasOpenEditTransaction = false;
 
     uint8_t session_passkey[8] = {0};
-    uint32_t session_time = 0;          // millis() when the current session passkey was issued
-    bool session_passkey_valid = false; // separate flag: millis() 0 at boot is a valid issue time
+    uint32_t session_time = 0;        // millis() when the current session passkey was issued
+    bool sessionPasskeyValid = false; // separate flag: millis() 0 at boot is a valid issue time
 
     void saveChanges(int saveWhat, bool shouldReboot = true);
 

--- a/src/modules/AdminModule.h
+++ b/src/modules/AdminModule.h
@@ -41,7 +41,8 @@ class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Obser
     bool hasOpenEditTransaction = false;
 
     uint8_t session_passkey[8] = {0};
-    uint32_t session_time = 0; // millis() when the current session passkey was issued (0 = none)
+    uint32_t session_time = 0;          // millis() when the current session passkey was issued
+    bool session_passkey_valid = false; // separate flag: millis() 0 at boot is a valid issue time
 
     void saveChanges(int saveWhat, bool shouldReboot = true);
 


### PR DESCRIPTION
Two security-relevant values were drawn from Arduino `random()`, which is a seedable PRNG, not a CSPRNG:

- `AdminModule::setPassKey` session passkey (authenticates admin replies)
- `CryptoEngine::encryptCurve25519` extra nonce

Both now use `HardwareRNG::fill`, mirroring the XEdDSA signing path, and fall back to the seeded CSPRNG (`CryptRNG`) only when no hardware entropy source is available on the platform. `HardwareRNG` already abstracts the per-platform hardware source, so no target-specific handling is added here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Strengthened Curve25519 encryption by generating the extra nonce with hardware-backed randomness when available, with a cryptographic software fallback.
  * Improved administrative session passkey generation using higher-quality entropy and refreshing passkeys based on a millisecond-based 150s window.
  * Updated session passkey validation to be rollover-safe, enforcing a 300s millisecond window and requiring an explicit passkey-valid flag for more reliable authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->