### PR TITLE
fix(router): don't hang on a null interface in NextHopRouter::setNextTx()

### DIFF
--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -483,7 +483,10 @@ int32_t NextHopRouter::doRetransmissions()
 
 void NextHopRouter::setNextTx(PendingPacket *pending)
 {
-    assert(iface);
+    if (!iface) {
+        LOG_WARN("setNextTx: no interface, cannot schedule retransmission");
+        return;
+    }
     auto d = iface->getRetransmissionMsec(pending->packet);
     pending->nextTxMsec = millis() + d;
     LOG_DEBUG("Setting next retransmission in %u msecs: ", d);


### PR DESCRIPTION
## Problem

`NextHopRouter::setNextTx()` has its own `assert(iface)` — a separate call site from the one in `Router::send()` (already fixed via #11223). On STM32WL this hangs forever with no diagnostic instead of skipping the retransmission scheduling gracefully.

This was originally part of #11231, which is otherwise fully superseded by #11223 (same `Router`/`NextHopRouter`/`MeshBeaconModule` packet-leak fixes) — this is just the one call site that PR doesn't cover, re-proposed on its own.

## Fix

Convert to a logged early return, matching the style already used for the `Router::send()` `assert(iface)` fix in #11223.

## Test plan

- [x] `pio run -e wio-e5` / `pio run -e rak3172` — build clean.
- [x] Hardware (wio-e5): flashed, confirmed clean boot/operation.
- [ ] The null-interface condition itself wasn't reproduced live (single-radio-interface architecture makes this essentially unreachable in normal operation today) — defensive hardening matching the established pattern.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below): wio-e5 — build + hardware verified per test plan above. rak3172 build-verified only.