### PR TITLE
added test if messurement of BME280Sensor was successfull fixes #11301

### DIFF
--- a/src/modules/Telemetry/Sensor/BME280Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/BME280Sensor.cpp
@@ -30,16 +30,42 @@ bool BME280Sensor::initDevice(TwoWire *bus, ScanI2C::FoundDevice *dev)
 
 bool BME280Sensor::getMetrics(meshtastic_Telemetry *measurement)
 {
-    measurement->variant.environment_metrics.has_temperature = true;
-    measurement->variant.environment_metrics.has_relative_humidity = true;
-    measurement->variant.environment_metrics.has_barometric_pressure = true;
-
     LOG_DEBUG("BME280 getMetrics");
-    bme280.takeForcedMeasurement();
-    measurement->variant.environment_metrics.temperature = bme280.readTemperature();
-    measurement->variant.environment_metrics.relative_humidity = bme280.readHumidity();
-    measurement->variant.environment_metrics.barometric_pressure = bme280.readPressure() / 100.0F;
-
+    if(bme280.takeForcedMeasurement())
+    {
+        measurement->variant.environment_metrics.temperature = bme280.readTemperature();
+        measurement->variant.environment_metrics.relative_humidity = bme280.readHumidity();
+        measurement->variant.environment_metrics.barometric_pressure = bme280.readPressure() / 100.0F;
+        measurement->variant.environment_metrics.has_temperature = true;
+        measurement->variant.environment_metrics.has_relative_humidity = true;
+        measurement->variant.environment_metrics.has_barometric_pressure = true;
+    }
+    else
+    {
+        LOG_WARN("BME280 meassurment failed, attempting reset.");
+        if(bme280.init())
+        {
+            bme280.setSampling(Adafruit_BME280::MODE_FORCED,
+                       Adafruit_BME280::SAMPLING_X1, // Temp. oversampling
+                       Adafruit_BME280::SAMPLING_X1, // Pressure oversampling
+                       Adafruit_BME280::SAMPLING_X1, // Humidity oversampling
+                       Adafruit_BME280::FILTER_OFF, Adafruit_BME280::STANDBY_MS_1000);
+            LOG_DEBUG("BME280 reset success, getMetrics");
+            if(bme280.takeForcedMeasurement())
+            {
+                measurement->variant.environment_metrics.temperature = bme280.readTemperature();
+                measurement->variant.environment_metrics.relative_humidity = bme280.readHumidity();
+                measurement->variant.environment_metrics.barometric_pressure = bme280.readPressure() / 100.0F;
+                measurement->variant.environment_metrics.has_temperature = true;
+                measurement->variant.environment_metrics.has_relative_humidity = true;
+                measurement->variant.environment_metrics.has_barometric_pressure = true;
+            }
+            else
+            {
+                LOG_WARN("BME280 meassurment failed again.");
+            }
+        }
+    }
     return true;
 }
 #endif

--- a/src/modules/Telemetry/Sensor/BME280Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/BME280Sensor.cpp
@@ -10,6 +10,15 @@
 
 BME280Sensor::BME280Sensor() : TelemetrySensor(meshtastic_TelemetrySensorType_BME280, "BME280") {}
 
+static void setSensorConfigs(Adafruit_BME280 *bme280)
+{
+    bme280->setSampling(Adafruit_BME280::MODE_FORCED,
+                       Adafruit_BME280::SAMPLING_X1, // Temp. oversampling
+                       Adafruit_BME280::SAMPLING_X1, // Pressure oversampling
+                       Adafruit_BME280::SAMPLING_X1, // Humidity oversampling
+                       Adafruit_BME280::FILTER_OFF, Adafruit_BME280::STANDBY_MS_1000);
+}
+
 bool BME280Sensor::initDevice(TwoWire *bus, ScanI2C::FoundDevice *dev)
 {
     bus->setTimeout(50);
@@ -19,14 +28,20 @@ bool BME280Sensor::initDevice(TwoWire *bus, ScanI2C::FoundDevice *dev)
         return status;
     }
 
-    bme280.setSampling(Adafruit_BME280::MODE_FORCED,
-                       Adafruit_BME280::SAMPLING_X1, // Temp. oversampling
-                       Adafruit_BME280::SAMPLING_X1, // Pressure oversampling
-                       Adafruit_BME280::SAMPLING_X1, // Humidity oversampling
-                       Adafruit_BME280::FILTER_OFF, Adafruit_BME280::STANDBY_MS_1000);
+    setSensorConfigs(&bme280);
 
     initI2CSensor();
     return status;
