### PR TITLE
lint: clean up pr_tests workflow lint findings

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -4,10 +4,11 @@ name: Tests
 on:
   workflow_dispatch:
     inputs:
+      # trunk-ignore(checkov/CKV_GHA_7): the reason input is a free-text run label, never fed into the build
       reason:
-        description: "Reason for manual test run"
+        description: Reason for manual test run
         required: false
-        default: "Manual test execution"
+        default: Manual test execution
 
 concurrency:
   group: tests-${{ github.head_ref || github.run_id }}
@@ -21,7 +22,7 @@ permissions:
 
 jobs:
   native-tests:
-    name: "🧪 Native Tests"
+    name: 🧪 Native Tests
     if: github.repository == 'meshtastic/firmware'
     uses: ./.github/workflows/test_native.yml
     permissions:
@@ -30,7 +31,7 @@ jobs:
       checks: write
 
   test-summary:
-    name: "📊 Test Results"
+    name: 📊 Test Results
     runs-on: ubuntu-latest
     needs: [native-tests]
     if: always()


### PR DESCRIPTION
Suppress checkov/CKV_GHA_7 (the workflow_dispatch reason input is a
free-text run label that never reaches the build) and drop the redundant
quotes yamllint flags on the description/default/name scalars.
---
One of a series of small, independent lint cleanups that clear `trunk check` failures. This PR contains a single commit.

Written by Claude (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated manual test-run workflow labeling and “Reason for manual test run” metadata formatting.
  * Refined job display names for native tests and test summary (emoji-based formatting).
  * Added an ignore annotation for automated security checks related to workflow inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->