### PR TITLE
Actions: Run --level pr on merge_group (for now)

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -3,31 +3,31 @@ concurrency:
   group: ci-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 on:
-  # Full CI now runs in the merge queue instead of on post-merge push. PRs build a
-  # narrowed board subset (--level pr) for fast feedback; the merge queue rebuilds
-  # the full release matrix against the merged result before it lands. Because the
-  # merge_group run is the gate, there is nothing left to rebuild after the merge
-  # commit reaches the protected branch - so the old `push` trigger is dropped.
-  #
-  # merge_group events have an empty github.head_ref, so the existing setup job
-  # (which keys off GITHUB_HEAD_REF) produces the full matrix automatically.
-  # Note: merge_group does not support paths/paths-ignore filters - it always runs
-  # the full required checks, which is what a merge queue needs (branch protection
-  # cannot skip a required check).
+  # The merge queue is the pre-merge gate for the protected branches (master,
+  # develop): a merge_group run validates the merged result before code lands. For
+  # now PRs and merge_group runs build the same narrowed board subset (--level pr);
+  # see the setup job. push still runs the full matrix on master/develop (post-merge)
+  # as well as on the event/* and feature/* branches, which have no merge queue.
   merge_group:
     types: [checks_requested]
     branches:
       - master
       - develop
-      - pioarduino # Remove when merged // use `feature/` in the future.
+
+  push:
+    branches:
+      - master
+      - develop
       - event/*
       - feature/*
+    paths-ignore:
+      - "**.md"
+      - version.properties
 
   pull_request:
     branches:
       - master
       - develop
-      - pioarduino # Remove when merged // use `feature/` in the future.
       - event/*
       - feature/*
     paths-ignore:
@@ -36,9 +36,9 @@ on:
 
   schedule:
     # Nightly develop build, published to meshtastic.github.io firmware-nightly/ (no GitHub release).
-    # Scheduled runs execute on the default branch (develop). 09:00 UTC avoids the 00:00 tests
+    # Scheduled runs execute on the default branch (develop). 07:00 UTC avoids the 00:00 tests
     # and 02:00 daily_packaging crons.
-    - cron: 0 9 * * * # Nightly develop build/publish (default branch is develop)
+    - cron: 0 7 * * * # Nightly develop build/publish (default branch is develop)
 
   workflow_dispatch:
     inputs:
@@ -69,10 +69,12 @@ jobs:
       - name: Generate matrix
         id: jsonStep
         run: |
-          if [[ "$GITHUB_HEAD_REF" == "" ]]; then
-            TARGETS=$(./bin/generate_ci_matrix.py ${{matrix.arch}})
-          else  
+          # PRs and (for now) merge_group builds use the narrowed --level pr board
+          # subset. Full-matrix builds run on push / schedule / workflow_dispatch.
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
             TARGETS=$(./bin/generate_ci_matrix.py ${{matrix.arch}} --level pr)
+          else
+            TARGETS=$(./bin/generate_ci_matrix.py ${{matrix.arch}})
           fi
           echo "Name: $GITHUB_REF_NAME Base: $GITHUB_BASE_REF Ref: $GITHUB_REF"
           echo "${{matrix.arch}}=$TARGETS" >> $GITHUB_OUTPUT


### PR DESCRIPTION
merge_group jobs run individually and *then* push. For now treat them like PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated CI triggers to stop considering the `pioarduino` branch for `merge_group` and `pull_request`.
  * Refined CI to run on `event/*` and `feature/*` branches for `push`, while skipping changes limited to `**.md` and `version.properties`.
  * Adjusted scheduled CI timing (moved earlier) and unified PR-level build handling for both `pull_request` and `merge_group`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->