### PR TITLE
Add RadioMaster Nomad primary 915 MHz support

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -41,6 +41,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Offer chance for variant-specific defines */
 #include "variant.h"
 
+#if defined(RF95_FAN_EN) && !defined(RADIO_FAN_EN)
+#define RADIO_FAN_EN RF95_FAN_EN
+#endif
+
 // -----------------------------------------------------------------------------
 // Display feature overrides
 // -----------------------------------------------------------------------------

--- a/src/input/InputBroker.cpp
+++ b/src/input/InputBroker.cpp
@@ -403,8 +403,10 @@ void InputBroker::Init()
             rotaryEncoderInterruptImpl1 = nullptr;
         }
 #endif
+#if !MESHTASTIC_EXCLUDE_I2C
         cardKbI2cImpl = new CardKbI2cImpl();
         cardKbI2cImpl->init();
+#endif
 #if defined(M5STACK_UNITC6L)
         i2cButton = new i2cButtonThread("i2cButtonThread");
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1136,16 +1136,15 @@ void setup()
     mqttInit();
 #endif
 
-#ifdef RF95_FAN_EN
-    // Ability to disable FAN if PIN has been set with RF95_FAN_EN.
-    // Make sure LoRa has been started before disabling FAN.
-    if (config.lora.pa_fan_disabled)
-        digitalWrite(RF95_FAN_EN, LOW ^ 0);
+#ifdef RADIO_FAN_EN
+    // Fan control is active-high and defaults on unless disabled by LoRa config.
+    pinMode(RADIO_FAN_EN, OUTPUT);
+    digitalWrite(RADIO_FAN_EN, config.lora.pa_fan_disabled ? LOW : HIGH);
 #endif
 
 #ifndef ARCH_PORTDUINO
 
-        // Initialize Wifi
+    // Initialize Wifi
 #if HAS_WIFI
     initWifi();
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -264,6 +264,8 @@ bool pauseBluetoothLogging = false;
 
 bool pmu_found;
 
+uint8_t pa_fan_percentage = 50;
+
 #if !MESHTASTIC_EXCLUDE_I2C
 // Array map of sensor types with i2c address and wire as we'll find in the i2c scan
 std::pair<uint8_t, TwoWire *> nodeTelemetrySensorsMap[_meshtastic_TelemetrySensorType_MAX + 1] = {};
@@ -1136,16 +1138,36 @@ void setup()
     mqttInit();
 #endif
 
-#ifdef RF95_FAN_EN
-    // Ability to disable FAN if PIN has been set with RF95_FAN_EN.
+#ifdef RADIO_FAN_EN
+    // Ability to disable FAN if PIN has been set with RADIO_FAN_EN.
     // Make sure LoRa has been started before disabling FAN.
-    if (config.lora.pa_fan_disabled)
-        digitalWrite(RF95_FAN_EN, LOW ^ 0);
+#ifdef RADIO_FAN_PWM
+#if defined(ARCH_ESP32)
+    // Set up PWM at Channel 1 at 25KHz, using 8-bit resolution
+    // Turn ON/OFF fan to the specified value if enabled by config.
+    // code by https://github.com/gjelsoe/
+    if (ledcSetup(1, 25000, 8)) {
+        ledcAttachPin(RADIO_FAN_EN, 1);
+        LOG_INFO("PWM init C1 P%d\n", RADIO_FAN_EN);
+        // Set PWM duty cycle based on fan disabled state
+        ledcWrite(1, config.lora.pa_fan_disabled ? 0 : (pa_fan_percentage * 2.55));
+    } else {
+        LOG_WARN("PWM init fail P%d\n", RADIO_FAN_EN);
+    }
+#elif defined(ARCH_NRF52)
+    pinMode(RADIO_FAN_EN, OUTPUT);
+    analogWrite(RADIO_FAN_EN, config.lora.pa_fan_disabled ? 0 : (pa_fan_percentage * 2.55));
+#endif
+#else
+    // Set up as ON/OFF switch of fan; default on unless disabled by config.
+    pinMode(RADIO_FAN_EN, OUTPUT);
+    digitalWrite(RADIO_FAN_EN, config.lora.pa_fan_disabled ? (LOW ^ 0) : (HIGH ^ 0));
+#endif
 #endif
 
 #ifndef ARCH_PORTDUINO
 
-        // Initialize Wifi
+    // Initialize Wifi
 #if HAS_WIFI
     initWifi();
 #endif

--- a/src/main.h
+++ b/src/main.h
@@ -107,6 +107,8 @@ extern volatile bool lockdownDisablePending;
 
 extern uint32_t serialSinceMsec;
 
+extern uint8_t pa_fan_percentage;
+
 // If a thread does something that might need for it to be rescheduled ASAP it can set this flag
 // This will suppress the current delay and instead try to run ASAP.
 extern bool runASAP;

