### PR TITLE
Update ci-gate condition to check event types and cancellation status

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -211,9 +211,9 @@ jobs:
 
   # Single, stable status check for branch protection.
   # Always runs and passes only if every build and check that ran succeeded.
-  # Consumed in PRs and Merge Queue
   ci-gate:
-    if: always()
+    # Consumed in PRs and Merge Queue
+    if: contains(fromJSON('["pull_request", "merge_group"]'), github.event_name) && !cancelled()
     needs: [build, check]
     runs-on: ubuntu-slim
     steps:


### PR DESCRIPTION
`ci-gate` only needs to be run upon PR / MQ. Also doesn't need to run if the job is cancelled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration checks to run only for eligible pull request and merge queue events when the workflow is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->