### PR TITLE
Remove board_check (now using normal matrix)

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -52,12 +52,6 @@ permissions: read-all
 
 jobs:
   setup:
-    strategy:
-      fail-fast: true
-      matrix:
-        arch:
-          - all
-          - check
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
@@ -72,16 +66,15 @@ jobs:
           # PRs and (for now) merge_group builds use the narrowed --level pr board
           # subset. Full-matrix builds run on push / schedule / workflow_dispatch.
           if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
-            TARGETS=$(./bin/generate_ci_matrix.py ${{matrix.arch}} --level pr)
+            TARGETS=$(./bin/generate_ci_matrix.py all --level pr)
           else
-            TARGETS=$(./bin/generate_ci_matrix.py ${{matrix.arch}})
+            TARGETS=$(./bin/generate_ci_matrix.py all)
           fi
           echo "Name: $GITHUB_REF_NAME Base: $GITHUB_BASE_REF Ref: $GITHUB_REF"
-          echo "${{matrix.arch}}=$TARGETS" >> $GITHUB_OUTPUT
+          echo "all=$TARGETS" >> $GITHUB_OUTPUT
           echo "$TARGETS" >> $GITHUB_STEP_SUMMARY
     outputs:
       all: ${{ steps.jsonStep.outputs.all }}
-      check: ${{ steps.jsonStep.outputs.check }}
 
   version:
     runs-on: ubuntu-latest
@@ -103,7 +96,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        check: ${{ fromJson(needs.setup.outputs.check) }}
+        check: ${{ fromJson(needs.setup.outputs.all) }}
     # Runs on GitHub-hosted runners so checks don't compete with builds for the
     # self-hosted 'arctastic' pool (which builds use).
     runs-on: ubuntu-latest

--- a/bin/generate_ci_matrix.py
+++ b/bin/generate_ci_matrix.py
@@ -60,31 +60,21 @@ for pio_env in pio_envs:
   env = {
     "ci": {"board": pio_env, "platform": env_platform},
     "board_level": board_level,
-    "board_check": cfg.get(f"env:{pio_env}", "board_check", default="false").strip().lower() == "true",
   }
   all_envs.append(env)
 
-# Filter outputs based on options
-# Check is mutually exclusive with other options (except 'pr')
-if "check" in args.platform:
-  for env in all_envs:
-    if env["board_check"]:
-      # '--level pr' narrows to the PR subset; otherwise check every level
-      if "pr" not in args.level or env["board_level"] == "pr":
-        outlist.append(env["ci"])
-# Filter (non-check) builds by platform
-else:
-  for env in all_envs:
-    if args.platform == env["ci"]["platform"] or args.platform == "all":
-      # Always include board_level = 'pr'
-      if env["board_level"] == "pr":
-        outlist.append(env["ci"])
-      # Include board_level = 'extra' when requested
-      elif "extra" in args.level and env["board_level"] == "extra":
-        outlist.append(env["ci"])
-      # Include board_level = 'release' unless narrowed to the PR subset
-      elif "pr" not in args.level and env["board_level"] == "release":
-        outlist.append(env["ci"])
+# Filter builds by platform
+for env in all_envs:
+  if args.platform == env["ci"]["platform"] or args.platform == "all":
+    # Always include board_level = 'pr'
+    if env["board_level"] == "pr":
+      outlist.append(env["ci"])
+    # Include board_level = 'extra' when requested
+    elif "extra" in args.level and env["board_level"] == "extra":
+      outlist.append(env["ci"])
+    # Include board_level = 'release' unless narrowed to the PR subset
+    elif "pr" not in args.level and env["board_level"] == "release":
+      outlist.append(env["ci"])
 
 # Return as a JSON list
 print(json.dumps(outlist))

--- a/variants/esp32/diy/v1/platformio.ini
+++ b/variants/esp32/diy/v1/platformio.ini
@@ -12,7 +12,6 @@ custom_meshtastic_tags = DIY
 extends = esp32_base
 board_level = release
 board = esp32doit-devkit-v1
-board_check = true
 build_flags =
   ${esp32_base.build_flags}
   -D DIY_V1

