### PR TITLE
Narrow "PR" candidates (now only 17)

### DIFF
--- a/variants/esp32/rak11200/platformio.ini
+++ b/variants/esp32/rak11200/platformio.ini
@@ -10,7 +10,6 @@ custom_meshtastic_tags = RAK
 
 extends = esp32_base
 board = wiscore_rak11200
-board_level = pr
 board_check = true
 build_flags = 
   ${esp32_base.build_flags}

--- a/variants/esp32s3/ELECROW-ThinkNode-M7/platformio.ini
+++ b/variants/esp32s3/ELECROW-ThinkNode-M7/platformio.ini
@@ -1,6 +1,7 @@
 [env:thinknode_m7]
 extends = esp32s3_base
 board = ThinkNode-M7
+board_level = pr
 
 build_flags =
   ${esp32s3_base.build_flags}

--- a/variants/esp32s3/elecrow_panel/platformio.ini
+++ b/variants/esp32s3/elecrow_panel/platformio.ini
@@ -127,7 +127,6 @@ custom_meshtastic_partition_scheme = 16MB
 custom_meshtastic_has_mui = true
 
 extends = crowpanel_small_esp32s3_base
-board_level = pr
 build_flags =
   ${crowpanel_small_esp32s3_base.build_flags}
   -D LV_CACHE_DEF_SIZE=2097152

--- a/variants/esp32s3/heltec_v4/platformio.ini
+++ b/variants/esp32s3/heltec_v4/platformio.ini
@@ -24,7 +24,6 @@ custom_meshtastic_partition_scheme = 16MB
 custom_meshtastic_has_mui = true
 
 extends = heltec_v4_base
-board_level = pr
 build_flags =
   ${heltec_v4_base.build_flags}
   -D HELTEC_V4_OLED

--- a/variants/esp32s3/meshnology-w10/platformio.ini
+++ b/variants/esp32s3/meshnology-w10/platformio.ini
@@ -10,7 +10,6 @@ custom_meshtastic_partition_scheme = 16MB
 
 ; ESP32-S3R8: 8 MB OPI PSRAM, W25Q128JVSIQ = 16 MB QIO flash (pg1)
 board = esp32-s3-devkitc-1
-board_level = pr
 board_build.partitions = default_16MB.csv
 board_upload.flash_size = 16MB
 board_build.flash_mode = qio

--- a/variants/esp32s3/meshnology-w12/platformio.ini
+++ b/variants/esp32s3/meshnology-w12/platformio.ini
@@ -12,7 +12,6 @@ custom_meshtastic_partition_scheme = 16MB
 
 extends = esp32s3_base
 board = esp32-s3-devkitc-1
-board_level = pr
 ; ESP32-S3R8: 8 MB OPI PSRAM, 16 MB QIO flash
 board_build.partitions = default_16MB.csv
 board_upload.flash_size = 16MB

--- a/variants/esp32s3/rak3312/platformio.ini
+++ b/variants/esp32s3/rak3312/platformio.ini
@@ -13,7 +13,6 @@ custom_meshtastic_has_mui = false
 
 extends = esp32s3_base
 board = wiscore_rak3312
-board_level = pr
 board_check = true
 upload_protocol = esptool
 

--- a/variants/esp32s3/seeed-sensecap-indicator/platformio.ini
+++ b/variants/esp32s3/seeed-sensecap-indicator/platformio.ini
@@ -74,6 +74,7 @@ custom_sdkconfig =
 
 [env:seeed-sensecap-indicator-tft]
 extends = env:seeed-sensecap-indicator
+board_level = pr
 board_check = true
 upload_speed = 460800
 

--- a/variants/esp32s3/seeed_xiao_s3/platformio.ini
+++ b/variants/esp32s3/seeed_xiao_s3/platformio.ini
@@ -12,7 +12,6 @@ custom_meshtastic_partition_scheme = 8MB
 
 extends = esp32s3_base
 board = seeed-xiao-s3
-board_level = pr
 board_check = true
 board_build.partitions = default_8MB.csv
 upload_protocol = esptool

