### PR TITLE
Actions: Also cache wasm

### DIFF
--- a/.github/workflows/build_macos_bin.yml
+++ b/.github/workflows/build_macos_bin.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: ~/.platformio/.cache
-          key: pio-macos-${{ inputs.macos_ver }}-${{ hashFiles('platformio.ini', 'variants/native/portduino.ini') }}
+          key: pio-macos-${{ inputs.macos_ver }}-${{ hashFiles('platformio.ini', 'variants/native/portduino.ini', 'variants/native/portduino/platformio.ini') }}
           restore-keys: |
             pio-macos-${{ inputs.macos_ver }}-
 
@@ -78,7 +78,7 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: ~/.platformio/.cache
-          key: pio-macos-${{ inputs.macos_ver }}-${{ hashFiles('platformio.ini', 'variants/native/portduino.ini') }}
+          key: pio-macos-${{ inputs.macos_ver }}-${{ hashFiles('platformio.ini', 'variants/native/portduino.ini', 'variants/native/portduino/platformio.ini') }}
 
       - name: List output files
         run: ls -lah .pio/build/native-macos/

--- a/.github/workflows/build_portduino_wasm.yml
+++ b/.github/workflows/build_portduino_wasm.yml
@@ -18,6 +18,10 @@ jobs:
   build-wasm:
     name: Build PortDuino WASM
     runs-on: ubuntu-latest
+    # Only pushes to the default branch (develop) populate the cache; PR / merge_group runs
+    # restore it but never save, so they stop filling up the repo's Actions cache storage.
+    env:
+      SAVE_CACHE: ${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -34,8 +38,24 @@ jobs:
           version: 6.0.1
           actions-cache-folder: emsdk-cache
 
+      - name: Restore PlatformIO cache
+        id: pio-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.platformio/.cache
+          key: pio-wasm-${{ hashFiles('platformio.ini', 'variants/native/portduino.ini', 'variants/native/portduino/platformio.ini') }}
+          restore-keys: |
+            pio-wasm-
+
       - name: Build PortDuino WASM
         run: platformio run -e native-wasm
+
+      - name: Save PlatformIO cache
+        if: env.SAVE_CACHE == 'true' && steps.pio-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.platformio/.cache
+          key: pio-wasm-${{ hashFiles('platformio.ini', 'variants/native/portduino.ini', 'variants/native/portduino/platformio.ini') }}
 
       - name: Assert WASM artifacts
         run: |

--- a/.github/workflows/build_windows_bin.yml
+++ b/.github/workflows/build_windows_bin.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: ~/.platformio/.cache
-          key: pio-windows-${{ inputs.windows_ver }}-${{ hashFiles('platformio.ini', 'variants/native/portduino.ini') }}
+          key: pio-windows-${{ inputs.windows_ver }}-${{ hashFiles('platformio.ini', 'variants/native/portduino.ini', 'variants/native/portduino/platformio.ini') }}
           restore-keys: |
             pio-windows-${{ inputs.windows_ver }}-
 
@@ -104,7 +104,7 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: ~/.platformio/.cache
-          key: pio-windows-${{ inputs.windows_ver }}-${{ hashFiles('platformio.ini', 'variants/native/portduino.ini') }}
+          key: pio-windows-${{ inputs.windows_ver }}-${{ hashFiles('platformio.ini', 'variants/native/portduino.ini', 'variants/native/portduino/platformio.ini') }}
 
       - name: List output files
         run: ls -lah .pio/build/native-windows/


### PR DESCRIPTION
Cache the WASM builds just like we do on MacOS/Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Added build caching for the native WebAssembly workflow, reducing repeated build times.
  * Improved cache accuracy for macOS and Windows builds by detecting changes to platform-specific configuration.
  * Limited cache updates to builds on the default branch while still allowing pull request builds to restore existing caches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->