--- a/src/mesh/LR1121Interface.cpp
+++ b/src/mesh/LR1121Interface.cpp
@@ -11,6 +11,10 @@ LR1121Interface::LR1121Interface(LockingArduinoHal *hal, RADIOLIB_PIN_TYPE cs, R
 
 bool LR1121Interface::wideLora()
 {
+#ifdef LR1121_SUBGHZ_ONLY
+    return false;
+#else
     return true;
+#endif
 }
 #endif

--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -54,6 +54,8 @@ template <typename T> bool LR11x0Interface<T>::init()
     digitalWrite(LR11X0_POWER_EN, HIGH);
 #endif
 
+    enableFan();
+
 #if ARCH_PORTDUINO
     float tcxoVoltage = (float)portduino_config.dio3_tcxo_voltage / 1000;
 // FIXME: correct logic to default to not using TCXO if no voltage is specified for LR11x0_DIO3_TCXO_VOLTAGE

--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -1,8 +1,10 @@
 #if RADIOLIB_EXCLUDE_LR11X0 != 1
 #include "LR11x0Interface.h"
+#include "RadioExternalPa.h"
 #include "Throttle.h"
 #include "configuration.h"
 #include "error.h"
+#include "main.h"
 #include "mesh/NodeDB.h"
 #ifdef LR11X0_DIO_AS_RF_SWITCH
 #include "rfswitch.h"
@@ -53,6 +55,8 @@ template <typename T> bool LR11x0Interface<T>::init()
     pinMode(LR11X0_POWER_EN, OUTPUT);
     digitalWrite(LR11X0_POWER_EN, HIGH);
 #endif
+
+    enableFan();
 
 #if ARCH_PORTDUINO
     float tcxoVoltage = (float)portduino_config.dio3_tcxo_voltage / 1000;
@@ -254,6 +258,7 @@ template <typename T> void LR11x0Interface<T>::addReceiveMetadata(meshtastic_Mes
  */
 template <typename T> void LR11x0Interface<T>::configHardwareForSend()
 {
+    radioExternalPaTxEnable(); // bias an external PA (if any) before we transmit
     RadioLibInterface::configHardwareForSend();
 }
 
@@ -267,6 +272,8 @@ template <typename T> void LR11x0Interface<T>::startReceive()
 #else
 
     setStandby();
+
+    radioExternalPaRxIdle(); // drop external PA bias while receiving/idle
 
     lora.setPreambleLength(preambleLength); // Solve RX ack fail after direct message sent.  Not sure why this is needed.
 
@@ -354,6 +361,8 @@ template <typename T> bool LR11x0Interface<T>::sleep()
     // \todo Display actual typename of the adapter, not just `LR11x0`
     LOG_DEBUG("LR11x0 entering sleep mode");
     setStandby(); // Stop any pending operations
+
+    radioExternalPaSleep(); // power down an external PA (if any)
 
     // turn off TCXO if it was powered
     lora.setTCXO(0);

--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -154,10 +154,7 @@ bool RF95Interface::init()
     digitalWrite(RF95_TXEN, 0);
 #endif
 
-#ifdef RF95_FAN_EN
-    pinMode(RF95_FAN_EN, OUTPUT);
-    digitalWrite(RF95_FAN_EN, 1);
-#endif
+    enableFan();
 
 #ifdef RF95_RXEN
     pinMode(RF95_RXEN, OUTPUT);
@@ -334,10 +331,7 @@ bool RF95Interface::sleep()
     // put chipset into sleep mode
     setStandby(); // First cancel any active receiving/sending
     lora->sleep();
-
-#ifdef RF95_FAN_EN
-    digitalWrite(RF95_FAN_EN, 0);
-#endif
+    disableFan();
 
     return true;
 }

--- a/src/mesh/RadioExternalPa.cpp
+++ b/src/mesh/RadioExternalPa.cpp
@@ -1,0 +1,18 @@
+#include "RadioExternalPa.h"
+
+// Weak default implementations: no external PA. A board with an external PA
+// provides strong overrides (see e.g.
+// src/platform/extra_variants/radiomaster_nomad_gemini/variant.cpp).
+
+int8_t __attribute__((weak)) radioExternalPaMapPower(int8_t requestedTotalDbm, float freqHz)
+{
+    (void)freqHz;
+    (void)requestedTotalDbm;
+    return RADIO_EXTERNAL_PA_NO_MAP;
+}
+
+void __attribute__((weak)) radioExternalPaTxEnable() {}
+
+void __attribute__((weak)) radioExternalPaRxIdle() {}
+
+void __attribute__((weak)) radioExternalPaSleep() {}

--- a/src/mesh/RadioExternalPa.h
+++ b/src/mesh/RadioExternalPa.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <stdint.h>
+
+/** Map desired total output to chip dBm and configure the external PA at the operating frequency in MHz. */
+int8_t radioExternalPaMapPower(int8_t requestedTotalDbm, float frequencyMhz);

--- a/src/mesh/RadioExternalPa.h
+++ b/src/mesh/RadioExternalPa.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <stdint.h>
+
+/**
+ * Generic hooks for boards with an external power amplifier whose gain/bias is
+ * controlled outside the LoRa transceiver (e.g. an analog PA biased through a DAC
+ * pin, as on the RadioMaster Nomad Gemini).
+ *
+ * All four functions have weak no-op / pass-through defaults (see RadioExternalPa.cpp),
+ * so boards without an external PA are completely unaffected. A board provides an
+ * external PA by giving STRONG overrides (typically in its
+ * src/platform/extra_variants/<board>/variant.cpp).
+ *
+ * Relationship to the existing TX_GAIN_LORA / LoRaFEMInterface mechanisms:
+ *   - TX_GAIN_LORA assumes the chip output index is a non-negative dBm value.
+ *   - LoRaFEMInterface models *digital* front-end modules (discrete enable pins).
+ * An analog PA that needs the transceiver driven at negative dBm fits neither, so it
+ * is handled here instead.
+ */
+
+/// Sentinel returned by radioExternalPaMapPower() when the board has no external PA.
+#define RADIO_EXTERNAL_PA_NO_MAP INT8_MIN
+
+/**
+ * Map a desired *total* radiated output power to the transceiver chip output power.
+ *
+ * Called from RadioInterface::limitPower() AFTER regional/regulatory clamping, so
+ * @p requestedTotalDbm is already the legal total output we want out of the antenna.
+ * The override returns the chip output power (dBm, may be negative) that, combined
+ * with the external PA gain, yields that total, and configures/stashes the PA bias.
+ *
+ * @param requestedTotalDbm desired total output power in dBm (already region-limited)
+ * @param freqHz            operating frequency in Hz (for band-dependent PAs)
+ * @return chip output power in dBm, or RADIO_EXTERNAL_PA_NO_MAP if no external PA
+ */
+int8_t radioExternalPaMapPower(int8_t requestedTotalDbm, float freqHz);
+
+/// Engage the external PA bias for transmit (called just before a transmission).
+void radioExternalPaTxEnable();
+
+/// Drop the external PA bias for receive/idle (called when entering RX/standby).
+void radioExternalPaRxIdle();
+
+/// Power the external PA fully down (called when the radio goes to sleep).
+void radioExternalPaSleep();

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -10,6 +10,7 @@
 #include "MeshService.h"
 #include "NodeDB.h"
 #include "RF95Interface.h"
+#include "RadioExternalPa.h"
 #include "Router.h"
 #include "SX1262Interface.h"
 #include "SX1268Interface.h"
@@ -1411,38 +1412,50 @@ void RadioInterface::limitPower(int8_t loraMaxPower)
         power = maxPower;
     }
 
