### PR TITLE
add preamble_length to settings list

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "protobufs"]
 	path = protobufs
-	url = https://github.com/meshtastic/protobufs.git
+	url = https://github.com/dinets/my_protobufs.git
 [submodule "meshtestic"]
 	path = meshtestic
 	url = https://github.com/meshtastic/meshTestic

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -1358,6 +1358,13 @@ void RadioInterface::applyModemConfig()
     }
 
     slotTimeMsec = computeSlotTimeMsec();
+
+      if(loraConfig.preamble_length != 0) {
+       preambleLength = loraConfig.preamble_length ;
+    } else {
+    preambleLength = preambleLengthDefault;
+    }
+
     preambleTimeMsec = preambleLength * (pow_of_2(sf) / bw);
 
     LOG_INFO("Radio freq=%.3f, config.lora.frequency_offset=%.3f", freq, loraConfig.frequency_offset);
@@ -1373,6 +1380,7 @@ void RadioInterface::applyModemConfig()
     }
     LOG_INFO("channel_num: %d", channel_num + 1);
     LOG_INFO("frequency: %f", getFreq());
+    LOG_INFO("preamble length: %d", preambleLength);
     LOG_INFO("Slot time: %u msec, preamble time: %u msec", slotTimeMsec, preambleTimeMsec);
 } // end of applyModemConfig
 

