### PR TITLE
Remove esp32c6 guard precluding NonBlockingRTTTL

### DIFF
--- a/src/modules/ExternalNotificationModule.h
+++ b/src/modules/ExternalNotificationModule.h
@@ -23,7 +23,7 @@ extern AmbientLightingThread *ambientLightingThread;
 #endif
 #endif
 
-#if !defined(ARCH_PORTDUINO) && !defined(ARCH_STM32WL) && !defined(CONFIG_IDF_TARGET_ESP32C6)
+#if !defined(ARCH_PORTDUINO) && !defined(ARCH_STM32WL)
 #include <NonBlockingRtttl.h>
 #else
 // Noop class for portduino.


### PR DESCRIPTION
This pull request updates the conditional compilation logic in `ExternalNotificationModule.h` to allow the inclusion of `NonBlockingRtttl.h` on more platforms. Specifically, it removes the check for `CONFIG_IDF_TARGET_ESP32C6`, so `NonBlockingRtttl.h` will now be included when building for ESP32C6.

Platform compatibility:

* [`src/modules/ExternalNotificationModule.h`](diffhunk://#diff-9ff83e2a3de8cfc6dbf0dfb19a3242ee3058939b69c33d00ec005e5c4ba33c96L26-R26): Modified the preprocessor condition to include `NonBlockingRtttl.h` for the ESP32C6 platform by removing the `CONFIG_IDF_TARGET_ESP32C6` exclusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for ESP32-C6 builds by enabling the appropriate external notification support on this platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->