+}
+
+static void getSensorData(meshtastic_Telemetry *measurement, Adafruit_BME280 *bme280)
+{
+    measurement->variant.environment_metrics.temperature = bme280->readTemperature();
+    measurement->variant.environment_metrics.relative_humidity = bme280->readHumidity();
+    measurement->variant.environment_metrics.barometric_pressure = bme280->readPressure() / 100.0F;
+    measurement->variant.environment_metrics.has_temperature = true;
+    measurement->variant.environment_metrics.has_relative_humidity = true;
+    measurement->variant.environment_metrics.has_barometric_pressure = true;
 }
 
 bool BME280Sensor::getMetrics(meshtastic_Telemetry *measurement)
@@ -34,39 +49,31 @@ bool BME280Sensor::getMetrics(meshtastic_Telemetry *measurement)
     LOG_DEBUG("BME280 getMetrics");
     if(bme280.takeForcedMeasurement())
     {
-        measurement->variant.environment_metrics.temperature = bme280.readTemperature();
-        measurement->variant.environment_metrics.relative_humidity = bme280.readHumidity();
-        measurement->variant.environment_metrics.barometric_pressure = bme280.readPressure() / 100.0F;
-        measurement->variant.environment_metrics.has_temperature = true;
-        measurement->variant.environment_metrics.has_relative_humidity = true;
-        measurement->variant.environment_metrics.has_barometric_pressure = true;
+        getSensorData(measurement, &bme280);
+        return true;
     }
     else
     {
-        LOG_WARN("BME280 meassurment failed, attempting reset.");
+        LOG_WARN("BME280 measurement failed, attempting reset.");
         if(bme280.init())
         {
-            bme280.setSampling(Adafruit_BME280::MODE_FORCED,
-                       Adafruit_BME280::SAMPLING_X1, // Temp. oversampling
-                       Adafruit_BME280::SAMPLING_X1, // Pressure oversampling
-                       Adafruit_BME280::SAMPLING_X1, // Humidity oversampling
-                       Adafruit_BME280::FILTER_OFF, Adafruit_BME280::STANDBY_MS_1000);
+            setSensorConfigs(&bme280);
             LOG_DEBUG("BME280 reset success, getMetrics");
             if(bme280.takeForcedMeasurement())
             {
-                measurement->variant.environment_metrics.temperature = bme280.readTemperature();
-                measurement->variant.environment_metrics.relative_humidity = bme280.readHumidity();
-                measurement->variant.environment_metrics.barometric_pressure = bme280.readPressure() / 100.0F;
-                measurement->variant.environment_metrics.has_temperature = true;
-                measurement->variant.environment_metrics.has_relative_humidity = true;
-                measurement->variant.environment_metrics.has_barometric_pressure = true;
+                getSensorData(measurement, &bme280);
+                return true;
             }
             else
             {
-                LOG_WARN("BME280 meassurment failed again.");
+                LOG_WARN("BME280 measurement failed again.");
             }
         }
+        else
+        {
+            LOG_WARN("BME280 reset/reinit failed.");
+        }
     }
-    return true;
+    return false;
 }
 #endif

--- a/src/modules/Telemetry/Sensor/BME280Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/BME280Sensor.cpp
@@ -12,6 +12,7 @@ BME280Sensor::BME280Sensor() : TelemetrySensor(meshtastic_TelemetrySensorType_BM
 
 bool BME280Sensor::initDevice(TwoWire *bus, ScanI2C::FoundDevice *dev)
 {
+    bus->setTimeout(50);
     LOG_INFO("Init sensor: %s", sensorName);
     status = bme280.begin(dev->address.address, bus);
     if (!status) {


### PR DESCRIPTION
See issue #11301 

I will test around if this fixes that issue, overall I think testing if the meassurment is successfull is needed. Also will need to test if millis() even works on the nRF or if the timeout never fires.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
  - [ ] Heltec T114


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sensor reliability by adding an I2C communication timeout.
  * Added automatic sensor recovery and a retry when measurements fail.
  * Ensured sensor metrics are reported only when valid readings are available.
  * Added error logging when recovery or subsequent measurements remain unsuccessful.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->