--- a/variants/esp32s3/station-g2/platformio.ini
+++ b/variants/esp32s3/station-g2/platformio.ini
@@ -12,7 +12,6 @@ custom_meshtastic_partition_scheme = 16MB
 
 extends = esp32s3_base
 board = station-g2
-board_level = pr
 board_check = true
 board_build.partitions = default_16MB.csv
 board_build.mcu = esp32s3

--- a/variants/esp32s3/station-g3/platformio.ini
+++ b/variants/esp32s3/station-g3/platformio.ini
@@ -12,7 +12,6 @@ custom_meshtastic_partition_scheme = 16MB
 
 extends = esp32s3_base
 board = station-g3
-board_level = pr
 board_check = true
 board_build.partitions = default_16MB.csv
 board_build.mcu = esp32s3

--- a/variants/esp32s3/t-eth-elite/platformio.ini
+++ b/variants/esp32s3/t-eth-elite/platformio.ini
@@ -1,7 +1,6 @@
 [env:t-eth-elite]
 extends = esp32s3_base
 board = esp32s3box
-board_level = pr
 board_check = true
 board_build.partitions = default_16MB.csv
 build_flags = 

--- a/variants/nrf52840/heltec_mesh_node_t096/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_node_t096/platformio.ini
@@ -11,7 +11,6 @@ custom_meshtastic_tags = Heltec
 
 extends = nrf52840_base
 board = heltec_mesh_node_t096
-board_level = pr
 debug_tool = jlink
 
 build_flags = ${nrf52840_base.build_flags}

--- a/variants/nrf52840/heltec_mesh_node_t1/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_node_t1/platformio.ini
@@ -11,7 +11,6 @@ custom_meshtastic_tags = Heltec
 
 extends = nrf52840_base
 board = heltec_mesh_node_t1
-board_level = pr
 debug_tool = jlink
 
 build_flags = ${nrf52840_base.build_flags}

--- a/variants/nrf52840/heltec_mesh_solar/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_solar/platformio.ini
@@ -2,7 +2,6 @@
 [heltec_mesh_solar_base]
 extends = nrf52840_base
 board = heltec_mesh_solar
-board_level = pr
 debug_tool = jlink
 
 # add -DCFG_SYSVIEW if you want to use the Segger systemview tool for OS profiling.

--- a/variants/nrf52840/heltec_mesh_tower_v2/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_tower_v2/platformio.ini
@@ -11,7 +11,6 @@ custom_meshtastic_tags = Heltec
 
 extends = nrf52840_base
 board = heltec_mesh_tower_v2
-board_level = pr
 debug_tool = jlink
 
 # add -DCFG_SYSVIEW if you want to use the Segger systemview tool for OS profiling.

--- a/variants/nrf52840/rak_wismeshtag/platformio.ini
+++ b/variants/nrf52840/rak_wismeshtag/platformio.ini
@@ -6,7 +6,6 @@ custom_meshtastic_tags = RAK
 
 extends = nrf52840_base
 board = wiscore_rak4631
-board_level = pr
 board_check = true
 custom_meshtastic_hw_model = 105
 custom_meshtastic_hw_model_slug = WISMESH_TAG

--- a/variants/nrf52840/seeed_xiao_nrf52840_kit/platformio.ini
+++ b/variants/nrf52840/seeed_xiao_nrf52840_kit/platformio.ini
@@ -11,7 +11,6 @@ custom_meshtastic_tags = Seeed
 
 extends = nrf52840_base
 board = xiao_ble_sense
-board_level = pr
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/seeed_xiao_nrf52840_kit
   -I src/platform/nrf52/softdevice

--- a/variants/nrf52840/t-echo/platformio.ini
+++ b/variants/nrf52840/t-echo/platformio.ini
@@ -12,7 +12,6 @@ custom_meshtastic_has_ink_hud = true
 
 extends = nrf52840_base
 board = t-echo
-board_level = pr
 board_check = true
 debug_tool = jlink
 
@@ -39,7 +38,6 @@ lib_deps =
 [env:t-echo-inkhud]
 extends = nrf52840_base, inkhud
 board = t-echo
