### PR TITLE
Actions: Restrict 'check' jobs to only run for pull requests and merge queue

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -107,7 +107,8 @@ jobs:
     # Runs on GitHub-hosted runners so checks don't compete with builds for the
     # self-hosted 'arctastic' pool (which builds use).
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'meshtastic' && github.event_name != 'workflow_dispatch' && github.event_name != 'schedule' && github.event.inputs.nightly != 'true'
+    # Only run checks for PRs and Merge Queue runs.
+    if: contains(fromJSON('["pull_request", "merge_group"]'), github.event_name)
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
Only run `check` jobs upon PR and Merge Queue. By the time it makes it to `push` it's not actionable.

---

This pull request updates the workflow conditions in `.github/workflows/main_matrix.yml` to simplify and clarify when certain jobs are executed. The main change is to restrict job execution to only pull requests and merge queue runs.

Workflow configuration update:

* Changed the job condition to use `contains(fromJSON('["pull_request", "merge_group"]'), github.event_name)`, ensuring jobs only run for pull requests and merge group events, making the workflow logic simpler and more maintainable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated checks to run for pull requests and merge queue events.
  * Removed checks triggered by manual or scheduled runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->