### PR TITLE
fix(promicro): exclude emoji to fit under the warm-store region

### DIFF
--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -880,8 +880,10 @@ bool CannedMessageModule::handleFreeTextInput(const InputEvent *event)
     // All hardware keys fall through to here (CardKB, physical, etc.)
 
     if (event->kbchar == INPUT_BROKER_MSG_EMOTE_LIST) {
-        updateState(CANNED_MESSAGE_RUN_STATE_EMOTE_PICKER);
-        screen->forceDisplay();
+        if (graphics::numEmotes > 0) { // no picker on EXCLUDE_EMOJI builds (empty emotes[])
+            updateState(CANNED_MESSAGE_RUN_STATE_EMOTE_PICKER);
+            screen->forceDisplay();
+        }
         return true;
     }
     // Confirm select (Enter)
@@ -965,6 +967,11 @@ bool CannedMessageModule::handleFreeTextInput(const InputEvent *event)
 int CannedMessageModule::handleEmotePickerInput(const InputEvent *event)
 {
     int numEmotes = graphics::numEmotes;
+    if (numEmotes == 0) { // EXCLUDE_EMOJI: emotes[] is empty, any index would read out of bounds
+        updateState(CANNED_MESSAGE_RUN_STATE_FREETEXT, true);
+        screen->forceDisplay();
+        return 1;
+    }
 
     // Override isDown and isSelect ONLY for emote picker behavior
     bool isUp = isUpEvent(event);

--- a/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/platformio.ini
+++ b/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/platformio.ini
@@ -15,6 +15,7 @@ board = promicro-nrf52840
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/diy/nrf52_promicro_diy_tcxo
   -D NRF52_PROMICRO_DIY
+  -D EXCLUDE_EMOJI ; this variant builds 4 radio driver families and is the largest nrf52 image; emote bitmaps don't fit under the 0xEA000 warm-store cap
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/diy/nrf52_promicro_diy_tcxo>
 debug_tool = jlink
 


### PR DESCRIPTION
## Problem

`nrf52_promicro_diy_tcxo` is failing the nrf52 warm-region guard on develop ([example run](https://github.com/meshtastic/firmware/actions/runs/30236257363/job/89884571080)):

```
*** nrf52 warm-region guard: image ends at 0xEA0C0, past the reserved warm-store region at 0xEA000 ***
```

It's only **192 bytes** over. This variant deliberately compiles four radio driver families (SX126x/LLCC68, SX127x/RF95, LR11x0/LR1121, LR2021) so builders can solder on whatever module they have, which makes it the largest nRF52 image we ship. Measured from the ELF: SX126x/LLCC68 24.5 KB, SX127x/RF95 14.1 KB, LR2021 12.0 KB, LR11x0/LR1121 11.4 KB.

For reference, rak4631 on the same commit ends at `0xE46D8` — 22 KB clear.

## Fix

Build the variant with `-D EXCLUDE_EMOJI`: **−6,808 bytes**, image ends at `0xE8618`, 6.6 KB clear of the warm region.

That flag wasn't usable before this PR. With it set, `graphics::emotes[]` is empty and `numEmotes == 0`, but the canned-message emote picker never checked:

- `drawEmotePickerScreen()` clamps `emotePickerIndex` to `numEmotes - 1`, i.e. **-1**
- selecting then evaluates `graphics::emotes[-1].label` and constructs a `String` from it — an out-of-bounds read of whatever precedes the array in flash

So this adds two guards: don't open the picker when there are no emotes, and bounce back to freetext if the picker state is reached anyway. (Same latent bug applies to any board that wants this flag — it's not promicro-specific.)

A nice side effect: under whole-image LTO the guards fold to constants, so the entire picker — draw path and input handler — dead-strips on `EXCLUDE_EMOJI` builds. That's why the saving is larger than the ~5.7 KB of bitmap data.

## Trade-off

On this variant only, received messages containing emoji render as their text label instead of a 16px bitmap, and the emote-list key becomes a no-op. Given the alternative is a variant that doesn't build at all, that seems like the right call — but I'm open to dropping `USE_LR2021` instead (−13,504 bytes, measured), since LR2021 support landed on this variant only two weeks ago in #10998 and the readme's known-modules table doesn't list an LR2021 module yet.

## Verification

Both built locally at `1e982fa`:

| env | image end | guard |
|---|---|---|
| `nrf52_promicro_diy_tcxo` before | `0xEA0B0` | FAIL |
| `nrf52_promicro_diy_tcxo` after | `0xE8618` | OK, 6.6 KB clear |
| `rak4631` (emoji enabled, unchanged) | `0xE46D8` | OK, 22 KB clear |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when no emotes are available, preventing invalid picker access.
  * The emote picker now closes safely and returns to text entry when its list is empty.

* **Configuration**
  * Added support for excluding emotes in the memory-constrained device variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->