### PR TITLE
Fix the two failing admin request-pinning tests on develop

### DIFF
--- a/test/test_admin_session_repro/test_main.cpp
+++ b/test/test_admin_session_repro/test_main.cpp
@@ -21,6 +21,10 @@
 #include "support/MockMeshService.h"
 #include <cstring>
 
+#ifdef ARCH_PORTDUINO
+#include "platform/portduino/PortduinoGlue.h"
+#endif
+
 static constexpr NodeNum LOCAL_NODE = 0x0A0A0A0A;
 static constexpr NodeNum ADMIN_NODE = 0x0B0B0B0B;   // authorized admin, sends remote admin to us
 static constexpr NodeNum QUERIED_NODE = 0x0C0C0C0C; // a remote we send admin requests to
@@ -156,6 +160,14 @@ void setUp(void)
     mockNodeDB->clearTestNodes();
     nodeDB = mockNodeDB;
     myNodeInfo.my_node_num = LOCAL_NODE;
+
+#ifdef ARCH_PORTDUINO
+    // The native test harness boots Portduino in simulated mode, and wouldEncryptWithPKC()
+    // hard-disables PKC whenever force_simradio is set. Left true, no outgoing admin request is
+    // ever key-pinned, so the pinning tests below cannot exercise what they are asserting.
+    // Model a real (non-sim) device instead.
+    portduino_config.force_simradio = false;
+#endif
 
     config = meshtastic_LocalConfig_init_zero;
     // A real device always holds a private key; without one perhapsEncode never picks PKC.


### PR DESCRIPTION
develop is currently red on `test-native`. Two tests in `test/test_admin_session_repro/` have failed since #11092 added them, and every branch that merges develop inherits the failure (e.g. #10967).

```
test_main.cpp:472:test_pinned_request_keeps_its_key_after_an_unpinned_request:FAIL: an unpinned request must not relax an earlier request's key pin
test_main.cpp:491:test_request_to_keyed_node_pins_the_stored_key:FAIL: a plaintext response must not answer a PKC-pinned request
```

## Root cause

The native test harness boots Portduino in simulated mode (the run prints `Running in simulated mode.`, `PortduinoGlue.cpp:362`). `wouldEncryptWithPKC()` short-circuits on that:

```cpp
return isFromUs(p) &&
#if ARCH_PORTDUINO
       !portduino_config.force_simradio &&   // always false under the harness
#endif
```

`noteOutgoingAdminRequest()` derives the pin from that predicate:

```cpp
keyValid = haveDestKey && wouldEncryptWithPKC(&p, p.channel, haveDestKey);
```

so `keyValid` is never set, nothing is pinned, and `responseIsSolicited()` admits a plaintext response to what should be a PKC-pinned request — exactly the two assertions.

Instrumenting the predicate confirms every other term was already satisfied, leaving only the simradio guard:

```
[DBG-PIN] to=0x0c0c0c0c haveDestKey=1 wouldPKC=0 keyValid=0 | isFromUs=1 privKey=32 bcast=0 portnum=6 chName=LongFast
```

## Fix

Clear the flag in `setUp` so the fixture models a real device.

Skipping PKC under `force_simradio` is correct for a simulated radio — there is no PKC to pin — so this deliberately does **not** relax `wouldEncryptWithPKC()` to make a test pass. The change is test-only.

The only sim-mode path in this suite is AdminModule's `exit_simulator` intercept, which no test here exercises, so clearing the flag cannot affect a sibling test.

## Verification

Full native suite on this branch (Docker, `coverage` env, ASan/LSan):

- **38 suites, 723/723 cases, 0 sanitizer findings, 0 ignored**
- both previously-failing tests now `PASS`

For contrast, develop at `d587f0848` reports `724 test cases: 2 failed, 721 succeeded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated device authentication test coverage for Portduino builds.
  * Tests now run against non-simulated device behavior, ensuring key-pinning scenarios are exercised correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->