--- a/variants/esp32/m5stack_coreink/platformio.ini
+++ b/variants/esp32/m5stack_coreink/platformio.ini
@@ -2,7 +2,6 @@
 extends = esp32_base
 board_level = release
 board = m5stack-coreink
-board_check = true
 build_src_filter = 
   ${esp32_base.build_src_filter}
 build_flags = 

--- a/variants/esp32/rak11200/platformio.ini
+++ b/variants/esp32/rak11200/platformio.ini
@@ -11,7 +11,6 @@ custom_meshtastic_tags = RAK
 extends = esp32_base
 board_level = release
 board = wiscore_rak11200
-board_check = true
 build_flags = 
   ${esp32_base.build_flags}
   -D RAK_11200

--- a/variants/esp32/tbeam/platformio.ini
+++ b/variants/esp32/tbeam/platformio.ini
@@ -13,7 +13,6 @@ extends = esp32_base
 board_level = release
 board = ttgo-tbeam
 
-board_check = true
 build_flags = ${esp32_base.build_flags}
   -D TBEAM_V10
   -I variants/esp32/tbeam

--- a/variants/esp32/tlora_v2_1_16/platformio.ini
+++ b/variants/esp32/tlora_v2_1_16/platformio.ini
@@ -11,7 +11,6 @@ custom_meshtastic_tags = LilyGo
 extends = esp32_base
 board_level = release
 board = ttgo-lora32-v21
-board_check = true
 build_flags = 
   ${esp32_base.build_flags} -D TLORA_V2_1_16 -I variants/esp32/tlora_v2_1_16
 upload_speed = 115200

--- a/variants/esp32s2/nugget_s2_lora/platformio.ini
+++ b/variants/esp32s2/nugget_s2_lora/platformio.ini
@@ -2,7 +2,6 @@
 extends = esp32s2_base
 board = lolin_s2_mini
 board_level = extra
-board_check = true
 build_flags = 
   ${esp32s2_base.build_flags}
   -D PRIVATE_HW

--- a/variants/esp32s3/elecrow_panel/platformio.ini
+++ b/variants/esp32s3/elecrow_panel/platformio.ini
@@ -1,7 +1,6 @@
 [crowpanel_base]
 extends = esp32s3_base
 board = crowpanel
-board_check = true
 upload_protocol = esptool
 board_build.partitions = default_16MB.csv ; must be here for some reason, board.json is not enough !?
 build_flags = ${esp32s3_base.build_flags} -Os

--- a/variants/esp32s3/hackaday-communicator/platformio.ini
+++ b/variants/esp32s3/hackaday-communicator/platformio.ini
@@ -3,7 +3,6 @@
 extends = esp32s3_base
 board_level = release
 board = hackaday-communicator
-board_check = true
 board_build.partitions = default_16MB.csv
 upload_protocol = esptool
 

--- a/variants/esp32s3/heltec_capsule_sensor_v3/platformio.ini
+++ b/variants/esp32s3/heltec_capsule_sensor_v3/platformio.ini
@@ -2,7 +2,6 @@
 extends = esp32s3_base
 board_level = release
 board = heltec_wifi_lora_32_V3
-board_check = true
 board_build.partitions = default_8MB.csv
 build_flags = 
   ${esp32s3_base.build_flags} -I variants/esp32s3/heltec_capsule_sensor_v3

--- a/variants/esp32s3/heltec_sensor_hub/platformio.ini
+++ b/variants/esp32s3/heltec_sensor_hub/platformio.ini
@@ -2,7 +2,6 @@
 extends = esp32s3_base
 board_level = release
 board = heltec_wifi_lora_32_V3
-board_check = true
 
 build_flags = 
   ${esp32s3_base.build_flags}

--- a/variants/esp32s3/heltec_v3/platformio.ini
+++ b/variants/esp32s3/heltec_v3/platformio.ini
@@ -12,7 +12,6 @@ custom_meshtastic_partition_scheme = 8MB
 extends = esp32s3_base
 board = heltec_wifi_lora_32_V3
 board_level = pr
-board_check = true
 board_build.partitions = default_8MB.csv
 build_flags = 
   ${esp32s3_base.build_flags}

--- a/variants/esp32s3/heltec_v4/platformio.ini
+++ b/variants/esp32s3/heltec_v4/platformio.ini
@@ -1,7 +1,6 @@
 [heltec_v4_base] 
 extends = esp32s3_base
 board = heltec_v4
