### PR TITLE
Fix: ESP32 NimBLE deinit/reinit cycle breaks bonded reconnect (reason…

### DIFF
--- a/src/modules/SystemCommandsModule.cpp
+++ b/src/modules/SystemCommandsModule.cpp
@@ -58,19 +58,20 @@ int SystemCommandsModule::handleInputEvent(const InputEvent *event)
 #if defined(ARDUINO_ARCH_NRF52)
         if (!config.bluetooth.enabled) {
             disableBluetooth();
-            IF_SCREEN(screen->showSimpleBanner("Bluetooth OFF\nRebooting", 3000));
-            rebootAtMsec = millis() + DEFAULT_REBOOT_SECONDS * 2000;
+            IF_SCREEN(screen->showSimpleBanner("Bluetooth OFF", 3000));
         } else {
-            IF_SCREEN(screen->showSimpleBanner("Bluetooth ON\nRebooting", 3000));
-            rebootAtMsec = millis() + DEFAULT_REBOOT_SECONDS * 1000;
+            IF_SCREEN(screen->showSimpleBanner("Bluetooth ON", 3000));
+            if (nrf52Bluetooth)
+                nrf52Bluetooth->resumeAdvertising();
         }
 #else
         if (!config.bluetooth.enabled) {
             disableBluetooth();
             IF_SCREEN(screen->showSimpleBanner("Bluetooth OFF", 3000));
         } else {
-            IF_SCREEN(screen->showSimpleBanner("Bluetooth ON\nRebooting", 3000));
-            rebootAtMsec = millis() + DEFAULT_REBOOT_SECONDS * 1000;
+            IF_SCREEN(screen->showSimpleBanner("Bluetooth ON", 3000));
+            if (nimbleBluetooth)
+                nimbleBluetooth->setup();
         }
 #endif
         return 0;

--- a/src/nimble/NimbleBluetooth.cpp
+++ b/src/nimble/NimbleBluetooth.cpp
@@ -22,8 +22,12 @@
 
 #if defined(CONFIG_NIMBLE_CPP_IDF)
 #include "host/ble_gap.h"
+#include "host/ble_hs.h"
+#include "host/ble_store.h"
 #else
 #include "nimble/nimble/host/include/host/ble_gap.h"
+#include "nimble/nimble/host/include/host/ble_hs.h"
+#include "nimble/nimble/host/include/host/ble_store.h"
 #endif
 
 #if defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C6)
@@ -51,6 +55,26 @@ NimBLEServer *bleServer;
 
 static bool passkeyShowing;
 static std::atomic<uint16_t> nimbleBluetoothConnHandle{BLE_HS_CONN_HANDLE_NONE}; // BLE_HS_CONN_HANDLE_NONE means "no connection"
+
+// Set by deinit() (menu toggle), checked in setup() to gate address
+// resolution + IRK restore on the first init after any deinit.
+//
+// After NimBLEDevice::deinit() resets the ESP32 controller, LE Address
+// Resolution defaults to OFF and the sync-time restore_irks() races with
+// controller readiness -> bonded phones using RPAs fail LTK lookup and
+// instant-disconnect with reason 531. The gated branch in setup() issues
+// an HCI 0x202D and a second restore_irks() after a short delay to fix this.
+//
+// Stays false on fresh power-on so the initial init() -- which already
+// synced the controller correctly -- isn't disturbed by a redundant restore.
+static std::atomic<bool> s_didSleepSinceBoot{false};
+
+// Non-public NimBLE host helpers used by the deinit/reinit fix in setup().
+// Both live in nimble/host/src/ble_hs_priv.h and are not exposed via the
+// public host/*.h headers shipped with esp32-arduino, so we forward-declare
+// them here. The linker resolves them from the NimBLE host library.
+extern "C" int ble_hs_hci_cmd_tx(uint16_t opcode, const void *cmd, uint8_t cmd_len, void *rsp, uint8_t rsp_len);
+extern "C" int ble_hs_misc_restore_irks(void);
 
 static void clearPairingDisplay()
 {
@@ -758,12 +782,15 @@ void NimbleBluetooth::shutdown()
 #endif
 }
 
-// Proper shutdown for ESP32. Needs reboot to reverse.
+// Full shutdown for ESP32. Recoverable via setup(); the address-resolution
+// + IRK restore in setup() gated by s_didSleepSinceBoot repairs the state
+// that NimBLEDevice::deinit() leaves the controller in.
 void NimbleBluetooth::deinit()
 {
 #ifdef ARCH_ESP32
-    LOG_INFO("Disable bluetooth until reboot");
+    LOG_INFO("Disable bluetooth (menu toggle)");
     isDeInit = true;
+    s_didSleepSinceBoot = true; // gate setup() to re-enable address resolution + IRKs
 
 #ifdef BLE_LED
     digitalWrite(BLE_LED, LED_STATE_OFF);
@@ -823,9 +850,41 @@ void NimbleBluetooth::setup()
     // Uncomment for testing
     // NimbleBluetooth::clearBonds();
 
+    isDeInit = false; // fresh init -- disconnect handler must process again
+
     LOG_INFO("Init the NimBLE bluetooth module");
 
     NimBLEDevice::init(getDeviceName());
+
+#ifdef ARCH_ESP32
+    if (s_didSleepSinceBoot) {
+        int peerCnt = 0, ourCnt = 0;
+        ble_store_util_count(BLE_STORE_OBJ_TYPE_PEER_SEC, &peerCnt);
+        ble_store_util_count(BLE_STORE_OBJ_TYPE_OUR_SEC, &ourCnt);
+        LOG_INFO("BLE init: peer_sec=%d our_sec=%d", peerCnt, ourCnt);
+
+        // The controller starts with LE Address Resolution DISABLED after any
+        // deinit+reinit. Re-enable it so bonded phones with RPAs can reconnect.
+        delay(50);
+        {
+            uint8_t enable = 1;
+            int rc = ble_hs_hci_cmd_tx(0x202D, &enable, 1, NULL, 0);
+            if (rc != 0) {
+                LOG_WARN("BLE set_addr_res_en failed rc=%d", rc);
+            } else {
+                LOG_INFO("BLE address resolution re-enabled");
+            }
+        }
+        // ble_hs_misc_restore_irks() during host sync may race with controller
+        // readiness. Retry after the delay to ensure IRKs reach the hardware.
+        int rc = ble_hs_misc_restore_irks();
+        if (rc != 0) {
+            LOG_WARN("BLE restore_irks retry failed rc=%d", rc);
+        }
+        s_didSleepSinceBoot = false; // one-shot per deinit cycle
+    }
+#endif
+
     NimBLEDevice::setPower(ESP_PWR_LVL_P9);
 
 #if NIMBLE_ENABLE_2M_PHY && (defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C6))


### PR DESCRIPTION
… 531)

Two independent bugs combine to break bonded reconnects after a NimBLE deinit + reinit cycle on ESP32. Together with the SystemCommandsModule change, this also removes the "reboot required" behavior of the display- menu Bluetooth toggle on both ESP32 and nRF52.

## 1. LE Address Resolution defaults to OFF after controller reset

`NimBLEDevice::deinit(true)` tears down the NimBLE host and resets the Bluetooth controller. On re-init, the host syncs and programs the Identity Resolving Keys (IRKs) of bonded peers into the controller's resolving list, but the controller starts with LE Address Resolution DISABLED (HCI LE Set Address Resolution Enable = off, opcode 0x202D).

When a bonded phone reconnects it uses a Resolvable Private Address (RPA). Without address resolution the controller cannot map the RPA back to the peer's identity -> cannot look up the stored Long Term Key (LTK) -> encryption setup fails with BLE_ERR_PIN_OR_KEY_MISSING (disconnect reason 531) -> link drops immediately.

Fix: send `ble_hs_hci_cmd_tx(0x202D, enable=1, ...)` after `init()` to re-enable controller-side address resolution.

## 2. `ble_hs_misc_restore_irks()` races with controller readiness

`ble_hs_sync()` calls `ble_hs_misc_restore_irks()` to load IRKs from NVS, but at that point the controller may still be initialising -- the HCI commands that program the resolving list get silently dropped or queued. Re-issuing `ble_hs_misc_restore_irks()` after a short `delay(50)` ensures the IRKs actually reach the controller.

Both `ble_hs_hci_cmd_tx` and `ble_hs_misc_restore_irks` live in `nimble/host/src/ble_hs_priv.h` and are not exposed via the public `host/*.h` headers shipped with esp32-arduino. Forward-declared with `extern "C"`; the linker resolves them from the NimBLE host library. Happy to wrap them differently if the maintainers prefer.

## Symptoms observed

- iOS tends to keep the bond and retry; user sees "not connecting" but the bond survives.
- Android interprets the immediate disconnect (reason 531) as "peer lost my bond" and silently deletes the pairing from its own database. The next attempt presents as a fresh device with a new pairing dialog -- users think Bluetooth "forgot" the device.

Both are symptoms of the same root cause; the fix addresses both.

## Gating on first-boot vs post-deinit

A fresh power-on has the controller and host synchronised correctly by the initial `NimBLEDevice::init()`. Running the extra `restore_irks()`/`set_addr_res_en` there causes a boot-loop crash at ~5s. A file-static `s_didSleepSinceBoot` flag guards the fix so it only runs after a real deinit -- `deinit()` sets the flag, `setup()` checks and clears it.

## SystemCommandsModule: menu-toggle no longer reboots

The original firmware had:
> "For ESP32, no way to recover from bluetooth shutdown without reboot"

That was true because NimBLE-Arduino's `deinit(true)` + `init()` left the host in an inconsistent state (address resolution off, IRKs missing). With both bugs fixed, the full enable<->disable<->enable cycle works reliably on ESP32. The display-menu BLE toggle can now call `nimbleBluetooth->setup()` directly instead of scheduling a reboot.

nRF52 already had shutdown/reinit working, so the reboot on that branch was pure conservatism -- the analogous change (call `nrf52Bluetooth->resumeAdvertising()`) also removes the reboot on nRF52.

## Also: reset isDeInit on setup()

The `isDeInit` flag was set to `true` in `deinit()` and never reset. Without a reset, all disconnect events after a re-toggle would be silently short-circuited in the disconnect callback. Set it to `false` at the top of `setup()`.

## Motivation

Beyond the standalone reconnect-bug fix, this is a prerequisite for a periodic BLE-sleep feature I plan to contribute in a follow-up PR. My fork already runs a small state machine that puts the BLE stack through the deinit/reinit sequence periodically while no phone is connected -- significant idle-current savings on ESP32, especially valuable for handheld and battery-only nodes. That sleep cycle triggers the reconnect bug on every wake, so it only becomes a shippable feature once the deinit/reinit path here is correct. Landing this fix first keeps that follow-up as a clean opt-in feature on top of a working stack rather than a workaround stack on top of a broken one.

## 🙏 Thank you for sending in a pull request, here's some tips to get started!

### ❌ (Please delete all these tips and replace them with your text) ❌

- Before starting on some new big chunk of code, it it is optional but highly recommended to open an issue first
  to say "Hey, I think this idea X should be implemented and I'm starting work on it. My general plan is Y, any feedback
  is appreciated." This will allow other devs to potentially save you time by not accidentally duplicating work etc...
- Please do not check in files that don't have real changes
- Please do not reformat lines that you didn't have to change the code on
- We recommend using the [Visual Studio Code](https://platformio.org/install/ide?install=vscode) editor along with the ['Trunk Check' extension](https://marketplace.visualstudio.com/items?itemName=trunk.io) (In beta for windows, WSL2 for the Linux version),
  because it automatically follows our indentation rules and its auto reformatting will not cause spurious changes to lines.
- If your PR fixes a bug, mention "fixes #bugnum" somewhere in your pull request description.
- If your other co-developers have comments on your PR please tweak as needed.
- Please also enable "Allow edits by maintainers".
- Please do not submit untested code.
- If you do not have the affected hardware to test your code changes adequately against regressions, please indicate this, so that contributors and community members can help test your changes.
- If your PR gets accepted you can request a "Contributor" role in the Meshtastic Discord

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
