### PR TITLE
Hold cryptLock around RNG use in admin and key verification

### DIFF
--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -1,5 +1,6 @@
 #include "AdminModule.h"
 #include "Channels.h"
+#include "CryptoEngine.h"
 #include "DisplayFormatters.h"
 #include "HardwareRNG.h"
 #include "MeshService.h"
@@ -1849,8 +1850,14 @@ void AdminModule::setPassKey(meshtastic_AdminMessage *res)
     if (!sessionPasskeyValid || !Throttle::isWithinTimespanMs(session_time, 150 * 1000UL)) {
         // Session passkey authenticates admin replies, so it must be unpredictable: prefer the
         // hardware RNG, falling back to the seeded CSPRNG only when no hardware source exists.
-        if (!HardwareRNG::fill(session_passkey, sizeof(session_passkey)))
-            CryptRNG.rand(session_passkey, sizeof(session_passkey));
+        // Hold cryptLock like the signing path does: this runs on the admin receive path, which on
+        // nRF52 is the BLE task, and the fill toggles the CC310 that packet crypto also uses while
+        // the CryptRNG state is shared with signing.
+        {
+            concurrency::LockGuard g(cryptLock);
+            if (!HardwareRNG::fill(session_passkey, sizeof(session_passkey)))
+                CryptRNG.rand(session_passkey, sizeof(session_passkey));
+        }
         session_time = millis();
         sessionPasskeyValid = true;
     }

--- a/src/modules/KeyVerificationModule.cpp
+++ b/src/modules/KeyVerificationModule.cpp
@@ -151,7 +151,14 @@ bool KeyVerificationModule::sendInitialRequest(NodeNum remoteNode)
         return false;
     }
     updateState(true);
-    currentNonce = random();
+    // The nonce binds the handshake, so draw it from the hardware RNG (falling back to the CSPRNG)
+    // under cryptLock, as allocReply does for the security number. random() is both predictable and
+    // only 32 bits wide, leaving half of this nonce zero.
+    {
+        concurrency::LockGuard g(cryptLock);
+        if (!HardwareRNG::fill((uint8_t *)&currentNonce, sizeof(currentNonce)))
+            CryptRNG.rand((uint8_t *)&currentNonce, sizeof(currentNonce));
+    }
     currentNonceTimestamp = getTime();
     currentRemoteNode = remoteNode;
     meshtastic_KeyVerification KeyVerification = meshtastic_KeyVerification_init_zero;


### PR DESCRIPTION
`AdminModule::setPassKey` draws the session passkey with the same `HardwareRNG::fill` / `CryptRNG.rand` pair used by `CryptoEngine::xeddsa_sign` and `KeyVerificationModule::allocReply`, but without `cryptLock`. Those callers hold it: `xeddsa_sign` runs inside `perhapsEncode`, and `allocReply` takes it directly. On nRF52 the fill toggles the CC310 that packet crypto also uses, and `CryptRNG` keeps shared state. `setPassKey` runs on the admin receive path, which is the BLE task there, so it can overlap the main loop.

`KeyVerificationModule::sendInitialRequest` also seeded its nonce with `random()`, which is predictable and returns 32 bits into a `uint64_t`, leaving the upper half zero. Switched to the same hardware RNG pair.

No deadlock: `perhapsDecode` releases `cryptLock` before `MeshModule::callModules` runs, and both new critical sections close before any send path that re-takes it.

Locking only, no protocol change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Improved thread safety during passkey regeneration.
  * Strengthened key-verification handshake nonce generation by using cryptographically secure randomness.
  * Added protection for shared cryptographic state during security-sensitive random number generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->