### PR TITLE
Add userprefs for telemetry screen settings

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1542,6 +1542,10 @@ void NodeDB::initModuleConfigIntervals()
     moduleConfig.telemetry.environment_update_interval = 0;
 #endif
 
+#ifdef USERPREFS_CONFIG_ENV_SCREEN_SCREEN_ENABLED
+    moduleConfig.telemetry.environment_screen_enabled = USERPREFS_CONFIG_ENV_SCREEN_SCREEN_ENABLED;
+#endif
+
 #ifdef USERPREFS_CONFIG_AQ_TELEM_UPDATE_INTERVAL
     moduleConfig.telemetry.air_quality_interval = USERPREFS_CONFIG_AQ_TELEM_UPDATE_INTERVAL;
 #else
@@ -1550,6 +1554,10 @@ void NodeDB::initModuleConfigIntervals()
 
 #ifdef USERPREFS_CONFIG_AQ_MEASUREMENT_ENABLED
     moduleConfig.telemetry.air_quality_enabled = USERPREFS_CONFIG_AQ_MEASUREMENT_ENABLED;
+#endif
+
+#ifdef USERPREFS_CONFIG_AQ_SCREEN_ENABLED
+    moduleConfig.telemetry.air_quality_screen_enabled = USERPREFS_CONFIG_AQ_SCREEN_ENABLED;
 #endif
 
     moduleConfig.telemetry.power_update_interval = 0;

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1536,6 +1536,12 @@ void NodeDB::initModuleConfigIntervals()
     moduleConfig.telemetry.environment_measurement_enabled = USERPREFS_CONFIG_ENVIRONMENT_MEASUREMENT_ENABLED;
 #endif
 
+#ifdef USERPREFS_CONFIG_ENV_TELEM_UPDATE_INTERVAL
+    moduleConfig.telemetry.environment_update_interval = USERPREFS_CONFIG_ENV_TELEM_UPDATE_INTERVAL;
+#else
+    moduleConfig.telemetry.environment_update_interval = 0;
+#endif
+
 #ifdef USERPREFS_CONFIG_AQ_TELEM_UPDATE_INTERVAL
     moduleConfig.telemetry.air_quality_interval = USERPREFS_CONFIG_AQ_TELEM_UPDATE_INTERVAL;
 #else

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1526,12 +1526,6 @@ void NodeDB::initModuleConfigIntervals()
     moduleConfig.telemetry.device_update_interval = MAX_INTERVAL;
 #endif
 
-#ifdef USERPREFS_CONFIG_ENV_TELEM_UPDATE_INTERVAL
-    moduleConfig.telemetry.environment_update_interval = USERPREFS_CONFIG_ENV_TELEM_UPDATE_INTERVAL;
-#else
-    moduleConfig.telemetry.environment_update_interval = 0;
-#endif
-
 #ifdef USERPREFS_CONFIG_ENVIRONMENT_MEASUREMENT_ENABLED
     moduleConfig.telemetry.environment_measurement_enabled = USERPREFS_CONFIG_ENVIRONMENT_MEASUREMENT_ENABLED;
 #endif

--- a/userPrefs.jsonc
+++ b/userPrefs.jsonc
@@ -37,8 +37,10 @@
   // "USERPREFS_CONFIG_DEVICE_TELEM_UPDATE_INTERVAL": "900", // Device telemetry update interval in seconds
   // "USERPREFS_CONFIG_ENV_TELEM_UPDATE_INTERVAL": "900",     // Environment telemetry update interval in seconds
   // "USERPREFS_CONFIG_ENVIRONMENT_MEASUREMENT_ENABLED": "1", // Force BMP280/sensor reads + LoRa broadcast on first boot
+  // "USERPREFS_CONFIG_ENV_SCREEN_SCREEN_ENABLED": "1",      // Environment telemetry enable on screen
   // "USERPREFS_CONFIG_AQ_TELEM_UPDATE_INTERVAL": "900",     // AQ telemetry update interval in seconds
   // "USERPREFS_CONFIG_AQ_MEASUREMENT_ENABLED": "1",         // AQ telemetry enable
+  // "USERPREFS_CONFIG_AQ_SCREEN_ENABLED": "1",              // AQ telemetry enable on screen
   // "USERPREFS_LORACONFIG_CHANNEL_NUM": "31",
   // "USERPREFS_LORACONFIG_TX_POWER": "0",
   // "USERPREFS_LORACONFIG_MODEM_PRESET": "meshtastic_Config_LoRaConfig_ModemPreset_SHORT_FAST",


### PR DESCRIPTION
Another small userprefs for adding telemetry metrics to screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options to enable or disable environment and air-quality telemetry displays.
  * Environment and air-quality screen settings can now be managed alongside existing telemetry preferences.
  * Telemetry intervals continue to default safely when no value is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->