### PR TITLE
add LR 2021 to portduino, and allow Framebuffer devices to rotate the screen from config

### DIFF
--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -11,8 +11,8 @@
 
 #ifdef ARCH_PORTDUINO
 #include "PortduinoGlue.h"
-#include <cstdio>  // snprintf
-#include <cstdlib> // setenv
+#include <cstdio>
+#include <cstdlib>
 #include <thread>
 #endif
 
@@ -62,8 +62,7 @@ void tftSetup(void)
         } else
 #elif defined(USE_FRAMEBUFFER)
         if (portduino_config.displayPanel == fb) {
-            // Config-driven display rotation, amount from yaml Display.OffsetRotate
-            // (1=90 deg, 2=180 deg, 3=270 deg)
+            // Rotation from yaml Display.OffsetRotate: 1=90, 2=180, 3=270 deg
             char rbuf[4];
             snprintf(rbuf, sizeof(rbuf), "%d", portduino_config.displayRotate ? (portduino_config.displayOffsetRotate & 3) : 0);
             setenv("MESHTASTIC_FB_ROTATION", rbuf, 1);

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -65,7 +65,8 @@ void tftSetup(void)
             // Rotation from yaml Display.OffsetRotate: 1=90, 2=180, 3=270 deg
             char rbuf[4];
             snprintf(rbuf, sizeof(rbuf), "%d", portduino_config.displayRotate ? (portduino_config.displayOffsetRotate & 3) : 0);
-            setenv("MESHTASTIC_FB_ROTATION", rbuf, 1);
+            if (setenv("MESHTASTIC_FB_ROTATION", rbuf, 1) != 0)
+                LOG_ERROR("Failed to set MESHTASTIC_FB_ROTATION, framebuffer will use its default rotation");
             if (portduino_config.displayWidth && portduino_config.displayHeight)
                 displayConfig = DisplayDriverConfig(DisplayDriverConfig::device_t::FB, (uint16_t)portduino_config.displayWidth,
                                                     (uint16_t)portduino_config.displayHeight);

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -60,6 +60,11 @@ void tftSetup(void)
         } else
 #elif defined(USE_FRAMEBUFFER)
         if (portduino_config.displayPanel == fb) {
+            // Config-driven display rotation:, amount from yaml Display.OffsetRotate
+            // (1=90°, 2=180°, 3=270°)
+            char rbuf[4];
+            snprintf(rbuf, sizeof(rbuf), "%d", portduino_config.displayRotate ? (portduino_config.displayOffsetRotate & 3) : 0);
+            setenv("MESHTASTIC_FB_ROTATION", rbuf, 1);
             if (portduino_config.displayWidth && portduino_config.displayHeight)
                 displayConfig = DisplayDriverConfig(DisplayDriverConfig::device_t::FB, (uint16_t)portduino_config.displayWidth,
                                                     (uint16_t)portduino_config.displayHeight);

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -11,6 +11,8 @@
 
 #ifdef ARCH_PORTDUINO
 #include "PortduinoGlue.h"
+#include <cstdio>  // snprintf
+#include <cstdlib> // setenv
 #include <thread>
 #endif
 
@@ -60,8 +62,8 @@ void tftSetup(void)
         } else
 #elif defined(USE_FRAMEBUFFER)
         if (portduino_config.displayPanel == fb) {
-            // Config-driven display rotation:, amount from yaml Display.OffsetRotate
-            // (1=90°, 2=180°, 3=270°)
+            // Config-driven display rotation, amount from yaml Display.OffsetRotate
+            // (1=90 deg, 2=180 deg, 3=270 deg)
             char rbuf[4];
             snprintf(rbuf, sizeof(rbuf), "%d", portduino_config.displayRotate ? (portduino_config.displayOffsetRotate & 3) : 0);
             setenv("MESHTASTIC_FB_ROTATION", rbuf, 1);

--- a/src/mesh/InterfacesTemplates.cpp
+++ b/src/mesh/InterfacesTemplates.cpp
@@ -27,7 +27,7 @@ template class LR11x0Interface<LR1110>;
 template class LR11x0Interface<LR1120>;
 template class LR11x0Interface<LR1121>;
 #endif
-#if defined(USE_LR2021) && RADIOLIB_EXCLUDE_LR2021 != 1
+#if (defined(USE_LR2021) || defined(ARCH_PORTDUINO)) && RADIOLIB_EXCLUDE_LR2021 != 1
 template class LR20x0Interface<LR2021>;
 #endif
 #ifdef ARCH_STM32WL

--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -380,9 +380,7 @@ template <typename T> int16_t LR11x0Interface<T>::getCurrentRSSI()
     return (int16_t)round(rssi);
 }
 
-// Undo the ARCH_PORTDUINO aliases for `portduino_config.rfswitch_dio_pins` /
-// `.rfswitch_table` so they do not leak into the interface translation units
-// included after this one by InterfacesTemplates.cpp.
+// Don't leak the aliases into the files InterfacesTemplates.cpp includes after this one.
 #undef rfswitch_dio_pins
 #undef rfswitch_table
 #endif

