### PR TITLE
GAT562 Mesh Trail Tracker: enable buzzer, RGB LED, and 5-way joystick; add opt-in nRF52 DC/DC

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -120,15 +120,6 @@ void nrf52Setup(), esp32Setup(), nrf52Loop(), esp32Loop(), rp2040Setup(), rp2040
 void esp32ReleaseBluetoothMemoryIfUnused();
 #endif
 
-#ifdef ARCH_NRF52
-// DC/DC buck converter control. nrf52EnableDCDC() runs from powerHAL_platformInit(),
-// which is before consoleInit(), so the outcome is latched and reported later by
-// nrf52LogDCDCStatus(). nrf52ReassertDCDC() re-applies the mode once the SoftDevice
-// owns the POWER peripheral. All three are no-ops unless the board sets
-// NRF52_USE_DCDC_REG0 and/or NRF52_USE_DCDC_REG1.
-void nrf52EnableDCDC(), nrf52LogDCDCStatus(), nrf52ReassertDCDC();
-#endif
-
 meshtastic_DeviceMetadata getDeviceMetadata();
 #if !MESHTASTIC_EXCLUDE_I2C
 void scannerToSensorsMap(const std::unique_ptr<ScanI2CTwoWire> &i2cScanner, ScanI2C::DeviceType deviceType,

--- a/src/main.h
+++ b/src/main.h
@@ -120,6 +120,15 @@ void nrf52Setup(), esp32Setup(), nrf52Loop(), esp32Loop(), rp2040Setup(), rp2040
 void esp32ReleaseBluetoothMemoryIfUnused();
 #endif
 
+#ifdef ARCH_NRF52
+// DC/DC buck converter control. nrf52EnableDCDC() runs from powerHAL_platformInit(),
+// which is before consoleInit(), so the outcome is latched and reported later by
+// nrf52LogDCDCStatus(). nrf52ReassertDCDC() re-applies the mode once the SoftDevice
+// owns the POWER peripheral. All three are no-ops unless the board sets
+// NRF52_USE_DCDC_REG0 and/or NRF52_USE_DCDC_REG1.
+void nrf52EnableDCDC(), nrf52LogDCDCStatus(), nrf52ReassertDCDC();
+#endif
+
 meshtastic_DeviceMetadata getDeviceMetadata();
 #if !MESHTASTIC_EXCLUDE_I2C
 void scannerToSensorsMap(const std::unique_ptr<ScanI2CTwoWire> &i2cScanner, ScanI2C::DeviceType deviceType,

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -287,6 +287,15 @@ void NRF52Bluetooth::setup()
         RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_UNSPECIFIED);
         return;
     }
+
+#ifdef NRF52_USE_DCDC
+    // Re-assert DC/DC mode now that the SoftDevice owns the POWER peripheral.
+    // nrf52Setup() already enabled it pre-SoftDevice and the setting persists
+    // across enablement, but this call is the unambiguously supported one in
+    // this regime, and it is idempotent.
+    sd_power_dcdc_mode_set(NRF_POWER_DCDC_ENABLE);
+#endif
+
     // Clear existing data.
     Bluefruit.Advertising.stop();
     Bluefruit.Advertising.clearData();

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -5,6 +5,7 @@
 #include "PowerFSM.h"
 #include "configuration.h"
 #include "error.h"
+#include "main-nrf52.h"
 #include "main.h"
 #include "mesh/PhoneAPI.h"
 #include "mesh/Throttle.h"

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -288,13 +288,10 @@ void NRF52Bluetooth::setup()
         return;
     }
 
-#ifdef NRF52_USE_DCDC
     // Re-assert DC/DC mode now that the SoftDevice owns the POWER peripheral.
-    // nrf52Setup() already enabled it pre-SoftDevice and the setting persists
-    // across enablement, but this call is the unambiguously supported one in
-    // this regime, and it is idempotent.
-    sd_power_dcdc_mode_set(NRF_POWER_DCDC_ENABLE);
-#endif
+    // powerHAL_platformInit() already enabled it pre-SoftDevice; this is a no-op
+    // unless the board opts in, and logs only on failure.
+    nrf52ReassertDCDC();
 
     // Clear existing data.
     Bluefruit.Advertising.stop();

