### PR TITLE
feat(lr2021): enable LR2021 LoRa radio support on native/portduino

### DIFF
--- a/bin/config.d/lora-femtofox_LR2021_TCXO.yaml
+++ b/bin/config.d/lora-femtofox_LR2021_TCXO.yaml
@@ -28,11 +28,6 @@ Lora:
   Busy: 22 #pin16 / GPIO54 1C6
   Reset: 25 #pin13 / GPIO57 1D1
 
-  # SubGHz max power (dBm). Chip raw max 22, module FEM amplifies beyond that.
-  LR2021_MAX_POWER: 22
-  # 2.4GHz max power (dBm).
-  LR2021_MAX_POWER_HF: 12
-
   spidev: spidev0.0 #pins are (CS=16, CLK=17, MOSI=18, MISO=19)
   spiSpeed: 2000000
 

--- a/bin/config.d/lora-femtofox_LR2021_TCXO.yaml
+++ b/bin/config.d/lora-femtofox_LR2021_TCXO.yaml
@@ -1,0 +1,49 @@
+---
+Meta:
+  name: Femtofox LR2021 with TCXO (GNiceRF LoRa2021F33-2G4)
+  support: community
+  compatible:
+    - luckfox-pico-mini # Armbian
+
+Lora:
+## GNiceRF LoRa2021F33-2G4 — 2W high-power dual-band LR2021 module
+## Integrated FEM (PA + LNA) with RF switch control via DIO5/DIO6/DIO8
+## Pin mapping matches the femtofox LR1121 template
+##
+## RF switch topology follows the Seeed Mesh Tracker X1 / T1000-E reference:
+##   DIO5 -> antenna path select (HIGH = sub-GHz LF)
+##   DIO6 -> TX enable / HP PA select
+##   DIO7 -> not connected
+##   DIO8 -> RF front-end power enable
+  Module: lr2021
+  gpiochip: 1 # subtract 32 from the gpio numbers
+  DIO3_TCXO_VOLTAGE: 1.8
+  # DIO5 is used for RF switch control (antenna path select), so the IRQ must
+  # be routed to a different DIO. DIO9 is the recommended IRQ pin when DIO5-8
+  # are used for RF switch control. The physical IRQ GPIO on the Luckfox must
+  # be connected to the LR2021's DIO9 for this to work.
+  IRQ_DIO_NUM: 9
+  CS: 16 #pin6 / GPIO48 1C0
+  IRQ: 23  #pin17 / GPIO55 1C7
+  Busy: 22 #pin16 / GPIO54 1C6
+  Reset: 25 #pin13 / GPIO57 1D1
+
+  # SubGHz max power (dBm). Chip raw max 22, module FEM amplifies beyond that.
+  LR2021_MAX_POWER: 22
+  # 2.4GHz max power (dBm).
+  LR2021_MAX_POWER_HF: 12
+
+  spidev: spidev0.0 #pins are (CS=16, CLK=17, MOSI=18, MISO=19)
+  spiSpeed: 2000000
+
+  # RF switch table for integrated FEM
+  # DIO5=antenna select, DIO6=TX enable, DIO7=NC, DIO8=FEM power enable
+  rfswitch_table:
+    pins: ["DIO5", "DIO6", "DIO7", "DIO8"]
+    MODE_STBY: ["LOW", "LOW", "LOW", "LOW"]
+    MODE_RX: ["HIGH", "LOW", "LOW", "HIGH"]
+    MODE_TX: ["HIGH", "HIGH", "LOW", "HIGH"]
+    # LR2021 uses MODE_RX_HF (2.4GHz RX) instead of LR11x0's MODE_TX_HP.
+    # FEM is sub-GHz only, so 2.4GHz modes disable the FEM (all LOW).
+    MODE_RX_HF: ["LOW", "LOW", "LOW", "LOW"]
+    MODE_TX_HF: ["LOW", "LOW", "LOW", "LOW"]

--- a/bin/config.d/lora-usb-meshtoad-nicerflora2021f33.yaml
+++ b/bin/config.d/lora-usb-meshtoad-nicerflora2021f33.yaml
@@ -1,0 +1,32 @@
+Meta:
+  name: meshtoad2021
+  support: community
+  compatible:
+    - usb
+
+Lora:
+  Module: lr2021
+  CS: 0
+  IRQ: 6
+  Reset: 2
+  Busy: 4
+  DIO3_TCXO_VOLTAGE: 1.8
+  # DIO5 is used for RF switch control, so IRQ must be on a different DIO.
+  IRQ_DIO_NUM: 9
+  # Defaults for LR2021, but can be overridden by user config
+  # LR2021_MAX_POWER: 22
+  # LR2021_MAX_POWER_HF: 12
+  spidev: ch341
+  USB_PID: 0x5512
+  USB_VID: 0x1A86
+  # Optional: Set the serial number for multi-radio support
+  # USB_Serialnum: 13374201
+
+  # NiceRF LoRa2021F33 module
+  rfswitch_table:
+    pins: [DIO5, DIO6, DIO8]
+    MODE_STBY: [LOW, LOW, LOW]
+    MODE_RX: [LOW, LOW, LOW]
+    MODE_TX: [LOW, HIGH, LOW]
+    MODE_RX_HF: [HIGH, LOW, LOW]
+    MODE_TX_HF: [LOW, LOW, HIGH]

--- a/bin/config.d/lora-usb-meshtoad-nicerflora2021f33.yaml
+++ b/bin/config.d/lora-usb-meshtoad-nicerflora2021f33.yaml
@@ -13,9 +13,6 @@ Lora:
   DIO3_TCXO_VOLTAGE: 1.8
   # DIO5 is used for RF switch control, so IRQ must be on a different DIO.
   IRQ_DIO_NUM: 9
-  # Defaults for LR2021, but can be overridden by user config
-  # LR2021_MAX_POWER: 22
-  # LR2021_MAX_POWER_HF: 12
   spidev: ch341
   USB_PID: 0x5512
   USB_VID: 0x1A86

--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -6,13 +6,15 @@
 #include "mesh/NodeDB.h"
 #ifdef LR11X0_DIO_AS_RF_SWITCH
 #include "rfswitch.h"
+#define lr11x0_rfswitch_dio_pins rfswitch_dio_pins
+#define lr11x0_rfswitch_table rfswitch_table
 #elif ARCH_PORTDUINO
 #include "PortduinoGlue.h"
-#define rfswitch_dio_pins portduino_config.rfswitch_dio_pins
-#define rfswitch_table portduino_config.rfswitch_table
+#define lr11x0_rfswitch_dio_pins portduino_config.rfswitch_dio_pins
+#define lr11x0_rfswitch_table portduino_config.rfswitch_table
 #else
