### PR TITLE
lint: drop dead terrascan ignore in devcontainer Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,3 @@
-# trunk-ignore-all(terrascan/AC_DOCKER_0002): Known terrascan issue
 # trunk-ignore-all(hadolint/DL3008): Do not pin apt package versions
 # trunk-ignore-all(hadolint/DL3013): Do not pin pip package versions
 FROM mcr.microsoft.com/devcontainers/cpp:2-debian-13


### PR DESCRIPTION
terrascan is not an enabled linter, so the trunk-ignore-all directive only
produced a "disabled linter" note. Remove it.
---
One of a series of small, independent lint cleanups that clear `trunk check` failures. This PR contains a single commit.

Written by Claude (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed an outdated security-scan suppression comment from the development container configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->