### PR TITLE
T-Beam BPF: Use the correct SVG

### DIFF
--- a/variants/esp32s3/t-beam-bpf/platformio.ini
+++ b/variants/esp32s3/t-beam-bpf/platformio.ini
@@ -6,7 +6,7 @@ custom_meshtastic_architecture = esp32s3
 custom_meshtastic_actively_supported = true
 custom_meshtastic_support_level = 3
 custom_meshtastic_display_name = LILYGO T-Beam BPF
-custom_meshtastic_images = tbeam-1w.svg
+custom_meshtastic_images = tbeam-bpf.svg
 custom_meshtastic_tags = LilyGo
 
 extends = esp32s3_base


### PR DESCRIPTION
Update the SVG for T-Beam BPF. Added to the web-flasher repo in https://github.com/meshtastic/web-flasher/commit/1b885865f12be306e312674f68c74fa3eab51317


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the T-Beam-BPF image asset to display the correct device illustration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->