### PR TITLE
Limit node database churn from unauthenticated packets

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -3120,6 +3120,9 @@ size_t NodeDB::getNumOnlineMeshNodes(bool localOnly)
 #include "MeshModule.h"
 #include "Throttle.h"
 
+// Minimum spacing between evictions once the node database is full.
+#define NODEDB_FULL_EVICTION_INTERVAL_MS (2 * 1000UL)
+
 static constexpr uint32_t HOPSTART_DROP_LOG_INTERVAL_MS = 15000;
 
 void logHopStartDrop(const meshtastic_MeshPacket &p, const char *context)
@@ -3312,15 +3315,18 @@ void NodeDB::addFromContact(meshtastic_SharedContact contact)
  */
 bool NodeDB::updateUser(uint32_t nodeId, meshtastic_User &p, uint8_t channelIndex, bool xeddsaSigned)
 {
-    meshtastic_NodeInfoLite *info = getOrCreateMeshNode(nodeId);
-    if (!info) {
+    // Once a node has proven it signs, only a signed update may change its identity. The public-key guard
+    // below is no help - an attacker can replay the victim's real (public) key. Our own record is exempt.
+    // Checked against the existing record before getOrCreateMeshNode, because creating an entry can evict
+    // another node and write the warm tier; a refused update must not leave those side effects behind.
+    const meshtastic_NodeInfoLite *existing = getMeshNode(nodeId);
+    if (nodeId != getNodeNum() && existing && nodeInfoLiteHasXeddsaSigned(existing) && !xeddsaSigned) {
+        LOG_WARN("Refusing unsigned identity update for node 0x%08x that previously signed", nodeId);
         return false;
     }
 
-    // Once a node has proven it signs, only a signed update may change its identity. The public-key guard
-    // below is no help - an attacker can replay the victim's real (public) key. Our own record is exempt.
-    if (nodeId != getNodeNum() && nodeInfoLiteHasXeddsaSigned(info) && !xeddsaSigned) {
-        LOG_WARN("Refusing unsigned identity update for node 0x%08x that previously signed", nodeId);
+    meshtastic_NodeInfoLite *info = getOrCreateMeshNode(nodeId);
+    if (!info) {
         return false;
     }
 
@@ -3414,7 +3420,22 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
     if (mp.which_payload_variant == meshtastic_MeshPacket_decoded_tag && mp.from) {
         LOG_DEBUG("Update DB node 0x%08x, rx_time=%u", mp.from, mp.rx_time);
 
-        meshtastic_NodeInfoLite *info = getOrCreateMeshNode(getFrom(&mp));
+        // Admitting a node this way costs an eviction once the database is full, and on some platforms a
+        // warm-tier write. mp.from is unauthenticated header data, so a flood of invented node numbers
+        // would otherwise churn the database at packet rate and push real neighbours out. Only the
+        // packet-driven path is limited, and only while the database is full: explicit admission still
+        // evicts freely, and discovery is untouched while slots remain.
+        meshtastic_NodeInfoLite *info = getMeshNode(getFrom(&mp));
+        if (!info) {
+            if (isFull()) {
+                if (Throttle::isWithinTimespanMs(lastFullEvictionMs, NODEDB_FULL_EVICTION_INTERVAL_MS)) {
+                    LOG_DEBUG("Node database full, defer admitting 0x%08x", mp.from);
+                    return;
+                }
+                lastFullEvictionMs = millis();
+            }
+            info = getOrCreateMeshNode(getFrom(&mp));
+        }
         if (!info) {
             return;
         }

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -3315,10 +3315,8 @@ void NodeDB::addFromContact(meshtastic_SharedContact contact)
  */
 bool NodeDB::updateUser(uint32_t nodeId, meshtastic_User &p, uint8_t channelIndex, bool xeddsaSigned)
 {
-    // Once a node has proven it signs, only a signed update may change its identity. The public-key guard
-    // below is no help - an attacker can replay the victim's real (public) key. Our own record is exempt.
-    // Checked against the existing record before getOrCreateMeshNode, because creating an entry can evict
-    // another node and write the warm tier; a refused update must not leave those side effects behind.
+    // Only a signed update may change the identity of a node that has proven it signs; our own record is
+    // exempt. Checked before getOrCreateMeshNode so a refused update cannot evict or write the warm tier.
     const meshtastic_NodeInfoLite *existing = getMeshNode(nodeId);
     if (nodeId != getNodeNum() && existing && nodeInfoLiteHasXeddsaSigned(existing) && !xeddsaSigned) {
         LOG_WARN("Refusing unsigned identity update for node 0x%08x that previously signed", nodeId);
@@ -3420,11 +3418,8 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
     if (mp.which_payload_variant == meshtastic_MeshPacket_decoded_tag && mp.from) {
         LOG_DEBUG("Update DB node 0x%08x, rx_time=%u", mp.from, mp.rx_time);
 
-        // Admitting a node this way costs an eviction once the database is full, and on some platforms a
-        // warm-tier write. mp.from is unauthenticated header data, so a flood of invented node numbers
-        // would otherwise churn the database at packet rate and push real neighbours out. Only the
-        // packet-driven path is limited, and only while the database is full: explicit admission still
-        // evicts freely, and discovery is untouched while slots remain.
+        // mp.from is unauthenticated, so rate-limit admission once the database is full: otherwise
+        // invented node numbers churn it at packet rate and push real neighbours out.
         meshtastic_NodeInfoLite *info = getMeshNode(getFrom(&mp));
         if (!info) {
             if (isFull()) {

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -529,9 +529,10 @@ class NodeDB
     /// skip boot keygen and skip persisting defaults, so a transient read failure can't change our NodeNum
     /// or overwrite the on-disk config. Cleared at the top of every loadFromDisk() run.
     bool configDecodeFailed = false;
-    uint32_t lastNodeDbSave = 0;    // when we last saved our db to flash
-    uint32_t lastBackupAttempt = 0; // when we last tried a backup automatically or manually
-    uint32_t lastSort = 0;          // When last sorted the nodeDB
+    uint32_t lastNodeDbSave = 0;     // when we last saved our db to flash
+    uint32_t lastFullEvictionMs = 0; // when we last evicted to admit a new node, once the db is full
+    uint32_t lastBackupAttempt = 0;  // when we last tried a backup automatically or manually
+    uint32_t lastSort = 0;           // When last sorted the nodeDB
 
     /*
      * Internal boolean to track sorting paused


### PR DESCRIPTION
Two related problems on the unauthenticated NodeDB path.

**Ordering.** `updateUser()` called `getOrCreateMeshNode()` before the signature gate added in 5ded0ec8c. Creating an entry can evict another node and write the warm tier, so a refused identity update had already caused both side effects before returning false. The gate now runs against the existing record, and the entry is created only once it passes. Behaviour is otherwise identical: the gate only ever fired for nodes already present and already known to sign.

**Admission churn.** `updateFrom()` creates an entry for any decoded packet, and `mp.from` is unauthenticated header data. On a channel whose key is known, including the default public channel, invented node numbers churn the database at packet rate. Eviction prefers keyless nodes, so a flood pushes real keyless neighbours out, and each eviction also writes the warm tier.

Admission from the packet path is now spaced once the database is full. The limit is deliberately narrow:

- only the packet-driven path, so explicit admission and internal callers still evict freely
- only while the database is full, so discovery is untouched while slots remain
- existing nodes update normally, since the throttle only applies to creating an entry

An earlier revision put the throttle inside `getOrCreateMeshNode()`; `test_nodedb_blocked` correctly rejected it, because that also gated eviction paths that must succeed. Narrowing it to `updateFrom()` addresses the threat without changing those semantics.

The nRF52840 warm store was also examined. Its immediate `persistEntry` write is by design, buffered through the shared flash page cache with `saveIfDirty()` as the durability point, so it is left alone.

test_nodedb_blocked, test_packet_signing, test_warm_store and test_optin_migration pass, 75 cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary node database churn when updates arrive while storage is full.
  * Prevented rejected unsigned identity updates from creating or evicting node records after prior valid signing.
  * Added rate-limiting for admitting unknown nodes when the node database reaches capacity, improving stability and performance.
  * Improved handling of decoded node updates by only creating new records when needed, deferring fabricated/unknown node admissions when at capacity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->