### PR TITLE
fix(security): round-trip packet policy defaults

### DIFF
--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -1138,9 +1138,9 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
         }
 #if MESHTASTIC_EXCLUDE_PKI || MESHTASTIC_EXCLUDE_XEDDSA
         if (incoming.packet_signature_policy !=
-            meshtastic_Config_SecurityConfig_PacketSignaturePolicy_PACKET_SIGNATURE_POLICY_BALANCED) {
+            meshtastic_Config_SecurityConfig_PacketSignaturePolicy_PACKET_SIGNATURE_POLICY_COMPATIBLE) {
             incoming.packet_signature_policy =
-                meshtastic_Config_SecurityConfig_PacketSignaturePolicy_PACKET_SIGNATURE_POLICY_BALANCED;
+                meshtastic_Config_SecurityConfig_PacketSignaturePolicy_PACKET_SIGNATURE_POLICY_COMPATIBLE;
             const char *warning = "Packet authenticity policy is unavailable on this firmware build";
             LOG_WARN(warning);
             sendWarning(warning);

--- a/test/test_admin_session_repro/test_main.cpp
+++ b/test/test_admin_session_repro/test_main.cpp
@@ -304,6 +304,26 @@ void test_local_security_config_keeps_private_key(void)
     admin->drainReply();
 }
 
+// A local client writes this device-owned policy, then receives the same value in its next config read.
+void test_local_security_config_round_trips_packet_signature_policy(void)
+{
+    meshtastic_Config set = meshtastic_Config_init_zero;
+    set.which_payload_variant = meshtastic_Config_security_tag;
+    set.payload_variant.security = config.security;
+    set.payload_variant.security.packet_signature_policy =
+        meshtastic_Config_SecurityConfig_PacketSignaturePolicy_PACKET_SIGNATURE_POLICY_STRICT;
+    admin->handleSetConfig(set, false);
+
+    meshtastic_MeshPacket req = makeGetConfigRequest(0);
+    admin->handleGetConfig(req, meshtastic_AdminMessage_ConfigType_SECURITY_CONFIG);
+
+    meshtastic_Config_SecurityConfig sec;
+    TEST_ASSERT_TRUE(decodeSecurityFromReply(admin->reply(), sec));
+    TEST_ASSERT_EQUAL(meshtastic_Config_SecurityConfig_PacketSignaturePolicy_PACKET_SIGNATURE_POLICY_STRICT,
+                      sec.packet_signature_policy);
+    admin->drainReply();
+}
+
 // Decode the NetworkConfig / MqttConfig out of the response a handler queued in myReply.
 static bool decodeNetworkFromReply(meshtastic_MeshPacket *reply, meshtastic_Config_NetworkConfig &out)
 {
@@ -652,6 +672,7 @@ void setup()
     RUN_TEST(test_session_gate_accepts_key_from_a_get_response);
     RUN_TEST(test_remote_security_config_omits_private_key);
     RUN_TEST(test_local_security_config_keeps_private_key);
+    RUN_TEST(test_local_security_config_round_trips_packet_signature_policy);
     RUN_TEST(test_remote_network_config_omits_wifi_psk);
     RUN_TEST(test_local_network_config_keeps_wifi_psk);
     RUN_TEST(test_remote_mqtt_config_omits_password);


### PR DESCRIPTION
## Summary

- normalize the unavailable packet-authenticity fallback to Compatible, the shipped protobuf zero/default
- cover a local SecurityConfig SET → GET round trip for Strict

## Validation

- `./bin/test-native-docker.sh -f test_admin_session_repro` — 25 test cases succeeded
- `git diff --check`

No hardware verification performed; this is firmware configuration/API behavior without a display UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for packet signature policy settings on devices with certain security features excluded.
  * Fixed local security configuration updates so the selected packet signature policy is preserved when retrieved.

* **Tests**
  * Added coverage to verify packet signature policy settings round-trip correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->