-static const uint32_t rfswitch_dio_pins[] = {RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC};
-static const Module::RfSwitchMode_t rfswitch_table[] = {
+static const uint32_t lr11x0_rfswitch_dio_pins[] = {RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC};
+static const Module::RfSwitchMode_t lr11x0_rfswitch_table[] = {
     {LR11x0::MODE_STBY, {}},  {LR11x0::MODE_RX, {}},   {LR11x0::MODE_TX, {}},   {LR11x0::MODE_TX_HP, {}},
     {LR11x0::MODE_TX_HF, {}}, {LR11x0::MODE_GNSS, {}}, {LR11x0::MODE_WIFI, {}}, END_OF_MODE_TABLE,
 };
@@ -146,7 +148,7 @@ template <typename T> bool LR11x0Interface<T>::init()
 #endif
 
     if (dioAsRfSwitch) {
-        lora.setRfSwitchTable(rfswitch_dio_pins, rfswitch_table);
+        lora.setRfSwitchTable(lr11x0_rfswitch_dio_pins, lr11x0_rfswitch_table);
         LOG_DEBUG("Set DIO RF switch");
     }
 
@@ -378,4 +380,5 @@ template <typename T> int16_t LR11x0Interface<T>::getCurrentRSSI()
 #endif
     return (int16_t)round(rssi);
 }
+
 #endif

--- a/src/mesh/LR20x0Interface.cpp
+++ b/src/mesh/LR20x0Interface.cpp
@@ -28,20 +28,14 @@ static const Module::RfSwitchMode_t lr20x0_rfswitch_table[] = {
 };
 #endif
 
-// Particular boards might define a different max power based on what their hardware can do, default to max power output if not
-// specified (may be dangerous if using external PA and LR20x0 power config forgotten)
-#if ARCH_PORTDUINO
-#define LR2021_MAX_POWER portduino_config.lr2021_max_power
-#endif
+// LR2021 power limits are handled intrinsically by RadioLib's setOutputPower()/checkOutputPower(),
+// which clamps to -9..22 dBm (sub-GHz PA) or -19..12 dBm (HF PA) based on the frequency band.
+// No module-level override is needed - the chip enforces its own limits.
 #ifndef LR2021_MAX_POWER
 #define LR2021_MAX_POWER 22
 #endif
 
 // the 2.4G part maxes at 12dBm
-
-#if ARCH_PORTDUINO
-#define LR2021_MAX_POWER_HF portduino_config.lr2021_max_power_hf
-#endif
 #ifndef LR2021_MAX_POWER_HF
 #define LR2021_MAX_POWER_HF 12
 #endif
@@ -84,48 +78,17 @@ template <typename T> bool LR20x0Interface<T>::init()
 
     RadioLibInterface::init();
 
-    // Set irqDioNum BEFORE lora.begin() - begin() → config() calls setDioFunction(irqDioNum, IRQ)
-    // to program the chip's internal DIO routing. Changing it after begin() is too late.
-    // This is critical when DIO5 is used for RF switch control: the default irqDioNum=5 would
-    // conflict with the RF switch table, causing setRfSwitchTable() to reconfigure DIO5 from
-    // IRQ to RF_SWITCH and silently break all interrupts.
-    //
-    // On ARCH_PORTDUINO, runtime YAML config takes precedence over compile-time macros so
-    // users can override IRQ routing without rebuilding.
+    // irqDioNum: set from compile-time macros or portduino config.
+    // Note: must be set before lora.begin() so config() programs the correct DIO.
+    // On ARCH_PORTDUINO, runtime YAML config takes precedence over compile-time macros.
+    // The user is responsible for ensuring IRQ_DIO_NUM doesn't conflict with RF switch pins.
 #if ARCH_PORTDUINO
     if (portduino_config.lr2021_irq_dio_num >= 5 && portduino_config.lr2021_irq_dio_num <= 11) {
-        // Check for conflict with pins claimed by the RF switch table
-        bool conflict = false;
-        if (portduino_config.has_rfswitch_table) {
-            for (int i = 0; i < 5 && !conflict; i++) {
-                uint32_t pin = portduino_config.rfswitch_dio_pins[i];
-                if (pin != RADIOLIB_NC && (pin & ~RFSWITCH_PIN_FLAG) == (uint32_t)(portduino_config.lr2021_irq_dio_num - 5))
-                    conflict = true;
-            }
-        }
-        if (conflict) {
-            LOG_WARN("IRQ_DIO_NUM %d conflicts with an RF switch table pin - set a non-conflicting"
-                     " DIO (e.g. 9) in config to avoid broken interrupts",
-                     portduino_config.lr2021_irq_dio_num);
-        } else {
-            lora.irqDioNum = portduino_config.lr2021_irq_dio_num;
-            LOG_DEBUG("Set irqDioNum %d (from config)", lora.irqDioNum);
-        }
+        lora.irqDioNum = portduino_config.lr2021_irq_dio_num;
+        LOG_DEBUG("Set irqDioNum %d (from config)", lora.irqDioNum);
     } else if (portduino_config.lr2021_irq_dio_num != 0) {
         LOG_WARN("IRQ_DIO_NUM %d out of range (5-11), using default %d", portduino_config.lr2021_irq_dio_num, lora.irqDioNum);
     } else {
-        // Default DIO5 is the most common RF switch pin - warn if it conflicts
-        if (portduino_config.has_rfswitch_table) {
-            bool defaultConflict = false;
-            for (int i = 0; i < 5 && !defaultConflict; i++) {
-                uint32_t pin = portduino_config.rfswitch_dio_pins[i];
-                if (pin != RADIOLIB_NC && (pin & ~RFSWITCH_PIN_FLAG) == 0) // DIO5 = index 0
-                    defaultConflict = true;
-            }
-            if (defaultConflict)
-                LOG_WARN("Default IRQ DIO5 conflicts with RF switch table - set IRQ_DIO_NUM to a"
-                         " non-conflicting DIO (e.g. 9) in config");
-        }
         LOG_DEBUG("Use default irqDioNum %d", lora.irqDioNum);
     }
 #elif defined(LR2021_IRQ_DIO_NUM)

--- a/src/mesh/LR20x0Interface.cpp
+++ b/src/mesh/LR20x0Interface.cpp
@@ -12,6 +12,10 @@
 
 #ifdef LR2021_DIO_AS_RF_SWITCH
 #include "rfswitch.h"
+#ifndef LR20X0_RFSWITCH_NATIVE
+#define lr20x0_rfswitch_dio_pins rfswitch_dio_pins
+#define lr20x0_rfswitch_table rfswitch_table
+#endif
 #elif ARCH_PORTDUINO
 #include "PortduinoGlue.h"
 #define lr20x0_rfswitch_dio_pins portduino_config.rfswitch_dio_pins