+    // Boards with an external PA controlled outside the transceiver (e.g. an analog PA
+    // biased through a DAC pin) map the desired total output to a possibly-negative chip
+    // output power here. This is applied even for licensed operators, because it reflects
+    // a hardware gain stage, not a regulatory limit (the regulatory clamp above already
+    // honors the license). Pass-through by default; see RadioExternalPa.h.
+    int8_t externalPaChip = radioExternalPaMapPower(power, getFreq());
+    if (externalPaChip != RADIO_EXTERNAL_PA_NO_MAP) {
+        LOG_INFO("External PA: %d dBm total -> chip %d dBm", power, externalPaChip);
+        power = externalPaChip;
+    } else {
 #if HAS_LORA_FEM
-    if (!devicestate.owner.is_licensed) {
-        power = loraFEMInterface.powerConversion(power);
-    }
+        if (!devicestate.owner.is_licensed) {
+            power = loraFEMInterface.powerConversion(power);
+        }
 #else
 // todo:All entries containing "lora fem" are grouped together above.
 #ifdef ARCH_PORTDUINO
-    size_t num_pa_points = portduino_config.num_pa_points;
-    const uint16_t *tx_gain = portduino_config.tx_gain_lora;
+        size_t num_pa_points = portduino_config.num_pa_points;
+        const uint16_t *tx_gain = portduino_config.tx_gain_lora;
 #else
-    size_t num_pa_points = NUM_PA_POINTS;
-    const uint16_t tx_gain[NUM_PA_POINTS] = {TX_GAIN_LORA};
+        size_t num_pa_points = NUM_PA_POINTS;
+        const uint16_t tx_gain[NUM_PA_POINTS] = {TX_GAIN_LORA};
 #endif
 
-    if (num_pa_points == 1) {
-        if (tx_gain[0] > 0 && !devicestate.owner.is_licensed) {
-            LOG_INFO("Requested Tx power: %d dBm; Device LoRa Tx gain: %d dB", power, tx_gain[0]);
-            power -= tx_gain[0];
-        }
-    } else if (!devicestate.owner.is_licensed) {
-        // we have an array of PA gain values.  Find the highest power setting that works.
-        for (int radio_dbm = 0; radio_dbm < (int)num_pa_points; radio_dbm++) {
-            if (((radio_dbm + tx_gain[radio_dbm]) > power) ||
-                ((radio_dbm == (int)(num_pa_points - 1)) && ((radio_dbm + tx_gain[radio_dbm]) <= power))) {
-                // we've exceeded the power limit, or hit the max we can do
-                LOG_INFO("Requested Tx power: %d dBm; Device LoRa Tx gain: %d dB", power, tx_gain[radio_dbm]);
-                power -= tx_gain[radio_dbm];
-                break;
+        if (num_pa_points == 1) {
+            if (tx_gain[0] > 0 && !devicestate.owner.is_licensed) {
+                LOG_INFO("Requested Tx power: %d dBm; Device LoRa Tx gain: %d dB", power, tx_gain[0]);
+                power -= tx_gain[0];
+            }
+        } else if (!devicestate.owner.is_licensed) {
+            // we have an array of PA gain values.  Find the highest power setting that works.
+            for (int radio_dbm = 0; radio_dbm < (int)num_pa_points; radio_dbm++) {
+                if (((radio_dbm + tx_gain[radio_dbm]) > power) ||
+                    ((radio_dbm == (int)(num_pa_points - 1)) && ((radio_dbm + tx_gain[radio_dbm]) <= power))) {
+                    // we've exceeded the power limit, or hit the max we can do
+                    LOG_INFO("Requested Tx power: %d dBm; Device LoRa Tx gain: %d dB", power, tx_gain[radio_dbm]);
+                    power -= tx_gain[radio_dbm];
+                    break;
+                }
             }
         }
-    }
 #endif
+    }
+
     if (power > loraMaxPower) // Clamp power to maximum defined level
         power = loraMaxPower;
 

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -10,6 +10,9 @@
 #include "MeshService.h"
 #include "NodeDB.h"
 #include "RF95Interface.h"
+#ifdef RADIO_EXTERNAL_PA
+#include "RadioExternalPa.h"
+#endif
 #include "Router.h"
 #include "SX1262Interface.h"
 #include "SX1268Interface.h"
@@ -1411,6 +1414,11 @@ void RadioInterface::limitPower(int8_t loraMaxPower)
         power = maxPower;
     }
 
+#ifdef RADIO_EXTERNAL_PA
+    const int8_t externalPaChip = radioExternalPaMapPower(power, getFreq());
+    LOG_INFO("External PA: %d dBm total -> chip %d dBm", power, externalPaChip);
+    power = externalPaChip;
+#else
 #if HAS_LORA_FEM
     if (!devicestate.owner.is_licensed) {
         power = loraFEMInterface.powerConversion(power);
@@ -1443,6 +1451,8 @@ void RadioInterface::limitPower(int8_t loraMaxPower)
         }
     }
 #endif
+#endif
+
     if (power > loraMaxPower) // Clamp power to maximum defined level
         power = loraMaxPower;
 

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -797,3 +797,36 @@ bool RadioLibInterface::startSend(meshtastic_MeshPacket *txp)
         return res == RADIOLIB_ERR_NONE;
     }
 }
+
+void RadioLibInterface::enableFan()
+{
+#ifdef RADIO_FAN_EN
+
+#ifdef RADIO_FAN_PWM
+#if defined(ARCH_ESP32)
+    ledcWrite(1, config.lora.pa_fan_disabled ? 0 : (pa_fan_percentage * 2.55));
+#elif defined(ARCH_NRF52)
+    analogWrite(RADIO_FAN_EN, config.lora.pa_fan_disabled ? 0 : (pa_fan_percentage * 2.55));
+#endif
+#else
+    pinMode(RADIO_FAN_EN, OUTPUT);
+    digitalWrite(RADIO_FAN_EN, config.lora.pa_fan_disabled ? 0 : 1);
+#endif
+#endif
+}
+
+void RadioLibInterface::disableFan()
+{
+#ifdef RADIO_FAN_EN
+#ifdef RADIO_FAN_PWM
+#if defined(ARCH_ESP32)
+    ledcWrite(1, 0);
+#elif defined(ARCH_NRF52)
+    analogWrite(RADIO_FAN_EN, 0);
+#endif
+#else
+    pinMode(RADIO_FAN_EN, OUTPUT);
+    digitalWrite(RADIO_FAN_EN, 0);
+#endif
+#endif
+}

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -797,3 +797,19 @@ bool RadioLibInterface::startSend(meshtastic_MeshPacket *txp)
         return res == RADIOLIB_ERR_NONE;
     }
 }
+
+void RadioLibInterface::enableFan()
+{
+#ifdef RADIO_FAN_EN
+    pinMode(RADIO_FAN_EN, OUTPUT);
+    digitalWrite(RADIO_FAN_EN, config.lora.pa_fan_disabled ? LOW : HIGH);
+#endif
+}
+
+void RadioLibInterface::disableFan()
+{
+#ifdef RADIO_FAN_EN
+    pinMode(RADIO_FAN_EN, OUTPUT);
+    digitalWrite(RADIO_FAN_EN, LOW);
+#endif
+}

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -211,6 +211,9 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
     /** Attempt to find a packet in the TxQueue. Returns true if the packet was found. */
     virtual bool findInTxQueue(NodeNum from, PacketId id) override;
 
