### PR TITLE
fix(admin): stop the admin dispatcher from overflowing the ESP32 loopTask stack

### DIFF
--- a/src/meshUtils.h
+++ b/src/meshUtils.h
@@ -5,6 +5,16 @@
 #include <iterator>
 #include <stdint.h>
 
+/// Keep a function out of line even when the compiler would rather inline it. Use on helpers that
+/// hold a large object on the stack: inlining several of them into one caller makes that caller's
+/// frame reserve every helper's locals at once, which on our 8 KB Arduino loopTask is enough to
+/// overflow the stack (see issue #11237).
+#if defined(__GNUC__)
+#define NOINLINE __attribute__((noinline))
+#else
+#define NOINLINE
+#endif
+
 /// C++ v17+ clamp function, limits a given value to a range defined by lo and hi
 template <class T> constexpr const T &clamp(const T &v, const T &lo, const T &hi)
 {

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -681,22 +681,41 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
 #endif
 
     default:
-        meshtastic_AdminMessage res = meshtastic_AdminMessage_init_default;
-        AdminMessageHandleResult handleResult = MeshModule::handleAdminMessageForAllModules(mp, r, &res);
-
-        if (handleResult == AdminMessageHandleResult::HANDLED_WITH_RESPONSE) {
-            setPassKey(&res);
-            myReply = allocDataProtobuf(res);
-        } else if (mp.decoded.want_response) {
-            LOG_DEBUG("Module API did not respond to admin message. req.variant=%d", r->which_payload_variant);
-        } else if (handleResult != AdminMessageHandleResult::HANDLED) {
-            // Probably a message sent by us or sent to our local node.  FIXME, we should avoid scanning these messages
-            LOG_DEBUG("Module API did not handle admin message %d", r->which_payload_variant);
-        }
+        handleViaModuleApi(mp, r);
         break;
     }
 
     // Allow any observers (e.g. the UI) to handle/respond
+    handleViaObservers(r);
+
+    // If asked for a response and it is not yet set, generate an 'ACK' response
+    if (mp.decoded.want_response && !myReply) {
+        myReply = allocErrorResponse(meshtastic_Routing_Error_NONE, &mp);
+    }
+    if (mp.pki_encrypted && myReply) {
+        myReply->pki_encrypted = true;
+    }
+    return handled;
+}
+
+void AdminModule::handleViaModuleApi(const meshtastic_MeshPacket &mp, meshtastic_AdminMessage *r)
+{
+    meshtastic_AdminMessage res = meshtastic_AdminMessage_init_default;
+    AdminMessageHandleResult handleResult = MeshModule::handleAdminMessageForAllModules(mp, r, &res);
+
+    if (handleResult == AdminMessageHandleResult::HANDLED_WITH_RESPONSE) {
+        setPassKey(&res);
+        myReply = allocDataProtobuf(res);
+    } else if (mp.decoded.want_response) {
+        LOG_DEBUG("Module API did not respond to admin message. req.variant=%d", r->which_payload_variant);
+    } else if (handleResult != AdminMessageHandleResult::HANDLED) {
+        // Probably a message sent by us or sent to our local node.  FIXME, we should avoid scanning these messages
+        LOG_DEBUG("Module API did not handle admin message %d", r->which_payload_variant);
+    }
+}
+
+void AdminModule::handleViaObservers(const meshtastic_AdminMessage *r)
+{
     AdminMessageHandleResult observerResult = AdminMessageHandleResult::NOT_HANDLED;
     meshtastic_AdminMessage observerResponse = meshtastic_AdminMessage_init_default;
     AdminModule_ObserverData observerData = {
@@ -714,15 +733,6 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
     } else if (observerResult == AdminMessageHandleResult::HANDLED) {
         LOG_DEBUG("Observer handled admin message");
     }
-
-    // If asked for a response and it is not yet set, generate an 'ACK' response
-    if (mp.decoded.want_response && !myReply) {
-        myReply = allocErrorResponse(meshtastic_Routing_Error_NONE, &mp);
-    }
-    if (mp.pki_encrypted && myReply) {
-        myReply->pki_encrypted = true;
-    }
-    return handled;
 }
 
 void AdminModule::handleGetModuleConfigResponse(const meshtastic_MeshPacket &mp, meshtastic_AdminMessage *r)

