### PR TITLE
Pioarduino 3.3.11

### DIFF
--- a/variants/esp32/esp32-common.ini
+++ b/variants/esp32/esp32-common.ini
@@ -6,8 +6,8 @@ custom_mtjson_part =
 platform =
   # TODO renovate
   ; Using forked pioarduino to fix --force-reinstall CI issue
-  https://github.com/meshtastic/pioarduino-platform-espressif32/archive/refs/heads/55.03.39.zip
-  ; https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
+  https://github.com/meshtastic/pioarduino-platform-espressif32/archive/refs/heads/55.03.311.zip
+  ; https://github.com/pioarduino/platform-espressif32/releases/download/55.03.311/platform-espressif32.zip
   ; https://github.com/pioarduino/platform-espressif32.git#develop
 platform_packages =
   # renovate: datasource=custom.pio depName=platformio/tool-mklittlefs packageName=platformio/tool/tool-mklittlefs
@@ -223,7 +223,7 @@ custom_sdkconfig =
   CONFIG_MBEDTLS_CAMELLIA_C=n
   CONFIG_MBEDTLS_CCM_C=n
   CONFIG_MBEDTLS_CMAC_C=n
-  CONFIG_MBEDTLS_SHA512_C=n
+  CONFIG_MBEDTLS_SHA512_C=y
   CONFIG_MBEDTLS_X509_CRL_PARSE_C=n
   CONFIG_MBEDTLS_X509_CSR_PARSE_C=n
   CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_PSK=n

--- a/variants/esp32/esp32.ini
+++ b/variants/esp32/esp32.ini
@@ -19,9 +19,11 @@ build_flags =
   -DMESHTASTIC_EXCLUDE_ACCELEROMETER=1
   -DMESHTASTIC_EXCLUDE_PAXCOUNTER=1
   -DMESHTASTIC_EXCLUDE_WEBSERVER=1
-  ; HACK HACK HACK this is just a proof of concept ESP32+NimBLE but these
-  ; includes need to be done properly somehow
+  ; HACK HACK HACK Original ESP32+NimBLE
+  ; These includes need to be done properly somehow.
+  ; Sourced from ~/.platformio/packages/framework-espidf/components/bt/host/nimble/CMakeLists.txt
   ; Quotes keep Windows packages_dir backslashes intact through POSIX flag parsing
+  -I"${platformio.packages_dir}/framework-espidf/components/bt/porting/include"
   -I"${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/nimble/host/include"
   -I"${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/nimble/include"
   -I"${platformio.packages_dir}/framework-espidf/components/bt/host/nimble/nimble/porting/nimble/include"

--- a/variants/esp32s3/seeed-sensecap-indicator/platformio.ini
+++ b/variants/esp32s3/seeed-sensecap-indicator/platformio.ini
@@ -14,7 +14,7 @@ custom_meshtastic_has_mui = true
 extends = esp32s3_base
 platform_packages =
   ; Version needs to match the pioarduino version used in esp32_common.ini
-  platformio/framework-arduinoespressif32 @ https://github.com/mverch67/arduino-esp32#c96df236ce132368f893e4d6cbb315831ea842d7 ; 3.3.9
+  platformio/framework-arduinoespressif32 @ https://github.com/mverch67/arduino-esp32#6dde0f3b58e32d9f884b94b4685b0f3a267c4624 ; 3.3.11
 
 board = seeed-sensecap-indicator
 board_check = true


### PR DESCRIPTION
Update pioarduino from 3.3.9 to 3.3.11
There was no 3.3.10 pioarduino release

Release notes:
- https://github.com/pioarduino/platform-espressif32/releases/tag/55.03.311
- https://github.com/espressif/arduino-esp32/releases/tag/3.3.10
- https://github.com/espressif/arduino-esp32/releases/tag/3.3.11

(Better) Release notes: https://release-notes.espressif.com/release/3.3.11?project=Arduino


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated ESP32 build tooling to version **55.03.311**.
  * Updated the Arduino-ESP32 framework pin for the **seeed-sensecap-indicator** environment.

* **Security**
  * Enabled **mbedTLS SHA-512** support for stronger cryptographic hashing.

* **Improvements**
  * Improved ESP32 NimBLE build configuration by adding the additional required header include path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->