### PR TITLE
lint: fix stale trivy rule codes in clusterfuzzlite Dockerfile

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -4,19 +4,16 @@
 # As this is not a long running service, health-checks are not required. ClusterFuzzLite
 # also only works if the user remains unchanged from the base image (it expects to run
 # as root).
-# trunk-ignore-all(trivy/DS026): No healthcheck is needed for this builder container
+# trunk-ignore-all(trivy/DS-0026): No healthcheck is needed for this builder container
 # trunk-ignore-all(checkov/CKV_DOCKER_2): No healthcheck is needed for this builder container
 # trunk-ignore-all(checkov/CKV_DOCKER_3): We must run as root for this container
-# trunk-ignore-all(trivy/DS002): We must run as root for this container
-# trunk-ignore-all(checkov/CKV_DOCKER_8): We must run as root for this container
-# trunk-ignore-all(hadolint/DL3002): We must run as root for this container
+# trunk-ignore-all(trivy/DS-0002): We must run as root for this container
 
 FROM gcr.io/oss-fuzz-base/base-builder:v1
 
 ENV PIP_ROOT_USER_ACTION=ignore
 
 # trunk-ignore(hadolint/DL3008): apt packages are not pinned.
-# trunk-ignore(terrascan/AC_DOCKER_0002): apt packages are not pinned.
 RUN apt-get update && apt-get install --no-install-recommends -y \
         cmake git zip libgpiod-dev libjsoncpp-dev libbluetooth-dev libi2c-dev \
         libunistring-dev libmicrohttpd-dev libgnutls28-dev libgcrypt20-dev \


### PR DESCRIPTION
The trunk upgrade (#11140) renamed trivy's Dockerfile rules from DSxxx to
DS-xxxx, so the trunk-ignore-all directives for DS026/DS002 stopped
suppressing and the HEALTHCHECK / non-root-USER findings resurfaced.
Update the codes to DS-0026 / DS-0002, and drop the checkov/CKV_DOCKER_8,
hadolint/DL3002 and disabled terrascan ignores that no longer match any
finding.
---
One of a series of small, independent lint cleanups that clear `trunk check` failures. This PR contains a single commit.

Written by Claude (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker security and compliance suppression annotations to better align with current healthcheck and root-execution handling.
  * Removed obsolete suppression entries while keeping the existing allowance for unpinned apt package usage.
  * Adjusted related review comments without changing exported product behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->