### PR TITLE
Reduce T-Echo firmware footprint to preserve future flash headroom

### DIFF
--- a/variants/nrf52840/t-echo/platformio.ini
+++ b/variants/nrf52840/t-echo/platformio.ini
@@ -35,6 +35,12 @@ lib_deps =
   lewisxhe/SensorLib@0.3.4
 ;upload_protocol = fs
 
+# The T-Echo was never manufactured with a BME680/BME688, so BSEC2 and its BME68x driver are removed to save space.
+lib_ignore =
+  ${nrf52840_base.lib_ignore}
+  bsec2
+  BME68x Sensor library
+
 [env:t-echo-inkhud]
 extends = nrf52840_base, inkhud
 board = t-echo
@@ -53,3 +59,8 @@ lib_deps =
   ${nrf52840_base.lib_deps}
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
   lewisxhe/SensorLib@0.3.4
+
+lib_ignore =
+  ${nrf52840_base.lib_ignore}
+  bsec2
+  BME68x Sensor library


### PR DESCRIPTION
Remove the unused BME68x Sensor library from the T-Echo build. The T-Echo only supports the BME280 sensor, so including the BME68x library provides no functional benefit while consuming a significant amount of flash.

## Results

Flash usage:

**Before: 93.8%** (764440 / 815104 bytes)
**After: 88.6%** (721792 / 815104 bytes)
This reclaims approximately 43 KB of flash (~5% of the available program memory), providing additional headroom for future features and reducing the risk of the T-Echo exceeding its flash limit as the firmware continues to evolve.

Build output before this change:
```
RAM:   [====      ]  37.5% (used 93212 bytes from 248832 bytes)
Flash: [========= ]  93.8% (used 764440 bytes from 815104 bytes)
```

Build output after this change:
```
RAM:   [====      ]  35.8% (used 89004 bytes from 248832 bytes)
Flash: [========= ]  88.6% (used 721792 bytes from 815104 bytes)
```

---

for the `t-echo-inkhud` version, there is also an improvement (this version was also tested):
Before the changes:
```
RAM:   [===       ]  33.9% (used 84372 bytes from 248832 bytes)
Flash: [========= ]  88.4% (used 720160 bytes from 815104 bytes)
```
After the changes:
```
RAM:   [===       ]  31.9% (used 79356 bytes from 248832 bytes)
Flash: [========  ]  82.7% (used 673904 bytes from 815104 bytes)
```
## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
  - [X] LilyGo T-Echo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved T-Echo firmware build configuration.
  - Prevented unsupported sensor libraries from being included in T-Echo builds, helping ensure more reliable compilation and device firmware generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->