### PR TITLE
CI: derive arch/source mapping from PlatformIO instead of hardcoding

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -80,18 +80,17 @@ jobs:
       - name: Generate matrix
         id: jsonStep
         run: |
-          CHANGED=.github/outputs/all_modified_files.txt
-          EXTRA=""
           # Narrow BOTH the build ('all') and static-analysis ('check') legs to the
-          # PR's affected variants. An absent/empty file (non-PR, 'ci:full-build'
-          # label, or diff failure) leaves EXTRA empty => the full set for that leg.
-          if [[ -s "$CHANGED" ]]; then
-            EXTRA="--changed-files $CHANGED"
-          fi
+          # PR's affected variants. The generator treats an absent/empty --changed-files
+          # as a no-op (full set), so it's passed unconditionally: a non-PR push, a
+          # 'ci:full-build'-labelled PR, or a diff failure all leave the file absent =>
+          # the full set for that leg. Pushes (empty GITHUB_HEAD_REF) build the full
+          # release set with no --level.
+          CHANGED=.github/outputs/all_modified_files.txt
           if [[ "$GITHUB_HEAD_REF" == "" ]]; then
             TARGETS=$(./bin/generate_ci_matrix.py ${{matrix.arch}})
-          else  
-            TARGETS=$(./bin/generate_ci_matrix.py ${{matrix.arch}} --level pr $EXTRA)
+          else
+            TARGETS=$(./bin/generate_ci_matrix.py ${{matrix.arch}} --level pr --changed-files "$CHANGED")
           fi
           echo "Name: $GITHUB_REF_NAME Base: $GITHUB_BASE_REF Ref: $GITHUB_REF"
           echo "${{matrix.arch}}=$TARGETS" >> $GITHUB_OUTPUT

--- a/bin/generate_ci_matrix.py
+++ b/bin/generate_ci_matrix.py
@@ -11,7 +11,13 @@ On pull requests the workflow additionally passes ``--changed-files``: the matri
 then narrowed to just the environments a PR's changed files can affect (see
 ``select_changed``). Any change to shared source, the build system, protobufs, or an
 unrecognized path deliberately falls back to the full set, so narrowing can never
-cause an under-build. ``select_changed`` and its helpers are import-safe without
+cause an under-build.
+
+The source-tree -> arch relationships are *derived from PlatformIO*, not hard-coded:
+``build_src_filter`` (which each env re-includes as ``+<platform/X>``) yields the
+``platform/<subdir> -> variant-top-dirs`` map, and the ``extra_configs`` globs come
+straight from ``[platformio]``. This keeps the mapping self-maintaining when a board
+or arch is added. ``select_changed`` and the pure helpers stay import-safe without
 PlatformIO (the PlatformIO import is deferred into ``load_all_envs``) so they can be
 unit-tested directly.
 """
@@ -24,27 +30,26 @@ import re
 import sys
 from collections import defaultdict
 
-# The ESP32 family. Every esp32*_base config extends [esp32_common], which adds
-# +<platform/esp32/> to build_src_filter, so src/platform/esp32 is compiled by them all.
-ESP32_FAMILY = ["esp32", "esp32c3", "esp32c6", "esp32p4", "esp32s2", "esp32s3"]
-
-# src/platform/<subdir>  ->  the variants/<top-dir>(s) whose envs compile that tree.
-PLATFORM_SRC_TOPDIRS = {
-    "esp32": ESP32_FAMILY,
-    "nrf52": ["nrf52840"],
-    "nrf54l15": ["nrf54l15"],
-    "rp2xx0": ["rp2040", "rp2350"],
-    "stm32wl": ["stm32"],
-    "portduino": ["native"],
-}
-
 # variants/<top-dir> whose envs are never in the firmware build matrix: portduino
 # (native) envs need Emscripten / macOS / Windows toolchains and are already exercised
 # on every PR by the dedicated test-native, docker, and build-wasm jobs.
 COVERED_ELSEWHERE = {"native"}
 
-# platformio.ini globs (from the root extra_configs) that hold [env:...] definitions.
-BOARD_INI_GLOBS = ("variants/*/*/platformio.ini", "variants/*/diy/*/platformio.ini")
+# board_level values an env may carry and still be emittable. An ALLOWLIST (not a
+# denylist) so an unknown/typo'd level fails CLOSED (excluded) rather than silently
+# building. None = release board, "pr"/"extra" = the two explicit tiers.
+EMITTABLE_LEVELS = {None, "pr", "extra"}
+
+# Fallback platformio.ini globs that hold [env:...] / [*_base] definitions. Production
+# overrides the env-definition scan with the real [platformio] extra_configs (see
+# load_all_envs / Win B) so nothing rots when that list changes; this constant only
+# backs the PlatformIO-free unit tests and the arch-base scan (arch bases always live
+# at variants/<top>/<name>.ini, which is covered here).
+DEFAULT_BOARD_INI_GLOBS = (
+    "variants/*/*.ini",
+    "variants/*/*/platformio.ini",
+    "variants/*/diy/*/platformio.ini",
+)
 
 # RAM/flash budgets file (repo-relative). Budgeted envs must always be in the matrix
 # so the fail-closed size-budget-gate has data to check against.
@@ -53,6 +58,9 @@ RAM_BUDGETS = "bin/ram_budgets.json"
 # -I variants/<dir> include flag. Anchored on start-or-space so the nrf52 flag
 # "-include variants/.../lfs_util.h" never matches; also handles glued "-Ivariants/…".
 INCLUDE_DIR_RE = re.compile(r"(?:^|\s)-I\s*(variants/[^\s\\]+)")
+# A build_src_filter whole-subdir re-include: +<platform/X> or +<platform/X/>. A
+# sub-path include like +<platform/rp2xx0/pico_sleep> is deliberately NOT matched.
+PLATFORM_INCL_RE = re.compile(r"\+<\s*platform/([^/>]+)/?>")
 # An arch base .ini lives directly under a platform dir: variants/<plat>/<name>.ini.
 ARCH_INI_RE = re.compile(r"^variants/([^/]+)/[^/]+\.ini$")
 # A per-arch platform source tree: src/platform/<arch>/...
@@ -76,7 +84,9 @@ def parse_args(argv=None):
         help=(
             "Newline-delimited list of a PR's changed files. When given and non-empty, "
             "restrict the matrix to the envs those files can affect; any shared or "
-            "unrecognized path falls back to the full set for the given --level."
+            "unrecognized path falls back to the full set for the given --level. An "
+            "absent or empty file is a no-op (full set), so the workflow can pass this "
+            "unconditionally."
         ),
     )
     return parser.parse_args(argv)
@@ -88,7 +98,14 @@ def repo_path(rel):
     return os.path.join(root, rel)
 
 
-def env_definition_dirs(root="."):
+def _ini_glob_list(raw):
+    """Normalize an extra_configs value (list or newline string) to .ini globs."""
+    if isinstance(raw, str):
+        raw = raw.splitlines()
+    return [g.strip() for g in (raw or []) if g and g.strip().endswith(".ini")]
+
+
+def env_definition_dirs(root=".", globs=DEFAULT_BOARD_INI_GLOBS):
     """Map env name -> repo-relative dir of the platformio.ini that declares it.
 
     This is reverse-map "B": it catches edits to a *derived* board's own
