### PR TITLE
fix(ScanI2C): fetch the SE050 probe response with requestFrom()

### DIFF
--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -905,13 +905,8 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
                 break;
 
             case 0x48: {
-                // T=1oI2C soft reset (S-block): NAD=0x5A PCB=0xC0 LEN=0x00 plus CRC,
-                // which an SE050 answers with A5 E0 00 3F 19.
-                //
-                // The answer has to be fetched with requestFrom(). readBytes() comes from
-                // Stream and only drains the Wire RX buffer, which requestFrom() is what
-                // fills, so on its own it returns 0 bytes after burning Stream's 1000ms
-                // default timeout - and every SE050 falls through to FT6336U below.
+                // T=1oI2C soft reset; an SE050 answers A5 E0 00 3F 19. requestFrom() is
+                // required: readBytes() only drains the RX buffer requestFrom() fills.
                 const uint8_t getInfo[] = {0x5A, 0xC0, 0x00, 0xFF, 0xFC};
                 const uint8_t expectedInfo[] = {0xA5, 0xE0, 0x00, 0x3F, 0x19};
                 uint8_t info[sizeof(expectedInfo)] = {0};

--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -905,15 +905,32 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
                 break;
 
             case 0x48: {
-                i2cBus->beginTransmission(addr.address);
-                uint8_t getInfo[] = {0x5A, 0xC0, 0x00, 0xFF, 0xFC};
-                uint8_t expectedInfo[] = {0xa5, 0xE0, 0x00, 0x3F, 0x19};
-                uint8_t info[5];
+                // T=1oI2C soft reset (S-block): NAD=0x5A PCB=0xC0 LEN=0x00 plus CRC,
+                // which an SE050 answers with A5 E0 00 3F 19.
+                //
+                // The answer has to be fetched with requestFrom(). readBytes() comes from
+                // Stream and only drains the Wire RX buffer, which requestFrom() is what
+                // fills, so on its own it returns 0 bytes after burning Stream's 1000ms
+                // default timeout - and every SE050 falls through to FT6336U below.
+                const uint8_t getInfo[] = {0x5A, 0xC0, 0x00, 0xFF, 0xFC};
+                const uint8_t expectedInfo[] = {0xA5, 0xE0, 0x00, 0x3F, 0x19};
+                uint8_t info[sizeof(expectedInfo)] = {0};
                 size_t len = 0;
-                i2cBus->write(getInfo, 5);
-                i2cBus->endTransmission();
-                len = i2cBus->readBytes(info, 5);
-                if (len == 5 && memcmp(expectedInfo, info, len) == 0) {
+                bool isSE050 = false;
+
+                i2cBus->beginTransmission(addr.address);
+                i2cBus->write(getInfo, sizeof(getInfo));
+                if (i2cBus->endTransmission() == 0) {
+                    delay(2); // guard time before the answer can be read back
+                    len = i2cBus->requestFrom((uint8_t)addr.address, (uint8_t)sizeof(info));
+                    if (len == sizeof(info)) {
+                        for (size_t i = 0; i < sizeof(info); i++)
+                            info[i] = i2cBus->read();
+                        isSE050 = (memcmp(expectedInfo, info, sizeof(info)) == 0);
+                    }
+                }
+
+                if (isSE050) {
                     LOG_INFO("NXP SE050 crypto chip found");
                     type = NXP_SE050;
                     break;


### PR DESCRIPTION
## Problem

SE050 detection has never been able to succeed.

The probe at `0x48` writes the T=1oI2C soft reset and then collects the answer with `readBytes()`. But `readBytes()` comes from `Stream` and only drains the Wire RX buffer — and `requestFrom()` is what fills that buffer. With no `requestFrom()`, the read returns 0 bytes, the compare never matches, and every SE050 falls through to the `FT6336U` branch and is reported as a touchscreen that isn't there.

This affects any core whose `TwoWire` does not override `readBytes()`, which includes both arduino-esp32 and arduino-pico.

It also costs boot time on boards that have nothing to do with the SE050. Any device that ACKs at `0x48` — an ADS1115 at its default address, for instance — goes through this probe first and pays `Stream::readBytes()`'s 1000 ms default timeout waiting on a buffer nothing is going to fill. It shows up as a one-second gap in the I2C scan log right before the `0x48` result:

```
DEBUG | 1 Register value from 0x44: 0x0
INFO  | 1 SHTXX found at address 0x44
DEBUG | 2 Register value from 0x48: 0x1082    <-- one second later
INFO  | 2 FT6336U touchscreen found           <-- this is actually an SE050
```

## Fix

Fetch the response with `requestFrom()` and read it back, with a short guard delay before the read.

A single attempt is enough — verified on hardware — so devices that are **not** an SE050 still see exactly one probe write, exactly as they do today. I deliberately did not add retries for that reason.

## Testing

Verified on an SE050E2 at `0x48` (RP2350 + arduino-pico, sharing the bus with an SHT40 at `0x44`):

```
INFO  | 0 SHTXX found at address 0x44
INFO  | 0 NXP SE050 crypto chip found
INFO  | 0 2 I2C devices found
```

Reported correctly instead of `FT6336U`, and the one-second scan delay is gone.

## What I could not test

**I do not have an ADS1115 to verify the other `0x48` path.** Since this keeps the probe to a single write, an ADS1115 sees byte-for-byte what it sees on `develop` today, so I would not expect any change in behaviour — but I have not confirmed it on hardware and would rather say so than imply otherwise. I should be able to get hold of one next month and can confirm then if you would prefer to hold the PR until that is done.

The `FT6336U` path is likewise unverified for the same reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of NXP SE050 devices during I2C scanning.
  * Enhanced reliability of reading and validating the SE050 response at I2C address 0x48 by using a more direct request/response flow and stricter signature comparison.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->