### PR TITLE
Make GxEPD2_Multi non-copyable to address cppcheck warnings

### DIFF
--- a/src/graphics/GxEPD2Multi.h
+++ b/src/graphics/GxEPD2Multi.h
@@ -115,6 +115,10 @@ template <typename Driver0, typename Driver1> class GxEPD2_Multi
     // Select driver by passing whichDriver as 0 or 1
     GxEPD2_Multi(uint8_t whichDriver, int16_t cs, int16_t dc, int16_t rst, int16_t busy, SPIClass &spi)
     {
+        // Only the selected driver is allocated; the other stays null
+        driver0 = nullptr;
+        driver1 = nullptr;
+
         assert(whichDriver == 0 || whichDriver == 1);
         which = whichDriver;
         LOG_DEBUG("GxEPD2_Multi driver: %d", which);
@@ -127,6 +131,11 @@ template <typename Driver0, typename Driver1> class GxEPD2_Multi
             epd2.m_epd2 = &(driver1->epd2);
         }
     }
+
+    // The driver we allocate above is owned by this object, and a single display can only be driven
+    // by one of them: copying would alias that pointer. There is exactly one instance per device.
+    GxEPD2_Multi(const GxEPD2_Multi &) = delete;
+    GxEPD2_Multi &operator=(const GxEPD2_Multi &) = delete;
 
   private:
     uint8_t which;


### PR DESCRIPTION
`pio check` reports `noCopyConstructor` and `noOperatorEq` against `GxEPD2_Multi` on every e-ink environment. A single `./bin/check-all.sh heltec-wireless-paper` run emits over 80 duplicate pairs of them — one per template instantiation point, all pointing at the same line:

```
src/graphics/GxEPD2Multi.h:123: [medium:warning] Class 'GxEPD2_Multi < GxEPD2_213_FC1 ,
GxEPD2_213_E0213A367 >' does not have a copy constructor which is recommended since it
has dynamic memory/resource allocation(s). [noCopyConstructor]
```

## Why the warning is right

The constructor `new`s one of two `GxEPD2_BW` drivers into a raw pointer member and caches `&driver->epd2` in `epd2.m_epd2`. The compiler-generated copy operations would duplicate that pointer, so two objects would drive the same panel, and whichever was destroyed second would be left pointing at a freed driver.

Nothing actually copies it — `EInkDisplay2` heap-allocates a single instance and holds a pointer to it — so this is latent, not a live bug. But the class is genuinely non-copyable, so the fix is to say so rather than to add a suppression.

## Changes

- Delete the copy constructor and copy assignment operator. This is what cppcheck is asking for, and it turns any future accidental copy into a compile error instead of a double free.
- Null `driver0`/`driver1` at the top of the constructor. Only the selected one is allocated; the other was left indeterminate. Every method branches on `which` before dereferencing, so nothing reads it today — but an indeterminate owning pointer is one refactor away from a wild dereference, and it sits on the same lines the new ownership comment covers.

No suppressions added; `suppressions.txt` is untouched.

## Behaviour

Unchanged. No caller could have copied this type (the implicit copy constructor was never instantiated), and the two added stores only initialize a pointer that is never read.

## Testing

| Check | Result |
| --- | --- |
| `./bin/check-all.sh heltec-wireless-paper` | PASSED, exit 0, "No defects found" (was: 80+ warnings) |
| `pio run -e heltec-wireless-paper` | SUCCESS |
| `trunk check` (pre-commit hook) | ✔ No issues |

The build is worth calling out separately: `syntaxError` is suppressed in `suppressions.txt`, so cppcheck alone would have stayed green on a malformed declaration. Compiling is what actually proves the new declarations parse.

**Not tested on hardware.** I don't have a Wireless Paper to hand. I'd normally flag that as a gap needing a community test, but here the change adds no reachable runtime behaviour — deleted functions emit no code, and the two pointer stores initialize a value nothing reads — so there is no on-device behaviour for a hardware test to exercise. Happy to have someone confirm an e-ink board still boots and renders if a reviewer would rather not take that on faith.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other: `heltec-wireless-paper` — static analysis and compile only, no hardware. See Testing above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graphics driver initialization to prevent unintended pointer aliasing.
  * Enhanced stability when selecting and using display drivers.

* **Refactor**
  * Prevented unsafe copying of multi-driver display configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->