### PR TITLE
Remove errant variablereassignment in chatter2 keyboard

### DIFF
--- a/src/input/SerialKeyboard.cpp
+++ b/src/input/SerialKeyboard.cpp
@@ -103,7 +103,6 @@ int32_t SerialKeyboard::runOnce()
                 } else {
                     e.inputEvent = INPUT_BROKER_RIGHT;
                 }
-                e.kbchar = 0;
             } else if (!(shiftRegister2 & (1 << 1))) {
                 e.inputEvent = INPUT_BROKER_SELECT;
             } else if (!(shiftRegister2 & (1 << 0))) {


### PR DESCRIPTION
Fixes cppcheck issues for `chatter2` variant.
```
src/input/SerialKeyboard.cpp:106: [low:style] Variable 'e.kbchar' is reassigned a value before the old one has been used. [redundantAssignment]
```

---
🤖 

That line was more than a redundant assignment — it was a latent bug. When shift > 0, the branch sets e.inputEvent = INPUT_BROKER_ANYKEY; e.kbchar = 0x09; (TAB), and the trailing e.kbchar = 0; immediately clobbered the TAB character, so shift+RIGHT emitted an ANYKEY event with a null char. In the non-shift path the assignment was pure noise, since InputEvent e = {} already zeroes it. Removing it makes the RIGHT branch identical in shape to the LEFT branch just above, which never had that line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal keyboard navigation event handling without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->