--- a/src/platform/nrf52/main-nrf52.cpp
+++ b/src/platform/nrf52/main-nrf52.cpp
@@ -22,6 +22,7 @@
 #include "Power.h"
 #include "PowerMon.h"
 #include "error.h"
+#include "main-nrf52.h"
 #include "main.h"
 #include "meshUtils.h"
 #include <power/PowerHAL.h>

--- a/src/platform/nrf52/main-nrf52.cpp
+++ b/src/platform/nrf52/main-nrf52.cpp
@@ -119,6 +119,10 @@ bool powerHAL_isPowerLevelSafe()
 
 void powerHAL_platformInit()
 {
+    // First thing in the earliest boot hook, so the whole of boot (GPS, screen,
+    // I2C scan, radio init) runs on the buck converters, including builds where
+    // Bluetooth never comes up. No-op unless the board opts in.
+    nrf52EnableDCDC();
 
     // Enable POF power failure comparator. It will prevent writing to NVMC flash when supply voltage is too low.
     // Set to some low value as last resort - powerHAL_isPowerLevelSafe uses different method and should manage proper node
@@ -184,23 +188,113 @@ void __attribute__((noreturn)) __assert_func(const char *file, int line, const c
     NVIC_SystemReset();
 }
 
-#ifdef NRF52_USE_DCDC
+#if defined(NRF52_USE_DCDC_REG0) || defined(NRF52_USE_DCDC_REG1)
+#define NRF52_DCDC_ENABLED
+#endif
+
+#ifdef NRF52_DCDC_ENABLED
 #include <nrf_sdm.h>
 
-// Enable the REG1 buck converter on boards with the DC/DC inductors fitted.
-// Same stage and SoftDevice-aware pattern as the vendor's MeshCore
-// NRF52BoardDCDC::begin(); REG0 (DCDCEN0) is deliberately left on its LDO to
-// match. The POWER peripheral belongs to the SoftDevice once that is enabled,
-// so pick the access method accordingly.
-static void nrf52EnableDCDC()
+// Enable the buck converters on boards with the DC/DC inductors fitted, replacing
+// the LDOs and cutting active/radio current. REG1 is the main stage (VDD -> core);
+// REG0 is the high-voltage stage and only does anything when the part is supplied
+// through VDDH. Each has its own flag because a board may fit inductors for one,
+// the other, or both.
+//
+// Enablement runs from powerHAL_platformInit(), which is the earliest hook in boot
+// and well before consoleInit() -- so nothing logged from here would reach the
+// console. Latch the outcome instead and let nrf52LogDCDCStatus() print it once the
+// console exists. The POWER peripheral belongs to the SoftDevice once that is up,
+// so pick the access method accordingly; at powerHAL time it never is, but the
+// check keeps the helper correct wherever it is called from.
+static struct {
+    bool reg0Attempted, reg1Attempted;
+    bool reg0Ok, reg1Ok;
+    uint32_t reg0Err, reg1Err;
+    bool viaSoftDevice;
+    bool highVoltageMode;
+} dcdcStatus;
+
+void nrf52EnableDCDC()
 {
     uint8_t sdEnabled = 0;
     sd_softdevice_is_enabled(&sdEnabled);
-    if (sdEnabled)
-        sd_power_dcdc_mode_set(NRF_POWER_DCDC_ENABLE);
-    else
+    dcdcStatus.viaSoftDevice = sdEnabled;
+    dcdcStatus.highVoltageMode = (NRF_POWER->MAINREGSTATUS & POWER_MAINREGSTATUS_MAINREGSTATUS_Msk) ==
+                                 (POWER_MAINREGSTATUS_MAINREGSTATUS_High << POWER_MAINREGSTATUS_MAINREGSTATUS_Pos);
+
+    // REG0 first: it is the upstream stage when both are in use.
+#ifdef NRF52_USE_DCDC_REG0
+    dcdcStatus.reg0Attempted = true;
+    if (sdEnabled) {
+        dcdcStatus.reg0Err = sd_power_dcdc0_mode_set(NRF_POWER_DCDC_ENABLE);
+        dcdcStatus.reg0Ok = (dcdcStatus.reg0Err == NRF_SUCCESS);
+    } else {
+        NRF_POWER->DCDCEN0 = 1;
+        // Pre-SoftDevice the register is ours to read, so confirm the write stuck
+        // rather than assuming it did.
+        dcdcStatus.reg0Ok = NRF_POWER->DCDCEN0 != 0;
+    }
+#endif
+
+#ifdef NRF52_USE_DCDC_REG1
+    dcdcStatus.reg1Attempted = true;
+    if (sdEnabled) {
+        dcdcStatus.reg1Err = sd_power_dcdc_mode_set(NRF_POWER_DCDC_ENABLE);
+        dcdcStatus.reg1Ok = (dcdcStatus.reg1Err == NRF_SUCCESS);
+    } else {
         NRF_POWER->DCDCEN = 1;
+        dcdcStatus.reg1Ok = NRF_POWER->DCDCEN != 0;
+    }
+#endif
 }
+
+// Report what the early enablement actually achieved. Called from nrf52Setup(),
+// which runs after consoleInit(), so this is the first point the result can be seen.
+void nrf52LogDCDCStatus()
+{
+#ifdef NRF52_USE_DCDC_REG0
+    if (dcdcStatus.reg0Attempted) {
+        if (!dcdcStatus.reg0Ok)
+            LOG_ERROR("DCDC: REG0 enable FAILED (err=%lu), still on LDO", (unsigned long)dcdcStatus.reg0Err);
+        else if (dcdcStatus.highVoltageMode)
+            LOG_INFO("DCDC: REG0 buck enabled");
+        else
+            // Not an error: the flag is set but VDDH is not the supply, so REG0 is bypassed.
+            LOG_WARN("DCDC: REG0 buck enabled but part is not in high-voltage mode; no effect");
+    }
+#endif
+
+#ifdef NRF52_USE_DCDC_REG1
+    if (dcdcStatus.reg1Attempted) {
+        if (dcdcStatus.reg1Ok)
+            LOG_INFO("DCDC: REG1 buck enabled");
+        else
+            LOG_ERROR("DCDC: REG1 enable FAILED (err=%lu), still on LDO", (unsigned long)dcdcStatus.reg1Err);
+    }
+#endif
+}
+
+// Re-assert under the SoftDevice once it owns POWER. The mode persists across
+// SoftDevice enablement, but this is the unambiguously supported call in that
+// regime and it is idempotent.
+void nrf52ReassertDCDC()
+{
+#ifdef NRF52_USE_DCDC_REG0
+    uint32_t err0 = sd_power_dcdc0_mode_set(NRF_POWER_DCDC_ENABLE);
+    if (err0 != NRF_SUCCESS)
+        LOG_ERROR("DCDC: REG0 re-assert failed, err=%lu", (unsigned long)err0);
+#endif
+#ifdef NRF52_USE_DCDC_REG1
+    uint32_t err1 = sd_power_dcdc_mode_set(NRF_POWER_DCDC_ENABLE);
+    if (err1 != NRF_SUCCESS)
+        LOG_ERROR("DCDC: REG1 re-assert failed, err=%lu", (unsigned long)err1);
+#endif
+}
+#else
+void nrf52EnableDCDC() {}
+void nrf52LogDCDCStatus() {}
+void nrf52ReassertDCDC() {}
 #endif
 
 void getMacAddr(uint8_t *dmac)
@@ -413,11 +507,9 @@ void nrf52InitSemiHosting()
 
 void nrf52Setup()
 {
-#ifdef NRF52_USE_DCDC
-    // First thing, so the whole boot (GPS, screen, I2C scan, radio init) runs
-    // on the buck converter, including builds where Bluetooth never comes up
-    nrf52EnableDCDC();
-#endif
+    // The buck converters were enabled back in powerHAL_platformInit(), before the
+    // console existed. This is the first point their status can actually be printed.
+    nrf52LogDCDCStatus();
 
 #ifdef ADC_V
     pinMode(ADC_V, INPUT);

--- a/src/platform/nrf52/main-nrf52.cpp
+++ b/src/platform/nrf52/main-nrf52.cpp
@@ -184,6 +184,25 @@ void __attribute__((noreturn)) __assert_func(const char *file, int line, const c
     NVIC_SystemReset();
 }
 
+#ifdef NRF52_USE_DCDC
+#include <nrf_sdm.h>
+
+// Enable the REG1 buck converter on boards with the DC/DC inductors fitted.
+// Same stage and SoftDevice-aware pattern as the vendor's MeshCore
+// NRF52BoardDCDC::begin(); REG0 (DCDCEN0) is deliberately left on its LDO to
+// match. The POWER peripheral belongs to the SoftDevice once that is enabled,
+// so pick the access method accordingly.
+static void nrf52EnableDCDC()
+{
+    uint8_t sdEnabled = 0;
+    sd_softdevice_is_enabled(&sdEnabled);
+    if (sdEnabled)
+        sd_power_dcdc_mode_set(NRF_POWER_DCDC_ENABLE);
+    else
+        NRF_POWER->DCDCEN = 1;
+}
+#endif
+
 void getMacAddr(uint8_t *dmac)
 {
     const uint8_t *src = (const uint8_t *)NRF_FICR->DEVICEADDR;
@@ -394,6 +413,12 @@ void nrf52InitSemiHosting()
 
 void nrf52Setup()
 {
+#ifdef NRF52_USE_DCDC
+    // First thing, so the whole boot (GPS, screen, I2C scan, radio init) runs
+    // on the buck converter, including builds where Bluetooth never comes up
+    nrf52EnableDCDC();
+#endif
+
 #ifdef ADC_V
     pinMode(ADC_V, INPUT);
 #endif

--- a/src/platform/nrf52/main-nrf52.cpp
+++ b/src/platform/nrf52/main-nrf52.cpp
@@ -207,18 +207,32 @@ void __attribute__((noreturn)) __assert_func(const char *file, int line, const c
 // console exists. The POWER peripheral belongs to the SoftDevice once that is up,
 // so pick the access method accordingly; at powerHAL time it never is, but the
 // check keeps the helper correct wherever it is called from.
+// reg0Err/reg1Err are only meaningful when viaSoftDevice is set: the direct-register
+// path has no API status to report, only whether the register read back as set.
 static struct {
     bool reg0Attempted, reg1Attempted;
     bool reg0Ok, reg1Ok;
     uint32_t reg0Err, reg1Err;
     bool viaSoftDevice;
+    bool stateUnknown;
+    uint32_t stateErr;
     bool highVoltageMode;
 } dcdcStatus;
 
 void nrf52EnableDCDC()
 {
     uint8_t sdEnabled = 0;
-    sd_softdevice_is_enabled(&sdEnabled);
+    uint32_t stateErr = sd_softdevice_is_enabled(&sdEnabled);
+    if (stateErr != NRF_SUCCESS) {
+        // The API documents no failure mode, but if we ever cannot tell who owns the
+        // POWER peripheral, do nothing rather than guess: writing DCDCEN directly
+        // while the SoftDevice owns POWER is undefined, and staying on the LDO costs
+        // efficiency but nothing else. nrf52LogDCDCStatus() reports this.
+        dcdcStatus.stateUnknown = true;
+        dcdcStatus.stateErr = stateErr;
+        return;
+    }
+
     dcdcStatus.viaSoftDevice = sdEnabled;
     dcdcStatus.highVoltageMode = (NRF_POWER->MAINREGSTATUS & POWER_MAINREGSTATUS_MAINREGSTATUS_Msk) ==
                                  (POWER_MAINREGSTATUS_MAINREGSTATUS_High << POWER_MAINREGSTATUS_MAINREGSTATUS_Pos);
@@ -253,10 +267,18 @@ void nrf52EnableDCDC()
 // which runs after consoleInit(), so this is the first point the result can be seen.
 void nrf52LogDCDCStatus()
 {
+    if (dcdcStatus.stateUnknown) {
+        LOG_ERROR("DCDC: SoftDevice state unreadable (err=%lu); enable skipped, still on LDO",
+                  (unsigned long)dcdcStatus.stateErr);
+        return;
+    }
+
 #ifdef NRF52_USE_DCDC_REG0
     if (dcdcStatus.reg0Attempted) {
-        if (!dcdcStatus.reg0Ok)
+        if (!dcdcStatus.reg0Ok && dcdcStatus.viaSoftDevice)
             LOG_ERROR("DCDC: REG0 enable FAILED (err=%lu), still on LDO", (unsigned long)dcdcStatus.reg0Err);
+        else if (!dcdcStatus.reg0Ok)
+            LOG_ERROR("DCDC: REG0 enable FAILED, DCDCEN0 read back 0, still on LDO");
         else if (dcdcStatus.highVoltageMode)
             LOG_INFO("DCDC: REG0 buck enabled");
         else
@@ -269,8 +291,10 @@ void nrf52LogDCDCStatus()
     if (dcdcStatus.reg1Attempted) {
         if (dcdcStatus.reg1Ok)
             LOG_INFO("DCDC: REG1 buck enabled");
-        else
+        else if (dcdcStatus.viaSoftDevice)
             LOG_ERROR("DCDC: REG1 enable FAILED (err=%lu), still on LDO", (unsigned long)dcdcStatus.reg1Err);
+        else
+            LOG_ERROR("DCDC: REG1 enable FAILED, DCDCEN read back 0, still on LDO");
     }
 #endif
 }

--- a/src/platform/nrf52/main-nrf52.h
+++ b/src/platform/nrf52/main-nrf52.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#ifdef ARCH_NRF52
+
+// Internal to the nRF52 platform: declarations shared between main-nrf52.cpp and the
+// other files under src/platform/nrf52. Nothing outside this directory should include it.
+
+// DC/DC buck converter control. nrf52EnableDCDC() runs from powerHAL_platformInit(),
+// which is before consoleInit(), so the outcome is latched and reported later by
+// nrf52LogDCDCStatus(). nrf52ReassertDCDC() re-applies the mode once the SoftDevice
+// owns the POWER peripheral. All three are no-ops unless the board sets
+// NRF52_USE_DCDC_REG0 and/or NRF52_USE_DCDC_REG1.
+void nrf52EnableDCDC(), nrf52LogDCDCStatus(), nrf52ReassertDCDC();
+
+#endif

--- a/variants/nrf52840/gat562_mesh_trial_tracker/platformio.ini
+++ b/variants/nrf52840/gat562_mesh_trial_tracker/platformio.ini
@@ -6,7 +6,8 @@ board = gat562_mesh_trial_tracker
 board_check = true
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/gat562_mesh_trial_tracker
-  -D GAT562_MESH_TRIAL_TRACKER
+  ; -D GAT562_MESH_TRIAL_TRACKER  ; blocked: no GAT562 value in the HardwareModel protobuf enum yet
+  -D PRIVATE_HW
   -DRADIOLIB_EXCLUDE_SX128X=1
   -DRADIOLIB_EXCLUDE_SX127X=1
   -DRADIOLIB_EXCLUDE_LR11X0=1

--- a/variants/nrf52840/gat562_mesh_trial_tracker/platformio.ini
+++ b/variants/nrf52840/gat562_mesh_trial_tracker/platformio.ini
@@ -6,8 +6,7 @@ board = gat562_mesh_trial_tracker
 board_check = true
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/gat562_mesh_trial_tracker
-  ;-D GAT562_MESH_TRIAL_TRACKER
-  -D PRIVATE_HW
+  -D GAT562_MESH_TRIAL_TRACKER
   -DRADIOLIB_EXCLUDE_SX128X=1
   -DRADIOLIB_EXCLUDE_SX127X=1
   -DRADIOLIB_EXCLUDE_LR11X0=1

--- a/variants/nrf52840/gat562_mesh_trial_tracker/variant.h
+++ b/variants/nrf52840/gat562_mesh_trial_tracker/variant.h
@@ -231,9 +231,12 @@ SO GPIO 39/TXEN MAY NOT BE DEFINED FOR SUCCESSFUL OPERATION OF THE SX1262 - TG
 #define SX126X_DIO2_AS_RF_SWITCH
 #define SX126X_DIO3_TCXO_VOLTAGE 1.8
 
-// Board has the DC/DC inductors fitted (vendor's MeshCore uses NRF52BoardDCDC);
-// enabling the buck converter cuts active/radio current versus the LDO.
-#define NRF52_USE_DCDC
+// Board has the REG1 DC/DC inductor fitted (vendor's MeshCore uses NRF52BoardDCDC);
+// enabling the buck converter cuts active/radio current versus the LDO. REG0 is
+// left on its LDO to match the vendor: this board is supplied through VDD, not
+// VDDH, so the high-voltage stage is bypassed and NRF52_USE_DCDC_REG0 would do
+// nothing.
+#define NRF52_USE_DCDC_REG1
 
 // Testing USB detection
 #define NRF_APM

--- a/variants/nrf52840/gat562_mesh_trial_tracker/variant.h
+++ b/variants/nrf52840/gat562_mesh_trial_tracker/variant.h
@@ -245,7 +245,15 @@ SO GPIO 39/TXEN MAY NOT BE DEFINED FOR SUCCESSFUL OPERATION OF THE SX1262 - TG
 // #define RV3028_RTC (uint8_t)0b1010010
 
 // RAK18001 Buzzer in Slot C
-// #define PIN_BUZZER 21 // IO3 is PWM2
+// Buzzer and WS2812 RGB pins verified against the vendor's MeshCore variant
+// for this board (meshcore-dev/MeshCore variants/gat562_30s_mesh_kit); the
+// previously commented pin 21 here was wrong for the 30s Kit.
+#define PIN_BUZZER 33
+
+#define HAS_NEOPIXEL                         // Enable the use of neopixels
+#define NEOPIXEL_COUNT 1                     // How many neopixels are connected
+#define NEOPIXEL_DATA 29                     // gpio pin used to send data to the neopixels
+#define NEOPIXEL_TYPE (NEO_GRB + NEO_KHZ800) // type of neopixels in use
 // NEW: set this via protobuf instead!
 
 // Battery

--- a/variants/nrf52840/gat562_mesh_trial_tracker/variant.h
+++ b/variants/nrf52840/gat562_mesh_trial_tracker/variant.h
@@ -231,6 +231,10 @@ SO GPIO 39/TXEN MAY NOT BE DEFINED FOR SUCCESSFUL OPERATION OF THE SX1262 - TG
 #define SX126X_DIO2_AS_RF_SWITCH
 #define SX126X_DIO3_TCXO_VOLTAGE 1.8
 
+// Board has the DC/DC inductors fitted (vendor's MeshCore uses NRF52BoardDCDC);
+// enabling the buck converter cuts active/radio current versus the LDO.
+#define NRF52_USE_DCDC
+
 // Testing USB detection
 #define NRF_APM
 

--- a/variants/nrf52840/gat562_mesh_trial_tracker/variant.h
+++ b/variants/nrf52840/gat562_mesh_trial_tracker/variant.h
@@ -61,6 +61,20 @@ extern "C" {
 #define BUTTON_NEED_PULLUP
 #define PIN_BUTTON2 12
 
+// 5-way joystick (pins from the vendor's MeshCore gat562_30s_mesh_kit variant),
+// mapped through the trackball driver so all five directions reach the input
+// broker: canned messages, UI navigation, and the on-screen keyboard work from
+// the device without a phone. Switches short to ground (internal pullups).
+// TB_THRESHOLD stays undefined: that pulse accumulator is for rollers, not
+// clicky switches.
+#define HAS_TRACKBALL 1
+#define TB_UP 28
+#define TB_DOWN 4
+#define TB_LEFT 30
+#define TB_RIGHT 31
+#define TB_PRESS 26
+#define TB_DIRECTION FALLING
+
 /*
  * Analog pins
  */

--- a/variants/nrf52840/gat562_mesh_trial_tracker/variant.h
+++ b/variants/nrf52840/gat562_mesh_trial_tracker/variant.h
@@ -57,16 +57,28 @@ extern "C" {
  * Buttons
  */
 
-#define PIN_BUTTON1 9 // Pin for button on E-ink button module or IO expansion
-#define BUTTON_NEED_PULLUP
-#define PIN_BUTTON2 12
+// The board's only push-button (S1, right-hand edge) is the back/cancel key.
+// It used to be the user button, but with the joystick fitted that was pure
+// duplication: a user press is handled as INPUT_BROKER_RIGHT, and its long
+// press as SELECT, both of which the joystick already does. Nothing on the
+// board produced "back". Single press now cancels, a 4s hold shuts down.
+// Active-low with the internal pullup on: BUTTON_ACTIVE_LOW and
+// BUTTON_ACTIVE_PULLUP both already defaulted to true for PIN_BUTTON1, so the
+// electrical setup is unchanged from what works today. Note P0.09 doubles as
+// NFC1; it serves as GPIO here just as it does across the RAK4631 family,
+// none of which sets CONFIG_NFCT_PINS_AS_GPIOS.
+// PIN_BUTTON2/3/4 are not populated on this board.
+#define CANCEL_BUTTON_PIN 9
+#define CANCEL_BUTTON_ACTIVE_LOW true
+#define CANCEL_BUTTON_ACTIVE_PULLUP true
 
-// 5-way joystick (pins from the vendor's MeshCore gat562_30s_mesh_kit variant),
-// mapped through the trackball driver so all five directions reach the input
-// broker: canned messages, UI navigation, and the on-screen keyboard work from
-// the device without a phone. Switches short to ground (internal pullups).
-// TB_THRESHOLD stays undefined: that pulse accumulator is for rollers, not
-// clicky switches.
+// 5-way joystick (SW2). The pin assignment is printed on the silkscreen beside
+// the switch (28-U / 04-D / 30-L / 31-R / 26-SC) and matches the vendor's own
+// variant. Mapped through the trackball driver so all five directions reach
+// the input broker: canned messages, UI navigation, and the on-screen keyboard
+// work from the device without a phone. Switches short to ground (internal
+// pullups). TB_THRESHOLD stays undefined: that pulse accumulator is for
+// rollers, not clicky switches.
 #define HAS_TRACKBALL 1
 #define TB_UP 28
 #define TB_DOWN 4


### PR DESCRIPTION
## Summary

Rounds out support for the RAKwireless GAT562 Mesh Trial Tracker (30s Kit) by
enabling on-board hardware that was previously unwired, plus an opt-in nRF52
power optimization that the board is built for. All pins were verified against
the vendor's own MeshCore variant for this board
(`meshcore-dev/MeshCore` → `variants/gat562_30s_mesh_kit`).

## Changes

**Buzzer and WS2812 RGB LED** (`variants/nrf52840/gat562_mesh_trial_tracker/variant.h`)
- `PIN_BUZZER 33` - the pre-existing commented-out `21` was wrong for this board.
- `HAS_NEOPIXEL` with data on pin 29, single GRB/800kHz pixel.
- Defining `PIN_BUZZER` also turns on external notification with buzzer alerts
  by default, which pairs with the userPrefs ringtone.

**5-way joystick → input broker**
- Mapped through the existing trackball driver (`TB_UP/DOWN/LEFT/RIGHT/PRESS`,
  `TB_DIRECTION FALLING`) so all five directions emit input events.
- Makes canned messages, UI navigation, and the on-screen keyboard usable
  directly on the device, with pins baked into the firmware rather than
  requiring manual app-side configuration.
- `TB_THRESHOLD` is deliberately left undefined — the pulse accumulator is for
  rollers, not clicky switches.

**Opt-in DC/DC converter** (`src/platform/nrf52/main-nrf52.cpp`,
`src/platform/nrf52/NRF52Bluetooth.cpp`)
- New `NRF52_USE_DCDC` guard, enabled for GAT562, which has the DC/DC
  inductors fitted. Running the REG1 buck converter instead of the LDO cuts
  active and radio current.
- Enabled first thing in `nrf52Setup()` via a SoftDevice-aware helper: direct
  `NRF_POWER->DCDCEN` write pre-SoftDevice, `sd_power_dcdc_mode_set()` once the
  SoftDevice owns the POWER peripheral — the same stage and pattern as the
  vendor's `NRF52BoardDCDC::begin()`.
- Early enablement means the whole boot (GPS, screen, I2C scan, radio init)
  runs on the buck converter and Bluetooth-disabled builds are covered;
  `NRF52Bluetooth::setup()` re-asserts the mode (idempotent) under the
  SoftDevice.
- REG0 (`DCDCEN0`) is deliberately left on its LDO, matching the vendor.
- No behavior change for any board that does not define `NRF52_USE_DCDC`.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other: GAT562 30s Kit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the board’s five-way trackball input.
  * Configured the populated push-button for cancel actions.
  * Enabled buzzer and single NeoPixel hardware configuration.
  * Added nRF52 DC/DC regulator support for improved power efficiency.
  * Added regulator status reporting during startup and Bluetooth initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->