### PR TITLE
Remove BASEUI_HAS_GAMES flag from portduino.ini

### DIFF
--- a/variants/native/portduino.ini
+++ b/variants/native/portduino.ini
@@ -56,7 +56,6 @@ build_flags_common =
   -luv
   -std=gnu17
   -std=gnu++17
-  -DBASEUI_HAS_GAMES=1
   -DMAX_TFT_COLOR_REGIONS=64
 
 build_flags =


### PR DESCRIPTION
Unintentionally caught this up in the games PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the games feature flag from the Portduino native build configuration.
  * Preserved existing display support and C++17 build settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->