### PR TITLE
Honour which_payload_variant on MQTT client-proxy ingress

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -335,7 +335,20 @@ void MQTT::mqttCallback(char *topic, byte *payload, unsigned int length)
 
 void MQTT::onClientProxyReceive(meshtastic_MqttClientProxyMessage msg)
 {
-    onReceive(msg.topic, msg.payload_variant.data.bytes, msg.payload_variant.data.size);
+    // payload_variant is a union: on the text variant, data.size aliases the first bytes of the
+    // string, so reading it unconditionally let a client name any length up to PB_SIZE_MAX.
+    switch (msg.which_payload_variant) {
+    case meshtastic_MqttClientProxyMessage_data_tag:
+        onReceive(msg.topic, msg.payload_variant.data.bytes, msg.payload_variant.data.size);
+        break;
+    case meshtastic_MqttClientProxyMessage_text_tag:
+        onReceive(msg.topic, (byte *)msg.payload_variant.text,
+                  strnlen(msg.payload_variant.text, sizeof(msg.payload_variant.text)));
+        break;
+    default:
+        LOG_WARN("MQTT proxy message carries no payload, topic %s", msg.topic);
+        break;
+    }
 }
 
 void MQTT::onReceive(char *topic, byte *payload, size_t length)

--- a/test/test_mqtt/MQTT.cpp
+++ b/test/test_mqtt/MQTT.cpp
@@ -584,7 +584,8 @@ void test_receiveEmptyDataFromProxy(void)
 }
 
 // Text must be read as text: data.size aliases the string's first bytes, so reading it regardless
-// of the variant let a client name a length of up to PB_SIZE_MAX.
+// of the variant let a client name a length of up to PB_SIZE_MAX. There is no delivery control for
+// this variant: an encoded ServiceEnvelope always contains NUL, so text can never carry one.
 void test_receiveTextVariantFromProxyIsNotReadAsBytes(void)
 {
     meshtastic_MqttClientProxyMessage message = meshtastic_MqttClientProxyMessage_init_default;
@@ -597,30 +598,6 @@ void test_receiveTextVariantFromProxyIsNotReadAsBytes(void)
     mqtt->onClientProxyReceive(message);
 
     TEST_ASSERT_TRUE(mockRouter->packets_.empty());
-}
-
-// Control: the variant check did not simply drop the text case.
-void test_receiveTextVariantFromProxyIsDelivered(void)
-{
-    const meshtastic_ServiceEnvelope env = {
-        .packet = const_cast<meshtastic_MeshPacket *>(&decoded), .channel_id = "test", .gateway_id = "!87654321"};
-    meshtastic_MqttClientProxyMessage message = meshtastic_MqttClientProxyMessage_init_default;
-    snprintf(message.topic, sizeof(message.topic), "msh/2/e/test/!87654321");
-    message.which_payload_variant = meshtastic_MqttClientProxyMessage_text_tag;
-    const size_t n = pb_encode_to_bytes((uint8_t *)message.payload_variant.text, sizeof(message.payload_variant.text) - 1,
-                                        &meshtastic_ServiceEnvelope_msg, &env);
-    TEST_ASSERT_GREATER_THAN(0, n);
-    // strnlen stops at the first NUL, so only an envelope without one round-trips as text.
-    if (memchr(message.payload_variant.text, 0, n) != nullptr) {
-        TEST_IGNORE_MESSAGE("encoded envelope contains a NUL; not representable as a text payload");
-        return;
-    }
-    message.payload_variant.text[n] = '\0';
-
-    mqtt->onClientProxyReceive(message);
-
-    TEST_ASSERT_EQUAL(1, mockRouter->packets_.size());
-    TEST_ASSERT_EQUAL(decoded.id, mockRouter->packets_.front().id);
 }
 
 // A proxy message with no payload variant set must be ignored rather than read as bytes.
@@ -1106,7 +1083,6 @@ void setup()
     RUN_TEST(test_receiveDecodedProtoFromProxy);
     RUN_TEST(test_receiveEmptyDataFromProxy);
     RUN_TEST(test_receiveTextVariantFromProxyIsNotReadAsBytes);
-    RUN_TEST(test_receiveTextVariantFromProxyIsDelivered);
     RUN_TEST(test_receiveNoVariantFromProxyIsIgnored);
     RUN_TEST(test_receiveWithoutChannelDownlink);
     RUN_TEST(test_receiveEncryptedPKITopicToUs);

--- a/test/test_mqtt/MQTT.cpp
+++ b/test/test_mqtt/MQTT.cpp
@@ -583,32 +583,29 @@ void test_receiveEmptyDataFromProxy(void)
     TEST_ASSERT_TRUE(mockRouter->packets_.empty());
 }
 
