### PR TITLE
Stop BLE log streaming from starving the NimBLE notify pool

### DIFF
--- a/src/nimble/NimbleBluetooth.cpp
+++ b/src/nimble/NimbleBluetooth.cpp
@@ -637,6 +637,21 @@ class NimbleBluetoothFromRadioCallback : public BLECharacteristicCallbacks
     }
 };
 
+// One log notify per log line shares the msys_1 mbuf pool with the fromNum doorbell and ATT
+// responses, so a logging burst starves them; back off on rejection until the pool refills.
+static constexpr uint32_t LOG_NOTIFY_BACKOFF_MS = 250;
+static std::atomic<uint32_t> lastLogNotifyFailureMs{0};
+
+class NimbleBluetoothLogRadioCallback : public BLECharacteristicCallbacks
+{
+    void onStatus(BLECharacteristic *, Status s, uint32_t) override
+    {
+        // ERROR_GATT is the only status meaning the host refused it; the rest never allocated.
+        if (s == Status::ERROR_GATT)
+            lastLogNotifyFailureMs.store(millis());
+    }
+};
+
 class NimbleBluetoothSecurityCallback : public BLESecurityCallbacks
 {
     void onPassKeyNotify(uint32_t passkey) override
@@ -1005,6 +1020,9 @@ void NimbleBluetooth::setupService()
     static NimbleBluetoothFromRadioCallback fromRadioCallbacks;
     FromRadioCharacteristic->setCallbacks(&fromRadioCallbacks);
 
+    static NimbleBluetoothLogRadioCallback logRadioCallbacks;
+    logRadioCharacteristic->setCallbacks(&logRadioCallbacks);
+
     bleService->start();
 
     // Setup the battery service
@@ -1056,6 +1074,11 @@ void NimbleBluetooth::sendLog(const uint8_t *logMessage, size_t length)
     if (!isConnected() || length > 512) {
         return;
     }
+    if (!logRadioCharacteristic) // BLE may have been torn down; never notify a freed characteristic
+        return;
+    // Pool still under pressure; drop this line rather than spend a buffer fromNum needs.
+    if (Throttle::isWithinTimespanMs(lastLogNotifyFailureMs.load(), LOG_NOTIFY_BACKOFF_MS))
+        return;
     logRadioCharacteristic->setValue(logMessage, length);
     logRadioCharacteristic->notify();
 }

--- a/variants/esp32/esp32-common.ini
+++ b/variants/esp32/esp32-common.ini
@@ -291,7 +291,9 @@ custom_sdkconfig =
   CONFIG_BT_CTRL_BLE_MAX_ACT=2
   CONFIG_BT_CTRL_SCAN_DUPL_CACHE_SIZE=10
   CONFIG_BT_NIMBLE_WHITELIST_SIZE=1
-  CONFIG_BT_NIMBLE_MSYS_1_BLOCK_COUNT=8
+  # msys_1 is the only pool GATT allocates from, and 8 blocks left no headroom for a notify burst
+  # (#11245); back to the IDF default of 12 for +1KB. Raising msys_2 would not help.
+  CONFIG_BT_NIMBLE_MSYS_1_BLOCK_COUNT=12
   CONFIG_BT_NIMBLE_MSYS_2_BLOCK_COUNT=8
   CONFIG_BT_NIMBLE_TRANSPORT_ACL_FROM_LL_COUNT=8
   CONFIG_BT_NIMBLE_TRANSPORT_EVT_COUNT=12


### PR DESCRIPTION
Fixes #11245.

On 2.8 / ESP32-S3, a connected phone produces a continuous stream of

```
[E][BLECharacteristic.cpp:1171] notify(): << ble_gatts_notify_custom: rc=6
```

`rc=6` is `BLE_HS_ENOMEM`: the NimBLE host had no mbuf left to build the notification, so it was dropped. @bruschill measured 694 of these in 479s on a Heltec V4, and none at all on the same workload on nRF52 — so it's the ESP32/NimBLE path specifically.

### What's actually failing

It's the **log characteristic**, not the packet path.

