### PR TITLE
fix: include board PSRAM class in the HybridCompile sdkconfig cache key

### DIFF
--- a/extra_scripts/esp32_pre.py
+++ b/extra_scripts/esp32_pre.py
@@ -71,3 +71,99 @@ def mtjson_esp32_part(target, source, env):
 
 
 env.AddPreAction("mtjson", mtjson_esp32_part)
+
+
+# ---------------------------------------------------------------------------
+# HybridCompile cache-poisoning workaround (pioarduino platform-espressif32)
+#
+# The platform decides whether the precompiled Arduino IDF libs can be reused
+# by hashing only the custom_sdkconfig text + mcu
+# (builder/frameworks/arduino.py::matching_custom_sdkconfig). The board JSON's
+# PSRAM configuration (BOARD_HAS_PSRAM / memory_type) is not part of that
+# hash, and nearly all our S3 variants share esp32s3_base's identical
+# custom_sdkconfig. Building a PSRAM env (e.g. heltec-v4) followed by a
+# no-PSRAM env (e.g. heltec-v3) therefore skips the framework-libs recompile
+# and links CONFIG_SPIRAM=y libs into the no-PSRAM firmware, which boot-loops
+# with "quad_psram: PSRAM chip is not connected".
+#
+# Workaround: before the platform's arduino.py SConscript reads the option,
+# append a comment line derived from the board's PSRAM/memory configuration to
+# this env's custom_sdkconfig. The comment is inert in kconfig but changes the
+# md5, forcing the IDF-libs recompile whenever the PSRAM class changes. The
+# derivation mirrors espidf.py::generate_board_specific_config().
+#
+# The marker must stay lowercase: arduino.py greps custom_sdkconfig for the
+# substrings "PSRAM" and "CONFIG_SPIRAM=y" (has_psram_config) and would
+# otherwise treat every board as having PSRAM.
+# ---------------------------------------------------------------------------
+
+SDKCONFIG_CACHE_KEY = "meshtastic_hybridcompile_cache_key"
+
+
+def spiram_cache_class(env):
+    board = env.BoardConfig()
+    mcu = board.get("build.mcu", "esp32")
+
+    # memory_type: platformio.ini override > build.arduino.memory_type > build.memory_type
+    memory_type = None
+    try:
+        memory_type = env.GetProjectOption("board_build.memory_type", None)
+    except Exception:
+        pass
+    if not memory_type:
+        build_section = board.get("build", {})
+        memory_type = build_section.get("arduino", {}).get(
+            "memory_type"
+        ) or build_section.get("memory_type")
+
+    extra_flags = board.get("build.extra_flags", "")
+    if isinstance(extra_flags, str):
+        has_psram = "PSRAM" in extra_flags
+    else:
+        has_psram = any("PSRAM" in str(flag) for flag in extra_flags)
+    if not has_psram:
+        if memory_type and (
+            "opi" in memory_type.lower() or "psram" in memory_type.lower()
+        ):
+            has_psram = True
+        elif "psram_type" in board.get("build", {}):
+            has_psram = True
+
+    if has_psram:
+        psram_type = None
+        try:
+            psram_type = env.GetProjectOption("board_build.psram_type", None)
+        except Exception:
+            pass
+        if not psram_type and memory_type and len(memory_type.split("_")) == 2:
+            psram_type = memory_type.split("_")[1]
+        if not psram_type:
+            psram_type = board.get("build.psram_type", "") or (
+                "hex" if mcu == "esp32p4" else "qio"
+            )
+        psram_type = psram_type.lower()
+        if psram_type == "opi" and mcu == "esp32s3":
+            spiram = "oct"
+        elif psram_type == "hex":
+            spiram = "hex"
+        else:
+            spiram = "quad"
+    else:
+        spiram = "none"
+
+    return "memory_type=%s spiram=%s" % ((memory_type or "default").lower(), spiram)
+
+
+def tag_sdkconfig_cache_key(env):
+    config = env.GetProjectConfig()
+    section = "env:" + env["PIOENV"]
+    if not config.has_option(section, "custom_sdkconfig"):
+        return
+    current = env.GetProjectOption("custom_sdkconfig")
+    if SDKCONFIG_CACHE_KEY in current:
+        return
+    marker = "# %s: %s" % (SDKCONFIG_CACHE_KEY, spiram_cache_class(env))
+    config.set(section, "custom_sdkconfig", current.rstrip("\n") + "\n" + marker)
+
+
+tag_sdkconfig_cache_key(env)


