### PR TITLE
Bounds-check detection sensor trigger type

### DIFF
--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -46,6 +46,16 @@ const static DetectionSensorTriggerHandler handlers[_meshtastic_ModuleConfig_Det
     [meshtastic_ModuleConfig_DetectionSensorConfig_TriggerType_EITHER_EDGE_ACTIVE_HIGH] = detection_trigger_either_edge,
 };
 
+// The configured trigger type arrives as an unvalidated protobuf enum, so a value outside the
+// generated range would index past the handler table. Fall back to the schema default instead.
+static meshtastic_ModuleConfig_DetectionSensorConfig_TriggerType configuredTriggerType()
+{
+    const uint32_t configured = (uint32_t)moduleConfig.detection_sensor.detection_trigger_type;
+    if (configured > (uint32_t)_meshtastic_ModuleConfig_DetectionSensorConfig_TriggerType_MAX)
+        return _meshtastic_ModuleConfig_DetectionSensorConfig_TriggerType_MIN;
+    return (meshtastic_ModuleConfig_DetectionSensorConfig_TriggerType)configured;
+}
+
 int32_t DetectionSensorModule::runOnce()
 {
     /*
@@ -89,8 +99,7 @@ int32_t DetectionSensorModule::runOnce()
     if (!Throttle::isWithinTimespanMs(lastSentToMesh,
                                       Default::getConfiguredOrDefaultMs(moduleConfig.detection_sensor.minimum_broadcast_secs))) {
         bool isDetected = hasDetectionEvent();
-        DetectionSensorTriggerVerdict verdict =
-            handlers[moduleConfig.detection_sensor.detection_trigger_type](wasDetected, isDetected);
+        DetectionSensorTriggerVerdict verdict = handlers[configuredTriggerType()](wasDetected, isDetected);
         wasDetected = isDetected;
         switch (verdict) {
         case DetectionSensorVerdictDetected:
@@ -160,5 +169,5 @@ bool DetectionSensorModule::hasDetectionEvent()
 {
     bool currentState = digitalRead(moduleConfig.detection_sensor.monitor_pin);
     // LOG_DEBUG("Detection Sensor Module: Current state: %i", currentState);
-    return (moduleConfig.detection_sensor.detection_trigger_type & 1) ? currentState : !currentState;
+    return (configuredTriggerType() & 1) ? currentState : !currentState;
 }


### PR DESCRIPTION
`detection_trigger_type` is a nanopb `UENUM`, which is not range-checked on decode, and `AdminModule::handleSetModuleConfig` assigns the config struct wholesale. A value outside the generated range therefore reaches `handlers[]` in `DetectionSensorModule::runOnce` and indexes past the six-entry table.

Validates at the point of use, so config restored from flash is covered as well as config set over the admin API. Out-of-range values fall back to the schema default, matching an unconfigured device.

`hasDetectionEvent` uses the same accessor so polarity and handler selection stay consistent.

No behaviour change for in-range values.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection sensor reliability when configured trigger types are invalid or out of range.
  * Ensured trigger handling and GPIO signal interpretation remain consistent across supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->