### PR TITLE
logging: audit log strings for terseness, reclaiming ~6.8 KB of string data

### DIFF
--- a/src/AmbientLightingThread.h
+++ b/src/AmbientLightingThread.h
@@ -66,7 +66,7 @@ class AmbientLightingThread : public concurrency::OSThread
 #if defined(HAS_NCP5623) || defined(HAS_LP5562)
         _type = type;
         if (_type == ScanI2C::DeviceType::NONE) {
-            LOG_DEBUG("AmbientLighting Disable due to no RGB leds found on I2C bus");
+            LOG_DEBUG("AmbientLighting disabled: no RGB leds on I2C");
             disable();
             return;
         }
@@ -92,7 +92,7 @@ class AmbientLightingThread : public concurrency::OSThread
                 pixels.setBrightness(moduleConfig.ambient_lighting.current);
 #endif
                 if (!moduleConfig.ambient_lighting.led_state) {
-                    LOG_DEBUG("AmbientLighting Disable due to moduleConfig.ambient_lighting.led_state OFF");
+                    LOG_DEBUG("AmbientLighting disabled: led_state OFF");
                     disable();
                     return;
                 }

--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -171,7 +171,7 @@ static bool initAdcCalibration()
     }
 #endif
 
-    LOG_INFO("ADC calibration not supported; using approximate scaling");
+    LOG_INFO("ADC calibration unsupported; use approx scaling");
     return false;
 }
 
@@ -885,8 +885,8 @@ void Power::reboot()
     HAL_NVIC_SystemReset();
 #else
     rebootAtMsec = -1;
-    LOG_WARN("FIXME implement reboot for this platform. Note that some settings "
-             "require a restart to be applied");
+    LOG_WARN("FIXME implement reboot for this platform; some settings "
+             "need restart to apply");
 #endif
 }
 
@@ -1926,7 +1926,7 @@ meshSolarBatteryLevel meshSolarLevel;
 bool Power::meshSolarInit()
 {
     bool result = meshSolarLevel.runOnce();
-    LOG_DEBUG("Power::meshSolarInit mesh solar sensor is %s", result ? "ready" : "not ready yet");
+    LOG_DEBUG("Power::meshSolarInit sensor is %s", result ? "ready" : "not ready yet");
     if (!result)
         return false;
     batteryLevel = &meshSolarLevel;
@@ -2059,7 +2059,7 @@ bool Power::serialBatteryInit()
 #endif
 
     bool result = serialBatteryLevel.runOnce();
-    LOG_DEBUG("Power::serialBatteryInit serial battery sensor is %s", result ? "ready" : "not ready yet");
+    LOG_DEBUG("Power::serialBatteryInit sensor is %s", result ? "ready" : "not ready yet");
     if (!result)
         return false;
     batteryLevel = &serialBatteryLevel;

--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -879,7 +879,7 @@ void Power::reboot()
     if (screen) {
         screen = nullptr;
     }
-    LOG_DEBUG("final reboot!");
+    LOG_DEBUG("final reboot");
     ::reboot();
 #elif defined(ARCH_STM32)
     HAL_NVIC_SystemReset();

--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -165,7 +165,7 @@ static void lsIdle()
                 wakeCause2 = doLightSleep(100); // leave led on for 1ms
 
                 secsSlept += sleepTime;
-                // LOG_INFO("Sleep, flash led!");
+                // LOG_INFO("Sleep, flash led");
                 break;
 
             case ESP_SLEEP_WAKEUP_UART:

--- a/src/SafeFile.cpp
+++ b/src/SafeFile.cpp
@@ -70,7 +70,7 @@ bool SafeFile::close()
     String filenameTmp = filename;
     filenameTmp += ".tmp";
     if (!renameFile(filenameTmp.c_str(), filename.c_str())) {
-        LOG_ERROR("Error: can't rename new pref file");
+        LOG_ERROR("Can't rename new pref file");
         return false;
     }
 

--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -419,7 +419,7 @@ GPS_RESPONSE GPS::getACKCas(uint8_t class_id, uint8_t msg_id, uint32_t waitMilli
             // Check for an ACK-ACK for the specified class and message id
             if ((msg_cls == 0x05) && (msg_msg_id == 0x01) && payload_cls == class_id && payload_msg == msg_id) {
 #ifdef GPS_DEBUG
-                LOG_INFO("Got ACK for class %02X message %02X in %dms", class_id, msg_id, millis() - startTime);
+                LOG_INFO("Got ACK for class %02X msg %02X in %dms", class_id, msg_id, millis() - startTime);
 #endif
                 return GNSS_RESPONSE_OK;
             }
@@ -427,7 +427,7 @@ GPS_RESPONSE GPS::getACKCas(uint8_t class_id, uint8_t msg_id, uint32_t waitMilli
             // Check for an ACK-NACK for the specified class and message id
             if ((msg_cls == 0x05) && (msg_msg_id == 0x00) && payload_cls == class_id && payload_msg == msg_id) {
 #ifdef GPS_DEBUG
-                LOG_WARN("Got NACK for class %02X message %02X in %dms", class_id, msg_id, millis() - startTime);
+                LOG_WARN("Got NACK for class %02X msg %02X in %dms", class_id, msg_id, millis() - startTime);
 #endif
                 return GNSS_RESPONSE_NAK;
             }
@@ -468,7 +468,7 @@ GPS_RESPONSE GPS::getACK(uint8_t class_id, uint8_t msg_id, uint32_t waitMillis)
     while (Throttle::isWithinTimespanMs(startTime, waitMillis)) {
         if (ack > 9) {
 #ifdef GPS_DEBUG
-            LOG_INFO("Got ACK for class %02X message %02X in %dms", class_id, msg_id, millis() - startTime);
+            LOG_INFO("Got ACK for class %02X msg %02X in %dms", class_id, msg_id, millis() - startTime);
 #endif
             return GNSS_RESPONSE_OK; // ACK received
         }
@@ -496,7 +496,7 @@ GPS_RESPONSE GPS::getACK(uint8_t class_id, uint8_t msg_id, uint32_t waitMillis)
 #ifdef GPS_DEBUG
                     LOG_DEBUG(debugmsg.c_str());
 #endif
-                    LOG_WARN("Got NAK for class %02X message %02X", class_id, msg_id);
+                    LOG_WARN("Got NAK for class %02X msg %02X", class_id, msg_id);
                     return GNSS_RESPONSE_NAK; // NAK received
                 }
                 ack = 0; // Reset the acknowledgement counter
@@ -505,7 +505,7 @@ GPS_RESPONSE GPS::getACK(uint8_t class_id, uint8_t msg_id, uint32_t waitMillis)
     }
 #ifdef GPS_DEBUG
     LOG_DEBUG(debugmsg.c_str());
-    LOG_WARN("No response for class %02X message %02X", class_id, msg_id);
+    LOG_WARN("No response for class %02X msg %02X", class_id, msg_id);
 #endif
     return GNSS_RESPONSE_NONE; // No response received within timeout
 }
@@ -578,7 +578,7 @@ int GPS::getACK(uint8_t *buffer, uint16_t size, uint8_t requestedClass, uint8_t 
                 } else {
                     // return payload length
 #ifdef GPS_DEBUG
-                    LOG_INFO("Got ACK for class %02X message %02X in %dms", requestedClass, requestedID, millis() - startTime);
+                    LOG_INFO("Got ACK for class %02X msg %02X in %dms", requestedClass, requestedID, millis() - startTime);
 #endif
                     return needRead;
                 }
@@ -789,7 +789,7 @@ bool GPS::verifyCachedProbePresence()
         present = sawNmeaSentenceAtBaud(_serial_gps, 3000);
     }
     if (!present) {
-        LOG_WARN("Cached GPS probe is stale (%s @ %d), clearing cache", cachedProbeModelName, cachedProbeBaud);
+        LOG_WARN("Cached GPS probe stale (%s @ %d), clearing", cachedProbeModelName, cachedProbeBaud);
         clearProbeCache();
         return false;
     }
@@ -843,7 +843,7 @@ bool GPS::setup()
                 if (gnssModel != GNSS_MODEL_UNKNOWN) {
                     detectedBaud = rareSerialSpeeds[speedSelect];
                 } else if (currentStep == 0 && ++speedSelect == array_count(rareSerialSpeeds)) {
-                    LOG_WARN("Give up on GPS probe and set to %d", GPS_BAUDRATE);
+                    LOG_WARN("Give up GPS probe, set to %d", GPS_BAUDRATE);
                     return true;
                 }
             }
@@ -922,14 +922,14 @@ bool GPS::setup()
             msglen = makeCASPacket(0x06, 0x07, sizeof(_message_CAS_CFG_NAVX_CONF), _message_CAS_CFG_NAVX_CONF);
             _serial_gps->write(UBXscratch, msglen);
             if (getACKCas(0x06, 0x07, 250) != GNSS_RESPONSE_OK) {
-                LOG_WARN("ATGM336H: Could not set Config");
+                LOG_WARN("ATGM336H: Can't set Config");
             }
 
             // Set the update frequency to 1Hz
             msglen = makeCASPacket(0x06, 0x04, sizeof(_message_CAS_CFG_RATE_1HZ), _message_CAS_CFG_RATE_1HZ);
             _serial_gps->write(UBXscratch, msglen);
             if (getACKCas(0x06, 0x04, 250) != GNSS_RESPONSE_OK) {
-                LOG_WARN("ATGM336H: Could not set Update Frequency");
+                LOG_WARN("ATGM336H: Can't set Update Frequency");
             }
 
             // Set the NEMA output messages
@@ -941,7 +941,7 @@ bool GPS::setup()
                 msglen = makeCASPacket(0x06, 0x01, sizeof(cas_cfg_msg_packet), cas_cfg_msg_packet);
                 _serial_gps->write(UBXscratch, msglen);
                 if (getACKCas(0x06, 0x01, 250) != GNSS_RESPONSE_OK) {
-                    LOG_WARN("ATGM336H: Could not enable NMEA MSG: %d", fields[i]);
+                    LOG_WARN("ATGM336H: Can't enable NMEA MSG: %d", fields[i]);
                 }
             }
         } else if (gnssModel == GNSS_MODEL_UC6580) {
@@ -1009,7 +1009,7 @@ bool GPS::setup()
             msglen = makeUBXPacket(0x06, 0x09, sizeof(_message_SAVE), _message_SAVE);
             _serial_gps->write(UBXscratch, msglen);
             if (getACK(0x06, 0x09, 2000) != GNSS_RESPONSE_OK) {
-                LOG_WARN("Unable to save GNSS module config");
+                LOG_WARN("Can't save GNSS module config");
             } else {
                 LOG_INFO("GNSS module config saved");
             }
@@ -1025,7 +1025,7 @@ bool GPS::setup()
 
             if (getACK(0x06, 0x3e, 800) == GNSS_RESPONSE_NAK) {
                 // It's not critical if the module doesn't acknowledge this configuration.
-                LOG_DEBUG("reconfigure GNSS - defaults maintained. Is this module GPS-only?");
+                LOG_DEBUG("reconfigure GNSS - defaults kept. GPS-only module?");
             } else {
                 if (gnssModel == GNSS_MODEL_UBLOX7) {
                     LOG_INFO("GPS+SBAS configured");
@@ -1078,9 +1078,9 @@ bool GPS::setup()
             msglen = makeUBXPacket(0x06, 0x09, sizeof(_message_SAVE), _message_SAVE);
             _serial_gps->write(UBXscratch, msglen);
             if (getACK(0x06, 0x09, 2000) != GNSS_RESPONSE_OK) {
-                LOG_WARN("Unable to save GNSS module config");
+                LOG_WARN("Can't save GNSS module config");
             } else {
-                LOG_INFO("GNSS module configuration saved");
+                LOG_INFO("GNSS module config saved");
             }
         } else if (gnssModel == GNSS_MODEL_UBLOX10) {
             delay(1000);
@@ -1126,9 +1126,9 @@ bool GPS::setup()
             msglen = makeUBXPacket(0x06, 0x09, sizeof(_message_SAVE_10), _message_SAVE_10);
             _serial_gps->write(UBXscratch, msglen);
             if (getACK(0x06, 0x09, 2000) != GNSS_RESPONSE_OK) {
-                LOG_WARN("Unable to save GNSS module config");
+                LOG_WARN("Can't save GNSS module config");
             } else {
-                LOG_INFO("GNSS module configuration saved");
+                LOG_INFO("GNSS module config saved");
             }
         } else if (gnssModel == GNSS_MODEL_CM121) {
             // only ask for RMC and GGA
@@ -1159,7 +1159,7 @@ void GPS::setPowerState(GPSPowerState newState, uint32_t sleepTime)
     // Update the stored GPSPowerstate, and create local copies
     GPSPowerState oldState = powerState;
     powerState = newState;
-    LOG_INFO("GPS power state move from %s to %s", getGPSPowerStateString(oldState), getGPSPowerStateString(newState));
+    LOG_INFO("GPS power state %s -> %s", getGPSPowerStateString(oldState), getGPSPowerStateString(newState));
 
     switch (newState) {
     case GPS_ACTIVE:
@@ -1422,7 +1422,7 @@ void GPS::down()
             // and M10050 https://www.desmos.com/calculator/6gvjghoumr This is not particularly accurate, but probably an
             // improvement over a single, fixed threshold
             uint32_t hardsleepThreshold = (2750 * pow(predictedSearchDuration / 1000, 1.22));
-            LOG_DEBUG("gps_update_interval >= %us needed to justify hardsleep", hardsleepThreshold / 1000);
+            LOG_DEBUG("gps_update_interval >= %us needed for hardsleep", hardsleepThreshold / 1000);
 
             // If update interval too short: softsleep (if supported by hardware)
             if (updateInterval < hardsleepThreshold) {
@@ -1480,7 +1480,7 @@ int32_t GPS::runOnce()
             return currentDelay; // Setup failed, re-run in two seconds
 
         if (gnssModel == GNSS_MODEL_UNKNOWN) {
-            LOG_WARN("GPS not detected; marked not present for this boot");
+            LOG_WARN("GPS not detected; not present this boot");
             return disable();
         }
 
@@ -1564,7 +1564,7 @@ int32_t GPS::runOnce()
 
         bool tooLong = scheduling.searchedTooLong();
         if (tooLong && !gotLoc) {
-            LOG_WARN("Couldn't publish a valid location: didn't get a GPS lock in time");
+            LOG_WARN("Can't publish valid location: no GPS lock in time");
             // we didn't get a location during this ack window, therefore declare loss of lock
             if (hasValidLocation) {
                 p = meshtastic_Position_init_default;
@@ -2025,7 +2025,7 @@ std::unique_ptr<GPS> GPS::createGps()
 #endif
 
 #if defined(SENSECAP_INDICATOR)
-        LOG_DEBUG("Use the RP2040 tunnel for GPS, no local pins");
+        LOG_DEBUG("Use RP2040 tunnel for GPS, no local pins");
 #else
         LOG_DEBUG("Use GPIO%d for GPS RX", new_gps->rx_gpio);
         LOG_DEBUG("Use GPIO%d for GPS TX", new_gps->tx_gpio);
@@ -2123,7 +2123,7 @@ bool GPS::lookForLocation()
 #ifndef GPS_DEBUG
         if (reader.failedChecksum() > 4)
 #endif
-            LOG_WARN("%u new GPS checksum failures, for a total of %u", reader.failedChecksum() - lastChecksumFailCount,
+            LOG_WARN("%u new GPS checksum failures, total %u", reader.failedChecksum() - lastChecksumFailCount,
                      reader.failedChecksum());
         lastChecksumFailCount = reader.failedChecksum();
     }
@@ -2159,7 +2159,7 @@ bool GPS::lookForLocation()
           (gsafixtype.age() < GPS_SOL_EXPIRY_MS) &&
 #endif
           (reader.time.age() < GPS_SOL_EXPIRY_MS) && (reader.date.age() < GPS_SOL_EXPIRY_MS))) {
-        LOG_WARN("SOME data is TOO OLD: LOC %u, TIME %u, DATE %u", reader.location.age(), reader.time.age(), reader.date.age());
+        LOG_WARN("SOME data TOO OLD: LOC %u, TIME %u, DATE %u", reader.location.age(), reader.time.age(), reader.date.age());
         return false;
     }
 
@@ -2270,7 +2270,7 @@ bool GPS::whileActive()
     }
 #ifdef SERIAL_BUFFER_SIZE
     if (_serial_gps->available() >= SERIAL_BUFFER_SIZE - 1) {
-        LOG_WARN("GPS Buffer full with %u bytes waiting. Flush to avoid corruption", _serial_gps->available());
+        LOG_WARN("GPS Buffer full (%u bytes). Flush to avoid corruption", _serial_gps->available());
         clearBuffer();
     }
 #endif

--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1011,7 +1011,7 @@ bool GPS::setup()
             if (getACK(0x06, 0x09, 2000) != GNSS_RESPONSE_OK) {
                 LOG_WARN("Unable to save GNSS module config");
             } else {
-                LOG_INFO("GNSS module config saved!");
+                LOG_INFO("GNSS module config saved");
             }
         } else if (IS_ONE_OF(gnssModel, GNSS_MODEL_UBLOX7, GNSS_MODEL_UBLOX8, GNSS_MODEL_UBLOX9)) {
             if (gnssModel == GNSS_MODEL_UBLOX7) {
@@ -1080,7 +1080,7 @@ bool GPS::setup()
             if (getACK(0x06, 0x09, 2000) != GNSS_RESPONSE_OK) {
                 LOG_WARN("Unable to save GNSS module config");
             } else {
-                LOG_INFO("GNSS module configuration saved!");
+                LOG_INFO("GNSS module configuration saved");
             }
         } else if (gnssModel == GNSS_MODEL_UBLOX10) {
             delay(1000);
@@ -1128,7 +1128,7 @@ bool GPS::setup()
             if (getACK(0x06, 0x09, 2000) != GNSS_RESPONSE_OK) {
                 LOG_WARN("Unable to save GNSS module config");
             } else {
-                LOG_INFO("GNSS module configuration saved!");
+                LOG_INFO("GNSS module configuration saved");
             }
         } else if (gnssModel == GNSS_MODEL_CM121) {
             // only ask for RMC and GGA
@@ -1623,7 +1623,7 @@ void GPS::clearBuffer()
 /// Prepare the GPS for the cpu entering deep or light sleep, expect to be gone for at least 100s of msecs
 int GPS::prepareDeepSleep(void *unused)
 {
-    LOG_INFO("GPS deep sleep!");
+    LOG_INFO("GPS deep sleep");
     disable();
     return 0;
 }

--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -22,7 +22,7 @@ static const uint32_t TIME_VALIDATION_WARNING_INTERVAL_MS = 15000; // 15 seconds
 static void onTimeSourceQualityChanged(RTCQuality oldQuality, RTCQuality newQuality)
 {
     if (oldQuality == RTCQualityNone && newQuality > RTCQualityNone && nodeInfoModule) {
-        LOG_DEBUG("Time source acquired (%s -> %s), triggering NodeInfo recheck", RtcName(oldQuality), RtcName(newQuality));
+        LOG_DEBUG("Time source acquired (%s -> %s), recheck NodeInfo", RtcName(oldQuality), RtcName(newQuality));
         nodeInfoModule->triggerImmediateNodeInfoCheck();
     }
     if (oldQuality < RTCQualityFromNet && newQuality >= RTCQualityFromNet && service) {
@@ -77,7 +77,7 @@ static struct timeval mockSystemTime = {};
             timeStartMsec = now;
             zeroOffsetSecs = tv.tv_sec;
         } else {
-            LOG_DEBUG("Ignore system clock fallback (%lu); current RTC quality is %s", (unsigned long)printableEpoch,
+            LOG_DEBUG("Ignore system clock fallback (%lu); RTC quality is %s", (unsigned long)printableEpoch,
                       RtcName(currentQuality));
         }
         return RTCSetResultSuccess;
@@ -127,7 +127,7 @@ RTCSetResult readFromRTC()
         }
 #endif
 
-        LOG_DEBUG("Read RTC time from RV3028 getTime as %02d-%02d-%02d %02d:%02d:%02d (%ld)", t.tm_year + 1900, t.tm_mon + 1,
+        LOG_DEBUG("RTC time from RV3028 getTime: %02d-%02d-%02d %02d:%02d:%02d (%ld)", t.tm_year + 1900, t.tm_mon + 1,
                   t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec, printableEpoch);
         if (currentQuality == RTCQualityNone) {
             RTCQuality oldQuality = currentQuality;
@@ -138,7 +138,7 @@ RTCSetResult readFromRTC()
         }
         return RTCSetResultSuccess;
     } else {
-        LOG_WARN("RTC not found (found address 0x%02X)", rtc_found.address);
+        LOG_WARN("RTC not found (addr 0x%02X)", rtc_found.address);
     }
 #elif defined(PCF8563_RTC) || defined(PCF85063_RTC)
 #if defined(PCF8563_RTC)
@@ -173,7 +173,7 @@ RTCSetResult readFromRTC()
         }
 #endif
 
-        LOG_DEBUG("Read RTC time from %s getDateTime as %02d-%02d-%02d %02d:%02d:%02d (%ld)", rtc.getChipName(), t.tm_year + 1900,
+        LOG_DEBUG("RTC time from %s getDateTime: %02d-%02d-%02d %02d:%02d:%02d (%ld)", rtc.getChipName(), t.tm_year + 1900,
                   t.tm_mon + 1, t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec, printableEpoch);
         if (currentQuality == RTCQualityNone) {
             RTCQuality oldQuality = currentQuality;
@@ -184,7 +184,7 @@ RTCSetResult readFromRTC()
         }
         return RTCSetResultSuccess;
     } else {
-        LOG_WARN("RTC not found (found address 0x%02X)", rtc_found.address);
+        LOG_WARN("RTC not found (addr 0x%02X)", rtc_found.address);
     }
 #elif defined(RX8130CE_RTC)
     if (rtc_found.address == RX8130CE_RTC) {
@@ -200,7 +200,7 @@ RTCSetResult readFromRTC()
             tv.tv_usec = 0;
 
             uint32_t printableEpoch = tv.tv_sec; // Print lib only supports 32 bit but time_t can be 64 bit on some platforms
-            LOG_DEBUG("Read RTC time from RX8130CE getDateTime as %02d-%02d-%02d %02d:%02d:%02d (%ld)", t.tm_year + 1900,
+            LOG_DEBUG("RTC time from RX8130CE getDateTime: %02d-%02d-%02d %02d:%02d:%02d (%ld)", t.tm_year + 1900,
                       t.tm_mon + 1, t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec, printableEpoch);
 #ifdef BUILD_EPOCH
             if (tv.tv_sec < BUILD_EPOCH) {
@@ -277,7 +277,7 @@ RTCSetResult perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpd
             // Calculate max allowed time safely to avoid overflow in logging
             uint64_t maxAllowedTime = (uint64_t)BUILD_EPOCH + FORTY_YEARS;
             uint32_t maxAllowedPrintable = (maxAllowedTime > UINT32_MAX) ? UINT32_MAX : (uint32_t)maxAllowedTime;
-            LOG_WARN("Ignore time (%ld) too far in the future (build epoch: %ld, max allowed: %ld)", printableEpoch,
+            LOG_WARN("Ignore time (%ld) too far in future (build epoch: %ld, max: %ld)", printableEpoch,
                      (uint32_t)BUILD_EPOCH, maxAllowedPrintable);
             lastTimeValidationWarning = millis();
         }
@@ -288,7 +288,7 @@ RTCSetResult perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpd
     bool shouldSet;
     if (forceUpdate) {
         shouldSet = true;
-        LOG_DEBUG("Override current RTC quality (%s) with incoming time of RTC quality of %s", RtcName(currentQuality),
+        LOG_DEBUG("Override RTC quality (%s) with incoming quality %s", RtcName(currentQuality),
                   RtcName(q));
     } else if (q > currentQuality) {
         shouldSet = true;
@@ -299,10 +299,10 @@ RTCSetResult perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpd
     } else if (q == RTCQualityNTP && !Throttle::isWithinTimespanMs(lastSetMsec, (30 * 60 * 1000UL))) {
         // Every 30 minutes we will slam in a new NTP or Phone GPS / NTP time, to correct for local RTC clock drift
         shouldSet = true;
-        LOG_DEBUG("Reapply external time to correct clock drift %ld secs", printableEpoch);
+        LOG_DEBUG("Reapply external time to fix clock drift %ld secs", printableEpoch);
     } else {
         shouldSet = false;
-        LOG_DEBUG("Current RTC quality: %s. Ignore time of RTC quality of %s", RtcName(currentQuality), RtcName(q));
+        LOG_DEBUG("RTC quality: %s. Ignore time of quality %s", RtcName(currentQuality), RtcName(q));
     }
 
     if (shouldSet) {
@@ -333,7 +333,7 @@ RTCSetResult perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpd
             LOG_DEBUG("RV3028_RTC setTime %02d-%02d-%02d %02d:%02d:%02d (%ld)", t->tm_year + 1900, t->tm_mon + 1, t->tm_mday,
                       t->tm_hour, t->tm_min, t->tm_sec, printableEpoch);
         } else {
-            LOG_WARN("RTC not found (found address 0x%02X)", rtc_found.address);
+            LOG_WARN("RTC not found (addr 0x%02X)", rtc_found.address);
         }
 #elif defined(PCF8563_RTC) || defined(PCF85063_RTC)
 #if defined(PCF8563_RTC)
@@ -358,7 +358,7 @@ RTCSetResult perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpd
             LOG_DEBUG("%s setDateTime %02d-%02d-%02d %02d:%02d:%02d (%ld)", rtc.getChipName(), t->tm_year + 1900, t->tm_mon + 1,
                       t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec, printableEpoch);
         } else {
-            LOG_WARN("RTC not found (found address 0x%02X)", rtc_found.address);
+            LOG_WARN("RTC not found (addr 0x%02X)", rtc_found.address);
         }
 #elif defined(RX8130CE_RTC)
         if (rtc_found.address == RX8130CE_RTC) {
@@ -375,7 +375,7 @@ RTCSetResult perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpd
                 LOG_DEBUG("RX8130CE setDateTime %02d-%02d-%02d %02d:%02d:%02d (%ld)", t->tm_year + 1900, t->tm_mon + 1,
                           t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec, printableEpoch);
             } else {
-                LOG_WARN("Failed to set time for RX8130CE");
+                LOG_WARN("RX8130CE set time failed");
             }
         }
 #elif HAS_LSE
@@ -444,7 +444,7 @@ RTCSetResult perhapsSetRTC(RTCQuality q, const struct tm &t)
             // Calculate max allowed time safely to avoid overflow in logging
             uint64_t maxAllowedTime = (uint64_t)BUILD_EPOCH + FORTY_YEARS;
             uint32_t maxAllowedPrintable = (maxAllowedTime > UINT32_MAX) ? UINT32_MAX : (uint32_t)maxAllowedTime;
-            LOG_WARN("Ignore time (%lu) too far in the future (build epoch: %lu, max allowed: %lu)", printableEpoch,
+            LOG_WARN("Ignore time (%lu) too far in future (build epoch: %lu, max: %lu)", printableEpoch,
                      (uint32_t)BUILD_EPOCH, maxAllowedPrintable);
             lastTimeValidationWarning = millis();
         }

--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -138,7 +138,7 @@ RTCSetResult readFromRTC()
         }
         return RTCSetResultSuccess;
     } else {
-        LOG_WARN("RTC not found (addr 0x%02X)", rtc_found.address);
+        LOG_WARN("RTC read: not found (addr 0x%02X)", rtc_found.address);
     }
 #elif defined(PCF8563_RTC) || defined(PCF85063_RTC)
 #if defined(PCF8563_RTC)
@@ -184,7 +184,7 @@ RTCSetResult readFromRTC()
         }
         return RTCSetResultSuccess;
     } else {
-        LOG_WARN("RTC not found (addr 0x%02X)", rtc_found.address);
+        LOG_WARN("RTC read: not found (addr 0x%02X)", rtc_found.address);
     }
 #elif defined(RX8130CE_RTC)
     if (rtc_found.address == RX8130CE_RTC) {
@@ -332,7 +332,7 @@ RTCSetResult perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpd
             LOG_DEBUG("RV3028_RTC setTime %02d-%02d-%02d %02d:%02d:%02d (%ld)", t->tm_year + 1900, t->tm_mon + 1, t->tm_mday,
                       t->tm_hour, t->tm_min, t->tm_sec, printableEpoch);
         } else {
-            LOG_WARN("RTC not found (addr 0x%02X)", rtc_found.address);
+            LOG_WARN("RTC set: not found (addr 0x%02X)", rtc_found.address);
         }
 #elif defined(PCF8563_RTC) || defined(PCF85063_RTC)
 #if defined(PCF8563_RTC)
@@ -357,7 +357,7 @@ RTCSetResult perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpd
             LOG_DEBUG("%s setDateTime %02d-%02d-%02d %02d:%02d:%02d (%ld)", rtc.getChipName(), t->tm_year + 1900, t->tm_mon + 1,
                       t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec, printableEpoch);
         } else {
-            LOG_WARN("RTC not found (addr 0x%02X)", rtc_found.address);
+            LOG_WARN("RTC set: not found (addr 0x%02X)", rtc_found.address);
         }
 #elif defined(RX8130CE_RTC)
         if (rtc_found.address == RX8130CE_RTC) {

--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -127,8 +127,8 @@ RTCSetResult readFromRTC()
         }
 #endif
 
-        LOG_DEBUG("RTC time from RV3028 getTime: %02d-%02d-%02d %02d:%02d:%02d (%ld)", t.tm_year + 1900, t.tm_mon + 1,
-                  t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec, printableEpoch);
+        LOG_DEBUG("RTC time from RV3028 getTime: %02d-%02d-%02d %02d:%02d:%02d (%ld)", t.tm_year + 1900, t.tm_mon + 1, t.tm_mday,
+                  t.tm_hour, t.tm_min, t.tm_sec, printableEpoch);
         if (currentQuality == RTCQualityNone) {
             RTCQuality oldQuality = currentQuality;
             timeStartMsec = now;
@@ -200,8 +200,8 @@ RTCSetResult readFromRTC()
             tv.tv_usec = 0;
 
             uint32_t printableEpoch = tv.tv_sec; // Print lib only supports 32 bit but time_t can be 64 bit on some platforms
-            LOG_DEBUG("RTC time from RX8130CE getDateTime: %02d-%02d-%02d %02d:%02d:%02d (%ld)", t.tm_year + 1900,
-                      t.tm_mon + 1, t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec, printableEpoch);
+            LOG_DEBUG("RTC time from RX8130CE getDateTime: %02d-%02d-%02d %02d:%02d:%02d (%ld)", t.tm_year + 1900, t.tm_mon + 1,
+                      t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec, printableEpoch);
 #ifdef BUILD_EPOCH
             if (tv.tv_sec < BUILD_EPOCH) {
                 if (Throttle::isWithinTimespanMs(lastTimeValidationWarning, TIME_VALIDATION_WARNING_INTERVAL_MS) == false) {
@@ -277,8 +277,8 @@ RTCSetResult perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpd
             // Calculate max allowed time safely to avoid overflow in logging
             uint64_t maxAllowedTime = (uint64_t)BUILD_EPOCH + FORTY_YEARS;
             uint32_t maxAllowedPrintable = (maxAllowedTime > UINT32_MAX) ? UINT32_MAX : (uint32_t)maxAllowedTime;
-            LOG_WARN("Ignore time (%ld) too far in future (build epoch: %ld, max: %ld)", printableEpoch,
-                     (uint32_t)BUILD_EPOCH, maxAllowedPrintable);
+            LOG_WARN("Ignore time (%ld) too far in future (build epoch: %ld, max: %ld)", printableEpoch, (uint32_t)BUILD_EPOCH,
+                     maxAllowedPrintable);
             lastTimeValidationWarning = millis();
         }
         return RTCSetResultInvalidTime;
@@ -288,8 +288,7 @@ RTCSetResult perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpd
     bool shouldSet;
     if (forceUpdate) {
         shouldSet = true;
-        LOG_DEBUG("Override RTC quality (%s) with incoming quality %s", RtcName(currentQuality),
-                  RtcName(q));
+        LOG_DEBUG("Override RTC quality (%s) with incoming quality %s", RtcName(currentQuality), RtcName(q));
     } else if (q > currentQuality) {
         shouldSet = true;
         LOG_DEBUG("Upgrade time to quality %s", RtcName(q));
@@ -444,8 +443,8 @@ RTCSetResult perhapsSetRTC(RTCQuality q, const struct tm &t)
             // Calculate max allowed time safely to avoid overflow in logging
             uint64_t maxAllowedTime = (uint64_t)BUILD_EPOCH + FORTY_YEARS;
             uint32_t maxAllowedPrintable = (maxAllowedTime > UINT32_MAX) ? UINT32_MAX : (uint32_t)maxAllowedTime;
-            LOG_WARN("Ignore time (%lu) too far in future (build epoch: %lu, max: %lu)", printableEpoch,
-                     (uint32_t)BUILD_EPOCH, maxAllowedPrintable);
+            LOG_WARN("Ignore time (%lu) too far in future (build epoch: %lu, max: %lu)", printableEpoch, (uint32_t)BUILD_EPOCH,
+                     maxAllowedPrintable);
             lastTimeValidationWarning = millis();
         }
         return RTCSetResultInvalidTime;

--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -121,7 +121,7 @@ RTCSetResult readFromRTC()
 #ifdef BUILD_EPOCH
         if (tv.tv_sec < BUILD_EPOCH) {
             if (Throttle::isWithinTimespanMs(lastTimeValidationWarning, TIME_VALIDATION_WARNING_INTERVAL_MS) == false) {
-                LOG_WARN("Ignore time (%ld) before build epoch (%ld)!", printableEpoch, BUILD_EPOCH);
+                LOG_WARN("Ignore time (%ld) before build epoch (%ld)", printableEpoch, BUILD_EPOCH);
             }
             return RTCSetResultInvalidTime;
         }
@@ -166,7 +166,7 @@ RTCSetResult readFromRTC()
 #ifdef BUILD_EPOCH
         if (tv.tv_sec < BUILD_EPOCH) {
             if (Throttle::isWithinTimespanMs(lastTimeValidationWarning, TIME_VALIDATION_WARNING_INTERVAL_MS) == false) {
-                LOG_WARN("Ignore time (%ld) before build epoch (%ld)!", printableEpoch, BUILD_EPOCH);
+                LOG_WARN("Ignore time (%ld) before build epoch (%ld)", printableEpoch, BUILD_EPOCH);
                 lastTimeValidationWarning = millis();
             }
             return RTCSetResultInvalidTime;
@@ -205,7 +205,7 @@ RTCSetResult readFromRTC()
 #ifdef BUILD_EPOCH
             if (tv.tv_sec < BUILD_EPOCH) {
                 if (Throttle::isWithinTimespanMs(lastTimeValidationWarning, TIME_VALIDATION_WARNING_INTERVAL_MS) == false) {
-                    LOG_WARN("Ignore time (%ld) before build epoch (%ld)!", printableEpoch, BUILD_EPOCH);
+                    LOG_WARN("Ignore time (%ld) before build epoch (%ld)", printableEpoch, BUILD_EPOCH);
                     lastTimeValidationWarning = millis();
                 }
                 return RTCSetResultInvalidTime;
@@ -230,7 +230,7 @@ RTCSetResult readFromRTC()
 #ifdef BUILD_EPOCH
         if (tv.tv_sec < BUILD_EPOCH) {
             if (Throttle::isWithinTimespanMs(lastTimeValidationWarning, TIME_VALIDATION_WARNING_INTERVAL_MS) == false) {
-                LOG_WARN("Ignore time (%ld) before build epoch (%ld)!", printableEpoch, BUILD_EPOCH);
+                LOG_WARN("Ignore time (%ld) before build epoch (%ld)", printableEpoch, BUILD_EPOCH);
                 lastTimeValidationWarning = millis();
             }
             return RTCSetResultInvalidTime;
@@ -268,7 +268,7 @@ RTCSetResult perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpd
 #ifdef BUILD_EPOCH
     if (tv->tv_sec < BUILD_EPOCH) {
         if (Throttle::isWithinTimespanMs(lastTimeValidationWarning, TIME_VALIDATION_WARNING_INTERVAL_MS) == false) {
-            LOG_WARN("Ignore time (%ld) before build epoch (%ld)!", printableEpoch, BUILD_EPOCH);
+            LOG_WARN("Ignore time (%ld) before build epoch (%ld)", printableEpoch, BUILD_EPOCH);
             lastTimeValidationWarning = millis();
         }
         return RTCSetResultInvalidTime;
@@ -277,7 +277,7 @@ RTCSetResult perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpd
             // Calculate max allowed time safely to avoid overflow in logging
             uint64_t maxAllowedTime = (uint64_t)BUILD_EPOCH + FORTY_YEARS;
             uint32_t maxAllowedPrintable = (maxAllowedTime > UINT32_MAX) ? UINT32_MAX : (uint32_t)maxAllowedTime;
-            LOG_WARN("Ignore time (%ld) too far in the future (build epoch: %ld, max allowed: %ld)!", printableEpoch,
+            LOG_WARN("Ignore time (%ld) too far in the future (build epoch: %ld, max allowed: %ld)", printableEpoch,
                      (uint32_t)BUILD_EPOCH, maxAllowedPrintable);
             lastTimeValidationWarning = millis();
         }
@@ -435,7 +435,7 @@ RTCSetResult perhapsSetRTC(RTCQuality q, const struct tm &t)
 #ifdef BUILD_EPOCH
     if (tv.tv_sec < BUILD_EPOCH) {
         if (Throttle::isWithinTimespanMs(lastTimeValidationWarning, TIME_VALIDATION_WARNING_INTERVAL_MS) == false) {
-            LOG_WARN("Ignore time (%lu) before build epoch (%lu)!", printableEpoch, BUILD_EPOCH);
+            LOG_WARN("Ignore time (%lu) before build epoch (%lu)", printableEpoch, BUILD_EPOCH);
             lastTimeValidationWarning = millis();
         }
         return RTCSetResultInvalidTime;
@@ -444,7 +444,7 @@ RTCSetResult perhapsSetRTC(RTCQuality q, const struct tm &t)
             // Calculate max allowed time safely to avoid overflow in logging
             uint64_t maxAllowedTime = (uint64_t)BUILD_EPOCH + FORTY_YEARS;
             uint32_t maxAllowedPrintable = (maxAllowedTime > UINT32_MAX) ? UINT32_MAX : (uint32_t)maxAllowedTime;
-            LOG_WARN("Ignore time (%lu) too far in the future (build epoch: %lu, max allowed: %lu)!", printableEpoch,
+            LOG_WARN("Ignore time (%lu) too far in the future (build epoch: %lu, max allowed: %lu)", printableEpoch,
                      (uint32_t)BUILD_EPOCH, maxAllowedPrintable);
             lastTimeValidationWarning = millis();
         }

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -581,7 +581,7 @@ Screen::Screen(ScanI2C::DeviceAddress address, meshtastic_Config_DisplayConfig_O
 #elif defined(USE_SPISSD1306)
     dispdev = new SSD1306Spi(SSD1306_RESET, SSD1306_RS, SSD1306_NSS, GEOMETRY_64_48);
     if (!dispdev->init()) {
-        LOG_DEBUG("Error: SSD1306 not detected!");
+        LOG_DEBUG("SSD1306 not detected");
     } else {
         static_cast<SSD1306Spi *>(dispdev)->setHorizontalOffset(32);
         LOG_INFO("SSD1306 init success");
@@ -592,14 +592,14 @@ Screen::Screen(ScanI2C::DeviceAddress address, meshtastic_Config_DisplayConfig_O
     // runtime via config.yaml Display: Panel: HUB75.
     if (portduino_config.displayPanel == hub75) {
 #if defined(HAS_HUB75_NATIVE)
-        LOG_DEBUG("Make HUB75Native!");
+        LOG_DEBUG("Make HUB75Native");
         dispdev = new HUB75Native(address.address, -1, -1, GEOMETRY_RAWMODE, HW_I2C::I2C_ONE);
 #else
-        LOG_ERROR("HUB75 panel requested but rpi-rgb-led-matrix not compiled in!");
+        LOG_ERROR("HUB75 panel requested but rpi-rgb-led-matrix not compiled in");
 #endif
     } else if (config.display.displaymode != meshtastic_Config_DisplayConfig_DisplayMode_COLOR) {
         if (portduino_config.displayPanel != no_screen) {
-            LOG_DEBUG("Make TFTDisplay!");
+            LOG_DEBUG("Make TFTDisplay");
             dispdev = new TFTDisplay(address.address, -1, -1, geometry,
                                      (address.port == ScanI2C::I2CPort::WIRE1) ? HW_I2C::I2C_TWO : HW_I2C::I2C_ONE);
         } else {
@@ -610,7 +610,7 @@ Screen::Screen(ScanI2C::DeviceAddress address, meshtastic_Config_DisplayConfig_O
         }
     }
 #elif USE_TFTDISPLAY
-    LOG_DEBUG("Make TFTDisplay!");
+    LOG_DEBUG("Make TFTDisplay");
     dispdev = new TFTDisplay(address.address, -1, -1, geometry,
                              (address.port == ScanI2C::I2CPort::WIRE1) ? HW_I2C::I2C_TWO : HW_I2C::I2C_ONE);
 #elif defined(USE_EINK) && defined(MESHTASTIC_INCLUDE_NICHE_GRAPHICS) && !defined(MESHTASTIC_INCLUDE_INKHUD)
@@ -1121,7 +1121,7 @@ int32_t Screen::runOnce()
 #ifdef USERPREFS_OEM_TEXT
     static bool showingOEMBootScreen = true;
     if (showingOEMBootScreen && (millis() > ((logo_timeout / 2) + serialSinceMsec))) {
-        LOG_INFO("Switch to OEM screen...");
+        LOG_INFO("Switch to OEM screen");
         // Change frames.
         static FrameCallback bootOEMFrames[] = {graphics::UIRenderer::drawOEMBootScreen};
         static const int bootOEMFrameCount = sizeof(bootOEMFrames) / sizeof(bootOEMFrames[0]);

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -430,7 +430,7 @@ void Screen::showAlphanumericPicker(const char *message, const char *initialText
 void Screen::showTextInput(const char *header, const char *initialText, uint32_t durationMs,
                            std::function<void(const std::string &)> textCallback)
 {
-    LOG_INFO("showTextInput called with header='%s', durationMs=%d", header ? header : "NULL", durationMs);
+    LOG_INFO("showTextInput header='%s', durationMs=%d", header ? header : "NULL", durationMs);
 
     // Start OnScreenKeyboardModule session (non-touch variant)
     OnScreenKeyboardModule::instance().start(header, initialText, durationMs, textCallback);
@@ -1271,7 +1271,7 @@ int32_t Screen::runOnce()
             EINK_ADD_FRAMEFLAG(dispdev, COSMETIC);
 #endif
 
-            LOG_DEBUG("LastScreenTransition exceeded %ums transition to next frame", (millis() - lastScreenTransition));
+            LOG_DEBUG("LastScreenTransition exceeded %ums, next frame", (millis() - lastScreenTransition));
             handleOnPress();
         }
     }

--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -851,7 +851,7 @@ class LGFX : public lgfx::LGFX_Device
 #endif
         else {
             _panel_instance = new lgfx::Panel_NULL;
-            LOG_ERROR("Unknown display panel configured!");
+            LOG_ERROR("Unknown display panel configured");
         }
 
         auto buscfg = _bus_instance.config();
@@ -1187,7 +1187,7 @@ static inline uint16_t getThemeDefaultOffColor()
 
 TFTDisplay::TFTDisplay(uint8_t address, int sda, int scl, OLEDDISPLAY_GEOMETRY geometry, HW_I2C i2cBus)
 {
-    LOG_DEBUG("TFTDisplay!");
+    LOG_DEBUG("TFTDisplay");
 
 #ifdef TFT_BL
     GpioPin *p = new GpioHwPin(TFT_BL);
@@ -1441,7 +1441,7 @@ void TFTDisplay::sdlLoop()
     if (portduino_config.displayPanel == x11) {
         lgfx::Panel_sdl *sdl_panel_ = (lgfx::Panel_sdl *)tft->_panel_instance;
         if (sdl_panel_->loop() && !shuttingDown) {
-            LOG_WARN("Window Closed!");
+            LOG_WARN("Window Closed");
             InputEvent event = {.inputEvent = (input_broker_event)INPUT_BROKER_SHUTDOWN, .kbchar = 0, .touchX = 0, .touchY = 0};
             inputBroker->injectInputEvent(&event);
         }
@@ -1625,9 +1625,9 @@ bool TFTDisplay::connect()
 #ifdef HACKADAY_COMMUNICATOR
     bool beginStatus = tft->begin();
     if (beginStatus)
-        LOG_DEBUG("TFT Success!");
+        LOG_DEBUG("TFT Success");
     else
-        LOG_ERROR("TFT Fail!");
+        LOG_ERROR("TFT Fail");
 #else
     tft->init();
 #endif
@@ -1656,7 +1656,7 @@ bool TFTDisplay::connect()
         this->linePixelBuffer = (uint16_t *)malloc(sizeof(uint16_t) * displayWidth);
 
         if (!this->linePixelBuffer) {
-            LOG_ERROR("Not enough memory to create TFT line buffer\n");
+            LOG_ERROR("Not enough memory to create TFT line buffer");
             return false;
         }
         memaudit::add("display", sizeof(uint16_t) * displayWidth);
@@ -1665,7 +1665,7 @@ bool TFTDisplay::connect()
         this->repaintChunkBuffer = (uint16_t *)malloc(sizeof(uint16_t) * displayWidth * kFullRepaintChunkRows);
 
         if (!this->repaintChunkBuffer) {
-            LOG_ERROR("Not enough memory to create TFT repaint chunk buffer\n");
+            LOG_ERROR("Not enough memory to create TFT repaint chunk buffer");
             return false;
         }
         memaudit::add("display", sizeof(uint16_t) * displayWidth * kFullRepaintChunkRows);

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -193,7 +193,7 @@ static void applyLoraRegion(meshtastic_Config_LoRaConfig_RegionCode region, bool
     // flip the region right back. The user picked the region, so the preset follows it.
     const RegionInfo *newRegion = getRegion(region);
     if (config.lora.use_preset && !newRegion->supportsPreset(config.lora.modem_preset)) {
-        LOG_INFO("Preset %s not available in %s, using default %s",
+        LOG_INFO("Preset %s unavailable in %s, use default %s",
                  DisplayFormatters::getModemPresetDisplayName(config.lora.modem_preset, false, true), newRegion->name,
                  DisplayFormatters::getModemPresetDisplayName(newRegion->getDefaultPreset(), false, true));
         config.lora.modem_preset = newRegion->getDefaultPreset();
@@ -319,7 +319,7 @@ void menuHandler::LoraRegionPicker(uint32_t duration)
                 menuQueue = HamModeConfirm;
                 screen->runNow();
             } else if (owner.is_licensed) {
-                LOG_INFO("Licensed user chose a non-ham region; prompting to revert licensed mode");
+                LOG_INFO("Licensed user chose non-ham region; prompt to revert licensed mode");
                 pendingRegion = selectedRegion;
                 menuQueue = LicensedToNormalConfirm;
                 screen->runNow();
@@ -439,10 +439,10 @@ void menuHandler::FrequencySlotPicker()
         if (denominator > 0.0) {
             numChannels = static_cast<uint32_t>(round(numerator / denominator));
         } else {
-            LOG_WARN("Invalid region configuration: non-positive channel spacing/width");
+            LOG_WARN("Invalid region config: non-positive channel spacing/width");
         }
     } else {
-        LOG_WARN("Region not set, cannot calculate number of channels");
+        LOG_WARN("Region not set, can't calc channel count");
         return;
     }
 
@@ -944,7 +944,7 @@ void menuHandler::deleteMessagesMenu()
 
         // This only appears in non-ALL modes
         if (selected == DeleteThis) {
-            LOG_INFO("Deleting all messages in this thread");
+            LOG_INFO("Deleting all messages in thread");
 
             if (mode == graphics::MessageRenderer::ThreadMode::CHANNEL) {
                 messageStore.deleteAllMessagesInChannel(ch);
@@ -1792,7 +1792,7 @@ void menuHandler::resetNodeDBMenu()
             disableBluetooth();
             rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
         } else if (selected == 2) {
-            LOG_INFO("Initiate node-db reset but keeping favorites");
+            LOG_INFO("Initiate node-db reset, keep favorites");
             nodeDB->resetNodes(1);
             disableBluetooth();
             rebootAtMsec = (millis() + DEFAULT_REBOOT_SECONDS * 1000);
@@ -2359,7 +2359,7 @@ void menuHandler::removeFavoriteMenu()
 void menuHandler::traceRouteMenu()
 {
     screen->showNodePicker("Node to Trace", 30000, [](uint32_t nodenum) -> void {
-        LOG_INFO("Menu: Node picker selected node 0x%08x, traceRouteModule=%p", nodenum, traceRouteModule);
+        LOG_INFO("Menu: Node picker selected 0x%08x, traceRouteModule=%p", nodenum, traceRouteModule);
         if (traceRouteModule) {
             traceRouteModule->startTraceRoute(nodenum);
         }

--- a/src/graphics/eink/Drivers/EInk.cpp
+++ b/src/graphics/eink/Drivers/EInk.cpp
@@ -54,7 +54,7 @@ int32_t EInk::runOnce()
     // - polling timeout
     // - other error (derived classes)
     if (failed) {
-        LOG_WARN("Display update failed. Check wiring & power supply.");
+        LOG_WARN("Display update failed. Check wiring & power supply");
         updateRunning = false;
         failed = false;
         return disable();

--- a/src/graphics/niche/Drivers/EInk/EInk.cpp
+++ b/src/graphics/niche/Drivers/EInk/EInk.cpp
@@ -54,7 +54,7 @@ int32_t EInk::runOnce()
     // - polling timeout
     // - other error (derived classes)
     if (failed) {
-        LOG_WARN("Display update failed. Check wiring & power supply.");
+        LOG_WARN("Display update failed. Check wiring & power supply");
         updateRunning = false;
         failed = false;
         return disable();

--- a/src/graphics/niche/Utils/FlashData.h
+++ b/src/graphics/niche/Utils/FlashData.h
@@ -135,10 +135,10 @@ template <typename T> class FlashData
         bool writeSucceeded = f.close();
 
         if (!writeSucceeded) {
-            LOG_ERROR("Can't write data!");
+            LOG_ERROR("Can't write data");
         }
 #else
-        LOG_ERROR("ERROR: Filesystem not implemented\n");
+        LOG_ERROR("Filesystem not implemented");
 #endif
     }
 };
@@ -165,7 +165,7 @@ inline void clearFlashData()
         file = dir.openNextFile();
     }
 #else
-    LOG_ERROR("ERROR: Filesystem not implemented\n");
+    LOG_ERROR("Filesystem not implemented");
 #endif
 }
 

--- a/src/graphics/niche/Utils/FlashData.h
+++ b/src/graphics/niche/Utils/FlashData.h
@@ -96,7 +96,7 @@ template <typename T> class FlashData
 
             f.close();
         } else {
-            LOG_ERROR("Could not open / read %s", filename.c_str());
+            LOG_ERROR("Can't open / read %s", filename.c_str());
             okay = false;
         }
 #else

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -407,7 +407,7 @@ void tftSetup(void)
         PacketAPI::create(PacketServer::init());
         deviceScreen->init(new PacketClient);
     } else {
-        LOG_INFO("Running without TFT display!");
+        LOG_INFO("Running without TFT display");
     }
 #endif
 

--- a/src/input/ButtonThread.cpp
+++ b/src/input/ButtonThread.cpp
@@ -226,7 +226,7 @@ int32_t ButtonThread::runOnce()
         }
 
         case BUTTON_EVENT_DOUBLE_PRESSED: { // not wired in if screen detected
-            LOG_INFO("Double press!");
+            LOG_INFO("Double press");
 #if defined(ELECROW_ThinkNode_M8)
             if (config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED)
                 config.device.buzzer_mode = meshtastic_Config_DeviceConfig_BuzzerMode_DISABLED;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -454,7 +454,7 @@ void setup()
     powerMonInit();
     serialSinceMsec = millis();
 
-    LOG_INFO("\n\n//\\ E S H T /\\ S T / C");
+    LOG_INFO("\n\n//\\ E S H T /\\ S T / C\n");
 
 #if defined(ARCH_ESP32) && defined(BOARD_HAS_PSRAM)
 #ifndef SENSECAP_INDICATOR

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -544,9 +544,9 @@ void setup()
     EncryptedStorage::initLocked();
     if (!EncryptedStorage::isUnlocked()) {
         if (!EncryptedStorage::isProvisioned()) {
-            LOG_WARN("Lockdown: Device not provisioned - connect and set a passphrase to unlock storage");
+            LOG_WARN("Lockdown: Device not provisioned - set passphrase to unlock storage");
         } else {
-            LOG_WARN("Lockdown: Device locked - connect and provide passphrase to unlock storage");
+            LOG_WARN("Lockdown: Device locked - provide passphrase to unlock storage");
         }
     }
 #endif
@@ -563,7 +563,7 @@ void setup()
     if (EncryptedStorage::isProvisioned()) {
         enableAPProtect();
     } else {
-        LOG_INFO("APPROTECT deferred: device not yet provisioned");
+        LOG_INFO("APPROTECT deferred: not provisioned");
     }
 #elif defined(MESHTASTIC_ENABLE_APPROTECT)
     // Lockdown without encrypted storage shouldn't be reachable per
@@ -650,7 +650,7 @@ void setup()
     // the bus behind it is scanned right below and its devices are registered
     // once, so the link has to be up by then
     if (!sensecapIndicator->wait_ready(5000))
-        LOG_ERROR("RP2040 co-processor did not answer, its sensors, GPS and SD card are unavailable this session");
+        LOG_ERROR("RP2040 co-processor no reply; sensors, GPS, SD card unavailable this session");
 #endif
 
 #if !MESHTASTIC_EXCLUDE_I2C
@@ -693,7 +693,7 @@ void setup()
 #ifdef ARCH_ESP32
     // Don't init display if we don't have one or we are waking headless due to a timer event
     if (wakeCause == ESP_SLEEP_WAKEUP_TIMER) {
-        LOG_DEBUG("suppress screen wake because this is a headless timer wakeup");
+        LOG_DEBUG("suppress screen wake: headless timer wakeup");
         i2cScanner->setSuppressScreen();
     }
 #endif
@@ -755,7 +755,7 @@ void setup()
             break;
         default:
             // use this as default since it's also just zero
-            LOG_WARN("kb_info.type is unknown(0x%02x), setting kb_model=0x00", kb_info.type);
+            LOG_WARN("kb_info.type unknown(0x%02x), set kb_model=0x00", kb_info.type);
             kb_model = 0x00;
         }
     }
@@ -1363,7 +1363,7 @@ void loop()
         lockdownDisablePending = false;
         LOG_INFO("Lockdown: disabling - reverting encrypted storage to plaintext");
         if (nodeDB->disableLockdownToPlaintext()) {
-            LOG_INFO("Lockdown: disabled, rebooting into normal mode");
+            LOG_INFO("Lockdown: disabled, reboot to normal mode");
             PhoneAPI::broadcastLockdownStatus(meshtastic_LockdownStatus_State_DISABLED, "", 0, 0, 0);
             rebootAtMsec = millis() + DEFAULT_REBOOT_SECONDS * 1000;
         } else {
@@ -1371,14 +1371,14 @@ void loop()
             // The DEK file is still present (it's deleted last), so the device
             // stays in lockdown and the operator can retry disable. Surface
             // the failure rather than leaving the client hanging.
-            LOG_ERROR("Lockdown: disable revert failed - device remains in lockdown");
+            LOG_ERROR("Lockdown: disable revert failed - still in lockdown");
             PhoneAPI::broadcastLockdownStatus(meshtastic_LockdownStatus_State_LOCKED, "disable_failed", 0, 0, 0);
         }
     }
 
     if (lockdownReloadPending) {
         lockdownReloadPending = false;
-        LOG_INFO("Lockdown: reloading config from disk after unlock");
+        LOG_INFO("Lockdown: reload config after unlock");
         bool reloadOk = nodeDB->reloadFromDisk();
         if (!reloadOk) {
             // Storage decrypt/decode failed during reload. Treat as
@@ -1389,7 +1389,7 @@ void loop()
             // might have), and notify clients. Storage will be locked
             // on next boot anyway; deferring to the user-visible
             // notification path is sufficient for now.
-            LOG_ERROR("Lockdown: reload failed - locking and notifying clients");
+            LOG_ERROR("Lockdown: reload failed - lock and notify clients");
             EncryptedStorage::lockNow();
             PhoneAPI::revokeAllAuth();
         }
@@ -1415,14 +1415,14 @@ void loop()
             //      sessions to grant. Hard lock (token deleted, DEK
             //      zeroed) and reboot. Operator must re-enter passphrase.
             if (EncryptedStorage::getBootsRemaining() == 0) {
-                LOG_WARN("Lockdown: session limit reached and boot budget exhausted, locking and rebooting");
+                LOG_WARN("Lockdown: session limit hit, boot budget exhausted - lock and reboot");
                 EncryptedStorage::lockNow();
                 PhoneAPI::revokeAllAuth();
                 PhoneAPI::broadcastLockdownStatus(meshtastic_LockdownStatus_State_LOCKED, "session_budget_exhausted", 0, 0, 0);
                 rebootAtMsec = millis() + DEFAULT_REBOOT_SECONDS * 1000;
             } else {
                 uint8_t newBoots = EncryptedStorage::consumeSessionBoot();
-                LOG_WARN("Lockdown: session expired, rolled to next budget slot (boots=%u remaining)", newBoots);
+                LOG_WARN("Lockdown: session expired, next budget slot (boots=%u left)", newBoots);
                 PhoneAPI::revokeAllAuth();
                 meshtastic_security::lockScreen();
                 // Signal clients that they need to re-auth on this
@@ -1484,7 +1484,7 @@ void loop()
         ch341Hal->checkError();
     }
     if (portduino_status.LoRa_in_error && rebootAtMsec == 0) {
-        LOG_ERROR("LoRa in error detected, attempting to recover");
+        LOG_ERROR("LoRa error detected, recovering");
         router->addInterface(nullptr);
         if (portduino_config.lora_spi_dev == "ch341") {
             if (ch341Hal != nullptr) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -454,7 +454,7 @@ void setup()
     powerMonInit();
     serialSinceMsec = millis();
 
-    LOG_INFO("\n\n//\\ E S H T /\\ S T / C\n");
+    LOG_INFO("\n\n//\\ E S H T /\\ S T / C");
 
 #if defined(ARCH_ESP32) && defined(BOARD_HAS_PSRAM)
 #ifndef SENSECAP_INDICATOR

--- a/src/mesh/CryptoEngine.cpp
+++ b/src/mesh/CryptoEngine.cpp
@@ -336,7 +336,7 @@ bool CryptoEngine::setDHPublicKey(uint8_t *pubKey)
     // Calculate the shared secret with the specified node's public key and our private key
     // This includes an internal weak key check, which among other things looks for an all 0 public key and shared key.
     if (!Curve25519::dh2(shared_key, local_priv)) {
-        LOG_WARN("Curve25519DH step 2 failed!");
+        LOG_WARN("Curve25519DH step 2 failed");
         return false;
     }
     return true;
@@ -373,7 +373,7 @@ concurrency::Lock *cryptLock;
 
 void CryptoEngine::setKey(const CryptoKey &k)
 {
-    LOG_DEBUG("Use AES%d key!", k.length * 8);
+    LOG_DEBUG("Use AES%d key", k.length * 8);
     key = k;
 }
 
@@ -389,7 +389,7 @@ void CryptoEngine::encryptPacket(uint32_t fromNode, uint64_t packetId, size_t nu
         if (numBytes <= MAX_BLOCKSIZE) {
             encryptAESCtr(key, nonce, numBytes, bytes);
         } else {
-            LOG_ERROR("Packet too large for crypto engine: %d. noop encryption!", numBytes);
+            LOG_ERROR("Packet too large for crypto engine: %d. noop encryption", numBytes);
         }
     }
 }

--- a/src/mesh/IndicatorSerial.cpp
+++ b/src/mesh/IndicatorSerial.cpp
@@ -486,7 +486,7 @@ bool SensecapIndicator::handle_packet(size_t payload_len)
             LOG_WARN("Request 0x%08x nacked by the co-processor", expected_id);
             request_nacked = true;
         } else if (message.id == 0) {
-            LOG_WARN("Co-processor could not decode a frame");
+            LOG_WARN("Co-processor can't decode a frame");
         }
         return true;
     case meshtastic_InterdeviceMessage_sd_info_tag:

--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -167,7 +167,7 @@ template <typename T> bool LR11x0Interface<T>::init()
     // 3. Some units need extra settling time, so give whichever oscillator we settled on one retry.
     //    After a step 2 fallback that is a second TCXO attempt, which is where settling actually matters.
     if (lr11x0SpiFailed(res)) {
-        LOG_WARN("LR11x0 init failed with %d (SPI command failure), retrying after delay...", res);
+        LOG_WARN("LR11x0 init failed with %d (SPI command failure), retrying after delay", res);
         delay(100);
         res = tryBegin(3, attemptVoltage);
     }
@@ -203,7 +203,7 @@ template <typename T> bool LR11x0Interface<T>::init()
     // older firmware than the baked-in image, so once it has succeeded it is a no-op on subsequent boots.
     if (transceiverDevice == RADIOLIB_LR11X0_DEVICE_LR1110 && transceiverFw != 0 && transceiverFw < LR11X0_UPDATE_FIRMWARE_TO) {
         LOG_WARN("LR1110 transceiver FW %d.%d is older than %d.%d - updating now. DO NOT POWER OFF: this "
-                 "erases and rewrites the radio's own flash.",
+                 "erases and rewrites the radio's own flash",
                  transceiverFw >> 8, transceiverFw & 0xFF, LR11X0_UPDATE_FIRMWARE_TO >> 8, LR11X0_UPDATE_FIRMWARE_TO & 0xFF);
 
         int upd = lora.updateFirmware(lr11xx_firmware_image, LR11XX_FIRMWARE_IMAGE_SIZE, true);

--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -104,11 +104,11 @@ template <typename T> bool LR11x0Interface<T>::init()
 
     // DIO3 is free to be used as an IRQ only while no TCXO Vref is driven on it
     if (tcxoVoltage > 0)
-        LOG_DEBUG("LR11x0 TCXO Vref %f V on DIO3 (DIO3 unavailable as an IRQ)", tcxoVoltage);
+        LOG_DEBUG("LR11x0 TCXO Vref %f V on DIO3 (DIO3 unavailable as IRQ)", tcxoVoltage);
     else
-        LOG_DEBUG("LR11x0 no TCXO Vref, XTAL only (DIO3 free as an IRQ)");
+        LOG_DEBUG("LR11x0 no TCXO Vref, XTAL only (DIO3 free as IRQ)");
 #if defined(TCXO_OPTIONAL)
-    LOG_DEBUG("TCXO_OPTIONAL: oscillator type unknown, probing XTAL first and using any TCXO Vref only as fallback");
+    LOG_DEBUG("TCXO_OPTIONAL: osc type unknown, probe XTAL first, TCXO Vref as fallback");
 #endif
 
     RadioLibInterface::init();
@@ -156,7 +156,7 @@ template <typename T> bool LR11x0Interface<T>::init()
 #if defined(TCXO_OPTIONAL)
     // 2. XTAL failed with the chip present, so fall back to the TCXO if the variant configured one
     if (res != RADIOLIB_ERR_NONE && res != RADIOLIB_ERR_CHIP_NOT_FOUND && tcxoVoltage > 0) {
-        LOG_WARN("LR11x0 XTAL init failed (err %d), retrying with TCXO Vref %f V", res, tcxoVoltage);
+        LOG_WARN("LR11x0 XTAL init failed (err %d), retry with TCXO Vref %f V", res, tcxoVoltage);
         attemptVoltage = tcxoVoltage;
         res = tryBegin(2, attemptVoltage);
         if (res == RADIOLIB_ERR_NONE)
@@ -167,7 +167,7 @@ template <typename T> bool LR11x0Interface<T>::init()
     // 3. Some units need extra settling time, so give whichever oscillator we settled on one retry.
     //    After a step 2 fallback that is a second TCXO attempt, which is where settling actually matters.
     if (lr11x0SpiFailed(res)) {
-        LOG_WARN("LR11x0 init failed with %d (SPI command failure), retrying after delay", res);
+        LOG_WARN("LR11x0 init failed with %d (SPI cmd failure), retry after delay", res);
         delay(100);
         res = tryBegin(3, attemptVoltage);
     }
@@ -179,9 +179,9 @@ template <typename T> bool LR11x0Interface<T>::init()
 #ifdef LR11X0_UPDATE_FIRMWARE_TO
         // An interrupted update leaves the radio sitting in bootloader mode, where begin() fails. Retry the
         // flash from here rather than giving up, otherwise the device could never recover on its own.
-        LOG_WARN("LR11x0 did not start; attempting firmware recovery in case an update was interrupted");
+        LOG_WARN("LR11x0 did not start; firmware recovery in case update was interrupted");
         if (lora.updateFirmware(lr11xx_firmware_image, LR11XX_FIRMWARE_IMAGE_SIZE, true) == RADIOLIB_ERR_NONE) {
-            LOG_INFO("LR1110 firmware recovery succeeded, re-initializing radio");
+            LOG_INFO("LR1110 firmware recovery OK, re-init radio");
             res = lora.begin(getFreq(), bw, sf, cr, syncWord, power, preambleLength, tcxoVoltage);
         }
 #endif
@@ -202,8 +202,8 @@ template <typename T> bool LR11x0Interface<T>::init()
     // One-shot transceiver firmware update, opt-in per variant. Only runs when the part is an LR1110 running
     // older firmware than the baked-in image, so once it has succeeded it is a no-op on subsequent boots.
     if (transceiverDevice == RADIOLIB_LR11X0_DEVICE_LR1110 && transceiverFw != 0 && transceiverFw < LR11X0_UPDATE_FIRMWARE_TO) {
-        LOG_WARN("LR1110 transceiver FW %d.%d is older than %d.%d - updating now. DO NOT POWER OFF: this "
-                 "erases and rewrites the radio's own flash",
+        LOG_WARN("LR1110 transceiver FW %d.%d older than %d.%d - updating. DO NOT POWER OFF: "
+                 "rewrites radio's own flash",
                  transceiverFw >> 8, transceiverFw & 0xFF, LR11X0_UPDATE_FIRMWARE_TO >> 8, LR11X0_UPDATE_FIRMWARE_TO & 0xFF);
 
         int upd = lora.updateFirmware(lr11xx_firmware_image, LR11XX_FIRMWARE_IMAGE_SIZE, true);
@@ -214,7 +214,7 @@ template <typename T> bool LR11x0Interface<T>::init()
             return false;
         }
 
-        LOG_INFO("LR1110 firmware update complete, re-initializing radio");
+        LOG_INFO("LR1110 firmware update complete, re-init radio");
         res = lora.begin(getFreq(), bw, sf, cr, syncWord, power, preambleLength, tcxoVoltage);
         if (res != RADIOLIB_ERR_NONE) {
             LOG_ERROR("LR11x0 re-init after firmware update failed %s%d", radioLibErr, res);
@@ -259,7 +259,7 @@ template <typename T> bool LR11x0Interface<T>::init()
             LOG_INFO("Set RX gain to boosted mode; result: %d", res);
         } else {
             res = lora.setRxBoostedGainMode(false);
-            LOG_INFO("Set RX gain to power saving mode (boosted mode off); result: %d", res);
+            LOG_INFO("Set RX gain to power saving mode; result: %d", res);
         }
     }
 
@@ -330,7 +330,7 @@ template <typename T> void LR11x0Interface<T>::setStandby()
     int err = lora.standby();
 
     if (err != RADIOLIB_ERR_NONE) {
-        LOG_DEBUG("LR11x0 standby failed with error %d", err);
+        LOG_DEBUG("LR11x0 standby failed, err %d", err);
     }
 
     assert(err == RADIOLIB_ERR_NONE);

--- a/src/mesh/LR20x0Interface.cpp
+++ b/src/mesh/LR20x0Interface.cpp
@@ -119,7 +119,7 @@ template <typename T> bool LR20x0Interface<T>::init()
 
     // Retry if we get SPI command failed - some units need extra TCXO stabilization time
     if (res == RADIOLIB_ERR_SPI_CMD_FAILED) {
-        LOG_WARN("LR20x0 init failed with %d (SPI_CMD_FAILED), retrying after delay...", res);
+        LOG_WARN("LR20x0 init failed with %d (SPI_CMD_FAILED), retrying after delay", res);
         delay(100);
         res = lora.begin(getFreq(), bw, sf, cr, syncWord, power, preambleLength, tcxoVoltage);
     }
@@ -220,7 +220,7 @@ template <typename T> bool LR20x0Interface<T>::reconfigure()
 
         int res = lora.begin(freq, bw, sf, cr, syncWord, power, preambleLength, tcxoVoltage);
         if (res == RADIOLIB_ERR_SPI_CMD_FAILED) {
-            LOG_WARN("LR20x0 band-hop begin SPI_CMD_FAILED, retrying...");
+            LOG_WARN("LR20x0 band-hop begin SPI_CMD_FAILED, retrying");
             delay(100);
             res = lora.begin(freq, bw, sf, cr, syncWord, power, preambleLength, tcxoVoltage);
         }

--- a/src/mesh/LR20x0Interface.cpp
+++ b/src/mesh/LR20x0Interface.cpp
@@ -69,17 +69,17 @@ template <typename T> bool LR20x0Interface<T>::init()
 // FIXME: correct logic to default to not using TCXO if no voltage is specified for LR20x0_DIO3_TCXO_VOLTAGE
 #elif defined(LR2021_DIO3_TCXO_VOLTAGE)
     float tcxoVoltage = LR2021_DIO3_TCXO_VOLTAGE;
-    LOG_DEBUG("LR2021_DIO3_TCXO_VOLTAGE defined, using DIO3 as TCXO reference voltage at %f V", LR2021_DIO3_TCXO_VOLTAGE);
+    LOG_DEBUG("LR2021_DIO3_TCXO_VOLTAGE defined, DIO3 as TCXO Vref %f V", LR2021_DIO3_TCXO_VOLTAGE);
     // (DIO3 is not free to be used as an IRQ)
 #elif defined(TCXO_OPTIONAL)
     float tcxoVoltage = 1.6f; // TCXO_OPTIONAL: try default 1.6 V first, fall back to XTAL on failure
-    LOG_DEBUG("TCXO_OPTIONAL: no LR2021_DIO3_TCXO_VOLTAGE defined, trying default TCXO Vref 1.6 V first");
+    LOG_DEBUG("TCXO_OPTIONAL: no LR2021_DIO3_TCXO_VOLTAGE, try default TCXO Vref 1.6 V first");
 #else
     float tcxoVoltage =
         0; // "TCXO reference voltage to be set on DIO3. Defaults to 1.6 V, set to 0 to skip." per
            // https://github.com/jgromes/RadioLib/blob/690a050ebb46e6097c5d00c371e961c1caa3b52e/src/modules/LR11x0/LR11x0.h#L471C26-L471C104
     // (DIO3 is free to be used as an IRQ)
-    LOG_DEBUG("LR2021_DIO3_TCXO_VOLTAGE not defined, not using DIO3 as TCXO reference voltage");
+    LOG_DEBUG("LR2021_DIO3_TCXO_VOLTAGE not defined, DIO3 not used as TCXO Vref");
 #endif
 
     RadioLibInterface::init();
@@ -119,7 +119,7 @@ template <typename T> bool LR20x0Interface<T>::init()
 
     // Retry if we get SPI command failed - some units need extra TCXO stabilization time
     if (res == RADIOLIB_ERR_SPI_CMD_FAILED) {
-        LOG_WARN("LR20x0 init failed with %d (SPI_CMD_FAILED), retrying after delay", res);
+        LOG_WARN("LR20x0 init failed with %d (SPI_CMD_FAILED), retry after delay", res);
         delay(100);
         res = lora.begin(getFreq(), bw, sf, cr, syncWord, power, preambleLength, tcxoVoltage);
     }
@@ -127,7 +127,7 @@ template <typename T> bool LR20x0Interface<T>::init()
 #if defined(TCXO_OPTIONAL)
     // If init failed for any reason other than chip not found, retry without TCXO (XTAL mode)
     if (res != RADIOLIB_ERR_NONE && res != RADIOLIB_ERR_CHIP_NOT_FOUND && tcxoVoltage > 0) {
-        LOG_WARN("LR20x0 init failed with TCXO Vref %f V (err %d), retrying without TCXO", tcxoVoltage, res);
+        LOG_WARN("LR20x0 init failed with TCXO Vref %f V (err %d), retry without TCXO", tcxoVoltage, res);
         tcxoVoltage = 0;
         res = lora.begin(getFreq(), bw, sf, cr, syncWord, power, preambleLength, tcxoVoltage);
         if (res == RADIOLIB_ERR_NONE)
@@ -166,7 +166,7 @@ template <typename T> bool LR20x0Interface<T>::init()
             LOG_INFO("Set RX gain to boosted mode; result: %d", res);
         } else {
             res = lora.setRxBoostedGainMode(false);
-            LOG_INFO("Set RX gain to power saving mode (boosted mode off); result: %d", res);
+            LOG_INFO("Set RX gain to power saving mode; result: %d", res);
         }
     }
 
@@ -335,7 +335,7 @@ template <typename T> void LR20x0Interface<T>::setStandby()
     int err = lora.standby();
 
     if (err != RADIOLIB_ERR_NONE) {
-        LOG_DEBUG("LR20x0 standby failed with error %d", err);
+        LOG_DEBUG("LR20x0 standby failed, err %d", err);
     }
 
     assert(err == RADIOLIB_ERR_NONE);

--- a/src/mesh/MemoryPool.h
+++ b/src/mesh/MemoryPool.h
@@ -115,7 +115,7 @@ template <class T> class MemoryDynamic : public Allocator<T>
     {
         T *p = (T *)malloc(sizeof(T));
         if (!p) {
-            LOG_WARN("malloc(%u) failed, heap exhausted!", (unsigned)sizeof(T));
+            LOG_WARN("malloc(%u) failed, heap exhausted", (unsigned)sizeof(T));
             return nullptr;
         }
         this->auditAdd((int32_t)sizeof(T));
@@ -156,7 +156,7 @@ template <class T, int MaxSize> class MemoryPool : public Allocator<T>
             this->auditAdd(-(int32_t)sizeof(T));
             LOG_HEAP("Released static pool item %d at 0x%x", index, p);
         } else {
-            LOG_WARN("Pointer 0x%x not from our pool!", p);
+            LOG_WARN("Pointer 0x%x not from our pool", p);
         }
     }
 
@@ -175,7 +175,7 @@ template <class T, int MaxSize> class MemoryPool : public Allocator<T>
         }
 
         // No free slots available - return nullptr instead of asserting
-        LOG_WARN("No free slots available in static memory pool!");
+        LOG_WARN("No free slots available in static memory pool");
         return nullptr;
     }
 };

--- a/src/mesh/MeshModule.cpp
+++ b/src/mesh/MeshModule.cpp
@@ -170,7 +170,7 @@ void MeshModule::callModules(meshtastic_MeshPacket &mp, RxSource src)
                         pi.sendResponse(mp);
                         LOG_INFO("Asked module '%s' to send a response", pi.name);
                     } else {
-                        LOG_DEBUG("Module '%s' cannot respond on portnum=%d", pi.name, mp.decoded.portnum);
+                        LOG_DEBUG("Module '%s' can't respond on portnum=%d", pi.name, mp.decoded.portnum);
                     }
                     ignoreRequest = ignoreRequest || pi.ignoreRequest; // If at least one module asks it, we may ignore a request
                 } else {

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -421,9 +421,8 @@ bool MeshService::trySendPosition(NodeNum dest, bool wantReplies)
                 if (!found) {
                     // No channel with position enabled: fall back to sending nodeinfo, as before.
                     if (nodeInfoModule) {
-                        LOG_INFO(
-                            "No position-enabled channel; send nodeinfo instead to 0x%08x, wantReplies=%d, channel=%d",
-                            dest, wantReplies, node->channel);
+                        LOG_INFO("No position-enabled channel; send nodeinfo instead to 0x%08x, wantReplies=%d, channel=%d", dest,
+                                 wantReplies, node->channel);
                         nodeInfoModule->sendOurNodeInfo(dest, wantReplies, node->channel);
                     }
                     return false;

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -95,7 +95,7 @@ int MeshService::handleFromRadio(const meshtastic_MeshPacket *mp)
                   meshtastic_Config_DeviceConfig_Role_CLIENT_BASE);
     if (mp->which_payload_variant == meshtastic_MeshPacket_decoded_tag &&
         mp->decoded.portnum == meshtastic_PortNum_TELEMETRY_APP && mp->decoded.request_id > 0) {
-        LOG_DEBUG("Received telemetry response. Skip sending our NodeInfo");
+        LOG_DEBUG("Got telemetry response. Skip our NodeInfo");
         //  ignore our request for its NodeInfo
     } else if (mp->which_payload_variant == meshtastic_MeshPacket_decoded_tag &&
                !nodeInfoLiteHasUser(nodeDB->getMeshNode(mp->from)) && nodeInfoModule && !isPreferredRebroadcaster &&
@@ -103,13 +103,13 @@ int MeshService::handleFromRadio(const meshtastic_MeshPacket *mp)
         if (airTime->isTxAllowedChannelUtil(true)) {
             const int8_t hopsUsed = getHopsAway(*mp, config.lora.hop_limit);
             if (hopsUsed > (int32_t)(config.lora.hop_limit + 2)) {
-                LOG_DEBUG("Skip send NodeInfo: %d hops away is too far away", hopsUsed);
+                LOG_DEBUG("Skip send NodeInfo: %d hops too far", hopsUsed);
             } else {
-                LOG_INFO("Heard new node on ch. %d, send NodeInfo and ask for response", mp->channel);
+                LOG_INFO("Heard new node on ch. %d, send NodeInfo, ask response", mp->channel);
                 nodeInfoModule->sendOurNodeInfo(mp->from, true, mp->channel);
             }
         } else {
-            LOG_DEBUG("Skip sending NodeInfo > 25%% ch. util");
+            LOG_DEBUG("Skip NodeInfo > 25%% ch. util");
         }
     }
 
@@ -204,7 +204,7 @@ void MeshService::reconcilePendingRxTimes()
             p->has_rx_time = true;
         }
         if (!toPhoneQueue.enqueue(p, 0)) { // mirrors sendToPhone()'s degrade-on-failure path
-            LOG_CRIT("Failed to requeue a packet into toPhoneQueue");
+            LOG_CRIT("Requeue to toPhoneQueue failed");
             releaseToPool(p);
             fromNum++; // notify observers so the phone can resync
         }
@@ -232,14 +232,14 @@ void MeshService::injectAsReceived(meshtastic_MeshPacket &p)
                 p.decoded.portnum = scratch.portnum;
             }
         } else {
-            LOG_ERROR("inject: could not decode Compressed envelope, dropping");
+            LOG_ERROR("inject: can't decode Compressed envelope, drop");
             return;
         }
     }
     // The real RX path (RadioLibInterface::handleReceiveInterrupt) drops sender==0; mirror it so injection
     // behaves identically to an over-the-air frame.
     if (p.from == 0) {
-        LOG_WARN("inject: dropping frame with from==0 (matches real LoRa RX)");
+        LOG_WARN("inject: drop frame with from==0 (matches real LoRa RX)");
         return;
     }
     meshtastic_MeshPacket *mp = packetPool.allocCopy(p);
@@ -341,7 +341,7 @@ ErrorCode MeshService::sendQueueStatusToPhone(const meshtastic_QueueStatus &qs, 
     copied->mesh_packet_id = mesh_packet_id;
 
     if (toPhoneQueueStatusQueue.numFree() == 0) {
-        LOG_INFO("tophone queue status queue is full, discard oldest");
+        LOG_INFO("tophone queue status queue full, discard oldest");
         meshtastic_QueueStatus *d = toPhoneQueueStatusQueue.dequeuePtr(0);
         if (d)
             releaseQueueStatusToPool(d);
@@ -422,7 +422,7 @@ bool MeshService::trySendPosition(NodeNum dest, bool wantReplies)
                     // No channel with position enabled: fall back to sending nodeinfo, as before.
                     if (nodeInfoModule) {
                         LOG_INFO(
-                            "No channel with position enabled; sending nodeinfo instead to 0x%08x, wantReplies=%d, channel=%d",
+                            "No position-enabled channel; send nodeinfo instead to 0x%08x, wantReplies=%d, channel=%d",
                             dest, wantReplies, node->channel);
                         nodeInfoModule->sendOurNodeInfo(dest, wantReplies, node->channel);
                     }
@@ -470,7 +470,7 @@ void MeshService::sendToPhone(meshtastic_MeshPacket *p)
     // Withhold decoded nested payloads a strict phone decoder would reject; still-encrypted packets
     // pass through (the phone may hold the key).
     if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag && !phonePayloadIsDecodable(p->decoded)) {
-        LOG_WARN("Dropping undecodable portnum=%d payload from phone delivery (from=0x%08x)", p->decoded.portnum, p->from);
+        LOG_WARN("Drop undecodable portnum=%d payload from phone delivery (from=0x%08x)", p->decoded.portnum, p->from);
         releaseToPool(p);
         fromNum++; // notify observers so the phone can resync
         return;
@@ -490,12 +490,12 @@ void MeshService::sendToPhone(meshtastic_MeshPacket *p)
     if (toPhoneQueue.numFree() == 0) {
         if (p->decoded.portnum == meshtastic_PortNum_TEXT_MESSAGE_APP ||
             p->decoded.portnum == meshtastic_PortNum_RANGE_TEST_APP) {
-            LOG_WARN("ToPhone queue is full, discard oldest");
+            LOG_WARN("ToPhone queue full, discard oldest");
             meshtastic_MeshPacket *d = toPhoneQueue.dequeuePtr(0);
             if (d)
                 releaseToPool(d);
         } else {
-            LOG_WARN("ToPhone queue is full, drop packet");
+            LOG_WARN("ToPhone queue full, drop packet");
             releaseToPool(p);
             fromNum++; // Make sure to notify observers in case they are reconnected so they can get the packets
             return;
@@ -503,7 +503,7 @@ void MeshService::sendToPhone(meshtastic_MeshPacket *p)
     }
 
     if (toPhoneQueue.enqueue(p, 0) == false) {
-        LOG_CRIT("Failed to queue a packet into toPhoneQueue");
+        LOG_CRIT("Queue to toPhoneQueue failed");
         releaseToPool(p);
         fromNum++; // notify observers so phone can resync
         return;
@@ -513,16 +513,16 @@ void MeshService::sendToPhone(meshtastic_MeshPacket *p)
 
 void MeshService::sendMqttMessageToClientProxy(meshtastic_MqttClientProxyMessage *m)
 {
-    LOG_DEBUG("Send mqtt message on topic '%s' to client for proxy", m->topic);
+    LOG_DEBUG("Send mqtt msg on topic '%s' to proxy client", m->topic);
     if (toPhoneMqttProxyQueue.numFree() == 0) {
-        LOG_WARN("MqttClientProxyMessagePool queue is full, discard oldest");
+        LOG_WARN("MqttClientProxyMessagePool queue full, discard oldest");
         meshtastic_MqttClientProxyMessage *d = toPhoneMqttProxyQueue.dequeuePtr(0);
         if (d)
             releaseMqttClientProxyMessageToPool(d);
     }
 
     if (toPhoneMqttProxyQueue.enqueue(m, 0) == false) {
-        LOG_CRIT("Failed to queue a packet into toPhoneMqttProxyQueue");
+        LOG_CRIT("Queue to toPhoneMqttProxyQueue failed");
         releaseMqttClientProxyMessageToPool(m);
         return;
     }
@@ -532,7 +532,7 @@ void MeshService::sendMqttMessageToClientProxy(meshtastic_MqttClientProxyMessage
 void MeshService::sendRoutingErrorResponse(meshtastic_Routing_Error error, const meshtastic_MeshPacket *mp)
 {
     if (!mp) {
-        LOG_WARN("Cannot send routing error response: null packet");
+        LOG_WARN("Can't send routing error response: null packet");
         return;
     }
 
@@ -540,7 +540,7 @@ void MeshService::sendRoutingErrorResponse(meshtastic_Routing_Error error, const
     if (routingModule) {
         routingModule->sendAckNak(error, mp->from, mp->id, mp->channel);
     } else {
-        LOG_ERROR("Cannot send routing error response: no routing module");
+        LOG_ERROR("Can't send routing error response: no routing module");
     }
 }
 
@@ -548,14 +548,14 @@ void MeshService::sendClientNotification(meshtastic_ClientNotification *n)
 {
     LOG_DEBUG("Send client notification to phone");
     if (toPhoneClientNotificationQueue.numFree() == 0) {
-        LOG_WARN("ClientNotification queue is full, discard oldest");
+        LOG_WARN("ClientNotification queue full, discard oldest");
         meshtastic_ClientNotification *d = toPhoneClientNotificationQueue.dequeuePtr(0);
         if (d)
             releaseClientNotificationToPool(d);
     }
 
     if (toPhoneClientNotificationQueue.enqueue(n, 0) == false) {
-        LOG_CRIT("Failed to queue a notification into toPhoneClientNotificationQueue");
+        LOG_CRIT("Queue to toPhoneClientNotificationQueue failed");
         releaseClientNotificationToPool(n);
         return;
     }

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -204,7 +204,7 @@ void MeshService::reconcilePendingRxTimes()
             p->has_rx_time = true;
         }
         if (!toPhoneQueue.enqueue(p, 0)) { // mirrors sendToPhone()'s degrade-on-failure path
-            LOG_CRIT("Failed to requeue a packet into toPhoneQueue!");
+            LOG_CRIT("Failed to requeue a packet into toPhoneQueue");
             releaseToPool(p);
             fromNum++; // notify observers so the phone can resync
         }
@@ -503,7 +503,7 @@ void MeshService::sendToPhone(meshtastic_MeshPacket *p)
     }
 
     if (toPhoneQueue.enqueue(p, 0) == false) {
-        LOG_CRIT("Failed to queue a packet into toPhoneQueue!");
+        LOG_CRIT("Failed to queue a packet into toPhoneQueue");
         releaseToPool(p);
         fromNum++; // notify observers so phone can resync
         return;
@@ -522,7 +522,7 @@ void MeshService::sendMqttMessageToClientProxy(meshtastic_MqttClientProxyMessage
     }
 
     if (toPhoneMqttProxyQueue.enqueue(m, 0) == false) {
-        LOG_CRIT("Failed to queue a packet into toPhoneMqttProxyQueue!");
+        LOG_CRIT("Failed to queue a packet into toPhoneMqttProxyQueue");
         releaseMqttClientProxyMessageToPool(m);
         return;
     }
@@ -555,7 +555,7 @@ void MeshService::sendClientNotification(meshtastic_ClientNotification *n)
     }
 
     if (toPhoneClientNotificationQueue.enqueue(n, 0) == false) {
-        LOG_CRIT("Failed to queue a notification into toPhoneClientNotificationQueue!");
+        LOG_CRIT("Failed to queue a notification into toPhoneClientNotificationQueue");
         releaseClientNotificationToPool(n);
         return;
     }

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -67,7 +67,7 @@ ErrorCode NextHopRouter::send(meshtastic_MeshPacket *p)
     wasSeenRecently(p);                                         // FIXME, move this to a sniffSent method
 
     p->next_hop = getNextHop(p->to, p->relay_node).value_or(NO_NEXT_HOP_PREFERENCE); // set the next hop
-    LOG_DEBUG("Setting next hop for packet with dest %x to %x", p->to, p->next_hop);
+    LOG_DEBUG("Set next hop for dest %x to %x", p->to, p->next_hop);
 
     // If it's from us, ReliableRouter already handles retransmissions if want_ack is set. If a next hop is set and hop limit is
     // not 0 or want_ack is set, start retransmissions
@@ -157,7 +157,7 @@ void NextHopRouter::sniffReceived(const meshtastic_MeshPacket *p, const meshtast
                 // -> store nothing and keep flooding (safe).
                 if (nodeDB->resolveUniqueLastByte(p->relay_node, /*requireDirectNeighbor=*/false)) {
                     if (origTx && origTx->next_hop != p->relay_node) { // Not already set
-                        LOG_INFO("Update next hop of 0x%08x to 0x%x based on ACK/reply (was relayer %d we were sole %d)", p->from,
+                        LOG_INFO("Update next hop of 0x%08x to 0x%x from ACK/reply (was relayer %d we were sole %d)", p->from,
                                  p->relay_node, wasAlreadyRelayer, weWereSoleRelayer);
                         origTx->next_hop = p->relay_node;
                     }
@@ -214,17 +214,17 @@ bool NextHopRouter::perhapsRebroadcast(const meshtastic_MeshPacket *p)
                     meshtastic_MeshPacket *tosend = packetPool.allocCopy(*p); // keep a copy because we will be sending it
                     if (!tosend)
                         return true;
-                    LOG_INFO("Rebroadcast received message coming from %x", p->relay_node);
+                    LOG_INFO("Rebroadcast msg from %x", p->relay_node);
 
                     // If exhausting hops, force hop_limit = 0 regardless of other logic
                     if (exhaustHops) {
                         tosend->hop_limit = 0;
-                        LOG_INFO("Traffic management: exhausting hops for 0x%08x, setting hop_limit=0", getFrom(p));
+                        LOG_INFO("Traffic management: exhaust hops for 0x%08x, hop_limit=0", getFrom(p));
                     } else if (shouldDecrementHopLimit(p)) {
                         // Use shared logic to determine if hop_limit should be decremented
                         tosend->hop_limit--; // bump down the hop count
                     } else {
-                        LOG_INFO("favorite-ROUTER/CLIENT_BASE-to-ROUTER/CLIENT_BASE rebroadcast: preserving hop_limit");
+                        LOG_INFO("favorite-ROUTER/CLIENT_BASE-to-ROUTER/CLIENT_BASE rebroadcast: keep hop_limit");
                     }
 #if USERPREFS_EVENT_MODE
                     capEventRelayHops(tosend);
@@ -266,7 +266,7 @@ std::optional<uint8_t> NextHopRouter::getNextHop(NodeNum to, uint8_t relay_node)
         // TraceRouteModule) with no matching record is left authoritative.
         const RouteHealth *h = findRouteHealth(to);
         if (h && h->lastNextHop == node->next_hop && isRouteStale(*h, millis())) {
-            LOG_INFO("Next hop 0x%x for 0x%08x is stale (age/fails); flood and clear", node->next_hop, to);
+            LOG_INFO("Next hop 0x%x for 0x%08x stale (age/fails); flood and clear", node->next_hop, to);
             node->next_hop = NO_NEXT_HOP_PREFERENCE; // clear persisted route
             clearRouteHealth(to);                    // clear RAM health
             return std::nullopt;
@@ -298,7 +298,7 @@ std::optional<uint8_t> NextHopRouter::getNextHop(NodeNum to, uint8_t relay_node)
         if (hint && hint != relay_node) {
             const RouteHealth *h = findRouteHealth(to);
             if (h && h->lastNextHop == hint && isRouteStale(*h, millis())) {
-                LOG_INFO("TMM next hop 0x%x for 0x%08x is stale (age/fails); flood and clear", hint, to);
+                LOG_INFO("TMM next hop 0x%x for 0x%08x stale (age/fails); flood and clear", hint, to);
                 trafficManagementModule->clearNextHop(to); // clear overflow route (setNextHop won't store 0)
                 clearRouteHealth(to);                      // clear RAM health
                 return std::nullopt;
@@ -409,7 +409,7 @@ int32_t NextHopRouter::doRetransmissions()
         if (p.nextTxMsec <= now) {
             if (p.numRetransmissions == 0) {
                 if (isFromUs(p.packet)) {
-                    LOG_DEBUG("Reliable send failed, returning a nak for fr=0x%08x,to=0x%08x,id=0x%08x", p.packet->from,
+                    LOG_DEBUG("Reliable send failed, return nak fr=0x%08x,to=0x%08x,id=0x%08x", p.packet->from,
                               p.packet->to, p.packet->id);
                     sendAckNak(meshtastic_Routing_Error_MAX_RETRANSMIT, getFrom(p.packet), p.packet->id, p.packet->channel);
                 }
@@ -417,7 +417,7 @@ int32_t NextHopRouter::doRetransmissions()
                 stopRetransmission(it->first);
                 stillValid = false; // just deleted it
             } else {
-                LOG_DEBUG("Sending retransmission fr=0x%08x,to=0x%08x,id=0x%08x, tries left=%d", p.packet->from, p.packet->to,
+                LOG_DEBUG("Send retransmission fr=0x%08x,to=0x%08x,id=0x%08x, tries left=%d", p.packet->from, p.packet->to,
                           p.packet->id, p.numRetransmissions);
 
                 if (!isBroadcast(p.packet->to)) {
@@ -430,7 +430,7 @@ int32_t NextHopRouter::doRetransmissions()
                         // Also reset it in the nodeDB
                         meshtastic_NodeInfoLite *sentTo = nodeDB->getMeshNode(p.packet->to);
                         if (sentTo) {
-                            LOG_INFO("Resetting next hop for packet with dest 0x%08x", p.packet->to);
+                            LOG_INFO("Reset next hop for dest 0x%08x", p.packet->to);
                             sentTo->next_hop = NO_NEXT_HOP_PREFERENCE;
                         }
 #if HAS_TRAFFIC_MANAGEMENT
@@ -503,7 +503,7 @@ void NextHopRouter::setNextTx(PendingPacket *pending)
     assert(iface);
     auto d = iface->getRetransmissionMsec(pending->packet);
     pending->nextTxMsec = millis() + d;
-    LOG_DEBUG("Setting next retransmission in %u msecs: ", d);
+    LOG_DEBUG("Next retransmission in %u msecs: ", d);
     printPacket("", pending->packet);
     setReceivedMessage(); // Run ASAP, so we can figure out our correct sleep time
 }

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -409,8 +409,8 @@ int32_t NextHopRouter::doRetransmissions()
         if (p.nextTxMsec <= now) {
             if (p.numRetransmissions == 0) {
                 if (isFromUs(p.packet)) {
-                    LOG_DEBUG("Reliable send failed, return nak fr=0x%08x,to=0x%08x,id=0x%08x", p.packet->from,
-                              p.packet->to, p.packet->id);
+                    LOG_DEBUG("Reliable send failed, return nak fr=0x%08x,to=0x%08x,id=0x%08x", p.packet->from, p.packet->to,
+                              p.packet->id);
                     sendAckNak(meshtastic_Routing_Error_MAX_RETRANSMIT, getFrom(p.packet), p.packet->id, p.packet->channel);
                 }
                 // Note: we don't stop retransmission here, instead the Nak packet gets processed in sniffReceived

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -67,7 +67,7 @@ ErrorCode NextHopRouter::send(meshtastic_MeshPacket *p)
     wasSeenRecently(p);                                         // FIXME, move this to a sniffSent method
 
     p->next_hop = getNextHop(p->to, p->relay_node).value_or(NO_NEXT_HOP_PREFERENCE); // set the next hop
-    LOG_DEBUG("Set next hop for dest %x to %x", p->to, p->next_hop);
+    LOG_DEBUG("Set next hop for dest 0x%08x to 0x%x", p->to, p->next_hop);
 
     // If it's from us, ReliableRouter already handles retransmissions if want_ack is set. If a next hop is set and hop limit is
     // not 0 or want_ack is set, start retransmissions
@@ -503,7 +503,7 @@ void NextHopRouter::setNextTx(PendingPacket *pending)
     assert(iface);
     auto d = iface->getRetransmissionMsec(pending->packet);
     pending->nextTxMsec = millis() + d;
-    LOG_DEBUG("Next retransmission in %u msecs: ", d);
+    LOG_DEBUG("Next retransmission in %u msecs", d);
     printPacket("", pending->packet);
     setReceivedMessage(); // Run ASAP, so we can figure out our correct sleep time
 }

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -4330,7 +4330,7 @@ bool NodeDB::createNewIdentity()
     // still streamed to clients, and made any DM/admin aimed at it fail forever with PKI_SEND_FAIL_PUBLIC_KEY.
     // removeNodeByNum() drops the lite entry, its satellite stores, and the warm-tier copy.
     if (getMeshNode(oldNodeNum) != NULL) {
-        LOG_DEBUG("Old node num %u now %u, remove stale identity", oldNodeNum, newNodeNum);
+        LOG_DEBUG("Old node num 0x%08x now 0x%08x, remove stale identity", oldNodeNum, newNodeNum);
         removeNodeByNum(oldNodeNum);
     } else {
         // Lite entry already absent: drop any orphaned satellite-store entries directly.

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -738,7 +738,7 @@ void NodeDB::resetRadioConfig(bool is_fresh_install)
     }
 
     if (channelFile.channels_count != MAX_NUM_CHANNELS) {
-        LOG_INFO("Set default channel and radio preferences!");
+        LOG_INFO("Set default channel and radio preferences");
 
         channels.initDefaults();
         // Defaults ship the public PSK, so strip it again before onConfigChanged() publishes hashes;
@@ -755,7 +755,7 @@ void NodeDB::resetRadioConfig(bool is_fresh_install)
 
 bool NodeDB::factoryReset(bool eraseBleBonds)
 {
-    LOG_INFO("Perform factory reset!");
+    LOG_INFO("Perform factory reset");
     // first, remove the "/prefs" (this removes most prefs)
     spiLock->lock();
     rmDir("/prefs"); // this uses spilock internally...
@@ -806,7 +806,7 @@ bool NodeDB::factoryReset(bool eraseBleBonds)
 #endif
 
 #ifdef ARCH_NRF52
-        LOG_INFO("Clear bluetooth bonds!");
+        LOG_INFO("Clear bluetooth bonds");
         bond_print_list(BLE_GAP_ROLE_PERIPH);
         bond_print_list(BLE_GAP_ROLE_CENTRAL);
         Bluefruit.Periph.clearBonds();
@@ -2072,11 +2072,11 @@ LoadFileResult NodeDB::loadProto(const char *filename, size_t protoSize, size_t 
             if (fields != &meshtastic_NodeDatabase_msg)
                 memset(dest_struct, 0, objSize);
             if (!pb_decode(&stream, fields, dest_struct)) {
-                LOG_ERROR("Error: can't decode protobuf %s", PB_GET_ERROR(&stream));
+                LOG_ERROR("Can't decode protobuf %s", PB_GET_ERROR(&stream));
                 state = LoadFileResult::DECODE_FAILED;
                 storageCorruptThisLoad = true;
             } else {
-                LOG_INFO("Loaded encrypted %s successfully", filename);
+                LOG_INFO("Loaded encrypted %s", filename);
                 state = LoadFileResult::LOAD_SUCCESS;
             }
         } else {
@@ -2100,10 +2100,10 @@ LoadFileResult NodeDB::loadProto(const char *filename, size_t protoSize, size_t 
             fields != &meshtastic_NodeDatabase_Legacy_msg) // both NodeDatabase descriptors contain std::vector members
             memset(dest_struct, 0, objSize);
         if (!pb_decode(&stream, fields, dest_struct)) {
-            LOG_ERROR("Error: can't decode protobuf %s", PB_GET_ERROR(&stream));
+            LOG_ERROR("Can't decode protobuf %s", PB_GET_ERROR(&stream));
             state = LoadFileResult::DECODE_FAILED;
         } else {
-            LOG_INFO("Loaded %s successfully", filename);
+            LOG_INFO("Loaded %s", filename);
             state = LoadFileResult::LOAD_SUCCESS;
         }
         f.close();
@@ -2111,7 +2111,7 @@ LoadFileResult NodeDB::loadProto(const char *filename, size_t protoSize, size_t 
         LOG_ERROR("Could not open / read %s", filename);
     }
 #else
-    LOG_ERROR("ERROR: Filesystem not implemented");
+    LOG_ERROR("Filesystem not implemented");
     state = LoadFileResult::NO_FILESYSTEM;
 #endif
     return state;
@@ -2268,7 +2268,7 @@ void NodeDB::loadFromDisk()
         const size_t usedBytes = fsUsedBytes();
         eventProfileStorageUnavailable = !hasEventProfileStorageSpace(totalBytes, usedBytes);
         if (eventProfileStorageUnavailable) {
-            LOG_ERROR("Event profile requires %u bytes free; only %u bytes available. Profile changes will not persist.",
+            LOG_ERROR("Event profile requires %u bytes free; only %u bytes available. Profile changes will not persist",
                       static_cast<unsigned>(EVENT_PROFILE_STORAGE_RESERVATION_BYTES),
                       static_cast<unsigned>(totalBytes >= usedBytes ? totalBytes - usedBytes : 0));
         }
@@ -2292,7 +2292,7 @@ void NodeDB::loadFromDisk()
 #if defined(FACTORY_INSTALL) && !defined(ARCH_PORTDUINO)
     spiLock->lock();
     if (!FSCom.exists("/prefs/" xstr(BUILD_EPOCH))) {
-        LOG_WARN("Factory Install Reset!");
+        LOG_WARN("Factory Install Reset");
         rmDir("/prefs");
         FSCom.mkdir("/prefs");
         File f2 = FSCom.open("/prefs/" xstr(BUILD_EPOCH), FILE_O_WRITE);
@@ -2582,7 +2582,7 @@ void NodeDB::loadFromDisk()
     }
     if (sum == 0) {
         numAdminKeys += 1;
-        LOG_INFO("Admin 0 key zero. Loading hard coded key from user preferences.");
+        LOG_INFO("Admin 0 key zero. Loading hard coded key from user preferences");
         memcpy(config.security.admin_key[0].bytes, userprefs_admin_key_0, 32);
         config.security.admin_key[0].size = 32;
     }
@@ -2595,7 +2595,7 @@ void NodeDB::loadFromDisk()
     }
     if (sum == 0) {
         numAdminKeys += 1;
-        LOG_INFO("Admin 1 key zero. Loading hard coded key from user preferences.");
+        LOG_INFO("Admin 1 key zero. Loading hard coded key from user preferences");
         memcpy(config.security.admin_key[1].bytes, userprefs_admin_key_1, 32);
         config.security.admin_key[1].size = 32;
     }
@@ -2608,14 +2608,14 @@ void NodeDB::loadFromDisk()
     }
     if (sum == 0) {
         numAdminKeys += 1;
-        LOG_INFO("Admin 2 key zero. Loading hard coded key from user preferences.");
+        LOG_INFO("Admin 2 key zero. Loading hard coded key from user preferences");
         memcpy(config.security.admin_key[2].bytes, userprefs_admin_key_2, 32);
         config.security.admin_key[2].size = 32;
     }
 #endif
 
     if (numAdminKeys > 0) {
-        LOG_INFO("Saving %d hard coded admin keys.", numAdminKeys);
+        LOG_INFO("Saving %d hard coded admin keys", numAdminKeys);
         config.security.admin_key_count = numAdminKeys;
         saveToDisk(SEGMENT_CONFIG);
     }
@@ -2903,7 +2903,7 @@ bool NodeDB::saveProto(const char *filename, size_t protoSize, const pb_msgdesc_
     // do not try to save anything if power level is not safe. In many cases flash will be lock-protected
     // and all writes will fail anyway. Device should be sleeping at this point anyway.
     if (!powerHAL_isPowerLevelSafe()) {
-        LOG_ERROR("Error: trying to saveProto() on unsafe device power level.");
+        LOG_ERROR("Trying to saveProto() on unsafe device power level");
         return false;
     }
 
@@ -2925,7 +2925,7 @@ bool NodeDB::saveProto(const char *filename, size_t protoSize, const pb_msgdesc_
 
         pb_ostream_t stream = pb_ostream_from_buffer(pbBuf.get(), protoSize);
         if (!pb_encode(&stream, fields, dest_struct)) {
-            LOG_ERROR("Error: can't encode protobuf %s", PB_GET_ERROR(&stream));
+            LOG_ERROR("Can't encode protobuf %s", PB_GET_ERROR(&stream));
             return false;
         }
 
@@ -2947,7 +2947,7 @@ bool NodeDB::saveProto(const char *filename, size_t protoSize, const pb_msgdesc_
     pb_ostream_t stream = {&writecb, static_cast<Print *>(&f), protoSize};
 
     if (!pb_encode(&stream, fields, dest_struct)) {
-        LOG_ERROR("Error: can't encode protobuf %s", PB_GET_ERROR(&stream));
+        LOG_ERROR("Can't encode protobuf %s", PB_GET_ERROR(&stream));
     } else {
         okay = true;
     }
@@ -2955,10 +2955,10 @@ bool NodeDB::saveProto(const char *filename, size_t protoSize, const pb_msgdesc_
     bool writeSucceeded = f.close();
 
     if (!okay || !writeSucceeded) {
-        LOG_ERROR("Can't write prefs!");
+        LOG_ERROR("Can't write prefs");
     }
 #else
-    LOG_ERROR("ERROR: Filesystem not implemented");
+    LOG_ERROR("Filesystem not implemented");
 #endif
     return okay;
 }
@@ -2969,7 +2969,7 @@ bool NodeDB::saveChannelsToDisk()
     // do not try to save anything if power level is not safe. In many cases flash will be lock-protected
     // and all writes will fail anyway.
     if (!powerHAL_isPowerLevelSafe()) {
-        LOG_ERROR("Error: trying to saveChannelsToDisk() on unsafe device power level.");
+        LOG_ERROR("Trying to saveChannelsToDisk() on unsafe device power level");
         return false;
     }
 
@@ -2988,7 +2988,7 @@ bool NodeDB::saveDeviceStateToDisk()
     // do not try to save anything if power level is not safe. In many cases flash will be lock-protected
     // and all writes will fail anyway. Device should be sleeping at this point anyway.
     if (!powerHAL_isPowerLevelSafe()) {
-        LOG_ERROR("Error: trying to saveDeviceStateToDisk() on unsafe device power level.");
+        LOG_ERROR("Trying to saveDeviceStateToDisk() on unsafe device power level");
         return false;
     }
 
@@ -3016,7 +3016,7 @@ bool NodeDB::saveNodeDatabaseToDisk()
     // do not try to save anything if power level is not safe. In many cases flash will be lock-protected
     // and all writes will fail anyway. Device should be sleeping at this point anyway.
     if (!powerHAL_isPowerLevelSafe()) {
-        LOG_ERROR("Error: trying to saveNodeDatabaseToDisk() on unsafe device power level.");
+        LOG_ERROR("Trying to saveNodeDatabaseToDisk() on unsafe device power level");
         return false;
     }
 
@@ -3125,7 +3125,7 @@ bool NodeDB::saveToDiskNoRetry(int saveWhat)
     // do not try to save anything if power level is not safe. In many cases flash will be lock-protected
     // and all writes will fail anyway. Device should be sleeping at this point anyway.
     if (!powerHAL_isPowerLevelSafe()) {
-        LOG_ERROR("Error: trying to saveToDiskNoRetry() on unsafe device power level.");
+        LOG_ERROR("Trying to saveToDiskNoRetry() on unsafe device power level");
         return false;
     }
 
@@ -3223,7 +3223,7 @@ bool NodeDB::saveToDisk(int saveWhat)
     // do not try to save anything if power level is not safe. In many cases flash will be lock-protected
     // and all writes will fail anyway. Device should be sleeping at this point anyway.
     if (!powerHAL_isPowerLevelSafe()) {
-        LOG_ERROR("Error: trying to saveToDisk() on unsafe device power level.");
+        LOG_ERROR("Trying to saveToDisk() on unsafe device power level");
         return false;
     }
 
@@ -3580,9 +3580,9 @@ bool NodeDB::updateUser(uint32_t nodeId, meshtastic_User &p, uint8_t channelInde
             LOG_WARN("Public Key mismatch, dropping NodeInfo");
             return false;
         }
-        LOG_INFO("Public Key set for node, not updating!");
+        LOG_INFO("Public Key set for node, not updating");
     } else if (p.public_key.size == 32) {
-        LOG_INFO("Update Node Pubkey!");
+        LOG_INFO("Update Node Pubkey");
     }
 #endif
 
@@ -4187,7 +4187,7 @@ meshtastic_NodeInfoLite *NodeDB::getOrCreateMeshNode(NodeNum n)
             }
         }
 #endif
-        LOG_INFO("Adding node to database with %i nodes and %u bytes free!", numMeshNodes, memGet.getFreeHeap());
+        LOG_INFO("Adding node to database with %i nodes and %u bytes free", numMeshNodes, memGet.getFreeHeap());
     }
 
     return lite;

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -486,12 +486,12 @@ NodeDB::NodeDB()
     preferences.begin("meshtastic", false);
     myNodeInfo.reboot_count = preferences.getUInt("rebootCounter", 0);
     preferences.end();
-    LOG_DEBUG("Number of Device Reboots: %d", myNodeInfo.reboot_count);
+    LOG_DEBUG("Device reboots: %d", myNodeInfo.reboot_count);
 #endif
 
     // UA_868 is obsolete; migrate to EU_868 before resetRadioConfig() below validates the region.
     if (config.lora.region == meshtastic_Config_LoRaConfig_RegionCode_UA_868) {
-        LOG_INFO("UA_868 region is obsolete, migrating saved config to EU_868");
+        LOG_INFO("UA_868 obsolete, migrating config to EU_868");
         config.lora.region = meshtastic_Config_LoRaConfig_RegionCode_EU_868;
     }
 
@@ -504,7 +504,7 @@ NodeDB::NodeDB()
     // If we are setup to broadcast on any default channel slot (with default frequency slot semantics),
     // ensure that the telemetry intervals are coerced to the role-aware minimum value.
     if (channels.hasDefaultChannel()) {
-        LOG_DEBUG("Coerce telemetry to role-aware minimum on defaults");
+        LOG_DEBUG("Coerce telemetry to role-aware min on defaults");
         moduleConfig.telemetry.device_update_interval = Default::getConfiguredOrMinimumValue(
             moduleConfig.telemetry.device_update_interval, min_default_telemetry_interval_secs);
         moduleConfig.telemetry.environment_update_interval = Default::getConfiguredOrMinimumValue(
@@ -527,7 +527,7 @@ NodeDB::NodeDB()
         }
     }
     if (positionUsesDefaultChannel) {
-        LOG_DEBUG("Coerce position broadcasts to role-aware minimum and smart broadcast min of 5 minutes on defaults");
+        LOG_DEBUG("Coerce position broadcasts to role-aware min and smart broadcast min of 5 min on defaults");
         config.position.position_broadcast_secs =
             Default::getConfiguredOrMinimumValue(config.position.position_broadcast_secs, min_default_broadcast_interval_secs);
         config.position.broadcast_smart_minimum_interval_secs = Default::getConfiguredOrMinimumValue(
@@ -738,7 +738,7 @@ void NodeDB::resetRadioConfig(bool is_fresh_install)
     }
 
     if (channelFile.channels_count != MAX_NUM_CHANNELS) {
-        LOG_INFO("Set default channel and radio preferences");
+        LOG_INFO("Set default channel and radio prefs");
 
         channels.initDefaults();
         // Defaults ship the public PSK, so strip it again before onConfigChanged() publishes hashes;
@@ -755,14 +755,14 @@ void NodeDB::resetRadioConfig(bool is_fresh_install)
 
 bool NodeDB::factoryReset(bool eraseBleBonds)
 {
-    LOG_INFO("Perform factory reset");
+    LOG_INFO("Factory reset");
     // first, remove the "/prefs" (this removes most prefs)
     spiLock->lock();
     rmDir("/prefs"); // this uses spilock internally...
 
 #ifdef FSCom
     if (FSCom.exists("/static/rangetest.csv") && !FSCom.remove("/static/rangetest.csv")) {
-        LOG_ERROR("Could not remove rangetest.csv file");
+        LOG_ERROR("Can't remove rangetest.csv");
     }
 #endif
 
@@ -884,7 +884,7 @@ void NodeDB::installDefaultConfig(bool preserveKey = false)
     // Restrict ROUTER*, LOST AND FOUND roles for security reasons
     if (IS_ONE_OF(USERPREFS_CONFIG_DEVICE_ROLE, meshtastic_Config_DeviceConfig_Role_ROUTER,
                   meshtastic_Config_DeviceConfig_Role_ROUTER_LATE, meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND)) {
-        LOG_WARN("ROUTER roles are restricted, falling back to CLIENT role");
+        LOG_WARN("ROUTER roles restricted, fall back to CLIENT");
         config.device.role = meshtastic_Config_DeviceConfig_Role_CLIENT;
     } else {
         config.device.role = USERPREFS_CONFIG_DEVICE_ROLE;
@@ -1627,7 +1627,7 @@ void NodeDB::resetNodes(bool keepFavorites)
     NodeNum ourNum = getNodeNum();
     numMeshNodes = 1;
     if (keepFavorites) {
-        LOG_INFO("Clearing node database - preserving favorites");
+        LOG_INFO("Clear node database, keep favorites");
         // Compact favorites into contiguous low slots: zeroing in place leaves one above
         // numMeshNodes, invisible to every `i < numMeshNodes` scan yet still serialized to flash.
         for (size_t i = 1; i < meshNodes->size(); i++) {
@@ -1642,7 +1642,7 @@ void NodeDB::resetNodes(bool keepFavorites)
         }
         std::fill(nodeDatabase.nodes.begin() + numMeshNodes, nodeDatabase.nodes.end(), meshtastic_NodeInfoLite());
     } else {
-        LOG_INFO("Clearing node database - removing favorites");
+        LOG_INFO("Clear node database, remove favorites");
         for (size_t i = 1; i < meshNodes->size(); i++) {
             const NodeNum gone = meshNodes->at(i).num;
             if (gone)
@@ -1698,7 +1698,7 @@ void NodeDB::removeNodeByNum(NodeNum nodeNum)
         trafficManagementModule->purgeNode(nodeNum);
 #endif
 
-    LOG_DEBUG("NodeDB::removeNodeByNum purged %d entries. Save changes", removed);
+    LOG_DEBUG("NodeDB::removeNodeByNum purged %d entries, saving", removed);
     saveNodeDatabaseToDisk();
 }
 
@@ -2040,7 +2040,7 @@ void NodeDB::pickNewNodeNum()
            (nodeNum == NODENUM_BROADCAST || nodeNum < NUM_RESERVED)) {
         NodeNum candidate = random(NUM_RESERVED, LONG_MAX); // try a new random choice
         if (found)
-            LOG_WARN("NOTE! Our desired nodenum 0x%08x is invalid or in use, picking 0x%08x", nodeNum, candidate);
+            LOG_WARN("NOTE! Desired nodenum 0x%08x invalid or in use, picking 0x%08x", nodeNum, candidate);
         nodeNum = candidate;
     }
     LOG_DEBUG("Use nodenum 0x%08x ", nodeNum);
@@ -2108,7 +2108,7 @@ LoadFileResult NodeDB::loadProto(const char *filename, size_t protoSize, size_t 
         }
         f.close();
     } else {
-        LOG_ERROR("Could not open / read %s", filename);
+        LOG_ERROR("Can't open/read %s", filename);
     }
 #else
     LOG_ERROR("Filesystem not implemented");
@@ -2250,7 +2250,7 @@ void NodeDB::loadFromDisk()
     spiLock->lock();
     for (const char *filename : eventProfileFiles) {
         if (FSCom.exists(filename) && !FSCom.remove(filename))
-            LOG_WARN("Unable to remove stale event profile file %s", filename);
+            LOG_WARN("Can't remove stale event profile file %s", filename);
     }
     spiLock->unlock();
 #endif
@@ -2268,7 +2268,7 @@ void NodeDB::loadFromDisk()
         const size_t usedBytes = fsUsedBytes();
         eventProfileStorageUnavailable = !hasEventProfileStorageSpace(totalBytes, usedBytes);
         if (eventProfileStorageUnavailable) {
-            LOG_ERROR("Event profile requires %u bytes free; only %u bytes available. Profile changes will not persist",
+            LOG_ERROR("Event profile needs %u bytes free; only %u available. Changes won't persist",
                       static_cast<unsigned>(EVENT_PROFILE_STORAGE_RESERVATION_BYTES),
                       static_cast<unsigned>(totalBytes >= usedBytes ? totalBytes - usedBytes : 0));
         }
@@ -2306,11 +2306,11 @@ void NodeDB::loadFromDisk()
     spiLock->lock();
     if (FSCom.exists(legacyPrefFileName)) {
         spiLock->unlock();
-        LOG_WARN("Legacy prefs version found, factory resetting");
+        LOG_WARN("Legacy prefs version, factory reset");
         if (loadProto(configFileName, meshtastic_LocalConfig_size, sizeof(meshtastic_LocalConfig), &meshtastic_LocalConfig_msg,
                       &config) == LoadFileResult::LOAD_SUCCESS &&
             config.has_security && config.security.private_key.size > 0) {
-            LOG_DEBUG("Saving backup of security config and keys");
+            LOG_DEBUG("Backup security config and keys");
             backupSecurity = config.security;
         }
         spiLock->lock();
@@ -2331,7 +2331,7 @@ void NodeDB::loadFromDisk()
         // Encrypted storage is locked. Install defaults and wait for the
         // passphrase over BLE/serial; PhoneAPI::handleLockdownAuthInline
         // calls reloadFromDisk() once the storage is unlocked.
-        LOG_WARN("NodeDB: Encrypted storage locked, using default config until unlocked");
+        LOG_WARN("NodeDB: Encrypted storage locked, default config until unlocked");
         installDefaultNodeDatabase();
         installDefaultDeviceState();
         installDefaultConfig();
@@ -2442,7 +2442,7 @@ void NodeDB::loadFromDisk()
         // Attempt recovery of owner fields from our own NodeDB entry if available.
         const meshtastic_NodeInfoLite *us = getMeshNode(getNodeNum());
         if (nodeInfoLiteHasUser(us)) {
-            LOG_WARN("Restoring owner fields (long_name/short_name/is_licensed/is_unmessagable) from NodeDB for our node 0x%08x",
+            LOG_WARN("Restore owner fields (long_name/short_name/is_licensed/is_unmessagable) from NodeDB for node 0x%08x",
                      us->num);
             // owner.long_name (40) is wider than the lite source (25); bound by the source
             memcpy(owner.long_name, us->long_name, sizeof(us->long_name));
@@ -2457,7 +2457,7 @@ void NodeDB::loadFromDisk()
             saveToDisk(SEGMENT_DEVICESTATE);
         }
     } else {
-        LOG_INFO("Loaded saved devicestate version %d", devicestate.version);
+        LOG_INFO("Loaded saved devicestate v%d", devicestate.version);
     }
 
     // Devicestate saved by firmware that allowed 39-byte names gets clamped on
@@ -2483,7 +2483,7 @@ void NodeDB::loadFromDisk()
             config.lora = eventLora;
             state = LoadFileResult::LOAD_SUCCESS;
             initializedEventConfig = true;
-            LOG_INFO("Initialized event config without modifying %s", STANDARD_CONFIG_FILE_NAME);
+            LOG_INFO("Init event config without modifying %s", STANDARD_CONFIG_FILE_NAME);
         } else {
             // Keep the event load outcome because loadProto() clears config before decoding.
             // A normal decode failure must not create a replacement identity.
@@ -2497,7 +2497,7 @@ void NodeDB::loadFromDisk()
         // our NodeNum (== crc32(public_key)) and orphan us on the mesh. configDecodeFailed freezes identity and
         // skips persisting (see ctor), so a transient failure self-heals on the next clean boot. A genuinely
         // absent config returns OTHER_FAILURE, so this never fires on first boot. Boot degraded + radio-silent.
-        LOG_ERROR("Config decode failed - freezing identity, booting degraded (radio silent until restored)");
+        LOG_ERROR("Config decode failed - freeze identity, boot degraded (radio silent until restored)");
         configDecodeFailed = true;
         installDefaultConfig(true);
         config.lora.region = meshtastic_Config_LoRaConfig_RegionCode_UNSET;
@@ -2510,7 +2510,7 @@ void NodeDB::loadFromDisk()
         LOG_WARN("config %d is old, discard", config.version);
         installDefaultConfig(true);
     } else {
-        LOG_INFO("Loaded saved config version %d", config.version);
+        LOG_INFO("Loaded saved config v%d", config.version);
     }
     configLoadComplete = true;
 
@@ -2558,12 +2558,12 @@ void NodeDB::loadFromDisk()
         // This is the first durable event-profile write.  A failed write is
         // safe: normal files remain untouched and the next event boot retries.
         if (!saveToDisk(SEGMENT_CONFIG))
-            LOG_ERROR("Unable to persist initial event config");
+            LOG_ERROR("Can't persist initial event config");
     }
 #endif
 
     if (backupSecurity.private_key.size > 0) {
-        LOG_DEBUG("Restoring backup of security config");
+        LOG_DEBUG("Restore security config backup");
         config.security = backupSecurity;
         saveToDisk(SEGMENT_CONFIG);
     }
@@ -2582,7 +2582,7 @@ void NodeDB::loadFromDisk()
     }
     if (sum == 0) {
         numAdminKeys += 1;
-        LOG_INFO("Admin 0 key zero. Loading hard coded key from user preferences");
+        LOG_INFO("Admin 0 key zero. Load hard coded key from user prefs");
         memcpy(config.security.admin_key[0].bytes, userprefs_admin_key_0, 32);
         config.security.admin_key[0].size = 32;
     }
@@ -2595,7 +2595,7 @@ void NodeDB::loadFromDisk()
     }
     if (sum == 0) {
         numAdminKeys += 1;
-        LOG_INFO("Admin 1 key zero. Loading hard coded key from user preferences");
+        LOG_INFO("Admin 1 key zero. Load hard coded key from user prefs");
         memcpy(config.security.admin_key[1].bytes, userprefs_admin_key_1, 32);
         config.security.admin_key[1].size = 32;
     }
@@ -2608,7 +2608,7 @@ void NodeDB::loadFromDisk()
     }
     if (sum == 0) {
         numAdminKeys += 1;
-        LOG_INFO("Admin 2 key zero. Loading hard coded key from user preferences");
+        LOG_INFO("Admin 2 key zero. Load hard coded key from user prefs");
         memcpy(config.security.admin_key[2].bytes, userprefs_admin_key_2, 32);
         config.security.admin_key[2].size = 32;
     }
@@ -2629,7 +2629,7 @@ void NodeDB::loadFromDisk()
             LOG_WARN("moduleConfig %d is old, discard", moduleConfig.version);
             installDefaultModuleConfig();
         } else {
-            LOG_INFO("Loaded saved moduleConfig version %d", moduleConfig.version);
+            LOG_INFO("Loaded saved moduleConfig v%d", moduleConfig.version);
         }
     }
 
@@ -2652,7 +2652,7 @@ void NodeDB::loadFromDisk()
             LOG_WARN("channelFile %d is old, discard", channelFile.version);
             installDefaultChannels();
         } else {
-            LOG_INFO("Loaded saved channelFile version %d", channelFile.version);
+            LOG_INFO("Loaded saved channelFile v%d", channelFile.version);
         }
     }
 
@@ -2704,7 +2704,7 @@ void NodeDB::loadFromDisk()
         if (activeBackupExists && !EncryptedStorage::isEncrypted(backupFileName)) {
             LOG_INFO("Migrating %s to encrypted storage", backupFileName);
             if (!EncryptedStorage::migrateFile(backupFileName)) {
-                LOG_ERROR("Unable to migrate %s to encrypted storage", backupFileName);
+                LOG_ERROR("Can't migrate %s to encrypted storage", backupFileName);
                 storageCorruptThisLoad = true;
             }
         }
@@ -2723,7 +2723,7 @@ void NodeDB::loadFromDisk()
             if (exists && !EncryptedStorage::isEncrypted(fn)) {
                 LOG_INFO("Migrating inactive radio profile %s to encrypted storage", fn);
                 if (!EncryptedStorage::migrateFile(fn)) {
-                    LOG_ERROR("Unable to migrate %s to encrypted storage", fn);
+                    LOG_ERROR("Can't migrate %s to encrypted storage", fn);
                     storageCorruptThisLoad = true;
                 }
             }
@@ -2735,7 +2735,7 @@ void NodeDB::loadFromDisk()
 
     // 2.4.X - configuration migration to update new default intervals
     if (moduleConfig.version < 23) {
-        LOG_DEBUG("ModuleConfig version %d is stale, upgrading to new default intervals", moduleConfig.version);
+        LOG_DEBUG("ModuleConfig v%d stale, upgrade to new default intervals", moduleConfig.version);
         moduleConfig.version = DEVICESTATE_CUR_VER;
         if (moduleConfig.telemetry.device_update_interval == 900)
             moduleConfig.telemetry.device_update_interval = 0;
@@ -2829,7 +2829,7 @@ bool NodeDB::reloadFromDisk()
     loadFromDisk();
 
     if (storageCorruptThisLoad) {
-        LOG_ERROR("NodeDB: storage decrypt/decode failed during reload - surfacing as corrupt");
+        LOG_ERROR("NodeDB: reload decrypt/decode failed - treat as corrupt");
         // Leave the radio sleeping. Caller will lock storage and emit
         // a LOCKED(storage_corrupt) status; we must not reconfigure
         // the chip with the locked-default placeholder values still
@@ -2874,7 +2874,7 @@ bool NodeDB::disableLockdownToPlaintext()
                                   moduleConfigFileName,      deviceStateFileName,        nodeDatabaseFileName};
     for (const char *fn : filesToCheck) {
         if (!EncryptedStorage::migrateFileToPlaintext(fn)) {
-            LOG_ERROR("NodeDB: failed to revert %s to plaintext; aborting disable (device stays in lockdown)", fn);
+            LOG_ERROR("NodeDB: revert %s to plaintext failed; abort disable (stays in lockdown)", fn);
             return false;
         }
     }
@@ -2903,7 +2903,7 @@ bool NodeDB::saveProto(const char *filename, size_t protoSize, const pb_msgdesc_
     // do not try to save anything if power level is not safe. In many cases flash will be lock-protected
     // and all writes will fail anyway. Device should be sleeping at this point anyway.
     if (!powerHAL_isPowerLevelSafe()) {
-        LOG_ERROR("Trying to saveProto() on unsafe device power level");
+        LOG_ERROR("saveProto() on unsafe device power level");
         return false;
     }
 
@@ -2933,7 +2933,7 @@ bool NodeDB::saveProto(const char *filename, size_t protoSize, const pb_msgdesc_
         bool ok = EncryptedStorage::encryptAndWrite(filename, pbBuf.get(), encodedSize, fullAtomic);
 
         if (!ok) {
-            LOG_ERROR("EncryptedStorage: Failed to encrypt and write %s", filename);
+            LOG_ERROR("EncryptedStorage: encrypt+write %s failed", filename);
         }
         return ok;
     }
@@ -2969,7 +2969,7 @@ bool NodeDB::saveChannelsToDisk()
     // do not try to save anything if power level is not safe. In many cases flash will be lock-protected
     // and all writes will fail anyway.
     if (!powerHAL_isPowerLevelSafe()) {
-        LOG_ERROR("Trying to saveChannelsToDisk() on unsafe device power level");
+        LOG_ERROR("saveChannelsToDisk() on unsafe device power level");
         return false;
     }
 
@@ -2988,7 +2988,7 @@ bool NodeDB::saveDeviceStateToDisk()
     // do not try to save anything if power level is not safe. In many cases flash will be lock-protected
     // and all writes will fail anyway. Device should be sleeping at this point anyway.
     if (!powerHAL_isPowerLevelSafe()) {
-        LOG_ERROR("Trying to saveDeviceStateToDisk() on unsafe device power level");
+        LOG_ERROR("saveDeviceStateToDisk() on unsafe device power level");
         return false;
     }
 
@@ -3016,7 +3016,7 @@ bool NodeDB::saveNodeDatabaseToDisk()
     // do not try to save anything if power level is not safe. In many cases flash will be lock-protected
     // and all writes will fail anyway. Device should be sleeping at this point anyway.
     if (!powerHAL_isPowerLevelSafe()) {
-        LOG_ERROR("Trying to saveNodeDatabaseToDisk() on unsafe device power level");
+        LOG_ERROR("saveNodeDatabaseToDisk() on unsafe device power level");
         return false;
     }
 
@@ -3024,7 +3024,7 @@ bool NodeDB::saveNodeDatabaseToDisk()
     // would propagate through saveToDisk() and trigger fsFormat() mid-transfer.
 #ifdef FSCom
     if (xModem.isBusy()) {
-        LOG_DEBUG("Deferring NodeDB save: xmodem transfer in progress");
+        LOG_DEBUG("Defer NodeDB save: xmodem in progress");
         return true;
     }
 #endif
@@ -3125,7 +3125,7 @@ bool NodeDB::saveToDiskNoRetry(int saveWhat)
     // do not try to save anything if power level is not safe. In many cases flash will be lock-protected
     // and all writes will fail anyway. Device should be sleeping at this point anyway.
     if (!powerHAL_isPowerLevelSafe()) {
-        LOG_ERROR("Trying to saveToDiskNoRetry() on unsafe device power level");
+        LOG_ERROR("saveToDiskNoRetry() on unsafe device power level");
         return false;
     }
 
@@ -3155,11 +3155,11 @@ bool NodeDB::saveToDiskNoRetry(int saveWhat)
 #if USERPREFS_EVENT_MODE
     if (eventProfileStorageUnavailable) {
         if (saveWhat & SEGMENT_CONFIG) {
-            LOG_WARN("Skipping event config write: insufficient profile storage at boot");
+            LOG_WARN("Skip event config write: insufficient profile storage at boot");
             saveWhat &= ~SEGMENT_CONFIG;
         }
         if (saveWhat & SEGMENT_CHANNELS) {
-            LOG_WARN("Skipping event channel write: insufficient profile storage at boot");
+            LOG_WARN("Skip event channel write: insufficient profile storage at boot");
             saveWhat &= ~SEGMENT_CHANNELS;
         }
     }
@@ -3223,14 +3223,14 @@ bool NodeDB::saveToDisk(int saveWhat)
     // do not try to save anything if power level is not safe. In many cases flash will be lock-protected
     // and all writes will fail anyway. Device should be sleeping at this point anyway.
     if (!powerHAL_isPowerLevelSafe()) {
-        LOG_ERROR("Trying to saveToDisk() on unsafe device power level");
+        LOG_ERROR("saveToDisk() on unsafe device power level");
         return false;
     }
 
     bool success = saveToDiskNoRetry(saveWhat);
 
     if (!success) {
-        LOG_ERROR("Failed to save to disk, retrying");
+        LOG_ERROR("Save to disk failed, retry");
         spiLock->lock();
         fsFormat();
         spiLock->unlock();
@@ -3536,7 +3536,7 @@ bool NodeDB::updateUser(uint32_t nodeId, meshtastic_User &p, uint8_t channelInde
     // Only a signed update may change the identity of a proven signer; our own record is exempt.
     // Checked before getOrCreateMeshNode so a refusal cannot evict; isKnownXeddsaSigner covers the warm tier.
     if (nodeId != getNodeNum() && isKnownXeddsaSigner(nodeId) && !xeddsaSigned) {
-        LOG_WARN("Refusing unsigned identity update for node 0x%08x that previously signed", nodeId);
+        LOG_WARN("Refuse unsigned identity update for 0x%08x that previously signed", nodeId);
         return false;
     }
 
@@ -3577,10 +3577,10 @@ bool NodeDB::updateUser(uint32_t nodeId, meshtastic_User &p, uint8_t channelInde
     if (info->public_key.size == 32) { // if we have a key for this user already, don't overwrite with a new one
         // if the key doesn't match, don't update nodeDB at all.
         if (p.public_key.size != 32 || (memcmp(p.public_key.bytes, info->public_key.bytes, 32) != 0)) {
-            LOG_WARN("Public Key mismatch, dropping NodeInfo");
+            LOG_WARN("Public Key mismatch, drop NodeInfo");
             return false;
         }
-        LOG_INFO("Public Key set for node, not updating");
+        LOG_INFO("Public Key set, not updating");
     } else if (p.public_key.size == 32) {
         LOG_INFO("Update Node Pubkey");
     }
@@ -3617,7 +3617,7 @@ bool NodeDB::updateUser(uint32_t nodeId, meshtastic_User &p, uint8_t channelInde
             saveToDisk(SEGMENT_NODEDATABASE);
             lastNodeDbSave = millis();
         } else {
-            LOG_DEBUG("Defer NodeDB saveToDisk for now");
+            LOG_DEBUG("Defer NodeDB saveToDisk");
         }
     }
 
@@ -3851,7 +3851,7 @@ void NodeDB::sortMeshDB()
                 }
             }
         }
-        LOG_INFO("Sort took %u milliseconds", millis() - lastSort);
+        LOG_INFO("Sort took %u ms", millis() - lastSort);
     }
 }
 
@@ -4091,7 +4091,7 @@ meshtastic_NodeInfoLite *NodeDB::getOrCreateMeshNode(NodeNum n)
 
     if (!lite) {
         if (isFull()) {
-            LOG_INFO("Node database full with %i nodes and %u bytes free. Erasing oldest entry", numMeshNodes,
+            LOG_INFO("Node database full: %i nodes, %u bytes free. Erase oldest", numMeshNodes,
                      memGet.getFreeHeap());
             // look for oldest node and erase it
             uint32_t oldest = UINT32_MAX;
@@ -4187,7 +4187,7 @@ meshtastic_NodeInfoLite *NodeDB::getOrCreateMeshNode(NodeNum n)
             }
         }
 #endif
-        LOG_INFO("Adding node to database with %i nodes and %u bytes free", numMeshNodes, memGet.getFreeHeap());
+        LOG_INFO("Add node to database: %i nodes, %u bytes free", numMeshNodes, memGet.getFreeHeap());
     }
 
     return lite;
@@ -4264,14 +4264,14 @@ bool NodeDB::generateCryptoKeyPair(const uint8_t *privateKey)
         if (crypto->regeneratePublicKey(config.security.public_key.bytes, config.security.private_key.bytes)) {
             keygenSuccess = true;
         } else {
-            LOG_ERROR("Failed to generate public key from provided private key");
+            LOG_ERROR("Can't generate public key from private key");
             return false;
         }
     }
     // Try to regenerate public key from existing private key if it's valid and not low entropy
     else if (config.security.private_key.size == 32 && !keyIsLowEntropy) {
         config.security.public_key.size = 32;
-        LOG_DEBUG("Regenerate PKI public key from existing private key");
+        LOG_DEBUG("Regenerate PKI public key from private key");
         if (crypto->regeneratePublicKey(config.security.public_key.bytes, config.security.private_key.bytes)) {
             keygenSuccess = true;
         }
@@ -4331,7 +4331,7 @@ bool NodeDB::createNewIdentity()
     // still streamed to clients, and made any DM/admin aimed at it fail forever with PKI_SEND_FAIL_PUBLIC_KEY.
     // removeNodeByNum() drops the lite entry, its satellite stores, and the warm-tier copy.
     if (getMeshNode(oldNodeNum) != NULL) {
-        LOG_DEBUG("Old node num %u is now %u, removing stale identity", oldNodeNum, newNodeNum);
+        LOG_DEBUG("Old node num %u now %u, remove stale identity", oldNodeNum, newNodeNum);
         removeNodeByNum(oldNodeNum);
     } else {
         // Lite entry already absent: drop any orphaned satellite-store entries directly.
@@ -4377,7 +4377,7 @@ bool NodeDB::backupPreferences(meshtastic_AdminMessage_BackupLocation location)
         if (success) {
             LOG_INFO("Saved backup preferences");
         } else {
-            LOG_ERROR("Failed to save backup preferences to file");
+            LOG_ERROR("Save backup prefs to file failed");
         }
     } else if (location == meshtastic_AdminMessage_BackupLocation_SD) {
         // TODO: After more mainline SD card support
@@ -4394,7 +4394,7 @@ bool NodeDB::restorePreferences(meshtastic_AdminMessage_BackupLocation location,
         spiLock->lock();
         if (!FSCom.exists(backupFileName)) {
             spiLock->unlock();
-            LOG_WARN("Could not restore. No backup file found");
+            LOG_WARN("Can't restore, no backup file");
             return false;
         } else {
             spiLock->unlock();
@@ -4429,12 +4429,12 @@ bool NodeDB::restorePreferences(meshtastic_AdminMessage_BackupLocation location,
 
             success = saveToDisk(restoreWhat);
             if (success) {
-                LOG_INFO("Restored preferences from backup");
+                LOG_INFO("Restored prefs from backup");
             } else {
-                LOG_ERROR("Failed to save restored preferences to flash");
+                LOG_ERROR("Save restored prefs to flash failed");
             }
         } else {
-            LOG_ERROR("Failed to restore preferences from backup file");
+            LOG_ERROR("Restore prefs from backup failed");
         }
     } else if (location == meshtastic_AdminMessage_BackupLocation_SD) {
         // TODO: After more mainline SD card support
@@ -4458,7 +4458,7 @@ void recordCriticalError(meshtastic_CriticalErrorCode code, uint32_t address, co
 
     // Currently portuino is mostly used for simulation.  Make sure the user notices something really bad happened
 #ifdef ARCH_PORTDUINO
-    LOG_ERROR("A critical failure occurred");
+    LOG_ERROR("Critical failure");
     // TODO: Determine if other critical errors should also cause an immediate exit
     if (code == meshtastic_CriticalErrorCode_FLASH_CORRUPTION_RECOVERABLE ||
         code == meshtastic_CriticalErrorCode_FLASH_CORRUPTION_UNRECOVERABLE)

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -4091,8 +4091,7 @@ meshtastic_NodeInfoLite *NodeDB::getOrCreateMeshNode(NodeNum n)
 
     if (!lite) {
         if (isFull()) {
-            LOG_INFO("Node database full: %i nodes, %u bytes free. Erase oldest", numMeshNodes,
-                     memGet.getFreeHeap());
+            LOG_INFO("Node database full: %i nodes, %u bytes free. Erase oldest", numMeshNodes, memGet.getFreeHeap());
             // look for oldest node and erase it
             uint32_t oldest = UINT32_MAX;
             uint32_t oldestBoring = UINT32_MAX;

--- a/src/mesh/PacketHistory.cpp
+++ b/src/mesh/PacketHistory.cpp
@@ -107,8 +107,8 @@ bool PacketHistory::wasSeenRecently(const meshtastic_MeshPacket *p, bool withUpd
 
     // Check for hop_limit upgrade scenario
     if (seenRecently && wasUpgraded && getHighestHopLimit(*found) < p->hop_limit) {
-        LOG_DEBUG("Packet History - Hop limit upgrade: packet 0x%08x hop_limit=%d -> %d", p->id,
-                  getHighestHopLimit(*found), p->hop_limit);
+        LOG_DEBUG("Packet History - Hop limit upgrade: packet 0x%08x hop_limit=%d -> %d", p->id, getHighestHopLimit(*found),
+                  p->hop_limit);
         *wasUpgraded = true;
     } else if (wasUpgraded) {
         *wasUpgraded = false; // Initialize to false if not an upgrade

--- a/src/mesh/PacketHistory.cpp
+++ b/src/mesh/PacketHistory.cpp
@@ -70,7 +70,7 @@ bool PacketHistory::wasSeenRecently(const meshtastic_MeshPacket *p, bool withUpd
 
     if (p->id == 0) {
 #if VERBOSE_PACKET_HISTORY
-        LOG_DEBUG("Packet History - Was Seen Recently: ID is 0, not a floodable message");
+        LOG_DEBUG("Packet History - Was Seen Recently: ID 0, not floodable");
 #endif
         return false; // Not a floodable message ID, so we don't care
     }
@@ -107,7 +107,7 @@ bool PacketHistory::wasSeenRecently(const meshtastic_MeshPacket *p, bool withUpd
 
     // Check for hop_limit upgrade scenario
     if (seenRecently && wasUpgraded && getHighestHopLimit(*found) < p->hop_limit) {
-        LOG_DEBUG("Packet History - Hop limit upgrade: packet 0x%08x from hop_limit=%d to hop_limit=%d", p->id,
+        LOG_DEBUG("Packet History - Hop limit upgrade: packet 0x%08x hop_limit=%d -> %d", p->id,
                   getHighestHopLimit(*found), p->hop_limit);
         *wasUpgraded = true;
     } else if (wasUpgraded) {
@@ -234,7 +234,7 @@ void PacketHistory::hashInsert(NodeNum sender, PacketId id, uint16_t slotIdx)
         }
         bucket = (bucket + 1) & hashMask;
     }
-    LOG_ERROR("Packet History - hashInsert: table full or corrupted, rebuilding");
+    LOG_ERROR("Packet History - hashInsert: table full or corrupt, rebuild");
     hashRebuild();
 }
 
@@ -357,8 +357,7 @@ void PacketHistory::insert(const PacketRecord &r)
             it = (base + recentPacketsCapacity);
         } else {
             if (it->rxTimeMsec == 0) {
-                LOG_WARN("Packet History - insert: Found packet s=0x%08x id=0x%08x with rxTimeMsec = 0, slot %d/%d. Should never "
-                         "happen",
+                LOG_WARN("Packet History - insert: Found s=0x%08x id=0x%08x rxTimeMsec = 0, slot %d/%d. Should never happen",
                          it->sender, it->id, it - base, recentPacketsCapacity);
             }
             if ((now_millis - it->rxTimeMsec) > OldtrxTimeMsec) { // 49.7 days rollover friendly
@@ -373,7 +372,7 @@ void PacketHistory::insert(const PacketRecord &r)
     }
 
     if (tu == NULL) {
-        LOG_ERROR("Packet History - insert: No free slot, no matched packet, no oldest to reuse. Something leaked"); // mx
+        LOG_ERROR("Packet History - insert: No free/matched/oldest slot. Something leaked"); // mx
         // assert(false); // This should never happen, we should always have at least one packet to clear
         return; // Return early if we can't update the history
     }
@@ -399,7 +398,7 @@ void PacketHistory::insert(const PacketRecord &r)
         } else {
             // debug only
 #if VERBOSE_PACKET_HISTORY
-            LOG_WARN("Packet History - insert: Reusing slot aged %.3fs < %ds with MATCHED PACKET - this is normal",
+            LOG_WARN("Packet History - insert: Reusing slot aged %.3fs < %ds with MATCHED PACKET - normal",
                      OldtrxTimeMsec / 1000., RECENT_WARN_AGE / 1000);
 #endif
         }
@@ -424,7 +423,7 @@ void PacketHistory::insert(const PacketRecord &r)
 
     if (r.rxTimeMsec == 0) {
 #if VERBOSE_PACKET_HISTORY
-        LOG_WARN("Packet History - insert: I will not store packet with rxTimeMsec = 0");
+        LOG_WARN("Packet History - insert: Won't store packet with rxTimeMsec = 0");
 #endif
         return; // Return early if we can't update the history
     }

--- a/src/mesh/PacketHistory.cpp
+++ b/src/mesh/PacketHistory.cpp
@@ -64,7 +64,7 @@ bool PacketHistory::wasSeenRecently(const meshtastic_MeshPacket *p, bool withUpd
                                     bool *wasUpgraded)
 {
     if (!initOk()) {
-        LOG_ERROR("Packet History - Was Seen Recently: NOT INITIALIZED!");
+        LOG_ERROR("Packet History - Was Seen Recently: NOT INITIALIZED");
         return false;
     }
 
@@ -358,7 +358,7 @@ void PacketHistory::insert(const PacketRecord &r)
         } else {
             if (it->rxTimeMsec == 0) {
                 LOG_WARN("Packet History - insert: Found packet s=0x%08x id=0x%08x with rxTimeMsec = 0, slot %d/%d. Should never "
-                         "happen!",
+                         "happen",
                          it->sender, it->id, it - base, recentPacketsCapacity);
             }
             if ((now_millis - it->rxTimeMsec) > OldtrxTimeMsec) { // 49.7 days rollover friendly
@@ -373,7 +373,7 @@ void PacketHistory::insert(const PacketRecord &r)
     }
 
     if (tu == NULL) {
-        LOG_ERROR("Packet History - insert: No free slot, no matched packet, no oldest to reuse. Something leaked."); // mx
+        LOG_ERROR("Packet History - insert: No free slot, no matched packet, no oldest to reuse. Something leaked"); // mx
         // assert(false); // This should never happen, we should always have at least one packet to clear
         return; // Return early if we can't update the history
     }
@@ -424,7 +424,7 @@ void PacketHistory::insert(const PacketRecord &r)
 
     if (r.rxTimeMsec == 0) {
 #if VERBOSE_PACKET_HISTORY
-        LOG_WARN("Packet History - insert: I will not store packet with rxTimeMsec = 0.");
+        LOG_WARN("Packet History - insert: I will not store packet with rxTimeMsec = 0");
 #endif
         return; // Return early if we can't update the history
     }
@@ -457,7 +457,7 @@ void PacketHistory::insert(const PacketRecord &r)
 bool PacketHistory::wasRelayer(const uint8_t relayer, const uint32_t id, const NodeNum sender, bool *wasSole)
 {
     if (!initOk()) {
-        LOG_ERROR("PacketHistory - wasRelayer: NOT INITIALIZED!");
+        LOG_ERROR("PacketHistory - wasRelayer: NOT INITIALIZED");
         return false;
     }
 
@@ -527,7 +527,7 @@ void PacketHistory::checkRelayers(uint8_t relayer1, uint8_t relayer2, uint32_t i
         *r2WasSole = false;
 
     if (!initOk()) {
-        LOG_ERROR("PacketHistory - checkRelayers: NOT INITIALIZED!");
+        LOG_ERROR("PacketHistory - checkRelayers: NOT INITIALIZED");
         return;
     }
 
@@ -545,7 +545,7 @@ void PacketHistory::checkRelayers(uint8_t relayer1, uint8_t relayer2, uint32_t i
 void PacketHistory::removeRelayer(const uint8_t relayer, const uint32_t id, const NodeNum sender)
 {
     if (!initOk()) {
-        LOG_ERROR("Packet History - remove Relayer: NOT INITIALIZED!");
+        LOG_ERROR("Packet History - remove Relayer: NOT INITIALIZED");
         return;
     }
 

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -524,7 +524,7 @@ bool PhoneAPI::handleToRadio(const uint8_t *buf, size_t bufLength)
             break;
         }
     } else {
-        LOG_ERROR("Error: ignore malformed toradio");
+        LOG_ERROR("Ignore malformed toradio");
     }
 
     return false;

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -216,11 +216,11 @@ static PhoneAuthSlot *findOrAllocSlot_LH(PhoneAPI *p)
         if (!s.authorized) {
             s.who = p;
             s.epoch = 0;
-            LOG_WARN("Lockdown: auth slot table full, evicted stale unauthorized slot for new PhoneAPI %p", p);
+            LOG_WARN("Lockdown: auth slots full, evicted stale unauthorized slot for new PhoneAPI %p", p);
             return &s;
         }
     }
-    LOG_WARN("Lockdown: auth slot table full of authorized sessions, refusing new PhoneAPI %p (fail-closed)", p);
+    LOG_WARN("Lockdown: auth slots full of authorized sessions, refuse new PhoneAPI %p (fail-closed)", p);
     return nullptr;
 }
 
@@ -304,7 +304,7 @@ void PhoneAPI::handleStartConfig()
     if (config_nonce == SPECIAL_NONCE_ONLY_NODES) {
         // If client only wants node info, jump directly to sending nodes
         state = STATE_SEND_OWN_NODEINFO;
-        LOG_INFO("Client only wants node info, skipping other config");
+        LOG_INFO("Client only wants node info, skip other config");
     } else {
         state = STATE_SEND_MY_INFO;
     }
@@ -457,7 +457,7 @@ bool PhoneAPI::handleToRadio(const uint8_t *buf, size_t bufLength)
                     ourNum != 0 && toRadioScratch.packet.which_payload_variant == meshtastic_MeshPacket_decoded_tag &&
                     toRadioScratch.packet.decoded.portnum == meshtastic_PortNum_ADMIN_APP && toRadioScratch.packet.to == ourNum;
                 if (!isLocalAdmin) {
-                    LOG_INFO("Lockdown: Dropping non-admin ToRadio packet from unauthorized client");
+                    LOG_INFO("Lockdown: Drop non-admin ToRadio packet from unauthorized client");
                     return false;
                 }
             }
@@ -475,7 +475,7 @@ bool PhoneAPI::handleToRadio(const uint8_t *buf, size_t bufLength)
         case meshtastic_ToRadio_xmodemPacket_tag:
 #ifdef MESHTASTIC_PHONEAPI_ACCESS_CONTROL
             if (!getAdminAuthorized()) {
-                LOG_INFO("Lockdown: Dropping xmodem packet from unauthorized client");
+                LOG_INFO("Lockdown: Drop xmodem packet from unauthorized client");
                 break;
             }
 #endif
@@ -488,15 +488,14 @@ bool PhoneAPI::handleToRadio(const uint8_t *buf, size_t bufLength)
         case meshtastic_ToRadio_mqttClientProxyMessage_tag:
             LOG_DEBUG("Got MqttClientProxy message");
             if (state != STATE_SEND_PACKETS) {
-                LOG_WARN("Ignore MqttClientProxy message while completing config handshake");
+                LOG_WARN("Ignore MqttClientProxy msg during config handshake");
                 break;
             }
             if (mqtt && moduleConfig.mqtt.proxy_to_client_enabled && moduleConfig.mqtt.enabled &&
                 (channels.anyMqttEnabled() || moduleConfig.mqtt.map_reporting_enabled)) {
                 mqtt->onClientProxyReceive(toRadioScratch.mqttClientProxyMessage);
             } else {
-                LOG_WARN("MqttClientProxy received but proxy is not enabled, no channels have up/downlink, or map reporting "
-                         "not enabled");
+                LOG_WARN("MqttClientProxy received but proxy disabled, no up/downlink channels, or map reporting off");
             }
             break;
 #endif
@@ -511,7 +510,7 @@ bool PhoneAPI::handleToRadio(const uint8_t *buf, size_t bufLength)
             // a queue-status reply.
             if (toRadioScratch.heartbeat.nonce == 1) {
                 if (nodeInfoModule) {
-                    LOG_INFO("Broadcasting nodeinfo ping (serial)");
+                    LOG_INFO("Broadcast nodeinfo ping (serial)");
                     nodeInfoModule->sendOurNodeInfo(NODENUM_BROADCAST, true, 0, true);
                 }
             } else {
@@ -1804,7 +1803,7 @@ bool PhoneAPI::handleToRadioPacket(meshtastic_MeshPacket &p)
             return true;
         }
         case LocalAdminGate::DropUnauthorized:
-            LOG_WARN("Lockdown: dropping admin payload variant=%d from unauthorized connection", admin.which_payload_variant);
+            LOG_WARN("Lockdown: drop admin payload variant=%d from unauthorized connection", admin.which_payload_variant);
             return false;
         case LocalAdminGate::NotAdmin:
         case LocalAdminGate::AuthorizedPassThrough:
@@ -1818,7 +1817,7 @@ bool PhoneAPI::handleToRadioPacket(meshtastic_MeshPacket &p)
     if (SimRadio::instance == nullptr)
 #endif
         if (p.id > 0 && wasSeenRecently(p.id)) {
-            LOG_DEBUG("Ignore packet from phone, already seen recently");
+            LOG_DEBUG("Ignore phone packet, seen recently");
             return false;
         }
 
@@ -1878,7 +1877,7 @@ int PhoneAPI::onNotify(uint32_t newValue)
                                              // doesn't call this from idle)
 
     if (state == STATE_SEND_PACKETS) {
-        LOG_INFO("Tell client we have new packets %u", newValue);
+        LOG_INFO("Tell client new packets %u", newValue);
         onNowHasData(newValue);
     } else {
         LOG_DEBUG("Client not yet interested in packets (state=%d)", state);
@@ -2049,7 +2048,7 @@ bool PhoneAPI::handleLockdownAuthInline(const meshtastic_LockdownAuth &la)
             zeroPassphrase();
             return true;
         }
-        LOG_INFO("Lockdown: LOCK NOW command received from authorized connection");
+        LOG_INFO("Lockdown: LOCK NOW from authorized connection");
         EncryptedStorage::lockNow();
         revokeAllAuth();
         queueLockdownStatus(meshtastic_LockdownStatus_State_LOCKED, "", 0, 0, 0);
@@ -2073,7 +2072,7 @@ bool PhoneAPI::handleLockdownAuthInline(const meshtastic_LockdownAuth &la)
         }
         if (!EncryptedStorage::isLockdownActive()) {
             // Already off - nothing to do; report DISABLED so the client UI settles.
-            LOG_INFO("Lockdown: disable requested but lockdown is not active");
+            LOG_INFO("Lockdown: disable requested but not active");
             queueLockdownStatus(meshtastic_LockdownStatus_State_DISABLED, "", 0, 0, 0);
             zeroPassphrase();
             return true;
@@ -2156,7 +2155,7 @@ bool PhoneAPI::handleLockdownAuthInline(const meshtastic_LockdownAuth &la)
                     slot->pendingUnlockAfterReload = true;
             }
             lockdownReloadPending = true;
-            LOG_INFO("Lockdown: storage unlocked, awaiting reload before client visibility");
+            LOG_INFO("Lockdown: storage unlocked, await reload before client visibility");
         }
     } else {
         LOG_INFO("Lockdown: passphrase re-verify for admin authorization");
@@ -2166,7 +2165,7 @@ bool PhoneAPI::handleLockdownAuthInline(const meshtastic_LockdownAuth &la)
             // Storage was already unlocked - no reload needed. Authorize
             // and surface UNLOCKED to the client immediately.
             setAdminAuthorized(true);
-            LOG_INFO("Lockdown: passphrase verified, this connection authorized");
+            LOG_INFO("Lockdown: passphrase verified, connection authorized");
         }
     }
 

--- a/src/mesh/ProtobufModule.h
+++ b/src/mesh/ProtobufModule.h
@@ -94,7 +94,7 @@ template <class T> class ProtobufModule : protected SinglePortModule
                 LOG_INFO("Received %s from=0x%08x, id=0x%08x, portnum=%d, payloadlen=%d", name, mp.from, mp.id, p.portnum,
                          p.payload.size);
             } else {
-                LOG_ERROR("Error decoding proto module!");
+                LOG_ERROR("Error decoding proto module");
                 // if we can't decode it, nobody can process it!
                 return ProcessMessage::STOP;
             }
@@ -115,7 +115,7 @@ template <class T> class ProtobufModule : protected SinglePortModule
             if (pb_decode_from_bytes(p.payload.bytes, p.payload.size, fields, &scratch)) {
                 decoded = &scratch;
             } else {
-                LOG_ERROR("Error decoding proto module!");
+                LOG_ERROR("Error decoding proto module");
                 // if we can't decode it, nobody can process it!
                 return;
             }

--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -318,14 +318,14 @@ bool RF95Interface::isChannelActive()
     result = lora->scanChannel();
 
     if (result == RADIOLIB_PREAMBLE_DETECTED) {
-        // LOG_DEBUG("Channel is busy!");
+        // LOG_DEBUG("Channel is busy");
         return true;
     }
     if (result != RADIOLIB_CHANNEL_FREE)
         LOG_ERROR("RF95 isChannelActive %s%d", radioLibErr, result);
     assert(result != RADIOLIB_ERR_WRONG_MODEM);
 
-    // LOG_DEBUG("Channel is free!");
+    // LOG_DEBUG("Channel is free");
     return false;
 }
 

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -692,7 +692,7 @@ void getRegionPresetMap(meshtastic_LoRaRegionPresetMap &map)
         // log once and stop. An incomplete map means clients won't constrain the
         // omitted regions, so this must be discoverable rather than silent.
         if (map.region_groups_count >= maxRegions) {
-            LOG_ERROR("Region preset map full at %u regions; remaining regions omitted", (unsigned)maxRegions);
+            LOG_ERROR("Region preset map full at %u regions; rest omitted", (unsigned)maxRegions);
             break;
         }
 
@@ -832,11 +832,11 @@ uint32_t RadioInterface::getTxDelayMsecWeighted(meshtastic_MeshPacket *p)
     // LOG_DEBUG("rx_snr of %f so setting CWsize to:%d", snr, CWsize);
     if (shouldRebroadcastEarlyLikeRouter(p)) {
         delay = random(0, 2 * CWsize) * slotTimeMsec;
-        LOG_DEBUG("rx_snr found in packet. Router: setting tx delay:%d", delay);
+        LOG_DEBUG("rx_snr in packet. Router: tx delay:%d", delay);
     } else {
         // offset the maximum delay for routers: (2 * CWmax * slotTimeMsec)
         delay = (2 * CWmax * slotTimeMsec) + random(0, pow_of_2(CWsize)) * slotTimeMsec;
-        LOG_DEBUG("rx_snr found in packet. Setting tx delay:%d", delay);
+        LOG_DEBUG("rx_snr in packet. Tx delay:%d", delay);
     }
 
     return delay;
@@ -1108,7 +1108,7 @@ bool RadioInterface::checkOrClampConfigLora(meshtastic_Config_LoRaConfig &loraCo
                     // Validation must still fail so callers route into the clamp, but quietly:
                     // the clamp will accept this config by swapping regions, so don't record a
                     // critical error or alarm the user over a change that is about to succeed.
-                    LOG_INFO("Preset %s implies region swap %s to %s, deferring to clamp", presetName, newRegion->name,
+                    LOG_INFO("Preset %s implies region swap %s to %s, defer to clamp", presetName, newRegion->name,
                              swapRegion->name);
                     return false;
                 }
@@ -1263,7 +1263,7 @@ void RadioInterface::applyModemConfig()
         // If custom CR is being used already, check if the new preset is higher
         if (loraConfig.coding_rate >= 5 && loraConfig.coding_rate <= 8 && loraConfig.coding_rate < newcr) {
             cr = newcr;
-            LOG_INFO("Default Coding Rate is higher than custom setting, using %u", cr);
+            LOG_INFO("Default Coding Rate above custom setting, use %u", cr);
         }
         // If the custom CR is higher than the preset, use it
         else if (loraConfig.coding_rate >= 5 && loraConfig.coding_rate <= 8 && loraConfig.coding_rate > newcr) {
@@ -1276,7 +1276,7 @@ void RadioInterface::applyModemConfig()
     } else { // if not using preset, then just use the custom settings
         if (validateConfigLora(loraConfig)) {
         } else {
-            LOG_WARN("Invalid LoRa config settings, cannot apply requested modem config - falling back to %s defaults",
+            LOG_WARN("Invalid LoRa config, can't apply modem config - fall back to %s defaults",
                      newRegion->name);
             clampConfigLora(loraConfig);
         }
@@ -1370,9 +1370,9 @@ void RadioInterface::applyModemConfig()
              newRegion->freqEnd - newRegion->freqStart);
     LOG_INFO("numFreqSlots: %u x %.3fkHz", numFreqSlots, bw);
     if (newRegion->overrideSlot > 0) {
-        LOG_INFO("Using region explicit override slot: %d", newRegion->overrideSlot);
+        LOG_INFO("Region explicit override slot: %d", newRegion->overrideSlot);
     } else if (newRegion->overrideSlot == OVERRIDE_SLOT_PRESET_HASH) {
-        LOG_INFO("Using region preset name hash for slot selection");
+        LOG_INFO("Use region preset name hash for slot");
     }
     LOG_INFO("channel_num: %d", channel_num + 1);
     LOG_INFO("frequency: %f", getFreq());
@@ -1410,7 +1410,7 @@ void RadioInterface::limitPower(int8_t loraMaxPower)
         maxPower = myRegion->powerLimit;
 
     if ((power > maxPower) && !devicestate.owner.is_licensed) {
-        LOG_INFO("Lower transmit power because of regulatory limits");
+        LOG_INFO("Lower Tx power: regulatory limits");
         power = maxPower;
     }
 
@@ -1477,7 +1477,7 @@ size_t RadioInterface::beginSending(meshtastic_MeshPacket *p)
     radioBuffer.header.next_hop = p->next_hop;
     radioBuffer.header.relay_node = p->relay_node;
     if (p->hop_limit > HOP_MAX) {
-        LOG_WARN("hop limit %d is too high, setting to %d", p->hop_limit, HOP_RELIABLE);
+        LOG_WARN("hop limit %d too high, set to %d", p->hop_limit, HOP_RELIABLE);
         p->hop_limit = HOP_RELIABLE;
     }
     radioBuffer.header.flags =

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -1276,8 +1276,7 @@ void RadioInterface::applyModemConfig()
     } else { // if not using preset, then just use the custom settings
         if (validateConfigLora(loraConfig)) {
         } else {
-            LOG_WARN("Invalid LoRa config, can't apply modem config - fall back to %s defaults",
-                     newRegion->name);
+            LOG_WARN("Invalid LoRa config, can't apply modem config - fall back to %s defaults", newRegion->name);
             clampConfigLora(loraConfig);
         }
         // Clamp at the source so numFreqSlots below can never be 0 (a bandwidth-0 config may already be persisted)

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -107,7 +107,7 @@ bool RadioLibInterface::canSendImmediately()
         // If we've been trying to send the same packet more than one minute and we haven't gotten a
         // TX IRQ from the radio, the radio is probably broken.
         if (busyTx && !Throttle::isWithinTimespanMs(lastTxStart, 60000)) {
-            LOG_ERROR("Hardware Failure! busyTx for more than 60s");
+            LOG_ERROR("Hardware Failure! busyTx >60s");
             RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_TRANSMIT_FAILED);
             // reboot in 5 seconds when this condition occurs.
             rebootAtMsec = lastTxStart + 65000;
@@ -339,7 +339,7 @@ void RadioLibInterface::resetNoiseFloor()
     currentSampleIndex = 0;
     isNoiseFloorBufferFull = false;
     currentNoiseFloor = NOISE_FLOOR_DEFAULT;
-    LOG_INFO("Noise floor reset - rolling window collection will restart");
+    LOG_INFO("Noise floor reset - rolling window will restart");
 }
 
 bool RadioLibInterface::randomBytes(uint8_t *buffer, size_t length)
@@ -445,7 +445,7 @@ void RadioLibInterface::onNotify(uint32_t notification)
                     // The beacon's target radio config is invalid (bad preset/region, or an
                     // unlicensed node keying up on a ham-only region). Drop the packet - never
                     // transmit it on the current (home) config - and move on to the next queued packet.
-                    LOG_DEBUG("Beacon: invalid TX radio config, dropping packet 0x%08x", txp->id);
+                    LOG_DEBUG("Beacon: invalid TX radio config, drop packet 0x%08x", txp->id);
                     meshtastic_MeshPacket *bad = txQueue.dequeue();
                     MeshBeaconModule::clearTargetRadioSettings(bad);
                     packetPool.release(bad);
@@ -468,7 +468,7 @@ void RadioLibInterface::onNotify(uint32_t notification)
                         txp = txQueue.dequeue();
                         assert(txp);
                         startSend(txp);
-                        LOG_DEBUG("%d packets remain in the TX queue", txQueue.getMaxLen() - txQueue.getFree());
+                        LOG_DEBUG("%d packets in TX queue", txQueue.getMaxLen() - txQueue.getFree());
                     }
                 }
             }
@@ -539,7 +539,7 @@ void RadioLibInterface::clampToLateRebroadcastWindow(NodeNum from, PacketId id)
         p->tx_after = millis() + getTxDelayMsecWeightedWorst(p->rx_snr);
         bool dropped = false;
         if (txQueue.enqueue(p, &dropped)) {
-            LOG_DEBUG("Move existing queued packet to the late rebroadcast window %dms from now", p->tx_after - millis());
+            LOG_DEBUG("Move queued packet to late rebroadcast window %dms from now", p->tx_after - millis());
         } else {
             packetPool.release(p);
         }
@@ -557,7 +557,7 @@ bool RadioLibInterface::removePendingTXPacket(NodeNum from, PacketId id, uint32_
 {
     meshtastic_MeshPacket *p = txQueue.remove(from, id, true, true, hop_limit_lt);
     if (p) {
-        LOG_DEBUG("Dropping pending-TX packet 0x%08x with hop limit %d", p->id, p->hop_limit);
+        LOG_DEBUG("Drop pending-TX packet 0x%08x, hop limit %d", p->id, p->hop_limit);
         packetPool.release(p);
         return true;
     }
@@ -607,7 +607,7 @@ void RadioLibInterface::handleReceiveInterrupt()
     // when this is called, we should be in receive mode - if we are not, just jump out instead of bombing. Possible Race
     // Condition?
     if (!isReceiving) {
-        LOG_ERROR("handleReceiveInterrupt called when not in rx mode, which shouldn't happen");
+        LOG_ERROR("handleReceiveInterrupt called while not in rx mode");
         return;
     }
 
@@ -634,7 +634,7 @@ void RadioLibInterface::handleReceiveInterrupt()
 #endif
     if (state != RADIOLIB_ERR_NONE) {
         // Log PacketHeader similar to RadioInterface::printPacket so we can try to match RX errors to other packets in the logs.
-        LOG_ERROR("Ignore received packet due to error=%d (maybe id=0x%08x fr=0x%08x to=0x%08x flags=0x%02x rxSNR=%g rxRSSI=%i "
+        LOG_ERROR("Ignore rx packet, error=%d (maybe id=0x%08x fr=0x%08x to=0x%08x flags=0x%02x rxSNR=%g rxRSSI=%i "
                   "nextHop=0x%x relay=0x%x)",
                   state, radioBuffer.header.id, radioBuffer.header.from, radioBuffer.header.to, radioBuffer.header.flags,
                   iface->getSNR(), lround(iface->getRSSI()), radioBuffer.header.next_hop, radioBuffer.header.relay_node);
@@ -759,7 +759,7 @@ bool RadioLibInterface::startSend(meshtastic_MeshPacket *txp)
     /* NOTE: Minimize the actions before startTransmit() to keep the time between
              channel scan and actual transmit as low as possible to avoid collisions. */
     if (disabled || !config.lora.tx_enabled) {
-        LOG_WARN("Drop Tx packet because LoRa Tx disabled");
+        LOG_WARN("Drop Tx packet: LoRa Tx disabled");
 #if !MESHTASTIC_EXCLUDE_BEACON
         // This packet may have already triggered a beacon radio switch in TRANSMIT_DELAY_COMPLETED;
         // since it never reaches completeSending() here, restore the radio so it isn't left on the

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -672,8 +672,7 @@ bool checkXeddsaReceivePolicy(meshtastic_MeshPacket *p)
         // senders emit only those two sizes (perhapsEncode sets 0 or XEDDSA_SIGNATURE_SIZE). Drop
         // it: a crafted partial signature would otherwise land in the unsigned branch below while
         // its bytes inflated the size estimate, letting a forged broadcast dodge the downgrade drop.
-        LOG_WARN("Malformed XEdDSA signature (%u bytes) from 0x%08x, drop", (unsigned)p->decoded.xeddsa_signature.size,
-                 p->from);
+        LOG_WARN("Malformed XEdDSA signature (%u bytes) from 0x%08x, drop", (unsigned)p->decoded.xeddsa_signature.size, p->from);
         return false;
     } else {
         if (p->pki_encrypted)
@@ -1161,8 +1160,7 @@ meshtastic_Routing_Error perhapsEncode(meshtastic_MeshPacket *p)
                 return meshtastic_Routing_Error_TOO_LARGE;
             // Check for a usable public key for the destination (NodeDB or a pending key-verification key)
             if (!haveDestKey) {
-                LOG_WARN("Unknown public key for 0x%08x (portnum %d), refuse legacy DM", p->to,
-                         p->decoded.portnum);
+                LOG_WARN("Unknown public key for 0x%08x (portnum %d), refuse legacy DM", p->to, p->decoded.portnum);
                 return meshtastic_Routing_Error_PKI_SEND_FAIL_PUBLIC_KEY;
             }
             if (p->pki_encrypted && !memfll(p->public_key.bytes, 0, 32) && memcmp(p->public_key.bytes, destKey.bytes, 32) != 0) {

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -336,7 +336,7 @@ meshtastic_QueueStatus Router::getQueueStatus()
 ErrorCode Router::sendLocal(meshtastic_MeshPacket *p, RxSource src)
 {
     if (p->to == 0) {
-        LOG_ERROR("Packet received with to: of 0");
+        LOG_ERROR("Packet received with to=0");
     }
     // No need to deliver externally if the destination is the local node
     if (isToUs(p)) {

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -223,7 +223,7 @@ int32_t Router::runOnce()
         perhapsHandleReceived(mp);
     }
 
-    // LOG_DEBUG("Sleep forever!");
+    // LOG_DEBUG("Sleep forever");
     return INT32_MAX; // Wait a long time - until we get woken for the message queue
 }
 
@@ -336,7 +336,7 @@ meshtastic_QueueStatus Router::getQueueStatus()
 ErrorCode Router::sendLocal(meshtastic_MeshPacket *p, RxSource src)
 {
     if (p->to == 0) {
-        LOG_ERROR("Packet received with to: of 0!");
+        LOG_ERROR("Packet received with to: of 0");
     }
     // No need to deliver externally if the destination is the local node
     if (isToUs(p)) {
@@ -385,7 +385,7 @@ ErrorCode Router::sendLocal(meshtastic_MeshPacket *p, RxSource src)
 ErrorCode Router::send(meshtastic_MeshPacket *p)
 {
     if (isToUs(p)) {
-        LOG_ERROR("BUG! send() called with packet destined for local node!");
+        LOG_ERROR("BUG! send() called with packet destined for local node");
         packetPool.release(p);
         return meshtastic_Routing_Error_BAD_REQUEST;
     } // should have already been handled by sendLocal
@@ -874,7 +874,7 @@ DecodeState perhapsDecode(meshtastic_MeshPacket *p)
                 adminKeyFallbackRefund();
         }
         if (decrypted) {
-            LOG_INFO("PKI Decryption worked!");
+            LOG_INFO("PKI Decryption worked");
             meshtastic_Data decodedtmp;
             memset(&decodedtmp, 0, sizeof(decodedtmp));
             size_t payloadSize = rawSize - MESHTASTIC_PKC_OVERHEAD;
@@ -888,7 +888,7 @@ DecodeState perhapsDecode(meshtastic_MeshPacket *p)
                 }
                 decrypted = true;
                 rawSize = payloadSize; // commit the overhead subtraction only on full success
-                LOG_INFO("Packet decrypted using PKI!");
+                LOG_INFO("Packet decrypted using PKI");
                 p->pki_encrypted = true;
                 memcpy(p->public_key.bytes, remotePublic.bytes, 32);
                 p->public_key.size = 32;
@@ -906,7 +906,7 @@ DecodeState perhapsDecode(meshtastic_MeshPacket *p)
             } else {
                 // AEAD already authenticated this ciphertext, so no other candidate could decode it -
                 // the payload is simply malformed.
-                LOG_ERROR("PKC Decrypted, but pb_decode failed!");
+                LOG_ERROR("PKC Decrypted, but pb_decode failed");
                 return DecodeState::DECODE_FAILURE;
             }
         }
@@ -1014,7 +1014,7 @@ DecodeState perhapsDecode(meshtastic_MeshPacket *p)
 #endif
         return DecodeState::DECODE_SUCCESS;
     } else {
-        LOG_WARN("No suitable channel found for decoding, hash was 0x%x!", p->channel);
+        LOG_WARN("No suitable channel found for decoding, hash was 0x%x", p->channel);
         return (matchedChannel || pkiAttempted || licensedPkiCandidate) ? DecodeState::DECODE_FAILURE
                                                                         : DecodeState::DECODE_OPAQUE;
     }
@@ -1156,7 +1156,7 @@ meshtastic_Routing_Error perhapsEncode(meshtastic_MeshPacket *p)
         // We may want to retool things so we can send a PKC packet when the client specifies a key and nodenum, even if the node
         // is not in the local nodedb
         if (wouldEncryptWithPKC(p, chIndex, haveDestKey)) {
-            LOG_DEBUG("Use PKI!");
+            LOG_DEBUG("Use PKI");
             if (numbytes + MESHTASTIC_HEADER_LENGTH + MESHTASTIC_PKC_OVERHEAD > MAX_LORA_PAYLOAD_LEN)
                 return meshtastic_Routing_Error_TOO_LARGE;
             // Check for a usable public key for the destination (NodeDB or a pending key-verification key)

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -202,7 +202,7 @@ bool Router::shouldDecrementHopLimit(const meshtastic_MeshPacket *p)
         if (node && nodeInfoLiteIsFavorite(node) && nodeInfoLiteHasUser(node) &&
             IS_ONE_OF(node->role, meshtastic_Config_DeviceConfig_Role_ROUTER, meshtastic_Config_DeviceConfig_Role_ROUTER_LATE,
                       meshtastic_Config_DeviceConfig_Role_CLIENT_BASE)) {
-            LOG_DEBUG("Identified unique favorite relay router 0x%08x from last byte 0x%x", resolved, p->relay_node);
+            LOG_DEBUG("Unique favorite relay router 0x%08x from last byte 0x%x", resolved, p->relay_node);
             return false; // Don't decrement hop_limit
         }
     }
@@ -385,7 +385,7 @@ ErrorCode Router::sendLocal(meshtastic_MeshPacket *p, RxSource src)
 ErrorCode Router::send(meshtastic_MeshPacket *p)
 {
     if (isToUs(p)) {
-        LOG_ERROR("BUG! send() called with packet destined for local node");
+        LOG_ERROR("BUG! send() with packet for local node");
         packetPool.release(p);
         return meshtastic_Routing_Error_BAD_REQUEST;
     } // should have already been handled by sendLocal
@@ -397,7 +397,7 @@ ErrorCode Router::send(meshtastic_MeshPacket *p)
         if (hourlyTxPercent > effectiveDutyCycle) {
             uint8_t silentMinutes = airTime->getSilentMinutes(hourlyTxPercent, effectiveDutyCycle);
 
-            LOG_WARN("Duty cycle limit exceeded. Aborting send for now, you can send again in %d mins", silentMinutes);
+            LOG_WARN("Duty cycle limit exceeded, abort send, retry in %d mins", silentMinutes);
 
             meshtastic_ClientNotification *cn = clientNotificationPool.allocZeroed();
             if (cn) {
@@ -475,7 +475,7 @@ ErrorCode Router::send(meshtastic_MeshPacket *p)
     // p->from as the original sender, so do not rewrite their POSITION_APP payload.
     if (isFromUs(p)) {
         if (!applyPositionPrecisionForChannel(*p, p->channel)) {
-            LOG_ERROR("Dropping malformed position packet before send");
+            LOG_ERROR("Drop malformed position packet before send");
             packetPool.release(p);
             return meshtastic_Routing_Error_BAD_REQUEST;
         }
@@ -652,18 +652,18 @@ bool checkXeddsaReceivePolicy(meshtastic_MeshPacket *p)
                 nodeInfoLiteSetBit(node, NODEINFO_BITFIELD_HAS_XEDDSA_SIGNED_MASK, true);
                 LOG_DEBUG("Verified XEdDSA signature from 0x%08x", p->from);
             } else {
-                LOG_WARN("XEdDSA signature verification failed from 0x%08x, dropping", p->from);
+                LOG_WARN("XEdDSA signature verify failed from 0x%08x, drop", p->from);
                 return false;
             }
         } else {
             const auto bootstrap = verifyFirstContactNodeInfo(p);
             if (bootstrap == NodeInfoBootstrapResult::INVALID) {
-                LOG_WARN("Invalid first-contact XEdDSA NodeInfo from 0x%08x, dropping", p->from);
+                LOG_WARN("Invalid first-contact XEdDSA NodeInfo from 0x%08x, drop", p->from);
                 return false;
             }
             if (bootstrap == NodeInfoBootstrapResult::VERIFIED)
                 return true;
-            LOG_DEBUG("No public key for 0x%08x, cannot verify XEdDSA signature", p->from);
+            LOG_DEBUG("No public key for 0x%08x, can't verify XEdDSA signature", p->from);
             if (strict)
                 return false;
         }
@@ -672,14 +672,14 @@ bool checkXeddsaReceivePolicy(meshtastic_MeshPacket *p)
         // senders emit only those two sizes (perhapsEncode sets 0 or XEDDSA_SIGNATURE_SIZE). Drop
         // it: a crafted partial signature would otherwise land in the unsigned branch below while
         // its bytes inflated the size estimate, letting a forged broadcast dodge the downgrade drop.
-        LOG_WARN("Malformed XEdDSA signature (%u bytes) from 0x%08x, dropping", (unsigned)p->decoded.xeddsa_signature.size,
+        LOG_WARN("Malformed XEdDSA signature (%u bytes) from 0x%08x, drop", (unsigned)p->decoded.xeddsa_signature.size,
                  p->from);
         return false;
     } else {
         if (p->pki_encrypted)
             return true;
         if (strict) {
-            LOG_WARN("Dropping unsigned packet from 0x%08x in Strict signature mode", p->from);
+            LOG_WARN("Drop unsigned packet from 0x%08x in Strict signature mode", p->from);
             return false;
         }
         if (compatible)
@@ -692,7 +692,7 @@ bool checkXeddsaReceivePolicy(meshtastic_MeshPacket *p)
             if (!canonicalSignableSize(&p->decoded, &canonicalSize))
                 return true; // can't size it; never drop on a sizing failure
             if (canonicalSize + XEDDSA_SIGNATURE_FIELD_BYTES + MESHTASTIC_HEADER_LENGTH <= MAX_LORA_PAYLOAD_LEN) {
-                LOG_WARN("Dropping unsigned packet from 0x%08x that previously signed", p->from);
+                LOG_WARN("Drop unsigned packet from 0x%08x that previously signed", p->from);
                 return false;
             }
         }
@@ -735,11 +735,11 @@ RoutingAuthVerdict passesRoutingAuthGate(meshtastic_MeshPacket *p)
         return RoutingAuthVerdict::REJECT;
     }
     if (state == DecodeState::DECODE_FATAL) {
-        LOG_WARN("Fatal decode error, dropping packet");
+        LOG_WARN("Fatal decode error, drop packet");
         return RoutingAuthVerdict::REJECT;
     }
     if (state == DecodeState::DECODE_FAILURE) {
-        LOG_WARN("Decryptable packet failed decoding, dropping packet");
+        LOG_WARN("Decryptable packet failed decoding, drop");
         return RoutingAuthVerdict::REJECT;
     }
 
@@ -804,7 +804,7 @@ DecodeState perhapsDecode(meshtastic_MeshPacket *p)
 
     if (config.device.rebroadcast_mode == meshtastic_Config_DeviceConfig_RebroadcastMode_KNOWN_ONLY &&
         !nodeInfoLiteHasUser(nodeDB->getMeshNode(p->from))) {
-        LOG_DEBUG("Node 0x%08x not in nodeDB-> Rebroadcast mode KNOWN_ONLY will ignore packet", p->from);
+        LOG_DEBUG("Node 0x%08x not in nodeDB, Rebroadcast KNOWN_ONLY ignores packet", p->from);
         return DecodeState::DECODE_FAILURE;
     }
 
@@ -817,7 +817,7 @@ DecodeState perhapsDecode(meshtastic_MeshPacket *p)
 
     size_t rawSize = p->encrypted.size;
     if (rawSize > sizeof(bytes)) {
-        LOG_ERROR("Packet too large to attempt decryption! (rawSize=%d > 256)", rawSize);
+        LOG_ERROR("Packet too large to decrypt (rawSize=%d > 256)", rawSize);
         return DecodeState::DECODE_FATAL;
     }
     bool decrypted = false;
@@ -1014,7 +1014,7 @@ DecodeState perhapsDecode(meshtastic_MeshPacket *p)
 #endif
         return DecodeState::DECODE_SUCCESS;
     } else {
-        LOG_WARN("No suitable channel found for decoding, hash was 0x%x", p->channel);
+        LOG_WARN("No channel found for decoding, hash 0x%x", p->channel);
         return (matchedChannel || pkiAttempted || licensedPkiCandidate) ? DecodeState::DECODE_FAILURE
                                                                         : DecodeState::DECODE_OPAQUE;
     }
@@ -1118,7 +1118,7 @@ meshtastic_Routing_Error perhapsEncode(meshtastic_MeshPacket *p)
             // If the compressed length is greater than or equal to the original size, don't use the compressed form
             if (compressed_len >= p->decoded.payload.size) {
 
-                LOG_DEBUG("Not using compressing message");
+                LOG_DEBUG("Not compressing");
                 // Set the uncompressed payload variant anyway. Shouldn't hurt?
                 // p->decoded.which_payloadVariant = Data_payload_tag;
 
@@ -1161,7 +1161,7 @@ meshtastic_Routing_Error perhapsEncode(meshtastic_MeshPacket *p)
                 return meshtastic_Routing_Error_TOO_LARGE;
             // Check for a usable public key for the destination (NodeDB or a pending key-verification key)
             if (!haveDestKey) {
-                LOG_WARN("Unknown public key for destination node 0x%08x (portnum %d), refusing to send legacy DM", p->to,
+                LOG_WARN("Unknown public key for 0x%08x (portnum %d), refuse legacy DM", p->to,
                          p->decoded.portnum);
                 return meshtastic_Routing_Error_PKI_SEND_FAIL_PUBLIC_KEY;
             }
@@ -1173,7 +1173,7 @@ meshtastic_Routing_Error perhapsEncode(meshtastic_MeshPacket *p)
             // On failure encrypted.bytes holds no ciphertext, so continuing would put the plaintext
             // on the air labelled pki_encrypted.
             if (!crypto->encryptCurve25519(p->to, getFrom(p), destKey, p->id, numbytes, bytes, p->encrypted.bytes)) {
-                LOG_WARN("PKI encryption failed for destination node 0x%08x", p->to);
+                LOG_WARN("PKI encryption failed for 0x%08x", p->to);
                 return meshtastic_Routing_Error_PKI_FAILED;
             }
             numbytes += MESHTASTIC_PKC_OVERHEAD;
@@ -1289,7 +1289,7 @@ void Router::deliverLocal(meshtastic_MeshPacket *p, RxSource src)
     // broadcast). Mirrors sendToPhone()'s degrade-on-exhaustion behavior.
     if (copy)
         packetPool.release(copy);
-    LOG_WARN("Deferred local queue full/alloc failed, dropping loopback of 0x%08x", p->id);
+    LOG_WARN("Deferred local queue full/alloc failed, drop loopback of 0x%08x", p->id);
 #ifdef PIO_UNIT_TESTING
     deferredLocalDropped++;
 #endif
@@ -1372,8 +1372,8 @@ void Router::dispatchReceived(meshtastic_MeshPacket *p, RxSource src)
         // Fatal decoding error, we can't do anything with this packet
         LOG_WARN(decodedState == DecodeState::DECODE_POLICY_REJECT
                      ? "Packet rejected by signature policy"
-                     : (decodedState == DecodeState::DECODE_FATAL ? "Fatal decode error, dropping packet"
-                                                                  : "Decryptable packet failed decoding, dropping packet"));
+                     : (decodedState == DecodeState::DECODE_FATAL ? "Fatal decode error, drop packet"
+                                                                  : "Decryptable packet failed decoding, drop"));
         // A policy rejection is attacker-controlled input and must not cancel a valid pending
         // transmission with the same (from, id). Preserve the pre-existing fatal-decode behavior.
         if (decodedState == DecodeState::DECODE_FATAL)
@@ -1404,7 +1404,7 @@ void Router::dispatchReceived(meshtastic_MeshPacket *p, RxSource src)
         if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag &&
             p->decoded.portnum == meshtastic_PortNum_NEIGHBORINFO_APP &&
             (!moduleConfig.has_neighbor_info || !moduleConfig.neighbor_info.enabled)) {
-            LOG_DEBUG("Neighbor info module is disabled, ignore neighbor packet");
+            LOG_DEBUG("Neighbor info module disabled, ignore packet");
             cancelSending(p->from, p->id);
             skipHandle = true;
         }
@@ -1416,7 +1416,7 @@ void Router::dispatchReceived(meshtastic_MeshPacket *p, RxSource src)
             p->decoded.portnum == meshtastic_PortNum_MESH_BEACON_APP &&
             (!moduleConfig.has_mesh_beacon ||
              !(moduleConfig.mesh_beacon.flags & meshtastic_ModuleConfig_MeshBeaconConfig_Flags_FLAG_LISTEN_ENABLED))) {
-            LOG_DEBUG("Beacon listening is disabled, ignore beacon packet");
+            LOG_DEBUG("Beacon listening disabled, ignore packet");
             cancelSending(p->from, p->id);
             skipHandle = true;
         }
@@ -1449,7 +1449,7 @@ void Router::dispatchReceived(meshtastic_MeshPacket *p, RxSource src)
 
 #if !MESHTASTIC_EXCLUDE_MQTT
         if (p_encrypted == nullptr) {
-            LOG_WARN("p_encrypted is null, skipping MQTT publish");
+            LOG_WARN("p_encrypted null, skip MQTT publish");
         } else {
             // Mark as pki_encrypted if it is not yet decoded and MQTT encryption is also enabled, hash matches and it's a DM not
             // to us (because we would be able to decrypt it)
@@ -1469,7 +1469,7 @@ void Router::dispatchReceived(meshtastic_MeshPacket *p, RxSource src)
                         if (encodeResult != meshtastic_Routing_Error_NONE) {
                             // Encryption failed, release the new packet and fall back to sending the original encrypted packet to
                             // MQTT
-                            LOG_WARN("Encryption of new TR packet failed, sending original TR to MQTT");
+                            LOG_WARN("New TR packet encrypt failed, send original TR to MQTT");
                             packetPool.release(p_encrypted_new);
                             p_encrypted_new = nullptr;
                         } else {
@@ -1479,7 +1479,7 @@ void Router::dispatchReceived(meshtastic_MeshPacket *p, RxSource src)
                         }
                     } else {
                         // Allocation failed, log a warning and fall back to sending the original encrypted packet to MQTT
-                        LOG_WARN("Failed to allocate new encrypted packet for TR, sending original TR to MQTT");
+                        LOG_WARN("Alloc encrypted TR packet failed, send original TR to MQTT");
                     }
                 }
                 mqtt->onSend(*p_encrypted, *p, p->channel);
@@ -1504,7 +1504,7 @@ void Router::perhapsHandleReceived(meshtastic_MeshPacket *p)
     // assert(radioConfig.has_preferences);
     if (is_in_repeated(config.lora.ignore_incoming, p->from)) {
         clearRoutingAuthCache();
-        LOG_DEBUG("Ignore msg, 0x%08x is in our ignore list", p->from);
+        LOG_DEBUG("Ignore msg, 0x%08x in ignore list", p->from);
         packetPool.release(p);
         return;
     }
@@ -1554,7 +1554,7 @@ void Router::perhapsHandleReceived(meshtastic_MeshPacket *p)
 
     if (shouldFilterReceived(p)) {
         clearRoutingAuthCache();
-        LOG_DEBUG("Incoming msg was filtered from 0x%08x", p->from);
+        LOG_DEBUG("Incoming msg filtered from 0x%08x", p->from);
         packetPool.release(p);
         return;
     }

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -77,9 +77,9 @@ template <typename T> bool SX126xInterface<T>::init()
     }
 #endif
     if (tcxoVoltage == 0.0)
-        LOG_DEBUG("SX126X_DIO3_TCXO_VOLTAGE not defined, not using DIO3 as TCXO reference voltage");
+        LOG_DEBUG("SX126X_DIO3_TCXO_VOLTAGE not defined, DIO3 not used as TCXO Vref");
     else
-        LOG_DEBUG("SX126X_DIO3_TCXO_VOLTAGE defined, using DIO3 as TCXO reference voltage at %f V", tcxoVoltage);
+        LOG_DEBUG("SX126X_DIO3_TCXO_VOLTAGE defined, DIO3 as TCXO Vref %f V", tcxoVoltage);
     setTransmitEnable(false);
     // FIXME: May want to set depending on a definition, currently all SX126x variant files use the DC-DC regulator option
     bool useRegulatorLDO = false; // Seems to depend on the connection to pin 9/DCC_SW - if an inductor DCDC?
@@ -139,21 +139,21 @@ template <typename T> bool SX126xInterface<T>::init()
 // no effect
 #if ARCH_PORTDUINO
     if (res == RADIOLIB_ERR_NONE) {
-        LOG_DEBUG("Use MCU pin %i as RXEN and pin %i as TXEN to control RF switching", portduino_config.lora_rxen_pin.pin,
+        LOG_DEBUG("Use MCU pin %i as RXEN, pin %i as TXEN for RF switching", portduino_config.lora_rxen_pin.pin,
                   portduino_config.lora_txen_pin.pin);
         lora.setRfSwitchPins(portduino_config.lora_rxen_pin.pin, portduino_config.lora_txen_pin.pin);
     }
 #else
 #ifndef SX126X_RXEN
 #define SX126X_RXEN RADIOLIB_NC
-    LOG_DEBUG("SX126X_RXEN not defined, defaulting to RADIOLIB_NC");
+    LOG_DEBUG("SX126X_RXEN not defined, default RADIOLIB_NC");
 #endif
 #ifndef SX126X_TXEN
 #define SX126X_TXEN RADIOLIB_NC
-    LOG_DEBUG("SX126X_TXEN not defined, defaulting to RADIOLIB_NC");
+    LOG_DEBUG("SX126X_TXEN not defined, default RADIOLIB_NC");
 #endif
     if (res == RADIOLIB_ERR_NONE) {
-        LOG_DEBUG("Use MCU pin %i as RXEN and pin %i as TXEN to control RF switching", SX126X_RXEN, SX126X_TXEN);
+        LOG_DEBUG("Use MCU pin %i as RXEN, pin %i as TXEN for RF switching", SX126X_RXEN, SX126X_TXEN);
         lora.setRfSwitchPins(SX126X_RXEN, SX126X_TXEN);
     }
 #endif
@@ -162,15 +162,15 @@ template <typename T> bool SX126xInterface<T>::init()
         LOG_INFO("Set RX gain to boosted mode; result: %d", result);
     } else {
         uint16_t result = lora.setRxBoostedGainMode(false);
-        LOG_INFO("Set RX gain to power saving mode (boosted mode off); result: %d", result);
+        LOG_INFO("Set RX gain to power saving mode; result: %d", result);
     }
 
     // Undocumented SX1262 register patch recommended by Heltec/Semtech for improved RX sensitivity.
     // Sets bit 0 of register 0x8B5.
     if (module.SPIsetRegValue(0x8B5, 0x01, 0, 0) == RADIOLIB_ERR_NONE) {
-        LOG_INFO("Applied SX1262 register 0x8B5 patch for RX improvement");
+        LOG_INFO("Applied SX1262 reg 0x8B5 RX patch");
     } else {
-        LOG_WARN("Failed to apply SX1262 register 0x8B5 patch for RX improvement");
+        LOG_WARN("Can't apply SX1262 reg 0x8B5 RX patch");
     }
 
     if (res == RADIOLIB_ERR_NONE)
@@ -230,7 +230,7 @@ template <typename T> bool SX126xInterface<T>::reconfigure()
     if (err != RADIOLIB_ERR_NONE) {
         // Don't abort: this power is operator config (tx_power/SX126X_MAX_POWER); a value above the
         // driver's max would crash the daemon before reloadConfig() persists. Flag it and keep prior power.
-        LOG_ERROR("SX126X setOutputPower %d dBm rejected (%s%d); keeping previous Tx power", power, radioLibErr, err);
+        LOG_ERROR("SX126X setOutputPower %d dBm rejected (%s%d); keep previous Tx power", power, radioLibErr, err);
         RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
     }
 
@@ -478,7 +478,7 @@ template <typename T> void SX126xInterface<T>::resetAGC()
     }
 
     if (module.hal->digitalRead(module.getGpio())) {
-        LOG_WARN("SX126x AGC reset: calibration did not complete within 50ms");
+        LOG_WARN("SX126x AGC reset: calibration not done in 50ms");
         startReceive();
         return;
     }
@@ -506,7 +506,7 @@ template <typename T> void SX126xInterface<T>::resetAGC()
     // Without this re-apply, every SX1262 node loses its RX boost ~60s after boot
     // and never recovers until reboot. See empirical evidence in the PR description.
     if (module.SPIsetRegValue(0x8B5, 0x01, 0, 0) != RADIOLIB_ERR_NONE) {
-        LOG_WARN("SX126x resetAGC: failed to re-apply 0x8B5 RX sensitivity patch");
+        LOG_WARN("SX126x resetAGC: 0x8B5 RX patch re-apply failed");
     }
 
     // 6. Resume receiving

--- a/src/mesh/WarmNodeStore.cpp
+++ b/src/mesh/WarmNodeStore.cpp
@@ -494,7 +494,7 @@ void WarmNodeStore::load()
 bool WarmNodeStore::save()
 {
     if (!powerHAL_isPowerLevelSafe()) {
-        LOG_ERROR("Error: trying to save WarmStore on unsafe device power level.");
+        LOG_ERROR("Trying to save WarmStore on unsafe device power level");
         return false;
     }
     concurrency::LockGuard g(spiLock);
@@ -605,7 +605,7 @@ bool WarmNodeStore::save()
     if (!entries)
         return false;
     if (!powerHAL_isPowerLevelSafe()) {
-        LOG_ERROR("Error: trying to save WarmStore on unsafe device power level.");
+        LOG_ERROR("Trying to save WarmStore on unsafe device power level");
         return false;
     }
 

--- a/src/mesh/api/PacketAPI.cpp
+++ b/src/mesh/api/PacketAPI.cpp
@@ -92,7 +92,7 @@ bool PacketAPI::receivePacket(void)
             }
             break;
         default:
-            LOG_ERROR("Error: unhandled meshtastic_ToRadio variant: %d", mr->which_payload_variant);
+            LOG_ERROR("Unhandled meshtastic_ToRadio variant: %d", mr->which_payload_variant);
             break;
         }
     }

--- a/src/mesh/eth/ethCert.cpp
+++ b/src/mesh/eth/ethCert.cpp
@@ -279,7 +279,7 @@ bool ensureCertForIp(IPAddress ip, EthCertMaterial &out)
         }
     }
 
-    LOG_INFO("ETH CERT: generating ECDSA P-256 self-signed cert for IP %s...", ipStr.c_str());
+    LOG_INFO("ETH CERT: generating ECDSA P-256 self-signed cert for IP %s", ipStr.c_str());
     uint32_t t0 = millis();
     if (!generateCert(ip, out)) {
         LOG_ERROR("ETH CERT: generation failed");

--- a/src/mesh/eth/ethCert.cpp
+++ b/src/mesh/eth/ethCert.cpp
@@ -270,7 +270,7 @@ bool ensureCertForIp(IPAddress ip, EthCertMaterial &out)
                          (unsigned)out.keyDer.size(), ipStr.c_str());
                 return true;
             }
-            LOG_WARN("ETH CERT: cached cert/key failed to parse (partial write?), regenerating");
+            LOG_WARN("ETH CERT: cached cert/key parse failed (partial write?), regen");
             out.certDer.clear();
             out.keyDer.clear();
         }
@@ -279,7 +279,7 @@ bool ensureCertForIp(IPAddress ip, EthCertMaterial &out)
         }
     }
 
-    LOG_INFO("ETH CERT: generating ECDSA P-256 self-signed cert for IP %s", ipStr.c_str());
+    LOG_INFO("ETH CERT: gen ECDSA P-256 self-signed cert for IP %s", ipStr.c_str());
     uint32_t t0 = millis();
     if (!generateCert(ip, out)) {
         LOG_ERROR("ETH CERT: generation failed");
@@ -299,7 +299,7 @@ bool ensureCertForIp(IPAddress ip, EthCertMaterial &out)
     writeText(IP_PATH, "");
     if (!writeBinary(CERT_PATH, out.certDer.data(), out.certDer.size()) ||
         !writeBinary(KEY_PATH, out.keyDer.data(), out.keyDer.size()) || !writeText(IP_PATH, ipStr)) {
-        LOG_WARN("ETH CERT: persist failed - will regenerate next boot");
+        LOG_WARN("ETH CERT: persist failed, regen next boot");
     } else {
         LOG_INFO("ETH CERT: persisted to LittleFS");
     }
@@ -337,7 +337,7 @@ class EthCertThread : public concurrency::OSThread
         // regenerates whenever its saved IP != ip, so the cert SAN follows.
         bool ok = ensureCertForIp(ip, material_);
         if (!ok) {
-            LOG_ERROR("ETH CERT: pipeline FAILED - TLS server will not start");
+            LOG_ERROR("ETH CERT: pipeline FAILED, no TLS server");
             // Don't leave isReady() reporting true with empty material: a later TLS
             // teardown (e.g. a W5500 reset) would then fail initTlsContext() and stay
             // disabled. Clear readiness so the TLS worker waits and the next poll
@@ -375,7 +375,7 @@ void initEthCertThread()
     if (certThread)
         return;
     certThread = new EthCertThread();
-    LOG_INFO("ETH CERT: deferred worker scheduled (waits for DHCP, runs once)");
+    LOG_INFO("ETH CERT: deferred worker scheduled (awaits DHCP)");
 }
 
 bool isEthCertReady()

--- a/src/mesh/eth/ethOTA.cpp
+++ b/src/mesh/eth/ethOTA.cpp
@@ -99,7 +99,7 @@ static bool authenticateClient(EthernetClient &client)
     // Rate-limit after failed auth - close silently so the error byte is not
     // misinterpreted as part of the nonce by a re-trying client.
     if (lastAuthFailure != 0 && (millis() - lastAuthFailure) < OTA_AUTH_COOLDOWN_MS) {
-        LOG_WARN("ETH OTA: Auth cooldown active, rejecting connection");
+        LOG_WARN("ETH OTA: Auth cooldown, reject connection");
         client.stop();
         return false;
     }

--- a/src/mesh/eth/ethOTA.cpp
+++ b/src/mesh/eth/ethOTA.cpp
@@ -260,7 +260,7 @@ static void handleOTAClient(EthernetClient &client)
         return;
     }
 
-    LOG_INFO("ETH OTA: Update staged successfully (%u bytes). Rebooting...", hdr.firmwareSize);
+    LOG_INFO("ETH OTA: Update staged (%u bytes). Rebooting", hdr.firmwareSize);
     client.write(OTA_OK);
     client.flush();
     delay(500);

--- a/src/mesh/http/WebServer.cpp
+++ b/src/mesh/http/WebServer.cpp
@@ -102,7 +102,7 @@ static void taskCreateCert(void *parameter)
     size_t certLen = prefs.getBytesLength("cert");
 
     if (pkLen && certLen) {
-        LOG_INFO("Existing SSL Certificate found!");
+        LOG_INFO("Existing SSL Certificate found");
 
         uint8_t *pkBuffer = new uint8_t[pkLen];
         prefs.getBytes("PK", pkBuffer, pkLen);
@@ -164,7 +164,7 @@ void createSSLCert()
         while (!isCertReady) {
             if ((millis() / 500) % 2) {
                 if (runLoop) {
-                    LOG_DEBUG(".");
+                    LOG_DEBUG("");
 
                     yield();
                     esp_task_wdt_reset();
@@ -180,7 +180,7 @@ void createSSLCert()
                 runLoop = true;
             }
         }
-        LOG_INFO("SSL Cert Ready!");
+        LOG_INFO("SSL Cert Ready");
     }
 }
 

--- a/src/mesh/http/WebServer.cpp
+++ b/src/mesh/http/WebServer.cpp
@@ -164,7 +164,7 @@ void createSSLCert()
         while (!isCertReady) {
             if ((millis() / 500) % 2) {
                 if (runLoop) {
-                    LOG_DEBUG("");
+                    LOG_DEBUG(".");
 
                     yield();
                     esp_task_wdt_reset();

--- a/src/mesh/raspihttp/PiWebServer.cpp
+++ b/src/mesh/raspihttp/PiWebServer.cpp
@@ -303,7 +303,7 @@ int handleAPIv1FromRadio(const struct _u_request *req, struct _u_response *res, 
             ulfius_set_string_body_response(res, 200, tmpa);
             // LOG_DEBUG("\n----webAPI response all:----");
             // LOG_DEBUG(tmpa);
-            // LOG_DEBUG("");
+            // LOG_DEBUG(".");
         }
         // Otherwise, just return one protobuf
     } else {
@@ -312,7 +312,7 @@ int handleAPIv1FromRadio(const struct _u_request *req, struct _u_response *res, 
         ulfius_set_binary_body_response(res, 200, tmpa, len);
         // LOG_DEBUG("\n----webAPI response:");
         // LOG_DEBUG(tmpa);
-        // LOG_DEBUG("");
+        // LOG_DEBUG(".");
     }
 
     // LOG_DEBUG("end radio->web", len);

--- a/src/mesh/raspihttp/PiWebServer.cpp
+++ b/src/mesh/raspihttp/PiWebServer.cpp
@@ -198,7 +198,7 @@ int callback_static_file(const struct _u_request *request, struct _u_response *r
                     content_type = u_map_get_case(&configWeb.mime_types, get_filename_ext(file_requested));
                     if (content_type == NULL) {
                         content_type = u_map_get(&configWeb.mime_types, "*");
-                        LOG_DEBUG("Static File Server - Unknown mime type for extension %s ", get_filename_ext(file_requested));
+                        LOG_DEBUG("Static File Server - Unknown mime type for ext %s ", get_filename_ext(file_requested));
                     }
                     u_map_put(response->map_header, "Content-Type", content_type);
                     u_map_copy_into(response->map_header, &configWeb.map_header);
@@ -230,7 +230,7 @@ int callback_static_file(const struct _u_request *request, struct _u_response *r
         free(real_path); // realpath uses malloc
         return U_CALLBACK_CONTINUE;
     } else {
-        LOG_DEBUG("Static File Server - Error, user_data is NULL or inconsistent");
+        LOG_DEBUG("Static File Server - user_data NULL or inconsistent");
         return U_CALLBACK_ERROR;
     }
 }
@@ -381,7 +381,7 @@ char *read_file_into_string(const char *filename)
     // reserve mem for file + 1 byte
     char *buffer = (char *)malloc(filesize + 1);
     if (buffer == NULL) {
-        LOG_ERROR("Malloc of mem failed for file : %s ", filename);
+        LOG_ERROR("Malloc failed for file : %s ", filename);
         fclose(file);
         return NULL;
     }
@@ -406,13 +406,13 @@ int PiWebServerThread::CheckSSLandLoad()
     // read certificate
     cert_pem = read_file_into_string(CERT_PATH);
     if (cert_pem == NULL) {
-        LOG_ERROR("ERROR SSL Certificate File can't be loaded or is missing");
+        LOG_ERROR("SSL Certificate File can't be loaded or missing");
         return 1;
     }
     // read private key
     key_pem = read_file_into_string(KEY_PATH);
     if (key_pem == NULL) {
-        LOG_ERROR("ERROR file private_key can't be loaded or is missing");
+        LOG_ERROR("File private_key can't be loaded or missing");
         return 2;
     }
 
@@ -479,13 +479,13 @@ PiWebServerThread::PiWebServerThread()
         webservport = portduino_config.webserverport;
         LOG_INFO("Use webserver port from yaml config %i ", webservport);
     } else {
-        LOG_INFO("Webserver port in yaml config set to 0, defaulting to port 9443");
+        LOG_INFO("Webserver port in yaml config 0, default to 9443");
         webservport = 9443;
     }
 
     // Web Content Service Instance
     if (ulfius_init_instance(&instanceWeb, webservport, NULL, DEFAULT_REALM) != U_OK) {
-        LOG_ERROR("Webserver couldn't be started, abort execution");
+        LOG_ERROR("Webserver start failed, abort");
     } else {
 
         LOG_INFO("Webserver started");
@@ -534,7 +534,7 @@ PiWebServerThread::PiWebServerThread()
             LOG_INFO("Web Server framework started on port: %i ", webservport);
             LOG_INFO("Web Server root %s", (char *)webrootpath.c_str());
         } else {
-            LOG_ERROR("Error starting Web Server framework, error number: %d", retssl);
+            LOG_ERROR("Web Server framework start failed, err: %d", retssl);
         }
     }
 }

--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -155,7 +155,7 @@ static void onNetworkConnected()
 
         // start mdns
         if (!MDNS.begin("Meshtastic")) {
-            LOG_ERROR("Error setting up mDNS responder!");
+            LOG_ERROR("Error setting up mDNS responder");
         } else {
             LOG_INFO("mDNS Host: Meshtastic.local");
             MDNS.addService("meshtastic", "tcp", SERVER_API_DEFAULT_PORT);

--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -155,7 +155,7 @@ static void onNetworkConnected()
 
         // start mdns
         if (!MDNS.begin("Meshtastic")) {
-            LOG_ERROR("Error setting up mDNS responder");
+            LOG_ERROR("mDNS setup failed");
         } else {
             LOG_INFO("mDNS Host: Meshtastic.local");
             MDNS.addService("meshtastic", "tcp", SERVER_API_DEFAULT_PORT);

--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -270,7 +270,7 @@ static int32_t reconnectWiFi()
     if (WiFi.isConnected() && (!Throttle::isWithinTimespanMs(lastrun_ntp, 43200000) || (lastrun_ntp == 0))) { // every 12 hours
         LOG_DEBUG("Update NTP time from %s", config.network.ntp_server);
         if (timeClient.update()) {
-            LOG_DEBUG("NTP Request Success - Setting RTCQualityNTP if needed");
+            LOG_DEBUG("NTP success - set RTCQualityNTP if needed");
 
             struct timeval tv;
             tv.tv_sec = timeClient.getEpochTime();
@@ -477,7 +477,7 @@ static void WiFiEvent(WiFiEvent_t event)
         }
         break;
     case ARDUINO_EVENT_WIFI_STA_AUTHMODE_CHANGE:
-        LOG_INFO("Authentication mode of access point has changed");
+        LOG_INFO("AP auth mode changed");
         break;
     case ARDUINO_EVENT_WIFI_STA_GOT_IP:
         LOG_INFO("Obtained IP address: %s", WiFi.localIP().toString().c_str());
@@ -493,7 +493,7 @@ static void WiFiEvent(WiFiEvent_t event)
 #endif
         break;
     case ARDUINO_EVENT_WIFI_STA_LOST_IP:
-        LOG_INFO("Lost IP address and IP address is reset to 0");
+        LOG_INFO("Lost IP address, reset to 0");
 #if HAS_UDP_MULTICAST
         if (udpHandler) {
             udpHandler->stop();
@@ -507,19 +507,19 @@ static void WiFiEvent(WiFiEvent_t event)
         }
         break;
     case ARDUINO_EVENT_WPS_ER_SUCCESS:
-        LOG_INFO("WiFi Protected Setup (WPS): succeeded in enrollee mode");
+        LOG_INFO("WPS: succeeded in enrollee mode");
         break;
     case ARDUINO_EVENT_WPS_ER_FAILED:
-        LOG_INFO("WiFi Protected Setup (WPS): failed in enrollee mode");
+        LOG_INFO("WPS: failed in enrollee mode");
         break;
     case ARDUINO_EVENT_WPS_ER_TIMEOUT:
-        LOG_INFO("WiFi Protected Setup (WPS): timeout in enrollee mode");
+        LOG_INFO("WPS: timeout in enrollee mode");
         break;
     case ARDUINO_EVENT_WPS_ER_PIN:
-        LOG_INFO("WiFi Protected Setup (WPS): pin code in enrollee mode");
+        LOG_INFO("WPS: pin code in enrollee mode");
         break;
     case ARDUINO_EVENT_WPS_ER_PBC_OVERLAP:
-        LOG_INFO("WiFi Protected Setup (WPS): push button overlap in enrollee mode");
+        LOG_INFO("WPS: push button overlap in enrollee mode");
         break;
     case ARDUINO_EVENT_WIFI_AP_START:
         LOG_INFO("WiFi access point started");

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -217,7 +217,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
             }
         } else {
             myReply = allocErrorResponse(meshtastic_Routing_Error_ADMIN_PUBLIC_KEY_UNAUTHORIZED, &mp);
-            LOG_INFO("Received PKC admin payload, but the sender public key does not match the admin authorized key!");
+            LOG_INFO("Received PKC admin payload, but the sender public key does not match the admin authorized key");
             return handled;
         }
     } else {
@@ -232,7 +232,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
     // any message that changes state, we want to check the passkey for
     if (mp.from != 0 && !messageIsRequest(r) && !messageIsResponse(r)) {
         if (!checkPassKey(r)) {
-            LOG_WARN("Admin message without session_key!");
+            LOG_WARN("Admin message without session_key");
             myReply = allocErrorResponse(meshtastic_Routing_Error_ADMIN_BAD_SESSION_KEY, &mp);
             return handled;
         }
@@ -638,7 +638,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
 #ifdef FSCom
         spiLock->lock();
         if (FSCom.remove(r->delete_file_request)) {
-            LOG_DEBUG("Successfully deleted file");
+            LOG_DEBUG("Deleted file");
         } else {
             LOG_DEBUG("Failed to delete file");
         }

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -206,10 +206,10 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
                 if (config.device.role == meshtastic_Config_DeviceConfig_Role_CLIENT_BASE) {
                     // Special case for CLIENT_BASE: is_favorite has special meaning, and we don't want to automatically set it
                     // without the user doing so deliberately.
-                    LOG_INFO("PKC admin valid, not auto-favoriting node %x: role==CLIENT_BASE", mp.from);
+                    LOG_INFO("PKC admin valid, not auto-favoriting node 0x%08x: role==CLIENT_BASE", mp.from);
                 } else {
                     if (nodeDB->setProtectedFlag(remoteNode, NODEINFO_BITFIELD_IS_FAVORITE_MASK, true)) {
-                        LOG_INFO("PKC admin valid. Auto-favoriting node %x", mp.from);
+                        LOG_INFO("PKC admin valid. Auto-favoriting node 0x%08x", mp.from);
                     } else {
                         LOG_WARN("PKC admin valid, but auto-favorite refused for node %x (protected-node cap)", mp.from);
                     }

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -170,13 +170,13 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         // apply: refuse all plain local admin and require PKC instead.
 #ifndef MESHTASTIC_PHONEAPI_ACCESS_CONTROL
         if (config.security.is_managed) {
-            LOG_INFO("Ignore local admin payload because is_managed");
+            LOG_INFO("Ignore local admin payload: is_managed");
             return handled;
         }
 #endif
     } else if (strcasecmp(ch->settings.name, Channels::adminChannel) == 0) {
         if (!config.security.admin_channel_enabled) {
-            LOG_INFO("Ignore admin channel, legacy admin is disabled");
+            LOG_INFO("Ignore admin channel, legacy admin disabled");
             myReply = allocErrorResponse(meshtastic_Routing_Error_NOT_AUTHORIZED, &mp);
             return handled;
         }
@@ -206,7 +206,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
                 if (config.device.role == meshtastic_Config_DeviceConfig_Role_CLIENT_BASE) {
                     // Special case for CLIENT_BASE: is_favorite has special meaning, and we don't want to automatically set it
                     // without the user doing so deliberately.
-                    LOG_INFO("PKC admin valid, but not auto-favoriting node %x because role==CLIENT_BASE", mp.from);
+                    LOG_INFO("PKC admin valid, not auto-favoriting node %x: role==CLIENT_BASE", mp.from);
                 } else {
                     if (nodeDB->setProtectedFlag(remoteNode, NODEINFO_BITFIELD_IS_FAVORITE_MASK, true)) {
                         LOG_INFO("PKC admin valid. Auto-favoriting node %x", mp.from);
@@ -217,7 +217,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
             }
         } else {
             myReply = allocErrorResponse(meshtastic_Routing_Error_ADMIN_PUBLIC_KEY_UNAUTHORIZED, &mp);
-            LOG_INFO("Received PKC admin payload, but the sender public key does not match the admin authorized key");
+            LOG_INFO("PKC admin payload: sender public key doesn't match admin authorized key");
             return handled;
         }
     } else {
@@ -249,7 +249,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
     // but if it ever does (e.g. injected via a non-PhoneAPI path), drop
     // it silently rather than leaking a partial response.
     case meshtastic_AdminMessage_lockdown_auth_tag:
-        LOG_WARN("AdminModule: lockdown_auth reached Router/AdminModule path; ignoring (should be handled in PhoneAPI)");
+        LOG_WARN("AdminModule: lockdown_auth reached Router/AdminModule path; ignoring (PhoneAPI handles)");
         return handled;
 #endif // MESHTASTIC_ENCRYPTED_STORAGE
 
@@ -293,7 +293,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
             while (*start && isspace((unsigned char)*start))
                 start++;
             if (*start == '\0') {
-                LOG_WARN("Rejected long_name: must contain at least 1 non-whitespace character");
+                LOG_WARN("Rejected long_name: needs 1+ non-whitespace char");
                 myReply = allocErrorResponse(meshtastic_Routing_Error_BAD_REQUEST, &mp);
                 break;
             }
@@ -303,7 +303,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
             while (*start && isspace((unsigned char)*start))
                 start++;
             if (*start == '\0') {
-                LOG_WARN("Rejected short_name: must contain at least 1 non-whitespace character");
+                LOG_WARN("Rejected short_name: needs 1+ non-whitespace char");
                 myReply = allocErrorResponse(meshtastic_Routing_Error_BAD_REQUEST, &mp);
                 break;
             }
@@ -336,7 +336,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
             break;
         }
 
-        LOG_WARN("Radio hardware does not support 2.4 GHz; rejecting LORA_24 region");
+        LOG_WARN("No 2.4 GHz radio support; rejecting LORA_24 region");
         myReply = allocErrorResponse(meshtastic_Routing_Error_BAD_REQUEST, &mp);
         break;
     }
@@ -479,14 +479,14 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         break;
     }
     case meshtastic_AdminMessage_begin_edit_settings_tag: {
-        LOG_INFO("Begin transaction for editing settings");
+        LOG_INFO("Begin settings edit transaction");
         hasOpenEditTransaction = true;
         editTransactionActivityMs = millis();
         break;
     }
     case meshtastic_AdminMessage_commit_edit_settings_tag: {
         disableBluetooth();
-        LOG_INFO("Commit transaction for edited settings");
+        LOG_INFO("Commit settings edit transaction");
         hasOpenEditTransaction = false;
         deferredEditSegments = 0;
         saveChanges(SEGMENT_CONFIG | SEGMENT_MODULECONFIG | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS | SEGMENT_NODEDATABASE);
@@ -499,7 +499,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         break;
     }
     case meshtastic_AdminMessage_get_module_config_response_tag: {
-        LOG_INFO("Client received a get_module_config response");
+        LOG_INFO("Client got get_module_config response");
         // which_payload_variant is the ModuleConfig oneof tag, so compare against that tag, not the
         // AdminMessage ModuleConfigType enum (whose REMOTEHARDWARE value is a different number).
         if (fromOthers && r->get_module_config_response.which_payload_variant == meshtastic_ModuleConfig_remote_hardware_tag) {
@@ -508,17 +508,17 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         break;
     }
     case meshtastic_AdminMessage_remove_by_nodenum_tag: {
-        LOG_INFO("Client received remove_nodenum command");
+        LOG_INFO("Client got remove_nodenum");
         nodeDB->removeNodeByNum(r->remove_by_nodenum);
         break;
     }
     case meshtastic_AdminMessage_add_contact_tag: {
-        LOG_INFO("Client received add_contact command");
+        LOG_INFO("Client got add_contact");
         nodeDB->addFromContact(r->add_contact);
         break;
     }
     case meshtastic_AdminMessage_set_favorite_node_tag: {
-        LOG_INFO("Client received set_favorite_node command");
+        LOG_INFO("Client got set_favorite_node");
         meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(r->set_favorite_node);
         if (node != NULL) {
             if (nodeDB->setProtectedFlag(node, NODEINFO_BITFIELD_IS_FAVORITE_MASK, true)) {
@@ -534,7 +534,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         break;
     }
     case meshtastic_AdminMessage_remove_favorite_node_tag: {
-        LOG_INFO("Client received remove_favorite_node command");
+        LOG_INFO("Client got remove_favorite_node");
         meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(r->remove_favorite_node);
         if (node != NULL) {
             nodeInfoLiteSetBit(node, NODEINFO_BITFIELD_IS_FAVORITE_MASK, false);
@@ -545,7 +545,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         break;
     }
     case meshtastic_AdminMessage_set_ignored_node_tag: {
-        LOG_INFO("Client received set_ignored_node command");
+        LOG_INFO("Client got set_ignored_node");
         // Unlike the sibling node-targeted admin commands, create the entry if
         // it's absent so the block sticks for a node we've not heard from yet
         // (e.g. one a remote admin asks us to block) with no NodeInfo or key.
@@ -570,7 +570,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         break;
     }
     case meshtastic_AdminMessage_remove_ignored_node_tag: {
-        LOG_INFO("Client received remove_ignored_node command");
+        LOG_INFO("Client got remove_ignored_node");
         meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(r->remove_ignored_node);
         if (node != NULL) {
             nodeInfoLiteSetBit(node, NODEINFO_BITFIELD_IS_IGNORED_MASK, false);
@@ -579,7 +579,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         break;
     }
     case meshtastic_AdminMessage_toggle_muted_node_tag: {
-        LOG_INFO("Client received toggle_muted_node command");
+        LOG_INFO("Client got toggle_muted_node");
         meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(r->toggle_muted_node);
         if (node != NULL) {
             nodeInfoLiteSetBit(node, NODEINFO_BITFIELD_IS_MUTED_MASK, !nodeInfoLiteIsMuted(node));
@@ -589,7 +589,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
     }
 
     case meshtastic_AdminMessage_set_fixed_position_tag: {
-        LOG_INFO("Client received set_fixed_position command");
+        LOG_INFO("Client got set_fixed_position");
         const meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(nodeDB->getNodeNum());
         // Route the fixed position through updatePosition so it lands in the
         // satellite map (or, on builds with PositionDB excluded, just sets
@@ -607,14 +607,14 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         break;
     }
     case meshtastic_AdminMessage_remove_fixed_position_tag: {
-        LOG_INFO("Client received remove_fixed_position command");
+        LOG_INFO("Client got remove_fixed_position");
         nodeDB->clearLocalPosition();
         config.position.fixed_position = false;
         saveChanges(SEGMENT_NODEDATABASE | SEGMENT_CONFIG, false);
         break;
     }
     case meshtastic_AdminMessage_set_time_only_tag: {
-        LOG_INFO("Client received set_time_only command");
+        LOG_INFO("Client got set_time_only");
         struct timeval tv;
         tv.tv_sec = r->set_time_only;
         tv.tv_usec = 0;
@@ -623,7 +623,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         break;
     }
     case meshtastic_AdminMessage_enter_dfu_mode_request_tag: {
-        LOG_INFO("Client requesting to enter DFU mode");
+        LOG_INFO("Client requests DFU mode");
 #if HAS_SCREEN
         IF_SCREEN(screen->showSimpleBanner("Device is rebooting\ninto DFU mode.", 0));
 #endif
@@ -633,21 +633,21 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         break;
     }
     case meshtastic_AdminMessage_delete_file_request_tag: {
-        LOG_DEBUG("Client requesting to delete file: %s", r->delete_file_request);
+        LOG_DEBUG("Client requests delete file: %s", r->delete_file_request);
 
 #ifdef FSCom
         spiLock->lock();
         if (FSCom.remove(r->delete_file_request)) {
             LOG_DEBUG("Deleted file");
         } else {
-            LOG_DEBUG("Failed to delete file");
+            LOG_DEBUG("File delete failed");
         }
         spiLock->unlock();
 #endif
         break;
     }
     case meshtastic_AdminMessage_backup_preferences_tag: {
-        LOG_INFO("Client requesting to backup preferences");
+        LOG_INFO("Client requests preferences backup");
         if (nodeDB->backupPreferences(r->backup_preferences)) {
             myReply = allocErrorResponse(meshtastic_Routing_Error_NONE, &mp);
         } else {
@@ -656,11 +656,11 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         break;
     }
     case meshtastic_AdminMessage_restore_preferences_tag: {
-        LOG_INFO("Client requesting to restore preferences");
+        LOG_INFO("Client requests preferences restore");
         if (nodeDB->restorePreferences(r->backup_preferences,
                                        SEGMENT_DEVICESTATE | SEGMENT_CONFIG | SEGMENT_MODULECONFIG | SEGMENT_CHANNELS)) {
             myReply = allocErrorResponse(meshtastic_Routing_Error_NONE, &mp);
-            LOG_DEBUG("Rebooting after successful restore of preferences");
+            LOG_DEBUG("Rebooting after preferences restore");
             reboot(1000);
             disableBluetooth();
         } else {
@@ -669,7 +669,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         break;
     }
     case meshtastic_AdminMessage_remove_backup_preferences_tag: {
-        LOG_INFO("Client requesting to remove backup preferences");
+        LOG_INFO("Client requests preferences backup removal");
 #ifdef FSCom
         if (r->remove_backup_preferences == meshtastic_AdminMessage_BackupLocation_FLASH) {
             spiLock->lock();
@@ -683,7 +683,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         break;
     }
     case meshtastic_AdminMessage_send_input_event_tag: {
-        LOG_INFO("Client requesting to send input event");
+        LOG_INFO("Client requests send input event");
         handleSendInputEvent(r->send_input_event);
         break;
     }
@@ -721,10 +721,10 @@ void AdminModule::handleViaModuleApi(const meshtastic_MeshPacket &mp, meshtastic
         setPassKey(&res);
         myReply = allocDataProtobuf(res);
     } else if (mp.decoded.want_response) {
-        LOG_DEBUG("Module API did not respond to admin message. req.variant=%d", r->which_payload_variant);
+        LOG_DEBUG("Module API didn't respond to admin msg. req.variant=%d", r->which_payload_variant);
     } else if (handleResult != AdminMessageHandleResult::HANDLED) {
         // Probably a message sent by us or sent to our local node.  FIXME, we should avoid scanning these messages
-        LOG_DEBUG("Module API did not handle admin message %d", r->which_payload_variant);
+        LOG_DEBUG("Module API didn't handle admin msg %d", r->which_payload_variant);
     }
 }
 
@@ -912,7 +912,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
             changes |= SEGMENT_NODEDATABASE | SEGMENT_DEVICESTATE; // Some role defaults affect owner
         }
         if (config.device.node_info_broadcast_secs < min_node_info_broadcast_secs) {
-            LOG_DEBUG("Tried to set node_info_broadcast_secs too low, setting to %d", min_node_info_broadcast_secs);
+            LOG_DEBUG("node_info_broadcast_secs too low, set to %d", min_node_info_broadcast_secs);
             config.device.node_info_broadcast_secs = min_node_info_broadcast_secs;
         }
         // Router Client and Repeater deprecated; Set it to client
@@ -965,7 +965,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
         config.power = c.payload_variant.power;
         if (c.payload_variant.power.on_battery_shutdown_after_secs > 0 &&
             c.payload_variant.power.on_battery_shutdown_after_secs < 30) {
-            LOG_WARN("Tried to set on_battery_shutdown_after_secs too low, set to min 30 seconds");
+            LOG_WARN("on_battery_shutdown_after_secs too low, set to min 30 sec");
             config.power.on_battery_shutdown_after_secs = 30;
         }
         break;
@@ -1007,12 +1007,12 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
         config.has_lora = true;
 
         if (validatedLora.coding_rate != clampCodingRate(validatedLora.coding_rate)) {
-            LOG_WARN("Invalid coding_rate %d, setting to %d", validatedLora.coding_rate, LORA_CR_DEFAULT);
+            LOG_WARN("Invalid coding_rate %d, set to %d", validatedLora.coding_rate, LORA_CR_DEFAULT);
             validatedLora.coding_rate = LORA_CR_DEFAULT;
         }
 
         if (validatedLora.spread_factor != clampSpreadFactor(validatedLora.spread_factor)) {
-            LOG_WARN("Invalid spread_factor %d, setting to %d", validatedLora.spread_factor, LORA_SF_DEFAULT);
+            LOG_WARN("Invalid spread_factor %d, set to %d", validatedLora.spread_factor, LORA_SF_DEFAULT);
             validatedLora.spread_factor = LORA_SF_DEFAULT;
         }
 
@@ -1023,7 +1023,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
         // preset mode bandwidth 0 is expected (the preset supplies it), so leave it untouched.
         const uint16_t clampedBandwidth = clampBandwidthCode(validatedLora.bandwidth);
         if (!validatedLora.use_preset && validatedLora.bandwidth != clampedBandwidth) {
-            LOG_WARN("Invalid bandwidth %d, setting to %d", validatedLora.bandwidth, clampedBandwidth);
+            LOG_WARN("Invalid bandwidth %d, set to %d", validatedLora.bandwidth, clampedBandwidth);
             validatedLora.bandwidth = clampedBandwidth;
         }
 
@@ -1085,13 +1085,13 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
                     validatedLora.region = swapRegion->code;
                 }
                 if (!swapRegion || !RadioInterface::validateConfigLora(validatedLora)) {
-                    LOG_WARN("Invalid LoRa config received from another node, rejecting changes");
+                    LOG_WARN("Invalid LoRa config from another node, rejecting changes");
                     // Rejecting means rejecting everything: a partial restore of region/preset
                     // could still apply other fields the validation already deemed invalid.
                     validatedLora = oldLoraConfig;
                 }
             } else {
-                LOG_WARN("Invalid LoRa config received from client, using corrected values");
+                LOG_WARN("Invalid LoRa config from client, using corrected values");
                 RadioInterface::clampConfigLora(validatedLora);
             }
             // A preset locked to a sibling EU region swaps the region during the clamp;
@@ -1138,7 +1138,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
             loraFEMInterface.setLNAEnable(validatedLora.fem_lna_mode != meshtastic_Config_LoRaConfig_FEM_LNA_Mode_DISABLED);
         } else if (validatedLora.fem_lna_mode != meshtastic_Config_LoRaConfig_FEM_LNA_Mode_NOT_PRESENT) {
             // Hardware FEM does not support LNA control; normalize stored config to match actual capability
-            LOG_WARN("FEM LNA mode configured but current FEM does not support LNA control; normalizing to NOT_PRESENT");
+            LOG_WARN("FEM LNA mode set but FEM lacks LNA control; normalizing to NOT_PRESENT");
             validatedLora.fem_lna_mode = meshtastic_Config_LoRaConfig_FEM_LNA_Mode_NOT_PRESENT;
         }
 #endif
@@ -1173,7 +1173,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
         // partial/legacy client, not an identity reset (that goes through factory_reset). Done outside the
         // PKI guard so non-PKI builds keep their key bytes too.
         if (incoming.private_key.size != 32 && config.security.private_key.size == 32) {
-            LOG_WARN("Security set omitted private key; preserving existing identity keypair");
+            LOG_WARN("Security set omitted private key; keeping identity keypair");
             incoming.private_key = config.security.private_key;
             incoming.public_key = config.security.public_key;
         }
@@ -1181,7 +1181,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
         // recourse but a physical connection. Clearing admin keys still works via a SET that leaves the private
         // key alone and sends an empty list.
         if (isBareKeypairRotation(incoming, config.security)) {
-            LOG_INFO("Security set is a bare keypair rotation; preserving remaining security config");
+            LOG_INFO("Security set is bare keypair rotation; keeping other security config");
             meshtastic_Config_SecurityConfig rotated = config.security;
             rotated.public_key = incoming.public_key; // usually empty; derived from the private key below
             rotated.private_key = incoming.private_key;
@@ -1249,7 +1249,7 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
     switch (c.which_payload_variant) {
     case meshtastic_ModuleConfig_mqtt_tag:
 #if MESHTASTIC_EXCLUDE_MQTT
-        LOG_WARN("Set module config: MESHTASTIC_EXCLUDE_MQTT is defined. Not setting MQTT config");
+        LOG_WARN("Set module config: MESHTASTIC_EXCLUDE_MQTT defined, skip MQTT config");
         return false;
 #else
         LOG_INFO("Set module config: MQTT");
@@ -1319,7 +1319,7 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
         moduleConfig.has_neighbor_info = true;
         moduleConfig.neighbor_info = c.payload_variant.neighbor_info;
         if (moduleConfig.neighbor_info.update_interval < min_neighbor_info_broadcast_secs) {
-            LOG_DEBUG("Tried to set update_interval too low, setting to %d", default_neighbor_info_broadcast_secs);
+            LOG_DEBUG("update_interval too low, set to %d", default_neighbor_info_broadcast_secs);
             moduleConfig.neighbor_info.update_interval = default_neighbor_info_broadcast_secs;
         }
         break;
@@ -1902,7 +1902,7 @@ void AdminModule::saveChanges(int saveWhat, bool shouldReboot)
         LOG_INFO("Save changes to disk");
         service->reloadConfig(saveWhat); // Calls saveToDisk among other things
     } else {
-        LOG_INFO("Delay save of changes to disk until the open transaction is committed");
+        LOG_INFO("Delay disk save until open transaction commits");
         editTransactionActivityMs = millis(); // still in use, so not the abandoned kind we time out
         deferredEditSegments |= saveWhat;
     }
@@ -1929,7 +1929,7 @@ void AdminModule::handleSetHamMode(const meshtastic_HamParameters &p)
             while (*start && isspace((unsigned char)*start))
                 start++;
             if (*start == '\0') {
-                LOG_WARN("Rejected ham %s: must contain at least 1 non-whitespace character", fieldNames[i]);
+                LOG_WARN("Rejected ham %s: needs 1+ non-whitespace char", fieldNames[i]);
                 return;
             }
         }
@@ -2116,7 +2116,7 @@ void AdminModule::noteOutgoingAdminRequest(const meshtastic_MeshPacket &p)
         memcpy(slot->key, destKey.bytes, 32);
     else
         memset(slot->key, 0, 32);
-    LOG_DEBUG("Admin request sent to 0x%08x, expecting its response", p.to);
+    LOG_DEBUG("Admin request sent to 0x%08x, expect response", p.to);
 }
 
 bool AdminModule::responseIsSolicited(const meshtastic_MeshPacket &mp, pb_size_t responseVariant, pb_size_t moduleConfigTag)
@@ -2195,7 +2195,7 @@ void AdminModule::handleSendInputEvent(const meshtastic_AdminMessage_InputEvent 
     if (inputBroker) {
         inputBroker->injectInputEvent(&event);
     } else {
-        LOG_ERROR("InputBroker not available for event injection");
+        LOG_ERROR("No InputBroker for event injection");
     }
 #endif
 }

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -1108,10 +1108,10 @@ void CannedMessageModule::sendText(NodeNum dest, ChannelIndex channel, const cha
         if (config.device.role != meshtastic_Config_DeviceConfig_Role_ROUTER &&
             config.device.role != meshtastic_Config_DeviceConfig_Role_ROUTER_LATE &&
             config.device.role != meshtastic_Config_DeviceConfig_Role_CLIENT_BASE) {
-            LOG_INFO("Proactively adding %x as favorite node", dest);
+            LOG_INFO("Proactively adding 0x%08x as favorite node", dest);
             nodeDB->set_favorite(true, dest);
         } else {
-            LOG_DEBUG("Not favoriting node %x: router-like role", dest);
+            LOG_DEBUG("Not favoriting node 0x%08x: router-like role", dest);
         }
     }
     sm.ackStatus = AckStatus::NONE;

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -71,7 +71,7 @@ CannedMessageModule::CannedMessageModule()
 {
     this->loadProtoForModule();
     if ((this->splitConfiguredMessages() <= 0) && (cardkb_found.address == 0x00) && !INPUTBROKER_MATRIX_TYPE) {
-        LOG_INFO("CannedMessageModule: No messages are configured. Module is disabled");
+        LOG_INFO("CannedMessage: none configured, disabled");
         this->updateState(CANNED_MESSAGE_RUN_STATE_DISABLED);
         disable();
     } else {
@@ -1111,7 +1111,7 @@ void CannedMessageModule::sendText(NodeNum dest, ChannelIndex channel, const cha
             LOG_INFO("Proactively adding %x as favorite node", dest);
             nodeDB->set_favorite(true, dest);
         } else {
-            LOG_DEBUG("Not favoriting node %x because role is router-like", dest);
+            LOG_DEBUG("Not favoriting node %x: router-like role", dest);
         }
     }
     sm.ackStatus = AckStatus::NONE;
@@ -1163,12 +1163,12 @@ int32_t CannedMessageModule::runOnce()
     if (this->runState == CANNED_MESSAGE_RUN_STATE_SENDING_ACTIVE && this->payload == CANNED_MESSAGE_RUN_STATE_FREETEXT) {
         // Virtual keyboard message sending case - text was not empty
         if (this->freetext.length() > 0) {
-            LOG_INFO("Processing delayed virtual keyboard send: '%s'", this->freetext.c_str());
+            LOG_INFO("Delayed vkbd send: '%s'", this->freetext.c_str());
             sendText(this->dest, this->channel, this->freetext.c_str(), true);
 
             // Clean up virtual keyboard after sending
             if (graphics::NotificationRenderer::virtualKeyboard) {
-                LOG_INFO("Cleaning up virtual keyboard after message send");
+                LOG_INFO("Vkbd cleanup after send");
                 graphics::OnScreenKeyboardModule::instance().stop(false);
                 graphics::NotificationRenderer::resetBanner();
             }
@@ -1178,7 +1178,7 @@ int32_t CannedMessageModule::runOnce()
             this->payload = 0;
         } else {
             // Empty message, just go inactive
-            LOG_INFO("Empty freetext detected in delayed processing, returning to inactive state");
+            LOG_INFO("Empty freetext, back to inactive");
             this->updateState(CANNED_MESSAGE_RUN_STATE_INACTIVE);
         }
 
@@ -1221,7 +1221,7 @@ int32_t CannedMessageModule::runOnce()
 
         // Clean up virtual keyboard if it exists during timeout
         if (graphics::NotificationRenderer::virtualKeyboard) {
-            LOG_INFO("Cleaning up virtual keyboard due to module timeout");
+            LOG_INFO("Vkbd cleanup on timeout");
             graphics::OnScreenKeyboardModule::instance().stop(false);
             graphics::NotificationRenderer::resetBanner();
         }
@@ -1230,7 +1230,7 @@ int32_t CannedMessageModule::runOnce()
     } else if (this->runState == CANNED_MESSAGE_RUN_STATE_ACTION_SELECT) {
         if (this->payload == 0) {
             // [Exit] button pressed - return to inactive state
-            LOG_INFO("Processing [Exit] action - returning to inactive state");
+            LOG_INFO("Exit action, back to inactive");
             this->updateState(CANNED_MESSAGE_RUN_STATE_INACTIVE);
         } else if (this->payload == CANNED_MESSAGE_RUN_STATE_FREETEXT) {
             if (this->freetext.length() > 0) {

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -294,7 +294,7 @@ void CannedMessageModule::updateDestinationSelectionList()
     scrollIndex = 0; // Show first result at the top
     destIndex = 0;   // Highlight the first entry
     if (nodesChanged && runState == CANNED_MESSAGE_RUN_STATE_DESTINATION_SELECTION) {
-        LOG_INFO("Nodes changed, forcing UI refresh.");
+        LOG_INFO("Nodes changed, forcing UI refresh");
         screen->forceDisplay();
     }
 }

--- a/src/modules/ExternalNotificationModule.cpp
+++ b/src/modules/ExternalNotificationModule.cpp
@@ -476,7 +476,7 @@ ProcessMessage ExternalNotificationModule::handleReceived(const meshtastic_MeshP
             if (buzzerShouldAlert) {
                 LOG_INFO("externalNotificationModule - Buzzer alert");
                 if (buzzerModeIsDirectOnly && !isDmToUs && !containsBell) {
-                    LOG_INFO("Message buzzer was suppressed because buzzer mode DIRECT_MSG_ONLY");
+                    LOG_INFO("Buzzer suppressed: mode DIRECT_MSG_ONLY");
                 } else {
                     // Buzz if buzzer mode is not in DIRECT_MSG_ONLY or is DM to us
                     if (moduleConfig.external_notification.use_i2s_as_buzzer) {

--- a/src/modules/HopScalingModule.cpp
+++ b/src/modules/HopScalingModule.cpp
@@ -182,7 +182,7 @@ void HopScalingModule::samplePacketForHistogram(uint32_t nodeId, uint8_t hopCoun
         this->count++;
     } else {
         LOG_WARN("[HOPSCALE] Histogram full at samp=1/%u (DENOM_MAX=%u); dropping node hash=0x%04x; hop recommendation may be "
-                 "skewed!!!",
+                 "skewed!!",
                  samplingDenominator, DENOM_MAX, hash);
     }
 }

--- a/src/modules/KeyVerificationModule.cpp
+++ b/src/modules/KeyVerificationModule.cpp
@@ -116,7 +116,7 @@ bool KeyVerificationModule::handleReceivedProtobuf(const meshtastic_MeshPacket &
             memset(message, 0, sizeof(message));
             sprintf(message, "Verification: \n");
             generateVerificationCode(message + 15);
-            LOG_INFO("Hash1 matches!");
+            LOG_INFO("Hash1 matches");
             static const char *optionsArray[] = {"Reject", "Accept"};
             // Don't try to put the array definition in the macro. Does not work with curly braces.
             IF_SCREEN(graphics::BannerOverlayOptions options; options.message = message; options.durationMs = 30000;

--- a/src/modules/MeshBeaconModule.cpp
+++ b/src/modules/MeshBeaconModule.cpp
@@ -429,8 +429,7 @@ void MeshBeaconBroadcastModule::sendBeacon()
             tgt.slot = config.lora.channel_num;
             if (bt.has_channel_index) {
                 if (bt.channel_index >= (uint32_t)channels.getNumChannels()) {
-                    LOG_WARN("Beacon: target %d channel_index %u out of range, use preset default", ti,
-                             bt.channel_index);
+                    LOG_WARN("Beacon: target %d channel_index %u out of range, use preset default", ti, bt.channel_index);
                 } else {
                     const meshtastic_ChannelSettings &cs = channels.getByIndex(bt.channel_index).settings;
                     if (cs.name[0] != '\0' || cs.psk.size > 0) {
@@ -438,8 +437,7 @@ void MeshBeaconBroadcastModule::sendBeacon()
                         tgt.channel = cs;
                         tgt.slot = cs.channel_num;
                     } else {
-                        LOG_DEBUG("Beacon: target %d channel_index %u blank, use preset default", ti,
-                                  bt.channel_index);
+                        LOG_DEBUG("Beacon: target %d channel_index %u blank, use preset default", ti, bt.channel_index);
                     }
                 }
             }

--- a/src/modules/MeshBeaconModule.cpp
+++ b/src/modules/MeshBeaconModule.cpp
@@ -198,7 +198,7 @@ bool MeshBeaconModule::reconfigureForBeaconTX(RadioInterface *iface, meshtastic_
         // transmit on it; the radio driver drops the packet outright (see RadioLibInterface,
         // beaconTxConfigInvalid) rather than letting it fall through onto the current config.
         if (beaconTxConfigInvalid(p)) {
-            LOG_DEBUG("Beacon: target preset %d/region %d invalid (or ham mismatch), not switching", targetPreset, targetRegion);
+            LOG_DEBUG("Beacon: target preset %d/region %d invalid (or ham mismatch), skip", targetPreset, targetRegion);
             return false;
         }
 
@@ -228,7 +228,7 @@ bool MeshBeaconModule::reconfigureForBeaconTX(RadioInterface *iface, meshtastic_
 
     } else if ((!p || !getTargetRadioSettings(p, nullptr, nullptr)) && radioSwitched) {
 
-        LOG_INFO("Beacon: restoring radio config after beacon TX");
+        LOG_INFO("Beacon: restore radio config after TX");
         config.lora.modem_preset = originalModemPreset;
         config.lora.channel_num = originalLoraChannel;
         config.lora.region = originalRegion;
@@ -315,7 +315,7 @@ void MeshBeaconBroadcastModule::sendBeacon()
                                  (bcfg.broadcast_offer_region != meshtastic_Config_LoRaConfig_RegionCode_UNSET);
 
     if (!hasText && !hasRadioContent) {
-        LOG_DEBUG("Beacon: nothing to send (empty message, no offer), skipping");
+        LOG_DEBUG("Beacon: empty msg, no offer, skip");
         return;
     }
 
@@ -375,7 +375,7 @@ void MeshBeaconBroadcastModule::sendBeacon()
         offerOnly.offer_region = bcfg.broadcast_offer_region;
         offerSize = (pb_size_t)pb_encode_to_bytes(offerBuf, sizeof(offerBuf), &meshtastic_MeshBeacon_msg, &offerOnly);
         if (offerSize == 0)
-            LOG_WARN("Beacon: offer encode failed, skipping offer packet(s)");
+            LOG_WARN("Beacon: offer encode failed, skip");
     }
     if (sendCombined && payloadCacheDirty)
         rebuildCache();
@@ -429,7 +429,7 @@ void MeshBeaconBroadcastModule::sendBeacon()
             tgt.slot = config.lora.channel_num;
             if (bt.has_channel_index) {
                 if (bt.channel_index >= (uint32_t)channels.getNumChannels()) {
-                    LOG_WARN("Beacon: target %d channel_index %u out of range, using default channel for preset", ti,
+                    LOG_WARN("Beacon: target %d channel_index %u out of range, use preset default", ti,
                              bt.channel_index);
                 } else {
                     const meshtastic_ChannelSettings &cs = channels.getByIndex(bt.channel_index).settings;
@@ -438,7 +438,7 @@ void MeshBeaconBroadcastModule::sendBeacon()
                         tgt.channel = cs;
                         tgt.slot = cs.channel_num;
                     } else {
-                        LOG_DEBUG("Beacon: target %d channel_index %u is a blank slot, using default channel for preset", ti,
+                        LOG_DEBUG("Beacon: target %d channel_index %u blank, use preset default", ti,
                                   bt.channel_index);
                     }
                 }
@@ -463,7 +463,7 @@ void MeshBeaconBroadcastModule::sendBeacon()
             }
         }
         if (duplicate) {
-            LOG_DEBUG("Beacon: target %d duplicates an earlier target's radio config, skipping", ti);
+            LOG_DEBUG("Beacon: target %d dup radio config, skip", ti);
             continue;
         }
         sent[sentCount] = tgt;
@@ -487,7 +487,7 @@ void MeshBeaconBroadcastModule::sendBeacon()
         if (sendOfferOnly && offerSize > 0) {
             meshtastic_MeshPacket *pA = allocDataPacket();
             if (!pA) {
-                LOG_WARN("Beacon: failed to allocate split-A packet (target %d)", ti);
+                LOG_WARN("Beacon: split-A alloc failed (target %d)", ti);
                 return;
             }
             memcpy(pA->decoded.payload.bytes, offerBuf, offerSize);
@@ -501,7 +501,7 @@ void MeshBeaconBroadcastModule::sendBeacon()
         if (sendTextOnly) {
             meshtastic_MeshPacket *pB = allocDataPacket();
             if (!pB) {
-                LOG_WARN("Beacon: failed to allocate split-B packet (target %d)", ti);
+                LOG_WARN("Beacon: split-B alloc failed (target %d)", ti);
                 return;
             }
             pb_size_t msgLen = (pb_size_t)strnlen(bcfg.broadcast_message, sizeof(bcfg.broadcast_message) - 1);

--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -138,7 +138,7 @@ int32_t NeighborInfoModule::runOnce()
 
 meshtastic_MeshPacket *NeighborInfoModule::allocReply()
 {
-    LOG_INFO("NeighborInfoRequested.");
+    LOG_INFO("NeighborInfoRequested");
     if (lastSentReply && Throttle::isWithinTimespanMs(lastSentReply, 3 * 60 * 1000)) {
         LOG_DEBUG("Skip Neighbors reply since we sent a reply <3min ago");
         ignoreRequest = true; // Mark it as ignored for MeshModule

--- a/src/modules/NodeInfoModule.cpp
+++ b/src/modules/NodeInfoModule.cpp
@@ -49,7 +49,7 @@ bool NodeInfoModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
     }
 
     if (p.is_licensed != owner.is_licensed) {
-        LOG_WARN("Invalid nodeInfo detected, is_licensed mismatch!");
+        LOG_WARN("Invalid nodeInfo detected, is_licensed mismatch");
         return true;
     }
     NodeNum sourceNum = getFrom(&mp);

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -170,7 +170,7 @@ bool PositionModule::hasGPS()
 meshtastic_MeshPacket *PositionModule::allocPositionPacket(uint32_t atPrecision)
 {
     if (atPrecision == 0) {
-        LOG_DEBUG("Skip location send because precision is set to 0!");
+        LOG_DEBUG("Skip location send because precision is set to 0");
         return nullptr;
     }
 
@@ -191,7 +191,7 @@ meshtastic_MeshPacket *PositionModule::allocPositionPacket(uint32_t atPrecision)
     localPosition.seq_number++;
 
     if (localPosition.latitude_i == 0 && localPosition.longitude_i == 0) {
-        LOG_WARN("Skip position send because lat/lon are zero!");
+        LOG_WARN("Skip position send because lat/lon are zero");
         return nullptr;
     }
 

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -68,7 +68,7 @@ bool PositionModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
     if (isFromUs(&mp)) {
         isLocal = true;
         if (config.position.fixed_position) {
-            LOG_DEBUG("Ignore incoming position update from myself except for time, because position.fixed_position is true");
+            LOG_DEBUG("Ignore own position update except time: position.fixed_position true");
 
 #ifdef T_WATCH_S3
             // Since we return early if position.fixed_position is true, set the T-Watch's RTC to the time received from the
@@ -117,7 +117,7 @@ void PositionModule::alterReceivedProtobuf(meshtastic_MeshPacket &mp, meshtastic
     // Phone position packets need to be truncated to the channel precision
     if (isFromUs(&mp)) {
         if (precision == 0)
-            LOG_DEBUG("Strip phone position due to channel precision 0");
+            LOG_DEBUG("Strip phone position: channel precision 0");
         else if (precision < 32)
             LOG_DEBUG("Truncate phone position to channel precision %i", precision);
         applyPositionPrecision(*p, precision);
@@ -129,11 +129,11 @@ void PositionModule::alterReceivedProtobuf(meshtastic_MeshPacket &mp, meshtastic
 void PositionModule::trySetRtc(meshtastic_Position p, bool isLocal, bool forceUpdate)
 {
     if (hasQualityTimesource() && !isLocal) {
-        LOG_DEBUG("Ignore time from mesh because we have a GPS, RTC, or Phone/NTP time source in the past day");
+        LOG_DEBUG("Ignore time from mesh: GPS/RTC/Phone/NTP time source in past day");
         return;
     }
     if (!isLocal && p.location_source < meshtastic_Position_LocSource_LOC_INTERNAL) {
-        LOG_DEBUG("Ignore time from mesh because it has a unknown or manual source");
+        LOG_DEBUG("Ignore time from mesh: unknown or manual source");
         return;
     }
     struct timeval tv;
@@ -170,7 +170,7 @@ bool PositionModule::hasGPS()
 meshtastic_MeshPacket *PositionModule::allocPositionPacket(uint32_t atPrecision)
 {
     if (atPrecision == 0) {
-        LOG_DEBUG("Skip location send because precision is set to 0");
+        LOG_DEBUG("Skip location send: precision 0");
         return nullptr;
     }
 
@@ -191,7 +191,7 @@ meshtastic_MeshPacket *PositionModule::allocPositionPacket(uint32_t atPrecision)
     localPosition.seq_number++;
 
     if (localPosition.latitude_i == 0 && localPosition.longitude_i == 0) {
-        LOG_WARN("Skip position send because lat/lon are zero");
+        LOG_WARN("Skip position send: lat/lon zero");
         return nullptr;
     }
 
@@ -276,7 +276,7 @@ meshtastic_MeshPacket *PositionModule::allocReply()
 {
     if (config.device.role != meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND && lastSentReply &&
         Throttle::isWithinTimespanMs(lastSentReply, 3 * 60 * 1000)) {
-        LOG_DEBUG("Skip Position reply since we sent a reply <3min ago");
+        LOG_DEBUG("Skip Position reply: sent one <3min ago");
         ignoreRequest = true; // Mark it as ignored for MeshModule
         return nullptr;
     }
@@ -349,7 +349,7 @@ meshtastic_MeshPacket *PositionModule::allocAtakPli()
     size_t proto_size = pb_encode_to_bytes(protobuf_bytes, sizeof(protobuf_bytes), &meshtastic_TAKPacketV2_msg, &takPacket);
 
     if (proto_size == 0) {
-        LOG_ERROR("Failed to encode TAK V2 PLI packet");
+        LOG_ERROR("TAK V2 PLI packet encode failed");
         packetPool.release(mp);
         return nullptr;
     }
@@ -380,7 +380,7 @@ void PositionModule::sendOurPosition()
             return;
         }
     }
-    LOG_INFO("Skip pos@%x:6 broadcast; position sharing is opt-in and disabled on all channels", localPosition.timestamp);
+    LOG_INFO("Skip pos@%x:6 broadcast; position sharing disabled on all channels", localPosition.timestamp);
 }
 
 // Position broadcasts are opt-in per channel in 2.8, but our own position still plays to the
@@ -506,7 +506,7 @@ int32_t PositionModule::runOnce()
     if (sleepOnNextExecution == true) {
         sleepOnNextExecution = false;
         uint32_t nightyNightMs = Default::getConfiguredOrDefaultMs(config.position.position_broadcast_secs);
-        LOG_DEBUG("Sleep for %ims, then awaking to send position again", nightyNightMs);
+        LOG_DEBUG("Sleep %ims, then wake to send position", nightyNightMs);
         doDeepSleep(nightyNightMs, false, false);
     }
 
@@ -593,7 +593,7 @@ int32_t PositionModule::runOnce()
                     &lastGpsSend, minimumTimeThreshold, []() { positionModule->sendOurPosition(); },
                     []() {
 #ifdef GPS_DEBUG
-                        LOG_DEBUG("Skip send smart broadcast due to time throttling");
+                        LOG_DEBUG("Skip smart broadcast: time throttled");
 #endif
                     })) {
 
@@ -703,7 +703,7 @@ void PositionModule::handleNewPosition()
                 &lastGpsSend, minimumTimeThreshold, []() { positionModule->sendOurPosition(); },
                 []() {
 #ifdef GPS_DEBUG
-                    LOG_DEBUG("Skip send smart broadcast due to time throttling");
+                    LOG_DEBUG("Skip smart broadcast: time throttled");
 #endif
                 })) {
             LOG_DEBUG("Sent smart pos@%x:6 to mesh (distanceTraveled=%fm, minDistanceThreshold=%im, timeElapsed=%ims, "

--- a/src/modules/PowerStressModule.cpp
+++ b/src/modules/PowerStressModule.cpp
@@ -125,7 +125,7 @@ int32_t PowerStressModule::runOnce()
                 // FIXME - implement
                 break;
             default:
-                LOG_ERROR("PowerStress operation %d not yet implemented!", p.cmd);
+                LOG_ERROR("PowerStress operation %d not yet implemented", p.cmd);
                 sleep_msec = 0; // Don't do whatever sleep was requested...
                 break;
             }

--- a/src/modules/RangeTestModule.cpp
+++ b/src/modules/RangeTestModule.cpp
@@ -334,18 +334,18 @@ bool RangeTestModuleRadio::removeFile()
     }
 
     if (!FSCom.exists("/static/rangetest.csv")) {
-        LOG_DEBUG("No range tests found.");
+        LOG_DEBUG("No range tests found");
         return 0;
     }
 
-    LOG_INFO("Deleting previous range test.");
+    LOG_INFO("Deleting previous range test");
     bool result = FSCom.remove("/static/rangetest.csv");
 
     if (!result) {
-        LOG_ERROR("Failed to delete range test.");
+        LOG_ERROR("Failed to delete range test");
         return 0;
     }
-    LOG_INFO("Range test removed.");
+    LOG_INFO("Range test removed");
 
     return 1;
 #else

--- a/src/modules/RangeTestModule.cpp
+++ b/src/modules/RangeTestModule.cpp
@@ -57,7 +57,7 @@ int32_t RangeTestModule::runOnce()
 
             if (moduleConfig.range_test.clear_on_reboot) {
                 // User wants to delete previous range test(s)
-                LOG_INFO("Range Test Module - Clearing out previous test file");
+                LOG_INFO("Range Test Module - Clear previous test file");
                 rangeTestModuleRadio->removeFile();
             }
             if (moduleConfig.range_test.sender) {
@@ -73,7 +73,7 @@ int32_t RangeTestModule::runOnce()
 
             if (moduleConfig.range_test.sender) {
                 // If sender
-                LOG_INFO("Range Test Module - Sending heartbeat every %d ms", (senderHeartbeat));
+                LOG_INFO("Range Test Module - Heartbeat every %d ms", (senderHeartbeat));
 
                 LOG_INFO("gpsStatus->getLatitude()     %d", gpsStatus->getLatitude());
                 LOG_INFO("gpsStatus->getLongitude()    %d", gpsStatus->getLongitude());
@@ -216,12 +216,12 @@ bool RangeTestModuleRadio::appendFile(const meshtastic_MeshPacket &mp)
     */
     concurrency::LockGuard g(spiLock);
     if (!FSBegin()) {
-        LOG_DEBUG("An Error has occurred while mounting the filesystem");
+        LOG_DEBUG("Filesystem mount error");
         return 0;
     }
 
     if (FSCom.totalBytes() - FSCom.usedBytes() < 51200) {
-        LOG_DEBUG("Filesystem doesn't have enough free space. Aborting write");
+        LOG_DEBUG("Filesystem low on free space. Abort write");
         return 0;
     }
 
@@ -233,14 +233,14 @@ bool RangeTestModuleRadio::appendFile(const meshtastic_MeshPacket &mp)
         File fileToWrite = FSCom.open("/static/rangetest.csv", FILE_WRITE);
 
         if (!fileToWrite) {
-            LOG_ERROR("There was an error opening the file for writing");
+            LOG_ERROR("Error opening file for writing");
             return 0;
         }
 
         // Print the CSV header
         if (fileToWrite.println("time,from,sender name,sender lat,sender long,rx lat,rx long,rx elevation,rx "
                                 "snr,distance,hop limit,payload,rx rssi")) {
-            LOG_INFO("File was written");
+            LOG_INFO("File written");
         } else {
             LOG_ERROR("File write failed");
         }
@@ -252,7 +252,7 @@ bool RangeTestModuleRadio::appendFile(const meshtastic_MeshPacket &mp)
     File fileToAppend = FSCom.open("/static/rangetest.csv", FILE_APPEND);
 
     if (!fileToAppend) {
-        LOG_ERROR("There was an error opening the file for appending");
+        LOG_ERROR("Error opening file for appending");
         return 0;
     }
 
@@ -319,7 +319,7 @@ bool RangeTestModuleRadio::appendFile(const meshtastic_MeshPacket &mp)
     return 1;
 
 #else
-    LOG_ERROR("Failed to store range test results - feature only available for ESP32");
+    LOG_ERROR("Can't store range test results - ESP32 only");
 
     return 0;
 #endif
@@ -329,7 +329,7 @@ bool RangeTestModuleRadio::removeFile()
 {
 #ifdef ARCH_ESP32
     if (!FSBegin()) {
-        LOG_DEBUG("An Error has occurred while mounting the filesystem");
+        LOG_DEBUG("Filesystem mount error");
         return 0;
     }
 
@@ -349,7 +349,7 @@ bool RangeTestModuleRadio::removeFile()
 
     return 1;
 #else
-    LOG_ERROR("Failed to remove range test results - feature only available for ESP32");
+    LOG_ERROR("Can't remove range test results - ESP32 only");
 
     return 0;
 #endif

--- a/src/modules/RemoteHardwareModule.cpp
+++ b/src/modules/RemoteHardwareModule.cpp
@@ -144,7 +144,7 @@ int32_t RemoteHardwareModule::runOnce()
 
             if (curVal != previousWatch) {
                 previousWatch = curVal;
-                LOG_INFO("Broadcast GPIOS 0x%llx changed!", curVal);
+                LOG_INFO("Broadcast GPIOS 0x%llx changed", curVal);
 
                 // Something changed!  Tell the world with a broadcast message
                 meshtastic_HardwareMessage r = meshtastic_HardwareMessage_init_default;

--- a/src/modules/StoreForwardModule.cpp
+++ b/src/modules/StoreForwardModule.cpp
@@ -567,8 +567,8 @@ bool StoreForwardModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp,
             // These fields only have informational purpose on a client. Fill them to consume later.
             if (p->which_variant == meshtastic_StoreAndForward_history_tag) {
                 this->historyReturnWindow = p->variant.history.window / 60000;
-                LOG_INFO("HISTORY response: %d msgs from last %d min",
-                         p->variant.history.history_messages, this->historyReturnWindow);
+                LOG_INFO("HISTORY response: %d msgs from last %d min", p->variant.history.history_messages,
+                         this->historyReturnWindow);
             }
         }
         break;

--- a/src/modules/StoreForwardModule.cpp
+++ b/src/modules/StoreForwardModule.cpp
@@ -421,7 +421,7 @@ ProcessMessage StoreForwardModule::handleReceived(const meshtastic_MeshPacket &m
                 }
             } else {
                 storeForwardModule->historyAdd(mp);
-                LOG_INFO("S&F stored. Message history contains %u records now", this->packetHistoryTotalCount);
+                LOG_INFO("S&F stored, history has %u records", this->packetHistoryTotalCount);
             }
         } else if (!isFromUs(&mp) && mp.decoded.portnum == meshtastic_PortNum_STORE_FORWARD_APP) {
             auto &p = mp.decoded;
@@ -567,7 +567,7 @@ bool StoreForwardModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp,
             // These fields only have informational purpose on a client. Fill them to consume later.
             if (p->which_variant == meshtastic_StoreAndForward_history_tag) {
                 this->historyReturnWindow = p->variant.history.window / 60000;
-                LOG_INFO("Router Response HISTORY - Sending %d messages from last %d minutes",
+                LOG_INFO("HISTORY response: %d msgs from last %d min",
                          p->variant.history.history_messages, this->historyReturnWindow);
             }
         }

--- a/src/modules/StoreForwardModule.cpp
+++ b/src/modules/StoreForwardModule.cpp
@@ -630,7 +630,7 @@ StoreForwardModule::StoreForwardModule()
                     this->populatePSRAM();
                     is_server = true;
                 } else {
-                    LOG_INFO("");
+                    LOG_INFO(".");
                     LOG_INFO("S&F: not enough PSRAM free, Disable");
                 }
             } else {

--- a/src/modules/StoreForwardModule.cpp
+++ b/src/modules/StoreForwardModule.cpp
@@ -431,7 +431,7 @@ ProcessMessage StoreForwardModule::handleReceived(const meshtastic_MeshPacket &m
                 if (pb_decode_from_bytes(p.payload.bytes, p.payload.size, &meshtastic_StoreAndForward_msg, &scratch)) {
                     decoded = &scratch;
                 } else {
-                    LOG_ERROR("Error decoding proto module!");
+                    LOG_ERROR("Error decoding proto module");
                     // if we can't decode it, nobody can process it!
                     return ProcessMessage::STOP;
                 }
@@ -630,7 +630,7 @@ StoreForwardModule::StoreForwardModule()
                     this->populatePSRAM();
                     is_server = true;
                 } else {
-                    LOG_INFO(".");
+                    LOG_INFO("");
                     LOG_INFO("S&F: not enough PSRAM free, Disable");
                 }
             } else {

--- a/src/modules/Telemetry/AirQualityTelemetry.cpp
+++ b/src/modules/Telemetry/AirQualityTelemetry.cpp
@@ -46,7 +46,7 @@ void AirQualityTelemetryModule::i2cScanFinished(ScanI2C *i2cScanner)
         return;
     }
 
-    LOG_INFO("Air Quality Telemetry adding I2C devices...");
+    LOG_INFO("Air Quality Telemetry adding I2C devices");
 
     /*
         Uncomment the preferences below if you want to use the module
@@ -81,7 +81,7 @@ void AirQualityTelemetryModule::i2cScanFinished(ScanI2C *i2cScanner)
 
     if (!firstTime) {
         // Re-scan for late comming sensors
-        LOG_INFO("Re-scanning supported sensors...");
+        LOG_INFO("Re-scanning supported sensors");
 
         for (const auto &[address, type] : supportedSensors) {
 
@@ -130,7 +130,7 @@ int32_t AirQualityTelemetryModule::runOnce()
         sleepOnNextExecution = false;
         uint32_t nightyNightMs = Default::getConfiguredOrDefaultMs(moduleConfig.telemetry.air_quality_interval,
                                                                    default_telemetry_broadcast_interval_secs);
-        LOG_DEBUG("Sleeping for %ims, then awaking to send metrics again.", nightyNightMs);
+        LOG_DEBUG("Sleeping for %ims, then awaking to send metrics again", nightyNightMs);
         doDeepSleep(nightyNightMs, true, false);
     }
 
@@ -187,7 +187,7 @@ int32_t AirQualityTelemetryModule::runOnce()
         // - We can publish the data on the mesh shortly
         // - Or we can send it to the phone
         // TODO: This will need to be refurbished once we implement separate intervals
-        LOG_INFO("Waking up sensors...");
+        LOG_INFO("Waking up sensors");
         for (TelemetrySensor *sensor : sensors) {
             if (!sensor->canSleep()) {
                 LOG_DEBUG("%s sensor doesn't have sleep feature. Skipping", sensor->sensorName);
@@ -429,7 +429,7 @@ meshtastic_MeshPacket *AirQualityTelemetryModule::allocReply()
         if (pb_decode_from_bytes(p.payload.bytes, p.payload.size, &meshtastic_Telemetry_msg, &scratch)) {
             decoded = &scratch;
         } else {
-            LOG_ERROR("Error decoding AirQualityTelemetry module!");
+            LOG_ERROR("Error decoding AirQualityTelemetry module");
             return NULL;
         }
         // Check for a request for air quality metrics

--- a/src/modules/Telemetry/AirQualityTelemetry.cpp
+++ b/src/modules/Telemetry/AirQualityTelemetry.cpp
@@ -130,7 +130,7 @@ int32_t AirQualityTelemetryModule::runOnce()
         sleepOnNextExecution = false;
         uint32_t nightyNightMs = Default::getConfiguredOrDefaultMs(moduleConfig.telemetry.air_quality_interval,
                                                                    default_telemetry_broadcast_interval_secs);
-        LOG_DEBUG("Sleeping for %ims, then awaking to send metrics again", nightyNightMs);
+        LOG_DEBUG("Sleep %ims until next send", nightyNightMs);
         doDeepSleep(nightyNightMs, true, false);
     }
 
@@ -190,7 +190,7 @@ int32_t AirQualityTelemetryModule::runOnce()
         LOG_INFO("Waking up sensors");
         for (TelemetrySensor *sensor : sensors) {
             if (!sensor->canSleep()) {
-                LOG_DEBUG("%s sensor doesn't have sleep feature. Skipping", sensor->sensorName);
+                LOG_DEBUG("%s: no sleep support, skip", sensor->sensorName);
                 continue;
             }
 
@@ -529,7 +529,7 @@ bool AirQualityTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
     // until the next telemetry interval and drains its battery
     if (!phoneOnly && isPowerSavingSensor()) {
         if (!validTelemetry)
-            LOG_WARN("Air quality telemetry unavailable this cycle, sleep without sending");
+            LOG_WARN("AQ telemetry unavailable, sleep without send");
         sleepOnNextExecution = true;
         preflightSleepDeferrals = 0;
         LOG_DEBUG("Start next execution in 5s, then sleep");

--- a/src/modules/Telemetry/DeviceTelemetry.cpp
+++ b/src/modules/Telemetry/DeviceTelemetry.cpp
@@ -76,7 +76,7 @@ meshtastic_MeshPacket *DeviceTelemetryModule::allocReply()
         if (pb_decode_from_bytes(p.payload.bytes, p.payload.size, &meshtastic_Telemetry_msg, &scratch)) {
             decoded = &scratch;
         } else {
-            LOG_ERROR("Error decoding DeviceTelemetry module!");
+            LOG_ERROR("Error decoding DeviceTelemetry module");
             return NULL;
         }
         // Check for a request for device metrics

--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -257,7 +257,7 @@ void EnvironmentTelemetryModule::i2cScanFinished(ScanI2C *i2cScanner)
     if (!moduleConfig.telemetry.environment_measurement_enabled && !ENVIRONMENTAL_TELEMETRY_MODULE_ENABLE) {
         return;
     }
-    LOG_INFO("Environment Telemetry adding I2C devices...");
+    LOG_INFO("Environment Telemetry adding I2C devices");
 
     /*
         Uncomment the preferences below if you want to use the module
@@ -735,7 +735,7 @@ meshtastic_MeshPacket *EnvironmentTelemetryModule::allocReply()
         if (pb_decode_from_bytes(p.payload.bytes, p.payload.size, &meshtastic_Telemetry_msg, &scratch)) {
             decoded = &scratch;
         } else {
-            LOG_ERROR("Error decoding EnvironmentTelemetry module!");
+            LOG_ERROR("Error decoding EnvironmentTelemetry module");
             return NULL;
         }
         // Check for a request for environment metrics

--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -366,7 +366,7 @@ int32_t EnvironmentTelemetryModule::runOnce()
         sleepOnNextExecution = false;
         uint32_t nightyNightMs = Default::getConfiguredOrDefaultMs(moduleConfig.telemetry.environment_update_interval,
                                                                    default_telemetry_broadcast_interval_secs);
-        LOG_DEBUG("Sleep for %ims, then awake to send metrics again", nightyNightMs);
+        LOG_DEBUG("Sleep %ims until next send", nightyNightMs);
         doDeepSleep(nightyNightMs, true, false);
     }
 
@@ -813,7 +813,7 @@ bool EnvironmentTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
     // otherwise it stays awake until the next telemetry interval and drains its battery
     if (!phoneOnly && isPowerSavingSensor()) {
         if (!validTelemetry)
-            LOG_WARN("Environment telemetry unavailable this cycle, sleep without sending");
+            LOG_WARN("Env telemetry unavailable, sleep without send");
         sleepOnNextExecution = true;
         preflightSleepDeferrals = 0;
         LOG_DEBUG("Start next execution in 5s, then sleep");

--- a/src/modules/Telemetry/HealthTelemetry.cpp
+++ b/src/modules/Telemetry/HealthTelemetry.cpp
@@ -127,7 +127,7 @@ void HealthTelemetryModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *
     const meshtastic_Data &p = lastMeasurementPacket->decoded;
     if (!pb_decode_from_bytes(p.payload.bytes, p.payload.size, &meshtastic_Telemetry_msg, &lastMeasurement)) {
         display->drawString(x, y, "Measurement Error");
-        LOG_ERROR("Unable to decode last packet");
+        LOG_ERROR("Can't decode last packet");
         return;
     }
 

--- a/src/modules/Telemetry/HealthTelemetry.cpp
+++ b/src/modules/Telemetry/HealthTelemetry.cpp
@@ -223,7 +223,7 @@ meshtastic_MeshPacket *HealthTelemetryModule::allocReply()
         if (pb_decode_from_bytes(p.payload.bytes, p.payload.size, &meshtastic_Telemetry_msg, &scratch)) {
             decoded = &scratch;
         } else {
-            LOG_ERROR("Error decoding HealthTelemetry module!");
+            LOG_ERROR("Error decoding HealthTelemetry module");
             return NULL;
         }
         // Check for a request for health metrics

--- a/src/modules/Telemetry/HostMetrics.cpp
+++ b/src/modules/Telemetry/HostMetrics.cpp
@@ -51,7 +51,7 @@ meshtastic_MeshPacket *HostMetricsModule::allocReply()
         if (pb_decode_from_bytes(p.payload.bytes, p.payload.size, &meshtastic_HostMetrics_msg, &scratch)) {
             decoded = &scratch;
         } else {
-            LOG_ERROR("Error decoding HostMetrics module!");
+            LOG_ERROR("Error decoding HostMetrics module");
             return NULL;
         }
         // Check for a request for device metrics

--- a/src/modules/Telemetry/HostMetrics.cpp
+++ b/src/modules/Telemetry/HostMetrics.cpp
@@ -51,7 +51,7 @@ meshtastic_MeshPacket *HostMetricsModule::allocReply()
         if (pb_decode_from_bytes(p.payload.bytes, p.payload.size, &meshtastic_HostMetrics_msg, &scratch)) {
             decoded = &scratch;
         } else {
-            LOG_ERROR("Error decoding HostMetrics module");
+            LOG_ERROR("Can't decode HostMetrics module");
             return NULL;
         }
         // Check for a request for device metrics

--- a/src/modules/Telemetry/PowerTelemetry.cpp
+++ b/src/modules/Telemetry/PowerTelemetry.cpp
@@ -247,7 +247,7 @@ meshtastic_MeshPacket *PowerTelemetryModule::allocReply()
         if (pb_decode_from_bytes(p.payload.bytes, p.payload.size, &meshtastic_Telemetry_msg, &scratch)) {
             decoded = &scratch;
         } else {
-            LOG_ERROR("Error decoding PowerTelemetry module!");
+            LOG_ERROR("Error decoding PowerTelemetry module");
             return NULL;
         }
         // Check for a request for power metrics

--- a/src/modules/Telemetry/PowerTelemetry.cpp
+++ b/src/modules/Telemetry/PowerTelemetry.cpp
@@ -149,7 +149,7 @@ void PowerTelemetryModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *s
     const meshtastic_Data &p = lastMeasurementPacket->decoded;
     if (!pb_decode_from_bytes(p.payload.bytes, p.payload.size, &meshtastic_Telemetry_msg, &lastMeasurement)) {
         display->drawString(x, graphics::getTextPositions(display)[line++], "Measurement Error");
-        LOG_ERROR("Unable to decode last packet");
+        LOG_ERROR("Can't decode last packet");
         return;
     }
 

--- a/src/modules/Telemetry/Sensor/BME680Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/BME680Sensor.cpp
@@ -142,7 +142,7 @@ void BME680Sensor::loadState()
     }
     spiLock->unlock();
 #else
-    LOG_ERROR("ERROR: Filesystem not implemented");
+    LOG_ERROR("Filesystem not implemented");
 #endif
 }
 
@@ -187,7 +187,7 @@ void BME680Sensor::updateState()
     }
     spiLock->unlock();
 #else
-    LOG_ERROR("ERROR: Filesystem not implemented");
+    LOG_ERROR("Filesystem not implemented");
 #endif
 }
 

--- a/src/modules/Telemetry/Sensor/DS248XSensor.cpp
+++ b/src/modules/Telemetry/Sensor/DS248XSensor.cpp
@@ -149,7 +149,7 @@ bool DS248XSensor::initDevice(TwoWire *bus, ScanI2C::FoundDevice *dev)
                 printROM(ds248xData.rom);
             }
         } else {
-            LOG_WARN("%s: Could not determine variant (%u/%u)", sensorName, retry, numRetries);
+            LOG_WARN("%s: Can't determine variant (%u/%u)", sensorName, retry, numRetries);
             initError = true;
         }
 

--- a/src/modules/Telemetry/Sensor/NAU7802Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/NAU7802Sensor.cpp
@@ -107,7 +107,7 @@ bool NAU7802Sensor::saveCalibrationData()
     pb_ostream_t stream = {&writecb, static_cast<Print *>(&file), meshtastic_Nau7802Config_size};
 
     if (!pb_encode(&stream, &meshtastic_Nau7802Config_msg, &nau7802config)) {
-        LOG_ERROR("Error: can't encode protobuf %s", PB_GET_ERROR(&stream));
+        LOG_ERROR("Can't encode protobuf %s", PB_GET_ERROR(&stream));
     } else {
         okay = true;
     }
@@ -126,7 +126,7 @@ bool NAU7802Sensor::loadCalibrationData()
         LOG_INFO("%s state read from %s", sensorName, nau7802ConfigFileName);
         pb_istream_t stream = {&readcb, &file, meshtastic_Nau7802Config_size};
         if (!pb_decode(&stream, &meshtastic_Nau7802Config_msg, &nau7802config)) {
-            LOG_ERROR("Error: can't decode protobuf %s", PB_GET_ERROR(&stream));
+            LOG_ERROR("Can't decode protobuf %s", PB_GET_ERROR(&stream));
         } else {
             nau7802.setZeroOffset(nau7802config.zeroOffset);
             nau7802.setCalibrationFactor(nau7802config.calibrationFactor);

--- a/src/modules/Telemetry/Sensor/RAK9154Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/RAK9154Sensor.cpp
@@ -63,7 +63,7 @@ static void onewire_evt(const uint8_t pid, const uint8_t sid, const SNHUBAPI_EVT
         // {
         //     LOG_INFO("%02x,", msg[i]);
         // }
-        // LOG_INFO("");
+        // LOG_INFO(".");
         switch (msg[0]) {
         case RAK_IPSO_CAPACITY:
             dc_prec = msg[1];
@@ -91,7 +91,7 @@ static void onewire_evt(const uint8_t pid, const uint8_t sid, const SNHUBAPI_EVT
         // {
         //     LOG_INFO("%02x,", msg[i]);
         // }
-        // LOG_INFO("");
+        // LOG_INFO(".");
 
         switch (msg[0]) {
         case RAK_IPSO_CAPACITY:

--- a/src/modules/Telemetry/Sensor/RCWL9620Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/RCWL9620Sensor.cpp
@@ -52,7 +52,7 @@ float RCWL9620Sensor::getDistance()
     _wire->requestFrom(_addr, (uint8_t)3);
 
     if (_wire->available() < 3) {
-        LOG_DEBUG("[RCWL9620] less than 3 octets !");
+        LOG_DEBUG("[RCWL9620] less than 3 octets ");
         return 0.0;
     }
 

--- a/src/modules/Telemetry/Sensor/SCD30Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/SCD30Sensor.cpp
@@ -102,7 +102,7 @@ bool SCD30Sensor::setMeasurementInterval(uint16_t measInterval)
     error = scd30.setMeasurementInterval(measInterval);
 
     if (error != SCD30_NO_ERROR) {
-        LOG_ERROR("%s: Can't set measurement interval. Error: %u", sensorName, error);
+        LOG_ERROR("%s: Can't set measurement interval, rc=%u", sensorName, error);
         return false;
     }
 
@@ -123,7 +123,7 @@ bool SCD30Sensor::getMeasurementInterval(uint16_t &measInterval)
     error = scd30.getMeasurementInterval(measInterval);
 
     if (error != SCD30_NO_ERROR) {
-        LOG_ERROR("%s: Can't get measurement interval. Error: %u", sensorName, error);
+        LOG_ERROR("%s: Can't get measurement interval, rc=%u", sensorName, error);
         return false;
     }
 
@@ -224,7 +224,7 @@ bool SCD30Sensor::getASC(uint16_t &_ascActive)
     error = scd30.getAutoCalibrationStatus(_ascActive);
 
     if (error != SCD30_NO_ERROR) {
-        LOG_ERROR("%s: Can't send command", sensorName);
+        LOG_ERROR("%s: Can't get ASC status", sensorName);
         return false;
     }
 
@@ -268,7 +268,7 @@ bool SCD30Sensor::setTemperature(float tempReference)
 
         error = scd30.readMeasurementData(co2, temperature, humidity);
         if (error != SCD30_NO_ERROR) {
-            LOG_ERROR("%s: Can't read current temp. Error: %u", sensorName, error);
+            LOG_ERROR("%s: Can't read current temp, rc=%u", sensorName, error);
             return false;
         }
 
@@ -288,7 +288,7 @@ bool SCD30Sensor::setTemperature(float tempReference)
 
     error = scd30.setTemperatureOffset(_tempOffset);
     if (error != SCD30_NO_ERROR) {
-        LOG_ERROR("%s: Can't set temp offset. Error: %u", sensorName, error);
+        LOG_ERROR("%s: Can't set temp offset, rc=%u", sensorName, error);
         return false;
     }
 
@@ -307,7 +307,7 @@ bool SCD30Sensor::setAltitude(uint16_t altitude)
     error = scd30.setAltitudeCompensation(altitude);
 
     if (error != SCD30_NO_ERROR) {
-        LOG_ERROR("%s: Can't set altitude. Error: %u", sensorName, error);
+        LOG_ERROR("%s: Can't set altitude, rc=%u", sensorName, error);
         return false;
     }
 
@@ -325,7 +325,7 @@ bool SCD30Sensor::getAltitude(uint16_t &altitude)
     error = scd30.getAltitudeCompensation(altitude);
 
     if (error != SCD30_NO_ERROR) {
-        LOG_ERROR("%s: Can't get altitude. Error: %u", sensorName, error);
+        LOG_ERROR("%s: Can't get altitude, rc=%u", sensorName, error);
         return false;
     }
     LOG_INFO("%s: Sensor altitude: %u", sensorName, altitude);
@@ -342,7 +342,7 @@ bool SCD30Sensor::softReset()
     error = scd30.softReset();
 
     if (error != SCD30_NO_ERROR) {
-        LOG_ERROR("%s: Can't soft reset. Error: %u", sensorName, error);
+        LOG_ERROR("%s: Can't soft reset, rc=%u", sensorName, error);
         return false;
     }
 

--- a/src/modules/Telemetry/Sensor/SCD30Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/SCD30Sensor.cpp
@@ -19,14 +19,14 @@ bool SCD30Sensor::initDevice(TwoWire *bus, ScanI2C::FoundDevice *dev)
     _port = dev->address.port;
     reClockI2C.setup(_bus, _port);
 
-    LOG_INFO("%s: attempting to reclock speed to %uHz", sensorName, SCD30_I2C_CLOCK_SPEED);
+    LOG_INFO("%s: reclock to %uHz", sensorName, SCD30_I2C_CLOCK_SPEED);
     reClockI2C.setClock(SCD30_I2C_CLOCK_SPEED);
 #endif /* SCD30_I2C_CLOCK_SPEED */
 
     scd30.begin(*_bus, _address);
 
     if (!startMeasurement()) {
-        LOG_ERROR("%s: Failed to start periodic measurement", sensorName);
+        LOG_ERROR("%s: Periodic measurement start failed", sensorName);
 #ifdef SCD30_I2C_CLOCK_SPEED
         LOG_INFO("%s: restoring clock speed", sensorName);
         reClockI2C.restoreClock();
@@ -35,7 +35,7 @@ bool SCD30Sensor::initDevice(TwoWire *bus, ScanI2C::FoundDevice *dev)
     }
 
     if (!getASC(ascActive)) {
-        LOG_WARN("%s: Could not determine ASC state", sensorName);
+        LOG_WARN("%s: Can't determine ASC state", sensorName);
     }
 
 #ifdef SCD30_I2C_CLOCK_SPEED
@@ -59,12 +59,12 @@ bool SCD30Sensor::getMetrics(meshtastic_Telemetry *measurement)
     float co2, temperature, humidity;
 
 #ifdef SCD30_I2C_CLOCK_SPEED
-    LOG_DEBUG("%s: attempting to reclock speed to %uHz", sensorName, SCD30_I2C_CLOCK_SPEED);
+    LOG_DEBUG("%s: reclock to %uHz", sensorName, SCD30_I2C_CLOCK_SPEED);
     reClockI2C.setClock(SCD30_I2C_CLOCK_SPEED);
 #endif /* SCD30_I2C_CLOCK_SPEED */
 
     if (scd30.readMeasurementData(co2, temperature, humidity) != SCD30_NO_ERROR) {
-        LOG_ERROR("%s: Failed to read measurement data", sensorName);
+        LOG_ERROR("%s: Measurement read failed", sensorName);
 #ifdef SCD30_I2C_CLOCK_SPEED
         LOG_DEBUG("%s: restoring clock speed", sensorName);
         reClockI2C.restoreClock();
@@ -102,7 +102,7 @@ bool SCD30Sensor::setMeasurementInterval(uint16_t measInterval)
     error = scd30.setMeasurementInterval(measInterval);
 
     if (error != SCD30_NO_ERROR) {
-        LOG_ERROR("%s: Unable to set measurement interval. Error code: %u", sensorName, error);
+        LOG_ERROR("%s: Can't set measurement interval. Error: %u", sensorName, error);
         return false;
     }
 
@@ -123,7 +123,7 @@ bool SCD30Sensor::getMeasurementInterval(uint16_t &measInterval)
     error = scd30.getMeasurementInterval(measInterval);
 
     if (error != SCD30_NO_ERROR) {
-        LOG_ERROR("%s: Unable to get measurement interval. Error code: %u", sensorName, error);
+        LOG_ERROR("%s: Can't get measurement interval. Error: %u", sensorName, error);
         return false;
     }
 
@@ -153,7 +153,7 @@ bool SCD30Sensor::startMeasurement()
         state = SCD30_MEASUREMENT;
         return true;
     } else {
-        LOG_ERROR("%s: Couldn't start measurement mode", sensorName);
+        LOG_ERROR("%s: Can't start measurement mode", sensorName);
         return false;
     }
 }
@@ -168,7 +168,7 @@ bool SCD30Sensor::stopMeasurement()
 
     error = scd30.stopPeriodicMeasurement();
     if (error != SCD30_NO_ERROR) {
-        LOG_ERROR("%s: Unable to stop measurement", sensorName);
+        LOG_ERROR("%s: Can't stop measurement", sensorName);
         return false;
     }
 
@@ -180,17 +180,17 @@ bool SCD30Sensor::performFRC(uint16_t targetCO2)
 {
     uint16_t error;
 
-    LOG_INFO("%s: Issuing FRC. Ensure device has been working at least 3 minutes in stable target environment", sensorName);
+    LOG_INFO("%s: Issuing FRC. Needs 3+ min in stable target environment", sensorName);
 
     LOG_INFO("%s: Target CO2: %u ppm", sensorName, targetCO2);
     error = scd30.forceRecalibration((uint16_t)targetCO2);
 
     if (error != SCD30_NO_ERROR) {
-        LOG_ERROR("%s: Unable to perform forced recalibration", sensorName);
+        LOG_ERROR("%s: Can't perform FRC", sensorName);
         return false;
     }
 
-    LOG_INFO("%s: FRC Correction successful", sensorName);
+    LOG_INFO("%s: FRC done", sensorName);
 
     return true;
 }
@@ -204,12 +204,12 @@ bool SCD30Sensor::setASC(bool ascEnabled)
     error = scd30.activateAutoCalibration((uint16_t)ascEnabled);
 
     if (error != SCD30_NO_ERROR) {
-        LOG_ERROR("%s: Unable to send command", sensorName);
+        LOG_ERROR("%s: Can't send command", sensorName);
         return false;
     }
 
     if (!getASC(ascActive)) {
-        LOG_ERROR("%s: Unable to check if ASC is enabled", sensorName);
+        LOG_ERROR("%s: Can't check if ASC enabled", sensorName);
         return false;
     }
 
@@ -224,7 +224,7 @@ bool SCD30Sensor::getASC(uint16_t &_ascActive)
     error = scd30.getAutoCalibrationStatus(_ascActive);
 
     if (error != SCD30_NO_ERROR) {
-        LOG_ERROR("%s: Unable to send command", sensorName);
+        LOG_ERROR("%s: Can't send command", sensorName);
         return false;
     }
 
@@ -260,23 +260,23 @@ bool SCD30Sensor::setTemperature(float tempReference)
 
     if (tempReference == 100) {
         // Requesting the value of 100 will restore the temperature offset
-        LOG_INFO("%s: Setting reference temperature at 0degC", sensorName);
+        LOG_INFO("%s: Setting reference temp at 0degC", sensorName);
         _tempOffset = 0;
     } else {
 
-        LOG_INFO("%s: Setting reference temperature at: %.2f", sensorName, tempReference);
+        LOG_INFO("%s: Setting reference temp at: %.2f", sensorName, tempReference);
 
         error = scd30.readMeasurementData(co2, temperature, humidity);
         if (error != SCD30_NO_ERROR) {
-            LOG_ERROR("%s: Unable to read current temperature. Error code: %u", sensorName, error);
+            LOG_ERROR("%s: Can't read current temp. Error: %u", sensorName, error);
             return false;
         }
 
-        LOG_INFO("%s: Current sensor temperature: %.2f", sensorName, temperature);
+        LOG_INFO("%s: Current sensor temp: %.2f", sensorName, temperature);
 
         tempOffset = (temperature - tempReference);
         if (tempOffset < 0) {
-            LOG_ERROR("%s: temperature offset is only positive", sensorName);
+            LOG_ERROR("%s: temp offset is only positive", sensorName);
             return false;
         }
 
@@ -284,16 +284,16 @@ bool SCD30Sensor::setTemperature(float tempReference)
         _tempOffset = static_cast<uint16_t>(tempOffset);
     }
 
-    LOG_INFO("%s: Setting temperature offset: %u (*100)", sensorName, _tempOffset);
+    LOG_INFO("%s: Setting temp offset: %u (*100)", sensorName, _tempOffset);
 
     error = scd30.setTemperatureOffset(_tempOffset);
     if (error != SCD30_NO_ERROR) {
-        LOG_ERROR("%s: Unable to set temperature offset. Error code: %u", sensorName, error);
+        LOG_ERROR("%s: Can't set temp offset. Error: %u", sensorName, error);
         return false;
     }
 
     scd30.getTemperatureOffset(updatedTempOffset);
-    LOG_INFO("%s: Updated sensor temperature offset: %u (*100)", sensorName, updatedTempOffset);
+    LOG_INFO("%s: Updated sensor temp offset: %u (*100)", sensorName, updatedTempOffset);
 
     return true;
 }
@@ -307,7 +307,7 @@ bool SCD30Sensor::setAltitude(uint16_t altitude)
     error = scd30.setAltitudeCompensation(altitude);
 
     if (error != SCD30_NO_ERROR) {
-        LOG_ERROR("%s: Unable to set altitude. Error code: %u", sensorName, error);
+        LOG_ERROR("%s: Can't set altitude. Error: %u", sensorName, error);
         return false;
     }
 
@@ -325,7 +325,7 @@ bool SCD30Sensor::getAltitude(uint16_t &altitude)
     error = scd30.getAltitudeCompensation(altitude);
 
     if (error != SCD30_NO_ERROR) {
-        LOG_ERROR("%s: Unable to get altitude. Error code: %u", sensorName, error);
+        LOG_ERROR("%s: Can't get altitude. Error: %u", sensorName, error);
         return false;
     }
     LOG_INFO("%s: Sensor altitude: %u", sensorName, altitude);
@@ -342,11 +342,11 @@ bool SCD30Sensor::softReset()
     error = scd30.softReset();
 
     if (error != SCD30_NO_ERROR) {
-        LOG_ERROR("%s: Unable to do soft reset. Error code: %u", sensorName, error);
+        LOG_ERROR("%s: Can't soft reset. Error: %u", sensorName, error);
         return false;
     }
 
-    LOG_INFO("%s: soft reset successful", sensorName);
+    LOG_INFO("%s: soft reset done", sensorName);
 
     return true;
 }
@@ -366,7 +366,7 @@ bool SCD30Sensor::isActive()
 uint32_t SCD30Sensor::wakeUp()
 {
 #ifdef SCD30_I2C_CLOCK_SPEED
-    LOG_INFO("%s: attempting to reclock speed to %uHz", sensorName, SCD30_I2C_CLOCK_SPEED);
+    LOG_INFO("%s: reclock to %uHz", sensorName, SCD30_I2C_CLOCK_SPEED);
     reClockI2C.setClock(SCD30_I2C_CLOCK_SPEED);
 #endif /* SCD30_I2C_CLOCK_SPEED */
 
@@ -387,7 +387,7 @@ uint32_t SCD30Sensor::wakeUp()
 void SCD30Sensor::sleep()
 {
 #ifdef SCD30_I2C_CLOCK_SPEED
-    LOG_INFO("%s: attempting to reclock speed to %uHz", sensorName, SCD30_I2C_CLOCK_SPEED);
+    LOG_INFO("%s: reclock to %uHz", sensorName, SCD30_I2C_CLOCK_SPEED);
     reClockI2C.setClock(SCD30_I2C_CLOCK_SPEED);
 #endif /* SCD30_I2C_CLOCK_SPEED */
 
@@ -420,7 +420,7 @@ AdminMessageHandleResult SCD30Sensor::handleAdminMessage(const meshtastic_MeshPa
     AdminMessageHandleResult result;
 
 #ifdef SCD30_I2C_CLOCK_SPEED
-    LOG_INFO("%s: attempting to reclock speed to %uHz", sensorName, SCD30_I2C_CLOCK_SPEED);
+    LOG_INFO("%s: reclock to %uHz", sensorName, SCD30_I2C_CLOCK_SPEED);
     reClockI2C.setClock(SCD30_I2C_CLOCK_SPEED);
 #endif /* SCD30_I2C_CLOCK_SPEED */
 

--- a/src/modules/Telemetry/Sensor/SCD30Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/SCD30Sensor.cpp
@@ -186,11 +186,11 @@ bool SCD30Sensor::performFRC(uint16_t targetCO2)
     error = scd30.forceRecalibration((uint16_t)targetCO2);
 
     if (error != SCD30_NO_ERROR) {
-        LOG_ERROR("%s: Unable to perform forced recalibration.", sensorName);
+        LOG_ERROR("%s: Unable to perform forced recalibration", sensorName);
         return false;
     }
 
-    LOG_INFO("%s: FRC Correction successful.", sensorName);
+    LOG_INFO("%s: FRC Correction successful", sensorName);
 
     return true;
 }
@@ -204,7 +204,7 @@ bool SCD30Sensor::setASC(bool ascEnabled)
     error = scd30.activateAutoCalibration((uint16_t)ascEnabled);
 
     if (error != SCD30_NO_ERROR) {
-        LOG_ERROR("%s: Unable to send command.", sensorName);
+        LOG_ERROR("%s: Unable to send command", sensorName);
         return false;
     }
 
@@ -224,7 +224,7 @@ bool SCD30Sensor::getASC(uint16_t &_ascActive)
     error = scd30.getAutoCalibrationStatus(_ascActive);
 
     if (error != SCD30_NO_ERROR) {
-        LOG_ERROR("%s: Unable to send command.", sensorName);
+        LOG_ERROR("%s: Unable to send command", sensorName);
         return false;
     }
 

--- a/src/modules/Telemetry/Sensor/SCD4XSensor.cpp
+++ b/src/modules/Telemetry/Sensor/SCD4XSensor.cpp
@@ -20,7 +20,7 @@ bool SCD4XSensor::initDevice(TwoWire *bus, ScanI2C::FoundDevice *dev)
     _port = dev->address.port;
     reClockI2C.setup(_bus, _port);
 
-    LOG_INFO("%s: attempting to reclock speed to %uHz", sensorName, SCD4X_I2C_CLOCK_SPEED);
+    LOG_INFO("%s: reclock to %uHz", sensorName, SCD4X_I2C_CLOCK_SPEED);
     reClockI2C.setClock(SCD4X_I2C_CLOCK_SPEED);
 #endif /* SCD4X_I2C_CLOCK_SPEED */
 
@@ -44,7 +44,7 @@ bool SCD4XSensor::initDevice(TwoWire *bus, ScanI2C::FoundDevice *dev)
     if (sensorVariant == SCD4X_SENSOR_VARIANT_SCD41) {
         LOG_INFO("%s: Found SCD41", sensorName);
         if (!powerUp()) {
-            LOG_ERROR("%s: Error trying to execute powerUp()", sensorName);
+            LOG_ERROR("%s: Error executing powerUp()", sensorName);
 #ifdef SCD4X_I2C_CLOCK_SPEED
             LOG_INFO("%s: restoring clock speed", sensorName);
             reClockI2C.restoreClock();
@@ -54,7 +54,7 @@ bool SCD4XSensor::initDevice(TwoWire *bus, ScanI2C::FoundDevice *dev)
     }
 
     if (!getASC(ascActive)) {
-        LOG_ERROR("%s: Unable to check if ASC is enabled", sensorName);
+        LOG_ERROR("%s: Can't check if ASC enabled", sensorName);
 #ifdef SCD4X_I2C_CLOCK_SPEED
         LOG_INFO("%s: restoring clock speed", sensorName);
         reClockI2C.restoreClock();
@@ -64,7 +64,7 @@ bool SCD4XSensor::initDevice(TwoWire *bus, ScanI2C::FoundDevice *dev)
 
     // Start measurement in selected power mode (low power by default)
     if (!startMeasurement()) {
-        LOG_ERROR("%s: Couldn't start measurement", sensorName);
+        LOG_ERROR("%s: Can't start measurement", sensorName);
 #ifdef SCD4X_I2C_CLOCK_SPEED
         LOG_INFO("%s: restoring clock speed", sensorName);
         reClockI2C.restoreClock();
@@ -100,7 +100,7 @@ bool SCD4XSensor::getMetrics(meshtastic_Telemetry *measurement)
     float temperature, humidity;
 
 #ifdef SCD4X_I2C_CLOCK_SPEED
-    LOG_DEBUG("%s: attempting to reclock speed to %uHz", sensorName, SCD4X_I2C_CLOCK_SPEED);
+    LOG_DEBUG("%s: reclock to %uHz", sensorName, SCD4X_I2C_CLOCK_SPEED);
     reClockI2C.setClock(SCD4X_I2C_CLOCK_SPEED);
 #endif /* SCD4X_I2C_CLOCK_SPEED */
 
@@ -134,7 +134,7 @@ bool SCD4XSensor::getMetrics(meshtastic_Telemetry *measurement)
 
     LOG_DEBUG("Got %s readings: co2=%u, co2_temp=%.2f, co2_hum%.2f", sensorName, co2, temperature, humidity);
     if (error != SCD4X_NO_ERROR) {
-        LOG_DEBUG("%s: Error while getting measurements: %u", sensorName, error);
+        LOG_DEBUG("%s: Error getting measurements: %u", sensorName, error);
         if (co2 == 0) {
             LOG_ERROR("%s: Skipping invalid measurement", sensorName);
         }
@@ -167,7 +167,7 @@ bool SCD4XSensor::performFRC(uint32_t targetCO2)
 {
     uint16_t error, frcCorr;
 
-    LOG_INFO("%s: Issuing FRC. Ensure device has been working at least 3 minutes in stable target environment", sensorName);
+    LOG_INFO("%s: Issuing FRC. Needs 3+ min in stable target environment", sensorName);
 
     if (!stopMeasurement()) {
         return false;
@@ -180,16 +180,16 @@ bool SCD4XSensor::performFRC(uint32_t targetCO2)
     delay(400);
 
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to perform forced recalibration", sensorName);
+        LOG_ERROR("%s: Can't perform FRC", sensorName);
         return false;
     }
 
     if (frcCorr == 0xFFFF) {
-        LOG_ERROR("%s: Error while performing forced recalibration", sensorName);
+        LOG_ERROR("%s: Error performing FRC", sensorName);
         return false;
     }
 
-    LOG_INFO("%s: FRC Correction successful. Correction output: %u", sensorName, (uint16_t)(frcCorr - 0x8000));
+    LOG_INFO("%s: FRC done. Correction output: %u", sensorName, (uint16_t)(frcCorr - 0x8000));
 
     return true;
 }
@@ -224,7 +224,7 @@ bool SCD4XSensor::startMeasurement()
         state = SCD4X_MEASUREMENT;
         return true;
     } else {
-        LOG_ERROR("%s: Unable to start measurement mode", sensorName);
+        LOG_ERROR("%s: Can't start measurement mode", sensorName);
         return false;
     }
 }
@@ -239,7 +239,7 @@ bool SCD4XSensor::stopMeasurement()
 
     error = scd4x.stopPeriodicMeasurement();
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to stop measurement", sensorName);
+        LOG_ERROR("%s: Can't stop measurement", sensorName);
         return false;
     }
 
@@ -286,7 +286,7 @@ bool SCD4XSensor::getASC(uint16_t &_ascActive)
     error = scd4x.getAutomaticSelfCalibrationEnabled(_ascActive);
 
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to send command", sensorName);
+        LOG_ERROR("%s: Can't send command", sensorName);
         return false;
     }
 
@@ -317,18 +317,18 @@ bool SCD4XSensor::setASC(bool ascEnabled)
     error = scd4x.setAutomaticSelfCalibrationEnabled((uint16_t)ascEnabled);
 
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to send command", sensorName);
+        LOG_ERROR("%s: Can't send command", sensorName);
         return false;
     }
 
     error = scd4x.persistSettings();
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to make settings persistent", sensorName);
+        LOG_ERROR("%s: Can't persist settings", sensorName);
         return false;
     }
 
     if (!getASC(ascActive)) {
-        LOG_ERROR("%s: Unable to check if ASC is enabled", sensorName);
+        LOG_ERROR("%s: Can't check if ASC enabled", sensorName);
         return false;
     }
 
@@ -356,7 +356,7 @@ bool SCD4XSensor::setASCBaseline(uint32_t targetCO2)
 
     getASC(ascActive);
     if (!ascActive) {
-        LOG_ERROR("%s: Can't set ASC baseline. ASC is not active", sensorName);
+        LOG_ERROR("%s: Can't set ASC baseline, ASC not active", sensorName);
         return false;
     }
 
@@ -367,17 +367,17 @@ bool SCD4XSensor::setASCBaseline(uint32_t targetCO2)
     error = scd4x.setAutomaticSelfCalibrationTarget((uint16_t)targetCO2);
 
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to send command", sensorName);
+        LOG_ERROR("%s: Can't send command", sensorName);
         return false;
     }
 
     error = scd4x.persistSettings();
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to make settings persistent", sensorName);
+        LOG_ERROR("%s: Can't persist settings", sensorName);
         return false;
     }
 
-    LOG_INFO("%s: Setting ASC baseline successful", sensorName);
+    LOG_INFO("%s: ASC baseline set", sensorName);
 
     return true;
 }
@@ -414,7 +414,7 @@ bool SCD4XSensor::setTemperature(float tempReference)
     float temperature;
     float humidity;
 
-    LOG_INFO("%s: Setting reference temperature at: %.2f", sensorName, tempReference);
+    LOG_INFO("%s: Setting reference temp at: %.2f", sensorName, tempReference);
 
     error = scd4x.getDataReadyStatus(dataReady);
     if (error != SCD4X_NO_ERROR || !dataReady) {
@@ -424,11 +424,11 @@ bool SCD4XSensor::setTemperature(float tempReference)
 
     error = scd4x.readMeasurement(co2, temperature, humidity);
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to read current temperature. Error code: %u", sensorName, error);
+        LOG_ERROR("%s: Can't read current temp. Error: %u", sensorName, error);
         return false;
     }
 
-    LOG_INFO("%s: Current sensor temperature: %.2f", sensorName, temperature);
+    LOG_INFO("%s: Current sensor temp: %.2f", sensorName, temperature);
 
     if (!stopMeasurement()) {
         return false;
@@ -437,28 +437,28 @@ bool SCD4XSensor::setTemperature(float tempReference)
     error = scd4x.getTemperatureOffset(prevTempOffset);
 
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to get temperature offset. Error code: %u", sensorName, error);
+        LOG_ERROR("%s: Can't get temp offset. Error: %u", sensorName, error);
         return false;
     }
-    LOG_INFO("%s: Current sensor temperature offset: %.2f", sensorName, prevTempOffset);
+    LOG_INFO("%s: Current sensor temp offset: %.2f", sensorName, prevTempOffset);
 
     tempOffset = temperature - tempReference + prevTempOffset;
 
-    LOG_INFO("%s: Setting temperature offset: %.2f", sensorName, tempOffset);
+    LOG_INFO("%s: Setting temp offset: %.2f", sensorName, tempOffset);
     error = scd4x.setTemperatureOffset(tempOffset);
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to set temperature offset. Error code: %u", sensorName, error);
+        LOG_ERROR("%s: Can't set temp offset. Error: %u", sensorName, error);
         return false;
     }
 
     error = scd4x.persistSettings();
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to make settings persistent. Error code: %u", sensorName, error);
+        LOG_ERROR("%s: Can't persist settings. Error: %u", sensorName, error);
         return false;
     }
 
     scd4x.getTemperatureOffset(updatedTempOffset);
-    LOG_INFO("%s: Updated sensor temperature offset: %.2f", sensorName, updatedTempOffset);
+    LOG_INFO("%s: Updated sensor temp offset: %.2f", sensorName, updatedTempOffset);
 
     return true;
 }
@@ -484,7 +484,7 @@ bool SCD4XSensor::getAltitude(uint16_t &altitude)
     error = scd4x.getSensorAltitude(altitude);
 
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to get altitude. Error code: %u", sensorName, error);
+        LOG_ERROR("%s: Can't get altitude. Error: %u", sensorName, error);
         return false;
     }
     LOG_INFO("%s: Sensor altitude: %u", sensorName, altitude);
@@ -508,7 +508,7 @@ bool SCD4XSensor::getAmbientPressure(uint32_t &ambientPressure)
     error = scd4x.getAmbientPressure(ambientPressure);
 
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to get altitude. Error code: %u", sensorName, error);
+        LOG_ERROR("%s: Can't get altitude. Error: %u", sensorName, error);
         return false;
     }
     LOG_INFO("%s: Sensor ambient pressure: %u", sensorName, ambientPressure);
@@ -537,7 +537,7 @@ bool SCD4XSensor::setAltitude(uint32_t altitude)
     error = scd4x.setSensorAltitude(altitude);
 
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to set altitude. Error code: %u", sensorName, error);
+        LOG_ERROR("%s: Can't set altitude. Error: %u", sensorName, error);
         return false;
     }
 
@@ -577,18 +577,18 @@ bool SCD4XSensor::setAmbientPressure(uint32_t ambientPressure)
     error = scd4x.setAmbientPressure(ambientPressure);
 
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to set altitude. Error code: %u", sensorName, error);
+        LOG_ERROR("%s: Can't set altitude. Error: %u", sensorName, error);
         return false;
     }
 
     // Sensirion doesn't indicate if this is necessary. We send it anyway
     error = scd4x.persistSettings();
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to make settings persistent. Error code: %u", sensorName, error);
+        LOG_ERROR("%s: Can't persist settings. Error: %u", sensorName, error);
         return false;
     }
 
-    LOG_INFO("%s: ambient pressure set set", sensorName);
+    LOG_INFO("%s: ambient pressure set", sensorName);
 
     return true;
 }
@@ -615,11 +615,11 @@ bool SCD4XSensor::factoryReset()
     error = scd4x.performFactoryReset();
 
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to do factory reset. Error code: %u", sensorName, error);
+        LOG_ERROR("%s: Can't factory reset. Error: %u", sensorName, error);
         return false;
     }
 
-    LOG_INFO("%s: Factory reset successful", sensorName);
+    LOG_INFO("%s: Factory reset done", sensorName);
 
     return true;
 }
@@ -636,15 +636,15 @@ bool SCD4XSensor::factoryReset()
  */
 bool SCD4XSensor::powerDown()
 {
-    LOG_INFO("%s: Trying to send sensor to sleep", sensorName);
+    LOG_INFO("%s: Sending sensor to sleep", sensorName);
 
     if (sensorVariant != SCD4X_SENSOR_VARIANT_SCD41) {
-        LOG_WARN("SCD4X: Can't send sensor to sleep. Incorrect variant. Ignoring");
+        LOG_WARN("SCD4X: Can't sleep: wrong variant, ignoring");
         return true;
     }
 
 #ifdef SCD4X_I2C_CLOCK_SPEED
-    LOG_INFO("%s: attempting to reclock speed to %uHz", sensorName, SCD4X_I2C_CLOCK_SPEED);
+    LOG_INFO("%s: reclock to %uHz", sensorName, SCD4X_I2C_CLOCK_SPEED);
     reClockI2C.setClock(SCD4X_I2C_CLOCK_SPEED);
 #endif /* SCD4X_I2C_CLOCK_SPEED */
 
@@ -657,7 +657,7 @@ bool SCD4XSensor::powerDown()
     }
 
     if (scd4x.powerDown() != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Error trying to execute sleep()", sensorName);
+        LOG_ERROR("%s: Error executing sleep()", sensorName);
 #ifdef SCD4X_I2C_CLOCK_SPEED
         LOG_INFO("%s: restoring clock speed", sensorName);
         reClockI2C.restoreClock();
@@ -690,7 +690,7 @@ bool SCD4XSensor::powerUp()
     LOG_INFO("%s: Waking up", sensorName);
 
     if (scd4x.wakeUp() != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Error trying to execute wakeUp()", sensorName);
+        LOG_ERROR("%s: Error executing wakeUp()", sensorName);
         return false;
     }
 
@@ -715,7 +715,7 @@ uint32_t SCD4XSensor::wakeUp()
 {
 
 #ifdef SCD4X_I2C_CLOCK_SPEED
-    LOG_INFO("%s: attempting to reclock speed to %uHz", sensorName, SCD4X_I2C_CLOCK_SPEED);
+    LOG_INFO("%s: reclock to %uHz", sensorName, SCD4X_I2C_CLOCK_SPEED);
     reClockI2C.setClock(SCD4X_I2C_CLOCK_SPEED);
 #endif /* SCD4X_I2C_CLOCK_SPEED */
 
@@ -743,7 +743,7 @@ uint32_t SCD4XSensor::wakeUp()
 void SCD4XSensor::sleep()
 {
 #ifdef SCD4X_I2C_CLOCK_SPEED
-    LOG_INFO("%s: attempting to reclock speed to %uHz", sensorName, SCD4X_I2C_CLOCK_SPEED);
+    LOG_INFO("%s: reclock to %uHz", sensorName, SCD4X_I2C_CLOCK_SPEED);
     reClockI2C.setClock(SCD4X_I2C_CLOCK_SPEED);
 #endif /* SCD4X_I2C_CLOCK_SPEED */
 
@@ -780,7 +780,7 @@ int32_t SCD4XSensor::pendingForReadyMs()
     LOG_DEBUG("%s: Since measure started: %ums", sensorName, sinceCO2MeasureStarted);
 
     if (sinceCO2MeasureStarted < SCD4X_WARMUP_MS) {
-        LOG_INFO("%s: not enough time passed since starting measurement", sensorName);
+        LOG_INFO("%s: not enough time since measurement start", sensorName);
         return SCD4X_WARMUP_MS - sinceCO2MeasureStarted;
     }
     return 0;
@@ -792,7 +792,7 @@ AdminMessageHandleResult SCD4XSensor::handleAdminMessage(const meshtastic_MeshPa
     AdminMessageHandleResult result;
 
 #ifdef SCD4X_I2C_CLOCK_SPEED
-    LOG_INFO("%s: attempting to reclock speed to %uHz", sensorName, SCD4X_I2C_CLOCK_SPEED);
+    LOG_INFO("%s: reclock to %uHz", sensorName, SCD4X_I2C_CLOCK_SPEED);
     reClockI2C.setClock(SCD4X_I2C_CLOCK_SPEED);
 #endif /* SCD4X_I2C_CLOCK_SPEED */
 

--- a/src/modules/Telemetry/Sensor/SCD4XSensor.cpp
+++ b/src/modules/Telemetry/Sensor/SCD4XSensor.cpp
@@ -44,7 +44,7 @@ bool SCD4XSensor::initDevice(TwoWire *bus, ScanI2C::FoundDevice *dev)
     if (sensorVariant == SCD4X_SENSOR_VARIANT_SCD41) {
         LOG_INFO("%s: Found SCD41", sensorName);
         if (!powerUp()) {
-            LOG_ERROR("%s: Error executing powerUp()", sensorName);
+            LOG_ERROR("%s: powerUp() failed", sensorName);
 #ifdef SCD4X_I2C_CLOCK_SPEED
             LOG_INFO("%s: restoring clock speed", sensorName);
             reClockI2C.restoreClock();
@@ -185,7 +185,7 @@ bool SCD4XSensor::performFRC(uint32_t targetCO2)
     }
 
     if (frcCorr == 0xFFFF) {
-        LOG_ERROR("%s: Error performing FRC", sensorName);
+        LOG_ERROR("%s: FRC failed", sensorName);
         return false;
     }
 
@@ -424,7 +424,7 @@ bool SCD4XSensor::setTemperature(float tempReference)
 
     error = scd4x.readMeasurement(co2, temperature, humidity);
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Can't read current temp. Error: %u", sensorName, error);
+        LOG_ERROR("%s: Can't read current temp, rc=%u", sensorName, error);
         return false;
     }
 
@@ -437,7 +437,7 @@ bool SCD4XSensor::setTemperature(float tempReference)
     error = scd4x.getTemperatureOffset(prevTempOffset);
 
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Can't get temp offset. Error: %u", sensorName, error);
+        LOG_ERROR("%s: Can't get temp offset, rc=%u", sensorName, error);
         return false;
     }
     LOG_INFO("%s: Current sensor temp offset: %.2f", sensorName, prevTempOffset);
@@ -447,13 +447,13 @@ bool SCD4XSensor::setTemperature(float tempReference)
     LOG_INFO("%s: Setting temp offset: %.2f", sensorName, tempOffset);
     error = scd4x.setTemperatureOffset(tempOffset);
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Can't set temp offset. Error: %u", sensorName, error);
+        LOG_ERROR("%s: Can't set temp offset, rc=%u", sensorName, error);
         return false;
     }
 
     error = scd4x.persistSettings();
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Can't persist settings. Error: %u", sensorName, error);
+        LOG_ERROR("%s: Can't persist settings, rc=%u", sensorName, error);
         return false;
     }
 
@@ -484,7 +484,7 @@ bool SCD4XSensor::getAltitude(uint16_t &altitude)
     error = scd4x.getSensorAltitude(altitude);
 
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Can't get altitude. Error: %u", sensorName, error);
+        LOG_ERROR("%s: Can't get altitude, rc=%u", sensorName, error);
         return false;
     }
     LOG_INFO("%s: Sensor altitude: %u", sensorName, altitude);
@@ -508,7 +508,7 @@ bool SCD4XSensor::getAmbientPressure(uint32_t &ambientPressure)
     error = scd4x.getAmbientPressure(ambientPressure);
 
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Can't get altitude. Error: %u", sensorName, error);
+        LOG_ERROR("%s: Can't get ambient pressure, rc=%u", sensorName, error);
         return false;
     }
     LOG_INFO("%s: Sensor ambient pressure: %u", sensorName, ambientPressure);
@@ -537,7 +537,7 @@ bool SCD4XSensor::setAltitude(uint32_t altitude)
     error = scd4x.setSensorAltitude(altitude);
 
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Can't set altitude. Error: %u", sensorName, error);
+        LOG_ERROR("%s: Can't set altitude, rc=%u", sensorName, error);
         return false;
     }
 
@@ -577,14 +577,14 @@ bool SCD4XSensor::setAmbientPressure(uint32_t ambientPressure)
     error = scd4x.setAmbientPressure(ambientPressure);
 
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Can't set altitude. Error: %u", sensorName, error);
+        LOG_ERROR("%s: Can't set ambient pressure, rc=%u", sensorName, error);
         return false;
     }
 
     // Sensirion doesn't indicate if this is necessary. We send it anyway
     error = scd4x.persistSettings();
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Can't persist settings. Error: %u", sensorName, error);
+        LOG_ERROR("%s: Can't persist settings, rc=%u", sensorName, error);
         return false;
     }
 
@@ -615,7 +615,7 @@ bool SCD4XSensor::factoryReset()
     error = scd4x.performFactoryReset();
 
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Can't factory reset. Error: %u", sensorName, error);
+        LOG_ERROR("%s: Can't factory reset, rc=%u", sensorName, error);
         return false;
     }
 
@@ -657,7 +657,7 @@ bool SCD4XSensor::powerDown()
     }
 
     if (scd4x.powerDown() != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Error executing sleep()", sensorName);
+        LOG_ERROR("%s: sleep() failed", sensorName);
 #ifdef SCD4X_I2C_CLOCK_SPEED
         LOG_INFO("%s: restoring clock speed", sensorName);
         reClockI2C.restoreClock();
@@ -690,7 +690,7 @@ bool SCD4XSensor::powerUp()
     LOG_INFO("%s: Waking up", sensorName);
 
     if (scd4x.wakeUp() != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Error executing wakeUp()", sensorName);
+        LOG_ERROR("%s: wakeUp() failed", sensorName);
         return false;
     }
 

--- a/src/modules/Telemetry/Sensor/SCD4XSensor.cpp
+++ b/src/modules/Telemetry/Sensor/SCD4XSensor.cpp
@@ -136,7 +136,7 @@ bool SCD4XSensor::getMetrics(meshtastic_Telemetry *measurement)
     if (error != SCD4X_NO_ERROR) {
         LOG_DEBUG("%s: Error while getting measurements: %u", sensorName, error);
         if (co2 == 0) {
-            LOG_ERROR("%s: Skipping invalid measurement.", sensorName);
+            LOG_ERROR("%s: Skipping invalid measurement", sensorName);
         }
         return false;
     } else {
@@ -180,12 +180,12 @@ bool SCD4XSensor::performFRC(uint32_t targetCO2)
     delay(400);
 
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to perform forced recalibration.", sensorName);
+        LOG_ERROR("%s: Unable to perform forced recalibration", sensorName);
         return false;
     }
 
     if (frcCorr == 0xFFFF) {
-        LOG_ERROR("%s: Error while performing forced recalibration.", sensorName);
+        LOG_ERROR("%s: Error while performing forced recalibration", sensorName);
         return false;
     }
 
@@ -239,7 +239,7 @@ bool SCD4XSensor::stopMeasurement()
 
     error = scd4x.stopPeriodicMeasurement();
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to stop measurement.", sensorName);
+        LOG_ERROR("%s: Unable to stop measurement", sensorName);
         return false;
     }
 
@@ -286,7 +286,7 @@ bool SCD4XSensor::getASC(uint16_t &_ascActive)
     error = scd4x.getAutomaticSelfCalibrationEnabled(_ascActive);
 
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to send command.", sensorName);
+        LOG_ERROR("%s: Unable to send command", sensorName);
         return false;
     }
 
@@ -317,13 +317,13 @@ bool SCD4XSensor::setASC(bool ascEnabled)
     error = scd4x.setAutomaticSelfCalibrationEnabled((uint16_t)ascEnabled);
 
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to send command.", sensorName);
+        LOG_ERROR("%s: Unable to send command", sensorName);
         return false;
     }
 
     error = scd4x.persistSettings();
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to make settings persistent.", sensorName);
+        LOG_ERROR("%s: Unable to make settings persistent", sensorName);
         return false;
     }
 
@@ -367,13 +367,13 @@ bool SCD4XSensor::setASCBaseline(uint32_t targetCO2)
     error = scd4x.setAutomaticSelfCalibrationTarget((uint16_t)targetCO2);
 
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to send command.", sensorName);
+        LOG_ERROR("%s: Unable to send command", sensorName);
         return false;
     }
 
     error = scd4x.persistSettings();
     if (error != SCD4X_NO_ERROR) {
-        LOG_ERROR("%s: Unable to make settings persistent.", sensorName);
+        LOG_ERROR("%s: Unable to make settings persistent", sensorName);
         return false;
     }
 

--- a/src/modules/Telemetry/Sensor/SCD4XSensor.cpp
+++ b/src/modules/Telemetry/Sensor/SCD4XSensor.cpp
@@ -545,7 +545,7 @@ bool SCD4XSensor::setAltitude(uint32_t altitude)
     // doesn't indicate it's needed.
     // error = scd4x.persistSettings();
     // if (error != SCD4X_NO_ERROR) {
-    //     LOG_ERROR("%s: Unable to make settings persistent. Error code: %u", sensorName, error);
+    //     LOG_ERROR("%s: Can't make settings persistent. Error code: %u", sensorName, error);
     //     return false;
     // }
 

--- a/src/modules/Telemetry/Sensor/SEN5XSensor.cpp
+++ b/src/modules/Telemetry/Sensor/SEN5XSensor.cpp
@@ -132,7 +132,7 @@ bool SEN5XSensor::sendCommand(uint16_t command, uint8_t *buffer, uint8_t byteNum
     }
 
 #ifdef SEN5X_I2C_CLOCK_SPEED
-    LOG_DEBUG("%s: Attempting to reclock speed to %uHz", sensorName, SEN5X_I2C_CLOCK_SPEED);
+    LOG_DEBUG("%s: Reclock to %uHz", sensorName, SEN5X_I2C_CLOCK_SPEED);
     reClockI2C.setClock(SEN5X_I2C_CLOCK_SPEED);
 #endif /* SEN5X_I2C_CLOCK_SPEED */
 
@@ -164,7 +164,7 @@ bool SEN5XSensor::sendCommand(uint16_t command, uint8_t *buffer, uint8_t byteNum
 uint8_t SEN5XSensor::readBuffer(uint8_t *buffer, uint8_t byteNumber)
 {
 #ifdef SEN5X_I2C_CLOCK_SPEED
-    LOG_DEBUG("%s: Attempting to reclock speed to %uHz", sensorName, SEN5X_I2C_CLOCK_SPEED);
+    LOG_DEBUG("%s: Reclock to %uHz", sensorName, SEN5X_I2C_CLOCK_SPEED);
     reClockI2C.setClock(SEN5X_I2C_CLOCK_SPEED);
 #endif /* SEN5X_I2C_CLOCK_SPEED */
 
@@ -186,7 +186,7 @@ uint8_t SEN5XSensor::readBuffer(uint8_t *buffer, uint8_t byteNumber)
         uint8_t recvCRC = _bus->read();
         uint8_t calcCRC = sen5xCRC(&buffer[i - 2]);
         if (recvCRC != calcCRC) {
-            LOG_ERROR("%s: Checksum error while receiving msg", sensorName);
+            LOG_ERROR("%s: Checksum error receiving msg", sensorName);
 #ifdef SEN5X_I2C_CLOCK_SPEED
             LOG_DEBUG("%s: restoring clock speed", sensorName);
             reClockI2C.restoreClock();
@@ -259,7 +259,7 @@ bool SEN5XSensor::idle(bool checkState)
             }
 
             if (!(vocStateStable() && vocValid)) {
-                LOG_INFO("%s: Not stopping measurement, vocState is not stable yet", sensorName);
+                LOG_INFO("%s: Not stopping measurement, vocState not stable yet", sensorName);
                 return true;
             }
         }
@@ -378,7 +378,7 @@ bool SEN5XSensor::vocStateFromSensor()
     }
 
     // Print the state (if debug is on)
-    LOG_DEBUG("%s: VOC state retrieved from sensor: [%u, %u, %u, %u, %u, %u, %u, %u]", sensorName, vocState[0], vocState[1],
+    LOG_DEBUG("%s: VOC state from sensor: [%u, %u, %u, %u, %u, %u, %u, %u]", sensorName, vocState[0], vocState[1],
               vocState[2], vocState[3], vocState[4], vocState[5], vocState[6], vocState[7]);
 
     return true;
@@ -473,7 +473,7 @@ bool SEN5XSensor::saveState()
     okay &= file.close();
 
     if (okay)
-        LOG_INFO("%s: state write to %s successful", sensorName, sen5XStateFileName);
+        LOG_INFO("%s: state write to %s OK", sensorName, sen5XStateFileName);
 
     return okay;
 #else
@@ -537,7 +537,7 @@ bool SEN5XSensor::startCleaning()
     delay(20); // From Sensirion Datasheet
 
     // This message will be always printed so the user knows the device it's not hung
-    LOG_INFO("%s: Started fan cleaning it will take 10 seconds", sensorName);
+    LOG_INFO("%s: Started fan cleaning (10 sec)", sensorName);
 
     uint16_t started = millis();
     while (millis() - started < 10500) {
@@ -586,7 +586,7 @@ bool SEN5XSensor::initDevice(TwoWire *bus, ScanI2C::FoundDevice *dev)
     if (!getVersion())
         return false;
     if (firmwareVer < 2) {
-        LOG_ERROR("%s: firmware is too old and will not work with this implementation", sensorName);
+        LOG_ERROR("%s: firmware too old, unsupported", sensorName);
         return false;
     }
     delay(200); // From Sensirion Datasheet
@@ -611,11 +611,11 @@ bool SEN5XSensor::initDevice(TwoWire *bus, ScanI2C::FoundDevice *dev)
 
             if (passed > ONE_WEEK_IN_SECONDS && (now > SEN5X_VOC_VALID_DATE)) {
                 // If current date greater than 01/01/2018 (validity check)
-                LOG_INFO("%s: More than a week (%us) since last cleaning in epoch (%us). Trigger, cleaning", sensorName,
+                LOG_INFO("%s: Over a week (%us) since last cleaning (%us), trigger cleaning", sensorName,
                          passed, lastCleaning);
                 startCleaning();
             } else {
-                LOG_INFO("%s: Cleaning not needed (%ds passed). Last cleaning date (in epoch): %us", sensorName, passed,
+                LOG_INFO("%s: Cleaning not needed (%ds passed), last cleaning: %us", sensorName, passed,
                          lastCleaning);
             }
         } else {
@@ -625,7 +625,7 @@ bool SEN5XSensor::initDevice(TwoWire *bus, ScanI2C::FoundDevice *dev)
             // Otherwise, we will never trigger cleaning in some cases
             lastCleaning = now;
             lastCleaningValid = true;
-            LOG_INFO("%s: No valid last cleaning date found, saving it now: %us", sensorName, lastCleaning);
+            LOG_INFO("%s: No valid last cleaning date, saving now: %us", sensorName, lastCleaning);
             saveState();
         }
 
@@ -640,7 +640,7 @@ bool SEN5XSensor::initDevice(TwoWire *bus, ScanI2C::FoundDevice *dev)
                     LOG_INFO("%s: VOC state is valid and recent", sensorName);
                     vocStateToSensor();
                 } else {
-                    LOG_INFO("%s: VOC state is too old or date is invalid", sensorName);
+                    LOG_INFO("%s: VOC state too old or date invalid", sensorName);
                     LOG_DEBUG("%s: vocTime %u, Passed %u, and now %u", sensorName, vocTime, passed, now);
                 }
             }
@@ -821,7 +821,7 @@ int32_t SEN5XSensor::pendingForReadyMs()
     case SEN5X_MEASUREMENT: {
 
         if (sincePmMeasureStarted < SEN5X_WARMUP_MS_1) {
-            LOG_INFO("%s: not enough time passed since starting measurement", sensorName);
+            LOG_INFO("%s: not enough time since measurement start", sensorName);
             return SEN5X_WARMUP_MS_1 - sincePmMeasureStarted;
         }
 
@@ -835,7 +835,7 @@ int32_t SEN5XSensor::pendingForReadyMs()
 
         // If the reading is low (the tyhreshold is in #/cm3) and second warmUp hasn't passed we return to come back later
         if ((sen5xmeasurement.pN4p0 / 100) < SEN5X_PN4P0_CONC_THD && sincePmMeasureStarted < SEN5X_WARMUP_MS_2) {
-            LOG_INFO("%s: Concentration is low, we will ask again in the second warm up period", sensorName);
+            LOG_INFO("%s: Concentration low, will ask again in second warm up period", sensorName);
             state = SEN5X_MEASUREMENT_2;
             // Report how many seconds are pending to cover the first warm up period
             return SEN5X_WARMUP_MS_2 - sincePmMeasureStarted;
@@ -857,7 +857,7 @@ int32_t SEN5XSensor::pendingForReadyMs()
 
 bool SEN5XSensor::getMetrics(meshtastic_Telemetry *measurement)
 {
-    LOG_INFO("%s: Attempting to get metrics", sensorName);
+    LOG_INFO("%s: Get metrics", sensorName);
     if (!isActive()) {
         LOG_INFO("%s: not in measurement mode", sensorName);
         return false;
@@ -949,9 +949,9 @@ void SEN5XSensor::setMode(bool setOneShot)
 {
     oneShotMode = setOneShot;
     if (oneShotMode) {
-        LOG_INFO("%s: setting mode to one shot mode", sensorName);
+        LOG_INFO("%s: set one shot mode", sensorName);
     } else {
-        LOG_INFO("%s: setting mode to continuous mode", sensorName);
+        LOG_INFO("%s: set continuous mode", sensorName);
     }
 }
 

--- a/src/modules/Telemetry/Sensor/SEN5XSensor.cpp
+++ b/src/modules/Telemetry/Sensor/SEN5XSensor.cpp
@@ -378,8 +378,8 @@ bool SEN5XSensor::vocStateFromSensor()
     }
 
     // Print the state (if debug is on)
-    LOG_DEBUG("%s: VOC state from sensor: [%u, %u, %u, %u, %u, %u, %u, %u]", sensorName, vocState[0], vocState[1],
-              vocState[2], vocState[3], vocState[4], vocState[5], vocState[6], vocState[7]);
+    LOG_DEBUG("%s: VOC state from sensor: [%u, %u, %u, %u, %u, %u, %u, %u]", sensorName, vocState[0], vocState[1], vocState[2],
+              vocState[3], vocState[4], vocState[5], vocState[6], vocState[7]);
 
     return true;
 }
@@ -611,12 +611,10 @@ bool SEN5XSensor::initDevice(TwoWire *bus, ScanI2C::FoundDevice *dev)
 
             if (passed > ONE_WEEK_IN_SECONDS && (now > SEN5X_VOC_VALID_DATE)) {
                 // If current date greater than 01/01/2018 (validity check)
-                LOG_INFO("%s: Over a week (%us) since last cleaning (%us), trigger cleaning", sensorName,
-                         passed, lastCleaning);
+                LOG_INFO("%s: Over a week (%us) since last cleaning (%us), trigger cleaning", sensorName, passed, lastCleaning);
                 startCleaning();
             } else {
-                LOG_INFO("%s: Cleaning not needed (%ds passed), last cleaning: %us", sensorName, passed,
-                         lastCleaning);
+                LOG_INFO("%s: Cleaning not needed (%ds passed), last cleaning: %us", sensorName, passed, lastCleaning);
             }
         } else {
             // We assume the device has just been updated or it is new,

--- a/src/modules/Telemetry/Sensor/SEN5XSensor.cpp
+++ b/src/modules/Telemetry/Sensor/SEN5XSensor.cpp
@@ -259,7 +259,7 @@ bool SEN5XSensor::idle(bool checkState)
             }
 
             if (!(vocStateStable() && vocValid)) {
-                LOG_INFO("%s: Not stopping measurement, vocState is not stable yet!", sensorName);
+                LOG_INFO("%s: Not stopping measurement, vocState is not stable yet", sensorName);
                 return true;
             }
         }
@@ -268,7 +268,7 @@ bool SEN5XSensor::idle(bool checkState)
     }
 
     if (!oneShotMode) {
-        LOG_INFO("%s: Not stopping measurement, continuous mode!", sensorName);
+        LOG_INFO("%s: Not stopping measurement, continuous mode", sensorName);
         return true;
     } else {
         LOG_INFO("%s: One shot mode enabled", sensorName);
@@ -537,7 +537,7 @@ bool SEN5XSensor::startCleaning()
     delay(20); // From Sensirion Datasheet
 
     // This message will be always printed so the user knows the device it's not hung
-    LOG_INFO("%s: Started fan cleaning it will take 10 seconds...", sensorName);
+    LOG_INFO("%s: Started fan cleaning it will take 10 seconds", sensorName);
 
     uint16_t started = millis();
     while (millis() - started < 10500) {
@@ -611,7 +611,7 @@ bool SEN5XSensor::initDevice(TwoWire *bus, ScanI2C::FoundDevice *dev)
 
             if (passed > ONE_WEEK_IN_SECONDS && (now > SEN5X_VOC_VALID_DATE)) {
                 // If current date greater than 01/01/2018 (validity check)
-                LOG_INFO("%s: More than a week (%us) since last cleaning in epoch (%us). Trigger, cleaning...", sensorName,
+                LOG_INFO("%s: More than a week (%us) since last cleaning in epoch (%us). Trigger, cleaning", sensorName,
                          passed, lastCleaning);
                 startCleaning();
             } else {

--- a/src/modules/TraceRouteModule.cpp
+++ b/src/modules/TraceRouteModule.cpp
@@ -310,7 +310,7 @@ void TraceRouteModule::updateNextHops(const meshtastic_MeshPacket &p, meshtastic
         // point any node's next_hop anywhere. relay_node is 0 for MQTT-sourced packets, which cannot
         // corroborate an RF route either.
         if (p.relay_node == NO_RELAY_NODE || nextHopByte != p.relay_node) {
-            LOG_DEBUG("Ignore traceroute next-hop 0x%02x, packet was relayed by 0x%02x", nextHopByte, p.relay_node);
+            LOG_DEBUG("Ignore traceroute next-hop 0x%02x, relayed by 0x%02x", nextHopByte, p.relay_node);
             return;
         }
 
@@ -333,7 +333,7 @@ void TraceRouteModule::maybeSetNextHop(NodeNum target, uint8_t nextHopByte)
 
     meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(target);
     if (node && node->next_hop != nextHopByte) {
-        LOG_INFO("Updating next-hop for 0x%08x to 0x%02x based on traceroute", target, nextHopByte);
+        LOG_INFO("Update next-hop for 0x%08x to 0x%02x via traceroute", target, nextHopByte);
         node->next_hop = nextHopByte;
     }
 
@@ -437,7 +437,7 @@ void TraceRouteModule::appendMyIDandSNR(meshtastic_RouteDiscovery *updated, floa
         route[*route_count] = myNodeInfo.my_node_num;
         *route_count += 1;
     } else {
-        LOG_WARN("Route exceeded maximum hop limit"); // Are you bridging networks?
+        LOG_WARN("Route exceeded max hop limit"); // Are you bridging networks?
     }
 }
 
@@ -533,11 +533,11 @@ const char *TraceRouteModule::getNodeName(NodeNum node)
 
 bool TraceRouteModule::startTraceRoute(NodeNum node)
 {
-    LOG_INFO("=== TraceRoute startTraceRoute CALLED: node=0x%08x ===", node);
+    LOG_INFO("TraceRoute startTraceRoute: node=0x%08x", node);
     unsigned long now = millis();
 
     if (node == 0 || node == NODENUM_BROADCAST) {
-        LOG_ERROR("Invalid node number for trace route: 0x%08x", node);
+        LOG_ERROR("Invalid trace route node: 0x%08x", node);
         runState = TRACEROUTE_STATE_RESULT;
         setResultText("Invalid node");
         resultShowTime = millis();
@@ -567,7 +567,7 @@ bool TraceRouteModule::startTraceRoute(NodeNum node)
     if (!initialized) {
         lastTraceRouteTime = 0;
         initialized = true;
-        LOG_INFO("TraceRoute initialized for first time");
+        LOG_INFO("TraceRoute first init");
     }
 
     if (runState == TRACEROUTE_STATE_TRACKING) {
@@ -587,7 +587,7 @@ bool TraceRouteModule::startTraceRoute(NodeNum node)
         UIFrameEvent e;
         e.action = UIFrameEvent::Action::REGENERATE_FRAMESET;
         notifyObservers(&e);
-        LOG_INFO("Cooldown active, please wait %lu seconds before starting a new trace route", wait);
+        LOG_INFO("Cooldown active, wait %lu sec before new trace route", wait);
         return false;
     }
 
@@ -598,7 +598,7 @@ bool TraceRouteModule::startTraceRoute(NodeNum node)
     clearResultLines();
     bannerText = String("Tracing ") + getNodeName(node);
 
-    LOG_INFO("TraceRoute UI: Starting trace route to node 0x%08x, requesting focus", node);
+    LOG_INFO("TraceRoute UI: Start trace to 0x%08x, request focus", node);
 
     // 请求焦点，然后触发UI更新事件
     requestFocus();
@@ -629,7 +629,7 @@ bool TraceRouteModule::startTraceRoute(NodeNum node)
 
         LOG_INFO("Packet allocated: to=0x%08x, portnum=%d, want_response=%d, payload_size=%d", p->to,
                  p->decoded.portnum, p->decoded.want_response, p->decoded.payload.size);
-        LOG_INFO("About to call service->sendToMesh");
+        LOG_INFO("Calling service->sendToMesh");
 
         if (service) {
             LOG_INFO("MeshService is available, sending packet");
@@ -649,7 +649,7 @@ bool TraceRouteModule::startTraceRoute(NodeNum node)
             return false;
         }
     } else {
-        LOG_ERROR("Failed to allocate TraceRoute packet from router");
+        LOG_ERROR("TraceRoute packet alloc from router failed");
         runState = TRACEROUTE_STATE_RESULT;
         setResultText("Failed to send");
         resultShowTime = millis();
@@ -667,7 +667,7 @@ bool TraceRouteModule::startTraceRoute(NodeNum node)
 void TraceRouteModule::launch(NodeNum node)
 {
     if (node == 0 || node == NODENUM_BROADCAST) {
-        LOG_ERROR("Invalid node number for trace route: 0x%08x", node);
+        LOG_ERROR("Invalid trace route node: 0x%08x", node);
         runState = TRACEROUTE_STATE_RESULT;
         setResultText("Invalid node");
         resultShowTime = millis();
@@ -697,7 +697,7 @@ void TraceRouteModule::launch(NodeNum node)
     if (!initialized) {
         lastTraceRouteTime = 0;
         initialized = true;
-        LOG_INFO("TraceRoute initialized for first time");
+        LOG_INFO("TraceRoute first init");
     }
 
     unsigned long now = millis();
@@ -712,7 +712,7 @@ void TraceRouteModule::launch(NodeNum node)
         UIFrameEvent e;
         e.action = UIFrameEvent::Action::REGENERATE_FRAMESET;
         notifyObservers(&e);
-        LOG_INFO("Cooldown active, please wait %lu seconds before starting a new trace route", wait);
+        LOG_INFO("Cooldown active, wait %lu sec before new trace route", wait);
         return;
     }
 
@@ -760,7 +760,7 @@ void TraceRouteModule::launch(NodeNum node)
             tracingNode = 0;
         }
     } else {
-        LOG_ERROR("Failed to allocate TraceRoute packet from router");
+        LOG_ERROR("TraceRoute packet alloc from router failed");
         runState = TRACEROUTE_STATE_RESULT;
         setResultText("Failed to send");
         resultShowTime = millis();
@@ -775,7 +775,7 @@ void TraceRouteModule::handleTraceRouteResult(const String &result)
     resultShowTime = millis();
     tracingNode = 0;
 
-    LOG_INFO("TraceRoute result ready, requesting focus. Result: %s", result.c_str());
+    LOG_INFO("TraceRoute result ready, request focus: %s", result.c_str());
 
     setIntervalFromNow(1000);
 
@@ -784,7 +784,7 @@ void TraceRouteModule::handleTraceRouteResult(const String &result)
     e.action = UIFrameEvent::Action::REGENERATE_FRAMESET;
     notifyObservers(&e);
 
-    LOG_INFO("=== TraceRoute handleTraceRouteResult END ===");
+    LOG_INFO("TraceRoute handleTraceRouteResult END");
 }
 
 bool TraceRouteModule::shouldDraw()
@@ -850,7 +850,7 @@ int32_t TraceRouteModule::runOnce()
 
     // Check for tracking timeout
     if (runState == TRACEROUTE_STATE_TRACKING && now - lastTraceRouteTime > trackingTimeoutMs) {
-        LOG_INFO("TraceRoute timeout, no response received");
+        LOG_INFO("TraceRoute timeout, no response");
         runState = TRACEROUTE_STATE_RESULT;
         setResultText("No response received");
         resultShowTime = now;
@@ -886,7 +886,7 @@ int32_t TraceRouteModule::runOnce()
             return 1000;
         } else {
             // Cooldown finished
-            LOG_INFO("TraceRoute cooldown finished, returning to IDLE");
+            LOG_INFO("TraceRoute cooldown done, return to IDLE");
             runState = TRACEROUTE_STATE_IDLE;
             resultText = "";
             clearResultLines();

--- a/src/modules/TraceRouteModule.cpp
+++ b/src/modules/TraceRouteModule.cpp
@@ -437,7 +437,7 @@ void TraceRouteModule::appendMyIDandSNR(meshtastic_RouteDiscovery *updated, floa
         route[*route_count] = myNodeInfo.my_node_num;
         *route_count += 1;
     } else {
-        LOG_WARN("Route exceeded maximum hop limit!"); // Are you bridging networks?
+        LOG_WARN("Route exceeded maximum hop limit"); // Are you bridging networks?
     }
 }
 
@@ -587,7 +587,7 @@ bool TraceRouteModule::startTraceRoute(NodeNum node)
         UIFrameEvent e;
         e.action = UIFrameEvent::Action::REGENERATE_FRAMESET;
         notifyObservers(&e);
-        LOG_INFO("Cooldown active, please wait %lu seconds before starting a new trace route.", wait);
+        LOG_INFO("Cooldown active, please wait %lu seconds before starting a new trace route", wait);
         return false;
     }
 
@@ -610,7 +610,7 @@ bool TraceRouteModule::startTraceRoute(NodeNum node)
     setIntervalFromNow(1000); // 每秒检查一次状态
 
     meshtastic_RouteDiscovery req = meshtastic_RouteDiscovery_init_zero;
-    LOG_INFO("Creating RouteDiscovery protobuf...");
+    LOG_INFO("Creating RouteDiscovery protobuf");
 
     // Allocate a packet directly from router like the reference code
     meshtastic_MeshPacket *p = router->allocForSending();
@@ -627,16 +627,16 @@ bool TraceRouteModule::startTraceRoute(NodeNum node)
         p->decoded.payload.size =
             pb_encode_to_bytes(p->decoded.payload.bytes, sizeof(p->decoded.payload.bytes), &meshtastic_RouteDiscovery_msg, &req);
 
-        LOG_INFO("Packet allocated successfully: to=0x%08x, portnum=%d, want_response=%d, payload_size=%d", p->to,
+        LOG_INFO("Packet allocated: to=0x%08x, portnum=%d, want_response=%d, payload_size=%d", p->to,
                  p->decoded.portnum, p->decoded.want_response, p->decoded.payload.size);
-        LOG_INFO("About to call service->sendToMesh...");
+        LOG_INFO("About to call service->sendToMesh");
 
         if (service) {
-            LOG_INFO("MeshService is available, sending packet...");
+            LOG_INFO("MeshService is available, sending packet");
             service->sendToMesh(p, RX_SRC_USER);
-            LOG_INFO("sendToMesh called successfully for trace route to node 0x%08x", node);
+            LOG_INFO("sendToMesh called for trace route to node 0x%08x", node);
         } else {
-            LOG_ERROR("MeshService is NULL!");
+            LOG_ERROR("MeshService is NULL");
             runState = TRACEROUTE_STATE_RESULT;
             setResultText("Service unavailable");
             resultShowTime = millis();
@@ -712,7 +712,7 @@ void TraceRouteModule::launch(NodeNum node)
         UIFrameEvent e;
         e.action = UIFrameEvent::Action::REGENERATE_FRAMESET;
         notifyObservers(&e);
-        LOG_INFO("Cooldown active, please wait %lu seconds before starting a new trace route.", wait);
+        LOG_INFO("Cooldown active, please wait %lu seconds before starting a new trace route", wait);
         return;
     }
 
@@ -732,7 +732,7 @@ void TraceRouteModule::launch(NodeNum node)
     setIntervalFromNow(1000);
 
     meshtastic_RouteDiscovery req = meshtastic_RouteDiscovery_init_zero;
-    LOG_INFO("Creating RouteDiscovery protobuf...");
+    LOG_INFO("Creating RouteDiscovery protobuf");
 
     meshtastic_MeshPacket *p = router->allocForSending();
     if (p) {
@@ -746,14 +746,14 @@ void TraceRouteModule::launch(NodeNum node)
         p->decoded.payload.size =
             pb_encode_to_bytes(p->decoded.payload.bytes, sizeof(p->decoded.payload.bytes), &meshtastic_RouteDiscovery_msg, &req);
 
-        LOG_INFO("Packet allocated successfully: to=0x%08x, portnum=%d, want_response=%d, payload_size=%d", p->to,
+        LOG_INFO("Packet allocated: to=0x%08x, portnum=%d, want_response=%d, payload_size=%d", p->to,
                  p->decoded.portnum, p->decoded.want_response, p->decoded.payload.size);
 
         if (service) {
             service->sendToMesh(p, RX_SRC_USER);
-            LOG_INFO("sendToMesh called successfully for trace route to node 0x%08x", node);
+            LOG_INFO("sendToMesh called for trace route to node 0x%08x", node);
         } else {
-            LOG_ERROR("MeshService is NULL!");
+            LOG_ERROR("MeshService is NULL");
             runState = TRACEROUTE_STATE_RESULT;
             setResultText("Service unavailable");
             resultShowTime = millis();

--- a/src/modules/TraceRouteModule.cpp
+++ b/src/modules/TraceRouteModule.cpp
@@ -551,7 +551,7 @@ bool TraceRouteModule::startTraceRoute(NodeNum node)
     }
 
     if (node == nodeDB->getNodeNum()) {
-        LOG_ERROR("Cannot trace route to self: 0x%08x", node);
+        LOG_ERROR("Can't trace route to self: 0x%08x", node);
         runState = TRACEROUTE_STATE_RESULT;
         setResultText("Cannot trace self");
         resultShowTime = millis();
@@ -681,7 +681,7 @@ void TraceRouteModule::launch(NodeNum node)
     }
 
     if (node == nodeDB->getNodeNum()) {
-        LOG_ERROR("Cannot trace route to self: 0x%08x", node);
+        LOG_ERROR("Can't trace route to self: 0x%08x", node);
         runState = TRACEROUTE_STATE_RESULT;
         setResultText("Cannot trace self");
         resultShowTime = millis();

--- a/src/modules/TraceRouteModule.cpp
+++ b/src/modules/TraceRouteModule.cpp
@@ -627,8 +627,8 @@ bool TraceRouteModule::startTraceRoute(NodeNum node)
         p->decoded.payload.size =
             pb_encode_to_bytes(p->decoded.payload.bytes, sizeof(p->decoded.payload.bytes), &meshtastic_RouteDiscovery_msg, &req);
 
-        LOG_INFO("Packet allocated: to=0x%08x, portnum=%d, want_response=%d, payload_size=%d", p->to,
-                 p->decoded.portnum, p->decoded.want_response, p->decoded.payload.size);
+        LOG_INFO("Packet allocated: to=0x%08x, portnum=%d, want_response=%d, payload_size=%d", p->to, p->decoded.portnum,
+                 p->decoded.want_response, p->decoded.payload.size);
         LOG_INFO("Calling service->sendToMesh");
 
         if (service) {
@@ -746,8 +746,8 @@ void TraceRouteModule::launch(NodeNum node)
         p->decoded.payload.size =
             pb_encode_to_bytes(p->decoded.payload.bytes, sizeof(p->decoded.payload.bytes), &meshtastic_RouteDiscovery_msg, &req);
 
-        LOG_INFO("Packet allocated: to=0x%08x, portnum=%d, want_response=%d, payload_size=%d", p->to,
-                 p->decoded.portnum, p->decoded.want_response, p->decoded.payload.size);
+        LOG_INFO("Packet allocated: to=0x%08x, portnum=%d, want_response=%d, payload_size=%d", p->to, p->decoded.portnum,
+                 p->decoded.want_response, p->decoded.payload.size);
 
         if (service) {
             service->sendToMesh(p, RX_SRC_USER);

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -148,7 +148,7 @@ TrafficManagementModule::TrafficManagementModule() : MeshModule("TrafficManageme
     if (cache) {
         cacheFromPsram = true;
     } else {
-        TM_LOG_WARN("PSRAM allocation failed, falling back to heap");
+        TM_LOG_WARN("PSRAM alloc failed, fall back to heap");
         cache = new UnifiedCacheEntry[allocSize]();
     }
 #else
@@ -171,7 +171,7 @@ TrafficManagementModule::TrafficManagementModule() : MeshModule("TrafficManageme
         nodeInfoPayloadFromPsram = true;
         TM_LOG_INFO("NodeInfo PSRAM cache ready");
     } else {
-        TM_LOG_WARN("NodeInfo PSRAM payload allocation failed; direct responses will fall back to NodeDB");
+        TM_LOG_WARN("NodeInfo PSRAM payload alloc failed; direct responses fall back to NodeDB");
     }
 #else
     // Native unit-test build (see TMM_HAS_NODEINFO_CACHE): plain heap, so the cache paths
@@ -1515,7 +1515,7 @@ bool TrafficManagementModule::shouldRespondToNodeInfo(const meshtastic_MeshPacke
     // request declined above never spends the budget). false forwards the request instead of consuming
     // it. Rationale in docs/traffic_management_module.md "Throttling direct responses".
     if (!directResponseAllowed(getFrom(p), p->to, clockMs())) {
-        TM_LOG_DEBUG("NodeInfo direct response throttled for 0x%08x; forwarding request instead", getFrom(p));
+        TM_LOG_DEBUG("NodeInfo direct response throttled for 0x%08x; forwarding request", getFrom(p));
         return false;
     }
 

--- a/src/modules/esp32/PaxcounterModule.cpp
+++ b/src/modules/esp32/PaxcounterModule.cpp
@@ -24,7 +24,7 @@ static void startWifiChannelTimer(uint16_t wifi_channel_switch_interval)
     WifiChanTimer =
         xTimerCreate("WifiChannelTimer", pdMS_TO_TICKS(wifi_channel_switch_interval * 10), pdTRUE, (void *)0, switchWifiChannel);
     if (!WifiChanTimer) {
-        LOG_WARN("Paxcounter could not create WiFi channel switch timer");
+        LOG_WARN("Paxcounter can't create WiFi channel switch timer");
         return;
     }
     xTimerStart(WifiChanTimer, 0);
@@ -34,7 +34,7 @@ static void ensureDefaultEventLoop()
 {
     esp_err_t result = esp_event_loop_create_default();
     if (result != ESP_OK && result != ESP_ERR_INVALID_STATE) {
-        LOG_WARN("Paxcounter could not create ESP event loop: %d", result);
+        LOG_WARN("Paxcounter can't create ESP event loop: %d", result);
     }
 }
 

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -127,12 +127,12 @@ inline void onReceiveProto(char *topic, byte *payload, size_t length)
             if (router->sendLocal(pAck) == ERRNO_SHOULD_RELEASE)
                 packetPool.release(pAck);
         } else {
-            LOG_INFO("Ignore downlink message we originally sent");
+            LOG_INFO("Ignore downlink msg we sent");
         }
         return;
     }
     if (isFromUs(e.packet)) {
-        LOG_INFO("Ignore downlink message we originally sent");
+        LOG_INFO("Ignore downlink msg we sent");
         return;
     }
 
@@ -163,7 +163,7 @@ inline void onReceiveProto(char *topic, byte *payload, size_t length)
 
     if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
         if (moduleConfig.mqtt.encryption_enabled) {
-            LOG_INFO("Ignore decoded message on MQTT, encryption is enabled");
+            LOG_INFO("Ignore decoded msg on MQTT, encryption enabled");
             return;
         }
         if (p->decoded.portnum == meshtastic_PortNum_ADMIN_APP) {
@@ -179,7 +179,7 @@ inline void onReceiveProto(char *topic, byte *payload, size_t length)
         // (perhapsDecode) does - checkXeddsaReceivePolicy -> xeddsa_verify mutates shared
         // CryptoEngine cache state, and MQTT ingress can run on a different task.
         if (passesRoutingAuthGate(p.get()) != RoutingAuthVerdict::ACCEPT) {
-            LOG_INFO("Ignore decoded message failing XEdDSA policy");
+            LOG_INFO("Ignore decoded msg failing XEdDSA policy");
             return;
         }
 #endif
@@ -281,7 +281,7 @@ bool connectPubSub(const PubSubConfig &config, PubSubClient &pubSub, Client &cli
     pubSub.setClient(client);
     pubSub.setServer(config.serverAddr.c_str(), config.serverPort);
 
-    LOG_INFO("Connecting directly to MQTT server %s, port: %d, username: %s, password: ***", config.serverAddr.c_str(),
+    LOG_INFO("Direct MQTT connect %s, port %d, user %s, password ***", config.serverAddr.c_str(),
              config.serverPort, config.mqttUsername);
 
     // Generate node ID from nodenum for client identification
@@ -292,7 +292,7 @@ bool connectPubSub(const PubSubConfig &config, PubSubClient &pubSub, Client &cli
         LOG_INFO("MQTT connected");
     } else {
         isConnected = false;
-        LOG_WARN("Failed to connect to MQTT server");
+        LOG_WARN("MQTT server connect failed");
     }
     return connected;
 }
@@ -347,7 +347,7 @@ void MQTT::onClientProxyReceive(meshtastic_MqttClientProxyMessage msg)
                   strnlen(msg.payload_variant.text, sizeof(msg.payload_variant.text)));
         break;
     default:
-        LOG_WARN("MQTT proxy message carries no payload, topic %s", msg.topic);
+        LOG_WARN("MQTT proxy msg has no payload, topic %s", msg.topic);
         break;
     }
 }
@@ -355,7 +355,7 @@ void MQTT::onClientProxyReceive(meshtastic_MqttClientProxyMessage msg)
 void MQTT::onReceive(char *topic, byte *payload, size_t length)
 {
     if (length == 0) {
-        LOG_WARN("Empty MQTT payload received, topic %s", topic);
+        LOG_WARN("Empty MQTT payload, topic %s", topic);
         return;
     }
 
@@ -413,7 +413,7 @@ MQTT::MQTT() : concurrency::OSThread("mqtt"), mqttQueue(MAX_MQTT_QUEUE)
 #endif
 
         if (moduleConfig.mqtt.proxy_to_client_enabled) {
-            LOG_INFO("MQTT configured to use client proxy");
+            LOG_INFO("MQTT uses client proxy");
             enabled = true;
             runASAP = true;
             reconnectCount = 0;
@@ -520,16 +520,16 @@ void MQTT::reconnect()
         } else {
 #if HAS_WIFI && !defined(ARCH_PORTDUINO)
             reconnectCount++;
-            LOG_ERROR("Failed to contact MQTT server directly (%d/%d)", reconnectCount, reconnectMax);
+            LOG_ERROR("Direct MQTT contact failed (%d/%d)", reconnectCount, reconnectMax);
             if (reconnectCount >= reconnectMax) {
 #if defined(USE_WS5500) || defined(USE_CH390D)
-                LOG_WARN("MQTT connect failed repeatedly; waiting for Ethernet reconnect");
+                LOG_WARN("MQTT connect keeps failing; wait for Ethernet reconnect");
 #else
                 needReconnect = true;
                 if (wifiReconnect) {
                     wifiReconnect->setIntervalFromNow(0);
                 } else {
-                    LOG_WARN("MQTT connect failed repeatedly, but WiFi reconnect is unavailable");
+                    LOG_WARN("MQTT connect keeps failing, WiFi reconnect unavailable");
                 }
 #endif
                 reconnectCount = 0;
@@ -615,7 +615,7 @@ bool MQTT::isValidConfig(const meshtastic_ModuleConfig_MQTTConfig &config, MQTTC
 #if HAS_NETWORKING
         if (config.tls_enabled) {
 #if !MQTT_SUPPORTS_TLS
-            LOG_ERROR("Invalid MQTT config: tls_enabled is not supported on this node");
+            LOG_ERROR("Invalid MQTT config: tls_enabled unsupported on this node");
             return false;
 #endif
         }
@@ -715,13 +715,13 @@ void MQTT::onSend(const meshtastic_MeshPacket &mp_encrypted, const meshtastic_Me
         bool dontUplink = !mp_decoded.decoded.has_bitfield || !(mp_decoded.decoded.bitfield & BITFIELD_OK_TO_MQTT_MASK);
         // Respect the DontMqttMeBro flag for other nodes' packets on public MQTT servers
         if (!isFromUs(&mp_decoded) && !isMqttServerAddressPrivate && dontUplink) {
-            LOG_INFO("MQTT onSend - Not forwarding packet due to DontMqttMeBro flag");
+            LOG_INFO("MQTT onSend - drop packet: DontMqttMeBro flag");
             return;
         }
 
         if (isConfiguredForDefaultServer && (mp_decoded.decoded.portnum == meshtastic_PortNum_RANGE_TEST_APP ||
                                              mp_decoded.decoded.portnum == meshtastic_PortNum_DETECTION_SENSOR_APP)) {
-            LOG_DEBUG("MQTT onSend - Ignoring range test or detection sensor message on public mqtt");
+            LOG_DEBUG("MQTT onSend - Ignore range test/detection sensor msg on public mqtt");
             return;
         }
     }
@@ -769,7 +769,7 @@ void MQTT::onSend(const meshtastic_MeshPacket &mp_encrypted, const meshtastic_Me
         entry->topic = std::move(topic);
         entry->envBytes.assign(bytes, numBytes);
         if (mqttQueue.enqueue(entry, 0) == false) {
-            LOG_CRIT("Failed to add a message to mqttQueue");
+            LOG_CRIT("Can't add msg to mqttQueue");
             abort();
         }
     }
@@ -784,7 +784,7 @@ void MQTT::perhapsReportToMap()
     // Coerce the map position precision to be within the valid range
     // This removes obtusely large radius and privacy problematic ones from the map
     if (map_position_precision < 12 || map_position_precision > 15) {
-        LOG_WARN("MQTT Map report position precision %u is out of range, using default %u", map_position_precision,
+        LOG_WARN("MQTT Map report position precision %u out of range, use default %u", map_position_precision,
                  default_map_position_precision);
         map_position_precision = default_map_position_precision;
     }
@@ -794,7 +794,7 @@ void MQTT::perhapsReportToMap()
 
     if (localPosition.latitude_i == 0 && localPosition.longitude_i == 0) {
         if (Throttle::isWithinTimespanMs(lastPositionUnavailableWarning, POSITION_UNAVAILABLE_WARNING_INTERVAL_MS) == false) {
-            LOG_WARN("MQTT Map report enabled, but no position available");
+            LOG_WARN("MQTT Map report enabled but no position");
             lastPositionUnavailableWarning = millis();
         }
         return;

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -89,7 +89,7 @@ inline void onReceiveProto(char *topic, byte *payload, size_t length)
 {
     const DecodedServiceEnvelope e(payload, length);
     if (!e.validDecode || e.channel_id == NULL || e.gateway_id == NULL || e.packet == NULL) {
-        LOG_ERROR("Invalid MQTT service envelope, topic %s, len %u!", topic, length);
+        LOG_ERROR("Invalid MQTT service envelope, topic %s, len %u", topic, length);
         return;
     }
 
@@ -355,7 +355,7 @@ void MQTT::onClientProxyReceive(meshtastic_MqttClientProxyMessage msg)
 void MQTT::onReceive(char *topic, byte *payload, size_t length)
 {
     if (length == 0) {
-        LOG_WARN("Empty MQTT payload received, topic %s!", topic);
+        LOG_WARN("Empty MQTT payload received, topic %s", topic);
         return;
     }
 
@@ -769,7 +769,7 @@ void MQTT::onSend(const meshtastic_MeshPacket &mp_encrypted, const meshtastic_Me
         entry->topic = std::move(topic);
         entry->envBytes.assign(bytes, numBytes);
         if (mqttQueue.enqueue(entry, 0) == false) {
-            LOG_CRIT("Failed to add a message to mqttQueue!");
+            LOG_CRIT("Failed to add a message to mqttQueue");
             abort();
         }
     }

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -281,8 +281,8 @@ bool connectPubSub(const PubSubConfig &config, PubSubClient &pubSub, Client &cli
     pubSub.setClient(client);
     pubSub.setServer(config.serverAddr.c_str(), config.serverPort);
 
-    LOG_INFO("Direct MQTT connect %s, port %d, user %s, password ***", config.serverAddr.c_str(),
-             config.serverPort, config.mqttUsername);
+    LOG_INFO("Direct MQTT connect %s, port %d, user %s, password ***", config.serverAddr.c_str(), config.serverPort,
+             config.mqttUsername);
 
     // Generate node ID from nodenum for client identification
     std::string nodeId = nodeDB->getNodeId();

--- a/src/nimble/NimbleBluetooth.cpp
+++ b/src/nimble/NimbleBluetooth.cpp
@@ -347,8 +347,7 @@ class BluetoothPhoneAPI : public PhoneAPI, public concurrency::OSThread
                         toPhoneQueueSize++;
                     }
 #ifdef DEBUG_NIMBLE_ON_READ_TIMING
-                    LOG_DEBUG("BLE getFromRadio numBytes=%u, toPhoneQueueSize=%u", numBytes,
-                              toPhoneQueueSize.load());
+                    LOG_DEBUG("BLE getFromRadio numBytes=%u, toPhoneQueueSize=%u", numBytes, toPhoneQueueSize.load());
 #endif
                 } else {
                     // Shouldn't happen because the onRead callback shouldn't be waiting if the queue is full!
@@ -580,9 +579,8 @@ class NimbleBluetoothFromRadioCallback : public BLECharacteristicCallbacks
                 tries++;
 
                 if (tries == 4000) {
-                    LOG_WARN(
-                        "BLE onRead(%d): data timeout after %u ms, %d tries, returning 0-size response",
-                        currentReadCount, millis() - startMillis, tries);
+                    LOG_WARN("BLE onRead(%d): data timeout after %u ms, %d tries, returning 0-size response", currentReadCount,
+                             millis() - startMillis, tries);
                 }
             }
         }

--- a/src/nimble/NimbleBluetooth.cpp
+++ b/src/nimble/NimbleBluetooth.cpp
@@ -70,10 +70,10 @@ static void purgeIncompatibleBleBonds()
 
     bool wiped = false;
     if (mismatch) {
-        LOG_WARN("Wiping incompatible NimBLE bonds (on-disk format changed)");
+        LOG_WARN("Wiping incompatible NimBLE bonds (format changed)");
         wiped = nvs_erase_all(handle) == ESP_OK && nvs_commit(handle) == ESP_OK;
         if (!wiped) {
-            LOG_ERROR("Failed to erase nimble_bond namespace");
+            LOG_ERROR("nimble_bond namespace erase failed");
         }
     }
 
@@ -347,7 +347,7 @@ class BluetoothPhoneAPI : public PhoneAPI, public concurrency::OSThread
                         toPhoneQueueSize++;
                     }
 #ifdef DEBUG_NIMBLE_ON_READ_TIMING
-                    LOG_DEBUG("BLE getFromRadio returned numBytes=%u, pushed toPhoneQueueSize=%u", numBytes,
+                    LOG_DEBUG("BLE getFromRadio numBytes=%u, toPhoneQueueSize=%u", numBytes,
                               toPhoneQueueSize.load());
 #endif
                 } else {
@@ -370,7 +370,7 @@ class BluetoothPhoneAPI : public PhoneAPI, public concurrency::OSThread
             // Note: the comparison above is safe without a mutex because we are the only method that *decreases*
             // fromPhoneQueueSize. (It's okay if fromPhoneQueueSize *increases* in the NimBLE task meanwhile.)
 
-            LOG_DEBUG("NimbleBluetooth: handling ToRadio packet, fromPhoneQueueSize=%u", fromPhoneQueueSize.load());
+            LOG_DEBUG("NimbleBluetooth: ToRadio packet, fromPhoneQueueSize=%u", fromPhoneQueueSize.load());
 
             // Pop the front of fromPhoneQueue, holding the mutex only briefly while we pop.
             BLEValue val;
@@ -546,7 +546,7 @@ class NimbleBluetoothFromRadioCallback : public BLECharacteristicCallbacks
 
             // There's already a packet queued. Great! We don't need to wait for onReadCallbackIsWaitingForData.
 #ifdef DEBUG_NIMBLE_ON_READ_TIMING
-            LOG_DEBUG("BLE onRead(%d): packet already waiting, no need to set onReadCallbackIsWaitingForData", currentReadCount);
+            LOG_DEBUG("BLE onRead(%d): packet already waiting, skip onReadCallbackIsWaitingForData", currentReadCount);
 #endif
         } else if (!bleDraining) {
             // (If deinit() is tearing the stack down, skip the wait entirely and just return a 0-size
@@ -581,7 +581,7 @@ class NimbleBluetoothFromRadioCallback : public BLECharacteristicCallbacks
 
                 if (tries == 4000) {
                     LOG_WARN(
-                        "BLE onRead(%d): timeout waiting for data after %u ms, %d tries, giving up and returning 0-size response",
+                        "BLE onRead(%d): data timeout after %u ms, %d tries, returning 0-size response",
                         currentReadCount, millis() - startMillis, tries);
                 }
             }
@@ -697,7 +697,7 @@ class NimbleBluetoothSecurityCallback : public BLESecurityCallbacks
         // yields a *failed* encryption change here -- don't latch a connected/authenticated state
         // on a link that is actually being torn down.
         if (desc == nullptr || !desc->sec_state.encrypted) {
-            LOG_WARN("BLE encryption change without an encrypted link; ignoring");
+            LOG_WARN("BLE encryption change without encrypted link; ignoring");
             return;
         }
 
@@ -764,7 +764,7 @@ class NimbleBluetoothServerCallback : public BLEServerCallbacks
         if (dataLenResult == 0) {
             LOG_INFO("BLE conn %u requested data length %u bytes", connHandle, kPreferredBleTxOctets);
         } else {
-            LOG_WARN("Failed to raise data length for conn %u, rc=%d", connHandle, dataLenResult);
+            LOG_WARN("Can't raise data length for conn %u, rc=%d", connHandle, dataLenResult);
         }
 #endif
 
@@ -812,7 +812,7 @@ void NimbleBluetooth::startAdvertising()
     pAdvertising->setMaxPreferred(0x12);
 
     if (!pAdvertising->start(0)) {
-        LOG_ERROR("BLE failed to start advertising");
+        LOG_ERROR("BLE advertising start failed");
     } else {
         LOG_DEBUG("BLE Advertising started");
     }
@@ -908,7 +908,7 @@ void NimbleBluetooth::setup()
     // Uncomment for testing
     // NimbleBluetooth::clearBonds();
 
-    LOG_INFO("Init the NimBLE bluetooth module");
+    LOG_INFO("Init NimBLE bluetooth");
 
     // deinit() latches these teardown guards; clear them so a re-init on the same boot (e.g. an
     // admin disable-bluetooth followed by re-enable) doesn't leave onRead stuck draining or
@@ -929,7 +929,7 @@ void NimbleBluetooth::setup()
     if (mtuResult == 0) {
         LOG_INFO("BLE MTU request set to %u", kPreferredBleMtu);
     } else {
-        LOG_WARN("Unable to request MTU %u, rc=%d", kPreferredBleMtu, mtuResult);
+        LOG_WARN("Can't request MTU %u, rc=%d", kPreferredBleMtu, mtuResult);
     }
 
     // BLESecurity only forwards to static NimBLEDevice setters; a stack instance suffices.

--- a/src/nimble/NimbleBluetooth.cpp
+++ b/src/nimble/NimbleBluetooth.cpp
@@ -1063,7 +1063,7 @@ void updateBatteryLevel(uint8_t level)
 
 void NimbleBluetooth::clearBonds()
 {
-    LOG_INFO("Clearing bluetooth bonds!");
+    LOG_INFO("Clearing bluetooth bonds");
     ble_store_util_delete_all(BLE_STORE_OBJ_TYPE_OUR_SEC, nullptr);
     ble_store_util_delete_all(BLE_STORE_OBJ_TYPE_PEER_SEC, nullptr);
     ble_store_util_delete_all(BLE_STORE_OBJ_TYPE_CCCD, nullptr);

--- a/src/platform/esp32/ESP32CryptoEngine.cpp
+++ b/src/platform/esp32/ESP32CryptoEngine.cpp
@@ -32,7 +32,7 @@ class ESP32CryptoEngine : public CryptoEngine
                        sizeof(scratch) - numBytes); // Fill rest of buffer with zero (in case cypher looks at it)
                 mbedtls_aes_crypt_ctr(&aes, numBytes, &nc_off, _nonce, stream_block, scratch, bytes);
             } else {
-                LOG_ERROR("Packet too large for crypto engine: %d. noop encryption!", numBytes);
+                LOG_ERROR("Packet too large for crypto engine: %d. noop encryption", numBytes);
             }
         }
     }

--- a/src/platform/esp32/MeshtasticOTA.cpp
+++ b/src/platform/esp32/MeshtasticOTA.cpp
@@ -102,14 +102,14 @@ bool trySwitchToOTA()
     const esp_partition_t *part = getAppPartition();
 
     if (part == NULL) {
-        LOG_WARN("Unable to get app partition in preparation of OTA reboot");
+        LOG_WARN("Can't get app partition in preparation of OTA reboot");
         return false;
     }
 
     uint8_t result = esp_ota_set_boot_partition(part);
     // Partition and app checks should now be done in the AdminModule before this is called
     if (result != ESP_OK) {
-        LOG_WARN("Unable to switch to OTA partiton.  (Reason %d)", result);
+        LOG_WARN("Can't switch to OTA partiton.  (Reason %d)", result);
         return false;
     }
 

--- a/src/platform/esp32/MeshtasticOTA.cpp
+++ b/src/platform/esp32/MeshtasticOTA.cpp
@@ -109,7 +109,7 @@ bool trySwitchToOTA()
     uint8_t result = esp_ota_set_boot_partition(part);
     // Partition and app checks should now be done in the AdminModule before this is called
     if (result != ESP_OK) {
-        LOG_WARN("Can't switch to OTA partiton.  (Reason %d)", result);
+        LOG_WARN("Can't switch to OTA partition (reason %d)", result);
         return false;
     }
 

--- a/src/platform/esp32/main-esp32.cpp
+++ b/src/platform/esp32/main-esp32.cpp
@@ -69,7 +69,7 @@ static bool shouldReleaseBluetoothMemory()
     // Paxcounter disables the Meshtastic BLE service, but libpax still needs the
     // ESP32 BLE controller memory for scanning.
     if (isPaxcounterActiveForBoot()) {
-        LOG_DEBUG("Skipping Bluetooth memory release because Paxcounter is active");
+        LOG_DEBUG("Skip BT memory release: Paxcounter active");
         return false;
     }
 
@@ -96,7 +96,7 @@ void setBluetoothEnable(bool enable)
     if (enable && bluetoothMemoryReleased) {
         if (!shouldReleaseBluetoothMemory() && !bluetoothMemoryReleaseWarned) {
             bluetoothMemoryReleaseWarned = true;
-            LOG_WARN("Bluetooth memory has been released; reboot to re-enable Bluetooth");
+            LOG_WARN("BT memory released; reboot to re-enable");
         }
         return;
     }
@@ -205,7 +205,7 @@ void enableSlowCLK()
         LOG_DEBUG("32k XTAL OSC has not started up");
     } else {
         rtc_clk_slow_freq_set(RTC_SLOW_FREQ_32K_XTAL);
-        LOG_DEBUG("Switch RTC Source to 32.768kHz succeeded, using 32k XTAL");
+        LOG_DEBUG("RTC source now 32k XTAL");
         CALIBRATE_ONE(RTC_CAL_RTC_MUX);
         CALIBRATE_ONE(RTC_CAL_32K_XTAL);
     }
@@ -285,14 +285,14 @@ void esp32Setup()
     };
     res = esp_task_wdt_init(&wdt_config);
     if (res == ESP_ERR_INVALID_STATE) {
-        LOG_WARN("Task watchdog already initialized, reconfiguring existing instance");
+        LOG_WARN("Task watchdog already init, reconfiguring");
         res = esp_task_wdt_reconfigure(&wdt_config);
     }
     assert(res == ESP_OK);
 #else
     res = esp_task_wdt_init(APP_WATCHDOG_SECS, true);
     if (res == ESP_ERR_INVALID_STATE) {
-        LOG_WARN("Task watchdog already initialized, reusing existing instance");
+        LOG_WARN("Task watchdog already init, reusing");
         res = ESP_OK;
     }
     assert(res == ESP_OK);

--- a/src/platform/extra_variants/t5s3_epaper/variant.cpp
+++ b/src/platform/extra_variants/t5s3_epaper/variant.cpp
@@ -696,7 +696,7 @@ void lateInitVariant()
 #endif
     } else {
         touchControllerReady = false;
-        LOG_ERROR("Failed to find touch controller!");
+        LOG_ERROR("Failed to find touch controller");
     }
 
 #if defined(BOARD_PCA9535_ADDR) && defined(BOARD_PCA9535_BUTTON_MASK)

--- a/src/platform/extra_variants/t_deck_pro/variant.cpp
+++ b/src/platform/extra_variants/t_deck_pro/variant.cpp
@@ -119,7 +119,7 @@ void lateInitVariant()
 
                 break;
             } else {
-                LOG_DEBUG("CST3530 not response ~");
+                LOG_DEBUG("CST3530 no response");
             }
         }
         uint8_t cmd1[] = {0xD0, 0x00, 0x04, 0x00};

--- a/src/platform/extra_variants/t_deck_pro/variant.cpp
+++ b/src/platform/extra_variants/t_deck_pro/variant.cpp
@@ -119,7 +119,7 @@ void lateInitVariant()
 
                 break;
             } else {
-                LOG_DEBUG("CST3530 not response ~!");
+                LOG_DEBUG("CST3530 not response ~");
             }
         }
         uint8_t cmd1[] = {0xD0, 0x00, 0x04, 0x00};

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -255,7 +255,7 @@ void NRF52Bluetooth::startDisabled()
     // Shutdown bluetooth for minimum power draw
     Bluefruit.Advertising.stop();
     Bluefruit.setTxPower(-40); // Minimum power
-    LOG_INFO("Disable NRF52 Bluetooth. (Workaround: tx power min, advertise stopped)");
+    LOG_INFO("Disable NRF52 BT (tx power min, advertise stopped)");
 }
 bool NRF52Bluetooth::isConnected()
 {
@@ -283,7 +283,7 @@ void NRF52Bluetooth::setup()
         // current Bluefruit config. Without this check the node would silently run without BLE.
         // Rebuild with -DCFG_DEBUG=1 to get "SoftDevice's RAM requires: 0x..." in the log, then
         // raise the ORIGIN accordingly.
-        LOG_ERROR("Bluefruit.begin failed - SoftDevice RAM reservation too small for this config");
+        LOG_ERROR("Bluefruit.begin failed: SoftDevice RAM too small");
         RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_UNSPECIFIED);
         return;
     }
@@ -481,7 +481,7 @@ void NRF52Bluetooth::disconnect()
             delay(1);
 
         if (Bluefruit.connected())
-            LOG_WARN("BLE disconnect unconfirmed after %ums, continuing shutdown", millis() - start);
+            LOG_WARN("BLE disconnect unconfirmed after %ums, shutdown anyway", millis() - start);
         else
             LOG_INFO("Ended BLE connection");
     }

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -399,7 +399,7 @@ void updateBatteryLevel(uint8_t level)
 }
 void NRF52Bluetooth::clearBonds()
 {
-    LOG_INFO("Clear bluetooth bonds!");
+    LOG_INFO("Clear bluetooth bonds");
     bond_print_list(BLE_GAP_ROLE_PERIPH);
     bond_print_list(BLE_GAP_ROLE_CENTRAL);
     Bluefruit.Periph.clearBonds();

--- a/src/platform/nrf52/main-nrf52.cpp
+++ b/src/platform/nrf52/main-nrf52.cpp
@@ -419,7 +419,7 @@ void nrf52Setup()
 #ifdef BQ25703A_ADDR
     auto *bq = new BQ25713();
     if (!bq->setup())
-        LOG_ERROR("ERROR! Charge controller init failed");
+        LOG_ERROR("Charge controller init failed");
 #endif
 
     // Init random seed
@@ -526,7 +526,7 @@ void cpuDeepSleep(uint32_t msecToWake)
 
         auto ok = sd_power_system_off();
         if (ok != NRF_SUCCESS) {
-            LOG_ERROR("FIXME: Ignoring soft device (EasyDMA pending?) and forcing system-off!");
+            LOG_ERROR("FIXME: Ignoring soft device (EasyDMA pending?) and forcing system-off");
             NRF_POWER->SYSTEMOFF = 1;
         }
     }
@@ -534,7 +534,7 @@ void cpuDeepSleep(uint32_t msecToWake)
     // The following code should not be run, because we are off
     while (1) {
         delay(5000);
-        LOG_DEBUG(".");
+        LOG_DEBUG("");
     }
 }
 

--- a/src/platform/nrf52/main-nrf52.cpp
+++ b/src/platform/nrf52/main-nrf52.cpp
@@ -534,7 +534,7 @@ void cpuDeepSleep(uint32_t msecToWake)
     // The following code should not be run, because we are off
     while (1) {
         delay(5000);
-        LOG_DEBUG("");
+        LOG_DEBUG(".");
     }
 }
 

--- a/src/platform/nrf54l15/InternalFileSystem.cpp
+++ b/src/platform/nrf54l15/InternalFileSystem.cpp
@@ -77,7 +77,7 @@ bool InternalFileSystem::begin()
     }
 
     // Mount failed: attempt to format (creates a fresh LittleFS)
-    LOG_WARN("LittleFS mount failed (%d), formatting storage partition...", rc);
+    LOG_WARN("LittleFS mount failed (%d), formatting storage partition", rc);
     int fmt_rc = fs_mkfs(FS_LITTLEFS, (uintptr_t)FIXED_PARTITION_ID(storage_partition), NULL, 0);
     if (fmt_rc != 0) {
         LOG_ERROR("LittleFS format failed (%d)", fmt_rc);

--- a/src/platform/nrf54l15/NRF54L15Bluetooth.cpp
+++ b/src/platform/nrf54l15/NRF54L15Bluetooth.cpp
@@ -442,7 +442,7 @@ static void security_changed_cb(struct bt_conn *conn, bt_security_t level, enum 
     if (err == BT_SECURITY_ERR_PIN_OR_KEY_MISSING) {
         // Phone has a stale bond (device was wiped/reflashed).  Unpair the stale
         // entry so the phone re-pairs cleanly on the next connection attempt.
-        LOG_WARN("BLE stale bond detected (key missing) - unpairing");
+        LOG_WARN("BLE stale bond (key missing) - unpairing");
         bt_unpair(BT_ID_DEFAULT, bt_conn_get_dst(conn));
         bt_conn_disconnect(conn, BT_HCI_ERR_AUTH_FAIL);
     } else if (err) {
@@ -691,7 +691,7 @@ static bool nrf54l15_bt_init_common()
     // instead of leaving BLE silently broken.
     if (config.bluetooth.mode == meshtastic_Config_BluetoothConfig_PairingMode_NO_PIN) {
         LOG_WARN("BLE: NO_PIN not supported on nRF54L15-DK (MITM-only build); "
-                 "treating as RANDOM_PIN");
+                 "treat as RANDOM_PIN");
     }
 
     bt_conn_auth_cb_register(&auth_cb);
@@ -759,7 +759,7 @@ void NRF54L15Bluetooth::startDisabled()
         return;
     }
     ble_enabled = false;
-    LOG_INFO("BLE initialized, advertising stopped (startDisabled)");
+    LOG_INFO("BLE initialized, adv stopped (startDisabled)");
 }
 
 void NRF54L15Bluetooth::resumeAdvertising()

--- a/src/platform/portduino/GpsdSerial.cpp
+++ b/src/platform/portduino/GpsdSerial.cpp
@@ -115,7 +115,7 @@ bool GpsdSerial::connectToGpsd()
     std::string portStr = std::to_string(_port);
 
     if (getaddrinfo(_host.c_str(), portStr.c_str(), &hints, &res) != 0 || !res) {
-        LOG_WARN("gpsdSerial: could not resolve %s", _host.c_str());
+        LOG_WARN("gpsdSerial: can't resolve %s", _host.c_str());
         return false;
     }
 

--- a/src/platform/portduino/SimRadio.cpp
+++ b/src/platform/portduino/SimRadio.cpp
@@ -295,7 +295,7 @@ void SimRadio::unpackAndReceive(meshtastic_MeshPacket &p)
                 p.decoded.portnum = scratch.portnum;
             }
         } else
-            LOG_ERROR("Error decoding proto for simulator message!");
+            LOG_ERROR("Error decoding proto for simulator message");
     }
     // Let SimRadio receive as if it did via its LoRa chip
     startReceive(&p);
@@ -305,7 +305,7 @@ void SimRadio::startReceive(meshtastic_MeshPacket *p)
 {
 #ifdef USERPREFS_SIMRADIO_EMULATE_COLLISIONS
     if (isActivelyReceiving()) {
-        LOG_WARN("Collision detected, dropping current and previous packet!");
+        LOG_WARN("Collision detected, dropping current and previous packet");
         rxBad++;
         airTime->logAirtime(RX_ALL_LOG, getPacketTime(receivingPacket, true));
         packetPool.release(receivingPacket);
@@ -319,7 +319,7 @@ void SimRadio::startReceive(meshtastic_MeshPacket *p)
         } else if ((interval - airtimeLeft) > preambleTimeMsec) {
             // Only if transmitting for longer than preamble there is a collision
             // (channel should actually be detected as active otherwise)
-            LOG_WARN("Collision detected during transmission!");
+            LOG_WARN("Collision detected during transmission");
             return;
         }
     }

--- a/src/platform/portduino/SimRadio.cpp
+++ b/src/platform/portduino/SimRadio.cpp
@@ -238,7 +238,7 @@ void SimRadio::startSend(meshtastic_MeshPacket *txp)
             memcpy(&c.data.bytes, p->encrypted.bytes, p->encrypted.size);
             c.data.size = p->encrypted.size;
         } else {
-            LOG_WARN("Encrypted payload (%u) exceeds sim loopback capacity (%u)! Send empty payload", (unsigned)p->encrypted.size,
+            LOG_WARN("Encrypted payload (%u) > sim loopback capacity (%u), send empty", (unsigned)p->encrypted.size,
                      (unsigned)loopbackCapacity);
         }
     } else {
@@ -248,7 +248,7 @@ void SimRadio::startSend(meshtastic_MeshPacket *txp)
             memcpy(&c.data.bytes, p->decoded.payload.bytes, p->decoded.payload.size);
             c.data.size = p->decoded.payload.size;
         } else {
-            LOG_WARN("Payload size larger than compressed message allows! Send empty payload");
+            LOG_WARN("Payload > compressed max, send empty");
         }
     }
 
@@ -359,7 +359,7 @@ void SimRadio::handleReceiveInterrupt()
     }
 
     if (!isReceiving) {
-        LOG_DEBUG("*** WAS_ASSERT *** handleReceiveInterrupt called when not in receive mode");
+        LOG_DEBUG("*** WAS_ASSERT *** handleReceiveInterrupt outside receive mode");
         return;
     }
 

--- a/src/platform/portduino/USBHal.h
+++ b/src/platform/portduino/USBHal.h
@@ -89,7 +89,7 @@ class Ch341Hal : public RadioLibHal
         }
         auto res = pinedio_set_pin_mode(&pinedio, pin, mode);
         if (res < 0 && rebootAtMsec == 0) {
-            LOG_ERROR("USBHal pinMode: Could not set pin %u mode to %u: %d", pin, mode, res);
+            LOG_ERROR("USBHal pinMode: Can't set pin %u mode to %u: %d", pin, mode, res);
         }
     }
 
@@ -103,7 +103,7 @@ class Ch341Hal : public RadioLibHal
         }
         auto res = pinedio_digital_write(&pinedio, pin, value);
         if (res < 0 && rebootAtMsec == 0) {
-            LOG_ERROR("USBHal digitalWrite: Could not write pin %u: %d", pin, res);
+            LOG_ERROR("USBHal digitalWrite: Can't write pin %u: %d", pin, res);
             portduino_status.LoRa_in_error = true;
         }
     }
@@ -118,7 +118,7 @@ class Ch341Hal : public RadioLibHal
         }
         auto res = pinedio_digital_read(&pinedio, pin);
         if (res < 0 && rebootAtMsec == 0) {
-            LOG_ERROR("USBHal digitalRead: Could not read pin %u: %d", pin, res);
+            LOG_ERROR("USBHal digitalRead: Can't read pin %u: %d", pin, res);
             portduino_status.LoRa_in_error = true;
             return 0;
         }

--- a/src/platform/rp2xx0/main-rp2xx0.cpp
+++ b/src/platform/rp2xx0/main-rp2xx0.cpp
@@ -111,7 +111,7 @@ bool getDeviceId(uint8_t *deviceId)
 void rp2040Setup()
 {
     if (watchdog_caused_reboot()) {
-        LOG_WARN("Rebooted by watchdog!");
+        LOG_WARN("Rebooted by watchdog");
     }
 
     /* Sets a random seed to make sure we get different random numbers on each boot. */

--- a/src/platform/stm32wl/main-stm32wl.cpp
+++ b/src/platform/stm32wl/main-stm32wl.cpp
@@ -146,7 +146,7 @@ void cpuDeepSleep(uint32_t msecToWake)
     if (!stm32wlRtcAvailable()) {
         // Hardware can't shutdown, but firmware has already prepared itself for shutdown
         // Do not leave the device unresponsive, reset instead
-        LOG_WARN("STM32WL: hardware RTC failed, cannot deep sleep/shutdown");
+        LOG_WARN("STM32WL: hardware RTC failed, can't deep sleep/shutdown");
         if (Serial) {
             Serial.flush();
             Serial.end();

--- a/src/security/EncryptedStorage.cpp
+++ b/src/security/EncryptedStorage.cpp
@@ -204,7 +204,7 @@ static void writeBackoff(uint8_t attempts, uint8_t bootsSinceFail, uint32_t last
     bool ok = computeBackoffHmac(buf.data(), mac);
     nRFCrypto.end();
     if (!ok) {
-        LOG_ERROR("EncryptedStorage: backoff HMAC compute failed");
+        LOG_ERROR("EncryptedStorage: backoff HMAC failed");
         return;
     }
     memcpy(buf.data() + BACKOFF_BODY_SIZE, mac, HMAC_SIZE);
@@ -489,7 +489,7 @@ static bool loadDEK()
 
     const uint8_t *storedHmac = buf + DEK_SIZE - HMAC_SIZE;
     if (!constTimeEq(expectedHmac.data(), storedHmac, HMAC_SIZE)) {
-        LOG_ERROR("EncryptedStorage: DEK HMAC mismatch - wrong passphrase or tampered file");
+        LOG_ERROR("EncryptedStorage: DEK HMAC mismatch - wrong passphrase or tampered");
         return false;
     }
 
@@ -791,7 +791,7 @@ static bool writeUnlockToken(uint8_t bootsRemaining, uint32_t validUntilEpoch, u
     // greater than the persisted value); readAndConsumeToken will
     // promote .tokmono on the next read.
     if (!writeMonoCounter(newMonoCounter)) {
-        LOG_WARN("EncryptedStorage: mono-counter persist failed (will self-heal on next read)");
+        LOG_WARN("EncryptedStorage: mono-counter persist failed (self-heals on next read)");
     }
 
     LOG_INFO("EncryptedStorage: Unlock token written (boots=%d, epoch=%u, mono=%u)", bootsRemaining, validUntilEpoch,
@@ -893,7 +893,7 @@ static bool readAndConsumeToken()
     // current value. Equal is the normal case post-write.
     uint32_t maxSeenCounter = readMonoCounter();
     if (tokenMonoCounter < maxSeenCounter) {
-        LOG_ERROR("EncryptedStorage: Token rollback detected (counter=%u, max-seen=%u), deleting", (unsigned)tokenMonoCounter,
+        LOG_ERROR("EncryptedStorage: Token rollback (counter=%u, max-seen=%u), deleting", (unsigned)tokenMonoCounter,
                   (unsigned)maxSeenCounter);
         concurrency::LockGuard g(spiLock);
         FSCom.remove(TOKEN_FILENAME);
@@ -931,7 +931,7 @@ static bool readAndConsumeToken()
     if (validUntilEpoch != 0) {
         uint32_t now = getValidTime(RTCQualityDevice);
         if (now == 0) {
-            LOG_WARN("EncryptedStorage: Token wall-clock TTL unverifiable (no RTC), falling back to boot count (%u left)",
+            LOG_WARN("EncryptedStorage: Token wall-clock TTL unverifiable (no RTC), using boot count (%u left)",
                      bootsRemaining);
         } else if (now > validUntilEpoch) {
             LOG_WARN("EncryptedStorage: Token expired (now=%u, until=%u), deleting", now, validUntilEpoch);
@@ -1041,7 +1041,7 @@ void initLocked()
     if (isProvisioned()) {
         LOG_WARN("EncryptedStorage: Device LOCKED - reason: %s", lockReason);
     } else {
-        LOG_WARN("EncryptedStorage: Device NOT PROVISIONED - operator must set passphrase");
+        LOG_WARN("EncryptedStorage: Device NOT PROVISIONED - set passphrase");
     }
 }
 
@@ -1145,7 +1145,7 @@ bool provisionPassphrase(const uint8_t *passphrase, size_t passphraseLen, uint8_
 
     // Create unlock token (validUntilEpoch is an absolute Unix timestamp from the client; 0 = no limit)
     if (!writeUnlockToken(bootsRemaining, validUntilEpoch, sessionMaxSeconds)) {
-        LOG_WARN("EncryptedStorage: Token write failed after provision (continuing unlocked)");
+        LOG_WARN("EncryptedStorage: Token write failed after provision (still unlocked)");
     }
 
     // H4 (audit): seed an attempts=0 backoff sentinel so the file is
@@ -1234,7 +1234,7 @@ bool unlockWithPassphrase(const uint8_t *passphrase, size_t passphraseLen, uint8
 
             if (maxRemaining > 0) {
                 s_backoffSecondsRemaining = maxRemaining;
-                LOG_WARN("EncryptedStorage: Passphrase attempt blocked by backoff (~%us remaining)", s_backoffSecondsRemaining);
+                LOG_WARN("EncryptedStorage: Passphrase blocked by backoff (~%us left)", s_backoffSecondsRemaining);
                 return false;
             }
         }
@@ -1296,7 +1296,7 @@ bool unlockWithPassphrase(const uint8_t *passphrase, size_t passphraseLen, uint8
 
     // Create fresh unlock token (validUntilEpoch is an absolute Unix timestamp from the client; 0 = no limit)
     if (!writeUnlockToken(bootsRemaining, validUntilEpoch, sessionMaxSeconds)) {
-        LOG_WARN("EncryptedStorage: Token write failed after unlock (continuing unlocked this boot)");
+        LOG_WARN("EncryptedStorage: Token write failed after unlock (unlocked this boot)");
     }
 
     dekLoaded = true;
@@ -1318,7 +1318,7 @@ void lockNow()
     secureWipeKeys();
     s_sessionMaxMs = 0;
     s_sessionStartedMs = 0;
-    LOG_INFO("EncryptedStorage: Device locked - token deleted, DEK and KEK material zeroed");
+    LOG_INFO("EncryptedStorage: Device locked - token deleted, DEK/KEK zeroed");
 }
 
 void secureWipeKeys()
@@ -1433,7 +1433,7 @@ bool readAndDecrypt(const char *filename, uint8_t *outBuf, size_t outBufSize, si
         // MAX_NUM_NODES pushes the serialised protobuf past that limit.
         const size_t maxAcceptedFileSize = outBufSize + OVERHEAD;
         if (fileSize > maxAcceptedFileSize) {
-            LOG_ERROR("EncryptedStorage: File %s too large (%d bytes, max %d), refusing", filename, fileSize,
+            LOG_ERROR("EncryptedStorage: File %s too large (%d bytes, max %d)", filename, fileSize,
                       maxAcceptedFileSize);
             f.close();
             meshtastic_security::secure_zero(dekSnapshot, sizeof(dekSnapshot));
@@ -1512,7 +1512,7 @@ bool readAndDecrypt(const char *filename, uint8_t *outBuf, size_t outBufSize, si
     hmacData.reset();
 
     if (!hmacOk || !constTimeEq(computedHmac, storedHmac, HMAC_SIZE)) {
-        LOG_ERROR("EncryptedStorage: HMAC verification failed for %s", filename);
+        LOG_ERROR("EncryptedStorage: HMAC verify failed for %s", filename);
         meshtastic_security::secure_zero(computedHmac, sizeof(computedHmac));
         meshtastic_security::secure_zero(dekSnapshot, sizeof(dekSnapshot));
         return false;
@@ -1620,7 +1620,7 @@ bool encryptAndWrite(const char *filename, const uint8_t *plaintext, size_t plai
     hmacData.reset();
 
     if (!hmacOk) {
-        LOG_ERROR("EncryptedStorage: HMAC computation failed for %s", filename);
+        LOG_ERROR("EncryptedStorage: HMAC compute failed for %s", filename);
         meshtastic_security::secure_zero(dekSnapshot, sizeof(dekSnapshot));
         return false;
     }
@@ -1688,7 +1688,7 @@ bool migrateFile(const char *filename)
         // the device.
         constexpr size_t kMigrateMaxFileSize = 64 * 1024;
         if (fileSize > kMigrateMaxFileSize) {
-            LOG_ERROR("EncryptedStorage: refusing to migrate %s - size %u exceeds %u-byte cap", filename, (unsigned)fileSize,
+            LOG_ERROR("EncryptedStorage: won't migrate %s - size %u > %u-byte cap", filename, (unsigned)fileSize,
                       (unsigned)kMigrateMaxFileSize);
             f.close();
             return false;
@@ -1797,7 +1797,7 @@ void removeLockdownArtifacts()
     secureWipeKeys();
     s_sessionMaxMs = 0;
     s_sessionStartedMs = 0;
-    LOG_INFO("EncryptedStorage: lockdown artifacts removed - device is no longer in lockdown");
+    LOG_INFO("EncryptedStorage: lockdown artifacts removed - lockdown off");
 }
 
 } // namespace EncryptedStorage

--- a/src/security/EncryptedStorage.cpp
+++ b/src/security/EncryptedStorage.cpp
@@ -931,8 +931,7 @@ static bool readAndConsumeToken()
     if (validUntilEpoch != 0) {
         uint32_t now = getValidTime(RTCQualityDevice);
         if (now == 0) {
-            LOG_WARN("EncryptedStorage: Token wall-clock TTL unverifiable (no RTC), using boot count (%u left)",
-                     bootsRemaining);
+            LOG_WARN("EncryptedStorage: Token wall-clock TTL unverifiable (no RTC), using boot count (%u left)", bootsRemaining);
         } else if (now > validUntilEpoch) {
             LOG_WARN("EncryptedStorage: Token expired (now=%u, until=%u), deleting", now, validUntilEpoch);
             concurrency::LockGuard g(spiLock);
@@ -1433,8 +1432,7 @@ bool readAndDecrypt(const char *filename, uint8_t *outBuf, size_t outBufSize, si
         // MAX_NUM_NODES pushes the serialised protobuf past that limit.
         const size_t maxAcceptedFileSize = outBufSize + OVERHEAD;
         if (fileSize > maxAcceptedFileSize) {
-            LOG_ERROR("EncryptedStorage: File %s too large (%d bytes, max %d)", filename, fileSize,
-                      maxAcceptedFileSize);
+            LOG_ERROR("EncryptedStorage: File %s too large (%d bytes, max %d)", filename, fileSize, maxAcceptedFileSize);
             f.close();
             meshtastic_security::secure_zero(dekSnapshot, sizeof(dekSnapshot));
             return false;

--- a/src/security/EncryptedStorage.cpp
+++ b/src/security/EncryptedStorage.cpp
@@ -1733,7 +1733,7 @@ bool migrateFileToPlaintext(const char *filename)
         return true;
     }
     if (!dekLoaded) {
-        LOG_ERROR("EncryptedStorage: cannot revert %s - not unlocked", filename);
+        LOG_ERROR("EncryptedStorage: can't revert %s - not unlocked", filename);
         return false;
     }
 

--- a/src/serialization/MeshPacketSerializer.cpp
+++ b/src/serialization/MeshPacketSerializer.cpp
@@ -416,7 +416,7 @@ std::string MeshPacketSerializer::JsonSerialize(const meshtastic_MeshPacket *mp,
             break;
         }
     } else if (shouldLog) {
-        LOG_WARN("Couldn't convert encrypted payload of MeshPacket to JSON");
+        LOG_WARN("Can't convert encrypted payload of MeshPacket to JSON");
     }
 
     jsonObj["id"] = (Json::UInt)mp->id;

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -611,18 +611,18 @@ void enableLoraInterrupt()
     loraFEMInterface.setRxModeEnableWhenMCUSleep();
 #endif
 
-    LOG_INFO("setup LORA_DIO1 (GPIO%02d) with wakeup by gpio interrupt", LORA_DIO1);
+    LOG_INFO("Wake on LORA_DIO1 (GPIO%02d) gpio interrupt", LORA_DIO1);
     gpio_wakeup_enable((gpio_num_t)LORA_DIO1, GPIO_INTR_HIGH_LEVEL);
 
 #elif defined(LORA_DIO1) && (LORA_DIO1 != RADIOLIB_NC)
     if (radioType != RF95_RADIO) {
-        LOG_INFO("setup LORA_DIO1 (GPIO%02d) with wakeup by gpio interrupt", LORA_DIO1);
+        LOG_INFO("Wake on LORA_DIO1 (GPIO%02d) gpio interrupt", LORA_DIO1);
         gpio_wakeup_enable((gpio_num_t)LORA_DIO1, GPIO_INTR_HIGH_LEVEL); // SX126x/SX128x interrupt, active high
     }
 #endif
 #if defined(RF95_IRQ) && (RF95_IRQ != RADIOLIB_NC)
     if (radioType == RF95_RADIO) {
-        LOG_INFO("setup RF95_IRQ (GPIO%02d) with wakeup by gpio interrupt", RF95_IRQ);
+        LOG_INFO("Wake on RF95_IRQ (GPIO%02d) gpio interrupt", RF95_IRQ);
         gpio_wakeup_enable((gpio_num_t)RF95_IRQ, GPIO_INTR_HIGH_LEVEL); // RF95 interrupt, active high
     }
 #endif


### PR DESCRIPTION
Audits all 3,161 `LOG_*` format strings in `src/` and rewrites the verbose ones to terser equivalents, reducing total log-string data from 121,628 to 114,834 bytes — **6,794 bytes saved (5.6%)**, with no strings dropped. A typical firmware image reclaims roughly 3–5 KB, since the biggest trims are in code nearly every target compiles (NodeDB, Router, AdminModule, MeshService, GPS, PhoneAPI, sensors).

What was changed, in passes:

- **Mechanical pass (all of `src/`)**: strip trailing `.`/`!`/`...` and literal `\n` (the logger appends a newline itself), `Error:`/`Warning:` prefixes (the level tag already conveys it), and redundant "successfully".
- **Judgment pass (top ~40 byte-heaviest files)**: rewrite wordy prose — "Failed to initialize X" → "X init failed", "Attempting to send" → "Send", dropped articles and filler, house abbreviations (config, init, msg, temp, BT).
- **Global pass**: "Unable to / Could not / Cannot" → "Can't".
- **clang-format rewrap** of lines whose length changed, using the pinned style (`.trunk/configs/.clang-format`, clang-format 16).

Deliberately preserved: every printf format specifier and argument list byte-for-byte (verified by an automated pre/post specifier-sequence check on every call), greppable tokens (chip/sensor/function/state names, key=value field names), the `0x%08x` node/packet-ID convention, strings the external hardware-test harness greps for, the boot-logo banner's trailing newline and bare `"."` progress ticks, and identical duplicate literals (so linker string dedup still applies). Non-log strings (UI text, NMEA/UBX, MQTT topics, CSV headers) are untouched.

*(Follow-up work — the `MESHTASTIC_TRACE_LOGGING` gate, chatty-DEBUG demotions, and redundant-log removal — moved to #11391 after this PR merged.)*

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)

Tested via the native (portduino) target: full compile green and the native test suite **GREEN — 44/44 suites, 352/352 test cases, all CLEAN** (`./bin/run-tests.sh`). An automated check verified the format-specifier sequence of every `LOG_*` call is unchanged. No device-specific behavior is affected beyond log text.