### PR TITLE
Support esptool v5 command names in device-install.bat

### DIFF
--- a/bin/device-install.bat
+++ b/bin/device-install.bat
@@ -132,6 +132,24 @@ IF %ERRORLEVEL% EQU 9009 (
     CALL :LOG_MESSAGE ERROR "esptool not found: !ESPTOOL_CMD!"
     EXIT /B 1
 )
+
+@REM esptool v5 supports commands with dashes and deprecates commands with
+@REM underscores. Prior versions only support commands with underscores.
+SET "ESPTOOL_WRITE_FLASH=write_flash"
+SET "ESPTOOL_ERASE_FLASH=erase_flash"
+SET "ESPTOOL_READ_FLASH_STATUS=read_flash_status"
+SET "ESPTOOL_HELP_FILE=%TEMP%\meshtastic_esptool_help.txt"
+!ESPTOOL_CMD! >"!ESPTOOL_HELP_FILE!" 2>nul
+FINDSTR /C:"write-flash" "!ESPTOOL_HELP_FILE!" >nul 2>&1
+IF %ERRORLEVEL% EQU 0 (
+    SET "ESPTOOL_WRITE_FLASH=write-flash"
+    SET "ESPTOOL_ERASE_FLASH=erase-flash"
+    SET "ESPTOOL_READ_FLASH_STATUS=read-flash-status"
+)
+DEL /Q "!ESPTOOL_HELP_FILE!" >nul 2>&1
+CALL :RESET_ERROR
+CALL :LOG_MESSAGE DEBUG "Using esptool command style: !ESPTOOL_WRITE_FLASH!."
+
 IF %DEBUG% EQU 1 (
     CALL :LOG_MESSAGE DEBUG "Skipping ESPTOOL_CMD steps."
     SET "ESPTOOL_CMD=REM !ESPTOOL_CMD!"
@@ -148,7 +166,7 @@ CALL :LOG_MESSAGE INFO "Using esptool baud: !ESPTOOL_BAUD!."
 
 IF %BPS_RESET% EQU 1 (
     @REM Attempt to change mode via 1200bps Reset.
-    CALL :RUN_ESPTOOL 1200 --after no_reset read_flash_status
+    CALL :RUN_ESPTOOL 1200 --after no_reset !ESPTOOL_READ_FLASH_STATUS!
     GOTO eof
 )
 
@@ -174,14 +192,14 @@ IF NOT EXIST !SPIFFS_FILENAME! CALL :LOG_MESSAGE ERROR "File does not exist: "!S
 
 @REM Flashing operations.
 CALL :LOG_MESSAGE INFO "Trying to flash "!FILENAME!", but first erasing and writing system information..."
-CALL :RUN_ESPTOOL !ESPTOOL_BAUD! erase_flash || GOTO eof
-CALL :RUN_ESPTOOL !ESPTOOL_BAUD! write_flash 0x00 "!FILENAME!" || GOTO eof
+CALL :RUN_ESPTOOL !ESPTOOL_BAUD! !ESPTOOL_ERASE_FLASH! || GOTO eof
+CALL :RUN_ESPTOOL !ESPTOOL_BAUD! !ESPTOOL_WRITE_FLASH! 0x00 "!FILENAME!" || GOTO eof
 
 CALL :LOG_MESSAGE INFO "Trying to flash BLEOTA "!OTA_FILENAME!" at OTA_OFFSET !OTA_OFFSET!..."
-CALL :RUN_ESPTOOL !ESPTOOL_BAUD! write_flash !OTA_OFFSET! "!OTA_FILENAME!" || GOTO eof
+CALL :RUN_ESPTOOL !ESPTOOL_BAUD! !ESPTOOL_WRITE_FLASH! !OTA_OFFSET! "!OTA_FILENAME!" || GOTO eof
 
 CALL :LOG_MESSAGE INFO "Trying to flash SPIFFS "!SPIFFS_FILENAME!" at SPIFFS_OFFSET !SPIFFS_OFFSET!..."
-CALL :RUN_ESPTOOL !ESPTOOL_BAUD! write_flash !SPIFFS_OFFSET! "!SPIFFS_FILENAME!" || GOTO eof
+CALL :RUN_ESPTOOL !ESPTOOL_BAUD! !ESPTOOL_WRITE_FLASH! !SPIFFS_OFFSET! "!SPIFFS_FILENAME!" || GOTO eof
 
 CALL :LOG_MESSAGE INFO "Script complete!."
 
@@ -193,9 +211,9 @@ EXIT /B %ERRORLEVEL%
 :RUN_ESPTOOL
 @REM Subroutine used to run ESPTOOL_CMD with arguments.
 @REM Also handles %ERRORLEVEL%.
-@REM CALL :RUN_ESPTOOL [Baud] [erase_flash|write_flash] [OFFSET] [Filename]
+@REM CALL :RUN_ESPTOOL [Baud] [!ESPTOOL_ERASE_FLASH!|!ESPTOOL_WRITE_FLASH!] [OFFSET] [Filename]
 @REM.
-@REM Example:: CALL :RUN_ESPTOOL 115200 write_flash 0x10000 "firmwarefile.bin"
+@REM Example:: CALL :RUN_ESPTOOL 115200 !ESPTOOL_WRITE_FLASH! 0x10000 "firmwarefile.bin"
 IF %DEBUG% EQU 1 CALL :LOG_MESSAGE DEBUG "About to run command: !ESPTOOL_CMD! --baud %~1 %~2 %~3 %~4"
 CALL :RESET_ERROR
 !ESPTOOL_CMD! --baud %~1 %~2 %~3 %~4


### PR DESCRIPTION
## Summary

`device-install.sh` and `device-update.sh` already detect whether the installed esptool wants dash-style commands (`write-flash`, esptool v5+) or underscore-style (`write_flash`, esptool 4.x), but `device-install.bat` still hardcodes the underscore form, so esptool v5 prints deprecation warnings (and will break entirely once the aliases are removed in v6).

This ports the same detection to the batch script: probe the esptool help output for `write-flash` and pick the matching command names for `write_flash`/`erase_flash`/`read_flash_status`. esptool 4.x keeps working unchanged.

Implementation note: the probe writes help output to a temp file instead of piping to `FINDSTR`, because cmd pipes spawn child shells without delayed expansion, which breaks `!ESPTOOL_CMD!`.

Fixes #8156

## Testing

Ran on Windows 11 against real esptool 5.3.1 and 4.8.1 (venvs), in `--debug` mode (esptool invocations stubbed by the script's debug path) for both the `--1200bps-reset` path and the full flash path with dummy `firmware-*.factory.bin` + metadata files:

- esptool 5.3.1: `erase-flash` / `write-flash 0x00|0x260000|0x300000` / `read-flash-status`
- esptool 4.8.1: `erase_flash` / `write_flash ...` / `read_flash_status`

(Full-flash-path testing required the fix from the companion PR for the inverted `.factory.bin` filename check.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device installation compatibility across different `esptool` command naming conventions.
  * Updated firmware, OTA, and SPIFFS flashing steps to use the supported command format automatically.
  * Improved compatibility for the optional 1200bps reset workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->