--- a/src/mesh/generated/meshtastic/admin.pb.h
+++ b/src/mesh/generated/meshtastic/admin.pb.h
@@ -186,7 +186,7 @@ typedef struct _meshtastic_LockdownAuth {
  token at unlock time: the client-supplied boots_remaining when
  non-zero, otherwise the firmware default (TOKEN_DEFAULT_BOOTS).
  Note that boots_remaining == 0 in this message means "use firmware
- default", NOT "zero boots" - a client computing the ceiling for
+ default", NOT "zero boots" — a client computing the ceiling for
  display should mirror that resolution rather than multiplying the
  raw request value.
 
@@ -196,7 +196,7 @@ typedef struct _meshtastic_LockdownAuth {
 
  Uses millis() (CPU uptime), not wall-clock time, so the cap is
  immune to GPS spoofing, RTC backup-battery removal, and Faraday
- cage isolation - none of those move the uptime counter. The only
+ cage isolation — none of those move the uptime counter. The only
  way to reset the session clock is a reboot, which costs a boot
  from the on-flash, HMAC-bound counter. */
     uint32_t max_session_seconds;
@@ -213,7 +213,7 @@ typedef struct _meshtastic_LockdownAuth {
 
  NOT reversed by this operation: APPROTECT. Once the debug port
  lockout has been burned (on silicon where it is effective) it is
- permanent - disabling lockdown decrypts your data and removes the
+ permanent — disabling lockdown decrypts your data and removes the
  access gates, but the SWD/JTAG port stays locked for the life of
  the device (recoverable only via a full chip erase over a debug
  probe, which destroys all data). Clients should make this

--- a/src/mesh/generated/meshtastic/apponly.pb.h
+++ b/src/mesh/generated/meshtastic/apponly.pb.h
@@ -55,7 +55,7 @@ extern const pb_msgdesc_t meshtastic_ChannelSet_msg;
 
 /* Maximum encoded size of messages (where known) */
 #define MESHTASTIC_MESHTASTIC_APPONLY_PB_H_MAX_SIZE meshtastic_ChannelSet_size
-#define meshtastic_ChannelSet_size               685
+#define meshtastic_ChannelSet_size               692
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/mesh/generated/meshtastic/atak.pb.h
+++ b/src/mesh/generated/meshtastic/atak.pb.h
@@ -332,7 +332,7 @@ typedef enum _meshtastic_CotType {
     /* y-: TAKTALK room/membership broadcast. Payload carried via the
  TakTalkRoomData typed variant (sender_callsign, room_id, room_name,
  participants). The CoT type literally has a trailing dash and no
- second atom - not a typo. */
+ second atom — not a typo. */
     meshtastic_CotType_CotType_y = 126
 } meshtastic_CotType;
 
@@ -380,7 +380,7 @@ typedef enum _meshtastic_DrawnShape_Kind {
     /* u-r-b-bullseye: Bullseye ring with range rings and bearing reference */
     meshtastic_DrawnShape_Kind_Kind_Bullseye = 7,
     /* u-d-c-e: Ellipse with distinct major/minor axes (same storage as
- Kind_Circle - uses major_cm/minor_cm/angle_deg - but receivers
+ Kind_Circle — uses major_cm/minor_cm/angle_deg — but receivers
  render it as a non-circular ellipse rather than a round circle). */
     meshtastic_DrawnShape_Kind_Kind_Ellipse = 8,
     /* u-d-v: 2D vehicle outline drawn on the map. Vertices carry the
@@ -400,7 +400,7 @@ typedef enum _meshtastic_DrawnShape_Kind {
  end of parse; builder uses it to decide which of <strokeColor> /
  <fillColor> to emit in the reconstructed XML. */
 typedef enum _meshtastic_DrawnShape_StyleMode {
-    /* Unspecified - receiver infers from which color fields are non-zero. */
+    /* Unspecified — receiver infers from which color fields are non-zero. */
     meshtastic_DrawnShape_StyleMode_StyleMode_Unspecified = 0,
     /* Stroke only. No <fillColor> in the source XML. Used for polylines,
  ranging lines, bullseye rings. */
@@ -417,7 +417,7 @@ typedef enum _meshtastic_DrawnShape_StyleMode {
  alone is ambiguous (e.g. a-u-G could be a 2525 symbol or a custom icon
  depending on the iconset path). */
 typedef enum _meshtastic_Marker_Kind {
-    /* Unspecified - fall back to TAKPacketV2.cot_type_id */
+    /* Unspecified — fall back to TAKPacketV2.cot_type_id */
     meshtastic_Marker_Kind_Kind_Unspecified = 0,
     /* b-m-p-s-m: Spot map marker */
     meshtastic_Marker_Kind_Kind_Spot = 1,
@@ -680,10 +680,10 @@ typedef struct _meshtastic_AircraftTrack {
  hundred meters of the anchor has per-vertex deltas in the ±10^4 range.
  Under sint32+zigzag those encode as 2 bytes each (tag+varint), versus the
  4 bytes that sfixed32 would always require. At 32 vertices that is ~128
- bytes of savings - the difference between fitting under the LoRa MTU or
+ bytes of savings — the difference between fitting under the LoRa MTU or
  not. Absolute coordinates (values ~10^9) would cost sint32 varint 5 bytes
  per field, which is why TAKPacketV2's top-level latitude_i / longitude_i
- stay sfixed32 - only small values win with sint32. */
+ stay sfixed32 — only small values win with sint32. */
 typedef struct _meshtastic_CotGeoPoint {
     /* Latitude delta from TAKPacketV2.latitude_i, in 1e-7 degree units.
  Add to the enclosing event's latitude_i to recover the absolute latitude. */
@@ -791,7 +791,7 @@ typedef struct _meshtastic_Marker {
 
  Covers CoT type u-rb-a. The anchor position is on
  TAKPacketV2.latitude_i/longitude_i; the target endpoint is carried as a
- CotGeoPoint - same delta-from-anchor encoding used by DrawnShape.vertices
+ CotGeoPoint — same delta-from-anchor encoding used by DrawnShape.vertices
  so a self-anchored RAB (common case) encodes in zero bytes. */
 typedef struct _meshtastic_RangeAndBearing {
     /* Target/anchor endpoint (delta-encoded from TAKPacketV2.latitude_i/longitude_i). */
@@ -899,12 +899,12 @@ typedef struct _meshtastic_CasevacReport {
  same as the envelope callsign but ATAK sometimes carries a distinct
  ops-number here. */
     pb_callback_t title;
-    /* Primary medline free-text - the single most clinically important line
+    /* Primary medline free-text — the single most clinically important line
  on a MEDLINE form (e.g. "2 urgent litter patients, smoke on approach").
  MUST be preserved under MTU pressure as long as any casevac is sent. */
     pb_callback_t medline_remarks;
     /* Line 3 (newer ATAK format): patient counts by precedence level.
- Coexists with the enum-style `precedence` field (tag 1) - older ATAK
+ Coexists with the enum-style `precedence` field (tag 1) — older ATAK
  emits a single enum, newer ATAK emits these counts, and both can be
  set simultaneously. Senders populate whichever style(s) the source
  XML had; receivers prefer counts when non-zero. */
@@ -946,19 +946,19 @@ typedef struct _meshtastic_CasevacReport {
  (e.g. "Primary HLZ is soccer field"). */
     pb_callback_t hlz_remarks;
     /* Per-patient clinical records. Each entry is one patient's ZMIST card
- (Zap number / Mechanism / Injuries / Signs / Treatment). Repeatable -
+ (Zap number / Mechanism / Injuries / Signs / Treatment). Repeatable —
  a mass-casualty event can carry 1-6 entries in practice, limited by
  the 237 B LoRa MTU. */
     pb_callback_t zmist;
 } meshtastic_CasevacReport;
 
-/* Per-patient clinical summary record - one entry per patient in a CASEVAC.
+/* Per-patient clinical summary record — one entry per patient in a CASEVAC.
  Maps directly to ATAK's <zMist> child element inside <zMistsMap>.
  All fields are optional free-text; senders populate what they have. */
 typedef struct _meshtastic_ZMistEntry {
     /* Patient identifier / sequence label (e.g. "ZMIST-1", "ZMIST-2"). */
     pb_callback_t title;
-    /* Zap number - unique patient tracking ID (often a terse code like
+    /* Zap number — unique patient tracking ID (often a terse code like
  "Gunshot" or a serial). */
     pb_callback_t z;
     /* Mechanism of injury (e.g. "Penetrating trauma", "Blast injury"). */
@@ -997,7 +997,7 @@ typedef struct _meshtastic_EmergencyAlert {
  creation time; the fields below carry structured metadata the raw-detail
  fallback currently loses.
 
- Fields are deliberately lean - this variant is closer to the MTU ceiling
+ Fields are deliberately lean — this variant is closer to the MTU ceiling
  than the others, so every string is capped in options. */
 typedef struct _meshtastic_TaskRequest {
     /* Short tag for the task category (e.g. "engage", "observe", "recon",
@@ -1017,7 +1017,7 @@ typedef struct _meshtastic_TaskRequest {
 
 /* Weather annotation from <environment> CoT detail element.
 
- Attaches to any TAKPacketV2 regardless of payload_variant - an Aircraft,
+ Attaches to any TAKPacketV2 regardless of payload_variant — an Aircraft,
  PLI, or Marker can all carry observed conditions at the emitting station.
  ATAK-CIV ships an XSD for <environment> but no dedicated handler, so the
  element round-trips through the generic detail pipeline; this message
@@ -1026,7 +1026,7 @@ typedef struct _meshtastic_TaskRequest {
  Target wire cost: ~6-8 bytes compressed with a fully populated instance.
 
  Named `TAKEnvironment` (not just `Environment`) because the bare name
- collides with `SwiftUI.Environment` - every SwiftUI view in a consuming
+ collides with `SwiftUI.Environment` — every SwiftUI view in a consuming
  iOS app uses the `@Environment` property wrapper, and importing the
  generated proto module would make `Environment` ambiguous in every one
  of those files. The `TAK` prefix matches the convention used by the
@@ -1055,7 +1055,7 @@ typedef struct _meshtastic_TAKEnvironment {
  The receiving ATAK client restores those from its own defaults, same as
  every other CoT carried over Meshtastic today.
 
- Attaches to any TAKPacketV2 - a PLI with a sensor on the operator's head,
+ Attaches to any TAKPacketV2 — a PLI with a sensor on the operator's head,
  an Aircraft with a FLIR turret, a Marker dropped on a UAV.
  Target wire cost: ~7-14 bytes compressed (dominated by model string). */
 typedef struct _meshtastic_SensorFov {
@@ -1065,30 +1065,30 @@ typedef struct _meshtastic_SensorFov {
  SensorDetailHandler default (270°) and save varint bytes over centi-deg. */
     uint32_t azimuth_deg;
     /* Maximum range of the cone in meters.
- Optional - if unset, receivers should use the ATAK-CIV default of 100m. */
+ Optional — if unset, receivers should use the ATAK-CIV default of 100m. */
     bool has_range_m;
     uint32_t range_m;
     /* Horizontal field of view in whole degrees (cone's angular width).
  ATAK-CIV default is 45°. */
     uint32_t fov_horizontal_deg;
     /* Vertical field of view in whole degrees. ATAK-CIV default is 45°.
- Optional - a value of 0 means "not set / use horizontal FOV". */
+ Optional — a value of 0 means "not set / use horizontal FOV". */
     uint32_t fov_vertical_deg;
     /* Elevation angle in whole degrees. Positive = up, negative = down.
  Range -90 to +90. sint32 for varint efficiency on small negatives. */
     int32_t elevation_deg;
     /* Roll (camera tilt) in whole degrees, -180 to +180.
- Optional - use 0 if the sensor doesn't track roll. */
+ Optional — use 0 if the sensor doesn't track roll. */
     int32_t roll_deg;
     /* Free-form device model identifier, e.g. "FLIR-Boson-640", "SEEK".
- Optional - empty string means "unknown model" (ATAK-CIV default). */
+ Optional — empty string means "unknown model" (ATAK-CIV default). */
     pb_callback_t model;
 } meshtastic_SensorFov;
 
 /* TAKTALK chat message payload (CoT type m-t-t).
 
  TAKTALK is an ATAK plugin for voice + text team messaging. The voice
- audio stream goes over UDP/RTP and is NOT carried by the mesh - only
+ audio stream goes over UDP/RTP and is NOT carried by the mesh — only
  the text envelope (this message) is. `from_voice` marks messages sent
  via push-to-talk speech-to-text so receivers can render a mic icon
  next to the text.
@@ -1122,7 +1122,7 @@ typedef struct _meshtastic_TakTalkMessage {
  Announces a TAKTALK chatroom's friendly name and roster so peers can
  resolve room UUIDs (used in TakTalkMessage.chatroom_id and
  GeoChat.room_id) to a display name and participant list. Not a chat
- message itself - these events are emitted by TAKTALK when rooms are
+ message itself — these events are emitted by TAKTALK when rooms are
  created or memberships change. */
 typedef struct _meshtastic_TakTalkRoomData {
     /* Callsign of the device broadcasting the room state (typically the
@@ -1161,7 +1161,7 @@ typedef struct _meshtastic_Marti {
  primary-vs-cc distinction the same way ATAK does.
 
  If dest_callsign is [TAKPacketV2.callsign] (self-addressed, unusual but
- legal - e.g. ATAK echoing back to its own room), the builder still emits
+ legal — e.g. ATAK echoing back to its own room), the builder still emits
  the element so loopback shapes round-trip cleanly. */
     pb_callback_t dest_callsign;
 } meshtastic_Marti;

--- a/src/mesh/generated/meshtastic/config.pb.h
+++ b/src/mesh/generated/meshtastic/config.pb.h
@@ -668,6 +668,8 @@ typedef struct _meshtastic_Config_LoRaConfig {
     meshtastic_Config_LoRaConfig_FEM_LNA_Mode fem_lna_mode;
     /* Don't use radiolib to initialize the radio, instead listen for a serialHal connection */
     bool serial_hal_only;
+    /* The length of the preamble in symbols */
+    uint32_t preamble_length;
 } meshtastic_Config_LoRaConfig;
 
 typedef struct _meshtastic_Config_BluetoothConfig {
@@ -836,7 +838,7 @@ extern "C" {
 #define meshtastic_Config_NetworkConfig_init_default {0, "", "", "", 0, _meshtastic_Config_NetworkConfig_AddressMode_MIN, false, meshtastic_Config_NetworkConfig_IpV4Config_init_default, "", 0, 0}
 #define meshtastic_Config_NetworkConfig_IpV4Config_init_default {0, 0, 0, 0}
 #define meshtastic_Config_DisplayConfig_init_default {0, _meshtastic_Config_DisplayConfig_DeprecatedGpsCoordinateFormat_MIN, 0, 0, 0, _meshtastic_Config_DisplayConfig_DisplayUnits_MIN, _meshtastic_Config_DisplayConfig_OledType_MIN, _meshtastic_Config_DisplayConfig_DisplayMode_MIN, 0, 0, _meshtastic_Config_DisplayConfig_CompassOrientation_MIN, 0, 0, 0}
-#define meshtastic_Config_LoRaConfig_init_default {0, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, 0, 0, 0, 0, _meshtastic_Config_LoRaConfig_RegionCode_MIN, 0, 0, 0, 0, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, _meshtastic_Config_LoRaConfig_FEM_LNA_Mode_MIN, 0}
+#define meshtastic_Config_LoRaConfig_init_default {0, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, 0, 0, 0, 0, _meshtastic_Config_LoRaConfig_RegionCode_MIN, 0, 0, 0, 0, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, _meshtastic_Config_LoRaConfig_FEM_LNA_Mode_MIN, 0, 0}
 #define meshtastic_Config_BluetoothConfig_init_default {0, _meshtastic_Config_BluetoothConfig_PairingMode_MIN, 0}
 #define meshtastic_Config_SecurityConfig_init_default {{0, {0}}, {0, {0}}, 0, {{0, {0}}, {0, {0}}, {0, {0}}}, 0, 0, 0, 0, _meshtastic_Config_SecurityConfig_PacketSignaturePolicy_MIN}
 #define meshtastic_Config_SessionkeyConfig_init_default {0}
@@ -847,7 +849,7 @@ extern "C" {
 #define meshtastic_Config_NetworkConfig_init_zero {0, "", "", "", 0, _meshtastic_Config_NetworkConfig_AddressMode_MIN, false, meshtastic_Config_NetworkConfig_IpV4Config_init_zero, "", 0, 0}
 #define meshtastic_Config_NetworkConfig_IpV4Config_init_zero {0, 0, 0, 0}
 #define meshtastic_Config_DisplayConfig_init_zero {0, _meshtastic_Config_DisplayConfig_DeprecatedGpsCoordinateFormat_MIN, 0, 0, 0, _meshtastic_Config_DisplayConfig_DisplayUnits_MIN, _meshtastic_Config_DisplayConfig_OledType_MIN, _meshtastic_Config_DisplayConfig_DisplayMode_MIN, 0, 0, _meshtastic_Config_DisplayConfig_CompassOrientation_MIN, 0, 0, 0}
-#define meshtastic_Config_LoRaConfig_init_zero   {0, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, 0, 0, 0, 0, _meshtastic_Config_LoRaConfig_RegionCode_MIN, 0, 0, 0, 0, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, _meshtastic_Config_LoRaConfig_FEM_LNA_Mode_MIN, 0}
+#define meshtastic_Config_LoRaConfig_init_zero   {0, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, 0, 0, 0, 0, _meshtastic_Config_LoRaConfig_RegionCode_MIN, 0, 0, 0, 0, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, _meshtastic_Config_LoRaConfig_FEM_LNA_Mode_MIN, 0, 0}
 #define meshtastic_Config_BluetoothConfig_init_zero {0, _meshtastic_Config_BluetoothConfig_PairingMode_MIN, 0}
 #define meshtastic_Config_SecurityConfig_init_zero {{0, {0}}, {0, {0}}, 0, {{0, {0}}, {0, {0}}, {0, {0}}}, 0, 0, 0, 0, _meshtastic_Config_SecurityConfig_PacketSignaturePolicy_MIN}
 #define meshtastic_Config_SessionkeyConfig_init_zero {0}
@@ -935,6 +937,7 @@ extern "C" {
 #define meshtastic_Config_LoRaConfig_config_ok_to_mqtt_tag 105
 #define meshtastic_Config_LoRaConfig_fem_lna_mode_tag 106
 #define meshtastic_Config_LoRaConfig_serial_hal_only_tag 107
+#define meshtastic_Config_LoRaConfig_preamble_length_tag 108
 #define meshtastic_Config_BluetoothConfig_enabled_tag 1
 #define meshtastic_Config_BluetoothConfig_mode_tag 2
 #define meshtastic_Config_BluetoothConfig_fixed_pin_tag 3
@@ -1089,7 +1092,8 @@ X(a, STATIC,   REPEATED, UINT32,   ignore_incoming, 103) \
 X(a, STATIC,   SINGULAR, BOOL,     ignore_mqtt,     104) \
 X(a, STATIC,   SINGULAR, BOOL,     config_ok_to_mqtt, 105) \
 X(a, STATIC,   SINGULAR, UENUM,    fem_lna_mode,    106) \
-X(a, STATIC,   SINGULAR, BOOL,     serial_hal_only, 107)
+X(a, STATIC,   SINGULAR, BOOL,     serial_hal_only, 107) \
+X(a, STATIC,   SINGULAR, UINT32,   preamble_length, 108)
 #define meshtastic_Config_LoRaConfig_CALLBACK NULL
 #define meshtastic_Config_LoRaConfig_DEFAULT NULL
 
@@ -1147,7 +1151,7 @@ extern const pb_msgdesc_t meshtastic_Config_SessionkeyConfig_msg;
 #define meshtastic_Config_BluetoothConfig_size   10
 #define meshtastic_Config_DeviceConfig_size      100
 #define meshtastic_Config_DisplayConfig_size     36
-#define meshtastic_Config_LoRaConfig_size        91
+#define meshtastic_Config_LoRaConfig_size        98
 #define meshtastic_Config_NetworkConfig_IpV4Config_size 20
 #define meshtastic_Config_NetworkConfig_size     204
 #define meshtastic_Config_PositionConfig_size    62

--- a/src/mesh/generated/meshtastic/deviceonly.pb.h
+++ b/src/mesh/generated/meshtastic/deviceonly.pb.h
@@ -452,7 +452,7 @@ extern const pb_msgdesc_t meshtastic_BackupPreferences_msg;
 /* Maximum encoded size of messages (where known) */
 /* meshtastic_NodeDatabase_size depends on runtime parameters */
 #define MESHTASTIC_MESHTASTIC_DEVICEONLY_PB_H_MAX_SIZE meshtastic_BackupPreferences_size
-#define meshtastic_BackupPreferences_size        2740
+#define meshtastic_BackupPreferences_size        2747
 #define meshtastic_ChannelFile_size              718
 #define meshtastic_DeviceState_size              1944
 #define meshtastic_NodeEnvironmentEntry_size     170

--- a/src/mesh/generated/meshtastic/localonly.pb.h
+++ b/src/mesh/generated/meshtastic/localonly.pb.h
@@ -211,7 +211,7 @@ extern const pb_msgdesc_t meshtastic_LocalModuleConfig_msg;
 
 /* Maximum encoded size of messages (where known) */
 #define MESHTASTIC_MESHTASTIC_LOCALONLY_PB_H_MAX_SIZE meshtastic_LocalModuleConfig_size
-#define meshtastic_LocalConfig_size              759
+#define meshtastic_LocalConfig_size              766
 #define meshtastic_LocalModuleConfig_size        1126
 
 #ifdef __cplusplus

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -1252,15 +1252,15 @@ typedef struct _meshtastic_LockdownStatus {
     /* Current lockdown state being reported. */
     meshtastic_LockdownStatus_State state;
     /* For LOCKED: machine-readable reason. Known values:
-   "needs_auth"        - storage already unlocked, client must auth
-   "token_missing"     - no boot token on flash
-   "token_expired"     - boot token wall-clock TTL elapsed
-   "token_boots_zero"  - boot token boot-count TTL exhausted
-   "token_hmac_fail"   - token tampered or wrong device
-   "token_dek_fail"    - token DEK decrypt failed
-   "token_wrong_size"  - token file corrupted
-   "token_bad_magic"   - token file corrupted
-   "not_provisioned"   - should generally use NEEDS_PROVISION state instead
+   "needs_auth"        — storage already unlocked, client must auth
+   "token_missing"     — no boot token on flash
+   "token_expired"     — boot token wall-clock TTL elapsed
+   "token_boots_zero"  — boot token boot-count TTL exhausted
+   "token_hmac_fail"   — token tampered or wrong device
+   "token_dek_fail"    — token DEK decrypt failed
+   "token_wrong_size"  — token file corrupted
+   "token_bad_magic"   — token file corrupted
+   "not_provisioned"   — should generally use NEEDS_PROVISION state instead
  Other values may be added; clients should treat unknown values as
  "locked, ask for passphrase". */
     char lock_reason[32];

--- a/src/mesh/generated/meshtastic/mesh_beacon.pb.h
+++ b/src/mesh/generated/meshtastic/mesh_beacon.pb.h
@@ -15,7 +15,7 @@
 /* Payload for MESH_BEACON_APP packets.
  Periodically broadcast by nodes in beacon mode.
  Listeners deliver the text message to the local inbox and cache any offered
- channel/preset for the client app to act on - the firmware never auto-applies them. */
+ channel/preset for the client app to act on — the firmware never auto-applies them. */
 typedef struct _meshtastic_MeshBeacon {
     /* Human-readable beacon message. Max 100 bytes enforced by firmware on send. */
     char message[101];

--- a/src/mesh/generated/meshtastic/module_config.pb.h
+++ b/src/mesh/generated/meshtastic/module_config.pb.h
@@ -497,7 +497,7 @@ typedef struct _meshtastic_ModuleConfig_MeshBeaconConfig {
     /* Single-target TX channel: channel settings (name + PSK) to send beacons on.
  If unset, beacons go out on the primary channel. Used only when broadcast_targets is empty.
  NOTE: the single-target path embeds the ChannelSettings inline here, whereas a
- broadcast_targets entry references a channel-table slot by channel_index instead - see
+ broadcast_targets entry references a channel-table slot by channel_index instead — see
  BroadcastTarget. The two paths are equal, first-class options; only this representation differs. */
     bool has_broadcast_on_channel;
     meshtastic_ChannelSettings broadcast_on_channel;
@@ -514,7 +514,7 @@ typedef struct _meshtastic_ModuleConfig_MeshBeaconConfig {
  each temporarily switching the radio to that entry's preset/region/channel.
  When empty, the broadcaster uses the scalar broadcast_on_preset / broadcast_on_region /
  broadcast_on_channel fields instead (the single-target path).
- Single- and multi-target are equal, first-class options - neither is preferred or
+ Single- and multi-target are equal, first-class options — neither is preferred or
  deprecated. They differ only in how the TX channel is named: broadcast_on_channel embeds a
  ChannelSettings inline, while a target references an existing channel-table slot by
  channel_index (see BroadcastTarget). */


### PR DESCRIPTION
Adding preamble_length in Lora config list, to get ability change this parameter.

For what?

To controlling(using) external Power Amplifier, specially for old half_duplex PA with RF relays

Tested on LilyGo T-Beam
<img width="2560" height="798" alt="96d31e8a-8b38-4b5d-98a6-96665dc08aa7" src="https://github.com/user-attachments/assets/fe0499e9-8a34-4993-a9db-d1ae84aad978" />
<img width="2560" height="798" alt="15e82cfd-92b0-4773-80f3-1a5e70676ba1" src="https://github.com/user-attachments/assets/10c11021-89f1-4a68-91ab-df77f0a41647" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for customizing the LoRa preamble length through the radio configuration.
  - When no custom value is provided, the system continues using the appropriate regional default.
  - Radio configuration output now reports the final preamble length applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->