### PR TITLE
8mb partition table for ThinkNode-M7

### DIFF
--- a/variants/esp32s3/ELECROW-ThinkNode-M7/platformio.ini
+++ b/variants/esp32s3/ELECROW-ThinkNode-M7/platformio.ini
@@ -1,6 +1,7 @@
 [env:thinknode_m7]
 extends = esp32s3_base
 board = ThinkNode-M7
+board_build.partitions = partition-table-8MB.csv
 board_level = pr
 
 build_flags =


### PR DESCRIPTION
This will break OTA and result in FS wipes. Wouldn't hurt to recommend complete wipes for the install, too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the ThinkNode-M7 environment to use the correct 8 MB partition layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->