### PR TITLE
Fix nRF52 freeze + watchdog reset when saving config over BLE

### DIFF
--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -481,7 +481,7 @@ void NRF52Bluetooth::disconnect()
             delay(1);
 
         if (Bluefruit.connected())
-            LOG_INFO("BLE disconnect still pending, continuing shutdown");
+            LOG_WARN("BLE disconnect unconfirmed after %ums, continuing shutdown", millis() - start);
         else
             LOG_INFO("Ended BLE connection");
     }

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -467,6 +467,7 @@ bool NRF52Bluetooth::onUnwantedPairing(uint16_t conn_handle, uint8_t const passk
 // Disconnect any BLE connections
 void NRF52Bluetooth::disconnect()
 {
+    static constexpr uint32_t DISCONNECT_TIMEOUT_MSEC = 1000;
     uint8_t connection_num = Bluefruit.connected();
     if (connection_num) {
         // Close all connections. We're only expecting one.
@@ -476,7 +477,7 @@ void NRF52Bluetooth::disconnect()
         // Best-effort wait: on Bluefruit's BLE event task the DISCONNECTED event can't be processed
         // until this callback returns, so an unbounded wait would deadlock until the watchdog fires.
         uint32_t start = millis();
-        while (Bluefruit.connected() && Throttle::isWithinTimespanMs(start, 1000))
+        while (Bluefruit.connected() && Throttle::isWithinTimespanMs(start, DISCONNECT_TIMEOUT_MSEC))
             delay(1);
 
         if (Bluefruit.connected())

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -7,6 +7,7 @@
 #include "error.h"
 #include "main.h"
 #include "mesh/PhoneAPI.h"
+#include "mesh/Throttle.h"
 #include "mesh/mesh-pb-constants.h"
 #include <bluefruit.h>
 #include <utility/bonding.h>
@@ -472,14 +473,10 @@ void NRF52Bluetooth::disconnect()
         for (uint8_t i = 0; i < connection_num; i++)
             Bluefruit.disconnect(i);
 
-        // Wait for disconnection, but only best-effort with a timeout: phone-originated admin
-        // messages run on Bluefruit's own BLE event task (sendLocal delivers synchronously), and
-        // there the DISCONNECTED event that clears the connected flag can't be processed until we
-        // return - an unbounded wait deadlocks until the watchdog fires. The SoftDevice completes
-        // the link termination on its own regardless. delay() rather than yield() so lower-priority
-        // tasks (including the watchdog feed in the main loop) keep running while we wait.
+        // Best-effort wait: on Bluefruit's BLE event task the DISCONNECTED event can't be processed
+        // until this callback returns, so an unbounded wait would deadlock until the watchdog fires.
         uint32_t start = millis();
-        while (Bluefruit.connected() && millis() - start < 1000)
+        while (Bluefruit.connected() && Throttle::isWithinTimespanMs(start, 1000))
             delay(1);
 
         if (Bluefruit.connected())

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -472,11 +472,20 @@ void NRF52Bluetooth::disconnect()
         for (uint8_t i = 0; i < connection_num; i++)
             Bluefruit.disconnect(i);
 
-        // Wait for disconnection
-        while (Bluefruit.connected())
-            yield();
+        // Wait for disconnection, but only best-effort with a timeout: phone-originated admin
+        // messages run on Bluefruit's own BLE event task (sendLocal delivers synchronously), and
+        // there the DISCONNECTED event that clears the connected flag can't be processed until we
+        // return - an unbounded wait deadlocks until the watchdog fires. The SoftDevice completes
+        // the link termination on its own regardless. delay() rather than yield() so lower-priority
+        // tasks (including the watchdog feed in the main loop) keep running while we wait.
+        uint32_t start = millis();
+        while (Bluefruit.connected() && millis() - start < 1000)
+            delay(1);
 
-        LOG_INFO("Ended BLE connection");
+        if (Bluefruit.connected())
+            LOG_INFO("BLE disconnect still pending, continuing shutdown");
+        else
+            LOG_INFO("Ended BLE connection");
     }
 }
 


### PR DESCRIPTION
## Problem

Saving any config section that requires a reboot (position, security, role changes, `commit_edit_settings`, …) from a BLE-connected phone freezes nRF52 devices completely — screen, mesh, and serial all dead — until the 90 s hardware watchdog resets the board. Reproduced on a Seeed Wio Tracker L1; the mechanism affects every nRF52 target.

## Root cause

Since #10967, `Router::sendLocal` delivers self-addressed packets synchronously in the calling task, so phone-originated admin messages run on Bluefruit's BLE event task (the `toRadio` write callback is registered with `useAdaCallback=false`).

When the config change keeps `requiresReboot=true`, `AdminModule` calls `disableBluetooth()` while the phone is still connected. `NRF52Bluetooth::disconnect()` then busy-waits:

```cpp
while (Bluefruit.connected())
    yield();
```

The `BLE_GAP_EVT_DISCONNECTED` event that clears that flag can only be processed by `adafruit_ble_task` — the very task now spinning. The wait can never complete. Because the BLE task runs at `TASK_PRIO_HIGH` and `yield()` never lets lower-priority tasks run, the Arduino loop task starves, the watchdog feed stops, and the WDT resets the device ~90 s later.

Why it wasn't caught earlier: LoRa config applies live (`requiresReboot=false`) and skips `disableBluetooth()` entirely, so region/preset saves — the common test case — never hit this path. Position config always takes the reboot path. #11190 (BLE task stack bump) fixed the stack-overflow crash on this same relocated call chain but not this deadlock.

## Fix

Make the disconnect wait best-effort with a 1 s bound, and sleep (`delay(1)`) instead of spinning so lower-priority tasks — including the watchdog feed in the main loop — keep running during the wait:

- Called from the loop task (on-device menu, serial): behaves as before, disconnect completes in tens of ms and logs `Ended BLE connection`.
- Called from the BLE event task (phone-originated admin): times out after 1 s, logs `BLE disconnect still pending, continuing shutdown`, and proceeds. The SoftDevice completes the link termination on its own once the callback unwinds, and the normal save + scheduled reboot follow.

## Testing

On a Wio Tracker L1 (nRF52840):

- **Before:** position config save from the app → `Disable NRF52 bluetooth` is the last log line, device frozen, watchdog reset ~90 s later.
- **After:** position config save from the app → ~1 s pause, config saved, clean 5 s scheduled reboot, reconnects normally.
- Serial-path saves (no BLE connection) verified unaffected: save → reboot cycle completes in the normal ~11 s including USB re-enumeration.
- `seeed_wio_tracker_L1` build green; formatting checked against trunk's clang-format config.

The durable follow-up remains moving phone-originated admin handling off the BLE event task entirely (#11155).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth disconnection handling to avoid indefinite shutdown waits by using a timeout-bounded, best-effort completion check.
  * Added clearer status logging: reports when disconnection remains unconfirmed after the timeout, or confirms when the BLE connection has ended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->