### PR TITLE
#bugfix phantom/false "Direct Connections" and 0 SNR/RSSI node list corru…

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -3500,12 +3500,20 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
         }
 #endif
 
-        // If hopStart was set and there wasn't someone messing with the limit in the middle, add hopsAway
+       // If hopStart was set and there wasn't someone messing with the limit in the middle, add hopsAway
         const int8_t hopsAway = getHopsAway(mp);
-        if (hopsAway >= 0) {
+        
+        // Gating rule: 0-hop payloads must have real hardware metrics to be treated as a direct link.
+        // Prevent uninitialized historical sync / forwarded payloads from pretending to be local neighbors.
+        bool is_phantom_packet = (hopsAway == 0 && mp.rx_snr == 0.0f && mp.rx_rssi == 0);
+
+        if (hopsAway >= 0 && !is_phantom_packet) {
             info->has_hops_away = true;
             info->hops_away = hopsAway;
+        } else if (is_phantom_packet) {
+            info->has_hops_away = false; // Protect topology; drop direct neighbor flag
         }
+        
         sortMeshDB();
     }
 }

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -3500,7 +3500,7 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
         }
 #endif
 
-       // If hopStart was set and there wasn't someone messing with the limit in the middle, add hopsAway
+        // If hopStart was set and there wasn't someone messing with the limit in the middle, add hopsAway
         const int8_t hopsAway = getHopsAway(mp);
         
         // Gating rule: 0-hop payloads must have real hardware metrics to be treated as a direct link.


### PR DESCRIPTION
…ption caused by stripped sync/forwarded payloads

Problem Description / Findings: In Meshtastic firmware versions 2.8+, an issue occurs where remote nodes are incorrectly classified as 0-hop "Direct Connections" with 0 SNR and 0 RSSI in the node list, signal graph, and apps. This corrupts local mesh topology tracking.

Root Cause:This behavior is triggered by historical database syncs or specific store-and-forward position payloads received over the air (TRANSPORT_LORA) where via_mqtt is evaluated as false. Because these are stored data records rather than real-time over-the-air origin transmissions, their physical hop and radio headers are stripped or uninitialized. When NodeDB.cpp processes these packets getHopsAway(mp) evaluates mathematically to 0. The logic block if (hopsAway >= 0) accepts the 0 value without verifying physical hardware metrics.The UI and database interpret 0 hops as a direct neighbor, overwriting healthy historical RF signal stats with absolute 0 placeholders, and displays nodes that are not directly connected as a "Good" 0 RSSI 0 SNR direct connection.

The fix enforces a physical validation rule in NodeDB.cpp: a packet can only be evaluated as a 0-hop (Direct) neighbor if the local radio hardware actually measured an active RF signal during arrival. If hopsAway == 0 but both rx_snr and rx_rssi are exactly 0, the packet is flagged as a phantom sync payload and blocked from registering as a local neighbor.

Code Modification Applied (in NodeDB.cpp lines 3500 - 3520):  


      // If hopStart was set and there wasn't someone messing with the limit in the middle, add hopsAway
        const int8_t hopsAway = getHopsAway(mp);
        
        // Gating rule: 0-hop payloads must have real hardware metrics to be treated as a direct link.
        // Prevent uninitialized historical sync / forwarded payloads from pretending to be local neighbors.
        bool is_phantom_packet = (hopsAway == 0 && mp.rx_snr == 0.0f && mp.rx_rssi == 0);

        if (hopsAway >= 0 && !is_phantom_packet) {
            info->has_hops_away = true;
            info->hops_away = hopsAway;
        } else if (is_phantom_packet) {
            info->has_hops_away = false; // Protect topology; drop direct neighbor flag
        }
        
        sortMeshDB();
        
        
        
Impact: Preserves Mesh Map Integrity: Stops phantom nodes from hijacking the direct neighbor list and signal graphs.Safe for Low Signals: Genuine weak packets still carry real hardware register readings (e.g., negative RSSI/SNR) and remain perfectly tracked, while mathematical absolute zeros from uninitialized structs are safely isolated.

assisted by Google Gemini


- [ X] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
   rak3401-1watt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hop-distance reporting by ignoring invalid zero-hop packets that lack signal data.
  * Ensures hop-distance state is correctly set when reliable hop metrics are available, and cleared when the packet is identified as non-RF/placeholder information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->