### PR TITLE
Enable merge queues

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -3,17 +3,25 @@ concurrency:
   group: ci-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 on:
-  # # Triggers the workflow on push but only for the main branches
-  push:
+  # Full CI now runs in the merge queue instead of on post-merge push. PRs build a
+  # narrowed board subset (--level pr) for fast feedback; the merge queue rebuilds
+  # the full release matrix against the merged result before it lands. Because the
+  # merge_group run is the gate, there is nothing left to rebuild after the merge
+  # commit reaches the protected branch - so the old `push` trigger is dropped.
+  #
+  # merge_group events have an empty github.head_ref, so the existing setup job
+  # (which keys off GITHUB_HEAD_REF) produces the full matrix automatically.
+  # Note: merge_group does not support paths/paths-ignore filters - it always runs
+  # the full required checks, which is what a merge queue needs (branch protection
+  # cannot skip a required check).
+  merge_group:
+    types: [checks_requested]
     branches:
       - master
       - develop
       - pioarduino # Remove when merged // use `feature/` in the future.
       - event/*
       - feature/*
-    paths-ignore:
-      - "**.md"
-      - version.properties
 
   pull_request:
     branches:


### PR DESCRIPTION
Merge queueueueuesssss

~This probably also has to get cherrypicked to `master`~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration checks to run through GitHub’s merge queue.
  * Enabled full validation for queued changes across supported branch patterns.
  * Added documentation clarifying merge-queue behavior and validation selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->