### PR TITLE
Remove Ubuntu 'questing' series from PPA and release channel workflows

### DIFF
--- a/.github/workflows/daily_packaging.yml
+++ b/.github/workflows/daily_packaging.yml
@@ -35,8 +35,8 @@ jobs:
         series:
           - jammy # 22.04 LTS
           - noble # 24.04 LTS
-          - questing # 25.10
           - resolute # 26.04 LTS
+          - stonking # 26.10
     uses: ./.github/workflows/package_ppa.yml
     with:
       ppa_repo: ppa:meshtastic/daily

--- a/.github/workflows/release_channels.yml
+++ b/.github/workflows/release_channels.yml
@@ -23,8 +23,8 @@ jobs:
         series:
           - jammy # 22.04 LTS
           - noble # 24.04 LTS
-          - questing # 25.10
           - resolute # 26.04 LTS
+          - stonking # 26.10
     uses: ./.github/workflows/package_ppa.yml
     with:
       ppa_repo: |-


### PR DESCRIPTION
`questing` went EOL July 9th and no longer builds on PPA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release packaging configuration to target jammy, noble, resolute, and stonking.
  * Replaced questing with stonking in daily and release-channel packaging workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->