+    void enableFan();
+    void disableFan();
+
     /**
      * Update the noise floor measurement by sampling RSSI from a slow path.
      * This should not be called from radio interrupt or TX/RX critical paths.

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -64,10 +64,7 @@ template <typename T> bool SX126xInterface<T>::init()
     }
 #endif
 
-#ifdef RF95_FAN_EN
-    pinMode(RF95_FAN_EN, OUTPUT);
-    digitalWrite(RF95_FAN_EN, HIGH);
-#endif
+    enableFan();
 
 #if ARCH_PORTDUINO
     tcxoVoltage = (float)portduino_config.dio3_tcxo_voltage / 1000;

--- a/src/mesh/SX128xInterface.cpp
+++ b/src/mesh/SX128xInterface.cpp
@@ -35,10 +35,7 @@ template <typename T> bool SX128xInterface<T>::init()
     digitalWrite(SX128X_POWER_EN, HIGH);
 #endif
 
-#ifdef RF95_FAN_EN
-    pinMode(RF95_FAN_EN, OUTPUT);
-    digitalWrite(RF95_FAN_EN, 1);
-#endif
+    enableFan();
 
 #if ARCH_PORTDUINO
     if (portduino_config.lora_rxen_pin.pin != RADIOLIB_NC) {

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -1071,13 +1071,8 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
         }
 #endif
 
-#ifdef RF95_FAN_EN
-        // Turn PA off if disabled by config
-        if (c.payload_variant.lora.pa_fan_disabled) {
-            digitalWrite(RF95_FAN_EN, LOW ^ 0);
-        } else {
-            digitalWrite(RF95_FAN_EN, HIGH ^ 0);
-        }
+#ifdef RADIO_FAN_EN
+        digitalWrite(RADIO_FAN_EN, validatedLora.pa_fan_disabled ? LOW : HIGH);
 #endif
 
 #if HAS_LORA_FEM

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -1071,13 +1071,21 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
         }
 #endif
 
-#ifdef RF95_FAN_EN
+#ifdef RADIO_FAN_EN
+#ifdef RADIO_FAN_PWM
+#if defined(ARCH_ESP32)
+        ledcWrite(1, c.payload_variant.lora.pa_fan_disabled ? 0 : (pa_fan_percentage * 2.55));
+#elif defined(ARCH_NRF52)
+        analogWrite(RADIO_FAN_EN, c.payload_variant.lora.pa_fan_disabled ? 0 : (pa_fan_percentage * 2.55));
+#endif
+#else
         // Turn PA off if disabled by config
         if (c.payload_variant.lora.pa_fan_disabled) {
-            digitalWrite(RF95_FAN_EN, LOW ^ 0);
+            digitalWrite(RADIO_FAN_EN, LOW ^ 0);
         } else {
-            digitalWrite(RF95_FAN_EN, HIGH ^ 0);
+            digitalWrite(RADIO_FAN_EN, HIGH ^ 0);
         }
+#endif
 #endif
 
 #if HAS_LORA_FEM

--- a/src/platform/extra_variants/radiomaster_nomad_gemini/variant.cpp
+++ b/src/platform/extra_variants/radiomaster_nomad_gemini/variant.cpp
@@ -1,0 +1,97 @@
+#include "configuration.h"
+
+#ifdef RADIOMASTER_NOMAD_GEMINI
+
+#include "RadioExternalPa.h"
+#include <Arduino.h>
+
+/**
+ * RadioMaster Nomad Gemini external analog PA driver.
+ *
+ * The Nomad's PA is biased by an analog control voltage on the APC2 pin
+ * (RADIO_PA_APC2_PIN = GPIO26 = ESP32 DAC channel 2), driven with dacWrite()
+ * (0-255 -> 0-3.3V). The DAC is essentially a fixed bias; the actual output power
+ * is set by driving the LR1121 chip at a (negative) output power and letting the PA
+ * add ~25-31 dB of gain.
+ *
+ * The calibration below is derived from the ExpressLRS hardware target
+ * "TX/Radiomaster Nomad.json" (power_values = APC2 DAC codes, power_values2 = chip
+ * output dBm). These values reproduce ELRS behaviour but have NOT been validated on
+ * a bench against a power meter for Meshtastic — verify before trusting at 1 W, both
+ * for PA safety and for regulatory compliance.
+ *
+ * TODO: dual-band (Gemini) operation uses ELRS power_values_dual and a second radio;
+ * once JANUS_RADIO is implemented, branch on freqHz / active radio here.
+ */
+
+// total dBm corresponds to the ELRS power presets 10/25/50/100/250/500/1000 mW.
+static const struct {
+    int8_t totalDbm; // desired total radiated power
+    int8_t chipDbm;  // LR1121 output power register (ELRS power_values2)
+    uint8_t apc2;    // APC2 DAC code (ELRS power_values)
+} NOMAD_PA_CAL[] = {
+    {10, -17, 120}, // 10 mW
+    {14, -16, 120}, // 25 mW
+    {17, -14, 120}, // 50 mW
+    {20, -11, 120}, // 100 mW
+    {24, -7, 120},  // 250 mW
+    {27, -3, 120},  // 500 mW
+    {30, 5, 95},    // 1000 mW (1 W)
+};
+static const size_t NOMAD_PA_CAL_N = sizeof(NOMAD_PA_CAL) / sizeof(NOMAD_PA_CAL[0]);
+
+// APC2 bias chosen for the currently-configured power level; applied on TX, dropped
+// to 0 for RX/idle/sleep so the PA only draws current while transmitting.
+static uint8_t nomadApc2Level = 0;
+
+// Runs at the start of setup(), before the LoRa radio is initialized.
+void earlyInitVariant()
+{
+    dacWrite(RADIO_PA_APC2_PIN, 0); // bias the PA off until we actually transmit
+    nomadApc2Level = 0;
+}
+
+int8_t radioExternalPaMapPower(int8_t requestedTotalDbm, float freqHz)
+{
+    (void)freqHz; // single-band for now (see dual-band TODO above)
+
+    if (requestedTotalDbm <= NOMAD_PA_CAL[0].totalDbm) {
+        nomadApc2Level = NOMAD_PA_CAL[0].apc2;
+        return NOMAD_PA_CAL[0].chipDbm;
+    }
+    const size_t last = NOMAD_PA_CAL_N - 1;
+    if (requestedTotalDbm >= NOMAD_PA_CAL[last].totalDbm) {
+        nomadApc2Level = NOMAD_PA_CAL[last].apc2;
+        return NOMAD_PA_CAL[last].chipDbm;
+    }
+
+    // Piecewise-linear interpolation of chip dBm between the bracketing points.
+    for (size_t i = 1; i < NOMAD_PA_CAL_N; i++) {
+        if (requestedTotalDbm <= NOMAD_PA_CAL[i].totalDbm) {
+            const int t0 = NOMAD_PA_CAL[i - 1].totalDbm, t1 = NOMAD_PA_CAL[i].totalDbm;
+            const int c0 = NOMAD_PA_CAL[i - 1].chipDbm, c1 = NOMAD_PA_CAL[i].chipDbm;
+            const int chip = c0 + ((c1 - c0) * (requestedTotalDbm - t0) + (t1 - t0) / 2) / (t1 - t0); // round-to-nearest
+            nomadApc2Level = NOMAD_PA_CAL[i - 1].apc2; // only the top point lowers the bias
+            return (int8_t)chip;
+        }
+    }
+    nomadApc2Level = NOMAD_PA_CAL[last].apc2; // unreachable
+    return NOMAD_PA_CAL[last].chipDbm;
+}
+
+void radioExternalPaTxEnable()
+{
+    dacWrite(RADIO_PA_APC2_PIN, nomadApc2Level);
+}
+
+void radioExternalPaRxIdle()
+{
+    dacWrite(RADIO_PA_APC2_PIN, 0);
+}
+
+void radioExternalPaSleep()
+{
+    dacWrite(RADIO_PA_APC2_PIN, 0);
+}
+
+#endif // RADIOMASTER_NOMAD_GEMINI

