### PR TITLE
Add IN_433 regulatory region

### DIFF
--- a/docs/lora_region_preset_compatibility_client_spec.md
+++ b/docs/lora_region_preset_compatibility_client_spec.md
@@ -80,7 +80,7 @@ what you can receive:
 | field                               | max_count                            |
 | ----------------------------------- | ------------------------------------ |
 | `LoRaRegionPresetMap.groups`        | 8                                    |
-| `LoRaRegionPresetMap.region_groups` | 38 (= number of `RegionCode` values) |
+| `LoRaRegionPresetMap.region_groups` | 39 (= number of `RegionCode` values) |
 | `LoRaPresetGroup.presets`           | 11                                   |
 
 ---
@@ -271,14 +271,14 @@ which is why they remain distinct groups despite sharing this preset list.
 
 `region_groups` (region → group_index):
 
-| group | regions                                                                                                                                                       |
-| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 0     | US, EU_433, CN, JP, ANZ, ANZ_433, RU, KR, TW, IN, NZ_865, TH, UA_433, MY_433, MY_919, SG_923, PH_433, PH_868, PH_915, KZ_433, KZ_863, NP_865, BR_902, LORA_24 |
-| 1     | EU_868                                                                                                                                                        |
-| 2     | EU_866                                                                                                                                                        |
-| 3     | EU_N_868                                                                                                                                                      |
-| 4     | ITU1_2M, ITU2_2M, ITU3_2M                                                                                                                                     |
-| 5     | ITU2_125CM                                                                                                                                                    |
+| group | regions                                                                                                                                                               |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0     | US, EU_433, CN, JP, ANZ, ANZ_433, RU, KR, TW, IN, IN_433, NZ_865, TH, UA_433, MY_433, MY_919, SG_923, PH_433, PH_868, PH_915, KZ_433, KZ_863, NP_865, BR_902, LORA_24 |
+| 1     | EU_868                                                                                                                                                                |
+| 2     | EU_866                                                                                                                                                                |
+| 3     | EU_N_868                                                                                                                                                              |
+| 4     | ITU1_2M, ITU2_2M, ITU3_2M                                                                                                                                             |
+| 5     | ITU2_125CM                                                                                                                                                            |
 
 > Note that several groups can carry overlapping preset lists but remain distinct: groups 1,
 > 2 and 3 share the EU 86x superset yet differ in `default_preset`, and group **5** (ham

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -197,6 +197,10 @@ const RegionInfo regions[] = {
      */
     RDEF(IN, 865.0f, 867.0f, 100, 30, false, false, PROFILE_STD, PRESET(LONG_FAST), 0),
 
+    // G.S.R. 347(E), 2022: 433.05-434.79 MHz, 10 mW ERP, maximum 10% duty cycle.
+    // https://eservices.dot.gov.in/sites/default/files/circular-notifications/the-use-of-low-power-radio-frequency-devices-in-the-frequency-band-433.05-to-434.79-mhz-exemption-from-license-rules-2022.pdf
+    RDEF(IN_433, 433.05f, 434.79f, 10, 10, false, false, PROFILE_STD, PRESET(LONG_FAST), 0),
+
     /*
          https://rrf.rsm.govt.nz/smart-web/smart/page/-smart/domain/licence/LicenceSummary.wdk?id=219752
          https://iotalliance.org.nz/wp-content/uploads/sites/4/2019/05/IoT-Spectrum-in-NZ-Briefing-Paper.pdf

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -80,6 +80,18 @@ static void test_getRegion_returnsCorrectRegion_LORA24()
     TEST_ASSERT_TRUE(r->wideLora);
 }
 
+static void test_getRegion_returnsCorrectRegion_IN433()
+{
+    const RegionInfo *r = getRegion(meshtastic_Config_LoRaConfig_RegionCode_IN_433);
+    TEST_ASSERT_NOT_NULL(r);
+    TEST_ASSERT_EQUAL(meshtastic_Config_LoRaConfig_RegionCode_IN_433, r->code);
+    TEST_ASSERT_EQUAL_STRING("IN_433", r->name);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 433.05f, r->freqStart);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 434.79f, r->freqEnd);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 10.0f, r->dutyCycle);
+    TEST_ASSERT_EQUAL_UINT8(10, r->powerLimit);
+}
+
 static void test_getRegion_unsetCodeReturnsUnsetEntry()
 {
     const RegionInfo *r = getRegion(meshtastic_Config_LoRaConfig_RegionCode_UNSET);
@@ -1765,6 +1777,7 @@ void setup()
     RUN_TEST(test_getRegion_returnsCorrectRegion_US);
     RUN_TEST(test_getRegion_returnsCorrectRegion_EU868);
     RUN_TEST(test_getRegion_returnsCorrectRegion_LORA24);
+    RUN_TEST(test_getRegion_returnsCorrectRegion_IN433);
     RUN_TEST(test_getRegion_unsetCodeReturnsUnsetEntry);
     RUN_TEST(test_getRegion_unknownCodeFallsToUnset);
 


### PR DESCRIPTION
Configure India 433 MHz operation for 433.05-434.79 MHz at 10 dBm with a 10% duty-cycle limit, as specified by G.S.R. 347(E), 2022.

[PDF reference of the G.S.R.](https://github.com/user-attachments/files/30444731/the-use-of-low-power-radio-frequency-devices-in-the-frequency-band-433.05-to-434.79-mhz-exemption-from-license-rules-2022.pdf)

Add region lookup coverage and update the client compatibility snapshot.

Note: Depends on meshtastic/protobufs#998.

On why we need a different region configuration:

```
   Existing region    Why it cannot represent India safely
  ━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   ANZ_433            Same frequency range, but permits 14 dBm and 100% duty cycle.
  ─────────────────  ───────────────────────────────────────────────────────────────────────────────
   UA_433             Same 10 dBm/10%, but starts at 433.00 MHz—below India’s 433.05 MHz boundary.
  ─────────────────  ───────────────────────────────────────────────────────────────────────────────
   EU_433             Also starts below the Indian boundary and stops at 434.00 MHz.
  ─────────────────  ───────────────────────────────────────────────────────────────────────────────
   KZ_433             Frequency is a legal subset and power is 10 dBm, but permits 100% duty cycle.
```

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the India 433 MHz LoRa region (`IN_433`), including its applicable frequency range, duty-cycle, and power limits.
  - Updated region-to-preset compatibility information to include `IN_433` in the default region group.

- **Documentation**
  - Updated the compatibility specification and reference tables to reflect the new regional option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->