-board_level = pr
 board_check = true
 debug_tool = jlink
 build_flags = 

--- a/variants/nrf52840/t-impulse-plus/platformio.ini
+++ b/variants/nrf52840/t-impulse-plus/platformio.ini
@@ -10,7 +10,6 @@ custom_meshtastic_requires_dfu = true
 
 extends = nrf52840_base
 board = t-impulse-plus
-board_level = pr
 
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/t-impulse-plus

--- a/variants/rp2040/rak11310/platformio.ini
+++ b/variants/rp2040/rak11310/platformio.ini
@@ -11,7 +11,6 @@ custom_meshtastic_requires_dfu = true
 
 extends = rp2040_base
 board = rakwireless_rak11300
-board_level = pr
 upload_protocol = picotool
 # add our variants files to the include and src paths
 build_flags = 

--- a/variants/rp2040/rpipico/platformio.ini
+++ b/variants/rp2040/rpipico/platformio.ini
@@ -11,7 +11,6 @@ custom_meshtastic_requires_dfu = true
 
 extends = rp2040_base
 board = rpipico
-board_level = pr
 upload_protocol = picotool
 # add our variants files to the include and src paths
 build_flags =

--- a/variants/rp2040/seeed_xiao_rp2040/platformio.ini
+++ b/variants/rp2040/seeed_xiao_rp2040/platformio.ini
@@ -1,7 +1,6 @@
 [env:seeed_xiao_rp2040]
 extends = rp2040_base
 board = seeed_xiao_rp2040
-board_level = pr
 upload_protocol = picotool
 # add our variants files to the include and src paths
 build_src_filter = ${rp2040_base.build_src_filter} +<../variants/rp2040/seeed_xiao_rp2040/>

--- a/variants/rp2350/diy/pico2_w5500_e22/platformio.ini
+++ b/variants/rp2350/diy/pico2_w5500_e22/platformio.ini
@@ -1,7 +1,7 @@
 [env:pico2_w5500_e22]
 extends = rp2350_base
 board = rpipico2
-board_level = community
+board_level = extra
 upload_protocol = picotool
 
 # Increase LittleFS from 0.5m to 0.75m so GZIP firmware (~614KB) fits for OTA staging

--- a/variants/rp2350/diy/wiznet_5500_evb_pico2_e22p/platformio.ini
+++ b/variants/rp2350/diy/wiznet_5500_evb_pico2_e22p/platformio.ini
@@ -1,7 +1,7 @@
 [env:wiznet_5500_evb_pico2_e22p]
 extends = rp2350_base
 board = wiznet_5500_evb_pico2
-board_level = community
+board_level = extra
 upload_protocol = picotool
 
 # Reuses the variant.h from variants/rp2350/diy/pico2_w5500_e22 - same LoRa

--- a/variants/rp2350/rpipico2/platformio.ini
+++ b/variants/rp2350/rpipico2/platformio.ini
@@ -1,7 +1,6 @@
 [env:pico2]
 extends = rp2350_base
 board = rpipico2
-board_level = pr
 upload_protocol = picotool
 
 # add our variants files to the include and src paths

--- a/variants/rp2350/seeed_xiao_rp2350/platformio.ini
+++ b/variants/rp2350/seeed_xiao_rp2350/platformio.ini
@@ -1,7 +1,6 @@
 [env:seeed_xiao_rp2350]
 extends = rp2350_base
 board = seeed_xiao_rp2350
-board_level = pr
 upload_protocol = picotool
 
 # add our variants files to the include and src paths


### PR DESCRIPTION
These 17 boards should serve as a "canary in the coal mine" when changes are made to the Meshtastic Core. Narrowed significantly to stop wasting time.

Prereq for #11151



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved board targeting by adjusting or removing `board_level` overrides across many ESP32, ESP32-S3, nRF52840, RP2040, and RP2350 environments.
  * Ensured builds follow inherited board-level configuration where appropriate for better consistency.
  * Updated select RP2350 devices to use the intended enhanced board-level setting.
  * Preserved existing hardware options, upload methods, build flags, and debug configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->