@@ -80,12 +84,24 @@ template <typename T> bool LR20x0Interface<T>::init()
 
     RadioLibInterface::init();
 
+    // Set irqDioNum BEFORE lora.begin() - begin() → config() calls setDioFunction(irqDioNum, IRQ)
+    // to program the chip's internal DIO routing. Changing it after begin() is too late.
+    // This is critical when DIO5 is used for RF switch control: the default irqDioNum=5 would
+    // conflict with the RF switch table, causing setRfSwitchTable() to reconfigure DIO5 from
+    // IRQ to RF_SWITCH and silently break all interrupts.
 #ifdef LR2021_IRQ_DIO_NUM
     lora.irqDioNum = LR2021_IRQ_DIO_NUM;
-    LOG_DEBUG("Set irqDioNum %d", lora.irqDioNum);
+    LOG_DEBUG("Set irqDioNum %d (compile-time)", lora.irqDioNum);
 #elif defined(IRQ_DIO_NUM)
     lora.irqDioNum = IRQ_DIO_NUM;
-    LOG_DEBUG("Set irqDioNum %d", lora.irqDioNum);
+    LOG_DEBUG("Set irqDioNum %d (compile-time)", lora.irqDioNum);
+#elif ARCH_PORTDUINO
+    if (portduino_config.lr2021_irq_dio_num > 0) {
+        lora.irqDioNum = portduino_config.lr2021_irq_dio_num;
+        LOG_DEBUG("Set irqDioNum %d (from config)", lora.irqDioNum);
+    } else {
+        LOG_DEBUG("Use default irqDioNum %d", lora.irqDioNum);
+    }
 #else
     LOG_DEBUG("Use default irqDioNum %d", lora.irqDioNum);
 #endif

--- a/src/mesh/LR20x0Interface.cpp
+++ b/src/mesh/LR20x0Interface.cpp
@@ -89,13 +89,10 @@ template <typename T> bool LR20x0Interface<T>::init()
     // This is critical when DIO5 is used for RF switch control: the default irqDioNum=5 would
     // conflict with the RF switch table, causing setRfSwitchTable() to reconfigure DIO5 from
     // IRQ to RF_SWITCH and silently break all interrupts.
-#ifdef LR2021_IRQ_DIO_NUM
-    lora.irqDioNum = LR2021_IRQ_DIO_NUM;
-    LOG_DEBUG("Set irqDioNum %d (compile-time)", lora.irqDioNum);
-#elif defined(IRQ_DIO_NUM)
-    lora.irqDioNum = IRQ_DIO_NUM;
-    LOG_DEBUG("Set irqDioNum %d (compile-time)", lora.irqDioNum);
-#elif ARCH_PORTDUINO
+    //
+    // On ARCH_PORTDUINO, runtime YAML config takes precedence over compile-time macros so
+    // users can override IRQ routing without rebuilding.
+#if ARCH_PORTDUINO
     if (portduino_config.lr2021_irq_dio_num >= 5 && portduino_config.lr2021_irq_dio_num <= 11) {
         // Check for conflict with pins claimed by the RF switch table
         bool conflict = false;
@@ -118,6 +115,12 @@ template <typename T> bool LR20x0Interface<T>::init()
     } else {
         LOG_DEBUG("Use default irqDioNum %d", lora.irqDioNum);
     }
+#elif defined(LR2021_IRQ_DIO_NUM)
+    lora.irqDioNum = LR2021_IRQ_DIO_NUM;
+    LOG_DEBUG("Set irqDioNum %d (compile-time)", lora.irqDioNum);
+#elif defined(IRQ_DIO_NUM)
+    lora.irqDioNum = IRQ_DIO_NUM;
+    LOG_DEBUG("Set irqDioNum %d (compile-time)", lora.irqDioNum);
 #else
     LOG_DEBUG("Use default irqDioNum %d", lora.irqDioNum);
 #endif

--- a/src/mesh/LR20x0Interface.cpp
+++ b/src/mesh/LR20x0Interface.cpp
@@ -96,9 +96,11 @@ template <typename T> bool LR20x0Interface<T>::init()
     lora.irqDioNum = IRQ_DIO_NUM;
     LOG_DEBUG("Set irqDioNum %d (compile-time)", lora.irqDioNum);
 #elif ARCH_PORTDUINO
