### PR TITLE
TrafficManagement: gate role/NodeInfo cache writes on signer authenticity

### DIFF
--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -729,8 +729,15 @@ ProcessMessage TrafficManagementModule::handleReceived(const meshtastic_MeshPack
     // Learn NodeInfo payloads into the dedicated PSRAM cache, and refresh the tier-3
     // role cache for any node we already track (keeps the dedup role exception current).
     if (mp.decoded.portnum == meshtastic_PortNum_NODEINFO_APP) {
-        cacheNodeInfoPacket(mp);
-        updateCachedRoleFromNodeInfo(mp);
+        // A known signer's NodeInfo arriving unsigned is unauthenticated (the sender is forgeable),
+        // so don't let it drive the role cache or the direct-response NodeInfo cache. Same gate the
+        // identity-update path below uses.
+        const meshtastic_NodeInfoLite *senderNode = nodeDB->getMeshNode(getFrom(&mp));
+        const bool unauthenticatedSigner = senderNode && nodeInfoLiteHasXeddsaSigned(senderNode) && !mp.xeddsa_signed;
+        if (!unauthenticatedSigner) {
+            cacheNodeInfoPacket(mp);
+            updateCachedRoleFromNodeInfo(mp);
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -726,18 +726,18 @@ ProcessMessage TrafficManagementModule::handleReceived(const meshtastic_MeshPack
         return ProcessMessage::CONTINUE;
     }
 
+    // A known signer's NodeInfo arriving unsigned is unauthenticated (the sender is forgeable), so
+    // it must not drive any cache or identity write below. Computed once here (getMeshNode is O(N))
+    // and reused by both the cache-refresh and the direct-response identity path.
+    const bool isNodeInfo = mp.decoded.portnum == meshtastic_PortNum_NODEINFO_APP;
+    const meshtastic_NodeInfoLite *senderNode = isNodeInfo ? nodeDB->getMeshNode(getFrom(&mp)) : nullptr;
+    const bool unauthenticatedSigner = senderNode && nodeInfoLiteHasXeddsaSigned(senderNode) && !mp.xeddsa_signed;
+
     // Learn NodeInfo payloads into the dedicated PSRAM cache, and refresh the tier-3
     // role cache for any node we already track (keeps the dedup role exception current).
-    if (mp.decoded.portnum == meshtastic_PortNum_NODEINFO_APP) {
-        // A known signer's NodeInfo arriving unsigned is unauthenticated (the sender is forgeable),
-        // so don't let it drive the role cache or the direct-response NodeInfo cache. Same gate the
-        // identity-update path below uses.
-        const meshtastic_NodeInfoLite *senderNode = nodeDB->getMeshNode(getFrom(&mp));
-        const bool unauthenticatedSigner = senderNode && nodeInfoLiteHasXeddsaSigned(senderNode) && !mp.xeddsa_signed;
-        if (!unauthenticatedSigner) {
-            cacheNodeInfoPacket(mp);
-            updateCachedRoleFromNodeInfo(mp);
-        }
+    if (isNodeInfo && !unauthenticatedSigner) {
+        cacheNodeInfoPacket(mp);
+        updateCachedRoleFromNodeInfo(mp);
     }
 
     // -------------------------------------------------------------------------
@@ -753,8 +753,7 @@ ProcessMessage TrafficManagementModule::handleReceived(const meshtastic_MeshPack
         if (shouldRespondToNodeInfo(&mp, true)) {
             // Unicast NodeInfo is never signed, so a known signer's identity claim here is
             // unauthenticated: don't overwrite its stored name. The cached response is unaffected.
-            const meshtastic_NodeInfoLite *senderNode = nodeDB->getMeshNode(getFrom(&mp));
-            const bool unauthenticatedSigner = senderNode && nodeInfoLiteHasXeddsaSigned(senderNode) && !mp.xeddsa_signed;
+            // unauthenticatedSigner was computed above (this branch is NodeInfo-only).
             meshtastic_User requester = meshtastic_User_init_zero;
             if (!unauthenticatedSigner &&
                 pb_decode_from_bytes(mp.decoded.payload.bytes, mp.decoded.payload.size, &meshtastic_User_msg, &requester)) {


### PR DESCRIPTION
The tier-3 role cache (`updateCachedRoleFromNodeInfo`) and the PSRAM NodeInfo response cache (`cacheNodeInfoPacket`) were refreshed from any received NodeInfo without an authenticity check. A spoofed NodeInfo (the sender field is forgeable) could therefore:

- set a tracked node's cached role, granting the tracker / lost-and-found position-dedup exceptions and pinning the entry against eviction, or
- overwrite the cached user that direct NodeInfo responses serve to requestors.

Both cache writes now use the same gate the identity-update path already applies: when a node known to sign its NodeInfo (`nodeInfoLiteHasXeddsaSigned`) sends an unsigned NodeInfo, the update is skipped. Nodes that have never signed are unaffected. No overlap with the existing direct-response `updateUser` gate; that guards a separate sink.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unauthenticated (unsigned) NodeInfo packets from updating trusted cached identity details.
  * Ensured NodeInfo processing consistently applies enhanced authentication gating, avoiding unintended updates to cached role data and related refresh behavior.
  * Updated the direct-response handling path to reuse the same authentication decision, preventing unsigned senders from triggering guarded identity overwrites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->