### PR TITLE
Release the opaque relay copy the interface declines to send

### DIFF
--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -27,7 +27,12 @@ bool NextHopRouter::relayOpaquePacket(const meshtastic_MeshPacket *p)
         return false;
     relay->hop_limit--;
     relay->relay_node = nodeDB->getLastByteOfNodeNum(getNodeNum());
-    return Router::send(relay) == ERRNO_OK;
+    // The interface declines some packets (NODENUM_BROADCAST_NO_LORA) with ERRNO_SHOULD_RELEASE,
+    // which leaves the copy ours to free. Dropping it here would leak a pool slot per opaque frame.
+    ErrorCode res = Router::send(relay);
+    if (res == ERRNO_SHOULD_RELEASE)
+        packetPool.release(relay);
+    return res == ERRNO_OK;
 }
 
 PendingPacket::PendingPacket(meshtastic_MeshPacket *p, uint8_t numRetransmissions)


### PR DESCRIPTION
`relayOpaquePacket()` allocates a copy and returns `Router::send(relay) == ERRNO_OK`, discarding ERRNO_SHOULD_RELEASE. The interface returns that for NODENUM_BROADCAST_NO_LORA (RadioLibInterface.cpp), so the copy is never freed and one pool slot leaks per frame.

The opaque path is taken when `passesRoutingAuthGate` returns OPAQUE_RELAY_ONLY, which is the verdict for a packet on a channel we hold no key for. No key, PSK or admin access is required: a frame with an unknown channel hash, `to=NODENUM_BROADCAST_NO_LORA`, a nonzero id and `hop_limit > 0` leaks a slot on every default-configured rebroadcaster, and roughly MAX_PACKETS of them exhaust the pool until reboot.

#11087 fixed this same pattern in `perhapsRebroadcast` and the retransmission paths, and added the NODENUM_BROADCAST_NO_LORA guard now at NextHopRouter.cpp:180, but `relayOpaquePacket` was not covered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed packet handling during relay operations to prevent resource leaks.
  - Improved relay result processing for more reliable packet delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->