-board_check = true
 board_build.partitions = default_16MB.csv
 build_flags = 
   ${esp32s3_base.build_flags}

--- a/variants/esp32s3/heltec_v4_r8/platformio.ini
+++ b/variants/esp32s3/heltec_v4_r8/platformio.ini
@@ -1,7 +1,6 @@
 [heltec_v4_r8_base] 
 extends = esp32s3_base
 board = heltec_v4_r8
-board_check = true
 board_build.partitions = default_16MB.csv
 build_flags = 
   ${esp32s3_base.build_flags}

--- a/variants/esp32s3/icarus/platformio.ini
+++ b/variants/esp32s3/icarus/platformio.ini
@@ -2,7 +2,6 @@
 extends = esp32s3_base
 board = icarus
 board_level = extra
-board_check = true
 board_build.mcu = esp32s3
 board_build.partitions = default_8MB.csv
 upload_protocol = esptool

--- a/variants/esp32s3/m5stack_cardputer_adv/platformio.ini
+++ b/variants/esp32s3/m5stack_cardputer_adv/platformio.ini
@@ -3,7 +3,6 @@
 extends = esp32s3_base
 board_level = release
 board = m5stack-stamps3
-board_check = true
 board_build.partitions = default_8MB.csv
 upload_protocol = esptool
 build_flags = 

--- a/variants/esp32s3/m5stack_cores3/platformio.ini
+++ b/variants/esp32s3/m5stack_cores3/platformio.ini
@@ -3,7 +3,6 @@
 extends = esp32s3_base
 board_level = release
 board = m5stack-cores3
-board_check = true
 board_build.partitions = default_16MB.csv
 upload_protocol = esptool
 build_flags = 

--- a/variants/esp32s3/mini-epaper-s3/platformio.ini
+++ b/variants/esp32s3/mini-epaper-s3/platformio.ini
@@ -13,7 +13,6 @@ custom_meshtastic_has_mui = false
 extends = esp32s3_base
 board_level = release
 board = mini-epaper-s3
-board_check = true
 upload_protocol = esptool
 
 build_flags = 
@@ -40,7 +39,6 @@ lib_deps =
 extends = esp32s3_base, inkhud
 board_level = release
 board = mini-epaper-s3
-board_check = true
 upload_protocol = esptool
 build_src_filter =
   ${esp32s3_base.build_src_filter}

--- a/variants/esp32s3/picomputer-s3/platformio.ini
+++ b/variants/esp32s3/picomputer-s3/platformio.ini
@@ -11,7 +11,6 @@ custom_meshtastic_has_mui = true
 extends = esp32s3_base
 board_level = release
 board = bpi_picow_esp32_s3
-board_check = true
 board_build.partitions = partition-table-8MB.csv
 ;OpenOCD flash method
 ;upload_protocol = esp-builtin

--- a/variants/esp32s3/rak3312/platformio.ini
+++ b/variants/esp32s3/rak3312/platformio.ini
@@ -14,7 +14,6 @@ custom_meshtastic_has_mui = false
 extends = esp32s3_base
 board_level = release
 board = wiscore_rak3312
-board_check = true
 upload_protocol = esptool
 
 build_flags = 

--- a/variants/esp32s3/rak_wismesh_tap_v2/platformio.ini
+++ b/variants/esp32s3/rak_wismesh_tap_v2/platformio.ini
@@ -25,7 +25,6 @@ custom_meshtastic_has_mui = true
 extends = esp32s3_base
 board_level = release
 board = wiscore_rak3312
-board_check = true
 upload_protocol = esptool
 board_build.partitions = default_16MB.csv
 

--- a/variants/esp32s3/seeed-sensecap-indicator/platformio.ini
+++ b/variants/esp32s3/seeed-sensecap-indicator/platformio.ini
@@ -18,7 +18,6 @@ platform_packages =
 
 board = seeed-sensecap-indicator
 board_level = release
-board_check = true
 board_build.partitions = partition-table-8MB.csv
 upload_protocol = esptool
 
@@ -45,7 +44,6 @@ lib_deps = ${esp32s3_base.lib_deps}
 [env:seeed-sensecap-indicator-tft]
 extends = env:seeed-sensecap-indicator
 board_level = pr
