### PR TITLE
fix: defensive buffer-write hardening (sprintf, mt_sprintf, NMEA checksum)

### DIFF
--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -386,7 +386,6 @@ std::string RedirectablePrint::mt_sprintf(const std::string fmt_str, ...)
     va_list ap;
     while (1) {
         formatted.reset(new char[n]); /* Wrap the plain char array into the unique_ptr */
-        strcpy(&formatted[0], fmt_str.c_str());
         va_start(ap, fmt_str);
         int final_n = vsnprintf(&formatted[0], n, fmt_str.c_str(), ap);
         va_end(ap);

--- a/src/gps/NMEAWPL.cpp
+++ b/src/gps/NMEAWPL.cpp
@@ -27,11 +27,19 @@ uint32_t printWPL(char *buf, size_t bufsz, const meshtastic_PositionLite &pos, c
                             (abs(geoCoord.getLatitude()) - geoCoord.getDMSLatDeg() * 1e+7) * 6e-6, geoCoord.getDMSLatCP(),
                             geoCoord.getDMSLonDeg(), (abs(geoCoord.getLongitude()) - geoCoord.getDMSLonDeg() * 1e+7) * 6e-6,
                             geoCoord.getDMSLonCP(), name);
+    // snprintf() returns the length that *would* have been written, which can exceed bufsz if
+    // truncated - clamp before using it as an index/size, or the checksum loop reads out of
+    // bounds and bufsz-len underflows into a huge size for the next snprintf().
+    if (len >= bufsz)
+        len = bufsz > 0 ? bufsz - 1 : 0;
+
     uint32_t chk = 0;
     for (uint32_t i = 1; i < len; i++) {
         chk ^= buf[i];
     }
     len += snprintf(buf + len, bufsz - len, "*%02X\r\n", chk);
+    if (len >= bufsz)
+        len = bufsz > 0 ? bufsz - 1 : 0;
     return len;
 }
 
@@ -43,11 +51,19 @@ uint32_t printWPL(char *buf, size_t bufsz, const meshtastic_Position &pos, const
                             (abs(geoCoord.getLatitude()) - geoCoord.getDMSLatDeg() * 1e+7) * 6e-6, geoCoord.getDMSLatCP(),
                             geoCoord.getDMSLonDeg(), (abs(geoCoord.getLongitude()) - geoCoord.getDMSLonDeg() * 1e+7) * 6e-6,
                             geoCoord.getDMSLonCP(), name);
+    // snprintf() returns the length that *would* have been written, which can exceed bufsz if
+    // truncated - clamp before using it as an index/size, or the checksum loop reads out of
+    // bounds and bufsz-len underflows into a huge size for the next snprintf().
+    if (len >= bufsz)
+        len = bufsz > 0 ? bufsz - 1 : 0;
+
     uint32_t chk = 0;
     for (uint32_t i = 1; i < len; i++) {
         chk ^= buf[i];
     }
     len += snprintf(buf + len, bufsz - len, "*%02X\r\n", chk);
