### PR TITLE
mark way fewer boards as board_level = pr

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -646,6 +646,10 @@ Variants can specify their support level in `platformio.ini`:
 
 - `custom_meshtastic_support_level = 1` - Actively supported, built on every PR
 - `custom_meshtastic_support_level = 2` - Supported, built on merge to main branches
+- `board_level = pr` - Built on PRs for fast feedback. Exactly one board per
+  platform (the most feature-complete one) carries this flag; do not add it to
+  new variants. The full matrix runs in the merge queue.
+- (no `board_level`) - Default: built on full runs (merge queue, releases)
 - `board_level = extra` - Extra builds, only on full releases
 
 ### Running Workflows Locally

--- a/.github/prompts/new-variant.prompt.md
+++ b/.github/prompts/new-variant.prompt.md
@@ -112,6 +112,7 @@ upload_speed = 921600
 
 - `custom_meshtastic_support_level = 1` - Built on every PR (actively supported)
 - `custom_meshtastic_support_level = 2` - Built only on merge to main branches
+- `board_level = pr` - PR fast-feedback build; reserved for one board per platform, do not set on new variants
 - `board_level = extra` - Only built on full releases
 
 ## Build Manifest Metadata

--- a/variants/esp32/rak11200/platformio.ini
+++ b/variants/esp32/rak11200/platformio.ini
@@ -10,7 +10,6 @@ custom_meshtastic_tags = RAK
 
 extends = esp32_base
 board = wiscore_rak11200
-board_level = pr
 board_check = true
 build_flags = 
   ${esp32_base.build_flags}

--- a/variants/esp32/tbeam/platformio.ini
+++ b/variants/esp32/tbeam/platformio.ini
@@ -12,6 +12,7 @@ custom_meshtastic_tags = LilyGo
 extends = esp32_base
 board = ttgo-tbeam
 
+board_level = pr
 board_check = true
 build_flags = ${esp32_base.build_flags}
   -D TBEAM_V10

--- a/variants/esp32s3/elecrow_panel/platformio.ini
+++ b/variants/esp32s3/elecrow_panel/platformio.ini
@@ -127,7 +127,6 @@ custom_meshtastic_partition_scheme = 16MB
 custom_meshtastic_has_mui = true
 
 extends = crowpanel_small_esp32s3_base
-board_level = pr
 build_flags =
   ${crowpanel_small_esp32s3_base.build_flags}
   -D LV_CACHE_DEF_SIZE=2097152

--- a/variants/esp32s3/heltec_v3/platformio.ini
+++ b/variants/esp32s3/heltec_v3/platformio.ini
@@ -11,7 +11,6 @@ custom_meshtastic_partition_scheme = 8MB
  
 extends = esp32s3_base
 board = heltec_wifi_lora_32_V3
-board_level = pr
 board_check = true
 board_build.partitions = default_8MB.csv
 build_flags = 

--- a/variants/esp32s3/heltec_v4/platformio.ini
+++ b/variants/esp32s3/heltec_v4/platformio.ini
@@ -24,7 +24,6 @@ custom_meshtastic_partition_scheme = 16MB
 custom_meshtastic_has_mui = true
 
 extends = heltec_v4_base
-board_level = pr
 build_flags =
   ${heltec_v4_base.build_flags}
   -D HELTEC_V4_OLED

--- a/variants/esp32s3/heltec_vision_master_e213/platformio.ini
+++ b/variants/esp32s3/heltec_vision_master_e213/platformio.ini
@@ -37,7 +37,6 @@ upload_speed = 115200
 [env:heltec-vision-master-e213-inkhud]
 extends = esp32s3_base, inkhud
 board = heltec_vision_master_e213
-board_level = pr
 board_build.partitions = default_8MB.csv
 build_src_filter =
   ${esp32s3_base.build_src_filter}

--- a/variants/esp32s3/meshnology-w10/platformio.ini
+++ b/variants/esp32s3/meshnology-w10/platformio.ini
@@ -10,7 +10,6 @@ custom_meshtastic_partition_scheme = 16MB
 
 ; ESP32-S3R8: 8 MB OPI PSRAM, W25Q128JVSIQ = 16 MB QIO flash (pg1)
 board = esp32-s3-devkitc-1
-board_level = pr
 board_build.partitions = default_16MB.csv
 board_upload.flash_size = 16MB
 board_build.flash_mode = qio

--- a/variants/esp32s3/rak3312/platformio.ini
+++ b/variants/esp32s3/rak3312/platformio.ini
@@ -13,7 +13,6 @@ custom_meshtastic_has_mui = false
 
 extends = esp32s3_base
 board = wiscore_rak3312
