### PR TITLE
QMA6100PSingleton constructor fix pio check warnings

### DIFF
--- a/src/motion/QMA6100PSensor.cpp
+++ b/src/motion/QMA6100PSensor.cpp
@@ -170,7 +170,13 @@ QMA6100PSingleton *QMA6100PSingleton::GetInstance()
     return pinstance;
 }
 
-QMA6100PSingleton::QMA6100PSingleton() {}
+// The QMA6100P library leaves these base class members uninitialised until begin() runs
+QMA6100PSingleton::QMA6100PSingleton()
+{
+    rawAccelData = {0, 0, 0};
+    _i2cPort = nullptr;
+    _deviceAddress = 0;
+}
 
 QMA6100PSingleton::~QMA6100PSingleton() {}
 


### PR DESCRIPTION
Fixes cppcheck issues on T1000E
```
src/motion/QMA6100PSensor.cpp:173: [medium:warning] Member variable 'QMA6100P::rawAccelData' is not initialized in the constructor. Maybe it should be initialized directly in the class QMA6100P? [uninitDerivedMemberVar]
src/motion/QMA6100PSensor.cpp:173: [medium:warning] Member variable 'QMA6100P::_i2cPort' is not initialized in the constructor. Maybe it should be initialized directly in the class QMA6100P? [uninitDerivedMemberVar]
src/motion/QMA6100PSensor.cpp:173: [medium:warning] Member variable 'QMA6100P::_deviceAddress' is not initialized in the constructor. Maybe it should be initialized directly in the class QMA6100P? [uninitDerivedMemberVar]
```

---

This pull request improves the initialization of the `QMA6100PSingleton` class to ensure base class members are properly set up before use. The constructor now explicitly initializes `rawAccelData`, `_i2cPort`, and `_deviceAddress`, which helps prevent potential issues with uninitialized member variables.

**Initialization improvements:**

* [`src/motion/QMA6100PSensor.cpp`](diffhunk://#diff-4fa1cd0668d50b5ca52dce5c501ab050952ba97b77399f3ad434c14a7d598bc2L173-R179): Updated the `QMA6100PSingleton` constructor to initialize `rawAccelData`, `_i2cPort`, and `_deviceAddress` to safe default values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sensor initialization reliability by explicitly setting internal acceleration, communication, and device address state when the sensor starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->