### PR TITLE
nrf52840/feather_diy Enhancements

### DIFF
--- a/variants/nrf52840/feather_diy/variant.cpp
+++ b/variants/nrf52840/feather_diy/variant.cpp
@@ -22,3 +22,13 @@
 #include "nrf.h"
 #include "wiring_constants.h"
 #include "wiring_digital.h"
+
+void lateInitVariant()
+{
+    // power off NeoPixel on Feather RevE
+    // (on RevD that pin is not connected and the NeoPixel is on the
+    // 3.3V LDO along with the MCU and thus cannot be turned off)
+    // pinMode already set by initVariant() in
+    // framework-arduinoadafruitnrf52/variants/feather_nrf52840_express/variant.cpp
+    digitalWrite(PIN_NEOPIXEL_POWER, LOW);
+}

--- a/variants/nrf52840/feather_diy/variant.h
+++ b/variants/nrf52840/feather_diy/variant.h
@@ -49,8 +49,8 @@ extern "C" {
 #define PIN_LED1 3 // P1.15 3
 #define PIN_LED2 4 // P1.10 4
 
-#define LED_GREEN PIN_LED2 // Actually red
-#define LED_BLUE PIN_LED1
+#define LED_RED PIN_LED1
+#define LED_BLUE PIN_LED2
 
 #define LED_STATE_ON 1 // State when LED is lit
 

--- a/variants/nrf52840/feather_diy/variant.h
+++ b/variants/nrf52840/feather_diy/variant.h
@@ -86,6 +86,11 @@ extern "C" {
 
 #define PIN_NEOPIXEL_POWER 34 // P1.14 34 - Neopixel power on RevE, not connected on RevD
 
+#define BATTERY_PIN 20      // P0.29 A6
+#define ADC_MULTIPLIER 2.0f // 100K/100K voltage divider
+#define AREF_VOLTAGE 3.6f
+#define BATTERY_SENSE_RESOLUTION_BITS 12
+
 #undef USE_EINK
 
 // supported modules list

--- a/variants/nrf52840/feather_diy/variant.h
+++ b/variants/nrf52840/feather_diy/variant.h
@@ -43,41 +43,41 @@ extern "C" {
 
 #define WIRE_INTERFACES_COUNT 1
 
-#define PIN_WIRE_SDA (0 + 12) // P0.12 22
-#define PIN_WIRE_SCL (0 + 11) // P0.12 23
+#define PIN_WIRE_SDA 22 // P0.12 22
+#define PIN_WIRE_SCL 23 // P0.12 23
 
-#define PIN_LED1 (32 + 15) // P1.15 3
-#define PIN_LED2 (32 + 10) // P1.10 4
+#define PIN_LED1 3 // P1.15 3
+#define PIN_LED2 4 // P1.10 4
 
 #define LED_GREEN PIN_LED2 // Actually red
 #define LED_BLUE PIN_LED1
 
 #define LED_STATE_ON 1 // State when LED is lit
 
-#define BUTTON_PIN (32 + 2) // P1.02 7
+#define BUTTON_PIN 7 // P1.02 7
 
 /*
  * Serial interfaces
  */
-#define PIN_SERIAL1_RX (0 + 24) // P0.24 1
-#define PIN_SERIAL1_TX (0 + 25) // P0.25 0
+#define PIN_SERIAL1_RX 1 // P0.24 1
+#define PIN_SERIAL1_TX 0 // P0.25 0
 
 #define PIN_SERIAL2_RX (-1)
 #define PIN_SERIAL2_TX (-1)
 
 #define SPI_INTERFACES_COUNT 1
 
-#define PIN_SPI_MISO (0 + 15) // P0.15 24
-#define PIN_SPI_MOSI (0 + 13) // P0.13 25
-#define PIN_SPI_SCK (0 + 14)  // P0.14 26
+#define PIN_SPI_MISO 24 // P0.15 24
+#define PIN_SPI_MOSI 25 // P0.13 25
+#define PIN_SPI_SCK 26  // P0.14 26
 
 #define SS 2
 
-#define LORA_DIO0 -1        // a No connect on the SX1262/SX1268 module
-#define LORA_RESET (32 + 9) // P1.09 13 // RST for SX1276, and for SX1262/SX1268
-#define LORA_DIO1 (0 + 6)   // P0.06 11  // IRQ for SX1262/SX1268
-#define LORA_DIO2 (0 + 8)   // P0.08 12  // BUSY for SX1262/SX1268
-#define LORA_DIO3           // Not connected on PCB, but internally on the TTGO SX1262/SX1268, if DIO3 is high the TXCO is enabled
+#define LORA_DIO0 -1  // a No connect on the SX1262/SX1268 module
+#define LORA_RESET 13 // P1.09 13 // RST for SX1276, and for SX1262/SX1268
+#define LORA_DIO1 11  // P0.06 11 // IRQ for SX1262/SX1268
+#define LORA_DIO2 12  // P0.08 12 // BUSY for SX1262/SX1268
+#define LORA_DIO3     // Not connected on PCB, but internally on the TTGO SX1262/SX1268, if DIO3 is high the TXCO is enabled
 
 #define LORA_SCK SCK
 #define LORA_MISO MI
@@ -85,7 +85,7 @@ extern "C" {
 #define LORA_CS SS
 
 // enables 3.3V periphery like GPS or IO Module
-#define PIN_3V3_EN (-1)
+#define PIN_3V3_EN 34 // P1.14 34 - Neopixel power on RevE, not connected on RevD
 
 #undef USE_EINK
 
@@ -97,8 +97,8 @@ extern "C" {
 #define SX126X_DIO1 LORA_DIO1
 #define SX126X_BUSY LORA_DIO2
 #define SX126X_RESET LORA_RESET
-#define SX126X_RXEN (0 + 27) // P0.27 10
-#define SX126X_TXEN (0 + 26) // P0.26 9
+#define SX126X_RXEN 10 // P0.27 10
+#define SX126X_TXEN 9  // P0.26 9
 
 #ifdef EBYTE_E22
 // Internally the TTGO module hooks the SX126x-DIO2 in to control the TX/RX switch

--- a/variants/nrf52840/feather_diy/variant.h
+++ b/variants/nrf52840/feather_diy/variant.h
@@ -84,8 +84,7 @@ extern "C" {
 #define LORA_MOSI MO
 #define LORA_CS SS
 
-// enables 3.3V periphery like GPS or IO Module
-#define PIN_3V3_EN 34 // P1.14 34 - Neopixel power on RevE, not connected on RevD
+#define PIN_NEOPIXEL_POWER 34 // P1.14 34 - Neopixel power on RevE, not connected on RevD
 
 #undef USE_EINK
 


### PR DESCRIPTION
Some fixes and cleanups to make my self-built node based on an Adafruit Feather nRF52840 Express work and be useful:

- Fixes #9250
- Fix some inconsistent pin defines
- Power off NeoPixel to save power on Feather RevE
- Enable battery voltage measurement

See commit messages for details.

I have had this in use for several months on several firmware versions (up to 2.7.26). Note that I only have RevD boards, so I have not been able to test whether the NeoPixel change has the desired effect on RevE, only that it doesn’t break anything on RevD.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other: Adafruit Feather nRF52840 Express RevD with Seeed Wio-SX1262 LoRa module (using the Wio-SX1262 requires some additional changes that are _not_ part of this PR but will be submitted separately)
  - [x] Other: Seeed XIAO nRF52840 & Wio SX1262 Kit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Feather DIY board pin assignments for LEDs, buttons, LoRa, serial, SPI, I²C, battery sensing, and NeoPixel controls.
  - Fixed LED mappings, including support for the red LED.
  - Improved SX126X radio receive/transmit control pin behavior.
  - NeoPixel power is now disabled after startup when not in use, reducing unnecessary power consumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->