### PR TITLE
Add retries for SCD4X data reading

### DIFF
--- a/src/modules/Telemetry/Sensor/SCD4XSensor.cpp
+++ b/src/modules/Telemetry/Sensor/SCD4XSensor.cpp
@@ -104,8 +104,18 @@ bool SCD4XSensor::getMetrics(meshtastic_Telemetry *measurement)
     reClockI2C.setClock(SCD4X_I2C_CLOCK_SPEED);
 #endif /* SCD4X_I2C_CLOCK_SPEED */
 
-    bool dataReady;
-    error = scd4x.getDataReadyStatus(dataReady);
+    bool dataReady = false;
+    uint8_t dataReadyTries = 0;
+
+    while (!dataReady && (dataReadyTries < SCD4X_MAX_RETRIES)) {
+        delay(100);
+        error = scd4x.getDataReadyStatus(dataReady);
+        if (error != SCD4X_NO_ERROR || !dataReady) {
+            LOG_WARN("SCD4X: Error collecting data. Retrying");
+            dataReadyTries++;
+        }
+    }
+
     if (error != SCD4X_NO_ERROR || !dataReady) {
 #ifdef SCD4X_I2C_CLOCK_SPEED
         LOG_DEBUG("%s: restoring clock speed", sensorName);

--- a/src/modules/Telemetry/Sensor/SCD4XSensor.cpp
+++ b/src/modules/Telemetry/Sensor/SCD4XSensor.cpp
@@ -108,10 +108,10 @@ bool SCD4XSensor::getMetrics(meshtastic_Telemetry *measurement)
     uint8_t dataReadyTries = 0;
 
     while (!dataReady && (dataReadyTries < SCD4X_MAX_RETRIES)) {
-        delay(100);
         error = scd4x.getDataReadyStatus(dataReady);
         if (error != SCD4X_NO_ERROR || !dataReady) {
-            LOG_WARN("SCD4X: Error collecting data. Retrying");
+            LOG_WARN("%s: Error collecting data. Retrying", sensorName);
+            delay(100);
             dataReadyTries++;
         }
     }

--- a/src/modules/Telemetry/Sensor/SCD4XSensor.h
+++ b/src/modules/Telemetry/Sensor/SCD4XSensor.h
@@ -11,6 +11,7 @@
 // Max speed 400kHz
 #define SCD4X_I2C_CLOCK_SPEED 400000
 #define SCD4X_WARMUP_MS 5000
+#define SCD4X_MAX_RETRIES 3
 
 class SCD4XSensor : public TelemetrySensor
 {


### PR DESCRIPTION
Adds a retry mechanism for SCD4X CO2 sensor, to avoid "Data not ready".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CO₂ sensor data collection by waiting for readings to become available before attempting to read.
  * Added a small retry mechanism to reduce temporary “not ready” failures.
  * Preserved existing fallback/error handling if valid readings still aren’t available after retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->