-// A text-variant proxy message must be read as text. payload_variant is a union, so data.size
-// aliases the first bytes of the string: reading it regardless of which_payload_variant let a
-// client name a length of up to PB_SIZE_MAX and walk ~64KB off the end of the struct.
+// Text must be read as text: data.size aliases the string's first bytes, so reading it regardless
+// of the variant let a client name a length of up to PB_SIZE_MAX.
 void test_receiveTextVariantFromProxyIsNotReadAsBytes(void)
 {
     meshtastic_MqttClientProxyMessage message = meshtastic_MqttClientProxyMessage_init_default;
-    strcat(message.topic, "msh/2/e/test/!87654321");
+    snprintf(message.topic, sizeof(message.topic), "msh/2/e/test/!87654321");
     message.which_payload_variant = meshtastic_MqttClientProxyMessage_text_tag;
-    // 0xFF 0xFF is what data.size would read as: the largest length a pb_size_t can name.
+    // data.size would read these as the largest length a pb_size_t can name.
     memset(message.payload_variant.text, 0xFF, sizeof(message.payload_variant.text) - 1);
     message.payload_variant.text[sizeof(message.payload_variant.text) - 1] = '\0';
 
     mqtt->onClientProxyReceive(message);
 
-    // Not a ServiceEnvelope, so nothing is delivered - the point is that the read stays in bounds.
     TEST_ASSERT_TRUE(mockRouter->packets_.empty());
 }
 