--- a/src/platform/extra_variants/radiomaster_nomad_gemini/variant.cpp
+++ b/src/platform/extra_variants/radiomaster_nomad_gemini/variant.cpp
@@ -1,0 +1,39 @@
+#include "configuration.h"
+
+#ifdef RADIOMASTER_NOMAD_GEMINI
+
+#include "RadioExternalPa.h"
+#include <Arduino.h>
+
+static const struct {
+    int8_t totalDbm;
+    int8_t chipDbm;
+    uint8_t apc2;
+} NOMAD_PA_CAL[] = {
+    {10, -17, 150}, {14, -16, 120}, {17, -14, 120}, {20, -11, 120}, {24, -7, 120}, {27, -3, 120}, {30, 5, 95},
+};
+static const size_t NOMAD_PA_CAL_N = sizeof(NOMAD_PA_CAL) / sizeof(NOMAD_PA_CAL[0]);
+
+void earlyInitVariant()
+{
+    pinMode(NOMAD_SECOND_RADIO_NSS_PIN, OUTPUT);
+    digitalWrite(NOMAD_SECOND_RADIO_NSS_PIN, HIGH);
+    pinMode(NOMAD_SECOND_RADIO_NRESET_PIN, OUTPUT);
+    digitalWrite(NOMAD_SECOND_RADIO_NRESET_PIN, LOW);
+    pinMode(NOMAD_WIFI_BACKPACK_NRESET_PIN, OUTPUT);
+    digitalWrite(NOMAD_WIFI_BACKPACK_NRESET_PIN, LOW);
+    dacWrite(RADIO_PA_APC2_PIN, 150);
+}
+
+int8_t radioExternalPaMapPower(int8_t requestedTotalDbm, float frequencyMhz)
+{
+    size_t selected = 0;
+    if (frequencyMhz < 1000.0f) {
+        for (size_t i = 1; i < NOMAD_PA_CAL_N && requestedTotalDbm >= NOMAD_PA_CAL[i].totalDbm; i++)
+            selected = i;
+    }
+    dacWrite(RADIO_PA_APC2_PIN, NOMAD_PA_CAL[selected].apc2);
+    return NOMAD_PA_CAL[selected].chipDbm;
+}
+
+#endif // RADIOMASTER_NOMAD_GEMINI

--- a/src/platform/extra_variants/radiomaster_nomad_gemini/variant.cpp
+++ b/src/platform/extra_variants/radiomaster_nomad_gemini/variant.cpp
@@ -17,7 +17,7 @@
  * The calibration below is derived from the ExpressLRS hardware target
  * "TX/Radiomaster Nomad.json" (power_values = APC2 DAC codes, power_values2 = chip
  * output dBm). These values reproduce ELRS behaviour but have NOT been validated on
- * a bench against a power meter for Meshtastic — verify before trusting at 1 W, both
+ * a bench against a power meter for Meshtastic - verify before trusting at 1 W, both
  * for PA safety and for regulatory compliance.
  *
  * TODO: dual-band (Gemini) operation uses ELRS power_values_dual and a second radio;

--- a/variants/esp32/betafpv_2400_tx_micro/variant.h
+++ b/variants/esp32/betafpv_2400_tx_micro/variant.h
@@ -12,7 +12,7 @@
 #define LORA_MISO 19
 #define LORA_MOSI 23
 #define LORA_CS 5
-#define RF95_FAN_EN 17
+#define RADIO_FAN_EN 17
 
 // This is a LED_WS2812 not a standard LED
 #define HAS_NEOPIXEL                         // Enable the use of neopixels

--- a/variants/esp32/radiomaster_900_bandit/variant.h
+++ b/variants/esp32/radiomaster_900_bandit/variant.h
@@ -46,7 +46,8 @@
   FAN is active at 250mW on it's ExpressLRS Firmware.
   This FAN has TACHO signal on Pin 27 for use with PWM.
 */
-#define RF95_FAN_EN 2
+#define RADIO_FAN_EN 2
+#define RADIO_FAN_PWM
 
 /*
   LED PIN setup and it has a NeoPixel LED.

--- a/variants/esp32/radiomaster_900_bandit/variant.h
+++ b/variants/esp32/radiomaster_900_bandit/variant.h
@@ -46,7 +46,7 @@
   FAN is active at 250mW on it's ExpressLRS Firmware.
   This FAN has TACHO signal on Pin 27 for use with PWM.
 */
-#define RF95_FAN_EN 2
+#define RADIO_FAN_EN 2
 
 /*
   LED PIN setup and it has a NeoPixel LED.

--- a/variants/esp32/radiomaster_900_bandit_nano/variant.h
+++ b/variants/esp32/radiomaster_900_bandit_nano/variant.h
@@ -32,7 +32,7 @@
   This unit has a FAN built-in.
   FAN is active at 250mW on it's ExpressLRS Firmware.
 */
