### PR TITLE
Switch to forked pioarduino platform (with penv fixes for CI issues)

### DIFF
--- a/variants/esp32/esp32-common.ini
+++ b/variants/esp32/esp32-common.ini
@@ -5,7 +5,9 @@ custom_esp32_kind =
 custom_mtjson_part =
 platform =
   # TODO renovate
-  https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
+  ; Using forked pioarduino to fix --force-reinstall CI issue
+  https://github.com/meshtastic/pioarduino-platform-espressif32/archive/refs/heads/55.03.39.zip
+  ; https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
   ; https://github.com/pioarduino/platform-espressif32.git#develop
 platform_packages =
   # renovate: datasource=custom.pio depName=platformio/tool-mklittlefs packageName=platformio/tool/tool-mklittlefs


### PR DESCRIPTION
Alternative to #11217 use our forked pioarduino platform
This forked pioarduino replaces `--force-reinstall` with `--reinstall-package esptool`
https://github.com/meshtastic/pioarduino-platform-espressif32/commit/cfdf56eb27d7e5c889c844af08a01a750a734493

The same fix has been proposed upstream in https://github.com/pioarduino/platform-espressif32/pull/513

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the ESP32 platform configuration to improve compatibility and reliability when building ESP32 firmware.
  * Refined platform configuration documentation for clearer maintenance and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->