### PR TITLE
claw back some space from signing policies

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -70,8 +70,8 @@ static uint8_t bytes[MAX_LORA_PAYLOAD_LEN + 1] __attribute__((__aligned__));
 
 struct RoutingAuthCache {
     bool valid = false;
-    meshtastic_Config_SecurityConfig_PacketSignaturePolicy policy =
-        meshtastic_Config_SecurityConfig_PacketSignaturePolicy_PACKET_SIGNATURE_POLICY_BALANCED;
+    // Deliberately NOT initialized in-class as this eats flash space.
+    meshtastic_Config_SecurityConfig_PacketSignaturePolicy policy;
     meshtastic_MeshPacket wire = meshtastic_MeshPacket_init_zero;
     meshtastic_MeshPacket authenticated = meshtastic_MeshPacket_init_zero;
 };
@@ -161,6 +161,8 @@ Router::Router() : concurrency::OSThread("Router"), fromRadioQueue(MAX_RX_FROMRA
     cryptLock = new concurrency::Lock();
     if (!routingAuthCacheLock)
         routingAuthCacheLock = new concurrency::Lock();
+    // Runtime default for the auth-cache snapshot policy. Keep it here, saves flash.
+    routingAuthCache.policy = meshtastic_Config_SecurityConfig_PacketSignaturePolicy_PACKET_SIGNATURE_POLICY_BALANCED;
 }
 
 bool Router::shouldDecrementHopLimit(const meshtastic_MeshPacket *p)
@@ -705,7 +707,7 @@ RoutingAuthVerdict passesRoutingAuthGate(meshtastic_MeshPacket *p)
 #if !(MESHTASTIC_EXCLUDE_PKI) && !(MESHTASTIC_EXCLUDE_XEDDSA)
         concurrency::LockGuard g(cryptLock);
         if (!checkXeddsaReceivePolicy(&authCandidate)) {
-            LOG_WARN("Already-decoded packet rejected by signature policy before routing state update");
+            LOG_WARN("Already-decoded packet rejected by signature policy");
             return RoutingAuthVerdict::REJECT;
         }
 #endif
@@ -716,15 +718,15 @@ RoutingAuthVerdict passesRoutingAuthGate(meshtastic_MeshPacket *p)
     }
     const DecodeState state = perhapsDecode(&authCandidate);
     if (state == DecodeState::DECODE_POLICY_REJECT) {
-        LOG_WARN("Packet rejected by signature policy before routing state update");
+        LOG_WARN("Packet rejected by signature policy");
         return RoutingAuthVerdict::REJECT;
     }
     if (state == DecodeState::DECODE_FATAL) {
-        LOG_WARN("Fatal decode error before routing state update");
+        LOG_WARN("Fatal decode error, dropping packet");
         return RoutingAuthVerdict::REJECT;
     }
     if (state == DecodeState::DECODE_FAILURE) {
-        LOG_WARN("Decryptable packet failed decoding/authentication before routing state update");
+        LOG_WARN("Decryptable packet failed decoding, dropping packet");
         return RoutingAuthVerdict::REJECT;
     }
 


### PR DESCRIPTION
https://github.com/meshtastic/firmware/pull/10967 introduced some large flash objects due to the way it was initialised, plus some long and unoptimised logging strings.

* The `policy` member of `RoutingAuthCache` is no longer initialized in-class, which saves flash memory. Instead, it is set to its default value at runtime in the `Router` constructor. [[1]](diffhunk://#diff-fb9b4a4da3229ad0f8213d3e55e97cb8068e71ba0225002aa050cf06788f6b8aL73-R74) [[2]](diffhunk://#diff-fb9b4a4da3229ad0f8213d3e55e97cb8068e71ba0225002aa050cf06788f6b8aR164-R165)

* Several log messages in `passesRoutingAuthGate` have been shortened and clarified to remove redundant phrases and better indicate packet handling outcomes. [[1]](diffhunk://#diff-fb9b4a4da3229ad0f8213d3e55e97cb8068e71ba0225002aa050cf06788f6b8aL708-R710) [[2]](diffhunk://#diff-fb9b4a4da3229ad0f8213d3e55e97cb8068e71ba0225002aa050cf06788f6b8aL719-R729)

May conflict or be duplicated by https://github.com/meshtastic/firmware/pull/11144


## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the default balanced routing policy during router initialization.
  * Clarified warning messages for routing signature-policy rejections and decoding failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->