### PR TITLE
Deliver locally-generated replies addressed to us to the phone

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -324,13 +324,24 @@ void MeshService::sendToMesh(meshtastic_MeshPacket *p, RxSource src, bool ccToPh
     uint32_t mesh_packet_id = p->id;
     nodeDB->updateFrom(*p); // update our local DB for this packet (because phone might have sent position packets etc...)
 
+    // A locally-generated packet addressed to ourselves (e.g. a module's response to a
+    // phone-originated admin/config request) can only be consumed by local API clients:
+    // sendLocal() dispatches it with src preserved, and the loopback gate in
+    // MeshModule::callModules hides RX_SRC_LOCAL packets from RoutingModule, the phone
+    // forwarder. Deliver the phone's copy here or the client times out waiting for it.
+    const bool localDelivery = isToUs(p);
+    if (src == RX_SRC_LOCAL && localDelivery)
+        ccToPhone = true;
+
     // Note: We might return !OK if our fifo was full, at that point the only option we have is to drop it
     ErrorCode res = router->sendLocal(p, src);
 
     /* NOTE(pboldin): Prepare and send QueueStatus message to the phone as a
      * high-priority message. */
     meshtastic_QueueStatus qs = router->getQueueStatus();
-    ErrorCode r = sendQueueStatusToPhone(qs, res, mesh_packet_id);
+    // Local delivery reports ERRNO_SHOULD_RELEASE (caller frees) - that is success, not a
+    // failure the phone should surface in the QueueStatus.
+    ErrorCode r = sendQueueStatusToPhone(qs, (res == ERRNO_SHOULD_RELEASE && localDelivery) ? ERRNO_OK : res, mesh_packet_id);
     if (r != ERRNO_OK) {
         LOG_DEBUG("Can't send status to phone");
     }

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -324,11 +324,8 @@ void MeshService::sendToMesh(meshtastic_MeshPacket *p, RxSource src, bool ccToPh
     uint32_t mesh_packet_id = p->id;
     nodeDB->updateFrom(*p); // update our local DB for this packet (because phone might have sent position packets etc...)
 
-    // A locally-generated packet addressed to ourselves (e.g. a module's response to a
-    // phone-originated admin/config request) can only be consumed by local API clients:
-    // sendLocal() dispatches it with src preserved, and the loopback gate in
-    // MeshModule::callModules hides RX_SRC_LOCAL packets from RoutingModule, the phone
-    // forwarder. Deliver the phone's copy here or the client times out waiting for it.
+    // callModules' loopback gate keeps RX_SRC_LOCAL packets from RoutingModule, the only module
+    // that forwards to the phone, so deliver our own reply's copy here or the client never sees it.
     const bool localDelivery = isToUs(p);
     if (src == RX_SRC_LOCAL && localDelivery)
         ccToPhone = true;
@@ -339,8 +336,7 @@ void MeshService::sendToMesh(meshtastic_MeshPacket *p, RxSource src, bool ccToPh
     /* NOTE(pboldin): Prepare and send QueueStatus message to the phone as a
      * high-priority message. */
     meshtastic_QueueStatus qs = router->getQueueStatus();
-    // Local delivery reports ERRNO_SHOULD_RELEASE (caller frees) - that is success, not a
-    // failure the phone should surface in the QueueStatus.
+    // SHOULD_RELEASE means "caller frees", not a send failure, so don't report it as one.
     ErrorCode r = sendQueueStatusToPhone(qs, (res == ERRNO_SHOULD_RELEASE && localDelivery) ? ERRNO_OK : res, mesh_packet_id);
     if (r != ERRNO_OK) {
         LOG_DEBUG("Can't send status to phone");

--- a/test/test_mesh_module/test_main.cpp
+++ b/test/test_mesh_module/test_main.cpp
@@ -473,14 +473,7 @@ static void test_dispatch_realNeighborInfoCannotShadowTelemetryOwner()
     TEST_ASSERT_EQUAL_UINT32(0, mockRoutingModule->ackNaks.size());
 }
 
-// Regression tests for the 2.8 config-timeout report (regressed by PR #10967): sendLocal now
-// preserves src, so a module reply addressed to the local node reaches callModules as
-// RX_SRC_LOCAL, where the loopback gate hides it from RoutingModule - the only path into the
-// phone queue. MeshService::sendToMesh must deliver the phone's copy itself.
-
-// A module-style reply addressed to ourselves must land in the phone queue, and its
-// QueueStatus must report success (not ERRNO_SHOULD_RELEASE) even though sendLocal asked the
-// caller to release it.
+// A reply addressed to ourselves reaches the phone queue, with SHOULD_RELEASE reported as success.
 static void test_localReplyToSelf_isDeliveredToPhone()
 {
     meshtastic_MeshPacket reply = meshtastic_MeshPacket_init_zero;
@@ -535,11 +528,14 @@ static void test_phoneRequest_replyReachesPhone()
     mockService->releaseToPool(toPhone);
     TEST_ASSERT_NULL(mockService->getForPhone()); // the request itself must not echo back
 
-    // Both the request's and the reply's QueueStatus report success
+    // One QueueStatus for the request, one for the reply, both reporting success
+    uint32_t statuses = 0;
     while (auto *qs = mockService->getQueueStatusForPhone()) {
         TEST_ASSERT_EQUAL(ERRNO_OK, qs->res);
         mockService->releaseQueueStatusToPool(qs);
+        statuses++;
     }
+    TEST_ASSERT_EQUAL_UINT32(2, statuses);
 
     TEST_ASSERT_EQUAL_UINT32(0, mockRouter->sentPackets.size());
     TEST_ASSERT_EQUAL_UINT32(0, mockRoutingModule->ackNaks.size());

--- a/test/test_mesh_module/test_main.cpp
+++ b/test/test_mesh_module/test_main.cpp
@@ -256,6 +256,8 @@ void tearDown(void)
 
     while (auto *status = mockService->getQueueStatusForPhone())
         mockService->releaseQueueStatusToPool(status);
+    while (auto *toPhone = mockService->getForPhone())
+        mockService->releaseToPool(toPhone);
     delete mockService;
     mockService = nullptr;
     service = nullptr;
@@ -471,6 +473,78 @@ static void test_dispatch_realNeighborInfoCannotShadowTelemetryOwner()
     TEST_ASSERT_EQUAL_UINT32(0, mockRoutingModule->ackNaks.size());
 }
 
+// Regression tests for the 2.8 config-timeout report (regressed by PR #10967): sendLocal now
+// preserves src, so a module reply addressed to the local node reaches callModules as
+// RX_SRC_LOCAL, where the loopback gate hides it from RoutingModule - the only path into the
+// phone queue. MeshService::sendToMesh must deliver the phone's copy itself.
+
+// A module-style reply addressed to ourselves must land in the phone queue, and its
+// QueueStatus must report success (not ERRNO_SHOULD_RELEASE) even though sendLocal asked the
+// caller to release it.
+static void test_localReplyToSelf_isDeliveredToPhone()
+{
+    meshtastic_MeshPacket reply = meshtastic_MeshPacket_init_zero;
+    reply.from = LOCAL_NODE;
+    reply.to = LOCAL_NODE;
+    reply.id = 0xABCD1234;
+    reply.which_payload_variant = meshtastic_MeshPacket_decoded_tag;
+    reply.decoded.portnum = meshtastic_PortNum_ADMIN_APP;
+    reply.decoded.request_id = 0x12345678;
+
+    service->sendToMesh(packetPool.allocCopy(reply)); // default src == RX_SRC_LOCAL, as callModules sends replies
+
+    meshtastic_MeshPacket *toPhone = mockService->getForPhone();
+    TEST_ASSERT_NOT_NULL(toPhone);
+    TEST_ASSERT_EQUAL_UINT32(0xABCD1234, toPhone->id);
+    TEST_ASSERT_EQUAL_UINT32(0x12345678, toPhone->decoded.request_id);
+    mockService->releaseToPool(toPhone);
+    TEST_ASSERT_NULL(mockService->getForPhone()); // exactly one delivery
+
+    meshtastic_QueueStatus *qs = mockService->getQueueStatusForPhone();
+    TEST_ASSERT_NOT_NULL(qs);
+    TEST_ASSERT_EQUAL(ERRNO_OK, qs->res);
+    mockService->releaseQueueStatusToPool(qs);
+
+    TEST_ASSERT_EQUAL_UINT32(0, mockRouter->sentPackets.size()); // nothing went toward the radio
+}
+
+// Full loop: a phone-originated want_response request (from == 0, RX_SRC_USER) dispatched
+// through the real router must produce a module reply that reaches the phone queue.
+static void test_phoneRequest_replyReachesPhone()
+{
+    auto *replyOwner = registerDispatchModule(
+        new SyntheticReplyModule("private-owner", meshtastic_PortNum_PRIVATE_APP, meshtastic_PortNum_PRIVATE_APP));
+
+    meshtastic_MeshPacket request = meshtastic_MeshPacket_init_zero;
+    request.from = 0; // phone-originated, as MeshService::handleToRadio stamps it
+    request.to = LOCAL_NODE;
+    request.id = 0x5EED0001;
+    request.which_payload_variant = meshtastic_MeshPacket_decoded_tag;
+    request.decoded.portnum = meshtastic_PortNum_PRIVATE_APP;
+    request.decoded.want_response = true;
+
+    service->sendToMesh(packetPool.allocCopy(request), RX_SRC_USER);
+
+    TEST_ASSERT_EQUAL_UINT32(1, replyOwner->allocReplyCalls);
+
+    meshtastic_MeshPacket *toPhone = mockService->getForPhone();
+    TEST_ASSERT_NOT_NULL(toPhone);
+    TEST_ASSERT_EQUAL(meshtastic_PortNum_PRIVATE_APP, toPhone->decoded.portnum);
+    TEST_ASSERT_EQUAL_UINT32(0x5EED0001, toPhone->decoded.request_id);
+    TEST_ASSERT_EQUAL_UINT32(LOCAL_NODE, toPhone->to);
+    mockService->releaseToPool(toPhone);
+    TEST_ASSERT_NULL(mockService->getForPhone()); // the request itself must not echo back
+
+    // Both the request's and the reply's QueueStatus report success
+    while (auto *qs = mockService->getQueueStatusForPhone()) {
+        TEST_ASSERT_EQUAL(ERRNO_OK, qs->res);
+        mockService->releaseQueueStatusToPool(qs);
+    }
+
+    TEST_ASSERT_EQUAL_UINT32(0, mockRouter->sentPackets.size());
+    TEST_ASSERT_EQUAL_UINT32(0, mockRoutingModule->ackNaks.size());
+}
+
 void setup()
 {
     initializeTestEnvironment();
@@ -495,6 +569,8 @@ void setup()
     RUN_TEST(test_dispatch_noResponderSendsNak);
     RUN_TEST(test_dispatch_ignoreRequestIsClearedPerPacket);
     RUN_TEST(test_dispatch_realNeighborInfoCannotShadowTelemetryOwner);
+    RUN_TEST(test_localReplyToSelf_isDeliveredToPhone);
+    RUN_TEST(test_phoneRequest_replyReachesPhone);
     exit(UNITY_END());
 }
 


### PR DESCRIPTION
## The bug

Config get/set from a client times out on every device running current develop. The client
connects fine and downloads config at connect, but opening a config screen or changing a
setting (e.g. Device Role) times out.

Reported by an alpha tester on a Seeed Xiao nRF52840 Kit against `2.8.0.ef1aedd`, working on
`2.8.0.5ded0ec`. It is not board- or app-specific — both Android 2.8.0 and 2.7.14 behave the
same, and the mechanism is platform-independent.

## Regression

`d6b12ea3f` (#10967, packet authenticity policies) changed `Router::sendLocal`'s `isToUs`
branch:

```diff
-        enqueueReceivedMessage(p);
-        return ERRNO_OK;
+        handleReceived(p, src);
+        return ERRNO_SHOULD_RELEASE;
```

Preserving the `RxSource` is the right call — the queue round-trip used to relabel local
packets `RX_SRC_RADIO`, which is exactly the confusion the new policy gates need gone. But
module replies are sent through `MeshService::sendToMesh()` with the default `RX_SRC_LOCAL`,
and a reply to a phone-originated request is addressed to our own node (`setReplyTo` resolves
`from == 0` to `ourNodeNum`). So those replies now re-enter `callModules` as `RX_SRC_LOCAL`,
where the loopback gate skips every module with `loopbackOk == false`:

https://github.com/meshtastic/firmware/blob/develop/src/mesh/MeshModule.cpp#L121-L124

That includes `RoutingModule`, whose promiscuous sniff is the only code that moves a received
packet into `toPhoneQueue`:

https://github.com/meshtastic/firmware/blob/develop/src/modules/RoutingModule.cpp#L35-L38

The reply is released without ever being queued.

Requests still work, because the phone's own packets arrive as `RX_SRC_USER` and pass the
gate. So a `set_config` **is applied** and only its acknowledgement is lost — which is why a
client can connect and download config but times out on every config screen and every setter.
Testers who saw a timeout may find the setting actually took effect.

## The fix

Deliver the phone's copy from `sendToMesh()` for a local packet addressed to us. The loopback
gate is doing its job keeping the packet out of module re-dispatch; the phone copy is the part
that went missing.

Two alternatives I ruled out:

- `loopbackOk = true` on `RoutingModule` — would also echo every locally-generated *broadcast*
  (position, nodeinfo, telemetry) back to the phone through the promiscuous sniff.
- Relabeling module replies `RX_SRC_RADIO` in `sendLocal` — re-muddles the exact local/remote
  distinction #10967 introduced.

Also stops reporting `ERRNO_SHOULD_RELEASE` (35) to the phone in the `QueueStatus` for these
packets. It means "caller frees", not a send failure, and the same hunk changed it from the 0
the phone used to see.

## Tests

Two regression tests in `test/test_mesh_module`:

- `test_localReplyToSelf_isDeliveredToPhone` — a reply addressed to ourselves reaches the
  phone queue exactly once, with a success `QueueStatus` and no radio traffic.
- `test_phoneRequest_replyReachesPhone` — full loop through the real router: a `from == 0`
  `want_response` request produces a module reply that reaches the phone queue with the right
  `request_id`, and the request itself does not echo back.

Both fail on unpatched develop (empty phone queue) and pass with the fix.

## Validation

Native suites with the fix applied: **native-macos 577 cases, 573 passed + 4
environment-conditional ignores, 0 failed**; **Docker 751/751 passed**.

End-to-end on the portduino simulator over the TCP PhoneAPI (same client path as BLE), as a
minimal pair at the reporter's exact commit `ef1aedd56`, with only `MeshService.cpp` differing:

| | unpatched `ef1aedd56` | `ef1aedd56` + this fix |
|---|---|---|
| `--set device.role CLIENT_MUTE` | hangs >180 s (killed) | completes in 0.6 s, persists across reboot |
| `--get-ringtone` (admin round-trip) | hangs >180 s (killed) | completes in 0.4 s |
| `--get device.role` | works | works |

`--get device.role` passing on both is itself diagnostic — the Python CLI serves it from the
want_config cache rather than an admin round-trip, which is the same reason a client can
connect while every config screen times out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured locally addressed module replies are consistently delivered to the phone callback/queue.
  - Updated queue status forwarding so local delivery failures are no longer reported incorrectly.
  - Prevented phone-originated requests/replies from being echoed back or sent to the radio.
- **Tests**
  - Added regression tests covering local reply-to-phone delivery and phone request response routing.
  - Improved test teardown to properly drain pending phone deliveries and statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->