### PR TITLE
Fix up the BiColor boot screen

### DIFF
--- a/src/graphics/draw/UIRenderer.cpp
+++ b/src/graphics/draw/UIRenderer.cpp
@@ -1473,11 +1473,15 @@ void UIRenderer::drawIconScreen(const char *upperMsg, OLEDDisplay *display, OLED
     display->setFont(FONT_MEDIUM);
     display->setTextAlignment(TEXT_ALIGN_LEFT);
     const char *title = "meshtastic.org";
-    display->drawString(x + getStringCenteredX(title), y + SCREEN_HEIGHT - FONT_HEIGHT_MEDIUM - 6 + (additionalYOffset / 2),
-                        title);
+#if defined(BICOLOR_OLED_DISPLAY)
+    additionalYOffset /= 2;
+#else
+    additionalYOffset = 0;
+#endif
+    display->drawString(x + getStringCenteredX(title), y + SCREEN_HEIGHT - FONT_HEIGHT_MEDIUM - 5 + additionalYOffset, title);
     if (gBootSplashBoldPass) {
-        display->drawString(x + getStringCenteredX(title) + 1,
-                            y + SCREEN_HEIGHT - FONT_HEIGHT_MEDIUM - 6 + (additionalYOffset / 2), title);
+        display->drawString(x + getStringCenteredX(title) + 1, y + SCREEN_HEIGHT - FONT_HEIGHT_MEDIUM - 5 + additionalYOffset,
+                            title);
     }
     display->setFont(FONT_SMALL);
     // Draw region in upper left

--- a/src/graphics/draw/UIRenderer.cpp
+++ b/src/graphics/draw/UIRenderer.cpp
@@ -1461,15 +1461,23 @@ void UIRenderer::drawIconScreen(const char *upperMsg, OLEDDisplay *display, OLED
 
     display->setTextAlignment(TEXT_ALIGN_LEFT); // Restore left align, just to be kind to any other unsuspecting code
 #else
-    display->drawXbm(x + (SCREEN_WIDTH - icon_width) / 2, y + (SCREEN_HEIGHT - FONT_HEIGHT_MEDIUM - icon_height) / 2 + 2,
-                     icon_width, icon_height, icon_bits);
+
+    int additionalYOffset = 2;
+#if defined(BICOLOR_OLED_DISPLAY)
+    additionalYOffset += 5;
+#endif
+    display->drawXbm(x + (SCREEN_WIDTH - icon_width) / 2,
+                     y + (SCREEN_HEIGHT - FONT_HEIGHT_MEDIUM - icon_height) / 2 + additionalYOffset, icon_width, icon_height,
+                     icon_bits);
 
     display->setFont(FONT_MEDIUM);
     display->setTextAlignment(TEXT_ALIGN_LEFT);
     const char *title = "meshtastic.org";
-    display->drawString(x + getStringCenteredX(title), y + SCREEN_HEIGHT - FONT_HEIGHT_MEDIUM - 5, title);
+    display->drawString(x + getStringCenteredX(title), y + SCREEN_HEIGHT - FONT_HEIGHT_MEDIUM - 6 + (additionalYOffset / 2),
+                        title);
     if (gBootSplashBoldPass) {
-        display->drawString(x + getStringCenteredX(title) + 1, y + SCREEN_HEIGHT - FONT_HEIGHT_MEDIUM - 5, title);
+        display->drawString(x + getStringCenteredX(title) + 1,
+                            y + SCREEN_HEIGHT - FONT_HEIGHT_MEDIUM - 6 + (additionalYOffset / 2), title);
     }
     display->setFont(FONT_SMALL);
     // Draw region in upper left


### PR DESCRIPTION
Fits the logo below the divide of the two OLED colors for better boot appearance. Calculates out the same math for any other screens.

![image](https://github.com/user-attachments/assets/a51eaab5-22b8-48c2-b87c-8ed8896c933b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved icon and title positioning across non-OLED and bicolor OLED displays.
  * Refined vertical spacing to improve layout alignment, including bold titles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->