### PR TITLE
lint: drop redundant bandit ignores in c3 exception decoder

### DIFF
--- a/monitor/filter_c3_exception_decoder.py
+++ b/monitor/filter_c3_exception_decoder.py
@@ -1,6 +1,3 @@
-# trunk-ignore-all(bandit/B404): subprocess is used to call addr2line
-# trunk-ignore-all(bandit/B603): subprocess is used to call addr2line
-
 # Copyright (c) 2014-present PlatformIO <contact@platformio.org>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
B404 and B603 are already skipped globally in .trunk/configs/.bandit, so
the file-level ignore-all directives never suppressed anything.
---
One of a series of small, independent lint cleanups that clear `trunk check` failures. This PR contains a single commit.

Written by Claude (Claude Code).