### PR TITLE
Fix W12 battery reading: add ADC_CTRL and correct the divider ratio

### DIFF
--- a/variants/esp32s3/meshnology-w12/variant.h
+++ b/variants/esp32s3/meshnology-w12/variant.h
@@ -17,23 +17,14 @@
 #define BUTTON_PIN 0 // BOOT doubles as user button
 
 // ─── Battery ──────────────────────────────────────────────────────────────────
-// Schematic W12-MB-V0.2 sheet 1: the divider hangs off a P-MOSFET high-side switch, so it only
-// draws from the cell while a reading is in flight.
-//
-//   BAT --S[Q6 AO3401A]D-- R50 390K --IO1_ADC_IN-- R51 100K -- GND
-//          |G  R49 1K to BAT (gate pull-up: Q6 off by default)
-//          +-- R48 1K -- C[Q7 S8050 NPN]E -- GND,  base <- R52 1K <- IO2
-//
-// The NPN inverts, so ADC_CTRL is active HIGH. Left undriven, Q6 stays off and GPIO1 reads a hard
-// 0 mV through R51 - which is how this board first shipped, reporting "no battery" on every boot.
+// GPIO2 gates a P-MOSFET high-side switch on the divider (schematic W12-MB-V0.2 sheet 1); an NPN
+// inverts it, so it is active HIGH. Undriven, the switch stays off and GPIO1 reads a hard 0 mV.
 #define BATTERY_PIN 1
 #define ADC_CHANNEL ADC_CHANNEL_0 // GPIO1 = ADC1_CH0
 #define ADC_CTRL 2
 #define ADC_CTRL_ENABLED HIGH
-// 4.2V at the cell is only ~857mV after the 390K/100K divider, so the 0-1250mV range fits it far
-// more tightly than the 0-3100mV default would.
-#define ADC_ATTENUATION ADC_ATTEN_DB_2_5
-#define ADC_MULTIPLIER (490.0 / 100.0) // R50 + R51 over R51
+#define ADC_ATTENUATION ADC_ATTEN_DB_2_5 // 4.2V cell is only ~857mV after the divider
+#define ADC_MULTIPLIER (490.0 / 100.0)   // R50 390K + R51 100K, over R51
 
 // ─── LoRa radio ───────────────────────────────────────────────────────────────
 // RF switching is hardwired to the radio's CTX/CPS pins, and the external PA enables

--- a/variants/esp32s3/meshnology-w12/variant.h
+++ b/variants/esp32s3/meshnology-w12/variant.h
@@ -17,10 +17,23 @@
 #define BUTTON_PIN 0 // BOOT doubles as user button
 
 // ─── Battery ──────────────────────────────────────────────────────────────────
-// GPIO2 monitors a second (solar/VUSB) divider and is not used here
+// Schematic W12-MB-V0.2 sheet 1: the divider hangs off a P-MOSFET high-side switch, so it only
+// draws from the cell while a reading is in flight.
+//
+//   BAT --S[Q6 AO3401A]D-- R50 390K --IO1_ADC_IN-- R51 100K -- GND
+//          |G  R49 1K to BAT (gate pull-up: Q6 off by default)
+//          +-- R48 1K -- C[Q7 S8050 NPN]E -- GND,  base <- R52 1K <- IO2
+//
+// The NPN inverts, so ADC_CTRL is active HIGH. Left undriven, Q6 stays off and GPIO1 reads a hard
+// 0 mV through R51 - which is how this board first shipped, reporting "no battery" on every boot.
 #define BATTERY_PIN 1
 #define ADC_CHANNEL ADC_CHANNEL_0 // GPIO1 = ADC1_CH0
-#define ADC_MULTIPLIER 2.0
+#define ADC_CTRL 2
+#define ADC_CTRL_ENABLED HIGH
+// 4.2V at the cell is only ~857mV after the 390K/100K divider, so the 0-1250mV range fits it far
+// more tightly than the 0-3100mV default would.
+#define ADC_ATTENUATION ADC_ATTEN_DB_2_5
+#define ADC_MULTIPLIER (490.0 / 100.0) // R50 + R51 over R51
 
 // ─── LoRa radio ───────────────────────────────────────────────────────────────
 // RF switching is hardwired to the radio's CTX/CPS pins, and the external PA enables