+    if (len >= bufsz)
+        len = bufsz > 0 ? bufsz - 1 : 0;
     return len;
 }
 /* -------------------------------------------
@@ -91,11 +107,19 @@ uint32_t printGGA(char *buf, size_t bufsz, const meshtastic_Position &pos)
         (abs(geoCoord.getLongitude()) - geoCoord.getDMSLonDeg() * 1e+7) * 6e-6, geoCoord.getDMSLonCP(), pos.fix_quality,
         pos.sats_in_view, pos.HDOP, geoCoord.getAltitude(), 'M', pos.altitude_geoidal_separation, 'M', 0, 0);
 
+    // snprintf() returns the length that *would* have been written, which can exceed bufsz if
+    // truncated - clamp before using it as an index/size, or the checksum loop reads out of
+    // bounds and bufsz-len underflows into a huge size for the next snprintf().
+    if (len >= bufsz)
+        len = bufsz > 0 ? bufsz - 1 : 0;
+
     uint32_t chk = 0;
     for (uint32_t i = 1; i < len; i++) {
         chk ^= buf[i];
     }
     len += snprintf(buf + len, bufsz - len, "*%02X\r\n", chk);
+    if (len >= bufsz)
+        len = bufsz > 0 ? bufsz - 1 : 0;
     return len;
 }
 

--- a/src/modules/DropzoneModule.cpp
+++ b/src/modules/DropzoneModule.cpp
@@ -32,13 +32,13 @@ ProcessMessage DropzoneModule::handleReceived(const meshtastic_MeshPacket &mp)
     auto &p = mp.decoded;
     char matchCompare[54];
     auto incomingMessage = reinterpret_cast<const char *>(p.payload.bytes);
-    sprintf(matchCompare, "%s conditions", owner.short_name);
+    snprintf(matchCompare, sizeof(matchCompare), "%s conditions", owner.short_name);
     if (strncasecmp(incomingMessage, matchCompare, strlen(matchCompare)) == 0) {
         LOG_DEBUG("Received dropzone conditions request");
         startSendConditions = millis();
     }
 
-    sprintf(matchCompare, "%s conditions", owner.long_name);
+    snprintf(matchCompare, sizeof(matchCompare), "%s conditions", owner.long_name);
     if (strncasecmp(incomingMessage, matchCompare, strlen(matchCompare)) == 0) {
         LOG_DEBUG("Received dropzone conditions request");
         startSendConditions = millis();
@@ -79,11 +79,11 @@ meshtastic_MeshPacket *DropzoneModule::sendConditions()
         auto windDirection = telemetry.variant.environment_metrics.wind_direction;
         auto temp = telemetry.variant.environment_metrics.temperature;
         auto baro = UnitConversions::HectoPascalToInchesOfMercury(telemetry.variant.environment_metrics.barometric_pressure);
-        sprintf(replyStr, "%s @ %02d:%02d:%02dz\nWind %.2f kts @ %d°\nBaro %.2f inHg %.2f°C", dropzoneStatus, hour, min, sec,
-                windSpeed, windDirection, baro, temp);
+        snprintf(replyStr, sizeof(replyStr), "%s @ %02d:%02d:%02dz\nWind %.2f kts @ %d°\nBaro %.2f inHg %.2f°C", dropzoneStatus,
+                 hour, min, sec, windSpeed, windDirection, baro, temp);
     } else {
         LOG_ERROR("No sensor found");
-        sprintf(replyStr, "%s @ %02d:%02d:%02d\nNo sensor found", dropzoneStatus, hour, min, sec);
+        snprintf(replyStr, sizeof(replyStr), "%s @ %02d:%02d:%02d\nNo sensor found", dropzoneStatus, hour, min, sec);
     }
     LOG_DEBUG("Conditions reply: %s", replyStr);
     reply->decoded.payload.size = strlen(replyStr); // You must specify how many bytes are in the reply

--- a/src/platform/stm32wl/STM32_LittleFS.cpp
+++ b/src/platform/stm32wl/STM32_LittleFS.cpp
@@ -272,8 +272,8 @@ const char *dbg_strerr_lfs(int32_t err)
         return "LFS_ERR_NOMEM";
 
     default:
-        static char errcode[10];
-        sprintf(errcode, "%ld", err);
+        static char errcode[13]; // "-2147483648\0" (INT32_MIN) is the longest possible value
+        snprintf(errcode, sizeof(errcode), "%ld", err);
         return errcode;
     }
 


### PR DESCRIPTION
## Problem

A full-tree sweep for unsafe buffer writes (as part of an ongoing STM32WL memory-safety audit) found the codebase in good shape overall — this is the small remaining handful of loose ends. None are demonstrated as exploitable today; all are latent landmines worth closing while in this area.

- `src/modules/DropzoneModule.cpp`: 4 raw `sprintf()` calls into fixed-size buffers, safe today only because of current nanopb field-size invariants (no defense-in-depth if those change).
- `src/platform/stm32wl/STM32_LittleFS.cpp`: `dbg_strerr_lfs`'s `sprintf(errcode, "%ld", err)` into a 10-byte buffer — `INT32_MIN` needs 12 bytes (debug-build-only code path).
- `src/RedirectablePrint.cpp`: `mt_sprintf()` had a `strcpy()` immediately overwritten by the `vsnprintf()` right after it — pure dead code, and on an empty format string it underflows, writing 1 byte past a 0-size allocation.
- `src/gps/NMEAWPL.cpp`: `printWPL()`/`printGGA()` use `snprintf()`'s return value (which can exceed `bufsz` on truncation) directly as an offset/size for a second `snprintf()` call and a checksum loop — both need the length clamped first, or `bufsz-len` underflows into a huge `size_t`. Safe today only because of current field-size bounds.

## Fix

- Swap the remaining raw `sprintf()` calls for `snprintf()`.
- Remove the dead/unsafe `strcpy()` in `mt_sprintf()` — `vsnprintf()` alone already produces the correct result.
- Clamp `len` to `bufsz` (or 0) after each `snprintf()` call in `NMEAWPL.cpp` before using it as an offset or in the checksum loop.

## Test plan

- [x] `pio run -e wio-e5` / `pio run -e rak3172` — build clean, confirms all four touched files actually compile on the memory-constrained target these were audited for.
- [x] Hardware (wio-e5): flashed, confirmed clean boot.
- [ ] None of the specific overflow conditions were reproduced live (all require values outside current field-size invariants to trigger) — this is defensive hardening, not a fix for a demonstrated live bug.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below): wio-e5 — build + hardware verified per test plan above. rak3172 build-verified only.