### PR TITLE
fix(router): release packets Router::send() declines instead of leaking them

### DIFF
--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -27,7 +27,10 @@ bool NextHopRouter::relayOpaquePacket(const meshtastic_MeshPacket *p)
         return false;
     relay->hop_limit--;
     relay->relay_node = nodeDB->getLastByteOfNodeNum(getNodeNum());
-    return Router::send(relay) == ERRNO_OK;
+    ErrorCode res = Router::send(relay);
+    if (res == ERRNO_SHOULD_RELEASE)
+        packetPool.release(relay);
+    return res == ERRNO_OK;
 }
 
 PendingPacket::PendingPacket(meshtastic_MeshPacket *p, uint8_t numRetransmissions)
@@ -483,7 +486,10 @@ int32_t NextHopRouter::doRetransmissions()
 
 void NextHopRouter::setNextTx(PendingPacket *pending)
 {
-    assert(iface);
+    if (!iface) {
+        LOG_WARN("setNextTx: no interface, cannot schedule retransmission");
+        return;
+    }
     auto d = iface->getRetransmissionMsec(pending->packet);
     pending->nextTxMsec = millis() + d;
     LOG_DEBUG("Setting next retransmission in %u msecs: ", d);

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -451,6 +451,7 @@ ErrorCode Router::send(meshtastic_MeshPacket *p)
 
     if (!(p->which_payload_variant == meshtastic_MeshPacket_encrypted_tag ||
           p->which_payload_variant == meshtastic_MeshPacket_decoded_tag)) {
+        packetPool.release(p);
         return meshtastic_Routing_Error_BAD_REQUEST;
     }
 
@@ -495,7 +496,11 @@ ErrorCode Router::send(meshtastic_MeshPacket *p)
     }
 #endif
 
-    assert(iface); // This should have been detected already in sendLocal (or we just received a packet from outside)
+    if (!iface) {
+        // assert() here hangs forever on STM32WL with no diagnostic; NAK like every other error path instead.
+        abortSendAndNak(meshtastic_Routing_Error_NO_INTERFACE, p);
+        return ERRNO_NO_INTERFACES;
+    }
     return iface->send(p);
 }
 

--- a/src/modules/MeshBeaconModule.cpp
+++ b/src/modules/MeshBeaconModule.cpp
@@ -286,7 +286,8 @@ void MeshBeaconBroadcastModule::sendBeaconPacket(meshtastic_MeshPacket *p, mesht
     const bool cryptoOverride =
         has_channel && overrideChannel && (overrideChannel->name[0] != '\0' || overrideChannel->psk.size > 0);
     if (!cryptoOverride) {
-        router->send(p);
+        if (router->send(p) == ERRNO_SHOULD_RELEASE)
+            packetPool.release(p);
         return;
     }
 
@@ -300,7 +301,9 @@ void MeshBeaconBroadcastModule::sendBeaconPacket(meshtastic_MeshPacket *p, mesht
     primary.settings = beaconChannelSettings(saved, targetPreset, overrideChannel);
     channels.fixupChannel(channels.getPrimaryIndex());
 
-    router->send(p); // encrypts with the beacon channel's key and stamps its hash
+    // encrypts with the beacon channel's key and stamps its hash
+    if (router->send(p) == ERRNO_SHOULD_RELEASE)
+        packetPool.release(p);
 
     primary.settings = saved;
     channels.fixupChannel(channels.getPrimaryIndex());


### PR DESCRIPTION
## Problem

Two related packet-lifecycle bugs in `src/mesh/Router.cpp` and its callers, both against the STM32WL dynamic `packetPool` context from the ongoing memory-safety audit (#11230 and follow-ups):

1. `Router::send()` leaked `p` on the invalid-payload-variant `BAD_REQUEST` early return — every other early return in this function releases the packet first.
2. `assert(iface)` (both in `Router::send()` and separately in `NextHopRouter::setNextTx()`) hangs forever with no diagnostic on STM32WL instead of NAK'ing/logging like every other error path in the same file.
3. `ERRNO_SHOULD_RELEASE` is a documented contract: `RadioLibInterface::send()` can decline to send a packet and return this code *without* releasing it, expecting the caller to release (`MeshService::sendToMesh()` already does this correctly). `NextHopRouter::relayOpaquePacket()` and both `MeshBeaconModule::sendBeaconPacket()` call sites ignored the return value entirely and leaked `p` whenever `send()` declined — e.g. the `p->to == NODENUM_BROADCAST_NO_LORA` path in `RadioLibInterface::send()`.

I also traced `NextHopRouter::shouldFilterReceived()`'s rebroadcast path and all five call sites in `doRetransmissions()`, which looked like the same bug in an earlier audit pass — those turned out to already be fixed upstream (they already check for `ERRNO_SHOULD_RELEASE` and release correctly). Verified against a clean `upstream/develop` checkout rather than re-fixing already-fixed code.

## Fix

- `Router::send()`: release `p` before the `BAD_REQUEST` return; convert `assert(iface)` to the same `abortSendAndNak()` pattern already used for every other error in this function.
- `NextHopRouter::setNextTx()`: convert `assert(iface)` to a logged early return.
- `NextHopRouter::relayOpaquePacket()`, `MeshBeaconModule::sendBeaconPacket()` (both call sites): check the `send()` return value and release on `ERRNO_SHOULD_RELEASE`, matching `MeshService::sendToMesh()`'s existing correct handling.

## Test plan

- [x] `pio run -e wio-e5` / `pio run -e rak3172` — build clean.
- [x] Hardware (wio-e5): flashed, confirmed clean boot, set region, sent a text message, confirmed the device stays responsive throughout (`--info` healthy before/after).
- [ ] The specific leak triggers (`p->to == NODENUM_BROADCAST_NO_LORA` via `RadioLibInterface::send()`, opaque-relay mode, beacon broadcast under a declined send) are narrow, protocol-level conditions that weren't independently reproduced live in this pass — the fix is a mechanical return-value check mirroring the already-shipped-correct `MeshService::sendToMesh()` pattern in the same file.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below): wio-e5 — build + hardware verified per test plan above. rak3172 build-verified only.