### PR TITLE
Actions: Add caching for MacOS and Windows build workflows

### DIFF
--- a/.github/workflows/build_macos_bin.yml
+++ b/.github/workflows/build_macos_bin.yml
@@ -20,24 +20,45 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install deps
+      - name: Capture runner image version (for caching)
+        id: r_image
+        run: echo "ver=$ImageVersion" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Homebrew downloads
+        uses: actions/cache@v6
+        with:
+          path: ~/Library/Caches/Homebrew
+          key: brew-macos-${{ inputs.macos_ver }}-${{ steps.r_image.outputs.ver }}
+
+      - name: Install deps (Homebrew)
         shell: bash
-        run: |
-          brew update
-          brew install platformio yaml-cpp libuv openssl@3 libusb argp-standalone pkg-config ulfius
+        env:
+          # GitHub-Hosted MacOS runner images are updated frequently
+          # so skip running `brew update` to avoid unnecessary failures and delays.
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_NO_INSTALL_CLEANUP: "1"
+        run: >
+          brew install
+          platformio yaml-cpp libuv openssl@3 libusb argp-standalone pkg-config ulfius jsoncpp
 
       - name: Get release version string
         run: |
           echo "long=$(./bin/buildinfo.py long)" >> $GITHUB_OUTPUT
         id: version
 
+      - name: Cache PlatformIO packages
+        uses: actions/cache@v6
+        with:
+          path: ~/.platformio/.cache
+          key: pio-macos-${{ inputs.macos_ver }}-${{ hashFiles('platformio.ini', 'variants/native/portduino.ini') }}
+          restore-keys: |
+            pio-macos-${{ inputs.macos_ver }}-
+
       - name: Build for MacOS
         run: |
           platformio run -e native-macos
         env:
           PKG_VERSION: ${{ steps.version.outputs.long }}
-        # Errors in this step should not fail the entire workflow while MacOS support is in development.
-        continue-on-error: true
 
       - name: List output files
         run: ls -lah .pio/build/native-macos/

--- a/.github/workflows/build_windows_bin.yml
+++ b/.github/workflows/build_windows_bin.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           msystem: UCRT64
           update: true
+          cache: true
           # argp is not packaged for the mingw environments and is built below.
           # Python is omitted too: MSYS2's reports a `mingw` platform tag no wheel matches.
           install: >-
@@ -51,6 +52,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.14"
+          cache: pip
 
       # framework-portduino calls argp_parse(); MSYS2 packages argp only for the
       # msys runtime, which cannot link into a native binary. No install() rules.
@@ -68,6 +70,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install platformio
+
+      - name: Cache PlatformIO packages
+        uses: actions/cache@v6
+        with:
+          path: ~/.platformio/.cache
+          key: pio-windows-${{ inputs.windows_ver }}-${{ hashFiles('platformio.ini', 'variants/native/portduino.ini') }}
+          restore-keys: |
+            pio-windows-${{ inputs.windows_ver }}-
 
       - name: Get release version string
         shell: pwsh


### PR DESCRIPTION
This pull request introduces improvements to the CI build workflows for both MacOS and Windows, mainly focused on speeding up builds and reducing redundant downloads by adding caching for Homebrew, PlatformIO, and pip dependencies. These changes help make the builds more reliable and efficient.

**Build caching improvements:**

* **MacOS workflow (`.github/workflows/build_macos_bin.yml`):**
  - Added caching for Homebrew downloads using the runner image version, which will reduce repeated downloads and speed up dependency installation.
  - Added caching for PlatformIO packages, using a cache key based on the MacOS version and relevant config files, to avoid re-downloading packages on every build.

* **Windows workflow (`.github/workflows/build_windows_bin.yml`):**
  - Enabled MSYS2 package manager caching, which helps avoid redundant downloads of MSYS2 packages.
  - Enabled pip caching in the Python setup step, reducing time spent reinstalling Python packages.
  - Added caching for PlatformIO packages, using a cache key based on the Windows version and config files, similar to the MacOS workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Added build-time caching to both macOS and Windows workflows to reduce repeated downloads and speed up build runs.
  * Cached PlatformIO package downloads based on OS version and configuration hashes.

* **Reliability**
  * macOS builds now fail the workflow on native build errors instead of continuing.

* **Maintenance**
  * Streamlined macOS dependency installation by avoiding automatic Homebrew updates/cleanup during the workflow.
  * Updated dependency list to include the required `jsoncpp` package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->