@@ -96,7 +113,7 @@ def env_definition_dirs(root="."):
     seeed_xiao_nrf52840_e22 boards live in their own dir but -I the shared kit dir).
     """
     defdir = {}
-    for pattern in BOARD_INI_GLOBS:
+    for pattern in globs:
         for path in sorted(glob.glob(os.path.join(root, pattern))):
             rel = os.path.relpath(path, root).replace(os.sep, "/")
             board_dir = os.path.dirname(rel)
@@ -111,18 +128,45 @@ def env_definition_dirs(root="."):
     return defdir
 
 
+def base_ini_platform_incl(root=".", globs=DEFAULT_BOARD_INI_GLOBS):
+    """Map repo-relative .ini path -> the platform subdir it re-includes, if any.
+
+    Only arch-base .inis that carry a ``+<platform/X>`` re-include appear (e.g.
+    esp32-common.ini -> "esp32"). These are the *family-wide* bases; a chip base that
+    merely inherits the include (esp32.ini) is absent, so a change to it scopes to its
+    own top-dir instead of the whole family.
+    """
+    incl = {}
+    for pattern in globs:
+        for path in sorted(glob.glob(os.path.join(root, pattern))):
+            rel = os.path.relpath(path, root).replace(os.sep, "/")
+            try:
+                with open(path) as f:
+                    hits = set(PLATFORM_INCL_RE.findall(f.read()))
+            except OSError:
+                continue
+            # A base that re-includes exactly one platform tree is a family base for
+            # it. (Multiple would be ambiguous; none means it inherits -> scoped.)
+            if len(hits) == 1:
+                incl[rel] = next(iter(hits))
+    return incl
+
+
 def load_all_envs():
     """Load every PlatformIO env with the metadata selection/filtering need.
 
     Each entry: {"ci": {"board", "platform"}, "board_level", "board_check",
-    "include_dirs": [repo-relative variants dirs from -I], "def_dir": <repo-rel dir>}.
-    The PlatformIO import is deferred here so the rest of this module stays import-safe
-    for unit tests.
+    "include_dirs": [repo-relative variants dirs from -I], "def_dir": <repo-rel dir>,
+    "src_platforms": [platform/<subdir> names this env compiles]}. The PlatformIO
+    import is deferred here so the rest of this module stays import-safe for tests.
     """
     from platformio.project.config import ProjectConfig
 
     cfg = ProjectConfig.get_instance()
-    defdir = env_definition_dirs()
+    # Win B: derive the env-definition scan globs from the real extra_configs so a new
+    # glob (or the InkHUD config) is never silently missed.
+    globs = _ini_glob_list(cfg.get("platformio", "extra_configs", default=[]))
+    defdir = env_definition_dirs(globs=globs or DEFAULT_BOARD_INI_GLOBS)
     all_envs = []
     for pio_env in cfg.envs():
         build_flags = cfg.get(f"env:{pio_env}", "build_flags")
@@ -139,6 +183,8 @@ def load_all_envs():
                 file=sys.stderr,
             )
             sys.exit(1)
+        bsf = cfg.get(f"env:{pio_env}", "build_src_filter", default=[])
+        bsf_text = " ".join(bsf) if isinstance(bsf, list) else str(bsf or "")
         board_check = (
             cfg.get(f"env:{pio_env}", "board_check", default="false").strip().lower()
             == "true"
@@ -150,9 +196,25 @@ def load_all_envs():
                 "board_check": board_check,
                 "include_dirs": include_dirs,
                 "def_dir": defdir.get(pio_env),
+                "src_platforms": sorted(set(PLATFORM_INCL_RE.findall(bsf_text))),
             }
         )
     return all_envs
+
+
+def platform_src_map_from_envs(all_envs):
+    """Derive ``platform/<subdir> -> {variant-top-dirs}`` from envs' build_src_filter.
+
+    The ESP32 family self-groups here (every esp32* env re-includes +<platform/esp32>),
+    so no hard-coded family list is needed; adding a new arch/board updates this map
+    automatically.
+    """
+    m = defaultdict(set)
+    for e in all_envs:
+        top = e["ci"]["platform"]
+        for sub in e.get("src_platforms", []):
+            m[sub].add(top)
+    return m
 
 
 def budget_envs(path=None):
@@ -166,18 +228,27 @@ def budget_envs(path=None):
 
 
 def _emittable(env):
-    """True if an env can appear in the firmware build matrix at all."""
+    """True if an env can appear in the firmware build matrix at all.
+
+    Allowlist on board_level (unknown levels fail closed) plus the covered-elsewhere
+    platform exclusion.
+    """
     return (
-        env["board_level"] != "community"
+        env["board_level"] in EMITTABLE_LEVELS
         and env["ci"]["platform"] not in COVERED_ELSEWHERE
     )
 
 
-def select_changed(all_envs, changed, budgets=frozenset()):
+def select_changed(
+    all_envs, changed, platform_src_map, base_ini_incl, budgets=frozenset()
+):
     """Return the set of env board-names to build for a PR's ``changed`` files.
 
     Returns ``None`` to mean "fall back to the full set": any shared, build-system,
     or unrecognized path trips this, so narrowing can never drop an affected board.