### PR DESCRIPTION
## Why

pioarduino's HybridCompile "libs already current" check (`arduino.py::matching_custom_sdkconfig`) hashes only the `custom_sdkconfig` text + mcu against the `# TASMOTA__<hash>` header in the project-root `sdkconfig.defaults`. The PSRAM configuration that `espidf.py` derives from the **board JSON** (`BOARD_HAS_PSRAM` in `build.extra_flags`, `memory_type`, `psram_type`) is not part of that hash — and nearly all our esp32s3 variants share `esp32s3_base`'s identical `custom_sdkconfig`.

So building a PSRAM S3 env (heltec-v4, vision-master, t-deck, …) and then a no-PSRAM one (heltec-v3, wireless-paper, …) skips the `*** Compile Arduino IDF libs ***` step and links `CONFIG_SPIRAM=y` framework libs into the no-PSRAM firmware. The device boot-loops:

```
E quad_psram: PSRAM chip is not connected
E cpu_start: Failed to init external RAM!
```

The reverse order silently strips PSRAM from PSRAM boards. Deleting `.pio` doesn't help (the libs live in the shared `framework-arduinoespressif32-libs` package). This bit tester HarukiToreda on develop (2026-07-20, Heltec V3 no-boot after a V4 build on the same machine).

## What

`extra_scripts/esp32_pre.py` (pre stage, runs before the platform's `arduino.py` SConscript) now appends an inert comment line derived from the board's PSRAM/memory configuration to each env's `custom_sdkconfig` project option:

```
# meshtastic_hybridcompile_cache_key: memory_type=qio_qspi spiram=quad   (heltec-v4)
# meshtastic_hybridcompile_cache_key: memory_type=default spiram=none    (heltec-v3)
```

A comment is invisible to kconfig but changes the md5 on both the check side (`arduino.py`) and the write side (`espidf.py`), so the IDF-libs recompile fires whenever the PSRAM class (none / quad / oct / hex, plus `memory_type`) changes. The derivation mirrors `espidf.py::generate_board_specific_config()`, including the `board_build.*` platformio.ini overrides. The marker is deliberately lowercase: `arduino.py` greps `custom_sdkconfig` for the substrings `PSRAM` / `CONFIG_SPIRAM=y` and would otherwise treat every board as having PSRAM.

Nothing is written to `platformio.ini` — the option is amended in-memory per build.

## Verification

Back-to-back clean builds on macOS reproducing the poisoning order:

1. `pio run -e heltec-v4` → libs compiled, `sdkconfig.defaults` hash `TASMOTA__c0b18cc662b3fcf0`, marker `spiram=quad`, `CONFIG_SPIRAM=y`.
2. `pio run -e heltec-v3` → hash mismatch now detected: `*** Reinstall Arduino framework ***` + `*** Compile Arduino IDF libs for heltec-v3 ***` (previously skipped — the bug), new hash `TASMOTA__b8682f392d9f2478`, marker `spiram=none`, and `# CONFIG_SPIRAM is not set` in the generated config.

The real fix belongs upstream (include board PSRAM/memory_type in the hash in `arduino.py`/`espidf.py`); this is the repo-side guard until then.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ESP32 and ESP32-S3 builds to correctly refresh compiled libraries when switching PSRAM configurations.
  * Prevented stale cached libraries from being reused across incompatible board or memory settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->