-#define RF95_FAN_EN 2
+#define RADIO_FAN_EN 2
 
 /*
   LED PIN setup.

--- a/variants/esp32/radiomaster_nomad_gemini/README.md
+++ b/variants/esp32/radiomaster_nomad_gemini/README.md
@@ -1,0 +1,31 @@
+# RadioMaster Nomad
+
+This prototype target enables the primary LR1121 sub-GHz path and is initially validated for the US 902-928 MHz band. The second LR1121 is held in reset with its chip-select inactive until Meshtastic has a dual-radio/backhaul design; its reserved pins are CS 13, reset 21, DIO1 34, and busy 39.
+
+The primary radio uses CS 27, reset 15, DIO1 37, busy 36, SCK 25, MOSI 32, and MISO 33. Its LR1121-controlled RF switch is:
+
+| Mode             | DIO5 | DIO6 | DIO7 | DIO8 |
+| ---------------- | ---- | ---- | ---- | ---- |
+| Standby          | low  | low  | low  | low  |
+| 900 MHz receive  | low  | low  | high | low  |
+| 900 MHz transmit | low  | low  | low  | high |
+| 2.4 GHz transmit | low  | high | low  | low  |
+| Wi-Fi scan       | high | low  | low  | low  |
+
+DIO8 enables the 900 MHz transmit path. APC2 on GPIO26 is a calibrated DAC bias and remains at the selected value; it is not treated as a transmit-enable signal. The 915 MHz power table is:
+
+| Total dBm | LR1121 dBm | APC2 DAC |
+| --------: | ---------: | -------: |
+|        10 |        -17 |      150 |
+|        14 |        -16 |      120 |
+|        17 |        -14 |      120 |
+|        20 |        -11 |      120 |
+|        24 |         -7 |      120 |
+|        27 |         -3 |      120 |
+|        30 |          5 |       95 |
+
+GPIO2 controls the active-high fan. `lora.pa_fan_disabled` switches it fully off or on, with on as the default.
+
+Meshtastic Wi-Fi runs on the primary ESP32. The currently unsupported ESP32-C3 Wi-Fi backpack is held in reset on GPIO19.
+
+Pin assignments and RF behavior follow the local mLRS Nomad HAL and the [ExpressLRS RadioMaster Nomad target](https://github.com/ExpressLRS/targets/blob/master/TX/Radiomaster%20Nomad.json). Output power still requires bench verification before this prototype is promoted beyond support level 3.

--- a/variants/esp32/radiomaster_nomad_gemini/platformio.ini
+++ b/variants/esp32/radiomaster_nomad_gemini/platformio.ini
@@ -1,0 +1,20 @@
+[env:radiomaster_nomad_gemini]
+extends = esp32_base
+board = esp32doit-devkit-v1
+build_flags =
+  ${esp32_base.build_flags}
+  -DRADIOMASTER_NOMAD_GEMINI
+  -DPRIVATE_HW
+  -DVTABLES_IN_FLASH=1
+  -DCONFIG_DISABLE_HAL_LOCKS=1
+  -O2
+  -Ivariants/esp32/radiomaster_nomad_gemini
+  -DMESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR=1
+  -DMESHTASTIC_EXCLUDE_I2C=1
+  -DRADIOLIB_EXCLUDE_SX128X=1
+  -DRADIOLIB_EXCLUDE_SX127X=1
+  -DRADIOLIB_EXCLUDE_SX126X=1
+board_build.f_cpu = 240000000L
+upload_protocol = esptool
+lib_deps =
+  ${esp32_base.lib_deps}

--- a/variants/esp32/radiomaster_nomad_gemini/platformio.ini
+++ b/variants/esp32/radiomaster_nomad_gemini/platformio.ini
@@ -1,0 +1,29 @@
+[env:radiomaster_nomad_gemini]
+custom_meshtastic_hw_model = 255
+custom_meshtastic_hw_model_slug = RADIOMASTER_NOMAD
+custom_meshtastic_architecture = esp32
+custom_meshtastic_actively_supported = false
+custom_meshtastic_support_level = 3
+custom_meshtastic_display_name = RadioMaster Nomad
+custom_meshtastic_tags = RadioMaster
+
+extends = esp32_base
+board = esp32doit-devkit-v1
+board_level = extra
+build_flags =
+  ${esp32_base.build_flags}
+  -DRADIOMASTER_NOMAD_GEMINI
+  -DPRIVATE_HW
+  -DVTABLES_IN_FLASH=1
+  -DCONFIG_DISABLE_HAL_LOCKS=1
+  -O2
+  -Ivariants/esp32/radiomaster_nomad_gemini
+  -DMESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR=1
+  -DMESHTASTIC_EXCLUDE_I2C=1
+  -DRADIOLIB_EXCLUDE_SX128X=1
+  -DRADIOLIB_EXCLUDE_SX127X=1
+  -DRADIOLIB_EXCLUDE_SX126X=1
+board_build.f_cpu = 240000000L
+upload_protocol = esptool
+lib_deps =
+  ${esp32_base.lib_deps}

--- a/variants/esp32/radiomaster_nomad_gemini/rfswitch.h
+++ b/variants/esp32/radiomaster_nomad_gemini/rfswitch.h
@@ -1,0 +1,56 @@
+#include "RadioLib.h"
+
+static const uint32_t rfswitch_dio_pins[] = {RADIOLIB_LR11X0_DIO5, RADIOLIB_LR11X0_DIO6, RADIOLIB_LR11X0_DIO7,
+                                             RADIOLIB_LR11X0_DIO8, RADIOLIB_NC};
+
+static const Module::RfSwitchMode_t rfswitch_table[] = {
+    // mode                  DIO5  DIO6 DIO7 DIO8
+    {LR11x0::MODE_STBY, {LOW, LOW, LOW, LOW}},   {LR11x0::MODE_RX, {LOW, LOW, HIGH, LOW}},
+    {LR11x0::MODE_TX, {LOW, LOW, LOW, HIGH}},    {LR11x0::MODE_TX_HP, {LOW, LOW, LOW, HIGH}},
+    {LR11x0::MODE_TX_HF, {LOW, HIGH, LOW, LOW}}, {LR11x0::MODE_GNSS, {LOW, LOW, LOW, LOW}},
+    {LR11x0::MODE_WIFI, {HIGH, LOW, LOW, LOW}},  END_OF_MODE_TABLE,
+};
+
+/*
+
+DIO5: RXEN 2.4GHz
+DIO6: TXEN 2.4GHz
+DIO7: RXEN 900MHz
+DIO8: TXEN 900MHz
+
+
+  "radio_dcdc": true,
+  "radio_rfo_hf": true,
+
+    "power_apc2": 26,
+    "power_min": 0,
+    "power_high": 6,
+    "power_max": 6,
+    "power_default": 3,
+    "power_control": 3, POWER_OUTPUT_DACWRITE // use internal dacWrite function to set value on GPIO_PIN_RFamp_APC2
+                         [0,   1,   2,   3,   4,   5,   6 ] // 0-6
+    "power_values":      [120, 120, 120, 120, 120, 120, 95] // DAC Value
+    "power_values2":     [-17, -16, -14, -11, -7,  -3,  5 ] // 900M
+    "power_values_dual": [-18, -14,  -8,  -6, -2,   3,  5 ] // 2.4G
+
+    // default value 0 means direct!
+#define POWER_OUTPUT_DACWRITE (hardware_int(HARDWARE_power_control)==3)
+#define POWER_OUTPUT_VALUES hardware_i16_array(HARDWARE_power_values)
+#define POWER_OUTPUT_VALUES_COUNT hardware_int(HARDWARE_power_values_count)
+#define POWER_OUTPUT_VALUES2 hardware_i16_array(HARDWARE_power_values2)
+#define POWER_OUTPUT_VALUES_DUAL hardware_i16_array(HARDWARE_power_values_dual)
+#define POWER_OUTPUT_VALUES_DUAL_COUNT hardware_int(HARDWARE_power_values_dual_count)
+
+#define GPIO_PIN_FAN_EN hardware_pin(HARDWARE_misc_fan_en)
+
+    case PWR_10mW: return 10;
+    case PWR_25mW: return 14;
+    case PWR_50mW: return 17;
+    case PWR_100mW: return 20;
+    case PWR_250mW: return 24;
+    case PWR_500mW: return 27;
+    case PWR_1000mW: return 30;
+
+    95 -> +25dBm
+    120 -> +24dBm
+*/