--- a/src/modules/AdminModule.h
+++ b/src/modules/AdminModule.h
@@ -3,6 +3,7 @@
 #include <esp_ota_ops.h>
 #endif
 #include "ProtobufModule.h"
+#include "meshUtils.h"
 #include <sys/types.h>
 #if HAS_WIFI
 #include "mesh/wifi/WiFiAPClient.h"
@@ -48,16 +49,24 @@ class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Obser
 
     /**
      * Getters
+     *
+     * Each of the NOINLINE ones below builds a whole meshtastic_AdminMessage (480 bytes) on the
+     * stack. They are only ever reached from one case of handleReceivedProtobuf()'s switch, but
+     * when the compiler inlines them the dispatcher's frame has to reserve a slot for every one of
+     * them at once - measured at 3008 bytes on ESP32-S3, 37% of the 8 KB Arduino loopTask stack
+     * that also has to carry PhoneAPI, the router, nanopb and LittleFS below it. Keeping them out
+     * of line means only the request actually being served pays for its response buffer.
+     * See issue #11237.
      */
     void handleGetModuleConfigResponse(const meshtastic_MeshPacket &req, meshtastic_AdminMessage *p);
-    void handleGetOwner(const meshtastic_MeshPacket &req);
-    void handleGetConfig(const meshtastic_MeshPacket &req, uint32_t configType);
-    void handleGetModuleConfig(const meshtastic_MeshPacket &req, uint32_t configType);
-    void handleGetChannel(const meshtastic_MeshPacket &req, uint32_t channelIndex);
-    void handleGetDeviceMetadata(const meshtastic_MeshPacket &req);
-    void handleGetDeviceConnectionStatus(const meshtastic_MeshPacket &req);
-    void handleGetNodeRemoteHardwarePins(const meshtastic_MeshPacket &req);
-    void handleGetDeviceUIConfig(const meshtastic_MeshPacket &req);
+    NOINLINE void handleGetOwner(const meshtastic_MeshPacket &req);
+    NOINLINE void handleGetConfig(const meshtastic_MeshPacket &req, uint32_t configType);
+    NOINLINE void handleGetModuleConfig(const meshtastic_MeshPacket &req, uint32_t configType);
+    NOINLINE void handleGetChannel(const meshtastic_MeshPacket &req, uint32_t channelIndex);
+    NOINLINE void handleGetDeviceMetadata(const meshtastic_MeshPacket &req);
+    NOINLINE void handleGetDeviceConnectionStatus(const meshtastic_MeshPacket &req);
+    NOINLINE void handleGetNodeRemoteHardwarePins(const meshtastic_MeshPacket &req);
+    NOINLINE void handleGetDeviceUIConfig(const meshtastic_MeshPacket &req);
     /**
      * Setters
      */
@@ -102,6 +111,13 @@ class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Obser
     /// Whether a response (variant responseVariant, module-config subtype moduleConfigTag or 0)
     /// from mp.from answers a request we sent; consumes the matched request so it can't be replayed.
     bool responseIsSolicited(const meshtastic_MeshPacket &mp, pb_size_t responseVariant, pb_size_t moduleConfigTag);
+
+    /// Offer an admin message we have no case for to the module API, and let observers (e.g. the UI)
+    /// see every admin message. Both build a response on the stack, so like the getters above they
+    /// stay out of line to keep handleReceivedProtobuf()'s frame small.
+    NOINLINE void handleViaModuleApi(const meshtastic_MeshPacket &mp, meshtastic_AdminMessage *r);
+    NOINLINE void handleViaObservers(const meshtastic_AdminMessage *r);
+
     void handleStoreDeviceUIConfig(const meshtastic_DeviceUIConfig &uicfg);
     void handleSendInputEvent(const meshtastic_AdminMessage_InputEvent &inputEvent);
     void reboot(int32_t seconds);


### PR DESCRIPTION
Fixes #11237

## What users see

