### PR TITLE
ESP32: Don't run pkg install on build

### DIFF
--- a/bin/build-esp32.sh
+++ b/bin/build-esp32.sh
@@ -12,7 +12,8 @@ rm -f $OUTDIR/firmware*
 rm -r $OUTDIR/* || true
 
 # Important to pull latest version of libs into all device flavors, otherwise some devices might be stale
-platformio pkg install -e $1
+# platformio pkg install -e $1
+# ...redundant with pioarduino
 
 echo "Building for $1 with $PLATFORMIO_BUILD_FLAGS"
 rm -f $BUILDDIR/firmware*


### PR DESCRIPTION
pioarduino runs this anyways. No need to do it twice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the ESP32 build process by removing the automatic package installation step.
  * Build and artifact generation steps remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->