### PR TITLE
mesh: suppress relayed broadcast responses

### DIFF
--- a/src/mesh/MeshModule.cpp
+++ b/src/mesh/MeshModule.cpp
@@ -108,11 +108,11 @@ void MeshModule::callModules(meshtastic_MeshPacket &mp, RxSource src)
     // Was this message directed to us specifically?  Will be false if we are sniffing someone elses packets
     auto ourNodeNum = nodeDB->getNodeNum();
     bool toUs = isBroadcast(mp.to) || isToUs(&mp);
-    const bool relayedBroadcastResponseRequest = isDecoded && mp.decoded.want_response && isBroadcast(mp.to) &&
-                                                 mp.hop_limit < mp.hop_start;
-    const bool suppressResponse = relayedBroadcastResponseRequest &&
-                                  (config.device.role != meshtastic_Config_DeviceConfig_Role_TRACKER ||
-                                   mp.decoded.portnum != meshtastic_PortNum_POSITION_APP);
+    const bool relayedBroadcastResponseRequest =
+        isDecoded && mp.decoded.want_response && isBroadcast(mp.to) && mp.hop_limit < mp.hop_start;
+    const bool suppressResponse =
+        relayedBroadcastResponseRequest && (config.device.role != meshtastic_Config_DeviceConfig_Role_TRACKER ||
+                                            mp.decoded.portnum != meshtastic_PortNum_POSITION_APP);
 
     // A relayed broadcast request reaches every node in range. Suppress both module replies and the fallback NAK to avoid a
     // mesh-wide response storm. Trackers retain Position replies so a fleet can answer a broadcast location request.

--- a/src/mesh/MeshModule.cpp
+++ b/src/mesh/MeshModule.cpp
@@ -108,6 +108,16 @@ void MeshModule::callModules(meshtastic_MeshPacket &mp, RxSource src)
     // Was this message directed to us specifically?  Will be false if we are sniffing someone elses packets
     auto ourNodeNum = nodeDB->getNodeNum();
     bool toUs = isBroadcast(mp.to) || isToUs(&mp);