-    if (portduino_config.lr2021_irq_dio_num > 0) {
+    if (portduino_config.lr2021_irq_dio_num >= 5 && portduino_config.lr2021_irq_dio_num <= 11) {
         lora.irqDioNum = portduino_config.lr2021_irq_dio_num;
         LOG_DEBUG("Set irqDioNum %d (from config)", lora.irqDioNum);
+    } else if (portduino_config.lr2021_irq_dio_num != 0) {
+        LOG_WARN("IRQ_DIO_NUM %d out of range (5-11), using default %d", portduino_config.lr2021_irq_dio_num, lora.irqDioNum);
     } else {
         LOG_DEBUG("Use default irqDioNum %d", lora.irqDioNum);
     }

--- a/src/mesh/LR20x0Interface.cpp
+++ b/src/mesh/LR20x0Interface.cpp
@@ -97,8 +97,22 @@ template <typename T> bool LR20x0Interface<T>::init()
     LOG_DEBUG("Set irqDioNum %d (compile-time)", lora.irqDioNum);
 #elif ARCH_PORTDUINO
     if (portduino_config.lr2021_irq_dio_num >= 5 && portduino_config.lr2021_irq_dio_num <= 11) {
-        lora.irqDioNum = portduino_config.lr2021_irq_dio_num;
-        LOG_DEBUG("Set irqDioNum %d (from config)", lora.irqDioNum);
+        // Check for conflict with pins claimed by the RF switch table
+        bool conflict = false;
+        if (portduino_config.has_rfswitch_table) {
+            for (int i = 0; i < 5 && !conflict; i++) {
+                uint32_t pin = portduino_config.rfswitch_dio_pins[i];
+                if (pin != RADIOLIB_NC && (pin & ~RFSWITCH_PIN_FLAG) == (uint32_t)(portduino_config.lr2021_irq_dio_num - 5))
+                    conflict = true;
+            }
+        }
+        if (conflict) {
+            LOG_WARN("IRQ_DIO_NUM %d conflicts with an RF switch table pin, using default %d",
+                     portduino_config.lr2021_irq_dio_num, lora.irqDioNum);
+        } else {
+            lora.irqDioNum = portduino_config.lr2021_irq_dio_num;
+            LOG_DEBUG("Set irqDioNum %d (from config)", lora.irqDioNum);
+        }
     } else if (portduino_config.lr2021_irq_dio_num != 0) {
         LOG_WARN("IRQ_DIO_NUM %d out of range (5-11), using default %d", portduino_config.lr2021_irq_dio_num, lora.irqDioNum);
     } else {

--- a/src/mesh/LR20x0Interface.cpp
+++ b/src/mesh/LR20x0Interface.cpp
@@ -104,8 +104,9 @@ template <typename T> bool LR20x0Interface<T>::init()
             }
         }
         if (conflict) {
-            LOG_WARN("IRQ_DIO_NUM %d conflicts with an RF switch table pin, using default %d",
-                     portduino_config.lr2021_irq_dio_num, lora.irqDioNum);
+            LOG_WARN("IRQ_DIO_NUM %d conflicts with an RF switch table pin - set a non-conflicting"
+                     " DIO (e.g. 9) in config to avoid broken interrupts",
+                     portduino_config.lr2021_irq_dio_num);
         } else {
             lora.irqDioNum = portduino_config.lr2021_irq_dio_num;
             LOG_DEBUG("Set irqDioNum %d (from config)", lora.irqDioNum);
@@ -113,6 +114,18 @@ template <typename T> bool LR20x0Interface<T>::init()
     } else if (portduino_config.lr2021_irq_dio_num != 0) {
         LOG_WARN("IRQ_DIO_NUM %d out of range (5-11), using default %d", portduino_config.lr2021_irq_dio_num, lora.irqDioNum);
     } else {
+        // Default DIO5 is the most common RF switch pin - warn if it conflicts
+        if (portduino_config.has_rfswitch_table) {
+            bool defaultConflict = false;
+            for (int i = 0; i < 5 && !defaultConflict; i++) {
+                uint32_t pin = portduino_config.rfswitch_dio_pins[i];
+                if (pin != RADIOLIB_NC && (pin & ~RFSWITCH_PIN_FLAG) == 0) // DIO5 = index 0
+                    defaultConflict = true;
+            }
+            if (defaultConflict)
+                LOG_WARN("Default IRQ DIO5 conflicts with RF switch table - set IRQ_DIO_NUM to a"
+                         " non-conflicting DIO (e.g. 9) in config");
+        }
         LOG_DEBUG("Use default irqDioNum %d", lora.irqDioNum);
     }
 #elif defined(LR2021_IRQ_DIO_NUM)

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -399,8 +399,10 @@ std::unique_ptr<RadioInterface> initLoRa()
             return std::unique_ptr<RadioInterface>(new LR1120Interface(hal, cs, irq, rst, busy));
         case use_lr1121:
             return std::unique_ptr<RadioInterface>(new LR1121Interface(hal, cs, irq, rst, busy));
+#if defined(USE_LR2021) && RADIOLIB_EXCLUDE_LR2021 != 1
         case use_lr2021:
             return std::unique_ptr<RadioInterface>(new LR2021Interface(hal, cs, irq, rst, busy));
+#endif
         case use_llcc68:
             return std::unique_ptr<RadioInterface>(new LLCC68Interface(hal, cs, irq, rst, busy));
         case use_simradio:

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -399,6 +399,8 @@ std::unique_ptr<RadioInterface> initLoRa()
             return std::unique_ptr<RadioInterface>(new LR1120Interface(hal, cs, irq, rst, busy));
         case use_lr1121:
             return std::unique_ptr<RadioInterface>(new LR1121Interface(hal, cs, irq, rst, busy));
+        case use_lr2021:
+            return std::unique_ptr<RadioInterface>(new LR2021Interface(hal, cs, irq, rst, busy));
         case use_llcc68:
             return std::unique_ptr<RadioInterface>(new LLCC68Interface(hal, cs, irq, rst, busy));
         case use_simradio:
@@ -603,7 +605,7 @@ std::unique_ptr<RadioInterface> initLoRa()
     }
 #endif
 