-board_level = pr
 board_check = true
 upload_protocol = esptool
 

--- a/variants/esp32s3/seeed_xiao_s3/platformio.ini
+++ b/variants/esp32s3/seeed_xiao_s3/platformio.ini
@@ -12,7 +12,6 @@ custom_meshtastic_partition_scheme = 8MB
 
 extends = esp32s3_base
 board = seeed-xiao-s3
-board_level = pr
 board_check = true
 board_build.partitions = default_8MB.csv
 upload_protocol = esptool

--- a/variants/esp32s3/station-g2/platformio.ini
+++ b/variants/esp32s3/station-g2/platformio.ini
@@ -12,7 +12,6 @@ custom_meshtastic_partition_scheme = 16MB
 
 extends = esp32s3_base
 board = station-g2
-board_level = pr
 board_check = true
 board_build.partitions = default_16MB.csv
 board_build.mcu = esp32s3

--- a/variants/esp32s3/station-g3/platformio.ini
+++ b/variants/esp32s3/station-g3/platformio.ini
@@ -12,7 +12,6 @@ custom_meshtastic_partition_scheme = 16MB
 
 extends = esp32s3_base
 board = station-g3
-board_level = pr
 board_check = true
 board_build.partitions = default_16MB.csv
 board_build.mcu = esp32s3

--- a/variants/esp32s3/t-eth-elite/platformio.ini
+++ b/variants/esp32s3/t-eth-elite/platformio.ini
@@ -1,7 +1,6 @@
 [env:t-eth-elite]
 extends = esp32s3_base
 board = esp32s3box
-board_level = pr
 board_check = true
 board_build.partitions = default_16MB.csv
 build_flags = 

--- a/variants/nrf52840/heltec_mesh_node_t096/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_node_t096/platformio.ini
@@ -11,7 +11,6 @@ custom_meshtastic_tags = Heltec
 
 extends = nrf52840_base
 board = heltec_mesh_node_t096
-board_level = pr
 debug_tool = jlink
 
 build_flags = ${nrf52840_base.build_flags}

--- a/variants/nrf52840/heltec_mesh_node_t1/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_node_t1/platformio.ini
@@ -11,7 +11,6 @@ custom_meshtastic_tags = Heltec
 
 extends = nrf52840_base
 board = heltec_mesh_node_t1
-board_level = pr
 debug_tool = jlink
 
 build_flags = ${nrf52840_base.build_flags}

--- a/variants/nrf52840/heltec_mesh_node_t114/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_node_t114/platformio.ini
@@ -11,7 +11,6 @@ custom_meshtastic_tags = Heltec
 
 extends = nrf52840_base
 board = heltec_mesh_node_t114
-board_level = pr
 debug_tool = jlink
 
 # add -DCFG_SYSVIEW if you want to use the Segger systemview tool for OS profiling.

--- a/variants/nrf52840/heltec_mesh_solar/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_solar/platformio.ini
@@ -2,7 +2,6 @@
 [heltec_mesh_solar_base]
 extends = nrf52840_base
 board = heltec_mesh_solar
-board_level = pr
 debug_tool = jlink
 
 # add -DCFG_SYSVIEW if you want to use the Segger systemview tool for OS profiling.

--- a/variants/nrf52840/heltec_mesh_tower_v2/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_tower_v2/platformio.ini
@@ -11,7 +11,6 @@ custom_meshtastic_tags = Heltec
 
 extends = nrf52840_base
 board = heltec_mesh_tower_v2
-board_level = pr
 debug_tool = jlink
 
 # add -DCFG_SYSVIEW if you want to use the Segger systemview tool for OS profiling.

--- a/variants/nrf52840/rak4631/platformio.ini
+++ b/variants/nrf52840/rak4631/platformio.ini
@@ -47,6 +47,7 @@ lib_deps =
 ; RAK10728 WisMesh Repeater Mini V2 (RAK4631 + RAK19003 + solar battery + GPS module)
 [env:rak_wismesh_repeater_mini]
 extends = env:rak4631
+board_level = ; default level: don't inherit 'pr' from env:rak4631
 custom_meshtastic_display_name = RAK WisMesh Repeater Mini V2
 custom_meshtastic_images = rak4631.svg
 build_flags =
@@ -59,6 +60,7 @@ build_flags =
 ; RAK WisMesh Pocket V3 - rak4631 pin map + OLED; no ethernet (unlike env:rak4631)
 [env:rak_wismesh_pocket]
 extends = env:rak4631
