### PR TITLE
lint: suppress intentional root USER in runtime Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-# trunk-ignore-all(trivy/DS002): We must run as root for this container
+# trunk-ignore-all(trivy/DS-0002): We must run as root for this container
+# trunk-ignore-all(checkov/CKV_DOCKER_8): We must run as root for this container
 # trunk-ignore-all(hadolint/DL3002): We must run as root for this container
 # trunk-ignore-all(hadolint/DL3008): Do not pin apt package versions
 # trunk-ignore-all(hadolint/DL3013): Do not pin pip package versions

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -1,4 +1,5 @@
-# trunk-ignore-all(trivy/DS002): We must run as root for this container
+# trunk-ignore-all(trivy/DS-0002): We must run as root for this container
+# trunk-ignore-all(checkov/CKV_DOCKER_8): We must run as root for this container
 # trunk-ignore-all(hadolint/DL3002): We must run as root for this container
 # trunk-ignore-all(hadolint/DL3018): Do not pin apk package versions
 # trunk-ignore-all(hadolint/DL3013): Do not pin pip package versions


### PR DESCRIPTION
meshtasticd must run as root to reach GPIO/I2C/SPI hardware, so the final
USER root is deliberate. The existing file-level ignore used the old trivy
code (DS002); rename it to DS-0002 and add checkov/CKV_DOCKER_8 so the
last-USER-root findings are suppressed with an explicit justification.
---
One of a series of small, independent lint cleanups that clear `trunk check` failures. This PR contains a single commit.

Written by Claude (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated top-of-file security scan suppression comments in the container build files to reflect current Trivy rule formatting, including the updated Trivy ignore identifier.
  * Added a Checkov suppression entry for the documented requirement that the container runs as root.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->