-#if defined(USE_LR2021) && RADIOLIB_EXCLUDE_LR2021 != 1
+#if defined(USE_LR2021) && !defined(ARCH_PORTDUINO) && RADIOLIB_EXCLUDE_LR2021 != 1
     if (!rIf) {
         rIf = std::unique_ptr<LR2021Interface>(
             new LR2021Interface(loraHal, LR2021_SPI_NSS_PIN, LR2021_IRQ_PIN, LR2021_NRESET_PIN, LR2021_BUSY_PIN));

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -899,6 +899,14 @@ bool loadConfig(const char *configPath)
                 portduino_config.lr1110_max_power = yamlConfig["Lora"]["LR1110_MAX_POWER"].as<int>(22);
             if (yamlConfig["Lora"]["LR1120_MAX_POWER"])
                 portduino_config.lr1120_max_power = yamlConfig["Lora"]["LR1120_MAX_POWER"].as<int>(13);
+            if (yamlConfig["Lora"]["LR2021_MAX_POWER"])
+                portduino_config.lr2021_max_power = yamlConfig["Lora"]["LR2021_MAX_POWER"].as<int>(22);
+            if (yamlConfig["Lora"]["LR2021_MAX_POWER_HF"])
+                portduino_config.lr2021_max_power_hf = yamlConfig["Lora"]["LR2021_MAX_POWER_HF"].as<int>(12);
+            if (yamlConfig["Lora"]["IRQ_DIO_NUM"])
+                portduino_config.lr2021_irq_dio_num = yamlConfig["Lora"]["IRQ_DIO_NUM"].as<int>(0);
+            else if (yamlConfig["Lora"]["LR2021_IRQ_DIO_NUM"])
+                portduino_config.lr2021_irq_dio_num = yamlConfig["Lora"]["LR2021_IRQ_DIO_NUM"].as<int>(0);
             if (yamlConfig["Lora"]["RF95_MAX_POWER"])
                 portduino_config.rf95_max_power = yamlConfig["Lora"]["RF95_MAX_POWER"].as<int>(20);
 
@@ -965,18 +973,37 @@ bool loadConfig(const char *configPath)
             }
             if (yamlConfig["Lora"]["rfswitch_table"]) {
                 portduino_config.has_rfswitch_table = true;
-                portduino_config.rfswitch_table[0].mode = LR11x0::MODE_STBY;
-                portduino_config.rfswitch_table[1].mode = LR11x0::MODE_RX;
-                portduino_config.rfswitch_table[2].mode = LR11x0::MODE_TX;
-                portduino_config.rfswitch_table[3].mode = LR11x0::MODE_TX_HP;
-                portduino_config.rfswitch_table[4].mode = LR11x0::MODE_TX_HF;
-                portduino_config.rfswitch_table[5].mode = LR11x0::MODE_GNSS;
-                portduino_config.rfswitch_table[6].mode = LR11x0::MODE_WIFI;
-                portduino_config.rfswitch_table[7] = END_OF_MODE_TABLE;
+
+                // LR2021 has a different OpMode_t enum than LR11x0:
+                //   LR11x0: STBY=1, RX=2, TX=3, TX_HP=4, TX_HF=5, GNSS=6, WIFI=7
+                //   LR2021: STBY=1, RX=2, TX=3, RX_HF=4, TX_HF=5  (no TX_HP/GNSS/WIFI)
+                // Using LR11x0 modes for an LR2021 would program incorrect DIO RF switch
+                // config bits (mode 4 = RX_HF not TX_HP; modes 6/7 don't exist).
+#if !RADIOLIB_EXCLUDE_LR2021
+                if (portduino_config.lora_module == use_lr2021) {
+                    portduino_config.rfswitch_table[0].mode = LR2021::MODE_STBY;
+                    portduino_config.rfswitch_table[1].mode = LR2021::MODE_RX;
+                    portduino_config.rfswitch_table[2].mode = LR2021::MODE_TX;
+                    portduino_config.rfswitch_table[3].mode = LR2021::MODE_RX_HF;
+                    portduino_config.rfswitch_table[4].mode = LR2021::MODE_TX_HF;
+                    portduino_config.rfswitch_table[5] = END_OF_MODE_TABLE;
+                } else
+#endif
+                {
+                    portduino_config.rfswitch_table[0].mode = LR11x0::MODE_STBY;
+                    portduino_config.rfswitch_table[1].mode = LR11x0::MODE_RX;
+                    portduino_config.rfswitch_table[2].mode = LR11x0::MODE_TX;
+                    portduino_config.rfswitch_table[3].mode = LR11x0::MODE_TX_HP;
+                    portduino_config.rfswitch_table[4].mode = LR11x0::MODE_TX_HF;
+                    portduino_config.rfswitch_table[5].mode = LR11x0::MODE_GNSS;
+                    portduino_config.rfswitch_table[6].mode = LR11x0::MODE_WIFI;
+                    portduino_config.rfswitch_table[7] = END_OF_MODE_TABLE;
+                }
 
                 for (int i = 0; i < 5; i++) {
 
                     // set up the pin array first
+                    // DIO pin constants are the same for LR11x0 and LR2021 (both use LRXXXX_DIOx)
                     if (yamlConfig["Lora"]["rfswitch_table"]["pins"][i].as<std::string>("") == "DIO5")
                         portduino_config.rfswitch_dio_pins[i] = RADIOLIB_LR11X0_DIO5;
                     if (yamlConfig["Lora"]["rfswitch_table"]["pins"][i].as<std::string>("") == "DIO6")
@@ -995,14 +1022,25 @@ bool loadConfig(const char *configPath)
                         portduino_config.rfswitch_table[1].values[i] = HIGH;
                     if (yamlConfig["Lora"]["rfswitch_table"]["MODE_TX"][i].as<std::string>("") == "HIGH")
                         portduino_config.rfswitch_table[2].values[i] = HIGH;
-                    if (yamlConfig["Lora"]["rfswitch_table"]["MODE_TX_HP"][i].as<std::string>("") == "HIGH")
-                        portduino_config.rfswitch_table[3].values[i] = HIGH;
-                    if (yamlConfig["Lora"]["rfswitch_table"]["MODE_TX_HF"][i].as<std::string>("") == "HIGH")
-                        portduino_config.rfswitch_table[4].values[i] = HIGH;
-                    if (yamlConfig["Lora"]["rfswitch_table"]["MODE_GNSS"][i].as<std::string>("") == "HIGH")
-                        portduino_config.rfswitch_table[5].values[i] = HIGH;
-                    if (yamlConfig["Lora"]["rfswitch_table"]["MODE_WIFI"][i].as<std::string>("") == "HIGH")
-                        portduino_config.rfswitch_table[6].values[i] = HIGH;
+#if !RADIOLIB_EXCLUDE_LR2021
+                    if (portduino_config.lora_module == use_lr2021) {
+                        // LR2021: slot 3 = MODE_RX_HF (not TX_HP), slot 4 = MODE_TX_HF
+                        if (yamlConfig["Lora"]["rfswitch_table"]["MODE_RX_HF"][i].as<std::string>("") == "HIGH")
+                            portduino_config.rfswitch_table[3].values[i] = HIGH;
+                        if (yamlConfig["Lora"]["rfswitch_table"]["MODE_TX_HF"][i].as<std::string>("") == "HIGH")
+                            portduino_config.rfswitch_table[4].values[i] = HIGH;
+                    } else
+#endif
+                    {
+                        if (yamlConfig["Lora"]["rfswitch_table"]["MODE_TX_HP"][i].as<std::string>("") == "HIGH")
+                            portduino_config.rfswitch_table[3].values[i] = HIGH;
+                        if (yamlConfig["Lora"]["rfswitch_table"]["MODE_TX_HF"][i].as<std::string>("") == "HIGH")
+                            portduino_config.rfswitch_table[4].values[i] = HIGH;
+                        if (yamlConfig["Lora"]["rfswitch_table"]["MODE_GNSS"][i].as<std::string>("") == "HIGH")
+                            portduino_config.rfswitch_table[5].values[i] = HIGH;
+                        if (yamlConfig["Lora"]["rfswitch_table"]["MODE_WIFI"][i].as<std::string>("") == "HIGH")
+                            portduino_config.rfswitch_table[6].values[i] = HIGH;
+                    }
                 }
             }
         }

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -903,10 +903,19 @@ bool loadConfig(const char *configPath)
                 portduino_config.lr2021_max_power = yamlConfig["Lora"]["LR2021_MAX_POWER"].as<int>(22);
             if (yamlConfig["Lora"]["LR2021_MAX_POWER_HF"])
                 portduino_config.lr2021_max_power_hf = yamlConfig["Lora"]["LR2021_MAX_POWER_HF"].as<int>(12);
