### PR TITLE
fix(heltec-v1): bring the board build back to life

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -89,10 +89,10 @@
 #if defined(BATTERY_PIN) && defined(ARCH_ESP32)
 
 #ifndef BAT_MEASURE_ADC_UNIT // ADC1 is default
-static const adc_channel_t adc_channel = ADC_CHANNEL;
+static const adc_channel_t adc_channel = static_cast<adc_channel_t>(ADC_CHANNEL);
 static const adc_unit_t unit = ADC_UNIT_1;
 #else  // ADC2
-static const adc_channel_t adc_channel = ADC_CHANNEL;
+static const adc_channel_t adc_channel = static_cast<adc_channel_t>(ADC_CHANNEL);
 static const adc_unit_t unit = ADC_UNIT_2;
 #endif // BAT_MEASURE_ADC_UNIT
 


### PR DESCRIPTION
# Fix building Heltec (Lora32) V1

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [x] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ESP32 analog-to-digital converter channel configuration for more reliable power measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->