### PR TITLE
MUI: use PSRAM for MBED TLS (https map tile download)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -129,6 +129,9 @@ lib_deps =
 lib_deps =
 	# renovate: datasource=git-refs depName=meshtastic/device-ui packageName=https://github.com/meshtastic/device-ui gitBranch=master
 	https://github.com/meshtastic/device-ui/archive/95483d8c6e28fcda2160161d5d5a8825f729df62.zip
+custom_sdkconfig =
+	# CONFIG_MBEDTLS_INTERNAL_MEM_ALLOC is not set
+	CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC=y
 
 ; Common libs for environmental measurements in telemetry module
 [environmental_base]

--- a/variants/esp32s3/elecrow_panel/platformio.ini
+++ b/variants/esp32s3/elecrow_panel/platformio.ini
@@ -52,6 +52,10 @@ lib_deps = ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.26
 
+custom_sdkconfig =
+  ${esp32s3_base.custom_sdkconfig}
+  ${device-ui_base.custom_sdkconfig}
+
 [crowpanel_small_esp32s3_base] ; 2.4, 2.8, 3.5 inch
 extends = crowpanel_base
 build_flags =

--- a/variants/esp32s3/heltec_v4/platformio.ini
+++ b/variants/esp32s3/heltec_v4/platformio.ini
@@ -71,7 +71,6 @@ build_flags =
   -D HAS_TFT=1
   -D MAP_TILES_GREY ; required for 2MB PSRAM
   -D RAM_SIZE=1432
-  -D STBI_ARENA_SIZE=450000
   -D LV_CACHE_DEF_SIZE=0
   -D LV_LVGL_H_INCLUDE_SIMPLE
   -D LV_CONF_INCLUDE_SIMPLE
@@ -137,3 +136,7 @@ lib_deps = ${heltec_v4_base.lib_deps}
   lovyan03/LovyanGFX@1.2.26
   # renovate: datasource=git-refs depName=Quency-D_chsc6x packageName=https://github.com/Quency-D/chsc6x gitBranch=master
   https://github.com/Quency-D/chsc6x/archive/3b2b6cebf3177b3e2c33d06e07909b0b10159516.zip
+
+custom_sdkconfig =
+  ${esp32s3_base.custom_sdkconfig}
+  ${device-ui_base.custom_sdkconfig}

--- a/variants/esp32s3/heltec_v4_r8/platformio.ini
+++ b/variants/esp32s3/heltec_v4_r8/platformio.ini
@@ -144,3 +144,7 @@ lib_deps = ${heltec_v4_r8_base.lib_deps}
   lovyan03/LovyanGFX@1.2.26
   # renovate: datasource=git-refs depName=Quency-D_chsc6x packageName=https://github.com/Quency-D/chsc6x gitBranch=master
   https://github.com/Quency-D/chsc6x/archive/3b2b6cebf3177b3e2c33d06e07909b0b10159516.zip
+
+custom_sdkconfig =
+  ${esp32s3_base.custom_sdkconfig}
+  ${device-ui_base.custom_sdkconfig}

--- a/variants/esp32s3/picomputer-s3/platformio.ini
+++ b/variants/esp32s3/picomputer-s3/platformio.ini
@@ -69,3 +69,7 @@ build_flags =
 lib_deps =
   ${env:picomputer-s3.lib_deps}
   ${device-ui_base.lib_deps}
+
+custom_sdkconfig =
+  ${esp32s3_base.custom_sdkconfig}
+  ${device-ui_base.custom_sdkconfig}

--- a/variants/esp32s3/rak_wismesh_tap_v2/platformio.ini
+++ b/variants/esp32s3/rak_wismesh_tap_v2/platformio.ini
@@ -100,4 +100,7 @@ lib_deps =
   ${env:rak_wismesh_tap_v2.lib_deps}
   ${device-ui_base.lib_deps}
 
+custom_sdkconfig =
+  ${esp32s3_base.custom_sdkconfig}
+  ${device-ui_base.custom_sdkconfig}
 

--- a/variants/esp32s3/seeed-sensecap-indicator/platformio.ini
+++ b/variants/esp32s3/seeed-sensecap-indicator/platformio.ini
@@ -79,3 +79,7 @@ lib_deps =
   ;# renovate: datasource=github-tags depName=bb_captouch packageName=bitbank2/bb_captouch
   ;https://github.com/bitbank2/bb_captouch/archive/refs/tags/1.3.1.zip ; not working
   https://github.com/mverch67/bb_captouch/archive/8626412fe650d808a267791c0eae6e5860c85a5d.zip ; alternative touch library supporting FT6x36
+
+custom_sdkconfig =
+  ${esp32s3_base.custom_sdkconfig}
+  ${device-ui_base.custom_sdkconfig}

--- a/variants/esp32s3/t-deck/platformio.ini
+++ b/variants/esp32s3/t-deck/platformio.ini
@@ -88,3 +88,7 @@ lib_deps =
   ${env:t-deck.lib_deps}
   ${device-ui_base.lib_deps}
   ;https://github.com/bitbank2/bb_captouch/archive/refs/tags/1.3.1.zip
+
+custom_sdkconfig =
+  ${esp32s3_base.custom_sdkconfig}
+  ${device-ui_base.custom_sdkconfig}

--- a/variants/esp32s3/tlora-pager/platformio.ini
+++ b/variants/esp32s3/tlora-pager/platformio.ini
@@ -92,3 +92,7 @@ build_flags =
 lib_deps =
   ${env:tlora-pager.lib_deps}
   ${device-ui_base.lib_deps}
+
+custom_sdkconfig =
+  ${esp32s3_base.custom_sdkconfig}
+  ${device-ui_base.custom_sdkconfig}

--- a/variants/esp32s3/unphone/platformio.ini
+++ b/variants/esp32s3/unphone/platformio.ini
@@ -76,3 +76,7 @@ build_flags =
 lib_deps =
   ${env:unphone.lib_deps}
   ${device-ui_base.lib_deps}
+
+custom_sdkconfig =
+  ${esp32s3_base.custom_sdkconfig}
+  ${device-ui_base.custom_sdkconfig}


### PR DESCRIPTION
fixes [#360](https://github.com/meshtastic/device-ui/issues/360) (out of memory)

moves the 48000 bytes TLS block allocation from SRAM (internal) into PSRAM (external):
```
DEBUG | 17:56:48 28 [DeviceUI] Failed to load tile S:/maps/google/11/1055/658.png from SD
INFO  | 17:56:48 28 [DeviceUI] [RAM PRE] Internal SRAM Free: 109124 bytes | PSRAM Free: 2552576 bytes
INFO  | 17:56:48 29 [DeviceUI] [RAM POST] Internal SRAM Free: 108296 bytes | PSRAM Free: 2504576 bytes
INFO  | 17:56:48 29 [DeviceUI] [RAM DELTA] SRAM dropped by: 828 bytes | PSRAM dropped by: 48000 bytes
DEBUG | 17:56:48 29 [DeviceUI] SUCCESS(0): GET https://mt0.google.com/vt?lyrs=m&x=1055&s=&y=658&z=11 (178 bytes)
DEBUG | 17:56:48 29 [DeviceUI] SDCardService::save(/maps/google/11/1055/658.png): 178
```

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [x] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] ThinkNode M9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory allocation handling for ESP32-S3 device interfaces.
  * Updated multiple display and hardware variants to use consistent memory settings.
  * Removed an unnecessary large image-processing memory allocation from the Heltec V4 TFT configuration.
  * Improved stability and compatibility across supported ESP32-S3 hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->