-            if (yamlConfig["Lora"]["IRQ_DIO_NUM"])
-                portduino_config.lr2021_irq_dio_num = yamlConfig["Lora"]["IRQ_DIO_NUM"].as<int>(0);
-            else if (yamlConfig["Lora"]["LR2021_IRQ_DIO_NUM"])
-                portduino_config.lr2021_irq_dio_num = yamlConfig["Lora"]["LR2021_IRQ_DIO_NUM"].as<int>(0);
+            if (yamlConfig["Lora"]["IRQ_DIO_NUM"]) {
+                int dio = yamlConfig["Lora"]["IRQ_DIO_NUM"].as<int>(0);
+                if (dio == 0 || (dio >= 5 && dio <= 11))
+                    portduino_config.lr2021_irq_dio_num = dio;
+                else
+                    LOG_WARN("IRQ_DIO_NUM %d out of range (0 or 5-11), ignored", dio);
+            } else if (yamlConfig["Lora"]["LR2021_IRQ_DIO_NUM"]) {
+                int dio = yamlConfig["Lora"]["LR2021_IRQ_DIO_NUM"].as<int>(0);
+                if (dio == 0 || (dio >= 5 && dio <= 11))
+                    portduino_config.lr2021_irq_dio_num = dio;
+                else
+                    LOG_WARN("LR2021_IRQ_DIO_NUM %d out of range (0 or 5-11), ignored", dio);
+            }
             if (yamlConfig["Lora"]["RF95_MAX_POWER"])
                 portduino_config.rf95_max_power = yamlConfig["Lora"]["RF95_MAX_POWER"].as<int>(20);
 

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -984,8 +984,8 @@ bool loadConfig(const char *configPath)
                 portduino_config.has_rfswitch_table = true;
 
                 // LR2021 has a different OpMode_t enum than LR11x0:
-                //   LR11x0: STBY=1, RX=2, TX=3, TX_HP=4, TX_HF=5, GNSS=6, WIFI=7
-                //   LR2021: STBY=1, RX=2, TX=3, RX_HF=4, TX_HF=5  (no TX_HP/GNSS/WIFI)
+                //   LR11x0: STBY=0, RX=1, TX=2, TX_HP=3, TX_HF=4, GNSS=5, WIFI=6
+                //   LR2021: STBY=0, RX=1, TX=2, RX_HF=3, TX_HF=4  (no TX_HP/GNSS/WIFI)
                 // Using LR11x0 modes for an LR2021 would program incorrect DIO RF switch
                 // config bits (mode 4 = RX_HF not TX_HP; modes 6/7 don't exist).
 #if !RADIOLIB_EXCLUDE_LR2021

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -899,10 +899,6 @@ bool loadConfig(const char *configPath)
                 portduino_config.lr1110_max_power = yamlConfig["Lora"]["LR1110_MAX_POWER"].as<int>(22);
             if (yamlConfig["Lora"]["LR1120_MAX_POWER"])
                 portduino_config.lr1120_max_power = yamlConfig["Lora"]["LR1120_MAX_POWER"].as<int>(13);
