### PR TITLE
Update earlephilhower/arduino-pico to 5.7.0

### DIFF
--- a/variants/rp2040/rp2040.ini
+++ b/variants/rp2040/rp2040.ini
@@ -2,12 +2,12 @@
 [rp2040_base]
 platform =
   # TODO renovate
-  https://github.com/maxgerhardt/platform-raspberrypi#cc24cfef37ed22ca9f2a6aead28c2deb76c39f24
-  ; For arduino-pico >= 5.4.4
+  https://github.com/maxgerhardt/platform-raspberrypi#aa70b802be8851668053d4f09734e4089fe41932
+  ; For arduino-pico >= 5.6.1
 extends = arduino_base
 platform_packages =
   # TODO renovate
-  arduino-pico@https://github.com/earlephilhower/arduino-pico/releases/download/5.4.4/rp2040-5.4.4.zip
+  arduino-pico@https://github.com/earlephilhower/arduino-pico/releases/download/5.7.0/rp2040-5.7.0.zip
 
 board_build.core = earlephilhower
 board_build.filesystem_size = 0.5m

--- a/variants/rp2350/rp2350.ini
+++ b/variants/rp2350/rp2350.ini
@@ -2,12 +2,12 @@
 [rp2350_base]
 platform =
   # TODO renovate
-  https://github.com/maxgerhardt/platform-raspberrypi#cc24cfef37ed22ca9f2a6aead28c2deb76c39f24
-  ; For arduino-pico >= 5.4.4
+  https://github.com/maxgerhardt/platform-raspberrypi#aa70b802be8851668053d4f09734e4089fe41932
+  ; For arduino-pico >= 5.6.1
 extends = arduino_base
 platform_packages =
   # TODO renovate
-  arduino-pico@https://github.com/earlephilhower/arduino-pico/releases/download/5.4.4/rp2040-5.4.4.zip
+  arduino-pico@https://github.com/earlephilhower/arduino-pico/releases/download/5.7.0/rp2040-5.7.0.zip
 
 board_build.core = earlephilhower
 board_build.filesystem_size = 0.5m


### PR DESCRIPTION
Update raspberry pi pico platform from 5.4.4 to 5.7.0.

Release Notes:
- https://github.com/earlephilhower/arduino-pico/releases/tag/5.5.0
  - Add BLE support library
- https://github.com/earlephilhower/arduino-pico/releases/tag/5.5.1
  - Add WIFI AP+STA Support
  - Bluetooth (HID Master)
- https://github.com/earlephilhower/arduino-pico/releases/tag/5.6.0
- https://github.com/earlephilhower/arduino-pico/releases/tag/5.6.1
- https://github.com/earlephilhower/arduino-pico/releases/tag/5.7.0
  - Pico SDK 2.3.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated RP2040 and RP2350 platform tooling to newer pinned versions.
  * Upgraded the Arduino-Pico package from 5.4.4 to 5.7.0.
  * Refreshed platform compatibility references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->