### PR TITLE
Serial config validation

### DIFF
--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -63,10 +63,10 @@
 #if !defined(ARCH_STM32WL) && !MESHTASTIC_EXCLUDE_I2C && !MESHTASTIC_EXCLUDE_ACCELEROMETER
 #include "motion/AccelerometerThread.h"
 #endif
-#if (defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040)) && !defined(CONFIG_IDF_TARGET_ESP32S2) &&               \
-    !defined(CONFIG_IDF_TARGET_ESP32C3)
+// Unguarded: serialConfigIsValid() is declared here and the serial config is validated on every
+// platform, including the ones with no SerialModule behind it. The class itself stays guarded
+// inside the header.
 #include "SerialModule.h"
-#endif
 
 AdminModule *adminModule;
 
@@ -1271,14 +1271,16 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
         break;
     case meshtastic_ModuleConfig_serial_tag:
         LOG_INFO("Set module config: Serial");
-#if (defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040)) && !defined(CONFIG_IDF_TARGET_ESP32S2) &&               \
-    !defined(CONFIG_IDF_TARGET_ESP32C3)
-        if (!SerialModule::isValidConfig(c.payload_variant.serial)) {
+        // No architecture guard here. The guard this replaces was availability, not policy: it
+        // existed because SerialModule::isValidConfig lived inside the class's hardware guard, and
+        // it silently took disableBluetooth() with it. The assignment below was never inside it, so
+        // platforms without a SerialModule stored configs this rejects. disableBluetooth() guards
+        // itself on HAS_BLUETOOTH and compiles to an empty function where there is no radio.
+        if (!serialConfigIsValid(c.payload_variant.serial)) {
             LOG_ERROR("Invalid serial config");
             return false;
         }
         disableBluetooth(); // Disable Bluetooth to prevent interference during Serial configuration
-#endif
         moduleConfig.has_serial = true;
         moduleConfig.serial = c.payload_variant.serial;
         break;

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -63,9 +63,7 @@
 #if !defined(ARCH_STM32WL) && !MESHTASTIC_EXCLUDE_I2C && !MESHTASTIC_EXCLUDE_ACCELEROMETER
 #include "motion/AccelerometerThread.h"
 #endif
-// Unguarded: serialConfigIsValid() is declared here and the serial config is validated on every
-// platform, including the ones with no SerialModule behind it. The class itself stays guarded
-// inside the header.
+// Unguarded: serialConfigIsValid() is needed on every platform. The class stays guarded in the header.
 #include "SerialModule.h"
 
 AdminModule *adminModule;
@@ -1271,11 +1269,8 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
         break;
     case meshtastic_ModuleConfig_serial_tag:
         LOG_INFO("Set module config: Serial");
-        // No architecture guard here. The guard this replaces was availability, not policy: it
-        // existed because SerialModule::isValidConfig lived inside the class's hardware guard, and
-        // it silently took disableBluetooth() with it. The assignment below was never inside it, so
-        // platforms without a SerialModule stored configs this rejects. disableBluetooth() guards
-        // itself on HAS_BLUETOOTH and compiles to an empty function where there is no radio.
+        // No architecture guard: the check and the store below must agree on every platform.
+        // disableBluetooth() self-guards on HAS_BLUETOOTH, so it is empty where there is no radio.
         if (!serialConfigIsValid(c.payload_variant.serial)) {
             LOG_ERROR("Invalid serial config");
             return false;

--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -49,6 +49,32 @@
 #include "meshSolarApp.h"
 #endif
 
+// Outside the architecture guard on purpose: this is config validation, not serial I/O. The admin
+// path validates a serial config before storing it on every platform, including the ones that have
+// no SerialModule to run it - see serialConfigIsValid() in SerialModule.h.
+bool serialConfigIsValid(const meshtastic_ModuleConfig_SerialConfig &config)
+{
+    if (config.override_console_serial_port && !IS_ONE_OF(config.mode, meshtastic_ModuleConfig_SerialConfig_Serial_Mode_NMEA,
+                                                          meshtastic_ModuleConfig_SerialConfig_Serial_Mode_CALTOPO,
+                                                          meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MS_CONFIG)) {
+        const char *warning =
+            "Invalid Serial config: override console serial port is only supported in NMEA and CalTopo output-only modes.";
+        LOG_ERROR(warning);
+#ifndef PIO_UNIT_TESTING
+        meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
+        if (cn) {
+            cn->level = meshtastic_LogRecord_Level_ERROR;
+            cn->time = getValidTime(RTCQualityFromNet);
+            snprintf(cn->message, sizeof(cn->message), "%s", warning);
+            service->sendClientNotification(cn);
+        }
+#endif
+        return false;
+    }
+
+    return true;
+}
+
 #if (defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040) || defined(ARCH_STM32WL)) &&                             \
     !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
 
@@ -85,29 +111,6 @@ static Print *serialPrint = &SERIAL_PRINT_OBJECT;
 
 char serialBytes[512];
 size_t serialPayloadSize;
-
-bool SerialModule::isValidConfig(const meshtastic_ModuleConfig_SerialConfig &config)
-{
-    if (config.override_console_serial_port && !IS_ONE_OF(config.mode, meshtastic_ModuleConfig_SerialConfig_Serial_Mode_NMEA,
-                                                          meshtastic_ModuleConfig_SerialConfig_Serial_Mode_CALTOPO,
-                                                          meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MS_CONFIG)) {
-        const char *warning =
-            "Invalid Serial config: override console serial port is only supported in NMEA and CalTopo output-only modes.";
-        LOG_ERROR(warning);
-#ifndef PIO_UNIT_TESTING
-        meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
-        if (cn) {
-            cn->level = meshtastic_LogRecord_Level_ERROR;
-            cn->time = getValidTime(RTCQualityFromNet);
-            snprintf(cn->message, sizeof(cn->message), "%s", warning);
-            service->sendClientNotification(cn);
-        }
-#endif
-        return false;
-    }
-
-    return true;
-}
 
 SerialModuleRadio::SerialModuleRadio() : SinglePortModule("SerialModuleRadio", meshtastic_PortNum_SERIAL_APP)
 {

--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -49,9 +49,7 @@
 #include "meshSolarApp.h"
 #endif
 
-// Outside the architecture guard on purpose: this is config validation, not serial I/O. The admin
-// path validates a serial config before storing it on every platform, including the ones that have
-// no SerialModule to run it - see serialConfigIsValid() in SerialModule.h.
+// Outside the architecture guard on purpose: config validation, not serial I/O. See SerialModule.h.
 bool serialConfigIsValid(const meshtastic_ModuleConfig_SerialConfig &config)
 {
     if (config.override_console_serial_port && !IS_ONE_OF(config.mode, meshtastic_ModuleConfig_SerialConfig_Serial_Mode_NMEA,

--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -58,7 +58,7 @@ bool serialConfigIsValid(const meshtastic_ModuleConfig_SerialConfig &config)
                                                           meshtastic_ModuleConfig_SerialConfig_Serial_Mode_CALTOPO,
                                                           meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MS_CONFIG)) {
         const char *warning =
-            "Invalid Serial config: override console serial port is only supported in NMEA and CalTopo output-only modes.";
+            "Invalid Serial config: override console serial port is only supported in NMEA, CalTopo, or MS Config output-only modes.";
         LOG_ERROR(warning);
 #ifndef PIO_UNIT_TESTING
         meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();

--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -55,8 +55,8 @@ bool serialConfigIsValid(const meshtastic_ModuleConfig_SerialConfig &config)
     if (config.override_console_serial_port && !IS_ONE_OF(config.mode, meshtastic_ModuleConfig_SerialConfig_Serial_Mode_NMEA,
                                                           meshtastic_ModuleConfig_SerialConfig_Serial_Mode_CALTOPO,
                                                           meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MS_CONFIG)) {
-        const char *warning =
-            "Invalid Serial config: override console serial port is only supported in NMEA, CalTopo, or MS Config output-only modes.";
+        const char *warning = "Invalid Serial config: override console serial port is only supported in NMEA, CalTopo, or MS "
+                              "Config output-only modes.";
         LOG_ERROR(warning);
 #ifndef PIO_UNIT_TESTING
         meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();

--- a/src/modules/SerialModule.h
+++ b/src/modules/SerialModule.h
@@ -8,6 +8,14 @@
 #include <Arduino.h>
 #include <functional>
 
+/**
+ * Is this serial config one we will accept? Declared outside the architecture guard below because
+ * validation is pure config logic with no serial hardware behind it, and AdminModule has to run it
+ * on every platform - including the ones where SerialModule itself does not exist. Guarding it with
+ * the class meant meshtasticd stored configs it should have rejected.
+ */
+bool serialConfigIsValid(const meshtastic_ModuleConfig_SerialConfig &config);
+
 #if (defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040) || defined(ARCH_STM32WL)) &&                             \
     !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
 
@@ -19,8 +27,6 @@ class SerialModule : public StreamAPI, private concurrency::OSThread
 
   public:
     SerialModule();
-
-    static bool isValidConfig(const meshtastic_ModuleConfig_SerialConfig &config);
 
   protected:
     virtual int32_t runOnce() override;

--- a/src/modules/SerialModule.h
+++ b/src/modules/SerialModule.h
@@ -8,9 +8,9 @@
 #include <Arduino.h>
 #include <functional>
 
-// Is this serial config one we will accept? Outside the architecture guard below because validation
-// is pure config logic with no serial hardware behind it, and AdminModule must run it on every
-// platform - including those where SerialModule itself does not exist.
+// Is this serial config one we will accept? Outside the architecture guard below because it touches
+// no serial hardware, and AdminModule must run it on every platform - including those where
+// SerialModule itself does not exist. Logs and notifies the client on rejection.
 bool serialConfigIsValid(const meshtastic_ModuleConfig_SerialConfig &config);
 
 #if (defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040) || defined(ARCH_STM32WL)) &&                             \

--- a/src/modules/SerialModule.h
+++ b/src/modules/SerialModule.h
@@ -8,12 +8,9 @@
 #include <Arduino.h>
 #include <functional>
 
-/**
- * Is this serial config one we will accept? Declared outside the architecture guard below because
- * validation is pure config logic with no serial hardware behind it, and AdminModule has to run it
- * on every platform - including the ones where SerialModule itself does not exist. Guarding it with
- * the class meant meshtasticd stored configs it should have rejected.
- */
+// Is this serial config one we will accept? Outside the architecture guard below because validation
+// is pure config logic with no serial hardware behind it, and AdminModule must run it on every
+// platform - including those where SerialModule itself does not exist.
 bool serialConfigIsValid(const meshtastic_ModuleConfig_SerialConfig &config);
 
 #if (defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040) || defined(ARCH_STM32WL)) &&                             \

--- a/test/test_serial/SerialModule.cpp
+++ b/test/test_serial/SerialModule.cpp
@@ -5,20 +5,14 @@
 #ifdef ARCH_PORTDUINO
 #include "configuration.h"
 
-#if (defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040)) && !defined(CONFIG_IDF_TARGET_ESP32S2) &&               \
-    !defined(CONFIG_IDF_TARGET_ESP32C3)
 #include "modules/SerialModule.h"
-#endif
-
-#if (defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040)) && !defined(CONFIG_IDF_TARGET_ESP32S2) &&               \
-    !defined(CONFIG_IDF_TARGET_ESP32C3)
 
 // Test that empty configuration is valid.
 void test_serialConfigEmptyIsValid(void)
 {
     meshtastic_ModuleConfig_SerialConfig config = {};
 
-    TEST_ASSERT_TRUE(SerialModule::isValidConfig(config));
+    TEST_ASSERT_TRUE(serialConfigIsValid(config));
 }
 
 // Test that basic enabled configuration is valid.
@@ -26,61 +20,61 @@ void test_serialConfigEnabledIsValid(void)
 {
     meshtastic_ModuleConfig_SerialConfig config = {.enabled = true};
 
-    TEST_ASSERT_TRUE(SerialModule::isValidConfig(config));
+    TEST_ASSERT_TRUE(serialConfigIsValid(config));
 }
 
 // Test that configuration with override_console_serial_port and NMEA mode is valid.
 void test_serialConfigWithOverrideConsoleNmeaModeIsValid(void)
 {
     meshtastic_ModuleConfig_SerialConfig config = {
-        .enabled = true, .override_console_serial_port = true, .mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_NMEA};
+        .enabled = true, .mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_NMEA, .override_console_serial_port = true};
 
-    TEST_ASSERT_TRUE(SerialModule::isValidConfig(config));
+    TEST_ASSERT_TRUE(serialConfigIsValid(config));
 }
 
 // Test that configuration with override_console_serial_port and CalTopo mode is valid.
 void test_serialConfigWithOverrideConsoleCalTopoModeIsValid(void)
 {
     meshtastic_ModuleConfig_SerialConfig config = {
-        .enabled = true, .override_console_serial_port = true, .mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_CALTOPO};
+        .enabled = true, .mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_CALTOPO, .override_console_serial_port = true};
 
-    TEST_ASSERT_TRUE(SerialModule::isValidConfig(config));
+    TEST_ASSERT_TRUE(serialConfigIsValid(config));
 }
 
 // Test that configuration with override_console_serial_port and DEFAULT mode is invalid.
 void test_serialConfigWithOverrideConsoleDefaultModeIsInvalid(void)
 {
     meshtastic_ModuleConfig_SerialConfig config = {
-        .enabled = true, .override_console_serial_port = true, .mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_DEFAULT};
+        .enabled = true, .mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_DEFAULT, .override_console_serial_port = true};
 
-    TEST_ASSERT_FALSE(SerialModule::isValidConfig(config));
+    TEST_ASSERT_FALSE(serialConfigIsValid(config));
 }
 
 // Test that configuration with override_console_serial_port and SIMPLE mode is invalid.
 void test_serialConfigWithOverrideConsoleSimpleModeIsInvalid(void)
 {
     meshtastic_ModuleConfig_SerialConfig config = {
-        .enabled = true, .override_console_serial_port = true, .mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_SIMPLE};
+        .enabled = true, .mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_SIMPLE, .override_console_serial_port = true};
 
-    TEST_ASSERT_FALSE(SerialModule::isValidConfig(config));
+    TEST_ASSERT_FALSE(serialConfigIsValid(config));
 }
 
 // Test that configuration with override_console_serial_port and TEXTMSG mode is invalid.
 void test_serialConfigWithOverrideConsoleTextMsgModeIsInvalid(void)
 {
     meshtastic_ModuleConfig_SerialConfig config = {
-        .enabled = true, .override_console_serial_port = true, .mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_TEXTMSG};
+        .enabled = true, .mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_TEXTMSG, .override_console_serial_port = true};
 
-    TEST_ASSERT_FALSE(SerialModule::isValidConfig(config));
+    TEST_ASSERT_FALSE(serialConfigIsValid(config));
 }
 
 // Test that configuration with override_console_serial_port and PROTO mode is invalid.
 void test_serialConfigWithOverrideConsoleProtoModeIsInvalid(void)
 {
     meshtastic_ModuleConfig_SerialConfig config = {
-        .enabled = true, .override_console_serial_port = true, .mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_PROTO};
+        .enabled = true, .mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_PROTO, .override_console_serial_port = true};
 
-    TEST_ASSERT_FALSE(SerialModule::isValidConfig(config));
+    TEST_ASSERT_FALSE(serialConfigIsValid(config));
 }
 
 // Test that various modes work without override_console_serial_port.