-            if (yamlConfig["Lora"]["LR2021_MAX_POWER"])
-                portduino_config.lr2021_max_power = yamlConfig["Lora"]["LR2021_MAX_POWER"].as<int>(22);
-            if (yamlConfig["Lora"]["LR2021_MAX_POWER_HF"])
-                portduino_config.lr2021_max_power_hf = yamlConfig["Lora"]["LR2021_MAX_POWER_HF"].as<int>(12);
             if (yamlConfig["Lora"]["IRQ_DIO_NUM"]) {
                 int dio = yamlConfig["Lora"]["IRQ_DIO_NUM"].as<int>(0);
                 if (dio == 0 || (dio >= 5 && dio <= 11))

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -983,11 +983,8 @@ bool loadConfig(const char *configPath)
             if (yamlConfig["Lora"]["rfswitch_table"]) {
                 portduino_config.has_rfswitch_table = true;
 
-                // LR2021 has a different OpMode_t enum than LR11x0:
-                //   LR11x0: STBY=0, RX=1, TX=2, TX_HP=3, TX_HF=4, GNSS=5, WIFI=6
-                //   LR2021: STBY=0, RX=1, TX=2, RX_HF=3, TX_HF=4  (no TX_HP/GNSS/WIFI)
-                // Using LR11x0 modes for an LR2021 would program incorrect DIO RF switch
-                // config bits (mode 4 = RX_HF not TX_HP; modes 6/7 don't exist).
+                // LR2021 OpMode_t differs from LR11x0: slot 3 = RX_HF (not TX_HP), slot 4 = TX_HF; no TX_HP/GNSS/WIFI.
+                // Using LR11x0 modes for LR2021 would program incorrect DIO RF switch config bits.
 #if !RADIOLIB_EXCLUDE_LR2021
                 if (portduino_config.lora_module == use_lr2021) {
                     portduino_config.rfswitch_table[0].mode = LR2021::MODE_STBY;

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -352,12 +352,8 @@ extern struct portduino_config_struct {
             }
             out << YAML::EndSeq;
 
-            // LR2021 has a different mode enum than LR11x0:
-            //   LR11x0: STBY=0, RX=1, TX=2, TX_HP=3, TX_HF=4, GNSS=5, WIFI=6 (7 entries)
-            //   LR2021: STBY=0, RX=1, TX=2, RX_HF=3, TX_HF=4 (5 entries, no GNSS/WIFI)
-            // The load path in PortduinoGlue.cpp branches on use_lr2021 to use the
-            // correct LR2021::MODE_* enums; this save path must match so configs
-            // round-trip correctly.
+            // LR2021 OpMode_t differs from LR11x0: slot 3 = RX_HF (not TX_HP), slot 4 = TX_HF; no TX_HP/GNSS/WIFI.
+            // The load path in PortduinoGlue.cpp branches on use_lr2021; this save path must match.
 #if !RADIOLIB_EXCLUDE_LR2021
             int numModes = (lora_module == use_lr2021) ? 5 : 7;
 #else

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -47,7 +47,8 @@ enum lora_module_enum {
     use_lr1110,
     use_lr1120,
     use_lr1121,
-    use_llcc68
+    use_llcc68,
+    use_lr2021
 };
 
 struct pinMapping {
@@ -76,9 +77,10 @@ std::string exec(const char *cmd);
 
 extern struct portduino_config_struct {
     // Lora
-    std::map<lora_module_enum, std::string> loraModules = {
-        {use_simradio, "sim"},  {use_autoconf, "auto"}, {use_rf95, "RF95"},     {use_sx1262, "sx1262"}, {use_sx1268, "sx1268"},
-        {use_sx1280, "sx1280"}, {use_lr1110, "lr1110"}, {use_lr1120, "lr1120"}, {use_lr1121, "lr1121"}, {use_llcc68, "LLCC68"}};
+    std::map<lora_module_enum, std::string> loraModules = {{use_simradio, "sim"},  {use_autoconf, "auto"}, {use_rf95, "RF95"},
+                                                           {use_sx1262, "sx1262"}, {use_sx1268, "sx1268"}, {use_sx1280, "sx1280"},
+                                                           {use_lr1110, "lr1110"}, {use_lr1120, "lr1120"}, {use_lr1121, "lr1121"},
+                                                           {use_llcc68, "LLCC68"}, {use_lr2021, "lr2021"}};
 
     std::map<screen_modules, std::string> screen_names = {{x11, "X11"},         {fb, "FB"},           {st7789, "ST7789"},
                                                           {st7735, "ST7735"},   {st7735s, "ST7735S"}, {st7796, "ST7796"},
@@ -100,6 +102,9 @@ extern struct portduino_config_struct {
     int sx128x_max_power = 13;
     int lr1110_max_power = 22;
     int lr1120_max_power = 13;
+    int lr2021_max_power = 22;
+    int lr2021_max_power_hf = 12;
+    int lr2021_irq_dio_num = 0; // 0 = use chip default (5); set to 5-11 to override
     int rf95_max_power = 20;
     bool dio2_as_rf_switch = false;
     int dio3_tcxo_voltage = 0;
@@ -287,6 +292,12 @@ extern struct portduino_config_struct {
             out << YAML::Key << "LR1110_MAX_POWER" << YAML::Value << lr1110_max_power;
         if (lr1120_max_power != 13)
             out << YAML::Key << "LR1120_MAX_POWER" << YAML::Value << lr1120_max_power;
+        if (lr2021_max_power != 22)
+            out << YAML::Key << "LR2021_MAX_POWER" << YAML::Value << lr2021_max_power;
+        if (lr2021_max_power_hf != 12)
+            out << YAML::Key << "LR2021_MAX_POWER_HF" << YAML::Value << lr2021_max_power_hf;
+        if (lr2021_irq_dio_num != 0)
+            out << YAML::Key << "IRQ_DIO_NUM" << YAML::Value << lr2021_irq_dio_num;
         if (rf95_max_power != 20)
             out << YAML::Key << "RF95_MAX_POWER" << YAML::Value << rf95_max_power;
 
@@ -338,7 +349,18 @@ extern struct portduino_config_struct {
             }
             out << YAML::EndSeq;
 
-            for (int i = 0; i < 7; i++) {
+            // LR2021 has a different mode enum than LR11x0:
+            //   LR11x0: STBY=0, RX=1, TX=2, TX_HP=3, TX_HF=4, GNSS=5, WIFI=6 (7 entries)
+            //   LR2021: STBY=0, RX=1, TX=2, RX_HF=3, TX_HF=4 (5 entries, no GNSS/WIFI)
+            // The load path in PortduinoGlue.cpp branches on use_lr2021 to use the
+            // correct LR2021::MODE_* enums; this save path must match so configs
+            // round-trip correctly.
+#if !RADIOLIB_EXCLUDE_LR2021
+            int numModes = (lora_module == use_lr2021) ? 5 : 7;
+#else
+            int numModes = 7;
+#endif
+            for (int i = 0; i < numModes; i++) {
                 switch (i) {
                 case 0:
                     out << YAML::Key << "MODE_STBY";
@@ -350,7 +372,11 @@ extern struct portduino_config_struct {
                     out << YAML::Key << "MODE_TX";
                     break;
                 case 3:
+#if !RADIOLIB_EXCLUDE_LR2021
+                    out << YAML::Key << ((lora_module == use_lr2021) ? "MODE_RX_HF" : "MODE_TX_HP");
+#else
                     out << YAML::Key << "MODE_TX_HP";
+#endif
                     break;
                 case 4:
                     out << YAML::Key << "MODE_TX_HF";

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -77,10 +77,13 @@ std::string exec(const char *cmd);
 
 extern struct portduino_config_struct {
     // Lora
-    std::map<lora_module_enum, std::string> loraModules = {{use_simradio, "sim"},  {use_autoconf, "auto"}, {use_rf95, "RF95"},
-                                                           {use_sx1262, "sx1262"}, {use_sx1268, "sx1268"}, {use_sx1280, "sx1280"},
-                                                           {use_lr1110, "lr1110"}, {use_lr1120, "lr1120"}, {use_lr1121, "lr1121"},
-                                                           {use_llcc68, "LLCC68"}, {use_lr2021, "lr2021"}};
+    std::map<lora_module_enum, std::string> loraModules = {
+        {use_simradio, "sim"},  {use_autoconf, "auto"}, {use_rf95, "RF95"},     {use_sx1262, "sx1262"}, {use_sx1268, "sx1268"},
+        {use_sx1280, "sx1280"}, {use_lr1110, "lr1110"}, {use_lr1120, "lr1120"}, {use_lr1121, "lr1121"}, {use_llcc68, "LLCC68"},
+#if !RADIOLIB_EXCLUDE_LR2021
+        {use_lr2021, "lr2021"}
+#endif
+    };
 
     std::map<screen_modules, std::string> screen_names = {{x11, "X11"},         {fb, "FB"},           {st7789, "ST7789"},
                                                           {st7735, "ST7735"},   {st7735s, "ST7735S"}, {st7796, "ST7796"},

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -105,8 +105,6 @@ extern struct portduino_config_struct {
     int sx128x_max_power = 13;
     int lr1110_max_power = 22;
     int lr1120_max_power = 13;
-    int lr2021_max_power = 22;
-    int lr2021_max_power_hf = 12;
     int lr2021_irq_dio_num = 0; // 0 = use chip default (5); set to 5-11 to override
     int rf95_max_power = 20;
     bool dio2_as_rf_switch = false;
@@ -295,10 +293,6 @@ extern struct portduino_config_struct {
             out << YAML::Key << "LR1110_MAX_POWER" << YAML::Value << lr1110_max_power;
         if (lr1120_max_power != 13)
             out << YAML::Key << "LR1120_MAX_POWER" << YAML::Value << lr1120_max_power;
-        if (lr2021_max_power != 22)
-            out << YAML::Key << "LR2021_MAX_POWER" << YAML::Value << lr2021_max_power;
-        if (lr2021_max_power_hf != 12)
-            out << YAML::Key << "LR2021_MAX_POWER_HF" << YAML::Value << lr2021_max_power_hf;
         if (lr2021_irq_dio_num != 0)
             out << YAML::Key << "IRQ_DIO_NUM" << YAML::Value << lr2021_irq_dio_num;
         if (rf95_max_power != 20)

--- a/variants/native/portduino.ini
+++ b/variants/native/portduino.ini
@@ -46,6 +46,7 @@ lib_deps =
 build_flags_common =
   ${arduino_base.build_flags}
   -D ARCH_PORTDUINO
+  -D USE_LR2021
   -fPIC
   -Isrc/platform/portduino
   -DRADIOLIB_EEPROM_UNSUPPORTED

--- a/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/rfswitch.h
+++ b/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/rfswitch.h
@@ -6,6 +6,8 @@
 #define LR20x0 LR2021
 #endif
 
+#ifndef RFSWITCH_NRF52TCXO_LR11X0_DEFINED
+#define RFSWITCH_NRF52TCXO_LR11X0_DEFINED
 // This is rewritten to match the requirements of the E80-900M2213S
 // The E80 does not conform to the reference Semtech switches(!) and therefore needs a custom matrix.
 // See footnote #3 in "https://www.cdebyte.com/products/E80-900M2213S/2#Pin"
@@ -30,14 +32,26 @@ static const Module::RfSwitchMode_t rfswitch_table[] = {
     END_OF_MODE_TABLE,
     // clang-format on
 };
-#endif
+#endif // USE_LR1121
+#endif // RFSWITCH_NRF52TCXO_LR11X0_DEFINED
 
 // LR2021 RF switch matrix following the standard Semtech / Seeed T1000-E reference topology.
 // DIO5 -> antenna path select (HIGH = sub-GHz LF)
 // DIO6 -> TX enable / HP PA select
 // DIO7 -> not connected (no GNSS on LR2021)
 // DIO8 -> RF front-end power enable
+//
+// LR20X0_RFSWITCH_NATIVE tells LR20x0Interface.cpp that lr20x0_rfswitch_* are defined here
+// directly, so it should not alias rfswitch_dio_pins (which points to the LR11x0 table above).
+#ifndef RFSWITCH_NRF52TCXO_LR20X0_DEFINED
+#define RFSWITCH_NRF52TCXO_LR20X0_DEFINED
 #ifdef USE_LR2021
+#define LR20X0_RFSWITCH_NATIVE
+// DIO7 is in the pin array for RF switch matrix completeness (the T1000-E reference
+// topology includes it in the control bus), but all mode entries drive it LOW - it is
+// not physically connected on this variant. Using RADIOLIB_NC here would skip the pin
+// in setRfSwitchTable(), which is fine functionally, but keeping it mapped ensures the
+// pin array indices align with the mode table column layout.
 static const uint32_t lr20x0_rfswitch_dio_pins[] = {RADIOLIB_LR2021_DIO5, RADIOLIB_LR2021_DIO6, RADIOLIB_LR2021_DIO7,
                                                     RADIOLIB_LR2021_DIO8, RADIOLIB_NC};
 
@@ -52,4 +66,5 @@ static const Module::RfSwitchMode_t lr20x0_rfswitch_table[] = {
     END_OF_MODE_TABLE,
     // clang-format on
 };
-#endif
+#endif // USE_LR2021
+#endif // RFSWITCH_NRF52TCXO_LR20X0_DEFINED


### PR DESCRIPTION
Add full LR2021 radio support for meshtasticd on Linux native builds, including USB (CH341) and SPI (GPIO) configurations.

Key changes:

PortduinoGlue (config plumbing):
- Add use_lr2021 to lora_module_enum and loraModules map
- Add lr2021_max_power, lr2021_max_power_hf, lr2021_irq_dio_num config fields
- Parse LR2021_MAX_POWER, LR2021_MAX_POWER_HF, IRQ_DIO_NUM (and LR2021_IRQ_DIO_NUM alias) from YAML
- Use LR2021::MODE_* enums for rfswitch_table when module is lr2021 (LR2021 has MODE_RX_HF at value 4 where LR11x0 has MODE_TX_HP; no MODE_GNSS/MODE_WIFI)
- Parse MODE_RX_HF YAML key for LR2021 configs instead of MODE_TX_HP
- Branch YAML serialization on use_lr2021 so configs round-trip correctly

LR20x0Interface (radio driver):
- Set irqDioNum BEFORE lora.begin() so config() programs the correct DIO for IRQ routing. Setting it after begin() is too late - config() has already configured DIO5 as IRQ, then setRfSwitchTable() overrides it to RF_SWITCH, breaking all radio interrupts. This is the fix for the DIO5 IRQ/RF-switch conflict that caused meshtasticd to crash (SIGABRT/segfault) on TX when DIO5 is used for both IRQ and RF switch control.
- Add ARCH_PORTDUINO path for reading irqDioNum from config
- Add LR20X0_RFSWITCH_NATIVE guard for variant-defined RF switch tables

LR11x0Interface (symbol namespacing):
- Namespace RF switch symbols as lr11x0_rfswitch_* to prevent collisions when LR11x0 and LR20x0 templates share a translation unit (InterfacesTemplates.cpp). Removes the old #undef hack.

RadioInterface:
- Add case use_lr2021 to construct LR2021Interface in portduino mode
- Guard hardcoded SPI pin fallback with !defined(ARCH_PORTDUINO)

ProMicro rfswitch.h:
- Add per-table include guards (RFSWITCH_NRF52TCXO_LR11X0_DEFINED, RFSWITCH_NRF52TCXO_LR20X0_DEFINED) to prevent redefinition
- Nest #ifdef USE_LR1121 / #ifdef USE_LR2021 inside include guards so tables are only emitted when their radio is built
- Add LR20X0_RFSWITCH_NATIVE define so LR20x0Interface uses the variant's native lr20x0_rfswitch_* symbols
- Add explanatory comment for DIO7 (in pin array for matrix completeness, never driven HIGH on this variant)

Native build config:
- Add -D USE_LR2021 to portduino.ini build flags

Sample configs:
- lora-femtofox_LR2021_TCXO.yaml: SPI/GPIO config for Luckfox Pico Mini with GNiceRF LoRa2021F33-2G4 module (DIO3 TCXO, DIO5-8 RF switch, IRQ_DIO_NUM: 9 to avoid DIO5 conflict)
- lora-usb-meshtoad-nicerflora2021f33.yaml: USB/CH341 config for NiceRF LoRa2021F33 module

Ref: meshtastic/firmware#10567 (portions of LR11x0 symbol namespacing, ProMicro rfswitch.h guards, and USB config YAML adapted from this PR)

This PR was indirectly co-authored by: @jessm33 - I modified my PR to include their findings as well as the comments from Copilot/other bots on Jess' original PR.

## 🤝 Attestations
- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [X] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [X] Other (please specify below)
    - [X] mPWRD-OS FemtoFox Pro Alpha 1.7 w/ GNiceRF LoRa2021F33


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new configuration profiles for a Femtofox LR2021 with TCXO LoRa module and a NiceRF LoRa2021F33 “meshtoad2021” USB radio.
  * Enabled LR2021 support on Portduino, including an LR2021 module option, configurable IRQ DIO routing, and LR2021-aware RF switch behavior for HF RX/TX.
* **Bug Fixes**
  * Improved IRQ DIO selection and validation to avoid routing conflicts.
  * Corrected RF switch table ordering/mode mappings across LR11x0 and LR20x0/LR2021, and tightened default LR2021 power limiting (22 dBm sub-GHz / 12 dBm 2.4 GHz).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->