### PR TITLE
fix(mesh): don't assert on malloc() failure in MemoryDynamic::alloc()

### DIFF
--- a/src/mesh/MemoryPool.h
+++ b/src/mesh/MemoryPool.h
@@ -114,7 +114,10 @@ template <class T> class MemoryDynamic : public Allocator<T>
     virtual T *alloc(TickType_t maxWait) override
     {
         T *p = (T *)malloc(sizeof(T));
-        assert(p);
+        if (!p) {
+            LOG_WARN("malloc(%u) failed, heap exhausted!", (unsigned)sizeof(T));
+            return nullptr;
+        }
         this->auditAdd((int32_t)sizeof(T));
         return p;
     }

--- a/src/mesh/udp/UdpMulticastHandler.h
+++ b/src/mesh/udp/UdpMulticastHandler.h
@@ -84,6 +84,8 @@ class UdpMulticastHandler final
             mp.pki_encrypted = false;
             mp.public_key.size = 0;
             UniquePacketPoolPacket p = packetPool.allocUniqueCopy(mp);
+            if (!p)
+                return;
             // Unset received SNR/RSSI
             p->rx_snr = 0;
             p->rx_rssi = 0;

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -143,6 +143,8 @@ inline void onReceiveProto(char *topic, byte *payload, size_t length)
     }
 
     UniquePacketPoolPacket p = packetPool.allocUniqueZeroed();
+    if (!p)
+        return;
     p->from = e.packet->from;
     p->to = e.packet->to;
     p->id = e.packet->id;

--- a/src/platform/portduino/SimRadio.cpp
+++ b/src/platform/portduino/SimRadio.cpp
@@ -323,13 +323,19 @@ void SimRadio::startReceive(meshtastic_MeshPacket *p)
             return;
         }
     }
-    isReceiving = true;
     receivingPacket = packetPool.allocCopy(*p);
+    if (!receivingPacket) {
+        return;
+    }
+    isReceiving = true;
     uint32_t airtimeMsec = getPacketTime(p, true);
     notifyLater(airtimeMsec, ISR_RX, false); // Model the time it is busy receiving
 #else
-    isReceiving = true;
     receivingPacket = packetPool.allocCopy(*p);
+    if (!receivingPacket) {
+        return;
+    }
+    isReceiving = true;
     handleReceiveInterrupt(); // Simulate receiving the packet immediately
     startTransmitTimer();
 #endif


### PR DESCRIPTION
## Problem

`MemoryDynamic<T>::alloc()` (`src/mesh/MemoryPool.h`) does:

```cpp
T *p = (T *)malloc(sizeof(T));
assert(p);
```

`#10948`/`#10951` null-checked `allocCopy()`/`allocZeroed()` call sites so callers skip the send/reply/notification on allocation failure instead of dereferencing null. That hardening is unreachable on real OOM here: `assert(p)` fires one level down, inside `alloc()`, before any caller sees a return value. The static `MemoryPool<T, MaxSize>::alloc()` in the same file returns `nullptr` and logs a warning on exhaustion instead.

On `ARCH_STM32WL`/`BOARD_HAS_PSRAM` (`packetPool` is heap-backed via `MemoryDynamic` there — see `src/mesh/Router.cpp:48-57`), `assert()` failures route through a platform handler. On STM32WL that handler is an infinite `while(true);` loop (`src/platform/stm32wl/main-stm32wl.cpp`), not an abort or reset, so a real `malloc()` failure hangs the calling thread instead of returning `nullptr`.

Reproduced on wio-e5 hardware: a burst of incoming DMs drained free heap toward zero (`LOG_HEAP` showing ~1.7-1.8KB free right before the hang), then the device locked up.

## Fix

- `src/mesh/MemoryPool.h`: `MemoryDynamic::alloc()` returns `nullptr` and logs a warning on `malloc()` failure, matching `MemoryPool::alloc()`.
- `src/mesh/udp/UdpMulticastHandler.h`, `src/mqtt/MQTT.cpp`: null-check the two `allocUniqueCopy()`/`allocUniqueZeroed()` call sites that dereferenced the result unconditionally. These were unreachable with a null result before this PR (the `assert` above made it impossible), so #10948/#10951's audit of raw-pointer call sites didn't cover them.

Audited every `packetPool` allocation call site in the codebase (the only pool `MemoryDynamic` backs) for null-safety; the two above were the only unguarded ones.

## Test plan

- [x] `pio run -e wio-e5` — exercises the `MemoryPool.h` change.
- [x] `pio run -e tbeam0_7` — exercises the MQTT/UDP-multicast paths (excluded from stm32wl builds).
- [ ] Not verified on physical hardware that this prevents the hang under real OOM (no wio-e5 attached to the machine this was developed on). Draft pending that confirmation.

Related: #11196.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below): wio-e5, tbeam0_7 — build-verified only, not yet flashed to hardware

## CodeRabbit review summary

This PR makes heap-backed packet allocation recoverable under out-of-memory conditions:

- `MemoryDynamic<T>::alloc()` now logs a warning and returns `nullptr` when `malloc()` fails, instead of asserting. Successful allocations retain their existing memory-audit accounting.
- UDP multicast reception and MQTT downlink handling now drop the incoming message if their `UniquePacketPoolPacket` allocation fails, rather than dereferencing a null unique pointer.
- `SimRadio::startReceive()` now allocates the receive packet before setting `isReceiving` and before scheduling or handling reception. This prevents a failed initial allocation from leaving the simulated radio marked as busy.

The allocation behavior is relevant to the dynamic `packetPool` configurations used by Portduino, STM32WL, and PSRAM-enabled boards. The author reports successful builds for `wio-e5`, `tbeam0_7`, and `native-macos`; physical OOM validation remains pending.

No public API declarations changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability when memory allocation fails by safely handling heap exhaustion.
  - Prevented crashes when packet allocation is unavailable during multicast and MQTT message processing.
  - Added warning logging for memory allocation failures.
  - Strengthened simulated radio receive startup to safely return early if packet allocation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->