@@ -90,37 +84,33 @@ void test_serialConfigVariousModesWithoutOverrideAreValid(void)
 
     // Test DEFAULT mode
     config.mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_DEFAULT;
-    TEST_ASSERT_TRUE(SerialModule::isValidConfig(config));
+    TEST_ASSERT_TRUE(serialConfigIsValid(config));
 
     // Test SIMPLE mode
     config.mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_SIMPLE;
-    TEST_ASSERT_TRUE(SerialModule::isValidConfig(config));
+    TEST_ASSERT_TRUE(serialConfigIsValid(config));
 
     // Test TEXTMSG mode
     config.mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_TEXTMSG;
-    TEST_ASSERT_TRUE(SerialModule::isValidConfig(config));
+    TEST_ASSERT_TRUE(serialConfigIsValid(config));
 
     // Test PROTO mode
     config.mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_PROTO;
-    TEST_ASSERT_TRUE(SerialModule::isValidConfig(config));
+    TEST_ASSERT_TRUE(serialConfigIsValid(config));
 
     // Test NMEA mode
     config.mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_NMEA;
-    TEST_ASSERT_TRUE(SerialModule::isValidConfig(config));
+    TEST_ASSERT_TRUE(serialConfigIsValid(config));
 
     // Test CALTOPO mode
     config.mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_CALTOPO;
