### PR TITLE
replace screens with unique_ptr

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -868,7 +868,6 @@ void Power::reboot()
     Wire.end();
     Serial1.end();
     if (screen) {
-        delete screen;
         screen = nullptr;
     }
     LOG_DEBUG("final reboot!");

--- a/src/detect/ReClockI2C.h
+++ b/src/detect/ReClockI2C.h
@@ -18,7 +18,7 @@
     Only for cases where we can know it (ESP32 or known screen) we can do this.
 */
 
-extern graphics::Screen *screen;
+extern std::unique_ptr<graphics::Screen> screen;
 
 class ReClockI2C
 {

--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -6,6 +6,7 @@
 #include "mesh/generated/meshtastic/config.pb.h"
 #include <OLEDDisplay.h>
 #include <functional>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -842,6 +843,6 @@ class Screen : public concurrency::OSThread
 // Extern declarations for function symbols used in UIRenderer
 extern std::vector<std::string> functionSymbol;
 extern std::string functionSymbolString;
-extern graphics::Screen *screen;
+extern std::unique_ptr<graphics::Screen> screen;
 
 #endif

--- a/src/graphics/draw/DebugRenderer.cpp
+++ b/src/graphics/draw/DebugRenderer.cpp
@@ -38,7 +38,7 @@
 using namespace meshtastic;
 
 // External variables
-extern graphics::Screen *screen;
+extern std::unique_ptr<graphics::Screen> screen;
 extern PowerStatus *powerStatus;
 extern NodeStatus *nodeStatus;
 extern GPSStatus *gpsStatus;

--- a/src/graphics/draw/MessageRenderer.cpp
+++ b/src/graphics/draw/MessageRenderer.cpp
@@ -23,7 +23,7 @@
 
 // External declarations
 extern bool hasUnreadMessage;
-extern graphics::Screen *screen;
+extern std::unique_ptr<graphics::Screen> screen;
 
 using graphics::Emote;
 using graphics::emotes;

--- a/src/graphics/draw/NodeListRenderer.cpp
+++ b/src/graphics/draw/NodeListRenderer.cpp
@@ -18,7 +18,7 @@
 #include <algorithm>
 
 // Global screen instance
-extern graphics::Screen *screen;
+extern std::unique_ptr<graphics::Screen> screen;
 
 #if defined(OLED_TINY)
 static uint32_t lastSwitchTime = 0;

--- a/src/graphics/draw/UIRenderer.cpp
+++ b/src/graphics/draw/UIRenderer.cpp
@@ -28,7 +28,7 @@
 #include <gps/RTC.h>
 
 // External variables
-extern graphics::Screen *screen;
+extern std::unique_ptr<graphics::Screen> screen;
 #if defined(OLED_TINY)
 static uint32_t lastSwitchTime = 0;
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -212,7 +212,7 @@ using namespace concurrency;
 volatile static const char slipstreamTZString[] = {USERPREFS_TZ_STRING};
 
 // We always create a screen object, but we only init it if we find the hardware
-graphics::Screen *screen = nullptr;
+std::unique_ptr<graphics::Screen> screen = nullptr;
 
 // Global power status
 meshtastic::PowerStatus *powerStatus = new meshtastic::PowerStatus();
@@ -966,15 +966,15 @@ void setup()
     if (config.display.displaymode != meshtastic_Config_DisplayConfig_DisplayMode_COLOR) {
 
 #if defined(HAS_SPI_TFT) || defined(USE_EINK) || defined(USE_SPISSD1306)
-        screen = new graphics::Screen(screen_found, screen_model, screen_geometry);
+        screen = std::make_unique<graphics::Screen>(screen_found, screen_model, screen_geometry);
 #elif defined(ARCH_PORTDUINO)
         if ((screen_found.port != ScanI2C::I2CPort::NO_I2C || portduino_config.displayPanel) &&
             config.display.displaymode != meshtastic_Config_DisplayConfig_DisplayMode_COLOR) {
-            screen = new graphics::Screen(screen_found, screen_model, screen_geometry);
+            screen = std::make_unique<graphics::Screen>(screen_found, screen_model, screen_geometry);
         }
 #else
         if (screen_found.port != ScanI2C::I2CPort::NO_I2C)
-            screen = new graphics::Screen(screen_found, screen_model, screen_geometry);
+            screen = std::make_unique<graphics::Screen>(screen_found, screen_model, screen_geometry);
 #endif
     }
 #endif // HAS_SCREEN

--- a/src/main.h
+++ b/src/main.h
@@ -11,6 +11,7 @@
 #include "mesh/generated/meshtastic/telemetry.pb.h"
 #include <SPI.h>
 #include <map>
+#include <memory>
 #if defined(ARCH_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32S2) && !MESHTASTIC_EXCLUDE_BLUETOOTH
 #include "nimble/NimbleBluetooth.h"
 extern NimbleBluetooth *nimbleBluetooth;
@@ -68,7 +69,7 @@ extern UdpMulticastHandler *udpHandler;
 #endif
 
 // Global Screen singleton.
-extern graphics::Screen *screen;
+extern std::unique_ptr<graphics::Screen> screen;
 
 #if !defined(ARCH_STM32WL) && !MESHTASTIC_EXCLUDE_I2C && !MESHTASTIC_EXCLUDE_ACCELEROMETER
 #include "motion/AccelerometerThread.h"

--- a/src/modules/TraceRouteModule.cpp
+++ b/src/modules/TraceRouteModule.cpp
@@ -12,7 +12,7 @@
 #include "modules/TrafficManagementModule.h"
 #endif
 
-extern graphics::Screen *screen;
+extern std::unique_ptr<graphics::Screen> screen;
 
 TraceRouteModule *traceRouteModule;
 

--- a/src/motion/BMM150Sensor.cpp
+++ b/src/motion/BMM150Sensor.cpp
@@ -4,7 +4,7 @@
 #if !defined(MESHTASTIC_EXCLUDE_SCREEN)
 
 // screen is defined in main.cpp
-extern graphics::Screen *screen;
+extern std::unique_ptr<graphics::Screen> screen;
 #endif
 
 BMM150Sensor::BMM150Sensor(ScanI2C::FoundDevice foundDevice) : MotionSensor::MotionSensor(foundDevice) {}

--- a/src/motion/BMX160Sensor.cpp
+++ b/src/motion/BMX160Sensor.cpp
@@ -8,7 +8,7 @@ BMX160Sensor::BMX160Sensor(ScanI2C::FoundDevice foundDevice) : MotionSensor::Mot
 #if !defined(MESHTASTIC_EXCLUDE_SCREEN)
 
 // screen is defined in main.cpp
-extern graphics::Screen *screen;
+extern std::unique_ptr<graphics::Screen> screen;
 #endif
 
 bool BMX160Sensor::init()

--- a/src/motion/ICM20948Sensor.cpp
+++ b/src/motion/ICM20948Sensor.cpp
@@ -4,7 +4,7 @@
 #if !defined(MESHTASTIC_EXCLUDE_SCREEN)
 
 // screen is defined in main.cpp
-extern graphics::Screen *screen;
+extern std::unique_ptr<graphics::Screen> screen;
 #endif
 
 // Flag when an interrupt has been detected

--- a/src/motion/MMC5983MASensor.cpp
+++ b/src/motion/MMC5983MASensor.cpp
@@ -6,7 +6,7 @@
 #include "detect/ScanI2CTwoWire.h"
 
 #if !defined(MESHTASTIC_EXCLUDE_SCREEN)
-extern graphics::Screen *screen;
+extern std::unique_ptr<graphics::Screen> screen;
 #endif
 
 static constexpr float MMC5983MA_ZERO_FIELD = 131072.0f;

--- a/src/motion/MotionSensor.cpp
+++ b/src/motion/MotionSensor.cpp
@@ -45,7 +45,7 @@ CompassAccelSample latestCompassAccelSample;
 } // namespace
 
 // screen is defined in main.cpp
-extern graphics::Screen *screen;
+extern std::unique_ptr<graphics::Screen> screen;
 
 MotionSensor::MotionSensor(ScanI2C::FoundDevice foundDevice)
 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display lifecycle handling during reboot by safely resetting the active screen reference before restart.
* **Refactor**
  * Updated the shared screen handle to use automatic ownership management, reducing the chance of stale references and resource leaks while keeping existing screen usage behavior the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->