### PR TITLE
Make board_level = release explicit instead of relying on an empty value

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -557,8 +557,9 @@ pio run -e native-macos       # Build headless macOS meshtasticd (Homebrew prere
 1. Create directory under `variants/<arch>/<name>/`
 2. Add `variant.h` with pin definitions and hardware capability defines
 3. Add `platformio.ini` with build config - use `extends` to reference common base (e.g., `esp32s3_base`)
-4. Set `custom_meshtastic_support_level = 1` (PR builds) or `2` (merge builds)
-5. For e-ink displays, add `nicheGraphics.h` for InkHUD configuration
+4. Set `board_level` (required - `release` for a normal variant; see "Build Matrix Generation")
+5. Set `custom_meshtastic_support_level` (1-3) and the other `custom_meshtastic_*` metadata
+6. For e-ink displays, add `nicheGraphics.h` for InkHUD configuration
 
 ### Adding a New Telemetry Sensor
 
@@ -642,11 +643,16 @@ The CI uses `bin/generate_ci_matrix.py` to dynamically select which targets to b
 ./bin/generate_ci_matrix.py all --level pr
 ```
 
-Variants can specify their support level in `platformio.ini`:
+Every variant env **must** declare a `board_level` in its `platformio.ini`; the matrix
+generator exits non-zero if any env is missing it or uses an unrecognized value:
 
-- `custom_meshtastic_support_level = 1` - Actively supported, built on every PR
-- `custom_meshtastic_support_level = 2` - Supported, built on merge to main branches
-- `board_level = extra` - Extra builds, only on full releases
+- `board_level = pr` - Smallest subset, built on every PR (and in every larger matrix)
+- `board_level = release` - The full release matrix, built on push / schedule / `workflow_dispatch`
+- `board_level = extra` - Opt-in only, built when explicitly requested via `--level extra`
+
+`custom_meshtastic_support_level` (1-3) is **not** part of this filtering. It is variant
+metadata that `bin/platformio-custom.py` emits as `supportLevel` in the generated
+hardware list; changing it does not change which targets CI builds.
 
 ### Running Workflows Locally
 

--- a/bin/generate_ci_matrix.py
+++ b/bin/generate_ci_matrix.py
@@ -5,7 +5,14 @@
 import argparse
 import json
 import re
+
 from platformio.project.config import ProjectConfig
+
+# Every variant env must declare one of these as its 'board_level':
+#   pr      - smallest subset, built on every PR (and in every larger matrix)
+#   release - the full release matrix, built on push / schedule / workflow_dispatch
+#   extra   - opt-in only, built when explicitly requested via '--level extra'
+BOARD_LEVELS = ("pr", "release", "extra")
 
 parser = argparse.ArgumentParser(description="Generate the CI matrix")
 parser.add_argument("platform", help="Platform to build for")
@@ -14,7 +21,7 @@ parser.add_argument(
   choices=["extra", "pr"],
   nargs="*",
   default=[],
-  help="Board level to build for (omit for full release boards)",
+  help="Board level to build for (omit for the 'pr' + 'release' matrix)",
 )
 args = parser.parse_args()
 
@@ -39,10 +46,20 @@ for pio_env in pio_envs:
   if not env_platform:
     print(f"Error: Could not determine platform for environment '{pio_env}'")
     exit(1)
+  board_level = cfg.get(f"env:{pio_env}", "board_level", default=None)
+  # Intentionally fail on a missing or unrecognized level: every env must opt in
+  # explicitly, so a new variant can't silently drop out of (or into) the matrix.
+  if board_level not in BOARD_LEVELS:
+    found = f"'{board_level}'" if board_level else "no value"
+    print(
+      f"Error: environment '{pio_env}' has {found} for 'board_level'; "
+      f"expected one of: {', '.join(BOARD_LEVELS)}"
+    )
+    exit(1)
   # Store env details as a dictionary, and add to 'all_envs' list
   env = {
     "ci": {"board": pio_env, "platform": env_platform},
-    "board_level": cfg.get(f"env:{pio_env}", "board_level", default=None),
+    "board_level": board_level,
     "board_check": cfg.get(f"env:{pio_env}", "board_check", default="false").strip().lower() == "true",
   }
   all_envs.append(env)
@@ -52,10 +69,8 @@ for pio_env in pio_envs:
 if "check" in args.platform:
   for env in all_envs:
     if env["board_check"]:
-      if "pr" in args.level:
-        if env["board_level"] == "pr":
-          outlist.append(env["ci"])
-      else:
+      # '--level pr' narrows to the PR subset; otherwise check every level
+      if "pr" not in args.level or env["board_level"] == "pr":
         outlist.append(env["ci"])
 # Filter (non-check) builds by platform
 else:
@@ -67,8 +82,8 @@ else:
       # Include board_level = 'extra' when requested
       elif "extra" in args.level and env["board_level"] == "extra":
         outlist.append(env["ci"])
-      # If no board level is specified, include in release builds (not PR)
-      elif "pr" not in args.level and not env["board_level"]:
+      # Include board_level = 'release' unless narrowed to the PR subset
+      elif "pr" not in args.level and env["board_level"] == "release":
         outlist.append(env["ci"])
 
 # Return as a JSON list

--- a/variants/esp32/chatter2/platformio.ini
+++ b/variants/esp32/chatter2/platformio.ini
@@ -1,6 +1,7 @@
 ; CircuitMess Chatter 2  based on ESP32-WROOM-32 (38 pins) devkit & DeeamLNK DL-LLCC68 or Heltec HT RA62 SX1262/SX1268 module
 [env:chatter2]
 extends = esp32_base
+board_level = release
 board = esp32doit-devkit-v1
 build_flags =
   ${esp32_base.build_flags}

--- a/variants/esp32/diy/hydra/platformio.ini
+++ b/variants/esp32/diy/hydra/platformio.ini
@@ -9,6 +9,7 @@ custom_meshtastic_display_name = Hydra
 custom_meshtastic_tags = DIY
 
 extends = esp32_base
+board_level = release
 board = esp32doit-devkit-v1
 build_flags =
   ${esp32_base.build_flags}

--- a/variants/esp32/diy/v1/platformio.ini
+++ b/variants/esp32/diy/v1/platformio.ini
@@ -10,6 +10,7 @@ custom_meshtastic_images = diy.svg
 custom_meshtastic_tags = DIY
 
 extends = esp32_base
+board_level = release
 board = esp32doit-devkit-v1
 board_check = true
 build_flags =

--- a/variants/esp32/m5stack_core/platformio.ini
+++ b/variants/esp32/m5stack_core/platformio.ini
@@ -8,6 +8,7 @@ custom_meshtastic_display_name = M5 Stack
 custom_meshtastic_tags = M5Stack
 
 extends = esp32_base
+board_level = release
 board = m5stack-core-esp32
 monitor_filters = esp32_exception_decoder
 build_src_filter = 

--- a/variants/esp32/m5stack_coreink/platformio.ini
+++ b/variants/esp32/m5stack_coreink/platformio.ini
@@ -1,5 +1,6 @@
 [env:m5stack-coreink]
 extends = esp32_base
+board_level = release
 board = m5stack-coreink
 board_check = true
 build_src_filter = 

--- a/variants/esp32/nano-g1-explorer/platformio.ini
+++ b/variants/esp32/nano-g1-explorer/platformio.ini
@@ -9,6 +9,7 @@ custom_meshtastic_display_name = Nano G1 Explorer
 custom_meshtastic_tags = B&Q
 
 extends = esp32_base
+board_level = release
 board = ttgo-tbeam
 build_flags = 
   ${esp32_base.build_flags}

--- a/variants/esp32/nano-g1/platformio.ini
+++ b/variants/esp32/nano-g1/platformio.ini
@@ -9,6 +9,7 @@ custom_meshtastic_display_name = Nano G1
 custom_meshtastic_tags = B&Q
 
 extends = esp32_base
+board_level = release
 board = ttgo-tbeam
 build_flags = 
   ${esp32_base.build_flags}

--- a/variants/esp32/radiomaster_900_bandit/platformio.ini
+++ b/variants/esp32/radiomaster_900_bandit/platformio.ini
@@ -1,5 +1,6 @@
 [env:radiomaster_900_bandit]
 extends = esp32_base
+board_level = release
 board = esp32doit-devkit-v1
 build_flags =
   ${esp32_base.build_flags}

--- a/variants/esp32/radiomaster_900_bandit_micro/platformio.ini
+++ b/variants/esp32/radiomaster_900_bandit_micro/platformio.ini
@@ -5,6 +5,7 @@
 ;
 [env:radiomaster_900_bandit_micro]
 extends = esp32_base
+board_level = release
 board = esp32doit-devkit-v1
 build_flags =
   ${esp32_base.build_flags}

--- a/variants/esp32/radiomaster_900_bandit_nano/platformio.ini
+++ b/variants/esp32/radiomaster_900_bandit_nano/platformio.ini
@@ -8,6 +8,7 @@ custom_meshtastic_display_name = RadioMaster 900 Bandit Nano
 custom_meshtastic_tags = RadioMaster
 
 extends = esp32_base
+board_level = release
 board = esp32doit-devkit-v1
 build_flags =
   ${esp32_base.build_flags}

--- a/variants/esp32/rak11200/platformio.ini
+++ b/variants/esp32/rak11200/platformio.ini
@@ -9,6 +9,7 @@ custom_meshtastic_images = rak11200.svg
 custom_meshtastic_tags = RAK
 
 extends = esp32_base
+board_level = release
 board = wiscore_rak11200
 board_check = true
 build_flags = 

--- a/variants/esp32/station-g1/platformio.ini
+++ b/variants/esp32/station-g1/platformio.ini
@@ -9,6 +9,7 @@ custom_meshtastic_display_name = Station G1
 custom_meshtastic_tags = B&Q
 
 extends = esp32_base
+board_level = release
 board = ttgo-tbeam
 build_flags = 
   ${esp32_base.build_flags}

--- a/variants/esp32/tbeam/platformio.ini
+++ b/variants/esp32/tbeam/platformio.ini
@@ -10,6 +10,7 @@ custom_meshtastic_images = tbeam.svg
 custom_meshtastic_tags = LilyGo
 
 extends = esp32_base
+board_level = release
 board = ttgo-tbeam
 
 board_check = true

--- a/variants/esp32/tlora_v2_1_16/platformio.ini
+++ b/variants/esp32/tlora_v2_1_16/platformio.ini
@@ -9,6 +9,7 @@ custom_meshtastic_images = tlora-v2-1-1_6.svg
 custom_meshtastic_tags = LilyGo
 
 extends = esp32_base
+board_level = release
 board = ttgo-lora32-v21
 board_check = true
 build_flags = 

--- a/variants/esp32/tlora_v3_3_0_tcxo/platformio.ini
+++ b/variants/esp32/tlora_v3_3_0_tcxo/platformio.ini
@@ -1,5 +1,6 @@
 [env:tlora-v3-3-0-tcxo]
 extends = esp32_base
+board_level = release
 board = ttgo-lora32-v21
 build_flags = 
   ${esp32_base.build_flags}

--- a/variants/esp32c3/heltec_hru_3601/platformio.ini
+++ b/variants/esp32c3/heltec_hru_3601/platformio.ini
@@ -1,5 +1,6 @@
 [env:heltec-hru-3601]
 extends = esp32c3_base
+board_level = release
 board = adafruit_qtpy_esp32c3
 build_flags =
   ${esp32c3_base.build_flags}

--- a/variants/esp32c6/m5stack_unitc6l/platformio.ini
+++ b/variants/esp32c6/m5stack_unitc6l/platformio.ini
@@ -9,6 +9,7 @@ custom_meshtastic_images = m5_c6l.svg
 custom_meshtastic_tags = M5Stack
 
 extends = esp32c6_base
+board_level = release
 board = esp32-c6-devkitc-1
 board_upload.flash_size = 16MB
 board_build.partitions = default_16MB.csv

--- a/variants/esp32s3/CDEBYTE_EoRa-S3/platformio.ini
+++ b/variants/esp32s3/CDEBYTE_EoRa-S3/platformio.ini
@@ -9,6 +9,7 @@ custom_meshtastic_tags = EByte
 custom_meshtastic_requires_dfu = true
 
 extends = esp32s3_base
+board_level = release
 board = CDEBYTE_EoRa-S3
 build_flags =
   ${esp32s3_base.build_flags}

--- a/variants/esp32s3/ELECROW-ThinkNode-G3/platformio.ini
+++ b/variants/esp32s3/ELECROW-ThinkNode-G3/platformio.ini
@@ -1,5 +1,6 @@
 [env:thinknode_g3]
 extends = esp32s3_base
+board_level = release
 board = ESP32-S3-WROOM-1-N4
 board_build.psram_type = opi
 

--- a/variants/esp32s3/ELECROW-ThinkNode-M2/platformio.ini
+++ b/variants/esp32s3/ELECROW-ThinkNode-M2/platformio.ini
@@ -10,6 +10,7 @@ custom_meshtastic_tags = Elecrow
 custom_meshtastic_requires_dfu = false
 
 extends = esp32s3_base
+board_level = release
 board = ESP32-S3-WROOM-1-N4
 build_flags =
   ${esp32s3_base.build_flags}

--- a/variants/esp32s3/ELECROW-ThinkNode-M5/platformio.ini
+++ b/variants/esp32s3/ELECROW-ThinkNode-M5/platformio.ini
@@ -10,6 +10,7 @@ custom_meshtastic_tags = Elecrow
 custom_meshtastic_requires_dfu = false
 
 extends = esp32s3_base
+board_level = release
 board = ESP32-S3-WROOM-1-N4
 build_src_filter =
   ${esp32s3_base.build_src_filter}

--- a/variants/esp32s3/elecrow_panel/platformio.ini
+++ b/variants/esp32s3/elecrow_panel/platformio.ini
@@ -91,6 +91,7 @@ custom_meshtastic_partition_scheme = 16MB
 custom_meshtastic_has_mui = true
 
 extends = crowpanel_small_esp32s3_base
+board_level = release
 build_flags =
   ${crowpanel_small_esp32s3_base.build_flags}
   -D SPI_FREQUENCY=80000000
@@ -127,6 +128,7 @@ custom_meshtastic_partition_scheme = 16MB
 custom_meshtastic_has_mui = true
 
 extends = crowpanel_small_esp32s3_base
+board_level = release
 build_flags =
   ${crowpanel_small_esp32s3_base.build_flags}
   -D LV_CACHE_DEF_SIZE=2097152
@@ -166,6 +168,7 @@ custom_meshtastic_partition_scheme = 16MB
 custom_meshtastic_has_mui = true
 
 extends = crowpanel_large_esp32s3_base
+board_level = release
 build_flags =
   ${crowpanel_large_esp32s3_base.build_flags}
   -D VIEW_320x240

--- a/variants/esp32s3/hackaday-communicator/platformio.ini
+++ b/variants/esp32s3/hackaday-communicator/platformio.ini
@@ -1,6 +1,7 @@
 ; Hackaday Communicator
 [env:hackaday-communicator]
 extends = esp32s3_base
+board_level = release
 board = hackaday-communicator
 board_check = true
 board_build.partitions = default_16MB.csv

--- a/variants/esp32s3/heltec_capsule_sensor_v3/platformio.ini
+++ b/variants/esp32s3/heltec_capsule_sensor_v3/platformio.ini
@@ -1,5 +1,6 @@
 [env:heltec_capsule_sensor_v3]
 extends = esp32s3_base
+board_level = release
 board = heltec_wifi_lora_32_V3
 board_check = true
 board_build.partitions = default_8MB.csv

--- a/variants/esp32s3/heltec_sensor_hub/platformio.ini
+++ b/variants/esp32s3/heltec_sensor_hub/platformio.ini
@@ -1,5 +1,6 @@
 [env:heltec_sensor_hub]
 extends = esp32s3_base
+board_level = release
 board = heltec_wifi_lora_32_V3
 board_check = true
 

--- a/variants/esp32s3/heltec_v4/platformio.ini
+++ b/variants/esp32s3/heltec_v4/platformio.ini
@@ -24,6 +24,7 @@ custom_meshtastic_partition_scheme = 16MB
 custom_meshtastic_has_mui = true
 
 extends = heltec_v4_base
+board_level = release
 build_flags =
   ${heltec_v4_base.build_flags}
   -D HELTEC_V4_OLED
@@ -48,6 +49,7 @@ custom_meshtastic_requires_dfu = true
 custom_meshtastic_partition_scheme = 16MB
 
 extends = heltec_v4_base
+board_level = release
 build_flags = 
   ${heltec_v4_base.build_flags} ;-Os
   -D HELTEC_V4_TFT

--- a/variants/esp32s3/heltec_v4_r8/platformio.ini
+++ b/variants/esp32s3/heltec_v4_r8/platformio.ini
@@ -24,6 +24,7 @@ custom_meshtastic_requires_dfu = true
 custom_meshtastic_partition_scheme = 16MB
 
 extends = heltec_v4_r8_base
+board_level = release
 build_flags = 
   ${heltec_v4_r8_base.build_flags}
   -D HELTEC_V4_R8_OLED
@@ -46,6 +47,7 @@ custom_meshtastic_requires_dfu = true
 custom_meshtastic_partition_scheme = 16MB
 
 extends = heltec_v4_r8_base
+board_level = release
 build_flags = 
   ${heltec_v4_r8_base.build_flags} ;-Os
   -D HELTEC_V4_R8_TFT

--- a/variants/esp32s3/heltec_vision_master_e213/platformio.ini
+++ b/variants/esp32s3/heltec_vision_master_e213/platformio.ini
@@ -12,6 +12,7 @@ custom_meshtastic_partition_scheme = 8MB
 custom_meshtastic_has_ink_hud = true
 
 extends = esp32s3_base
+board_level = release
 board = heltec_vision_master_e213
 board_build.partitions = default_8MB.csv
 build_flags = 

--- a/variants/esp32s3/heltec_vision_master_e290/platformio.ini
+++ b/variants/esp32s3/heltec_vision_master_e290/platformio.ini
@@ -13,6 +13,7 @@ custom_meshtastic_partition_scheme = 8MB
 custom_meshtastic_has_ink_hud = true
 
 extends = esp32s3_base
+board_level = release
 board = heltec_vision_master_e290
 board_build.partitions = default_8MB.csv
 build_flags = 
@@ -38,6 +39,7 @@ upload_speed = 115200
 
 [env:heltec-vision-master-e290-inkhud]
 extends = esp32s3_base, inkhud
+board_level = release
 board = heltec_vision_master_e290
 board_build.partitions = default_8MB.csv
 build_src_filter = 

--- a/variants/esp32s3/heltec_vision_master_t190/platformio.ini
+++ b/variants/esp32s3/heltec_vision_master_t190/platformio.ini
@@ -11,6 +11,7 @@ custom_meshtastic_requires_dfu = true
 custom_meshtastic_partition_scheme = 8MB
 
 extends = esp32s3_base
+board_level = release
 board = heltec_vision_master_t190
 board_build.partitions = default_8MB.csv
 build_flags = 

--- a/variants/esp32s3/heltec_wireless_paper/platformio.ini
+++ b/variants/esp32s3/heltec_wireless_paper/platformio.ini
@@ -12,6 +12,7 @@ custom_meshtastic_partition_scheme = 8MB
 custom_meshtastic_has_ink_hud = true
 
 extends = esp32s3_base
+board_level = release
 board = heltec_wifi_lora_32_V3
 board_build.partitions = default_8MB.csv
 build_flags = 
@@ -35,6 +36,7 @@ upload_speed = 115200
 
 [env:heltec-wireless-paper-inkhud]
 extends = esp32s3_base, inkhud
+board_level = release
 board = heltec_wifi_lora_32_V3
 board_build.partitions = default_8MB.csv
 build_src_filter =

--- a/variants/esp32s3/heltec_wireless_tracker/platformio.ini
+++ b/variants/esp32s3/heltec_wireless_tracker/platformio.ini
@@ -11,6 +11,7 @@ custom_meshtastic_requires_dfu = true
 custom_meshtastic_partition_scheme = 8MB
 
 extends = esp32s3_base
+board_level = release
 board = heltec_wireless_tracker
 board_build.partitions = default_8MB.csv
 upload_protocol = esptool

--- a/variants/esp32s3/heltec_wireless_tracker_v2/platformio.ini
+++ b/variants/esp32s3/heltec_wireless_tracker_v2/platformio.ini
@@ -4,6 +4,7 @@ custom_meshtastic_images = heltec_wireless_tracker_v2.svg
 custom_meshtastic_tags = Heltec
 
 extends = esp32s3_base
+board_level = release
 board = heltec_wireless_tracker_v2
 board_build.partitions = default_8MB.csv
 upload_protocol = esptool

--- a/variants/esp32s3/heltec_wsl_v3/platformio.ini
+++ b/variants/esp32s3/heltec_wsl_v3/platformio.ini
@@ -10,6 +10,7 @@ custom_meshtastic_tags = Heltec
 custom_meshtastic_partition_scheme = 8MB
  
 extends = esp32s3_base
+board_level = release
 board = heltec_wifi_lora_32_V3
 board_build.partitions = default_8MB.csv
 # Temporary until espressif creates a release with this new target

--- a/variants/esp32s3/m5stack_cardputer_adv/platformio.ini
+++ b/variants/esp32s3/m5stack_cardputer_adv/platformio.ini
@@ -1,6 +1,7 @@
 ; M5stack Cardputer Advanced
 [env:m5stack-cardputer-adv]
 extends = esp32s3_base
+board_level = release
 board = m5stack-stamps3
 board_check = true
 board_build.partitions = default_8MB.csv

--- a/variants/esp32s3/m5stack_cores3/platformio.ini
+++ b/variants/esp32s3/m5stack_cores3/platformio.ini
@@ -1,6 +1,7 @@
 ; M5stack CoreS3
 [env:m5stack-cores3]
 extends = esp32s3_base
+board_level = release
 board = m5stack-cores3
 board_check = true
 board_build.partitions = default_16MB.csv

--- a/variants/esp32s3/meshnology-w10/platformio.ini
+++ b/variants/esp32s3/meshnology-w10/platformio.ini
@@ -17,6 +17,7 @@ board_build.psram_type = opi
 board_build.arduino.memory_type = qio_opi
 
 extends = esp32s3_base
+board_level = release
 build_flags =
   ${esp32s3_base.build_flags}
   -D MESHNOLOGY_W10

--- a/variants/esp32s3/meshnology-w12/platformio.ini
+++ b/variants/esp32s3/meshnology-w12/platformio.ini
@@ -11,6 +11,7 @@ custom_meshtastic_requires_dfu = true
 custom_meshtastic_partition_scheme = 16MB
 
 extends = esp32s3_base
+board_level = release
 board = esp32-s3-devkitc-1
 ; ESP32-S3R8: 8 MB OPI PSRAM, 16 MB QIO flash
 board_build.partitions = default_16MB.csv

--- a/variants/esp32s3/mini-epaper-s3/platformio.ini
+++ b/variants/esp32s3/mini-epaper-s3/platformio.ini
@@ -11,6 +11,7 @@ custom_meshtastic_requires_dfu = no
 custom_meshtastic_has_mui = false
 
 extends = esp32s3_base
+board_level = release
 board = mini-epaper-s3
 board_check = true
 upload_protocol = esptool
@@ -37,6 +38,7 @@ lib_deps =
 
 [env:mini-epaper-s3-inkhud]
 extends = esp32s3_base, inkhud
+board_level = release
 board = mini-epaper-s3
 board_check = true
 upload_protocol = esptool

--- a/variants/esp32s3/picomputer-s3/platformio.ini
+++ b/variants/esp32s3/picomputer-s3/platformio.ini
@@ -9,6 +9,7 @@ custom_meshtastic_partition_scheme = 8MB
 custom_meshtastic_has_mui = true
 
 extends = esp32s3_base
+board_level = release
 board = bpi_picow_esp32_s3
 board_check = true
 board_build.partitions = partition-table-8MB.csv
@@ -33,6 +34,7 @@ build_src_filter =
 
 [env:picomputer-s3-tft]
 extends = env:picomputer-s3
+board_level = release
 
 build_flags =
   ${env:picomputer-s3.build_flags}

--- a/variants/esp32s3/rak3312/platformio.ini
+++ b/variants/esp32s3/rak3312/platformio.ini
@@ -12,6 +12,7 @@ custom_meshtastic_partition_scheme = 16MB
 custom_meshtastic_has_mui = false
 
 extends = esp32s3_base
+board_level = release
 board = wiscore_rak3312
 board_check = true
 upload_protocol = esptool

--- a/variants/esp32s3/rak_wismesh_tap_v2/platformio.ini
+++ b/variants/esp32s3/rak_wismesh_tap_v2/platformio.ini
@@ -23,6 +23,7 @@ custom_meshtastic_partition_scheme = 16MB
 custom_meshtastic_has_mui = true
 
 extends = esp32s3_base
+board_level = release
 board = wiscore_rak3312
 board_check = true
 upload_protocol = esptool
@@ -41,6 +42,7 @@ lib_deps =
 
 [env:rak_wismesh_tap_v2-tft]
 extends = env:rak_wismesh_tap_v2
+board_level = release
 ; The MUI build overflows default_8MB.csv's 0x330000 app slots; use the MUI
 ; layout (large app0 + small flasher slot) like the other has_mui 8MB boards.
 board_build.partitions = partition-table-8MB.csv

--- a/variants/esp32s3/seeed-sensecap-indicator/platformio.ini
+++ b/variants/esp32s3/seeed-sensecap-indicator/platformio.ini
@@ -12,6 +12,7 @@ custom_meshtastic_partition_scheme = 8MB
 custom_meshtastic_has_mui = true
 
 extends = esp32s3_base
+board_level = release
 platform_packages =
   ; Version needs to match the pioarduino version used in esp32_common.ini
   platformio/framework-arduinoespressif32 @ https://github.com/mverch67/arduino-esp32#6dde0f3b58e32d9f884b94b4685b0f3a267c4624 ; 3.3.11

--- a/variants/esp32s3/seeed_xiao_s3/platformio.ini
+++ b/variants/esp32s3/seeed_xiao_s3/platformio.ini
@@ -11,6 +11,7 @@ custom_meshtastic_requires_dfu = true
 custom_meshtastic_partition_scheme = 8MB
 
 extends = esp32s3_base
+board_level = release
 board = seeed-xiao-s3
 board_check = true
 board_build.partitions = default_8MB.csv

--- a/variants/esp32s3/station-g2/platformio.ini
+++ b/variants/esp32s3/station-g2/platformio.ini
@@ -11,6 +11,7 @@ custom_meshtastic_requires_dfu = true
 custom_meshtastic_partition_scheme = 16MB
 
 extends = esp32s3_base
+board_level = release
 board = station-g2
 board_check = true
 board_build.partitions = default_16MB.csv

--- a/variants/esp32s3/station-g3/platformio.ini
+++ b/variants/esp32s3/station-g3/platformio.ini
@@ -11,6 +11,7 @@ custom_meshtastic_requires_dfu = true
 custom_meshtastic_partition_scheme = 16MB
 
 extends = esp32s3_base
+board_level = release
 board = station-g3
 board_check = true
 board_build.partitions = default_16MB.csv

--- a/variants/esp32s3/t-beam-1w/platformio.ini
+++ b/variants/esp32s3/t-beam-1w/platformio.ini
@@ -11,6 +11,7 @@ custom_meshtastic_tags = LilyGo
 custom_meshtastic_has_mui = false
 
 extends = esp32s3_base
+board_level = release
 board = t-beam-1w
 board_build.partitions = default_8MB.csv
 board_check = true

--- a/variants/esp32s3/t-beam-bpf/platformio.ini
+++ b/variants/esp32s3/t-beam-bpf/platformio.ini
@@ -10,6 +10,7 @@ custom_meshtastic_images = tbeam-1w.svg
 custom_meshtastic_tags = LilyGo
 
 extends = esp32s3_base
+board_level = release
 board = t-beam-bpf
 board_build.partitions = default_16MB.csv
 board_check = true

--- a/variants/esp32s3/t-deck-pro-v1_1/platformio.ini
+++ b/variants/esp32s3/t-deck-pro-v1_1/platformio.ini
@@ -11,6 +11,7 @@ custom_meshtastic_requires_dfu = true
 custom_meshtastic_partition_scheme = 16MB
 
 extends = esp32s3_base
+board_level = release
 board = t-deck-pro
 board_check = true
 upload_protocol = esptool

--- a/variants/esp32s3/t-deck-pro/platformio.ini
+++ b/variants/esp32s3/t-deck-pro/platformio.ini
@@ -12,6 +12,7 @@ custom_meshtastic_partition_scheme = 16MB
 custom_meshtastic_has_mui = false
 
 extends = esp32s3_base
+board_level = release
 board = t-deck-pro
 board_check = true
 upload_protocol = esptool

--- a/variants/esp32s3/t-deck/platformio.ini
+++ b/variants/esp32s3/t-deck/platformio.ini
@@ -13,6 +13,7 @@ custom_meshtastic_partition_scheme = 16MB
 custom_meshtastic_has_mui = true
 
 extends = esp32s3_base
+board_level = release
 board = t-deck
 board_check = true
 board_build.partitions = default_16MB.csv

--- a/variants/esp32s3/t-eth-elite/platformio.ini
+++ b/variants/esp32s3/t-eth-elite/platformio.ini
@@ -1,5 +1,6 @@
 [env:t-eth-elite]
 extends = esp32s3_base
+board_level = release
 board = esp32s3box
 board_check = true
 board_build.partitions = default_16MB.csv

--- a/variants/esp32s3/t-watch-s3/platformio.ini
+++ b/variants/esp32s3/t-watch-s3/platformio.ini
@@ -11,6 +11,7 @@ custom_meshtastic_tags = LilyGo
 custom_meshtastic_partition_scheme = 8MB
 
 extends = esp32s3_base
+board_level = release
 board = t-watch-s3
 board_check = true
 board_build.partitions = default_16MB.csv

--- a/variants/esp32s3/t5s3_epaper/platformio.ini
+++ b/variants/esp32s3/t5s3_epaper/platformio.ini
@@ -55,6 +55,7 @@ lib_deps =
 
 [env:t5s3-epaper-v1] ; H752
 extends = t5s3_epaper_base
+board_level = release
 build_flags =
   ${t5s3_epaper_base.build_flags}
   -D T5_S3_EPAPER_PRO_V1
@@ -62,6 +63,7 @@ build_flags =
 
 [env:t5s3-epaper-v2] ; H752-01
 extends = t5s3_epaper_base
+board_level = release
 build_flags =
   ${t5s3_epaper_base.build_flags}
   -D T5_S3_EPAPER_PRO_V2

--- a/variants/esp32s3/tbeam-s3-core/platformio.ini
+++ b/variants/esp32s3/tbeam-s3-core/platformio.ini
@@ -12,6 +12,7 @@ custom_meshtastic_requires_dfu = true
 custom_meshtastic_partition_scheme = 8MB
 
 extends = esp32s3_base
+board_level = release
 board = tbeam-s3-core
 board_build.partitions = default_8MB.csv
 board_check = true

--- a/variants/esp32s3/tlora-pager/platformio.ini
+++ b/variants/esp32s3/tlora-pager/platformio.ini
@@ -13,6 +13,7 @@ custom_meshtastic_partition_scheme = 16MB
 custom_meshtastic_has_mui = true
 
 extends = esp32s3_base
+board_level = release
 board = t-deck-pro ; same as T-Deck Pro
 board_check = true
 board_build.partitions = default_16MB.csv

--- a/variants/esp32s3/tlora_t3s3_epaper/platformio.ini
+++ b/variants/esp32s3/tlora_t3s3_epaper/platformio.ini
@@ -11,6 +11,7 @@ custom_meshtastic_requires_dfu = true
 custom_meshtastic_has_ink_hud = true
 
 extends = esp32s3_base
+board_level = release
 board = tlora-t3s3-v1
 board_check = true
 board_build.partitions = partition-table-t3s3.csv
@@ -39,6 +40,7 @@ lib_deps =
 
 [env:tlora-t3s3-epaper-inkhud]
 extends = esp32s3_base, inkhud
+board_level = release
 board = tlora-t3s3-v1
 board_check = true
 board_build.partitions = partition-table-t3s3.csv

--- a/variants/esp32s3/tlora_t3s3_v1/platformio.ini
+++ b/variants/esp32s3/tlora_t3s3_v1/platformio.ini
@@ -10,6 +10,7 @@ custom_meshtastic_tags = LilyGo
 custom_meshtastic_requires_dfu = true
 
 extends = esp32s3_base
+board_level = release
 board = tlora-t3s3-v1
 board_check = true
 board_build.partitions = partition-table-t3s3.csv

--- a/variants/esp32s3/tracksenger/platformio.ini
+++ b/variants/esp32s3/tracksenger/platformio.ini
@@ -9,6 +9,7 @@ custom_meshtastic_requires_dfu = true
 custom_meshtastic_partition_scheme = 8MB
 
 extends = esp32s3_base
+board_level = release
 board = heltec_wireless_tracker
 board_build.partitions = default_8MB.csv
 upload_protocol = esp-builtin
@@ -35,6 +36,7 @@ custom_meshtastic_requires_dfu = true
 custom_meshtastic_partition_scheme = 8MB
 
 extends = esp32s3_base
+board_level = release
 board = heltec_wireless_tracker
 board_build.partitions = default_8MB.csv
 upload_protocol = esp-builtin
@@ -60,6 +62,7 @@ custom_meshtastic_display_name = TrackSenger (big OLED)
 custom_meshtastic_partition_scheme = 8MB
 
 extends = esp32s3_base
+board_level = release
 board = heltec_wireless_tracker
 board_build.partitions = default_8MB.csv
 upload_protocol = esp-builtin

--- a/variants/esp32s3/unphone/platformio.ini
+++ b/variants/esp32s3/unphone/platformio.ini
@@ -11,6 +11,7 @@ custom_meshtastic_requires_dfu = true
 custom_meshtastic_partition_scheme = 8MB
 
 extends = esp32s3_base
+board_level = release
 board = unphone
 board_build.partitions = partition-table-8MB.csv
 upload_speed = 921600

--- a/variants/nrf52840/ELECROW-ThinkNode-M1/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M1/platformio.ini
@@ -11,6 +11,7 @@ custom_meshtastic_tags = Elecrow
 custom_meshtastic_has_ink_hud = true
 
 extends = nrf52840_base
+board_level = release
 board = ThinkNode-M1
 board_check = true
 debug_tool = jlink
@@ -41,6 +42,7 @@ lib_deps =
 
 [env:thinknode_m1-inkhud]
 extends = nrf52840_base, inkhud
+board_level = release
 board = ThinkNode-M1
 board_check = true
 debug_tool = jlink

--- a/variants/nrf52840/ELECROW-ThinkNode-M3/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M3/platformio.ini
@@ -4,6 +4,7 @@ custom_meshtastic_images = thinknode_m3.svg
 custom_meshtastic_tags = Elecrow
 
 extends = nrf52840_base
+board_level = release
 board = ThinkNode-M3
 board_check = true
 debug_tool = jlink

--- a/variants/nrf52840/ELECROW-ThinkNode-M4/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M4/platformio.ini
@@ -1,6 +1,7 @@
 ; ThinkNode M4 - Powerbank nrf52840/LR1110 by Elecrow
 [env:thinknode_m4]
 extends = nrf52840_base
+board_level = release
 board = ThinkNode-M4
 board_check = true
 debug_tool = jlink

--- a/variants/nrf52840/ELECROW-ThinkNode-M6/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M6/platformio.ini
@@ -10,6 +10,7 @@ custom_meshtastic_images = thinknode_m6.svg
 custom_meshtastic_tags = Elecrow
 
 extends = nrf52840_base
+board_level = release
 board = ThinkNode-M6
 board_check = true
 debug_tool = jlink

--- a/variants/nrf52840/ELECROW-ThinkNode-M8/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M8/platformio.ini
@@ -10,6 +10,7 @@ custom_meshtastic_display_name = Elecrow ThinkNode M8
 custom_meshtastic_actively_supported = true
 
 extends = nrf52840_base
+board_level = release
 board = ThinkNode-M8
 board_check = true
 debug_tool = jlink

--- a/variants/nrf52840/canaryone/platformio.ini
+++ b/variants/nrf52840/canaryone/platformio.ini
@@ -9,6 +9,7 @@ custom_meshtastic_display_name = Canary One
 custom_meshtastic_tags = Canary
 
 extends = nrf52840_base
+board_level = release
 board = canaryone
 debug_tool = jlink
 

--- a/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/platformio.ini
+++ b/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/platformio.ini
@@ -11,6 +11,7 @@ custom_meshtastic_tags = DIY
 custom_meshtastic_requires_dfu = true
 
 extends = nrf52840_base
+board_level = release
 board = promicro-nrf52840
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/diy/nrf52_promicro_diy_tcxo

--- a/variants/nrf52840/feather_diy/platformio.ini
+++ b/variants/nrf52840/feather_diy/platformio.ini
@@ -1,6 +1,7 @@
 ; The very slick RAK wireless RAK 4631 / 4630 board - Unified firmware for 5005/19003, with or without OLED RAK 1921
 [env:feather_diy]
 extends = nrf52840_base
+board_level = release
 board = adafruit_feather_nrf52840
 build_flags = ${nrf52840_base.build_flags}
   -Ivariants/nrf52840/feather_diy

--- a/variants/nrf52840/heltec_mesh_node_t096/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_node_t096/platformio.ini
@@ -10,6 +10,7 @@ custom_meshtastic_images = heltec-mesh-node-t096.svg, heltec-mesh-node-t096-case
 custom_meshtastic_tags = Heltec
 
 extends = nrf52840_base
+board_level = release
 board = heltec_mesh_node_t096
 debug_tool = jlink
 

--- a/variants/nrf52840/heltec_mesh_node_t1/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_node_t1/platformio.ini
@@ -10,6 +10,7 @@ custom_meshtastic_images = heltec-mesh-node-t1.svg
 custom_meshtastic_tags = Heltec
 
 extends = nrf52840_base
+board_level = release
 board = heltec_mesh_node_t1
 debug_tool = jlink
 

--- a/variants/nrf52840/heltec_mesh_pocket/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_pocket/platformio.ini
@@ -5,6 +5,7 @@ custom_meshtastic_images = heltec_mesh_pocket.svg
 custom_meshtastic_tags = Heltec
 
 extends = nrf52840_base
+board_level = release
 board = heltec_mesh_pocket
 debug_tool = jlink
 custom_device_hw_model = 94
@@ -43,6 +44,7 @@ lib_deps =
 
 [env:heltec-mesh-pocket-5000-inkhud]
 extends = nrf52840_base, inkhud
+board_level = release
 board = heltec_mesh_pocket
 custom_meshtastic_hw_model = 94
 custom_meshtastic_hw_model_slug = HELTEC_MESH_POCKET
@@ -70,6 +72,7 @@ custom_meshtastic_images = heltec_mesh_pocket.svg
 custom_meshtastic_tags = Heltec
 
 extends = nrf52840_base
+board_level = release
 board = heltec_mesh_pocket
 debug_tool = jlink
 custom_meshtastic_hw_model = 94
@@ -107,6 +110,7 @@ lib_deps =
 
 [env:heltec-mesh-pocket-10000-inkhud]
 extends = nrf52840_base, inkhud
+board_level = release
 board = heltec_mesh_pocket
 custom_meshtastic_hw_model = 94
 custom_meshtastic_hw_model_slug = HELTEC_MESH_POCKET

--- a/variants/nrf52840/heltec_mesh_solar/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_solar/platformio.ini
@@ -28,11 +28,13 @@ custom_meshtastic_images = heltec-mesh-solar.svg
 custom_meshtastic_tags = Heltec
 
 extends = heltec_mesh_solar_base
+board_level = release
 build_flags = ${heltec_mesh_solar_base.build_flags}
     -DSPI_INTERFACES_COUNT=1
 
 [env:heltec-mesh-solar-eink]
 extends = heltec_mesh_solar_base
+board_level = release
 build_flags = ${heltec_mesh_solar_base.build_flags}
   -DHELTEC_MESH_SOLAR_EINK
   -DSPI_INTERFACES_COUNT=2
@@ -71,6 +73,7 @@ lib_deps =
 
 [env:heltec-mesh-solar-inkhud]
 extends = heltec_mesh_solar_base, inkhud
+board_level = release
 build_src_filter = ${heltec_mesh_solar_base.build_src_filter} ${inkhud.build_src_filter}
 build_flags = ${heltec_mesh_solar_base.build_flags}
   ${inkhud.build_flags}
@@ -92,6 +95,7 @@ lib_deps =
 
 [env:heltec-mesh-solar-oled]
 extends = heltec_mesh_solar_base
+board_level = release
 build_flags = ${heltec_mesh_solar_base.build_flags}
   -DHELTEC_MESH_SOLAR_OLED
   -DSPI_INTERFACES_COUNT=1
@@ -103,6 +107,7 @@ build_flags = ${heltec_mesh_solar_base.build_flags}
 
 [env:heltec-mesh-solar-tft]
 extends = heltec_mesh_solar_base
+board_level = release
 build_flags = ${heltec_mesh_solar_base.build_flags}
   -UOLEDDISPLAY_REDUCE_MEMORY ; TFTDisplay.cpp needs the lib's buffer_back for dirty-window diffing
   -DHELTEC_MESH_SOLAR_TFT

--- a/variants/nrf52840/heltec_mesh_tower_v2/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_tower_v2/platformio.ini
@@ -10,6 +10,7 @@ custom_meshtastic_images = heltec-mesh-tower-v2.svg
 custom_meshtastic_tags = Heltec
 
 extends = nrf52840_base
+board_level = release
 board = heltec_mesh_tower_v2
 debug_tool = jlink
 

--- a/variants/nrf52840/muzi_base/platformio.ini
+++ b/variants/nrf52840/muzi_base/platformio.ini
@@ -9,6 +9,7 @@ custom_meshtastic_images = muzi_base.svg
 custom_meshtastic_tags = muzi
 
 extends = nrf52840_base
+board_level = release
 board = muzi-base
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/muzi_base

--- a/variants/nrf52840/nano-g2-ultra/platformio.ini
+++ b/variants/nrf52840/nano-g2-ultra/platformio.ini
@@ -10,6 +10,7 @@ custom_meshtastic_images = nano-g2-ultra.svg
 custom_meshtastic_tags = B&Q
 
 extends = nrf52840_base
+board_level = release
 board = nano-g2-ultra
 debug_tool = jlink
 

--- a/variants/nrf52840/r1-neo/platformio.ini
+++ b/variants/nrf52840/r1-neo/platformio.ini
@@ -10,6 +10,7 @@ custom_meshtastic_images = muzi_r1_neo.svg
 custom_meshtastic_tags = muzi
 
 extends = nrf52840_base
+board_level = release
 board = r1-neo
 board_check = true
 build_flags = ${nrf52840_base.build_flags}

--- a/variants/nrf52840/rak2560/platformio.ini
+++ b/variants/nrf52840/rak2560/platformio.ini
@@ -10,6 +10,7 @@ custom_meshtastic_images = rak2560.svg
 custom_meshtastic_tags = RAK
 
 extends = nrf52840_base
+board_level = release
 board = wiscore_rak4631
 board_check = true
 build_flags = ${nrf52840_base.build_flags}

--- a/variants/nrf52840/rak3401_1watt/platformio.ini
+++ b/variants/nrf52840/rak3401_1watt/platformio.ini
@@ -11,6 +11,7 @@ custom_meshtastic_tags = RAK
 custom_meshtastic_requires_dfu = true
 
 extends = nrf52840_base
+board_level = release
 board = wiscore_rak4631
 board_check = true
 build_flags = ${nrf52840_base.build_flags} 
@@ -39,6 +40,7 @@ lib_deps =
 ; RAK10729 WisMesh Repeater Mini V2 HP (RAK3401 + RAK19007 + RAK13302 + solar battery)
 [env:rak_wismesh_repeater_mini_hp]
 extends = env:rak3401-1watt
+board_level = release
 custom_meshtastic_display_name = RAK WisMesh Repeater Mini V2 HP
 custom_meshtastic_images = rak3401.svg
 build_flags =

--- a/variants/nrf52840/rak4631/platformio.ini
+++ b/variants/nrf52840/rak4631/platformio.ini
@@ -47,6 +47,7 @@ lib_deps =
 ; RAK10728 WisMesh Repeater Mini V2 (RAK4631 + RAK19003 + solar battery + GPS module)
 [env:rak_wismesh_repeater_mini]
 extends = env:rak4631
+board_level = release
 custom_meshtastic_display_name = RAK WisMesh Repeater Mini V2
 custom_meshtastic_images = rak4631.svg
 build_flags =
@@ -59,6 +60,7 @@ build_flags =
 ; RAK WisMesh Pocket V3 - rak4631 pin map + OLED; no ethernet (unlike env:rak4631)
 [env:rak_wismesh_pocket]
 extends = env:rak4631
+board_level = release
 custom_meshtastic_display_name = RAK WisMesh Pocket V3
 custom_meshtastic_images = rak4631.svg
 build_flags =

--- a/variants/nrf52840/rak4631_epaper/platformio.ini
+++ b/variants/nrf52840/rak4631_epaper/platformio.ini
@@ -1,6 +1,7 @@
 ; The very slick RAK wireless RAK 4631 / 4630 board - Firmware for 5005 with the RAK 14000 ePaper
 [env:rak4631_eink]
 extends = nrf52840_base
+board_level = release
 board = wiscore_rak4631
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/rak4631_epaper

--- a/variants/nrf52840/rak4631_eth_gw/platformio.ini
+++ b/variants/nrf52840/rak4631_eth_gw/platformio.ini
@@ -1,6 +1,7 @@
 ; The very slick RAK wireless RAK 4631 / 4630 board - Unified firmware for 5005/19003, with or without OLED RAK 1921
 [env:rak4631_eth_gw]
 extends = nrf52840_base
+board_level = release
 board = wiscore_rak4631
 board_check = true
 build_flags = ${nrf52840_base.build_flags}

--- a/variants/nrf52840/rak4631_nomadstar_meteor_pro/platformio.ini
+++ b/variants/nrf52840/rak4631_nomadstar_meteor_pro/platformio.ini
@@ -10,6 +10,7 @@ custom_meshtastic_images = meteor_pro.svg
 custom_meshtastic_tags = NomadStar
 
 extends = nrf52840_base
+board_level = release
 board = wiscore_rak4631
 board_check = true
 build_flags = ${nrf52840_base.build_flags}

--- a/variants/nrf52840/rak_wismeshtag/platformio.ini
+++ b/variants/nrf52840/rak_wismeshtag/platformio.ini
@@ -5,6 +5,7 @@ custom_meshtastic_images = rak_wismesh_tag.svg
 custom_meshtastic_tags = RAK
 
 extends = nrf52840_base
+board_level = release
 board = wiscore_rak4631
 board_check = true
 custom_meshtastic_hw_model = 105
@@ -26,6 +27,7 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/rak_wis
 ; RAK WisMesh Pod - same board as Tag (no user buttons on hardware; shares Tag pin map)
 [env:rak_wismesh_pod]
 extends = env:rak_wismeshtag
+board_level = release
 custom_meshtastic_display_name = RAK WisMesh Pod
 build_flags =
   ${env:rak_wismeshtag.build_flags}

--- a/variants/nrf52840/rak_wismeshtap/platformio.ini
+++ b/variants/nrf52840/rak_wismeshtap/platformio.ini
@@ -10,6 +10,7 @@ custom_meshtastic_images = rak-wismeshtap.svg
 custom_meshtastic_tags = RAK
 
 extends = nrf52840_base
+board_level = release
 board = wiscore_rak4631
 build_flags = ${nrf52840_base.build_flags}
   -UOLEDDISPLAY_REDUCE_MEMORY ; TFTDisplay.cpp needs the lib's buffer_back for dirty-window diffing

--- a/variants/nrf52840/seeed_solar_node/platformio.ini
+++ b/variants/nrf52840/seeed_solar_node/platformio.ini
@@ -10,6 +10,7 @@ custom_meshtastic_tags = Seeed
 
 board = seeed_solar_node
 extends = nrf52840_base
+board_level = release
 ;board_level = extra
 build_flags = ${nrf52840_base.build_flags} 
   -I variants/nrf52840/seeed_solar_node 

--- a/variants/nrf52840/seeed_wio_tracker_L1_eink/platformio.ini
+++ b/variants/nrf52840/seeed_wio_tracker_L1_eink/platformio.ini
@@ -11,6 +11,7 @@ custom_meshtastic_has_ink_hud = true
 
 board = seeed_wio_tracker_L1
 extends = nrf52840_base
+board_level = release
 ;board_level = extra
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/seeed_wio_tracker_L1_eink
@@ -41,6 +42,7 @@ debug_tool = jlink
 [env:seeed_wio_tracker_L1_eink-inkhud]
 board = seeed_wio_tracker_L1
 extends = env:seeed_wio_tracker_L1_eink, inkhud
+board_level = release
 build_flags = 
   ${env:seeed_wio_tracker_L1_eink.build_flags}
   ${inkhud.build_flags}

--- a/variants/nrf52840/seeed_xiao_nrf52840_kit/platformio.ini
+++ b/variants/nrf52840/seeed_xiao_nrf52840_kit/platformio.ini
@@ -10,6 +10,7 @@ custom_meshtastic_images = seeed_xiao_nrf52_kit.svg
 custom_meshtastic_tags = Seeed
 
 extends = nrf52840_base
+board_level = release
 board = xiao_ble_sense
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/seeed_xiao_nrf52840_kit

--- a/variants/nrf52840/t-echo-lite/platformio.ini
+++ b/variants/nrf52840/t-echo-lite/platformio.ini
@@ -10,6 +10,7 @@ custom_meshtastic_images = techo_lite.svg
 custom_meshtastic_tags = LilyGo
 
 extends = nrf52840_base
+board_level = release
 board = t-echo
 board_check = true
 debug_tool = jlink

--- a/variants/nrf52840/t-echo/platformio.ini
+++ b/variants/nrf52840/t-echo/platformio.ini
@@ -11,6 +11,7 @@ custom_meshtastic_tags = LilyGo
 custom_meshtastic_has_ink_hud = true
 
 extends = nrf52840_base
+board_level = release
 board = t-echo
 board_check = true
 debug_tool = jlink
@@ -37,6 +38,7 @@ lib_deps =
 
 [env:t-echo-inkhud]
 extends = nrf52840_base, inkhud
+board_level = release
 board = t-echo
 board_check = true
 debug_tool = jlink

--- a/variants/nrf52840/t-impulse-plus/platformio.ini
+++ b/variants/nrf52840/t-impulse-plus/platformio.ini
@@ -9,6 +9,7 @@ custom_meshtastic_tags = LilyGo
 custom_meshtastic_requires_dfu = true
 
 extends = nrf52840_base
+board_level = release
 board = t-impulse-plus
 
 build_flags = ${nrf52840_base.build_flags}

--- a/variants/nrf52840/wio-sdk-wm1110/platformio.ini
+++ b/variants/nrf52840/wio-sdk-wm1110/platformio.ini
@@ -1,6 +1,7 @@
 ; The black Wio-WM1110 Dev Kit with sensors and the WM1110 module
 [env:wio-sdk-wm1110]
 extends = nrf52840_base
+board_level = release
 board = wio-sdk-wm1110
 
 extra_scripts =

--- a/variants/nrf52840/wio-tracker-wm1110/platformio.ini
+++ b/variants/nrf52840/wio-tracker-wm1110/platformio.ini
@@ -11,6 +11,7 @@ custom_meshtastic_tags = Seeed
 custom_meshtastic_requires_dfu = true
 
 extends = nrf52840_base
+board_level = release
 board = wio-tracker-wm1110
 build_flags = ${nrf52840_base.build_flags}
   -Ivariants/nrf52840/wio-tracker-wm1110

--- a/variants/rp2040/rak11310/platformio.ini
+++ b/variants/rp2040/rak11310/platformio.ini
@@ -10,6 +10,7 @@ custom_meshtastic_tags = RAK
 custom_meshtastic_requires_dfu = true
 
 extends = rp2040_base
+board_level = release
 board = rakwireless_rak11300
 upload_protocol = picotool
 # add our variants files to the include and src paths

--- a/variants/rp2040/rp2040-lora/platformio.ini
+++ b/variants/rp2040/rp2040-lora/platformio.ini
@@ -9,6 +9,7 @@ custom_meshtastic_tags = Waveshare
 custom_meshtastic_requires_dfu = true
 
 extends = rp2040_base
+board_level = release
 board = rpipico
 upload_protocol = picotool
 # add our variants files to the include and src paths

--- a/variants/rp2040/rpipico/platformio.ini
+++ b/variants/rp2040/rpipico/platformio.ini
@@ -10,6 +10,7 @@ custom_meshtastic_tags = RPi, DIY
 custom_meshtastic_requires_dfu = true
 
 extends = rp2040_base
+board_level = release
 board = rpipico
 upload_protocol = picotool
 # add our variants files to the include and src paths

--- a/variants/rp2040/seeed_xiao_rp2040/platformio.ini
+++ b/variants/rp2040/seeed_xiao_rp2040/platformio.ini
@@ -1,5 +1,6 @@
 [env:seeed_xiao_rp2040]
 extends = rp2040_base
+board_level = release
 board = seeed_xiao_rp2040
 upload_protocol = picotool
 # add our variants files to the include and src paths

--- a/variants/rp2350/rpipico2/platformio.ini
+++ b/variants/rp2350/rpipico2/platformio.ini
@@ -1,5 +1,6 @@
 [env:pico2]
 extends = rp2350_base
+board_level = release
 board = rpipico2
 upload_protocol = picotool
 

--- a/variants/rp2350/seeed_xiao_rp2350/platformio.ini
+++ b/variants/rp2350/seeed_xiao_rp2350/platformio.ini
@@ -1,5 +1,6 @@
 [env:seeed_xiao_rp2350]
 extends = rp2350_base
+board_level = release
 board = seeed_xiao_rp2350
 upload_protocol = picotool
 


### PR DESCRIPTION
## What & why

`generate_ci_matrix.py` treated **absence** of `board_level` as "this is a release board". That sentinel is an inheritance footgun: an env's level was decided by whatever it inherited (or failed to inherit) through `extends`, so a variant could silently land in — or drop out of — the release matrix without anything in its `platformio.ini` saying so, and forgetting the key entirely was indistinguishable from deliberately choosing release.

This makes the release level explicit. Every variant env now declares one of `pr`, `release`, or `extra`, and the matrix generator refuses to run if any env is missing the key or uses an unrecognized value.

## What changed

- **`variants/**/platformio.ini`** (97 files, +122 lines): added `board_level = release` to every env that had no level of its own and inherited none. Existing `board_level = pr` and `board_level = extra` values were left untouched. These are pure one-line additions — no other content changed in any variant file.
- **`bin/generate_ci_matrix.py`**:
  - Added a `BOARD_LEVELS` constant documenting the three levels.
  - The release branch now tests `board_level == "release"` instead of `not board_level`.
  - **New**: exits non-zero on a missing or unrecognized `board_level`, naming the offending env. This is the point of the change — a new variant can no longer omit the key and get a level by accident.
  - Collapsed the nested conditional in the `check` path into an equivalent single condition.
- **`.github/copilot-instructions.md`**: documented all three levels and the new hard requirement. Also corrected a stale claim that `custom_meshtastic_support_level` controls PR-vs-merge builds — it does not; nothing reads it for matrix filtering. It is variant metadata that `bin/platformio-custom.py` emits as `supportLevel` in the generated hardware list.

## Behavior

**The generated CI matrix is unchanged.** This is a refactor of how the release level is *spelled*, not which boards get built. The only intended behavior change is the new fail-fast validation, which cannot trigger on this branch precisely because all 249 envs now declare a level.

## Testing

Built two git worktrees — `develop` (before) and this branch (after) — and diffed the generator's output across **14 targets** (all 12 `variants/` platform dirs plus `all` and `check`) × **4 level forms** (bare, `--level pr`, `--level extra`, `--level pr extra`) = **56 invocations per tree, 112 runs**. Each pair was compared both as an exact stdout string and as an order-insensitive board set.

**All 56 pairs are byte-for-byte identical** — not merely same-set-different-order, which would still have reshuffled CI job ordering.

| Invocation | Boards | Result |
| --- | --- | --- |
| `all` | 141 | identical |
| `all --level pr` | 19 | identical |
| `all --level extra` | 249 | identical |
| `all --level pr extra` | 127 | identical |
| `check` | 80 | identical |
| `check --level pr` | 9 | identical |

`check` = 80 and `check --level extra` = 80 both match, which specifically confirms the rewritten `check` path still keeps `extra`-level `board_check` envs in the non-PR check matrix.

The new validation was verified separately by running the updated script against `develop`'s un-migrated variants, where it correctly fails:

```
Error: environment 'rp2040-lora' has no value for 'board_level'; expected one of: pr, release, extra
Error: environment 'rp2040-lora' has 'Release' for 'board_level'; expected one of: pr, release, extra
```

Also confirmed PlatformIO already strips trailing whitespace and inline `;` comments from the value, so `board_level = release ; note` parses fine and needs no special handling.

## Reviewer notes

- Two envs are easy to miss when sweeping this file set: `t5s3-epaper-v1` and `t5s3-epaper-v2` in `variants/esp32s3/t5s3_epaper/platformio.ini`. Their section headers carry trailing comments (`[env:t5s3-epaper-v1] ; H752`), which defeats a naive `^\[env:...\]$` match. Both are included here; the post-change audit confirms all **249** envs resolve to exactly one level (122 `release` / 108 `extra` / 19 `pr`), zero missing.
- Nothing under `src/` or `test/` is touched — there is no runtime/firmware change, so there is no device-level regression surface.
- `--level` still accepts only `pr` and `extra`. Adding `release` as a choice would be redundant (the bare form already means "pr + release") and ambiguous in combinations like `--level pr release`.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)

On-device testing is not applicable: this changes only CI matrix metadata and the matrix generator. No firmware source is modified, and the produced build matrix is byte-identical to `develop`, so every board builds exactly as it did before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI Improvements**
  * Standardized hardware classification into PR, release, and extra levels.
  * CI matrix generation now validates classifications and applies clearer default filtering.
  * Release-level hardware is now included in appropriate builds.

* **Documentation**
  * Clarified required hardware classification settings and how metadata is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->