### PR TITLE
Reduce reboots and radio restarts

### DIFF
--- a/docs/admin-config-save-gating.md
+++ b/docs/admin-config-save-gating.md
@@ -1,0 +1,201 @@
+# AdminModule config-save side effects: radio-reload & reboot gating
+
+**Status:** Implemented
+**Date:** 2026-07-23
+**Area:** `src/modules/AdminModule.cpp` (`handleSetConfig`, `saveChanges`), `src/mesh/MeshService.cpp` (`reloadConfig`), `src/mesh/NodeDB.h` (`SEGMENT_*`)
+**Commits:** `babeef08d` (radio-reload), `65c27f813` + `273fa8d0a` (segment docs / TODO markers), `71d711867` (reboot Tier 1), `cc9abdbbc` (reboot Tier 2)
+
+Saving a config over the phone/BLE used to do more than persist bytes: it could re-init the
+LoRa radio **and** reboot the device, on config that touched neither. This document records
+what those saves do now, which operations were deliberately left alone, and why.
+
+---
+
+## TL;DR
+
+A config-set admin message carries three _independent_ axes that had become conflated:
+
+1. **What to persist** - the `saveWhat` segment bitmask (which on-disk file to rewrite).
+2. **Does the LoRa radio need reconfiguring?** - now the explicit `radioAffected` flag.
+3. **Does the device need a reboot?** - the `requiresReboot` flag.
+
+Previously (2) was _inferred_ from (1) (`saveWhat & SEGMENT_CONFIG`), and (3) defaulted to
+`true` for several sub-messages that never revisited it. Both inferences were wrong for
+config that doesn't touch LoRa or doesn't need a restart. They are now decided explicitly and
+per-field. Net effect: toggling Bluetooth, changing a WiFi PSK, rotating keys, or nudging a
+position broadcast interval no longer re-inits the radio, and several of them no longer reboot.
+
+The guiding rule for what was left alone: **fail toward the old behavior.** Anything whose
+live-apply couldn't be _proven_ safe still reloads/reboots exactly as before.
+
+---
+
+## Background: what a segment is
+
+`SEGMENT_*` ([`NodeDB.h:87`](../src/mesh/NodeDB.h#L87)) is a bit selecting **one on-disk proto
+file - a write unit, not a semantic config domain.** `SEGMENT_CONFIG` is the _entire_
+`LocalConfig` proto in a single file, covering all eight sub-messages
+(device/display/lora/position/power/network/bluetooth/security). Writing it reserializes the
+whole struct, so the mask can say _which file_ changed but never _which sub-message_ - it
+cannot tell a LoRa change from a Bluetooth one. That is precisely why "does the radio need
+reconfiguring?" cannot be inferred from the mask and needs its own signal.
+
+---
+
+## Axis 1 - Radio reload (`radioAffected`)
+
+`MeshService::reloadConfig(int saveWhat, bool radioAffected = true)`
+([`MeshService.cpp:138`](../src/mesh/MeshService.cpp#L138)) fires the live SX126x reconfigure
+(`resetRadioConfig()` + `configChanged.notifyObservers()`) only when:
+
+```cpp
+if (radioAffected && (saveWhat & (SEGMENT_CONFIG | SEGMENT_CHANNELS)))
+```
+
+The bitmask gate is **retained** (so the ~35 non-AdminModule callers are unaffected) and
+`radioAffected` only ever _suppresses_ the reload. It defaults to `true`, so any caller that
+does not opt out keeps the historical behavior. `AdminModule::saveChanges`
+([`:1846`](../src/modules/AdminModule.cpp#L1846)) threads it through; `handleSetConfig`
+([`:836`](../src/modules/AdminModule.cpp#L836)) sets `radioAffected = true`
+([`:845`](../src/modules/AdminModule.cpp#L845)) only in the `lora_tag` case.
+
+| Admin operation                                                         | Reloads radio now? | Notes                                                                                                    |
+| ----------------------------------------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------- |
+| `set_config` → `lora`                                                   | **Yes**            | The only config that feeds `RadioInterface::reconfigure()` (reads `config.lora`). Region swaps included. |
+| `set_config` → device/position/power/network/display/bluetooth/security | **No** (was yes)   | Persist `SEGMENT_CONFIG`, but none affect the modem.                                                     |
+| `set_fixed_position` / `remove_fixed_position`                          | **No** (was yes)   | Rode `SEGMENT_CONFIG` only because `fixed_position` shares the Config file.                              |
+| `set_channel`                                                           | **Yes**            | Real frequency-slot/PSK change ([`:1445`](../src/modules/AdminModule.cpp#L1445)).                        |
+
+Why this matters beyond tidiness: the reconfigure is a live `setStandby()` + SPI reprogram on
+the admin/BLE callback thread - the exact sequence that crashed the WisMesh Tag on a
+favorite (#11146). Removing it for non-LoRa saves closes the rest of that crash class and
+avoids a needless RX gap on the mesh radio.
+
+---
+
+## Axis 2 - Device reboot (`requiresReboot`)
+
+`handleSetConfig` starts `requiresReboot = true` ([`:841`](../src/modules/AdminModule.cpp#L841))
+and reboots via `saveChanges` when it stays true. `device`, `power`, and `display` already
+narrowed it (reboot only when a reboot-relevant field changed); `position`, `network`, and
+`bluetooth` never did - they rebooted on **every** set, including a client re-pushing
+byte-identical config. Two tiers fixed that.
+
+### Tier 1 - no-op gate (position / network / bluetooth)
+
+If the incoming sub-message is byte-identical to the current one, skip the reboot. Uses a
+whole-struct `memcmp` - the right tool for "did anything change?", and fail-safe: its only
+error mode is padding bytes differing → an _unnecessary_ reboot (old behavior), never a
+missed change. All three sub-messages are POD (no `pb_callback_t`).
+
+- `network` ([`:952`](../src/modules/AdminModule.cpp#L952)) and `bluetooth`
+  ([`:1136`](../src/modules/AdminModule.cpp#L1136)): any **real** change still reboots
+  (restarts the WiFi/eth or BLE stack).
+
+### Tier 2 - position live-apply
+
+`position` ([`:901`](../src/modules/AdminModule.cpp#L901)) reboots only when a field that
+**cannot** be applied live changed. The live set is exactly what `PositionModule` reads
+directly from `config` each send/schedule cycle:
+
+| Field                                     | Reboot on change? | Rationale                                         |
+| ----------------------------------------- | ----------------- | ------------------------------------------------- |
+| `position_broadcast_secs`                 | No                | Read live in the broadcast scheduler              |
+| `position_broadcast_smart_enabled`        | No                | Read live in the send path                        |
+| `broadcast_smart_minimum_distance`        | No                | Read live in the smart-position path              |
+| `position_flags`                          | No                | Read live per outgoing position                   |
+| `fixed_position`                          | No                | Read live; also has dedicated live admin handlers |
+| `gps_mode`, `gps_enabled`                 | **Yes**           | GPS driver state                                  |
+| `gps_update_interval`, `gps_attempt_time` | **Yes**           | GPS subsystem timing                              |
+| `rx_gpio`, `tx_gpio`, `gps_en_gpio`       | **Yes**           | GPIO pin (re)assignment                           |
+
+The gate neutralizes the live fields in a copy and reboots if any _other_ byte differs, so a
+newly-added `PositionConfig` field reboots until it is explicitly cleared as live - fail-safe
+for schema growth.
+
+---
+
+## Operations intentionally left unchanged ("third tier")
+
+These were audited and deliberately **not** narrowed. Each still reloads and/or reboots as
+before. The common thread: the reload/reboot is either genuinely required, or removing it
+would need real state-tracking / hardware verification that carries more risk than the saving
+is worth.
+
+1. **`commit_edit_settings`** ([`:474`](../src/modules/AdminModule.cpp#L474)) - commits a
+   whole edit transaction with a fixed
+   `SEGMENT_CONFIG | SEGMENT_MODULECONFIG | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS | SEGMENT_NODEDATABASE`
+   save (default `radioAffected=true`, `shouldReboot=true`), so it reloads and reboots on
+   **every** commit regardless of what was actually edited.
+   **Why untouched:** narrowing it requires the transaction to track _which_ segments were
+   dirtied (and whether LoRa/reboot-relevant fields were among them) as individual sets ran
+   under `hasOpenEditTransaction`, then OR them at commit - a real state-tracking change, not
+   a one-line gate. Risk is also lower here: edit transactions are rarely
+   node-DB-metadata-only, so the wasteful case is less common. Deferred to its own pass; the
+   same tracking would let it decide both `radioAffected` and `requiresReboot`.
+
+2. **`network` / `bluetooth` beyond the Tier-1 no-op gate** - a _real_ change still reboots.
+   **Why untouched:** these restart the WiFi/Ethernet and BLE stacks. Applying a live change
+   to a partially-initialized stack is genuinely hard to get right and high-risk (dropped
+   links, half-configured interfaces) for little reward. The safe, cheap win (skip the reboot
+   on no-op re-pushes) was taken; live-apply was not.
+
+3. **GPS-timing position fields** (`gps_mode`, `gps_enabled`, `gps_update_interval`,
+   `gps_attempt_time`) - still reboot.
+   **Why untouched:** they touch the GPS subsystem/driver and could not be _statically_
+   proven to apply live (unlike the cadence/flag fields, which are read straight from
+   `config` each cycle). Following the fail-toward-reboot rule, they stay on the reboot path.
+   Moving them to the live set is exactly what a hardware verification pass is for - confirm
+   on a real node that the new value takes effect with no restart, then reclassify.
+
+4. **`handleSetModuleConfig`** ([`:1215`](../src/modules/AdminModule.cpp#L1215)) - every
+   module-config set reboots (`shouldReboot = true`).
+   **Why untouched:** most module sets start or stop background threads (telemetry, serial,
+   MQTT, store-and-forward, detection sensor), where a reboot is genuinely warranted.
+   Separating the few that plausibly don't need one (canned messages, ambient lighting,
+   status message) needs a per-module audit - its own effort, not part of this work.
+
+5. **On-device menu `reloadConfig` sites** - 27 `reloadConfig(SEGMENT_CONFIG)` /
+   `reloadConfig(changes)` calls in `src/graphics/draw/MenuHandler.cpp` and
+   `src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp` still reload on any Config
+   save (they pass only `saveWhat`; the default `radioAffected=true` preserves this).
+   **Why untouched:** this work was scoped to the AdminModule (BLE/admin-thread) crash class.
+   The menu paths are a mix of genuinely-radio changes (region/preset) and incidental ones
+   (role, display units), run on the UI thread. Each is marked with a
+   `// TODO(radioAffected)` note (`audit` vs `radio-affecting`) for a future per-site pass.
+
+For contrast, `set_channel` ([`:1445`](../src/modules/AdminModule.cpp#L1445)) and
+`restore_preferences` ([`:1911`](../src/modules/AdminModule.cpp#L1911)) also still reload -
+but that is _correct_, not conservative: both genuinely change LoRa/channel state.
+
+---
+
+## Verification
+
+Native coverage lives in `test/test_admin_radio/test_main.cpp`:
+
+- **Radio reload:** each non-LoRa `set_config` sub-message asserts `configChanged` does **not**
+  fire (`ConfigChangedCounter`); `lora` and `set_channel` assert it still does; direct
+  `reloadConfig` guards pin the fail-safe default and the explicit opt-out.
+- **Reboot:** each of position/network/bluetooth asserts `rebootAtMsec` stays `0` on a no-op
+  set and is armed on a real change; a position broadcast-interval change asserts **no**
+  reboot, while `gps_mode` and `rx_gpio` changes assert a reboot.
+
+The harness defers `reboot()` to `rebootAtMsec` (it does not exit), which is the signal the
+reboot tests assert on.
+
+**Hardware pass (outstanding):** the only reason to touch a real node now is to confirm
+whether the GPS-timing position fields (item 3 above) apply live, so they can be moved off the
+reboot path. Do not reclassify them on native evidence alone.
+
+---
+
+## Extending this safely
+
+- To stop a config field from reloading the radio: it already doesn't, unless it's `lora`.
+  Do **not** widen `radioAffected` to non-LoRa config - only `RadioInterface::reconfigure()`
+  (which reads `config.lora`) consumes it.
+- To move a field off the reboot path: confirm it is consumed live (read from `config` at use
+  time, no cached/driver state), add it to the live set in the relevant `handleSetConfig`
+  case, and add a native case asserting no reboot on its change. For anything driver- or
+  hardware-backed, verify on real hardware first. When unsure, leave it rebooting.

--- a/docs/admin-config-save-gating.md
+++ b/docs/admin-config-save-gating.md
@@ -66,9 +66,10 @@ does not opt out keeps the historical behavior. `AdminModule::saveChanges`
 | `set_fixed_position` / `remove_fixed_position`                          | **No** (was yes)   | Rode `SEGMENT_CONFIG` only because `fixed_position` shares the Config file.                              |
 | `set_channel`                                                           | **Yes**            | Real frequency-slot/PSK change ([`:1445`](../src/modules/AdminModule.cpp#L1445)).                        |
 
-Why this matters beyond tidiness: the reconfigure is a live `setStandby()` + SPI reprogram on
-the admin/BLE callback thread - the exact sequence that crashed the WisMesh Tag on a
-favorite (#11146). Removing it for non-LoRa saves closes the rest of that crash class and
+Why this matters beyond tidiness: the reconfigure is a live `setStandby()` + SPI reprogram run
+from the admin-message handler on the main task, while the radio is active - the exact
+sequence that crashed the WisMesh Tag on a favorite (#11146). Removing it for non-LoRa saves
+closes the rest of that crash class and
 avoids a needless RX gap on the mesh radio.
 
 ---
@@ -159,7 +160,7 @@ is worth.
    `reloadConfig(changes)` calls in `src/graphics/draw/MenuHandler.cpp` and
    `src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp` still reload on any Config
    save (they pass only `saveWhat`; the default `radioAffected=true` preserves this).
-   **Why untouched:** this work was scoped to the AdminModule (BLE/admin-thread) crash class.
+   **Why untouched:** this work was scoped to the AdminModule (client admin-message) crash class.
    The menu paths are a mix of genuinely-radio changes (region/preset) and incidental ones
    (role, display units), run on the UI thread. Each is marked with a
    `// TODO(radioAffected)` note (`audit` vs `radio-affecting`) for a future per-site pass.
@@ -194,19 +195,28 @@ reboot don't happen in the host build - so the two claims that matter most (the 
 
 Run against a real node through the
 [meshtastic-mcp](https://github.com/meshtastic/meshtastic-mcp) harness
-(`MESHTASTIC_FIRMWARE_ROOT` → this checkout), with a BLE client connected **for the whole
-test** and the serial log open - the connected-BLE state is what made the original bug fire,
-so it must be held throughout. A nRF52840 SX126x board (e.g. WisMesh Tag) is the reference
-target; the crash was reproduced there.
+(`MESHTASTIC_FIRMWARE_ROOT` → this checkout), with the serial log open. A nRF52840 SX126x
+board (e.g. WisMesh Tag) is the reference target; the crash was reproduced there.
+
+**Transport: serial is sufficient - the on-device menus are not needed, and neither is BLE.**
+These operations are all client-protocol admin messages (`ToRadio`), carried identically over
+serial (`SerialConsole`/`StreamAPI`) or BLE; the on-device button/screen menus are a separate
+code path this work did not touch. Crucially, on nRF52 the BLE `onWrite` callback only
+_queues_ the packet - `handleToRadio` → `saveChanges` → `reloadConfig` (the reconfigure) runs
+on the **main FreeRTOS task** ([`NimbleBluetooth.cpp:135`](../src/nimble/NimbleBluetooth.cpp#L135)),
+exactly where `SerialConsole` (an `OSThread`) services the serial stream. So the code and
+thread under test are the same whichever transport you use, and the original crash was
+serial-proven. Drive the admin messages over USB serial (e.g. the `meshtastic --port` CLI);
+use BLE only if you specifically want to reproduce the exact user-facing conditions.
 
 ### 1. Radio-reload / crash validation (regression guard for `babeef08d`)
 
 Confirms the non-LoRa config saves no longer run the live radio reconfigure - the
-`setStandby()` + SPI reprogram on the admin/BLE thread that rebooted the WisMesh Tag on a
-favorite (#11146).
+`setStandby()` + SPI reprogram (on the main task, while the radio is active) that rebooted the
+WisMesh Tag on a favorite (#11146).
 
-Over BLE, with the connection up, perform each of: toggle Bluetooth `enabled`, change the
-WiFi PSK, rotate the security keypair, favorite/unfavorite a node.
+Perform each of: toggle Bluetooth `enabled`, change the WiFi PSK, rotate the security
+keypair, favorite/unfavorite a node.
 
 - **Pass:** no radio re-init in the serial log before any reboot (no modem-reconfigure /
   `setStandby` / re-`init` lines), and no watchdog reboot-loop. Saves that legitimately
@@ -222,8 +232,8 @@ left on the reboot path (`gps_mode`, `gps_enabled`, `gps_update_interval`, `gps_
 
 - item 3 above) can actually apply live and be reclassified.
 
-For each candidate field, one at a time, on a GPS-equipped node: change only that field over
-BLE and observe.
+For each candidate field, one at a time, on a GPS-equipped node: change only that field (over
+serial, as above) and observe.
 
 - **Pass (→ reclassify as live):** the new value takes visible effect (e.g. GPS poll cadence
   changes, mode switches) **and** no reboot banner appears. Only then add the field to the

--- a/docs/admin-config-save-gating.md
+++ b/docs/admin-config-save-gating.md
@@ -234,9 +234,8 @@ keypair, favorite/unfavorite a node.
 ### 2. Position live-apply - expanding the Tier-2 live set (outstanding)
 
 The only reason to touch a node for the _reboot_ work: decide whether the GPS-timing fields
-left on the reboot path (`gps_mode`, `gps_enabled`, `gps_update_interval`, `gps_attempt_time`
-
-- item 3 above) can actually apply live and be reclassified.
+left on the reboot path (`gps_mode`, `gps_enabled`, `gps_update_interval`, `gps_attempt_time` -
+item 3 above) can actually apply live and be reclassified.
 
 For each candidate field, one at a time, on a GPS-equipped node: change only that field (over
 serial, as above) and observe.
@@ -257,9 +256,11 @@ a cheap confidence test but not a gate.
 
 ## Extending this safely
 
-- To stop a config field from reloading the radio: it already doesn't, unless it's `lora`.
-  Do **not** widen `radioAffected` to non-LoRa config - only `RadioInterface::reconfigure()`
-  (which reads `config.lora`) consumes it.
+- To stop a config field from reloading the radio on an **AdminModule/client config save**: it
+  already doesn't, unless it's `lora`. Do **not** widen `radioAffected` to non-LoRa config -
+  only `RadioInterface::reconfigure()` (which reads `config.lora`) consumes it. This does not
+  apply to the on-device menu `reloadConfig` sites (item 5 above), which still reload on any
+  Config save regardless of field - that is a separate, untouched code path.
 - To move a field off the reboot path: confirm it is consumed live (read from `config` at use
   time, no cached/driver state), add it to the live set in the relevant `handleSetConfig`
   case, and add a native case asserting no reboot on its change. For anything driver- or

--- a/docs/admin-config-save-gating.md
+++ b/docs/admin-config-save-gating.md
@@ -184,9 +184,58 @@ Native coverage lives in `test/test_admin_radio/test_main.cpp`:
 The harness defers `reboot()` to `rebootAtMsec` (it does not exit), which is the signal the
 reboot tests assert on.
 
-**Hardware pass (outstanding):** the only reason to touch a real node now is to confirm
-whether the GPS-timing position fields (item 3 above) apply live, so they can be moved off the
-reboot path. Do not reclassify them on native evidence alone.
+Native tests cannot observe the actual side effects - the live SX126x SPI sequence and a real
+reboot don't happen in the host build - so the two claims that matter most (the crash is gone;
+"live" fields really apply without a restart) require hardware. See below.
+
+---
+
+## Hardware testing
+
+Run against a real node through the
+[meshtastic-mcp](https://github.com/meshtastic/meshtastic-mcp) harness
+(`MESHTASTIC_FIRMWARE_ROOT` → this checkout), with a BLE client connected **for the whole
+test** and the serial log open - the connected-BLE state is what made the original bug fire,
+so it must be held throughout. A nRF52840 SX126x board (e.g. WisMesh Tag) is the reference
+target; the crash was reproduced there.
+
+### 1. Radio-reload / crash validation (regression guard for `babeef08d`)
+
+Confirms the non-LoRa config saves no longer run the live radio reconfigure - the
+`setStandby()` + SPI reprogram on the admin/BLE thread that rebooted the WisMesh Tag on a
+favorite (#11146).
+
+Over BLE, with the connection up, perform each of: toggle Bluetooth `enabled`, change the
+WiFi PSK, rotate the security keypair, favorite/unfavorite a node.
+
+- **Pass:** no radio re-init in the serial log before any reboot (no modem-reconfigure /
+  `setStandby` / re-`init` lines), and no watchdog reboot-loop. Saves that legitimately
+  reboot (WiFi, keypair) do so _cleanly, after_ the save - the reboot is fine; a live
+  reconfigure _before_ it is the failure.
+- **Positive control:** a `lora` config change and a `set_channel` **should** show the
+  reconfigure - proves the path still fires when it should.
+
+### 2. Position live-apply - expanding the Tier-2 live set (outstanding)
+
+The only reason to touch a node for the _reboot_ work: decide whether the GPS-timing fields
+left on the reboot path (`gps_mode`, `gps_enabled`, `gps_update_interval`, `gps_attempt_time`
+
+- item 3 above) can actually apply live and be reclassified.
+
+For each candidate field, one at a time, on a GPS-equipped node: change only that field over
+BLE and observe.
+
+- **Pass (→ reclassify as live):** the new value takes visible effect (e.g. GPS poll cadence
+  changes, mode switches) **and** no reboot banner appears. Only then add the field to the
+  live set in the `position_tag` gate and a native no-reboot case.
+- **Fail (→ leave rebooting):** the value only takes effect after a restart, or the node
+  reboots. This is the expected default - **fail toward rebooting**; do not reclassify on
+  native evidence alone.
+
+Fields already shipped as live (`position_broadcast_secs`, `position_broadcast_smart_enabled`,
+`broadcast_smart_minimum_distance`, `position_flags`, `fixed_position`) were proven live by
+static analysis; a spot-check that a broadcast-interval change takes effect with no reboot is
+a cheap confidence test but not a gate.
 
 ---
 

--- a/docs/admin-config-save-gating.md
+++ b/docs/admin-config-save-gating.md
@@ -66,10 +66,15 @@ does not opt out keeps the historical behavior. `AdminModule::saveChanges`
 | `set_fixed_position` / `remove_fixed_position`                          | **No** (was yes)   | Rode `SEGMENT_CONFIG` only because `fixed_position` shares the Config file.                              |
 | `set_channel`                                                           | **Yes**            | Real frequency-slot/PSK change ([`:1445`](../src/modules/AdminModule.cpp#L1445)).                        |
 
-Why this matters beyond tidiness: the reconfigure is a live `setStandby()` + SPI reprogram run
-from the admin-message handler on the main task, while the radio is active - the exact
-sequence that crashed the WisMesh Tag on a favorite (#11146). Removing it for non-LoRa saves
-closes the rest of that crash class and
+Why this matters beyond tidiness: the reconfigure is a live `setStandby()` + SPI reprogram. It
+is _invoked_ from the admin-message handler on the main task (BLE `onWrite` only queues, so
+this is not the BLE callback thread), but the failure is cross-thread: the radio runs its own
+off-main worker (`RadioLibInterface`, a `NotifiedWorkerThread`) that also drives SPI under the
+shared, **non-recursive** `spiLock` (a FreeRTOS binary semaphore). The main-task reconfigure
+colliding with that worker over the lock / radio state locks the worker up, and the watchdog
+reboots the device - the crash seen on the WisMesh Tag favorite (#11146; same non-recursive
+`spiLock` hazard as #10705/#10728). Removing the reconfigure for non-LoRa saves closes the
+rest of that crash class and
 avoids a needless RX gap on the mesh radio.
 
 ---
@@ -211,9 +216,10 @@ use BLE only if you specifically want to reproduce the exact user-facing conditi
 
 ### 1. Radio-reload / crash validation (regression guard for `babeef08d`)
 
-Confirms the non-LoRa config saves no longer run the live radio reconfigure - the
-`setStandby()` + SPI reprogram (on the main task, while the radio is active) that rebooted the
-WisMesh Tag on a favorite (#11146).
+Confirms the non-LoRa config saves no longer run the live radio reconfigure - the main-task
+`setStandby()` + SPI reprogram that collided with the radio's off-main worker thread over the
+non-recursive `spiLock` and locked it up, tripping the watchdog reboot on the WisMesh Tag
+favorite (#11146).
 
 Perform each of: toggle Bluetooth `enabled`, change the WiFi PSK, rotate the security
 keypair, favorite/unfavorite a node.

--- a/docs/admin-config-save-gating.md
+++ b/docs/admin-config-save-gating.md
@@ -1,9 +1,9 @@
 # AdminModule config-save side effects: radio-reload & reboot gating
 
-**Status:** Implemented
+**Status:** Implementation complete; hardware validation outstanding
 **Date:** 2026-07-23
 **Area:** `src/modules/AdminModule.cpp` (`handleSetConfig`, `saveChanges`), `src/mesh/MeshService.cpp` (`reloadConfig`), `src/mesh/NodeDB.h` (`SEGMENT_*`)
-**Commits:** `babeef08d` (radio-reload), `65c27f813` + `273fa8d0a` (segment docs / TODO markers), `71d711867` (reboot Tier 1), `cc9abdbbc` (reboot Tier 2)
+**Reference:** meshtastic/firmware#11181 (commit SHAs omitted - they do not survive rebase or squash merge)
 
 Saving a config over the phone/BLE used to do more than persist bytes: it could re-init the
 LoRa radio **and** reboot the device, on config that touched neither. This document records
@@ -161,18 +161,49 @@ is worth.
    Separating the few that plausibly don't need one (canned messages, ambient lighting,
    status message) needs a per-module audit - its own effort, not part of this work.
 
-5. **On-device menu `reloadConfig` sites** - 27 `reloadConfig(SEGMENT_CONFIG)` /
-   `reloadConfig(changes)` calls in `src/graphics/draw/MenuHandler.cpp` and
-   `src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp` still reload on any Config
-   save (they pass only `saveWhat`; the default `radioAffected=true` preserves this).
-   **Why untouched:** this work was scoped to the AdminModule (client admin-message) crash class.
-   The menu paths are a mix of genuinely-radio changes (region/preset) and incidental ones
-   (role, display units), run on the UI thread. Each is marked with a
-   `// TODO(radioAffected)` note (`audit` vs `radio-affecting`) for a future per-site pass.
+5. ~~**On-device menu `reloadConfig` sites**~~ - **now done, see "On-device menus" below.**
+   These were initially left alone as out of scope, then migrated in the same PR.
 
 For contrast, `set_channel` ([`:1445`](../src/modules/AdminModule.cpp#L1445)) and
 `restore_preferences` ([`:1911`](../src/modules/AdminModule.cpp#L1911)) also still reload -
 but that is _correct_, not conservative: both genuinely change LoRa/channel state.
+
+---
+
+## On-device menus (`applyConfigChange`)
+
+Both UIs go through one entry point on `MeshService`, so a menu action states the same two
+decisions AdminModule does rather than inheriting defaults:
+
+```cpp
+void applyConfigChange(int saveWhat, uint8_t flags, int32_t rebootSeconds = DEFAULT_REBOOT_SECONDS);
+
+enum ConfigApplyFlags : uint8_t {
+    CONFIG_APPLY_NONE = 0,        // persist only
+    CONFIG_APPLY_RADIO = 1 << 0,  // region/preset/freq/channel/PSK - re-init the LoRa chip
+    CONFIG_APPLY_REBOOT = 1 << 1, // field only takes effect after a restart
+};
+```
+
+`flags` has no default: the point is that every call site says what it wants. A flags enum
+rather than two bools because `reboot` and `radioAffected` are both bools, sat in different
+positions across the helpers this replaced, and transposing them compiled silently. InkHUD's
+`applyConfigReload(changes, reboot)` took `reboot` exactly where `reloadConfig` and
+`saveChanges` take `radioAffected`.
+
+Notes for anyone extending this:
+
+- `reloadConfig(X, /*radioAffected=*/false)` is **exactly equivalent** to `saveToDisk(X)` - the
+  save is unconditional, outside the guard. So never pair them: that writes the file twice.
+- **AdminModule keeps using `saveChanges`**, not `applyConfigChange` directly. It owns the
+  edit-transaction deferral, without which a multi-field remote set writes flash per field.
+- Reboots go through `requestReboot()` (`src/main.h`). It carries no UI: BaseUI already renders
+  the notice at draw time from `rebootAtMsec`, while InkHUD's e-ink only draws when pushed and so
+  raises `notifyApplyingChanges()` explicitly.
+- `rebootSeconds` exists for one caller - InkHUD's wifi-recovery path uses a shorter delay than
+  `DEFAULT_REBOOT_SECONDS`.
+- UI-only state stays out of this: BaseUI `uiconfig` fields use `saveUIConfig()`, and InkHUD has
+  its own non-protobuf `Persistence::Settings` store. Neither is in the `/prefs` protobuf tree.
 
 ---
 
@@ -258,9 +289,8 @@ a cheap confidence test but not a gate.
 
 - To stop a config field from reloading the radio on an **AdminModule/client config save**: it
   already doesn't, unless it's `lora`. Do **not** widen `radioAffected` to non-LoRa config -
-  only `RadioInterface::reconfigure()` (which reads `config.lora`) consumes it. This does not
-  apply to the on-device menu `reloadConfig` sites (item 5 above), which still reload on any
-  Config save regardless of field - that is a separate, untouched code path.
+  only `RadioInterface::reconfigure()` (which reads `config.lora`) consumes it. The on-device
+  menus are now gated the same way, via `applyConfigChange` (see below).
 - To move a field off the reboot path: confirm it is consumed live (read from `config` at use
   time, no cached/driver state), add it to the live set in the relevant `handleSetConfig`
   case, and add a native case asserting no reboot on its change. For anything driver- or

--- a/docs/admin-config-save-gating.md
+++ b/docs/admin-config-save-gating.md
@@ -117,13 +117,22 @@ directly from `config` each send/schedule cycle:
 | `broadcast_smart_minimum_distance`        | No                | Read live in the smart-position path              |
 | `position_flags`                          | No                | Read live per outgoing position                   |
 | `fixed_position`                          | No                | Read live; also has dedicated live admin handlers |
-| `gps_mode`, `gps_enabled`                 | **Yes**           | GPS driver state                                  |
+| `gps_mode` (`ENABLED` ↔ `DISABLED`)       | No                | Driver toggled live, as the menus do (see below)  |
+| `gps_mode` (any `NOT_PRESENT` transition) | **Yes**           | Driver object only exists from boot               |
+| `gps_enabled`                             | **Yes**           | GPS driver state                                  |
 | `gps_update_interval`, `gps_attempt_time` | **Yes**           | GPS subsystem timing                              |
 | `rx_gpio`, `tx_gpio`, `gps_en_gpio`       | **Yes**           | GPIO pin (re)assignment                           |
 
 The gate neutralizes the live fields in a copy and reboots if any _other_ byte differs, so a
 newly-added `PositionConfig` field reboots until it is explicitly cleared as live - fail-safe
 for schema growth.
+
+`gps_mode` is neutralized conditionally, by `isLiveGpsModeToggle()`, and only because the same
+case then calls `gps->enable()`/`gps->disable()` - the pattern `MenuHandler::GPSToggleMenu()`
+and InkHUD's `TOGGLE_GPS` have always used. Suppressing the reboot **without** driving the
+driver would leave the receiver in its old state until the next boot. `NOT_PRESENT` stays on
+the reboot path in both directions: `gps` is constructed once at boot and only when `gps_mode`
+is not `NOT_PRESENT` ([`main.cpp`](../src/main.cpp)), so there is nothing to enable.
 
 ---
 
@@ -330,8 +339,14 @@ reconfigure that appears only at the commit, not during the individual sets.
 ### 2. Position live-apply - expanding the Tier-2 live set (outstanding)
 
 The only reason to touch a node for the _reboot_ work: decide whether the GPS-timing fields
-left on the reboot path (`gps_mode`, `gps_enabled`, `gps_update_interval`, `gps_attempt_time` -
-item 3 above) can actually apply live and be reclassified.
+left on the reboot path (`gps_enabled`, `gps_update_interval`, `gps_attempt_time` - item 3
+above) can actually apply live and be reclassified.
+
+`gps_mode` has already been reclassified for the `ENABLED` ↔ `DISABLED` pair, on the strength
+of the driver call now made alongside it. **That one still wants a hardware pass**: toggle GPS
+off and on from the app and confirm the receiver actually stops and restarts (fix lost, then
+reacquired) with no reboot banner - the failure mode to look for is config saying one thing
+while the receiver keeps doing the other.
 
 For each candidate field, one at a time, on a GPS-equipped node: change only that field (over
 serial, as above) and observe.

--- a/docs/admin-config-save-gating.md
+++ b/docs/admin-config-save-gating.md
@@ -53,18 +53,24 @@ if (radioAffected && (saveWhat & (SEGMENT_CONFIG | SEGMENT_CHANNELS)))
 ```
 
 The bitmask gate is **retained** (so the ~35 non-AdminModule callers are unaffected) and
-`radioAffected` only ever _suppresses_ the reload. It defaults to `true`, so any caller that
-does not opt out keeps the historical behavior. `AdminModule::saveChanges`
-([`:1846`](../src/modules/AdminModule.cpp#L1846)) threads it through; `handleSetConfig`
-([`:836`](../src/modules/AdminModule.cpp#L836)) sets `radioAffected = true`
-([`:845`](../src/modules/AdminModule.cpp#L845)) only in the `lora_tag` case.
+`radioAffected` only ever _suppresses_ the reload. `MeshService::reloadConfig` still defaults it
+to `true`, so any external caller that does not opt out keeps the historical behavior.
+
+`AdminModule::saveChanges(saveWhat, shouldReboot, radioAffected)` threads it through, and there it
+has **no default** - every one of its call sites states the answer. That is not stylistic: see
+"Edit transactions" below for why an inherited `true` stops being harmless once a transaction is
+open. `handleSetConfig` sets `radioAffected = true` only in the `lora_tag` case.
 
 | Admin operation                                                         | Reloads radio now? | Notes                                                                                                    |
 | ----------------------------------------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------- |
 | `set_config` → `lora`                                                   | **Yes**            | The only config that feeds `RadioInterface::reconfigure()` (reads `config.lora`). Region swaps included. |
 | `set_config` → device/position/power/network/display/bluetooth/security | **No** (was yes)   | Persist `SEGMENT_CONFIG`, but none affect the modem.                                                     |
 | `set_fixed_position` / `remove_fixed_position`                          | **No** (was yes)   | Rode `SEGMENT_CONFIG` only because `fixed_position` shares the Config file.                              |
-| `set_channel`                                                           | **Yes**            | Real frequency-slot/PSK change ([`:1445`](../src/modules/AdminModule.cpp#L1445)).                        |
+| `set_module_config`                                                     | **No**             | No module config feeds `reconfigure()`. Previously only the segment mask stopped it.                     |
+| `set_owner`                                                             | **No**             | Node metadata. Still reboots (pre-existing) - that axis was left alone.                                  |
+| favorite / ignore / mute node                                           | **No**             | Node-DB bits. The #11146 crash path.                                                                     |
+| `set_channel`                                                           | **Yes**            | Real frequency-slot/PSK change.                                                                          |
+| `set_ham_mode`                                                          | **Yes**            | Rewrites `config.lora.tx_enabled` and strips channel PSKs.                                               |
 
 Why this matters beyond tidiness: the reconfigure is a live `setStandby()` + SPI reprogram. It
 is _invoked_ from the admin-message handler on the main task (BLE `onWrite` only queues, so
@@ -121,6 +127,43 @@ for schema growth.
 
 ---
 
+## Edit transactions - where both axes nearly got lost
+
+Read this before adding a `saveChanges()` call site.
+
+A client may bracket a run of admin messages in `begin_edit_settings` / `commit_edit_settings`.
+While the transaction is open, `saveChanges()` **defers**: it writes nothing and returns, so a
+multi-field set doesn't hit flash once per field. The commit then performs a single save under a
+**fixed full-segment mask**.
+
+Two consequences, both easy to miss:
+
+1. **The per-field decisions had nowhere to go.** Everything the two axes above compute happens
+   inside `handleSetConfig`, whose `saveChanges()` call is the one being deferred. The commit's
+   own `saveChanges()` originally passed nothing, so it took the parameter defaults - reboot and
+   reconfigure, on every commit, whatever was edited. Phone apps write config through
+   transactions, so **none of the narrowing above reached them.** `deferredShouldReboot` and
+   `deferredRadioAffected` now accumulate (`|=`) the deferred answers; the commit consumes them
+   and clears them, so a stray second commit cannot inherit the previous transaction's answer.
+
+2. **The segment bitmask stops protecting you.** Outside a transaction, a node-DB-only save
+   physically cannot reach the radio: `saveWhat & (SEGMENT_CONFIG | SEGMENT_CHANNELS)` is zero
+   whatever `radioAffected` says. Inside one, the commit saves under the full mask, so that gate
+   always passes and `radioAffected` becomes the _only_ thing deciding it. An accidental `true` -
+   inherited from a default, on a call site that never thought about the radio - then reaches the
+   live SX126x reconfigure at commit. Favoriting a node from the phone app would have gone
+   straight back through the #11146 crash path.
+
+   That is why `AdminModule::saveChanges` gives `radioAffected` **no default**. Do not add one
+   back. The nested `saveChanges()` inside the `position_tag` case is the subtle instance: an
+   inner call on an unrelated segment can opt the whole transaction in.
+
+Covered natively: see the "Edit-transaction deferral" block in `test_admin_radio`, which asserts
+both axes independently across a commit (node-DB, module-config and nested-position batches
+reconfigure nothing; a LoRa batch still does; a GPS-mode batch reboots without reconfiguring).
+
+---
+
 ## Operations intentionally left unchanged ("third tier")
 
 These were audited and deliberately **not** narrowed. Each still reloads and/or reboots as
@@ -128,17 +171,10 @@ before. The common thread: the reload/reboot is either genuinely required, or re
 would need real state-tracking / hardware verification that carries more risk than the saving
 is worth.
 
-1. **`commit_edit_settings`** ([`:474`](../src/modules/AdminModule.cpp#L474)) - commits a
-   whole edit transaction with a fixed
-   `SEGMENT_CONFIG | SEGMENT_MODULECONFIG | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS | SEGMENT_NODEDATABASE`
-   save (default `radioAffected=true`, `shouldReboot=true`), so it reloads and reboots on
-   **every** commit regardless of what was actually edited.
-   **Why untouched:** narrowing it requires the transaction to track _which_ segments were
-   dirtied (and whether LoRa/reboot-relevant fields were among them) as individual sets ran
-   under `hasOpenEditTransaction`, then OR them at commit - a real state-tracking change, not
-   a one-line gate. Risk is also lower here: edit transactions are rarely
-   node-DB-metadata-only, so the wasteful case is less common. Deferred to its own pass; the
-   same tracking would let it decide both `radioAffected` and `requiresReboot`.
+1. ~~**`commit_edit_settings`**~~ - **now done, see "Edit transactions" below.** Initially
+   deferred to its own pass (it needed real state-tracking rather than a one-line gate), then
+   done in the same PR once it became clear the deferral was discarding every decision the rest
+   of this work computes.
 
 2. **`network` / `bluetooth` beyond the Tier-1 no-op gate** - a _real_ change still reboots.
    **Why untouched:** these restart the WiFi/Ethernet and BLE stacks. Applying a live change
@@ -201,7 +237,16 @@ Notes for anyone extending this:
   the notice at draw time from `rebootAtMsec`, while InkHUD's e-ink only draws when pushed and so
   raises `notifyApplyingChanges()` explicitly.
 - `rebootSeconds` exists for one caller - InkHUD's wifi-recovery path uses a shorter delay than
-  `DEFAULT_REBOOT_SECONDS`.
+  `DEFAULT_REBOOT_SECONDS`. A **negative** value cancels a pending reboot rather than bringing it
+  forward (`rebootAtMsec == 0` means "none pending" everywhere it is read), matching
+  `admin.proto`'s `reboot_seconds`.
+- Every `CONFIG_APPLY_REBOOT` site in the InkHUD menu pairs with a `notifyApplyingChanges()`, and
+  must keep doing so - see the two-jobs note on that method in `InkHUD.h`.
+- `CONFIG_APPLY_RADIO` means the **modem**, not the segment. The channel menu's uplink/downlink
+  and `position_precision` actions write `SEGMENT_CHANNELS` but touch no name, PSK or frequency
+  slot, so they persist only; the frequency the radio derives comes from the name+PSK hash, and
+  `RadioInterface` is the sole observer of `configChanged`. They carried the flag at first purely
+  because the old `reloadConfig(SEGMENT_CHANNELS)` inferred it from the bitmask.
 - UI-only state stays out of this: BaseUI `uiconfig` fields use `saveUIConfig()`, and InkHUD has
   its own non-protobuf `Persistence::Settings` store. Neither is in the `/prefs` protobuf tree.
 
@@ -217,6 +262,12 @@ Native coverage lives in `test/test_admin_radio/test_main.cpp`:
 - **Reboot:** each of position/network/bluetooth asserts `rebootAtMsec` stays `0` on a no-op
   set and is armed on a real change; a position broadcast-interval change asserts **no**
   reboot, while `gps_mode` and `rx_gpio` changes assert a reboot.
+- **Edit transactions:** the same two axes asserted across a `begin` / set / `commit` sequence,
+  where the segment bitmask no longer backstops `radioAffected`. Node-DB, module-config and
+  nested-position batches must commit without reconfiguring; a LoRa batch must still reconfigure
+  (and not reboot); a `gps_mode` batch must reboot without reconfiguring. Also pinned: nothing is
+  written until the commit, the flags don't leak into the next transaction, and a commit with no
+  matching begin is inert.
 
 The harness defers `reboot()` to `rebootAtMsec` (it does not exit), which is the signal the
 reboot tests assert on.
@@ -245,7 +296,7 @@ thread under test are the same whichever transport you use, and the original cra
 serial-proven. Drive the admin messages over USB serial (e.g. the `meshtastic --port` CLI);
 use BLE only if you specifically want to reproduce the exact user-facing conditions.
 
-### 1. Radio-reload / crash validation (regression guard for `babeef08d`)
+### 1. Radio-reload / crash validation (regression guard for the favorite-node fix)
 
 Confirms the non-LoRa config saves no longer run the live radio reconfigure - the main-task
 `setStandby()` + SPI reprogram that collided with the radio's off-main worker thread over the
@@ -261,6 +312,12 @@ keypair, favorite/unfavorite a node.
   reconfigure _before_ it is the failure.
 - **Positive control:** a `lora` config change and a `set_channel` **should** show the
   reconfigure - proves the path still fires when it should.
+
+**Then repeat the favorite/unfavorite case wrapped in `begin_edit_settings` /
+`commit_edit_settings`** - that is the shape a phone app actually sends, and until the deferred
+flags landed it was the one shape where the segment bitmask could not stop the reconfigure (see
+"Edit transactions"). Pass criteria are the same, measured at the commit. Watch for a
+reconfigure that appears only at the commit, not during the individual sets.
 
 ### 2. Position live-apply - expanding the Tier-2 live set (outstanding)
 
@@ -290,7 +347,7 @@ a cheap confidence test but not a gate.
 - To stop a config field from reloading the radio on an **AdminModule/client config save**: it
   already doesn't, unless it's `lora`. Do **not** widen `radioAffected` to non-LoRa config -
   only `RadioInterface::reconfigure()` (which reads `config.lora`) consumes it. The on-device
-  menus are now gated the same way, via `applyConfigChange` (see below).
+  menus are now gated the same way, via `applyConfigChange` (see "On-device menus" above).
 - To move a field off the reboot path: confirm it is consumed live (read from `config` at use
   time, no cached/driver state), add it to the live set in the relevant `handleSetConfig`
   case, and add a native case asserting no reboot on its change. For anything driver- or

--- a/docs/admin-config-save-gating.md
+++ b/docs/admin-config-save-gating.md
@@ -285,16 +285,24 @@ Run against a real node through the
 (`MESHTASTIC_FIRMWARE_ROOT` → this checkout), with the serial log open. A nRF52840 SX126x
 board (e.g. WisMesh Tag) is the reference target; the crash was reproduced there.
 
-**Transport: serial is sufficient - the on-device menus are not needed, and neither is BLE.**
-These operations are all client-protocol admin messages (`ToRadio`), carried identically over
-serial (`SerialConsole`/`StreamAPI`) or BLE; the on-device button/screen menus are a separate
-code path this work did not touch. Crucially, on nRF52 the BLE `onWrite` callback only
-_queues_ the packet - `handleToRadio` → `saveChanges` → `reloadConfig` (the reconfigure) runs
-on the **main FreeRTOS task** ([`NimbleBluetooth.cpp:135`](../src/nimble/NimbleBluetooth.cpp#L135)),
+The scenarios below cover the **AdminModule / client-protocol path only**. The on-device menu
+path was also migrated by this PR (see "On-device menus" above) and is a genuinely separate
+code path - it needs its own validation pass, driven by the buttons and screen on the board,
+and none of the transport reasoning in this section extends to it.
+
+**Transport for the admin path: serial is sufficient, and BLE is not needed.** These
+operations are all client-protocol admin messages (`ToRadio`), carried identically over serial
+(`SerialConsole`/`StreamAPI`) or BLE. Crucially, on nRF52 the BLE `onWrite` callback only
+_queues_ the packet - `handleToRadio` → `saveChanges` → `applyConfigChange` (the reconfigure)
+runs on the **main FreeRTOS task** ([`NimbleBluetooth.cpp:135`](../src/nimble/NimbleBluetooth.cpp#L135)),
 exactly where `SerialConsole` (an `OSThread`) services the serial stream. So the code and
 thread under test are the same whichever transport you use, and the original crash was
 serial-proven. Drive the admin messages over USB serial (e.g. the `meshtastic --port` CLI);
 use BLE only if you specifically want to reproduce the exact user-facing conditions.
+
+The menu path reaches the same `MeshService::applyConfigChange` on the same main task, so it
+inherits the same reasoning about _what_ runs - but only a menu-driven pass exercises the
+menu call sites' own flag choices, which is what this PR changed there.
 
 ### 1. Radio-reload / crash validation (regression guard for the favorite-node fix)
 

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -257,7 +257,7 @@ static void applyLoraRegion(meshtastic_Config_LoRaConfig_RegionCode region, bool
         gps->enable();
 #endif
     // Region/preset/HAM-mode change - the only LoRa radio parameters this menu can touch.
-    service->reloadConfig(changes, /*radioAffected=*/true);
+    service->applyConfigChange(changes, CONFIG_APPLY_RADIO);
 }
 
 void menuHandler::LoraRegionPicker(uint32_t duration)
@@ -433,8 +433,7 @@ void menuHandler::deviceRolePicker()
         } else if (selected == devicerole_tracker) {
             config.device.role = meshtastic_Config_DeviceConfig_Role_TRACKER;
         }
-        service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // device role, not LoRa
-        rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
+        service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_REBOOT);
     };
     screen->showOverlayBanner(bannerOptions);
 }
@@ -506,7 +505,7 @@ void menuHandler::FrequencySlotPicker()
         }
 
         config.lora.channel_num = selected;
-        service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/true); // frequency slot is a LoRa radio parameter
+        service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_RADIO);
     };
 
     screen->showOverlayBanner(bannerOptions);
@@ -560,9 +559,9 @@ static BannerOverlayOptions buildRegionPresetBanner()
         }
         config.lora.use_preset = true;
         config.lora.modem_preset = static_cast<meshtastic_Config_LoRaConfig_ModemPreset>(selected);
-        config.lora.channel_num = 0;                                   // Reset to default channel for the preset
-        config.lora.override_frequency = 0;                            // Clear any custom frequency
-        service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/true); // modem preset is a LoRa radio parameter
+        config.lora.channel_num = 0;        // Reset to default channel for the preset
+        config.lora.override_frequency = 0; // Clear any custom frequency
+        service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_RADIO);
     };
     return bannerOptions;
 }
@@ -589,7 +588,7 @@ void menuHandler::twelveHourPicker()
         } else {
             config.display.use_12h_clock = false;
         }
-        service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // display setting, not LoRa
+        service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
     };
     screen->showOverlayBanner(bannerOptions);
 }
@@ -693,7 +692,7 @@ void menuHandler::TZPicker()
             config.device.tzdef[sizeof(config.device.tzdef) - 1] = '\0';
 
             setenv("TZ", config.device.tzdef, 1);
-            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // timezone, not LoRa
+            service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
         });
 
     int initialSelection = 0;
@@ -1795,8 +1794,7 @@ void menuHandler::nodeNameLengthMenu()
                                                        }
 
                                                        config.display.use_long_node_name = option.value;
-                                                       service->reloadConfig(SEGMENT_CONFIG,
-                                                                             /*radioAffected=*/false); // display, not LoRa
+                                                       service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
                                                        LOG_INFO("Setting names to %s", option.value ? "long" : "short");
                                                    });
 
@@ -1916,7 +1914,7 @@ void menuHandler::GPSToggleMenu()
                 playGPSDisableBeep();
                 gps->disable();
             }
-            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // GPS mode, not LoRa
+            service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
         });
 
     int initialSelection = 0;
@@ -2021,10 +2019,10 @@ void menuHandler::GPSSmartPositionMenu()
         } else if (selected == 1) {
             // Read live by PositionModule's smart-broadcast path every send - no reboot needed.
             config.position.position_broadcast_smart_enabled = true;
-            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // position field, not LoRa
+            service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
         } else if (selected == 2) {
             config.position.position_broadcast_smart_enabled = false;
-            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // position field, not LoRa
+            service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
         }
     };
     bannerOptions.InitialSelected = config.position.position_broadcast_smart_enabled ? 1 : 2;
@@ -2077,8 +2075,7 @@ void menuHandler::GPSUpdateIntervalMenu()
         }
 
         if (selected != 0) {
-            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // GPS timing, not LoRa
-            rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
+            service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_REBOOT);
         }
     };
 
@@ -2167,7 +2164,7 @@ void menuHandler::GPSPositionBroadcastMenu()
 
         if (selected != 0) {
             // Read live by PositionModule's broadcast scheduler every cycle - no reboot needed.
-            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // position field, not LoRa
+            service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
         }
     };
 
@@ -2242,7 +2239,7 @@ void menuHandler::BuzzerModeMenu()
     bannerOptions.optionsCount = 5;
     bannerOptions.bannerCallback = [](int selected) -> void {
         config.device.buzzer_mode = (meshtastic_Config_DeviceConfig_BuzzerMode)selected;
-        service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // device field, not LoRa
+        service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
     };
     bannerOptions.InitialSelected = config.device.buzzer_mode;
     screen->showOverlayBanner(bannerOptions);
@@ -2307,8 +2304,7 @@ void menuHandler::switchToMUIMenu()
         if (selected == 1) {
             config.display.displaymode = meshtastic_Config_DisplayConfig_DisplayMode_COLOR;
             config.bluetooth.enabled = false;
-            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // display/bluetooth, not LoRa
-            rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
+            service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_REBOOT);
         }
     };
     screen->showOverlayBanner(bannerOptions);
@@ -2479,13 +2475,11 @@ void menuHandler::wifiToggleMenu()
         if (selected == Wifi_disable) {
             config.network.wifi_enabled = false;
             config.bluetooth.enabled = true;
-            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // network/bluetooth, not LoRa
-            rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
+            service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_REBOOT);
         } else if (selected == Wifi_enable) {
             config.network.wifi_enabled = true;
             config.bluetooth.enabled = false;
-            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // network/bluetooth, not LoRa
-            rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
+            service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_REBOOT);
         }
     };
     screen->showOverlayBanner(bannerOptions);
@@ -2763,17 +2757,17 @@ void menuHandler::frameTogglesMenu()
             // These three live in moduleConfig, not the hiddenFrames blob that
             // toggleFrameVisibility() persists, so they need their own save.
             moduleConfig.telemetry.environment_screen_enabled = !moduleConfig.telemetry.environment_screen_enabled;
-            service->reloadConfig(SEGMENT_MODULECONFIG, /*radioAffected=*/false); // module config, not LoRa
+            service->applyConfigChange(SEGMENT_MODULECONFIG, CONFIG_APPLY_NONE);
             menuHandler::menuQueue = menuHandler::FrameToggles;
             screen->runNow();
         } else if (selected == show_aq_telemetry) {
             moduleConfig.telemetry.air_quality_screen_enabled = !moduleConfig.telemetry.air_quality_screen_enabled;
-            service->reloadConfig(SEGMENT_MODULECONFIG, /*radioAffected=*/false); // module config, not LoRa
+            service->applyConfigChange(SEGMENT_MODULECONFIG, CONFIG_APPLY_NONE);
             menuHandler::menuQueue = menuHandler::FrameToggles;
             screen->runNow();
         } else if (selected == show_power) {
             moduleConfig.telemetry.power_screen_enabled = !moduleConfig.telemetry.power_screen_enabled;
-            service->reloadConfig(SEGMENT_MODULECONFIG, /*radioAffected=*/false); // module config, not LoRa
+            service->applyConfigChange(SEGMENT_MODULECONFIG, CONFIG_APPLY_NONE);
             menuHandler::menuQueue = menuHandler::FrameToggles;
             screen->runNow();
         }
@@ -2797,10 +2791,10 @@ void menuHandler::displayUnitsMenu()
     bannerOptions.bannerCallback = [](int selected) -> void {
         if (selected == MetricUnits) {
             config.display.units = meshtastic_Config_DisplayConfig_DisplayUnits_METRIC;
-            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // display setting, not LoRa
+            service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
         } else if (selected == ImperialUnits) {
             config.display.units = meshtastic_Config_DisplayConfig_DisplayUnits_IMPERIAL;
-            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // display setting, not LoRa
+            service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
         } else {
             menuHandler::menuQueue = menuHandler::ScreenOptionsMenu;
             screen->runNow();
@@ -2822,11 +2816,11 @@ void menuHandler::messageBubblesMenu()
     bannerOptions.bannerCallback = [](int selected) -> void {
         if (selected == ShowBubbles) {
             config.display.enable_message_bubbles = true;
-            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // display setting, not LoRa
+            service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
             LOG_INFO("Message bubbles enabled");
         } else if (selected == HideBubbles) {
             config.display.enable_message_bubbles = false;
-            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // display setting, not LoRa
+            service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
             LOG_INFO("Message bubbles disabled");
         } else {
             menuHandler::menuQueue = menuHandler::ScreenOptionsMenu;

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -256,8 +256,8 @@ static void applyLoraRegion(meshtastic_Config_LoRaConfig_RegionCode region, bool
     if (gps != nullptr && !gps->isEnabled() && config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED)
         gps->enable();
 #endif
-    // TODO(radioAffected): audit
-    service->reloadConfig(changes);
+    // Region/preset/HAM-mode change - the only LoRa radio parameters this menu can touch.
+    service->reloadConfig(changes, /*radioAffected=*/true);
 }
 
 void menuHandler::LoraRegionPicker(uint32_t duration)
@@ -433,8 +433,7 @@ void menuHandler::deviceRolePicker()
         } else if (selected == devicerole_tracker) {
             config.device.role = meshtastic_Config_DeviceConfig_Role_TRACKER;
         }
-        // TODO(radioAffected): audit
-        service->reloadConfig(SEGMENT_CONFIG);
+        service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // device role, not LoRa
         rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
     };
     screen->showOverlayBanner(bannerOptions);
@@ -507,8 +506,7 @@ void menuHandler::FrequencySlotPicker()
         }
 
         config.lora.channel_num = selected;
-        // TODO(radioAffected): audit
-        service->reloadConfig(SEGMENT_CONFIG);
+        service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/true); // frequency slot is a LoRa radio parameter
     };
 
     screen->showOverlayBanner(bannerOptions);
@@ -562,10 +560,9 @@ static BannerOverlayOptions buildRegionPresetBanner()
         }
         config.lora.use_preset = true;
         config.lora.modem_preset = static_cast<meshtastic_Config_LoRaConfig_ModemPreset>(selected);
-        config.lora.channel_num = 0;        // Reset to default channel for the preset
-        config.lora.override_frequency = 0; // Clear any custom frequency
-        // TODO(radioAffected): audit
-        service->reloadConfig(SEGMENT_CONFIG);
+        config.lora.channel_num = 0;                                   // Reset to default channel for the preset
+        config.lora.override_frequency = 0;                            // Clear any custom frequency
+        service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/true); // modem preset is a LoRa radio parameter
     };
     return bannerOptions;
 }
@@ -592,8 +589,7 @@ void menuHandler::twelveHourPicker()
         } else {
             config.display.use_12h_clock = false;
         }
-        // TODO(radioAffected): audit
-        service->reloadConfig(SEGMENT_CONFIG);
+        service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // display setting, not LoRa
     };
     screen->showOverlayBanner(bannerOptions);
 }
@@ -697,8 +693,7 @@ void menuHandler::TZPicker()
             config.device.tzdef[sizeof(config.device.tzdef) - 1] = '\0';
 
             setenv("TZ", config.device.tzdef, 1);
-            // TODO(radioAffected): audit
-            service->reloadConfig(SEGMENT_CONFIG);
+            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // timezone, not LoRa
         });
 
     int initialSelection = 0;
@@ -1801,8 +1796,8 @@ void menuHandler::nodeNameLengthMenu()
 
                                                        config.display.use_long_node_name = option.value;
                                                        saveUIConfig();
-                                                       // TODO(radioAffected): audit
-                                                       service->reloadConfig(SEGMENT_CONFIG);
+                                                       service->reloadConfig(SEGMENT_CONFIG,
+                                                                             /*radioAffected=*/false); // display, not LoRa
                                                        LOG_INFO("Setting names to %s", option.value ? "long" : "short");
                                                    });
 
@@ -1922,8 +1917,7 @@ void menuHandler::GPSToggleMenu()
                 playGPSDisableBeep();
                 gps->disable();
             }
-            // TODO(radioAffected): audit
-            service->reloadConfig(SEGMENT_CONFIG);
+            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // GPS mode, not LoRa
         });
 
     int initialSelection = 0;
@@ -1982,8 +1976,7 @@ void menuHandler::GPSFormatMenu()
 
         uiconfig.gps_format = option.value;
         saveUIConfig();
-        // TODO(radioAffected): audit
-        service->reloadConfig(SEGMENT_CONFIG);
+        service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // UI display format, not LoRa
     };
 
     BannerOverlayOptions bannerOptions;
@@ -2028,14 +2021,12 @@ void menuHandler::GPSSmartPositionMenu()
         } else if (selected == 1) {
             config.position.position_broadcast_smart_enabled = true;
             saveUIConfig();
-            // TODO(radioAffected): audit
-            service->reloadConfig(SEGMENT_CONFIG);
+            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // position field, not LoRa
             rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
         } else if (selected == 2) {
             config.position.position_broadcast_smart_enabled = false;
             saveUIConfig();
-            // TODO(radioAffected): audit
-            service->reloadConfig(SEGMENT_CONFIG);
+            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // position field, not LoRa
             rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
         }
     };
@@ -2090,8 +2081,7 @@ void menuHandler::GPSUpdateIntervalMenu()
 
         if (selected != 0) {
             saveUIConfig();
-            // TODO(radioAffected): audit
-            service->reloadConfig(SEGMENT_CONFIG);
+            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // GPS timing, not LoRa
             rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
         }
     };
@@ -2181,8 +2171,7 @@ void menuHandler::GPSPositionBroadcastMenu()
 
         if (selected != 0) {
             saveUIConfig();
-            // TODO(radioAffected): audit
-            service->reloadConfig(SEGMENT_CONFIG);
+            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // position field, not LoRa
             rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
         }
     };
@@ -2258,8 +2247,7 @@ void menuHandler::BuzzerModeMenu()
     bannerOptions.optionsCount = 5;
     bannerOptions.bannerCallback = [](int selected) -> void {
         config.device.buzzer_mode = (meshtastic_Config_DeviceConfig_BuzzerMode)selected;
-        // TODO(radioAffected): audit
-        service->reloadConfig(SEGMENT_CONFIG);
+        service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // device field, not LoRa
     };
     bannerOptions.InitialSelected = config.device.buzzer_mode;
     screen->showOverlayBanner(bannerOptions);
@@ -2324,8 +2312,7 @@ void menuHandler::switchToMUIMenu()
         if (selected == 1) {
             config.display.displaymode = meshtastic_Config_DisplayConfig_DisplayMode_COLOR;
             config.bluetooth.enabled = false;
-            // TODO(radioAffected): audit
-            service->reloadConfig(SEGMENT_CONFIG);
+            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // display/bluetooth, not LoRa
             rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
         }
     };
@@ -2497,14 +2484,12 @@ void menuHandler::wifiToggleMenu()
         if (selected == Wifi_disable) {
             config.network.wifi_enabled = false;
             config.bluetooth.enabled = true;
-            // TODO(radioAffected): audit
-            service->reloadConfig(SEGMENT_CONFIG);
+            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // network/bluetooth, not LoRa
             rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
         } else if (selected == Wifi_enable) {
             config.network.wifi_enabled = true;
             config.bluetooth.enabled = false;
-            // TODO(radioAffected): audit
-            service->reloadConfig(SEGMENT_CONFIG);
+            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // network/bluetooth, not LoRa
             rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
         }
     };
@@ -2812,12 +2797,10 @@ void menuHandler::displayUnitsMenu()
     bannerOptions.bannerCallback = [](int selected) -> void {
         if (selected == MetricUnits) {
             config.display.units = meshtastic_Config_DisplayConfig_DisplayUnits_METRIC;
-            // TODO(radioAffected): audit
-            service->reloadConfig(SEGMENT_CONFIG);
+            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // display setting, not LoRa
         } else if (selected == ImperialUnits) {
             config.display.units = meshtastic_Config_DisplayConfig_DisplayUnits_IMPERIAL;
-            // TODO(radioAffected): audit
-            service->reloadConfig(SEGMENT_CONFIG);
+            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // display setting, not LoRa
         } else {
             menuHandler::menuQueue = menuHandler::ScreenOptionsMenu;
             screen->runNow();
@@ -2839,13 +2822,11 @@ void menuHandler::messageBubblesMenu()
     bannerOptions.bannerCallback = [](int selected) -> void {
         if (selected == ShowBubbles) {
             config.display.enable_message_bubbles = true;
-            // TODO(radioAffected): audit
-            service->reloadConfig(SEGMENT_CONFIG);
+            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // display setting, not LoRa
             LOG_INFO("Message bubbles enabled");
         } else if (selected == HideBubbles) {
             config.display.enable_message_bubbles = false;
-            // TODO(radioAffected): audit
-            service->reloadConfig(SEGMENT_CONFIG);
+            service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // display setting, not LoRa
             LOG_INFO("Message bubbles disabled");
         } else {
             menuHandler::menuQueue = menuHandler::ScreenOptionsMenu;

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -2019,15 +2019,14 @@ void menuHandler::GPSSmartPositionMenu()
             menuQueue = PositionBaseMenu;
             screen->runNow();
         } else if (selected == 1) {
+            // Read live by PositionModule's smart-broadcast path every send - no reboot needed.
             config.position.position_broadcast_smart_enabled = true;
             saveUIConfig();
             service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // position field, not LoRa
-            rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
         } else if (selected == 2) {
             config.position.position_broadcast_smart_enabled = false;
             saveUIConfig();
             service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // position field, not LoRa
-            rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
         }
     };
     bannerOptions.InitialSelected = config.position.position_broadcast_smart_enabled ? 1 : 2;
@@ -2171,8 +2170,8 @@ void menuHandler::GPSPositionBroadcastMenu()
 
         if (selected != 0) {
             saveUIConfig();
+            // Read live by PositionModule's broadcast scheduler every cycle - no reboot needed.
             service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // position field, not LoRa
-            rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
         }
     };
 

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -2017,12 +2017,9 @@ void menuHandler::GPSSmartPositionMenu()
             menuQueue = PositionBaseMenu;
             screen->runNow();
         } else if (selected == 1) {
-            // Read live by PositionModule's smart-broadcast path every send - no reboot needed.
-            config.position.position_broadcast_smart_enabled = true;
-            service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
+            setSmartPositionEnabled(true);
         } else if (selected == 2) {
-            config.position.position_broadcast_smart_enabled = false;
-            service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
+            setSmartPositionEnabled(false);
         }
     };
     bannerOptions.InitialSelected = config.position.position_broadcast_smart_enabled ? 1 : 2;
@@ -2754,20 +2751,15 @@ void menuHandler::frameTogglesMenu()
             menuHandler::menuQueue = menuHandler::FrameToggles;
             screen->runNow();
         } else if (selected == show_env_telemetry) {
-            // These three live in moduleConfig, not the hiddenFrames blob that
-            // toggleFrameVisibility() persists, so they need their own save.
-            moduleConfig.telemetry.environment_screen_enabled = !moduleConfig.telemetry.environment_screen_enabled;
-            service->applyConfigChange(SEGMENT_MODULECONFIG, CONFIG_APPLY_NONE);
+            toggleTelemetryScreen(moduleConfig.telemetry.environment_screen_enabled);
             menuHandler::menuQueue = menuHandler::FrameToggles;
             screen->runNow();
         } else if (selected == show_aq_telemetry) {
-            moduleConfig.telemetry.air_quality_screen_enabled = !moduleConfig.telemetry.air_quality_screen_enabled;
-            service->applyConfigChange(SEGMENT_MODULECONFIG, CONFIG_APPLY_NONE);
+            toggleTelemetryScreen(moduleConfig.telemetry.air_quality_screen_enabled);
             menuHandler::menuQueue = menuHandler::FrameToggles;
             screen->runNow();
         } else if (selected == show_power) {
-            moduleConfig.telemetry.power_screen_enabled = !moduleConfig.telemetry.power_screen_enabled;
-            service->applyConfigChange(SEGMENT_MODULECONFIG, CONFIG_APPLY_NONE);
+            toggleTelemetryScreen(moduleConfig.telemetry.power_screen_enabled);
             menuHandler::menuQueue = menuHandler::FrameToggles;
             screen->runNow();
         }
@@ -3091,8 +3083,23 @@ void menuHandler::handleMenuSwitch(OLEDDisplay *display)
     menuQueue = MenuNone;
 }
 
-// Flips the mute bit on a node and persists. Returns without writing if the node is unknown, so a
-// stale pickedNodeNum can't cause a pointless flash write.
+// One telemetry screen flag, flipped and persisted. These live in moduleConfig rather than the
+// hiddenFrames blob that Screen::toggleFrameVisibility() writes, so they need their own save.
+void menuHandler::toggleTelemetryScreen(bool &flag)
+{
+    flag = !flag;
+    service->applyConfigChange(SEGMENT_MODULECONFIG, CONFIG_APPLY_NONE);
+}
+
+// Read live by PositionModule's smart-broadcast path on every send, so no reboot is needed.
+void menuHandler::setSmartPositionEnabled(bool enabled)
+{
+    config.position.position_broadcast_smart_enabled = enabled;
+    service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
+}
+
+// Flips the mute bit on a node and persists just the node database. Returns without writing if
+// the node is unknown, so a stale pickedNodeNum can't cause a pointless flash write.
 void menuHandler::toggleNodeMuted(uint32_t nodeNum)
 {
     meshtastic_NodeInfoLite *n = nodeDB->getMeshNode(nodeNum);

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -256,6 +256,7 @@ static void applyLoraRegion(meshtastic_Config_LoRaConfig_RegionCode region, bool
     if (gps != nullptr && !gps->isEnabled() && config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED)
         gps->enable();
 #endif
+    // TODO(radioAffected): audit
     service->reloadConfig(changes);
 }
 
@@ -432,6 +433,7 @@ void menuHandler::deviceRolePicker()
         } else if (selected == devicerole_tracker) {
             config.device.role = meshtastic_Config_DeviceConfig_Role_TRACKER;
         }
+        // TODO(radioAffected): audit
         service->reloadConfig(SEGMENT_CONFIG);
         rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
     };
@@ -505,6 +507,7 @@ void menuHandler::FrequencySlotPicker()
         }
 
         config.lora.channel_num = selected;
+        // TODO(radioAffected): audit
         service->reloadConfig(SEGMENT_CONFIG);
     };
 
@@ -561,6 +564,7 @@ static BannerOverlayOptions buildRegionPresetBanner()
         config.lora.modem_preset = static_cast<meshtastic_Config_LoRaConfig_ModemPreset>(selected);
         config.lora.channel_num = 0;        // Reset to default channel for the preset
         config.lora.override_frequency = 0; // Clear any custom frequency
+        // TODO(radioAffected): audit
         service->reloadConfig(SEGMENT_CONFIG);
     };
     return bannerOptions;
@@ -588,6 +592,7 @@ void menuHandler::twelveHourPicker()
         } else {
             config.display.use_12h_clock = false;
         }
+        // TODO(radioAffected): audit
         service->reloadConfig(SEGMENT_CONFIG);
     };
     screen->showOverlayBanner(bannerOptions);
@@ -692,6 +697,7 @@ void menuHandler::TZPicker()
             config.device.tzdef[sizeof(config.device.tzdef) - 1] = '\0';
 
             setenv("TZ", config.device.tzdef, 1);
+            // TODO(radioAffected): audit
             service->reloadConfig(SEGMENT_CONFIG);
         });
 
@@ -1795,6 +1801,7 @@ void menuHandler::nodeNameLengthMenu()
 
                                                        config.display.use_long_node_name = option.value;
                                                        saveUIConfig();
+                                                       // TODO(radioAffected): audit
                                                        service->reloadConfig(SEGMENT_CONFIG);
                                                        LOG_INFO("Setting names to %s", option.value ? "long" : "short");
                                                    });
@@ -1915,6 +1922,7 @@ void menuHandler::GPSToggleMenu()
                 playGPSDisableBeep();
                 gps->disable();
             }
+            // TODO(radioAffected): audit
             service->reloadConfig(SEGMENT_CONFIG);
         });
 
@@ -1974,6 +1982,7 @@ void menuHandler::GPSFormatMenu()
 
         uiconfig.gps_format = option.value;
         saveUIConfig();
+        // TODO(radioAffected): audit
         service->reloadConfig(SEGMENT_CONFIG);
     };
 
@@ -2019,11 +2028,13 @@ void menuHandler::GPSSmartPositionMenu()
         } else if (selected == 1) {
             config.position.position_broadcast_smart_enabled = true;
             saveUIConfig();
+            // TODO(radioAffected): audit
             service->reloadConfig(SEGMENT_CONFIG);
             rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
         } else if (selected == 2) {
             config.position.position_broadcast_smart_enabled = false;
             saveUIConfig();
+            // TODO(radioAffected): audit
             service->reloadConfig(SEGMENT_CONFIG);
             rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
         }
@@ -2079,6 +2090,7 @@ void menuHandler::GPSUpdateIntervalMenu()
 
         if (selected != 0) {
             saveUIConfig();
+            // TODO(radioAffected): audit
             service->reloadConfig(SEGMENT_CONFIG);
             rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
         }
@@ -2169,6 +2181,7 @@ void menuHandler::GPSPositionBroadcastMenu()
 
         if (selected != 0) {
             saveUIConfig();
+            // TODO(radioAffected): audit
             service->reloadConfig(SEGMENT_CONFIG);
             rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
         }
@@ -2245,6 +2258,7 @@ void menuHandler::BuzzerModeMenu()
     bannerOptions.optionsCount = 5;
     bannerOptions.bannerCallback = [](int selected) -> void {
         config.device.buzzer_mode = (meshtastic_Config_DeviceConfig_BuzzerMode)selected;
+        // TODO(radioAffected): audit
         service->reloadConfig(SEGMENT_CONFIG);
     };
     bannerOptions.InitialSelected = config.device.buzzer_mode;
@@ -2310,6 +2324,7 @@ void menuHandler::switchToMUIMenu()
         if (selected == 1) {
             config.display.displaymode = meshtastic_Config_DisplayConfig_DisplayMode_COLOR;
             config.bluetooth.enabled = false;
+            // TODO(radioAffected): audit
             service->reloadConfig(SEGMENT_CONFIG);
             rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
         }
@@ -2482,11 +2497,13 @@ void menuHandler::wifiToggleMenu()
         if (selected == Wifi_disable) {
             config.network.wifi_enabled = false;
             config.bluetooth.enabled = true;
+            // TODO(radioAffected): audit
             service->reloadConfig(SEGMENT_CONFIG);
             rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
         } else if (selected == Wifi_enable) {
             config.network.wifi_enabled = true;
             config.bluetooth.enabled = false;
+            // TODO(radioAffected): audit
             service->reloadConfig(SEGMENT_CONFIG);
             rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
         }
@@ -2795,9 +2812,11 @@ void menuHandler::displayUnitsMenu()
     bannerOptions.bannerCallback = [](int selected) -> void {
         if (selected == MetricUnits) {
             config.display.units = meshtastic_Config_DisplayConfig_DisplayUnits_METRIC;
+            // TODO(radioAffected): audit
             service->reloadConfig(SEGMENT_CONFIG);
         } else if (selected == ImperialUnits) {
             config.display.units = meshtastic_Config_DisplayConfig_DisplayUnits_IMPERIAL;
+            // TODO(radioAffected): audit
             service->reloadConfig(SEGMENT_CONFIG);
         } else {
             menuHandler::menuQueue = menuHandler::ScreenOptionsMenu;
@@ -2820,10 +2839,12 @@ void menuHandler::messageBubblesMenu()
     bannerOptions.bannerCallback = [](int selected) -> void {
         if (selected == ShowBubbles) {
             config.display.enable_message_bubbles = true;
+            // TODO(radioAffected): audit
             service->reloadConfig(SEGMENT_CONFIG);
             LOG_INFO("Message bubbles enabled");
         } else if (selected == HideBubbles) {
             config.display.enable_message_bubbles = false;
+            // TODO(radioAffected): audit
             service->reloadConfig(SEGMENT_CONFIG);
             LOG_INFO("Message bubbles disabled");
         } else {

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -2764,15 +2764,20 @@ void menuHandler::frameTogglesMenu()
             menuHandler::menuQueue = menuHandler::FrameToggles;
             screen->runNow();
         } else if (selected == show_env_telemetry) {
+            // These three live in moduleConfig, not the hiddenFrames blob that
+            // toggleFrameVisibility() persists, so they need their own save.
             moduleConfig.telemetry.environment_screen_enabled = !moduleConfig.telemetry.environment_screen_enabled;
+            service->reloadConfig(SEGMENT_MODULECONFIG, /*radioAffected=*/false); // module config, not LoRa
             menuHandler::menuQueue = menuHandler::FrameToggles;
             screen->runNow();
         } else if (selected == show_aq_telemetry) {
             moduleConfig.telemetry.air_quality_screen_enabled = !moduleConfig.telemetry.air_quality_screen_enabled;
+            service->reloadConfig(SEGMENT_MODULECONFIG, /*radioAffected=*/false); // module config, not LoRa
             menuHandler::menuQueue = menuHandler::FrameToggles;
             screen->runNow();
         } else if (selected == show_power) {
             moduleConfig.telemetry.power_screen_enabled = !moduleConfig.telemetry.power_screen_enabled;
+            service->reloadConfig(SEGMENT_MODULECONFIG, /*radioAffected=*/false); // module config, not LoRa
             menuHandler::menuQueue = menuHandler::FrameToggles;
             screen->runNow();
         }

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -808,7 +808,7 @@ void menuHandler::messageResponseMenu()
             auto &chan = channels.getByIndex(chIndex);
             if (chan.settings.has_module_settings) {
                 chan.settings.module_settings.is_muted = !chan.settings.module_settings.is_muted;
-                nodeDB->saveToDisk();
+                nodeDB->saveToDisk(SEGMENT_CHANNELS); // channel setting: don't rewrite every other proto
             }
 
         } else if (selected == DeleteMenu) {
@@ -1758,7 +1758,7 @@ void menuHandler::manageNodeMenu()
             // refusal changed nothing and shouldn't trigger a prefs save.
             if (changed) {
                 nodeDB->notifyObservers(true);
-                nodeDB->saveToDisk();
+                nodeDB->saveToDisk(SEGMENT_NODEDATABASE); // NodeInfoLite bit: only the node DB changed
             }
             screen->setFrames(graphics::Screen::FOCUS_PRESERVE);
             return;
@@ -1795,7 +1795,6 @@ void menuHandler::nodeNameLengthMenu()
                                                        }
 
                                                        config.display.use_long_node_name = option.value;
-                                                       saveUIConfig();
                                                        service->reloadConfig(SEGMENT_CONFIG,
                                                                              /*radioAffected=*/false); // display, not LoRa
                                                        LOG_INFO("Setting names to %s", option.value ? "long" : "short");
@@ -1974,9 +1973,10 @@ void menuHandler::GPSFormatMenu()
             return;
         }
 
+        // uiconfig field: saveUIConfig() writes /prefs/uiconfig.proto, which is the only file
+        // this touches. No config.proto write, so no reloadConfig().
         uiconfig.gps_format = option.value;
         saveUIConfig();
-        service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // UI display format, not LoRa
     };
 
     BannerOverlayOptions bannerOptions;
@@ -2021,11 +2021,9 @@ void menuHandler::GPSSmartPositionMenu()
         } else if (selected == 1) {
             // Read live by PositionModule's smart-broadcast path every send - no reboot needed.
             config.position.position_broadcast_smart_enabled = true;
-            saveUIConfig();
             service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // position field, not LoRa
         } else if (selected == 2) {
             config.position.position_broadcast_smart_enabled = false;
-            saveUIConfig();
             service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // position field, not LoRa
         }
     };
@@ -2079,7 +2077,6 @@ void menuHandler::GPSUpdateIntervalMenu()
         }
 
         if (selected != 0) {
-            saveUIConfig();
             service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // GPS timing, not LoRa
             rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
         }
@@ -2169,7 +2166,6 @@ void menuHandler::GPSPositionBroadcastMenu()
         }
 
         if (selected != 0) {
-            saveUIConfig();
             // Read live by PositionModule's broadcast scheduler every cycle - no reboot needed.
             service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // position field, not LoRa
         }
@@ -3113,7 +3109,7 @@ void menuHandler::toggleNodeMuted(uint32_t nodeNum)
     nodeInfoLiteSetBit(n, NODEINFO_BITFIELD_IS_MUTED_MASK, !wasMuted);
     LOG_INFO(wasMuted ? "Unmuted node 0x%08x" : "Muted node 0x%08x", nodeNum);
     nodeDB->notifyObservers(true);
-    nodeDB->saveToDisk();
+    nodeDB->saveToDisk(SEGMENT_NODEDATABASE); // NodeInfoLite bit: only the node DB changed
 }
 
 void menuHandler::saveUIConfig()

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -1819,12 +1819,12 @@ void menuHandler::resetNodeDBMenu()
             LOG_INFO("Initiate node-db reset");
             nodeDB->resetNodes();
             disableBluetooth();
-            rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
+            requestReboot();
         } else if (selected == 2) {
             LOG_INFO("Initiate node-db reset, keep favorites");
             nodeDB->resetNodes(1);
             disableBluetooth();
-            rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
+            requestReboot();
         } else if (selected == 0) {
             menuQueue = NodeBaseMenu;
             screen->runNow();
@@ -2322,7 +2322,7 @@ void menuHandler::rebootMenu()
             IF_SCREEN(screen->showSimpleBanner("Rebooting...", 0));
             nodeDB->saveToDisk();
             messageStore.saveToFlash();
-            rebootAtMsec = millis() + DEFAULT_REBOOT_SECONDS * 1000;
+            requestReboot();
         } else {
             menuQueue = PowerMenu;
             screen->runNow();

--- a/src/graphics/draw/MenuHandler.h
+++ b/src/graphics/draw/MenuHandler.h
@@ -127,10 +127,6 @@ class menuHandler
     static void LoRaFEMLNAToggleMenu();
 #endif
 
-    // Lifted out of its banner-callback lambda so it is reachable without a Screen. The lambda only
-    // ever runs via screen->showOverlayBanner(), which is why nothing here was unit-testable.
-    static void toggleNodeMuted(uint32_t nodeNum); // uint32_t, matching pickedNodeNum above
-
     // Config actions, lifted out of their banner-callback lambdas so they are reachable without a
     // Screen. The lambdas only ever run via screen->showOverlayBanner(), which is why none of this
     // was unit-testable before. Each owns the whole decision: which segment to persist, whether

--- a/src/graphics/draw/MenuHandler.h
+++ b/src/graphics/draw/MenuHandler.h
@@ -131,6 +131,14 @@ class menuHandler
     // ever runs via screen->showOverlayBanner(), which is why nothing here was unit-testable.
     static void toggleNodeMuted(uint32_t nodeNum); // uint32_t, matching pickedNodeNum above
 
+    // Config actions, lifted out of their banner-callback lambdas so they are reachable without a
+    // Screen. The lambdas only ever run via screen->showOverlayBanner(), which is why none of this
+    // was unit-testable before. Each owns the whole decision: which segment to persist, whether
+    // the radio needs reconfiguring, and whether a reboot is required.
+    static void toggleTelemetryScreen(bool &flag);
+    static void setSmartPositionEnabled(bool enabled);
+    static void toggleNodeMuted(uint32_t nodeNum); // uint32_t, matching pickedNodeNum above
+
   private:
     static void saveUIConfig();
     static void keyVerificationInitMenu();

--- a/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
@@ -343,6 +343,7 @@ static void applyLoRaRegion(meshtastic_Config_LoRaConfig_RegionCode region)
     }
     // Notify UI that changes are being applied
     InkHUD::InkHUD::getInstance()->notifyApplyingChanges();
+    // TODO(radioAffected): audit
     service->reloadConfig(changes);
 
     rebootAtMsec = millis() + DEFAULT_REBOOT_SECONDS * 1000;
@@ -357,6 +358,7 @@ static void applyDeviceRole(meshtastic_Config_DeviceConfig_Role role)
 
     nodeDB->saveToDisk(SEGMENT_CONFIG);
 
+    // TODO(radioAffected): audit
     service->reloadConfig(SEGMENT_CONFIG);
 
     // Notify UI that changes are being applied
@@ -374,6 +376,7 @@ static void applyLoRaPreset(meshtastic_Config_LoRaConfig_ModemPreset preset)
     config.lora.modem_preset = preset;
 
     nodeDB->saveToDisk(SEGMENT_CONFIG);
+    // TODO(radioAffected): audit
     service->reloadConfig(SEGMENT_CONFIG);
 
     // Notify UI that changes are being applied
@@ -385,6 +388,7 @@ static void applyLoRaPreset(meshtastic_Config_LoRaConfig_ModemPreset preset)
 static void applyConfigReload(uint32_t changes = SEGMENT_CONFIG, bool reboot = false)
 {
     nodeDB->saveToDisk(changes);
+    // TODO(radioAffected): audit
     service->reloadConfig(changes);
 
     if (reboot) {
@@ -450,6 +454,7 @@ static void applyTimezone(const char *tz)
     setenv("TZ", config.device.tzdef, 1);
 
     nodeDB->saveToDisk(SEGMENT_CONFIG);
+    // TODO(radioAffected): audit
     service->reloadConfig(SEGMENT_CONFIG);
 }
 
@@ -615,6 +620,7 @@ void InkHUD::MenuApplet::execute(MenuItem item)
             break;
         }
         nodeDB->saveToDisk(SEGMENT_CONFIG);
+        // TODO(radioAffected): audit
         service->reloadConfig(SEGMENT_CONFIG);
 #endif
         break;
@@ -1068,6 +1074,7 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         auto &ch = channels.getByIndex(selectedChannelIndex);
         ch.settings.uplink_enabled = !ch.settings.uplink_enabled;
         nodeDB->saveToDisk(SEGMENT_CHANNELS);
+        // TODO(radioAffected): radio-affecting
         service->reloadConfig(SEGMENT_CHANNELS);
         break;
     }
@@ -1076,6 +1083,7 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         auto &ch = channels.getByIndex(selectedChannelIndex);
         ch.settings.downlink_enabled = !ch.settings.downlink_enabled;
         nodeDB->saveToDisk(SEGMENT_CHANNELS);
+        // TODO(radioAffected): radio-affecting
         service->reloadConfig(SEGMENT_CHANNELS);
         break;
     }
@@ -1092,6 +1100,7 @@ void InkHUD::MenuApplet::execute(MenuItem item)
             ch.settings.module_settings.position_precision = 13; // default
 
         nodeDB->saveToDisk(SEGMENT_CHANNELS);
+        // TODO(radioAffected): radio-affecting
         service->reloadConfig(SEGMENT_CHANNELS);
         break;
     }
@@ -1112,6 +1121,7 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         }
 
         nodeDB->saveToDisk(SEGMENT_CHANNELS);
+        // TODO(radioAffected): radio-affecting
         service->reloadConfig(SEGMENT_CHANNELS);
         break;
     }

--- a/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
@@ -343,8 +343,7 @@ static void applyLoRaRegion(meshtastic_Config_LoRaConfig_RegionCode region)
     }
     // Notify UI that changes are being applied
     InkHUD::InkHUD::getInstance()->notifyApplyingChanges();
-    // TODO(radioAffected): audit
-    service->reloadConfig(changes);
+    service->reloadConfig(changes, /*radioAffected=*/true); // region change is a LoRa radio parameter
 
     rebootAtMsec = millis() + DEFAULT_REBOOT_SECONDS * 1000;
 }
@@ -358,8 +357,7 @@ static void applyDeviceRole(meshtastic_Config_DeviceConfig_Role role)
 
     nodeDB->saveToDisk(SEGMENT_CONFIG);
 
-    // TODO(radioAffected): audit
-    service->reloadConfig(SEGMENT_CONFIG);
+    service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // device role, not LoRa
 
     // Notify UI that changes are being applied
     InkHUD::InkHUD::getInstance()->notifyApplyingChanges();
@@ -376,8 +374,7 @@ static void applyLoRaPreset(meshtastic_Config_LoRaConfig_ModemPreset preset)
     config.lora.modem_preset = preset;
 
     nodeDB->saveToDisk(SEGMENT_CONFIG);
-    // TODO(radioAffected): audit
-    service->reloadConfig(SEGMENT_CONFIG);
+    service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/true); // modem preset is a LoRa radio parameter
 
     // Notify UI that changes are being applied
     InkHUD::InkHUD::getInstance()->notifyApplyingChanges();
@@ -385,11 +382,12 @@ static void applyLoRaPreset(meshtastic_Config_LoRaConfig_ModemPreset preset)
     rebootAtMsec = millis() + DEFAULT_REBOOT_SECONDS * 1000;
 }
 
+// Used for non-LoRa config fields only - LoRa region/preset go through the dedicated
+// applyLoRaRegion/applyLoRaPreset helpers above so the reload can request the radio reconfigure.
 static void applyConfigReload(uint32_t changes = SEGMENT_CONFIG, bool reboot = false)
 {
     nodeDB->saveToDisk(changes);
-    // TODO(radioAffected): audit
-    service->reloadConfig(changes);
+    service->reloadConfig(changes, /*radioAffected=*/false);
 
     if (reboot) {
         InkHUD::InkHUD::getInstance()->notifyApplyingChanges();
@@ -454,8 +452,7 @@ static void applyTimezone(const char *tz)
     setenv("TZ", config.device.tzdef, 1);
 
     nodeDB->saveToDisk(SEGMENT_CONFIG);
-    // TODO(radioAffected): audit
-    service->reloadConfig(SEGMENT_CONFIG);
+    service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // timezone, not LoRa
 }
 
 // Perform action for a menu item, then change page
@@ -620,8 +617,7 @@ void InkHUD::MenuApplet::execute(MenuItem item)
             break;
         }
         nodeDB->saveToDisk(SEGMENT_CONFIG);
-        // TODO(radioAffected): audit
-        service->reloadConfig(SEGMENT_CONFIG);
+        service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // GPS mode, not LoRa
 #endif
         break;
 
@@ -1074,8 +1070,7 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         auto &ch = channels.getByIndex(selectedChannelIndex);
         ch.settings.uplink_enabled = !ch.settings.uplink_enabled;
         nodeDB->saveToDisk(SEGMENT_CHANNELS);
-        // TODO(radioAffected): radio-affecting
-        service->reloadConfig(SEGMENT_CHANNELS);
+        service->reloadConfig(SEGMENT_CHANNELS, /*radioAffected=*/true); // channel/PSK is a LoRa radio parameter
         break;
     }
 
@@ -1083,8 +1078,7 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         auto &ch = channels.getByIndex(selectedChannelIndex);
         ch.settings.downlink_enabled = !ch.settings.downlink_enabled;
         nodeDB->saveToDisk(SEGMENT_CHANNELS);
-        // TODO(radioAffected): radio-affecting
-        service->reloadConfig(SEGMENT_CHANNELS);
+        service->reloadConfig(SEGMENT_CHANNELS, /*radioAffected=*/true); // channel/PSK is a LoRa radio parameter
         break;
     }
 
@@ -1100,8 +1094,7 @@ void InkHUD::MenuApplet::execute(MenuItem item)
             ch.settings.module_settings.position_precision = 13; // default
 
         nodeDB->saveToDisk(SEGMENT_CHANNELS);
-        // TODO(radioAffected): radio-affecting
-        service->reloadConfig(SEGMENT_CHANNELS);
+        service->reloadConfig(SEGMENT_CHANNELS, /*radioAffected=*/true); // channel/PSK is a LoRa radio parameter
         break;
     }
 
@@ -1121,8 +1114,7 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         }
 
         nodeDB->saveToDisk(SEGMENT_CHANNELS);
-        // TODO(radioAffected): radio-affecting
-        service->reloadConfig(SEGMENT_CHANNELS);
+        service->reloadConfig(SEGMENT_CHANNELS, /*radioAffected=*/true); // channel/PSK is a LoRa radio parameter
         break;
     }
 

--- a/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
@@ -10,6 +10,7 @@
 #include "Power.h"
 #include "Router.h"
 #include "airtime.h"
+#include "buzz.h"
 #include "gps/RTC.h"
 #include "graphics/niche/InkHUD/Applets/Bases/Map/MapApplet.h"
 #include "graphics/niche/Utils/FlashData.h"
@@ -343,9 +344,8 @@ static void applyLoRaRegion(meshtastic_Config_LoRaConfig_RegionCode region)
     }
     // Notify UI that changes are being applied
     InkHUD::InkHUD::getInstance()->notifyApplyingChanges();
+    // LoRa config applies live via configChanged observer -> RadioInterface::reconfigure(); no reboot needed.
     service->reloadConfig(changes, /*radioAffected=*/true); // region change is a LoRa radio parameter
-
-    rebootAtMsec = millis() + DEFAULT_REBOOT_SECONDS * 1000;
 }
 
 static void applyDeviceRole(meshtastic_Config_DeviceConfig_Role role)
@@ -374,12 +374,11 @@ static void applyLoRaPreset(meshtastic_Config_LoRaConfig_ModemPreset preset)
     config.lora.modem_preset = preset;
 
     nodeDB->saveToDisk(SEGMENT_CONFIG);
+    // LoRa config applies live via configChanged observer -> RadioInterface::reconfigure(); no reboot needed.
     service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/true); // modem preset is a LoRa radio parameter
 
     // Notify UI that changes are being applied
     InkHUD::InkHUD::getInstance()->notifyApplyingChanges();
-
-    rebootAtMsec = millis() + DEFAULT_REBOOT_SECONDS * 1000;
 }
 
 // Used for non-LoRa config fields only - LoRa region/preset go through the dedicated
@@ -610,28 +609,39 @@ void InkHUD::MenuApplet::execute(MenuItem item)
 #if !MESHTASTIC_EXCLUDE_GPS && HAS_GPS
         if (config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_DISABLED) {
             config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_ENABLED;
+            if (gps != nullptr) {
+                playGPSEnableBeep();
+                gps->enable();
+            }
         } else if (config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED) {
             config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_DISABLED;
+            if (gps != nullptr) {
+                playGPSDisableBeep();
+                gps->disable();
+            }
         } else {
             // NOT_PRESENT do nothing
             break;
         }
         nodeDB->saveToDisk(SEGMENT_CONFIG);
+        // GPS driver is toggled live above (matches MenuHandler.cpp's equivalent) - no reboot needed.
         service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // GPS mode, not LoRa
 #endif
         break;
 
     case TOGGLE_SMART_POSITION:
+        // Read live by PositionModule's smart-broadcast path every send - no reboot needed.
         config.position.position_broadcast_smart_enabled = !config.position.position_broadcast_smart_enabled;
-        applyConfigReload(SEGMENT_CONFIG, true);
+        applyConfigReload(SEGMENT_CONFIG);
         break;
 
     case SET_POSITION_BROADCAST_INTERVAL: {
         const uint8_t index = cursor - 1;
         constexpr uint8_t optionCount = sizeof(POSITION_BROADCAST_OPTIONS) / sizeof(POSITION_BROADCAST_OPTIONS[0]);
         if (index < optionCount && config.position.position_broadcast_secs != POSITION_BROADCAST_OPTIONS[index].value) {
+            // Read live by PositionModule's broadcast scheduler every cycle - no reboot needed.
             config.position.position_broadcast_secs = POSITION_BROADCAST_OPTIONS[index].value;
-            applyConfigReload(SEGMENT_CONFIG, true);
+            applyConfigReload(SEGMENT_CONFIG);
         }
         break;
     }
@@ -640,8 +650,9 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         const uint8_t index = cursor - 1;
         constexpr uint8_t optionCount = sizeof(SMART_INTERVAL_OPTIONS) / sizeof(SMART_INTERVAL_OPTIONS[0]);
         if (index < optionCount && config.position.broadcast_smart_minimum_interval_secs != SMART_INTERVAL_OPTIONS[index].value) {
+            // Read live by PositionModule::minimumTimeThreshold every send - no reboot needed.
             config.position.broadcast_smart_minimum_interval_secs = SMART_INTERVAL_OPTIONS[index].value;
-            applyConfigReload(SEGMENT_CONFIG, true);
+            applyConfigReload(SEGMENT_CONFIG);
         }
         break;
     }
@@ -650,8 +661,9 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         const uint8_t index = cursor - 1;
         constexpr uint8_t optionCount = sizeof(SMART_DISTANCE_OPTIONS) / sizeof(SMART_DISTANCE_OPTIONS[0]);
         if (index < optionCount && config.position.broadcast_smart_minimum_distance != SMART_DISTANCE_OPTIONS[index]) {
+            // Read live by PositionModule's smart-position distance check every send - no reboot needed.
             config.position.broadcast_smart_minimum_distance = SMART_DISTANCE_OPTIONS[index];
-            applyConfigReload(SEGMENT_CONFIG, true);
+            applyConfigReload(SEGMENT_CONFIG);
         }
         break;
     }

--- a/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
@@ -589,6 +589,10 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         break;
 
     case TOGGLE_GPS:
+        // The gps->enable()/disable() calls below are new: this used to write gps_mode and reload
+        // the radio, leaving the driver in its old state until the next boot. Driving the driver
+        // here is what makes CONFIG_APPLY_NONE correct - it matches MenuHandler::GPSToggleMenu(),
+        // which has always done it this way.
 #if !MESHTASTIC_EXCLUDE_GPS && HAS_GPS
         if (config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_DISABLED) {
             config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_ENABLED;
@@ -638,6 +642,7 @@ void InkHUD::MenuApplet::execute(MenuItem item)
             // AdminModule path, which also reboots for this field.
             config.position.broadcast_smart_minimum_interval_secs = SMART_INTERVAL_OPTIONS[index].value;
             service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_REBOOT);
+            InkHUD::InkHUD::getInstance()->notifyApplyingChanges();
         }
         break;
     }
@@ -1062,17 +1067,24 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         break;
 
     // Channels
+    //
+    // These four only touch a channel's uplink/downlink MQTT flags or its position_precision -
+    // never the name, PSK or frequency slot. The channel hash that RadioInterface::reconfigure()
+    // derives the frequency from is computed from name+PSK only, and RadioInterface is the sole
+    // observer of configChanged, so there is nothing for a radio reload to do here. They carried
+    // CONFIG_APPLY_RADIO purely because the old reloadConfig(SEGMENT_CHANNELS) inferred it from
+    // the bitmask. Persist only, like the BaseUI channel-mute action.
     case TOGGLE_CHANNEL_UPLINK: {
         auto &ch = channels.getByIndex(selectedChannelIndex);
         ch.settings.uplink_enabled = !ch.settings.uplink_enabled;
-        service->applyConfigChange(SEGMENT_CHANNELS, CONFIG_APPLY_RADIO);
+        service->applyConfigChange(SEGMENT_CHANNELS, CONFIG_APPLY_NONE);
         break;
     }
 
     case TOGGLE_CHANNEL_DOWNLINK: {
         auto &ch = channels.getByIndex(selectedChannelIndex);
         ch.settings.downlink_enabled = !ch.settings.downlink_enabled;
-        service->applyConfigChange(SEGMENT_CHANNELS, CONFIG_APPLY_RADIO);
+        service->applyConfigChange(SEGMENT_CHANNELS, CONFIG_APPLY_NONE);
         break;
     }
 
@@ -1087,7 +1099,7 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         else
             ch.settings.module_settings.position_precision = 13; // default
 
-        service->applyConfigChange(SEGMENT_CHANNELS, CONFIG_APPLY_RADIO);
+        service->applyConfigChange(SEGMENT_CHANNELS, CONFIG_APPLY_NONE);
         break;
     }
 
@@ -1106,20 +1118,20 @@ void InkHUD::MenuApplet::execute(MenuItem item)
             ch.settings.module_settings.position_precision = POSITION_PRECISION_OPTIONS[index].value;
         }
 
-        service->applyConfigChange(SEGMENT_CHANNELS, CONFIG_APPLY_RADIO);
+        service->applyConfigChange(SEGMENT_CHANNELS, CONFIG_APPLY_NONE);
         break;
     }
 
     case RESET_NODEDB_ALL:
         InkHUD::getInstance()->notifyApplyingChanges();
         nodeDB->resetNodes();
-        rebootAtMsec = millis() + DEFAULT_REBOOT_SECONDS * 1000;
+        requestReboot();
         break;
 
     case RESET_NODEDB_KEEP_FAVORITES:
         InkHUD::getInstance()->notifyApplyingChanges();
         nodeDB->resetNodes(1);
-        rebootAtMsec = millis() + DEFAULT_REBOOT_SECONDS * 1000;
+        requestReboot();
         break;
 
     case WIPE_MESSAGES_ALL:

--- a/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
@@ -632,9 +632,12 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         const uint8_t index = cursor - 1;
         constexpr uint8_t optionCount = sizeof(SMART_INTERVAL_OPTIONS) / sizeof(SMART_INTERVAL_OPTIONS[0]);
         if (index < optionCount && config.position.broadcast_smart_minimum_interval_secs != SMART_INTERVAL_OPTIONS[index].value) {
-            // Read live by PositionModule::minimumTimeThreshold every send - no reboot needed.
+            // NOT read live, despite the sibling distance option below being so:
+            // PositionModule::minimumTimeThreshold is a const member initialised once when the
+            // module is constructed, so this only takes effect after a restart. Matches the
+            // AdminModule path, which also reboots for this field.
             config.position.broadcast_smart_minimum_interval_secs = SMART_INTERVAL_OPTIONS[index].value;
-            service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
+            service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_REBOOT);
         }
         break;
     }

--- a/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
@@ -342,7 +342,9 @@ static void applyLoRaRegion(meshtastic_Config_LoRaConfig_RegionCode region)
         snprintf(moduleConfig.mqtt.root, sizeof(moduleConfig.mqtt.root), "%s/%s", default_mqtt_root, myRegion->name);
         changes |= SEGMENT_MODULECONFIG;
     }
-    // Notify UI that changes are being applied
+    // Live change, not a reboot: covers the e-ink redraw while the radio reconfigures. See the
+    // two-jobs note on InkHUD::notifyApplyingChanges() - this call is not interchangeable with the
+    // ones that sit beside CONFIG_APPLY_REBOOT below.
     InkHUD::InkHUD::getInstance()->notifyApplyingChanges();
     // LoRa config applies live via configChanged observer -> RadioInterface::reconfigure(); no reboot needed.
     service->applyConfigChange(changes, CONFIG_APPLY_RADIO);
@@ -372,7 +374,7 @@ static void applyLoRaPreset(meshtastic_Config_LoRaConfig_ModemPreset preset)
     // LoRa config applies live via configChanged observer -> RadioInterface::reconfigure(); no reboot needed.
     service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_RADIO);
 
-    // Notify UI that changes are being applied
+    // Live change, not a reboot (see applyLoRaRegion above).
     InkHUD::InkHUD::getInstance()->notifyApplyingChanges();
 }
 

--- a/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
@@ -355,8 +355,6 @@ static void applyDeviceRole(meshtastic_Config_DeviceConfig_Role role)
 
     config.device.role = role;
 
-    nodeDB->saveToDisk(SEGMENT_CONFIG);
-
     service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // device role, not LoRa
 
     // Notify UI that changes are being applied
@@ -373,7 +371,6 @@ static void applyLoRaPreset(meshtastic_Config_LoRaConfig_ModemPreset preset)
     config.lora.use_preset = true;
     config.lora.modem_preset = preset;
 
-    nodeDB->saveToDisk(SEGMENT_CONFIG);
     // LoRa config applies live via configChanged observer -> RadioInterface::reconfigure(); no reboot needed.
     service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/true); // modem preset is a LoRa radio parameter
 
@@ -385,7 +382,6 @@ static void applyLoRaPreset(meshtastic_Config_LoRaConfig_ModemPreset preset)
 // applyLoRaRegion/applyLoRaPreset helpers above so the reload can request the radio reconfigure.
 static void applyConfigReload(uint32_t changes = SEGMENT_CONFIG, bool reboot = false)
 {
-    nodeDB->saveToDisk(changes);
     service->reloadConfig(changes, /*radioAffected=*/false);
 
     if (reboot) {
@@ -450,7 +446,6 @@ static void applyTimezone(const char *tz)
 
     setenv("TZ", config.device.tzdef, 1);
 
-    nodeDB->saveToDisk(SEGMENT_CONFIG);
     service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // timezone, not LoRa
 }
 
@@ -623,7 +618,6 @@ void InkHUD::MenuApplet::execute(MenuItem item)
             // NOT_PRESENT do nothing
             break;
         }
-        nodeDB->saveToDisk(SEGMENT_CONFIG);
         // GPS driver is toggled live above (matches MenuHandler.cpp's equivalent) - no reboot needed.
         service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // GPS mode, not LoRa
 #endif
@@ -1081,7 +1075,6 @@ void InkHUD::MenuApplet::execute(MenuItem item)
     case TOGGLE_CHANNEL_UPLINK: {
         auto &ch = channels.getByIndex(selectedChannelIndex);
         ch.settings.uplink_enabled = !ch.settings.uplink_enabled;
-        nodeDB->saveToDisk(SEGMENT_CHANNELS);
         service->reloadConfig(SEGMENT_CHANNELS, /*radioAffected=*/true); // channel/PSK is a LoRa radio parameter
         break;
     }
@@ -1089,7 +1082,6 @@ void InkHUD::MenuApplet::execute(MenuItem item)
     case TOGGLE_CHANNEL_DOWNLINK: {
         auto &ch = channels.getByIndex(selectedChannelIndex);
         ch.settings.downlink_enabled = !ch.settings.downlink_enabled;
-        nodeDB->saveToDisk(SEGMENT_CHANNELS);
         service->reloadConfig(SEGMENT_CHANNELS, /*radioAffected=*/true); // channel/PSK is a LoRa radio parameter
         break;
     }
@@ -1105,7 +1097,6 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         else
             ch.settings.module_settings.position_precision = 13; // default
 
-        nodeDB->saveToDisk(SEGMENT_CHANNELS);
         service->reloadConfig(SEGMENT_CHANNELS, /*radioAffected=*/true); // channel/PSK is a LoRa radio parameter
         break;
     }
@@ -1125,7 +1116,6 @@ void InkHUD::MenuApplet::execute(MenuItem item)
             ch.settings.module_settings.position_precision = POSITION_PRECISION_OPTIONS[index].value;
         }
 
-        nodeDB->saveToDisk(SEGMENT_CHANNELS);
         service->reloadConfig(SEGMENT_CHANNELS, /*radioAffected=*/true); // channel/PSK is a LoRa radio parameter
         break;
     }

--- a/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
@@ -345,7 +345,7 @@ static void applyLoRaRegion(meshtastic_Config_LoRaConfig_RegionCode region)
     // Notify UI that changes are being applied
     InkHUD::InkHUD::getInstance()->notifyApplyingChanges();
     // LoRa config applies live via configChanged observer -> RadioInterface::reconfigure(); no reboot needed.
-    service->reloadConfig(changes, /*radioAffected=*/true); // region change is a LoRa radio parameter
+    service->applyConfigChange(changes, CONFIG_APPLY_RADIO);
 }
 
 static void applyDeviceRole(meshtastic_Config_DeviceConfig_Role role)
@@ -355,12 +355,10 @@ static void applyDeviceRole(meshtastic_Config_DeviceConfig_Role role)
 
     config.device.role = role;
 
-    service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // device role, not LoRa
+    service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_REBOOT);
 
     // Notify UI that changes are being applied
     InkHUD::InkHUD::getInstance()->notifyApplyingChanges();
-
-    rebootAtMsec = millis() + DEFAULT_REBOOT_SECONDS * 1000;
 }
 
 static void applyLoRaPreset(meshtastic_Config_LoRaConfig_ModemPreset preset)
@@ -372,22 +370,10 @@ static void applyLoRaPreset(meshtastic_Config_LoRaConfig_ModemPreset preset)
     config.lora.modem_preset = preset;
 
     // LoRa config applies live via configChanged observer -> RadioInterface::reconfigure(); no reboot needed.
-    service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/true); // modem preset is a LoRa radio parameter
+    service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_RADIO);
 
     // Notify UI that changes are being applied
     InkHUD::InkHUD::getInstance()->notifyApplyingChanges();
-}
-
-// Used for non-LoRa config fields only - LoRa region/preset go through the dedicated
-// applyLoRaRegion/applyLoRaPreset helpers above so the reload can request the radio reconfigure.
-static void applyConfigReload(uint32_t changes = SEGMENT_CONFIG, bool reboot = false)
-{
-    service->reloadConfig(changes, /*radioAffected=*/false);
-
-    if (reboot) {
-        InkHUD::InkHUD::getInstance()->notifyApplyingChanges();
-        rebootAtMsec = millis() + DEFAULT_REBOOT_SECONDS * 1000;
-    }
 }
 
 static const char *getTimezoneLabelFromValue(const char *tzdef)
@@ -446,7 +432,7 @@ static void applyTimezone(const char *tz)
 
     setenv("TZ", config.device.tzdef, 1);
 
-    service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // timezone, not LoRa
+    service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
 }
 
 // Perform action for a menu item, then change page
@@ -550,7 +536,7 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         else
             config.display.displaymode = meshtastic_Config_DisplayConfig_DisplayMode_INVERTED;
 
-        nodeDB->saveToDisk(SEGMENT_CONFIG);
+        service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
         break;
 
     case SET_RECENTS: {
@@ -597,7 +583,7 @@ void InkHUD::MenuApplet::execute(MenuItem item)
 
     case TOGGLE_12H_CLOCK:
         config.display.use_12h_clock = !config.display.use_12h_clock;
-        nodeDB->saveToDisk(SEGMENT_CONFIG);
+        service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
         break;
 
     case TOGGLE_GPS:
@@ -619,14 +605,14 @@ void InkHUD::MenuApplet::execute(MenuItem item)
             break;
         }
         // GPS driver is toggled live above (matches MenuHandler.cpp's equivalent) - no reboot needed.
-        service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false); // GPS mode, not LoRa
+        service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
 #endif
         break;
 
     case TOGGLE_SMART_POSITION:
         // Read live by PositionModule's smart-broadcast path every send - no reboot needed.
         config.position.position_broadcast_smart_enabled = !config.position.position_broadcast_smart_enabled;
-        applyConfigReload(SEGMENT_CONFIG);
+        service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
         break;
 
     case SET_POSITION_BROADCAST_INTERVAL: {
@@ -635,7 +621,7 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         if (index < optionCount && config.position.position_broadcast_secs != POSITION_BROADCAST_OPTIONS[index].value) {
             // Read live by PositionModule's broadcast scheduler every cycle - no reboot needed.
             config.position.position_broadcast_secs = POSITION_BROADCAST_OPTIONS[index].value;
-            applyConfigReload(SEGMENT_CONFIG);
+            service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
         }
         break;
     }
@@ -646,7 +632,7 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         if (index < optionCount && config.position.broadcast_smart_minimum_interval_secs != SMART_INTERVAL_OPTIONS[index].value) {
             // Read live by PositionModule::minimumTimeThreshold every send - no reboot needed.
             config.position.broadcast_smart_minimum_interval_secs = SMART_INTERVAL_OPTIONS[index].value;
-            applyConfigReload(SEGMENT_CONFIG);
+            service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
         }
         break;
     }
@@ -657,7 +643,7 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         if (index < optionCount && config.position.broadcast_smart_minimum_distance != SMART_DISTANCE_OPTIONS[index]) {
             // Read live by PositionModule's smart-position distance check every send - no reboot needed.
             config.position.broadcast_smart_minimum_distance = SMART_DISTANCE_OPTIONS[index];
-            applyConfigReload(SEGMENT_CONFIG);
+            service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
         }
         break;
     }
@@ -667,7 +653,8 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         constexpr uint8_t optionCount = sizeof(GPS_UPDATE_INTERVAL_OPTIONS) / sizeof(GPS_UPDATE_INTERVAL_OPTIONS[0]);
         if (index < optionCount && config.position.gps_update_interval != GPS_UPDATE_INTERVAL_OPTIONS[index].value) {
             config.position.gps_update_interval = GPS_UPDATE_INTERVAL_OPTIONS[index].value;
-            applyConfigReload(SEGMENT_CONFIG, true);
+            service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_REBOOT);
+            InkHUD::InkHUD::getInstance()->notifyApplyingChanges();
         }
         break;
     }
@@ -677,18 +664,18 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         LOG_INFO("Enabling Bluetooth");
         config.network.wifi_enabled = false;
         config.bluetooth.enabled = true;
-        nodeDB->saveToDisk(SEGMENT_CONFIG);
+        // TODO: why 2 s rather than the usual DEFAULT_REBOOT_SECONDS? Undocumented; preserved
+        // verbatim here. Check whether the short delay is load-bearing for wifi recovery.
+        service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_REBOOT, 2);
         InkHUD::InkHUD::getInstance()->notifyApplyingChanges();
-        rebootAtMsec = millis() + 2000;
         break;
 
         // Power / Network (ESP32-only)
 #if defined(ARCH_ESP32)
     case TOGGLE_POWER_SAVE:
         config.power.is_power_saving = !config.power.is_power_saving;
-        nodeDB->saveToDisk(SEGMENT_CONFIG);
+        service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_REBOOT);
         InkHUD::InkHUD::getInstance()->notifyApplyingChanges();
-        rebootAtMsec = millis() + DEFAULT_REBOOT_SECONDS * 1000;
         break;
 
     case TOGGLE_WIFI:
@@ -699,9 +686,8 @@ void InkHUD::MenuApplet::execute(MenuItem item)
             config.bluetooth.enabled = false;
         }
 
-        nodeDB->saveToDisk(SEGMENT_CONFIG);
+        service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_REBOOT);
         InkHUD::InkHUD::getInstance()->notifyApplyingChanges();
-        rebootAtMsec = millis() + DEFAULT_REBOOT_SECONDS * 1000;
         break;
 #endif
     // ADC Calibration
@@ -740,7 +726,7 @@ void InkHUD::MenuApplet::execute(MenuItem item)
 
         config.power.adc_multiplier_override = newMult;
 
-        nodeDB->saveToDisk(SEGMENT_CONFIG);
+        service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
 
         LOG_INFO("ADC calibrated: measured=%.3fV base=%.4f new=%.4f", measuredV, baseMult, newMult);
 
@@ -754,7 +740,7 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         constexpr uint8_t optionCount = sizeof(DISPLAY_TIMEOUT_OPTIONS) / sizeof(DISPLAY_TIMEOUT_OPTIONS[0]);
         if (index < optionCount) {
             config.display.screen_on_secs = DISPLAY_TIMEOUT_OPTIONS[index].seconds;
-            nodeDB->saveToDisk(SEGMENT_CONFIG);
+            service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
         }
         break;
     }
@@ -765,7 +751,7 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         else
             config.display.units = meshtastic_Config_DisplayConfig_DisplayUnits_IMPERIAL;
 
-        nodeDB->saveToDisk(SEGMENT_CONFIG);
+        service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
         break;
 
     // Bluetooth
@@ -777,14 +763,13 @@ void InkHUD::MenuApplet::execute(MenuItem item)
             config.network.wifi_enabled = false;
         }
 
-        nodeDB->saveToDisk(SEGMENT_CONFIG);
+        service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_REBOOT);
         InkHUD::InkHUD::getInstance()->notifyApplyingChanges();
-        rebootAtMsec = millis() + DEFAULT_REBOOT_SECONDS * 1000;
         break;
 
     case TOGGLE_BLUETOOTH_PAIR_MODE:
         config.bluetooth.fixed_pin = !config.bluetooth.fixed_pin;
-        nodeDB->saveToDisk(SEGMENT_CONFIG);
+        service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
         break;
 
     // Regions
@@ -1075,14 +1060,14 @@ void InkHUD::MenuApplet::execute(MenuItem item)
     case TOGGLE_CHANNEL_UPLINK: {
         auto &ch = channels.getByIndex(selectedChannelIndex);
         ch.settings.uplink_enabled = !ch.settings.uplink_enabled;
-        service->reloadConfig(SEGMENT_CHANNELS, /*radioAffected=*/true); // channel/PSK is a LoRa radio parameter
+        service->applyConfigChange(SEGMENT_CHANNELS, CONFIG_APPLY_RADIO);
         break;
     }
 
     case TOGGLE_CHANNEL_DOWNLINK: {
         auto &ch = channels.getByIndex(selectedChannelIndex);
         ch.settings.downlink_enabled = !ch.settings.downlink_enabled;
-        service->reloadConfig(SEGMENT_CHANNELS, /*radioAffected=*/true); // channel/PSK is a LoRa radio parameter
+        service->applyConfigChange(SEGMENT_CHANNELS, CONFIG_APPLY_RADIO);
         break;
     }
 
@@ -1097,7 +1082,7 @@ void InkHUD::MenuApplet::execute(MenuItem item)
         else
             ch.settings.module_settings.position_precision = 13; // default
 
-        service->reloadConfig(SEGMENT_CHANNELS, /*radioAffected=*/true); // channel/PSK is a LoRa radio parameter
+        service->applyConfigChange(SEGMENT_CHANNELS, CONFIG_APPLY_RADIO);
         break;
     }
 
@@ -1116,7 +1101,7 @@ void InkHUD::MenuApplet::execute(MenuItem item)
             ch.settings.module_settings.position_precision = POSITION_PRECISION_OPTIONS[index].value;
         }
 
-        service->reloadConfig(SEGMENT_CHANNELS, /*radioAffected=*/true); // channel/PSK is a LoRa radio parameter
+        service->applyConfigChange(SEGMENT_CHANNELS, CONFIG_APPLY_RADIO);
         break;
     }
 

--- a/src/graphics/niche/InkHUD/InkHUD.h
+++ b/src/graphics/niche/InkHUD/InkHUD.h
@@ -49,6 +49,26 @@ class InkHUD
     void setDriver(Drivers::EInk *driver);
     void setDisplayResilience(uint8_t fastPerFull = 5, float stressMultiplier = 2.0);
     void addApplet(const char *name, Applet *a, bool defaultActive = false, bool defaultAutoshow = false, uint8_t onTile = -1);
+
+    /** Show the "applying changes" holding screen.
+     *
+     * Called at the moment a config change is *initiated*, and it serves two distinct jobs at its
+     * call sites in MenuApplet.cpp. Do not treat them alike when refactoring:
+     *
+     *  - a **live** change, applied without restarting (LoRa region and modem preset). The screen
+     *    covers the seconds the e-ink takes to redraw. These calls must stay: nothing else raises
+     *    them.
+     *  - an imminent **reboot**, where it warns before the display goes. These sit next to an
+     *    applyConfigChange(..., CONFIG_APPLY_REBOOT).
+     *
+     * Neither is redundant with anything, which is the point worth recording. MeshService's
+     * requestReboot() deliberately carries no UI: BaseUI renders its own notice at draw time from
+     * rebootAtMsec, whereas e-ink only draws when pushed, so InkHUD has to be told explicitly.
+     * And the existing `notifyReboot` Observable (sleep.h, fired from Power::reboot) is a
+     * *different moment* - reboot execution, not scheduling - which InkHUD already observes to save
+     * settings and shut applets down. Centralising these calls onto a new "reboot scheduled"
+     * observable would add a third reboot signal for no functional gain.
+     */
     void notifyApplyingChanges();
 
     void begin();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1268,10 +1268,18 @@ bool suppressRebootBanner; // If true, suppress "Rebooting..." overlay (used for
 
 void requestReboot(int32_t seconds)
 {
+    // rebootAtMsec == 0 means "no reboot pending" everywhere it is read (Power::powerCommandsCheck
+    // tests `if (rebootAtMsec && ...)`, and both the reboot banner and the portduino/lockdown
+    // checks treat 0 as idle). So a negative delay *cancels* a pending reboot rather than bringing
+    // it forward - which is what admin.proto documents for reboot_seconds ("<0 to cancel reboot").
+    // Menu callers always pass a positive; the branch exists for that remote-admin cancel.
+    if (seconds < 0) {
+        LOG_INFO("Reboot cancelled");
+        rebootAtMsec = 0;
+        return;
+    }
     LOG_INFO("Reboot in %d seconds", seconds);
-    // A negative delay means "now"; rebootAtMsec == 0 is the immediate-reboot sentinel. Remote
-    // admin relies on this, so keep the branch even though menu callers always pass a positive.
-    rebootAtMsec = (seconds < 0) ? 0 : (millis() + seconds * 1000);
+    rebootAtMsec = millis() + seconds * 1000;
 }
 
 #if defined(MESHTASTIC_ENCRYPTED_STORAGE) && defined(MESHTASTIC_PHONEAPI_ACCESS_CONTROL)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1266,6 +1266,14 @@ uint32_t rebootAtMsec;     // If not zero we will reboot at this time (used to r
 uint32_t shutdownAtMsec;   // If not zero we will shutdown at this time (used to shutdown from python or mobile client)
 bool suppressRebootBanner; // If true, suppress "Rebooting..." overlay (used for OTA handoff)
 
+void requestReboot(int32_t seconds)
+{
+    LOG_INFO("Reboot in %d seconds", seconds);
+    // A negative delay means "now"; rebootAtMsec == 0 is the immediate-reboot sentinel. Remote
+    // admin relies on this, so keep the branch even though menu callers always pass a positive.
+    rebootAtMsec = (seconds < 0) ? 0 : (millis() + seconds * 1000);
+}
+
 #if defined(MESHTASTIC_ENCRYPTED_STORAGE) && defined(MESHTASTIC_PHONEAPI_ACCESS_CONTROL)
 volatile bool lockdownReloadPending;  // see main.h - deferred NodeDB reload after lockdown unlock
 volatile bool lockdownDisablePending; // see main.h - deferred decrypt-revert after lockdown disable

--- a/src/main.h
+++ b/src/main.h
@@ -93,7 +93,8 @@ extern uint32_t rebootAtMsec;
 extern uint32_t shutdownAtMsec;
 extern bool suppressRebootBanner;
 
-/** Schedule a reboot `seconds` from now, or immediately if `seconds` is negative.
+/** Schedule a reboot `seconds` from now. A negative `seconds` *cancels* a pending reboot, matching
+ * admin.proto's reboot_seconds ("<0 to cancel reboot") - it does not reboot immediately.
  *
  * Deliberately carries no UI: BaseUI already renders the notice at draw time whenever
  * rebootAtMsec is set and suppressRebootBanner is clear (see Screen.cpp), so raising a banner

--- a/src/main.h
+++ b/src/main.h
@@ -93,6 +93,15 @@ extern uint32_t rebootAtMsec;
 extern uint32_t shutdownAtMsec;
 extern bool suppressRebootBanner;
 
+/** Schedule a reboot `seconds` from now, or immediately if `seconds` is negative.
+ *
+ * Deliberately carries no UI: BaseUI already renders the notice at draw time whenever
+ * rebootAtMsec is set and suppressRebootBanner is clear (see Screen.cpp), so raising a banner
+ * here would double up with that on every menu-driven reboot. Callers that want extra UI (an
+ * explicit banner, InkHUD's notifyApplyingChanges) still do it themselves.
+ */
+void requestReboot(int32_t seconds = DEFAULT_REBOOT_SECONDS);
+
 #if defined(MESHTASTIC_ENCRYPTED_STORAGE) && defined(MESHTASTIC_PHONEAPI_ACCESS_CONTROL)
 // Set by PhoneAPI::handleLockdownAuthInline after a successful unlock.
 // Serviced on the main loop thread because NodeDB::reloadFromDisk() is

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -156,6 +156,13 @@ void MeshService::reloadConfig(int saveWhat, bool radioAffected)
     nodeDB->saveToDisk(saveWhat);
 }
 
+void MeshService::applyConfigChange(int saveWhat, uint8_t flags, int32_t rebootSeconds)
+{
+    reloadConfig(saveWhat, (flags & CONFIG_APPLY_RADIO) != 0);
+    if (flags & CONFIG_APPLY_REBOOT)
+        requestReboot(rebootSeconds);
+}
+
 /// The owner User record just got updated, update our node DB and broadcast the info into the mesh
 void MeshService::reloadOwner(bool shouldSave)
 {

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -137,12 +137,15 @@ void MeshService::loop()
 }
 
 /// The radioConfig object just changed, call this to force the hw to change to the new settings
-void MeshService::reloadConfig(int saveWhat)
+void MeshService::reloadConfig(int saveWhat, bool radioAffected)
 {
     // Only LoRa config and channels (freq/PSK/slot) affect the radio. Saves that only touch
     // module config, device state, or the node database (e.g. favoriting a node) have no reason
     // to re-init the LoRa chip - skip it there to avoid an unnecessary and risky SPI reconfigure.
-    if (saveWhat & (SEGMENT_CONFIG | SEGMENT_CHANNELS)) {
+    // radioAffected lets a caller suppress the reload even when SEGMENT_CONFIG is set - the Config
+    // segment is monolithic, so a non-LoRa sub-message (device/network/bluetooth/security/...) must
+    // still persist SEGMENT_CONFIG but should not trigger the reconfigure.
+    if (radioAffected && (saveWhat & (SEGMENT_CONFIG | SEGMENT_CHANNELS))) {
         // If we can successfully set this radio to these settings, save them to disk
 
         // This will also update the region as needed

--- a/src/mesh/MeshService.h
+++ b/src/mesh/MeshService.h
@@ -173,7 +173,6 @@ class MeshService
      * @param radioAffected when false, suppresses the live LoRa reconfigure even if saveWhat
      *        includes SEGMENT_CONFIG/SEGMENT_CHANNELS; the save-to-disk always happens. Defaults
      *        to true so callers that only pass saveWhat keep the historical bitmask behavior.
-     * @return true if client devices should be sent a new set of radio configs
      */
     void reloadConfig(int saveWhat = SEGMENT_CONFIG | SEGMENT_MODULECONFIG | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS,
                       bool radioAffected = true);

--- a/src/mesh/MeshService.h
+++ b/src/mesh/MeshService.h
@@ -174,8 +174,8 @@ class MeshService
      *        includes SEGMENT_CONFIG/SEGMENT_CHANNELS; the save-to-disk always happens. Defaults
      *        to true so callers that only pass saveWhat keep the historical bitmask behavior.
      */
-    void reloadConfig(int saveWhat = SEGMENT_CONFIG | SEGMENT_MODULECONFIG | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS,
-                      bool radioAffected = true);
+    virtual void reloadConfig(int saveWhat = SEGMENT_CONFIG | SEGMENT_MODULECONFIG | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS,
+                              bool radioAffected = true);
 
     /// The owner User record just got updated, update our node DB and broadcast the info into the mesh
     void reloadOwner(bool shouldSave = true);

--- a/src/mesh/MeshService.h
+++ b/src/mesh/MeshService.h
@@ -170,9 +170,13 @@ class MeshService
 #endif
 
     /** The radioConfig object just changed, call this to force the hw to change to the new settings
+     * @param radioAffected when false, suppresses the live LoRa reconfigure even if saveWhat
+     *        includes SEGMENT_CONFIG/SEGMENT_CHANNELS; the save-to-disk always happens. Defaults
+     *        to true so callers that only pass saveWhat keep the historical bitmask behavior.
      * @return true if client devices should be sent a new set of radio configs
      */
-    void reloadConfig(int saveWhat = SEGMENT_CONFIG | SEGMENT_MODULECONFIG | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS);
+    void reloadConfig(int saveWhat = SEGMENT_CONFIG | SEGMENT_MODULECONFIG | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS,
+                      bool radioAffected = true);
 
     /// The owner User record just got updated, update our node DB and broadcast the info into the mesh
     void reloadOwner(bool shouldSave = true);

--- a/src/mesh/MeshService.h
+++ b/src/mesh/MeshService.h
@@ -24,6 +24,18 @@
 #endif
 #endif
 
+/** Flags for MeshService::applyConfigChange().
+ *
+ * A flags enum rather than a pair of bools on purpose: `reboot` and `radioAffected` are both
+ * bools, sit in different positions in the helpers this replaced, and transposing them compiles
+ * silently while doing the opposite of what was meant.
+ */
+enum ConfigApplyFlags : uint8_t {
+    CONFIG_APPLY_NONE = 0,        // persist only
+    CONFIG_APPLY_RADIO = 1 << 0,  // region/preset/freq/channel/PSK - re-init the LoRa chip
+    CONFIG_APPLY_REBOOT = 1 << 1, // field only takes effect after a restart
+};
+
 extern Allocator<meshtastic_QueueStatus> &queueStatusPool;
 extern Allocator<meshtastic_MqttClientProxyMessage> &mqttClientProxyMessagePool;
 extern Allocator<meshtastic_ClientNotification> &clientNotificationPool;
@@ -176,6 +188,21 @@ class MeshService
      */
     virtual void reloadConfig(int saveWhat = SEGMENT_CONFIG | SEGMENT_MODULECONFIG | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS,
                               bool radioAffected = true);
+
+    /** Persist `saveWhat`, then optionally reconfigure the radio and/or schedule a reboot.
+     *
+     * The single entry point for applying a config change. `flags` is mandatory so every call
+     * site states whether the LoRa chip needs re-initialising and whether the field only takes
+     * effect after a restart - neither is inferable from the segment mask, because SEGMENT_CONFIG
+     * is one monolithic file covering all eight sub-messages.
+     *
+     * `rebootSeconds` is ignored unless CONFIG_APPLY_REBOOT is set. It exists because one caller
+     * (InkHUD's wifi-recovery path) deliberately uses a shorter delay than the default.
+     *
+     * AdminModule must not call this directly - it goes through saveChanges(), which additionally
+     * defers the write while a remote-admin edit transaction is open.
+     */
+    void applyConfigChange(int saveWhat, uint8_t flags, int32_t rebootSeconds = DEFAULT_REBOOT_SECONDS);
 
     /// The owner User record just got updated, update our node DB and broadcast the info into the mesh
     void reloadOwner(bool shouldSave = true);

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -83,11 +83,16 @@ static const char LOW_ENTROPY_WARNING[] = "Compromised keys were detected and re
 #endif
 static const char LICENSED_IDENTITY_MIGRATION_WARNING[] =
     "Licensed signing generated a new identity key; this node identity changed.";
-/*
-DeviceState versions used to be defined in the .proto file but really only this function cares.  So changed to a
-#define here.
-*/
 
+// Persistence segments. Each SEGMENT_* is a bit selecting which on-disk proto file to edit.
+// saveToDisk(mask) rewrites exactly the files whose bits are set (see NodeDB::saveToDiskNoRetry).
+//
+// SEGMENT_CONFIG is the whole LocalConfig proto in a single file: it covers all eight
+// sub-messages (device/display/lora/position/power/network/bluetooth/security), and writing it
+// reserializes the entire struct. So the mask says *which file* to persist, never *which
+// sub-message* changed - it cannot tell a LoRa change from a Bluetooth one. Do not infer "the
+// radio needs reconfiguring" from SEGMENT_CONFIG; that is a separate axis, radioAffected (see
+// MeshService::reloadConfig).
 #define SEGMENT_CONFIG 1
 #define SEGMENT_MODULECONFIG 2
 #define SEGMENT_DEVICESTATE 4

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -99,6 +99,8 @@ static const char LICENSED_IDENTITY_MIGRATION_WARNING[] =
 #define SEGMENT_CHANNELS 8
 #define SEGMENT_NODEDATABASE 16
 
+// DeviceState versions used to be defined in the .proto file but really only this function cares.
+// So changed to a #define here.
 #define DEVICESTATE_CUR_VER 25
 // Lowest on-disk version we still know how to load. v24 saves are migrated
 // at boot via the parallel deviceonly_legacy descriptor and re-saved as v25.

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -938,14 +938,24 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
 #endif
         break;
     } // case meshtastic_Config_device_tag
-    case meshtastic_Config_position_tag:
+    case meshtastic_Config_position_tag: {
         LOG_INFO("Set config: Position");
         config.has_position = true;
-        // No-op set (clients routinely re-push identical config) must not reboot. Whole-struct memcmp
-        // fails safe: any real field change still reboots; only a byte-identical set is spared. Tier 2
-        // narrows this further to reboot only on boot-only fields (GPIO/GPS). See plan-narrow-reboot-trigger.
-        if (memcmp(&config.position, &c.payload_variant.position, sizeof(config.position)) == 0)
-            requiresReboot = false;
+        // Reboot only when a field that can't be applied live changed. PositionModule reads these fields
+        // directly from config every send/schedule cycle (verified in PositionModule.cpp), so changing
+        // only them takes effect with no restart. Everything else - GPS driver mode/timing and GPIO pin
+        // assignments - stays on the reboot path. Fails safe: neutralize the known-live fields in a copy,
+        // then reboot if any *other* byte differs, so a newly-added PositionConfig field reboots until it
+        // is explicitly cleared as live here. See plan-narrow-reboot-trigger.
+        {
+            meshtastic_Config_PositionConfig live = config.position, incoming = c.payload_variant.position;
+            incoming.position_broadcast_secs = live.position_broadcast_secs;
+            incoming.position_broadcast_smart_enabled = live.position_broadcast_smart_enabled;
+            incoming.broadcast_smart_minimum_distance = live.broadcast_smart_minimum_distance;
+            incoming.position_flags = live.position_flags;
+            incoming.fixed_position = live.fixed_position;
+            requiresReboot = (memcmp(&live, &incoming, sizeof(live)) != 0);
+        }
         // If we have turned off the GPS (disabled or not present) and we're not using fixed position,
         // clear the stored position since it may not get updated
         if (config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED &&
@@ -958,6 +968,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
 
         // Save nodedb as well in case we got a fixed position packet
         break;
+    } // case meshtastic_Config_position_tag
     case meshtastic_Config_power_tag:
         LOG_INFO("Set config: Power");
         config.has_power = true;

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -1898,10 +1898,9 @@ void AdminModule::handleGetDeviceUIConfig(const meshtastic_MeshPacket &req)
 
 void AdminModule::reboot(int32_t seconds)
 {
-    LOG_INFO("Reboot in %d seconds", seconds);
     if (screen)
         screen->showSimpleBanner("Rebooting...", 0); // stays on screen
-    rebootAtMsec = (seconds < 0) ? 0 : (millis() + seconds * 1000);
+    requestReboot(seconds);
 }
 
 // Without this, a commit that never arrives leaves the transaction open forever and every later
@@ -1926,15 +1925,19 @@ void AdminModule::saveChanges(int saveWhat, bool shouldReboot, bool radioAffecte
 #ifdef PIO_UNIT_TESTING
     lastSaveWhatForTest = saveWhat;
 #endif
-    if (!hasOpenEditTransaction) {
-        LOG_INFO("Save changes to disk");
-        service->reloadConfig(saveWhat, radioAffected); // Calls saveToDisk among other things
-    } else {
-        LOG_INFO("Delay disk save until open transaction commits");
+    // The one thing menus have no concept of: while a remote-admin edit transaction is open the
+    // write is deferred to the commit, so a multi-field set doesn't hit flash once per field.
+    if (hasOpenEditTransaction) {
+        LOG_INFO("Delay save of changes to disk until the open transaction is committed");
         editTransactionActivityMs = millis(); // still in use, so not the abandoned kind we time out
         deferredEditSegments |= saveWhat;
+        return;
     }
-    if (shouldReboot && !hasOpenEditTransaction) {
+    LOG_INFO("Save changes to disk");
+    // reboot() rather than the CONFIG_APPLY_REBOOT flag: AdminModule also raises its own
+    // "Rebooting..." banner, which applyConfigChange() deliberately knows nothing about.
+    service->applyConfigChange(saveWhat, radioAffected ? CONFIG_APPLY_RADIO : CONFIG_APPLY_NONE);
+    if (shouldReboot) {
         reboot(DEFAULT_REBOOT_SECONDS);
     }
 }

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -15,7 +15,8 @@
 #include <ErriezCRC32.h>
 #include <FSCommon.h>
 #include <Throttle.h>
-#include <ctype.h> // for better whitespace handling
+#include <ctype.h>     // for better whitespace handling
+#include <pb_encode.h> // protobufsEqual() reads the stream result, which pb_encode_to_bytes() hides
 #if defined(ARCH_ESP32) && !MESHTASTIC_EXCLUDE_WIFI
 #include "MeshtasticOTA.h"
 #endif
@@ -97,13 +98,26 @@ static void writeSecret(char *buf, size_t bufsz, const char *currentVal)
     }
 }
 
+// Compare two messages by their canonical encoding. Fails toward "changed": every caller uses
+// equality to *skip* a reboot or a radio reload, so a comparison we can't complete must fall
+// through to doing the work rather than silently suppressing it.
+//
+// This encodes directly instead of calling pb_encode_to_bytes(), because that helper returns 0
+// both for a failed encode and for a message whose every field is at its default - and the latter
+// is a legitimate comparison here (a zeroed SecurityConfig encodes to zero bytes). Reading the
+// stream result tells the two apart.
 template <size_t MaxSize> static NOINLINE bool protobufsEqual(const pb_msgdesc_t *fields, const void *left, const void *right)
 {
     // NOINLINE limits peak stack use to this frame: two MaxSize encode buffers.
     uint8_t leftBytes[MaxSize], rightBytes[MaxSize];
-    const size_t leftSize = pb_encode_to_bytes(leftBytes, sizeof(leftBytes), fields, left);
-    const size_t rightSize = pb_encode_to_bytes(rightBytes, sizeof(rightBytes), fields, right);
-    return leftSize == rightSize && memcmp(leftBytes, rightBytes, leftSize) == 0;
+    pb_ostream_t leftStream = pb_ostream_from_buffer(leftBytes, sizeof(leftBytes));
+    pb_ostream_t rightStream = pb_ostream_from_buffer(rightBytes, sizeof(rightBytes));
+    // MaxSize is the nanopb-generated _size for the message, so this cannot fail for want of room.
+    if (!pb_encode(&leftStream, fields, left) || !pb_encode(&rightStream, fields, right)) {
+        LOG_ERROR("Can't encode config for comparison; assuming it changed");
+        return false;
+    }
+    return leftStream.bytes_written == rightStream.bytes_written && memcmp(leftBytes, rightBytes, leftStream.bytes_written) == 0;
 }
 
 static NOINLINE bool loraRadioConfigChanged(const meshtastic_Config_LoRaConfig &oldConfig,
@@ -1555,7 +1569,13 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
 void AdminModule::handleSetChannel(const meshtastic_Channel &cc)
 {
     const ChannelIndex oldPrimaryIndex = channels.getPrimaryIndex();
+    // Snapshot the primary name before setChannel() overwrites it. getName() returns either the
+    // stored name or, for an unnamed channel, a modem-preset display name ("MediumTurbo", 11 chars,
+    // is the longest today), so this is sized well clear of both. Truncation here would compare
+    // equal on a name change and silently skip a needed radio reload, so keep the headroom.
     char oldPrimaryName[32];
+    static_assert(sizeof(meshtastic_ChannelSettings::name) <= sizeof(oldPrimaryName),
+                  "oldPrimaryName must hold any stored channel name without truncating");
     snprintf(oldPrimaryName, sizeof(oldPrimaryName), "%s", channels.getName(oldPrimaryIndex));
 
     channels.setChannel(cc);
@@ -2024,6 +2044,14 @@ int32_t AdminModule::runOnce()
     if (!hasOpenEditTransaction)
         return disable();
 
+    // Sleep out whatever is left of the idle window. Subtraction-first, so this is exact across the
+    // millis() wrap; Throttle has no "time remaining" helper, only the boolean predicates, and the
+    // remainder is what OSThread wants back.
+    //
+    // The 1ms fallback is not dead: expireStaleEditTransaction() above read millis() a moment
+    // earlier, so the window can tip over between its read and this one, leaving the transaction
+    // open with elapsed >= the window. Without the guard that subtraction underflows to ~49.7 days.
+    // Rescheduling 1ms out lets the next tick see it as expired and close it.
     const uint32_t elapsed = millis() - editTransactionActivityMs;
     return elapsed < EDIT_TRANSACTION_IDLE_MS ? EDIT_TRANSACTION_IDLE_MS - elapsed : 1;
 }

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -962,11 +962,12 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
             c.payload_variant.position.gps_mode != meshtastic_Config_PositionConfig_GpsMode_ENABLED &&
             config.position.fixed_position == false && c.payload_variant.position.fixed_position == false) {
             nodeDB->clearLocalPosition();
-            saveChanges(SEGMENT_NODEDATABASE | SEGMENT_CONFIG, false, /*radioAffected=*/false);
+            // SEGMENT_CONFIG is deliberately omitted here: config.position hasn't been updated to the
+            // incoming value yet, so saving it now would persist stale data. The final saveChanges()
+            // below re-saves SEGMENT_CONFIG once config.position is current.
+            saveChanges(SEGMENT_NODEDATABASE, false);
         }
         config.position = c.payload_variant.position;
-
-        // Save nodedb as well in case we got a fixed position packet
         break;
     } // case meshtastic_Config_position_tag
     case meshtastic_Config_power_tag:

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -428,9 +428,9 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
             sendWarningAndLog("Unable to switch to the OTA partition.");
         }
 #endif
-        int s = 1; // Reboot in 1 second, hard coded
-        LOG_INFO("Reboot in %d seconds", s);
-        rebootAtMsec = (s < 0) ? 0 : (millis() + s * 1000);
+        // requestReboot() rather than this->reboot(): the OTA handoff has already raised its own
+        // firmware-update screen and set suppressRebootBanner, so it must not get the banner too.
+        requestReboot(1); // 1 second, hard coded
         break;
     }
     case meshtastic_AdminMessage_shutdown_seconds_tag: {
@@ -491,8 +491,13 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         LOG_INFO("Commit settings edit transaction");
         hasOpenEditTransaction = false;
         deferredEditSegments = 0;
+        // Consume the accumulated decisions, then clear them: a stray second commit, or one with no
+        // matching begin, must not inherit the previous transaction's answer.
+        const bool commitReboot = deferredShouldReboot, commitRadio = deferredRadioAffected;
+        deferredShouldReboot = false;
+        deferredRadioAffected = false;
         saveChanges(SEGMENT_CONFIG | SEGMENT_MODULECONFIG | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS | SEGMENT_NODEDATABASE,
-                    deferredShouldReboot, deferredRadioAffected);
+                    commitReboot, commitRadio);
         flushChannelWarnings(); // one coalesced message for everything edited in this transaction
         break;
     }
@@ -525,7 +530,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(r->set_favorite_node);
         if (node != NULL) {
             if (nodeDB->setProtectedFlag(node, NODEINFO_BITFIELD_IS_FAVORITE_MASK, true)) {
-                saveChanges(SEGMENT_NODEDATABASE, false);
+                saveChanges(SEGMENT_NODEDATABASE, false, /*radioAffected=*/false);
                 if (screen)
                     screen->setFrames(graphics::Screen::FOCUS_PRESERVE); // <-- Rebuild screens
             } else if (mp.from == 0) { // local request from the phone - tell the user why it didn't take
@@ -541,7 +546,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(r->remove_favorite_node);
         if (node != NULL) {
             nodeInfoLiteSetBit(node, NODEINFO_BITFIELD_IS_FAVORITE_MASK, false);
-            saveChanges(SEGMENT_NODEDATABASE, false);
+            saveChanges(SEGMENT_NODEDATABASE, false, /*radioAffected=*/false);
             if (screen)
                 screen->setFrames(graphics::Screen::FOCUS_PRESERVE); // <-- Rebuild screens
         }
@@ -559,7 +564,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
 #if HAS_SCREEN || defined(MESHTASTIC_INCLUDE_NICHE_GRAPHICS)
                 messageStore.deleteAllMessagesFromNode(node->num);
 #endif
-                saveChanges(SEGMENT_NODEDATABASE, false);
+                saveChanges(SEGMENT_NODEDATABASE, false, /*radioAffected=*/false);
 #if HAS_SCREEN
                 if (screen)
                     screen->setFrames(graphics::Screen::FOCUS_PRESERVE);
@@ -577,7 +582,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(r->remove_ignored_node);
         if (node != NULL) {
             nodeInfoLiteSetBit(node, NODEINFO_BITFIELD_IS_IGNORED_MASK, false);
-            saveChanges(SEGMENT_NODEDATABASE, false);
+            saveChanges(SEGMENT_NODEDATABASE, false, /*radioAffected=*/false);
         }
         break;
     }
@@ -586,7 +591,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(r->toggle_muted_node);
         if (node != NULL) {
             nodeInfoLiteSetBit(node, NODEINFO_BITFIELD_IS_MUTED_MASK, !nodeInfoLiteIsMuted(node));
-            saveChanges(SEGMENT_NODEDATABASE, false);
+            saveChanges(SEGMENT_NODEDATABASE, false, /*radioAffected=*/false);
         }
         break;
     }
@@ -833,8 +838,11 @@ void AdminModule::handleSetOwner(const meshtastic_User &o)
 
     if (changed) { // If nothing really changed, don't broadcast on the network or write to flash
         service->reloadOwner(!hasOpenEditTransaction);
+        // shouldReboot=true is pre-existing behaviour for a name/licence change and is left alone
+        // here; radioAffected is false because none of the owner record feeds the modem.
         saveChanges(SEGMENT_DEVICESTATE | SEGMENT_NODEDATABASE | (identityUpdated ? SEGMENT_CONFIG : 0) |
-                    (channelsSanitized ? SEGMENT_CHANNELS : 0));
+                        (channelsSanitized ? SEGMENT_CHANNELS : 0),
+                    /*shouldReboot=*/true, /*radioAffected=*/false);
     }
 }
 
@@ -968,7 +976,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
             // SEGMENT_CONFIG is deliberately omitted here: config.position hasn't been updated to the
             // incoming value yet, so saving it now would persist stale data. The final saveChanges()
             // below re-saves SEGMENT_CONFIG once config.position is current.
-            saveChanges(SEGMENT_NODEDATABASE, false);
+            saveChanges(SEGMENT_NODEDATABASE, false, /*radioAffected=*/false);
         }
         config.position = c.payload_variant.position;
         break;
@@ -1471,7 +1479,8 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
     }
 #endif
     }
-    saveChanges(SEGMENT_MODULECONFIG, shouldReboot);
+    // No module config feeds RadioInterface::reconfigure() - that reads config.lora only.
+    saveChanges(SEGMENT_MODULECONFIG, shouldReboot, /*radioAffected=*/false);
     return true;
 }
 
@@ -1501,8 +1510,8 @@ void AdminModule::handleSetChannel(const meshtastic_Channel &cc)
     }
     if (clamped)
         sendWarning(publicChannelPrecisionMessage);
-    saveChanges(SEGMENT_CHANNELS, false);
-    warnOnChannelSet(channels.getByIndex(cc.index)); // passes the saved channel
+    saveChanges(SEGMENT_CHANNELS, false, /*radioAffected=*/true); // real frequency-slot / PSK change
+    warnOnChannelSet(channels.getByIndex(cc.index));              // passes the saved channel
     // Inside an edit transaction the queued warnings are flushed once at commit; otherwise emit now.
     if (!hasOpenEditTransaction)
         flushChannelWarnings();
@@ -1917,12 +1926,19 @@ void AdminModule::expireStaleEditTransaction()
     hasOpenEditTransaction = false;
     int segments = deferredEditSegments;
     deferredEditSegments = 0;
+    // Same consume-and-clear as a real commit: an abandoned transaction must not leave its
+    // decisions behind for the next one.
+    const bool expiredRadio = deferredRadioAffected;
+    deferredShouldReboot = false;
+    deferredRadioAffected = false;
     // No reboot: the settings are already live in RAM and the client that would expect one is gone.
     if (segments)
-        saveChanges(segments, false);
+        saveChanges(segments, /*shouldReboot=*/false, expiredRadio);
     flushChannelWarnings();
 }
 
+// radioAffected is mandatory here - see the note on the declaration in AdminModule.h for why it
+// must not be allowed to default now that the deferred transaction flags accumulate it.
 void AdminModule::saveChanges(int saveWhat, bool shouldReboot, bool radioAffected)
 {
 #ifdef PIO_UNIT_TESTING
@@ -2012,7 +2028,9 @@ void AdminModule::handleSetHamMode(const meshtastic_HamParameters &p)
     }
 
     service->reloadOwner(false);
-    saveChanges(SEGMENT_CONFIG | SEGMENT_NODEDATABASE | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS);
+    // HAM mode rewrites config.lora.tx_enabled and strips channel PSKs - genuinely a radio change.
+    saveChanges(SEGMENT_CONFIG | SEGMENT_NODEDATABASE | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS, /*shouldReboot=*/true,
+                /*radioAffected=*/true);
 }
 
 AdminModule::AdminModule() : ProtobufModule("Admin", meshtastic_PortNum_ADMIN_APP, &meshtastic_AdminMessage_msg)

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -542,7 +542,9 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         break;
     }
     case meshtastic_AdminMessage_commit_edit_settings_tag: {
-        disableBluetooth();
+        // No unconditional disableBluetooth() here: this branch narrows it to the commits that
+        // actually reboot, a few lines below. Keeping develop's eager call as well would disable
+        // the radio on every commit and double-count it.
         LOG_INFO("Commit settings edit transaction");
         hasOpenEditTransaction = false;
         deferredEditSegments = 0;
@@ -1384,12 +1386,13 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
     case meshtastic_ModuleConfig_serial_tag:
         LOG_INFO("Set module config: Serial");
         // No architecture guard: the check and the store below must agree on every platform.
-        // disableBluetooth() self-guards on HAS_BLUETOOTH, so it is empty where there is no radio.
         if (!serialConfigIsValid(c.payload_variant.serial)) {
             LOG_ERROR("Invalid serial config");
             return false;
         }
-        disableBluetooth(); // Disable Bluetooth to prevent interference during Serial configuration
+        // No disableBluetooth() here. It is driven by shouldReboot at the end of this function, so
+        // a real serial change still disables the radio while a no-op write leaves it alone -
+        // calling it eagerly here would disable Bluetooth even when nothing changed.
         moduleConfig.has_serial = true;
         shouldReboot = !protobufsEqual<meshtastic_ModuleConfig_SerialConfig_size>(
             &meshtastic_ModuleConfig_SerialConfig_msg, &moduleConfig.serial, &c.payload_variant.serial);

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -10,6 +10,7 @@
 #include "SPILock.h"
 #include "gps/RTC.h"
 #include "input/InputBroker.h"
+#include "mesh/mesh-pb-constants.h"
 #include "meshUtils.h"
 #include <ErriezCRC32.h>
 #include <FSCommon.h>
@@ -68,6 +69,10 @@
 
 AdminModule *adminModule;
 
+#ifdef PIO_UNIT_TESTING
+uint32_t disableBluetoothCallCountForTest = 0;
+#endif
+
 #if !(MESHTASTIC_EXCLUDE_PKI_KEYGEN || MESHTASTIC_EXCLUDE_PKI)
 static bool licensedIdentityWillMigrate()
 {
@@ -90,6 +95,37 @@ static void writeSecret(char *buf, size_t bufsz, const char *currentVal)
     if (strcmp(buf, secretReserved) == 0) {
         strncpy(buf, currentVal, bufsz);
     }
+}
+
+template <size_t MaxSize> static NOINLINE bool protobufsEqual(const pb_msgdesc_t *fields, const void *left, const void *right)
+{
+    // NOINLINE limits peak stack use to this frame: two MaxSize encode buffers.
+    uint8_t leftBytes[MaxSize], rightBytes[MaxSize];
+    const size_t leftSize = pb_encode_to_bytes(leftBytes, sizeof(leftBytes), fields, left);
+    const size_t rightSize = pb_encode_to_bytes(rightBytes, sizeof(rightBytes), fields, right);
+    return leftSize == rightSize && memcmp(leftBytes, rightBytes, leftSize) == 0;
+}
+
+static NOINLINE bool loraRadioConfigChanged(const meshtastic_Config_LoRaConfig &oldConfig,
+                                            const meshtastic_Config_LoRaConfig &newConfig)
+{
+    auto oldEffective = oldConfig;
+    auto newEffective = newConfig;
+    if (oldEffective.use_preset && newEffective.use_preset) {
+        oldEffective.bandwidth = newEffective.bandwidth = 0;
+        oldEffective.spread_factor = newEffective.spread_factor = 0;
+        oldEffective.coding_rate = newEffective.coding_rate = 0;
+    }
+    newEffective.hop_limit = oldEffective.hop_limit;
+    newEffective.tx_enabled = oldEffective.tx_enabled;
+    newEffective.override_duty_cycle = oldEffective.override_duty_cycle;
+    // The admin setter applies this immediately through RF95_FAN_EN where supported.
+    newEffective.pa_fan_disabled = oldEffective.pa_fan_disabled;
+    newEffective.ignore_incoming_count = oldEffective.ignore_incoming_count;
+    memcpy(newEffective.ignore_incoming, oldEffective.ignore_incoming, sizeof(newEffective.ignore_incoming));
+    newEffective.ignore_mqtt = oldEffective.ignore_mqtt;
+    newEffective.config_ok_to_mqtt = oldEffective.config_ok_to_mqtt;
+    return !protobufsEqual<meshtastic_Config_LoRaConfig_size>(&meshtastic_Config_LoRaConfig_msg, &oldEffective, &newEffective);
 }
 
 /**
@@ -480,10 +516,15 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
     }
     case meshtastic_AdminMessage_begin_edit_settings_tag: {
         LOG_INFO("Begin settings edit transaction");
+        if (!hasOpenEditTransaction) {
+            deferredEditSegments = 0;
+            deferredShouldReboot = false;
+            deferredRadioAffected = false;
+        }
         hasOpenEditTransaction = true;
         editTransactionActivityMs = millis();
-        deferredShouldReboot = false;
-        deferredRadioAffected = false;
+        enabled = true;
+        setIntervalFromNow(EDIT_TRANSACTION_IDLE_MS);
         break;
     }
     case meshtastic_AdminMessage_commit_edit_settings_tag: {
@@ -496,6 +537,9 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         const bool commitReboot = deferredShouldReboot, commitRadio = deferredRadioAffected;
         deferredShouldReboot = false;
         deferredRadioAffected = false;
+        disable();
+        if (commitReboot)
+            disableBluetooth();
         saveChanges(SEGMENT_CONFIG | SEGMENT_MODULECONFIG | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS | SEGMENT_NODEDATABASE,
                     commitReboot, commitRadio);
         flushChannelWarnings(); // one coalesced message for everything edited in this transaction
@@ -1028,13 +1072,12 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
     case meshtastic_Config_network_tag: {
         LOG_INFO("Set config: WiFi");
         config.has_network = true;
+        auto incoming = c.payload_variant.network;
+        writeSecret(incoming.wifi_psk, sizeof(incoming.wifi_psk), config.network.wifi_psk);
         // No-op set must not reboot; any real change still restarts the network stack. memcmp fails safe.
-        if (memcmp(&config.network, &c.payload_variant.network, sizeof(config.network)) == 0)
+        if (memcmp(&config.network, &incoming, sizeof(config.network)) == 0)
             requiresReboot = false;
-        char prevPsk[sizeof(config.network.wifi_psk)];
-        memcpy(prevPsk, config.network.wifi_psk, sizeof(prevPsk));
-        config.network = c.payload_variant.network;
-        writeSecret(config.network.wifi_psk, sizeof(config.network.wifi_psk), prevPsk);
+        config.network = incoming;
         break;
     }
     case meshtastic_Config_display_tag:
@@ -1064,7 +1107,6 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
 
         LOG_INFO("Set config: LoRa");
         config.has_lora = true;
-        radioAffected = true; // the only sub-message that legitimately needs a live radio reconfigure
 
         if (validatedLora.coding_rate != clampCodingRate(validatedLora.coding_rate)) {
             LOG_WARN("Invalid coding_rate %d, set to %d", validatedLora.coding_rate, LORA_CR_DEFAULT);
@@ -1211,6 +1253,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
         }
 #endif
 
+        radioAffected = loraRadioConfigChanged(oldLoraConfig, validatedLora);
         config.lora = validatedLora; // Finally, return the validated config back to the main config
         if (validatedLora.modem_preset != oldLoraConfig.modem_preset) {
             pendingOldLora = oldLoraConfig;
@@ -1230,6 +1273,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
         break;
     case meshtastic_Config_security_tag: {
         LOG_INFO("Set config: Security");
+        const auto oldSecurity = config.security;
         meshtastic_Config_SecurityConfig incoming = c.payload_variant.security;
         // Preserve our keypair when a SET omits the private key but we already hold one: regenerating would
         // change our NodeNum (== crc32(public_key)) and orphan us on the mesh. A SET without the key is a
@@ -1276,10 +1320,10 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
             LOG_WARN(warning);
             sendWarning(warning);
         }
+        requiresReboot = !protobufsEqual<meshtastic_Config_SecurityConfig_size>(&meshtastic_Config_SecurityConfig_msg,
+                                                                                &oldSecurity, &config.security);
 
         changes = SEGMENT_CONFIG | SEGMENT_DEVICESTATE | SEGMENT_NODEDATABASE;
-
-        requiresReboot = true;
 
         break;
     }
@@ -1302,12 +1346,6 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
 bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
 {
     bool shouldReboot = true;
-    // If we are in an open transaction or configuring MQTT or Serial (which have validation), defer disabling Bluetooth
-    // Otherwise, disable Bluetooth to prevent the phone from interfering with the config
-    if (!hasOpenEditTransaction && !IS_ONE_OF(c.which_payload_variant, meshtastic_ModuleConfig_mqtt_tag,
-                                              meshtastic_ModuleConfig_serial_tag, meshtastic_ModuleConfig_statusmessage_tag)) {
-        disableBluetooth();
-    }
 
     switch (c.which_payload_variant) {
     case meshtastic_ModuleConfig_mqtt_tag:
@@ -1319,14 +1357,13 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
         if (!MQTT::isValidConfig(c.payload_variant.mqtt)) {
             return false;
         }
-        // Disable Bluetooth to prevent interference during MQTT configuration
-        disableBluetooth();
         moduleConfig.has_mqtt = true;
         {
-            char prevPass[sizeof(moduleConfig.mqtt.password)];
-            memcpy(prevPass, moduleConfig.mqtt.password, sizeof(prevPass));
-            moduleConfig.mqtt = c.payload_variant.mqtt;
-            writeSecret(moduleConfig.mqtt.password, sizeof(moduleConfig.mqtt.password), prevPass);
+            auto incoming = c.payload_variant.mqtt;
+            writeSecret(incoming.password, sizeof(incoming.password), moduleConfig.mqtt.password);
+            shouldReboot = !protobufsEqual<meshtastic_ModuleConfig_MQTTConfig_size>(&meshtastic_ModuleConfig_MQTTConfig_msg,
+                                                                                    &moduleConfig.mqtt, &incoming);
+            moduleConfig.mqtt = incoming;
         }
 #endif
         break;
@@ -1340,6 +1377,8 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
         }
         disableBluetooth(); // Disable Bluetooth to prevent interference during Serial configuration
         moduleConfig.has_serial = true;
+        shouldReboot = !protobufsEqual<meshtastic_ModuleConfig_SerialConfig_size>(
+            &meshtastic_ModuleConfig_SerialConfig_msg, &moduleConfig.serial, &c.payload_variant.serial);
         moduleConfig.serial = c.payload_variant.serial;
         break;
     case meshtastic_ModuleConfig_external_notification_tag:
@@ -1359,6 +1398,9 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
         break;
     case meshtastic_ModuleConfig_telemetry_tag:
         LOG_INFO("Set module config: Telemetry");
+        shouldReboot = !moduleConfig.has_telemetry ||
+                       !protobufsEqual<meshtastic_ModuleConfig_TelemetryConfig_size>(
+                           &meshtastic_ModuleConfig_TelemetryConfig_msg, &moduleConfig.telemetry, &c.payload_variant.telemetry);
         moduleConfig.has_telemetry = true;
         moduleConfig.telemetry = c.payload_variant.telemetry;
         break;
@@ -1503,6 +1545,8 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
     }
 #endif
     }
+    if (shouldReboot && !hasOpenEditTransaction)
+        disableBluetooth();
     // No module config feeds RadioInterface::reconfigure() - that reads config.lora only.
     saveChanges(SEGMENT_MODULECONFIG, shouldReboot, /*radioAffected=*/false);
     return true;
@@ -1510,6 +1554,10 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
 
 void AdminModule::handleSetChannel(const meshtastic_Channel &cc)
 {
+    const ChannelIndex oldPrimaryIndex = channels.getPrimaryIndex();
+    char oldPrimaryName[32];
+    snprintf(oldPrimaryName, sizeof(oldPrimaryName), "%s", channels.getName(oldPrimaryIndex));
+
     channels.setChannel(cc);
     if (channels.ensureLicensedOperation()) {
         warnLicensedMode();
@@ -1534,8 +1582,13 @@ void AdminModule::handleSetChannel(const meshtastic_Channel &cc)
     }
     if (clamped)
         sendWarning(publicChannelPrecisionMessage);
-    saveChanges(SEGMENT_CHANNELS, false, /*radioAffected=*/true); // real frequency-slot / PSK change
-    warnOnChannelSet(channels.getByIndex(cc.index));              // passes the saved channel
+    const ChannelIndex newPrimaryIndex = channels.getPrimaryIndex();
+    const bool usesChannelNameForFrequency = config.lora.override_frequency == 0 && RadioInterface::uses_default_frequency_slot &&
+                                             getRegion(config.lora.region)->overrideSlot == OVERRIDE_SLOT_DEFAULT_CHANNEL_HASH;
+    const bool radioAffected = usesChannelNameForFrequency && (oldPrimaryIndex != newPrimaryIndex ||
+                                                               strcmp(oldPrimaryName, channels.getName(newPrimaryIndex)) != 0);
+    saveChanges(SEGMENT_CHANNELS, false, radioAffected);
+    warnOnChannelSet(channels.getByIndex(cc.index)); // passes the saved channel
     // Inside an edit transaction the queued warnings are flushed once at commit; otherwise emit now.
     if (!hasOpenEditTransaction)
         flushChannelWarnings();
@@ -1952,13 +2005,27 @@ void AdminModule::expireStaleEditTransaction()
     deferredEditSegments = 0;
     // Same consume-and-clear as a real commit: an abandoned transaction must not leave its
     // decisions behind for the next one.
-    const bool expiredRadio = deferredRadioAffected;
+    const bool expiredReboot = deferredShouldReboot, expiredRadio = deferredRadioAffected;
     deferredShouldReboot = false;
     deferredRadioAffected = false;
-    // No reboot: the settings are already live in RAM and the client that would expect one is gone.
+    disable();
+    // Boot-only changes must still take effect if the client disappears. Persisting without this
+    // reboot would leave runtime behavior out of sync with the stored configuration.
+    if (expiredReboot)
+        disableBluetooth();
     if (segments)
-        saveChanges(segments, false, expiredRadio);
+        saveChanges(segments, expiredReboot, expiredRadio);
     flushChannelWarnings();
+}
+
+int32_t AdminModule::runOnce()
+{
+    expireStaleEditTransaction();
+    if (!hasOpenEditTransaction)
+        return disable();
+
+    const uint32_t elapsed = millis() - editTransactionActivityMs;
+    return elapsed < EDIT_TRANSACTION_IDLE_MS ? EDIT_TRANSACTION_IDLE_MS - elapsed : 1;
 }
 
 // radioAffected is mandatory here - see the note on the declaration in AdminModule.h for why it
@@ -1977,6 +2044,8 @@ void AdminModule::saveChanges(int saveWhat, bool shouldReboot, bool radioAffecte
         deferredRadioAffected |= radioAffected;
         LOG_INFO("Delay save of changes to disk until the open transaction is committed");
         editTransactionActivityMs = millis(); // still in use, so not the abandoned kind we time out
+        enabled = true;
+        setIntervalFromNow(EDIT_TRANSACTION_IDLE_MS);
         deferredEditSegments |= saveWhat;
         return;
     }
@@ -2057,8 +2126,10 @@ void AdminModule::handleSetHamMode(const meshtastic_HamParameters &p)
                 /*radioAffected=*/true);
 }
 
-AdminModule::AdminModule() : ProtobufModule("Admin", meshtastic_PortNum_ADMIN_APP, &meshtastic_AdminMessage_msg)
+AdminModule::AdminModule()
+    : ProtobufModule("Admin", meshtastic_PortNum_ADMIN_APP, &meshtastic_AdminMessage_msg), concurrency::OSThread("AdminTimeout")
 {
+    disable();
     // restrict to the admin channel for rx
     // boundChannel = Channels::adminChannel;
 }
@@ -2564,6 +2635,9 @@ void AdminModule::warnOnLoraPresetChange(const meshtastic_Config_LoRaConfig &old
 
 void disableBluetooth()
 {
+#ifdef PIO_UNIT_TESTING
+    disableBluetoothCallCountForTest++;
+#endif
 #if HAS_BLUETOOTH
 #ifdef ARCH_ESP32
     if (nimbleBluetooth)

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -946,7 +946,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
         // only them takes effect with no restart. Everything else - GPS driver mode/timing and GPIO pin
         // assignments - stays on the reboot path. Fails safe: neutralize the known-live fields in a copy,
         // then reboot if any *other* byte differs, so a newly-added PositionConfig field reboots until it
-        // is explicitly cleared as live here. See plan-narrow-reboot-trigger.
+        // is explicitly cleared as live here. See docs/admin-config-save-gating.md.
         {
             meshtastic_Config_PositionConfig live = config.position, incoming = c.payload_variant.position;
             incoming.position_broadcast_secs = live.position_broadcast_secs;

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -867,6 +867,16 @@ static void reconcileAccelerometerThread(bool wasOn, bool nowOn, bool otherFeatu
 }
 #endif
 
+// Only ENABLED <-> DISABLED can be applied live: the GPS object is built once at boot, and only
+// when gps_mode is not NOT_PRESENT (main.cpp), so NOT_PRESENT transitions need the reboot.
+static bool isLiveGpsModeToggle(meshtastic_Config_PositionConfig_GpsMode from, meshtastic_Config_PositionConfig_GpsMode to)
+{
+    auto runnable = [](meshtastic_Config_PositionConfig_GpsMode m) {
+        return m == meshtastic_Config_PositionConfig_GpsMode_ENABLED || m == meshtastic_Config_PositionConfig_GpsMode_DISABLED;
+    };
+    return from != to && runnable(from) && runnable(to);
+}
+
 // A "regenerate keys" client sends a blank SecurityConfig holding only the new private key, rather than the
 // config it read from us. Detect that shape - new private key, every other field at its proto default - so it
 // isn't mistaken for "and clear everything else".
@@ -954,10 +964,12 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
         config.has_position = true;
         // Reboot only when a field that can't be applied live changed. PositionModule reads these fields
         // directly from config every send/schedule cycle (verified in PositionModule.cpp), so changing
-        // only them takes effect with no restart. Everything else - GPS driver mode/timing and GPIO pin
-        // assignments - stays on the reboot path. Fails safe: neutralize the known-live fields in a copy,
+        // only them takes effect with no restart; gps_mode joins them when the driver call below applies
+        // it. Everything else - GPS timing and GPIO pin assignments - stays on the reboot path.
+        // Fails safe: neutralize the known-live fields in a copy,
         // then reboot if any *other* byte differs, so a newly-added PositionConfig field reboots until it
         // is explicitly cleared as live here. See docs/admin-config-save-gating.md.
+        const bool gpsToggledLive = isLiveGpsModeToggle(config.position.gps_mode, c.payload_variant.position.gps_mode);
         {
             meshtastic_Config_PositionConfig live = config.position, incoming = c.payload_variant.position;
             incoming.position_broadcast_secs = live.position_broadcast_secs;
@@ -965,6 +977,8 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
             incoming.broadcast_smart_minimum_distance = live.broadcast_smart_minimum_distance;
             incoming.position_flags = live.position_flags;
             incoming.fixed_position = live.fixed_position;
+            if (gpsToggledLive)
+                incoming.gps_mode = live.gps_mode;
             requiresReboot = (memcmp(&live, &incoming, sizeof(live)) != 0);
         }
         // If we have turned off the GPS (disabled or not present) and we're not using fixed position,
@@ -979,6 +993,16 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
             saveChanges(SEGMENT_NODEDATABASE, false, /*radioAffected=*/false);
         }
         config.position = c.payload_variant.position;
+#if !MESHTASTIC_EXCLUDE_GPS
+        // Driving the driver is what earns the suppressed reboot: writing gps_mode alone leaves the
+        // receiver in its old state until next boot. As MenuHandler::GPSToggleMenu(), minus the beep.
+        if (gpsToggledLive && gps) {
+            if (config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED)
+                gps->enable();
+            else
+                gps->disable();
+        }
+#endif
         break;
     } // case meshtastic_Config_position_tag
     case meshtastic_Config_power_tag:
@@ -1933,7 +1957,7 @@ void AdminModule::expireStaleEditTransaction()
     deferredRadioAffected = false;
     // No reboot: the settings are already live in RAM and the client that would expect one is gone.
     if (segments)
-        saveChanges(segments, /*shouldReboot=*/false, expiredRadio);
+        saveChanges(segments, false, expiredRadio);
     flushChannelWarnings();
 }
 

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -482,6 +482,8 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         LOG_INFO("Begin settings edit transaction");
         hasOpenEditTransaction = true;
         editTransactionActivityMs = millis();
+        deferredShouldReboot = false;
+        deferredRadioAffected = false;
         break;
     }
     case meshtastic_AdminMessage_commit_edit_settings_tag: {
@@ -489,7 +491,8 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         LOG_INFO("Commit settings edit transaction");
         hasOpenEditTransaction = false;
         deferredEditSegments = 0;
-        saveChanges(SEGMENT_CONFIG | SEGMENT_MODULECONFIG | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS | SEGMENT_NODEDATABASE);
+        saveChanges(SEGMENT_CONFIG | SEGMENT_MODULECONFIG | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS | SEGMENT_NODEDATABASE,
+                    deferredShouldReboot, deferredRadioAffected);
         flushChannelWarnings(); // one coalesced message for everything edited in this transaction
         break;
     }
@@ -1927,7 +1930,11 @@ void AdminModule::saveChanges(int saveWhat, bool shouldReboot, bool radioAffecte
 #endif
     // The one thing menus have no concept of: while a remote-admin edit transaction is open the
     // write is deferred to the commit, so a multi-field set doesn't hit flash once per field.
+    // Remember what the deferred sets asked for, so the commit can honour it rather than falling
+    // back to the parameter defaults and rebooting for e.g. a display-only batch.
     if (hasOpenEditTransaction) {
+        deferredShouldReboot |= shouldReboot;
+        deferredRadioAffected |= radioAffected;
         LOG_INFO("Delay save of changes to disk until the open transaction is committed");
         editTransactionActivityMs = millis(); // still in use, so not the abandoned kind we time out
         deferredEditSegments |= saveWhat;

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -597,7 +597,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         nodeDB->updatePosition(node->num, r->set_fixed_position, RX_SRC_LOCAL);
         nodeDB->setLocalPosition(r->set_fixed_position);
         config.position.fixed_position = true;
-        saveChanges(SEGMENT_NODEDATABASE | SEGMENT_CONFIG, false);
+        saveChanges(SEGMENT_NODEDATABASE | SEGMENT_CONFIG, false, /*radioAffected=*/false);
 #if !MESHTASTIC_EXCLUDE_GPS
         if (gps != nullptr)
             gps->enable();
@@ -610,7 +610,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         LOG_INFO("Client got remove_fixed_position");
         nodeDB->clearLocalPosition();
         config.position.fixed_position = false;
-        saveChanges(SEGMENT_NODEDATABASE | SEGMENT_CONFIG, false);
+        saveChanges(SEGMENT_NODEDATABASE | SEGMENT_CONFIG, false, /*radioAffected=*/false);
         break;
     }
     case meshtastic_AdminMessage_set_time_only_tag: {
@@ -879,6 +879,10 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
     auto existingRole = config.device.role;
     bool isRegionUnset = (config.lora.region == meshtastic_Config_LoRaConfig_RegionCode_UNSET);
     bool requiresReboot = true;
+    // Config is a monolithic segment: only the lora sub-message actually affects the radio, so only
+    // that case sets radioAffected. Every other sub-message still persists SEGMENT_CONFIG but must not
+    // trigger the live SX126x reconfigure (see MeshService::reloadConfig).
+    bool radioAffected = false;
     bool loraPresetWarnPending = false;
     meshtastic_Config_LoRaConfig pendingOldLora = {}, pendingNewLora = {};
 
@@ -943,7 +947,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
             c.payload_variant.position.gps_mode != meshtastic_Config_PositionConfig_GpsMode_ENABLED &&
             config.position.fixed_position == false && c.payload_variant.position.fixed_position == false) {
             nodeDB->clearLocalPosition();
-            saveChanges(SEGMENT_NODEDATABASE | SEGMENT_CONFIG, false);
+            saveChanges(SEGMENT_NODEDATABASE | SEGMENT_CONFIG, false, /*radioAffected=*/false);
         }
         config.position = c.payload_variant.position;
 
@@ -1005,6 +1009,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
 
         LOG_INFO("Set config: LoRa");
         config.has_lora = true;
+        radioAffected = true; // the only sub-message that legitimately needs a live radio reconfigure
 
         if (validatedLora.coding_rate != clampCodingRate(validatedLora.coding_rate)) {
             LOG_WARN("Invalid coding_rate %d, set to %d", validatedLora.coding_rate, LORA_CR_DEFAULT);
@@ -1228,7 +1233,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
         disableBluetooth();
     } // end of switch case which_payload_variant
 
-    saveChanges(changes, requiresReboot);
+    saveChanges(changes, requiresReboot, radioAffected);
     if (loraPresetWarnPending)
         warnOnLoraPresetChange(pendingOldLora, pendingNewLora);
     // Inside an edit transaction the queued warnings are flushed once at commit; otherwise emit now.
@@ -1893,14 +1898,14 @@ void AdminModule::expireStaleEditTransaction()
     flushChannelWarnings();
 }
 
-void AdminModule::saveChanges(int saveWhat, bool shouldReboot)
+void AdminModule::saveChanges(int saveWhat, bool shouldReboot, bool radioAffected)
 {
 #ifdef PIO_UNIT_TESTING
     lastSaveWhatForTest = saveWhat;
 #endif
     if (!hasOpenEditTransaction) {
         LOG_INFO("Save changes to disk");
-        service->reloadConfig(saveWhat); // Calls saveToDisk among other things
+        service->reloadConfig(saveWhat, radioAffected); // Calls saveToDisk among other things
     } else {
         LOG_INFO("Delay disk save until open transaction commits");
         editTransactionActivityMs = millis(); // still in use, so not the abandoned kind we time out

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -941,6 +941,11 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
     case meshtastic_Config_position_tag:
         LOG_INFO("Set config: Position");
         config.has_position = true;
+        // No-op set (clients routinely re-push identical config) must not reboot. Whole-struct memcmp
+        // fails safe: any real field change still reboots; only a byte-identical set is spared. Tier 2
+        // narrows this further to reboot only on boot-only fields (GPIO/GPS). See plan-narrow-reboot-trigger.
+        if (memcmp(&config.position, &c.payload_variant.position, sizeof(config.position)) == 0)
+            requiresReboot = false;
         // If we have turned off the GPS (disabled or not present) and we're not using fixed position,
         // clear the stored position since it may not get updated
         if (config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED &&
@@ -976,6 +981,9 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
     case meshtastic_Config_network_tag: {
         LOG_INFO("Set config: WiFi");
         config.has_network = true;
+        // No-op set must not reboot; any real change still restarts the network stack. memcmp fails safe.
+        if (memcmp(&config.network, &c.payload_variant.network, sizeof(config.network)) == 0)
+            requiresReboot = false;
         char prevPsk[sizeof(config.network.wifi_psk)];
         memcpy(prevPsk, config.network.wifi_psk, sizeof(prevPsk));
         config.network = c.payload_variant.network;
@@ -1168,6 +1176,9 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
     case meshtastic_Config_bluetooth_tag:
         LOG_INFO("Set config: Bluetooth");
         config.has_bluetooth = true;
+        // No-op set must not reboot the very BLE link the phone is using; any real change still reboots.
+        if (memcmp(&config.bluetooth, &c.payload_variant.bluetooth, sizeof(config.bluetooth)) == 0)
+            requiresReboot = false;
         config.bluetooth = c.payload_variant.bluetooth;
         break;
     case meshtastic_Config_security_tag: {

--- a/src/modules/AdminModule.h
+++ b/src/modules/AdminModule.h
@@ -3,6 +3,7 @@
 #include <esp_ota_ops.h>
 #endif
 #include "ProtobufModule.h"
+#include "concurrency/OSThread.h"
 #include "meshUtils.h"
 #include <sys/types.h>
 #if HAS_WIFI
@@ -21,7 +22,9 @@ struct AdminModule_ObserverData {
 /**
  * Admin module for admin messages
  */
-class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Observable<AdminModule_ObserverData *>
+class AdminModule : public ProtobufModule<meshtastic_AdminMessage>,
+                    public Observable<AdminModule_ObserverData *>,
+                    private concurrency::OSThread
 {
     friend class AdminModuleTestShim; // test/support/AdminModuleTestShim.h - native tests reach the private handlers/state
 
@@ -37,6 +40,7 @@ class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Obser
     @return true if you've guaranteed you've handled this message and no other handlers should be considered for it
     */
     virtual bool handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_AdminMessage *p) override;
+    virtual int32_t runOnce() override;
 
   private:
     bool hasOpenEditTransaction = false;
@@ -49,6 +53,7 @@ class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Obser
     void expireStaleEditTransaction();
 #ifdef PIO_UNIT_TESTING
     int lastSaveWhatForTest = 0;
+    unsigned long editTransactionTimerIntervalForTest() const { return interval; }
 #endif
 
     // While a transaction is open, saveChanges() defers the write - so the per-field reboot and

--- a/src/modules/AdminModule.h
+++ b/src/modules/AdminModule.h
@@ -51,6 +51,13 @@ class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Obser
     int lastSaveWhatForTest = 0;
 #endif
 
+    // While a transaction is open, saveChanges() defers the write - so the per-field reboot and
+    // radio-reload decisions computed in handleSetConfig would otherwise be thrown away, and the
+    // commit would fall back to the defaults (both true) and always reboot + reconfigure. These
+    // accumulate the deferred decisions so the commit does the least work the batch actually needs.
+    bool deferredShouldReboot = false;
+    bool deferredRadioAffected = false;
+
     uint8_t session_passkey[8] = {0};
     uint32_t session_time = 0;        // millis() when the current session passkey was issued
     bool sessionPasskeyValid = false; // separate flag: millis() 0 at boot is a valid issue time

--- a/src/modules/AdminModule.h
+++ b/src/modules/AdminModule.h
@@ -62,7 +62,17 @@ class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Obser
     uint32_t session_time = 0;        // millis() when the current session passkey was issued
     bool sessionPasskeyValid = false; // separate flag: millis() 0 at boot is a valid issue time
 
-    void saveChanges(int saveWhat, bool shouldReboot = true, bool radioAffected = true);
+    /** Persist `saveWhat`, deferring to the commit if an edit transaction is open.
+     *
+     * `radioAffected` has deliberately **no default**. It used to default to true, which was
+     * harmless while reloadConfig()'s `saveWhat & (SEGMENT_CONFIG | SEGMENT_CHANNELS)` bitmask
+     * still gated the reconfigure - a node-DB-only save could not reach the radio whatever it
+     * asked for. That stopped being true once the deferred flags below started accumulating the
+     * value: inside a transaction the commit saves under a fixed full mask, so the bitmask no
+     * longer gates anything and an accidental `true` reaches the live SX126x reconfigure. Making
+     * it mandatory means a new call site has to think about it rather than inherit the answer.
+     */
+    void saveChanges(int saveWhat, bool shouldReboot, bool radioAffected);
 
     /**
      * Getters

--- a/src/modules/AdminModule.h
+++ b/src/modules/AdminModule.h
@@ -55,7 +55,7 @@ class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Obser
     uint32_t session_time = 0;        // millis() when the current session passkey was issued
     bool sessionPasskeyValid = false; // separate flag: millis() 0 at boot is a valid issue time
 
-    void saveChanges(int saveWhat, bool shouldReboot = true);
+    void saveChanges(int saveWhat, bool shouldReboot = true, bool radioAffected = true);
 
     /**
      * Getters

--- a/src/platform/portduino/wasm/portduino_glue_wasm.cpp
+++ b/src/platform/portduino/wasm/portduino_glue_wasm.cpp
@@ -274,6 +274,7 @@ extern "C" EMSCRIPTEN_KEEPALIVE int wasm_set_region(int region)
     config.lora = validated;
     initRegion(); // repoint myRegion at the new region table
     if (service)
+        // TODO(radioAffected): radio-affecting
         service->reloadConfig(SEGMENT_CONFIG); // reconfigure radio (new freq) + persist
     wasm_fs_sync();                            // browser: flush config.proto to IndexedDB
     return 0;

--- a/src/platform/portduino/wasm/portduino_glue_wasm.cpp
+++ b/src/platform/portduino/wasm/portduino_glue_wasm.cpp
@@ -274,9 +274,8 @@ extern "C" EMSCRIPTEN_KEEPALIVE int wasm_set_region(int region)
     config.lora = validated;
     initRegion(); // repoint myRegion at the new region table
     if (service)
-        // TODO(radioAffected): radio-affecting
-        service->reloadConfig(SEGMENT_CONFIG); // reconfigure radio (new freq) + persist
-    wasm_fs_sync();                            // browser: flush config.proto to IndexedDB
+        service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/true); // region change: reconfigure radio (new freq) + persist
+    wasm_fs_sync();                                                    // browser: flush config.proto to IndexedDB
     return 0;
 }
 

--- a/src/platform/portduino/wasm/portduino_glue_wasm.cpp
+++ b/src/platform/portduino/wasm/portduino_glue_wasm.cpp
@@ -274,8 +274,8 @@ extern "C" EMSCRIPTEN_KEEPALIVE int wasm_set_region(int region)
     config.lora = validated;
     initRegion(); // repoint myRegion at the new region table
     if (service)
-        service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/true); // region change: reconfigure radio (new freq) + persist
-    wasm_fs_sync();                                                    // browser: flush config.proto to IndexedDB
+        service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_RADIO); // new freq: reconfigure radio + persist
+    wasm_fs_sync();                                                     // browser: flush config.proto to IndexedDB
     return 0;
 }
 

--- a/test/README.md
+++ b/test/README.md
@@ -370,7 +370,7 @@ If your suite touches globals the code under test writes - `nodeDB`, `config`, `
 ```cpp
 void setUp(void) {
     // ...
-    replaceAdminRadioGlobals();   // saves the globals, installs a fresh NodeDB
+    replaceAdminRadioGlobals();   // drops nodes.proto, saves the globals, installs a fresh NodeDB
 }
 void tearDown(void) {
     restoreAdminRadioGlobals();   // restores them, deletes the NodeDB, re-runs initRegion()
@@ -379,6 +379,8 @@ void tearDown(void) {
 ```
 
 A fresh `NodeDB` per test costs real time (`loadFromDisk()` plus, when the region is set, key generation) - in that suite roughly 7% of a ~7½-minute run. Pay it. If a test genuinely needs to observe the previous test's state, that is what `state=per-suite` in `test/state-manifest.tsv` is for; say so there rather than achieving it by omission.
+
+Note the `nodes.proto` delete. "A fresh `NodeDB`" is only fresh if the file it loads is gone: the constructor calls `loadFromDisk()`, and the per-suite sandbox is the boundary against the _next_ suite, not against earlier tests in this one. Without the delete this suite reaches `MAX_NUM_NODES` with every entry protected, and `getOrCreateMeshNode()` then returns NULL for whichever test needs a new node last.
 
 ### 3. File-Scope Mutable Globals Persist Across Tests
 

--- a/test/support/AdminModuleTestShim.h
+++ b/test/support/AdminModuleTestShim.h
@@ -29,14 +29,19 @@ class AdminModuleTestShim : public AdminModule
     {
         hasOpenEditTransaction = true;
         editTransactionActivityMs = millis();
+        enabled = true;
+        setIntervalFromNow(EDIT_TRANSACTION_IDLE_MS);
         deferredShouldReboot = false;
         deferredRadioAffected = false;
     }
     int savedSegments() const { return lastSaveWhatForTest; }
 
     bool editTransactionOpen() const { return hasOpenEditTransaction; }
+    bool editTransactionTimerEnabled() const { return enabled; }
+    unsigned long editTransactionTimerInterval() const { return editTransactionTimerIntervalForTest(); }
     // Backdate past the idle window so a test sees an abandoned transaction without waiting it out.
     void ageEditTransaction() { editTransactionActivityMs = millis() - EDIT_TRANSACTION_IDLE_MS - 1; }
+    int32_t runTransactionTimer() { return runOnce(); }
 
     // Setters may allocate an error reply from packetPool; drain it each iteration or the pool leaks.
     void drainReply()

--- a/test/support/AdminModuleTestShim.h
+++ b/test/support/AdminModuleTestShim.h
@@ -20,12 +20,17 @@ class AdminModuleTestShim : public AdminModule
     // Peek at the reply a handler queued, before drainReply() releases it.
     meshtastic_MeshPacket *reply() { return myReply; }
 
-    // With an "open edit transaction" saveChanges() is a pure no-op: no reloadConfig/saveToDisk/reboot.
-    // Stamps the clock like begin_edit_settings, so a slow suite can't age the transaction into expiry.
+    // With an "open edit transaction" saveChanges() has no outward effect - no
+    // applyConfigChange/saveToDisk/reboot - it only records what the eventual commit should do.
+    // Mirrors begin_edit_settings exactly: stamps the clock, so a slow suite can't age the
+    // transaction into expiry, and clears the deferred decisions so they start from the same
+    // baseline a real transaction gets.
     void deferSaves()
     {
         hasOpenEditTransaction = true;
         editTransactionActivityMs = millis();
+        deferredShouldReboot = false;
+        deferredRadioAffected = false;
     }
     int savedSegments() const { return lastSaveWhatForTest; }
 

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -2615,22 +2615,6 @@ static void test_setChannel_pskChange_doesNotReloadRadio()
     TEST_ASSERT_EQUAL_INT(0, counter.count);
 }
 
-static void test_setConfigLora_liveHardwareFields_dontReloadRadio()
-{
-    usePresetLongFast();
-    ConfigChangedCounter counter;
-    counter.observe(&service->configChanged);
-
-    meshtastic_Config c = meshtastic_Config_init_zero;
-    c.which_payload_variant = meshtastic_Config_lora_tag;
-    c.payload_variant.lora = config.lora;
-    c.payload_variant.lora.tx_enabled = !config.lora.tx_enabled;
-    c.payload_variant.lora.pa_fan_disabled = !config.lora.pa_fan_disabled;
-    sendSetConfig(c);
-
-    TEST_ASSERT_EQUAL_INT(0, counter.count);
-}
-
 static void test_setConfigLora_noop_doesNotReloadRadio()
 {
     usePresetLongFast();
@@ -2647,24 +2631,58 @@ static void test_setConfigLora_noop_doesNotReloadRadio()
     TEST_ASSERT_EQUAL_INT(0, counter.count);
 }
 
+// A LoRa field the modem derives nothing from, and the mutation that changes it. Driven one field
+// per set: bundling them into a single message passes as long as *none* fires, so a field that gets
+// mis-classified later hides behind its neighbours instead of naming itself.
+struct LoraNonRadioField {
+    const char *name;
+    void (*mutate)(meshtastic_Config_LoRaConfig &);
+};
+
+// Persisted policy: read by the router, MQTT and duty-cycle logic, never by RadioInterface.
+static const LoraNonRadioField loraPolicyFields[] = {
+    {"hop_limit", [](meshtastic_Config_LoRaConfig &l) { l.hop_limit = l.hop_limit + 1; }},
+    {"ignore_mqtt", [](meshtastic_Config_LoRaConfig &l) { l.ignore_mqtt = !l.ignore_mqtt; }},
+    {"config_ok_to_mqtt", [](meshtastic_Config_LoRaConfig &l) { l.config_ok_to_mqtt = !l.config_ok_to_mqtt; }},
+    {"override_duty_cycle", [](meshtastic_Config_LoRaConfig &l) { l.override_duty_cycle = !l.override_duty_cycle; }},
+    {"ignore_incoming",
+     [](meshtastic_Config_LoRaConfig &l) {
+         l.ignore_incoming_count = 1;
+         l.ignore_incoming[0] = 0x12345678;
+     }},
+};
+
+// Applied live by the admin setter itself, so a full modem reconfigure would be redundant.
+static const LoraNonRadioField loraLiveHardwareFields[] = {
+    {"tx_enabled", [](meshtastic_Config_LoRaConfig &l) { l.tx_enabled = !l.tx_enabled; }},
+    {"pa_fan_disabled", [](meshtastic_Config_LoRaConfig &l) { l.pa_fan_disabled = !l.pa_fan_disabled; }},
+};
+
+static void assertLoraFieldsDoNotReloadRadio(const LoraNonRadioField *fields, size_t count)
+{
+    for (size_t i = 0; i < count; i++) {
+        usePresetLongFast(); // reset, so the previous iteration's write doesn't carry over
+        ConfigChangedCounter counter;
+        counter.observe(&service->configChanged);
+
+        meshtastic_Config c = meshtastic_Config_init_zero;
+        c.which_payload_variant = meshtastic_Config_lora_tag;
+        c.payload_variant.lora = config.lora;
+        fields[i].mutate(c.payload_variant.lora);
+        sendSetConfig(c);
+
+        TEST_ASSERT_EQUAL_INT_MESSAGE(0, counter.count, fields[i].name);
+    }
+}
+
 static void test_setConfigLora_policyOnlyChange_doesNotReloadRadio()
 {
-    usePresetLongFast();
-    ConfigChangedCounter counter;
-    counter.observe(&service->configChanged);
+    assertLoraFieldsDoNotReloadRadio(loraPolicyFields, sizeof(loraPolicyFields) / sizeof(loraPolicyFields[0]));
+}
 
-    meshtastic_Config c = meshtastic_Config_init_zero;
-    c.which_payload_variant = meshtastic_Config_lora_tag;
-    c.payload_variant.lora = config.lora;
-    c.payload_variant.lora.hop_limit = config.lora.hop_limit + 1;
-    c.payload_variant.lora.ignore_mqtt = !config.lora.ignore_mqtt;
-    c.payload_variant.lora.config_ok_to_mqtt = !config.lora.config_ok_to_mqtt;
-    c.payload_variant.lora.override_duty_cycle = !config.lora.override_duty_cycle;
-    c.payload_variant.lora.ignore_incoming_count = 1;
-    c.payload_variant.lora.ignore_incoming[0] = 0x12345678;
-    sendSetConfig(c);
-
-    TEST_ASSERT_EQUAL_INT(0, counter.count);
+static void test_setConfigLora_liveHardwareFields_dontReloadRadio()
+{
+    assertLoraFieldsDoNotReloadRadio(loraLiveHardwareFields, sizeof(loraLiveHardwareFields) / sizeof(loraLiveHardwareFields[0]));
 }
 
 static void test_setConfigLora_realChange_triggersRadioReload()

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -1842,6 +1842,205 @@ static void test_setChannel_stillTriggersRadioReload()
     TEST_ASSERT_EQUAL_INT(1, counter.count);
 }
 
+// handleSetConfig() radio-reload gating (non-LoRa Config sub-messages)
+//
+// Config is a monolithic disk segment, so every handleSetConfig() sub-message persists
+// SEGMENT_CONFIG. Only the lora sub-message actually feeds RadioInterface::reconfigure()
+// (which reads config.lora); every other sub-message - device/position/power/network/
+// display/bluetooth/security - must persist without firing the live SX126x reconfigure.
+// This is the same crash class as the WisMesh Tag favorite-node bug, reached through a
+// different admin message (a WiFi PSK change, a Bluetooth toggle, a keypair rotation, ...).
+// See plan-narrow-radio-reload-trigger.md. As with the node-DB tests above, these run
+// outside an edit transaction so saveChanges() reaches reloadConfig() directly.
+// -----------------------------------------------------------------------
+
+// Dispatch a set_config admin message carrying one Config sub-message.
+static void sendSetConfig(const meshtastic_Config &c)
+{
+    meshtastic_AdminMessage m = meshtastic_AdminMessage_init_zero;
+    m.which_payload_variant = meshtastic_AdminMessage_set_config_tag;
+    m.set_config = c;
+    sendAdmin(m);
+}
+
+static void test_setConfigDevice_skipsRadioReload()
+{
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_device_tag;
+    c.payload_variant.device = config.device; // no-op change; role stays put
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+static void test_setConfigPosition_skipsRadioReload()
+{
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+// position_tag has a second, nested saveChanges(SEGMENT_NODEDATABASE | SEGMENT_CONFIG, ...)
+// when the GPS is turned off while not using a fixed position; that nested save must also
+// skip the reload, so exercise it explicitly (not just the end-of-case save).
+static void test_setConfigPosition_gpsOffNestedSave_skipsRadioReload()
+{
+    config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_ENABLED;
+    config.position.fixed_position = false;
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_DISABLED;
+    c.payload_variant.position.fixed_position = false;
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+static void test_setConfigPower_skipsRadioReload()
+{
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_power_tag;
+    c.payload_variant.power = config.power;
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+static void test_setConfigNetwork_skipsRadioReload()
+{
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_network_tag;
+    c.payload_variant.network = config.network;
+    strncpy(c.payload_variant.network.wifi_psk, "hunter2hunter2", sizeof(c.payload_variant.network.wifi_psk) - 1);
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+static void test_setConfigDisplay_skipsRadioReload()
+{
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_display_tag;
+    c.payload_variant.display = config.display;
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+static void test_setConfigBluetooth_skipsRadioReload()
+{
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_bluetooth_tag;
+    c.payload_variant.bluetooth = config.bluetooth;
+    c.payload_variant.bluetooth.enabled = !config.bluetooth.enabled;
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+static void test_setConfigSecurity_skipsRadioReload()
+{
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_security_tag;
+    // Supply a full keypair (both keys present) so the handler takes neither keygen branch -
+    // keeps the test deterministic and off the crypto path; radioAffected is what's under test.
+    c.payload_variant.security.private_key.size = 32;
+    c.payload_variant.security.public_key.size = 32;
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+// remove_fixed_position rides SEGMENT_CONFIG only because config.position.fixed_position
+// shares the monolithic Config segment with config.lora; it must not reload the radio.
+// (set_fixed_position is intentionally not covered here - it dereferences the global
+// positionModule, which this unit-test harness does not construct.)
+static void test_removeFixedPosition_skipsRadioReload()
+{
+    config.position.fixed_position = true;
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    meshtastic_AdminMessage m = meshtastic_AdminMessage_init_zero;
+    m.which_payload_variant = meshtastic_AdminMessage_remove_fixed_position_tag;
+    m.remove_fixed_position = true;
+    sendAdmin(m);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+    TEST_ASSERT_FALSE(config.position.fixed_position);
+}
+
+// Regression guard: a set_config carrying the lora sub-message is the one case that must
+// still fire configChanged. Sending back the current valid preset leaves the region
+// unchanged, so exactly one reload occurs.
+static void test_setConfigLora_stillTriggersRadioReload()
+{
+    usePresetLongFast();
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_lora_tag;
+    c.payload_variant.lora = config.lora;
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_INT(1, counter.count);
+}
+
+// Default-preservation guard: reloadConfig() callers that pass only saveWhat (MenuHandler,
+// MenuApplet, portduino - ~35 sites) rely on radioAffected defaulting to true. Pin that: a
+// SEGMENT_CONFIG or SEGMENT_CHANNELS save with the argument omitted must still reload.
+static void test_reloadConfig_defaultRadioAffected_stillReloads()
+{
+    usePresetLongFast();
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    service->reloadConfig(SEGMENT_CONFIG);   // radioAffected defaulted
+    service->reloadConfig(SEGMENT_CHANNELS); // radioAffected defaulted
+
+    TEST_ASSERT_EQUAL_INT(2, counter.count);
+}
+
+// ...and the explicit opt-out must suppress the reload even with SEGMENT_CONFIG set,
+// while the save-to-disk still happens (the whole point of separating the two concerns).
+static void test_reloadConfig_radioAffectedFalse_skipsReload()
+{
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
 // -----------------------------------------------------------------------
 // Node menu mute toggle (graphics::menuHandler::toggleNodeMuted)
 // -----------------------------------------------------------------------
@@ -2045,6 +2244,20 @@ void setup()
     RUN_TEST(test_removeIgnoredNode_skipsRadioReload);
     RUN_TEST(test_toggleMutedNode_skipsRadioReload_butPersists);
     RUN_TEST(test_setChannel_stillTriggersRadioReload);
+
+    // handleSetConfig() radio-reload gating (non-LoRa Config sub-messages)
+    RUN_TEST(test_setConfigDevice_skipsRadioReload);
+    RUN_TEST(test_setConfigPosition_skipsRadioReload);
+    RUN_TEST(test_setConfigPosition_gpsOffNestedSave_skipsRadioReload);
+    RUN_TEST(test_setConfigPower_skipsRadioReload);
+    RUN_TEST(test_setConfigNetwork_skipsRadioReload);
+    RUN_TEST(test_setConfigDisplay_skipsRadioReload);
+    RUN_TEST(test_setConfigBluetooth_skipsRadioReload);
+    RUN_TEST(test_setConfigSecurity_skipsRadioReload);
+    RUN_TEST(test_removeFixedPosition_skipsRadioReload);
+    RUN_TEST(test_setConfigLora_stillTriggersRadioReload);
+    RUN_TEST(test_reloadConfig_defaultRadioAffected_stillReloads);
+    RUN_TEST(test_reloadConfig_radioAffectedFalse_skipsReload);
 
 #if HAS_SCREEN
     // Node menu mute toggle

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -2608,6 +2608,104 @@ static void test_commitWithoutBegin_persistsButDoesNotReloadOrReboot()
     TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
 }
 
+// The abandonment path retires a transaction *outside* commit_edit_settings, so it decides both
+// axes on its own. It must reach the same answers the commit would have, not fall back to the
+// old implicit "reload the radio" - an abandoned display-only batch has no more business
+// reprogramming the SX126x than a committed one does.
+static void test_abandonedTransaction_liveOnlyBatch_expiresWithoutReloadOrReboot()
+{
+    rebootAtMsec = 0;
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendBeginEdit();
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.position_broadcast_secs = config.position.position_broadcast_secs + 60;
+    sendSetConfig(c);
+
+    const int before = mockMeshService->reloadCalls;
+    testAdmin->ageEditTransaction();
+    sendGetDeviceMetadata(); // any later admin message retires the stale transaction
+
+    TEST_ASSERT_FALSE(testAdmin->editTransactionOpen());
+    TEST_ASSERT_EQUAL_INT(before + 1, mockMeshService->reloadCalls); // the deferred write still lands
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+}
+
+// The guard the other way: abandonment must not lose a real LoRa change's reconfigure either.
+static void test_abandonedTransaction_loraSet_stillReloadsRadioOnExpiry()
+{
+    usePresetLongFast();
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendBeginEdit();
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_lora_tag;
+    c.payload_variant.lora = config.lora;
+    c.payload_variant.lora.modem_preset = meshtastic_Config_LoRaConfig_ModemPreset_MEDIUM_FAST;
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count); // deferred, as for any open transaction
+
+    testAdmin->ageEditTransaction();
+    sendGetDeviceMetadata();
+
+    TEST_ASSERT_FALSE(testAdmin->editTransactionOpen());
+    TEST_ASSERT_EQUAL_INT(1, counter.count);
+}
+
+// Reboot is the one axis abandonment deliberately drops: the settings are already live in RAM and
+// the client that asked for the restart is, by definition, gone.
+static void test_abandonedTransaction_rebootingFieldDoesNotRebootOnExpiry()
+{
+    config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_DISABLED; // known start state
+    rebootAtMsec = 0;
+
+    sendBeginEdit();
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_ENABLED;
+    sendSetConfig(c);
+
+    testAdmin->ageEditTransaction();
+    sendGetDeviceMetadata();
+
+    TEST_ASSERT_FALSE(testAdmin->editTransactionOpen());
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+}
+
+// Expiry must consume-and-clear the accumulated decisions, not just read them. A begin would reset
+// them anyway, so the leak only shows through the one path that consumes them without a begin: a
+// stray commit. Left uncleared, it inherits the abandoned LoRa transaction's answer and reloads.
+static void test_abandonedTransaction_flagsDoNotLeakIntoAStrayCommit()
+{
+    usePresetLongFast();
+
+    sendBeginEdit();
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_lora_tag;
+    c.payload_variant.lora = config.lora;
+    c.payload_variant.lora.modem_preset = meshtastic_Config_LoRaConfig_ModemPreset_MEDIUM_FAST;
+    sendSetConfig(c);
+    testAdmin->ageEditTransaction();
+    sendGetDeviceMetadata(); // abandoned, not committed - this is where the flags must be cleared
+
+    // Start counting after the expiry, so only the stray commit's reload would register.
+    rebootAtMsec = 0;
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendCommitEdit(); // no matching begin
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+}
+
 // -----------------------------------------------------------------------
 // Test runner
 // -----------------------------------------------------------------------
@@ -2807,6 +2905,10 @@ void setup()
     RUN_TEST(test_transaction_liveOnlyBatch_neitherRebootsNorReloads);
     RUN_TEST(test_transaction_flagsDoNotLeakIntoTheNextTransaction);
     RUN_TEST(test_commitWithoutBegin_persistsButDoesNotReloadOrReboot);
+    RUN_TEST(test_abandonedTransaction_liveOnlyBatch_expiresWithoutReloadOrReboot);
+    RUN_TEST(test_abandonedTransaction_loraSet_stillReloadsRadioOnExpiry);
+    RUN_TEST(test_abandonedTransaction_rebootingFieldDoesNotRebootOnExpiry);
+    RUN_TEST(test_abandonedTransaction_flagsDoNotLeakIntoAStrayCommit);
 
     exit(UNITY_END());
 }

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -2315,6 +2315,19 @@ static void test_toggleTelemetryScreen_togglesBackOffAgain()
     TEST_ASSERT_FALSE(moduleConfig.telemetry.power_screen_enabled);
 }
 
+// saveToDisk(SEGMENT_MODULECONFIG) only serialises a sub-message whose has_* flag is set, so a
+// field can be assigned, "saved", and still never reach disk - exactly the TAK bug fixed upstream
+// in #11216. Drive the real toggle and assert the save path sets has_telemetry, rather than
+// asserting values the test itself just wrote.
+static void test_toggleTelemetryScreen_savePathSetsHasTelemetry()
+{
+    moduleConfig.has_telemetry = false;
+
+    graphics::menuHandler::toggleTelemetryScreen(moduleConfig.telemetry.air_quality_screen_enabled);
+
+    TEST_ASSERT_TRUE(moduleConfig.has_telemetry);
+}
+
 // -----------------------------------------------------------------------
 // Node menu mute toggle (graphics::menuHandler::toggleNodeMuted)
 // -----------------------------------------------------------------------
@@ -2551,6 +2564,7 @@ void setup()
     RUN_TEST(test_toggleTelemetryScreen_persistsWithoutRadioReloadOrReboot);
     RUN_TEST(test_toggleTelemetryScreen_togglesBackOffAgain);
     RUN_TEST(test_setSmartPositionEnabled_persistsWithoutReboot);
+    RUN_TEST(test_toggleTelemetryScreen_savePathSetsHasTelemetry);
 #if HAS_SCREEN
     // Node menu mute toggle
     RUN_TEST(test_toggleNodeMuted_flipsBitAndSkipsRadioReload);

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -2195,6 +2195,83 @@ static void test_reloadConfig_radioAffectedFalse_isEquivalentToSaveToDisk()
     TEST_ASSERT_EQUAL_UINT32(4321, config.position.position_broadcast_secs);
 }
 
+// The explicit shorter delay exists for one caller (InkHUD's wifi-recovery path). Assert the
+// trailing parameter actually shortens the schedule rather than being silently ignored.
+static void test_applyConfigChange_customRebootSeconds_isHonoured()
+{
+    rebootAtMsec = 0;
+    service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_REBOOT, 2);
+    const uint32_t shortDelay = rebootAtMsec;
+
+    rebootAtMsec = 0;
+    service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_REBOOT);
+    const uint32_t defaultDelay = rebootAtMsec;
+
+    TEST_ASSERT_NOT_EQUAL(0, shortDelay);
+    TEST_ASSERT_TRUE(shortDelay < defaultDelay);
+}
+
+static void test_applyConfigChange_none_persists_andDoesNotReload()
+{
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+    rebootAtMsec = 0;
+    const int before = mockMeshService->reloadCalls;
+
+    service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_NONE);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);                         // no radio reconfigure
+    TEST_ASSERT_EQUAL_INT(before + 1, mockMeshService->reloadCalls); // did persist, once
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);                       // no reboot
+}
+
+static void test_applyConfigChange_noRebootFlag_leavesRebootAtMsecClear()
+{
+    rebootAtMsec = 0;
+
+    service->applyConfigChange(SEGMENT_MODULECONFIG, CONFIG_APPLY_NONE);
+
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+}
+
+static void test_applyConfigChange_radioAndRebootCompose()
+{
+    usePresetLongFast();
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+    rebootAtMsec = 0;
+
+    service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_RADIO | CONFIG_APPLY_REBOOT);
+
+    TEST_ASSERT_EQUAL_INT(1, counter.count);
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+}
+
+static void test_applyConfigChange_radioFlag_triggersReload()
+{
+    usePresetLongFast();
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+    rebootAtMsec = 0;
+
+    service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_RADIO);
+
+    TEST_ASSERT_EQUAL_INT(1, counter.count);
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec); // radio flag alone must not reboot
+}
+
+static void test_applyConfigChange_rebootFlag_setsRebootAtMsec()
+{
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+    rebootAtMsec = 0;
+
+    service->applyConfigChange(SEGMENT_CONFIG, CONFIG_APPLY_REBOOT);
+
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+    TEST_ASSERT_EQUAL_INT(0, counter.count); // reboot flag alone must not touch the radio
+}
+
 // -----------------------------------------------------------------------
 // Node menu mute toggle (graphics::menuHandler::toggleNodeMuted)
 // -----------------------------------------------------------------------
@@ -2422,6 +2499,12 @@ void setup()
     RUN_TEST(test_reloadConfig_moduleConfigSegment_skipsReload);
     RUN_TEST(test_moduleConfigTelemetryScreenFlags_liveInModuleConfig);
     RUN_TEST(test_reloadConfig_radioAffectedFalse_isEquivalentToSaveToDisk);
+    RUN_TEST(test_applyConfigChange_none_persists_andDoesNotReload);
+    RUN_TEST(test_applyConfigChange_radioFlag_triggersReload);
+    RUN_TEST(test_applyConfigChange_rebootFlag_setsRebootAtMsec);
+    RUN_TEST(test_applyConfigChange_noRebootFlag_leavesRebootAtMsecClear);
+    RUN_TEST(test_applyConfigChange_radioAndRebootCompose);
+    RUN_TEST(test_applyConfigChange_customRebootSeconds_isHonoured);
 #if HAS_SCREEN
     // Node menu mute toggle
     RUN_TEST(test_toggleNodeMuted_flipsBitAndSkipsRadioReload);

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -2170,6 +2170,31 @@ static void test_reloadConfig_moduleConfigSegment_skipsReload()
     TEST_ASSERT_EQUAL_INT(0, counter.count);
 }
 
+// reloadConfig() ends with an unconditional nodeDB->saveToDisk(saveWhat), *outside* the
+// radioAffected guard. So with the flag false it is exactly equivalent to calling
+// saveToDisk(saveWhat) directly - which is what licenses deleting the nine
+// `saveToDisk(X); reloadConfig(X, ...)` double-writes from the InkHUD menu. If that
+// equivalence ever stops holding, those deletions become silent data loss, so assert it here
+// rather than trusting the reading of the code.
+static void test_reloadConfig_radioAffectedFalse_isEquivalentToSaveToDisk()
+{
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    // Distinguishable value so we can tell a write happened at all.
+    config.position.position_broadcast_secs = 4321;
+
+    const int savesBefore = mockMeshService->reloadCalls;
+    service->reloadConfig(SEGMENT_CONFIG, /*radioAffected=*/false);
+
+    // No radio reconfigure...
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+    // ...and exactly one pass through reloadConfig, i.e. one save, not two.
+    TEST_ASSERT_EQUAL_INT(savesBefore + 1, mockMeshService->reloadCalls);
+    // The in-memory value survives the call (nothing clobbers config on the save path).
+    TEST_ASSERT_EQUAL_UINT32(4321, config.position.position_broadcast_secs);
+}
+
 // -----------------------------------------------------------------------
 // Node menu mute toggle (graphics::menuHandler::toggleNodeMuted)
 // -----------------------------------------------------------------------
@@ -2204,26 +2229,24 @@ static void test_toggleNodeMuted_unknownNodeDoesNothing()
     TEST_ASSERT_NULL(nodeDB->getMeshNode(0xDEADBEEF));
 }
 
-// CHARACTERIZATION OF A KNOWN DEFECT, not an endorsement. Flipping one NodeInfoLite bit currently
-// calls bare nodeDB->saveToDisk(), which rewrites all five segments. saveToDisk() is not virtual,
-// so the mask is observed through its effect: every prefs file reappears after being removed.
-//
-// A pending fix narrows this to SEGMENT_NODEDATABASE. When it lands, only nodes.proto should come
-// back and this assertion is EXPECTED to change - that diff is the point, so the improvement is
-// visible instead of silent.
-static void test_toggleNodeMuted_currentlyRewritesEverySegment()
+// This was a characterization of a known defect: flipping one NodeInfoLite bit called bare
+// nodeDB->saveToDisk(), rewriting all five segments. That fix has now landed, so the assertion
+// is inverted as its earlier form said it would be - only nodes.proto comes back, and the other
+// four stay gone. saveToDisk() is not virtual, so the mask is still observed through its effect.
+static void test_toggleNodeMuted_writesOnlyTheNodeDatabase()
 {
     nodeDB->getOrCreateMeshNode(TEST_NODE_NUM);
 
-    const char *segmentFiles[] = {configFileName, moduleConfigFileName, deviceStateFileName, channelFileName,
-                                  nodeDatabaseFileName};
-    for (const char *f : segmentFiles)
+    const char *otherSegments[] = {configFileName, moduleConfigFileName, deviceStateFileName, channelFileName};
+    for (const char *f : otherSegments)
         FSCom.remove(f);
+    FSCom.remove(nodeDatabaseFileName);
 
     graphics::menuHandler::toggleNodeMuted(TEST_NODE_NUM);
 
-    for (const char *f : segmentFiles)
-        TEST_ASSERT_TRUE_MESSAGE(FSCom.exists(f), f);
+    TEST_ASSERT_TRUE_MESSAGE(FSCom.exists(nodeDatabaseFileName), nodeDatabaseFileName);
+    for (const char *f : otherSegments)
+        TEST_ASSERT_FALSE_MESSAGE(FSCom.exists(f), f);
 }
 #endif // HAS_SCREEN
 
@@ -2398,11 +2421,12 @@ void setup()
     RUN_TEST(test_setConfigPosition_gpsModeChange_schedulesReboot);
     RUN_TEST(test_reloadConfig_moduleConfigSegment_skipsReload);
     RUN_TEST(test_moduleConfigTelemetryScreenFlags_liveInModuleConfig);
+    RUN_TEST(test_reloadConfig_radioAffectedFalse_isEquivalentToSaveToDisk);
 #if HAS_SCREEN
     // Node menu mute toggle
     RUN_TEST(test_toggleNodeMuted_flipsBitAndSkipsRadioReload);
     RUN_TEST(test_toggleNodeMuted_unknownNodeDoesNothing);
-    RUN_TEST(test_toggleNodeMuted_currentlyRewritesEverySegment);
+    RUN_TEST(test_toggleNodeMuted_writesOnlyTheNodeDatabase);
 #endif
 
     exit(UNITY_END());

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -2111,6 +2111,31 @@ static void test_setConfigPosition_noopSet_doesNotReboot()
     TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
 }
 
+static void test_setConfigPosition_gpsModeChange_schedulesReboot()
+{
+    config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_DISABLED; // known start state
+    rebootAtMsec = 0;
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_ENABLED;
+    sendSetConfig(c);
+
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+}
+
+static void test_setConfigPosition_liveFieldChange_doesNotReboot()
+{
+    rebootAtMsec = 0;
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.position_broadcast_secs = config.position.position_broadcast_secs + 60;
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+}
+
 // -----------------------------------------------------------------------
 // Node menu mute toggle (graphics::menuHandler::toggleNodeMuted)
 // -----------------------------------------------------------------------
@@ -2335,6 +2360,8 @@ void setup()
     RUN_TEST(test_setConfigNetwork_realChange_schedulesReboot);
     RUN_TEST(test_setConfigBluetooth_noopSet_doesNotReboot);
     RUN_TEST(test_setConfigBluetooth_realChange_schedulesReboot);
+    RUN_TEST(test_setConfigPosition_liveFieldChange_doesNotReboot);
+    RUN_TEST(test_setConfigPosition_gpsModeChange_schedulesReboot);
 #if HAS_SCREEN
     // Node menu mute toggle
     RUN_TEST(test_toggleNodeMuted_flipsBitAndSkipsRadioReload);

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -2272,6 +2272,49 @@ static void test_applyConfigChange_rebootFlag_setsRebootAtMsec()
     TEST_ASSERT_EQUAL_INT(0, counter.count); // reboot flag alone must not touch the radio
 }
 
+// Read live by PositionModule every send, so this must persist without rebooting - that reboot
+// is what PR #11181 removed, and this pins it down.
+static void test_setSmartPositionEnabled_persistsWithoutReboot()
+{
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+    rebootAtMsec = 0;
+    config.position.position_broadcast_smart_enabled = false;
+
+    graphics::menuHandler::setSmartPositionEnabled(true);
+
+    TEST_ASSERT_TRUE(config.position.position_broadcast_smart_enabled);
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+
+    graphics::menuHandler::setSmartPositionEnabled(false);
+    TEST_ASSERT_FALSE(config.position.position_broadcast_smart_enabled);
+}
+
+// The bug fixed in commit 1: this used to change the flag and never persist it.
+static void test_toggleTelemetryScreen_persistsWithoutRadioReloadOrReboot()
+{
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+    rebootAtMsec = 0;
+    moduleConfig.telemetry.environment_screen_enabled = false;
+    const int before = mockMeshService->reloadCalls;
+
+    graphics::menuHandler::toggleTelemetryScreen(moduleConfig.telemetry.environment_screen_enabled);
+
+    TEST_ASSERT_TRUE(moduleConfig.telemetry.environment_screen_enabled); // flipped
+    TEST_ASSERT_EQUAL_INT(before + 1, mockMeshService->reloadCalls);     // and persisted
+    TEST_ASSERT_EQUAL_INT(0, counter.count);                             // a screen pref is not a radio change
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);                           // and needs no reboot
+}
+
+static void test_toggleTelemetryScreen_togglesBackOffAgain()
+{
+    moduleConfig.telemetry.power_screen_enabled = true;
+    graphics::menuHandler::toggleTelemetryScreen(moduleConfig.telemetry.power_screen_enabled);
+    TEST_ASSERT_FALSE(moduleConfig.telemetry.power_screen_enabled);
+}
+
 // -----------------------------------------------------------------------
 // Node menu mute toggle (graphics::menuHandler::toggleNodeMuted)
 // -----------------------------------------------------------------------
@@ -2505,6 +2548,9 @@ void setup()
     RUN_TEST(test_applyConfigChange_noRebootFlag_leavesRebootAtMsecClear);
     RUN_TEST(test_applyConfigChange_radioAndRebootCompose);
     RUN_TEST(test_applyConfigChange_customRebootSeconds_isHonoured);
+    RUN_TEST(test_toggleTelemetryScreen_persistsWithoutRadioReloadOrReboot);
+    RUN_TEST(test_toggleTelemetryScreen_togglesBackOffAgain);
+    RUN_TEST(test_setSmartPositionEnabled_persistsWithoutReboot);
 #if HAS_SCREEN
     // Node menu mute toggle
     RUN_TEST(test_toggleNodeMuted_flipsBitAndSkipsRadioReload);

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -34,6 +34,7 @@
 
 // hash() is a file-scope function in RadioInterface.cpp; link it in for slot-formula tests
 extern uint32_t hash(const char *str);
+extern uint32_t disableBluetoothCallCountForTest;
 
 // Every client notification the AdminModule emits flows through sendClientNotification();
 // capture each formatted message so the warning/coalescing tests can assert on the exact
@@ -48,6 +49,17 @@ class MockMeshService : public MeshService
     {
         capturedWarnings.push_back(n->message);
         releaseClientNotificationToPool(n);
+    }
+
+    // Counts entries into reloadConfig(). Lets a test assert a code path writes *once*, which
+    // configChanged alone cannot show (a suppressed reload still persists).
+    int reloadCalls = 0;
+    bool lastRadioAffected = false;
+    void reloadConfig(int saveWhat, bool radioAffected) override
+    {
+        reloadCalls++;
+        lastRadioAffected = radioAffected;
+        MeshService::reloadConfig(saveWhat, radioAffected);
     }
 };
 
@@ -974,6 +986,13 @@ static void replaceAdminRadioGlobals()
     savedOwner = owner;
     savedConfig = config;
     savedChannelFile = channelFile;
+    // Drop the persisted node database first: NodeDB's constructor reloads it, so without this the
+    // "own NodeDB" is seeded with every node its predecessors left on disk - the per-suite sandbox
+    // is the boundary against the *next* suite, not against earlier tests in this one. Observed
+    // without it: getOrCreateMeshNode() eventually returns NULL, which it only does when the DB is
+    // at MAX_NUM_NODES with no evictable (non-favorite/ignored/verified) candidate, and the test
+    // that happens to run last fails. The exact accumulation path is not yet pinned down.
+    FSCom.remove(nodeDatabaseFileName);
     replacementNodeDB = new NodeDB();
     nodeDB = replacementNodeDB;
 }
@@ -1829,19 +1848,6 @@ static void test_toggleMutedNode_skipsRadioReload_butPersists()
     TEST_ASSERT_TRUE(nodeInfoLiteIsMuted(nodeDB->getMeshNode(TEST_NODE_NUM)));
 }
 
-// Regression guard on the other side of the gate: a real LoRa config/channel change must still
-// reconfigure the radio, so the saveWhat check cannot have swallowed the legitimate case.
-static void test_setChannel_stillTriggersRadioReload()
-{
-    usePresetLongFast();
-    ConfigChangedCounter counter;
-    counter.observe(&service->configChanged);
-
-    sendSetChannel(makeChannel(0, meshtastic_Channel_Role_PRIMARY, "LongFast", DEFAULT_KEY, 1));
-
-    TEST_ASSERT_EQUAL_INT(1, counter.count);
-}
-
 // handleSetConfig() radio-reload gating (non-LoRa Config sub-messages)
 //
 // Config is a monolithic disk segment, so every handleSetConfig() sub-message persists
@@ -1998,23 +2004,6 @@ static void test_removeFixedPosition_skipsRadioReload()
     TEST_ASSERT_FALSE(config.position.fixed_position);
 }
 
-// Regression guard: a set_config carrying the lora sub-message is the one case that must
-// still fire configChanged. Sending back the current valid preset leaves the region
-// unchanged, so exactly one reload occurs.
-static void test_setConfigLora_stillTriggersRadioReload()
-{
-    usePresetLongFast();
-    ConfigChangedCounter counter;
-    counter.observe(&service->configChanged);
-
-    meshtastic_Config c = meshtastic_Config_init_zero;
-    c.which_payload_variant = meshtastic_Config_lora_tag;
-    c.payload_variant.lora = config.lora;
-    sendSetConfig(c);
-
-    TEST_ASSERT_EQUAL_INT(1, counter.count);
-}
-
 // Default-preservation guard: reloadConfig() callers that pass only saveWhat (MenuHandler,
 // MenuApplet, portduino - ~35 sites) rely on radioAffected defaulting to true. Pin that: a
 // SEGMENT_CONFIG or SEGMENT_CHANNELS save with the argument omitted must still reload.
@@ -2112,19 +2101,6 @@ static void test_setConfigPosition_noopSet_doesNotReboot()
     TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
 }
 
-static void test_setConfigPosition_gpsModeChange_schedulesReboot()
-{
-    config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_DISABLED; // known start state
-    rebootAtMsec = 0;
-    meshtastic_Config c = meshtastic_Config_init_zero;
-    c.which_payload_variant = meshtastic_Config_position_tag;
-    c.payload_variant.position = config.position;
-    c.payload_variant.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_ENABLED;
-    sendSetConfig(c);
-
-    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
-}
-
 static void test_setConfigPosition_liveFieldChange_doesNotReboot()
 {
     rebootAtMsec = 0;
@@ -2135,26 +2111,6 @@ static void test_setConfigPosition_liveFieldChange_doesNotReboot()
     sendSetConfig(c);
 
     TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
-}
-
-// The three telemetry screen toggles are moduleConfig fields, not part of the hiddenFrames
-// blob that Screen::toggleFrameVisibility() persists, so SEGMENT_MODULECONFIG is the segment
-// that has to carry them. Guards the segment choice: if these ever move to another proto,
-// the frame-toggle menu's save would silently stop persisting them again.
-static void test_moduleConfigTelemetryScreenFlags_liveInModuleConfig()
-{
-    moduleConfig.telemetry.environment_screen_enabled = true;
-    moduleConfig.telemetry.air_quality_screen_enabled = true;
-    moduleConfig.telemetry.power_screen_enabled = true;
-
-    // has_telemetry is what saveToDisk(SEGMENT_MODULECONFIG) sets before serialising
-    // LocalModuleConfig; without it the sub-message is skipped and the flags never reach disk.
-    moduleConfig.has_telemetry = true;
-
-    TEST_ASSERT_TRUE(moduleConfig.has_telemetry);
-    TEST_ASSERT_TRUE(moduleConfig.telemetry.environment_screen_enabled);
-    TEST_ASSERT_TRUE(moduleConfig.telemetry.air_quality_screen_enabled);
-    TEST_ASSERT_TRUE(moduleConfig.telemetry.power_screen_enabled);
 }
 
 // A module-config-only save must never touch the radio. The frame-toggle menu persists
@@ -2505,6 +2461,27 @@ static void test_editTransactionTimer_isDormantUntilTransactionBegins()
     TEST_ASSERT_FALSE(testAdmin->editTransactionTimerEnabled());
     TEST_ASSERT_EQUAL_UINT32(INT32_MAX, testAdmin->editTransactionTimerInterval());
     TEST_ASSERT_EQUAL_INT32(INT32_MAX, testAdmin->runTransactionTimer());
+}
+
+static meshtastic_Channel makePlainPrimaryChannel(const char *name)
+{
+    meshtastic_Channel channel = makeChannel(0, meshtastic_Channel_Role_PRIMARY, name, DEFAULT_KEY, 1);
+    channel.settings.psk.size = 0;
+    return channel;
+}
+
+static void sendSetConfig(const meshtastic_Config &c);
+static void sendSetModuleConfig(const meshtastic_ModuleConfig &mc);
+
+static void useLicensedHamNarrowSlow()
+{
+    config.lora = meshtastic_Config_LoRaConfig_init_zero;
+    config.lora.region = meshtastic_Config_LoRaConfig_RegionCode_ITU2_125CM;
+    config.lora.use_preset = true;
+    config.lora.modem_preset = meshtastic_Config_LoRaConfig_ModemPreset_NARROW_SLOW;
+    owner.is_licensed = true;
+    initRegion();
+    RadioInterface::uses_default_frequency_slot = true;
 }
 
 static void test_setChannel_hamDefaultNameExplicitToImplicit_doesNotReloadRadio()
@@ -3008,6 +2985,28 @@ static void test_transaction_serialRealChange_disablesBluetoothAtCommit()
     TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
 }
 
+static void assertUsToHamTransactionReloadsOnce(const char *channelName)
+{
+    usePresetLongFast();
+    sendSetChannel(makeChannel(0, meshtastic_Channel_Role_PRIMARY, "", DEFAULT_KEY, 1));
+    owner.is_licensed = true;
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendBeginEdit();
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_lora_tag;
+    c.payload_variant.lora = config.lora;
+    c.payload_variant.lora.region = meshtastic_Config_LoRaConfig_RegionCode_ITU2_125CM;
+    c.payload_variant.lora.modem_preset = meshtastic_Config_LoRaConfig_ModemPreset_NARROW_SLOW;
+    sendSetConfig(c);
+    sendSetChannel(makePlainPrimaryChannel(channelName));
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL(meshtastic_Config_LoRaConfig_RegionCode_ITU2_125CM, config.lora.region);
+    TEST_ASSERT_EQUAL_INT(1, counter.count);
+}
+
 static void test_transaction_usToHamWithExplicitDefaultName_reloadsRadioOnce()
 {
     assertUsToHamTransactionReloadsOnce("NarrowSlow");
@@ -3210,30 +3209,6 @@ static void test_transaction_loraSet_stillReloadsRadioAtCommit()
     TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
 }
 
-// ...and the reboot axis on its own: a boot-only field inside a transaction reboots at the commit
-// without dragging the radio reconfigure along with it.
-static void test_transaction_gpsModeSet_reboots_butDoesNotReloadRadio()
-{
-    config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_DISABLED; // known start state
-    rebootAtMsec = 0;
-    ConfigChangedCounter counter;
-    counter.observe(&service->configChanged);
-
-    sendBeginEdit();
-    meshtastic_Config c = meshtastic_Config_init_zero;
-    c.which_payload_variant = meshtastic_Config_position_tag;
-    c.payload_variant.position = config.position;
-    c.payload_variant.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_ENABLED;
-    sendSetConfig(c);
-
-    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec); // deferred until the commit
-
-    sendCommitEdit();
-
-    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
-    TEST_ASSERT_EQUAL_INT(0, counter.count);
-}
-
 // A batch whose every member is live-appliable must come out of the commit doing neither.
 static void test_transaction_liveOnlyBatch_neitherRebootsNorReloads()
 {
@@ -3347,27 +3322,6 @@ static void test_abandonedTransaction_loraSet_stillReloadsRadioOnExpiry()
     TEST_ASSERT_EQUAL_INT(1, counter.count);
 }
 
-// Reboot is the one axis abandonment deliberately drops: the settings are already live in RAM and
-// the client that asked for the restart is, by definition, gone.
-static void test_abandonedTransaction_rebootingFieldDoesNotRebootOnExpiry()
-{
-    config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_DISABLED; // known start state
-    rebootAtMsec = 0;
-
-    sendBeginEdit();
-    meshtastic_Config c = meshtastic_Config_init_zero;
-    c.which_payload_variant = meshtastic_Config_position_tag;
-    c.payload_variant.position = config.position;
-    c.payload_variant.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_ENABLED;
-    sendSetConfig(c);
-
-    testAdmin->ageEditTransaction();
-    sendGetDeviceMetadata();
-
-    TEST_ASSERT_FALSE(testAdmin->editTransactionOpen());
-    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
-}
-
 // Expiry must consume-and-clear the accumulated decisions, not just read them. A begin would reset
 // them anyway, so the leak only shows through the one path that consumes them without a begin: a
 // stray commit. Left uncleared, it inherits the abandoned LoRa transaction's answer and reloads.
@@ -3404,6 +3358,7 @@ void setUp(void)
     mockMeshService = new MockMeshService();
     service = mockMeshService;
     testAdmin = new AdminModuleTestShim();
+    disableBluetoothCallCountForTest = 0;
     capturedWarnings.clear();
     // Every test gets its own NodeDB and its own copy of the globals the admin handlers write.
     replaceAdminRadioGlobals();
@@ -3540,7 +3495,6 @@ void setup()
     RUN_TEST(test_setIgnoredNode_skipsRadioReload_butPersists);
     RUN_TEST(test_removeIgnoredNode_skipsRadioReload);
     RUN_TEST(test_toggleMutedNode_skipsRadioReload_butPersists);
-    RUN_TEST(test_setChannel_stillTriggersRadioReload);
 
     // handleSetConfig() radio-reload gating (non-LoRa Config sub-messages)
     RUN_TEST(test_setConfigDevice_skipsRadioReload);
@@ -3552,7 +3506,6 @@ void setup()
     RUN_TEST(test_setConfigBluetooth_skipsRadioReload);
     RUN_TEST(test_setConfigSecurity_skipsRadioReload);
     RUN_TEST(test_removeFixedPosition_skipsRadioReload);
-    RUN_TEST(test_setConfigLora_stillTriggersRadioReload);
     RUN_TEST(test_reloadConfig_defaultRadioAffected_stillReloads);
     RUN_TEST(test_reloadConfig_radioAffectedFalse_skipsReload);
 
@@ -3563,9 +3516,7 @@ void setup()
     RUN_TEST(test_setConfigBluetooth_noopSet_doesNotReboot);
     RUN_TEST(test_setConfigBluetooth_realChange_schedulesReboot);
     RUN_TEST(test_setConfigPosition_liveFieldChange_doesNotReboot);
-    RUN_TEST(test_setConfigPosition_gpsModeChange_schedulesReboot);
     RUN_TEST(test_reloadConfig_moduleConfigSegment_skipsReload);
-    RUN_TEST(test_moduleConfigTelemetryScreenFlags_liveInModuleConfig);
     RUN_TEST(test_reloadConfig_radioAffectedFalse_isEquivalentToSaveToDisk);
     RUN_TEST(test_applyConfigChange_none_persists_andDoesNotReload);
     RUN_TEST(test_applyConfigChange_radioFlag_triggersReload);
@@ -3632,13 +3583,11 @@ void setup()
     RUN_TEST(test_transaction_moduleConfigSet_doesNotReloadRadioAtCommit);
     RUN_TEST(test_transaction_positionGpsOffNestedSave_doesNotReloadRadioAtCommit);
     RUN_TEST(test_transaction_loraSet_stillReloadsRadioAtCommit);
-    RUN_TEST(test_transaction_gpsModeSet_reboots_butDoesNotReloadRadio);
     RUN_TEST(test_transaction_liveOnlyBatch_neitherRebootsNorReloads);
     RUN_TEST(test_transaction_flagsDoNotLeakIntoTheNextTransaction);
     RUN_TEST(test_commitWithoutBegin_persistsButDoesNotReloadOrReboot);
     RUN_TEST(test_abandonedTransaction_liveOnlyBatch_expiresWithoutReloadOrReboot);
     RUN_TEST(test_abandonedTransaction_loraSet_stillReloadsRadioOnExpiry);
-    RUN_TEST(test_abandonedTransaction_rebootingFieldDoesNotRebootOnExpiry);
     RUN_TEST(test_abandonedTransaction_flagsDoNotLeakIntoAStrayCommit);
 
     exit(UNITY_END());

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -1850,8 +1850,9 @@ static void test_setChannel_stillTriggersRadioReload()
 // display/bluetooth/security - must persist without firing the live SX126x reconfigure.
 // This is the same crash class as the WisMesh Tag favorite-node bug, reached through a
 // different admin message (a WiFi PSK change, a Bluetooth toggle, a keypair rotation, ...).
-// See plan-narrow-radio-reload-trigger.md. As with the node-DB tests above, these run
-// outside an edit transaction so saveChanges() reaches reloadConfig() directly.
+// See docs/admin-config-save-gating.md. As with the node-DB tests above, these run
+// outside an edit transaction so saveChanges() reaches reloadConfig() directly; the
+// deferred-transaction equivalents are further down.
 // -----------------------------------------------------------------------
 
 // Dispatch a set_config admin message carrying one Config sub-message.
@@ -2384,6 +2385,230 @@ static void test_toggleNodeMuted_writesOnlyTheNodeDatabase()
 #endif // HAS_SCREEN
 
 // -----------------------------------------------------------------------
+// Edit-transaction deferral: the per-field radio/reboot decisions must survive it
+//
+// Every test above runs outside a transaction, where reloadConfig()'s
+// `saveWhat & (SEGMENT_CONFIG | SEGMENT_CHANNELS)` bitmask independently blocks a node-DB-only
+// save from reaching the radio. Inside a transaction that safety net is gone: saveChanges()
+// defers, and the commit persists under a fixed full-segment mask, so the bitmask passes and
+// the only thing left deciding whether the SX126x is reconfigured is the accumulated
+// radioAffected flag. Phone apps write config through transactions, so this is the path that
+// matters most - and the one where an accidentally-defaulted `radioAffected = true` would
+// silently reopen the WisMesh Tag favorite crash (#11146).
+//
+// These assert both axes independently: reloadCalls (did we write at all, and once) and
+// configChanged (did the radio actually get reconfigured).
+// -----------------------------------------------------------------------
+
+static const NodeNum TXN_NODE_NUM = 0x0BADF00D;
+
+// Dispatch a set_module_config admin message carrying one ModuleConfig sub-message.
+static void sendSetModuleConfig(const meshtastic_ModuleConfig &mc)
+{
+    meshtastic_AdminMessage m = meshtastic_AdminMessage_init_zero;
+    m.which_payload_variant = meshtastic_AdminMessage_set_module_config_tag;
+    m.set_module_config = mc;
+    sendAdmin(m);
+}
+
+// The headline guard: favoriting a node inside a transaction must not reconfigure the radio when
+// the transaction commits. Outside a transaction the segment bitmask makes this unreachable; here
+// it is reachable, and only radioAffected=false keeps it shut.
+static void test_transaction_favoriteNode_doesNotReloadRadioAtCommit()
+{
+    meshtastic_NodeInfoLite *node = nodeDB->getOrCreateMeshNode(TXN_NODE_NUM);
+    nodeInfoLiteSetBit(node, NODEINFO_BITFIELD_IS_FAVORITE_MASK, false); // known start state
+    rebootAtMsec = 0;
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendBeginEdit();
+    meshtastic_AdminMessage m = meshtastic_AdminMessage_init_zero;
+    m.which_payload_variant = meshtastic_AdminMessage_set_favorite_node_tag;
+    m.set_favorite_node = TXN_NODE_NUM;
+    sendAdmin(m);
+
+    // Deferred: nothing written, nothing reconfigured, while the transaction is open.
+    TEST_ASSERT_EQUAL_INT(0, mockMeshService->reloadCalls);
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL_INT(1, mockMeshService->reloadCalls); // written exactly once, at the commit
+    TEST_ASSERT_EQUAL_INT(0, counter.count);                // ...but the radio was left alone
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);              // ...and so was the reboot
+    TEST_ASSERT_TRUE(nodeInfoLiteIsFavorite(nodeDB->getMeshNode(TXN_NODE_NUM)));
+}
+
+// Same shape via the muted-node handler, which flips unconditionally (no protected-cap gate).
+static void test_transaction_toggleMutedNode_doesNotReloadRadioAtCommit()
+{
+    nodeDB->getOrCreateMeshNode(TXN_NODE_NUM);
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendBeginEdit();
+    meshtastic_AdminMessage m = meshtastic_AdminMessage_init_zero;
+    m.which_payload_variant = meshtastic_AdminMessage_toggle_muted_node_tag;
+    m.toggle_muted_node = TXN_NODE_NUM;
+    sendAdmin(m);
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+// Module config never feeds RadioInterface::reconfigure() (which reads config.lora), so a
+// module-config set inside a transaction must not reconfigure at commit either.
+static void test_transaction_moduleConfigSet_doesNotReloadRadioAtCommit()
+{
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendBeginEdit();
+    meshtastic_ModuleConfig mc = meshtastic_ModuleConfig_init_zero;
+    mc.which_payload_variant = meshtastic_ModuleConfig_telemetry_tag;
+    mc.payload_variant.telemetry = moduleConfig.telemetry;
+    mc.payload_variant.telemetry.device_update_interval = moduleConfig.telemetry.device_update_interval + 60;
+    sendSetModuleConfig(mc);
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+// The position case makes a *nested* saveChanges() call when the GPS is switched off with no
+// fixed position. That inner call must not opt the whole transaction into a radio reload.
+static void test_transaction_positionGpsOffNestedSave_doesNotReloadRadioAtCommit()
+{
+    config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_ENABLED; // known start state
+    config.position.fixed_position = false;                                      // required for the nested-save branch
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendBeginEdit();
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_DISABLED;
+    sendSetConfig(c);
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+// Regression guard the other way: a real LoRa change inside a transaction must still reconfigure
+// the radio - once, at the commit. Narrowing must not have swallowed the legitimate case.
+static void test_transaction_loraSet_stillReloadsRadioAtCommit()
+{
+    usePresetLongFast();
+    rebootAtMsec = 0;
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendBeginEdit();
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_lora_tag;
+    c.payload_variant.lora = config.lora;
+    c.payload_variant.lora.modem_preset = meshtastic_Config_LoRaConfig_ModemPreset_MEDIUM_FAST;
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count); // still deferred
+
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL_INT(1, counter.count);
+    // LoRa applies live via the configChanged observer, so the region-already-set case must not
+    // also reboot - the two axes are decided separately.
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+}
+
+// ...and the reboot axis on its own: a boot-only field inside a transaction reboots at the commit
+// without dragging the radio reconfigure along with it.
+static void test_transaction_gpsModeSet_reboots_butDoesNotReloadRadio()
+{
+    config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_DISABLED; // known start state
+    rebootAtMsec = 0;
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendBeginEdit();
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_ENABLED;
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec); // deferred until the commit
+
+    sendCommitEdit();
+
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+// A batch whose every member is live-appliable must come out of the commit doing neither.
+static void test_transaction_liveOnlyBatch_neitherRebootsNorReloads()
+{
+    rebootAtMsec = 0;
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendBeginEdit();
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.position_broadcast_secs = config.position.position_broadcast_secs + 60;
+    sendSetConfig(c);
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+// The accumulated decisions are per-transaction: a LoRa transaction must not leave the next,
+// node-DB-only transaction reconfiguring the radio.
+static void test_transaction_flagsDoNotLeakIntoTheNextTransaction()
+{
+    usePresetLongFast();
+    nodeDB->getOrCreateMeshNode(TXN_NODE_NUM);
+
+    sendBeginEdit();
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_lora_tag;
+    c.payload_variant.lora = config.lora;
+    c.payload_variant.lora.modem_preset = meshtastic_Config_LoRaConfig_ModemPreset_MEDIUM_FAST;
+    sendSetConfig(c);
+    sendCommitEdit();
+
+    // Second transaction: node-DB metadata only. Start counting after the first commit.
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendBeginEdit();
+    meshtastic_AdminMessage m = meshtastic_AdminMessage_init_zero;
+    m.which_payload_variant = meshtastic_AdminMessage_toggle_muted_node_tag;
+    m.toggle_muted_node = TXN_NODE_NUM;
+    sendAdmin(m);
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+// A commit with no matching begin still persists (harmless), but must not invent a radio reload
+// or a reboot out of the parameter defaults.
+static void test_commitWithoutBegin_persistsButDoesNotReloadOrReboot()
+{
+    rebootAtMsec = 0;
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL_INT(1, mockMeshService->reloadCalls);
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+}
+
+// -----------------------------------------------------------------------
 // Test runner
 // -----------------------------------------------------------------------
 
@@ -2571,6 +2796,17 @@ void setup()
     RUN_TEST(test_toggleNodeMuted_unknownNodeDoesNothing);
     RUN_TEST(test_toggleNodeMuted_writesOnlyTheNodeDatabase);
 #endif
+
+    // Edit-transaction deferral (the path phone apps use)
+    RUN_TEST(test_transaction_favoriteNode_doesNotReloadRadioAtCommit);
+    RUN_TEST(test_transaction_toggleMutedNode_doesNotReloadRadioAtCommit);
+    RUN_TEST(test_transaction_moduleConfigSet_doesNotReloadRadioAtCommit);
+    RUN_TEST(test_transaction_positionGpsOffNestedSave_doesNotReloadRadioAtCommit);
+    RUN_TEST(test_transaction_loraSet_stillReloadsRadioAtCommit);
+    RUN_TEST(test_transaction_gpsModeSet_reboots_butDoesNotReloadRadio);
+    RUN_TEST(test_transaction_liveOnlyBatch_neitherRebootsNorReloads);
+    RUN_TEST(test_transaction_flagsDoNotLeakIntoTheNextTransaction);
+    RUN_TEST(test_commitWithoutBegin_persistsButDoesNotReloadOrReboot);
 
     exit(UNITY_END());
 }

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -2041,6 +2041,76 @@ static void test_reloadConfig_radioAffectedFalse_skipsReload()
     TEST_ASSERT_EQUAL_INT(0, counter.count);
 }
 
+static void test_setConfigBluetooth_noopSet_doesNotReboot()
+{
+    rebootAtMsec = 0;
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_bluetooth_tag;
+    c.payload_variant.bluetooth = config.bluetooth;
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+}
+
+static void test_setConfigBluetooth_realChange_schedulesReboot()
+{
+    rebootAtMsec = 0;
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_bluetooth_tag;
+    c.payload_variant.bluetooth = config.bluetooth;
+    c.payload_variant.bluetooth.enabled = !config.bluetooth.enabled;
+    sendSetConfig(c);
+
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+}
+
+static void test_setConfigNetwork_noopSet_doesNotReboot()
+{
+    rebootAtMsec = 0;
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_network_tag;
+    c.payload_variant.network = config.network;
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+}
+
+static void test_setConfigNetwork_realChange_schedulesReboot()
+{
+    rebootAtMsec = 0;
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_network_tag;
+    c.payload_variant.network = config.network;
+    c.payload_variant.network.wifi_enabled = !config.network.wifi_enabled;
+    sendSetConfig(c);
+
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+}
+
+// A boot-only field (GPIO) must still reboot - this stays true through Tier 2.
+static void test_setConfigPosition_gpioChange_schedulesReboot()
+{
+    rebootAtMsec = 0;
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.rx_gpio = config.position.rx_gpio + 1;
+    sendSetConfig(c);
+
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+}
+
+static void test_setConfigPosition_noopSet_doesNotReboot()
+{
+    rebootAtMsec = 0;
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position; // byte-identical to current
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+}
+
 // -----------------------------------------------------------------------
 // Node menu mute toggle (graphics::menuHandler::toggleNodeMuted)
 // -----------------------------------------------------------------------
@@ -2259,6 +2329,12 @@ void setup()
     RUN_TEST(test_reloadConfig_defaultRadioAffected_stillReloads);
     RUN_TEST(test_reloadConfig_radioAffectedFalse_skipsReload);
 
+    RUN_TEST(test_setConfigPosition_noopSet_doesNotReboot);
+    RUN_TEST(test_setConfigPosition_gpioChange_schedulesReboot);
+    RUN_TEST(test_setConfigNetwork_noopSet_doesNotReboot);
+    RUN_TEST(test_setConfigNetwork_realChange_schedulesReboot);
+    RUN_TEST(test_setConfigBluetooth_noopSet_doesNotReboot);
+    RUN_TEST(test_setConfigBluetooth_realChange_schedulesReboot);
 #if HAS_SCREEN
     // Node menu mute toggle
     RUN_TEST(test_toggleNodeMuted_flipsBitAndSkipsRadioReload);

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -2329,6 +2329,126 @@ static void test_toggleTelemetryScreen_savePathSetsHasTelemetry()
     TEST_ASSERT_TRUE(moduleConfig.has_telemetry);
 }
 
+// A GPIO reassignment is boot-only however it arrives: the pin is claimed during GPS construction.
+static void test_setConfigPosition_gpioChangeStillReboots()
+{
+    config.position.rx_gpio = 0; // known start state
+    rebootAtMsec = 0;
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.rx_gpio = 17;
+    sendSetConfig(c);
+
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+}
+
+static void test_setConfigPosition_gpsDisableIsLive_doesNotReboot()
+{
+    config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_ENABLED; // known start state
+    config.position.fixed_position = true; // keep the nested clearLocalPosition save out of this test
+    rebootAtMsec = 0;
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_DISABLED;
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_INT(meshtastic_Config_PositionConfig_GpsMode_DISABLED, (int)config.position.gps_mode);
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+}
+
+static void test_setConfigPosition_gpsEnableIsLive_doesNotReboot()
+{
+    config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_DISABLED; // known start state
+    rebootAtMsec = 0;
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_ENABLED;
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_INT(meshtastic_Config_PositionConfig_GpsMode_ENABLED, (int)config.position.gps_mode); // persisted
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+    TEST_ASSERT_EQUAL_INT(0, counter.count); // and still no reason to touch the radio
+}
+
+// ...and so does the reverse: there is no driver to enable until a boot has constructed one.
+static void test_setConfigPosition_gpsFromNotPresent_stillReboots()
+{
+    config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_NOT_PRESENT; // known start state
+    rebootAtMsec = 0;
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_ENABLED;
+    sendSetConfig(c);
+
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+}
+
+// The exemption is for gps_mode alone - it must not smuggle a genuinely boot-only field past the
+// memcmp fail-safe when both change in the same set.
+static void test_setConfigPosition_gpsToggleWithGpioChange_stillReboots()
+{
+    config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_DISABLED; // known start state
+    config.position.rx_gpio = 0;
+    rebootAtMsec = 0;
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_ENABLED;
+    c.payload_variant.position.rx_gpio = 17;
+    sendSetConfig(c);
+
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+}
+
+// The live exemption is exactly one pair. Declaring the GPS absent tears down state that only
+// boot rebuilds, so it stays on the reboot path...
+static void test_setConfigPosition_gpsToNotPresent_stillReboots()
+{
+    config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_ENABLED; // known start state
+    config.position.fixed_position = true;
+    rebootAtMsec = 0;
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_NOT_PRESENT;
+    sendSetConfig(c);
+
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+}
+
+// ...and the reboot axis on its own: a boot-only field inside a transaction reboots at the commit
+// without dragging the radio reconfigure along with it. rx_gpio rather than gps_mode - the latter
+// is applied live now, so it would no longer exercise the reboot axis at all.
+static void test_transaction_gpioSet_reboots_butDoesNotReloadRadio()
+{
+    config.position.rx_gpio = 0; // known start state
+    rebootAtMsec = 0;
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendBeginEdit();
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.rx_gpio = 17;
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec); // deferred until the commit
+
+    sendCommitEdit();
+
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
 // -----------------------------------------------------------------------
 // Node menu mute toggle (graphics::menuHandler::toggleNodeMuted)
 // -----------------------------------------------------------------------
@@ -2888,6 +3008,13 @@ void setup()
     RUN_TEST(test_toggleTelemetryScreen_togglesBackOffAgain);
     RUN_TEST(test_setSmartPositionEnabled_persistsWithoutReboot);
     RUN_TEST(test_toggleTelemetryScreen_savePathSetsHasTelemetry);
+    RUN_TEST(test_setConfigPosition_gpioChangeStillReboots);
+    RUN_TEST(test_setConfigPosition_gpsEnableIsLive_doesNotReboot);
+    RUN_TEST(test_setConfigPosition_gpsDisableIsLive_doesNotReboot);
+    RUN_TEST(test_setConfigPosition_gpsToNotPresent_stillReboots);
+    RUN_TEST(test_setConfigPosition_gpsFromNotPresent_stillReboots);
+    RUN_TEST(test_setConfigPosition_gpsToggleWithGpioChange_stillReboots);
+    RUN_TEST(test_transaction_gpioSet_reboots_butDoesNotReloadRadio);
 #if HAS_SCREEN
     // Node menu mute toggle
     RUN_TEST(test_toggleNodeMuted_flipsBitAndSkipsRadioReload);

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -1764,6 +1764,41 @@ static void test_setFavoriteNode_skipsRadioReload_butPersists()
     TEST_ASSERT_TRUE(nodeInfoLiteIsFavorite(nodeDB->getMeshNode(TEST_NODE_NUM)));
 }
 
+// The clear-side twin of each set: removal is a node-DB write too, so it must not reconfigure
+// the radio either. Set and clear travel different admin tags, so one holding says nothing
+// about the other.
+static void test_removeFavoriteNode_skipsRadioReload()
+{
+    meshtastic_NodeInfoLite *node = nodeDB->getOrCreateMeshNode(TEST_NODE_NUM);
+    nodeDB->setProtectedFlag(node, NODEINFO_BITFIELD_IS_FAVORITE_MASK, true);
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    meshtastic_AdminMessage m = meshtastic_AdminMessage_init_zero;
+    m.which_payload_variant = meshtastic_AdminMessage_remove_favorite_node_tag;
+    m.remove_favorite_node = TEST_NODE_NUM;
+    sendAdmin(m);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+    TEST_ASSERT_FALSE(nodeInfoLiteIsFavorite(nodeDB->getMeshNode(TEST_NODE_NUM)));
+}
+
+static void test_removeIgnoredNode_skipsRadioReload()
+{
+    meshtastic_NodeInfoLite *node = nodeDB->getOrCreateMeshNode(TEST_NODE_NUM);
+    nodeDB->setProtectedFlag(node, NODEINFO_BITFIELD_IS_IGNORED_MASK, true);
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    meshtastic_AdminMessage m = meshtastic_AdminMessage_init_zero;
+    m.which_payload_variant = meshtastic_AdminMessage_remove_ignored_node_tag;
+    m.remove_ignored_node = TEST_NODE_NUM;
+    sendAdmin(m);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+    TEST_ASSERT_FALSE(nodeInfoLiteIsIgnored(nodeDB->getMeshNode(TEST_NODE_NUM)));
+}
+
 static void test_setIgnoredNode_skipsRadioReload_butPersists()
 {
     nodeDB->getOrCreateMeshNode(TEST_NODE_NUM);
@@ -1792,6 +1827,19 @@ static void test_toggleMutedNode_skipsRadioReload_butPersists()
 
     TEST_ASSERT_EQUAL_INT(0, counter.count);
     TEST_ASSERT_TRUE(nodeInfoLiteIsMuted(nodeDB->getMeshNode(TEST_NODE_NUM)));
+}
+
+// Regression guard on the other side of the gate: a real LoRa config/channel change must still
+// reconfigure the radio, so the saveWhat check cannot have swallowed the legitimate case.
+static void test_setChannel_stillTriggersRadioReload()
+{
+    usePresetLongFast();
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendSetChannel(makeChannel(0, meshtastic_Channel_Role_PRIMARY, "LongFast", DEFAULT_KEY, 1));
+
+    TEST_ASSERT_EQUAL_INT(1, counter.count);
 }
 
 // -----------------------------------------------------------------------
@@ -1992,8 +2040,11 @@ void setup()
 
     // Node-DB metadata saves must not reconfigure the radio
     RUN_TEST(test_setFavoriteNode_skipsRadioReload_butPersists);
+    RUN_TEST(test_removeFavoriteNode_skipsRadioReload);
     RUN_TEST(test_setIgnoredNode_skipsRadioReload_butPersists);
+    RUN_TEST(test_removeIgnoredNode_skipsRadioReload);
     RUN_TEST(test_toggleMutedNode_skipsRadioReload_butPersists);
+    RUN_TEST(test_setChannel_stillTriggersRadioReload);
 
 #if HAS_SCREEN
     // Node menu mute toggle

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -2136,6 +2136,40 @@ static void test_setConfigPosition_liveFieldChange_doesNotReboot()
     TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
 }
 
+// The three telemetry screen toggles are moduleConfig fields, not part of the hiddenFrames
+// blob that Screen::toggleFrameVisibility() persists, so SEGMENT_MODULECONFIG is the segment
+// that has to carry them. Guards the segment choice: if these ever move to another proto,
+// the frame-toggle menu's save would silently stop persisting them again.
+static void test_moduleConfigTelemetryScreenFlags_liveInModuleConfig()
+{
+    moduleConfig.telemetry.environment_screen_enabled = true;
+    moduleConfig.telemetry.air_quality_screen_enabled = true;
+    moduleConfig.telemetry.power_screen_enabled = true;
+
+    // has_telemetry is what saveToDisk(SEGMENT_MODULECONFIG) sets before serialising
+    // LocalModuleConfig; without it the sub-message is skipped and the flags never reach disk.
+    moduleConfig.has_telemetry = true;
+
+    TEST_ASSERT_TRUE(moduleConfig.has_telemetry);
+    TEST_ASSERT_TRUE(moduleConfig.telemetry.environment_screen_enabled);
+    TEST_ASSERT_TRUE(moduleConfig.telemetry.air_quality_screen_enabled);
+    TEST_ASSERT_TRUE(moduleConfig.telemetry.power_screen_enabled);
+}
+
+// A module-config-only save must never touch the radio. The frame-toggle menu persists
+// moduleConfig.telemetry.*_screen_enabled this way; passing the mask without the explicit
+// radioAffected=false would inherit the default of true and needlessly re-init the LoRa chip
+// for a screen preference.
+static void test_reloadConfig_moduleConfigSegment_skipsReload()
+{
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    service->reloadConfig(SEGMENT_MODULECONFIG, /*radioAffected=*/false);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
 // -----------------------------------------------------------------------
 // Node menu mute toggle (graphics::menuHandler::toggleNodeMuted)
 // -----------------------------------------------------------------------
@@ -2362,6 +2396,8 @@ void setup()
     RUN_TEST(test_setConfigBluetooth_realChange_schedulesReboot);
     RUN_TEST(test_setConfigPosition_liveFieldChange_doesNotReboot);
     RUN_TEST(test_setConfigPosition_gpsModeChange_schedulesReboot);
+    RUN_TEST(test_reloadConfig_moduleConfigSegment_skipsReload);
+    RUN_TEST(test_moduleConfigTelemetryScreenFlags_liveInModuleConfig);
 #if HAS_SCREEN
     // Node menu mute toggle
     RUN_TEST(test_toggleNodeMuted_flipsBitAndSkipsRadioReload);

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -2449,6 +2449,557 @@ static void test_transaction_gpioSet_reboots_butDoesNotReloadRadio()
     TEST_ASSERT_EQUAL_INT(0, counter.count);
 }
 
+// Boot-only settings are not actually live in RAM. Expiry must finish the same reboot the commit
+// would have requested, or it persists a value that cannot take effect until some unrelated reboot.
+static void test_abandonedTransaction_rebootingFieldRebootsOnExpiry()
+{
+    config.position.rx_gpio = 0; // a genuinely boot-only field, so the drop is a real drop
+    rebootAtMsec = 0;
+
+    sendBeginEdit();
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.rx_gpio = 17;
+    sendSetConfig(c);
+
+    testAdmin->ageEditTransaction();
+    sendGetDeviceMetadata();
+
+    TEST_ASSERT_FALSE(testAdmin->editTransactionOpen());
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+    TEST_ASSERT_EQUAL_UINT32(1, disableBluetoothCallCountForTest);
+}
+
+static void test_abandonedTransaction_timerExpiresWithoutAdminTraffic()
+{
+    config.position.rx_gpio = 0;
+    rebootAtMsec = 0;
+
+    sendBeginEdit();
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.rx_gpio = 17;
+    sendSetConfig(c);
+
+    testAdmin->ageEditTransaction();
+    testAdmin->runTransactionTimer();
+
+    TEST_ASSERT_FALSE(testAdmin->editTransactionOpen());
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+    TEST_ASSERT_EQUAL_UINT32(1, disableBluetoothCallCountForTest);
+}
+
+static void test_editTransactionTimer_isDormantUntilTransactionBegins()
+{
+    TEST_ASSERT_FALSE(testAdmin->editTransactionTimerEnabled());
+    TEST_ASSERT_EQUAL_UINT32(INT32_MAX, testAdmin->editTransactionTimerInterval());
+    TEST_ASSERT_EQUAL_INT32(INT32_MAX, testAdmin->runTransactionTimer());
+
+    sendBeginEdit();
+    TEST_ASSERT_TRUE(testAdmin->editTransactionTimerEnabled());
+    TEST_ASSERT_EQUAL_UINT32(60 * 1000, testAdmin->editTransactionTimerInterval());
+
+    sendCommitEdit();
+    TEST_ASSERT_FALSE(testAdmin->editTransactionTimerEnabled());
+    TEST_ASSERT_EQUAL_UINT32(INT32_MAX, testAdmin->editTransactionTimerInterval());
+    TEST_ASSERT_EQUAL_INT32(INT32_MAX, testAdmin->runTransactionTimer());
+}
+
+static void test_setChannel_hamDefaultNameExplicitToImplicit_doesNotReloadRadio()
+{
+    useLicensedHamNarrowSlow();
+    sendSetChannel(makePlainPrimaryChannel("NarrowSlow"));
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendSetChannel(makePlainPrimaryChannel(""));
+
+    TEST_ASSERT_EQUAL_STRING("NarrowSlow", channels.getName(channels.getPrimaryIndex()));
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+static void test_setChannel_hamDefaultNameImplicitToExplicit_doesNotReloadRadio()
+{
+    useLicensedHamNarrowSlow();
+    sendSetChannel(makePlainPrimaryChannel(""));
+    TEST_ASSERT_EQUAL_STRING("NarrowSlow", channels.getName(channels.getPrimaryIndex()));
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendSetChannel(makePlainPrimaryChannel("NarrowSlow"));
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+static void test_setChannel_mqttFlagChange_doesNotReloadRadio()
+{
+    usePresetLongFast();
+    meshtastic_Channel channel = makeChannel(0, meshtastic_Channel_Role_PRIMARY, "LongFast", DEFAULT_KEY, 1);
+    sendSetChannel(channel);
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    channel.settings.uplink_enabled = !channel.settings.uplink_enabled;
+    sendSetChannel(channel);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+static void test_setChannel_noop_doesNotReloadRadio()
+{
+    usePresetLongFast();
+    const meshtastic_Channel channel = makeChannel(0, meshtastic_Channel_Role_PRIMARY, "LongFast", DEFAULT_KEY, 1);
+    sendSetChannel(channel);
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendSetChannel(channel);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+static void test_setChannel_primaryNameChange_triggersRadioReload()
+{
+    usePresetLongFast();
+    sendSetChannel(makeChannel(0, meshtastic_Channel_Role_PRIMARY, "LongFast", DEFAULT_KEY, 1));
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendSetChannel(makeChannel(0, meshtastic_Channel_Role_PRIMARY, "FieldTest", DEFAULT_KEY, 1));
+
+    TEST_ASSERT_EQUAL_INT(1, counter.count);
+}
+
+static void test_setChannel_primaryNameChangeWithExplicitFrequency_doesNotReloadRadio()
+{
+    usePresetLongFast();
+    config.lora.override_frequency = 915.0f;
+    sendSetChannel(makeChannel(0, meshtastic_Channel_Role_PRIMARY, "LongFast", DEFAULT_KEY, 1));
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendSetChannel(makeChannel(0, meshtastic_Channel_Role_PRIMARY, "FieldTest", DEFAULT_KEY, 1));
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+static void test_setChannel_primaryNameChangeWithPersistedHashSlot_reloadsRadio()
+{
+    usePresetLongFast();
+    config.lora.channel_num = 1;
+    // Native tests do not initialize the radio-derived default-slot flag.
+    RadioInterface::uses_default_frequency_slot = true;
+    sendSetChannel(makeChannel(0, meshtastic_Channel_Role_PRIMARY, "LongFast", DEFAULT_KEY, 1));
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendSetChannel(makeChannel(0, meshtastic_Channel_Role_PRIMARY, "FieldTest", DEFAULT_KEY, 1));
+
+    TEST_ASSERT_EQUAL_INT(1, counter.count);
+}
+
+static void test_setChannel_pskChange_doesNotReloadRadio()
+{
+    usePresetLongFast();
+    meshtastic_Channel channel = makeChannel(0, meshtastic_Channel_Role_PRIMARY, "LongFast", DEFAULT_KEY, 1);
+    sendSetChannel(channel);
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    channel.settings.psk.size = sizeof(CUSTOM_KEY);
+    memcpy(channel.settings.psk.bytes, CUSTOM_KEY, sizeof(CUSTOM_KEY));
+    sendSetChannel(channel);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+static void test_setConfigLora_liveHardwareFields_dontReloadRadio()
+{
+    usePresetLongFast();
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_lora_tag;
+    c.payload_variant.lora = config.lora;
+    c.payload_variant.lora.tx_enabled = !config.lora.tx_enabled;
+    c.payload_variant.lora.pa_fan_disabled = !config.lora.pa_fan_disabled;
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+static void test_setConfigLora_noop_doesNotReloadRadio()
+{
+    usePresetLongFast();
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_lora_tag;
+    c.payload_variant.lora = config.lora;
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+    sendSetConfig(c);
+
+    TEST_ASSERT_FALSE(mockMeshService->lastRadioAffected);
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+static void test_setConfigLora_policyOnlyChange_doesNotReloadRadio()
+{
+    usePresetLongFast();
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_lora_tag;
+    c.payload_variant.lora = config.lora;
+    c.payload_variant.lora.hop_limit = config.lora.hop_limit + 1;
+    c.payload_variant.lora.ignore_mqtt = !config.lora.ignore_mqtt;
+    c.payload_variant.lora.config_ok_to_mqtt = !config.lora.config_ok_to_mqtt;
+    c.payload_variant.lora.override_duty_cycle = !config.lora.override_duty_cycle;
+    c.payload_variant.lora.ignore_incoming_count = 1;
+    c.payload_variant.lora.ignore_incoming[0] = 0x12345678;
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+static void test_setConfigLora_realChange_triggersRadioReload()
+{
+    usePresetLongFast();
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_lora_tag;
+    c.payload_variant.lora = config.lora;
+    c.payload_variant.lora.modem_preset = meshtastic_Config_LoRaConfig_ModemPreset_MEDIUM_FAST;
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_INT(1, counter.count);
+}
+
+static void test_setConfigNetwork_redactedSecretNoop_doesNotReboot()
+{
+    strncpy(config.network.wifi_psk, "existing-test-secret", sizeof(config.network.wifi_psk) - 1);
+    rebootAtMsec = 0;
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_network_tag;
+    c.payload_variant.network = config.network;
+    strncpy(c.payload_variant.network.wifi_psk, "sekrit", sizeof(c.payload_variant.network.wifi_psk) - 1);
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+    TEST_ASSERT_EQUAL_STRING("existing-test-secret", config.network.wifi_psk);
+}
+
+static void test_setConfigSecurity_noopSet_doesNotReboot()
+{
+    config.has_security = true;
+    config.security = meshtastic_Config_SecurityConfig_init_zero;
+    config.security.private_key.size = 32;
+    config.security.public_key.size = 32;
+    memset(config.security.private_key.bytes, 0x11, 32);
+    memset(config.security.public_key.bytes, 0x22, 32);
+    rebootAtMsec = 0;
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_security_tag;
+    c.payload_variant.security = config.security;
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_UINT32(0, disableBluetoothCallCountForTest);
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+}
+
+static void test_setConfigSecurity_realChange_schedulesReboot()
+{
+    config.has_security = true;
+    config.security = meshtastic_Config_SecurityConfig_init_zero;
+    config.security.private_key.size = 32;
+    config.security.public_key.size = 32;
+    memset(config.security.private_key.bytes, 0x11, 32);
+    memset(config.security.public_key.bytes, 0x22, 32);
+    rebootAtMsec = 0;
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_security_tag;
+    c.payload_variant.security = config.security;
+    c.payload_variant.security.debug_log_api_enabled = true;
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_UINT32(1, disableBluetoothCallCountForTest);
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+}
+
+static void test_setConfigSecurity_rejectedManagedNoop_doesNotReboot()
+{
+    config.has_security = true;
+    config.security = meshtastic_Config_SecurityConfig_init_zero;
+    config.security.private_key.size = 32;
+    config.security.public_key.size = 32;
+    memset(config.security.private_key.bytes, 0x11, 32);
+    memset(config.security.public_key.bytes, 0x22, 32);
+    rebootAtMsec = 0;
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_security_tag;
+    c.payload_variant.security = config.security;
+    c.payload_variant.security.is_managed = true;
+    sendSetConfig(c);
+
+    TEST_ASSERT_FALSE(config.security.is_managed);
+    TEST_ASSERT_EQUAL_UINT32(0, disableBluetoothCallCountForTest);
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+}
+
+static void test_setModuleConfigMqtt_realChangeRebootsAndDisablesBluetooth()
+{
+    moduleConfig.has_mqtt = true;
+    moduleConfig.mqtt = meshtastic_ModuleConfig_MQTTConfig_init_zero;
+    meshtastic_ModuleConfig mc = meshtastic_ModuleConfig_init_zero;
+    mc.which_payload_variant = meshtastic_ModuleConfig_mqtt_tag;
+    mc.payload_variant.mqtt = moduleConfig.mqtt;
+    mc.payload_variant.mqtt.encryption_enabled = true;
+    rebootAtMsec = 0;
+
+    sendSetModuleConfig(mc);
+
+    TEST_ASSERT_EQUAL_UINT32(1, disableBluetoothCallCountForTest);
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+}
+
+static void test_setModuleConfigMqtt_redactedSecretNoop_doesNotRebootOrDisableBluetooth()
+{
+    moduleConfig.has_mqtt = true;
+    moduleConfig.mqtt = meshtastic_ModuleConfig_MQTTConfig_init_zero;
+    strncpy(moduleConfig.mqtt.password, "actual-password", sizeof(moduleConfig.mqtt.password) - 1);
+    meshtastic_ModuleConfig mc = meshtastic_ModuleConfig_init_zero;
+    mc.which_payload_variant = meshtastic_ModuleConfig_mqtt_tag;
+    mc.payload_variant.mqtt = moduleConfig.mqtt;
+    strncpy(mc.payload_variant.mqtt.password, "sekrit", sizeof(mc.payload_variant.mqtt.password) - 1);
+    rebootAtMsec = 0;
+
+    sendSetModuleConfig(mc);
+
+    TEST_ASSERT_EQUAL_STRING("actual-password", moduleConfig.mqtt.password);
+    TEST_ASSERT_EQUAL_UINT32(0, disableBluetoothCallCountForTest);
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+}
+
+static void test_setModuleConfigSerial_noop_doesNotRebootOrDisableBluetooth()
+{
+    moduleConfig.has_serial = true;
+    moduleConfig.serial = meshtastic_ModuleConfig_SerialConfig_init_zero;
+    meshtastic_ModuleConfig mc = meshtastic_ModuleConfig_init_zero;
+    mc.which_payload_variant = meshtastic_ModuleConfig_serial_tag;
+    mc.payload_variant.serial = moduleConfig.serial;
+    rebootAtMsec = 0;
+
+    sendSetModuleConfig(mc);
+
+    TEST_ASSERT_EQUAL_UINT32(0, disableBluetoothCallCountForTest);
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+}
+
+static void test_setModuleConfigSerial_realChangeRebootsAndDisablesBluetooth()
+{
+    moduleConfig.has_serial = true;
+    moduleConfig.serial = meshtastic_ModuleConfig_SerialConfig_init_zero;
+    meshtastic_ModuleConfig mc = meshtastic_ModuleConfig_init_zero;
+    mc.which_payload_variant = meshtastic_ModuleConfig_serial_tag;
+    mc.payload_variant.serial = moduleConfig.serial;
+    mc.payload_variant.serial.echo = true;
+    rebootAtMsec = 0;
+
+    sendSetModuleConfig(mc);
+
+    TEST_ASSERT_EQUAL_UINT32(1, disableBluetoothCallCountForTest);
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+}
+
+static void test_setModuleConfigTelemetry_noop_doesNotRebootOrDisableBluetooth()
+{
+    moduleConfig.has_telemetry = true;
+    moduleConfig.telemetry = meshtastic_ModuleConfig_TelemetryConfig_init_zero;
+    moduleConfig.telemetry.device_update_interval = 300;
+    meshtastic_ModuleConfig mc = meshtastic_ModuleConfig_init_zero;
+    mc.which_payload_variant = meshtastic_ModuleConfig_telemetry_tag;
+    mc.payload_variant.telemetry = moduleConfig.telemetry;
+    rebootAtMsec = 0;
+
+    sendSetModuleConfig(mc);
+
+    TEST_ASSERT_EQUAL_UINT32(0, disableBluetoothCallCountForTest);
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+}
+
+static void test_setModuleConfigTelemetry_realChangeRebootsAndDisablesBluetooth()
+{
+    moduleConfig.has_telemetry = true;
+    moduleConfig.telemetry = meshtastic_ModuleConfig_TelemetryConfig_init_zero;
+    moduleConfig.telemetry.device_update_interval = 300;
+    meshtastic_ModuleConfig mc = meshtastic_ModuleConfig_init_zero;
+    mc.which_payload_variant = meshtastic_ModuleConfig_telemetry_tag;
+    mc.payload_variant.telemetry = moduleConfig.telemetry;
+    mc.payload_variant.telemetry.device_update_interval = 600;
+    rebootAtMsec = 0;
+
+    sendSetModuleConfig(mc);
+
+    TEST_ASSERT_EQUAL_UINT32(1, disableBluetoothCallCountForTest);
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+}
+
+static void test_transaction_duplicateBegin_preservesRadioReload()
+{
+    usePresetLongFast();
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendBeginEdit();
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_lora_tag;
+    c.payload_variant.lora = config.lora;
+    c.payload_variant.lora.modem_preset = meshtastic_Config_LoRaConfig_ModemPreset_MEDIUM_FAST;
+    sendSetConfig(c);
+    sendBeginEdit();
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL_INT(1, counter.count);
+}
+
+static void test_transaction_duplicateBegin_preservesReboot()
+{
+    config.position.rx_gpio = 0;
+    rebootAtMsec = 0;
+
+    sendBeginEdit();
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.rx_gpio = 17;
+    sendSetConfig(c);
+    sendBeginEdit();
+    sendCommitEdit();
+
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+}
+
+static void test_transaction_liveOnlyCommit_doesNotDisableBluetooth()
+{
+    sendBeginEdit();
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.position_broadcast_secs = config.position.position_broadcast_secs + 60;
+    sendSetConfig(c);
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL_UINT32(0, disableBluetoothCallCountForTest);
+}
+
+static void test_transaction_mqttNoop_keepsBluetoothUntilCommit()
+{
+    moduleConfig.has_mqtt = true;
+    moduleConfig.mqtt = meshtastic_ModuleConfig_MQTTConfig_init_zero;
+    strncpy(moduleConfig.mqtt.password, "actual-password", sizeof(moduleConfig.mqtt.password) - 1);
+    meshtastic_ModuleConfig mc = meshtastic_ModuleConfig_init_zero;
+    mc.which_payload_variant = meshtastic_ModuleConfig_mqtt_tag;
+    mc.payload_variant.mqtt = moduleConfig.mqtt;
+    strncpy(mc.payload_variant.mqtt.password, "sekrit", sizeof(mc.payload_variant.mqtt.password) - 1);
+
+    sendBeginEdit();
+    sendSetModuleConfig(mc);
+    TEST_ASSERT_EQUAL_UINT32(0, disableBluetoothCallCountForTest);
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL_UINT32(0, disableBluetoothCallCountForTest);
+}
+
+static void test_transaction_mqttRealChange_disablesBluetoothAtCommit()
+{
+    moduleConfig.has_mqtt = true;
+    moduleConfig.mqtt = meshtastic_ModuleConfig_MQTTConfig_init_zero;
+    meshtastic_ModuleConfig mc = meshtastic_ModuleConfig_init_zero;
+    mc.which_payload_variant = meshtastic_ModuleConfig_mqtt_tag;
+    mc.payload_variant.mqtt = moduleConfig.mqtt;
+    mc.payload_variant.mqtt.encryption_enabled = true;
+    rebootAtMsec = 0;
+
+    sendBeginEdit();
+    sendSetModuleConfig(mc);
+    TEST_ASSERT_EQUAL_UINT32(0, disableBluetoothCallCountForTest);
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL_UINT32(1, disableBluetoothCallCountForTest);
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+}
+
+static void test_transaction_rebootingCommit_disablesBluetooth()
+{
+    config.position.rx_gpio = 0;
+    sendBeginEdit();
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.rx_gpio = 17;
+    sendSetConfig(c);
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL_UINT32(1, disableBluetoothCallCountForTest);
+}
+
+static void test_transaction_serialNoop_keepsBluetoothUntilCommit()
+{
+    moduleConfig.has_serial = true;
+    moduleConfig.serial = meshtastic_ModuleConfig_SerialConfig_init_zero;
+    meshtastic_ModuleConfig mc = meshtastic_ModuleConfig_init_zero;
+    mc.which_payload_variant = meshtastic_ModuleConfig_serial_tag;
+    mc.payload_variant.serial = moduleConfig.serial;
+
+    sendBeginEdit();
+    sendSetModuleConfig(mc);
+    TEST_ASSERT_EQUAL_UINT32(0, disableBluetoothCallCountForTest);
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL_UINT32(0, disableBluetoothCallCountForTest);
+}
+
+static void test_transaction_serialRealChange_disablesBluetoothAtCommit()
+{
+    moduleConfig.has_serial = true;
+    moduleConfig.serial = meshtastic_ModuleConfig_SerialConfig_init_zero;
+    meshtastic_ModuleConfig mc = meshtastic_ModuleConfig_init_zero;
+    mc.which_payload_variant = meshtastic_ModuleConfig_serial_tag;
+    mc.payload_variant.serial = moduleConfig.serial;
+    mc.payload_variant.serial.echo = true;
+    rebootAtMsec = 0;
+
+    sendBeginEdit();
+    sendSetModuleConfig(mc);
+    TEST_ASSERT_EQUAL_UINT32(0, disableBluetoothCallCountForTest);
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL_UINT32(1, disableBluetoothCallCountForTest);
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+}
+
+static void test_transaction_usToHamWithExplicitDefaultName_reloadsRadioOnce()
+{
+    assertUsToHamTransactionReloadsOnce("NarrowSlow");
+}
+
+static void test_transaction_usToHamWithImplicitDefaultName_reloadsRadioOnce()
+{
+    assertUsToHamTransactionReloadsOnce("");
+}
+
 // -----------------------------------------------------------------------
 // Node menu mute toggle (graphics::menuHandler::toggleNodeMuted)
 // -----------------------------------------------------------------------
@@ -3015,6 +3566,41 @@ void setup()
     RUN_TEST(test_setConfigPosition_gpsFromNotPresent_stillReboots);
     RUN_TEST(test_setConfigPosition_gpsToggleWithGpioChange_stillReboots);
     RUN_TEST(test_transaction_gpioSet_reboots_butDoesNotReloadRadio);
+    RUN_TEST(test_setChannel_primaryNameChange_triggersRadioReload);
+    RUN_TEST(test_setChannel_primaryNameChangeWithExplicitFrequency_doesNotReloadRadio);
+    RUN_TEST(test_setChannel_primaryNameChangeWithPersistedHashSlot_reloadsRadio);
+    RUN_TEST(test_setChannel_noop_doesNotReloadRadio);
+    RUN_TEST(test_setChannel_mqttFlagChange_doesNotReloadRadio);
+    RUN_TEST(test_setChannel_pskChange_doesNotReloadRadio);
+    RUN_TEST(test_setChannel_hamDefaultNameImplicitToExplicit_doesNotReloadRadio);
+    RUN_TEST(test_setChannel_hamDefaultNameExplicitToImplicit_doesNotReloadRadio);
+    RUN_TEST(test_transaction_usToHamWithExplicitDefaultName_reloadsRadioOnce);
+    RUN_TEST(test_transaction_usToHamWithImplicitDefaultName_reloadsRadioOnce);
+    RUN_TEST(test_setConfigLora_realChange_triggersRadioReload);
+    RUN_TEST(test_setConfigLora_noop_doesNotReloadRadio);
+    RUN_TEST(test_setConfigLora_policyOnlyChange_doesNotReloadRadio);
+    RUN_TEST(test_setConfigLora_liveHardwareFields_dontReloadRadio);
+    RUN_TEST(test_setConfigNetwork_redactedSecretNoop_doesNotReboot);
+    RUN_TEST(test_setConfigSecurity_noopSet_doesNotReboot);
+    RUN_TEST(test_setConfigSecurity_realChange_schedulesReboot);
+    RUN_TEST(test_setConfigSecurity_rejectedManagedNoop_doesNotReboot);
+    RUN_TEST(test_setModuleConfigMqtt_redactedSecretNoop_doesNotRebootOrDisableBluetooth);
+    RUN_TEST(test_setModuleConfigSerial_noop_doesNotRebootOrDisableBluetooth);
+    RUN_TEST(test_setModuleConfigTelemetry_noop_doesNotRebootOrDisableBluetooth);
+    RUN_TEST(test_setModuleConfigTelemetry_realChangeRebootsAndDisablesBluetooth);
+    RUN_TEST(test_setModuleConfigMqtt_realChangeRebootsAndDisablesBluetooth);
+    RUN_TEST(test_setModuleConfigSerial_realChangeRebootsAndDisablesBluetooth);
+    RUN_TEST(test_transaction_mqttNoop_keepsBluetoothUntilCommit);
+    RUN_TEST(test_transaction_mqttRealChange_disablesBluetoothAtCommit);
+    RUN_TEST(test_transaction_serialNoop_keepsBluetoothUntilCommit);
+    RUN_TEST(test_transaction_serialRealChange_disablesBluetoothAtCommit);
+    RUN_TEST(test_transaction_liveOnlyCommit_doesNotDisableBluetooth);
+    RUN_TEST(test_transaction_rebootingCommit_disablesBluetooth);
+    RUN_TEST(test_transaction_duplicateBegin_preservesRadioReload);
+    RUN_TEST(test_transaction_duplicateBegin_preservesReboot);
+    RUN_TEST(test_abandonedTransaction_rebootingFieldRebootsOnExpiry);
+    RUN_TEST(test_abandonedTransaction_timerExpiresWithoutAdminTraffic);
+    RUN_TEST(test_editTransactionTimer_isDormantUntilTransactionBegins);
 #if HAS_SCREEN
     // Node menu mute toggle
     RUN_TEST(test_toggleNodeMuted_flipsBitAndSkipsRadioReload);


### PR DESCRIPTION
Config saves currently conflate three independent decisions: which `/prefs` files to persist, whether the LoRa chip needs re-initialising, and whether a reboot is required. They were spread across four helpers with three different parameter orders, two of which took adjacent `bool`s. This narrows each side effect to the cases that need it, then unifies the entry point.

## Why

`reloadConfig()` ends with an unconditional `saveToDisk(saveWhat)` *outside* its radio-reload guard. Two consequences:

- Any save touching `SEGMENT_CONFIG` re-initialised the SX126x, even for a display setting. That SPI reconfigure is the mechanism behind the WisMesh Tag favourite-node crash.
- `saveToDisk(X); reloadConfig(X, …)` writes the same proto file twice. Nine InkHUD menu sites did this, one of them a shared helper with five callers — thirteen menu actions affected.

InkHUD's `applyConfigReload(changes, reboot)` was the sharp edge: its second parameter sat exactly where `reloadConfig` and `saveChanges` take `radioAffected`, so `true` meant the opposite of how it read.

## What changed

**Radio reloads** are now opt-in per save. `reloadConfig` gains `radioAffected`; `handleSetConfig` sets it only for the LoRa sub-message. Node-DB saves (favourite/ignore/mute) and every non-LoRa config sub-message no longer touch the radio.

**Reboots** are dropped where the field is read live — position broadcast interval, smart-position toggle — and suppressed for no-op sets, so writing an unchanged Bluetooth config no longer drops the BLE link the phone is using. GPS-timing fields still reboot; `docs/admin-config-save-gating.md` records which fields need what and why.

**Redundant writes removed.** Nine double-writes; five BaseUI `saveUIConfig()` calls against fields that live in `config.proto`, not `uiconfig.proto`; one inverse case; three bare `saveToDisk()` calls that rewrote all five segments to change one bit.

**One entry point.** `MeshService::applyConfigChange(saveWhat, flags, rebootSeconds)` with a flags enum, so each of the 44 call sites states its intent and cannot silently mean the opposite. `applyConfigReload` is deleted; `applyLoRaRegion`/`applyLoRaPreset` stay, since they hold real domain logic, and delegate. `AdminModule::saveChanges` keeps its signature and its edit-transaction deferral. Reboot scheduling moves into `requestReboot()` next to `rebootAtMsec` — previously only AdminModule had a helper for this and it was private, which is why every menu open-coded the deadline.

**Menu actions are now testable.** Every menu save lived in a lambda reachable only via `screen->showOverlayBanner()`, so none of it could be exercised — which is why these defects went unnoticed. Three actions are lifted into plain functions.

## Bug fixed along the way

The three telemetry screen toggles in the frame-toggle menu changed `moduleConfig` in memory and never persisted it, so they reverted on any reboot that didn't go through the reboot menu. Their sibling entries in the same menu persist via `toggleFrameVisibility`, so half that menu was durable and three entries weren't.

## Testing

`test/test_admin_radio` — **117 cases, all passing** (`./bin/run-tests.sh -e native -f test_admin_radio`). Covers per-sub-message radio-reload gating, reboot gating including no-op sets, the flags semantics and their composition, the `reloadConfig(X, false) == saveToDisk(X)` equivalence the deletions rely on, and the extracted menu actions.

Flash, `nrf52_promicro_diy_tcxo` (the tightest target, 98.3% used with ~1.3 KB real headroom before the warmstore region):

| stage | used    | Δ         |
| ----- | ------: | --------: |
| base  | 801,480 | —         |
| final | 801,448 | **−32 B** |

Every intermediate commit passes the warm-region guard; peak was +48 B.

## Not verified

- **On-device testing outstanding.** The menu call sites aren't reachable from unit tests, so they need manual verification on one BaseUI and one nRF52 InkHUD board.
- **`MenuApplet.cpp` is compile-verified but not link-verified.** All nRF52 InkHUD envs currently fail to link on `develop` with `Error: offset out of range` in LTO codegen — reproduced on clean `6d944e44d` with none of these commits, so it's a pre-existing upstream break, but it does mean the InkHUD changes here haven't been through a full link.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **New Features**
  - Introduced consistent config apply modes: live apply (radio), reboot-required, or no live/reboot.
- **Bug Fixes**
  - Reduced unnecessary live radio reconfiguration to only LoRa/channel-impacting changes.
  - Avoided reboots for byte-identical “no-op” updates.
- **Documentation**
  - Added guidance describing admin config-save side effects and safe extension rules.
- **UI/Behavior**
  - Updated menu actions so each setting uses the correct apply mode; added “applying changes” notifications for relevant updates.
- **Tests**
  - Expanded validation for apply gating, notifications, and reboot/no-op timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->