### PR TITLE
nrf52: fix BLE-task stack overflow crashing pairing and wiping LittleFS

### DIFF
--- a/variants/nrf52840/nrf52.ini
+++ b/variants/nrf52840/nrf52.ini
@@ -30,6 +30,13 @@ build_flags =
   ; 2048 words = 8 KB, validated on hardware. Value is in WORDS; requires the #ifndef guard
   ; from meshtastic/Adafruit_nRF52_Arduino#7 (harmless redefinition warning until it merges).
   -DLOOP_STACK_SZ=2048
+  ; The Bluefruit BLE task runs the ENTIRE phone-API chain inline (toRadioWriteCb ->
+  ; handleToRadio -> admin set-config -> radio reconfigure -> LittleFS save): its stock
+  ; 5 KB (1280-word) stack overflows during pairing/first-sync, resetting mid-flash-write
+  ; and tearing LittleFS (auto-format -> total config/key wipe, critical fault #13).
+  ; Reproduced on Wio Tracker L1 @ develop 6908d27. Same rationale as LOOP_STACK_SZ above;
+  ; bluefruit.cpp's #ifndef guard makes the -D take effect without a framework patch.
+  -DCFG_BLE_TASK_STACKSIZE=2048
   -DLFS_NO_ASSERT                      ; Disable LFS assertions , see https://github.com/meshtastic/firmware/pull/3818
   -DMESHTASTIC_EXCLUDE_AUDIO=1
   -DMESHTASTIC_EXCLUDE_PAXCOUNTER=1


### PR DESCRIPTION
## The bug

On nRF52 targets, BLE pairing/first-sync can crash the device the moment the client writes config — and repeated crashes escalate to a **total filesystem wipe**: LittleFS metadata gets torn by the mid-write reset, `lfs_assert` fires on the next boot, the corruption handler formats the FS, and the node loses region, channels, module config, and its keypair (critical fault #13, new identity once region is set again).

Reproduced 100% on a Seeed Wio Tracker L1 on stock develop `6908d27`: every iPhone pairing attempt reset the device at `Opening /prefs/config.proto, fullAtomic=1`, and the wipe cascade followed. This is very likely also #10905 (L1 display-thread crash on full config request) and a match for 2.8 field reports of nodes losing region/keys after a BLE session.

## Root cause

Since #10967 made `Router::sendLocal()` handle self-addressed packets synchronously, the entire phone-API chain runs inline in the Bluefruit characteristic write callback:

```
toRadioWriteCb -> PhoneAPI::handleToRadio -> MeshService -> Router::sendLocal
  -> handleReceived -> callModules -> AdminModule::handleSetConfig
  -> radio reconfigure -> NodeDB::saveToDisk (LittleFS write)
```

That callback executes on the **Bluefruit BLE FreeRTOS task**, whose stock stack is 5 KB (`CFG_BLE_TASK_STACKSIZE = 256*5` words). #10944 raised the Arduino **loop** task to 8 KB for exactly this chain — but after #10967, BLE-originated writes no longer run there, so the fix protects the wrong task. Measured frames (`-fstack-usage`, seeed_wio_tracker_L1): `handleToRadio` 520 B + `handleReceivedProtobuf` 584 B + `handleSetConfig` 520 B + `perhapsDecode` 472 B + ~450 B of glue ≈ 2.5 KB of application frames before LittleFS and the SX126x reconfigure even start — a 5 KB task can't carry it.

## The fix

`-DCFG_BLE_TASK_STACKSIZE=2048` (words = 8 KB) in `variants/nrf52840/nrf52.ini`, right next to the existing `LOOP_STACK_SZ=2048` and for the same reason. `bluefruit.cpp` guards the define with `#ifndef`, so it takes effect without a framework patch. Costs 3 KB RAM, nrf52840 targets only.

## Validation

A/B on the Wio Tracker L1, same commit, only this flag differing:

| | 5 KB BLE stack | 8 KB BLE stack |
|---|---|---|
| iPhone pairing + first-sync | reset every attempt, then FS wipe | pairs cleanly |
| App config screens (admin gets) | n/a (dead before this) | load instantly |
| `set_config` device + LoRa/region (two `config.proto` saves over BLE) | reset mid-write | both saves complete, settings persist |

The 8 KB constant was verified in the shipped ELF (`mov.w r2, #2048` into `xTaskCreate` in `Bluefruit::begin`). rak4631 and seeed_wio_tracker_L1 both build green. Native suites unaffected (build-flag change only).

## Credit and relationship to #11155

@Ixitxachitl independently established during #11155 testing that the save-path crash persists after #11185 and that re-queueing `sendLocal` (which moves this pipeline back to the Router thread, i.e. the 8 KB loop task) makes it disappear — corroborating this diagnosis from the other direction. This PR is the minimal capacity-side guard that stops the crash-and-wipe today; #11155's relocation of the pipeline off the BLE task is the right architectural follow-up, and this guard remains correct after it lands (the BLE task still services SoftDevice events and other callback work, and 5 KB was marginal for that regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth Low Energy pairing and initial synchronization reliability by increasing the task stack allocation.
  * Helps prevent stack overflows during early BLE operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->