--- a/variants/esp32/radiomaster_nomad_gemini/rfswitch.h
+++ b/variants/esp32/radiomaster_nomad_gemini/rfswitch.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "RadioLib.h"
+
+static const uint32_t rfswitch_dio_pins[] = {RADIOLIB_LR11X0_DIO5, RADIOLIB_LR11X0_DIO6, RADIOLIB_LR11X0_DIO7,
+                                             RADIOLIB_LR11X0_DIO8, RADIOLIB_NC};
+
+static const Module::RfSwitchMode_t rfswitch_table[] = {
+    // mode                  DIO5  DIO6 DIO7 DIO8
+    {LR11x0::MODE_STBY, {LOW, LOW, LOW, LOW}},   {LR11x0::MODE_RX, {LOW, LOW, HIGH, LOW}},
+    {LR11x0::MODE_TX, {LOW, LOW, LOW, HIGH}},    {LR11x0::MODE_TX_HP, {LOW, LOW, LOW, HIGH}},
+    {LR11x0::MODE_TX_HF, {LOW, HIGH, LOW, LOW}}, {LR11x0::MODE_GNSS, {LOW, LOW, LOW, LOW}},
+    {LR11x0::MODE_WIFI, {HIGH, LOW, LOW, LOW}},  END_OF_MODE_TABLE,
+};

--- a/variants/esp32/radiomaster_nomad_gemini/variant.h
+++ b/variants/esp32/radiomaster_nomad_gemini/variant.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#define HAS_SCREEN 0
+#define HAS_WIRE 0
+#define HAS_GPS 0
+#undef GPS_RX_PIN
+#undef GPS_TX_PIN
+
+#define PIN_SPI_MISO 33
+#define PIN_SPI_MOSI 32
+#define PIN_SPI_SCK 25
+#define PIN_SPI_NSS 27
+
+#define LORA_RESET 15
+#define LORA_DIO1 37
+#define LORA_DIO2 36
+#define LORA_SCK PIN_SPI_SCK
+#define LORA_MISO PIN_SPI_MISO
+#define LORA_MOSI PIN_SPI_MOSI
+#define LORA_CS PIN_SPI_NSS
+
+// supported modules list
+#define USE_LR1121
+#define LR1121_SUBGHZ_ONLY
+
+#define LR1121_IRQ_PIN LORA_DIO1
+#define LR1121_NRESET_PIN LORA_RESET
+#define LR1121_BUSY_PIN LORA_DIO2
+#define LR1121_SPI_NSS_PIN LORA_CS
+#define LR1121_SPI_SCK_PIN LORA_SCK
+#define LR1121_SPI_MOSI_PIN LORA_MOSI
+#define LR1121_SPI_MISO_PIN LORA_MISO
+
+// The calibrated external PA supplies the remaining gain above the LR1121 output.
+#define LR1110_MAX_POWER 5
+
+// The second LR1121 is held inactive until dual-radio support is implemented.
+#define NOMAD_SECOND_RADIO_NSS_PIN 13
+#define NOMAD_SECOND_RADIO_NRESET_PIN 21
+#define NOMAD_WIFI_BACKPACK_NRESET_PIN 19
+
+#define LR11X0_DIO_AS_RF_SWITCH
+
+#define HAS_NEOPIXEL                         // Enable the use of neopixels
+#define NEOPIXEL_COUNT 2                     // How many neopixels are connected
+#define NEOPIXEL_DATA 22                     // GPIO pin used to send data to the neopixels
+#define NEOPIXEL_TYPE (NEO_GRB + NEO_KHZ800) // Type of neopixels in use
+#define ENABLE_AMBIENTLIGHTING               // Turn on Ambient Lighting
+
+// Primary button is GPIO14; GPIO12 is the second hardware button.
+#define BUTTON_PIN 14
+#define BUTTON_NEED_PULLUP
+
+#undef EXT_NOTIFY_OUT
+
+#define RADIO_FAN_EN 2
+
+#define RADIO_EXTERNAL_PA
+#define RADIO_PA_APC2_PIN 26

