### PR TITLE
Time out an abandoned admin edit transaction

### DIFF
--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -69,7 +69,6 @@
 #endif
 
 AdminModule *adminModule;
-bool hasOpenEditTransaction;
 
 #if !(MESHTASTIC_EXCLUDE_PKI_KEYGEN || MESHTASTIC_EXCLUDE_PKI)
 static bool licensedIdentityWillMigrate()
@@ -240,6 +239,9 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
             return handled;
         }
     }
+    // Before the switch, so every case below sees consistent transaction state.
+    expireStaleEditTransaction();
+
     switch (r->which_payload_variant) {
 
 #ifdef MESHTASTIC_ENCRYPTED_STORAGE
@@ -481,12 +483,14 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
     case meshtastic_AdminMessage_begin_edit_settings_tag: {
         LOG_INFO("Begin transaction for editing settings");
         hasOpenEditTransaction = true;
+        editTransactionActivityMs = millis();
         break;
     }
     case meshtastic_AdminMessage_commit_edit_settings_tag: {
         disableBluetooth();
         LOG_INFO("Commit transaction for edited settings");
         hasOpenEditTransaction = false;
+        deferredEditSegments = 0;
         saveChanges(SEGMENT_CONFIG | SEGMENT_MODULECONFIG | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS | SEGMENT_NODEDATABASE);
         flushChannelWarnings(); // one coalesced message for everything edited in this transaction
         break;
@@ -1875,6 +1879,23 @@ void AdminModule::reboot(int32_t seconds)
     rebootAtMsec = (seconds < 0) ? 0 : (millis() + seconds * 1000);
 }
 
+// Without this, a commit that never arrives leaves the transaction open forever and every later
+// config write from any client is applied, acknowledged, and then never saved.
+void AdminModule::expireStaleEditTransaction()
+{
+    if (!hasOpenEditTransaction || Throttle::isWithinTimespanMs(editTransactionActivityMs, EDIT_TRANSACTION_IDLE_MS))
+        return;
+
+    LOG_WARN("Edit transaction abandoned for %us; committing what it applied", EDIT_TRANSACTION_IDLE_MS / 1000);
+    hasOpenEditTransaction = false;
+    int segments = deferredEditSegments;
+    deferredEditSegments = 0;
+    // No reboot: the settings are already live in RAM and the client that would expect one is gone.
+    if (segments)
+        saveChanges(segments, false);
+    flushChannelWarnings();
+}
+
 void AdminModule::saveChanges(int saveWhat, bool shouldReboot)
 {
 #ifdef PIO_UNIT_TESTING
@@ -1885,6 +1906,8 @@ void AdminModule::saveChanges(int saveWhat, bool shouldReboot)
         service->reloadConfig(saveWhat); // Calls saveToDisk among other things
     } else {
         LOG_INFO("Delay save of changes to disk until the open transaction is committed");
+        editTransactionActivityMs = millis(); // still in use, so not the abandoned kind we time out
+        deferredEditSegments |= saveWhat;
     }
     if (shouldReboot && !hasOpenEditTransaction) {
         reboot(DEFAULT_REBOOT_SECONDS);

--- a/src/modules/AdminModule.h
+++ b/src/modules/AdminModule.h
@@ -40,6 +40,13 @@ class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Obser
 
   private:
     bool hasOpenEditTransaction = false;
+    // Each deferred write restarts the clock, so this bounds the gap between writes, not the length
+    // of the edit; a bulk import sends them milliseconds apart.
+    static constexpr uint32_t EDIT_TRANSACTION_IDLE_MS = 60 * 1000;
+    uint32_t editTransactionActivityMs = 0; // millis() of the last save this transaction deferred
+    int deferredEditSegments = 0;           // segments that transaction has touched but not yet saved
+    /// Retire an open edit transaction whose client stopped talking, persisting what it applied.
+    void expireStaleEditTransaction();
 #ifdef PIO_UNIT_TESTING
     int lastSaveWhatForTest = 0;
 #endif

--- a/test/support/AdminModuleTestShim.h
+++ b/test/support/AdminModuleTestShim.h
@@ -21,8 +21,17 @@ class AdminModuleTestShim : public AdminModule
     meshtastic_MeshPacket *reply() { return myReply; }
 
     // With an "open edit transaction" saveChanges() is a pure no-op: no reloadConfig/saveToDisk/reboot.
-    void deferSaves() { hasOpenEditTransaction = true; }
+    // Stamps the clock like begin_edit_settings, so a slow suite can't age the transaction into expiry.
+    void deferSaves()
+    {
+        hasOpenEditTransaction = true;
+        editTransactionActivityMs = millis();
+    }
     int savedSegments() const { return lastSaveWhatForTest; }
+
+    bool editTransactionOpen() const { return hasOpenEditTransaction; }
+    // Backdate past the idle window so a test sees an abandoned transaction without waiting it out.
+    void ageEditTransaction() { editTransactionActivityMs = millis() - EDIT_TRANSACTION_IDLE_MS - 1; }
 
     // Setters may allocate an error reply from packetPool; drain it each iteration or the pool leaks.
     void drainReply()

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -1574,6 +1574,16 @@ static void sendCommitEdit()
     sendAdmin(m);
 }
 
+// An admin message that changes nothing. It answers, so drain the reply or the packet pool leaks.
+static void sendGetDeviceMetadata()
+{
+    meshtastic_AdminMessage m = meshtastic_AdminMessage_init_zero;
+    m.which_payload_variant = meshtastic_AdminMessage_get_device_metadata_request_tag;
+    m.get_device_metadata_request = true;
+    sendAdmin(m);
+    testAdmin->drainReply();
+}
+
 // Preset = LongFast on US, unlicensed owner. "LongFast" is the display name we compare against.
 static void usePresetLongFast()
 {
@@ -1638,6 +1648,53 @@ static void test_warn_transaction_singleChannel_keepsSpecificMessage()
     TEST_ASSERT_EQUAL_INT(1, (int)capturedWarnings.size());
     TEST_ASSERT_EQUAL_INT(1, warningsContaining("looks like a mistype of 'LongFast'"));
     TEST_ASSERT_EQUAL_INT(0, warningsContaining("on channels"));
+}
+
+// An idle transaction is retired by the next admin message, flushing the warnings it held.
+static void test_editTransaction_abandoned_isRetiredOnNextAdminMessage()
+{
+    usePresetLongFast();
+    sendBeginEdit();
+    sendSetChannel(makeChannel(0, meshtastic_Channel_Role_PRIMARY, "long fast", DEFAULT_KEY, 1));
+    // Deferred, exactly as before: nothing emitted while the transaction looks alive.
+    TEST_ASSERT_EQUAL_INT(0, (int)capturedWarnings.size());
+    TEST_ASSERT_TRUE(testAdmin->editTransactionOpen());
+
+    testAdmin->ageEditTransaction();
+    sendGetDeviceMetadata(); // any later admin message, from any client
+
+    TEST_ASSERT_FALSE(testAdmin->editTransactionOpen());
+    TEST_ASSERT_EQUAL_INT(1, warningsContaining("looks like a mistype of 'LongFast'"));
+}
+
+// A write arriving after abandonment is saved, not deferred to a commit that never comes.
+static void test_editTransaction_abandoned_laterWriteIsNoLongerDeferred()
+{
+    usePresetLongFast();
+    sendBeginEdit();
+    testAdmin->ageEditTransaction();
+
+    sendSetChannel(makeChannel(0, meshtastic_Channel_Role_PRIMARY, "long fast", DEFAULT_KEY, 1));
+
+    // The write itself retired the stale transaction, so its own warning is emitted immediately.
+    TEST_ASSERT_FALSE(testAdmin->editTransactionOpen());
+    TEST_ASSERT_EQUAL_INT(1, warningsContaining("looks like a mistype of 'LongFast'"));
+}
+
+// A transaction still in use is left alone: each write refreshes the window.
+static void test_editTransaction_active_isNotRetired()
+{
+    usePresetLongFast();
+    sendBeginEdit();
+    sendSetChannel(makeChannel(0, meshtastic_Channel_Role_PRIMARY, "long fast", DEFAULT_KEY, 1));
+    sendSetChannel(makeChannel(1, meshtastic_Channel_Role_SECONDARY, "long fast", DEFAULT_KEY, 1));
+
+    TEST_ASSERT_TRUE(testAdmin->editTransactionOpen());
+    TEST_ASSERT_EQUAL_INT(0, (int)capturedWarnings.size());
+
+    sendCommitEdit();
+    TEST_ASSERT_FALSE(testAdmin->editTransactionOpen());
+    TEST_ASSERT_EQUAL_INT(1, warningsContaining("There may be name issues on channels 0, 1"));
 }
 
 static void test_warn_license_noTransaction_emittedImmediately()
@@ -1801,6 +1858,9 @@ void setup()
     RUN_TEST(test_warn_cleanChannel_noMessage);
     RUN_TEST(test_warn_transaction_multipleChannels_singleCoalescedMessage);
     RUN_TEST(test_warn_transaction_singleChannel_keepsSpecificMessage);
+    RUN_TEST(test_editTransaction_abandoned_isRetiredOnNextAdminMessage);
+    RUN_TEST(test_editTransaction_abandoned_laterWriteIsNoLongerDeferred);
+    RUN_TEST(test_editTransaction_active_isNotRetired);
     RUN_TEST(test_warn_license_noTransaction_emittedImmediately);
     RUN_TEST(test_warn_license_transaction_coalescedToSingleMessage);
 


### PR DESCRIPTION
Reported alongside #11245, but a separate defect with its own cause.

### The problem

`begin_edit_settings` / `commit_edit_settings` brackets a bulk config write so the node saves once at the end instead of after every field. The "transaction" is a single `bool` on the AdminModule singleton, and nothing ever closes it except the matching commit — no timeout, no binding to the client that opened it, and no hook on disconnect.

So if the commit never arrives, the flag stays set forever. From that moment on, every config write — **from any client, not just the one that opened it** — is applied to RAM, acknowledged, and then quietly not saved:

```
Delay save of changes to disk until the open transaction is committed
```

The writes look successful to the app and are visible in `get_config`, but the node reverts all of them at the next boot. Only a reboot clears it.

@bruschill hit exactly this: an iOS device-profile import dropped its link after 16 of 20 writes. Their capture shows the 16 deferred saves, no commit, and the transaction still open when the log ends.

### The fix

Give the transaction an idle timeout. Each write it defers refreshes the clock; if it then sits untouched for a minute, the next admin message retires it — persisting exactly the segments it had deferred and flushing the warnings it was holding.

Because every deferred write restarts the clock, the minute bounds the gap *between* writes rather than the length of the edit — a bulk import sends them milliseconds apart, so it has no bearing on how long an import may take. And expiring early is cheap: the transaction saves what it applied, so the worst case for a client that really was still going is that its remaining writes get saved individually instead of batched. Nothing is lost either way, which is what makes it safe to keep the window short and get the node back to normal quickly.

The check runs at the top of `handleReceivedProtobuf()`, after the auth gates and before the switch, so every case below sees consistent transaction state. That's a plain main-loop context, which matters: the recovery does a flash write, and doing that from a BLE disconnect callback is how you get the stack overflows and disconnect deadlocks we've been fixing lately (#11190, #11202).

The expiry saves rather than rolls back. There's nothing to roll back to — each write already took effect in RAM and was acknowledged, so the transaction only ever deferred the *save*, not the change. Persisting what's already live is the outcome with no surprises in it. It saves only the segments actually touched rather than the blanket set that commit uses, to avoid gratuitous nodeDB writes.

### Why not close it on disconnect

That was my first instinct, and the reporter's logs argue against it: their session shows four disconnect/reconnect cycles, with iOS reconnecting within half a second. Aborting the transaction on the first BLE blip would break imports that currently survive one. A timeout tolerates the blip and still bounds the damage.

### Also here

Removed the file-scope `bool hasOpenEditTransaction;` in AdminModule.cpp. It's shadowed by the class member of the same name at every use site and referenced nowhere else in the tree — dead since the member was introduced, and actively confusing to read next to the real one.

### Testing

Three cases added to `test_admin_radio`, which already covers transaction-scoped warning coalescing:

- an abandoned transaction is retired by the next admin message, flushing its deferred warning
- a config write arriving after abandonment is saved instead of deferred
- an in-use transaction is left alone and still commits normally

The test shim backdates the activity clock rather than waiting out the real window. Native suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented abandoned settings edits from leaving configuration saves pending indefinitely.
  - Automatically finalizes inactive edits when a subsequent administrative message arrives.
  - Ensures deferred channel warnings and configuration changes are saved and released correctly.
  - Preserves active edit sessions until they are explicitly committed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->