On ESP32, any config change from the phone app or CLI can panic with
`Guru Meditation Error: ... Stack canary watchpoint triggered (loopTask)` partway through writing
`/prefs/config.proto`. The device reboots, the new config is never persisted, and settings look
permanently "stuck". A full erase doesn't help, because nothing is wrong with the filesystem.

## Root cause

I decoded the reporter's backtrace against a `heltec-v4` build of the same commit
(2.8.0.6be7d9c) — the addresses line up exactly, so this is the real chain, and the recorded frame
pointers give the exact stack cost of each frame:

```
loopTask                                          8192 B stack
└ ThreadController::runOrDelay
  └ BluetoothPhoneAPI::runOnce
    └ runOnceHandleFromPhoneQueue                  624 B   (PhoneAPI::handleToRadio inlined)
      └ MeshService::handleToRadio → … → MeshModule::callModules
        └ ProtobufModule<AdminMessage>::handleReceived  544 B
          └ AdminModule::handleReceivedProtobuf   3008 B   ← 37% of the whole stack
            └ AdminModule::handleSetConfig         752 B
              └ NodeDB::saveToDisk → saveProto → pb_encode
                └ SafeFile::write → LittleFS → esp_flash → panic
```

**7824 of 8192 bytes consumed when the canary fired — 368 bytes left.**

`handleReceivedProtobuf` is one switch over every admin variant, and GCC inlines the eight
`handleGet*` helpers into it. Each of those builds a whole `meshtastic_AdminMessage` (480 B) on the
stack, so the dispatcher's frame has to reserve a slot for every one of them at once even though
only one case ever runs. Two more full `meshtastic_AdminMessage`s live directly in the function (the
`default:` module-API case and the observer response). That is how a single function ends up holding
3008 bytes of an 8 KB stack that still has PhoneAPI, the router, nanopb, LittleFS and the flash
driver to fit underneath it.

Nothing here is specific to LoRa config — every admin write lands in the same frame, which matches
the reporter's follow-up that Bluetooth, device and ADC-calibration changes fail identically. What
decides whether a given device tips over is how much stack LittleFS needs beneath it, which varies
with filesystem state. Hence "works for most people, fails every single time for me".

## The fix

Keep the response builders out of line (`NOINLINE`) and move the two response buffers that lived
directly in the dispatcher into their own functions, so only the request actually being served pays
for its response buffer. No behaviour change — the moved code is unmodified.

Measured on `heltec-v4`, same toolchain, before vs after:

| | before | after |
| --- | --- | --- |
| `AdminModule::handleReceivedProtobuf` frame | 3008 B | **384 B** |
| peak loopTask usage on the crashing path | 7824 B | **5200 B** |
| headroom on the 8192 B stack | 368 B (4.5%) | **2992 B (37%)** |

Cost: +1240 B flash, +8 B static RAM.

## Testing

- Native suite in Docker (CI parity): **40/40 suites, 761/761 test cases passed, 0 failures,
  0 ignored** — including `test_admin_radio`, `test_admin_session_repro` and
  `test_pki_admin_fallback`, which drive the refactored dispatcher.
- `heltec-v4` builds clean; the frame sizes above are read straight out of the two ELFs.
- `clang-format` clean.

Not yet reproduced on my own hardware — the pre-fix margin is 368 bytes, so whether a board crashes
depends on filesystem state, and I don't have a heltec-v4. The static numbers are exact, though, and
a >2.6 KB reduction on the frame that overflowed covers the reported case with a lot of room to
spare. Happy to have @jodecki confirm on a nightly.

## Follow-up worth a separate look

`PositionModule::allocPositionPacket` holds a 2640-byte frame on the same 8 KB loopTask, and
`PhoneAPI::getFromRadio` holds 1072. Neither is implicated in this crash, but they're the next two
largest single frames on that stack if similar reports turn up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved administrative message handling and response generation.
  * Ensured requests that expect a response receive a default acknowledgment when no specific response is produced.
  * Preserved encryption status in generated acknowledgments.
* **Performance**
  * Reduced stack and dispatch-frame impact when processing administrative requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->