-// A text-variant proxy message carrying a real envelope is still delivered, so the variant check
-// did not simply drop the text case.
+// Control: the variant check did not simply drop the text case.
 void test_receiveTextVariantFromProxyIsDelivered(void)
 {
     const meshtastic_ServiceEnvelope env = {
         .packet = const_cast<meshtastic_MeshPacket *>(&decoded), .channel_id = "test", .gateway_id = "!87654321"};
     meshtastic_MqttClientProxyMessage message = meshtastic_MqttClientProxyMessage_init_default;
-    strcat(message.topic, "msh/2/e/test/!87654321");
+    snprintf(message.topic, sizeof(message.topic), "msh/2/e/test/!87654321");
     message.which_payload_variant = meshtastic_MqttClientProxyMessage_text_tag;
     const size_t n = pb_encode_to_bytes((uint8_t *)message.payload_variant.text, sizeof(message.payload_variant.text) - 1,
                                         &meshtastic_ServiceEnvelope_msg, &env);
@@ -630,7 +627,7 @@ void test_receiveTextVariantFromProxyIsDelivered(void)
 void test_receiveNoVariantFromProxyIsIgnored(void)
 {
     meshtastic_MqttClientProxyMessage message = meshtastic_MqttClientProxyMessage_init_default;
-    strcat(message.topic, "msh/2/e/test/!87654321");
+    snprintf(message.topic, sizeof(message.topic), "msh/2/e/test/!87654321");
     message.which_payload_variant = 0;
     memset(message.payload_variant.data.bytes, 0xFF, sizeof(message.payload_variant.data.bytes));
     message.payload_variant.data.size = sizeof(message.payload_variant.data.bytes);

--- a/test/test_mqtt/MQTT.cpp
+++ b/test/test_mqtt/MQTT.cpp
@@ -583,6 +583,63 @@ void test_receiveEmptyDataFromProxy(void)
     TEST_ASSERT_TRUE(mockRouter->packets_.empty());
 }
 
+// A text-variant proxy message must be read as text. payload_variant is a union, so data.size
+// aliases the first bytes of the string: reading it regardless of which_payload_variant let a
+// client name a length of up to PB_SIZE_MAX and walk ~64KB off the end of the struct.
+void test_receiveTextVariantFromProxyIsNotReadAsBytes(void)
+{
+    meshtastic_MqttClientProxyMessage message = meshtastic_MqttClientProxyMessage_init_default;
+    strcat(message.topic, "msh/2/e/test/!87654321");
+    message.which_payload_variant = meshtastic_MqttClientProxyMessage_text_tag;
+    // 0xFF 0xFF is what data.size would read as: the largest length a pb_size_t can name.
+    memset(message.payload_variant.text, 0xFF, sizeof(message.payload_variant.text) - 1);
+    message.payload_variant.text[sizeof(message.payload_variant.text) - 1] = '\0';
+
+    mqtt->onClientProxyReceive(message);
+
+    // Not a ServiceEnvelope, so nothing is delivered - the point is that the read stays in bounds.
+    TEST_ASSERT_TRUE(mockRouter->packets_.empty());
+}
+
+// A text-variant proxy message carrying a real envelope is still delivered, so the variant check
+// did not simply drop the text case.
+void test_receiveTextVariantFromProxyIsDelivered(void)
+{
+    const meshtastic_ServiceEnvelope env = {
+        .packet = const_cast<meshtastic_MeshPacket *>(&decoded), .channel_id = "test", .gateway_id = "!87654321"};
+    meshtastic_MqttClientProxyMessage message = meshtastic_MqttClientProxyMessage_init_default;
+    strcat(message.topic, "msh/2/e/test/!87654321");
+    message.which_payload_variant = meshtastic_MqttClientProxyMessage_text_tag;
+    const size_t n = pb_encode_to_bytes((uint8_t *)message.payload_variant.text, sizeof(message.payload_variant.text) - 1,
+                                        &meshtastic_ServiceEnvelope_msg, &env);
+    TEST_ASSERT_GREATER_THAN(0, n);
+    // strnlen stops at the first NUL, so only an envelope without one round-trips as text.
+    if (memchr(message.payload_variant.text, 0, n) != nullptr) {
+        TEST_IGNORE_MESSAGE("encoded envelope contains a NUL; not representable as a text payload");
+        return;
+    }
+    message.payload_variant.text[n] = '\0';
+
+    mqtt->onClientProxyReceive(message);
+
+    TEST_ASSERT_EQUAL(1, mockRouter->packets_.size());
+    TEST_ASSERT_EQUAL(decoded.id, mockRouter->packets_.front().id);
+}
+
+// A proxy message with no payload variant set must be ignored rather than read as bytes.
+void test_receiveNoVariantFromProxyIsIgnored(void)
+{
+    meshtastic_MqttClientProxyMessage message = meshtastic_MqttClientProxyMessage_init_default;
+    strcat(message.topic, "msh/2/e/test/!87654321");
+    message.which_payload_variant = 0;
+    memset(message.payload_variant.data.bytes, 0xFF, sizeof(message.payload_variant.data.bytes));
+    message.payload_variant.data.size = sizeof(message.payload_variant.data.bytes);
+
+    mqtt->onClientProxyReceive(message);
+
+    TEST_ASSERT_TRUE(mockRouter->packets_.empty());
+}
+
 // Packets should be ignored if downlink is not enabled.
 void test_receiveWithoutChannelDownlink(void)
 {
@@ -1051,6 +1108,9 @@ void setup()
     RUN_TEST(test_receiveDecodedProto);
     RUN_TEST(test_receiveDecodedProtoFromProxy);
     RUN_TEST(test_receiveEmptyDataFromProxy);
+    RUN_TEST(test_receiveTextVariantFromProxyIsNotReadAsBytes);
+    RUN_TEST(test_receiveTextVariantFromProxyIsDelivered);
+    RUN_TEST(test_receiveNoVariantFromProxyIsIgnored);
     RUN_TEST(test_receiveWithoutChannelDownlink);
     RUN_TEST(test_receiveEncryptedPKITopicToUs);
     RUN_TEST(test_receiveIgnoresOwnPublishedMessages);


### PR DESCRIPTION
`MQTT::onClientProxyReceive` read `msg.payload_variant.data.bytes/.size` without checking `which_payload_variant`.

`payload_variant` is a union of `data` (`PB_BYTES_ARRAY_T(435)`) and `text` (`char[435]`). On the text variant, `data.size` aliases the first bytes of the string, so a client sending text beginning `0xFF 0xFF` yields a length of 65535. That length is passed to `onReceive` and on to `DecodedServiceEnvelope`, reading up to ~64KB past a 501-byte by-value stack copy.

Reachable from any client that can send a ToRadio `mqttClientProxyMessage` (PhoneAPI.cpp:488) when MQTT and proxy_to_client are enabled.

Both variants are legitimate on this path: the firmware publishes text for JSON topics and data for protobuf, so the fix dispatches on the variant rather than dropping text. Text length comes from `strnlen` bounded by the buffer. A message with no variant set is ignored.

Tests added in `test_mqtt` for the text variant with a `0xFF`-filled payload, a text-variant envelope still being delivered, and an unset variant being ignored.

Note: `test_mqtt` does not build on `native-windows` (it includes `arpa/inet.h`), so these tests were not run locally. They are covered by the Linux native CI job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MQTT client proxy payload handling by decoding according to the selected payload variant (binary vs text).
  * Prevented delivery when the proxy payload variant is missing or unrecognized.
  * Ensured valid text payloads continue to be processed and forwarded correctly.

* **Tests**
  * Added unit tests covering correct text-variant interpretation (not treated as raw bytes) and ignoring proxy messages with no selected payload variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->