### PR TITLE
MUI: portduino SDL support

### DIFF
--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -38,6 +38,15 @@ void tft_task_handler(void *param = nullptr)
     }
 }
 
+#if defined(ARCH_PORTDUINO)
+void tft_thread_entry(void)
+{
+    // SDL expects window/event/render work on a single thread.
+    deviceScreen->init(new PacketClient);
+    tft_task_handler();
+}
+#endif
+
 void tftSetup(void)
 {
 #ifndef ARCH_PORTDUINO
@@ -47,10 +56,16 @@ void tftSetup(void)
 #else
     if (portduino_config.displayPanel != no_screen) {
         DisplayDriverConfig displayConfig;
-        static char *panels[] = {"NOSCREEN", "X11",     "FB",      "ST7789",  "ST7735",  "ST7735S",
-                                 "ST7796",   "ILI9341", "ILI9342", "ILI9486", "ILI9488", "HX8357D"};
+        static char *panels[] = {"NOSCREEN", "X11", "SDL", "FB", "ST7789", "ST7735", "ST7735S",
+                                 "ST7796", "ILI9341", "ILI9342", "ILI9486", "ILI9488", "HX8357D"};
         static char *touch[] = {"NOTOUCH", "XPT2046", "STMPE610", "GT911", "FT5x06"};
-#if defined(USE_X11)
+        if (portduino_config.displayPanel == sdl) {
+            if (portduino_config.displayWidth && portduino_config.displayHeight)
+                displayConfig = DisplayDriverConfig(DisplayDriverConfig::device_t::SDL, (uint16_t)portduino_config.displayWidth,
+                                                    (uint16_t)portduino_config.displayHeight);
+            else
+                displayConfig.device(DisplayDriverConfig::device_t::SDL);
+        } else
         if (portduino_config.displayPanel == x11) {
             if (portduino_config.displayWidth && portduino_config.displayHeight)
                 displayConfig = DisplayDriverConfig(DisplayDriverConfig::device_t::X11, (uint16_t)portduino_config.displayWidth,
@@ -58,16 +73,13 @@ void tftSetup(void)
             else
                 displayConfig.device(DisplayDriverConfig::device_t::X11);
         } else
-#elif defined(USE_FRAMEBUFFER)
         if (portduino_config.displayPanel == fb) {
             if (portduino_config.displayWidth && portduino_config.displayHeight)
                 displayConfig = DisplayDriverConfig(DisplayDriverConfig::device_t::FB, (uint16_t)portduino_config.displayWidth,
                                                     (uint16_t)portduino_config.displayHeight);
             else
                 displayConfig.device(DisplayDriverConfig::device_t::FB);
-        } else
-#endif
-        {
+        } else {
             displayConfig.device(DisplayDriverConfig::device_t::CUSTOM_TFT)
                 .panel(DisplayDriverConfig::panel_config_t{.type = panels[portduino_config.displayPanel],
                                                            .panel_width = (uint16_t)portduino_config.displayWidth,
@@ -121,7 +133,6 @@ void tftSetup(void)
         }
         deviceScreen = &DeviceScreen::create(&displayConfig);
         PacketAPI::create(PacketServer::init());
-        deviceScreen->init(new PacketClient);
     } else {
         LOG_INFO("Running without TFT display!");
     }
@@ -133,7 +144,7 @@ void tftSetup(void)
         endSleepObserver.observe(&notifyLightSleepEnd);
         xTaskCreatePinnedToCore(tft_task_handler, "tft", TFT_TASK_STACK_SIZE, NULL, 1, NULL, 0);
 #elif defined(ARCH_PORTDUINO)
-        std::thread *tft_task = new std::thread([] { tft_task_handler(); });
+        std::thread *tft_task = new std::thread([] { tft_thread_entry(); });
 #endif
     }
 }

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -29,7 +29,7 @@ inline const std::unordered_map<std::string, std::string> configProducts = {
     {"RAK6421-13300-S1", "lora-RAK6421-13300-slot1.yaml"},
     {"RAK6421-13300-S2", "lora-RAK6421-13300-slot2.yaml"}};
 
-enum screen_modules { no_screen, x11, fb, st7789, st7735, st7735s, st7796, ili9341, ili9342, ili9486, ili9488, hx8357d };
+enum screen_modules { no_screen, x11, sdl, fb, st7789, st7735, st7735s, st7796, ili9341, ili9342, ili9486, ili9488, hx8357d };
 enum touchscreen_modules { no_touchscreen, xpt2046, stmpe610, gt911, ft5x06 };
 enum portduino_log_level { level_error, level_warn, level_info, level_debug, level_trace };
 enum lora_module_enum {
@@ -73,7 +73,7 @@ extern struct portduino_config_struct {
         {use_simradio, "sim"},  {use_autoconf, "auto"}, {use_rf95, "RF95"},     {use_sx1262, "sx1262"}, {use_sx1268, "sx1268"},
         {use_sx1280, "sx1280"}, {use_lr1110, "lr1110"}, {use_lr1120, "lr1120"}, {use_lr1121, "lr1121"}, {use_llcc68, "LLCC68"}};
 
-    std::map<screen_modules, std::string> screen_names = {{x11, "X11"},         {fb, "FB"},           {st7789, "ST7789"},
+    std::map<screen_modules, std::string> screen_names = {{x11, "X11"}, {sdl, "SDL"}, {fb, "FB"}, {st7789, "ST7789"},
                                                           {st7735, "ST7735"},   {st7735s, "ST7735S"}, {st7796, "ST7796"},
                                                           {ili9341, "ILI9341"}, {ili9342, "ILI9342"}, {ili9486, "ILI9486"},
                                                           {ili9488, "ILI9488"}, {hx8357d, "HX8357D"}};

--- a/variants/native/portduino/platformio.ini
+++ b/variants/native/portduino/platformio.ini
@@ -29,12 +29,14 @@ lib_deps =
   ${device-ui_base.lib_deps}
 build_flags = ${native_base.build_flags} -Os -lX11 -linput -lxkbcommon -ffunction-sections -fdata-sections -Wl,--gc-sections
   -D RAM_SIZE=16384
-  -D USE_X11=1
   -D HAS_TFT=1
   -D HAS_SCREEN=1
-  -D LV_CACHE_DEF_SIZE=6291456
-  -D LV_BUILD_TEST=0
+  -D USE_X11=1
+  -D USE_SDL=1
+  -D LV_USE_EVDEV=1
   -D LV_USE_LIBINPUT=1
+;  -D LV_CACHE_DEF_SIZE=6291456
+  -D LV_BUILD_TEST=0
   -D LV_LVGL_H_INCLUDE_SIMPLE
   -D LV_CONF_INCLUDE_SIMPLE
   -D LV_COMP_CONF_INCLUDE_SIMPLE


### PR DESCRIPTION
This PR adds support for SDL.

Note: requires device-ui [PR#227](https://github.com/meshtastic/device-ui/pull/227) and lvgl 9.5.0

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
      - [x] native linux
      - [ ] native Windows