### PR TITLE
Update earlephilhower/arduino-pico to 6.0.0

### DIFF
--- a/variants/rp2040/rp2040.ini
+++ b/variants/rp2040/rp2040.ini
@@ -7,7 +7,7 @@ platform =
 extends = arduino_base
 platform_packages =
   # TODO renovate
-  arduino-pico@https://github.com/earlephilhower/arduino-pico/releases/download/5.7.0/rp2040-5.7.0.zip
+  arduino-pico@https://github.com/earlephilhower/arduino-pico/releases/download/6.0.0/rp2040-6.0.0.zip
 
 board_build.core = earlephilhower
 board_build.filesystem_size = 0.5m


### PR DESCRIPTION
Update raspberry pi pico platform from 5.7.0 to 6.0.0.

Release Notes:
- https://github.com/earlephilhower/arduino-pico/releases/tag/6.0.0

> A large infrastructure upgrade from 5.7.0. Includes the latest version of GCC available, the latest NEWLIB snapshot (re-enabling nano-printf), enables GNU23/GNU++23 extensions, and SDK 2.3.0 goodness. Lot of updates so the pain of updating your apps and the core all happens at once instead of a steady stream of niggles. Any issues, release 5.7.0 (or prior) is available with the older toolchain.

Worth checking for regressions here 😬 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the RP2040 Arduino-Pico platform package to version 6.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->