### PR TITLE
lint: drop redundant quotes in .coderabbit.yaml

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,7 +13,7 @@ reviews:
     drafts: false
     # Review PRs regardless of target branch.
     base_branches:
-      - ".*"
+      - .*
     # Skip Renovate dependency updates - CI gates dependencies; we review for substance, not every bump.
     ignore_usernames:
       - renovate
@@ -27,7 +27,7 @@ reviews:
     - "!protobufs/**"
 
   path_instructions:
-    - path: "bin/config.d/**"
+    - path: bin/config.d/**
       instructions: >
         meshtasticd configuration files. Bundled with meshtasticd Linux/MacOS packaging.
         Ensure configurations include metadata found in other configs.


### PR DESCRIPTION
yamllint quoted-strings (only-when-needed) flags the plain-scalar values
".*" and "bin/config.d/**", which do not require quoting.
---
One of a series of small, independent lint cleanups that clear `trunk check` failures. This PR contains a single commit.

Written by Claude (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the review path configuration to use unquoted glob patterns, improving how matching rules are applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->