### PR TITLE
fix(rak4631): enable GPS power rail for WisMesh Repeater Mini

### DIFF
--- a/variants/nrf52840/rak4631/variant.h
+++ b/variants/nrf52840/rak4631/variant.h
@@ -231,8 +231,9 @@ SO GPIO 39/TXEN MAY NOT BE DEFINED FOR SUCCESSFUL OPERATION OF THE SX1262 - TG
 #define PIN_3V3_EN (34)
 #define WB_IO2 PIN_3V3_EN
 
-#if defined(WISMESH_POCKET)
-// Pocket v3: P1.02 (GPIO 34) = GPS_PWR_EN
+// GPS EN only for finished products that accept cutting 3V3_S with GPS off.
+// Generic rak4631 / sensor bases keep this undefined so sensors on 3V3_S stay powered.
+#if defined(WISMESH_POCKET) || defined(WISMESH_REPEATER_MINI)
 #define PIN_GPS_EN PIN_3V3_EN
 #endif
 


### PR DESCRIPTION
## Summary
- Define `PIN_GPS_EN` as `PIN_3V3_EN` for `WISMESH_REPEATER_MINI` as well as `WISMESH_POCKET`, so GPS Off actually cuts the shared 3V3_S rail on finished GPS products.
- Leave generic `rak4631` / sensor bases without `PIN_GPS_EN`, so modules on 3V3_S stay powered when GPS is disabled.

## Context
Without `PIN_GPS_EN`, Meshtastic only stops the GPS UART/driver and does not deassert the power enable. On Repeater Mini that left ~35 mA idle; with this define, GPS Off can drop to ~8 mA. Pocket already had this; Repeater Mini (`-D WISMESH_REPEATER_MINI`) did not.

## Test plan
- [ ] Build `rak_wismesh_repeater_mini` and confirm `PIN_GPS_EN` is defined
- [ ] Build `rak4631` (generic) and confirm `PIN_GPS_EN` is **not** defined
- [ ] Build `rak_wismesh_pocket` still defines `PIN_GPS_EN`
- [ ] On Repeater Mini hardware: GPS On → Off and check current drop on 3V3_S / battery

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled GPS functionality for the WISMESH Pocket and WISMESH Repeater Mini variants.
  * Preserved existing behavior for other hardware variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->