### PR TITLE
CI: defuse pioarduino's 60s esptool install on esp32 builds

### DIFF
--- a/bin/build-esp32.sh
+++ b/bin/build-esp32.sh
@@ -14,6 +14,12 @@ rm -r $OUTDIR/* || true
 # Important to pull latest version of libs into all device flavors, otherwise some devices might be stale
 platformio pkg install -e $1
 
+# Defuse pioarduino's esptool install, which otherwise runs a network-bound
+# `uv pip install --force-reinstall` under a hard-coded 60s timeout on every esp32
+# build and fails the build when it loses that race. Must run after `pkg install`
+# (which extracts the platform) and before `pio run` (which triggers penv setup).
+bin/ci/esp32-esptool-preflight.sh
+
 echo "Building for $1 with $PLATFORMIO_BUILD_FLAGS"
 rm -f $BUILDDIR/firmware*
 

--- a/bin/ci/esp32-esptool-preflight.sh
+++ b/bin/ci/esp32-esptool-preflight.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Defuse pioarduino's esptool install on esp32 builds.
+#
+# The espressif32 platform (pinned to 55.03.39 in variants/esp32/esp32-common.ini)
+# guards its esptool install with a probe that only passes when `import esptool`
+# resolves from inside the tool-esptoolpy package dir. Nothing ever satisfies that
+# probe on a first pass -- the editable install is never performed at container-build
+# time, and python_deps carries no esptool -- so every esp32 build falls through to:
+#
+#   uv pip install --quiet --force-reinstall --python=<penv> -e <tool-esptoolpy>
+#
+# under a hard-coded timeout=60 (builder/penv_setup.py:811-814). `--force-reinstall`
+# is an alias of uv's `--reinstall`, which implies `--refresh`, so that call re-resolves
+# esptool and its dependencies against PyPI instead of being served from cache. It is a
+# latency coin-flip against a 60s budget, and it loses whenever the runners are busy.
+#
+# When it loses, subprocess.TimeoutExpired is not caught (only CalledProcessError is,
+# at penv_setup.py:817), so _setup_python_environment_core never reaches its
+# `return penv_python, esptool_binary_path`. platform.py swallows the exception, and
+# setup_python_env then returns None implicitly, which surfaces as the real-world
+# symptom:
+#
+#   TypeError: cannot unpack non-iterable NoneType object   (builder/main.py:52)
+#
+# This script runs inside the build container -- gh-action-firmware bind-mounts the
+# workspace and its entrypoint invokes bin/build-esp32.sh -- so it takes effect on the
+# next job, against any container image vintage.
+#
+# It is deliberately fail-open. Part A alone removes the hard failure, so nothing here
+# is worth reddening a build over: an unrecognized upstream layout warns and continues.
+
+set -uo pipefail
+
+core="${PLATFORMIO_CORE_DIR:-$HOME/.platformio}"
+penv="$core/penv"
+pkg="$core/packages/tool-esptoolpy"
+
+# --- Part A: de-fang the install command itself -------------------------------------
+#
+# Drop `--force-reinstall` so the install is cache-served rather than re-resolved, and
+# raise the 60s cap to 600s so residual slowness becomes a slow success instead of a
+# build failure. Both `--force-reinstall` call sites are patched: only the one at line
+# 811 is reachable from the minimal (env is None) path this build takes, but the file is
+# vendored third-party code and a global edit is cheaper to reason about than a targeted
+# one. The `], timeout=60, env=uv_env)` anchor is specific enough to leave the unrelated
+# timeouts at lines 414 and 887 untouched.
+patched=0
+while IFS= read -r f; do
+	tmp="$f.preflight.tmp"
+	sed -e 's/ "--force-reinstall",//g' \
+		-e 's/], timeout=60, env=uv_env)/], timeout=600, env=uv_env)/g' \
+		"$f" >"$tmp" && mv -f "$tmp" "$f" || {
+		rm -f "$tmp"
+		continue
+	}
+
+	# Drop bytecode compiled from the pre-patch source so the edit actually takes effect.
+	rm -f "$(dirname "$f")/__pycache__/penv_setup."*.pyc
+
+	if grep -q -- '--force-reinstall' "$f"; then
+		echo "preflight: WARNING --force-reinstall survived in $f (upstream layout changed?)" >&2
+	fi
+	echo "preflight: patched $f"
+	patched=$((patched + 1))
+done < <(find "$core/platforms" -path '*/builder/penv_setup.py' -type f 2>/dev/null)
+
+if [ "$patched" -eq 0 ]; then
+	echo "preflight: no builder/penv_setup.py under $core/platforms - nothing to patch" >&2
+fi
+
+# --- Part B: pre-satisfy the probe so the install is skipped entirely ---------------
+#
+# Best-effort only. tool-esptoolpy is not reliably materialized as a Python project this
+# early in the build, which is why this checks for packaging metadata rather than just a
+# directory. If it is not ready, Part A has already made the platform's own install safe.
+if [ -x "$penv/bin/uv" ] && { [ -f "$pkg/pyproject.toml" ] || [ -f "$pkg/setup.py" ]; }; then
+	export UV_CACHE_DIR="${UV_CACHE_DIR:-$core/.cache/uv}"
+
+	# Replicates the probe at penv_setup.py:785-804 exactly (realpath + normcase + startswith).
+	probe() {
+		"$penv/bin/python" - "$pkg" <<'PY'
+import esptool, os, sys
+expected = os.path.normcase(os.path.realpath(sys.argv[1]))
+actual = os.path.normcase(os.path.realpath(os.path.dirname(esptool.__file__)))
+sys.exit(0 if actual.startswith(expected) else 1)
+PY
+	}
+
+	if probe; then
+		echo "preflight: esptool already resolves under $pkg (probe will MATCH)"
+	else
+		# A regular esptool ahead of the tool package on sys.path shadows it and makes the
+		# probe miss, so drop it before installing the tool package editable.
+		"$penv/bin/uv" pip uninstall --python "$penv/bin/python" esptool >/dev/null 2>&1
+		if "$penv/bin/uv" pip install --python "$penv/bin/python" -e "$pkg" && probe; then
+			echo "preflight: esptool baked editable from $pkg"
+		else
+			echo "preflight: could not bake esptool; relying on the patched install path" >&2
+		fi
+	fi
+else
+	echo "preflight: penv or tool-esptoolpy not ready - relying on the patched install path" >&2
+fi
+
+exit 0

