### PR TITLE
Phantom node fix perhaps

### DIFF
--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -247,6 +247,7 @@ template <typename T> void LR11x0Interface<T>::addReceiveMetadata(meshtastic_Mes
     // LOG_DEBUG("PacketStatus %x", lora.getPacketStatus());
     mp->rx_snr = lora.getSNR();
     mp->rx_rssi = lround(lora.getRSSI());
+    mp->has_rx_rssi = true; // rx_rssi has explicit presence - a genuine reading must be marked present to survive encoding
     LOG_DEBUG("Corrected frequency offset: %f", lora.getFrequencyError());
 }
 

--- a/src/mesh/LR20x0Interface.cpp
+++ b/src/mesh/LR20x0Interface.cpp
@@ -253,6 +253,7 @@ template <typename T> void LR20x0Interface<T>::addReceiveMetadata(meshtastic_Mes
     // LOG_DEBUG("PacketStatus %x", lora.getPacketStatus());
     mp->rx_snr = lora.getSNR();
     mp->rx_rssi = lround(lora.getRSSI());
+    mp->has_rx_rssi = true; // rx_rssi has explicit presence - a genuine reading must be marked present to survive encoding
     // LOG_DEBUG("Corrected frequency offset: %f", lora.getFrequencyError()); // not implemented for LR20x0, but noop for LR11x0
     // too(!)
 }

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -216,8 +216,10 @@ void MeshService::injectAsReceived(meshtastic_MeshPacket &p)
         return;
     if (mp->rx_snr == 0) // plausible synthetic link metadata unless the caller set it
         mp->rx_snr = 8;
