### PR TITLE
Bound remote-initiated key verification sessions

### DIFF
--- a/src/modules/KeyVerificationModule.cpp
+++ b/src/modules/KeyVerificationModule.cpp
@@ -71,8 +71,7 @@ AdminMessageHandleResult KeyVerificationModule::handleAdminMessageForModule(cons
 
 bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_KeyVerification *r)
 {
-    // Do not refresh the deadline here: this runs before the sender is checked, so any node could keep
-    // the session alive indefinitely. The deadline is extended only when the protocol actually advances.
+    // No refresh here: this runs before the sender is checked, so any node could hold the session open.
     updateState(false);
     // Note: pki_encrypted is not required here. The first response (M2) may arrive channel-encrypted in
     // the bootstrap case; the follow-on hash1 packet (M3) is required to be PKI in its branch below.
@@ -198,8 +197,7 @@ meshtastic_MeshPacket *KeyVerificationModule::allocReply()
         ignoreRequest = true; // do not let the busy path emit a NAK back to the requester
         return nullptr;
     }
-    // Opening a session raises a 30 second banner and a client notification, and locks out the only slot,
-    // all before the peer has authenticated anything. Space remote-initiated sessions out.
+    // Opening a session raises a banner and locks the only slot, before the peer has authenticated.
     if (lastRemoteSessionMs != 0 && Throttle::isWithinTimespanMs(lastRemoteSessionMs, KEY_VERIFICATION_REMOTE_COOLDOWN_MS)) {
         LOG_WARN("Key Verification requested, but within cooldown");
         ignoreRequest = true;
@@ -369,12 +367,10 @@ void KeyVerificationModule::updateState(bool resetTimer)
 {
     if (currentState != KEY_VERIFICATION_IDLE) {
         uint32_t now = getTime();
-        // Absolute cap first: incoming packets refresh the idle timer below, so this is what stops a peer
-        // from holding the slot open forever. millis() based, so it still applies when the RTC is unset.
+        // Absolute cap first: it is millis() based, so it bounds the session even when the RTC is unset.
         if (!Throttle::isWithinTimespanMs(sessionStartedMs, KEY_VERIFICATION_MAX_SESSION_MS)) {
             resetToIdle();
-        } else if (now >= currentNonceTimestamp + KEY_VERIFICATION_TIMEOUT_SECS) {
-            // Addition rather than getTime() - 60, which underflows before the clock passes 60.
+        } else if (now - currentNonceTimestamp >= KEY_VERIFICATION_TIMEOUT_SECS) {
             resetToIdle();
         } else if (resetTimer) {
             currentNonceTimestamp = now;

--- a/src/modules/KeyVerificationModule.cpp
+++ b/src/modules/KeyVerificationModule.cpp
@@ -6,11 +6,18 @@
 #include "gps/RTC.h"
 #include "graphics/draw/MenuHandler.h"
 #include "main.h"
+#include "mesh/Throttle.h"
 #include "meshUtils.h"
 #include "modules/AdminModule.h"
 #include "modules/NodeInfoModule.h"
 #include <RNG.h>
 #include <SHA256.h>
+
+#define KEY_VERIFICATION_TIMEOUT_SECS 60
+// Hard cap on one session, independent of the refreshable idle timeout above.
+#define KEY_VERIFICATION_MAX_SESSION_MS (3 * 60 * 1000UL)
+// Minimum spacing between remote-initiated sessions.
+#define KEY_VERIFICATION_REMOTE_COOLDOWN_MS (60 * 1000UL)
 
 KeyVerificationModule *keyVerificationModule;
 
@@ -64,7 +71,9 @@ AdminMessageHandleResult KeyVerificationModule::handleAdminMessageForModule(cons
 
 bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_KeyVerification *r)
 {
-    updateState();
+    // Do not refresh the deadline here: this runs before the sender is checked, so any node could keep
+    // the session alive indefinitely. The deadline is extended only when the protocol actually advances.
+    updateState(false);
     // Note: pki_encrypted is not required here. The first response (M2) may arrive channel-encrypted in
     // the bootstrap case; the follow-on hash1 packet (M3) is required to be PKI in its branch below.
     if (mp.from != currentRemoteNode) { // because the inital connection request is handled in allocReply()
@@ -98,6 +107,7 @@ bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &
             service->sendClientNotification(cn);
         }
         LOG_INFO("Received hash2");
+        currentNonceTimestamp = getTime(); // the protocol advanced, so extend the deadline
         currentState = KEY_VERIFICATION_SENDER_AWAITING_NUMBER;
         return true;
 
@@ -134,6 +144,7 @@ bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &
                 service->sendClientNotification(cn);
             }
 
+            currentNonceTimestamp = getTime(); // the protocol advanced, so extend the deadline
             currentState = KEY_VERIFICATION_RECEIVER_AWAITING_USER;
             return true;
         }
@@ -153,6 +164,7 @@ bool KeyVerificationModule::sendInitialRequest(NodeNum remoteNode)
     updateState(true);
     currentNonce = random();
     currentNonceTimestamp = getTime();
+    sessionStartedMs = millis();
     currentRemoteNode = remoteNode;
     meshtastic_KeyVerification KeyVerification = meshtastic_KeyVerification_init_zero;
     KeyVerification.nonce = currentNonce;
@@ -181,10 +193,20 @@ meshtastic_MeshPacket *KeyVerificationModule::allocReply()
     SHA256 hash;
     NodeNum ourNodeNum = nodeDB->getNodeNum();
     updateState();
-    if (currentState != KEY_VERIFICATION_IDLE) { // TODO: cooldown period
+    if (currentState != KEY_VERIFICATION_IDLE) {
         LOG_WARN("Key Verification requested, but already in a request");
+        ignoreRequest = true; // do not let the busy path emit a NAK back to the requester
         return nullptr;
     }
+    // Opening a session raises a 30 second banner and a client notification, and locks out the only slot,
+    // all before the peer has authenticated anything. Space remote-initiated sessions out.
+    if (lastRemoteSessionMs != 0 && Throttle::isWithinTimespanMs(lastRemoteSessionMs, KEY_VERIFICATION_REMOTE_COOLDOWN_MS)) {
+        LOG_WARN("Key Verification requested, but within cooldown");
+        ignoreRequest = true;
+        return nullptr;
+    }
+    sessionStartedMs = millis();
+    sessionFromRemote = true;
     currentState = KEY_VERIFICATION_RECEIVER_AWAITING_HASH1;
 
     auto req = *currentRequest;
@@ -346,11 +368,16 @@ void KeyVerificationModule::processSecurityNumber(uint32_t incomingNumber)
 void KeyVerificationModule::updateState(bool resetTimer)
 {
     if (currentState != KEY_VERIFICATION_IDLE) {
-        // check for the 60 second timeout
-        if (currentNonceTimestamp < getTime() - 60) {
+        uint32_t now = getTime();
+        // Absolute cap first: incoming packets refresh the idle timer below, so this is what stops a peer
+        // from holding the slot open forever. millis() based, so it still applies when the RTC is unset.
+        if (!Throttle::isWithinTimespanMs(sessionStartedMs, KEY_VERIFICATION_MAX_SESSION_MS)) {
+            resetToIdle();
+        } else if (now >= currentNonceTimestamp + KEY_VERIFICATION_TIMEOUT_SECS) {
+            // Addition rather than getTime() - 60, which underflows before the clock passes 60.
             resetToIdle();
         } else if (resetTimer) {
-            currentNonceTimestamp = getTime();
+            currentNonceTimestamp = now;
         }
     }
 }
@@ -359,8 +386,12 @@ void KeyVerificationModule::resetToIdle()
 {
     memset(hash1, 0, 32);
     memset(hash2, 0, 32);
+    if (sessionFromRemote)
+        lastRemoteSessionMs = millis(); // start the cooldown when the session ends, not when it opened
+    sessionFromRemote = false;
     currentNonce = 0;
     currentNonceTimestamp = 0;
+    sessionStartedMs = 0;
     currentSecurityNumber = 0;
     currentRemoteNode = 0;
     currentState = KEY_VERIFICATION_IDLE;

--- a/src/modules/KeyVerificationModule.h
+++ b/src/modules/KeyVerificationModule.h
@@ -84,12 +84,10 @@ class KeyVerificationModule : public ProtobufModule<meshtastic_KeyVerification> 
   private:
     uint64_t currentNonce = 0;
     uint32_t currentNonceTimestamp = 0;
-    // millis() when the current session was opened, never refreshed, so a peer cannot hold the single
-    // slot open indefinitely by resetting the idle timer with one packet per timeout window.
+    // millis() the session opened, never refreshed, so a peer cannot hold the slot open indefinitely.
     uint32_t sessionStartedMs = 0;
-    // millis() when a remote-initiated session last ended. Opening a session raises a banner and a client
-    // notification, so spacing sessions bounds both the slot DoS and the notification spam. Stamped at the
-    // end rather than the start, so the cooldown is a real gap between sessions.
+    // millis() a remote-initiated session last ended. Spacing sessions bounds the slot DoS and the
+    // banner spam; stamped at the end rather than the start so the cooldown is a real gap.
     uint32_t lastRemoteSessionMs = 0;
     bool sessionFromRemote = false;
     NodeNum currentRemoteNode = 0;

--- a/src/modules/KeyVerificationModule.h
+++ b/src/modules/KeyVerificationModule.h
@@ -84,6 +84,14 @@ class KeyVerificationModule : public ProtobufModule<meshtastic_KeyVerification> 
   private:
     uint64_t currentNonce = 0;
     uint32_t currentNonceTimestamp = 0;
+    // millis() when the current session was opened, never refreshed, so a peer cannot hold the single
+    // slot open indefinitely by resetting the idle timer with one packet per timeout window.
+    uint32_t sessionStartedMs = 0;
+    // millis() when a remote-initiated session last ended. Opening a session raises a banner and a client
+    // notification, so spacing sessions bounds both the slot DoS and the notification spam. Stamped at the
+    // end rather than the start, so the cooldown is a real gap between sessions.
+    uint32_t lastRemoteSessionMs = 0;
+    bool sessionFromRemote = false;
     NodeNum currentRemoteNode = 0;
     uint32_t currentSecurityNumber = 0;
     KeyVerificationState currentState = KEY_VERIFICATION_IDLE;


### PR DESCRIPTION
`KeyVerificationModule` holds a single verification slot. A remote packet opens it in `allocReply()`, which also raises a 30 second banner and a WARNING client notification. None of that required authentication: the peer supplies any 32 bytes in `hash1`, and `pki_encrypted` is not needed on the first message because bootstrapping a peer that does not yet hold our key is intentional.

Four problems, all remotely reachable:

- `updateState()` ran at the top of `handleReceivedProtobuf` before the `mp.from` check, so any node could refresh the deadline of someone else's session and keep the slot occupied indefinitely.
- `resetToIdle()` left no cooldown, so the slot could be reoccupied immediately and the banner raised again.
- The busy path returned `nullptr` without setting `ignoreRequest`, so `MeshModule` answered with a NAK.
- `currentNonceTimestamp < getTime() - 60` underflows while the clock is below 60, so the timeout behaved differently depending on the time source.

Changes:

- `sessionStartedMs` gives an absolute cap of 3 minutes that incoming packets cannot refresh. It is millis() based, so it still applies when the RTC is unset.
- The idle deadline is now extended only where the protocol actually advances, not on every arriving packet.
- `lastRemoteSessionMs` enforces 60 seconds between remote-initiated sessions, stamped when a session ends so the cooldown is a real gap. Locally initiated verification is not affected.
- Because the banner and notification are raised only when a session is opened, spacing sessions also bounds the notification spam. No separate notification throttle is needed.
- The busy and cooldown paths set `ignoreRequest`.
- The timeout comparison uses addition.

Builds clean on native-windows, which compiles this module.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened key verification session timing with explicit per-step deadlines and an absolute maximum session duration.
  * Prevented unauthenticated inbound traffic from extending session deadlines.
  * Added stronger rate limiting and a remote-initiated cooldown to reduce repeated attempts.
  * Rejected remote requests when a session is already active.
  * Improved session cleanup by recording remote session timing and resetting origin tracking after completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->