### PR TITLE
Throttle NodeInfo direct responses

### DIFF
--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -1092,8 +1092,7 @@ bool TrafficManagementModule::shouldRespondToNodeInfo(const meshtastic_MeshPacke
     if (!sendResponse)
         return true;
 
-    // Checked here, once we know a reply would actually go out, so requests we decline for other
-    // reasons do not consume the budget.
+    // Checked here, once a reply would actually go out, so declined requests do not consume the budget.
     if (!directResponseAllowed(getFrom(p), clockMs())) {
         TM_LOG_DEBUG("NodeInfo direct response throttled for 0x%08x", getFrom(p));
         return false;
@@ -1153,6 +1152,9 @@ bool TrafficManagementModule::shouldRespondToNodeInfo(const meshtastic_MeshPacke
 
 bool TrafficManagementModule::directResponseAllowed(NodeNum requestor, uint32_t nowMs)
 {
+    // Reached from the packet path and from runOnce, so the throttle state needs the same lock as the cache.
+    concurrency::LockGuard guard(&cacheLock);
+
     if (lastDirectResponseMs != 0 && (nowMs - lastDirectResponseMs) < kDirectResponseGlobalMs)
         return false;
 

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -1092,6 +1092,13 @@ bool TrafficManagementModule::shouldRespondToNodeInfo(const meshtastic_MeshPacke
     if (!sendResponse)
         return true;
 
+    // Checked here, once we know a reply would actually go out, so requests we decline for other
+    // reasons do not consume the budget.
+    if (!directResponseAllowed(getFrom(p), clockMs())) {
+        TM_LOG_DEBUG("NodeInfo direct response throttled for 0x%08x", getFrom(p));
+        return false;
+    }
+
     meshtastic_MeshPacket *reply = router->allocForSending();
     if (!reply) {
         TM_LOG_WARN("NodeInfo direct response dropped: no packet buffer");
@@ -1141,6 +1148,40 @@ bool TrafficManagementModule::shouldRespondToNodeInfo(const meshtastic_MeshPacke
     reply->priority = meshtastic_MeshPacket_Priority_DEFAULT;
 
     service->sendToMesh(reply);
+    return true;
+}
+
+bool TrafficManagementModule::directResponseAllowed(NodeNum requestor, uint32_t nowMs)
+{
+    if (lastDirectResponseMs != 0 && (nowMs - lastDirectResponseMs) < kDirectResponseGlobalMs)
+        return false;
+
+    DirectResponseThrottleEntry *slot = nullptr;
+    for (size_t i = 0; i < kDirectResponseTrackedRequestors; i++) {
+        if (directResponseSeen[i].requestor == requestor) {
+            if ((nowMs - directResponseSeen[i].lastReplyMs) < kDirectResponsePerRequestorMs)
+                return false;
+            slot = &directResponseSeen[i];
+            break;
+        }
+    }
+
+    if (slot == nullptr) {
+        // Unseen requester: take a free slot, otherwise reuse the least recently used one.
+        slot = &directResponseSeen[0];
+        for (size_t i = 0; i < kDirectResponseTrackedRequestors; i++) {
+            if (directResponseSeen[i].requestor == 0) {
+                slot = &directResponseSeen[i];
+                break;
+            }
+            if (directResponseSeen[i].lastReplyMs < slot->lastReplyMs)
+                slot = &directResponseSeen[i];
+        }
+    }
+
+    slot->requestor = requestor;
+    slot->lastReplyMs = nowMs;
+    lastDirectResponseMs = nowMs;
     return true;
 }
 

--- a/src/modules/TrafficManagementModule.h
+++ b/src/modules/TrafficManagementModule.h
@@ -294,10 +294,8 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     bool shouldDropPosition(const meshtastic_MeshPacket *p, const meshtastic_Position *pos, uint32_t nowMs);
     bool shouldRespondToNodeInfo(const meshtastic_MeshPacket *p, bool sendResponse);
 
-    // A direct NodeInfo response is addressed from the requesting packet's `from`, which is
-    // unauthenticated. One request therefore makes every neighbour holding the target in cache transmit
-    // at an address the requester chose. Spacing replies per requester bounds how much any single node
-    // can be made to receive; a global floor bounds the airtime this feature can consume overall.
+    // Replies go to the requesting packet's unauthenticated `from`, so space them per requester to bound
+    // what any one node can be made to receive, plus a global floor on airtime.
     static constexpr uint32_t kDirectResponsePerRequestorMs = 60'000UL;
     static constexpr uint32_t kDirectResponseGlobalMs = 1'000UL;
     static constexpr size_t kDirectResponseTrackedRequestors = 8;

--- a/src/modules/TrafficManagementModule.h
+++ b/src/modules/TrafficManagementModule.h
@@ -293,6 +293,21 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
 
     bool shouldDropPosition(const meshtastic_MeshPacket *p, const meshtastic_Position *pos, uint32_t nowMs);
     bool shouldRespondToNodeInfo(const meshtastic_MeshPacket *p, bool sendResponse);
+
+    // A direct NodeInfo response is addressed from the requesting packet's `from`, which is
+    // unauthenticated. One request therefore makes every neighbour holding the target in cache transmit
+    // at an address the requester chose. Spacing replies per requester bounds how much any single node
+    // can be made to receive; a global floor bounds the airtime this feature can consume overall.
+    static constexpr uint32_t kDirectResponsePerRequestorMs = 60'000UL;
+    static constexpr uint32_t kDirectResponseGlobalMs = 1'000UL;
+    static constexpr size_t kDirectResponseTrackedRequestors = 8;
+    struct DirectResponseThrottleEntry {
+        NodeNum requestor;
+        uint32_t lastReplyMs;
+    };
+    DirectResponseThrottleEntry directResponseSeen[kDirectResponseTrackedRequestors] = {};
+    uint32_t lastDirectResponseMs = 0;
+    bool directResponseAllowed(NodeNum requestor, uint32_t nowMs);
     bool isMinHopsFromRequestor(const meshtastic_MeshPacket *p) const;
     bool isRateLimited(NodeNum from, uint32_t nowMs);
     bool shouldDropUnknown(const meshtastic_MeshPacket *p, uint32_t nowMs);


### PR DESCRIPTION
`nodeinfo_direct_response_max_hops` lets a bystander answer a NodeInfo request from cache. The reply is built with `reply->from = p->to` and `reply->to = getFrom(p)`, both taken from the incoming packet, and `p->from` is unauthenticated header data.

That makes it a reflector. One request with `from` set to a victim causes every neighbour holding the target in cache to transmit a NodeInfo at that victim, all at once, with no suppression between responders and no jitter. The trigger can be a bare header with an empty payload, and the reply carries a full `meshtastic_User`, so it amplifies by size as well as by responder count. The request is consumed with STOP, so the real target never sees it.

Nothing limited this. The module's existing `isRateLimited()` sits after the direct-response block returns, so it never ran on this path, and it keys on the spoofable `from` anyway.

Replies are now spaced per requester, which is what bounds the harm: an attacker can vary `from` freely, but the responses then scatter across different addresses rather than concentrating on one victim. A global floor additionally bounds the airtime this feature can consume regardless of how the requests are spread.

The check sits immediately before a reply is sent, so requests declined for other reasons, such as the target not being cached, do not consume the budget.

This path is opt-in and defaults to off, so this affects only meshes that enabled it.

test_traffic_management passes, 47 cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added throttling for direct NodeInfo responses to prevent too-frequent replies.
  * Enforced limits on reply frequency both globally and per requesting device.
  * Avoided unnecessary reply-budget consumption and packet buffering when requests come in rapidly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->