### PR TITLE
fix(radio): replace beginSending() asserts with graceful rejection

### DIFF
--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -1462,10 +1462,18 @@ void RadioInterface::deliverToReceiver(meshtastic_MeshPacket *p)
  */
 size_t RadioInterface::beginSending(meshtastic_MeshPacket *p)
 {
-    assert(!sendingPacket);
-
-    // LOG_DEBUG("Send queued packet on mesh (txGood=%d,rxGood=%d,rxBad=%d)", rf95.txGood(), rf95.rxGood(), rf95.rxBad());
-    assert(p->which_payload_variant == meshtastic_MeshPacket_encrypted_tag); // It should have already been encoded by now
+    // These used to be asserts, which hang forever with no diagnostic on STM32WL. Reject and release
+    // instead - the caller must treat a 0 return as "not sent, p already released".
+    if (sendingPacket) {
+        LOG_ERROR("beginSending called while a send is already in progress");
+        packetPool.release(p);
+        return 0;
+    }
+    if (p->which_payload_variant != meshtastic_MeshPacket_encrypted_tag) {
+        LOG_ERROR("beginSending called with an unencrypted packet");
+        packetPool.release(p);
+        return 0;
+    }
 
     radioBuffer.header.from = p->from;
     radioBuffer.header.to = p->to;
@@ -1482,8 +1490,17 @@ size_t RadioInterface::beginSending(meshtastic_MeshPacket *p)
     radioBuffer.header.flags |= (p->hop_start << PACKET_FLAGS_HOP_START_SHIFT) & PACKET_FLAGS_HOP_START_MASK;
 
     // if the sender nodenum is zero, that means uninitialized
-    assert(radioBuffer.header.from);
-    assert(p->encrypted.size <= sizeof(radioBuffer.payload));
+    if (!radioBuffer.header.from) {
+        LOG_ERROR("beginSending called with an unset sender node num");
+        packetPool.release(p);
+        return 0;
+    }
+    if (p->encrypted.size > sizeof(radioBuffer.payload)) {
+        LOG_ERROR("beginSending: encrypted size %u exceeds radio buffer capacity %zu", p->encrypted.size,
+                  sizeof(radioBuffer.payload));
+        packetPool.release(p);
+        return 0;
+    }
     memcpy(radioBuffer.payload, p->encrypted.bytes, p->encrypted.size);
 
     sendingPacket = p;

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -773,6 +773,8 @@ bool RadioLibInterface::startSend(meshtastic_MeshPacket *txp)
         configHardwareForSend(); // must be after setStandby
 
         size_t numbytes = beginSending(txp);
+        if (numbytes == 0) // beginSending() already released txp and logged why
+            return false;
 
         int res = iface->startTransmit((uint8_t *)&radioBuffer, numbytes);
         if (res != RADIOLIB_ERR_NONE) {

--- a/src/platform/portduino/SimRadio.cpp
+++ b/src/platform/portduino/SimRadio.cpp
@@ -208,6 +208,8 @@ void SimRadio::startSend(meshtastic_MeshPacket *txp)
     printPacket("Start low level send", txp);
     isReceiving = false;
     size_t numbytes = beginSending(txp);
+    if (numbytes == 0) // beginSending() already released txp and logged why
+        return;
     meshtastic_MeshPacket *p = packetPool.allocCopy(*txp);
     if (!p)
         return;


### PR DESCRIPTION
## Problem

`RadioInterface::beginSending()` guards four invariants with `assert()`: no send already in progress, payload already encrypted, sender node num set, and encrypted payload fits the radio buffer. On STM32WL these all hang forever with no diagnostic instead of dropping the one bad packet (`__wrap___assert_func` is `while(true);`).

## Fix

Convert each `assert()` to a checked early return: log, release `p`, return 0. Both callers (`RadioLibInterface::startSend()`, `SimRadio::startSend()`) are updated to check for a 0 return and bail out cleanly instead of proceeding to transmit/use the now-released packet.

## Test plan

- [x] `pio run -e wio-e5` / `pio run -e rak3172` / `pio run -e native-macos` — build clean (native-macos exercises the `SimRadio.cpp` caller).
- [x] Hardware (wio-e5): flashed, confirmed clean boot, sent a text message over LoRa and confirmed the device stays responsive — exercises the normal (non-failing) path through the new checks.
- [ ] The four specific invariant violations weren't independently reproduced live (they require corrupting internal router state to trigger) — this is a mechanical assert→checked-return conversion, same pattern as #11231/#11232.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below): wio-e5 — build + hardware verified per test plan above. rak3172 build-verified only.