### PR TITLE
lint: drop dead CKV2_GHA_1 ignore in main_matrix workflow

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -215,7 +215,6 @@ jobs:
       push: false
 
   gather-artifacts:
-    # trunk-ignore(checkov/CKV2_GHA_1)
     if: github.repository == 'meshtastic/firmware'
     strategy:
       fail-fast: false


### PR DESCRIPTION
The trunk-ignore no longer matches any finding (the job sets its own
permissions), so it only produced an ignore-does-nothing note.
---
One of a series of small, independent lint cleanups that clear `trunk check` failures. This PR contains a single commit.

Written by Claude (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the continuous integration workflow to remove an outdated inline security-scan suppression that was no longer needed during the artifact collection phase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->