### PR TITLE
fix(gps): PA1010D stuck at 0 satellites because 5-constellation config command fails

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -896,11 +896,11 @@ bool GPS::setup()
             // PA1010D is MTK3333-family (same as L76B above); the 5-constellation request is
             // NAK'd by real hardware, so use GPS + GLONASS instead, matching the L76B command.
             _serial_gps->write("$PMTK353,1,1,0,0,0*2B\r\n");
-            // Above command will reset the GPS and takes longer before it will accept new commands
-            delay(1000);
             if (getACK("$PMTK001,353,3", 900) != GNSS_RESPONSE_OK) {
                 LOG_WARN("PA1010D: constellation config (PMTK353) not acknowledged");
             }
+            // Above command will reset the GPS and takes longer before it will accept new commands
+            delay(1000);
             // Only ask for RMC and GGA (GNRMC and GNGGA)
             _serial_gps->write("$PMTK314,0,1,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0*28\r\n");
             delay(250);

--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -893,10 +893,14 @@ bool GPS::setup()
         } else if (gnssModel == GNSS_MODEL_MTK_PA1010D) {
             // PA1010D is used in the Pimoroni GPS board.
 
-            // Enable all constellations.
-            _serial_gps->write("$PMTK353,1,1,1,1,1*2A\r\n");
+            // PA1010D is MTK3333-family (same as L76B above); the 5-constellation request is
+            // NAK'd by real hardware, so use GPS + GLONASS instead, matching the L76B command.
+            _serial_gps->write("$PMTK353,1,1,0,0,0*2B\r\n");
             // Above command will reset the GPS and takes longer before it will accept new commands
             delay(1000);
+            if (getACK("$PMTK001,353,3", 900) != GNSS_RESPONSE_OK) {
+                LOG_WARN("PA1010D: constellation config (PMTK353) not acknowledged");
+            }
             // Only ask for RMC and GGA (GNRMC and GNGGA)
             _serial_gps->write("$PMTK314,0,1,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0*28\r\n");
             delay(250);


### PR DESCRIPTION
## Summary

The `GNSS_MODEL_MTK_PA1010D` branch of `GPS::setup()` sends `$PMTK353,1,1,1,1,1*2A` to enable all 5 GNSS constellations (GPS+GLONASS+Galileo+BeiDou+QZSS). On real CD-PA1010D hardware (MTK3333-family silicon) this command is NAK'd by the receiver on every boot (`$PMTK001,353,2` = "valid command, action failed"), and as a result the receiver never tracks any satellites (`$GNGGA` numSV=0 / `$GNRMC` status=V indefinitely, even with clear sky view).

This fix switches to `$PMTK353,1,1,0,0,0*2B` (GPS+GLONASS only), matching the command already used successfully by the sibling `GNSS_MODEL_MTK_L76B` branch a few lines above — PA1010D is the same MTK3333 silicon generation as L76B. It also adds an ACK check (mirroring the existing pattern for `GNSS_MODEL_ATGM336H` elsewhere in this file) so a future silent failure is visible in logs instead of just manifesting as an unexplained 0-satellite lock.

This command has been unchanged since it was introduced in 947191a79 ("Add PA1010D GPS support (#6691)", merged 2025-05-02, first shipped in v2.6.7), so every release since v2.6.7 through current develop carries this bug. It affects any board where a real PA1010D module is runtime-probed, since the MTK family probe in `GPS::probe()` detects "PA1010D" generically — this isn't limited to any one variant.

## Verification on real hardware

Tested over multiple independent boots on a Meshtastic "russell" STM32WL board with a wired real CD-PA1010D module:

- 5-constellation command (current develop): fails identically every time, 0 satellites tracked indefinitely.
- GPS+GLONASS command (this fix): ACKs successfully (`$PMTK001,353,3`), receiver locks 7-9 satellites within ~1s of boot.
- Ruled out a receiver settle-time/timing hypothesis: adding a 1.5s delay before the config command did not change the outcome for the 5-constellation command, confirming the constellation combination itself — not timing — is what the silicon rejects.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)

None of the listed reference devices are PA1010D-based. This change is scoped entirely to the `GNSS_MODEL_MTK_PA1010D` branch of `GPS::setup()` — no other chipset code paths are touched, so there's no regression risk to those devices. Verified via build-check across representative envs (`tbeam`, `rak4631`, `t-echo`) to confirm the change compiles cleanly everywhere GPS support is enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPS setup compatibility by limiting satellite systems to supported GPS and GLONASS configurations.
  * Added confirmation checks for GPS configuration commands, including warning output when acknowledgements aren’t received.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->