+    ``platform_src_map`` (platform subdir -> top-dirs) and ``base_ini_incl`` (arch-base
+    .ini path -> the platform subdir it re-includes) are derived from PlatformIO in
+    ``main``; passing them in keeps this function unit-testable without PlatformIO.
     ``budgets`` (env names) are always unioned in so the fail-closed size-budget-gate
     always has data, which also guarantees a non-empty matrix.
     """
@@ -220,18 +291,19 @@ def select_changed(all_envs, changed, budgets=frozenset()):
         if hit is not None:
             sel.update(dir_to_envs[hit] & emittable)
             continue
-        # Tier 2a: a per-arch platform source tree.
+        # Tier 2a: a per-arch platform source tree -> every top-dir that compiles it.
         m = PLATFORM_SRC_RE.match(p)
-        if m and m.group(1) in PLATFORM_SRC_TOPDIRS:
-            add_top(PLATFORM_SRC_TOPDIRS[m.group(1)], sel)
+        if m and m.group(1) in platform_src_map:
+            add_top(platform_src_map[m.group(1)], sel)
             continue
         # Tier 2b: an arch base .ini (variants/<plat>/<name>.ini).
         m = ARCH_INI_RE.match(p)
         if m:
-            if p.endswith("/esp32-common.ini"):
-                add_top(ESP32_FAMILY, sel)  # the family-wide base
+            incl = base_ini_incl.get(p)
+            if incl and incl in platform_src_map:
+                add_top(platform_src_map[incl], sel)  # family-wide base
             else:
-                add_top([m.group(1)], sel)  # a chip base -> its own top dir
+                add_top([m.group(1)], sel)  # chip/board base -> its own top dir
             continue
         # Tier 3: shared source / build system / unknown -> full fallback.
         return None
@@ -279,6 +351,7 @@ def build_outlist(all_envs, platform, level, selected):
 def main(argv=None):
     args = parse_args(argv)
     all_envs = load_all_envs()
+    platform_src_map = platform_src_map_from_envs(all_envs)
 
     selected = None
     if args.changed_files:
@@ -287,9 +360,16 @@ def main(argv=None):
                 changed = [ln.strip() for ln in f if ln.strip()]
         except OSError:
             changed = []
-        # Empty (diff failed / nothing changed) -> selected stays None -> full set.
+        # Empty (diff failed / nothing changed / non-PR) -> selected stays None -> full
+        # set, so the workflow can pass --changed-files unconditionally.
         if changed:
-            selected = select_changed(all_envs, changed, budgets=budget_envs())
+            selected = select_changed(
+                all_envs,
+                changed,
+                platform_src_map,
+                base_ini_platform_incl(),
+                budgets=budget_envs(),
+            )
 
     # Return as a JSON list
     print(json.dumps(build_outlist(all_envs, args.platform, args.level, selected)))

--- a/bin/generate_ci_matrix.py
+++ b/bin/generate_ci_matrix.py
@@ -129,12 +129,14 @@ def env_definition_dirs(root=".", globs=DEFAULT_BOARD_INI_GLOBS):
 
 
 def base_ini_platform_incl(root=".", globs=DEFAULT_BOARD_INI_GLOBS):
-    """Map repo-relative .ini path -> the platform subdir it re-includes, if any.
+    """Map repo-relative .ini path -> the set of platform subdirs it re-includes.
 
-    Only arch-base .inis that carry a ``+<platform/X>`` re-include appear (e.g.
-    esp32-common.ini -> "esp32"). These are the *family-wide* bases; a chip base that
-    merely inherits the include (esp32.ini) is absent, so a change to it scopes to its
-    own top-dir instead of the whole family.
+    Only arch-base .inis that carry at least one ``+<platform/X>`` re-include appear
+    (e.g. esp32-common.ini -> {"esp32"}). These are the *family-wide* bases; a chip
+    base that merely inherits the include (esp32.ini) has no direct re-include and is
+    absent, so a change to it scopes to its own top-dir instead of the whole family.
+    A base that re-includes multiple platform trees maps to all of them, so Tier 2b
+    fans out to a safe superset rather than silently dropping the extra trees.
     """
     incl = {}
     for pattern in globs:
@@ -145,11 +147,25 @@ def base_ini_platform_incl(root=".", globs=DEFAULT_BOARD_INI_GLOBS):
                     hits = set(PLATFORM_INCL_RE.findall(f.read()))
             except OSError:
                 continue
-            # A base that re-includes exactly one platform tree is a family base for
-            # it. (Multiple would be ambiguous; none means it inherits -> scoped.)
-            if len(hits) == 1:
-                incl[rel] = next(iter(hits))
+            if hits:
+                incl[rel] = hits
     return incl
+
+
+def board_ini_globs(cfg=None):
+    """The .ini globs from [platformio] extra_configs (Win B), or the defaults.
+
+    Derived once and shared by every .ini scan (env_definition_dirs and
+    base_ini_platform_incl) so they never diverge: a new extra_configs glob is picked
+    up by both, not just one. Pass an existing cfg to avoid a redundant get_instance;
+    the PlatformIO import stays deferred so the module is import-safe for unit tests.
+    """
+    if cfg is None:
+        from platformio.project.config import ProjectConfig
+
+        cfg = ProjectConfig.get_instance()
+    globs = _ini_glob_list(cfg.get("platformio", "extra_configs", default=[]))
+    return globs or DEFAULT_BOARD_INI_GLOBS
 
 
 def load_all_envs():
@@ -165,8 +181,7 @@ def load_all_envs():
     cfg = ProjectConfig.get_instance()
     # Win B: derive the env-definition scan globs from the real extra_configs so a new
     # glob (or the InkHUD config) is never silently missed.
-    globs = _ini_glob_list(cfg.get("platformio", "extra_configs", default=[]))
-    defdir = env_definition_dirs(globs=globs or DEFAULT_BOARD_INI_GLOBS)
+    defdir = env_definition_dirs(globs=board_ini_globs(cfg))
     all_envs = []
     for pio_env in cfg.envs():
         build_flags = cfg.get(f"env:{pio_env}", "build_flags")
@@ -299,9 +314,13 @@ def select_changed(
         # Tier 2b: an arch base .ini (variants/<plat>/<name>.ini).
         m = ARCH_INI_RE.match(p)
         if m:
-            incl = base_ini_incl.get(p)
-            if incl and incl in platform_src_map:
-                add_top(platform_src_map[incl], sel)  # family-wide base
+            incls = base_ini_incl.get(p) or set()
+            mapped = [platform_src_map[s] for s in incls if s in platform_src_map]
+            if mapped:
+                # Family-wide base: fan out to every arch that compiles each
+                # re-included platform tree (a safe superset if it re-includes >1).
+                for tops in mapped:
+                    add_top(tops, sel)
             else:
                 add_top([m.group(1)], sel)  # chip/board base -> its own top dir
             continue
@@ -367,7 +386,7 @@ def main(argv=None):
                 all_envs,
                 changed,
                 platform_src_map,
-                base_ini_platform_incl(),
+                base_ini_platform_incl(globs=board_ini_globs()),
                 budgets=budget_envs(),
             )
 

--- a/bin/test_generate_ci_matrix.py
+++ b/bin/test_generate_ci_matrix.py
@@ -27,10 +27,12 @@ _SPEC.loader.exec_module(gcm)
 
 BUDGETS = frozenset({"rak4631"})
 
