### PR TITLE
Signature key resolution and a send-path leak

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -633,7 +633,9 @@ bool checkXeddsaReceivePolicy(meshtastic_MeshPacket *p)
     if (p->decoded.xeddsa_signature.size == XEDDSA_SIGNATURE_SIZE) {
         meshtastic_NodeInfoLite_public_key_t senderKey = {0, {0}};
         meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(p->from);
-        if (nodeDB->copyPublicKey(p->from, senderKey)) {
+        // Authoritative keys only: verifying against an opportunistic cache key would let a planted
+        // key mark its own node a signer, the trust loop #11116 closed on the decrypt path.
+        if (nodeDB->copyPublicKeyAuthoritative(p->from, senderKey)) {
             p->xeddsa_signed =
                 crypto->xeddsa_verify(senderKey.bytes, p->from, p->id, p->decoded.portnum, p->decoded.payload.bytes,
                                       p->decoded.payload.size, p->decoded.xeddsa_signature.bytes);

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -465,6 +465,8 @@ ErrorCode Router::send(meshtastic_MeshPacket *p)
 
     if (!(p->which_payload_variant == meshtastic_MeshPacket_encrypted_tag ||
           p->which_payload_variant == meshtastic_MeshPacket_decoded_tag)) {
+        // Error returns from here own the packet, as the position-precision path below does.
+        packetPool.release(p);
         return meshtastic_Routing_Error_BAD_REQUEST;
     }
 


### PR DESCRIPTION
Two follow-ups from the post-release backlog, one commit each. Independent of #11282; both branch from develop and merge cleanly in either order.

- `checkXeddsaReceivePolicy` resolved the sender key with `copyPublicKey`, which falls through to the opportunistic TrafficManagement cache. A key planted there could verify a signature and so mark its own node a signer, the trust loop #11116 closed on the decrypt path. Now uses `copyPublicKeyAuthoritative`.
- `Router::send` returned BAD_REQUEST for a packet with no `payload_variant` without releasing it, unlike the position-precision path a few lines below. Reachable from a ToRadio MeshPacket with the variant unset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unsupported packet payloads to ensure they are properly released when rejected.
  * Strengthened XEdDSA signature verification by requiring an authoritative public key, helping prevent verification with untrusted or opportunistically cached keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->