### PR TITLE
lint: suppress ifdef-complexity on ad-hoc board lists

### DIFF
--- a/src/graphics/EInkDisplay2.cpp
+++ b/src/graphics/EInkDisplay2.cpp
@@ -211,6 +211,7 @@ bool EInkDisplay::connect()
         }
     }
 
+// trunk-ignore(too-many-defined/too-many-defined): explicit HSPI e-paper board list, no umbrella macro fits
 #elif defined(HELTEC_WIRELESS_PAPER_V1_0) || defined(HELTEC_VISION_MASTER_E290) || defined(TLORA_T3S3_EPAPER) ||                 \
     defined(CROWPANEL_ESP32S3_5_EPAPER) || defined(CROWPANEL_ESP32S3_4_EPAPER) || defined(CROWPANEL_ESP32S3_2_EPAPER) ||         \
     defined(MINI_EPAPER_S3)

--- a/src/graphics/EInkDisplay2.h
+++ b/src/graphics/EInkDisplay2.h
@@ -87,6 +87,7 @@ class EInkDisplay : public OLEDDisplay
 #endif
 
     // If display uses HSPI
+    // trunk-ignore(too-many-defined/too-many-defined): explicit HSPI e-paper board list, no umbrella macro fits
 #if defined(HELTEC_WIRELESS_PAPER) || defined(HELTEC_WIRELESS_PAPER_V1_0) || defined(HELTEC_VISION_MASTER_E213) ||               \
     defined(HELTEC_VISION_MASTER_E290) || defined(TLORA_T3S3_EPAPER) || defined(CROWPANEL_ESP32S3_5_EPAPER) ||                   \
     defined(CROWPANEL_ESP32S3_4_EPAPER) || defined(CROWPANEL_ESP32S3_2_EPAPER) || defined(ELECROW_ThinkNode_M5) ||               \

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1005,6 +1005,7 @@ void NodeDB::installDefaultConfig(bool preserveKey = false)
     resetRadioConfig(true); // This also triggers NodeInfo/Position requests since we're fresh
     strncpy(config.network.ntp_server, "meshtastic.pool.ntp.org", 32);
 
+// trunk-ignore(too-many-defined/too-many-defined): explicit TFT keyboard board list, no umbrella macro fits
 #if (defined(T_DECK) || defined(T_WATCH_S3) || defined(UNPHONE) || defined(PICOMPUTER_S3) || defined(SENSECAP_INDICATOR) ||      \
      defined(ELECROW_PANEL) || defined(HELTEC_V4_TFT) || defined(HELTEC_V4_R8_TFT) || defined(RAK_WISMESH_TAP_V2)) &&            \
     HAS_TFT


### PR DESCRIPTION
NodeDB and EInkDisplay2 gate behaviour on explicit board-name lists (TFT
keyboard devices that default Bluetooth off; e-paper panels wired on HSPI).
Unlike the SerialModule arch gate, these are one-off enumerations with no
umbrella feature macro to fold them into, and rewriting them blind risks
silently dropping a board. Suppress the too-many-defined findings with an
explicit justification instead. Comments are kept on a single line so
clang-format's reflow does not detach them from the directive.
---
One of a series of small, independent lint cleanups that clear `trunk check` failures. This PR contains a single commit.

Written by Claude (Claude Code).