### PR TITLE
fix(devcontainer): install platformio as the vscode user

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,8 +36,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     libinput-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN pipx install platformio
-
 COPY 99-platformio-udev.rules /etc/udev/rules.d/99-platformio-udev.rules
 
 USER vscode

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -3,4 +3,6 @@
 git submodule update --init
 
 pip install --no-cache-dir setuptools
+
+pipx install platformio
 pipx install esptool


### PR DESCRIPTION
## Problem

The devcontainer comes up without `pio` on PATH:

```
vscode ➜ /workspaces/firmware $ pio
bash: pio: command not found
```

`pipx install platformio` runs in the Dockerfile as root, before the devcontainers python feature sets `PIPX_HOME`/`PIPX_BIN_DIR`. pipx therefore falls back to root's defaults and installs to `/root/.local/bin/pio`. A directory that is mode 700 and not on the `vscode` user's PATH. The binary is in the image, just unreachable from the user the container actually runs as.

## Fix

Move the install to `.devcontainer/setup.sh`, which runs as `postCreateCommand` as `vscode`, after features are applied and already installs esptool the same way. It lands in `/usr/local/py-utils/bin`, which is on PATH.

## Trade-off

platformio is now fetched on container create rather than baked into the image. The alternative is keeping the Dockerfile install and setting `ENV PIPX_HOME=/usr/local/py-utils PIPX_BIN_DIR=/usr/local/py-utils/bin` above it. Happy to switch if that is preferred.

## Testing

Created a fresh container with the devcontainer CLI:

- `pio` resolves to `/usr/local/py-utils/bin/pio` (PlatformIO Core 6.1.19)
- `/root/.local/bin/pio` is no longer present, confirming the Dockerfile change took effect
- `pio run -e rak4631` succeeds in that container (SUCCESS, 2:26)

Before this change the same steps produced `pio: command not found`.

This PR touches only `.devcontainer/`; no firmware code changed, so the per-device regression list is not applicable.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)

N/A - no firmware code is changed by this PR. The `rak4631` build above was run only to confirm the toolchain works inside the container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development container setup to install PlatformIO during environment initialization.
  * Preserved PlatformIO device access configuration and existing container health-check behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->