### PR TITLE
lint: hoist SerialModule arch gate into HAS_SERIALMODULE

### DIFF
--- a/src/modules/Modules.cpp
+++ b/src/modules/Modules.cpp
@@ -244,8 +244,7 @@ void setupModules()
         new PowerTelemetryModule();
     }
 #endif
-#if (defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040) || defined(ARCH_STM32WL)) &&                             \
-    !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+#if HAS_SERIALMODULE
 #if !MESHTASTIC_EXCLUDE_SERIAL
     if (moduleConfig.has_serial && moduleConfig.serial.enabled &&
         config.display.displaymode != meshtastic_Config_DisplayConfig_DisplayMode_COLOR) {

--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -49,8 +49,7 @@
 #include "meshSolarApp.h"
 #endif
 
-#if (defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040) || defined(ARCH_STM32WL)) &&                             \
-    !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+#if HAS_SERIALMODULE
 
 #define RX_BUFFER 256
 #define TIMEOUT 250

--- a/src/modules/SerialModule.h
+++ b/src/modules/SerialModule.h
@@ -8,8 +8,20 @@
 #include <Arduino.h>
 #include <functional>
 
-#if (defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040) || defined(ARCH_STM32WL)) &&                             \
-    !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+// Platforms with a spare hardware UART available for the Serial module. The
+// ESP32-S2 and ESP32-C3 targets are excluded because their single UART is
+// reserved for other use. Split across nested directives to keep each
+// preprocessor conditional under the too-many-defined complexity limit.
+#if defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040) || defined(ARCH_STM32WL)
+#if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+#define HAS_SERIALMODULE 1
+#endif
+#endif
+#ifndef HAS_SERIALMODULE
+#define HAS_SERIALMODULE 0
+#endif
+
+#if HAS_SERIALMODULE
 
 class SerialModule : public StreamAPI, private concurrency::OSThread
 {


### PR DESCRIPTION
The (ARCH_ESP32||ARCH_NRF52||ARCH_RP2040||ARCH_STM32WL) && !ESP32S2 &&
!ESP32C3 guard was duplicated verbatim in SerialModule.h, SerialModule.cpp
and Modules.cpp, and each copy tripped the too-many-defined ifdef-complexity
check. Define it once as HAS_SERIALMODULE in SerialModule.h (split across
nested directives to stay under the complexity limit) and reference the
macro at the three sites. Verified boolean-equivalent to the original
expression across arch/target combinations with the preprocessor.
---
One of a series of small, independent lint cleanups that clear `trunk check` failures. This PR contains a single commit.

Written by Claude (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform detection for serial module support.
  * Preserved serial functionality on supported platforms while correctly excluding unsupported ESP32 variants and other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->