### PR TITLE
lint: use find_spec for the intelhex availability check

### DIFF
--- a/extra_scripts/esp32_extra.py
+++ b/extra_scripts/esp32_extra.py
@@ -3,6 +3,7 @@
 # trunk-ignore-all(flake8/F821): For SConstruct imports
 # trunk-ignore-all(ruff/E402): Hacky esptool import
 # trunk-ignore-all(flake8/E402): Hacky esptool import
+import importlib.util
 import sys
 from os.path import join
 
@@ -12,9 +13,7 @@ platform = env.PioPlatform()
 sys.path.append(join(platform.get_package_dir("tool-esptoolpy")))
 # IntelHex workaround, remove after fixed upstream
 # https://github.com/platformio/platform-espressif32/issues/1632
-try:
-    import intelhex
-except ImportError:
+if importlib.util.find_spec("intelhex") is None:
     env.Execute("$PYTHONEXE -m pip install intelhex")
 import esptool
 


### PR DESCRIPTION
flake8/ruff F401 flag the bare `import intelhex` as unused; it only exists
to probe whether the package is installed. Use importlib.util.find_spec so
the intent is explicit and no unused import remains.
---
One of a series of small, independent lint cleanups that clear `trunk check` failures. This PR contains a single commit.

Written by Claude (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build-time detection and installation of the required Intel HEX tooling.
  * Increased reliability when creating combined ESP32 factory binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->