--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -379,4 +379,9 @@ template <typename T> int16_t LR11x0Interface<T>::getCurrentRSSI()
 #endif
     return (int16_t)round(rssi);
 }
+
+// Undo the ARCH_PORTDUINO macro aliases. This would pollute
+// `portduino_config.portduino_config.rfswitch_dio_pins`.
+#undef rfswitch_dio_pins
+#undef rfswitch_table
 #endif

--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -380,8 +380,9 @@ template <typename T> int16_t LR11x0Interface<T>::getCurrentRSSI()
     return (int16_t)round(rssi);
 }
 
-// Undo the ARCH_PORTDUINO macro aliases. This would pollute
-// `portduino_config.portduino_config.rfswitch_dio_pins`.
+// Undo the ARCH_PORTDUINO aliases for `portduino_config.rfswitch_dio_pins` /
+// `.rfswitch_table` so they do not leak into the interface translation units
+// included after this one by InterfacesTemplates.cpp.
 #undef rfswitch_dio_pins
 #undef rfswitch_table
 #endif

--- a/src/mesh/LR2021Interface.cpp
+++ b/src/mesh/LR2021Interface.cpp
@@ -1,6 +1,6 @@
 #include "configuration.h"
 
-#if defined(USE_LR2021) && RADIOLIB_EXCLUDE_LR2021 != 1
+#if (defined(USE_LR2021) || defined(ARCH_PORTDUINO)) && RADIOLIB_EXCLUDE_LR2021 != 1
 
 #include "LR2021Interface.h"
 #include "error.h"

--- a/src/mesh/LR20x0Interface.cpp
+++ b/src/mesh/LR20x0Interface.cpp
@@ -1,6 +1,6 @@
 #include "configuration.h"
 
-#if defined(USE_LR2021) && RADIOLIB_EXCLUDE_LR2021 != 1
+#if (defined(USE_LR2021) || defined(ARCH_PORTDUINO)) && RADIOLIB_EXCLUDE_LR2021 != 1
 #include "LR20x0Interface.h"
 #include "error.h"
 #include "mesh/NodeDB.h"
@@ -381,4 +381,10 @@ template <typename T> int16_t LR20x0Interface<T>::getCurrentRSSI()
     float rssi = lora.getRSSI(false, true);
     return (int16_t)round(rssi);
 }
+
+// See LR11x0Interface.cpp: undo the amalgamation-scoped macro aliases so they do not
+// leak into other interface translation units included after this one.
+#undef lr20x0_rfswitch_dio_pins
+#undef lr20x0_rfswitch_table
+#undef LR20x0
 #endif

--- a/src/mesh/LR20x0Interface.cpp
+++ b/src/mesh/LR20x0Interface.cpp
@@ -382,8 +382,7 @@ template <typename T> int16_t LR20x0Interface<T>::getCurrentRSSI()
     return (int16_t)round(rssi);
 }
 
-// See LR11x0Interface.cpp: undo the amalgamation-scoped macro aliases so they do not
-// leak into other interface translation units included after this one.
+// Don't leak the aliases into the files InterfacesTemplates.cpp includes after this one.
 #undef lr20x0_rfswitch_dio_pins
 #undef lr20x0_rfswitch_table
 #undef LR20x0

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -401,6 +401,8 @@ std::unique_ptr<RadioInterface> initLoRa()
             return std::unique_ptr<RadioInterface>(new LR1121Interface(hal, cs, irq, rst, busy));
         case use_llcc68:
             return std::unique_ptr<RadioInterface>(new LLCC68Interface(hal, cs, irq, rst, busy));
+        case use_lr2021:
+            return std::unique_ptr<RadioInterface>(new LR2021Interface(hal, cs, irq, rst, busy));
         case use_simradio:
             return std::unique_ptr<RadioInterface>(new SimRadio);
         default:

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -899,6 +899,10 @@ bool loadConfig(const char *configPath)
                 portduino_config.lr1110_max_power = yamlConfig["Lora"]["LR1110_MAX_POWER"].as<int>(22);
             if (yamlConfig["Lora"]["LR1120_MAX_POWER"])
                 portduino_config.lr1120_max_power = yamlConfig["Lora"]["LR1120_MAX_POWER"].as<int>(13);
