### PR TITLE
serial heap status messages

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -86,6 +86,12 @@
 #define DELAY_FOREVER portMAX_DELAY
 #endif
 
+// How often the free-heap line is written to the debug log. The Power thread polls every
+// 20s once it is initialized, so that is the effective granularity. Set to 0 to disable.
+#ifndef HEAP_LOG_INTERVAL_MS
+#define HEAP_LOG_INTERVAL_MS (5 * 60 * 1000)
+#endif
+
 #if defined(BATTERY_PIN) && defined(ARCH_ESP32)
 
 #ifndef BAT_MEASURE_ADC_UNIT // ADC1 is default
@@ -1075,9 +1081,42 @@ void Power::readPowerStatus()
     }
 }
 
+/**
+ * Emit a free-heap line to the debug log every HEAP_LOG_INTERVAL_MS, so a slow leak shows up
+ * as a trend in a field log instead of only as an out-of-memory reboot. Unlike the DEBUG_HEAP
+ * instrumentation above this is always on, and costs one line per interval.
+ */
+void Power::logHeapUsage()
+{
+#if HEAP_LOG_INTERVAL_MS > 0
+    if (Throttle::isWithinTimespanMs(lastHeapLogTime, HEAP_LOG_INTERVAL_MS))
+        return;
+
+    const uint32_t heapTotal = memGet.getHeapSize();
+    // Platforms without heap accounting report UINT32_MAX (or 0) - nothing worth logging
+    if (heapTotal == 0 || heapTotal == UINT32_MAX)
+        return;
+
+    const uint32_t heapFree = memGet.getFreeHeap();
+    // The first line has no earlier sample to difference against
+    const int32_t delta = lastHeapLogTime ? (int32_t)(heapFree - lastHeapLogFree) : 0;
+
+    const uint32_t psramTotal = memGet.getPsramSize();
+    if (psramTotal)
+        LOG_INFO("Heap: %u/%u bytes free (%d since last), PSRAM: %u/%u bytes free", heapFree, heapTotal, delta,
+                 memGet.getFreePsram(), psramTotal);
+    else
+        LOG_INFO("Heap: %u/%u bytes free (%d since last)", heapFree, heapTotal, delta);
+
+    lastHeapLogFree = heapFree;
+    lastHeapLogTime = millis();
+#endif
+}
+
 int32_t Power::runOnce()
 {
     readPowerStatus();
+    logHeapUsage();
 
 #ifdef HAS_PMU
     // WE no longer use the IRQ line to wake the CPU (due to false wakes from

--- a/src/Power.h
+++ b/src/Power.h
@@ -93,6 +93,7 @@ class Power : public concurrency::OSThread
 
     void powerCommandsCheck();
     void readPowerStatus();
+    void logHeapUsage();
     virtual bool setup();
     virtual int32_t runOnce() override;
     void setStatusHandler(meshtastic::PowerStatus *handler) { statusHandler = handler; }
@@ -131,6 +132,9 @@ class Power : public concurrency::OSThread
     // open circuit voltage lookup table
     uint8_t low_voltage_counter;
     uint32_t lastLogTime = 0;
+    // Periodic free-heap logging: time of the last line emitted, and the reading it carried
+    uint32_t lastHeapLogTime = 0;
+    uint32_t lastHeapLogFree = 0;
 
 #ifdef ARCH_ESP32
     // Get notified when lightsleep begins and ends


### PR DESCRIPTION
This pull request adds a new feature to periodically log heap (memory) usage in the `Power` thread, making it easier to detect slow memory leaks from field logs. The logging interval is configurable and the feature is always enabled (unless the interval is set to zero). The main changes include the implementation of the logging logic, integration into the main power loop, and the addition of supporting member variables.

**Heap usage logging feature:**

* Added a new `logHeapUsage()` method to the `Power` class, which emits a line to the debug log every `HEAP_LOG_INTERVAL_MS` milliseconds with current and delta heap usage, and PSRAM usage if available.
* Integrated `logHeapUsage()` into the main `runOnce()` loop, so heap usage is logged periodically as the power thread runs.
* Introduced a new `HEAP_LOG_INTERVAL_MS` macro (default 5 minutes) to control the logging interval, with the ability to disable logging by setting it to 0.

**Supporting changes to `Power` class:**

* Declared `logHeapUsage()` in the `Power` class interface.
* Added `lastHeapLogTime` and `lastHeapLogFree` member variables to track the last log emission and heap reading.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable periodic heap-usage logging, enabled by default every five minutes.
  * Logs free and total heap memory, plus optional PSRAM usage and changes since the previous reading.
  * Set the interval to zero to disable periodic logging.
  * Automatically skips logging on platforms without supported heap accounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->