-# Arch-base .ini -> the platform subdir it re-includes (family-wide bases). Mirrors
-# what base_ini_platform_incl() derives from the real tree: only esp32-common.ini
-# carries a +<platform/esp32> re-include; the chip base esp32.ini merely inherits it.
-BASE_INI_INCL = {"variants/esp32/esp32-common.ini": "esp32"}
+# Arch-base .ini -> the set of platform subdirs it re-includes (family-wide bases).
+# Mirrors what base_ini_platform_incl() derives from the real tree: only
+# esp32-common.ini carries a +<platform/esp32> re-include; the chip base esp32.ini
+# merely inherits it. Values are sets so a base that re-includes multiple platform
+# trees fans out to a safe superset instead of being silently dropped.
+BASE_INI_INCL = {"variants/esp32/esp32-common.ini": {"esp32"}}
 
 
 def env(
@@ -427,10 +429,11 @@ def test_env_definition_dirs_parses_headers():
 
 
 def test_base_ini_platform_incl_finds_family_base_only():
-    """A base .ini that re-includes exactly one platform tree is a family base.
+    """A base .ini that re-includes one or more platform trees is a family base.
 
     A chip base that only inherits (${esp32_common.build_src_filter}) has no direct
-    +<platform/X> and must be absent, so a change to it stays scoped to its top-dir."""
+    +<platform/X> and must be absent, so a change to it stays scoped to its top-dir.
+    Values are sets; a base re-including multiple trees maps to all of them."""
     with tempfile.TemporaryDirectory() as root:
         esp32_dir = os.path.join(root, "variants", "esp32")
         os.makedirs(esp32_dir)
@@ -454,9 +457,78 @@ def test_base_ini_platform_incl_finds_family_base_only():
             f.write("[nrf52_base]\nbuild_src_filter =\n  +<platform/nrf52/>\n")
 
         incl = gcm.base_ini_platform_incl(root=root)
-        assert incl["variants/esp32/esp32-common.ini"] == "esp32"
-        assert incl["variants/nrf52840/nrf52.ini"] == "nrf52"
+        assert incl["variants/esp32/esp32-common.ini"] == {"esp32"}
+        assert incl["variants/nrf52840/nrf52.ini"] == {"nrf52"}
         assert "variants/esp32/esp32.ini" not in incl
+
+
+def test_base_ini_platform_incl_multi_include_maps_to_all():
+    """A base re-including 2+ platform trees maps to the full set (fail-safe).
+
+    Previously such a base was silently dropped (len(hits)==1 guard), which would
+    scope a change to it to its own top-dir only -> under-build. Now it maps to every
+    re-included tree so Tier 2b fans out to a safe superset."""
+    with tempfile.TemporaryDirectory() as root:
+        esp32_dir = os.path.join(root, "variants", "esp32")
+        os.makedirs(esp32_dir)
+        with open(os.path.join(esp32_dir, "esp32-common.ini"), "w") as f:
+            f.write(
+                "[esp32_common]\nbuild_src_filter =\n"
+                "  -<platform/> +<platform/esp32/> +<platform/firmware_common/>\n"
+            )
+
+        incl = gcm.base_ini_platform_incl(root=root)
+        assert incl["variants/esp32/esp32-common.ini"] == {"esp32", "firmware_common"}
+
+
+def test_tier2b_multi_include_base_fans_out_superset():
+    """A multi-include family base selects every arch that compiles either tree.
+
+    esp32-common re-includes both esp32 and (hypothetically) extra_variants; a change
+    to it must build every esp32-family env AND every arch compiling extra_variants --
+    a safe superset, never an under-build."""
+    u = universe()
+    multi = dict(BASE_INI_INCL)
+    multi["variants/esp32/esp32-common.ini"] = {"esp32", "extra_variants"}
+    result = gcm.select_changed(
+        u,
+        ["variants/esp32/esp32-common.ini"],
+        gcm.platform_src_map_from_envs(u),
+        multi,
+        budgets=BUDGETS,
+    )
+    # esp32 family (esp32-pr-rep, heltec-v3) plus every extra_variants arch's pr reps.
+    assert result == {
+        "esp32-pr-rep",
+        "heltec-v3",
+        "rak4631",
+        "rpipico",
+        "rak11310",
+        "nrf54l15dk",
+    }
+
+
+def test_board_ini_globs_prefers_extra_configs():
+    """board_ini_globs returns the derived extra_configs globs, or the defaults.
+
+    A fake cfg lets this run without PlatformIO. Ensures the same glob list backs both
+    env_definition_dirs and base_ini_platform_incl (Win B applied consistently)."""
+
+    class _Cfg:
+        def __init__(self, value):
+            self._value = value
+
+        def get(self, section, option, default=None):
+            assert section == "platformio" and option == "extra_configs"
+            return self._value
+
+    derived = "variants/*/*.ini\nvariants/*/bases/*.ini\nnot_a.txt"
+    assert gcm.board_ini_globs(cfg=_Cfg(derived)) == [
+        "variants/*/*.ini",
+        "variants/*/bases/*.ini",
+    ]
+    # Empty extra_configs falls back to the built-in defaults.
+    assert gcm.board_ini_globs(cfg=_Cfg([])) == gcm.DEFAULT_BOARD_INI_GLOBS
 
 
 def test_budget_envs_reads_ram_budgets():

--- a/bin/test_generate_ci_matrix.py
+++ b/bin/test_generate_ci_matrix.py
@@ -5,6 +5,11 @@
 These exercise the pure selection logic with a synthetic env universe, so they run
 without PlatformIO installed (the PlatformIO import in generate_ci_matrix.py is
 deferred into load_all_envs, which these tests never call).
+
+The source-tree -> arch maps that select_changed consumes are themselves derived from
+the envs' build_src_filter (platform_src_map_from_envs) and the arch-base .inis
+(base_ini_platform_incl); the synthetic universe below carries the same
+``src_platforms`` metadata a real env would, so the derivation is exercised end-to-end.
 """
 
 import importlib.util
@@ -22,8 +27,21 @@ _SPEC.loader.exec_module(gcm)
 
 BUDGETS = frozenset({"rak4631"})
 
+# Arch-base .ini -> the platform subdir it re-includes (family-wide bases). Mirrors
+# what base_ini_platform_incl() derives from the real tree: only esp32-common.ini
+# carries a +<platform/esp32> re-include; the chip base esp32.ini merely inherits it.
+BASE_INI_INCL = {"variants/esp32/esp32-common.ini": "esp32"}
 
-def env(board, platform, level=None, check=False, include_dirs=None, def_dir=None):
+
+def env(
+    board,
+    platform,
+    level=None,
+    check=False,
+    include_dirs=None,
+    def_dir=None,
+    src_platforms=None,
+):
     """Build one synthetic all_envs entry."""
     return {
         "ci": {"board": board, "platform": platform},
@@ -31,7 +49,14 @@ def env(board, platform, level=None, check=False, include_dirs=None, def_dir=Non
         "board_check": check,
         "include_dirs": include_dirs if include_dirs is not None else [],
         "def_dir": def_dir,
+        "src_platforms": src_platforms if src_platforms is not None else [],
     }
+
+
+# Every firmware env compiles its own arch tree plus the shared extra_variants tree
+# (base does -<platform/> then +<platform/extra_variants/> +<platform/<arch>/>).
+def _sp(arch):
+    return [arch, "extra_variants"]
 
 
 def universe():
@@ -44,6 +69,7 @@ def universe():
             level=None,
             include_dirs=["variants/esp32/tbeam"],
             def_dir="variants/esp32/tbeam",
+            src_platforms=_sp("esp32"),
         ),
         env(
             "tbeam-displayshield",
@@ -51,6 +77,7 @@ def universe():
             level="extra",
             include_dirs=["variants/esp32/tbeam"],
             def_dir="variants/esp32/tbeam",
+            src_platforms=_sp("esp32"),
         ),
         env(
             "esp32-pr-rep",
@@ -58,6 +85,7 @@ def universe():
             level="pr",
             include_dirs=["variants/esp32/somepr"],
             def_dir="variants/esp32/somepr",
+            src_platforms=_sp("esp32"),
         ),
         # esp32s3: a pr rep + two boards whose dirs nest (heltec_v4 / heltec_v4_r8).
         env(
@@ -67,6 +95,7 @@ def universe():
             check=True,
             include_dirs=["variants/esp32s3/heltec_v3"],
             def_dir="variants/esp32s3/heltec_v3",
+            src_platforms=_sp("esp32"),
         ),
         env(
             "heltec_v4",
@@ -74,6 +103,7 @@ def universe():
             level="extra",
             include_dirs=["variants/esp32s3/heltec_v4"],
             def_dir="variants/esp32s3/heltec_v4",
+            src_platforms=_sp("esp32"),
         ),
         env(
             "heltec_v4_r8",
@@ -81,6 +111,7 @@ def universe():
             level="extra",
             include_dirs=["variants/esp32s3/heltec_v4_r8"],
             def_dir="variants/esp32s3/heltec_v4_r8",
+            src_platforms=_sp("esp32"),
         ),
         # nrf52840: the budgeted pr board, a shared "kit" base, and two derived boards
         # that live in their own dir but -I the shared kit dir.
@@ -91,6 +122,7 @@ def universe():
             check=True,
             include_dirs=["variants/nrf52840/rak4631"],
             def_dir="variants/nrf52840/rak4631",
+            src_platforms=_sp("nrf52"),
         ),
         env(
             "kit_base",
@@ -98,6 +130,7 @@ def universe():
             level="extra",
             include_dirs=["variants/nrf52840/seeed_xiao_nrf52840_kit"],
             def_dir="variants/nrf52840/seeed_xiao_nrf52840_kit",
+            src_platforms=_sp("nrf52"),
         ),
         env(
             "xiao_e22_30",
@@ -105,6 +138,7 @@ def universe():
             level="extra",
             include_dirs=["variants/nrf52840/seeed_xiao_nrf52840_kit"],
             def_dir="variants/nrf52840/diy/seeed_xiao_nrf52840_e22",
+            src_platforms=_sp("nrf52"),
         ),
         env(
             "xiao_e22_33",
@@ -112,6 +146,7 @@ def universe():
             level="extra",
             include_dirs=["variants/nrf52840/seeed_xiao_nrf52840_kit"],
             def_dir="variants/nrf52840/diy/seeed_xiao_nrf52840_e22",
+            src_platforms=_sp("nrf52"),
         ),
         # rp2040 / rp2350 pr reps (share the src/platform/rp2xx0 tree).
         env(
@@ -120,6 +155,7 @@ def universe():
             level="pr",
             include_dirs=["variants/rp2040/rpipico"],
             def_dir="variants/rp2040/rpipico",
+            src_platforms=_sp("rp2xx0"),
         ),
         env(
             "rak11310",
@@ -127,6 +163,7 @@ def universe():
             level="pr",
             include_dirs=["variants/rp2350/rak11310"],
             def_dir="variants/rp2350/rak11310",
+            src_platforms=_sp("rp2xx0"),
         ),
         # nrf54l15: zero pr-tier envs -> arch changes must escalate to all its envs.
         env(
@@ -135,6 +172,7 @@ def universe():
             level="extra",
             include_dirs=["variants/nrf54l15/nrf54l15dk"],
             def_dir="variants/nrf54l15/nrf54l15dk",
+            src_platforms=_sp("nrf54l15"),
         ),
         # native: excluded from the build matrix (covered by test-native/docker/wasm).
         env(
@@ -143,6 +181,7 @@ def universe():
             level="extra",
             include_dirs=["variants/native/portduino"],
             def_dir="variants/native/portduino",
+            src_platforms=["portduino"],
         ),
         env(
             "native-tft",
@@ -150,12 +189,21 @@ def universe():
             level="extra",
             include_dirs=["variants/native/portduino"],
             def_dir="variants/native/portduino",
+            src_platforms=["portduino"],
         ),
     ]
 
 
 def sel(changed):
-    return gcm.select_changed(universe(), changed, budgets=BUDGETS)
+    """Run select_changed with maps derived from the synthetic universe."""
+    u = universe()
+    return gcm.select_changed(
+        u,
+        changed,
+        gcm.platform_src_map_from_envs(u),
+        BASE_INI_INCL,
+        budgets=BUDGETS,
+    )
 
 
 def test_variant_local_builds_touched_boards_incl_extra():
@@ -195,7 +243,7 @@ def test_shared_include_dir_fans_out():
 
 
 def test_platform_src_esp32_family():
-    """src/platform/esp32 maps to the whole ESP32 family's pr reps."""
+    """src/platform/esp32 maps to the whole ESP32 family's pr reps (derived)."""
     result = sel(["src/platform/esp32/ESP32CryptoEngine.cpp"])
     assert result == {"esp32-pr-rep", "heltec-v3", "rak4631"}
 
@@ -218,6 +266,23 @@ def test_zero_pr_arch_escalates_to_all_envs():
     }
 
 
