### PR TITLE
Add Waveshare ESP32-C3-Zero DIY variant

### DIFF
--- a/variants/esp32c3/diy/esp32c3_zero/README.md
+++ b/variants/esp32c3/diy/esp32c3_zero/README.md
@@ -1,0 +1,47 @@
+# Waveshare ESP32-C3-Zero with Ai-Thinker Ra-02
+
+This variant connects a [Waveshare ESP32-C3-Zero](https://docs.waveshare.com/ESP32-C3-Zero) to an Ai-Thinker Ra-02
+(SX1278) LoRa module.
+
+## Wiring
+
+| Ra-02 pin | ESP32-C3-Zero pin |
+| --------- | ----------------- |
+| 3.3V      | 3V3               |
+| GND       | GND               |
+| SCK       | GPIO4             |
+| MISO      | GPIO5             |
+| MOSI      | GPIO6             |
+| NSS       | GPIO7             |
+| RESET     | GPIO8             |
+| DIO0      | GPIO3             |
+| DIO1      | Not connected     |
+| DIO2      | Not connected     |
+
+The Ra-02 is a 3.3 V device. Do not connect its VCC or signal pins to 5 V. Attach a suitable antenna before powering
+the module; transmitting without an antenna can damage its RF output stage.
+
+The SX1278-based Ra-02 operates from 410 to 525 MHz. Configure Meshtastic for a legal regional band within that
+range; this module cannot operate on 868 or 915 MHz networks.
+
+## Optional peripherals
+
+| Peripheral  | ESP32-C3-Zero pin |
+| ----------- | ----------------- |
+| I2C SDA     | GPIO1             |
+| I2C SCL     | GPIO0             |
+| GPS RX      | GPIO20            |
+| GPS TX      | GPIO21            |
+| BOOT button | GPIO9             |
+
+Connect the GPS module's TX output to GPIO20 and its RX input to GPIO21.
+
+## Build
+
+From the firmware repository root, run:
+
+```sh
+pio run -e esp32c3_zero
+```
+
+Native USB CDC is enabled for flashing and serial logging through the board's USB-C connector.

--- a/variants/esp32c3/diy/esp32c3_zero/pins_arduino.h
+++ b/variants/esp32c3/diy/esp32c3_zero/pins_arduino.h
@@ -1,0 +1,24 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+static const uint8_t TX = 21;
+static const uint8_t RX = 20;
+
+static const uint8_t SDA = 1;
+static const uint8_t SCL = 0;
+
+static const uint8_t SS = 7;
+static const uint8_t MOSI = 6;
+static const uint8_t MISO = 5;
+static const uint8_t SCK = 4;
+
+static const uint8_t A0 = 0;
+static const uint8_t A1 = 1;
+static const uint8_t A2 = 2;
+static const uint8_t A3 = 3;
+static const uint8_t A4 = 4;
+static const uint8_t A5 = 5;
+
+#endif /* Pins_Arduino_h */

--- a/variants/esp32c3/diy/esp32c3_zero/platformio.ini
+++ b/variants/esp32c3/diy/esp32c3_zero/platformio.ini
@@ -1,0 +1,13 @@
+; Waveshare ESP32-C3-Zero Development Board
+; https://docs.waveshare.com/ESP32-C3-Zero
+[env:esp32c3_zero]
+extends = esp32c3_base
+board = esp32-c3-devkitm-1
+build_flags =
+  ${esp32c3_base.build_flags}
+  -D PRIVATE_HW
+  -I variants/esp32c3/diy/esp32c3_zero
+  -D ARDUINO_USB_MODE=1
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+custom_meshtastic_support_level = 3
+board_level = extra

--- a/variants/esp32c3/diy/esp32c3_zero/variant.h
+++ b/variants/esp32c3/diy/esp32c3_zero/variant.h
@@ -1,0 +1,46 @@
+#ifndef _VARIANT_ESP32C3_ZERO_
+#define _VARIANT_ESP32C3_ZERO_
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+// I2C (Wire)
+#define I2C_SDA (1)
+#define I2C_SCL (0)
+
+#define HAS_SCREEN 0
+
+// GPS
+#undef GPS_RX_PIN
+#undef GPS_TX_PIN
+#define GPS_RX_PIN (20)
+#define GPS_TX_PIN (21)
+
+// Button
+#define BUTTON_PIN (9) // BOOT button
+
+// Ai-Thinker Ra-02 (SX1278)
+#define USE_RF95
+#define LORA_SCK (4)
+#define LORA_MISO (5)
+#define LORA_MOSI (6)
+#define LORA_CS (7)
+#define LORA_RESET (8)
+#define LORA_DIO0 (3)
+#define LORA_DIO1 RADIOLIB_NC
+#define LORA_DIO2 RADIOLIB_NC
+
+#ifdef __cplusplus
+}
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#endif


### PR DESCRIPTION
Add an extra build target for the ESP32-C3-Zero paired with an Ai-Thinker Ra-02 SX1278 radio. Define the radio, I2C, GPS, and button pins, enable native USB CDC, and document wiring and frequency constraints.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)

The PR changes are standalone and will not affect other boards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Waveshare ESP32-C3-Zero with the Ai-Thinker Ra-02 (SX1278) LoRa module.
  * Introduced board-specific pin mappings for LoRa, I2C, GPS, SPI, analog inputs, and the boot button.
  * Enabled native USB (CDC) for flashing and serial logging.
  * Added PlatformIO environment configuration for building this board.
* **Documentation**
  * Added board-specific setup guidance, including wiring notes, power/voltage considerations, and build instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->