### PR TITLE
fix(crypto): hash full size_t inputs

### DIFF
--- a/src/mesh/CryptoEngine.cpp
+++ b/src/mesh/CryptoEngine.cpp
@@ -302,8 +302,8 @@ void CryptoEngine::hash(uint8_t *bytes, size_t numBytes)
 {
     SHA256 hash;
     size_t posn;
-    uint8_t size = numBytes;
-    uint8_t inc = 16;
+    size_t size = numBytes;
+    constexpr size_t inc = 16;
     hash.reset();
     for (posn = 0; posn < size; posn += inc) {
         size_t len = size - posn;

--- a/test/test_crypto/test_main.cpp
+++ b/test/test_crypto/test_main.cpp
@@ -47,6 +47,17 @@ void test_SHA256(void)
     crypto->hash(hash, 2);
     TEST_ASSERT_EQUAL_MEMORY(hash, expected, 32);
 }
+
+void test_SHA256_large_input(void)
+{
+    uint8_t hash[300] = {0};
+    uint8_t expected[32];
+
+    HexToBytes(expected, "d13d4a8b3b8add19b5970157f09d00c12cbda4fed4d74d8493156523f7069b66");
+    crypto->hash(hash, sizeof(hash));
+    TEST_ASSERT_EQUAL_MEMORY(hash, expected, sizeof(expected));
+}
+
 void test_ECB_AES256(void)
 {
     // https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/AES_ECB.pdf
@@ -357,6 +368,7 @@ void setup()
     initializeTestEnvironment();
     UNITY_BEGIN(); // IMPORTANT LINE!
     RUN_TEST(test_SHA256);
+    RUN_TEST(test_SHA256_large_input);
     RUN_TEST(test_ECB_AES256);
     RUN_TEST(test_DH25519);
     RUN_TEST(test_AES_CTR);


### PR DESCRIPTION
## Summary

`CryptoEngine::hash()` accepts a `size_t` input length but narrowed it to `uint8_t` before chunking, causing inputs longer than 255 bytes to be hashed incorrectly. Preserve the declared length type through the loop and add a 300-byte SHA-256 regression test.

## Testing

- [x] `trunk check src/mesh/CryptoEngine.cpp test/test_crypto/test_main.cpp`
- [x] `pio test -e native-macos -f test_crypto`
- [ ] Hardware testing not applicable: this change only corrects the software SHA-256 input-length handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SHA-256 hashing accuracy for inputs larger than 255 bytes.

* **Tests**
  * Added coverage for hashing 300-byte inputs to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->