### PR TITLE
fix(api): bound the stream drain so a full config dump can't starve the watchdog

### DIFF
--- a/src/mesh/StreamAPI.cpp
+++ b/src/mesh/StreamAPI.cpp
@@ -13,7 +13,9 @@
 int32_t StreamAPI::runOncePart()
 {
     auto result = readStream();
-    writeStream();
+    // More to send: come straight back instead of sleeping out readStream's idle delay.
+    if (writeStream())
+        result = 0;
     checkConnectionTimeout();
     return result;
 }
@@ -22,7 +24,8 @@ int32_t StreamAPI::runOncePart()
 int32_t StreamAPI::runOncePart(char *buf, uint16_t bufLen)
 {
     auto result = readStream(buf, bufLen);
-    writeStream();
+    if (writeStream())
+        result = 0;
     checkConnectionTimeout();
     return result;
 }
@@ -44,25 +47,29 @@ int32_t StreamAPI::readStream(const char *buf, uint16_t bufLen)
     }
 }
 
-/**
- * call getFromRadio() and deliver encapsulated packets to the Stream
- */
-void StreamAPI::writeStream()
+/// Emit a slice of pending output. True means "more to send, come straight back"; false covers
+/// both a drained queue and backpressure, where retrying at once would only spin.
+bool StreamAPI::writeStream()
 {
-    if (canWrite) {
-        // A transport that retained a short frame must complete it before
-        // getFromRadio() advances the PhoneAPI state to the next packet.
-        if (!finishPendingFrame())
-            return;
+    if (!canWrite)
+        return false;
 
-        uint32_t len;
-        do {
-            // Send every packet we can
-            len = getFromRadio(txBuf + HEADER_LEN);
-            if (len != 0 && !emitTxBuffer(len))
-                break;
-        } while (len);
-    }
+    // A retained short frame must complete before getFromRadio() advances the PhoneAPI state.
+    if (!finishPendingFrame())
+        return false;
+
+    // Draining a full dump in one call never returns to loop(), so the 8s hardware watchdog
+    // fires mid-dump. PhoneAPI is resumable, so stop at the budget and continue next dispatch.
+    uint32_t len;
+    uint32_t started = millis();
+    do {
+        // Send every packet we can, up to this slice's budget
+        len = getFromRadio(txBuf + HEADER_LEN);
+        if (len != 0 && !emitTxBuffer(len))
+            return false;
+    } while (len && Throttle::isWithinTimespanMs(started, STREAM_WRITE_BUDGET_MSEC));
+
+    return len != 0;
 }
 
 /// Parse supplied bytes through the framed ToRadio receive state machine.

--- a/src/mesh/StreamAPI.h
+++ b/src/mesh/StreamAPI.h
@@ -9,6 +9,10 @@
 // A To/FromRadio packet + our 32 bit header
 #define MAX_STREAM_BUF_SIZE (MAX_TO_FROM_RADIO_SIZE + sizeof(uint32_t))
 
+// Cap on one writeStream() slice: an uncapped dump never reaches loop(), so a board with a
+// hardware watchdog (RP2350 arms 8s) resets mid-dump.
+#define STREAM_WRITE_BUDGET_MSEC 100
+
 /**
  * A version of our 'phone' API that talks over a Stream.  So therefore well suited to use with serial links
  * or TCP connections.
@@ -64,10 +68,9 @@ class StreamAPI : public PhoneAPI
     int32_t readStream(const char *buf, uint16_t bufLen);
     int32_t handleRecStream(const char *buf, uint16_t bufLen);
 
-    /**
-     * call getFromRadio() and deliver encapsulated packets to the Stream
-     */
-    void writeStream();
+    /// Emit a slice of pending output. True asks the caller to come straight back; false covers
+    /// both a drained queue and backpressure, so it does not mean the queue is empty.
+    bool writeStream();
 
   protected:
     /**


### PR DESCRIPTION
## Problem

`StreamAPI::writeStream()` drains the entire queue in a single call — "send every packet we can":

```cpp
uint32_t len;
do {
    len = getFromRadio(txBuf + HEADER_LEN);
    if (len != 0 && !emitTxBuffer(len))
        break;
} while (len);
```

When a client asks for the full config, that one call sends the node database, then the file manifest, then the packet backlog and the position replay. None of it returns to `loop()`.

On RP2350 `rp2040Loop()` arms an 8 s hardware watchdog and is the only caller of `watchdog_update()`, so a dump that runs longer than 8 s resets the board in the middle of the file manifest. With a full node database (120 entries) it does, on every single connection. With a small database the dump finished under the timeout and nothing looked wrong, which is why this is easy to miss.

The reset is silent — no panic text, no fault, no FreeRTOS hook — because nothing is wrong with the code that is running; the loop simply never gets its turn.

## Measurement

Instrumented build on a `pico2_w5500_e22`, crumb kept in the watchdog scratch registers (SRAM does not survive this reset — the RP2350 watchdog restarts the power sequencer, so `POWMAN.CHIP_RESET` reads `HAD_POR`):

- last `rp2040Loop()` iteration at `millis=27242`
- `ServerAPI` kept logging until uptime 35 s (`Config Send Complete millis=34404`, `Begin position replay: 24 entries millis=34684`)
- reset at ≈35.2 s uptime = **27.242 + 8.0**

`watchdog_hw->reason` reads `TIMER`, and `POWMAN.CHIP_RESET` shows no `HAD_BOR` / `HAD_GLITCH_DETECT` / `HAD_RUN_LOW`, ruling out a supply problem.

Control: a second node on the same firmware with an equally full node database, but which no client ever ran a `want_config` against, ran all day with zero resets.

## Fix

Take a slice instead of the whole queue. The `PhoneAPI` state machine is resumable, so `writeStream()` stops after `STREAM_WRITE_BUDGET_MSEC` (100 ms) and reports whether anything is left; `runOncePart()` then returns 0 so the thread is re-dispatched on the next loop iteration rather than sleeping out `readStream()`'s idle delay mid-dump.

That keeps throughput — the dump still completes in ~8 s, same as before — while `loop()` gets to feed the watchdog between slices.

Backpressure on a retained frame keeps returning the caller's normal delay, as before: asking to be re-run immediately would just spin on a full transport.

## Testing

Hardware, `pico2_w5500_e22` (RP2350 + W5500), node database at 120 entries:

- before: reset on **15/15** full config dumps
- after: **10/10** dumps completed, no resets, boot counter in syslog unchanged

Boards without a hardware watchdog will not have seen a reset from this, but they were still spending seconds inside one `runOnce()` call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved outgoing stream delivery when write availability is paused or constrained.
  - Outgoing data is now processed in bounded time slices to prevent prolonged blocking.
  - Stream sending reliably resumes across dispatch iterations until pending bytes are fully transmitted.
  - Improved handling of partial frames and transmission backpressure.
  - Pending data now continues sending promptly when the connection becomes available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->