### PR TITLE
lint: disable MD060 to match the markdown formatter

### DIFF
--- a/.trunk/configs/.markdownlint.yaml
+++ b/.trunk/configs/.markdownlint.yaml
@@ -9,3 +9,6 @@ spaces: false
 url: false
 whitespace: false
 headings: false
+# Table column alignment is decided by the markdown formatter, which pads by
+# codepoint count and so disagrees with MD060 on emoji-width table columns.
+MD060: false


### PR DESCRIPTION
The formatter aligns table columns by codepoint count, which disagrees
with markdownlint MD060 (Table column style) on emoji-width columns such as
the InkHUD glyph table. Disable MD060 in the autoformatter-friendly config.
---
One of a series of small, independent lint cleanups that clear `trunk check` failures. This PR contains a single commit.

Written by Claude (Claude Code).