### PR TITLE
Reserve the [Exit] slot when splitting canned messages

### DIFF
--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -179,7 +179,7 @@ int CannedMessageModule::splitConfiguredMessages()
     while (i < upTo) {
         if (this->messageBuffer[i] == '|') {
             this->messageBuffer[i] = '\0'; // End previous message
-            if (tempCount >= CANNED_MESSAGE_MODULE_MESSAGE_MAX_COUNT)
+            if (tempCount >= CANNED_MESSAGE_MODULE_MESSAGE_MAX_COUNT - 1)
                 break;
             tempMessages[tempCount++] = (this->messageBuffer + i + 1);
         }


### PR DESCRIPTION
`messages[]` holds `CANNED_MESSAGE_MODULE_MESSAGE_MAX_COUNT` (50) entries. The split loop broke at 50, then `[Exit]` was appended unconditionally, giving a count of 51. The copy loop then wrote `messages[50]`, one past the end, and set `messagesCount` to 51.

`int messagesCount` is declared immediately after `messages[]`, so the stray write lands on it. It is reassigned on the next line, but the resulting count of 51 makes every later `for (i = 0; i < messagesCount; ++i)` read `messages[50]` and use adjacent members as a `char *`. `LaunchWithDestination()` passes that to `strcmp()`.

Reachable with roughly 47 short canned messages, since the configured string allows about 100 separator-delimited entries.

The loop now stops one slot early so `[Exit]` fits.

Simulating the counting logic over separator counts 0-400, with and without the Free Text entry: before, the highest index written is 50 into a 50-element array; after, it is 49.

Builds clean on native-windows, which compiles this module.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of configured canned messages when multiple entries are separated by delimiters.
  * Prevented the final exit option from being omitted when the maximum number of canned messages is reached.
  * Canned-message menus now remain complete and reliable at their configured capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->