### PR TITLE
Save/Restore seperately in MacOS/Windows caching workflows.

### DIFF
--- a/.github/workflows/build_macos_bin.yml
+++ b/.github/workflows/build_macos_bin.yml
@@ -14,6 +14,10 @@ permissions:
 jobs:
   build-MacOS:
     runs-on: macos-${{ inputs.macos_ver }}
+    # Only pushes to the default branch (develop) populate the cache; PR / merge_group runs
+    # restore it but never save, so they stop filling up the repo's Actions cache storage.
+    env:
+      SAVE_CACHE: ${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -24,8 +28,9 @@ jobs:
         id: r_image
         run: echo "ver=$ImageVersion" >> "$GITHUB_OUTPUT"
 
-      - name: Cache Homebrew downloads
-        uses: actions/cache@v6
+      - name: Restore Homebrew cache
+        id: brew-cache
+        uses: actions/cache/restore@v6
         with:
           path: ~/Library/Caches/Homebrew
           key: brew-macos-${{ inputs.macos_ver }}-${{ steps.r_image.outputs.ver }}
@@ -41,13 +46,21 @@ jobs:
           brew install
           platformio yaml-cpp libuv openssl@3 libusb argp-standalone pkg-config ulfius jsoncpp
 
+      - name: Save Homebrew cache
+        if: env.SAVE_CACHE == 'true' && steps.brew-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ~/Library/Caches/Homebrew
+          key: brew-macos-${{ inputs.macos_ver }}-${{ steps.r_image.outputs.ver }}
+
       - name: Get release version string
         run: |
           echo "long=$(./bin/buildinfo.py long)" >> $GITHUB_OUTPUT
         id: version
 
-      - name: Cache PlatformIO packages
-        uses: actions/cache@v6
+      - name: Restore PlatformIO cache
+        id: pio-cache
+        uses: actions/cache/restore@v6
         with:
           path: ~/.platformio/.cache
           key: pio-macos-${{ inputs.macos_ver }}-${{ hashFiles('platformio.ini', 'variants/native/portduino.ini') }}
@@ -59,6 +72,13 @@ jobs:
           platformio run -e native-macos
         env:
           PKG_VERSION: ${{ steps.version.outputs.long }}
+
+      - name: Save PlatformIO cache
+        if: env.SAVE_CACHE == 'true' && steps.pio-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.platformio/.cache
+          key: pio-macos-${{ inputs.macos_ver }}-${{ hashFiles('platformio.ini', 'variants/native/portduino.ini') }}
 
       - name: List output files
         run: ls -lah .pio/build/native-macos/

--- a/.github/workflows/build_portduino_wasm.yml
+++ b/.github/workflows/build_portduino_wasm.yml
@@ -29,7 +29,7 @@ jobs:
         uses: ./.github/actions/setup-native
 
       - name: Setup Emscripten SDK
-        uses: emscripten-core/setup-emsdk@v16
+        uses: emscripten-core/setup-emsdk@0822153d7a5488b70a269cfa0a631b2a86ab4da2 # 'v17' main
         with:
           version: 6.0.1
           actions-cache-folder: emsdk-cache

--- a/.github/workflows/build_windows_bin.yml
+++ b/.github/workflows/build_windows_bin.yml
@@ -14,6 +14,10 @@ permissions:
 jobs:
   build-Windows:
     runs-on: windows-${{ inputs.windows_ver }}
+    # Only pushes to the default branch (develop) populate the cache; PR / merge_group runs
+    # restore it but never save, so they stop filling up the repo's Actions cache storage.
+    env:
+      SAVE_CACHE: ${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
     defaults:
       run:
         # UCRT64 is the MinGW-w64 environment native-windows targets; the `msys`
@@ -71,8 +75,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install platformio
 
-      - name: Cache PlatformIO packages
-        uses: actions/cache@v6
+      - name: Restore PlatformIO cache
+        id: pio-cache
+        uses: actions/cache/restore@v6
         with:
           path: ~/.platformio/.cache
           key: pio-windows-${{ inputs.windows_ver }}-${{ hashFiles('platformio.ini', 'variants/native/portduino.ini') }}
@@ -93,6 +98,13 @@ jobs:
           platformio run -e native-windows
         env:
           PKG_VERSION: ${{ steps.version.outputs.long }}
+
+      - name: Save PlatformIO cache
+        if: env.SAVE_CACHE == 'true' && steps.pio-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.platformio/.cache
+          key: pio-windows-${{ inputs.windows_ver }}-${{ hashFiles('platformio.ini', 'variants/native/portduino.ini') }}
 
       - name: List output files
         run: ls -lah .pio/build/native-windows/


### PR DESCRIPTION
Only *save* cache on the default branch (develop), restore it everywhere it fits


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Reliability**
  * Improved macOS and Windows build caching to reuse existing caches while avoiding unnecessary cache writes during pull request builds.
  * Updated the WebAssembly build environment to use a pinned Emscripten SDK setup version for more consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->