### PR TITLE
Add RAK WisMesh Pod variant and fix Tag LPCOMP wake on user shutdown

### DIFF
--- a/variants/nrf52840/rak_wismeshtag/platformio.ini
+++ b/variants/nrf52840/rak_wismeshtag/platformio.ini
@@ -23,3 +23,11 @@ build_flags = ${nrf52840_base.build_flags}
   -DRADIOLIB_EXCLUDE_LR2021=1
   -DMESHTASTIC_EXCLUDE_WIFI=1
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/rak_wismeshtag>
+
+; RAK WisMesh Pod — same board as Tag (no user buttons on hardware; shares Tag pin map)
+[env:rak_wismesh_pod]
+extends = env:rak_wismeshtag
+custom_meshtastic_display_name = RAK WisMesh Pod
+build_flags =
+  ${env:rak_wismeshtag.build_flags}
+  -D WISMESH_POD

--- a/variants/nrf52840/rak_wismeshtag/platformio.ini
+++ b/variants/nrf52840/rak_wismeshtag/platformio.ini
@@ -24,7 +24,7 @@ build_flags = ${nrf52840_base.build_flags}
   -DMESHTASTIC_EXCLUDE_WIFI=1
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/rak_wismeshtag>
 
-; RAK WisMesh Pod — same board as Tag (no user buttons on hardware; shares Tag pin map)
+; RAK WisMesh Pod - same board as Tag (no user buttons on hardware; shares Tag pin map)
 [env:rak_wismesh_pod]
 extends = env:rak_wismeshtag
 custom_meshtastic_display_name = RAK WisMesh Pod

--- a/variants/nrf52840/rak_wismeshtag/variant.cpp
+++ b/variants/nrf52840/rak_wismeshtag/variant.cpp
@@ -46,6 +46,14 @@ void initVariant()
 }
 
 #ifdef LOW_VDD_SYSTEMOFF_DELAY_MS
+static bool lowVddSystemOff = false; // Set when brownout forces System OFF (enables LPCOMP wake).
+
+// Strong override; must be noinline (see main-nrf52.cpp weak default).
+__attribute__((noinline)) bool variant_enableBatteryLpcompWake()
+{
+    return lowVddSystemOff;
+}
+
 void variant_nrf52LoopHook(void)
 {
     // If VDD stays unsafe for a while (brownout), force System OFF.
@@ -72,6 +80,7 @@ void variant_nrf52LoopHook(void)
                 low_vdd_timer_armed = true;
             }
             if ((uint32_t)(now - low_vdd_since_ms) >= (uint32_t)LOW_VDD_SYSTEMOFF_DELAY_MS) {
+                lowVddSystemOff = true;
                 cpuDeepSleep(portMAX_DELAY);
             }
         } else {

--- a/variants/nrf52840/rak_wismeshtag/variant.h
+++ b/variants/nrf52840/rak_wismeshtag/variant.h
@@ -55,10 +55,13 @@ extern "C" {
 /*
  * Buttons
  */
-
+#ifndef WISMESH_POD
 #define PIN_BUTTON1 9 // Pin for button on E-ink button module or IO expansion
 #define BUTTON_NEED_PULLUP
 #define PIN_BUTTON2 12
+#else
+#define HAS_BUTTON 0
+#endif
 
 /*
  * Analog pins


### PR DESCRIPTION
## Summary

- Add `[env:rak_wismesh_pod]` for **RAK WisMesh Pod** (extends `rak_wismeshtag`, pin map shared).
- Pod has **no user buttons**: under `WISMESH_POD`, skip `PIN_BUTTON*` and set `HAS_BUTTON 0`.
- Fix Tag/Pod **user shutdown / config reboot wake loop**: port `variant_enableBatteryLpcompWake()` from `#10918` so LPCOMP is enabled only for brownout-driven System OFF, not CLI/App shutdown.

## Files changed

| File | Change |
|------|--------|
| `rak_wismeshtag/platformio.ini` | New `env:rak_wismesh_pod` + `WISMESH_POD` |
| `rak_wismeshtag/variant.h` | Disable buttons when `WISMESH_POD` |
| `rak_wismeshtag/variant.cpp` | LPCOMP wake only after low-VDD System OFF |

## Test plan

- [ ] `pio run -e rak_wismeshtag`
- [ ] `pio run -e rak_wismesh_pod`
- [ ] Tag: App/CLI config + battery ~3.4V — no reboot loop after save/shutdown
- [ ] Tag: low-VDD brownout still enters System OFF and can wake when battery recovers
- [ ] Pod: no button GPIO / no phantom button events
- [ ] Tag: button behavior unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new board build configuration for the RAK WisMesh Pod.
  * Updated the WisMesh Pod variant to reflect that hardware buttons are not present.
  * Enabled low-battery/low-VDD wake behavior after the device enters System OFF.

* **Bug Fixes**
  * Improved low-voltage brownout handling to ensure wake behavior works correctly following forced System OFF.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->