+board_level = ; default level: don't inherit 'pr' from env:rak4631
 custom_meshtastic_display_name = RAK WisMesh Pocket V3
 custom_meshtastic_images = rak4631.svg
 build_flags =

--- a/variants/nrf52840/rak_wismeshtag/platformio.ini
+++ b/variants/nrf52840/rak_wismeshtag/platformio.ini
@@ -6,7 +6,6 @@ custom_meshtastic_tags = RAK
 
 extends = nrf52840_base
 board = wiscore_rak4631
-board_level = pr
 board_check = true
 custom_meshtastic_hw_model = 105
 custom_meshtastic_hw_model_slug = WISMESH_TAG

--- a/variants/nrf52840/seeed_mesh_tracker_X1/platformio.ini
+++ b/variants/nrf52840/seeed_mesh_tracker_X1/platformio.ini
@@ -10,7 +10,6 @@ custom_meshtastic_actively_supported = true
 
 extends = nrf52840_base
 board = mesh-tracker-x1
-board_level = pr
 build_flags = ${nrf52840_base.build_flags}
   -Ivariants/nrf52840/seeed_mesh_tracker_X1
   -Isrc/platform/nrf52/softdevice

--- a/variants/nrf52840/seeed_wio_tracker_L1/platformio.ini
+++ b/variants/nrf52840/seeed_wio_tracker_L1/platformio.ini
@@ -10,7 +10,6 @@ custom_meshtastic_tags = Seeed
 custom_meshtastic_requires_dfu = true
 
 board = seeed_wio_tracker_L1
-board_level = pr
 extends = nrf52840_base
 build_flags = ${nrf52840_base.build_flags} 
   -I variants/nrf52840/seeed_wio_tracker_L1

--- a/variants/nrf52840/seeed_xiao_nrf52840_kit/platformio.ini
+++ b/variants/nrf52840/seeed_xiao_nrf52840_kit/platformio.ini
@@ -11,7 +11,6 @@ custom_meshtastic_tags = Seeed
 
 extends = nrf52840_base
 board = xiao_ble_sense
-board_level = pr
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/seeed_xiao_nrf52840_kit
   -I src/platform/nrf52/softdevice

--- a/variants/nrf52840/t-echo-plus/platformio.ini
+++ b/variants/nrf52840/t-echo-plus/platformio.ini
@@ -12,7 +12,6 @@ custom_meshtastic_has_ink_hud = true
 
 extends = nrf52840_base
 board = t-echo
-board_level = pr
 board_check = true
 debug_tool = jlink
 

--- a/variants/nrf52840/t-echo/platformio.ini
+++ b/variants/nrf52840/t-echo/platformio.ini
@@ -12,7 +12,6 @@ custom_meshtastic_has_ink_hud = true
 
 extends = nrf52840_base
 board = t-echo
-board_level = pr
 board_check = true
 debug_tool = jlink
 
@@ -39,7 +38,6 @@ lib_deps =
 [env:t-echo-inkhud]
 extends = nrf52840_base, inkhud
 board = t-echo
-board_level = pr
 board_check = true
 debug_tool = jlink
 build_flags = 

--- a/variants/nrf52840/t-impulse-plus/platformio.ini
+++ b/variants/nrf52840/t-impulse-plus/platformio.ini
@@ -10,7 +10,6 @@ custom_meshtastic_requires_dfu = true
 
 extends = nrf52840_base
 board = t-impulse-plus
-board_level = pr
 
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/t-impulse-plus

--- a/variants/nrf52840/tracker-t1000-e/platformio.ini
+++ b/variants/nrf52840/tracker-t1000-e/platformio.ini
@@ -5,7 +5,6 @@ custom_meshtastic_tags = Seeed
 
 extends = nrf52840_base
 board = tracker-t1000-e
-board_level = pr
 custom_meshtastic_hw_model = 71
 custom_meshtastic_hw_model_slug = TRACKER_T1000_E
 custom_meshtastic_architecture = nrf52840

--- a/variants/rp2040/rak11310/platformio.ini
+++ b/variants/rp2040/rak11310/platformio.ini
@@ -11,7 +11,6 @@ custom_meshtastic_requires_dfu = true
 
 extends = rp2040_base
 board = rakwireless_rak11300
-board_level = pr
 upload_protocol = picotool
 # add our variants files to the include and src paths
 build_flags = 