`log_to_ble()` calls `sendLog()` once per firmware log line, and `sendLog()` notified unconditionally. With `debug_log_api_enabled` set and a client subscribed (the iOS app subscribes to both notify characteristics on every connect), every single log line becomes a GATT notification. In the reporter's captures the errors alternate 1:1 with ordinary log lines — disk-save messages, dedup chatter, module dispatch — and outnumber the `fromNum` doorbell attempts by 5-15x. They arrive in bursts at ~12ms intervals aligned with logging storms (a config import, the position replay that runs at connect), not at the steady 1.4/s the averages suggest.

Then it feeds itself: each failed notify prints an error line over serial at roughly 12ms apiece, which is enough to visibly throttle the main loop during a burst.

Every GATT notification and ATT response allocates through `ble_hs_mbuf_att_pkt()` → `os_msys_get_pkthdr(0, 0)`, so once that pool is dry the `fromNum` doorbell and ATT responses fail too. The phone stops being told there is data waiting.

### What this changes

**Treat a rejected log notify as backpressure.** The Arduino BLE wrapper's `notify()` returns `void`, but it does invoke `onStatus(..., ERROR_GATT, rc)` on failure. Registering a callback on the log characteristic gives the host's own verdict, so `sendLog()` can stand down for 250ms and let the pool refill instead of hammering it once per line. Debug logs are best-effort; the doorbell isn't, and this stops the former from starving the latter. Keying off the failure rather than a free-block count means it stays correct however the pools are sized.

**Restore `CONFIG_BT_NIMBLE_MSYS_1_BLOCK_COUNT` to the IDF default of 12** (from the 8 set in #10741). `_os_msys_find_pool()` selects by block size, and a notify request always resolves to the smallest pool, so msys_1 is the only pool GATT ever draws from — 8 blocks is thin once anything chains or fragments. This costs 1KB.

I deliberately did **not** touch `MSYS_2`, `TRANSPORT_ACL_FROM_LL_COUNT` or `TRANSPORT_EVT_COUNT`. Raising msys_2 would do nothing for this bug (nothing on the notify path allocates from it), and the ACL/EVT pools are separate controller→host transport pools, also not involved. Restoring the full IDF defaults would re-spend ~6KB, most of it as one large contiguous allocation at NimBLE init — which is the exact allocation profile #10741 was fixing on heap-tight boards like heltec-v3, so I'd rather not.

**Null-check `logRadioCharacteristic` in `sendLog()`.** `deinit()` nulls it, and `onNowHasData()` already guards its characteristic the same way — `sendLog()` was the one path that didn't, so a log line arriving during BLE teardown would dereference a freed pointer. Latent, unrelated to the ENOMEM, but it's two lines away.

### A note on the 2.7 → 2.8 comparison

The issue reports zero occurrences on 2.7.27. Worth being precise about that: 2.7 used NimBLE-Arduino 1.4.3, whose pool was 12 blocks of 292B — actually *smaller* in bytes than 2.8's trimmed 8+8 — and its `notify()` discarded the return code without logging. So "zero errors on 2.7.27" is partly that the old stack couldn't report the failure. The reporter's own 2.7.27 data point supports this: they saw an ATT error 17 (`insufficient resources`) on a 104-byte write, which is the same pool exhaustion surfacing on the write path, at default sizing.

What genuinely changed in 2.8 is demand — noticeably more log lines, plus the position replay burst at every connect — and a BLE wrapper that now reports each drop. That's why the primary fix here is backpressure rather than just buying more buffers.

### Testing

Builds clean for `heltec-v4` (the reporter's board). The config change forces a framework rebuild, so expect a slow first build.

I don't have a device that reproduces this in front of me, so **this is not hardware-verified yet** — if anyone with an S3 and a phone can run with `debug_log_api_enabled` on, connect, and do a config import, the `rc=6` count during that window is the number to watch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth log notification reliability by handling backpressure when the host can’t accept more data.
  * Added a cooldown to pause further notify attempts after `ERROR_GATT` failures to reduce repeated delivery failures.
  * Prevented log notifications from being sent when the log characteristic is no longer available.
  * Increased NimBLE memory pool capacity for GATT allocations to better handle notify bursts and responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->