### PR TITLE
nRF52: don't truncate the AES-CTR block length to uint8_t

### DIFF
--- a/src/platform/nrf52/NRF52CryptoEngine.cpp
+++ b/src/platform/nrf52/NRF52CryptoEngine.cpp
@@ -18,7 +18,10 @@ class NRF52CryptoEngine : public CryptoEngine
         } else if (_key.length > 0) {
             nRFCrypto.begin();
             nRFCrypto_AES ctx;
-            uint8_t myLen = ctx.blockLen(numBytes);
+            // Must not be uint8_t: blockLen() rounds up to the AES block size, so numBytes in
+            // 241..256 yields 256, which truncates to 0 and leaves Process() writing numBytes
+            // attacker-controlled bytes onto a zero-length stack buffer.
+            size_t myLen = ctx.blockLen(numBytes);
             char encBuf[myLen] = {0};
             ctx.begin();
             ctx.Process((char *)bytes, numBytes, _nonce, _key.bytes, _key.length, encBuf, ctx.encryptFlag, ctx.ctrMode);


### PR DESCRIPTION
`blockLen()` rounds numBytes up to the AES block size, so 241..256 returns 256. It was stored in a uint8_t, truncating to 0, so `encBuf` became a zero-length stack VLA that `Process()` then wrote numBytes bytes into. Attacker-controlled ciphertext, stack destination.

MeshPacket.encrypted is a 256-byte protobuf field and encryptPacket admits numBytes up to MAX_BLOCKSIZE (256). The 239-byte ceiling that keeps RF traffic under the limit does not apply to the MQTT (MQTT.cpp) and UDP multicast (UdpMulticastHandler.h) ingress paths, which hand the packet to the router without clamping encrypted.size, so a publisher or a same-link sender can reach the truncating range.

Only the hardware AES branch is affected, taken for keys of 16 bytes or less, which includes the default channel PSK. Keys over 16 bytes use tiny-aes and were never affected.

Pre-existing, not a regression in this release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AES-CTR encryption reliability for larger data sizes.
  * Prevented incorrect buffer sizing that could cause encryption failures or corrupted results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->