### PR TITLE
Add opt-in persisted random device identity (USERPREFS_RANDOM_DEVICE_ID)

### DIFF
--- a/src/PersistedRandomDeviceId.cpp
+++ b/src/PersistedRandomDeviceId.cpp
@@ -1,0 +1,95 @@
+#include "PersistedRandomDeviceId.h"
+#include "FSCommon.h"
+#include "SPILock.h"
+#include "concurrency/LockGuard.h"
+#include "configuration.h"
+#include "mesh/HardwareRNG.h"
+#include <string.h>
+
+#if USERPREFS_RANDOM_DEVICE_ID && defined(FSCom)
+
+static const char *idFileName = "/prefs/deviceid.dat";
+static uint8_t cachedMac[6];
+static bool haveMac = false;
+
+// Locally administered, unicast; the two high bits are also set so the same
+// bytes are usable verbatim as a BLE random static address.
+static void fixupMacBits(uint8_t *mac)
+{
+    mac[0] |= 0xc2;
+    mac[0] &= 0xfe;
+}
+
+static bool loadMac(uint8_t *mac)
+{
+    concurrency::LockGuard g(spiLock);
+    auto f = FSCom.open(idFileName, FILE_O_READ);
+    if (!f)
+        return false;
+    bool ok = f.read(mac, sizeof(cachedMac)) == (int)sizeof(cachedMac);
+    f.close();
+    // Reject anything that generateMac() could not have produced
+    return ok && (mac[0] & 0xc3) == 0xc2;
+}
+
+static bool saveMac(const uint8_t *mac)
+{
+    concurrency::LockGuard g(spiLock);
+    FSCom.mkdir("/prefs");
+    FSCom.remove(idFileName);
+    auto f = FSCom.open(idFileName, FILE_O_WRITE);
+    if (!f)
+        return false;
+    bool ok = f.write(mac, sizeof(cachedMac)) == sizeof(cachedMac);
+    f.close();
+    return ok;
+}
+
+static bool generateMac(uint8_t *mac)
+{
+    if (!HardwareRNG::fill(mac, sizeof(cachedMac)))
+        return false;
+    fixupMacBits(mac);
+    return true;
+}
+
+bool persistedRandomDeviceIdGet(uint8_t out[6])
+{
+    if (!haveMac) {
+        if (loadMac(cachedMac)) {
+            haveMac = true;
+        } else if (generateMac(cachedMac)) {
+            if (!saveMac(cachedMac))
+                LOG_WARN("Could not persist random MAC; it will change next boot");
+            haveMac = true;
+        } else {
+            LOG_ERROR("No entropy for random MAC, falling back to hardware address");
+            return false;
+        }
+    }
+    memcpy(out, cachedMac, sizeof(cachedMac));
+    return true;
+}
+
+void persistedRandomDeviceIdRegenerate()
+{
+    uint8_t mac[6];
+    if (!generateMac(mac))
+        return;
+    if (!saveMac(mac))
+        LOG_WARN("Could not persist random MAC; it will change next boot");
+    memcpy(cachedMac, mac, sizeof(cachedMac));
+    haveMac = true;
+}
+
+#else
+
+bool persistedRandomDeviceIdGet(uint8_t out[6])
+{
+    (void)out;
+    return false;
+}
+
+void persistedRandomDeviceIdRegenerate() {}
+
+#endif

--- a/src/PersistedRandomDeviceId.h
+++ b/src/PersistedRandomDeviceId.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <stdint.h>
+
+/**
+ * A randomly generated, locally administered MAC address persisted in the
+ * filesystem. It gives the device a random link-layer identity (BLE address,
+ * node number, default names) that is stable across reboots but re-rolled by
+ * factory reset, which removes /prefs.
+ *
+ * Opt-in: compiled out unless USERPREFS_RANDOM_DEVICE_ID is set (userPrefs.jsonc or
+ * a variant define), in which case platforms without support fall back to the
+ * hardware address.
+ *
+ * @return false if disabled, or no random MAC could be loaded or generated;
+ *         callers should fall back to the hardware address.
+ */
+bool persistedRandomDeviceIdGet(uint8_t out[6]);
+
+/**
+ * Generate, persist, and cache a fresh random MAC. Called during factory reset
+ * after /prefs has been wiped, so the device comes back with a new identity.
+ */
+void persistedRandomDeviceIdRegenerate();

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -7,6 +7,7 @@
 #include "CryptoEngine.h"
 #include "Default.h"
 #include "FSCommon.h"
