### PR TITLE
Null-check packet allocations in allocForSending and its callers

### DIFF
--- a/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
@@ -2614,6 +2614,8 @@ uint16_t InkHUD::MenuApplet::getSystemInfoPanelHeight()
 void InkHUD::MenuApplet::sendText(NodeNum dest, ChannelIndex channel, const char *message)
 {
     meshtastic_MeshPacket *p = router->allocForSending();
+    if (!p)
+        return;
     p->decoded.portnum = meshtastic_PortNum_TEXT_MESSAGE_APP;
     p->to = dest;
     p->channel = channel;

--- a/src/mesh/MeshModule.cpp
+++ b/src/mesh/MeshModule.cpp
@@ -57,6 +57,8 @@ meshtastic_MeshPacket *MeshModule::allocAckNak(meshtastic_Routing_Error err, Nod
     // So we manually call pb_encode_to_bytes and specify routing port number
     // auto p = allocDataProtobuf(c);
     meshtastic_MeshPacket *p = router->allocForSending();
+    if (!p)
+        return nullptr;
     p->decoded.portnum = meshtastic_PortNum_ROUTING_APP;
     p->decoded.payload.size =
         pb_encode_to_bytes(p->decoded.payload.bytes, sizeof(p->decoded.payload.bytes), &meshtastic_Routing_msg, &c);

--- a/src/mesh/ProtobufModule.h
+++ b/src/mesh/ProtobufModule.h
@@ -44,6 +44,8 @@ template <class T> class ProtobufModule : protected SinglePortModule
     {
         // Update our local node info with our position (even if we don't decide to update anyone else)
         meshtastic_MeshPacket *p = allocDataPacket();
+        if (!p)
+            return nullptr;
 
         p->decoded.payload.size =
             pb_encode_to_bytes(p->decoded.payload.bytes, sizeof(p->decoded.payload.bytes), fields, &payload);

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -194,6 +194,8 @@ PacketId generatePacketId()
 meshtastic_MeshPacket *Router::allocForSending()
 {
     meshtastic_MeshPacket *p = packetPool.allocZeroed();
+    if (!p)
+        return nullptr;
 
     p->which_payload_variant = meshtastic_MeshPacket_decoded_tag; // Assume payload is decoded at start.
     p->from = nodeDB->getNodeNum();

--- a/src/mesh/SinglePortModule.h
+++ b/src/mesh/SinglePortModule.h
@@ -32,6 +32,8 @@ class SinglePortModule : public MeshModule
     {
         // Update our local node info with our position (even if we don't decide to update anyone else)
         meshtastic_MeshPacket *p = router->allocForSending();
+        if (!p)
+            return nullptr;
         p->decoded.portnum = ourPortNum;
 
         return p;

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -1389,6 +1389,9 @@ void AdminModule::handleGetOwner(const meshtastic_MeshPacket &req)
         res.which_payload_variant = meshtastic_AdminMessage_get_owner_response_tag;
         setPassKey(&res);
         myReply = allocDataProtobuf(res);
+        if (!myReply) {
+            return;
+        }
         if (req.pki_encrypted) {
             myReply->pki_encrypted = true;
         }
@@ -1472,6 +1475,9 @@ void AdminModule::handleGetConfig(const meshtastic_MeshPacket &req, const uint32
         res.which_payload_variant = meshtastic_AdminMessage_get_config_response_tag;
         setPassKey(&res);
         myReply = allocDataProtobuf(res);
+        if (!myReply) {
+            return;
+        }
         if (req.pki_encrypted) {
             myReply->pki_encrypted = true;
         }
@@ -1581,6 +1587,9 @@ void AdminModule::handleGetModuleConfig(const meshtastic_MeshPacket &req, const 
         res.which_payload_variant = meshtastic_AdminMessage_get_module_config_response_tag;
         setPassKey(&res);
         myReply = allocDataProtobuf(res);
+        if (!myReply) {
+            return;
+        }
         if (req.pki_encrypted) {
             myReply->pki_encrypted = true;
         }
@@ -1608,6 +1617,9 @@ void AdminModule::handleGetNodeRemoteHardwarePins(const meshtastic_MeshPacket &r
     }
     setPassKey(&r);
     myReply = allocDataProtobuf(r);
+    if (!myReply) {
+        return;
+    }
     if (req.pki_encrypted) {
         myReply->pki_encrypted = true;
     }
@@ -1627,6 +1639,9 @@ void AdminModule::handleGetDeviceMetadata(const meshtastic_MeshPacket &req)
     r.which_payload_variant = meshtastic_AdminMessage_get_device_metadata_response_tag;
     setPassKey(&r);
     myReply = allocDataProtobuf(r);
+    if (!myReply) {
+        return;
+    }
     if (req.pki_encrypted) {
         myReply->pki_encrypted = true;
     }
@@ -1702,6 +1717,9 @@ void AdminModule::handleGetDeviceConnectionStatus(const meshtastic_MeshPacket &r
     r.which_payload_variant = meshtastic_AdminMessage_get_device_connection_status_response_tag;
     setPassKey(&r);
     myReply = allocDataProtobuf(r);
+    if (!myReply) {
+        return;
+    }
     if (req.pki_encrypted) {
         myReply->pki_encrypted = true;
     }
@@ -1716,6 +1734,9 @@ void AdminModule::handleGetChannel(const meshtastic_MeshPacket &req, uint32_t ch
         r.which_payload_variant = meshtastic_AdminMessage_get_channel_response_tag;
         setPassKey(&r);
         myReply = allocDataProtobuf(r);
+        if (!myReply) {
+            return;
+        }
         if (req.pki_encrypted) {
             myReply->pki_encrypted = true;
         }
@@ -1728,6 +1749,9 @@ void AdminModule::handleGetDeviceUIConfig(const meshtastic_MeshPacket &req)
     r.which_payload_variant = meshtastic_AdminMessage_get_ui_config_response_tag;
     r.get_ui_config_response = uiconfig;
     myReply = allocDataProtobuf(r);
+    if (!myReply) {
+        return;
+    }
     if (req.pki_encrypted) {
         myReply->pki_encrypted = true;
     }

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -1022,6 +1022,8 @@ void CannedMessageModule::sendText(NodeNum dest, ChannelIndex channel, const cha
     lastDestSet = true;
 
     meshtastic_MeshPacket *p = allocDataPacket();
+    if (!p)
+        return;
     p->to = dest;
     p->channel = channel;
     p->want_ack = true;

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -122,6 +122,10 @@ void DetectionSensorModule::sendDetectionMessage()
     char *message = new char[40];
     sprintf(message, "%s detected", moduleConfig.detection_sensor.name);
     meshtastic_MeshPacket *p = allocDataPacket();
+    if (!p) {
+        delete[] message;
+        return;
+    }
     p->want_ack = false;
     p->decoded.payload.size = strlen(message);
     memcpy(p->decoded.payload.bytes, message, p->decoded.payload.size);
@@ -144,6 +148,10 @@ void DetectionSensorModule::sendCurrentStateMessage(bool state)
     char *message = new char[40];
     sprintf(message, "%s state: %i", moduleConfig.detection_sensor.name, state);
     meshtastic_MeshPacket *p = allocDataPacket();
+    if (!p) {
+        delete[] message;
+        return;
+    }
     p->want_ack = false;
     p->decoded.payload.size = strlen(message);
     memcpy(p->decoded.payload.bytes, message, p->decoded.payload.size);

--- a/src/modules/DropzoneModule.cpp
+++ b/src/modules/DropzoneModule.cpp
@@ -68,6 +68,8 @@ meshtastic_MeshPacket *DropzoneModule::sendConditions()
     // the dropzone is open
     auto dropzoneStatus = analogRead(A1) < 100 ? "OPEN" : "CLOSED";
     auto reply = allocDataPacket();
+    if (!reply)
+        return nullptr;
 
     auto node = nodeDB->getMeshNode(nodeDB->getNodeNum());
     if (sensor.hasSensor()) {

--- a/src/modules/KeyVerificationModule.cpp
+++ b/src/modules/KeyVerificationModule.cpp
@@ -162,6 +162,8 @@ bool KeyVerificationModule::sendInitialRequest(NodeNum remoteNode)
     KeyVerification.hash1.size = 32;
     memcpy(KeyVerification.hash1.bytes, owner.public_key.bytes, 32);
     meshtastic_MeshPacket *p = allocDataProtobuf(KeyVerification);
+    if (!p)
+        return false;
     p->to = remoteNode;
     p->channel = 0;
     // Only request PKI when we already hold the destination's key. Otherwise this first message goes out
@@ -318,6 +320,8 @@ void KeyVerificationModule::processSecurityNumber(uint32_t incomingNumber)
     KeyVerification.hash1.size = 32;
     memcpy(KeyVerification.hash1.bytes, hash1, 32);
     meshtastic_MeshPacket *p = allocDataProtobuf(KeyVerification);
+    if (!p)
+        return;
     p->to = currentRemoteNode;
     p->channel = 0;
     p->pki_encrypted = true;

--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -110,6 +110,8 @@ void NeighborInfoModule::sendNeighborInfo(NodeNum dest, bool wantReplies)
     // only send neighbours if we have some to send
     if (neighborInfo.neighbors_count > 0) {
         meshtastic_MeshPacket *p = allocDataProtobuf(neighborInfo);
+        if (!p)
+            return;
         p->to = dest;
         p->decoded.want_response = wantReplies;
         p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -292,6 +292,8 @@ meshtastic_MeshPacket *PositionModule::allocAtakPli()
 {
     LOG_INFO("Send TAK V2 PLI packet");
     meshtastic_MeshPacket *mp = allocDataPacket();
+    if (!mp)
+        return nullptr;
     mp->decoded.portnum = meshtastic_PortNum_ATAK_PLUGIN_V2;
 
     meshtastic_TAKPacketV2 takPacket = meshtastic_TAKPacketV2_init_zero;
@@ -572,6 +574,8 @@ int32_t PositionModule::runOnce()
 void PositionModule::sendLostAndFoundText()
 {
     meshtastic_MeshPacket *p = allocDataPacket();
+    if (!p)
+        return;
     p->to = NODENUM_BROADCAST;
     char message[128];
     int written = snprintf(message, sizeof(message), "🚨I'm lost! Lat / Lon: %f, %f\a", (lastGpsLatitude * 1e-7),

--- a/src/modules/RangeTestModule.cpp
+++ b/src/modules/RangeTestModule.cpp
@@ -114,6 +114,8 @@ int32_t RangeTestModule::runOnce()
 void RangeTestModuleRadio::sendPayload(NodeNum dest, bool wantReplies)
 {
     meshtastic_MeshPacket *p = allocDataPacket();
+    if (!p)
+        return;
     p->to = dest;
     p->decoded.want_response = wantReplies;
     p->hop_limit = 0;

--- a/src/modules/ReplyBotModule.cpp
+++ b/src/modules/ReplyBotModule.cpp
@@ -168,6 +168,8 @@ void ReplyBotModule::sendDm(const meshtastic_MeshPacket &rx, const char *text)
     if (!text)
         return;
     meshtastic_MeshPacket *p = allocDataPacket();
+    if (!p)
+        return;
     p->to = rx.from;
     p->channel = rx.channel;
     p->want_ack = false;

--- a/src/modules/ReplyModule.cpp
+++ b/src/modules/ReplyModule.cpp
@@ -16,7 +16,9 @@ meshtastic_MeshPacket *ReplyModule::allocReply()
 #endif
 
     const char *replyStr = "Message Received";
-    auto reply = allocDataPacket();                 // Allocate a packet for sending
+    auto reply = allocDataPacket(); // Allocate a packet for sending
+    if (!reply)
+        return nullptr;
     reply->decoded.payload.size = strlen(replyStr); // You must specify how many bytes are in the reply
     memcpy(reply->decoded.payload.bytes, replyStr, reply->decoded.payload.size);
 

--- a/src/modules/RoutingModule.cpp
+++ b/src/modules/RoutingModule.cpp
@@ -51,6 +51,8 @@ void RoutingModule::sendAckNak(meshtastic_Routing_Error err, NodeNum to, PacketI
                                bool ackWantsAck)
 {
     auto p = allocAckNak(err, to, idFrom, chIndex, hopLimit);
+    if (!p)
+        return;
 
     // Allow the caller to set want_ack on this ACK packet if it's important that the ACK be delivered reliably
     p->want_ack = ackWantsAck;

--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -314,6 +314,8 @@ int32_t SerialModule::runOnce()
 void SerialModule::sendTelemetry(meshtastic_Telemetry m)
 {
     meshtastic_MeshPacket *p = router->allocForSending();
+    if (!p)
+        return;
     p->decoded.portnum = meshtastic_PortNum_TELEMETRY_APP;
     p->decoded.payload.size =
         pb_encode_to_bytes(p->decoded.payload.bytes, sizeof(p->decoded.payload.bytes), &meshtastic_Telemetry_msg, &m);
@@ -350,6 +352,8 @@ void SerialModuleRadio::sendPayload(NodeNum dest, bool wantReplies)
 {
     const meshtastic_Channel *ch = (boundChannel != NULL) ? &channels.getByName(boundChannel) : NULL;
     meshtastic_MeshPacket *p = allocReply();
+    if (!p)
+        return;
     p->to = dest;
     if (ch != NULL) {
         p->channel = ch->index;

--- a/src/modules/SerialModule.h
+++ b/src/modules/SerialModule.h
@@ -71,6 +71,8 @@ class SerialModuleRadio : public MeshModule
     {
         // Update our local node info with our position (even if we don't decide to update anyone else)
         meshtastic_MeshPacket *p = router->allocForSending();
+        if (!p)
+            return nullptr;
         p->decoded.portnum = ourPortNum;
 
         return p;

--- a/src/modules/StatusMessageModule.cpp
+++ b/src/modules/StatusMessageModule.cpp
@@ -15,6 +15,8 @@ int32_t StatusMessageModule::runOnce()
         strncpy(ourStatus.status, moduleConfig.statusmessage.node_status, sizeof(ourStatus.status));
         ourStatus.status[sizeof(ourStatus.status) - 1] = '\0'; // ensure null termination
         meshtastic_MeshPacket *p = allocDataPacket();
+        if (!p)
+            return 1000 * 12 * 60 * 60;
         p->decoded.payload.size = pb_encode_to_bytes(p->decoded.payload.bytes, sizeof(p->decoded.payload.bytes),
                                                      meshtastic_StatusMessage_fields, &ourStatus);
         p->to = NODENUM_BROADCAST;

--- a/src/modules/StoreForwardModule.cpp
+++ b/src/modules/StoreForwardModule.cpp
@@ -306,6 +306,8 @@ meshtastic_MeshPacket *StoreForwardModule::preparePayload(NodeNum dest, uint32_t
 void StoreForwardModule::sendMessage(NodeNum dest, const meshtastic_StoreAndForward &payload)
 {
     meshtastic_MeshPacket *p = allocDataProtobuf(payload);
+    if (!p)
+        return;
 
     p->to = dest;
 

--- a/src/modules/StoreForwardModule.cpp
+++ b/src/modules/StoreForwardModule.cpp
@@ -248,6 +248,8 @@ meshtastic_MeshPacket *StoreForwardModule::preparePayload(NodeNum dest, uint32_t
                 (this->packetHistory[i].to == NODENUM_BROADCAST || this->packetHistory[i].to == dest)) {
 
                 meshtastic_MeshPacket *p = allocDataPacket();
+                if (!p)
+                    return nullptr;
 
                 p->to = local ? this->packetHistory[i].to : dest; // PhoneAPI can handle original `to`
                 p->from = this->packetHistory[i].from;
@@ -340,6 +342,8 @@ void StoreForwardModule::sendMessage(NodeNum dest, meshtastic_StoreAndForward_Re
 void StoreForwardModule::sendErrorTextMessage(NodeNum dest, bool want_response)
 {
     meshtastic_MeshPacket *pr = allocDataPacket();
+    if (!pr)
+        return;
     pr->to = dest;
     pr->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
     pr->want_ack = false;

--- a/src/modules/Telemetry/AirQualityTelemetry.cpp
+++ b/src/modules/Telemetry/AirQualityTelemetry.cpp
@@ -464,6 +464,8 @@ bool AirQualityTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
         }
 
         meshtastic_MeshPacket *p = allocDataProtobuf(m);
+        if (!p)
+            return false;
         p->to = dest;
         p->decoded.want_response = false;
         if (config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR)

--- a/src/modules/Telemetry/AirQualityTelemetry.cpp
+++ b/src/modules/Telemetry/AirQualityTelemetry.cpp
@@ -464,37 +464,39 @@ bool AirQualityTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
         }
 
         meshtastic_MeshPacket *p = allocDataProtobuf(m);
-        if (!p)
-            return false;
-        p->to = dest;
-        p->decoded.want_response = false;
-        if (config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR)
-            p->priority = meshtastic_MeshPacket_Priority_RELIABLE;
-        else
-            p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
-
-        // release previous packet before occupying a new spot
-        if (lastMeasurementPacket != nullptr)
-            packetPool.release(lastMeasurementPacket);
-
-        lastMeasurementPacket = packetPool.allocCopy(*p);
-        if (phoneOnly) {
-            LOG_INFO("Sending packet to phone");
-            service->sendToPhone(p);
+        if (!p) {
+            validTelemetry = false;
         } else {
-            LOG_INFO("Sending packet to mesh");
-            service->sendToMesh(p, RX_SRC_LOCAL, true);
+            p->to = dest;
+            p->decoded.want_response = false;
+            if (config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR)
+                p->priority = meshtastic_MeshPacket_Priority_RELIABLE;
+            else
+                p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
 
-            if (isPowerSavingSensor()) {
-                meshtastic_ClientNotification *notification = clientNotificationPool.allocZeroed();
-                if (notification) {
-                    notification->level = meshtastic_LogRecord_Level_INFO;
-                    notification->time = getValidTime(RTCQualityFromNet);
-                    sprintf(notification->message, "Sending telemetry and sleeping for %us interval in a moment",
-                            Default::getConfiguredOrDefaultMs(moduleConfig.telemetry.air_quality_interval,
-                                                              default_telemetry_broadcast_interval_secs) /
-                                1000U);
-                    service->sendClientNotification(notification);
+            // release previous packet before occupying a new spot
+            if (lastMeasurementPacket != nullptr)
+                packetPool.release(lastMeasurementPacket);
+
+            lastMeasurementPacket = packetPool.allocCopy(*p);
+            if (phoneOnly) {
+                LOG_INFO("Sending packet to phone");
+                service->sendToPhone(p);
+            } else {
+                LOG_INFO("Sending packet to mesh");
+                service->sendToMesh(p, RX_SRC_LOCAL, true);
+
+                if (isPowerSavingSensor()) {
+                    meshtastic_ClientNotification *notification = clientNotificationPool.allocZeroed();
+                    if (notification) {
+                        notification->level = meshtastic_LogRecord_Level_INFO;
+                        notification->time = getValidTime(RTCQualityFromNet);
+                        sprintf(notification->message, "Sending telemetry and sleeping for %us interval in a moment",
+                                Default::getConfiguredOrDefaultMs(moduleConfig.telemetry.air_quality_interval,
+                                                                  default_telemetry_broadcast_interval_secs) /
+                                    1000U);
+                        service->sendClientNotification(notification);
+                    }
                 }
             }
         }

--- a/src/modules/Telemetry/DeviceTelemetry.cpp
+++ b/src/modules/Telemetry/DeviceTelemetry.cpp
@@ -172,6 +172,8 @@ meshtastic_Telemetry DeviceTelemetryModule::getLocalStatsTelemetry()
 void DeviceTelemetryModule::sendLocalStatsToPhone()
 {
     meshtastic_MeshPacket *p = allocDataProtobuf(getLocalStatsTelemetry());
+    if (!p)
+        return;
     p->to = NODENUM_BROADCAST;
     p->decoded.want_response = false;
     p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
@@ -191,6 +193,8 @@ bool DeviceTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
     meshtastic_MeshPacket *p = allocDataProtobuf(telemetry);
     DEBUG_HEAP_AFTER("DeviceTelemetryModule::sendTelemetry", p);
 
+    if (!p)
+        return false;
     p->to = dest;
     p->decoded.want_response = false;
     p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;

--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -661,36 +661,38 @@ bool EnvironmentTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
                  m.variant.environment_metrics.soil_moisture);
 
         meshtastic_MeshPacket *p = allocDataProtobuf(m);
-        if (!p)
-            return false;
-        p->to = dest;
-        p->decoded.want_response = false;
-        if (config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR)
-            p->priority = meshtastic_MeshPacket_Priority_RELIABLE;
-        else
-            p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
-        // release previous packet before occupying a new spot
-        if (lastMeasurementPacket != nullptr)
-            packetPool.release(lastMeasurementPacket);
-
-        lastMeasurementPacket = packetPool.allocCopy(*p);
-        if (phoneOnly) {
-            LOG_INFO("Send packet to phone");
-            service->sendToPhone(p);
+        if (!p) {
+            validTelemetry = false;
         } else {
-            LOG_INFO("Send packet to mesh");
-            service->sendToMesh(p, RX_SRC_LOCAL, true);
+            p->to = dest;
+            p->decoded.want_response = false;
+            if (config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR)
+                p->priority = meshtastic_MeshPacket_Priority_RELIABLE;
+            else
+                p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
+            // release previous packet before occupying a new spot
+            if (lastMeasurementPacket != nullptr)
+                packetPool.release(lastMeasurementPacket);
 
-            if (isPowerSavingSensor()) {
-                meshtastic_ClientNotification *notification = clientNotificationPool.allocZeroed();
-                if (notification) {
-                    notification->level = meshtastic_LogRecord_Level_INFO;
-                    notification->time = getValidTime(RTCQualityFromNet);
-                    sprintf(notification->message, "Sending telemetry and sleeping for %us interval in a moment",
-                            Default::getConfiguredOrDefaultMs(moduleConfig.telemetry.environment_update_interval,
-                                                              default_telemetry_broadcast_interval_secs) /
-                                1000U);
-                    service->sendClientNotification(notification);
+            lastMeasurementPacket = packetPool.allocCopy(*p);
+            if (phoneOnly) {
+                LOG_INFO("Send packet to phone");
+                service->sendToPhone(p);
+            } else {
+                LOG_INFO("Send packet to mesh");
+                service->sendToMesh(p, RX_SRC_LOCAL, true);
+
+                if (isPowerSavingSensor()) {
+                    meshtastic_ClientNotification *notification = clientNotificationPool.allocZeroed();
+                    if (notification) {
+                        notification->level = meshtastic_LogRecord_Level_INFO;
+                        notification->time = getValidTime(RTCQualityFromNet);
+                        sprintf(notification->message, "Sending telemetry and sleeping for %us interval in a moment",
+                                Default::getConfiguredOrDefaultMs(moduleConfig.telemetry.environment_update_interval,
+                                                                  default_telemetry_broadcast_interval_secs) /
+                                    1000U);
+                        service->sendClientNotification(notification);
+                    }
                 }
             }
         }

--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -661,6 +661,8 @@ bool EnvironmentTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
                  m.variant.environment_metrics.soil_moisture);
 
         meshtastic_MeshPacket *p = allocDataProtobuf(m);
+        if (!p)
+            return false;
         p->to = dest;
         p->decoded.want_response = false;
         if (config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR)

--- a/src/modules/Telemetry/HealthTelemetry.cpp
+++ b/src/modules/Telemetry/HealthTelemetry.cpp
@@ -248,25 +248,27 @@ bool HealthTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
         sensor_read_error_count = 0;
 
         meshtastic_MeshPacket *p = allocDataProtobuf(m);
-        if (!p)
-            return false;
-        p->to = dest;
-        p->decoded.want_response = false;
-        if (config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR)
-            p->priority = meshtastic_MeshPacket_Priority_RELIABLE;
-        else
-            p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
-        // release previous packet before occupying a new spot
-        if (lastMeasurementPacket != nullptr)
-            packetPool.release(lastMeasurementPacket);
-
-        lastMeasurementPacket = packetPool.allocCopy(*p);
-        if (phoneOnly) {
-            LOG_INFO("Send packet to phone");
-            service->sendToPhone(p);
+        if (!p) {
+            validTelemetry = false;
         } else {
-            LOG_INFO("Send packet to mesh");
-            service->sendToMesh(p, RX_SRC_LOCAL, true);
+            p->to = dest;
+            p->decoded.want_response = false;
+            if (config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR)
+                p->priority = meshtastic_MeshPacket_Priority_RELIABLE;
+            else
+                p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
+            // release previous packet before occupying a new spot
+            if (lastMeasurementPacket != nullptr)
+                packetPool.release(lastMeasurementPacket);
+
+            lastMeasurementPacket = packetPool.allocCopy(*p);
+            if (phoneOnly) {
+                LOG_INFO("Send packet to phone");
+                service->sendToPhone(p);
+            } else {
+                LOG_INFO("Send packet to mesh");
+                service->sendToMesh(p, RX_SRC_LOCAL, true);
+            }
         }
     }
 

--- a/src/modules/Telemetry/HealthTelemetry.cpp
+++ b/src/modules/Telemetry/HealthTelemetry.cpp
@@ -248,6 +248,8 @@ bool HealthTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
         sensor_read_error_count = 0;
 
         meshtastic_MeshPacket *p = allocDataProtobuf(m);
+        if (!p)
+            return false;
         p->to = dest;
         p->decoded.want_response = false;
         if (config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR)

--- a/src/modules/Telemetry/HostMetrics.cpp
+++ b/src/modules/Telemetry/HostMetrics.cpp
@@ -128,6 +128,8 @@ bool HostMetricsModule::sendMetrics()
     // telemetry.variant.host_metrics.has_user_string ? telemetry.variant.host_metrics.user_string : "");
 
     meshtastic_MeshPacket *p = allocDataProtobuf(telemetry);
+    if (!p)
+        return false;
     p->to = NODENUM_BROADCAST;
     p->decoded.want_response = false;
     p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;

--- a/src/modules/Telemetry/PowerTelemetry.cpp
+++ b/src/modules/Telemetry/PowerTelemetry.cpp
@@ -275,25 +275,27 @@ bool PowerTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
         sensor_read_error_count = 0;
 
         meshtastic_MeshPacket *p = allocDataProtobuf(m);
-        if (!p)
-            return false;
-        p->to = dest;
-        p->decoded.want_response = false;
-        if (config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR)
-            p->priority = meshtastic_MeshPacket_Priority_RELIABLE;
-        else
-            p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
-        // release previous packet before occupying a new spot
-        if (lastMeasurementPacket != nullptr)
-            packetPool.release(lastMeasurementPacket);
-
-        lastMeasurementPacket = packetPool.allocCopy(*p);
-        if (phoneOnly) {
-            LOG_INFO("Send packet to phone");
-            service->sendToPhone(p);
+        if (!p) {
+            validTelemetry = false;
         } else {
-            LOG_INFO("Send packet to mesh");
-            service->sendToMesh(p, RX_SRC_LOCAL, true);
+            p->to = dest;
+            p->decoded.want_response = false;
+            if (config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR)
+                p->priority = meshtastic_MeshPacket_Priority_RELIABLE;
+            else
+                p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
+            // release previous packet before occupying a new spot
+            if (lastMeasurementPacket != nullptr)
+                packetPool.release(lastMeasurementPacket);
+
+            lastMeasurementPacket = packetPool.allocCopy(*p);
+            if (phoneOnly) {
+                LOG_INFO("Send packet to phone");
+                service->sendToPhone(p);
+            } else {
+                LOG_INFO("Send packet to mesh");
+                service->sendToMesh(p, RX_SRC_LOCAL, true);
+            }
         }
     }
 

--- a/src/modules/Telemetry/PowerTelemetry.cpp
+++ b/src/modules/Telemetry/PowerTelemetry.cpp
@@ -275,6 +275,8 @@ bool PowerTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
         sensor_read_error_count = 0;
 
         meshtastic_MeshPacket *p = allocDataProtobuf(m);
+        if (!p)
+            return false;
         p->to = dest;
         p->decoded.want_response = false;
         if (config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR)

--- a/src/modules/esp32/AudioModule.cpp
+++ b/src/modules/esp32/AudioModule.cpp
@@ -258,6 +258,8 @@ bool AudioModule::shouldDraw()
 void AudioModule::sendPayload(NodeNum dest, bool wantReplies)
 {
     meshtastic_MeshPacket *p = allocReply();
+    if (!p)
+        return;
     p->to = dest;
     p->decoded.want_response = wantReplies;
 

--- a/src/modules/esp32/PaxcounterModule.cpp
+++ b/src/modules/esp32/PaxcounterModule.cpp
@@ -81,6 +81,8 @@ bool PaxcounterModule::sendInfo(NodeNum dest)
     pl.uptime = millis() / 1000;
 
     meshtastic_MeshPacket *p = allocDataProtobuf(pl);
+    if (!p)
+        return false;
     p->to = dest;
     p->decoded.want_response = false;
     p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;

--- a/src/modules/games/GamesModule.cpp
+++ b/src/modules/games/GamesModule.cpp
@@ -105,6 +105,8 @@ void GamesModule::announceHighScore(const char *initials, uint32_t score)
     if (!initials || initials[0] == '\0')
         return;
     meshtastic_MeshPacket *p = allocDataPacket();
+    if (!p)
+        return;
     p->to = NODENUM_BROADCAST;
     p->channel = 0; // primary channel
     p->decoded.portnum = meshtastic_PortNum_TEXT_MESSAGE_APP;

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -121,6 +121,8 @@ inline void onReceiveProto(char *topic, byte *payload, size_t length)
         // receives it when we get our own packet back. Then we'll stop our retransmissions.
         if (isFromUs(e.packet)) {
             auto pAck = routingModule->allocAckNak(meshtastic_Routing_Error_NONE, getFrom(e.packet), e.packet->id, ch.index);
+            if (!pAck)
+                return;
             pAck->transport_mechanism = meshtastic_MeshPacket_TransportMechanism_TRANSPORT_MQTT;
             router->sendLocal(pAck);
         } else {


### PR DESCRIPTION
`Router::allocForSending()` dereferenced `packetPool.allocZeroed()` without a null check. Sibling of 0ae44d701.

The pool is heap-backed on ARCH_STM32WL and BOARD_HAS_PSRAM, so allocation can fail. Guarding `allocForSending()` alone moves the deref to its callers, so the `allocDataPacket()` wrappers and all unguarded call sites are guarded too. 31 call sites: 29 guarded, 2 return the pointer directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability by safely handling packet/protobuf allocation failures during outgoing mesh communication.
  * Prevented potential crashes and invalid sends across routing ACK/Nak, MQTT local ACK generation, and multiple telemetry and module message paths (including sensors, status, position/PLI, audio, games, neighbor info, admin replies, key verification, store-and-forward, and paxcounter).
  * Messages/telemetry now fail gracefully with early exit/backoff instead of dereferencing null allocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->