### PR TITLE
Re-enable mbedtls secp384r1 on ESP32

### DIFF
--- a/variants/esp32/esp32-common.ini
+++ b/variants/esp32/esp32-common.ini
@@ -232,7 +232,12 @@ custom_sdkconfig =
   CONFIG_MBEDTLS_KEY_EXCHANGE_ECJPAKE=n
   CONFIG_MBEDTLS_ECP_DP_SECP192R1_ENABLED=n
   CONFIG_MBEDTLS_ECP_DP_SECP224R1_ENABLED=n
-  CONFIG_MBEDTLS_ECP_DP_SECP384R1_ENABLED=n
+  ; Required, do not disable. Let's Encrypt "Generation Y" chains (used by
+  ; mqtt.meshtastic.org since 2026-07-29) sign a P-256 leaf with the P-384
+  ; intermediate YE1 under ISRG Root YE. Without this curve mbedtls cannot
+  ; parse the chain and every TLS handshake fails with
+  ; MBEDTLS_ERR_PK_UNKNOWN_NAMED_CURVE (-0x3A00). Costs ~4 kB flash. (#11316)
+  CONFIG_MBEDTLS_ECP_DP_SECP384R1_ENABLED=y
   CONFIG_MBEDTLS_ECP_DP_SECP521R1_ENABLED=n
   CONFIG_MBEDTLS_ECP_DP_SECP192K1_ENABLED=n
   CONFIG_MBEDTLS_ECP_DP_SECP224K1_ENABLED=n


### PR DESCRIPTION
Fixes #11316

## Problem

MQTT over TLS is broken on every ESP32 target. The handshake aborts with `MBEDTLS_ERR_PK_UNKNOWN_NAMED_CURVE` (-0x3A00).

`CONFIG_MBEDTLS_ECP_DP_SECP384R1_ENABLED=n` was set in #9122 as part of the Arduino 3 flash optimization pass. Let's Encrypt then activated its Generation Y hierarchy, and `mqtt.meshtastic.org` was reissued onto that chain on 2026-07-29.

Current live chain:

| depth | subject | key | signature |
| --- | --- | --- | --- |
| 0 | mqtt.meshtastic.org | P-256 | ecdsa-with-SHA384 |
| 1 | Let's Encrypt YE1 | P-384 | ecdsa-with-SHA384 |
| 2 | ISRG Root YE | P-384 | ecdsa-with-SHA384 |
| 3 | ISRG Root X2 | P-384 | sha256WithRSA |

This fails even though `MQTT.cpp` calls `setInsecure()`. Verification is skipped, but mbedtls still parses the peer chain during the handshake, and parsing a P-384 SubjectPublicKeyInfo fails when the curve is compiled out.

SHA-384 is already available via `CONFIG_MBEDTLS_SHA512_C=y`, so P-384 is the only missing piece.

## Change

`CONFIG_MBEDTLS_ECP_DP_SECP384R1_ENABLED=y` in `variants/esp32/esp32-common.ini`, with a comment recording why it must stay enabled.

## Cost

About 4 kB of flash on every ESP32 target. `custom_sdkconfig` is family-wide, so this cannot be scoped to MQTT-only builds.

## Scope

ESP32 only. No other platform in the tree carries an mbedtls curve configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled support for the mbedTLS P-384 elliptic curve on ESP32 devices.
  * Improved compatibility with Let’s Encrypt certificate chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->