-    if (mp->rx_rssi == 0)
+    if (!mp->has_rx_rssi) { // rx_rssi has explicit presence; only fabricate if the caller didn't supply a real one
         mp->rx_rssi = -40;
+        mp->has_rx_rssi = true;
+    }
     mp->rx_time = getValidTime(RTCQualityFromNet);
     LOG_INFO("inject: RX from=0x%08x to=0x%08x id=0x%08x ch=%d %s", mp->from, mp->to, mp->id, mp->channel,
              mp->which_payload_variant == meshtastic_MeshPacket_encrypted_tag ? "encrypted" : "decoded");

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -219,7 +219,7 @@ bool meshtastic_NodeDatabase_callback(pb_istream_t *istream, pb_ostream_t *ostre
                 // snr_q4 = 0 is byte-identical to "field never written" but 0 dB is valid.
                 // NODEINFO_BITFIELD_HAS_SNR_MASK disambiguates going forward; legacy
                 // records (bit clear) treat this as unknown.
-                if (node.bitfield & NODEINFO_BITFIELD_HAS_SNR_MASK) {
+                if (nodeInfoLiteHasSnr(&node)) {
                     node.snr = node.snr_q4 / 4.0f;
                 } else if (node.snr_q4) {
                     node.snr = node.snr_q4 / 4.0f;
@@ -3632,13 +3632,17 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
         if (mp.rx_time) // if the packet has a valid timestamp use it to update our last_heard
             info->last_heard = mp.rx_time;
 
-        // Gate on the packet actually having been received over our own radio, not on
-        // rx_snr being truthy but 0 dB is valid.
-        // TRANSPORT_LORA is set only on the real over-the-air RX path
-        // (RadioInterface.cpp); it excludes TRANSPORT_INTERNAL
-        // and TRANSPORT_MQTT, while still accepting readings from an MQTT-origin packet rebroadcasts onto LoRa - we genuinely
-        // measured that one ourselves. Mirrors hop histogram below.
-        if (mp.transport_mechanism == meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA) {
+        // Gate on the packet actually having been received over our own radio, not on rx_snr being
+        // truthy, because 0 dB is valid. TRANSPORT_LORA is set only on the real over-the-air RX path
+        // (RadioInterface.cpp); it excludes TRANSPORT_INTERNAL and TRANSPORT_MQTT, while still accepting
+        // an MQTT-origin packet that a gateway rebroadcasts onto LoRa - we genuinely measured that one
+        // ourselves. Mirrors hop histogram below.
+        // Belt-and-braces: also require has_rx_rssi, which every genuine RF-reception site sets
+        // unconditionally alongside rx_snr - unlike PhoneAPI's replay packets, which set TRANSPORT_LORA
+        // too (so the client treats restored history as if heard over the air) but never has_rx_rssi.
+        // Replay packets don't reach updateFrom() today; this check guards against a future change that
+        // routes them back through this path silently recording a replayed rx_snr as a fresh measurement.
+        if (mp.transport_mechanism == meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA && mp.has_rx_rssi) {
             info->snr = mp.rx_snr; // keep the most recent SNR we received for this node.
             nodeInfoLiteSetBit(info, NODEINFO_BITFIELD_HAS_SNR_MASK, true);
         }

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -203,7 +203,7 @@ bool meshtastic_NodeDatabase_callback(pb_istream_t *istream, pb_ostream_t *ostre
             const auto *vec = static_cast<const std::vector<meshtastic_NodeInfoLite> *>(iter->pData);
             for (auto item : *vec) {
                 // Round rather than truncate: truncation wiped any |SNR| < 0.25 dB to exactly
-                // 0, which collided with the "never stored" sentinel below (defect D1).
+                // 0, which collided with the "never stored" sentinel below.
                 item.snr_q4 = (int32_t)lroundf(item.snr * 4.0f);
                 item.snr = 0.0f;
                 if (!pb_encode_tag_for_field(ostream, iter))
@@ -216,13 +216,9 @@ bool meshtastic_NodeDatabase_callback(pb_istream_t *istream, pb_ostream_t *ostre
             meshtastic_NodeInfoLite node = meshtastic_NodeInfoLite_init_zero;
             auto *vec = static_cast<std::vector<meshtastic_NodeInfoLite> *>(iter->pData);
             if (pb_decode(istream, meshtastic_NodeInfoLite_fields, &node)) {
-                // snr_q4 is proto3 singular sint32, so a stored 0 is byte-identical to "field
-                // never written" - it cannot self-distinguish a genuine 0 dB reading (defect
-                // D2). NODEINFO_BITFIELD_HAS_SNR_MASK disambiguates going forward; legacy
-                // records (bit clear) fall back to the old `snr_q4 != 0` heuristic, which is
-                // still exact for them: the write-site gate (see updateFrom) never stored a
-                // real 0 dB reading before this bit existed, so a legacy 0 is unambiguously
-                // "unknown", not data.
+                // snr_q4 = 0 is byte-identical to "field never written" but 0 dB is valid.
+                // NODEINFO_BITFIELD_HAS_SNR_MASK disambiguates going forward; legacy
+                // records (bit clear) treat this as unknown.
                 if (node.bitfield & NODEINFO_BITFIELD_HAS_SNR_MASK) {
                     node.snr = node.snr_q4 / 4.0f;
                 } else if (node.snr_q4) {
@@ -3637,12 +3633,11 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
             info->last_heard = mp.rx_time;
 
         // Gate on the packet actually having been received over our own radio, not on
-        // rx_snr being truthy (defect D3) - `if (mp.rx_snr)` silently refused to store a
-        // genuine 0 dB reading. TRANSPORT_LORA is set only on the real over-the-air RX path
-        // (RadioInterface.cpp); it excludes TRANSPORT_INTERNAL (locally generated/injected)
-        // and TRANSPORT_MQTT (no local RF measurement exists for those), while still covering
-        // an MQTT-origin packet a gateway rebroadcasts onto LoRa - we genuinely measured that
-        // one ourselves. Mirrors the same transport check used for the hop histogram below.
+        // rx_snr being truthy but 0 dB is valid.
+        // TRANSPORT_LORA is set only on the real over-the-air RX path
+        // (RadioInterface.cpp); it excludes TRANSPORT_INTERNAL
+        // and TRANSPORT_MQTT, while still accepting readings from an MQTT-origin packet rebroadcasts onto LoRa - we genuinely
+        // measured that one ourselves. Mirrors hop histogram below.
         if (mp.transport_mechanism == meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA) {
             info->snr = mp.rx_snr; // keep the most recent SNR we received for this node.
             nodeInfoLiteSetBit(info, NODEINFO_BITFIELD_HAS_SNR_MASK, true);
@@ -3659,18 +3654,10 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
         // hop_start==0, landing in the hop-0 bucket that pulls the recommendation lowest), so
         // exclude via_mqtt too.
         //
-        // The std::max clamp below is deliberate, not a bug: by this point the sample has
-        // already passed the TRANSPORT_LORA && !via_mqtt filter above, so it is a genuine RF
-        // neighbor whose hop count merely can't be *proven* - getHopsAway() returns -1 (unknown)
-        // for pre-2.3.0 senders that never populated hop_start, for a still-encrypted packet
-        // whose disambiguating 2.5.0 bitfield isn't readable yet, or for an invalid
-        // hop_start < hop_limit. Counting an unproven-but-real neighbor as 0 hops is the
-        // conservative direction: bucket 0 is the one that pulls the hop-limit recommendation
-        // *lowest*. Dropping the sample instead would discard a real RF node and bias the
-        // mesh-size estimate low. This intentionally does not agree with the `hopsAway >= 0`
+        // The std::max clamp below is deliberate, not a bug: Counting an unproven-but-real neighbor as 0 hops is the
+        // conservative direction. This intentionally does not agree with the `hopsAway >= 0`
         // gate below, which rejects the same -1 rather than storing it as a fabricated 0 -
-        // the histogram and the stored hops_away answer different questions ("how many hops,
-        // conservatively, for sizing" vs. "do we actually know").
+        // the histogram and the stored hops_away serve different purposes.
         if (mp.transport_mechanism == meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA && !mp.via_mqtt &&
             hopScalingModule) {
             uint8_t hopCount = std::max(int8_t(0), getHopsAway(mp));

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -202,7 +202,9 @@ bool meshtastic_NodeDatabase_callback(pb_istream_t *istream, pb_ostream_t *ostre
         if (ostream) {
             const auto *vec = static_cast<const std::vector<meshtastic_NodeInfoLite> *>(iter->pData);
             for (auto item : *vec) {
-                item.snr_q4 = (int32_t)(item.snr * 4.0f);
+                // Round rather than truncate: truncation wiped any |SNR| < 0.25 dB to exactly
+                // 0, which collided with the "never stored" sentinel below (defect D1).
+                item.snr_q4 = (int32_t)lroundf(item.snr * 4.0f);
                 item.snr = 0.0f;
                 if (!pb_encode_tag_for_field(ostream, iter))
                     return false;
@@ -214,8 +216,18 @@ bool meshtastic_NodeDatabase_callback(pb_istream_t *istream, pb_ostream_t *ostre
             meshtastic_NodeInfoLite node = meshtastic_NodeInfoLite_init_zero;
             auto *vec = static_cast<std::vector<meshtastic_NodeInfoLite> *>(iter->pData);
             if (pb_decode(istream, meshtastic_NodeInfoLite_fields, &node)) {
-                if (node.snr_q4)
+                // snr_q4 is proto3 singular sint32, so a stored 0 is byte-identical to "field
+                // never written" - it cannot self-distinguish a genuine 0 dB reading (defect
+                // D2). NODEINFO_BITFIELD_HAS_SNR_MASK disambiguates going forward; legacy
+                // records (bit clear) fall back to the old `snr_q4 != 0` heuristic, which is
+                // still exact for them: the write-site gate (see updateFrom) never stored a
+                // real 0 dB reading before this bit existed, so a legacy 0 is unambiguously
+                // "unknown", not data.
+                if (node.bitfield & NODEINFO_BITFIELD_HAS_SNR_MASK) {
                     node.snr = node.snr_q4 / 4.0f;
+                } else if (node.snr_q4) {
+                    node.snr = node.snr_q4 / 4.0f;
+                }
                 node.snr_q4 = 0;
                 vec->push_back(node);
             }
@@ -3624,8 +3636,17 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
         if (mp.rx_time) // if the packet has a valid timestamp use it to update our last_heard
             info->last_heard = mp.rx_time;
 
-        if (mp.rx_snr)
+        // Gate on the packet actually having been received over our own radio, not on
+        // rx_snr being truthy (defect D3) - `if (mp.rx_snr)` silently refused to store a
+        // genuine 0 dB reading. TRANSPORT_LORA is set only on the real over-the-air RX path
+        // (RadioInterface.cpp); it excludes TRANSPORT_INTERNAL (locally generated/injected)
+        // and TRANSPORT_MQTT (no local RF measurement exists for those), while still covering
+        // an MQTT-origin packet a gateway rebroadcasts onto LoRa - we genuinely measured that
+        // one ourselves. Mirrors the same transport check used for the hop histogram below.
+        if (mp.transport_mechanism == meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA) {
             info->snr = mp.rx_snr; // keep the most recent SNR we received for this node.
+            nodeInfoLiteSetBit(info, NODEINFO_BITFIELD_HAS_SNR_MASK, true);
+        }
 
         nodeInfoLiteSetBit(info, NODEINFO_BITFIELD_VIA_MQTT_MASK,
                            mp.via_mqtt); // Store if we received this packet via MQTT
@@ -3637,6 +3658,19 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
         // inflate the local mesh-size estimate with non-RF nodes (and they usually carry
         // hop_start==0, landing in the hop-0 bucket that pulls the recommendation lowest), so
         // exclude via_mqtt too.
+        //
+        // The std::max clamp below is deliberate, not a bug: by this point the sample has
+        // already passed the TRANSPORT_LORA && !via_mqtt filter above, so it is a genuine RF
+        // neighbor whose hop count merely can't be *proven* - getHopsAway() returns -1 (unknown)
+        // for pre-2.3.0 senders that never populated hop_start, for a still-encrypted packet
+        // whose disambiguating 2.5.0 bitfield isn't readable yet, or for an invalid
+        // hop_start < hop_limit. Counting an unproven-but-real neighbor as 0 hops is the
+        // conservative direction: bucket 0 is the one that pulls the hop-limit recommendation
+        // *lowest*. Dropping the sample instead would discard a real RF node and bias the
+        // mesh-size estimate low. This intentionally does not agree with the `hopsAway >= 0`
+        // gate below, which rejects the same -1 rather than storing it as a fabricated 0 -
+        // the histogram and the stored hops_away answer different questions ("how many hops,
+        // conservatively, for sizing" vs. "do we actually know").
         if (mp.transport_mechanism == meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA && !mp.via_mqtt &&
             hopScalingModule) {
             uint8_t hopCount = std::max(int8_t(0), getHopsAway(mp));

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -740,7 +740,13 @@ extern uint32_t error_address;
 #define NODEINFO_BITFIELD_HAS_IS_UNMESSAGABLE_MASK (1u << NODEINFO_BITFIELD_HAS_IS_UNMESSAGABLE_SHIFT)
 #define NODEINFO_BITFIELD_HAS_XEDDSA_SIGNED_SHIFT 9
 #define NODEINFO_BITFIELD_HAS_XEDDSA_SIGNED_MASK (1u << NODEINFO_BITFIELD_HAS_XEDDSA_SIGNED_SHIFT)
-// Bits 10..31 reserved for future single-bit flags.
+// snr_q4 (persisted, sint32) is proto3 singular, so a stored 0 is indistinguishable from
+// "never written" - and 0 dB is a perfectly ordinary reading. This bit disambiguates: set
+// whenever snr_q4 is written from a genuine RF measurement, tested instead of `if (snr_q4)`.
+// Legacy records (bit clear) are unambiguously "unknown" - see NodeDB.cpp for why.
+#define NODEINFO_BITFIELD_HAS_SNR_SHIFT 10
+#define NODEINFO_BITFIELD_HAS_SNR_MASK (1u << NODEINFO_BITFIELD_HAS_SNR_SHIFT)
+// Bits 11..31 reserved for future single-bit flags.
 
 // Convenience accessors so call sites read like the old struct fields.
 inline bool nodeInfoLiteHasUser(const meshtastic_NodeInfoLite *n)
@@ -782,6 +788,12 @@ inline bool nodeInfoLiteIsKeyManuallyVerified(const meshtastic_NodeInfoLite *n)
 inline bool nodeInfoLiteHasXeddsaSigned(const meshtastic_NodeInfoLite *n)
 {
     return n && (n->bitfield & NODEINFO_BITFIELD_HAS_XEDDSA_SIGNED_MASK);
+}
+/// True if this node's snr_q4 was written from a genuine RF measurement (including a real
+/// 0 dB reading). False means "never measured" - do not treat 0 as data.
+inline bool nodeInfoLiteHasSnr(const meshtastic_NodeInfoLite *n)
+{
+    return n && (n->bitfield & NODEINFO_BITFIELD_HAS_SNR_MASK);
 }
 /// A node that the eviction/migration paths must not drop: a favourite, an
 /// ignored (blocked) node, or a manually-verified key.

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -740,10 +740,9 @@ extern uint32_t error_address;
 #define NODEINFO_BITFIELD_HAS_IS_UNMESSAGABLE_MASK (1u << NODEINFO_BITFIELD_HAS_IS_UNMESSAGABLE_SHIFT)
 #define NODEINFO_BITFIELD_HAS_XEDDSA_SIGNED_SHIFT 9
 #define NODEINFO_BITFIELD_HAS_XEDDSA_SIGNED_MASK (1u << NODEINFO_BITFIELD_HAS_XEDDSA_SIGNED_SHIFT)
-// snr_q4 (persisted, sint32) is proto3 singular, so a stored 0 is indistinguishable from
-// "never written" - and 0 dB is a perfectly ordinary reading. This bit disambiguates: set
-// whenever snr_q4 is written from a genuine RF measurement, tested instead of `if (snr_q4)`.
-// Legacy records (bit clear) are unambiguously "unknown" - see NodeDB.cpp for why.
+// snr_q4 (persisted, sint32) is proto3 singular, so 0 == "never written", but 0 dB is valid.
+// This bit disambiguates: whenever snr_q4 is written from a genuine RF measurement.
+// Use this instead of `if (snr_q4)`. Legacy records (bit clear) are unambiguously "unknown".
 #define NODEINFO_BITFIELD_HAS_SNR_SHIFT 10
 #define NODEINFO_BITFIELD_HAS_SNR_MASK (1u << NODEINFO_BITFIELD_HAS_SNR_SHIFT)
 // Bits 11..31 reserved for future single-bit flags.

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -1224,13 +1224,32 @@ uint32_t makeReplayPacketId(NodeNum num, uint32_t timestamp, uint32_t kind)
 
 /// Populate hop_start/hop_limit from the node's real last-known hop count (if any) so a
 /// replayed packet doesn't read as "heard directly" when it wasn't.
+///
+/// When the hop count is genuinely unknown (no stored has_hops_away), emit hop_start = 0
+/// rather than fabricating hop_start == hop_limit. A fabricated equality reads as a direct
+/// (0-hop) neighbor to any receiver - firmware included: getHopsAway() (NodeDB.cpp) treats
+/// hop_start == 0 on an un-bitfielded packet (which this replay packet always is - it never
+/// sets decoded.has_bitfield) as "unknown", not "direct". Downstream clients that don't mirror
+/// that exact convention may still render hop_start == 0 as a measurement rather than absence;
+/// this is a known residual risk, see [[phantom-zero-hop-direct-nodes]] defect C.
 void setReplayHopFields(meshtastic_MeshPacket &pkt, const meshtastic_NodeInfoLite *header)
 {
+    if (!header || !header->has_hops_away) {
+        pkt.hop_start = 0; // unknown - do not fabricate a direct-neighbor reading
+        pkt.hop_limit = 0;
+        return;
+    }
     uint8_t hopLimit = Default::getConfiguredOrDefaultHopLimit(config.lora.hop_limit);
-    uint8_t hopsAway = (header && header->has_hops_away) ? header->hops_away : 0;
+    uint8_t hopsAway = header->hops_away;
     pkt.hop_start = hopLimit;
     pkt.hop_limit = hopsAway < hopLimit ? (uint8_t)(hopLimit - hopsAway) : 0;
 }
+
+// Replayed packets deliberately leave rx_rssi absent. NodeInfoLite stores no RSSI, so there is
+// nothing to restore after a reboot - and now that rx_rssi has explicit presence on the wire,
+// absent is the honest encoding. Previously these packets carried a bare 0, which a client
+// renders as a real (if impossibly strong) reading. Note the asymmetry with rx_snr below: that
+// field is still proto3 singular, so "unknown" and "0 dB" remain indistinguishable there.
 } // namespace
 
 meshtastic_MeshPacket PhoneAPI::makeReplayPositionPacket(NodeNum num, const meshtastic_PositionLite &pos)
@@ -1242,12 +1261,17 @@ meshtastic_MeshPacket PhoneAPI::makeReplayPositionPacket(NodeNum num, const mesh
     const meshtastic_NodeInfoLite *header = nodeDB->getMeshNode(num);
     pkt.from = num;
     pkt.to = NODENUM_BROADCAST;
-    pkt.rx_time = pos.time;
+    // rx_time means "when *we* received this" - use last_heard, not the position's own GPS
+    // fix time (which is often 0 and, when present, already round-trips inside the payload
+    // via ConvertToPosition). Using pos.time here made every replayed position look like it
+    // was just heard, regardless of how stale it actually was.
+    pkt.rx_time = header ? header->last_heard : 0;
     // Stable per-node/per-fix id: replaying the same unchanged history on every
     // reconnect must not look like a brand new packet to the phone's history/dedup.
     pkt.id = makeReplayPacketId(num, pkt.rx_time, meshtastic_PortNum_POSITION_APP);
-    pkt.channel = 0;
+    pkt.channel = header ? header->channel : 0;
     pkt.rx_snr = header ? header->snr : 0;
+    pkt.via_mqtt = nodeInfoLiteViaMqtt(header);
     setReplayHopFields(pkt, header);
     pkt.priority = meshtastic_MeshPacket_Priority_BACKGROUND;
     // Mark as if heard over the air, not internally generated
@@ -1270,8 +1294,9 @@ meshtastic_MeshPacket PhoneAPI::makeReplayTelemetryPacket(NodeNum num, const mes
     const meshtastic_NodeInfoLite *header = nodeDB->getMeshNode(num);
     pkt.rx_time = header ? header->last_heard : 0;
     pkt.id = makeReplayPacketId(num, pkt.rx_time, meshtastic_Telemetry_device_metrics_tag);
-    pkt.channel = 0;
+    pkt.channel = header ? header->channel : 0;
     pkt.rx_snr = header ? header->snr : 0;
+    pkt.via_mqtt = nodeInfoLiteViaMqtt(header);
     setReplayHopFields(pkt, header);
     pkt.priority = meshtastic_MeshPacket_Priority_BACKGROUND;
     // Mark as if heard over the air, not internally generated - iOS client filters
@@ -1375,8 +1400,9 @@ meshtastic_MeshPacket PhoneAPI::makeReplayEnvironmentPacket(uint32_t num, const 
     const meshtastic_NodeInfoLite *header = nodeDB->getMeshNode(num);
     pkt.rx_time = header ? header->last_heard : 0;
     pkt.id = makeReplayPacketId(num, pkt.rx_time, meshtastic_Telemetry_environment_metrics_tag);
-    pkt.channel = 0;
+    pkt.channel = header ? header->channel : 0;
     pkt.rx_snr = header ? header->snr : 0;
+    pkt.via_mqtt = nodeInfoLiteViaMqtt(header);
     setReplayHopFields(pkt, header);
     pkt.priority = meshtastic_MeshPacket_Priority_BACKGROUND;
     // Mark as if heard over the air, not internally generated - iOS client filters
@@ -1439,8 +1465,9 @@ meshtastic_MeshPacket PhoneAPI::makeReplayStatusPacket(uint32_t num, const mesht
     const meshtastic_NodeInfoLite *header = nodeDB->getMeshNode(num);
     pkt.rx_time = header ? header->last_heard : 0;
     pkt.id = makeReplayPacketId(num, pkt.rx_time, meshtastic_PortNum_NODE_STATUS_APP);
-    pkt.channel = 0;
+    pkt.channel = header ? header->channel : 0;
     pkt.rx_snr = header ? header->snr : 0;
+    pkt.via_mqtt = nodeInfoLiteViaMqtt(header);
     setReplayHopFields(pkt, header);
     pkt.priority = meshtastic_MeshPacket_Priority_BACKGROUND;
     // Mark as if heard over the air, not internally generated - client filters

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -1222,16 +1222,9 @@ uint32_t makeReplayPacketId(NodeNum num, uint32_t timestamp, uint32_t kind)
     return h ? h : 1; // some clients treat id 0 as "unset"
 }
 
-/// Populate hop_start/hop_limit from the node's real last-known hop count (if any) so a
-/// replayed packet doesn't read as "heard directly" when it wasn't.
-///
-/// When the hop count is genuinely unknown (no stored has_hops_away), emit hop_start = 0
-/// rather than fabricating hop_start == hop_limit. A fabricated equality reads as a direct
-/// (0-hop) neighbor to any receiver - firmware included: getHopsAway() (NodeDB.cpp) treats
-/// hop_start == 0 on an un-bitfielded packet (which this replay packet always is - it never
-/// sets decoded.has_bitfield) as "unknown", not "direct". Downstream clients that don't mirror
-/// that exact convention may still render hop_start == 0 as a measurement rather than absence;
-/// this is a known residual risk, see [[phantom-zero-hop-direct-nodes]] defect C.
+/// Populate hop_start/hop_limit from the node's last-known hop count - never fabricate one.
+/// hop_start == 0 with no decoded bitfield means unknown, not a direct neighbor; clients must
+/// treat it that way too (see hop_start in mesh.proto).
 void setReplayHopFields(meshtastic_MeshPacket &pkt, const meshtastic_NodeInfoLite *header)
 {
     if (!header || !header->has_hops_away) {
@@ -1245,13 +1238,13 @@ void setReplayHopFields(meshtastic_MeshPacket &pkt, const meshtastic_NodeInfoLit
     pkt.hop_limit = hopsAway < hopLimit ? (uint8_t)(hopLimit - hopsAway) : 0;
 }
 
-// Replayed packets deliberately leave rx_rssi absent. NodeInfoLite stores no RSSI, so there is
-// nothing to restore after a reboot - and now that rx_rssi has explicit presence on the wire,
-// absent is the honest encoding. Previously these packets carried a bare 0, which a client
-// renders as a real (if impossibly strong) reading. Note the asymmetry with rx_snr below: that
-// field is still proto3 singular, so "unknown" and "0 dB" remain indistinguishable there.
 } // namespace
 
+// Replayed packets deliberately leave rx_rssi absent. NodeInfoLite stores no RSSI, and
+// rx_rssi has explicit presence on the wire, indicating "unknown".
+// Previously these packets carried a bare 0, which a client renders as a real reading.
+// Note the asymmetry with rx_snr below: that field is still proto3 singular, so "unknown" and
+//  "0 dB" remain indistinguishable there.
 meshtastic_MeshPacket PhoneAPI::makeReplayPositionPacket(NodeNum num, const meshtastic_PositionLite &pos)
 {
     // Shape this exactly like a fresh live broadcast Position from the peer so the
@@ -1263,8 +1256,7 @@ meshtastic_MeshPacket PhoneAPI::makeReplayPositionPacket(NodeNum num, const mesh
     pkt.to = NODENUM_BROADCAST;
     // rx_time means "when *we* received this" - use last_heard, not the position's own GPS
     // fix time (which is often 0 and, when present, already round-trips inside the payload
-    // via ConvertToPosition). Using pos.time here made every replayed position look like it
-    // was just heard, regardless of how stale it actually was.
+    // via ConvertToPosition).
     pkt.rx_time = header ? header->last_heard : 0;
     // Stable per-node/per-fix id: replaying the same unchanged history on every
     // reconnect must not look like a brand new packet to the phone's history/dedup.

--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -267,6 +267,7 @@ void RF95Interface::addReceiveMetadata(meshtastic_MeshPacket *mp)
 {
     mp->rx_snr = lora->getSNR();
     mp->rx_rssi = lround(lora->getRSSI());
+    mp->has_rx_rssi = true; // rx_rssi has explicit presence - a genuine reading must be marked present to survive encoding
     LOG_DEBUG("Corrected frequency offset: %f", lora->getFrequencyError());
 }
 

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -881,7 +881,7 @@ void printPacket(const char *prefix, const meshtastic_MeshPacket *p)
         out += DEBUG_PORT.mt_sprintf(" rxtime=%u", p->rx_time);
     if (p->rx_snr != 0.0)
         out += DEBUG_PORT.mt_sprintf(" rxSNR=%g", p->rx_snr);
-    if (p->rx_rssi != 0)
+    if (p->has_rx_rssi) // rx_rssi has explicit presence; a != 0 check would hide a genuine 0 dBm reading
         out += DEBUG_PORT.mt_sprintf(" rxRSSI=%i", p->rx_rssi);
     if (p->via_mqtt != 0)
         out += DEBUG_PORT.mt_sprintf(" via MQTT");

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -335,6 +335,7 @@ template <typename T> void SX126xInterface<T>::addReceiveMetadata(meshtastic_Mes
     // LOG_DEBUG("PacketStatus %x", lora.getPacketStatus());
     mp->rx_snr = lora.getSNR();
     mp->rx_rssi = lround(lora.getRSSI());
+    mp->has_rx_rssi = true; // rx_rssi has explicit presence - a genuine reading must be marked present to survive encoding
     LOG_DEBUG("Corrected frequency offset: %f", lora.getFrequencyError());
 }
 

--- a/src/mesh/SX128xInterface.cpp
+++ b/src/mesh/SX128xInterface.cpp
@@ -205,6 +205,7 @@ template <typename T> void SX128xInterface<T>::addReceiveMetadata(meshtastic_Mes
     // LOG_DEBUG("PacketStatus %x", lora.getPacketStatus());
     mp->rx_snr = lora.getSNR();
     mp->rx_rssi = lround(lora.getRSSI());
+    mp->has_rx_rssi = true; // rx_rssi has explicit presence - a genuine reading must be marked present to survive encoding
     LOG_DEBUG("Corrected frequency offset: %f", lora.getFrequencyError());
 }
 

--- a/src/mesh/TypeConversions.cpp
+++ b/src/mesh/TypeConversions.cpp
@@ -10,6 +10,9 @@ meshtastic_NodeInfo TypeConversions::ConvertToNodeInfo(const meshtastic_NodeInfo
     meshtastic_NodeInfo info = meshtastic_NodeInfo_init_default;
 
     info.num = lite->num;
+    // NodeInfo.snr (wire) is still proto3 singular float - unlike NodeInfoLite.snr_q4, it has no
+    // presence bit and cannot distinguish a genuine 0 dB from "unknown". nodeInfoLiteHasSnr(lite)
+    // is available if a future NodeInfo revision needs to carry that distinction to clients.
     info.snr = lite->snr;
     info.last_heard = lite->last_heard;
     info.channel = lite->channel;

--- a/src/mesh/generated/meshtastic/deviceonly.pb.h
+++ b/src/mesh/generated/meshtastic/deviceonly.pb.h
@@ -95,8 +95,11 @@ typedef struct _meshtastic_NodeInfoLite {
     /* The public key of the user's device, for PKI-based encrypted DMs. */
     meshtastic_NodeInfoLite_public_key_t public_key;
     /* Q4-encoded SNR: dB × 4, sint32 zigzag. Matches RouteDiscovery convention.
- Encode: snr_q4 = (int32_t)(snr * 4.0f). Decode: snr = snr_q4 / 4.0f.
- float snr is always zeroed on disk; this field carries all persisted SNR. */
+ Encode: snr_q4 = (int32_t)lroundf(snr * 4.0f). Decode: snr = snr_q4 / 4.0f.
+ float snr is always zeroed on disk; this field carries all persisted SNR.
+ A stored 0 does not by itself mean "unknown" here - see NODEINFO_BITFIELD_HAS_SNR in
+ src/mesh/NodeDB.h for the presence bit that disambiguates a genuine 0 dB reading from
+ "never measured". */
     int32_t snr_q4;
 } meshtastic_NodeInfoLite;
 

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -1103,7 +1103,13 @@ typedef struct _meshtastic_MeshPacket {
     /* The priority of this message for sending.
  See MeshPacket.Priority description for more details. */
     meshtastic_MeshPacket_Priority priority;
-    /* rssi of received packet. Only sent to phone for dispay purposes. */
+    /* rssi of received packet. Only sent to phone for dispay purposes.
+ Explicit presence: rssi 0 is a legitimate reading on some radios (SX126x can report exactly
+ 0 dBm; SX127x's formula can even go positive), so implicit-presence proto3 made an unset
+ value indistinguishable from a measured one. has_rx_rssi disambiguates; a replayed packet
+ built from history the device never restored an RSSI for should leave this field absent
+ rather than emitting 0. */
+    bool has_rx_rssi;
     int32_t rx_rssi;
     /* Describe if this message is delayed */
     meshtastic_MeshPacket_Delayed delayed;
@@ -1730,7 +1736,7 @@ extern "C" {
 #define meshtastic_Waypoint_init_default         {0, false, 0, false, 0, 0, 0, "", "", 0, 0, false, meshtastic_BoundingBox_init_default, 0, 0, 0}
 #define meshtastic_StatusMessage_init_default    {""}
 #define meshtastic_MqttClientProxyMessage_init_default {"", 0, {{0, {0}}}, 0}
-#define meshtastic_MeshPacket_init_default       {0, 0, 0, 0, {meshtastic_Data_init_default}, 0, 0, 0, 0, 0, _meshtastic_MeshPacket_Priority_MIN, 0, _meshtastic_MeshPacket_Delayed_MIN, 0, 0, {0, {0}}, 0, 0, 0, 0, _meshtastic_MeshPacket_TransportMechanism_MIN, 0}
+#define meshtastic_MeshPacket_init_default       {0, 0, 0, 0, {meshtastic_Data_init_default}, 0, 0, 0, 0, 0, _meshtastic_MeshPacket_Priority_MIN, false, 0, _meshtastic_MeshPacket_Delayed_MIN, 0, 0, {0, {0}}, 0, 0, 0, 0, _meshtastic_MeshPacket_TransportMechanism_MIN, 0}
 #define meshtastic_NodeInfo_init_default         {0, false, meshtastic_User_init_default, false, meshtastic_Position_init_default, 0, 0, false, meshtastic_DeviceMetrics_init_default, 0, 0, false, 0, 0, 0, 0, 0, 0}
 #define meshtastic_MyNodeInfo_init_default       {0, 0, 0, {0, {0}}, "", _meshtastic_FirmwareEdition_MIN, 0}
 #define meshtastic_LogRecord_init_default        {"", 0, "", _meshtastic_LogRecord_Level_MIN}
@@ -1769,7 +1775,7 @@ extern "C" {
 #define meshtastic_Waypoint_init_zero            {0, false, 0, false, 0, 0, 0, "", "", 0, 0, false, meshtastic_BoundingBox_init_zero, 0, 0, 0}
 #define meshtastic_StatusMessage_init_zero       {""}
 #define meshtastic_MqttClientProxyMessage_init_zero {"", 0, {{0, {0}}}, 0}
-#define meshtastic_MeshPacket_init_zero          {0, 0, 0, 0, {meshtastic_Data_init_zero}, 0, 0, 0, 0, 0, _meshtastic_MeshPacket_Priority_MIN, 0, _meshtastic_MeshPacket_Delayed_MIN, 0, 0, {0, {0}}, 0, 0, 0, 0, _meshtastic_MeshPacket_TransportMechanism_MIN, 0}
+#define meshtastic_MeshPacket_init_zero          {0, 0, 0, 0, {meshtastic_Data_init_zero}, 0, 0, 0, 0, 0, _meshtastic_MeshPacket_Priority_MIN, false, 0, _meshtastic_MeshPacket_Delayed_MIN, 0, 0, {0, {0}}, 0, 0, 0, 0, _meshtastic_MeshPacket_TransportMechanism_MIN, 0}
 #define meshtastic_NodeInfo_init_zero            {0, false, meshtastic_User_init_zero, false, meshtastic_Position_init_zero, 0, 0, false, meshtastic_DeviceMetrics_init_zero, 0, 0, false, 0, 0, 0, 0, 0, 0}
 #define meshtastic_MyNodeInfo_init_zero          {0, 0, 0, {0, {0}}, "", _meshtastic_FirmwareEdition_MIN, 0}
 #define meshtastic_LogRecord_init_zero           {"", 0, "", _meshtastic_LogRecord_Level_MIN}
@@ -2194,7 +2200,7 @@ X(a, STATIC,   SINGULAR, FLOAT,    rx_snr,            8) \
 X(a, STATIC,   SINGULAR, UINT32,   hop_limit,         9) \
 X(a, STATIC,   SINGULAR, BOOL,     want_ack,         10) \
 X(a, STATIC,   SINGULAR, UENUM,    priority,         11) \
-X(a, STATIC,   SINGULAR, INT32,    rx_rssi,          12) \
+X(a, STATIC,   OPTIONAL, INT32,    rx_rssi,          12) \
 X(a, STATIC,   SINGULAR, UENUM,    delayed,          13) \
 X(a, STATIC,   SINGULAR, BOOL,     via_mqtt,         14) \
 X(a, STATIC,   SINGULAR, UINT32,   hop_start,        15) \

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -1116,7 +1116,11 @@ typedef struct _meshtastic_MeshPacket {
     /* Describes whether this packet passed via MQTT somewhere along the path it currently took. */
     bool via_mqtt;
     /* Hop limit with which the original packet started. Sent via LoRa using three bits in the unencrypted header.
- When receiving a packet, the difference between hop_start and hop_limit gives how many hops it traveled. */
+ When receiving a packet, the difference between hop_start and hop_limit gives how many hops it traveled.
+ hop_start == 0 does not necessarily mean a direct (0-hop) neighbor: firmware prior to 2.3.0
+ never populated this field, so a receiver can only trust hop_start == 0 as genuine once it has
+ decoded the packet and confirmed the sender's bitfield is present (added in 2.5.0). Until then,
+ or for a sender that never sets that bitfield, treat hop_start == 0 as unknown, not direct. */
     uint8_t hop_start;
     /* Records the public key the packet was encrypted with, if applicable. */
     meshtastic_MeshPacket_public_key_t public_key;

--- a/src/mesh/udp/UdpMulticastHandler.h
+++ b/src/mesh/udp/UdpMulticastHandler.h
@@ -86,9 +86,13 @@ class UdpMulticastHandler final
             UniquePacketPoolPacket p = packetPool.allocUniqueCopy(mp);
             if (!p)
                 return;
-            // Unset received SNR/RSSI
+            // Unset received SNR/RSSI - no local RF measurement exists for a UDP arrival. rx_rssi
+            // has explicit presence, so also clear has_rx_rssi: `mp` may have arrived already
+            // carrying a real measurement from whichever node forwarded it onto UDP, and leaving
+            // the presence bit set would misrepresent that stale value as "0 dBm over UDP".
             p->rx_snr = 0;
             p->rx_rssi = 0;
+            p->has_rx_rssi = false;
             router->enqueueReceivedMessage(p.release());
         }
     }

--- a/src/modules/StoreForwardModule.cpp
+++ b/src/modules/StoreForwardModule.cpp
@@ -259,6 +259,7 @@ meshtastic_MeshPacket *StoreForwardModule::preparePayload(NodeNum dest, uint32_t
                 p->rx_time = this->packetHistory[i].time;
                 p->decoded.emoji = (uint32_t)this->packetHistory[i].emoji;
                 p->rx_rssi = this->packetHistory[i].rx_rssi;
+                p->has_rx_rssi = true; // rx_rssi has explicit presence; the stored value was a genuine measurement
                 p->rx_snr = this->packetHistory[i].rx_snr;
                 p->hop_start = this->packetHistory[i].hop_start;
                 p->hop_limit = this->packetHistory[i].hop_limit;

--- a/src/modules/TraceRouteModule.cpp
+++ b/src/modules/TraceRouteModule.cpp
@@ -422,7 +422,11 @@ void TraceRouteModule::appendMyIDandSNR(meshtastic_RouteDiscovery *updated, floa
     }
 
     if (*snr_count < ROUTE_SIZE) {
-        snr_list[*snr_count] = (int8_t)(snr * 4); // Convert SNR to 1 byte
+        // Clamp before the cast: q4-scaled SNR at or below the demodulation floor can reach
+        // -128 (=-32dB), which is bit-identical to the INT8_MIN "unknown SNR" sentinel used
+        // throughout this file. Reserve -128 for the sentinel; clamp real readings to -127.
+        int32_t q4 = clamp<int32_t>(lroundf(snr * 4.0f), -127, 127);
+        snr_list[*snr_count] = (int8_t)q4;
         *snr_count += 1;
     }
     if (SNRonly)

--- a/src/serialization/MeshPacketSerializer.cpp
+++ b/src/serialization/MeshPacketSerializer.cpp
@@ -426,7 +426,9 @@ std::string MeshPacketSerializer::JsonSerialize(const meshtastic_MeshPacket *mp,
     jsonObj["channel"] = (Json::UInt)mp->channel;
     jsonObj["type"] = msgType;
     jsonObj["sender"] = nodeDB->getNodeId();
-    if (mp->rx_rssi != 0)
+    // rx_rssi has explicit presence on the wire (unlike rx_snr): trust has_rx_rssi rather than a
+    // != 0 heuristic, since 0 dBm is a legitimate reading on some radios.
+    if (mp->has_rx_rssi)
         jsonObj["rssi"] = (int)mp->rx_rssi;
     if (mp->rx_snr != 0)
         jsonObj["snr"] = (float)mp->rx_snr;
@@ -456,7 +458,9 @@ std::string MeshPacketSerializer::JsonSerializeEncrypted(const meshtastic_MeshPa
     jsonObj["channel"] = (Json::UInt)mp->channel;
     jsonObj["want_ack"] = mp->want_ack;
 
-    if (mp->rx_rssi != 0)
+    // rx_rssi has explicit presence on the wire (unlike rx_snr): trust has_rx_rssi rather than a
+    // != 0 heuristic, since 0 dBm is a legitimate reading on some radios.
+    if (mp->has_rx_rssi)
         jsonObj["rssi"] = (int)mp->rx_rssi;
     if (mp->rx_snr != 0)
         jsonObj["snr"] = (float)mp->rx_snr;

--- a/test/test_fuzz_packets/test_main.cpp
+++ b/test/test_fuzz_packets/test_main.cpp
@@ -616,6 +616,7 @@ void test_E7_nodedb_update_fuzz(void)
             mp.id = rngNext();
             mp.rx_snr = (float)((int)rngRange(60) - 30);
             mp.rx_rssi = (int32_t)rngRange(256) - 128;
+            mp.has_rx_rssi = (rngRange(2) != 0); // exercise both the presence and absence paths
             mp.hop_start = (uint8_t)rngRange(8);
             mp.hop_limit = (uint8_t)rngRange(8);
             mp.which_payload_variant = meshtastic_MeshPacket_decoded_tag;
@@ -666,6 +667,7 @@ static void fuzzRxHeader(meshtastic_MeshPacket &mp, meshtastic_PortNum portnum)
     mp.channel = (uint8_t)rngRange(channels.getNumChannels());
     mp.rx_snr = (float)((int)rngRange(40) - 20);
     mp.rx_rssi = -(int)rngRange(130);
+    mp.has_rx_rssi = (rngRange(2) != 0); // exercise both the presence and absence paths
     mp.hop_start = (uint8_t)rngRange(8); // 0..7, wire-bounded
     mp.hop_limit = (uint8_t)rngRange(8);
     mp.want_ack = (rngRange(2) == 0);

--- a/test/test_meshpacket_serializer/test_helpers.h
+++ b/test/test_meshpacket_serializer/test_helpers.h
@@ -40,6 +40,7 @@ static meshtastic_MeshPacket create_test_packet(meshtastic_PortNum port, const u
     packet.rx_snr = 10.5f;
     packet.hop_start = 3;
     packet.rx_rssi = -85;
+    packet.has_rx_rssi = true; // rx_rssi has explicit presence; mark this synthetic reading as measured
     packet.delayed = meshtastic_MeshPacket_Delayed_NO_DELAY;
 
     // Set decoded variant


### PR DESCRIPTION
After a phone reconnects, the client synthesizes history packets from the stored NodeDB
(`PhoneAPI::makeReplay{Position,Telemetry,Environment,Status}Packet`) so the app doesn't have
to wait to re-hear every node live. Users report these replayed nodes sometimes appearing as
phantom direct (0-hop) connections with 0 SNR / 0 RSSI, indistinguishable from a real
zero-signal neighbor — originally reported in #11208.

Captured a full NodeDB dump plus a live BLE/serial replay trace from a real device and traced
this to several independent defects in the replay path and in how `snr`/`rssi` are stored on
`NodeInfoLite`, not one bug. All four replay builders start from a blank `MeshPacket` and copy
only a handful of fields from the stored node header, so several stored fields were silently
dropped — and two of the numeric fields involved (`rx_snr`, `rx_rssi`) had no wire-level way to
represent "never measured" at all, so a dropped value came back as a plausible 0 instead of
nothing.

### Fixes

1. **`rx_rssi` had no "unset" state on the wire.** proto3 implicit presence makes an absent
   value byte-identical to a genuine 0 dBm reading — and 0 dBm is a real reading on
   SX126x/LR11x0/LR20x0, sometimes even positive on SX127x. Made `MeshPacket.rx_rssi`
   `optional` (`has_rx_rssi`). Every genuine-reception site now sets the bit explicitly:
   `SX126xInterface`, `SX128xInterface`, `LR11x0Interface`, `LR20x0Interface`, `RF95Interface`,
   `StoreForwardModule`'s history replay, and the fabricated link metadata in
   `MeshService::injectAsReceived`. `UdpMulticastHandler` clears it when it deliberately zeroes
   SNR/RSSI for a UDP-relayed packet. `MeshPacketSerializer`'s JSON/serial dump switched from
   `rx_rssi != 0` to `has_rx_rssi`.

2. **Replay fabricated a direct-neighbor reading instead of leaving hop count unknown.**
   `setReplayHopFields` defaulted an unknown hop count to `0`, producing
   `hop_start == hop_limit` — indistinguishable from a genuine 0-hop neighbor. It now leaves
   both at `0` (documented as the "unknown" encoding on `hop_start` in `mesh.proto`), matching
   how firmware's own `getHopsAway()` already treats an un-bitfielded `hop_start == 0`.

3. **Persisted SNR (`snr_q4`) used truncation and a bare-zero sentinel.** Truncating instead of
   rounding collapsed any reading within ±0.25 dB of zero to exactly 0, indistinguishable from
   "never stored." Encoding now uses `lroundf`, and an explicit `NODEINFO_BITFIELD_HAS_SNR`
   presence bit (bit 10, following the existing `HAS_USER`/`HAS_IS_UNMESSAGABLE`/
   `HAS_XEDDSA_SIGNED` precedent) disambiguates a genuine 0 dB reading from "unmeasured."
   Legacy on-disk records (bit unset) still decode correctly, since the old write gate never
   stored a real 0 dB value before this bit existed.

4. **The live write gate for SNR was `if (mp.rx_snr)`** — truthiness, not presence — so a
   genuine 0 dB reading was silently discarded before it could even reach fix 3. Replaced with
   a check on `mp.transport_mechanism == TRANSPORT_LORA`, which is set only on the real
   over-the-air receive path (excludes locally-injected and MQTT-only packets, but still covers
   an MQTT-origin packet a gateway rebroadcasts onto LoRa, since that hop was genuinely
   measured).

5. **Position replay used the GPS fix time, not reception time, for `rx_time`.**
   `makeReplayPositionPacket` set `pkt.rx_time = pos.time` — the position's own, often-zero,
   GPS timestamp — so a position last heard 11 days ago replayed as "Last heard: Now" on every
   reconnect. Now uses `header->last_heard`, matching the other three replay builders; the GPS
   fix time is unaffected since it already round-trips inside the payload via
   `ConvertToPosition`.

6. **Replay silently dropped `channel` and `via_mqtt`.** All four builders hardcoded
   `channel = 0` and never set `via_mqtt`, so an MQTT-sourced or non-default-channel node
   replayed as a directly-received, default-channel LoRa packet. Both are now copied from the
   stored header.

7. **Incidental:** `TraceRouteModule::appendMyIDandSNR`'s SNR→int8 cast could produce exactly
   `-128` for a very low but real reading, colliding with the `INT8_MIN` "unknown" sentinel that
   `RouteDiscovery.snr_towards`/`snr_back` already use elsewhere in this file. Clamped to `-127`
   so a real reading can no longer alias the sentinel.

### Deliberately out of scope

- **RSSI still cannot survive a reboot.** `NodeInfoLite` has no RSSI field, so a replayed
  packet now leaves `rx_rssi` absent rather than fabricating 0 — honest, but the client shows
  no RSSI for any node until it's heard live again. Adding storage is a `NodeInfoLite` schema
  change with flash-budget impact across the 3-tier node sizing tiers, and is being kept out of
  this PR.
- The handful of nodes observed with stored `hops_away == 0` that may or may not be genuine
  direct neighbors isn't addressed — needs a live capture of the actual `hop_start`/`hop_limit`
  header from one of them, not a heuristic guess.
- `hopScalingModule`'s hop histogram deliberately buckets an unproven-but-real hop count as 0
  for its own conservative sizing purpose. That's an intentional disagreement with the stricter
  `hops_away` storage gate, documented in place, not changed here.

### Testing

- `./bin/run-tests.sh -e native` — full 41-suite native run GREEN on the branch prior to the
  final RSSI-field-removal + comment cleanup pass.
- `test_type_conversions` re-verified GREEN (28/28) after removing the `NodeInfoLite.rssi`
  storage field and regenerating the nanopb header.
- `test_fuzz_packets` exercises both the presence and absence of `has_rx_rssi`.
- Hardware compile check: `nrf52_promicro_diy_tcxo`, `heltec-mesh-pocket-5000-inkhud`.

## Acknowledgements

Hat tip to @folex-fire for https://github.com/meshtastic/firmware/pull/11208 - it wasn't right, but it did spur me to make a run at it.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of received RSSI values, including legitimate readings of 0.
  * Preserved RSSI presence through packet encoding, replay, storage, and serialization.
  * Prevented packets received over UDP from reporting stale radio measurements.
  * Corrected SNR storage and restoration, including accurate 0 dB readings.
  * Improved replayed packet metadata, including channel, SNR, route, and receive time.
* **Tests**
  * Expanded packet and RSSI presence coverage in fuzz and serialization tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->