### PR TITLE
Licensed channel defaults, phone map growth, and payload read bounds

### DIFF
--- a/src/MessageStore.cpp
+++ b/src/MessageStore.cpp
@@ -215,7 +215,12 @@ const StoredMessage *MessageStore::tryAddFromPacket(const meshtastic_MeshPacket 
     sm.channelIndex = packet.channel;
 
     const char *payload = reinterpret_cast<const char *>(packet.decoded.payload.bytes);
-    size_t len = strnlen(payload, MAX_MESSAGE_SIZE - 1);
+    // payload.bytes is not NUL-terminated, so bound by the received size too: a shorter message
+    // stored after a longer one would otherwise pick up the previous occupant's trailing bytes.
+    size_t avail = packet.decoded.payload.size;
+    if (avail > MAX_MESSAGE_SIZE - 1)
+        avail = MAX_MESSAGE_SIZE - 1;
+    size_t len = strnlen(payload, avail);
     sm.textOffset = storeTextInPool(payload, len);
     sm.textLength = len;
 

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -741,6 +741,10 @@ void NodeDB::resetRadioConfig(bool is_fresh_install)
         LOG_INFO("Set default channel and radio preferences!");
 
         channels.initDefaults();
+        // Defaults ship the public PSK, so strip it again before onConfigChanged() publishes hashes;
+        // loadFromDisk's sanitation is a no-op when the channel file was absent or corrupt.
+        if (owner.is_licensed)
+            channels.ensureLicensedOperation();
     }
 
     channels.onConfigChanged();

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -1855,7 +1855,12 @@ bool PhoneAPI::handleToRadioPacket(meshtastic_MeshPacket &p)
         p.want_ack = true;
     }
 
-    lastPortNumToRadio[p.decoded.portnum] = millis();
+    // Only the rate-limited ports above are ever read back, so recording any other portnum would let
+    // a client grow this map without bound by cycling through them.
+    if (IS_ONE_OF(p.decoded.portnum, meshtastic_PortNum_TRACEROUTE_APP, meshtastic_PortNum_POSITION_APP,
+                  meshtastic_PortNum_WAYPOINT_APP, meshtastic_PortNum_ALERT_APP, meshtastic_PortNum_TELEMETRY_APP,
+                  meshtastic_PortNum_TEXT_MESSAGE_APP))
+        lastPortNumToRadio[p.decoded.portnum] = millis();
     service->handleToRadio(p);
     return true;
 }

--- a/src/modules/DropzoneModule.cpp
+++ b/src/modules/DropzoneModule.cpp
@@ -32,14 +32,17 @@ ProcessMessage DropzoneModule::handleReceived(const meshtastic_MeshPacket &mp)
     auto &p = mp.decoded;
     char matchCompare[54];
     auto incomingMessage = reinterpret_cast<const char *>(p.payload.bytes);
-    sprintf(matchCompare, "%s conditions", owner.short_name);
-    if (strncasecmp(incomingMessage, matchCompare, strlen(matchCompare)) == 0) {
+    // payload.bytes is not NUL-terminated, so a comparison longer than the received size would read
+    // whatever the previous occupant of the packet left behind.
+    const size_t received = p.payload.size;
+    snprintf(matchCompare, sizeof(matchCompare), "%s conditions", owner.short_name);
+    if (received >= strlen(matchCompare) && strncasecmp(incomingMessage, matchCompare, strlen(matchCompare)) == 0) {
         LOG_DEBUG("Received dropzone conditions request");
         startSendConditions = millis();
     }
 
-    sprintf(matchCompare, "%s conditions", owner.long_name);
-    if (strncasecmp(incomingMessage, matchCompare, strlen(matchCompare)) == 0) {
+    snprintf(matchCompare, sizeof(matchCompare), "%s conditions", owner.long_name);
+    if (received >= strlen(matchCompare) && strncasecmp(incomingMessage, matchCompare, strlen(matchCompare)) == 0) {
         LOG_DEBUG("Received dropzone conditions request");
         startSendConditions = millis();
     }


### PR DESCRIPTION
Last three follow-ups from the post-release backlog, one commit each. Independent of #11282, #11283, #11284 and #11285; all five branch from develop and merge cleanly in any order.

- `resetRadioConfig()` installs the default channels, which carry the public PSK, but only `loadFromDisk()` sanitized them. When the channel file is absent or corrupt that call is a no-op (`channels_count` is 0), so a first boot or factory reset of a ham-only board could transmit encrypted on ham allocations until the next boot. Now stripped again right after `initDefaults()`, before `onConfigChanged()` publishes hashes.
- `lastPortNumToRadio` was written for every portnum a client sent, but only traceroute, position, waypoint, alert, telemetry and text are ever read back. A client cycling portnums grew the map without bound; it now records only those six.
- `payload.bytes` is not NUL-terminated, and two readers scanned past the received size into whatever the previous occupant of the pooled packet left behind: `MessageStore::addFromPacket` bounded `strnlen` only by `MAX_MESSAGE_SIZE`, and `DropzoneModule` compared `strlen(matchCompare)` bytes regardless of `payload.size`. Both are now bounded by the received size. In-field reads, so no OOB, but they leaked stale bytes into stored text and into a match decision. The two `sprintf` calls there became `snprintf` while in the area.

Item 18 from the backlog (splitting manually-verified from XEdDSA signer provenance in the warm store) needs no change: d6b12ea3f already added `WarmProtected::XeddsaSigner` alongside the independent signer bit, so the two are distinguished.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented message processing from reading beyond the received payload.
  * Improved handling of configuration resets on licensed devices, preserving the correct operating settings.
  * Prevented excessive resource usage caused by unsupported packet types.
  * Strengthened received-message matching to safely handle payloads that are not null-terminated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->