### PR TITLE
Seeed Studios ESP32S3 and Wio SX-1262

### DIFF
--- a/boards/seeed-xiao-s3-wio.json
+++ b/boards/seeed-xiao-s3-wio.json
@@ -1,0 +1,42 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_opi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=0"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "psram_type": "opi",
+    "hwids": [["0x2886", "0x0059"]],
+    "mcu": "esp32s3",
+    "variant": "seeed-xiao-s3-wio"
+  },
+  "connectivity": ["wifi", "bluetooth", "lora"],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": ["esp-builtin"],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": ["arduino", "espidf"],
+  "name": "seeed-xiao-s3-wio",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 8388608,
+    "maximum_size": 8388608,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://www.seeedstudio.com/XIAO-ESP32S3-p-5627.html",
+  "vendor": "Seeed Studio"
+}

--- a/variants/esp32s3/seeed_xiao_s3_wio/pins_arduino.h
+++ b/variants/esp32s3/seeed_xiao_s3_wio/pins_arduino.h
@@ -1,0 +1,19 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define USB_VID 0x2886
+#define USB_PID 0x0059
+
+// I2C Remapped to D6 and D7
+static const uint8_t SDA = 43; // D6
+static const uint8_t SCL = 44; // D7
+
+// Default SPI will be mapped to Radio
+static const uint8_t SS = 5;   // D4
+static const uint8_t SCK = 7;  // D8
+static const uint8_t MISO = 8; // D9
+static const uint8_t MOSI = 9; // D10
+
+#endif /* Pins_Arduino_h */

--- a/variants/esp32s3/seeed_xiao_s3_wio/platformio.ini
+++ b/variants/esp32s3/seeed_xiao_s3_wio/platformio.ini
@@ -1,0 +1,24 @@
+[env:seeed-xiao-s3-wio]
+custom_meshtastic_hw_model = 0000
+custom_meshtastic_hw_model_slug = SEEED_XIAO_S3_WIO
+custom_meshtastic_architecture = esp32-s3-wio
+custom_meshtastic_actively_supported = false
+custom_meshtastic_support_level = 3
+custom_meshtastic_display_name = Seeed Xiao ESP32-S3 Wio
+custom_meshtastic_images = seeed-xiao-s3-wio.svg
+custom_meshtastic_tags = Seeed
+custom_meshtastic_requires_dfu = true
+custom_meshtastic_partition_scheme = 8MB
+
+extends = esp32s3_base
+board = seeed-xiao-s3-wio
+board_level = pr
+board_check = true
+board_build.partitions = default_8MB.csv
+upload_protocol = esptool
+upload_speed = 921600
+build_flags = 
+  ${esp32s3_base.build_flags}
+  -D SEEED_XIAO_S3
+  -I variants/esp32s3/seeed_xiao_s3_wio
+  -DBOARD_HAS_PSRAM 

