### PR TITLE
GAT562: add measured PA gain curve so Tx power is honest

### DIFF
--- a/variants/nrf52840/gat562_mesh_trial_tracker/variant.h
+++ b/variants/nrf52840/gat562_mesh_trial_tracker/variant.h
@@ -217,6 +217,15 @@ SO GPIO 39/TXEN MAY NOT BE DEFINED FOR SUCCESSFUL OPERATION OF THE SX1262 - TG
 #define SX126X_DIO2_AS_RF_SWITCH
 #define SX126X_DIO3_TCXO_VOLTAGE 1.8
 
+// Per-setting PA gain (actual output minus radio setting, dB) so requested Tx
+// power matches what the PA actually radiates. From the vendor's GAT562 30s
+// measurements at 869 MHz. The PA saturates at 30 dBm from setting 15 up, so
+// the curve is truncated there: driving harder wastes battery and linearity
+// for zero extra output, and max-power requests map to setting 15.
+// https://shop.mtoolstec.com/product/gat562-30s-kit-30dbm-mesh-device
+#define NUM_PA_POINTS 16
+#define TX_GAIN_LORA 14, 15, 16, 17, 17, 18, 18, 18, 18, 18, 17, 17, 17, 16, 16, 15
+
 // Testing USB detection
 #define NRF_APM
 


### PR DESCRIPTION
The variant shipped with no TX_GAIN_LORA, so the firmware treated the radio setting as the actual output while the 30dBm PA added up to ~18dB on top; the stock tx_power=0 default drove the PA to a full watt. Use the vendor's measured 869MHz curve so requested dBm matches radiated dBm. The curve is truncated at the saturation knee (setting 15, 30dBm) so max-power requests use the minimum drive that reaches full output instead of pushing the PA deeper into compression.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other: GAT562 30s Kit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added a 16-point LoRa transmission power gain configuration for improved radio output control on the GAT562 Mesh Trial Tracker variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->