### PR TITLE
feat(motion): add BMX160 vertical-mount UP_AXIS remap + input smoothing

### DIFF
--- a/src/motion/BMX160Sensor.cpp
+++ b/src/motion/BMX160Sensor.cpp
@@ -43,13 +43,56 @@ int32_t BMX160Sensor::runOnce()
     magAccel.x -= (highestX + lowestX) / 2;
     magAccel.y -= (highestY + lowestY) / 2;
     magAccel.z -= (highestZ + lowestZ) / 2;
+
+    // Smooth raw inputs with a per-axis EMA to suppress dynamic acceleration
+    // noise during rotation (stateless FusionCompass turns it into heading jitter).
+    FusionVector accel = {{gAccel.x, gAccel.y, gAccel.z}};
+    FusionVector mag = {{magAccel.x, magAccel.y, magAccel.z}};
+    if (!filtersSeeded) {
+        accelFiltered = accel;
+        magFiltered = mag;
+        filtersSeeded = true;
+    } else {
+        for (int i = 0; i < 3; ++i) {
+            accelFiltered.array[i] = accelFilterAlpha * accel.array[i] + (1.0f - accelFilterAlpha) * accelFiltered.array[i];
+            magFiltered.array[i] = magFilterAlpha * mag.array[i] + (1.0f - magFilterAlpha) * magFiltered.array[i];
+        }
+    }
+    accel = accelFiltered;
+    mag = magFiltered;
+
     FusionVector ga, ma;
-    ga.axis.x = -gAccel.x; // default location for the BMX160 is on the rear of the board
-    ga.axis.y = -gAccel.y;
-    ga.axis.z = gAccel.z;
-    ma.axis.x = -magAccel.x;
-    ma.axis.y = -magAccel.y;
-    ma.axis.z = magAccel.z * 3;
+    ga.axis.x = -accel.axis.x; // default location for the BMX160 is on the rear of the board
+    ga.axis.y = -accel.axis.y;
+    ga.axis.z = accel.axis.z;
+    ma.axis.x = -mag.axis.x;
+    ma.axis.y = -mag.axis.y;
+    ma.axis.z = mag.axis.z * 3;
+
+    // Compensate for non-flat case mounting. FusionCompass() assumes chip Z is
+    // world-up; on a vertical mount (LCD perpendicular to the board) chip Z is
+    // horizontal and the tilt-comp math becomes unstable. Override which chip
+    // axis is treated as world-up via the BMX160_UP_AXIS_* defines.
+#ifndef BMX160_UP_AXIS
+#define BMX160_UP_AXIS BMX160_UP_AXIS_PZ
+#endif
+#if BMX160_UP_AXIS == BMX160_UP_AXIS_PX
+    ga = FusionRemap(ga, FusionRemapAlignmentNZPYPX);
+    ma = FusionRemap(ma, FusionRemapAlignmentNZPYPX);
+#elif BMX160_UP_AXIS == BMX160_UP_AXIS_PZ
+    // Default orientation (chip +Z up), no remap needed.
+#elif BMX160_UP_AXIS == BMX160_UP_AXIS_NX
+    ga = FusionRemap(ga, FusionRemapAlignmentPZPYNX);
+    ma = FusionRemap(ma, FusionRemapAlignmentPZPYNX);
+#elif BMX160_UP_AXIS == BMX160_UP_AXIS_PY
+    ga = FusionRemap(ga, FusionRemapAlignmentPXNZPY);
+    ma = FusionRemap(ma, FusionRemapAlignmentPXNZPY);
+#elif BMX160_UP_AXIS == BMX160_UP_AXIS_NY
+    ga = FusionRemap(ga, FusionRemapAlignmentPXPZNY);
+    ma = FusionRemap(ma, FusionRemapAlignmentPXPZNY);
+#else
+#error "BMX160_UP_AXIS must be one of BMX160_UP_AXIS_PZ/PX/NX/PY/NY"
+#endif
 
     // If we're set to one of the inverted positions
     if (config.display.compass_orientation > meshtastic_Config_DisplayConfig_CompassOrientation_DEGREES_270) {

--- a/src/motion/BMX160Sensor.h
+++ b/src/motion/BMX160Sensor.h
@@ -12,6 +12,14 @@
 #include "Fusion/Fusion.h"
 #include <Rak_BMX160.h>
 
+// Numeric IDs for selecting which chip axis maps to world-up (vertical case mounts).
+// Set BMX160_UP_AXIS to one of these via build flags (platformio.ini).
+#define BMX160_UP_AXIS_PZ 0
+#define BMX160_UP_AXIS_PX 1
+#define BMX160_UP_AXIS_NX 2
+#define BMX160_UP_AXIS_PY 3
+#define BMX160_UP_AXIS_NY 4
+
 class BMX160Sensor : public MotionSensor
 {
   private:
@@ -19,6 +27,14 @@ class BMX160Sensor : public MotionSensor
     bool showingScreen = false;
     static constexpr const char *compassCalibrationFileName = "/prefs/compass_bmx160.dat";
     float highestX = 0, lowestX = 0, highestY = 0, lowestY = 0, highestZ = 0, lowestZ = 0;
+
+    // Per-axis EMA on raw accel + mag: the stateless compass fusion turns dynamic
+    // acceleration into heading noise, so filtering the inputs steadies rotation.
+    static constexpr float accelFilterAlpha = 0.15f;
+    static constexpr float magFilterAlpha = 0.20f;
+    FusionVector accelFiltered = {{0, 0, 0}};
+    FusionVector magFiltered = {{0, 0, 0}};
+    bool filtersSeeded = false;
 
   public:
     explicit BMX160Sensor(ScanI2C::FoundDevice foundDevice);


### PR DESCRIPTION
## What

- Adds `BMX160_UP_AXIS` (`PZ`/`PX`/`NX`/`PY`/`NY`) to pick which chip axis is world-up.
- Adds per-axis EMA smoothing of accel/mag before fusion (0.15 / 0.20).

## Why

`FusionCompass()` assumes chip Z is world-up. On a vertical mount (display perpendicular to the board) chip Z is horizontal, tilt compensation breaks down, and the heading shakes.

`BMX160_UP_AXIS` already appeared in variant build flags but was read by no source file, so setting it did nothing. This makes it functional.

`MPU9250Sensor` already does both (#10556); this ports the same approach.

## Compatibility

Defaults to `PZ`, a no-op branch, so flat-mount behavior is unchanged. The only new behavior for existing users is the smoothing. Calibration still uses raw magnetometer values.

## Testing

RAK4631 + RAK12034 (BMX160) in a vertical case with `BMX160_UP_AXIS_PX`:

- Stationary heading is steady (was jittering constantly).
- Tilting 20-30 degrees without yaw no longer swings the heading.
- 90/180/270 degree rotations track and return correctly.

Builds clean on `rak4631`, `heltec-v3`, `rak11200`, `pico`, on both the `PZ` and `PX` paths.

Only RAK4631 + BMX160 was tested on hardware. The change sits behind `__has_include(<Rak_BMX160.h>)`, so boards without the RAK12034 library are unaffected. Testing on other BMX160 setups welcome.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [x] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)

Only RAK WisBlock 4631 was bench-tested; the others were compile-checked where listed.