--- a/variants/esp32s3/seeed_xiao_s3_wio/variant.h
+++ b/variants/esp32s3/seeed_xiao_s3_wio/variant.h
@@ -1,0 +1,67 @@
+/*
+ ▄▄▄▄▄▄▄▄▄▄▄  ▄▄▄▄▄▄▄▄▄▄▄  ▄▄▄▄▄▄▄▄▄▄▄  ▄▄▄▄▄▄▄▄▄▄▄  ▄▄▄▄▄▄▄▄▄▄
+▐░░░░░░░░░░░▌▐░░░░░░░░░░░▌▐░░░░░░░░░░░▌▐░░░░░░░░░░░▌▐░░░░░░░░░░▌
+▐░█▀▀▀▀▀▀▀▀▀ ▐░█▀▀▀▀▀▀▀▀▀ ▐░█▀▀▀▀▀▀▀▀▀ ▐░█▀▀▀▀▀▀▀▀▀ ▐░█▀▀▀▀▀▀▀█░▌
+▐░▌          ▐░▌          ▐░▌          ▐░▌          ▐░▌       ▐░▌
+▐░█▄▄▄▄▄▄▄▄▄ ▐░█▄▄▄▄▄▄▄▄▄ ▐░█▄▄▄▄▄▄▄▄▄ ▐░█▄▄▄▄▄▄▄▄▄ ▐░▌       ▐░▌
+▐░░░░░░░░░░░▌▐░░░░░░░░░░░▌▐░░░░░░░░░░░▌▐░░░░░░░░░░░▌▐░▌       ▐░▌
+ ▀▀▀▀▀▀▀▀▀█░▌▐░█▀▀▀▀▀▀▀▀▀ ▐░█▀▀▀▀▀▀▀▀▀ ▐░█▀▀▀▀▀▀▀▀▀ ▐░▌       ▐░▌
+          ▐░▌▐░▌          ▐░▌          ▐░▌          ▐░▌       ▐░▌
+ ▄▄▄▄▄▄▄▄▄█░▌▐░█▄▄▄▄▄▄▄▄▄ ▐░█▄▄▄▄▄▄▄▄▄ ▐░█▄▄▄▄▄▄▄▄▄ ▐░█▄▄▄▄▄▄▄█░▌
+▐░░░░░░░░░░░▌▐░░░░░░░░░░░▌▐░░░░░░░░░░░▌▐░░░░░░░░░░░▌▐░░░░░░░░░░▌
+ ▀▀▀▀▀▀▀▀▀▀▀  ▀▀▀▀▀▀▀▀▀▀▀  ▀▀▀▀▀▀▀▀▀▀▀  ▀▀▀▀▀▀▀▀▀▀▀  ▀▀▀▀▀▀▀▀▀▀
+
+  ▄       ▄  ▄▄▄▄▄▄▄▄▄▄▄  ▄▄▄▄▄▄▄▄▄▄▄  ▄▄▄▄▄▄▄▄▄▄▄       ▄▄▄▄▄▄▄▄▄▄▄  ▄▄▄▄▄▄▄▄▄▄▄
+ ▐░▌     ▐░▌▐░░░░░░░░░░░▌▐░░░░░░░░░░░▌▐░░░░░░░░░░░▌     ▐░░░░░░░░░░░▌▐░░░░░░░░░░░▌
+  ▐░▌   ▐░▌  ▀▀▀▀█░█▀▀▀▀ ▐░█▀▀▀▀▀▀▀█░▌▐░█▀▀▀▀▀▀▀█░▌     ▐░█▀▀▀▀▀▀▀▀▀  ▀▀▀▀▀▀▀▀▀█░▌
+   ▐░▌ ▐░▌       ▐░▌     ▐░▌       ▐░▌▐░▌       ▐░▌     ▐░▌                    ▐░▌
+    ▐░▐░▌        ▐░▌     ▐░█▄▄▄▄▄▄▄█░▌▐░▌       ▐░▌     ▐░█▄▄▄▄▄▄▄▄▄  ▄▄▄▄▄▄▄▄▄█░▌
+     ▐░▌         ▐░▌     ▐░░░░░░░░░░░▌▐░▌       ▐░▌     ▐░░░░░░░░░░░▌▐░░░░░░░░░░░▌
+    ▐░▌░▌        ▐░▌     ▐░█▀▀▀▀▀▀▀█░▌▐░▌       ▐░▌      ▀▀▀▀▀▀▀▀▀█░▌ ▀▀▀▀▀▀▀▀▀█░▌
+   ▐░▌ ▐░▌       ▐░▌     ▐░▌       ▐░▌▐░▌       ▐░▌               ▐░▌          ▐░▌
+  ▐░▌   ▐░▌  ▄▄▄▄█░█▄▄▄▄ ▐░▌       ▐░▌▐░█▄▄▄▄▄▄▄█░▌      ▄▄▄▄▄▄▄▄▄█░▌ ▄▄▄▄▄▄▄▄▄█░▌
+ ▐░▌     ▐░▌▐░░░░░░░░░░░▌▐░▌       ▐░▌▐░░░░░░░░░░░▌     ▐░░░░░░░░░░░▌▐░░░░░░░░░░░▌
+  ▀       ▀  ▀▀▀▀▀▀▀▀▀▀▀  ▀         ▀  ▀▀▀▀▀▀▀▀▀▀▀       ▀▀▀▀▀▀▀▀▀▀▀  ▀▀▀▀▀▀▀▀▀▀▀
+*/
+
+/*
+ ESP Board Information: https://www.seeedstudio.com/XIAO-ESP32S3-p-5627.html
+ Wio Board Information: https://www.seeedstudio.com/Wio-SX1262-for-XIAO-p-6379.html
+*/
+
+#define LED_POWER 21 // Device LED
+#define LED_STATE_ON 1 // On when high
+
+#define BUTTON_PIN 1 // D0
+#define BUTTON_NEED_PULLUP
+
+#define BATTERY_PIN -1
+#define ADC_CHANNEL ADC_CHANNEL_0
+#define BATTERY_SENSE_RESOLUTION_BITS 12
+
+#define I2C_SDA 43 // D6
+#define I2C_SCL 44 // D7
+
+// XIAO S3 LORA module
+#define USE_SX1262
+
+#define LORA_CS 5   // D4
+#define LORA_SCK 7  // D8
+#define LORA_MISO 8 // D9
+#define LORA_MOSI 9 // D10
+
+#define LORA_RESET 3 // D2
+#define LORA_DIO1 2  // D1
+
+#ifdef USE_SX1262
+#define SX126X_CS LORA_CS
+#define SX126X_DIO1 LORA_DIO1
+#define SX126X_BUSY 4 // D3
+#define SX126X_RESET LORA_RESET
+
+// DIO2 controlls an antenna switch and the TCXO voltage is controlled by DIO3
+#define SX126X_DIO2_AS_RF_SWITCH
+#define SX126X_RXEN  6 // D5
+#define SX126X_TXEN RADIOLIB_NC
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8
+#endif


### PR DESCRIPTION
This is the Wio SX-1262 radio using the GPIO Pins, not the currently supported method using the ESP32S3-Sense and the top expansion port.
- Working I2C (remapped to D6/D7)
- Display
- Bluetooth
- WiFi
- Webserver
- Mesh Radio with both RX and TX
- other standard features

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the Seeed XIAO ESP32-S3 Wio board.
  - Enabled Arduino and ESP-IDF development workflows.
  - Added Wi-Fi, Bluetooth, and LoRa connectivity support.
  - Configured 8 MB flash, PSRAM, DFU uploads, and high-speed programming.
  - Added board-specific I2C, SPI, button, LED, battery, and SX1262 LoRa pin mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->