+    const bool relayedBroadcastResponseRequest = isDecoded && mp.decoded.want_response && isBroadcast(mp.to) &&
+                                                 mp.hop_limit < mp.hop_start;
+    const bool suppressResponse = relayedBroadcastResponseRequest &&
+                                  (config.device.role != meshtastic_Config_DeviceConfig_Role_TRACKER ||
+                                   mp.decoded.portnum != meshtastic_PortNum_POSITION_APP);
+
+    // A relayed broadcast request reaches every node in range. Suppress both module replies and the fallback NAK to avoid a
+    // mesh-wide response storm. Trackers retain Position replies so a fleet can answer a broadcast location request.
+    if (suppressResponse)
+        ignoreRequest = true;
 
     for (auto i = modules->begin(); i != modules->end(); ++i) {
         auto &pi = **i;
@@ -145,7 +155,7 @@ void MeshModule::callModules(meshtastic_MeshPacket &mp, RxSource src)
                 // no one should have already replied!
                 assert(!currentReply);
 
-                if (isDecoded && mp.decoded.want_response) {
+                if (isDecoded && mp.decoded.want_response && !suppressResponse) {
                     printPacket("packet on wrong channel, returning error", &mp);
                     currentReply = pi.allocErrorResponse(meshtastic_Routing_Error_NOT_AUTHORIZED, &mp);
                 } else
@@ -163,7 +173,8 @@ void MeshModule::callModules(meshtastic_MeshPacket &mp, RxSource src)
                 // because currently when the phone sends things, it sends things using the local node ID as the from address.  A
                 // better solution (FIXME) would be to let phones have their own distinct addresses and we 'route' to them like
                 // any other node.
-                if (isDecoded && mp.decoded.want_response && toUs && (!isFromUs(&mp) || isToUs(&mp)) && !currentReply) {
+                if (isDecoded && mp.decoded.want_response && toUs && (!isFromUs(&mp) || isToUs(&mp)) && !currentReply &&
+                    !suppressResponse) {
                     if (replyPortMatches(pi.ourPortNum, mp)) {
                         pi.sendResponse(mp);
                         LOG_INFO("Asked module '%s' to send a response", pi.name);

--- a/test/test_mesh_module/test_main.cpp
+++ b/test/test_mesh_module/test_main.cpp
@@ -204,6 +204,14 @@ static void dispatch(meshtastic_PortNum port)
     MeshModule::callModules(request);
 }
 
+static void dispatchRelayedBroadcast(meshtastic_PortNum port)
+{
+    meshtastic_MeshPacket request = makeRequest(port);
+    request.to = NODENUM_BROADCAST;
+    request.hop_limit = request.hop_start - 1;
+    MeshModule::callModules(request);
+}
+
 } // namespace
 
 void setUp(void)
@@ -439,6 +447,44 @@ static void test_dispatch_noResponderSendsNak()
     TEST_ASSERT_EQUAL_HEX32(REMOTE_NODE, mockRoutingModule->ackNaks[0].to);
 }
 
+static void test_dispatch_relayedBroadcastDoesNotReplyOrNak()
+{
+    auto *telemetry = registerDispatchModule(
+        new SyntheticReplyModule("telemetry-owner", meshtastic_PortNum_TELEMETRY_APP, meshtastic_PortNum_TELEMETRY_APP));
+
+    dispatchRelayedBroadcast(meshtastic_PortNum_TELEMETRY_APP);
+
+    TEST_ASSERT_EQUAL_UINT32(0, telemetry->allocReplyCalls);
+    TEST_ASSERT_EQUAL_UINT32(0, mockRouter->sentPackets.size());
+    TEST_ASSERT_EQUAL_UINT32(0, mockRoutingModule->ackNaks.size());
+}
+
+static void test_dispatch_relayedBroadcastTrackerPositionReplies()
+{
+    config.device.role = meshtastic_Config_DeviceConfig_Role_TRACKER;
+    auto *position = registerDispatchModule(
+        new SyntheticReplyModule("position-owner", meshtastic_PortNum_POSITION_APP, meshtastic_PortNum_POSITION_APP));
+
+    dispatchRelayedBroadcast(meshtastic_PortNum_POSITION_APP);
+
+    TEST_ASSERT_EQUAL_UINT32(1, position->allocReplyCalls);
+    TEST_ASSERT_EQUAL_UINT32(1, mockRouter->sentPackets.size());
+    TEST_ASSERT_EQUAL_UINT32(0, mockRoutingModule->ackNaks.size());
+}
+
+static void test_dispatch_relayedBroadcastTrackerOnlyAllowsPosition()
+{
+    config.device.role = meshtastic_Config_DeviceConfig_Role_TRACKER;
+    auto *telemetry = registerDispatchModule(
+        new SyntheticReplyModule("telemetry-owner", meshtastic_PortNum_TELEMETRY_APP, meshtastic_PortNum_TELEMETRY_APP));
+
+    dispatchRelayedBroadcast(meshtastic_PortNum_TELEMETRY_APP);
+
+    TEST_ASSERT_EQUAL_UINT32(0, telemetry->allocReplyCalls);
+    TEST_ASSERT_EQUAL_UINT32(0, mockRouter->sentPackets.size());
+    TEST_ASSERT_EQUAL_UINT32(0, mockRoutingModule->ackNaks.size());
+}
+
 static void test_dispatch_ignoreRequestIsClearedPerPacket()
 {
     auto *ignoring = registerDispatchModule(new ReplyIgnoreModule());
@@ -493,6 +539,9 @@ void setup()
     RUN_TEST(test_dispatch_crossPortReplyUsesRequestOwner);
     RUN_TEST(test_dispatch_foreignPortObserverCanSuppressNak);
     RUN_TEST(test_dispatch_noResponderSendsNak);
+    RUN_TEST(test_dispatch_relayedBroadcastDoesNotReplyOrNak);
+    RUN_TEST(test_dispatch_relayedBroadcastTrackerPositionReplies);
+    RUN_TEST(test_dispatch_relayedBroadcastTrackerOnlyAllowsPosition);
     RUN_TEST(test_dispatch_ignoreRequestIsClearedPerPacket);
     RUN_TEST(test_dispatch_realNeighborInfoCannotShadowTelemetryOwner);
     exit(UNITY_END());


### PR DESCRIPTION
## Summary
- suppress module replies, bound-channel errors, and fallback NAKs for relayed broadcast `want_response` packets
- retain the narrow fleet-tracker exception for `POSITION_APP` requests only
- cover suppression and Tracker exception behavior in `test_mesh_module`

## Why
A relayed broadcast reaches every receiver; allowing each receiver to reply causes mesh-wide response fan-out.

## Validation
- `pio test -e native-macos -f test_mesh_module` (22 passed)
- `pio run -e native-macos`
- launched `meshtasticd -s` for a five-second macOS SimRadio smoke test
- `git diff --check`

`trunk fmt` was unavailable on this host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary replies to relayed broadcast requests to help prevent mesh-wide response storms.
  * Ensured suppressed relayed broadcasts no longer generate inappropriate NAKs or authorization error responses.
  * Preserved tracker behavior: relayed position requests still receive responses, while other relayed broadcasts do not.
* **Tests**
  * Added automated coverage for relayed broadcast scenarios, including role-based response/NAK expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->