### PR TITLE
fix(rak4631): default OLED to SSD1306 when display.oled is AUTO

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -859,6 +859,10 @@ void setup()
 #elif defined(USE_SH1107_128_64)
     screen_model = meshtastic_Config_DisplayConfig_OledType_OLED_SH1107; // keep dimension of 128x64
 #else
+#ifdef OLED_MODEL_OVERRIDE
+    // Variant default for panels probeOLED() gets wrong; display.oled still wins below.
+    screen_model = OLED_MODEL_OVERRIDE;
+#endif
     if (config.display.oled != meshtastic_Config_DisplayConfig_OledType_OLED_AUTO) {
         screen_model = config.display.oled;
 

--- a/variants/nrf52840/rak4631/variant.h
+++ b/variants/nrf52840/rak4631/variant.h
@@ -146,6 +146,10 @@ static const uint8_t SCK = PIN_SPI_SCK;
 #define PIN_WIRE_SDA (WB_I2C1_SDA)
 #define PIN_WIRE_SCL (WB_I2C1_SCL)
 
+// The RAK1921 is an SSD1306, but probeOLED() reads its status byte as SH1106, whose
+// +2 column offset wraps the right edge. display.oled can still override this.
+#define OLED_MODEL_OVERRIDE meshtastic_Config_DisplayConfig_OledType_OLED_SSD1306
+
 // QSPI Pins
 #define PIN_QSPI_SCK 3
 #define PIN_QSPI_CS 26


### PR DESCRIPTION
## Problem

On a RAK4631 (RAK WisBlock) with the RAK1921 OLED, pixels at the far right of the display (x >= 126) wrap around to the left edge.

## Root cause

`ScanI2CTwoWire::probeOLED()` classifies the controller from the status byte the panel returns, masked to its low nibble:

```cpp
r &= 0x0f;

if (r == 0x08 || r == 0x00) {
    logFoundDevice("SH1106", (uint8_t)addr.address);
    o_probe = SCREEN_SH1106; // SH1106
} else if (r == 0x03 || r == 0x04 || r == 0x06 || r == 0x07 || r == 0x05) {
```

The RAK1921 is an SSD1306 but answers in the SH1106 range, so `screen_model` comes up as `OLED_SH1106`. The SH1106 driver addresses a 132-column RAM and shifts the 128px canvas right by two columns; on real SSD1306 glass, columns 126-127 then run off the end of the page and wrap.

Setting `display.oled` to `SSD1306` by hand fixes the rendering, which confirms the diagnosis — the controller choice is the only thing that changes.

## Fix

Add an `OLED_MODEL_OVERRIDE` hook in `main.cpp`, mirroring the existing `OLED_GEOMETRY_OVERRIDE` a few lines below it, and set it to `OLED_SSD1306` in the rak4631 variant.

It is applied **before** the `config.display.oled` check, so an explicit setting from the client still beats it out. WisBlock is modular and people do attach third-party SH1106 panels, so this changes the default rather than hard-coding the driver `-D USE_SSD1306` would have swapped `AutoOLEDWire` for `SSD1306Wire` at compile time and removed SH1106 support from the target entirely.

Scope: `env:rak4631` plus `rak4631_dbg`, `rak_wismesh_repeater_mini` and `rak_wismesh_pocket`, which inherit `-I variants/nrf52840/rak4631`. The other RAK variants have their own variant directories and are untouched.

## Why not fix the probe instead

The real defect is the `r == 0x00` arm `0x00` is a plausible answer from any panel that does not implement the status register meaningfully, so other SSD1306 clones will keep hitting this. Narrowing it to `r == 0x08` risks regressing boards that currently rely on the `0x00` path, so it needs testing across other hardware and belongs in its own PR.

## Testing

Built and flashed to a RAK4631 + RAK1921. The right-edge wrap is gone and the display renders correctly.

Setting `display.oled` to `SH1106` from the client brings the wrap back, confirming both that the variant default is what fixes the rendering and that an explicit setting still overrides it.

No other target is affected: `OLED_MODEL_OVERRIDE` is defined only in the rak4631 variant header, so for every other board the `#ifdef` block is preprocessed away and the firmware is unchanged.

Testing from anyone running a genuine SH1106 panel on a WisBlock base board would be welcome, to confirm the `display.oled` escape hatch still selects SH1106 for them.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [x] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)

Also built and flashed `heltec-mesh-node-t114` as a general smoke test, with no issues. That board uses an ST7789 TFT and does not compile the changed code path, so it is unaffected by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OLED display detection and initialization for supported hardware.
  * Corrected display alignment behavior for SSD1306 screens.
  * Preserved the ability to manually override the detected display model through configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->