### PR TITLE
lint: hoist stdlib imports above Import(env) in add_mbedtls_sources

### DIFF
--- a/scripts/add_mbedtls_sources.py
+++ b/scripts/add_mbedtls_sources.py
@@ -10,12 +10,10 @@
 
 # trunk-ignore-all(ruff/F821)
 # trunk-ignore-all(flake8/F821): Import/env/Return are SCons-injected globals
-# trunk-ignore-all(ruff/E402)
-# trunk-ignore-all(flake8/E402): stdlib imports must follow Import("env")
-Import("env")
-
 import glob
 import os
+
+Import("env")
 
 framework_dir = env.PioPlatform().get_package_dir("framework-arduinopico")
 if not framework_dir:


### PR DESCRIPTION
glob and os do not depend on the SCons-injected env, so importing them at
the top of the file removes the flake8 E402 findings and lets the E402
ignore-all directives (which were no longer suppressing anything) go away.
---
One of a series of small, independent lint cleanups that clear `trunk check` failures. This PR contains a single commit.

Written by Claude (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved script organization and linting consistency without changing build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->