### PR TITLE
fix(mesh): harden MemoryPool<T,MaxSize>::release() against bad pointers

### DIFF
--- a/src/mesh/MemoryPool.h
+++ b/src/mesh/MemoryPool.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <Arduino.h>
-#include <assert.h>
 #include <functional>
 #include <memory>
 
@@ -148,13 +147,18 @@ template <class T, int MaxSize> class MemoryPool : public Allocator<T>
             return;
         }
 
-        // Find the index of this pointer in our pool
-        int index = p - pool;
-        if (index >= 0 && index < MaxSize) {
-            assert(used[index]); // Should be marked as used
+        // Pointer subtraction is UB unless p actually points into pool, so find the index via address
+        // arithmetic instead - a foreign/garbage pointer must be rejected, not fed to p - pool.
+        uintptr_t offset = reinterpret_cast<uintptr_t>(p) - reinterpret_cast<uintptr_t>(pool);
+        size_t index = offset / sizeof(T);
+        if (offset % sizeof(T) == 0 && index < (size_t)MaxSize) {
+            if (!used[index]) {
+                LOG_WARN("Double release of pool item %d at 0x%x", (int)index, p);
+                return;
+            }
             used[index] = false;
             this->auditAdd(-(int32_t)sizeof(T));
-            LOG_HEAP("Released static pool item %d at 0x%x", index, p);
+            LOG_HEAP("Released static pool item %d at 0x%x", (int)index, p);
         } else {
             LOG_WARN("Pointer 0x%x not from our pool!", p);
         }


### PR DESCRIPTION
## Problem

`MemoryPool<T,MaxSize>::release()` (`src/mesh/MemoryPool.h`) computed `int index = p - pool;` — pointer subtraction that's undefined behavior unless `p` already points into `pool`. A double-free hit `assert(used[index])`, which hangs forever with no diagnostic on STM32WL (`__wrap___assert_func` is `while(true);`).

This static pool backs `clientNotificationPool`/`staticQueueStatusPool`/`staticMqttClientProxyMessagePool` on every platform including STM32WL (unlike `packetPool`, which is `MemoryDynamic`-backed there) — so this is reachable, not theoretical.

## Fix

Validate via address arithmetic (`reinterpret_cast<uintptr_t>`) instead of raw pointer subtraction, rejecting a foreign/misaligned pointer before it's used as an index. Convert the double-free `assert()` into a logged, graceful return — matching the `MemoryDynamic::alloc()` precedent from #11197.

## Test plan

- [x] `pio run -e wio-e5` / `pio run -e rak3172` — build clean.
- [x] Hardware (wio-e5): temporarily patched in a one-shot test (not part of this diff) that allocates a `meshtastic_ClientNotification`, releases it, then deliberately releases the same pointer again and a misaligned pointer. Confirmed over serial: `"Double release of pool item 0 at 0x...`" and `"Pointer 0x... not from our pool!"` logged, no hang, boot continues normally (radio init succeeds). Test hook reverted before opening this PR.
- [x] Hardware (wio-e5): reflashed the clean committed fix afterward, confirmed normal boot/operation.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below): wio-e5 — build + hardware verified per test plan above. rak3172 build-verified only.