+#include "PersistedRandomDeviceId.h"
 #include "MeshRadio.h"
 #include "MeshService.h"
 #include "MessageStore.h"
@@ -777,6 +778,13 @@ bool NodeDB::factoryReset(bool eraseBleBonds)
         trafficManagementModule->purgeAll();
 #endif
 
+#if USERPREFS_RANDOM_DEVICE_ID
+    // Mint a fresh random identity: rmDir above deleted the persisted random
+    // device id, so generate and save a new one, and clear the node number so
+    // pickNewNodeNum() below re-derives it from the new MAC.
+    persistedRandomDeviceIdRegenerate();
+    myNodeInfo.my_node_num = 0;
+#endif
     // second, install default state (this will deal with the duplicate mac address issue)
     installDefaultNodeDatabase();
     installDefaultDeviceState();

--- a/src/platform/esp32/main-esp32.cpp
+++ b/src/platform/esp32/main-esp32.cpp
@@ -1,3 +1,4 @@
+#include "PersistedRandomDeviceId.h"
 #include "PowerFSM.h"
 #include "PowerMon.h"
 #include "configuration.h"
@@ -151,6 +152,9 @@ void esp32ReleaseBluetoothMemoryIfUnused()
 
 void getMacAddr(uint8_t *dmac)
 {
+    if (persistedRandomDeviceIdGet(dmac))
+        return;
+
 #if defined(CONFIG_IDF_TARGET_ESP32C6) && defined(CONFIG_SOC_IEEE802154_SUPPORTED)
     auto res = esp_base_mac_addr_get(dmac);
     assert(res == ESP_OK);
@@ -220,6 +224,16 @@ void enableSlowCLK()
 
 void esp32Setup()
 {
+    // Install our persisted random device id as the base MAC before any radio
+    // interface initializes, so the BLE (and WiFi) addresses derive from it
+    // rather than the factory eFuse address.
+    uint8_t rmac[6];
+    if (persistedRandomDeviceIdGet(rmac)) {
+        auto macres = esp_base_mac_addr_set(rmac);
+        if (macres != ESP_OK)
+            LOG_ERROR("Failed to set random base MAC (%d)", macres);
+    }
+
     /* We explicitly don't want to do call randomSeed,
     // as that triggers the esp32 core to use a less secure pseudorandom function.
     uint32_t seed = esp_random();

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -2,6 +2,7 @@
 #include "BLEDfuSecure.h"
 #include "BluetoothCommon.h"
 #include "HardwareRNG.h"
+#include "PersistedRandomDeviceId.h"
 #include "PowerFSM.h"
 #include "configuration.h"
 #include "error.h"
@@ -286,6 +287,22 @@ void NRF52Bluetooth::setup()
         RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_UNSPECIFIED);
         return;
     }
+
+    // Advertise our persisted random device id instead of the factory FICR address.
+    // getMacAddr() returns it most-significant byte first; ble_gap_addr_t wants
+    // least-significant first. The generator already sets the two high bits
+    // required of a random static address.
+    uint8_t rmac[6];
+    if (persistedRandomDeviceIdGet(rmac)) {
+        ble_gap_addr_t addr;
+        memset(&addr, 0, sizeof(addr));
+        addr.addr_type = BLE_GAP_ADDR_TYPE_RANDOM_STATIC;
+        for (int i = 0; i < 6; i++)
+            addr.addr[i] = rmac[5 - i];
+        if (!Bluefruit.setAddr(&addr))
+            LOG_ERROR("Failed to set random BLE address");
+    }
+
     // Clear existing data.
     Bluefruit.Advertising.stop();
     Bluefruit.Advertising.clearData();

--- a/src/platform/nrf52/main-nrf52.cpp
+++ b/src/platform/nrf52/main-nrf52.cpp
@@ -1,4 +1,5 @@
 #include "configuration.h"
+#include "PersistedRandomDeviceId.h"
 #include <Adafruit_TinyUSB.h>
 #include <Adafruit_nRFCrypto.h>
 #include <InternalFileSystem.h>
@@ -186,6 +187,9 @@ void __attribute__((noreturn)) __assert_func(const char *file, int line, const c
 
 void getMacAddr(uint8_t *dmac)
 {
+    if (persistedRandomDeviceIdGet(dmac))
+        return;
+
     const uint8_t *src = (const uint8_t *)NRF_FICR->DEVICEADDR;
     dmac[5] = src[0];
     dmac[4] = src[1];

--- a/src/platform/rp2xx0/main-rp2xx0.cpp
+++ b/src/platform/rp2xx0/main-rp2xx0.cpp
@@ -1,4 +1,5 @@
 #include "HardwareRNG.h"
+#include "PersistedRandomDeviceId.h"
 #include "configuration.h"
 #include "hardware/xosc.h"
 #include <cstring>
@@ -89,6 +90,9 @@ void updateBatteryLevel(uint8_t level)
 
 void getMacAddr(uint8_t *dmac)
 {
+    if (persistedRandomDeviceIdGet(dmac))
+        return;
+
     pico_unique_board_id_t src;
     pico_get_unique_board_id(&src);
     dmac[5] = src.id[7];

--- a/userPrefs.jsonc
+++ b/userPrefs.jsonc
@@ -25,6 +25,7 @@
   // "USERPREFS_CONFIG_DEVICE_ROLE": "meshtastic_Config_DeviceConfig_Role_CLIENT", // Defaults to CLIENT. ROUTER*, and LOST AND FOUND roles are restricted.
   // "USERPREFS_EVENT_MODE": "1",
   // "USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS": "1", // Extend TMM position dedup and precision clamping to private/custom-key channels (default: well-known channels only)
+  // "USERPREFS_RANDOM_DEVICE_ID": "1", // Persisted random device identity: random BLE address/node id/names, stable until factory reset
   // "USERPREFS_FIRMWARE_EDITION": "meshtastic_FirmwareEdition_BURNING_MAN",
   // "USERPREFS_FIXED_BLUETOOTH": "121212",
   // "USERPREFS_FIXED_GPS": "",


### PR DESCRIPTION
When enabled, generate a random locally-administered MAC-format id on first boot, persist it in /prefs/deviceid.dat, and return it from `getMacAddr()` on ESP32, nRF52, and RP2040 - so the BLE address, node number, node id, default names, and the `owner.macaddr` broadcast in `NodeInfo` all derive from it instead of the factory hardware address. Stable across reboots; factory reset wipes /prefs, mints a fresh id, and clears `my_node_num` so the whole identity re-rolls together.

nRF52 installs the id as the BLE random static address; ESP32 sets it as the base MAC before radio init so BLE/WiFi addresses derive from it; RP2040 has no BLE stack (the W boards' CYW43 WiFi MAC is not covered). Platforms without support, and any failure to load or generate, fall back to the hardware address. Node number collisions from the smaller random space are handled by the existing re-roll in `pickNewNodeNum()`.

Off by default: compiled out entirely unless `USERPREFS_RANDOM_DEVICE_ID` is set in `userPrefs.jsonc` or a variant define. Intended for event and privacy-conscious deployments, in the spirit of `USERPREFS_EVENT_MODE`.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other: GAT562 30s Kit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional persisted random device identity for supported hardware.
  - Device and Bluetooth addresses can remain stable across restarts while avoiding use of factory identifiers.
  - Added support for regenerating the identity during factory reset.
  - Added a configuration option to enable the feature.

- **Bug Fixes**
  - Ensured device-derived node identity is refreshed after factory reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->