### PR TITLE
Lockdown PIN redaction, a build guard, and favorite compaction

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1607,15 +1607,19 @@ void NodeDB::resetNodes(bool keepFavorites)
     numMeshNodes = 1;
     if (keepFavorites) {
         LOG_INFO("Clearing node database - preserving favorites");
-        for (size_t i = 0; i < meshNodes->size(); i++) {
+        // Compact favorites into contiguous low slots: zeroing in place leaves one above
+        // numMeshNodes, invisible to every `i < numMeshNodes` scan yet still serialized to flash.
+        for (size_t i = 1; i < meshNodes->size(); i++) {
             meshtastic_NodeInfoLite &node = meshNodes->at(i);
-            if (i > 0 && !nodeInfoLiteIsFavorite(&node)) {
-                eraseNodeSatellites(node.num);
-                node = meshtastic_NodeInfoLite();
-            } else {
+            if (nodeInfoLiteIsFavorite(&node)) {
+                if (numMeshNodes != i)
+                    meshNodes->at(numMeshNodes) = node;
                 numMeshNodes += 1;
+            } else if (node.num) {
+                eraseNodeSatellites(node.num);
             }
-        };
+        }
+        std::fill(nodeDatabase.nodes.begin() + numMeshNodes, nodeDatabase.nodes.end(), meshtastic_NodeInfoLite());
     } else {
         LOG_INFO("Clearing node database - removing favorites");
         for (size_t i = 1; i < meshNodes->size(); i++) {

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1610,7 +1610,7 @@ void NodeDB::resetNodes(bool keepFavorites)
         // Compact favorites into contiguous low slots: zeroing in place leaves one above
         // numMeshNodes, invisible to every `i < numMeshNodes` scan yet still serialized to flash.
         for (size_t i = 1; i < meshNodes->size(); i++) {
-            meshtastic_NodeInfoLite &node = meshNodes->at(i);
+            const meshtastic_NodeInfoLite &node = meshNodes->at(i);
             if (nodeInfoLiteIsFavorite(&node)) {
                 if (numMeshNodes != i)
                     meshNodes->at(numMeshNodes) = node;

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -767,6 +767,12 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
             LOG_DEBUG("Send config: bluetooth");
             fromRadioScratch.config.which_payload_variant = meshtastic_Config_bluetooth_tag;
             fromRadioScratch.config.payload_variant.bluetooth = config.bluetooth;
+#ifdef MESHTASTIC_PHONEAPI_ACCESS_CONTROL
+            if (!getAdminAuthorized()) {
+                // The pairing PIN is a shared secret; never expose it to an unauthenticated client.
+                fromRadioScratch.config.payload_variant.bluetooth.fixed_pin = 0;
+            }
+#endif
             break;
         case meshtastic_Config_security_tag:
             LOG_DEBUG("Send config: security");

--- a/src/mesh/api/PacketAPI.cpp
+++ b/src/mesh/api/PacketAPI.cpp
@@ -6,6 +6,12 @@
 #include "RadioInterface.h"
 #include "modules/NodeInfoModule.h"
 
+#ifdef MESHTASTIC_PHONEAPI_ACCESS_CONTROL
+// receivePacket() dispatches ToRadio straight to MeshService, bypassing handleToRadioPacket and so
+// the lockdown admin gate. Fail the build rather than silently ship an admin-auth bypass.
+#error "USE_PACKET_API is incompatible with MESHTASTIC_PHONEAPI_ACCESS_CONTROL (PacketAPI bypasses the lockdown admin gate)"
+#endif
+
 PacketAPI *packetAPI = nullptr;
 
 PacketAPI *PacketAPI::create(PacketServer *_server)


### PR DESCRIPTION
Three follow-ups from the post-release backlog, one commit each. Independent of #11282, #11283 and #11284; all four branch from develop and merge cleanly in any order.

- The bluetooth config was streamed to an unauthorized lockdown connection with `fixed_pin` intact, unlike the network, lora and security cases next to it which already redact. The pairing PIN is now zeroed for an unauthorized client.
- `PacketAPI::receivePacket` calls `service->handleToRadio()` directly, bypassing `handleToRadioPacket` and therefore the lockdown per-connection admin gate. The two features cannot coexist today (`MESHTASTIC_PHONEAPI_ACCESS_CONTROL` is defined only under `ARCH_NRF52`, `USE_PACKET_API` only on esp32s3 variants), so this is a dormant guard that fails the build instead of silently shipping an admin-auth bypass if lockdown ever broadens.
- `resetNodes(keepFavorites)` zeroed non-favorites in place without compacting, so a favorite above the resulting `numMeshNodes` was invisible to every `i < numMeshNodes` scan while still being serialized to flash and restored on the next load. Favorites are now compacted into contiguous low slots and the tail is cleared. This also drops a spurious double-count of the self node at index 0.

These were drafted against an older develop; each site was re-checked against current HEAD before committing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node database cleanup to keep favorite nodes intact and maintain a consistent node list.
  * Hardened Bluetooth access-control behavior to prevent unnecessary exposure of sensitive pairing details.
  * Rate-limiting now tracks activity only for a defined set of supported ports to avoid unbounded growth from other traffic.

* **Security**
  * Added protections to prevent incompatible settings from undermining administrator protections during packet dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->