+def test_platform_src_extra_variants_covers_every_arch():
+    """The shared extra_variants tree fans out to a rep of every (non-native) arch.
+
+    Previously this was an unmapped path -> Tier-3 full fallback; deriving the map
+    from build_src_filter makes it explicit. The result is a safe superset (every
+    arch's pr envs), never an under-build, and never None here."""
+    result = sel(["src/platform/extra_variants/foo.cpp"])
+    assert result == {
+        "esp32-pr-rep",
+        "heltec-v3",
+        "rak4631",
+        "rpipico",
+        "rak11310",
+        "nrf54l15dk",
+    }
+
+
 def test_native_platform_src_adds_nothing_but_not_full():
     """A portduino-only change adds no build env (covered elsewhere), not a fallback."""
     assert sel(["src/platform/portduino/PortduinoGlue.cpp"]) == {"rak4631"}
@@ -229,7 +294,7 @@ def test_native_variant_change_adds_nothing_but_not_full():
 
 
 def test_arch_ini_common_is_family_wide():
-    """esp32-common.ini affects the whole ESP32 family."""
+    """esp32-common.ini (a +<platform/esp32> base) affects the whole ESP32 family."""
     assert sel(["variants/esp32/esp32-common.ini"]) == {
         "esp32-pr-rep",
         "heltec-v3",
@@ -238,7 +303,7 @@ def test_arch_ini_common_is_family_wide():
 
 
 def test_arch_ini_chip_base_is_scoped():
-    """esp32.ini ([esp32_base]) affects only the original-esp32 top dir."""
+    """esp32.ini (inherits the include, not a family base) affects only its top dir."""
     result = sel(["variants/esp32/esp32.ini"])
     assert result == {"esp32-pr-rep", "rak4631"}
     assert "heltec-v3" not in result  # s3 boards unaffected by the esp32-only base
@@ -298,6 +363,51 @@ def test_build_outlist_check_leg_full_when_not_narrowed():
     assert {e["board"] for e in out} == {"heltec-v3", "rak4631"}
 
 
+def test_platform_src_map_from_envs_derives_family_grouping():
+    """The platform subdir -> top-dirs map is derived from envs' src_platforms."""
+    m = gcm.platform_src_map_from_envs(universe())
+    assert m["esp32"] == {"esp32", "esp32s3"}  # family self-groups, no hard-coded list
+    assert m["nrf52"] == {"nrf52840"}
+    assert m["rp2xx0"] == {"rp2040", "rp2350"}
+    assert m["nrf54l15"] == {"nrf54l15"}
+    assert m["portduino"] == {"native"}
+    # extra_variants is shared across every firmware arch's top-dir. native envs
+    # compile platform/portduino only (not extra_variants), so native is absent.
+    assert m["extra_variants"] == {
+        "esp32",
+        "esp32s3",
+        "nrf52840",
+        "rp2040",
+        "rp2350",
+        "nrf54l15",
+    }
+
+
+def test_emittable_allowlist_fails_closed():
+    """Unknown board_level values are excluded; only None/pr/extra emit."""
+    assert gcm._emittable(env("a", "esp32", level=None))
+    assert gcm._emittable(env("a", "esp32", level="pr"))
+    assert gcm._emittable(env("a", "esp32", level="extra"))
+    # Retired 'community' tier and any typo fail closed.
+    assert not gcm._emittable(env("a", "esp32", level="community"))
+    assert not gcm._emittable(env("a", "esp32", level="bogus"))
+    # covered-elsewhere platform is excluded regardless of a valid level.
+    assert not gcm._emittable(env("a", "native", level="pr"))
+
+
+def test_ini_glob_list_normalizes_str_and_list():
+    """extra_configs may arrive as a newline string or a list; only .ini globs pass."""
+    raw = "variants/*/*.ini\nvariants/*/*/platformio.ini\nsrc/x/Config.ini\nnot_a.txt"
+    assert gcm._ini_glob_list(raw) == [
+        "variants/*/*.ini",
+        "variants/*/*/platformio.ini",
+        "src/x/Config.ini",
+    ]
+    assert gcm._ini_glob_list(["a.ini", " b.ini ", "c.json"]) == ["a.ini", "b.ini"]
+    assert gcm._ini_glob_list([]) == []
+    assert gcm._ini_glob_list(None) == []
+
+
 def test_env_definition_dirs_parses_headers():
     """env_definition_dirs maps each [env:NAME] to its platformio.ini's dir."""
     with tempfile.TemporaryDirectory() as root:
@@ -314,6 +424,39 @@ def test_env_definition_dirs_parses_headers():
         assert defdir["tbeam"] == "variants/esp32/tbeam"
         assert defdir["tbeam-displayshield"] == "variants/esp32/tbeam"
         assert defdir["WashTastic"] == "variants/nrf52840/diy/washy"
+
+
+def test_base_ini_platform_incl_finds_family_base_only():
+    """A base .ini that re-includes exactly one platform tree is a family base.
+
+    A chip base that only inherits (${esp32_common.build_src_filter}) has no direct
+    +<platform/X> and must be absent, so a change to it stays scoped to its top-dir."""
+    with tempfile.TemporaryDirectory() as root:
+        esp32_dir = os.path.join(root, "variants", "esp32")
+        os.makedirs(esp32_dir)
+        # Family base: carries the +<platform/esp32> re-include. (In the real tree
+        # +<platform/extra_variants/> lives in the root base, so this file's only
+        # direct +<platform/X> is esp32 -> exactly one hit.)
+        with open(os.path.join(esp32_dir, "esp32-common.ini"), "w") as f:
+            f.write(
+                "[esp32_common]\nbuild_src_filter =\n"
+                "  ${arduino_base.build_src_filter} +<platform/esp32/>\n"
+            )
+        # Chip base: only inherits, no direct +<platform/X>.
+        with open(os.path.join(esp32_dir, "esp32.ini"), "w") as f:
+            f.write(
+                "[esp32_base]\nbuild_src_filter =\n"
+                "  ${esp32_common.build_src_filter}\n"
+            )
+        nrf_dir = os.path.join(root, "variants", "nrf52840")
+        os.makedirs(nrf_dir)
+        with open(os.path.join(nrf_dir, "nrf52.ini"), "w") as f:
+            f.write("[nrf52_base]\nbuild_src_filter =\n  +<platform/nrf52/>\n")
+
+        incl = gcm.base_ini_platform_incl(root=root)
+        assert incl["variants/esp32/esp32-common.ini"] == "esp32"
+        assert incl["variants/nrf52840/nrf52.ini"] == "nrf52"
+        assert "variants/esp32/esp32.ini" not in incl
 
 
 def test_budget_envs_reads_ram_budgets():


### PR DESCRIPTION
Builds on #11151. Three of the hardcoded constants in `generate_ci_matrix.py` can be *derived from PlatformIO*, which makes the change-detection self-maintaining when a board/arch is added:

- **Derive `platform/<subdir> -> arch` from `build_src_filter`.** Each env re-includes its tree via `+<platform/X>`, so the reverse-map (including the ESP32 family self-grouping) is read from config. Drops `ESP32_FAMILY` and `PLATFORM_SRC_TOPDIRS` entirely, and fixes `src/platform/extra_variants/` which was unmapped and fell back to a full build.
- **Read `[platformio] extra_configs` for the env-definition ini globs** instead of a hardcoded 2-glob tuple. Anti-rot / future-proofing; no behavior change on the current tree.
- **`_emittable` is now an allowlist** (`None`/`pr`/`extra`) so a retired or typo'd `board_level` fails closed rather than silently building. (Relevant now that `community` is being retired in this PR.)
- **Workflow:** drop the `EXTRA` / `[[ -s ]]` bash plumbing -- the generator no-ops on an absent/empty `--changed-files`, so it is passed unconditionally.

Verified against real PlatformIO: full, PR, and check sets plus every changed-file scenario produce **identical** matrices to this PR's head (zero under-build). 28/28 unit tests pass.

Targeted at `feature/surgical-ci` so a merge folds straight into #11151. Happy to reshape or split however you prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull-request CI matrix narrowing for both build and check jobs using the changed-files list when in PR context.
  * Updated change detection to derive platform/architecture relationships from PlatformIO metadata for more accurate target coverage.
  * Added stricter filtering so unknown or retired target levels are excluded (fails closed).

* **Tests**
  * Expanded CI matrix generation and selection tests to validate derived platform mappings, ini/glob discovery, base-inclusion behavior, and the tightened filtering rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->