### PR TITLE
Don't misdetect the ES7210 audio codec as an INA219

### DIFF
--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -220,6 +220,44 @@ bool detectSHT21SerialNumber(TwoWire *i2cBus, uint8_t address)
 }
 #endif
 
+// Everest Semiconductor ES7210 4-channel audio ADC, as found on the T-Deck. Its AD1/AD0 straps
+// select 0x40..0x43, so it lands squarely on the INA/SHT2X addresses. Chip ID registers and their
+// reset values, per the ES7210 datasheet rev 2.0.
+static constexpr uint8_t ES7210_CHIP_ID1_REG = 0x3D;
+static constexpr uint8_t ES7210_CHIP_ID1 = 0x72;
+static constexpr uint8_t ES7210_CHIP_ID0_REG = 0x3E;
+static constexpr uint8_t ES7210_CHIP_ID0 = 0x10;
+
+static bool readByteRegister(TwoWire *i2cBus, uint8_t address, uint8_t reg, uint8_t &value)
+{
+    i2cBus->beginTransmission(address);
+    i2cBus->write(reg);
+
+    if (i2cBus->endTransmission() != 0)
+        return false;
+
+    if (i2cBus->requestFrom(address, (uint8_t)1) != 1 || !i2cBus->available())
+        return false;
+
+    value = i2cBus->read();
+    return true;
+}
+
+// The INA219 has no manufacturer or die ID register to check, so it is inferred from "something
+// answered here and it wasn't anything else we know". That makes positively identifying the other
+// occupants of this address the only way to keep them out of the fallback.
+static bool detectES7210(TwoWire *i2cBus, uint8_t address)
+{
+    uint8_t id = 0;
+
+    // Read the high ID byte first so anything that clearly isn't an ES7210 costs a single
+    // transaction, then confirm with the low byte.
+    if (!readByteRegister(i2cBus, address, ES7210_CHIP_ID1_REG, id) || id != ES7210_CHIP_ID1)
+        return false;
+
+    return readByteRegister(i2cBus, address, ES7210_CHIP_ID0_REG, id) && id == ES7210_CHIP_ID0;
+}
+
 #define SCAN_SIMPLE_CASE(ADDR, T, ...)                                                                                           \
     case ADDR:                                                                                                                   \
         logFoundDevice(__VA_ARGS__);                                                                                             \
@@ -472,13 +510,23 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
                         type = INA260;
                     }
                 }
+
+                // The ES7210 audio ADC shares this address on some boards (T-Deck). It answers
+                // none of the checks above, so identify it here and leave the type unset - driving
+                // an audio codec as if it were a power monitor crashes the device. See #11115.
+                if (type == NONE && detectES7210(i2cBus, (uint8_t)addr.address)) {
+                    LOG_INFO("ES7210 audio codec at 0x%x, not a power sensor", (uint8_t)addr.address);
+                    break;
+                }
 #if HAS_TELEMETRY && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
                 if (type == NONE && detectSHT21SerialNumber(i2cBus, (uint8_t)addr.address)) {
                     logFoundDevice("SHTXX (SHT2X)", (uint8_t)addr.address);
                     type = SHTXX;
                 }
 #endif
-                else { // Assume INA219 if none of the above ones are found
+                // Guarded on the type rather than chained to the SHT2X check above, so that a
+                // positively identified INA226/INA260 isn't overwritten right after being found.
+                if (type == NONE) { // Assume INA219 if none of the above ones are found
                     logFoundDevice("INA219", (uint8_t)addr.address);
                     type = INA219;
                 }


### PR DESCRIPTION
Fixes #11115

### What happens

The T-Deck carries an Everest ES7210 audio ADC on the main I2C bus. Its `AD1`/`AD0` straps select `0x40..0x43`, and LilyGo wire it for `0x40` — see [their own T-Deck driver](https://github.com/Xinyuan-LilyGO/T-Deck/blob/master/lib/es7210/src/es7210.h): `ES7210_AD1_AD0_00 = 0x40` … `#define ES7210_ADDR ES7210_AD1_AD0_00`. That is `INA_ADDR`.

The `INA_ADDR` case in `ScanI2CTwoWire` ends with a bare *"assume INA219 if none of the above matched"*, so the codec gets enumerated as an INA219. Turn on `telemetry.power_measurement_enabled` and `INA219Sensor` runs `Adafruit_INA219::begin()` against the audio codec, which panics the board into a boot loop:

```
INFO  | [PowerTelemetry] Init sensor: INA219
[W][Wire.cpp:300] begin(): Bus already started in Master Mode.
Guru Meditation Error: Core  1 panic'ed (StoreProhibited). Exception was unhandled.
```

This was latent until #10482 (`5bce26d9b`): before that, `detectSHT21SerialNumber()` returned `true` for anything that ACKed and returned bytes, so the codec was swallowed as a harmless "SHT21" and never reached the INA219 branch. Validating the SHT2x serial CRC was the right change — it just uncovered the fallback sitting underneath.

### The fix

The INA219 has no manufacturer or die ID register (unlike the INA226/INA260/INA3221 identified just above it), so it can only ever be *inferred*. Since we can't positively identify the INA219, positively identify the other occupant of the address instead: read the ES7210's chip ID registers `0x3D`/`0x3E` — reset values `0x72`/`0x10` per the ES7210 datasheet rev 2.0 ("REGISTER 0X3D – CHIP ID1, DEFAULT 01110010" / "REGISTER 0X3E – CHIP ID0, DEFAULT 00010000") — and leave the device unclaimed when they match.

The high ID byte is read first, so anything that clearly isn't an ES7210 costs one extra transaction, and only on the already-ambiguous path (something ACKed at `0x40`/`0x41`/`0x43` and wasn't a recognized INA part). It runs ahead of the SHT2x probe so we also stop writing to undefined registers on the codec.

Being a runtime probe rather than an `#ifdef`, this covers any board carrying an ES7210, not just the ones that happen to define `ES7210_*` pins.

### Drive-by: INA226/INA260 have been reported as INA219 since #10247

`ba9cadc14d` split the middle link out of the if / else-if / else chain into a standalone `if`, but left the trailing `else` behind:

```cpp
if (mfg == 0x5449 || mfg == 0x190F) { ...; type = INA226; /* or INA260 */ }
#if HAS_TELEMETRY && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
if (type == NONE && detectSHT21SerialNumber(...)) { type = SHTXX; }
#endif
else { /* Assume INA219 */ type = INA219; }
```

That `else` now binds to the SHT2x `if`. For a real INA226, `type == NONE` short-circuits to false, the `if` fails, and the `else` overwrites the just-identified `INA226` with `INA219`. Every build with environmental telemetry compiled in — i.e. nearly all of them — has been driving INA226/INA260 parts with the INA219 driver since 2026-04-24. Now an explicit `if (type == NONE)`.

### Testing

- `pio run -e t-deck` builds clean.
- Not verified on hardware yet — I don't have a T-Deck in hand. @d3xt3r01 offered to test: the scan log should read `ES7210 audio codec at 0x40, not a power sensor` instead of `INA219`, and power telemetry can stay enabled without the boot loop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device detection on supported T-Deck boards by correctly identifying ES7210 audio codecs at overlapping I2C addresses.
  * Prevented detected devices from being incorrectly classified as INA219 sensors.
  * Preserved accurate identification of SHT21 sensors during I2C scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->