### PR TITLE
Address STM32 cppcheck warnings

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -61,6 +61,9 @@
 #define LL_ADC_RESOLUTION LL_ADC_DS_DATA_WIDTH_12_BIT
 #define BATTERY_SENSE_RESOLUTION_BITS 12
 #else
+// The ST HAL headers that define these are outside cppcheck's include path (check_skip_packages), so static
+// analysis always lands here even though real builds resolve one of the branches above.
+// cppcheck-suppress preprocessorErrorDirective
 #error "ADC resolution could not be defined!"
 #endif
 #define ADC_RANGE (1 << BATTERY_SENSE_RESOLUTION_BITS)

--- a/src/memGet.cpp
+++ b/src/memGet.cpp
@@ -23,7 +23,10 @@ static uint32_t sbrkHeadroom()
     extern char _estack;
     extern char _Min_Stack_Size;
 
-    uint32_t max_sp = (uint32_t)(&_estack - &_Min_Stack_Size);
+    // Both are linker-script symbols rather than real objects: _estack is the top-of-RAM address and
+    // _Min_Stack_Size is a plain value. Convert each to an integer before subtracting - differencing the
+    // pointers themselves is pointer arithmetic across unrelated objects.
+    uint32_t max_sp = (uint32_t)&_estack - (uint32_t)&_Min_Stack_Size;
     uint32_t heap_end = (uint32_t)sbrk(0);
     return (max_sp > heap_end) ? (max_sp - heap_end) : 0;
 }

--- a/src/modules/GenericThreadModule.cpp
+++ b/src/modules/GenericThreadModule.cpp
@@ -17,6 +17,9 @@ int32_t GenericThreadModule::runOnce()
     if (!enabled)
         return disable();
 
+    // Sample first-run gate: the body is where custom one-shot init goes. With logging compiled out (e.g.
+    // DEBUG_MUTE) only the flag assignment is left, which cppcheck reads as a redundant condition.
+    // cppcheck-suppress duplicateConditionalAssign
     if (firstTime) {
         // do something the first time we run
         firstTime = 0;


### PR DESCRIPTION
Addresses STM32 cppcheck issues
```
src/Power.cpp:64: [high:error] #error ADC resolution could not be defined! [preprocessorErrorDirective]
src/memGet.cpp:26: [high:error] Subtracting pointers that point to different objects [comparePointers]
src/modules/GenericThreadModule.cpp:20: [low:style] The statement 'if (firstTime) firstTime=0' is logically equivalent to 'firstTime=0'. [duplicateConditionalAssign]
```

- Suppress GenericThreadModule warning when DEBUG_MUTE
- Suppress warning stemming from check_skip_packages
- Cast pointers to uint32_t before subtracting to avoid cppcheck warning

@Stary2001 @ndoo 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with static analysis tools by suppressing false-positive diagnostics.
  * Corrected STM32 memory headroom calculations for more reliable results.
  * Prevented redundant-condition warnings when logging is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->