-board_check = true
 upload_speed = 921600
 
 build_flags =

--- a/variants/esp32s3/seeed_xiao_s3/platformio.ini
+++ b/variants/esp32s3/seeed_xiao_s3/platformio.ini
@@ -13,7 +13,6 @@ custom_meshtastic_partition_scheme = 8MB
 extends = esp32s3_base
 board_level = release
 board = seeed-xiao-s3
-board_check = true
 board_build.partitions = default_8MB.csv
 upload_protocol = esptool
 upload_speed = 921600

--- a/variants/esp32s3/station-g2/platformio.ini
+++ b/variants/esp32s3/station-g2/platformio.ini
@@ -13,7 +13,6 @@ custom_meshtastic_partition_scheme = 16MB
 extends = esp32s3_base
 board_level = release
 board = station-g2
-board_check = true
 board_build.partitions = default_16MB.csv
 board_build.mcu = esp32s3
 upload_protocol = esptool

--- a/variants/esp32s3/station-g3/platformio.ini
+++ b/variants/esp32s3/station-g3/platformio.ini
@@ -13,7 +13,6 @@ custom_meshtastic_partition_scheme = 16MB
 extends = esp32s3_base
 board_level = release
 board = station-g3
-board_check = true
 board_build.partitions = default_16MB.csv
 board_build.mcu = esp32s3
 upload_protocol = esptool

--- a/variants/esp32s3/t-beam-1w/platformio.ini
+++ b/variants/esp32s3/t-beam-1w/platformio.ini
@@ -14,7 +14,6 @@ extends = esp32s3_base
 board_level = release
 board = t-beam-1w
 board_build.partitions = default_8MB.csv
-board_check = true
 
 lib_deps =
   ${esp32s3_base.lib_deps}

--- a/variants/esp32s3/t-beam-bpf/platformio.ini
+++ b/variants/esp32s3/t-beam-bpf/platformio.ini
@@ -13,7 +13,6 @@ extends = esp32s3_base
 board_level = release
 board = t-beam-bpf
 board_build.partitions = default_16MB.csv
-board_check = true
 
 lib_deps =
   ${esp32s3_base.lib_deps}

--- a/variants/esp32s3/t-deck-pro-v1_1/platformio.ini
+++ b/variants/esp32s3/t-deck-pro-v1_1/platformio.ini
@@ -13,7 +13,6 @@ custom_meshtastic_partition_scheme = 16MB
 extends = esp32s3_base
 board_level = release
 board = t-deck-pro
-board_check = true
 upload_protocol = esptool
 
 build_flags = 

--- a/variants/esp32s3/t-deck-pro/platformio.ini
+++ b/variants/esp32s3/t-deck-pro/platformio.ini
@@ -14,7 +14,6 @@ custom_meshtastic_has_mui = false
 extends = esp32s3_base
 board_level = release
 board = t-deck-pro
-board_check = true
 upload_protocol = esptool
 
 build_src_filter =

--- a/variants/esp32s3/t-deck/platformio.ini
+++ b/variants/esp32s3/t-deck/platformio.ini
@@ -15,7 +15,6 @@ custom_meshtastic_has_mui = true
 extends = esp32s3_base
 board_level = release
 board = t-deck
-board_check = true
 board_build.partitions = default_16MB.csv
 upload_protocol = esptool
 

--- a/variants/esp32s3/t-eth-elite/platformio.ini
+++ b/variants/esp32s3/t-eth-elite/platformio.ini
@@ -2,7 +2,6 @@
 extends = esp32s3_base
 board_level = release
 board = esp32s3box
-board_check = true
 board_build.partitions = default_16MB.csv
 build_flags = 
   ${esp32s3_base.build_flags}

--- a/variants/esp32s3/t-watch-s3/platformio.ini
+++ b/variants/esp32s3/t-watch-s3/platformio.ini
@@ -13,7 +13,6 @@ custom_meshtastic_partition_scheme = 8MB
 extends = esp32s3_base
 board_level = release
 board = t-watch-s3
-board_check = true
 board_build.partitions = default_16MB.csv
 upload_protocol = esptool
 