--- a/bin/ci/esp32-esptool-preflight.sh
+++ b/bin/ci/esp32-esptool-preflight.sh
@@ -38,17 +38,27 @@ pkg="$core/packages/tool-esptoolpy"
 
 # --- Part A: de-fang the install command itself -------------------------------------
 #
-# Drop `--force-reinstall` so the install is cache-served rather than re-resolved, and
-# raise the 60s cap to 600s so residual slowness becomes a slow success instead of a
-# build failure. Both `--force-reinstall` call sites are patched: only the one at line
-# 811 is reachable from the minimal (env is None) path this build takes, but the file is
-# vendored third-party code and a global edit is cheaper to reason about than a targeted
-# one. The `], timeout=60, env=uv_env)` anchor is specific enough to leave the unrelated
-# timeouts at lines 414 and 887 untouched.
+# Drop whichever reinstall flag the pinned platform uses so the install is cache-served
+# rather than re-fetched, and raise the 60s cap to 600s so residual slowness becomes a
+# slow success instead of a build failure. Two spellings are handled:
+#
+#   "--force-reinstall"                  -- pioarduino 55.03.39 and earlier
+#   "--reinstall-package", "esptool"     -- meshtastic fork, cfdf56e onwards
+#
+# Both imply a uv refresh (`--reinstall` => `--refresh`, `--reinstall-package` =>
+# `--refresh-package`), so either one forces a network fetch on every build.
+#
+# Both call sites are patched. Only the second is reachable from the minimal
+# (env is None) path a CI build takes, but this is vendored third-party code and a
+# global edit is cheaper to reason about than a targeted one. The
+# `], timeout=60, env=uv_env)` anchor is specific enough to leave the unrelated 60s
+# timeouts elsewhere in the file untouched.
 patched=0
 while IFS= read -r f; do
 	tmp="$f.preflight.tmp"
 	sed -e 's/ "--force-reinstall",//g' \