+            if (yamlConfig["Lora"]["LR2021_MAX_POWER"])
+                portduino_config.lr2021_max_power = yamlConfig["Lora"]["LR2021_MAX_POWER"].as<int>(22);
+            if (yamlConfig["Lora"]["LR2021_MAX_POWER_HF"])
+                portduino_config.lr2021_max_power_hf = yamlConfig["Lora"]["LR2021_MAX_POWER_HF"].as<int>(12);
             if (yamlConfig["Lora"]["RF95_MAX_POWER"])
                 portduino_config.rf95_max_power = yamlConfig["Lora"]["RF95_MAX_POWER"].as<int>(20);
 

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -47,7 +47,8 @@ enum lora_module_enum {
     use_lr1110,
     use_lr1120,
     use_lr1121,
-    use_llcc68
+    use_llcc68,
+    use_lr2021
 };
 
 struct pinMapping {
@@ -76,9 +77,10 @@ std::string exec(const char *cmd);
 
 extern struct portduino_config_struct {
     // Lora
-    std::map<lora_module_enum, std::string> loraModules = {
-        {use_simradio, "sim"},  {use_autoconf, "auto"}, {use_rf95, "RF95"},     {use_sx1262, "sx1262"}, {use_sx1268, "sx1268"},
-        {use_sx1280, "sx1280"}, {use_lr1110, "lr1110"}, {use_lr1120, "lr1120"}, {use_lr1121, "lr1121"}, {use_llcc68, "LLCC68"}};
+    std::map<lora_module_enum, std::string> loraModules = {{use_simradio, "sim"},  {use_autoconf, "auto"}, {use_rf95, "RF95"},
+                                                           {use_sx1262, "sx1262"}, {use_sx1268, "sx1268"}, {use_sx1280, "sx1280"},
+                                                           {use_lr1110, "lr1110"}, {use_lr1120, "lr1120"}, {use_lr1121, "lr1121"},
+                                                           {use_llcc68, "LLCC68"}, {use_lr2021, "lr2021"}};
 
     std::map<screen_modules, std::string> screen_names = {{x11, "X11"},         {fb, "FB"},           {st7789, "ST7789"},
                                                           {st7735, "ST7735"},   {st7735s, "ST7735S"}, {st7796, "ST7796"},
@@ -100,6 +102,8 @@ extern struct portduino_config_struct {
     int sx128x_max_power = 13;
     int lr1110_max_power = 22;
     int lr1120_max_power = 13;
+    int lr2021_max_power = 22;
+    int lr2021_max_power_hf = 12;
     int rf95_max_power = 20;
     bool dio2_as_rf_switch = false;
     int dio3_tcxo_voltage = 0;
@@ -287,6 +291,10 @@ extern struct portduino_config_struct {
             out << YAML::Key << "LR1110_MAX_POWER" << YAML::Value << lr1110_max_power;
         if (lr1120_max_power != 13)
             out << YAML::Key << "LR1120_MAX_POWER" << YAML::Value << lr1120_max_power;
+        if (lr2021_max_power != 22)
+            out << YAML::Key << "LR2021_MAX_POWER" << YAML::Value << lr2021_max_power;
+        if (lr2021_max_power_hf != 12)
+            out << YAML::Key << "LR2021_MAX_POWER_HF" << YAML::Value << lr2021_max_power_hf;
         if (rf95_max_power != 20)
             out << YAML::Key << "RF95_MAX_POWER" << YAML::Value << rf95_max_power;
 

--- a/variants/native/portduino/platformio.ini
+++ b/variants/native/portduino/platformio.ini
@@ -431,9 +431,7 @@ build_src_filter =
   +<gps/RTC.cpp>
   +<buzz/buzz.cpp> +<buzz/BuzzerFeedbackThread.cpp>
   +<mesh/*.cpp> +<mesh/*.c>
-  ; LR20x0Interface.cpp is template-only and is amalgamated into
-  ; InterfacesTemplates.cpp; LR2021Interface.cpp has to build on its own because
-  ; initLoRa() constructs LR2021Interface for `Lora.Module: lr2021`.
+  ; template-only, amalgamated into InterfacesTemplates.cpp
   -<mesh/LR20x0Interface.cpp>
   +<mesh/generated/>
   +<concurrency/>

--- a/variants/native/portduino/platformio.ini
+++ b/variants/native/portduino/platformio.ini
@@ -431,7 +431,10 @@ build_src_filter =
   +<gps/RTC.cpp>
   +<buzz/buzz.cpp> +<buzz/BuzzerFeedbackThread.cpp>
   +<mesh/*.cpp> +<mesh/*.c>
-  -<mesh/LR2021Interface.cpp> -<mesh/LR20x0Interface.cpp>
+  ; LR20x0Interface.cpp is template-only and is amalgamated into
+  ; InterfacesTemplates.cpp; LR2021Interface.cpp has to build on its own because
+  ; initLoRa() constructs LR2021Interface for `Lora.Module: lr2021`.
+  -<mesh/LR20x0Interface.cpp>
   +<mesh/generated/>
   +<concurrency/>
   +<platform/portduino/PortduinoGlue.cpp> +<platform/portduino/SimRadio.cpp>


### PR DESCRIPTION
Requires https://github.com/meshtastic/device-ui/pull/355 and supersedes https://github.com/meshtastic/firmware/pull/10567 and https://github.com/meshtastic/firmware/pull/11138

Many thanks to the original authors https://github.com/a-li3n and https://github.com/jessm33

N.B. This PR enables meshtasticd with framebuffer MUI on Lilygo T-Display K230


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Portduino support for selecting and initializing the LR2021 LoRa module (including native/WASM builds).
  * Added configurable LR2021 maximum power limits (standard and high-frequency) with YAML import/export.
  * Added framebuffer rotation configuration via an environment value derived from the display rotation settings.
* **Bug Fixes**
  * Corrected which LR2021/LR20x0 interfaces are compiled and selected for Portduino and native targets, improving build consistency.
  * Improved safety by handling failures when setting the framebuffer rotation environment value, using a default if needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->