-    TEST_ASSERT_TRUE(SerialModule::isValidConfig(config));
+    TEST_ASSERT_TRUE(serialConfigIsValid(config));
 }
-
-#endif // Architecture check
 
 void setup()
 {
     initializeTestEnvironment();
 
-#if (defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040)) && !defined(CONFIG_IDF_TARGET_ESP32S2) &&               \
-    !defined(CONFIG_IDF_TARGET_ESP32C3)
     UNITY_BEGIN();
     RUN_TEST(test_serialConfigEmptyIsValid);
     RUN_TEST(test_serialConfigEnabledIsValid);
@@ -132,11 +122,6 @@ void setup()
     RUN_TEST(test_serialConfigWithOverrideConsoleProtoModeIsInvalid);
     RUN_TEST(test_serialConfigVariousModesWithoutOverrideAreValid);
     exit(UNITY_END());
-#else
-    LOG_WARN("This test requires ESP32, NRF52, or RP2040 architecture");
-    UNITY_BEGIN();
-    UNITY_END();
-#endif
 }
 #else
 void setup()
@@ -144,7 +129,7 @@ void setup()
     initializeTestEnvironment();
     LOG_WARN("This test requires the ARCH_PORTDUINO variant");
     UNITY_BEGIN();
-    UNITY_END();
+    exit(UNITY_END());
 }
 #endif
 void loop() {}