--- a/variants/esp32s3/t5s3_epaper/platformio.ini
+++ b/variants/esp32s3/t5s3_epaper/platformio.ini
@@ -2,7 +2,6 @@
 extends = esp32s3_base
 board = t5-epaper-s3
 board_build.partitions = default_16MB.csv
-board_check = true
 upload_protocol = esptool
 build_flags = -fno-strict-aliasing
   ${esp32s3_base.build_flags} 
@@ -39,7 +38,6 @@ custom_sdkconfig =
 [env:t5s3_epaper_inkhud]
 extends = t5s3_epaper_base, inkhud
 board_level = extra
-board_check = true
 build_flags =
   ${t5s3_epaper_base.build_flags}
   ${inkhud.build_flags}

--- a/variants/esp32s3/tbeam-s3-core/platformio.ini
+++ b/variants/esp32s3/tbeam-s3-core/platformio.ini
@@ -15,7 +15,6 @@ extends = esp32s3_base
 board_level = release
 board = tbeam-s3-core
 board_build.partitions = default_8MB.csv
-board_check = true
 
 lib_deps =
   ${esp32s3_base.lib_deps}

--- a/variants/esp32s3/tlora-pager/platformio.ini
+++ b/variants/esp32s3/tlora-pager/platformio.ini
@@ -15,7 +15,6 @@ custom_meshtastic_has_mui = true
 extends = esp32s3_base
 board_level = release
 board = t-deck-pro ; same as T-Deck Pro
-board_check = true
 board_build.partitions = default_16MB.csv
 upload_protocol = esptool
 

--- a/variants/esp32s3/tlora_t3s3_epaper/platformio.ini
+++ b/variants/esp32s3/tlora_t3s3_epaper/platformio.ini
@@ -13,7 +13,6 @@ custom_meshtastic_has_ink_hud = true
 extends = esp32s3_base
 board_level = release
 board = tlora-t3s3-v1
-board_check = true
 board_build.partitions = partition-table-t3s3.csv
 upload_protocol = esptool
 
@@ -42,7 +41,6 @@ lib_deps =
 extends = esp32s3_base, inkhud
 board_level = release
 board = tlora-t3s3-v1
-board_check = true
 board_build.partitions = partition-table-t3s3.csv
 upload_protocol = esptool
 custom_sdkconfig =

--- a/variants/esp32s3/tlora_t3s3_v1/platformio.ini
+++ b/variants/esp32s3/tlora_t3s3_v1/platformio.ini
@@ -12,7 +12,6 @@ custom_meshtastic_requires_dfu = true
 extends = esp32s3_base
 board_level = release
 board = tlora-t3s3-v1
-board_check = true
 board_build.partitions = partition-table-t3s3.csv
 upload_protocol = esptool
 

--- a/variants/esp32s3/visualizer-hub75/platformio.ini
+++ b/variants/esp32s3/visualizer-hub75/platformio.ini
@@ -2,7 +2,6 @@
 [env:visualizer-hub75]
 extends = esp32s3_base
 board = esp32-s3-devkitc-1
-board_check = true
 board_build.partitions = default_16MB.csv
 board_level = extra
 board_upload.flash_size = 16MB          ; N16R8 -> 16MB flash

--- a/variants/nrf52840/ELECROW-ThinkNode-M1/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M1/platformio.ini
@@ -13,7 +13,6 @@ custom_meshtastic_has_ink_hud = true
 extends = nrf52840_base
 board_level = release
 board = ThinkNode-M1
-board_check = true
 debug_tool = jlink
 
 # add -DCFG_SYSVIEW if you want to use the Segger systemview tool for OS profiling.
@@ -44,7 +43,6 @@ lib_deps =
 extends = nrf52840_base, inkhud
 board_level = release
 board = ThinkNode-M1
-board_check = true
 debug_tool = jlink
 build_flags = 
   ${nrf52840_base.build_flags}

--- a/variants/nrf52840/ELECROW-ThinkNode-M3/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M3/platformio.ini
@@ -6,7 +6,6 @@ custom_meshtastic_tags = Elecrow
 extends = nrf52840_base
 board_level = release
 board = ThinkNode-M3
