### PR TITLE
Trunk: Only cache nightly runs, base on develop

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Trunk Upgrade
         uses: trunk-io/trunk-action/upgrade@v1
         with:
-          base: master
+          base: develop

--- a/.github/workflows/trunk_annotate_pr.yml
+++ b/.github/workflows/trunk_annotate_pr.yml
@@ -24,3 +24,4 @@ jobs:
         uses: trunk-io/trunk-action@v1
         with:
           post-annotations: true
+          cache: false

--- a/.github/workflows/trunk_check.yml
+++ b/.github/workflows/trunk_check.yml
@@ -22,3 +22,4 @@ jobs:
         uses: trunk-io/trunk-action@v1
         with:
           save-annotations: true
+          cache: false


### PR DESCRIPTION
These trunk caches are eating us for dinner (using all the cache space). Remove them for PRs so we aren't storing 20 copies of the same thing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code-quality workflows to track the current development branch.
  * Disabled caching for quality checks and pull request annotations to ensure results reflect the latest configuration.
  * No changes were made to application functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->