--- a/variants/rp2040/rpipico/platformio.ini
+++ b/variants/rp2040/rpipico/platformio.ini
@@ -11,7 +11,6 @@ custom_meshtastic_requires_dfu = true
 
 extends = rp2040_base
 board = rpipico
-board_level = pr
 upload_protocol = picotool
 # add our variants files to the include and src paths
 build_flags =

--- a/variants/rp2040/seeed_xiao_rp2040/platformio.ini
+++ b/variants/rp2040/seeed_xiao_rp2040/platformio.ini
@@ -1,7 +1,6 @@
 [env:seeed_xiao_rp2040]
 extends = rp2040_base
 board = seeed_xiao_rp2040
-board_level = pr
 upload_protocol = picotool
 # add our variants files to the include and src paths
 build_src_filter = ${rp2040_base.build_src_filter} +<../variants/rp2040/seeed_xiao_rp2040/>

--- a/variants/rp2350/rpipico2/platformio.ini
+++ b/variants/rp2350/rpipico2/platformio.ini
@@ -1,7 +1,6 @@
 [env:pico2]
 extends = rp2350_base
 board = rpipico2
-board_level = pr
 upload_protocol = picotool
 
 # add our variants files to the include and src paths

--- a/variants/rp2350/seeed_xiao_rp2350/platformio.ini
+++ b/variants/rp2350/seeed_xiao_rp2350/platformio.ini
@@ -1,7 +1,6 @@
 [env:seeed_xiao_rp2350]
 extends = rp2350_base
 board = seeed_xiao_rp2350
-board_level = pr
 upload_protocol = picotool
 
 # add our variants files to the include and src paths

--- a/variants/stm32/rak3172/platformio.ini
+++ b/variants/stm32/rak3172/platformio.ini
@@ -1,7 +1,6 @@
 [env:rak3172]
 extends = stm32_base
 board = wiscore_rak3172
-board_level = pr
 board_upload.maximum_size = 247808 ; reserve the last 14KB for filesystem (reduced from 20KB in LittleFS.cpp)
 build_flags =
   ${stm32_base.build_flags}


### PR DESCRIPTION
I don't think we need to test as many things, particularly when there is the merge queue behind our back.

Many chances would be caught on all the boards for a platform. This PR asks claude to pick the most complete target for each platform and only mark it as PR CI worthy.

Idealy I think in the future a list similar to that one for shared files combined with logic to find files that wont be tested with theses boards (let's say someone changes station-g3/platformio.ini run station-g3 CI) would be ideal.

Here is the list of boards and why:
| Platform | PR target | Why |
| --- | --- | --- |
| esp32 | `tbeam` | The classic full-featured ESP32 reference: GPS, PMU (AXP192), OLED, WiFi webserver, Bluetooth, no `MESHTASTIC_EXCLUDE_*` flags, and `board_check = true`. Replaces `rak11200`, which excludes the webserver and paxcounter. |
| esp32s3 | `t-deck-tft` | Heaviest feature set on S3: TFT/LVGL device-ui (MUI), SD card, I2S audio, keyboard/encoder input, PSRAM. Inherits `board_check` from `env:t-deck`. |
| esp32c3 | `heltec-ht62-esp32c3-sx1262` | Only C3 board that was PR-level; kept as the platform representative. |
| esp32c6 | `tlora-c6` | Only C6 board that was PR-level; kept as the platform representative. |
| nrf52840 | `rak4631` | Canonical nRF52 reference board (WisBlock): OLED, GPS, ethernet paths, `board_check = true`. Its `extends` children (`rak_wismesh_pocket`, `rak_wismesh_repeater_mini`) get an explicit empty `board_level =` override so they don't inherit `pr`. |
| rp2040 | `picow` | WiFi variant, so it compiles the networking stack on top of the base RP2040 build; `board_check = true`. |
| rp2350 | `pico2w` | Same reasoning as `picow` for the RP2350 platform; `board_check = true`. |
| stm32 | `wio-e5` | More complete than `rak3172`: has GPS, I2C, and sensors, which `rak3172` explicitly excludes (`MESHTASTIC_EXCLUDE_GPS/I2C/ENVIRONMENTAL_SENSOR`). |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PR builds now use a streamlined, single-board-per-platform validation path for faster feedback.
  * Board-specific validation is enabled across affected hardware targets, improving detection of incompatible configurations.
  * Build configurations now select concrete hardware targets more consistently.

* **Documentation**
  * Clarified build-level behavior, including fast PR checks, full merge-queue and release builds, and release-only extras.
  * Updated variant guidance to explain when the PR-level setting should be used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->