-board_check = true
 debug_tool = jlink
 custom_meshtastic_hw_model = 115
 custom_meshtastic_hw_model_slug = THINKNODE_M3

--- a/variants/nrf52840/ELECROW-ThinkNode-M4/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M4/platformio.ini
@@ -3,7 +3,6 @@
 extends = nrf52840_base
 board_level = release
 board = ThinkNode-M4
-board_check = true
 debug_tool = jlink
 
 build_flags = ${nrf52840_base.build_flags}

--- a/variants/nrf52840/ELECROW-ThinkNode-M6/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M6/platformio.ini
@@ -12,7 +12,6 @@ custom_meshtastic_tags = Elecrow
 extends = nrf52840_base
 board_level = release
 board = ThinkNode-M6
-board_check = true
 debug_tool = jlink
 
 build_flags = ${nrf52840_base.build_flags}

--- a/variants/nrf52840/ELECROW-ThinkNode-M8/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M8/platformio.ini
@@ -12,7 +12,6 @@ custom_meshtastic_actively_supported = true
 extends = nrf52840_base
 board_level = release
 board = ThinkNode-M8
-board_check = true
 debug_tool = jlink
 # add -DCFG_SYSVIEW if you want to use the Segger systemview tool for OS profiling.
 build_flags = 

--- a/variants/nrf52840/gat562_mesh_trial_tracker/platformio.ini
+++ b/variants/nrf52840/gat562_mesh_trial_tracker/platformio.ini
@@ -3,7 +3,6 @@
 extends = nrf52840_base
 board_level = extra
 board = gat562_mesh_trial_tracker
-board_check = true
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/gat562_mesh_trial_tracker
   ;-D GAT562_MESH_TRIAL_TRACKER

--- a/variants/nrf52840/heltec_mesh_node_t114-inkhud/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_node_t114-inkhud/platformio.ini
@@ -2,7 +2,6 @@
 board_level = extra
 extends = nrf52840_base, inkhud
 board = heltec_mesh_node_t114
-board_check = true
 build_flags = 
   ${nrf52840_base.build_flags}
   ${inkhud.build_flags}

--- a/variants/nrf52840/meshlink/platformio.ini
+++ b/variants/nrf52840/meshlink/platformio.ini
@@ -5,7 +5,6 @@
 extends = nrf52840_base
 board = meshlink
 board_level = extra
-;board_check = true
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/meshlink
   -D MESHLINK
@@ -24,7 +23,6 @@ debug_tool = jlink
 extends = nrf52840_base
 board = meshlink
 board_level = extra
-;board_check = true
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/meshlink
   -D MESHLINK

--- a/variants/nrf52840/r1-neo/platformio.ini
+++ b/variants/nrf52840/r1-neo/platformio.ini
@@ -12,7 +12,6 @@ custom_meshtastic_tags = muzi
 extends = nrf52840_base
 board_level = release
 board = r1-neo
-board_check = true
 build_flags = ${nrf52840_base.build_flags}
   -Ivariants/nrf52840/r1-neo
   -D R1_NEO

--- a/variants/nrf52840/rak2560/platformio.ini
+++ b/variants/nrf52840/rak2560/platformio.ini
@@ -12,7 +12,6 @@ custom_meshtastic_tags = RAK
 extends = nrf52840_base
 board_level = release
 board = wiscore_rak4631
-board_check = true
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/rak2560
   -D RAK_4631

--- a/variants/nrf52840/rak3401_1watt/platformio.ini
+++ b/variants/nrf52840/rak3401_1watt/platformio.ini
@@ -13,7 +13,6 @@ custom_meshtastic_requires_dfu = true
 extends = nrf52840_base
 board_level = release
 board = wiscore_rak4631
-board_check = true
 build_flags = ${nrf52840_base.build_flags} 
   -Ivariants/nrf52840/rak3401_1watt
   -D RAK_4631

--- a/variants/nrf52840/rak4631/platformio.ini
+++ b/variants/nrf52840/rak4631/platformio.ini
@@ -12,7 +12,6 @@ custom_meshtastic_tags = RAK
 extends = nrf52840_base
 board = wiscore_rak4631
 board_level = pr
-board_check = true
 build_type = release
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/rak4631