### PR DESCRIPTION
The W12 has never reported a battery. Every boot logs `battery hardware absent (USB-only)` and sends `battery_level 101`, even with a healthy cell attached.

## Root cause

The battery config in #10910 came from the vendor's `Demo_06_ADC_Read.ino`, which reads GPIO1, multiplies by 2.0 under a literal `// Assumption: 2:1 voltage divider` comment, and never touches the ADC enable at all. All three of those details are wrong.

Schematic W12-MB-V0.2 sheet 1 puts the divider behind a P-MOSFET high-side switch, so it only draws from the cell while a reading is in flight:

```
BAT ──S[Q6 AO3401A P-MOSFET]D── R50 390K ──IO1_ADC_IN── R51 100K ── GND
       │G  R49 1K to BAT        (gate pull-up → Q6 OFF by default)
       └── R48 1K ── C[Q7 S8050 NPN]E ── GND,  base ← R52 1K ← IO2
```

GPIO2 is `ADC_CTRL` — not "a second (solar/VUSB) divider" as the variant claimed — and the NPN inverts it, so it is **active HIGH**. Left undriven, R49 holds Q6 off and GPIO1 sits at ground through R51.

| | Was | Now |
|---|---|---|
| ADC enable | absent | `ADC_CTRL 2`, `ADC_CTRL_ENABLED HIGH` |
| Divider | `2.0` (guessed by the demo) | `490.0/100.0` = 4.9 |
| Attenuation | 12 dB default (0–3100 mV) | `ADC_ATTEN_DB_2_5` (0–1250 mV) |

The 390K/100K network puts a 4.2 V cell at only ~857 mV on the pin, so the 12 dB default wasted most of its range.

This is the same divider Heltec V3/V4 use, but their `ADC_CTRL 37` cannot be reused here — GPIO33–37 are consumed by this board's octal PSRAM.

## How the pin was confirmed

Worth recording, because a wrong pin and a disabled divider look identical from the outside.

GPIO1 read a **hard 0 raw** — not the 100–250 mV of noise a floating pin gives, which GPIO2/5/6 all showed on the same sweep. That is the signature of a pin held at ground through a resistor, which is exactly what R51 does with Q6 off. A sweep of every free ADC-capable pin (the ESP32-S3 only has ADC on GPIO1–20; 8–14 are the LoRa bus, 17/18 I2C, 19/20 USB) found no other candidate carrying a battery-like voltage, and pull-up/pull-down on every plausible gate pin moved nothing.

The sweep also validated itself: GPIO3/GPIO4 sat pinned at 3100 mV, matching the sub-GHz/2.4 GHz PA enables the variant already documents as pulled high.

## Testing

Verified on real W12 hardware.

- **Before:** GPIO1 reads 0 mV with a 3.8347 V cell attached (measured at the terminals); `battery hardware absent (USB-only)`; `batteryLevel 101`.
- **After:** `Battery: usbPower=0, isCharging=0, batMv=4067, batPct=91`, identical across consecutive samples — stable to the mV despite the 80K source impedance. Cell was charging over USB at the time, which accounts for the rise from the 3.83 V at-rest measurement.

Variant-only change; no shared code touched, so no other board can be affected.

### Known limitation, pre-existing and not addressed here

This board exposes no VBUS-detect GPIO, so `isVbusIn()` falls back to `getBattVoltage() > chargingVolt` and only reports USB power once the cell is near full. Same behaviour as Heltec V3. Fixing it would need a sense pin the hardware does not bring out.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)

Tested on the Meshnology W12 itself. The change is confined to `variants/esp32s3/meshnology-w12/variant.h`, so no other board's build or behaviour is reachable from it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved battery voltage measurement accuracy for the ESP32-S3 Meshnology W12 variant.
  * Added active control for the switched resistor divider to support reliable battery readings.
  * Adjusted ADC attenuation and voltage scaling for more accurate measurements.
  * Updated battery measurement documentation to reflect the current hardware configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->