### PR TITLE
Add libcurl as a build dependency for meshtasticd packages

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,7 +28,8 @@ Build-Depends: debhelper-compat (= 13),
                libinput-dev,
                libxkbcommon-x11-dev,
                libsqlite3-dev,
-               libsdl2-dev
+               libsdl2-dev,
+               libcurl4-gnutls-dev
 Standards-Version: 4.6.2
 Homepage: https://github.com/meshtastic/firmware
 Rules-Requires-Root: no

--- a/meshtasticd.spec.rpkg
+++ b/meshtasticd.spec.rpkg
@@ -41,6 +41,7 @@ BuildRequires: pkgconfig(libusb-1.0)
 BuildRequires: libi2c-devel
 BuildRequires: pkgconfig(libuv)
 BuildRequires: pkgconfig(sqlite3)
+BuildRequires: pkgconfig(libcurl)
 # Web components:
 BuildRequires: pkgconfig(openssl)
 BuildRequires: pkgconfig(liborcania)


### PR DESCRIPTION
Followup to #11214
Adds libcurl as a dependency in Debian and Fedora packages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build dependencies for Debian and RPM packages to support improved package compilation and distribution compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->