--- a/variants/nrf52840/rak4631_eth_gw/platformio.ini
+++ b/variants/nrf52840/rak4631_eth_gw/platformio.ini
@@ -3,7 +3,6 @@
 extends = nrf52840_base
 board_level = release
 board = wiscore_rak4631
-board_check = true
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/rak4631_eth_gw
   -D RAK_4631

--- a/variants/nrf52840/rak4631_nomadstar_meteor_pro/platformio.ini
+++ b/variants/nrf52840/rak4631_nomadstar_meteor_pro/platformio.ini
@@ -12,7 +12,6 @@ custom_meshtastic_tags = NomadStar
 extends = nrf52840_base
 board_level = release
 board = wiscore_rak4631
-board_check = true
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/rak4631_nomadstar_meteor_pro
   -D NOMADSTAR_METEOR_PRO

--- a/variants/nrf52840/rak_wismeshtag/platformio.ini
+++ b/variants/nrf52840/rak_wismeshtag/platformio.ini
@@ -7,7 +7,6 @@ custom_meshtastic_tags = RAK
 extends = nrf52840_base
 board_level = release
 board = wiscore_rak4631
-board_check = true
 custom_meshtastic_hw_model = 105
 custom_meshtastic_hw_model_slug = WISMESH_TAG
 custom_meshtastic_architecture = nrf52840

--- a/variants/nrf52840/t-echo-lite/platformio.ini
+++ b/variants/nrf52840/t-echo-lite/platformio.ini
@@ -12,7 +12,6 @@ custom_meshtastic_tags = LilyGo
 extends = nrf52840_base
 board_level = release
 board = t-echo
-board_check = true
 debug_tool = jlink
 
 # add -DCFG_SYSVIEW if you want to use the Segger systemview tool for OS profiling.

--- a/variants/nrf52840/t-echo-plus/platformio.ini
+++ b/variants/nrf52840/t-echo-plus/platformio.ini
@@ -13,7 +13,6 @@ custom_meshtastic_has_ink_hud = true
 extends = nrf52840_base
 board = t-echo
 board_level = pr
-board_check = true
 debug_tool = jlink
 
 build_flags = ${nrf52840_base.build_flags}

--- a/variants/nrf52840/t-echo/platformio.ini
+++ b/variants/nrf52840/t-echo/platformio.ini
@@ -13,7 +13,6 @@ custom_meshtastic_has_ink_hud = true
 extends = nrf52840_base
 board_level = release
 board = t-echo
-board_check = true
 debug_tool = jlink
 
 # add -DCFG_SYSVIEW if you want to use the Segger systemview tool for OS profiling.
@@ -40,7 +39,6 @@ lib_deps =
 extends = nrf52840_base, inkhud
 board_level = release
 board = t-echo
-board_check = true
 debug_tool = jlink
 build_flags = 
   ${nrf52840_base.build_flags}

--- a/variants/rp2040/rpipicow/platformio.ini
+++ b/variants/rp2040/rpipicow/platformio.ini
@@ -12,7 +12,6 @@ custom_meshtastic_requires_dfu = true
 extends = rp2040_base
 board = rpipicow
 board_level = pr
-board_check = true
 upload_protocol = picotool
 # add our variants files to the include and src paths
 build_flags = 

--- a/variants/rp2350/rpipico2w/platformio.ini
+++ b/variants/rp2350/rpipico2w/platformio.ini
@@ -2,7 +2,6 @@
 extends = rp2350_base
 board = rpipico2w
 board_level = pr
-board_check = true
 upload_protocol = jlink
 # debug settings for external openocd with RP2040 support (custom build)
 debug_tool = custom


### PR DESCRIPTION
Forward-ported from #11151 (WIP)

This was being misused / misunderstood (most were a no-op already).

Depends on fixes in:
- #11313
- #11314 
- #11315
- #11324
- #11325
- #11326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI Improvements**
  * Streamlined automated build validation with a unified target matrix.
  * Pull requests and merge queues now run focused checks, while other builds use the complete target set.
  * Improved platform and release-level filtering for more consistent validation.

* **Configuration**
  * Simplified build settings across supported ESP32, nRF52, RP2040, and RP2350 hardware.
  * Standardized configuration handling and reduced unnecessary board-specific validation settings.
  * Improved consistency across supported device builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->