--- a/variants/esp32/radiomaster_nomad_gemini/variant.h
+++ b/variants/esp32/radiomaster_nomad_gemini/variant.h
@@ -1,0 +1,68 @@
+#define HAS_SCREEN 0
+#define HAS_WIRE 0
+#define HAS_GPS 0
+#undef GPS_RX_PIN
+#undef GPS_TX_PIN
+
+#define PIN_SPI_MISO 33
+#define PIN_SPI_MOSI 32
+#define PIN_SPI_SCK 25
+#define PIN_SPI_NSS 27
+
+#define LORA_RESET 15
+#define LORA_DIO1 37
+#define LORA_DIO2 36
+#define LORA_SCK PIN_SPI_SCK
+#define LORA_MISO PIN_SPI_MISO
+#define LORA_MOSI PIN_SPI_MOSI
+#define LORA_CS PIN_SPI_NSS
+
+// supported modules list
+#define USE_LR1121
+
+#define LR1121_IRQ_PIN LORA_DIO1
+#define LR1121_NRESET_PIN LORA_RESET
+#define LR1121_BUSY_PIN LORA_DIO2
+#define LR1121_SPI_NSS_PIN LORA_CS
+#define LR1121_SPI_SCK_PIN LORA_SCK
+#define LR1121_SPI_MOSI_PIN LORA_MOSI
+#define LR1121_SPI_MISO_PIN LORA_MISO
+
+// Caps for the LR1121 *chip* output. The external analog PA (driven via the APC2
+// DAC pin, see RADIO_PA_APC2_PIN below) provides the rest of the gain, so the chip
+// itself is driven low. See src/platform/extra_variants/radiomaster_nomad_gemini.
+#define LR1110_MAX_POWER 5
+// 2.4G Part
+#define LR1120_MAX_POWER 5
+
+// not yet implemented
+#define JANUS_RADIO
+#define LR1121_IRQ2_PIN 34
+#define LR1121_NRESET2_PIN 21
+#define LR1121_BUSY2_PIN 39
+#define LR1121_SPI_NSS2_PIN 13
+
+// TODO: check if this is correct
+// #define LR11X0_DIO3_TCXO_VOLTAGE 1.6
+#define LR11X0_DIO_AS_RF_SWITCH
+
+#define HAS_NEOPIXEL                         // Enable the use of neopixels
+#define NEOPIXEL_COUNT 2                     // How many neopixels are connected
+#define NEOPIXEL_DATA 22                     // GPIO pin used to send data to the neopixels
+#define NEOPIXEL_TYPE (NEO_GRB + NEO_KHZ800) // Type of neopixels in use
+#define ENABLE_AMBIENTLIGHTING               // Turn on Ambient Lighting
+
+// Primary button is GPIO14 (ELRS "button"); GPIO12 is the second button ("button2").
+// NOTE: GPIO34 is the second radio's DIO1 (LR1121_IRQ2_PIN) and is input-only with no
+// internal pull resistor, so it must NOT be reused as a button.
+#define BUTTON_PIN 14
+#define BUTTON_NEED_PULLUP
+
+#undef EXT_NOTIFY_OUT
+
+#define RADIO_FAN_EN 2
+
+// Analog PA bias control (ELRS APC2). GPIO26 = ESP32 DAC channel 2, driven with
+// dacWrite() (0-255 -> 0-3.3V). Defining this enables the external-PA driver in
+// src/platform/extra_variants/radiomaster_nomad_gemini/variant.cpp.
+#define RADIO_PA_APC2_PIN 26

--- a/variants/esp32/radiomaster_nomad_gemini/variant.h
+++ b/variants/esp32/radiomaster_nomad_gemini/variant.h
@@ -37,6 +37,7 @@
 #define LR1120_MAX_POWER 5
 
 // The second LR1121 is held inactive until dual-radio support is implemented.
+#define JANUS_RADIO
 #define LR1121_IRQ2_PIN 34
 #define LR1121_NRESET2_PIN 21
 #define LR1121_BUSY2_PIN 39

--- a/variants/esp32s3/t-beam-1w/variant.h
+++ b/variants/esp32s3/t-beam-1w/variant.h
@@ -84,7 +84,7 @@
 // Fan control
 #define FAN_CTRL_PIN 41
 // Meshtastic standard fan control pin macro
-#define RF95_FAN_EN FAN_CTRL_PIN
+#define RADIO_FAN_EN FAN_CTRL_PIN
 
 // PA Ramp Time - T-Beam 1W requires >800us stabilization (default is 200us)
 // Value 0x05 = RADIOLIB_SX126X_PA_RAMP_800U


### PR DESCRIPTION
## Summary

This draft is now a small hardening delta on top of #5318's `nomad-gemini` branch by @caveman99. It keeps the original Nomad implementation and attribution intact while adding the three safety items called out in review:

- hold the unused second LR1121 in reset with chip-select inactive
- hold the unsupported ESP32-C3 backpack in reset
- mark the primary LR1121 path sub-GHz-only until dual-radio/2.4 GHz support exists

The PR also adds target metadata and focused board documentation. The broader external-PA and fan rewrites from the earlier draft have been removed.

## Implementation

- Adds `LR1121_SUBGHZ_ONLY` handling and enables it only for the Nomad target.
- Drives second-radio CS GPIO13 high and reset GPIO21 low before primary SPI initialization.
- Drives ESP32-C3 backpack reset GPIO19 low while that path is unsupported.
- Retains `JANUS_RADIO` as the future dual-radio feature marker while the second LR1121 remains inactive.
- Registers the prototype target as `PRIVATE_HW`, support level 3, and `board_level = extra`.
- Documents the primary and reserved pin assignments, RF-switch table, PA lifecycle, fan behavior, and current limitations.

## PA calibration

This stacked delta inherits #5318's external-PA implementation and provisional table unchanged, including APC2 120 at 10 mW. That value is not claimed as bench-validated; the table should be updated after the planned RF power-meter measurements.

## Validation

### Software

- [x] `trunk fmt`
- [x] `pio run -e radiomaster_nomad_gemini`
- [x] Final comparison against `nomad-gemini`: 5 files, +56/-5
- [x] Final merge tree preserves the newer PKI and LR2021 autoLDRO changes carried by the base

### Hardware

- [x] Firmware `2.8.0.5081c59` flashed to the connected ESP32-PICO-D4 with on-device hash verification
- [x] Booted as `radiomaster_nomad_gemini` with US / MediumFast / 10 dBm
- [x] Received and decoded live 915 MHz mesh traffic
- [x] Completed outbound RF transmission; serial logs showed the traceroute request TX complete
- [x] Completed a multi-hop traceroute to `!625aa4fb`, including a return path
- [x] Joined the configured Wi-Fi network, obtained `192.168.1.252`, responded to ICMP, exposed TCP 4403, and completed a Meshtastic API configuration exchange
- [x] Fan disable and enable states both wrote and read back; final state is enabled
- [x] Broadcast validation text was accepted by the device API

## Suggested review focus

- second-LR1121 and ESP32-C3 reset polarity/timing
- scope of the sub-GHz-only guard
- metadata and documentation accuracy
