### PR TITLE
ci: warn and skip the pio check job on transient network failures

### DIFF
--- a/bin/check-all.sh
+++ b/bin/check-all.sh
@@ -31,16 +31,18 @@ export APP_VERSION=$VERSION
 
 if [[ $# -gt 0 ]]; then
 	# can override which environment by passing arg
-	BOARDS="$*"
+	BOARDS=("$@")
 else
-	BOARDS="tlora-v2 tlora-v1 tlora_v1_3 tlora-v2-1-1.6 tbeam heltec-v2.0 heltec-v2.1 tbeam0.7 meshtastic-diy-v1 rak4631 rak4631_eink rak11200 t-echo canaryone pca10059_diy_eink"
+	BOARDS=(tlora-v2 tlora-v1 tlora_v1_3 tlora-v2-1-1.6 tbeam heltec-v2.0 heltec-v2.1 tbeam0.7 meshtastic-diy-v1 rak4631 rak4631_eink rak11200 t-echo canaryone pca10059_diy_eink)
 fi
 
-echo "BOARDS:${BOARDS}"
+echo "BOARDS:${BOARDS[*]}"
 
-CHECK=""
-for BOARD in $BOARDS; do
-	CHECK="${CHECK} -e ${BOARD}"
+# Array, not a string: board names reach pio as literal arguments, so an override containing
+# whitespace or a glob character cannot turn into extra pio arguments.
+CHECK=()
+for BOARD in "${BOARDS[@]}"; do
+	CHECK+=(-e "${BOARD}")
 done
 
 LOG=$(mktemp)
@@ -48,7 +50,7 @@ trap 'rm -f "$LOG"' EXIT
 
 # Keep streaming to the console so the CI log reads exactly as it did before; tee a copy for the
 # post-mortem classification below.
-pio check --flags "-DAPP_VERSION=${APP_VERSION} --suppressions-list=suppressions.txt --inline-suppr" $CHECK --skip-packages --pattern="src/" --fail-on-defect=low --fail-on-defect=medium --fail-on-defect=high 2>&1 | tee "$LOG"
+pio check --flags "-DAPP_VERSION=${APP_VERSION} --suppressions-list=suppressions.txt --inline-suppr" "${CHECK[@]}" --skip-packages --pattern="src/" --fail-on-defect=low --fail-on-defect=medium --fail-on-defect=high 2>&1 | tee "$LOG"
 STATUS=${PIPESTATUS[0]}
 
 if [[ $STATUS -eq 0 ]]; then
@@ -70,10 +72,10 @@ fi
 
 REASON=$(grep -Em1 "$TRANSIENT" "$LOG" | tr -d '\r' | cut -c1-200)
 
-echo "RESULT: SKIPPED ${BOARDS} - transient network failure: ${REASON}"
+echo "RESULT: SKIPPED ${BOARDS[*]} - transient network failure: ${REASON}"
 
 if [[ ${GITHUB_ACTIONS:-false} == "true" ]]; then
-	echo "::warning title=Static analysis skipped (${BOARDS})::pio check could not download its packages: ${REASON}"
+	echo "::warning title=Static analysis skipped (${BOARDS[*]})::pio check could not download its packages: ${REASON}"
 	exit 0
 fi
 

--- a/bin/check-all.sh
+++ b/bin/check-all.sh
@@ -1,17 +1,37 @@
 #!/usr/bin/env bash
 
-# Note: This is a prototype for how we could add static code analysis to the CI.
+# Run cppcheck static analysis over one or more PlatformIO environments.
+#
+# Why this is more than a bare `pio check`: the CI `check` matrix job in main_matrix.yml runs this
+# script inside meshtastic/gh-action-firmware, and `pio check` must download the platform package
+# before it can analyse anything. That download is regularly reset mid-flight by the CDN, e.g.
+#
+#   Checking station-g3 > cppcheck (board: station-g3; platform: .../platform-espressif32.zip)
+#   requests.exceptions.ConnectionError: ('Connection aborted.', ConnectionResetError(104, ...))
+#
+# The analysis never starts, so there is no signal at all - just a red X someone has to re-run by
+# hand. `pio check` exits 1 for that AND for real defects, so the exit code cannot tell them apart;
+# only the output can. This script classifies the failure:
+#
+#   * cppcheck produced results (summary table or defect lines) -> real, propagate the exit status.
+#   * transport-level network error and nothing else            -> warn and skip.
+#   * anything else                                             -> propagate the exit status.
+#
+# A missing or forbidden package (404 / UnknownPackageError / 403) is deliberately NOT treated as
+# transient: that is a reproducible break from a bad pin in a .ini, not weather.
+#
+# Exit codes: 0 = clean (or skipped under CI), 1 = defects/error, 2 = skipped locally.
 
-set -e
+set -uo pipefail
 
-VERSION=$(bin/buildinfo.py long)
+VERSION=$(bin/buildinfo.py long) || exit 1
 
 # The shell vars the build tool expects to find
 export APP_VERSION=$VERSION
 
 if [[ $# -gt 0 ]]; then
 	# can override which environment by passing arg
-	BOARDS="$@"
+	BOARDS="$*"
 else
 	BOARDS="tlora-v2 tlora-v1 tlora_v1_3 tlora-v2-1-1.6 tbeam heltec-v2.0 heltec-v2.1 tbeam0.7 meshtastic-diy-v1 rak4631 rak4631_eink rak11200 t-echo canaryone pca10059_diy_eink"
 fi
@@ -23,4 +43,38 @@ for BOARD in $BOARDS; do
 	CHECK="${CHECK} -e ${BOARD}"
 done
 
-pio check --flags "-DAPP_VERSION=${APP_VERSION} --suppressions-list=suppressions.txt --inline-suppr" $CHECK --skip-packages --pattern="src/" --fail-on-defect=low --fail-on-defect=medium --fail-on-defect=high
+LOG=$(mktemp)
+trap 'rm -f "$LOG"' EXIT
+
+# Keep streaming to the console so the CI log reads exactly as it did before; tee a copy for the
+# post-mortem classification below.
+pio check --flags "-DAPP_VERSION=${APP_VERSION} --suppressions-list=suppressions.txt --inline-suppr" $CHECK --skip-packages --pattern="src/" --fail-on-defect=low --fail-on-defect=medium --fail-on-defect=high 2>&1 | tee "$LOG"
+STATUS=${PIPESTATUS[0]}
+
+if [[ $STATUS -eq 0 ]]; then
+	exit 0
+fi
+
+# Fail closed: if cppcheck got far enough to report anything, the run is real no matter what other
+# noise is in the log.
+if grep -Eqi '^Component[[:space:]]+.*HIGH|^Total[[:space:]]+[0-9]|^[^[:space:]]+:[0-9]+: \[(high|medium|low)' "$LOG"; then
+	exit "$STATUS"
+fi
+
+# Transport-level failures only. No 403/404/UnknownPackageError here, on purpose.
+TRANSIENT='requests\.exceptions\.(ConnectionError|Timeout|ReadTimeout|ConnectTimeout)|ConnectionResetError|urllib3\.exceptions\.(ProtocolError|MaxRetryError|NameResolutionError|ReadTimeoutError)|Read timed out|Connection aborted|Connection refused|Temporary failure in name resolution|Could not resolve host|(429|500|502|503|504) (Server|Client) Error|Too Many Requests'
+
+if ! grep -Eq "$TRANSIENT" "$LOG"; then
+	exit "$STATUS"
+fi
+
+REASON=$(grep -Em1 "$TRANSIENT" "$LOG" | tr -d '\r' | cut -c1-200)
+
+echo "RESULT: SKIPPED ${BOARDS} - transient network failure: ${REASON}"
+
+if [[ ${GITHUB_ACTIONS:-false} == "true" ]]; then
+	echo "::warning title=Static analysis skipped (${BOARDS})::pio check could not download its packages: ${REASON}"
+	exit 0
+fi
+
+exit 2


### PR DESCRIPTION
## Problem

The `check` matrix job intermittently fails before it analyses anything. `pio check` has to fetch the platform package before cppcheck can start, and that download gets reset mid-flight often enough to be a nuisance.

Three of the last ~200 CI runs died this way — all identical, all ~1 second in:

| run | board | failure |
| --- | --- | --- |
| [29883921204](https://github.com/meshtastic/firmware/actions/runs/29883921204) | station-g3 | `ConnectionResetError(104)` |
| [29880715107](https://github.com/meshtastic/firmware/actions/runs/29880715107) | heltec-v3 | `ConnectionResetError(104)` |
| [29858944295](https://github.com/meshtastic/firmware/actions/runs/29858944295) | tbeam | `ConnectionResetError(104)` |

```
Checking station-g3 > cppcheck (board: station-g3; platform:
https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip)
requests.exceptions.ConnectionError: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
```

cppcheck never ran, so there is no signal at all — just a red X someone has to re-run by hand.

## Fix

`pio check` exits 1 for both a dead socket and a real defect, so the exit code can't tell them apart — only the output can. `bin/check-all.sh` now tees the run and classifies the failure:

- **cppcheck reported something** (the summary table, or a `file:line: [severity]` defect line) → real, propagate the exit status. This is checked *first*, so no amount of network noise elsewhere in the log can mask a genuine defect.
- **Transport-level error and nothing else** → log a `::warning::` annotation naming the board and the underlying error, and exit 0 under CI. Locally it exits 2, so a local run never quietly reports itself clean.
- **Anything else** → propagate the exit status.

`404` / `403` / `UnknownPackageError` are deliberately *not* transient: a missing or forbidden package is a reproducible break from a bad pin in a `.ini`, not weather.

No workflow change is needed — `gh-action-firmware`'s entrypoint runs `/workspace/bin/check-all.sh` for `MT_TARGET=check`, so the whole fix lives in this repo and applies to local runs too.

Scope is `check` only. The `build` jobs use the same action but must keep failing loudly — they produce release artifacts.

## Verification

Replayed the captured CI logs through the script with a stubbed `pio`:

| case | expected | result |
| --- | --- | --- |
| station-g3 connection-reset log, CI | exit 0 + warning | ✅ |
| same log, local | exit 2, no warning | ✅ |
| rak11200 `Total 1 0 0` defect log | exit 1 | ✅ |
| that defect log with the reset traceback appended | exit 1 | ✅ |
| 404 / `UnknownPackageError` | exit 1 | ✅ |
| clean pass | exit 0 | ✅ |

The skipped case looks like this in the log, and shows up as an annotation on the run:

```
RESULT: SKIPPED station-g3 - transient network failure: ConnectionResetError: [Errno 104] Connection reset by peer
::warning title=Static analysis skipped (station-g3)::pio check could not download its packages: ConnectionResetError: [Errno 104] Connection reset by peer
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved static analysis to better separate real code defects from temporary network/service disruptions.
  * Added CI-friendly handling for transient check failures, emitting clear warnings while still reporting genuine analysis issues accurately.
  * Refined exit behavior so local and CI runs distinctly identify transient problems without masking legitimate failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->