--- a/test/test_serial/SerialModule.cpp
+++ b/test/test_serial/SerialModule.cpp
@@ -41,6 +41,16 @@ void test_serialConfigWithOverrideConsoleCalTopoModeIsValid(void)
     TEST_ASSERT_TRUE(serialConfigIsValid(config));
 }
 
+// Test that configuration with override_console_serial_port and MS Config mode is valid.
+void test_serialConfigWithOverrideConsoleMsConfigModeIsValid(void)
+{
+    meshtastic_ModuleConfig_SerialConfig config = {.enabled = true,
+                                                   .mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MS_CONFIG,
+                                                   .override_console_serial_port = true};
+
+    TEST_ASSERT_TRUE(serialConfigIsValid(config));
+}
+
 // Test that configuration with override_console_serial_port and DEFAULT mode is invalid.
 void test_serialConfigWithOverrideConsoleDefaultModeIsInvalid(void)
 {
@@ -116,6 +126,7 @@ void setup()
     RUN_TEST(test_serialConfigEnabledIsValid);
     RUN_TEST(test_serialConfigWithOverrideConsoleNmeaModeIsValid);
     RUN_TEST(test_serialConfigWithOverrideConsoleCalTopoModeIsValid);
+    RUN_TEST(test_serialConfigWithOverrideConsoleMsConfigModeIsValid);
     RUN_TEST(test_serialConfigWithOverrideConsoleDefaultModeIsInvalid);
     RUN_TEST(test_serialConfigWithOverrideConsoleSimpleModeIsInvalid);
     RUN_TEST(test_serialConfigWithOverrideConsoleTextMsgModeIsInvalid);


### PR DESCRIPTION
This pull request refactors how serial configuration validation is handled, making the validation logic available on all platforms instead of only those with `SerialModule`. The validation function is now a standalone function, and all code paths (including tests and admin configuration) use this new function to ensure consistent behavior across platforms. This prevents invalid serial configs from being stored on platforms that previously lacked validation.

**Serial configuration validation refactor:**
- Moved the serial config validation logic from the `SerialModule::isValidConfig` static method to a new standalone function `serialConfigIsValid` in `SerialModule.h` and `SerialModule.cpp`, making it available on all platforms regardless of hardware support. [[1]](diffhunk://#diff-5c08bf58fe232bc4105e2cfb01de18f7cc1862cfb6c895525f74e06a5d5decaeR11-R18) [[2]](diffhunk://#diff-d68fc7a0a96158febd5d87686deec70ecf54a3429c0ed339c91df3d4abbbb6a2R52-R77)
- Updated all usages in production code (e.g., `AdminModule::handleSetModuleConfig`) to call `serialConfigIsValid` unconditionally, ensuring consistent validation everywhere.
- Removed architecture guards around inclusion and usage of serial config validation, so the logic is always available and applied. [[1]](diffhunk://#diff-58b67564429ba04f82838fc361ae799063de4133ae7e59c79c281a119a95b0f9L66-L69) [[2]](diffhunk://#diff-122712fc5107d979c4b557f50b262f44d3c9b46c24e1e6e6291272bf306fbe85L8-R77)

**Test updates:**
- Updated all serial config validation tests to use the new `serialConfigIsValid` function instead of the removed `SerialModule::isValidConfig` method, and removed unnecessary architecture guards from the test code. [[1]](diffhunk://#diff-122712fc5107d979c4b557f50b262f44d3c9b46c24e1e6e6291272bf306fbe85L8-R77) [[2]](diffhunk://#diff-122712fc5107d979c4b557f50b262f44d3c9b46c24e1e6e6291272bf306fbe85L93-L123) [[3]](diffhunk://#diff-122712fc5107d979c4b557f50b262f44d3c9b46c24e1e6e6291272bf306fbe85L135-R132)

**Code cleanup:**
- Removed the now-obsolete `SerialModule::isValidConfig` method from the class definition and implementation. [[1]](diffhunk://#diff-5c08bf58fe232bc4105e2cfb01de18f7cc1862cfb6c895525f74e06a5d5decaeL23-L24) [[2]](diffhunk://#diff-d68fc7a0a96158febd5d87686deec70ecf54a3429c0ed339c91df3d4abbbb6a2L89-L111)
## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Serial settings are now validated and applied consistently across supported platforms.
  * Invalid console-port overrides are rejected with an error notification.
  * MS Config is now recognized as a supported output-only serial mode.
  * Serial configuration changes now provide more consistent behavior and clearer feedback when settings are unsupported.

* **Tests**
  * Expanded serial configuration coverage for valid and invalid mode and override combinations, including MS Config overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->