### PR TITLE
Fix cppcheck redundantAssignment for OLED_GEOMETRY_OVERRIDE variants

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -856,9 +856,13 @@ void setup()
 
 #if HAS_SCREEN
         // fixed screen override?
+        // The geometry picks below are skipped on variants that pin the panel size with
+        // OLED_GEOMETRY_OVERRIDE (see the end of this block) - there they would only be dead stores.
 #if defined(USE_SH1107)
     screen_model = meshtastic_Config_DisplayConfig_OledType_OLED_SH1107; // set dimension of 128x128
+#ifndef OLED_GEOMETRY_OVERRIDE
     screen_geometry = GEOMETRY_128_128;
+#endif
 #elif defined(USE_SH1107_128_64)
     screen_model = meshtastic_Config_DisplayConfig_OledType_OLED_SH1107; // keep dimension of 128x64
 #else
@@ -867,7 +871,9 @@ void setup()
 
         // Fix: update geometry for SH1107 128x128 selected via menu
         if (screen_model == meshtastic_Config_DisplayConfig_OledType_OLED_SH1107_128_128) {
+#ifndef OLED_GEOMETRY_OVERRIDE
             screen_geometry = GEOMETRY_128_128;
+#endif
             screen_model = meshtastic_Config_DisplayConfig_OledType_OLED_SH1107; // normalize
         }
     }


### PR DESCRIPTION
## What

`bin/check-all.sh t-impulse-plus` fails static analysis:

```
src/main.cpp:878: [low:style] Variable 'screen_geometry' is reassigned a value before the old one has been used. [redundantAssignment]
```

The same defect hits every variant that pins its panel size with `OLED_GEOMETRY_OVERRIDE` — currently `t-impulse-plus` (`GEOMETRY_64_32`) and `t-echo-card` (`GEOMETRY_72_40`).

## Why

cppcheck pairs the override write with the `screen_geometry = GEOMETRY_128_128` write in the SH1107 normalization branch, not with the declaration. On an override board that write is a genuine dead store — the override clobbers it a few lines later, by design ("Takes precedence over the default...").

The fix skips the geometry writes when the variant pins the panel size:

- `screen_model` normalization still runs — the driver needs `OLED_SH1107` rather than `OLED_SH1107_128_128`.
- Precedence is unchanged: the override still wins on those boards.
- Nothing changes for boards without an override — same preprocessor output.
- The compile-time `USE_SH1107` write is guarded the same way, so the defect can't reappear if a future variant combines the two. (No variant does today.)

## Testing

- Reproduced the defect on `develop` for `t-impulse-plus`, then confirmed it is gone.
- `./bin/check-all.sh t-impulse-plus t-echo-card muzi-base rak4631` → **4 passed, no defects.** Covers both override variants, the compile-time `USE_SH1107` path (`muzi-base`), and a plain menu-path board (`rak4631`).
- `pio run -e t-impulse-plus` → SUCCESS.

No hardware regression testing was done. The change is a no-op on boards without `OLED_GEOMETRY_OVERRIDE`, and on boards with one it only removes stores that were already being overwritten before use — so the runtime behaviour is unchanged everywhere. Confirmation on a physical t-impulse-plus or t-echo-card is still welcome.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other: not verified on hardware — verified by static analysis and a firmware build only (see Testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OLED display configuration when a custom panel geometry override is enabled.
  * Prevented automatic geometry assignment from replacing the user-defined display geometry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->