### PR TITLE
Treat backslash as a path separator in XModem filename validation

### DIFF
--- a/src/xmodem.cpp
+++ b/src/xmodem.cpp
@@ -62,7 +62,8 @@ bool XModemAdapter::isValidFilename(const char *name)
 {
     if (!name || name[0] == '\0')
         return false;
-    if (name[1] == ':')
+    const bool driveLetter = (name[0] >= 'A' && name[0] <= 'Z') || (name[0] >= 'a' && name[0] <= 'z');
+    if (driveLetter && name[1] == ':')
         return false;
     // Reject any ".." path component. Absolute paths and subdirectories are fine; they stay within
     // the filesystem root, so only traversal out of it needs blocking.

--- a/src/xmodem.cpp
+++ b/src/xmodem.cpp
@@ -62,10 +62,12 @@ bool XModemAdapter::isValidFilename(const char *name)
 {
     if (!name || name[0] == '\0')
         return false;
+    if (name[1] == ':')
+        return false;
     // Reject any ".." path component. Absolute paths and subdirectories are fine; they stay within
     // the filesystem root, so only traversal out of it needs blocking.
     for (const char *seg = name; *seg;) {
-        const char *slash = strchr(seg, '/');
+        const char *slash = strpbrk(seg, "/\\");
         const size_t len = slash ? (size_t)(slash - seg) : strlen(seg);
         if (len == 2 && seg[0] == '.' && seg[1] == '.')
             return false;

--- a/test/test_xmodem/test_main.cpp
+++ b/test/test_xmodem/test_main.cpp
@@ -21,6 +21,22 @@ void test_xmodem_rejects_dotdot_traversal(void)
     TEST_ASSERT_FALSE(XModemAdapter::isValidFilename("/.."));
 }
 
+void test_xmodem_rejects_backslash_traversal(void)
+{
+    TEST_ASSERT_FALSE(XModemAdapter::isValidFilename("..\\secret"));
+    TEST_ASSERT_FALSE(XModemAdapter::isValidFilename("..\\..\\Windows\\System32\\drivers\\etc\\hosts"));
+    TEST_ASSERT_FALSE(XModemAdapter::isValidFilename("dir\\..\\..\\x"));
+    TEST_ASSERT_FALSE(XModemAdapter::isValidFilename("dir/..\\x"));
+    TEST_ASSERT_FALSE(XModemAdapter::isValidFilename("dir\\.."));
+}
+
+void test_xmodem_rejects_drive_qualified(void)
+{
+    TEST_ASSERT_FALSE(XModemAdapter::isValidFilename("C:\\Windows\\System32\\x"));
+    TEST_ASSERT_FALSE(XModemAdapter::isValidFilename("C:/Windows/System32/x"));
+    TEST_ASSERT_FALSE(XModemAdapter::isValidFilename("c:relative.txt"));
+}
+
 void test_xmodem_rejects_empty(void)
 {
     TEST_ASSERT_FALSE(XModemAdapter::isValidFilename(""));
@@ -46,6 +62,8 @@ void setup()
     UNITY_BEGIN();
 #ifdef FSCom
     RUN_TEST(test_xmodem_rejects_dotdot_traversal);
+    RUN_TEST(test_xmodem_rejects_backslash_traversal);
+    RUN_TEST(test_xmodem_rejects_drive_qualified);
     RUN_TEST(test_xmodem_rejects_empty);
     RUN_TEST(test_xmodem_allows_legit_paths);
 #endif

--- a/test/test_xmodem/test_main.cpp
+++ b/test/test_xmodem/test_main.cpp
@@ -52,6 +52,9 @@ void test_xmodem_allows_legit_paths(void)
     // ".." only inside a name (not a whole component) is a valid filename, not traversal.
     TEST_ASSERT_TRUE(XModemAdapter::isValidFilename("my..file"));
     TEST_ASSERT_TRUE(XModemAdapter::isValidFilename("..."));
+    // A colon that cannot form a drive qualifier is a legal filename on the POSIX daemon.
+    TEST_ASSERT_TRUE(XModemAdapter::isValidFilename("1:30pm.txt"));
+    TEST_ASSERT_TRUE(XModemAdapter::isValidFilename("dir/1:30pm.txt"));
 }
 
 #endif // FSCom


### PR DESCRIPTION
`isValidFilename` in `src/xmodem.cpp` split path components on `/` only. Backslash separated components were therefore evaluated as a single component, and drive qualified names were not considered at all.

This is portable behaviour on the embedded targets, where the filesystem only recognises `/`. It matters for the native daemon: `FSCommon.h` maps `FSCom` to `PortduinoFS` under `ARCH_PORTDUINO`, so filenames reach the host filesystem, and the Windows build added in #11031 runs on a host where both separators are significant.

Changes:

- Split components with `strpbrk(seg, "/\\")` so `/` and `\` are both treated as separators.
- Reject drive qualified names such as `C:\dir\file`, which the component loop alone would not catch.
- Extend `test/test_xmodem` with backslash, mixed separator, and drive qualified cases.

Existing accepted forms are unchanged: absolute paths, subdirectories, and names that merely contain dots (`my..file`, `...`) still pass.

`native-windows` `test_xmodem` passes, 5 of 5 cases. Other suites were not run locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened filename validation to reject Windows-style drive-qualified and drive-relative paths (e.g., `C:\...`, `C:/...`, `c:relative.txt`).
  * Improved protection against directory traversal attempts by treating both forward slashes and backslashes as path separators.
  * Updated and expanded the automated test suite with additional negative cases to ensure unsafe filename patterns are rejected while valid colon-containing time-like filenames remain allowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->