+		-e 's/^[[:space:]]*"--reinstall-package",[[:space:]]*"esptool",[[:space:]]*$//' \
+		-e 's/ "--reinstall-package", "esptool",//g' \
 		-e 's/], timeout=60, env=uv_env)/], timeout=600, env=uv_env)/g' \
 		"$f" >"$tmp" && mv -f "$tmp" "$f" || {
 		rm -f "$tmp"
@@ -58,8 +68,12 @@ while IFS= read -r f; do
 	# Drop bytecode compiled from the pre-patch source so the edit actually takes effect.
 	rm -f "$(dirname "$f")/__pycache__/penv_setup."*.pyc
 
-	if grep -q -- '--force-reinstall' "$f"; then
-		echo "preflight: WARNING --force-reinstall survived in $f (upstream layout changed?)" >&2
+	# The hazard is a reinstall flag still paired with the 60s cap. Warn only when both
+	# survive, so this stays quiet once the fix lands upstream and the patterns stop
+	# matching because there is nothing left to patch.
+	if grep -qE -- '--force-reinstall|--reinstall-package' "$f" &&
+		grep -q 'timeout=60, env=uv_env)' "$f"; then
+		echo "preflight: WARNING $f still reinstalls under a 60s cap (upstream layout changed?)" >&2
 	fi
 	echo "preflight: patched $f"
 	patched=$((patched + 1))


### PR DESCRIPTION
## Problem

The [2026-07-25 nightly](https://github.com/meshtastic/firmware/actions/runs/30149645315) lost **23 of 139 build legs**, all esp32/esp32s3, all with a byte-identical error — and because `build` failed, `gather-artifacts` and `publish-nightly` were skipped, so **no nightly was published**.

```
Error in package configuration: TimeoutExpired: Command '['/pio/core/penv/bin/uv', 'pip',
 'install', '--quiet', '--force-reinstall', '--python=/pio/core/penv/bin/python', '-e',
 '/pio/core/packages/tool-esptoolpy']' timed out after 60 seconds
TypeError: cannot unpack non-iterable NoneType object:
  File "/pio/core/platforms/espressif32/builder/main.py", line 52:
    PYTHON_EXE, esptool_binary_path = platform.setup_python_env(env)
```

This is not new — the same failure hit on 07-18, 07-21, and the 07-24 nightly (2 legs). It is the reason `UV_OFFLINE=1` and `bin/patch-esp32_uv_reinstall.sh` were added to gh-action-firmware; both were then removed by [gh-action-firmware#50](https://github.com/meshtastic/gh-action-firmware/pull/50), whose branch was cut 2h39m before the patch it deleted.

## Root cause

espressif32 `55.03.39` (pinned at `variants/esp32/esp32-common.ini:8`) guards its esptool install with a probe (`builder/penv_setup.py:785-804`) that passes only when `import esptool` resolves from inside the `tool-esptoolpy` package dir.

**Nothing satisfies that probe on a first pass** — the editable install is never performed at container-build time (during `pio pkg install` the function early-returns at `penv_setup.py:774-775`), and `python_deps` carries no esptool. So *every* esp32 build falls through to:

```python
uv pip install --quiet --force-reinstall --python=<penv> -e <tool-esptoolpy>   # timeout=60
```

`--force-reinstall` is a hidden alias of uv's `--reinstall`, which implies `--refresh` — so this re-resolves esptool plus its dependencies against PyPI instead of being cache-served. It's a latency coin-flip against a 60s budget.

`TimeoutExpired` is not caught at `penv_setup.py:817` (only `CalledProcessError` is), so `_setup_python_environment_core` never reaches its `return penv_python, esptool_binary_path`; `platform.py` swallows the exception; `setup_python_env` returns `None` implicitly. **The `TypeError` is a downstream symptom, not the fault.**

Load is the trigger, not the cause — 15 of the 38 first-wave esp32 legs survived the same race, and all 37 later-starting esp32 legs passed.

## Fix

`bin/ci/esp32-esptool-preflight.sh`, called from `bin/build-esp32.sh` between `pkg install` (line 15) and `pio run` (line 25):

- **Part A** — strip `--force-reinstall` and raise `timeout=60` → `600` in the vendored `penv_setup.py`, so the install is cache-served and residual slowness degrades to a slow success rather than a failed build.
- **Part B** — best-effort: uninstall the shadowing regular esptool and install `tool-esptoolpy` editable, so the probe MATCHes and the install is skipped outright.

**Deliberately fail-open.** Part A alone removes the hard failure, so an unrecognized upstream layout warns and continues rather than reddening 79 builds. `exit 0` on every path.

### Why here, and not in the container

gh-action-firmware's `entrypoint.sh` runs `/workspace/bin/build-esp32.sh` and its `action.yml` bind-mounts `$GITHUB_WORKSPACE:/workspace` — **this repo owns the script that executes inside the container.** So this takes effect on the very next job, with no image rebuild, and works against any image vintage.

That matters because a container-side fix is *not* sufficient today: `action.yml` uses a bare `docker run` (Docker default `--pull=missing`, no digest pin), and no failing job log shows a pull — the 06:53Z image republish provably never reached the runners before the 07:37Z nightly.

## Verification

Placement verified: all 23 failures fire during `pio run`, never during `pkg install`, and the traceback itself names `/pio/core/platforms/espressif32/builder/penv_setup.py`, so the target file exists by then. No `Platform Manager:` line appears between the two steps, so nothing re-extracts the platform and reverts the edit.

The seds were dry-run against the pinned 55.03.39 source (md5 `9448800d6ddc186e7966a7d2cae1634f`) — **exactly 4 hunks** (585, 588, 811, 814), correctly leaving the unrelated `timeout=60` at lines 414 and 887 untouched, zero `--force-reinstall` residue.

Both parts were exercised end-to-end against a synthetic core with a properly pip-installed shadowing esptool:

```
run 1: preflight: patched .../penv_setup.py
       preflight: esptool baked editable from .../tool-esptoolpy
       import esptool -> .../tool-esptoolpy/esptool  (5.3.0, was 4.9.0 shadow)
run 2: preflight: esptool already resolves under .../tool-esptoolpy (probe will MATCH)
```

Idempotent, and the fail-open path was confirmed by an unbakeable variant (warns, exits 0).

### How to confirm after merge

Grep a build log for `preflight: ` plus either `esptool already resolves` or `esptool baked editable`, and assert the **absence** of `TimeoutExpired ... tool-esptoolpy`. A green run alone proves little — the failure is a race that 15 of 38 legs won unaided.

## Follow-ups (not in this PR)

- gh-action-firmware: [#52](https://github.com/meshtastic/gh-action-firmware/pull/52) fixes this properly at image-build time, but is currently a **no-op for esp32** because [#53](https://github.com/meshtastic/gh-action-firmware/pull/53) stops copying `/pio/core/penv` into esp32 images. Separate PR follows.
- `esp32c6 × master` has been hard-404ing on a deleted release asset, which makes every `Build Release` run report `failure` and masks real image regressions.
- No `timeout-minutes` or retry exists anywhere in the firmware build path.

/cc @vidplace7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ESP32 build reliability by preventing unnecessary network-dependent reinstalls during the build process.
  * Added a CI preflight step to verify and stabilize the required esptool installation.
  * Builds now proceed successfully (with warnings) even if the preflight adjustment or validation can’t be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->