### PR TITLE
Remove docker buildkit layer caching (for now)

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -105,6 +105,6 @@ jobs:
           platforms: ${{ inputs.platform }}
           build-args: |
             PIO_ENV=${{ inputs.pio_env }}
-          # Cache image layers in GitHub Actions cache to speed up subsequent builds.
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Disabled for now: Cache image layers in GitHub Actions cache to speed up subsequent builds.
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=max


### PR DESCRIPTION
Docker cache is taking up all our cache space, we need room for activities!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Temporarily disabled Docker layer caching during automated builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->