### PR TITLE
Null-check reply allocations in allocErrorResponse and RemoteHardware

### DIFF
--- a/src/mesh/MeshModule.cpp
+++ b/src/mesh/MeshModule.cpp
@@ -87,6 +87,8 @@ meshtastic_MeshPacket *MeshModule::allocErrorResponse(meshtastic_Routing_Error e
     uint8_t channelIndex =
         p->which_payload_variant == meshtastic_MeshPacket_decoded_tag ? p->channel : channels.getPrimaryIndex();
     auto r = allocAckNak(err, getFrom(p), p->id, channelIndex);
+    if (!r) // pool exhausted; callers treat a null reply as "no response"
+        return nullptr;
 
     setReplyTo(r, *p);
 

--- a/src/modules/RemoteHardwareModule.cpp
+++ b/src/modules/RemoteHardwareModule.cpp
@@ -103,8 +103,10 @@ bool RemoteHardwareModule::handleReceivedProtobuf(const meshtastic_MeshPacket &r
             r.gpio_value = res;
             r.gpio_mask = p.gpio_mask;
             meshtastic_MeshPacket *p2 = allocDataProtobuf(r);
-            setReplyTo(p2, req);
-            myReply = p2;
+            if (p2) {
+                setReplyTo(p2, req);
+                myReply = p2;
+            }
             break;
         }
 
@@ -149,7 +151,8 @@ int32_t RemoteHardwareModule::runOnce()
                 r.type = meshtastic_HardwareMessage_Type_GPIOS_CHANGED;
                 r.gpio_value = curVal;
                 meshtastic_MeshPacket *p = allocDataProtobuf(r);
-                service->sendToMesh(p);
+                if (p)
+                    service->sendToMesh(p);
             }
         }
     } else {


### PR DESCRIPTION
allocAckNak returns nullptr when the packet pool is exhausted (#11086), but allocErrorResponse passes the result straight to setReplyTo, which dereferences it. The assert there is compiled out in release builds, so it proceeds to a null store.

Reachable unauthenticated: AdminModule has no bound channel, so an ADMIN_APP packet on a channel whose key the sender has takes the NOT_AUTHORIZED path at AdminModule.cpp:227. Flooding to exhaust the pool then crashes the node. #11197 (MemoryDynamic::alloc no longer asserting on failure) made this reachable on PSRAM, STM32WL and Portduino targets, where it previously aborted instead.

Every consumer of the reply already null-checks, so returning nullptr degrades to no response. The two RemoteHardwareModule sites have the same unchecked pattern and are fixed alongside.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when packet resources are unavailable.
  * Prevented invalid replies and incomplete GPIO responses when packet allocation fails.
  * Prevented failed GPIO-change notifications from being sent as invalid packets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->