### PR TITLE
feat(cell): Air780E (EC618) 4G LTE Cat 1 cellular modem support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -668,6 +668,7 @@ Unit tests in `test/` directory. The canonical suite count is in `test/native-su
 - `test_admin_radio/` - LoRa region/config validation, AdminModule dispatch, node-DB metadata saves
 - `test_fscommon_getfiles/` - bounded file-manifest walk (cap, depth, truncation reporting)
 - `test_atak/` - ATAK integration
+- `test_cell_diag/` - Cellular modem diagnostic response parsers (CESQ, CEREG, BANDIND, CBC, COPS)
 - `test_crypto/` - Cryptography
 - `test_default/` - Default configuration
 - `test_hop_scaling/` - Hop scaling histogram and required-hop logic

--- a/src/DebugConfiguration.cpp
+++ b/src/DebugConfiguration.cpp
@@ -42,7 +42,7 @@ extern "C" void logLegacy(const char *level, const char *fmt, ...)
     va_end(args);
 }
 
-#if HAS_NETWORKING
+#if HAS_SYSLOG
 namespace meshtastic
 {
 Syslog::Syslog(UDP &client)

--- a/src/DebugConfiguration.cpp
+++ b/src/DebugConfiguration.cpp
@@ -42,7 +42,7 @@ extern "C" void logLegacy(const char *level, const char *fmt, ...)
     va_end(args);
 }
 
-#if HAS_SYSLOG
+#if HAS_NETWORKING_UDP
 namespace meshtastic
 {
 Syslog::Syslog(UDP &client)

--- a/src/DebugConfiguration.h
+++ b/src/DebugConfiguration.h
@@ -168,7 +168,7 @@ extern "C" void logLegacy(const char *level, const char *fmt, ...);
 #include <WiFi.h>
 #endif // HAS_WIFI
 
-#if HAS_NETWORKING
+#if HAS_SYSLOG
 
 namespace meshtastic
 {
@@ -207,4 +207,4 @@ class Syslog
 
 }; // namespace meshtastic
 
-#endif // HAS_NETWORKING
+#endif // HAS_SYSLOG

--- a/src/DebugConfiguration.h
+++ b/src/DebugConfiguration.h
@@ -168,7 +168,7 @@ extern "C" void logLegacy(const char *level, const char *fmt, ...);
 #include <WiFi.h>
 #endif // HAS_WIFI
 
-#if HAS_SYSLOG
+#if HAS_NETWORKING_UDP
 
 namespace meshtastic
 {
@@ -207,4 +207,4 @@ class Syslog
 
 }; // namespace meshtastic
 
-#endif // HAS_SYSLOG
+#endif // HAS_NETWORKING_UDP

--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -17,7 +17,7 @@
 #include "platform/portduino/PortduinoGlue.h"
 #endif
 
-#if HAS_NETWORKING
+#if HAS_SYSLOG
 extern meshtastic::Syslog syslog;
 #endif
 void RedirectablePrint::rpInit()
@@ -193,7 +193,7 @@ void RedirectablePrint::log_to_serial(const char *logLevel, const char *format, 
 
 void RedirectablePrint::log_to_syslog(const char *logLevel, const char *format, va_list arg)
 {
-#if HAS_NETWORKING && !defined(ARCH_PORTDUINO)
+#if HAS_SYSLOG && !defined(ARCH_PORTDUINO)
     // if syslog is in use, collect the log messages and send them to syslog
     if (syslog.isEnabled()) {
         int ll = 0;

--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -17,7 +17,7 @@
 #include "platform/portduino/PortduinoGlue.h"
 #endif
 
-#if HAS_SYSLOG
+#if HAS_NETWORKING_UDP
 extern meshtastic::Syslog syslog;
 #endif
 void RedirectablePrint::rpInit()
@@ -193,7 +193,7 @@ void RedirectablePrint::log_to_serial(const char *logLevel, const char *format, 
 
 void RedirectablePrint::log_to_syslog(const char *logLevel, const char *format, va_list arg)
 {
-#if HAS_SYSLOG && !defined(ARCH_PORTDUINO)
+#if HAS_NETWORKING_UDP && !defined(ARCH_PORTDUINO)
     // if syslog is in use, collect the log messages and send them to syslog
     if (syslog.isEnabled()) {
         int ll = 0;

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -376,7 +376,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MODEM_EN_VALUE HIGH
 #endif
 
-#if defined(MODEM_PWRKEY) && !defined(MODEM_PWRKEY_VALUE)
+#if defined(PIN_MODEM_PWRKEY) && !defined(MODEM_PWRKEY_VALUE)
 // GPIO level that asserts PWRKEY; its inverse releases it. Defaults to LOW for
 // an active-low PWRKEY wired straight to the pin.
 #define MODEM_PWRKEY_VALUE LOW
@@ -438,6 +438,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 #ifndef HAS_ETHERNET
 #define HAS_ETHERNET 0
+#endif
+#ifndef HAS_CELLULAR
+#define HAS_CELLULAR 0
 #endif
 #ifndef HAS_SCREEN
 #define HAS_SCREEN 0

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -590,8 +590,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define HAS_WIFI 0
 #endif
 
-// Allow code that needs internet to just check HAS_NETWORKING rather than HAS_WIFI || HAS_ETHERNET
-#define HAS_NETWORKING (HAS_WIFI || HAS_ETHERNET)
+// Allow code that needs internet to just check HAS_NETWORKING rather than HAS_WIFI || HAS_ETHERNET || HAS_CELLULAR
+#define HAS_NETWORKING (HAS_WIFI || HAS_ETHERNET || HAS_CELLULAR)
+
+// Syslog needs UDP, which the cellular AT socket API cannot provide
+#define HAS_SYSLOG (HAS_WIFI || HAS_ETHERNET)
 
 // // Turn off Bluetooth
 #ifdef MESHTASTIC_EXCLUDE_BLUETOOTH

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -593,8 +593,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // Allow code that needs internet to just check HAS_NETWORKING rather than HAS_WIFI || HAS_ETHERNET || HAS_CELLULAR
 #define HAS_NETWORKING (HAS_WIFI || HAS_ETHERNET || HAS_CELLULAR)
 
-// Syslog needs UDP, which the cellular AT socket API cannot provide
-#define HAS_SYSLOG (HAS_WIFI || HAS_ETHERNET)
+// Whether a compiled-in transport can carry a UDP socket. Syslog is the only consumer today;
+// cellular's AT socket driver is TCP-only for now, so it stays out of this until that changes.
+#define HAS_NETWORKING_UDP (HAS_WIFI || HAS_ETHERNET)
 
 // // Turn off Bluetooth
 #ifdef MESHTASTIC_EXCLUDE_BLUETOOTH

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -305,7 +305,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DS248X_ADDR_ALT7 0x1F // same as BBQ10_KB_ADDR
 #define HM330X_ADDR 0x40
 
-
 // -----------------------------------------------------------------------------
 // ACCELEROMETER
 // -----------------------------------------------------------------------------
@@ -370,6 +369,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if defined(VEXT_ENABLE) && !defined(VEXT_ON_VALUE)
 // Older variant.h files might not be defining this value, so stay with the old default
 #define VEXT_ON_VALUE LOW
+#endif
+
+#if defined(PIN_MODEM_EN) && !defined(MODEM_EN_VALUE)
+// Level that enables the modem's supply rail; its inverse cuts it.
+#define MODEM_EN_VALUE HIGH
+#endif
+
+#if defined(MODEM_PWRKEY) && !defined(MODEM_PWRKEY_VALUE)
+// GPIO level that asserts PWRKEY; its inverse releases it. Defaults to LOW for
+// an active-low PWRKEY wired straight to the pin.
+#define MODEM_PWRKEY_VALUE LOW
 #endif
 
 // -----------------------------------------------------------------------------

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1706,6 +1706,11 @@ void Screen::toggleFrameVisibility(const std::string &frameName)
     if (frameName == "chirpy") {
         hiddenFrames.chirpy = !hiddenFrames.chirpy;
     }
+#if HAS_CELLULAR
+    if (frameName == "cellular") {
+        hiddenFrames.cellular = !hiddenFrames.cellular;
+    }
+#endif
 
     // Save the new visibility state so it survives a reboot.
     saveFrameVisibility();
@@ -1743,6 +1748,10 @@ bool Screen::isFrameHidden(const std::string &frameName) const
         return hiddenFrames.show_favorites;
     if (frameName == "chirpy")
         return hiddenFrames.chirpy;
+#if HAS_CELLULAR
+    if (frameName == "cellular")
+        return hiddenFrames.cellular;
+#endif
 
     return false;
 }

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1526,6 +1526,17 @@ void Screen::setFrames(FrameFocus focus)
     }
 #endif
 
+#if HAS_CELLULAR
+    // Shown whenever the modem is built in, not only once the bearer is up - a
+    // modem stuck in REG_WAIT or FAILED is when the screen is worth having.
+    if (!hiddenFrames.cellular) {
+        fsi.positions.cellular = numframes;
+        normalFrames[numframes++] = graphics::DebugRenderer::drawFrameCellular;
+        indicatorIcons.push_back(icon_cellular);
+        PUSH_FRAME_TITLE("Cellular");
+    }
+#endif
+
     // Beware of what changes you make in this code!
     // We pass numframes into GetMeshModulesWithUIFrames() which is highly important!
     // Inside of that callback, goes over to MeshModule.cpp and we run
@@ -1768,6 +1779,7 @@ enum FrameVisBit : uint8_t {
     FVBIT_LORA = 13,
     FVBIT_SHOW_FAVORITES = 14,
     FVBIT_CHIRPY = 15,
+    FVBIT_CELLULAR = 16,
 };
 
 struct __attribute__((packed)) FrameVisFile {
@@ -1817,6 +1829,7 @@ uint32_t Screen::packHiddenFrames() const
     setBit(mask, FVBIT_LORA, hiddenFrames.lora);
     setBit(mask, FVBIT_SHOW_FAVORITES, hiddenFrames.show_favorites);
     setBit(mask, FVBIT_CHIRPY, hiddenFrames.chirpy);
+    setBit(mask, FVBIT_CELLULAR, hiddenFrames.cellular);
     return mask;
 }
 
@@ -1825,6 +1838,7 @@ void Screen::applyHiddenFramesMask(uint32_t mask)
     hiddenFrames.textMessage = getBit(mask, FVBIT_TEXT_MESSAGE);
     hiddenFrames.waypoint = getBit(mask, FVBIT_WAYPOINT);
     hiddenFrames.wifi = getBit(mask, FVBIT_WIFI);
+    hiddenFrames.cellular = getBit(mask, FVBIT_CELLULAR);
     hiddenFrames.system = getBit(mask, FVBIT_SYSTEM);
     hiddenFrames.home = getBit(mask, FVBIT_HOME);
     hiddenFrames.clock = getBit(mask, FVBIT_CLOCK);
@@ -2360,6 +2374,10 @@ int Screen::handleInputEvent(const InputEvent *event)
                     menuHandler::nodeListMenu();
                 } else if (this->ui->getUiState()->currentFrame == framesetInfo.positions.wifi) {
                     menuHandler::wifiBaseMenu();
+#if HAS_CELLULAR && (defined(PIN_MODEM_PWRKEY) || defined(PIN_MODEM_EN))
+                } else if (this->ui->getUiState()->currentFrame == framesetInfo.positions.cellular) {
+                    menuHandler::cellularBaseMenu();
+#endif
                 }
             } else if (event->inputEvent == INPUT_BROKER_BACK) {
                 showFrame(FrameDirection::PREVIOUS);

--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -726,6 +726,7 @@ class Screen : public concurrency::OSThread
             uint8_t log = 255;
             uint8_t settings = 255;
             uint8_t wifi = 255;
+            uint8_t cellular = 255;
             uint8_t deviceFocused = 255;
             uint8_t system = 255;
             uint8_t gps = 255;
@@ -752,6 +753,7 @@ class Screen : public concurrency::OSThread
         bool textMessage = false;
         bool waypoint = false;
         bool wifi = false;
+        bool cellular = false;
         bool system = false;
         bool home = false;
         bool clock = false;

--- a/src/graphics/draw/DebugRenderer.cpp
+++ b/src/graphics/draw/DebugRenderer.cpp
@@ -24,6 +24,11 @@
 #endif
 #endif
 
+#if HAS_CELLULAR
+#include "mesh/cell/cellBearer.h"
+#include "mesh/cell/cellDiag.h"
+#endif
+
 #include <DisplayFormatters.h>
 #include <RadioLibInterface.h>
 #include <target_specific.h>
@@ -117,6 +122,67 @@ void drawFrameWiFi(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, i
     display->drawString(x, getTextPositions(display)[line++], ssidStr);
 
     display->drawString(x, getTextPositions(display)[line++], "URL: http://meshtastic.local");
+
+    graphics::drawCommonFooter(display, x, y);
+
+    /* Display a heartbeat pixel that blinks every time the frame is redrawn */
+#ifdef SHOW_REDRAWS
+    if (heartbeat)
+        display->setPixel(0, 0);
+    heartbeat = !heartbeat;
+#endif
+#endif
+}
+
+// ****************************
+// * Cellular Screen          *
+// ****************************
+void drawFrameCellular(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y)
+{
+#if HAS_CELLULAR
+    display->clear();
+    display->setTextAlignment(TEXT_ALIGN_LEFT);
+    display->setFont(FONT_SMALL);
+    int line = 1;
+
+    graphics::drawCommonHeader(display, x, y, "Cellular");
+
+    char buf[64];
+
+    // Bearer state first: this frame is most useful when the link is down.
+    snprintf(buf, sizeof(buf), "State: %s", getCellStateName(getCellState()));
+    display->drawString(x, getTextPositions(display)[line++], buf);
+
+    const CellDiag &diag = getCellDiag();
+
+    if (diag.rsrpValid)
+        snprintf(buf, sizeof(buf), "RSRP: %d dBm", diag.rsrp);
+    else
+        snprintf(buf, sizeof(buf), "Signal: n/a");
+    display->drawString(x, getTextPositions(display)[line++], buf);
+
+    const String &ip = getCellLocalIP();
+    if (ip.length())
+        snprintf(buf, sizeof(buf), "IP: %s", ip.c_str());
+    else
+        snprintf(buf, sizeof(buf), "No IP");
+    display->drawString(x, getTextPositions(display)[line++], buf);
+
+    // No URL row: the socket API and web server cannot run over an outbound-only
+    // NAT'd socket API, so there is nothing to reach the node on.
+    if (!graphics::isCompactPanel(display)) {
+        snprintf(buf, sizeof(buf), "Net: %s", diag.operatorName[0] ? diag.operatorName : "unknown");
+        if (diag.bandValid) {
+            size_t used = strlen(buf);
+            snprintf(buf + used, sizeof(buf) - used, " B%u%s", (unsigned)diag.band, diag.act == 7 ? "/LTE" : "");
+        }
+        display->drawString(x, getTextPositions(display)[line++], buf);
+
+        if (diag.vbatValid) {
+            snprintf(buf, sizeof(buf), "Modem: %u.%uV", diag.vbatMv / 1000, (diag.vbatMv % 1000) / 100);
+            display->drawString(x, getTextPositions(display)[line++], buf);
+        }
+    }
 
     graphics::drawCommonFooter(display, x, y);
 

--- a/src/graphics/draw/DebugRenderer.h
+++ b/src/graphics/draw/DebugRenderer.h
@@ -20,6 +20,9 @@ namespace DebugRenderer
 // WiFi status display
 void drawFrameWiFi(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y);
 
+// Cellular modem status display
+void drawFrameCellular(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y);
+
 // LoRa information display
 void drawLoRaFocused(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y);
 

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -2708,6 +2708,9 @@ void menuHandler::frameTogglesMenu()
         show_env_telemetry,
         show_aq_telemetry,
         show_power,
+#if HAS_CELLULAR
+        show_cellular,
+#endif
         enumEnd
     };
     static const char *optionsArray[enumEnd] = {"Finish"};
@@ -2759,6 +2762,11 @@ void menuHandler::frameTogglesMenu()
 
     optionsArray[options] = moduleConfig.telemetry.power_screen_enabled ? "Hide Power" : "Show Power";
     optionsEnumArray[options++] = show_power;
+
+#if HAS_CELLULAR
+    optionsArray[options] = screen->isFrameHidden("cellular") ? "Show Cellular" : "Hide Cellular";
+    optionsEnumArray[options++] = show_cellular;
+#endif
 
     BannerOverlayOptions bannerOptions;
     bannerOptions.message = "Show/Hide Frames";
@@ -2830,6 +2838,12 @@ void menuHandler::frameTogglesMenu()
             moduleConfig.telemetry.power_screen_enabled = !moduleConfig.telemetry.power_screen_enabled;
             menuHandler::menuQueue = menuHandler::FrameToggles;
             screen->runNow();
+#if HAS_CELLULAR
+        } else if (selected == show_cellular) {
+            screen->toggleFrameVisibility("cellular");
+            menuHandler::menuQueue = menuHandler::FrameToggles;
+            screen->runNow();
+#endif
         }
     };
     screen->showOverlayBanner(bannerOptions);

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -22,6 +22,9 @@
 #include "mesh/Default.h"
 #include "mesh/MeshTypes.h"
 #include "mesh/RadioLibInterface.h"
+#if HAS_CELLULAR && (defined(PIN_MODEM_PWRKEY) || defined(PIN_MODEM_EN))
+#include "mesh/cell/cellBearer.h"
+#endif
 #include "modules/AdminModule.h"
 #include "modules/CannedMessageModule.h"
 #include "modules/ExternalNotificationModule.h"
@@ -1221,7 +1224,7 @@ void menuHandler::textMessageBaseMenu()
 
 void menuHandler::systemBaseMenu()
 {
-    enum optionsNumbers { Back, Notifications, ScreenOptions, Bluetooth, WiFiToggle, PowerMenu, Test, enumEnd };
+    enum optionsNumbers { Back, Notifications, ScreenOptions, Bluetooth, WiFiToggle, CellularToggle, PowerMenu, Test, enumEnd };
     static const char *optionsArray[enumEnd] = {"Back"};
     static int optionsEnumArray[enumEnd] = {Back};
     int options = 1;
@@ -1241,6 +1244,10 @@ void menuHandler::systemBaseMenu()
 #if HAS_WIFI && !defined(ARCH_PORTDUINO)
     optionsArray[options] = "WiFi Toggle";
     optionsEnumArray[options++] = WiFiToggle;
+#endif
+#if HAS_CELLULAR && (defined(PIN_MODEM_PWRKEY) || defined(PIN_MODEM_EN))
+    optionsArray[options] = "Cellular Toggle";
+    optionsEnumArray[options++] = CellularToggle;
 #endif
 
     if (currentResolution == ScreenResolution::UltraLow) {
@@ -1282,6 +1289,11 @@ void menuHandler::systemBaseMenu()
 #if HAS_WIFI && !defined(ARCH_PORTDUINO)
         } else if (selected == WiFiToggle) {
             menuQueue = WifiToggleMenu;
+            screen->runNow();
+#endif
+#if HAS_CELLULAR && (defined(PIN_MODEM_PWRKEY) || defined(PIN_MODEM_EN))
+        } else if (selected == CellularToggle) {
+            menuQueue = CellularToggleMenu;
             screen->runNow();
 #endif
         } else if (selected == Back && !test_enabled) {
@@ -2464,6 +2476,50 @@ void menuHandler::wifiToggleMenu()
     screen->showOverlayBanner(bannerOptions);
 }
 
+#if HAS_CELLULAR && (defined(PIN_MODEM_PWRKEY) || defined(PIN_MODEM_EN))
+void menuHandler::cellularBaseMenu()
+{
+    enum optionsNumbers { Back, Cellular_toggle };
+
+    static const char *optionsArray[] = {"Back", "Cellular Toggle"};
+    BannerOverlayOptions bannerOptions;
+    bannerOptions.message = "Cellular Menu";
+    bannerOptions.optionsArrayPtr = optionsArray;
+    bannerOptions.optionsCount = 2;
+    bannerOptions.bannerCallback = [](int selected) -> void {
+        if (selected == Cellular_toggle) {
+            menuQueue = CellularToggleMenu;
+            screen->runNow();
+        }
+    };
+    screen->showOverlayBanner(bannerOptions);
+}
+
+void menuHandler::cellularToggleMenu()
+{
+    enum optionsNumbers { Back, Cell_disable, Cell_enable };
+
+    static const char *optionsArray[] = {"Back", "Cellular Disabled", "Cellular Enabled"};
+    BannerOverlayOptions bannerOptions;
+    bannerOptions.message = "Cellular Actions";
+    bannerOptions.optionsArrayPtr = optionsArray;
+    bannerOptions.optionsCount = 3;
+    // The modem state machine handles power-down and power-up, so unlike WiFi
+    // this takes effect without a reboot - and is not persisted across one.
+    if (isCellularEnabled())
+        bannerOptions.InitialSelected = 2;
+    else
+        bannerOptions.InitialSelected = 1;
+    bannerOptions.bannerCallback = [](int selected) -> void {
+        if (selected == Cell_disable)
+            setCellularEnabled(false);
+        else if (selected == Cell_enable)
+            setCellularEnabled(true);
+    };
+    screen->showOverlayBanner(bannerOptions);
+}
+#endif
+
 void menuHandler::screenOptionsMenu()
 {
     // Check if brightness is supported
@@ -2965,6 +3021,11 @@ void menuHandler::handleMenuSwitch(OLEDDisplay *display)
     case WifiToggleMenu:
         wifiToggleMenu();
         break;
+#if HAS_CELLULAR && (defined(PIN_MODEM_PWRKEY) || defined(PIN_MODEM_EN))
+    case CellularToggleMenu:
+        cellularToggleMenu();
+        break;
+#endif
     case KeyVerificationInit:
         keyVerificationInitMenu();
         break;

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -2479,16 +2479,19 @@ void menuHandler::wifiToggleMenu()
 #if HAS_CELLULAR && (defined(PIN_MODEM_PWRKEY) || defined(PIN_MODEM_EN))
 void menuHandler::cellularBaseMenu()
 {
-    enum optionsNumbers { Back, Cellular_toggle };
+    enum optionsNumbers { Back, Cellular_toggle, Cellular_roaming };
 
-    static const char *optionsArray[] = {"Back", "Cellular Toggle"};
+    static const char *optionsArray[] = {"Back", "Cellular Toggle", "Cellular Roaming"};
     BannerOverlayOptions bannerOptions;
     bannerOptions.message = "Cellular Menu";
     bannerOptions.optionsArrayPtr = optionsArray;
-    bannerOptions.optionsCount = 2;
+    bannerOptions.optionsCount = 3;
     bannerOptions.bannerCallback = [](int selected) -> void {
         if (selected == Cellular_toggle) {
             menuQueue = CellularToggleMenu;
+            screen->runNow();
+        } else if (selected == Cellular_roaming) {
+            menuQueue = CellularRoamingMenu;
             screen->runNow();
         }
     };
@@ -2505,7 +2508,7 @@ void menuHandler::cellularToggleMenu()
     bannerOptions.optionsArrayPtr = optionsArray;
     bannerOptions.optionsCount = 3;
     // The modem state machine handles power-down and power-up, so unlike WiFi
-    // this takes effect without a reboot - and is not persisted across one.
+    // this takes effect without a reboot. Still persisted to config.network.cell_enabled.
     if (isCellularEnabled())
         bannerOptions.InitialSelected = 2;
     else
@@ -2515,6 +2518,33 @@ void menuHandler::cellularToggleMenu()
             setCellularEnabled(false);
         else if (selected == Cell_enable)
             setCellularEnabled(true);
+    };
+    screen->showOverlayBanner(bannerOptions);
+}
+
+void menuHandler::cellularRoamingMenu()
+{
+    enum optionsNumbers { Back, Roaming_disable, Roaming_enable };
+
+    static const char *optionsArray[] = {"Back", "Roaming Disabled", "Roaming Enabled"};
+    BannerOverlayOptions bannerOptions;
+    bannerOptions.message = "Cellular Roaming";
+    bannerOptions.optionsArrayPtr = optionsArray;
+    bannerOptions.optionsCount = 3;
+    if (config.network.cell_roaming_enabled)
+        bannerOptions.InitialSelected = 2;
+    else
+        bannerOptions.InitialSelected = 1;
+    // AT^SYSCONFIG is only written at modem session init, so this takes effect at the
+    // next modem restart rather than immediately, unlike the power toggle above.
+    bannerOptions.bannerCallback = [](int selected) -> void {
+        if (selected == Roaming_disable) {
+            config.network.cell_roaming_enabled = false;
+            service->reloadConfig(SEGMENT_CONFIG);
+        } else if (selected == Roaming_enable) {
+            config.network.cell_roaming_enabled = true;
+            service->reloadConfig(SEGMENT_CONFIG);
+        }
     };
     screen->showOverlayBanner(bannerOptions);
 }
@@ -3024,6 +3054,9 @@ void menuHandler::handleMenuSwitch(OLEDDisplay *display)
 #if HAS_CELLULAR && (defined(PIN_MODEM_PWRKEY) || defined(PIN_MODEM_EN))
     case CellularToggleMenu:
         cellularToggleMenu();
+        break;
+    case CellularRoamingMenu:
+        cellularRoamingMenu();
         break;
 #endif
     case KeyVerificationInit:

--- a/src/graphics/draw/MenuHandler.h
+++ b/src/graphics/draw/MenuHandler.h
@@ -41,6 +41,9 @@ class menuHandler
         EnvironmentTelemetryMenu,
         EnvironmentTelemetrySourceMenu,
         WifiToggleMenu,
+#if HAS_CELLULAR && (defined(PIN_MODEM_PWRKEY) || defined(PIN_MODEM_EN))
+        CellularToggleMenu,
+#endif
         BluetoothToggleMenu,
         ScreenOptionsMenu,
         PowerMenu,
@@ -110,6 +113,10 @@ class menuHandler
     static void environmentTelemetrySourceMenu();
     static void wifiBaseMenu();
     static void wifiToggleMenu();
+#if HAS_CELLULAR && (defined(PIN_MODEM_PWRKEY) || defined(PIN_MODEM_EN))
+    static void cellularBaseMenu();
+    static void cellularToggleMenu();
+#endif
     static void screenOptionsMenu();
     static void powerMenu();
     static void nodeNameLengthMenu();

--- a/src/graphics/draw/MenuHandler.h
+++ b/src/graphics/draw/MenuHandler.h
@@ -43,6 +43,7 @@ class menuHandler
         WifiToggleMenu,
 #if HAS_CELLULAR && (defined(PIN_MODEM_PWRKEY) || defined(PIN_MODEM_EN))
         CellularToggleMenu,
+        CellularRoamingMenu,
 #endif
         BluetoothToggleMenu,
         ScreenOptionsMenu,
@@ -116,6 +117,7 @@ class menuHandler
 #if HAS_CELLULAR && (defined(PIN_MODEM_PWRKEY) || defined(PIN_MODEM_EN))
     static void cellularBaseMenu();
     static void cellularToggleMenu();
+    static void cellularRoamingMenu();
 #endif
     static void screenOptionsMenu();
     static void powerMenu();

--- a/src/graphics/images.h
+++ b/src/graphics/images.h
@@ -125,6 +125,9 @@ const uint8_t icon_system[] PROGMEM = {
 const uint8_t icon_wifi[] PROGMEM = {0b00000000, 0b00011000, 0b00111100, 0b01111110,
                                      0b11011011, 0b00011000, 0b00011000, 0b00000000};
 
+// 📶 Cellular - four bars of increasing height, drawn LSB first.
+const uint8_t icon_cellular[] PROGMEM = {0x80, 0x80, 0xA0, 0xA0, 0xA8, 0xA8, 0xAA, 0xAA};
+
 const uint8_t icon_nodes[] PROGMEM = {
     0xF9, // Row 0  #..#######
     0x00, // Row 1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -476,14 +476,14 @@ void setup()
 
     initDeepSleep();
 
-#if defined(MODEM_POWER_EN)
-    pinMode(MODEM_POWER_EN, OUTPUT);
-    digitalWrite(MODEM_POWER_EN, LOW);
+#if defined(PIN_MODEM_EN)
+    pinMode(PIN_MODEM_EN, OUTPUT);
+    digitalWrite(PIN_MODEM_EN, !MODEM_EN_VALUE); // leave the modem rail off
 #endif
 
-#if defined(MODEM_PWRKEY)
-    pinMode(MODEM_PWRKEY, OUTPUT);
-    digitalWrite(MODEM_PWRKEY, LOW);
+#if defined(PIN_MODEM_PWRKEY)
+    pinMode(PIN_MODEM_PWRKEY, OUTPUT);
+    digitalWrite(PIN_MODEM_PWRKEY, !MODEM_PWRKEY_VALUE); // leave PWRKEY released so the modem stays off
 #endif
 
 #if defined(LORA_TCXO_GPIO)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,6 +103,10 @@ NRF54L15Bluetooth *nrf54l15Bluetooth = nullptr;
 #include "mesh/eth/ethClient.h"
 #endif
 
+#if HAS_CELLULAR
+#include "mesh/cell/cellBearer.h"
+#endif
+
 #if !MESHTASTIC_EXCLUDE_MQTT
 #include "mqtt/MQTT.h"
 #endif
@@ -1185,6 +1189,10 @@ void setup()
 #if HAS_ETHERNET
     // Initialize Ethernet
     initEthernet();
+#endif
+
+#if HAS_CELLULAR
+    initCellular();
 #endif
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1291,6 +1291,7 @@ extern meshtastic_DeviceMetadata getDeviceMetadata()
     deviceMetadata.hasBluetooth = HAS_BLUETOOTH;
     deviceMetadata.hasWifi = HAS_WIFI;
     deviceMetadata.hasEthernet = HAS_ETHERNET;
+    deviceMetadata.hasCellular = HAS_CELLULAR;
     deviceMetadata.role = config.device.role;
     deviceMetadata.position_flags = config.position.position_flags;
     deviceMetadata.hw_model = HW_VENDOR;

--- a/src/mesh/cell/ATModem.cpp
+++ b/src/mesh/cell/ATModem.cpp
@@ -1,0 +1,588 @@
+#include "mesh/cell/ATModem.h"
+
+#if HAS_CELLULAR
+
+ATModem *cellModem = nullptr;
+
+// Poll fast enough that a 115200 baud line doesn't sit in the UART FIFO.
+#define AT_TICK_MS 10
+
+#define AT_PWRKEY_SETTLE_MS 100
+
+#define AT_PROBE_INTERVAL_MS 500
+
+// A binary capture that stalls this long is abandoned so line framing resumes.
+#define AT_BINARY_TIMEOUT_MS 5000
+
+// Settle time after the power-down command before checking whether the module
+// really went quiet.
+#define AT_POWERDOWN_SETTLE_MS 2000
+
+ATModem::ATModem() : concurrency::OSThread("ATModem") {}
+
+void ATModem::start()
+{
+#if defined(PIN_MODEM_TX) && defined(PIN_MODEM_RX) && defined(ARCH_ESP32)
+    MODEM_SERIAL.begin(MODEM_BAUD, SERIAL_8N1, PIN_MODEM_RX, PIN_MODEM_TX);
+#else
+    MODEM_SERIAL.begin(MODEM_BAUD);
+#endif
+
+    powerOn();
+    setInterval(AT_TICK_MS);
+}
+
+void ATModem::powerOn()
+{
+#ifdef PIN_MODEM_EN
+    // Idle PWRKEY before cycling the rail, so a warm reboot doesn't leave it
+    // asserted once the rail comes back.
+#ifdef PIN_MODEM_PWRKEY
+    pinMode(PIN_MODEM_PWRKEY, OUTPUT);
+    digitalWrite(PIN_MODEM_PWRKEY, !MODEM_PWRKEY_VALUE);
+#endif
+    pinMode(PIN_MODEM_EN, OUTPUT);
+    digitalWrite(PIN_MODEM_EN, !MODEM_EN_VALUE);
+    setState(EN_OFF_HOLD);
+#elif defined(PIN_MODEM_PWRKEY)
+    // Drive the idle level first so a warm reboot doesn't leave PWRKEY asserted.
+    pinMode(PIN_MODEM_PWRKEY, OUTPUT);
+    digitalWrite(PIN_MODEM_PWRKEY, !MODEM_PWRKEY_VALUE);
+    setState(PWRKEY_IDLE);
+#else
+    // No PWRKEY wired: the board is assumed to auto-boot the modem.
+    setState(PROBE);
+#endif
+}
+
+void ATModem::enqueue(const char *cmd, uint32_t timeoutMs, ATCallback cb)
+{
+    Command c;
+    c.text = cmd;
+    c.timeoutMs = timeoutMs;
+    c.cb = cb;
+    queue.push_back(c);
+}
+
+// Shared teardown for restart() and expectReboot().
+void ATModem::clearSession()
+{
+    // A command genuinely in flight has its callback invoked with Error rather than
+    // dropped silently, so every submitted command's "called exactly once" contract
+    // holds even across a restart/power cycle.
+    cancelActive();
+    queue.clear();
+    commandActive = false;
+    awaitingFinalUrc = false;
+    active = Command();
+    response = "";
+    rxLine = "";
+    model = "";
+    version = "";
+    pulseToOff = false;
+}
+
+void ATModem::restart()
+{
+    LOG_WARN("Cell modem restarting");
+    clearSession();
+    powerOn();
+}
+
+void ATModem::powerOff()
+{
+    if (state == OFF)
+        return;
+
+    LOG_INFO("Cell modem powering down");
+    clearSession();
+    setState(POWERDOWN_WAIT);
+    // Either result is expected - the module may power off mid-response. With no
+    // power-down command the PWRKEY pulse in POWERDOWN_VERIFY does all the work.
+    if (!powerDown([this](ATResult, const String &) { setState(POWERDOWN_VERIFY); }))
+        setState(POWERDOWN_VERIFY);
+}
+
+void ATModem::powerUp()
+{
+    if (state != OFF)
+        return;
+
+    LOG_INFO("Cell modem powering up");
+    clearSession();
+    powerOn();
+}
+
+void ATModem::expectReboot()
+{
+    LOG_INFO("Cell modem rebooting, waiting for AT");
+    clearSession();
+    setState(PROBE);
+}
+
+void ATModem::setState(State next)
+{
+    state = next;
+    uint32_t now = millis();
+
+    switch (next) {
+    case OFF:
+#ifdef PIN_MODEM_EN
+        // Cut the rail last, after PWRKEY has already done its work.
+        digitalWrite(PIN_MODEM_EN, !MODEM_EN_VALUE);
+#endif
+        break;
+    case EN_OFF_HOLD:
+        stateDeadline = now + MODEM_EN_OFF_MS;
+        break;
+    case EN_ON:
+        stateDeadline = now + MODEM_EN_SETTLE_MS;
+        break;
+    case PWRKEY_IDLE:
+        stateDeadline = now + AT_PWRKEY_SETTLE_MS;
+        break;
+    case PWRKEY_ASSERT:
+        stateDeadline = now + MODEM_PWRKEY_PULSE_MS;
+        break;
+    case POWERDOWN_VERIFY:
+        stateDeadline = now + AT_POWERDOWN_SETTLE_MS;
+        break;
+    case PROBE:
+        stateDeadline = now + MODEM_BOOT_TIMEOUT_MS;
+        probeStart = now;
+        nextProbe = now;
+        break;
+    default:
+        break;
+    }
+}
+
+bool ATModem::submit(const char *cmd, uint32_t timeoutMs, ATCallback cb, const char *finalUrc, bool bareResponse)
+{
+    if (state == OFF || state == FAILED)
+        return false;
+    // Once powering down, a caller's command would only run against a module
+    // that is already going away, and its timeout would stall the sequence.
+    if (state == POWERDOWN_WAIT || state == POWERDOWN_VERIFY)
+        return false;
+
+    Command c;
+    c.text = cmd;
+    c.timeoutMs = timeoutMs;
+    c.cb = cb;
+    c.bareResponse = bareResponse;
+    if (finalUrc)
+        c.finalUrc = finalUrc;
+    queue.push_back(c);
+    return true;
+}
+
+bool ATModem::submitWithPayload(const char *cmd, const uint8_t *payload, size_t len, uint32_t timeoutMs, ATCallback cb)
+{
+    if (state == OFF || state == FAILED)
+        return false;
+    if (state == POWERDOWN_WAIT || state == POWERDOWN_VERIFY)
+        return false;
+
+    Command c;
+    c.text = cmd;
+    c.timeoutMs = timeoutMs;
+    c.cb = cb;
+    c.usePrompt = true;
+    c.payload.assign(payload, payload + len);
+    queue.push_back(c);
+    return true;
+}
+
+bool ATModem::captureBinary(size_t n, ATBinarySink sink)
+{
+    if (binaryRemaining || !n)
+        return false;
+
+    binarySink = sink;
+    binaryBuf.clear();
+    binaryBuf.reserve(n);
+    binaryRemaining = n;
+    binaryDeadline = millis() + AT_BINARY_TIMEOUT_MS;
+    return true;
+}
+
+void ATModem::cancelActive()
+{
+    if (commandActive || awaitingFinalUrc)
+        finish(ATResult::Error);
+}
+
+void ATModem::registerUrc(const char *prefix, ATUrcHandler handler)
+{
+    urcHandlers.push_back(std::make_pair(String(prefix), handler));
+}
+
+void ATModem::startNextCommand()
+{
+    if (commandActive || awaitingFinalUrc || queue.empty())
+        return;
+
+    active = queue.front();
+    queue.erase(queue.begin());
+    response = "";
+    commandActive = true;
+    promptPending = active.usePrompt;
+    commandDeadline = millis() + active.timeoutMs;
+
+    LOG_DEBUG("AT tx: %s", active.text.c_str());
+    MODEM_SERIAL.print(active.text);
+    MODEM_SERIAL.print("\r\n");
+}
+
+void ATModem::finish(ATResult result)
+{
+    commandActive = false;
+    awaitingFinalUrc = false;
+    promptPending = false;
+
+    ATCallback cb = active.cb;
+    String r = response;
+    active = Command();
+    response = "";
+
+    if (cb)
+        cb(result, r);
+}
+
+void ATModem::dispatchUrc(const String &line)
+{
+    for (auto &h : urcHandlers) {
+        if (line.startsWith(h.first)) {
+            h.second(line);
+            return;
+        }
+    }
+    LOG_DEBUG("AT urc: %s", line.c_str());
+}
+
+void ATModem::handleLine(const String &line)
+{
+    if (line.length() == 0)
+        return;
+
+#ifdef CELL_DEBUG
+    LOG_DEBUG("AT rx: %s", line.c_str());
+#endif
+
+    if (awaitingFinalUrc) {
+        if (line.startsWith(active.finalUrc)) {
+            response = line;
+            finish(ATResult::Ok);
+        } else {
+            dispatchUrc(line);
+        }
+        return;
+    }
+
+    if (!commandActive) {
+        dispatchUrc(line);
+        return;
+    }
+
+    // Echo of our own command, before ATE0 takes effect.
+    if (line == active.text)
+        return;
+
+    // Some commands answer with one line and no OK/ERROR at all.
+    if (active.bareResponse && line != "OK") {
+        response = line;
+        finish(line.startsWith("ERROR") || line.startsWith("+CME ERROR:") ? ATResult::Error : ATResult::Ok);
+        return;
+    }
+
+    // Data-mode result codes, which replace OK/ERROR entirely for a payload send.
+    if (line == "SEND OK") {
+        finish(ATResult::Ok);
+        return;
+    }
+    if (line == "SEND FAIL") {
+        response = line;
+        finish(ATResult::Error);
+        return;
+    }
+
+    // A payload command's OK is only the prompt's precursor, never completion.
+    if (active.usePrompt && line == "OK")
+        return;
+
+    // "SHUT OK" is accepted alongside OK so a dialect that terminates a
+    // command with its own success code still completes here.
+    if (line == "OK" || line == "SHUT OK") {
+        if (active.finalUrc.length()) {
+            awaitingFinalUrc = true; // OK is acceptance, not completion
+            commandActive = false;
+        } else {
+            finish(ATResult::Ok);
+        }
+        return;
+    }
+
+    if (line == "ERROR" || line.startsWith("+CME ERROR:") || line.startsWith("+CMS ERROR:")) {
+        response = line;
+        finish(ATResult::Error);
+        return;
+    }
+
+    // A URC can arrive in the middle of a command; route it rather than let it
+    // corrupt the response.
+    for (auto &h : urcHandlers) {
+        if (line.startsWith(h.first)) {
+            h.second(line);
+            return;
+        }
+    }
+
+    if (response.length())
+        response += "\n";
+    response += line;
+}
+
+void ATModem::pumpSerial()
+{
+    while (MODEM_SERIAL.available()) {
+        char c = (char)MODEM_SERIAL.read();
+
+        // A binary capture owns the stream until it is satisfied - payload
+        // bytes are not lines and must not touch the line buffer.
+        if (binaryRemaining) {
+            binaryBuf.push_back((uint8_t)c);
+            if (--binaryRemaining == 0) {
+                ATBinarySink sink = binarySink;
+                binarySink = nullptr;
+                if (sink)
+                    sink(binaryBuf.data(), binaryBuf.size());
+                binaryBuf.clear();
+            }
+            continue;
+        }
+
+        // The prompt has no line terminator, so it is matched on the raw stream.
+        if (promptPending && c == '>') {
+            promptPending = false;
+            rxLine = "";
+            if (!active.payload.empty())
+                MODEM_SERIAL.write(active.payload.data(), active.payload.size());
+            continue;
+        }
+
+        if (c == '\r')
+            continue;
+        if (c == '\n') {
+            String line = rxLine;
+            rxLine = "";
+            line.trim();
+            handleLine(line);
+            continue;
+        }
+        if (rxLine.length() < AT_LINE_MAX)
+            rxLine += c;
+    }
+}
+
+String ATModem::stripPrefix(const String &line, const char *prefix)
+{
+    String s = line;
+    if (s.startsWith(prefix))
+        s = s.substring(strlen(prefix));
+    s.trim();
+    if (s.startsWith(":"))
+        s = s.substring(1);
+    s.trim();
+    if (s.length() >= 2 && s.startsWith("\"") && s.endsWith("\""))
+        s = s.substring(1, s.length() - 1);
+    return s;
+}
+
+void ATModem::sessionInit()
+{
+    submit("ATE0");
+    submit("AT+CMEE=2");
+    submit("AT+CGMM", 5000, [this](ATResult r, const String &resp) {
+        if (r == ATResult::Ok)
+            model = stripPrefix(resp, "+CGMM");
+    });
+    queryVersion();
+}
+
+void ATModem::queryVersion()
+{
+    submit("AT+CGMR", 5000, [this](ATResult r, const String &resp) {
+        if (r == ATResult::Ok)
+            version = stripPrefix(resp, "+CGMR");
+    });
+}
+
+void ATModem::resetModule(ATCallback cb)
+{
+    submit("AT+CFUN=1,1", 5000, cb);
+}
+
+bool ATModem::powerDown(ATCallback cb)
+{
+    (void)cb;
+    return false;
+}
+
+bool ATModem::querySimDetect(ATCallback cb)
+{
+    (void)cb;
+    return false;
+}
+
+bool ATModem::queryBand(ATBandCallback cb)
+{
+    (void)cb;
+    return false;
+}
+
+bool ATModem::queryBatteryMv(ATBatteryCallback cb)
+{
+    (void)cb;
+    return false;
+}
+
+void ATModem::onReady()
+{
+    LOG_INFO("Cell modem ready - model '%s' version '%s'", model.c_str(), version.c_str());
+}
+
+int32_t ATModem::runOnce()
+{
+    service();
+    return AT_TICK_MS;
+}
+
+void ATModem::service()
+{
+    if (state == OFF)
+        return;
+
+    pumpSerial();
+    uint32_t now = millis();
+
+    if (binaryRemaining && (int32_t)(now - binaryDeadline) >= 0) {
+        LOG_WARN("AT binary capture short by %u bytes", (unsigned)binaryRemaining);
+        binaryRemaining = 0;
+        ATBinarySink sink = binarySink;
+        binarySink = nullptr;
+        if (sink)
+            sink(binaryBuf.data(), binaryBuf.size());
+        binaryBuf.clear();
+    }
+
+    switch (state) {
+#ifdef PIN_MODEM_EN
+    case EN_OFF_HOLD:
+        if ((int32_t)(now - stateDeadline) >= 0) {
+            digitalWrite(PIN_MODEM_EN, MODEM_EN_VALUE);
+            setState(EN_ON);
+        }
+        break;
+
+    case EN_ON:
+        if ((int32_t)(now - stateDeadline) >= 0) {
+#ifdef PIN_MODEM_PWRKEY
+            setState(PWRKEY_IDLE);
+#else
+            setState(PROBE);
+#endif
+        }
+        break;
+#endif
+
+#ifdef PIN_MODEM_PWRKEY
+    case PWRKEY_IDLE:
+        if ((int32_t)(now - stateDeadline) >= 0) {
+            digitalWrite(PIN_MODEM_PWRKEY, MODEM_PWRKEY_VALUE);
+            setState(PWRKEY_ASSERT);
+        }
+        break;
+
+    case PWRKEY_ASSERT:
+        if ((int32_t)(now - stateDeadline) >= 0) {
+            digitalWrite(PIN_MODEM_PWRKEY, !MODEM_PWRKEY_VALUE);
+            if (pulseToOff) {
+                pulseToOff = false;
+                LOG_INFO("Cell modem PWRKEY pulsed to power off");
+                setState(OFF);
+            } else {
+                LOG_INFO("Cell modem PWRKEY pulsed, waiting for AT");
+                setState(PROBE);
+            }
+        }
+        break;
+#endif
+
+    case POWERDOWN_VERIFY:
+        // Power-down has answered; a module that still replies to AT needs the pulse.
+        if (commandActive || awaitingFinalUrc)
+            break;
+        if ((int32_t)(now - stateDeadline) >= 0) {
+            enqueue("AT", AT_PROBE_INTERVAL_MS, [this](ATResult r, const String &) {
+                if (r != ATResult::Ok) {
+                    LOG_INFO("Cell modem powered down");
+                    setState(OFF);
+                    return;
+                }
+#ifdef PIN_MODEM_PWRKEY
+                LOG_WARN("Cell modem still answering after power-down, pulsing PWRKEY");
+                pulseToOff = true;
+                pinMode(PIN_MODEM_PWRKEY, OUTPUT);
+                digitalWrite(PIN_MODEM_PWRKEY, !MODEM_PWRKEY_VALUE);
+                setState(PWRKEY_IDLE);
+#else
+                // Nothing left to try; treat the modem as off so no further
+                // commands are issued to it.
+                LOG_WARN("Cell modem still answering after power-down and no PWRKEY wired");
+                setState(OFF);
+#endif
+            });
+        }
+        break;
+
+    case PROBE:
+        if (commandActive || awaitingFinalUrc)
+            break;
+        if ((int32_t)(now - stateDeadline) >= 0) {
+            LOG_ERROR("Cell modem did not answer AT within %u ms", (unsigned)MODEM_BOOT_TIMEOUT_MS);
+            setState(FAILED);
+            break;
+        }
+        if ((int32_t)(now - nextProbe) >= 0) {
+            nextProbe = now + AT_PROBE_INTERVAL_MS;
+            submit("AT", AT_PROBE_INTERVAL_MS, [this](ATResult r, const String &) {
+                if (r == ATResult::Ok && state == PROBE) {
+                    LOG_INFO("Cell modem answered AT after %u ms", (unsigned)(millis() - probeStart));
+                    setState(SESSION);
+                    sessionInit();
+                }
+            });
+        }
+        break;
+
+    case SESSION:
+        if (!commandActive && !awaitingFinalUrc && queue.empty()) {
+            setState(READY);
+            onReady();
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    if ((commandActive || awaitingFinalUrc) && (int32_t)(now - commandDeadline) >= 0) {
+        LOG_WARN("AT timeout: %s", active.text.c_str());
+        finish(ATResult::Timeout);
+    }
+
+    startNextCommand();
+}
+
+#endif

--- a/src/mesh/cell/ATModem.cpp
+++ b/src/mesh/cell/ATModem.cpp
@@ -67,9 +67,13 @@ void ATModem::enqueue(const char *cmd, uint32_t timeoutMs, ATCallback cb)
 // Shared teardown for restart() and expectReboot().
 void ATModem::clearSession()
 {
-    // A command genuinely in flight has its callback invoked with Error rather than
-    // dropped silently, so every submitted command's "called exactly once" contract
-    // holds even across a restart/power cycle.
+    // Every submitted command's callback runs exactly once, even across a restart:
+    // drain the queue first so each of its callbacks still gets notified below,
+    // rather than being silently dropped by the queue.clear() that follows
+    // cancelActive() - which stays, to discard anything submit() adds from the
+    // active callback, since the module hasn't finished restarting.
+    std::vector<Command> dropped;
+    dropped.swap(queue);
     cancelActive();
     queue.clear();
     commandActive = false;
@@ -77,9 +81,16 @@ void ATModem::clearSession()
     active = Command();
     response = "";
     rxLine = "";
+    binaryRemaining = 0;
+    binarySink = nullptr;
+    binaryBuf.clear();
     model = "";
     version = "";
     pulseToOff = false;
+
+    for (auto &c : dropped)
+        if (c.cb)
+            c.cb(ATResult::Error, "");
 }
 
 void ATModem::restart()
@@ -250,15 +261,33 @@ void ATModem::finish(ATResult result)
         cb(result, r);
 }
 
-void ATModem::dispatchUrc(const String &line)
+// Looks up and runs the handler for line's prefix. Returns false, without
+// logging, when nothing matches - the mid-command caller in handleLine() uses
+// that to fall through to response accumulation rather than treat every
+// non-URC response line as an unrecognized URC.
+bool ATModem::tryDispatchUrc(const String &line)
 {
     for (auto &h : urcHandlers) {
         if (line.startsWith(h.first)) {
             h.second(line);
-            return;
+            return true;
         }
     }
-    LOG_DEBUG("AT urc: %s", line.c_str());
+    return false;
+}
+
+void ATModem::dispatchUrc(const String &line)
+{
+    if (!tryDispatchUrc(line))
+        LOG_DEBUG("AT urc: %s", line.c_str());
+}
+
+// 3GPP TS 27.007 final result codes that report failure; +CME/+CMS ERROR both
+// carry a diagnostic code after the colon that response accumulation would
+// otherwise capture as an ordinary line.
+bool ATModem::isErrorLine(const String &line)
+{
+    return line == "ERROR" || line.startsWith("+CME ERROR:") || line.startsWith("+CMS ERROR:");
 }
 
 void ATModem::handleLine(const String &line)
@@ -292,7 +321,7 @@ void ATModem::handleLine(const String &line)
     // Some commands answer with one line and no OK/ERROR at all.
     if (active.bareResponse && line != "OK") {
         response = line;
-        finish(line.startsWith("ERROR") || line.startsWith("+CME ERROR:") ? ATResult::Error : ATResult::Ok);
+        finish(isErrorLine(line) ? ATResult::Error : ATResult::Ok);
         return;
     }
 
@@ -323,7 +352,7 @@ void ATModem::handleLine(const String &line)
         return;
     }
 
-    if (line == "ERROR" || line.startsWith("+CME ERROR:") || line.startsWith("+CMS ERROR:")) {
+    if (isErrorLine(line)) {
         response = line;
         finish(ATResult::Error);
         return;
@@ -331,12 +360,8 @@ void ATModem::handleLine(const String &line)
 
     // A URC can arrive in the middle of a command; route it rather than let it
     // corrupt the response.
-    for (auto &h : urcHandlers) {
-        if (line.startsWith(h.first)) {
-            h.second(line);
-            return;
-        }
-    }
+    if (tryDispatchUrc(line))
+        return;
 
     if (response.length())
         response += "\n";

--- a/src/mesh/cell/ATModem.cpp
+++ b/src/mesh/cell/ATModem.cpp
@@ -82,6 +82,7 @@ void ATModem::clearSession()
     response = "";
     rxLine = "";
     binaryRemaining = 0;
+    binaryDiscard = false;
     binarySink = nullptr;
     binaryBuf.clear();
     model = "";
@@ -213,6 +214,18 @@ bool ATModem::captureBinary(size_t n, ATBinarySink sink)
     binarySink = sink;
     binaryBuf.clear();
     binaryBuf.reserve(n);
+    binaryRemaining = n;
+    binaryDeadline = millis() + AT_BINARY_TIMEOUT_MS;
+    return true;
+}
+
+bool ATModem::discardBinary(size_t n)
+{
+    if (binaryRemaining || !n)
+        return false;
+
+    binarySink = nullptr;
+    binaryDiscard = true;
     binaryRemaining = n;
     binaryDeadline = millis() + AT_BINARY_TIMEOUT_MS;
     return true;
@@ -376,8 +389,10 @@ void ATModem::pumpSerial()
         // A binary capture owns the stream until it is satisfied - payload
         // bytes are not lines and must not touch the line buffer.
         if (binaryRemaining) {
-            binaryBuf.push_back((uint8_t)c);
+            if (!binaryDiscard)
+                binaryBuf.push_back((uint8_t)c);
             if (--binaryRemaining == 0) {
+                binaryDiscard = false;
                 ATBinarySink sink = binarySink;
                 binarySink = nullptr;
                 if (sink)
@@ -494,6 +509,7 @@ void ATModem::service()
     if (binaryRemaining && (int32_t)(now - binaryDeadline) >= 0) {
         LOG_WARN("AT binary capture short by %u bytes", (unsigned)binaryRemaining);
         binaryRemaining = 0;
+        binaryDiscard = false;
         ATBinarySink sink = binarySink;
         binarySink = nullptr;
         if (sink)

--- a/src/mesh/cell/ATModem.cpp
+++ b/src/mesh/cell/ATModem.cpp
@@ -487,6 +487,13 @@ bool ATModem::queryBatteryMv(ATBatteryCallback cb)
     return false;
 }
 
+void ATModem::socketSetTls(bool enabled, ATCallback cb)
+{
+    (void)enabled;
+    if (cb)
+        cb(ATResult::Error, "");
+}
+
 void ATModem::onReady()
 {
     LOG_INFO("Cell modem ready - model '%s' version '%s'", model.c_str(), version.c_str());

--- a/src/mesh/cell/ATModem.h
+++ b/src/mesh/cell/ATModem.h
@@ -133,6 +133,11 @@ class ATModem : public concurrency::OSThread
     // from a URC handler whose header line is immediately followed by binary payload.
     bool captureBinary(size_t n, ATBinarySink sink);
 
+    // Divert and drop the next n bytes off the UART without buffering them - for a payload
+    // the driver has decided not to keep (oversized), so line framing still resyncs after it
+    // without the unbounded allocation captureBinary() would need to hold all of it at once.
+    bool discardBinary(size_t n);
+
     // Abandon the command in flight so the queue moves on - for a deferred-result command
     // whose outcome arrived as a URC the caller recognised but the registered final URC did not.
     void cancelActive();
@@ -256,6 +261,7 @@ class ATModem : public concurrency::OSThread
     std::vector<uint8_t> binaryBuf;
     size_t binaryRemaining = 0;
     uint32_t binaryDeadline = 0;
+    bool binaryDiscard = false; // true: drop the diverted bytes instead of buffering them
 
     String rxLine;
     uint32_t stateDeadline = 0; // pulse/boot timeout, per state

--- a/src/mesh/cell/ATModem.h
+++ b/src/mesh/cell/ATModem.h
@@ -1,0 +1,266 @@
+#pragma once
+
+#include "configuration.h"
+
+#if HAS_CELLULAR
+
+#include "concurrency/OSThread.h"
+#include <Arduino.h>
+#include <functional>
+#include <vector>
+
+// UART framing and the 3GPP TS 27.007 command set every AT modem implements. Dialect-specific
+// behavior lives behind the hooks below, in a driver subclass (see EC618Modem).
+
+#ifndef MODEM_SERIAL
+#define MODEM_SERIAL Serial1
+#endif
+
+#ifndef MODEM_BAUD
+#define MODEM_BAUD 115200
+#endif
+
+#ifndef MODEM_PWRKEY_PULSE_MS
+#define MODEM_PWRKEY_PULSE_MS 1000
+#endif
+
+// How long the EN rail is held inactive before re-enabling it, so the output cap
+// (these modules typically carry a tantalum on the rail) has time to fully drain.
+#ifndef MODEM_EN_OFF_MS
+#define MODEM_EN_OFF_MS 5000
+#endif
+
+// Settle time on the rail before PWRKEY is touched.
+#ifndef MODEM_EN_SETTLE_MS
+#define MODEM_EN_SETTLE_MS 100
+#endif
+
+#ifndef MODEM_BOOT_TIMEOUT_MS
+#define MODEM_BOOT_TIMEOUT_MS 10000
+#endif
+
+// Longest single line accepted from the modem; longer lines are truncated.
+#define AT_LINE_MAX 256
+
+// Longest wait for the power-down command to answer before falling back to
+// PWRKEY. Used by drivers implementing powerDown().
+#define AT_POWERDOWN_TIMEOUT_MS 10000
+
+enum class ATResult { Ok, Error, Timeout };
+
+// Terminal result of a command, with the informational lines it produced
+// (final OK/ERROR excluded, newline separated).
+typedef std::function<void(ATResult, const String &)> ATCallback;
+typedef std::function<void(const String &)> ATUrcHandler;
+
+// Receives raw bytes captured outside line framing. Called once per capture,
+// with fewer bytes than requested only if the capture timed out.
+typedef std::function<void(const uint8_t *, size_t)> ATBinarySink;
+
+// Results of the diagnostic hooks, parsed by the driver so the sweep never sees a vendor
+// response format; valid is false when the module answered but the reading could not be parsed.
+typedef std::function<void(ATResult, bool valid, uint8_t band, uint8_t act)> ATBandCallback;
+typedef std::function<void(ATResult, bool valid, uint16_t millivolts)> ATBatteryCallback;
+
+// Socket events the driver raises from its own URC handlers, so the Client
+// implementation never matches a dialect's URC strings itself.
+struct ATSocketEvents {
+    std::function<void(const uint8_t *, size_t)> onData;
+    std::function<void(const char *why)> onClosed;
+    std::function<void()> onConnected;
+    std::function<void()> onConnectFail;
+    // Whether the module is holding unread bytes for us to fetch.
+    std::function<void(bool)> onRxPending;
+};
+
+class ATModem : public concurrency::OSThread
+{
+  public:
+    enum State {
+        OFF,
+        EN_OFF_HOLD,
+        EN_ON,
+        PWRKEY_IDLE,
+        PWRKEY_ASSERT,
+        PROBE,
+        SESSION,
+        READY,
+        FAILED,
+        POWERDOWN_WAIT,
+        POWERDOWN_VERIFY
+    };
+
+    // Bring-up sub-steps the bearer walks; the driver supplies the commands.
+    enum BearerStep { BEARER_SHUT, BEARER_CSTT, BEARER_CIICR, BEARER_CIFSR };
+
+    ATModem();
+    virtual ~ATModem() {}
+
+    void start();
+
+    // Drop any queued work and re-run the power-on sequence. Used when the
+    // modem has reset or gone silent, and after powerOff() leaves it off.
+    void restart();
+
+    // Drop any queued work and wait for the module to answer AT again, without touching
+    // PWRKEY - pulsing it mid-boot during an in-place AT+RESET could power the module off.
+    void expectReboot();
+
+    // Power the module down via powerDown(), falling back to a PWRKEY pulse if
+    // it keeps answering. Ends in OFF, where submit() rejects everything.
+    void powerOff();
+
+    // Bring a module powered down by powerOff() back up from OFF.
+    void powerUp();
+
+    State getState() const { return state; }
+    bool isOff() const { return state == OFF; }
+    bool isReady() const { return state == READY; }
+
+    // Queue an AT command. finalUrc defers cb from OK to a later URC with that prefix;
+    // bareResponse completes on the first line received, for commands with no OK/ERROR at all.
+    bool submit(const char *cmd, uint32_t timeoutMs = 5000, ATCallback cb = nullptr, const char *finalUrc = nullptr,
+                bool bareResponse = false);
+
+    // Queue a command that answers with a '>' prompt, after which payload is
+    // written as raw bytes. Completes on SEND OK / SEND FAIL.
+    bool submitWithPayload(const char *cmd, const uint8_t *payload, size_t len, uint32_t timeoutMs = 20000,
+                           ATCallback cb = nullptr);
+
+    void registerUrc(const char *prefix, ATUrcHandler handler);
+
+    // Divert the next n bytes off the UART straight to sink, bypassing line framing. Call
+    // from a URC handler whose header line is immediately followed by binary payload.
+    bool captureBinary(size_t n, ATBinarySink sink);
+
+    // Abandon the command in flight so the queue moves on - for a deferred-result command
+    // whose outcome arrived as a URC the caller recognised but the registered final URC did not.
+    void cancelActive();
+
+    // Run one service pass. The scheduler calls this via runOnce(); callers that
+    // must block on a modem result (the Client API) pump it directly.
+    void service();
+
+    // Drop a leading "<prefix>: " and any surrounding quotes from a response line.
+    static String stripPrefix(const String &line, const char *prefix);
+
+    const String &getModel() const { return model; }
+    const String &getVersion() const { return version; }
+
+    // --- Driver hooks --- defaults are 3GPP TS 27.007, or a no-op returning false; a
+    // driver overrides only what its module differs on.
+
+    // Reboot the module in place, without touching PWRKEY.
+    virtual void resetModule(ATCallback cb);
+
+    // Ask the module to power itself down, via enqueue() since state is already
+    // POWERDOWN_WAIT. False leaves powerOff() to fall straight through to the PWRKEY pulse.
+    virtual bool powerDown(ATCallback cb);
+
+    // Report why the module cannot read the SIM. False when unsupported.
+    virtual bool querySimDetect(ATCallback cb);
+
+    // Whether the module reports SIM insertion/removal on its own; when it does not, it
+    // only reads the SIM at boot, so a card inserted later is invisible until reset.
+    virtual bool hasSimHotplug() const { return false; }
+
+    // Serving band and access technology. False when unsupported, and the
+    // diagnostic sweep skips the step.
+    virtual bool queryBand(ATBandCallback cb);
+
+    // Module supply voltage. False when unsupported.
+    virtual bool queryBatteryMv(ATBatteryCallback cb);
+
+    // Run one step of the bearer bring-up. For BEARER_CIFSR the callback's
+    // response is the local address alone, with any dialect prefix removed.
+    virtual void bringUpBearer(BearerStep step, ATCallback cb) = 0;
+
+    // Install the socket event callbacks and register the driver's URC handlers.
+    virtual void socketAttach(const ATSocketEvents &events) = 0;
+
+    // Put the socket into manual-receive mode, so payload bytes never arrive
+    // interleaved with command responses.
+    virtual void socketRxMode(ATCallback cb) = 0;
+
+    // Open a TCP connection. OK from the callback means connected; drivers whose
+    // command only acknowledges must defer the callback to the outcome URC.
+    virtual void socketOpen(const char *host, uint16_t port, ATCallback cb) = 0;
+    virtual void socketSend(const uint8_t *buf, size_t len, ATCallback cb) = 0;
+
+    // Fetch up to want buffered bytes, delivered through ATSocketEvents::onData.
+    virtual void socketRecv(size_t want, uint32_t timeoutMs, ATCallback cb) = 0;
+    virtual void socketClose(ATCallback cb) = 0;
+
+    // Largest single send and receive the dialect's commands accept.
+    virtual size_t socketSendMax() const = 0;
+    virtual size_t socketRecvMax() const = 0;
+
+    // How long socketOpen() may take to settle, which the caller also waits on.
+    virtual uint32_t socketConnectTimeoutMs() const = 0;
+
+  protected:
+    int32_t runOnce() override;
+
+    // Commands run once the modem answers AT. Subclasses extend this.
+    virtual void sessionInit();
+
+    // Called when sessionInit()'s commands have all completed.
+    virtual void onReady();
+
+    // Firmware revision, stored into version. Overridden where the module does
+    // not implement the 3GPP command.
+    virtual void queryVersion();
+
+    // Queue a command without the state checks submit() applies, for the
+    // power-down sequence's own commands.
+    void enqueue(const char *cmd, uint32_t timeoutMs, ATCallback cb);
+
+    String model, version;
+
+  private:
+    struct Command {
+        String text;
+        uint32_t timeoutMs;
+        ATCallback cb;
+        String finalUrc;
+        bool bareResponse = false;
+        bool usePrompt = false;
+        std::vector<uint8_t> payload;
+    };
+
+    void powerOn();
+    void clearSession();
+    void setState(State next);
+    void pumpSerial();
+    void handleLine(const String &line);
+    void dispatchUrc(const String &line);
+    void finish(ATResult result);
+    void startNextCommand();
+
+    State state = OFF;
+    bool pulseToOff = false; // the pulse in flight is powering the module down
+    std::vector<Command> queue;
+    std::vector<std::pair<String, ATUrcHandler>> urcHandlers;
+
+    bool commandActive = false;    // a command has been written, awaiting terminator
+    bool awaitingFinalUrc = false; // terminator seen, waiting on the deferred URC
+    Command active;
+    String response;
+    uint32_t commandDeadline = 0;
+
+    bool promptPending = false; // command written, awaiting '>' before the payload
+
+    ATBinarySink binarySink;
+    std::vector<uint8_t> binaryBuf;
+    size_t binaryRemaining = 0;
+    uint32_t binaryDeadline = 0;
+
+    String rxLine;
+    uint32_t stateDeadline = 0; // pulse/boot timeout, per state
+    uint32_t nextProbe = 0;
+    uint32_t probeStart = 0; // when probing began, for the time-to-first-AT log
+};
+
+extern ATModem *cellModem;
+
+#endif

--- a/src/mesh/cell/ATModem.h
+++ b/src/mesh/cell/ATModem.h
@@ -187,6 +187,10 @@ class ATModem : public concurrency::OSThread
     // interleaved with command responses.
     virtual void socketRxMode(ATCallback cb) = 0;
 
+    // Ask the module to enable/disable TLS on the next socket it opens. Base default
+    // fails closed for dialects that don't implement it - see EC618Modem for the real one.
+    virtual void socketSetTls(bool enabled, ATCallback cb);
+
     // Open a TCP connection. OK from the callback means connected; drivers whose
     // command only acknowledges must defer the callback to the outcome URC.
     virtual void socketOpen(const char *host, uint16_t port, ATCallback cb) = 0;

--- a/src/mesh/cell/ATModem.h
+++ b/src/mesh/cell/ATModem.h
@@ -234,6 +234,8 @@ class ATModem : public concurrency::OSThread
     void pumpSerial();
     void handleLine(const String &line);
     void dispatchUrc(const String &line);
+    bool tryDispatchUrc(const String &line);
+    static bool isErrorLine(const String &line);
     void finish(ATResult result);
     void startNextCommand();
 

--- a/src/mesh/cell/ATModem.h
+++ b/src/mesh/cell/ATModem.h
@@ -96,6 +96,7 @@ class ATModem : public concurrency::OSThread
     ATModem();
     virtual ~ATModem() {}
 
+    // Open the UART and begin the power-on sequence. Call once from setup().
     void start();
 
     // Drop any queued work and re-run the power-on sequence. Used when the
@@ -127,6 +128,8 @@ class ATModem : public concurrency::OSThread
     bool submitWithPayload(const char *cmd, const uint8_t *payload, size_t len, uint32_t timeoutMs = 20000,
                            ATCallback cb = nullptr);
 
+    // Register a handler invoked whenever a line arrives whose prefix matches, outside
+    // normal command/response framing (e.g. +CIPRXGET, +CREG).
     void registerUrc(const char *prefix, ATUrcHandler handler);
 
     // Divert the next n bytes off the UART straight to sink, bypassing line framing. Call

--- a/src/mesh/cell/CellClient.cpp
+++ b/src/mesh/cell/CellClient.cpp
@@ -132,6 +132,7 @@ int CellClient::connect(const char *host, uint16_t port)
     cellModem->socketRxMode([rxModeDone](ATResult, const String &) { *rxModeDone = true; });
     if (!waitFor([rxModeDone] { return *rxModeDone; }, 5000)) {
         LOG_ERROR("Cell modem did not accept manual receive mode");
+        cellModem->cancelActive();
         return 0;
     }
 
@@ -195,6 +196,8 @@ size_t CellClient::write(const uint8_t *buf, size_t size)
         waitFor([finished] { return *finished; }, 20000);
         if (!*finished || *result != ATResult::Ok) {
             LOG_WARN("Cell send of %u bytes failed after %u sent", (unsigned)chunk, (unsigned)sent);
+            if (!*finished)
+                cellModem->cancelActive();
             socketClosed("send failed");
             return sent;
         }

--- a/src/mesh/cell/CellClient.cpp
+++ b/src/mesh/cell/CellClient.cpp
@@ -1,0 +1,309 @@
+#include "mesh/cell/CellClient.h"
+
+#if HAS_CELLULAR
+
+#include "mesh/cell/ATModem.h"
+#include "mesh/cell/cellBearer.h"
+#include <memory>
+
+// Bound on a single available()/read() fetch, so the caller's loop keeps turning.
+#define CELL_FETCH_TIMEOUT_MS 2000
+
+// Consecutive AT+CIPRXGET failures before giving up on the socket rather than
+// retrying forever - a caller that polls available() in a tight loop (the vendored
+// PubSubClient's connect() wait, for one) would otherwise flood the shared AT queue.
+#define CELL_RX_FAIL_LIMIT 3
+
+// Single socket, so its state is file scope rather than per-instance.
+static uint8_t rxRing[CELL_RX_BUFFER_SIZE];
+static size_t rxHead = 0, rxTail = 0, rxCount = 0;
+
+static bool sockConnected = false;   // the modem reports the socket up
+static bool sockConnectFail = false; // the pending connect was refused
+static bool rxPending = false;       // the modem is holding unread bytes
+static bool socketAttached = false;
+static uint8_t rxFailCount = 0; // consecutive AT+CIPRXGET failures
+
+static void rxPush(const uint8_t *data, size_t len)
+{
+    size_t space = CELL_RX_BUFFER_SIZE - rxCount;
+    if (len > space) {
+        LOG_WARN("Cell RX buffer full, dropping %u bytes", (unsigned)(len - space));
+        len = space;
+    }
+    for (size_t i = 0; i < len; i++) {
+        rxRing[rxHead] = data[i];
+        rxHead = (rxHead + 1) % CELL_RX_BUFFER_SIZE;
+        rxCount++;
+    }
+}
+
+static int rxPop()
+{
+    if (!rxCount)
+        return -1;
+    int c = rxRing[rxTail];
+    rxTail = (rxTail + 1) % CELL_RX_BUFFER_SIZE;
+    rxCount--;
+    return c;
+}
+
+static void rxReset()
+{
+    rxHead = rxTail = rxCount = 0;
+}
+
+static void socketClosed(const char *why)
+{
+    if (sockConnected)
+        LOG_INFO("Cell socket closed (%s)", why);
+    sockConnected = false;
+    rxPending = false;
+    rxFailCount = 0;
+}
+
+void CellClient::ensureUrcHandlers()
+{
+    if (socketAttached || !cellModem)
+        return;
+    socketAttached = true;
+
+    ATSocketEvents events;
+    events.onData = [](const uint8_t *data, size_t n) { rxPush(data, n); };
+    events.onClosed = [](const char *why) { socketClosed(why); };
+    events.onConnected = [] { sockConnected = true; };
+    events.onConnectFail = [] { sockConnectFail = true; };
+    events.onRxPending = [](bool pending) { rxPending = pending; };
+    cellModem->socketAttach(events);
+}
+
+bool CellClient::waitFor(std::function<bool()> done, uint32_t timeoutMs)
+{
+    uint32_t deadline = millis() + timeoutMs;
+    while (!done()) {
+        if ((int32_t)(millis() - deadline) >= 0)
+            return done();
+        cellModem->service();
+        delay(1);
+    }
+    return true;
+}
+
+CellClient::~CellClient()
+{
+    if (opened)
+        stop();
+}
+
+int CellClient::connect(IPAddress ip, uint16_t port)
+{
+    char buf[16];
+    snprintf(buf, sizeof(buf), "%u.%u.%u.%u", ip[0], ip[1], ip[2], ip[3]);
+    return connect(buf, port);
+}
+
+int CellClient::connect(const char *host, uint16_t port)
+{
+    if (!cellModem || !isCellularAvailable()) {
+        LOG_WARN("Cell connect refused: bearer is %s", getCellStateName(getCellState()));
+        return 0;
+    }
+
+    // An IPv6 literal is silently read as its first four octets by the AT socket
+    // API, so reject it here rather than let it fail as a wrong address.
+    if (strchr(host, ':')) {
+        LOG_ERROR("Cell socket is IPv4 only, refusing '%s'", host);
+        return 0;
+    }
+
+    if (opened)
+        stop();
+
+    ensureUrcHandlers();
+    rxReset();
+    sockConnected = false;
+    sockConnectFail = false;
+    rxPending = false;
+    rxFailCount = 0;
+
+    // Manual receive mode, so payload bytes never arrive interleaved with
+    // command responses.
+    auto rxModeDone = std::make_shared<bool>(false);
+    cellModem->socketRxMode([rxModeDone](ATResult, const String &) { *rxModeDone = true; });
+    if (!waitFor([rxModeDone] { return *rxModeDone; }, 5000)) {
+        LOG_ERROR("Cell modem did not accept manual receive mode");
+        return 0;
+    }
+
+    uint32_t connectTimeout = cellModem->socketConnectTimeoutMs();
+    auto result = std::make_shared<ATResult>(ATResult::Timeout);
+    auto finished = std::make_shared<bool>(false);
+
+    cellModem->socketOpen(host, port, [result, finished](ATResult r, const String &) {
+        *result = r;
+        *finished = true;
+    });
+
+    bool settled = waitFor([finished] { return *finished || sockConnected || sockConnectFail; }, connectTimeout);
+
+    // The outcome came as a URC the driver's final-URC match did not cover, or
+    // not at all; either way the open is still holding the queue.
+    if (!*finished)
+        cellModem->cancelActive();
+
+    bool ok = sockConnected || (*finished && *result == ATResult::Ok);
+    if (!ok || sockConnectFail) {
+        LOG_WARN("Cell connect to %s:%u %s", host, port, settled ? "failed" : "timed out");
+        sockConnectFail = false;
+        sockConnected = false;
+        opened = true; // so stop() closes the socket and clears any half-open state
+        stop();
+        return 0;
+    }
+
+    sockConnected = true;
+    opened = true;
+    LOG_INFO("Cell socket connected to %s:%u", host, port);
+    return 1;
+}
+
+size_t CellClient::write(uint8_t b)
+{
+    return write(&b, 1);
+}
+
+size_t CellClient::write(const uint8_t *buf, size_t size)
+{
+    if (!cellModem || !connected())
+        return 0;
+
+    size_t sendMax = cellModem->socketSendMax();
+    size_t sent = 0;
+    while (sent < size) {
+        size_t chunk = size - sent;
+        if (chunk > sendMax)
+            chunk = sendMax;
+
+        auto result = std::make_shared<ATResult>(ATResult::Timeout);
+        auto finished = std::make_shared<bool>(false);
+
+        cellModem->socketSend(buf + sent, chunk, [result, finished](ATResult r, const String &) {
+            *result = r;
+            *finished = true;
+        });
+
+        waitFor([finished] { return *finished; }, 20000);
+        if (!*finished || *result != ATResult::Ok) {
+            LOG_WARN("Cell send of %u bytes failed after %u sent", (unsigned)chunk, (unsigned)sent);
+            socketClosed("send failed");
+            return sent;
+        }
+        sent += chunk;
+    }
+    return sent;
+}
+
+void CellClient::fetchPending(uint32_t timeoutMs)
+{
+    if (!rxPending || !cellModem)
+        return;
+
+    size_t want = CELL_RX_BUFFER_SIZE - rxCount;
+    if (!want)
+        return;
+    size_t recvMax = cellModem->socketRecvMax();
+    if (want > recvMax)
+        want = recvMax;
+
+    auto result = std::make_shared<ATResult>(ATResult::Timeout);
+    auto finished = std::make_shared<bool>(false);
+    cellModem->socketRecv(want, timeoutMs, [result, finished](ATResult r, const String &) {
+        *result = r;
+        *finished = true;
+    });
+    waitFor([finished] { return *finished; }, timeoutMs);
+
+    if (*result == ATResult::Ok) {
+        rxFailCount = 0;
+        return;
+    }
+
+    // No well-formed +CIPRXGET line came back to clear rxPending, so without this
+    // the next available() would retry immediately, forever - give up on the socket
+    // instead of flooding the shared AT queue with a request that keeps failing.
+    if (++rxFailCount >= CELL_RX_FAIL_LIMIT)
+        socketClosed("rx stalled");
+}
+
+int CellClient::available()
+{
+    if (cellModem)
+        cellModem->service();
+
+    if (!rxCount)
+        fetchPending(CELL_FETCH_TIMEOUT_MS);
+
+    return (int)rxCount;
+}
+
+int CellClient::read()
+{
+    if (!rxCount && !available())
+        return -1;
+    return rxPop();
+}
+
+int CellClient::read(uint8_t *buf, size_t size)
+{
+    if (!rxCount && !available())
+        return -1;
+
+    size_t n = 0;
+    while (n < size && rxCount)
+        buf[n++] = (uint8_t)rxPop();
+    return (int)n;
+}
+
+int CellClient::peek()
+{
+    if (!rxCount && !available())
+        return -1;
+    return rxRing[rxTail];
+}
+
+void CellClient::flush()
+{
+    // write() only returns once the modem has answered SEND OK, so there is
+    // nothing buffered on this side to push.
+}
+
+void CellClient::stop()
+{
+    if (!opened) {
+        sockConnected = false;
+        return;
+    }
+    opened = false;
+
+    if (cellModem) {
+        auto finished = std::make_shared<bool>(false);
+        cellModem->socketClose([finished](ATResult, const String &) { *finished = true; });
+        waitFor([finished] { return *finished; }, 10000);
+    }
+
+    sockConnected = false;
+    rxPending = false;
+    rxReset();
+}
+
+uint8_t CellClient::connected()
+{
+    if (cellModem)
+        cellModem->service();
+
+    // Bytes already buffered stay readable after the peer closes, matching
+    // WiFiClient and what PubSubClient's read loop expects.
+    return (opened && sockConnected) || rxCount > 0;
+}
+
+#endif

--- a/src/mesh/cell/CellClient.cpp
+++ b/src/mesh/cell/CellClient.cpp
@@ -136,12 +136,25 @@ int CellClient::connect(const char *host, uint16_t port)
         return 0;
     }
 
-    // Queued ahead of socketOpen() below - the AT queue is sequential, so this always
-    // completes first. TLS support is assumed here; a rejection only warns, not refuses.
-    cellModem->socketSetTls(tlsRequested, [](ATResult r, const String &resp) {
+    // Wait for AT+CIPSSL to settle before opening the socket, so a rejected TLS request
+    // can refuse the connection instead of silently falling through to plaintext CIPSTART.
+    auto tlsDone = std::make_shared<bool>(false);
+    auto tlsResult = std::make_shared<ATResult>(ATResult::Timeout);
+    cellModem->socketSetTls(tlsRequested, [tlsDone, tlsResult](ATResult r, const String &resp) {
+        *tlsResult = r;
+        *tlsDone = true;
         if (r != ATResult::Ok)
             LOG_WARN("AT+CIPSSL rejected: %s", resp.c_str());
     });
+    if (!waitFor([tlsDone] { return *tlsDone; }, 5000)) {
+        LOG_ERROR("Cell modem did not respond to AT+CIPSSL");
+        cellModem->cancelActive();
+        return 0;
+    }
+    if (tlsRequested && *tlsResult != ATResult::Ok) {
+        LOG_ERROR("Refusing cell connect: AT+CIPSSL rejected, won't fall back to plaintext");
+        return 0;
+    }
 
     uint32_t connectTimeout = cellModem->socketConnectTimeoutMs();
     auto result = std::make_shared<ATResult>(ATResult::Timeout);

--- a/src/mesh/cell/CellClient.cpp
+++ b/src/mesh/cell/CellClient.cpp
@@ -136,6 +136,13 @@ int CellClient::connect(const char *host, uint16_t port)
         return 0;
     }
 
+    // Queued ahead of socketOpen() below - the AT queue is sequential, so this always
+    // completes first. TLS support is assumed here; a rejection only warns, not refuses.
+    cellModem->socketSetTls(tlsRequested, [](ATResult r, const String &resp) {
+        if (r != ATResult::Ok)
+            LOG_WARN("AT+CIPSSL rejected: %s", resp.c_str());
+    });
+
     uint32_t connectTimeout = cellModem->socketConnectTimeoutMs();
     auto result = std::make_shared<ATResult>(ATResult::Timeout);
     auto finished = std::make_shared<bool>(false);
@@ -154,7 +161,7 @@ int CellClient::connect(const char *host, uint16_t port)
 
     bool ok = sockConnected || (*finished && *result == ATResult::Ok);
     if (!ok || sockConnectFail) {
-        LOG_WARN("Cell connect to %s:%u %s", host, port, settled ? "failed" : "timed out");
+        LOG_WARN("Cell %sconnect to %s:%u %s", tlsRequested ? "TLS " : "", host, port, settled ? "failed" : "timed out");
         sockConnectFail = false;
         sockConnected = false;
         opened = true; // so stop() closes the socket and clears any half-open state
@@ -164,7 +171,7 @@ int CellClient::connect(const char *host, uint16_t port)
 
     sockConnected = true;
     opened = true;
-    LOG_INFO("Cell socket connected to %s:%u", host, port);
+    LOG_INFO("Cell %ssocket connected to %s:%u", tlsRequested ? "TLS " : "", host, port);
     return 1;
 }
 

--- a/src/mesh/cell/CellClient.h
+++ b/src/mesh/cell/CellClient.h
@@ -25,19 +25,29 @@ class CellClient : public Client
     ~CellClient() override;
 
     int connect(IPAddress ip, uint16_t port) override;
+
+    // Blocks until AT+CIPSTART settles (OK plus its outcome URC) or socketConnectTimeoutMs()
+    // elapses. Rejects an IPv6 literal outright - the AT socket API is IPv4 only.
     int connect(const char *host, uint16_t port) override;
 
     // Whether to negotiate TLS (AT+CIPSSL); set fresh by the caller before each connect().
     void setTlsEnabled(bool enabled) { tlsRequested = enabled; }
 
     size_t write(uint8_t b) override;
+
+    // Chunks against the dialect's socketSendMax(), blocking per chunk until SEND OK/FAIL.
     size_t write(const uint8_t *buf, size_t size) override;
 
+    // Services the modem and, if the RX ring is empty, asks for more pending bytes.
     int available() override;
     int read() override;
     int read(uint8_t *buf, size_t size) override;
     int peek() override;
+
+    // No-op: write() already blocks until the modem confirms SEND OK, so nothing is buffered here.
     void flush() override;
+
+    // Closes the AT socket (AT+CIPCLOSE) and resets the RX ring; safe to call when not opened.
     void stop() override;
     uint8_t connected() override;
     operator bool() override { return connected(); }
@@ -45,6 +55,7 @@ class CellClient : public Client
     using Print::write;
 
   private:
+    // Idempotent: registers this class's URC handlers with the modem on first use only.
     static void ensureUrcHandlers();
 
     // Pump the modem until done() or the timeout expires.

--- a/src/mesh/cell/CellClient.h
+++ b/src/mesh/cell/CellClient.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "configuration.h"
+
+#if HAS_CELLULAR
+
+#include <Arduino.h>
+#include <Client.h>
+#include <vector>
+
+// Arduino Client over the modem's AT socket API, so PubSubClient and anything else written
+// against Client works unmodified. One socket only, and IPv4 only - the AT socket API cannot carry IPv6.
+
+// RX ring capacity. MQTT's largest expected frame plus headroom; overflowing
+// drops bytes with a log line rather than truncating silently.
+#ifndef CELL_RX_BUFFER_SIZE
+#define CELL_RX_BUFFER_SIZE 2048
+#endif
+
+class CellClient : public Client
+{
+  public:
+    CellClient() {}
+    ~CellClient() override;
+
+    int connect(IPAddress ip, uint16_t port) override;
+    int connect(const char *host, uint16_t port) override;
+
+    size_t write(uint8_t b) override;
+    size_t write(const uint8_t *buf, size_t size) override;
+
+    int available() override;
+    int read() override;
+    int read(uint8_t *buf, size_t size) override;
+    int peek() override;
+    void flush() override;
+    void stop() override;
+    uint8_t connected() override;
+    operator bool() override { return connected(); }
+
+    using Print::write;
+
+  private:
+    static void ensureUrcHandlers();
+
+    // Pump the modem until done() or the timeout expires.
+    static bool waitFor(std::function<bool()> done, uint32_t timeoutMs);
+
+    // Ask the modem for up to CELL_RX_BUFFER_SIZE pending bytes.
+    void fetchPending(uint32_t timeoutMs);
+
+    bool opened = false;
+};
+
+#endif

--- a/src/mesh/cell/CellClient.h
+++ b/src/mesh/cell/CellClient.h
@@ -6,6 +6,7 @@
 
 #include <Arduino.h>
 #include <Client.h>
+#include <functional>
 #include <vector>
 
 // Arduino Client over the modem's AT socket API, so PubSubClient and anything else written

--- a/src/mesh/cell/CellClient.h
+++ b/src/mesh/cell/CellClient.h
@@ -27,6 +27,9 @@ class CellClient : public Client
     int connect(IPAddress ip, uint16_t port) override;
     int connect(const char *host, uint16_t port) override;
 
+    // Whether to negotiate TLS (AT+CIPSSL); set fresh by the caller before each connect().
+    void setTlsEnabled(bool enabled) { tlsRequested = enabled; }
+
     size_t write(uint8_t b) override;
     size_t write(const uint8_t *buf, size_t size) override;
 
@@ -51,6 +54,7 @@ class CellClient : public Client
     void fetchPending(uint32_t timeoutMs);
 
     bool opened = false;
+    bool tlsRequested = false;
 };
 
 #endif

--- a/src/mesh/cell/EC618Modem.cpp
+++ b/src/mesh/cell/EC618Modem.cpp
@@ -6,9 +6,7 @@
 #include "mesh/cell/cellBearer.h"
 #include "mesh/cell/cellDiagParse.h"
 
-// Strips characters that could break out of a double-quoted AT command argument -
-// a '"' closes the argument early and changes the parameter list, and a '\r' or
-// '\n' terminates the command line so the remainder is issued as a second command.
+// Strip quotes and line terminators before embedding values in AT arguments.
 static String sanitizeAtArg(const char *in)
 {
     String out;
@@ -171,12 +169,20 @@ void EC618Modem::onCipRxGet(const String &line)
 
     if (len > 0) {
         if ((size_t)len > socketRecvMax()) {
-            LOG_WARN("CIPRXGET len %d exceeds %u, ignoring", len, (unsigned)socketRecvMax());
+            // Still divert the announced bytes - just without buffering them - so line
+            // framing resyncs afterward instead of parsing raw payload as AT text.
+            LOG_WARN("CIPRXGET len %d exceeds %u, discarding", len, (unsigned)socketRecvMax());
+            discardBinary(len);
             return;
         }
         auto onData = socketEvents.onData;
-        if (!captureBinary(len, [onData](const uint8_t *data, size_t n) { onData(data, n); }))
-            LOG_ERROR("CIPRXGET capture rejected, %d payload bytes will desync framing", len);
+        if (!captureBinary(len, [onData](const uint8_t *data, size_t n) { onData(data, n); })) {
+            // A capture is already occupying the only diversion slot ATModem tracks, so these
+            // bytes cannot be diverted either; line framing will desync no matter what happens
+            // next. Resync by re-probing the session rather than let corrupt AT text propagate.
+            LOG_ERROR("CIPRXGET capture rejected, %d payload bytes will desync framing - resyncing", len);
+            expectReboot();
+        }
     }
 }
 

--- a/src/mesh/cell/EC618Modem.cpp
+++ b/src/mesh/cell/EC618Modem.cpp
@@ -6,6 +6,22 @@
 #include "mesh/cell/cellBearer.h"
 #include "mesh/cell/cellDiagParse.h"
 
+// Strips characters that could break out of a double-quoted AT command argument -
+// a '"' closes the argument early and changes the parameter list, and a '\r' or
+// '\n' terminates the command line so the remainder is issued as a second command.
+static String sanitizeAtArg(const char *in)
+{
+    String out;
+    if (!in)
+        return out;
+    for (const char *p = in; *p; p++) {
+        if (*p == '"' || *p == '\r' || *p == '\n')
+            continue;
+        out += *p;
+    }
+    return out;
+}
+
 void EC618Modem::sessionInit()
 {
     ATModem::sessionInit();
@@ -111,8 +127,8 @@ void EC618Modem::bringUpBearer(BearerStep step, ATCallback cb)
     case BEARER_CSTT: {
         // CSTT is not optional even with no APN: it moves the module from IP INITIAL to
         // IP START, and CIICR is only valid from IP START. An empty APN asks for the subscription default.
-        String cmd = String("AT+CSTT=\"") + config.network.cell_apn + "\",\"" + config.network.cell_apn_user + "\",\"" +
-                     config.network.cell_apn_pass + "\"";
+        String cmd = String("AT+CSTT=\"") + sanitizeAtArg(config.network.cell_apn) + "\",\"" +
+                     sanitizeAtArg(config.network.cell_apn_user) + "\",\"" + sanitizeAtArg(config.network.cell_apn_pass) + "\"";
         submit(cmd.c_str(), 10000, cb);
         break;
     }
@@ -154,8 +170,13 @@ void EC618Modem::onCipRxGet(const String &line)
     socketEvents.onRxPending(remaining > 0);
 
     if (len > 0) {
+        if ((size_t)len > socketRecvMax()) {
+            LOG_WARN("CIPRXGET len %d exceeds %u, ignoring", len, (unsigned)socketRecvMax());
+            return;
+        }
         auto onData = socketEvents.onData;
-        captureBinary(len, [onData](const uint8_t *data, size_t n) { onData(data, n); });
+        if (!captureBinary(len, [onData](const uint8_t *data, size_t n) { onData(data, n); }))
+            LOG_ERROR("CIPRXGET capture rejected, %d payload bytes will desync framing", len);
     }
 }
 
@@ -166,7 +187,9 @@ void EC618Modem::onCipRxGet(const String &line)
 void EC618Modem::onUnexpectedReboot()
 {
     LOG_WARN("Modem rebooted unexpectedly mid-command");
-    cancelActive();
+    // Session state (ATE0, roaming config, CIPRXGET mode, ...) is gone with the
+    // reboot; re-probe so sessionInit() runs again once AT answers.
+    expectReboot();
 }
 
 void EC618Modem::socketAttach(const ATSocketEvents &events)
@@ -189,7 +212,7 @@ void EC618Modem::socketRxMode(ATCallback cb)
 
 void EC618Modem::socketOpen(const char *host, uint16_t port, ATCallback cb)
 {
-    String cmd = String("AT+CIPSTART=\"TCP\",\"") + host + "\"," + port;
+    String cmd = String("AT+CIPSTART=\"TCP\",\"") + sanitizeAtArg(host) + "\"," + port;
     // OK from CIPSTART is acceptance only; the outcome arrives as a later URC.
     submit(cmd.c_str(), socketConnectTimeoutMs(), cb, "CONNECT OK");
 }

--- a/src/mesh/cell/EC618Modem.cpp
+++ b/src/mesh/cell/EC618Modem.cpp
@@ -2,6 +2,7 @@
 
 #if HAS_CELLULAR && defined(USE_EC618)
 
+#include "NodeDB.h"
 #include "mesh/cell/cellBearer.h"
 #include "mesh/cell/cellDiagParse.h"
 
@@ -30,7 +31,8 @@ void EC618Modem::sessionInit()
             LOG_WARN("Reading ^SYSCONFIG for roaming preference failed: %s", resp.c_str());
             return;
         }
-        String cmd = String("AT^SYSCONFIG=") + mode + "," + acqorder + "," + CELL_ROAMING_ENABLED + "," + srvdomain;
+        String cmd = String("AT^SYSCONFIG=") + mode + "," + acqorder + "," + (config.network.cell_roaming_enabled ? 1 : 0) + "," +
+                     srvdomain;
         submit(cmd.c_str(), 5000, [](ATResult r2, const String &resp2) {
             if (r2 != ATResult::Ok)
                 LOG_WARN("Setting roaming preference rejected: %s", resp2.c_str());
@@ -109,11 +111,8 @@ void EC618Modem::bringUpBearer(BearerStep step, ATCallback cb)
     case BEARER_CSTT: {
         // CSTT is not optional even with no APN: it moves the module from IP INITIAL to
         // IP START, and CIICR is only valid from IP START. An empty APN asks for the subscription default.
-#ifdef CELL_APN
-        String cmd = String("AT+CSTT=\"") + CELL_APN + "\",\"" + CELL_APN_USER + "\",\"" + CELL_APN_PASS + "\"";
-#else
-        String cmd = "AT+CSTT=\"\"";
-#endif
+        String cmd = String("AT+CSTT=\"") + config.network.cell_apn + "\",\"" + config.network.cell_apn_user + "\",\"" +
+                     config.network.cell_apn_pass + "\"";
         submit(cmd.c_str(), 10000, cb);
         break;
     }

--- a/src/mesh/cell/EC618Modem.cpp
+++ b/src/mesh/cell/EC618Modem.cpp
@@ -1,0 +1,215 @@
+#include "mesh/cell/EC618Modem.h"
+
+#if HAS_CELLULAR && defined(USE_EC618)
+
+#include "mesh/cell/cellBearer.h"
+#include "mesh/cell/cellDiagParse.h"
+
+void EC618Modem::sessionInit()
+{
+    ATModem::sessionInit();
+
+    // Boot reason, EC618 specific.
+    submit("AT*EXINFO?", 5000, [this](ATResult r, const String &resp) {
+        if (r == ATResult::Ok)
+            bootReason = stripPrefix(resp, "*EXINFO");
+    });
+
+    // Auto-FOTA defaults to on, so modem firmware could change underneath the
+    // application if a ProductKey is ever set. Make it an explicit choice.
+    submit("AT+UPGRADE=\"AUTO\",0", 5000, [](ATResult r, const String &resp) {
+        if (r != ATResult::Ok)
+            LOG_WARN("Disabling modem auto-FOTA rejected: %s", resp.c_str());
+    });
+
+    // Roaming preference: read mode/acqorder/srvdomain back first so the rewrite below only
+    // ever touches <roam>, not RAT selection or CS/PS domain.
+    submit("AT^SYSCONFIG?", 5000, [this](ATResult r, const String &resp) {
+        uint8_t mode = 0, acqorder = 0, srvdomain = 0;
+        if (r != ATResult::Ok || !parseSysConfig(resp.c_str(), &mode, &acqorder, &srvdomain)) {
+            LOG_WARN("Reading ^SYSCONFIG for roaming preference failed: %s", resp.c_str());
+            return;
+        }
+        String cmd = String("AT^SYSCONFIG=") + mode + "," + acqorder + "," + CELL_ROAMING_ENABLED + "," + srvdomain;
+        submit(cmd.c_str(), 5000, [](ATResult r2, const String &resp2) {
+            if (r2 != ATResult::Ok)
+                LOG_WARN("Setting roaming preference rejected: %s", resp2.c_str());
+        });
+    });
+
+#if MODEM_SIM_HOTPLUG
+    // Drive USIM_CD, so insertion and removal arrive as +CPIN URCs instead of
+    // being invisible until the module is reset.
+    String csdt = String("AT+CSDT=1,") + MODEM_SIM_HOTPLUG_EDGE;
+    submit(csdt.c_str(), 5000, [](ATResult r, const String &resp) {
+        if (r != ATResult::Ok)
+            LOG_WARN("SIM hotplug detect rejected: %s", resp.c_str());
+    });
+#endif
+}
+
+void EC618Modem::onReady()
+{
+    LOG_INFO("EC618 modem ready - model '%s' version '%s' boot '%s'", getModel().c_str(), getVersion().c_str(),
+             bootReason.c_str());
+}
+
+void EC618Modem::queryVersion()
+{
+    // The platform answers AT+VER, not the 3GPP AT+CGMR.
+    submit("AT+VER", 5000, [this](ATResult r, const String &resp) {
+        if (r == ATResult::Ok)
+            version = resp;
+    });
+}
+
+void EC618Modem::resetModule(ATCallback cb)
+{
+    submit("AT+RESET", 5000, cb);
+}
+
+bool EC618Modem::powerDown(ATCallback cb)
+{
+    enqueue("AT+CPOWD=1", AT_POWERDOWN_TIMEOUT_MS, cb);
+    return true;
+}
+
+bool EC618Modem::querySimDetect(ATCallback cb)
+{
+    return submit("AT*SIMDETEC=0", 5000, cb);
+}
+
+bool EC618Modem::queryBand(ATBandCallback cb)
+{
+    return submit("AT*BANDIND?", 5000, [cb](ATResult r, const String &resp) {
+        uint8_t band = 0, act = 0;
+        bool valid = (r == ATResult::Ok) && parseBandInd(resp.c_str(), &band, &act);
+        cb(r, valid, band, act);
+    });
+}
+
+bool EC618Modem::queryBatteryMv(ATBatteryCallback cb)
+{
+    return submit("AT+CBC", 5000, [cb](ATResult r, const String &resp) {
+        uint16_t mv = 0;
+        bool valid = (r == ATResult::Ok) && parseCbcMillivolts(resp.c_str(), &mv);
+        cb(r, valid, mv);
+    });
+}
+
+void EC618Modem::bringUpBearer(BearerStep step, ATCallback cb)
+{
+    switch (step) {
+    case BEARER_SHUT:
+        // CSTT is only accepted from IP INITIAL, and a context left active by a
+        // previous session survives an MCU reboot.
+        submit("AT+CIPSHUT", 15000, cb);
+        break;
+
+    case BEARER_CSTT: {
+        // CSTT is not optional even with no APN: it moves the module from IP INITIAL to
+        // IP START, and CIICR is only valid from IP START. An empty APN asks for the subscription default.
+#ifdef CELL_APN
+        String cmd = String("AT+CSTT=\"") + CELL_APN + "\",\"" + CELL_APN_USER + "\",\"" + CELL_APN_PASS + "\"";
+#else
+        String cmd = "AT+CSTT=\"\"";
+#endif
+        submit(cmd.c_str(), 10000, cb);
+        break;
+    }
+
+    case BEARER_CIICR:
+        // Context activation can take most of a minute on a cold attach.
+        submit("AT+CIICR", 60000, cb);
+        break;
+
+    case BEARER_CIFSR:
+        // CIFSR answers with the bare address and no OK.
+        submit(
+            "AT+CIFSR", 10000, [cb](ATResult r, const String &resp) { cb(r, stripPrefix(resp, "+CIFSR")); }, nullptr, true);
+        break;
+    }
+}
+
+// +CIPRXGET: 1 announces data; +CIPRXGET: 2,<len>,<remaining> heads a payload
+// of exactly <len> raw bytes, which line framing must not see.
+void EC618Modem::onCipRxGet(const String &line)
+{
+    String s = stripPrefix(line, "+CIPRXGET");
+    int mode = s.toInt();
+
+    if (mode == 1) {
+        socketEvents.onRxPending(true);
+        return;
+    }
+    if (mode != 2)
+        return;
+
+    int firstComma = s.indexOf(',');
+    if (firstComma < 0)
+        return;
+    int secondComma = s.indexOf(',', firstComma + 1);
+
+    int len = s.substring(firstComma + 1, secondComma < 0 ? s.length() : secondComma).toInt();
+    int remaining = secondComma < 0 ? 0 : s.substring(secondComma + 1).toInt();
+    socketEvents.onRxPending(remaining > 0);
+
+    if (len > 0) {
+        auto onData = socketEvents.onData;
+        captureBinary(len, [onData](const uint8_t *data, size_t n) { onData(data, n); });
+    }
+}
+
+// The module's own power-on banner - seeing it while a command is in flight means the
+// modem reset itself mid-command, so fail that command now rather than wait out its
+// full timeout. Text verified on Air780E/EX only; a sibling EC618 module should confirm
+// it prints the same lines before relying on this.
+void EC618Modem::onUnexpectedReboot()
+{
+    LOG_WARN("Modem rebooted unexpectedly mid-command");
+    cancelActive();
+}
+
+void EC618Modem::socketAttach(const ATSocketEvents &events)
+{
+    socketEvents = events;
+
+    registerUrc("+CIPRXGET", [this](const String &line) { onCipRxGet(line); });
+    registerUrc("ALREADY CONNECT", [this](const String &) { socketEvents.onConnected(); });
+    registerUrc("CONNECT FAIL", [this](const String &) { socketEvents.onConnectFail(); });
+    registerUrc("CLOSED", [this](const String &) { socketEvents.onClosed("peer"); });
+    registerUrc("+PDP: DEACT", [this](const String &) { socketEvents.onClosed("PDP deactivated"); });
+    registerUrc("^boot.rom", [this](const String &) { onUnexpectedReboot(); });
+    registerUrc("RDY", [this](const String &) { onUnexpectedReboot(); });
+}
+
+void EC618Modem::socketRxMode(ATCallback cb)
+{
+    submit("AT+CIPRXGET=1", 5000, cb);
+}
+
+void EC618Modem::socketOpen(const char *host, uint16_t port, ATCallback cb)
+{
+    String cmd = String("AT+CIPSTART=\"TCP\",\"") + host + "\"," + port;
+    // OK from CIPSTART is acceptance only; the outcome arrives as a later URC.
+    submit(cmd.c_str(), socketConnectTimeoutMs(), cb, "CONNECT OK");
+}
+
+void EC618Modem::socketSend(const uint8_t *buf, size_t len, ATCallback cb)
+{
+    String cmd = String("AT+CIPSEND=") + len;
+    submitWithPayload(cmd.c_str(), buf, len, 20000, cb);
+}
+
+void EC618Modem::socketRecv(size_t want, uint32_t timeoutMs, ATCallback cb)
+{
+    String cmd = String("AT+CIPRXGET=2,") + want;
+    submit(cmd.c_str(), timeoutMs, cb);
+}
+
+void EC618Modem::socketClose(ATCallback cb)
+{
+    submit("AT+CIPCLOSE", 10000, cb);
+}
+
+#endif

--- a/src/mesh/cell/EC618Modem.cpp
+++ b/src/mesh/cell/EC618Modem.cpp
@@ -216,6 +216,12 @@ void EC618Modem::socketRxMode(ATCallback cb)
     submit("AT+CIPRXGET=1", 5000, cb);
 }
 
+void EC618Modem::socketSetTls(bool enabled, ATCallback cb)
+{
+    String cmd = String("AT+CIPSSL=") + (enabled ? 1 : 0);
+    submit(cmd.c_str(), 5000, cb);
+}
+
 void EC618Modem::socketOpen(const char *host, uint16_t port, ATCallback cb)
 {
     String cmd = String("AT+CIPSTART=\"TCP\",\"") + sanitizeAtArg(host) + "\"," + port;

--- a/src/mesh/cell/EC618Modem.h
+++ b/src/mesh/cell/EC618Modem.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "configuration.h"
+
+#if HAS_CELLULAR && defined(USE_EC618)
+
+#include "mesh/cell/ATModem.h"
+
+// EigenComm EC618 platform driver (Air780E/Air780EG/Air700E/Air600E): the SIMCom-originated
+// bearer and socket dialect the platform clones, plus EC618's own AT* extensions.
+
+// Set when the board wires the module's USIM_CD pin to a SIM detect circuit, so insertion
+// and removal report as +CPIN URCs and a card inserted after boot is noticed without a reset.
+#ifndef MODEM_SIM_HOTPLUG
+#define MODEM_SIM_HOTPLUG 0
+#endif
+
+// AT+CSDT <level>: 0 falling edge (card present pulls low), 1 rising (default).
+#ifndef MODEM_SIM_HOTPLUG_EDGE
+#define MODEM_SIM_HOTPLUG_EDGE 1
+#endif
+
+// AT^SYSCONFIG <roam>: 0 disabled, 1 enabled. Written at session init, mode/acqorder/srvdomain
+// left as queried - this only ever touches roaming, not RAT selection or CS/PS domain.
+#ifndef CELL_ROAMING_ENABLED
+#define CELL_ROAMING_ENABLED 0
+#endif
+
+class EC618Modem : public ATModem
+{
+  public:
+    void resetModule(ATCallback cb) override;
+    bool powerDown(ATCallback cb) override;
+    bool querySimDetect(ATCallback cb) override;
+    bool hasSimHotplug() const override { return MODEM_SIM_HOTPLUG; }
+    bool queryBand(ATBandCallback cb) override;
+    bool queryBatteryMv(ATBatteryCallback cb) override;
+
+    void bringUpBearer(BearerStep step, ATCallback cb) override;
+
+    void socketAttach(const ATSocketEvents &events) override;
+    void socketRxMode(ATCallback cb) override;
+    void socketOpen(const char *host, uint16_t port, ATCallback cb) override;
+    void socketSend(const uint8_t *buf, size_t len, ATCallback cb) override;
+    void socketRecv(size_t want, uint32_t timeoutMs, ATCallback cb) override;
+    void socketClose(ATCallback cb) override;
+
+    // Largest AT+CIPSEND payload accepted in one command.
+    size_t socketSendMax() const override { return 1024; }
+
+    // Largest AT+CIPRXGET=2 request; the modem caps this at one TCP segment.
+    size_t socketRecvMax() const override { return 1460; }
+
+    // CIPSTART is slow to settle on a cold connection.
+    uint32_t socketConnectTimeoutMs() const override { return 75000; }
+
+  protected:
+    void sessionInit() override;
+    void onReady() override;
+    void queryVersion() override;
+
+  private:
+    void onCipRxGet(const String &line);
+    void onUnexpectedReboot();
+
+    String bootReason;
+    ATSocketEvents socketEvents;
+};
+
+#endif

--- a/src/mesh/cell/EC618Modem.h
+++ b/src/mesh/cell/EC618Modem.h
@@ -34,6 +34,7 @@ class EC618Modem : public ATModem
 
     void socketAttach(const ATSocketEvents &events) override;
     void socketRxMode(ATCallback cb) override;
+    void socketSetTls(bool enabled, ATCallback cb) override;
     void socketOpen(const char *host, uint16_t port, ATCallback cb) override;
     void socketSend(const uint8_t *buf, size_t len, ATCallback cb) override;
     void socketRecv(size_t want, uint32_t timeoutMs, ATCallback cb) override;

--- a/src/mesh/cell/EC618Modem.h
+++ b/src/mesh/cell/EC618Modem.h
@@ -20,12 +20,6 @@
 #define MODEM_SIM_HOTPLUG_EDGE 1
 #endif
 
-// AT^SYSCONFIG <roam>: 0 disabled, 1 enabled. Written at session init, mode/acqorder/srvdomain
-// left as queried - this only ever touches roaming, not RAT selection or CS/PS domain.
-#ifndef CELL_ROAMING_ENABLED
-#define CELL_ROAMING_ENABLED 0
-#endif
-
 class EC618Modem : public ATModem
 {
   public:

--- a/src/mesh/cell/cellBearer.cpp
+++ b/src/mesh/cell/cellBearer.cpp
@@ -1,0 +1,445 @@
+#include "mesh/cell/cellBearer.h"
+
+#if HAS_CELLULAR
+
+#include "concurrency/Periodic.h"
+#include "gps/RTC.h"
+#include "mesh/cell/ATModem.h"
+#include "mesh/cell/cellDiagParse.h"
+#include "mesh/cell/cellModem.h"
+#if HAS_SCREEN
+#include "graphics/Screen.h"
+#include "main.h"
+#endif
+
+using namespace concurrency;
+
+// Bearer poll interval, matching reconnectETH().
+#define CELL_POLL_MS 5000
+
+#define CELL_BACKOFF_MAX_MS 60000
+
+// A modem that stops answering AT for this long is power-cycled.
+#define CELL_SILENCE_MS 30000
+
+static Periodic *cellEvent;
+static CellState cellState = CELL_OFF;
+static String cellLocalIP;
+static bool cellBusy = false;      // a bring-up command is in flight
+static bool cellRtcSeeded = false; // AT+CCLK? has set the RTC this session
+static bool cellEnabled = true;    // cleared by the UI toggle, not persisted
+static uint8_t cellFailCount = 0;
+static uint32_t cellLastResponse = 0;
+
+// Whether the missing SIM has already been reported this session.
+static bool simAbsentLogged = false;
+static bool simAbsent = false;    // last CPIN? said no card is seated
+static uint32_t simWaitSince = 0; // when SIM_WAIT was entered
+static uint8_t simResetCount = 0; // resets already spent looking for a card
+
+// Where CELL_BEARER_UP's entry sequence has got to.
+static ATModem::BearerStep bearerStep = ATModem::BEARER_SHUT;
+
+const char *getCellStateName(CellState s)
+{
+    switch (s) {
+    case CELL_OFF:
+        return "OFF";
+    case CELL_BOOTING:
+        return "BOOTING";
+    case CELL_SIM_WAIT:
+        return "SIM_WAIT";
+    case CELL_REG_WAIT:
+        return "REG_WAIT";
+    case CELL_BEARER_UP:
+        return "BEARER_UP";
+    case CELL_IP_UP:
+        return "IP_UP";
+    case CELL_FAILED:
+        return "FAILED";
+    }
+    return "?";
+}
+
+CellState getCellState()
+{
+    return cellState;
+}
+
+const String &getCellLocalIP()
+{
+    return cellLocalIP;
+}
+
+bool isCellularAvailable()
+{
+    return cellState == CELL_IP_UP;
+}
+
+static void setCellState(CellState next)
+{
+    if (next == cellState)
+        return;
+    LOG_INFO("Cell state %s -> %s", getCellStateName(cellState), getCellStateName(next));
+    cellState = next;
+
+    if (next == CELL_SIM_WAIT) {
+        simWaitSince = millis();
+        simAbsent = false; // until the next CPIN? says otherwise
+    }
+
+#if HAS_SCREEN
+    // The Cellular frame redraws on the UI's own cadence, so without this a transition sits
+    // unrendered - most visibly the toggle, where the frame keeps claiming BEARER_UP after power-down.
+    if (screen)
+        screen->forceDisplay();
+#endif
+}
+
+// Common tail for every bring-up callback: note liveness and clear the in-flight flag.
+static void cellCommandDone(ATResult r)
+{
+    cellBusy = false;
+    if (r != ATResult::Timeout)
+        cellLastResponse = millis();
+}
+
+static void cellFail(const char *why, const String &detail = String())
+{
+    LOG_WARN("Cell bring-up failed: %s%s%s", why, detail.length() ? " - " : "", detail.c_str());
+    if (cellFailCount < 255)
+        cellFailCount++;
+    cellLocalIP = "";
+    setCellState(CELL_FAILED);
+}
+
+// +CCLK: "yy/MM/dd,hh:mm:ss+zz" - zz is the local offset in quarter hours.
+static bool setRtcFromCclk(const String &resp)
+{
+    String s = ATModem::stripPrefix(resp, "+CCLK");
+    if (s.length() < 17)
+        return false;
+
+    struct tm t = {};
+    int year = 0, mon = 0, day = 0, hour = 0, min = 0, sec = 0, tz = 0;
+    if (sscanf(s.c_str(), "%d/%d/%d,%d:%d:%d%d", &year, &mon, &day, &hour, &min, &sec, &tz) < 6)
+        return false;
+
+    t.tm_year = year + 100; // two digit year, 20xx
+    t.tm_mon = mon - 1;
+    t.tm_mday = day;
+    t.tm_hour = hour;
+    t.tm_min = min;
+    // Shift to UTC; mktime normalises the out-of-range seconds.
+    t.tm_sec = sec - tz * 15 * 60;
+
+    // Operator network time, not NTP, but it is the same order of accuracy and
+    // there is no distinct quality level for it.
+    return perhapsSetRTC(RTCQualityNTP, t) == RTCSetResultSuccess;
+}
+
+// How long to sit in SIM_WAIT with no card before resetting the module. A working SIM reaches
+// READY a few seconds in, so this must stay clear of that: resetting mid-init keeps a slow card from ever coming up.
+#ifndef MODEM_SIM_RESET_MS
+#define MODEM_SIM_RESET_MS 30000
+#endif
+
+// Wait before the next reset, growing to the bring-up backoff ceiling so a
+// board simply running without a SIM settles down instead of resetting forever.
+static uint32_t simResetBackoff()
+{
+    uint32_t backoff = MODEM_SIM_RESET_MS * (simResetCount + 1);
+    return backoff > CELL_BACKOFF_MAX_MS ? CELL_BACKOFF_MAX_MS : backoff;
+}
+
+// Without USIM_CD wired, a card inserted after boot goes unnoticed and re-pulsing PWRKEY does nothing while running.
+// With EN wired, a rail cycle forces a SIM re-read; without it, only an in-place reboot is available.
+static void stepSimReset()
+{
+    LOG_INFO("No SIM for %ums, resetting modem to look again", (unsigned)simResetBackoff());
+    if (simResetCount < 255)
+        simResetCount++;
+#ifdef PIN_MODEM_EN
+    // A direct, synchronous power cycle, same as reconnectCell()'s silence handling.
+    cellModem->restart();
+    cellLocalIP = "";
+    cellRtcSeeded = false;
+    cellLastResponse = millis();
+    simAbsentLogged = false;
+    setCellState(CELL_BOOTING);
+#else
+    cellBusy = true;
+    cellModem->resetModule([](ATResult, const String &) {
+        // Either result is expected: the module may reboot before answering.
+        cellCommandDone(ATResult::Ok);
+        cellModem->expectReboot();
+        setCellState(CELL_BOOTING);
+    });
+#endif
+}
+
+// Follows the detect result, so the diagnosis is logged before the advice.
+static void warnNoSimHotplug()
+{
+    if (cellModem->hasSimHotplug())
+        return;
+    // The module only reads the SIM at boot, so say that a card inserted now is
+    // picked up by the reset rather than immediately.
+    LOG_WARN("No SIM detect on this board; a card inserted now is picked up at the next modem reset");
+}
+
+static void stepSimWait()
+{
+    cellBusy = true;
+    cellModem->submit("AT+CPIN?", 5000, [](ATResult r, const String &resp) {
+        cellCommandDone(r);
+        if (r == ATResult::Ok && resp.indexOf("READY") >= 0) {
+            simAbsentLogged = false;
+            simAbsent = false;
+            simResetCount = 0;
+            setCellState(CELL_REG_WAIT);
+            return;
+        }
+        if (r == ATResult::Ok) {
+            // Present but not READY - PIN required, or still initialising.
+            // Resetting would not help either case.
+            simAbsent = false;
+            LOG_WARN("SIM not ready: %s", resp.c_str());
+            return; // retry next tick, the SIM may still be initialising
+        }
+        simAbsent = true;
+        // Distinguish "no SIM seated" from "SIM present, not READY" - a user error vs a provisioning
+        // error - and report it once, the way initEthernet() reports a missing shield.
+        if (simAbsentLogged)
+            return;
+        simAbsentLogged = true;
+        cellBusy = true;
+        bool asked = cellModem->querySimDetect([](ATResult r2, const String &resp2) {
+            cellCommandDone(r2);
+            if (r2 == ATResult::Ok)
+                LOG_WARN("SIM detect: %s", resp2.c_str());
+            else
+                LOG_WARN("SIM not readable and detect unsupported");
+            warnNoSimHotplug();
+        });
+        if (!asked) {
+            cellBusy = false;
+            LOG_WARN("SIM not readable and detect unsupported");
+            warnNoSimHotplug();
+        }
+    });
+}
+
+static void stepRegWait()
+{
+    cellBusy = true;
+    cellModem->submit("AT+CEREG?", 5000, [](ATResult r, const String &resp) {
+        cellCommandDone(r);
+        if (r != ATResult::Ok)
+            return;
+        int stat = parseCeregStat(resp.c_str());
+        if (stat == 1 || stat == 5) {
+            LOG_INFO("Cell registered (%s)", stat == 5 ? "roaming" : "home");
+            bearerStep = ATModem::BEARER_SHUT;
+            cellFailCount = 0;
+            setCellState(CELL_BEARER_UP); // provisional; cleared if bring-up fails
+            cellLocalIP = "";
+        }
+    });
+}
+
+static void stepBearer()
+{
+    cellBusy = true;
+
+    switch (bearerStep) {
+    case ATModem::BEARER_SHUT:
+        // Clearing a context left active by a previous session is best effort,
+        // so either result moves on.
+        cellModem->bringUpBearer(bearerStep, [](ATResult, const String &) {
+            cellCommandDone(ATResult::Ok);
+            bearerStep = ATModem::BEARER_CSTT;
+        });
+        break;
+
+    case ATModem::BEARER_CSTT:
+        cellModem->bringUpBearer(bearerStep, [](ATResult r, const String &resp) {
+            cellCommandDone(r);
+            if (r == ATResult::Ok)
+                bearerStep = ATModem::BEARER_CIICR;
+            else
+                cellFail("APN setup rejected", resp);
+        });
+        break;
+
+    case ATModem::BEARER_CIICR:
+        cellModem->bringUpBearer(bearerStep, [](ATResult r, const String &resp) {
+            cellCommandDone(r);
+            if (r == ATResult::Ok)
+                bearerStep = ATModem::BEARER_CIFSR;
+            else
+                cellFail("context did not activate", resp);
+        });
+        break;
+
+    case ATModem::BEARER_CIFSR:
+        cellModem->bringUpBearer(bearerStep, [](ATResult r, const String &resp) {
+            cellCommandDone(r);
+            if (r != ATResult::Ok || resp.length() == 0) {
+                cellFail("no local address", resp);
+                return;
+            }
+            cellLocalIP = resp;
+            LOG_INFO("Cell bearer up - IP %s", cellLocalIP.c_str());
+            setCellState(CELL_IP_UP);
+        });
+        break;
+    }
+}
+
+bool isCellularEnabled()
+{
+    return cellEnabled;
+}
+
+void setCellularEnabled(bool enabled)
+{
+#if !defined(PIN_MODEM_PWRKEY) && !defined(PIN_MODEM_EN)
+    // Neither PWRKEY nor EN wired means a powered-down module could never be brought back
+    // up, so the toggle is compiled out of the menu; reached only by another caller.
+    (void)enabled;
+    LOG_WARN("Cell toggle ignored: no PWRKEY or EN wired");
+#else
+    if (enabled == cellEnabled)
+        return;
+    cellEnabled = enabled;
+
+    if (!cellModem) // toggled before initCellular(), nothing to power
+        return;
+
+    cellLocalIP = "";
+    cellRtcSeeded = false;
+    cellBusy = false;
+
+    if (enabled) {
+        cellModem->powerUp();
+        cellLastResponse = millis();
+        cellFailCount = 0;
+        simAbsentLogged = false;
+        simResetCount = 0;
+        setCellState(CELL_BOOTING);
+    } else {
+        cellModem->powerOff();
+        setCellState(CELL_OFF);
+    }
+#endif
+}
+
+static int32_t reconnectCell()
+{
+    if (!cellModem || !cellEnabled)
+        return CELL_POLL_MS;
+
+    if (cellBusy)
+        return CELL_POLL_MS;
+
+    uint32_t now = millis();
+
+    // A modem that has reset or gone silent gets a fresh PWRKEY pulse - the
+    // pulse is also mandatory after powerOff(), which leaves the module off.
+    bool silent =
+        (cellState == CELL_SIM_WAIT || cellState == CELL_REG_WAIT || cellState == CELL_BEARER_UP || cellState == CELL_IP_UP) &&
+        (int32_t)(now - cellLastResponse) > (int32_t)CELL_SILENCE_MS;
+    if (cellModem->getState() == ATModem::FAILED || silent) {
+        cellModem->restart();
+        cellLocalIP = "";
+        cellRtcSeeded = false;
+        cellLastResponse = now;
+        simAbsentLogged = false;
+        setCellState(CELL_BOOTING);
+        return CELL_POLL_MS;
+    }
+
+    if (!cellModem->isReady()) {
+        setCellState(CELL_BOOTING);
+        return CELL_POLL_MS;
+    }
+
+    switch (cellState) {
+    case CELL_OFF:
+    case CELL_BOOTING:
+        cellLastResponse = now;
+        setCellState(CELL_SIM_WAIT);
+        break;
+
+    case CELL_FAILED: {
+        // Linear backoff before retrying from registration.
+        uint32_t backoff = CELL_POLL_MS * cellFailCount;
+        if (backoff > CELL_BACKOFF_MAX_MS)
+            backoff = CELL_BACKOFF_MAX_MS;
+        cellLastResponse = now;
+        setCellState(CELL_REG_WAIT);
+        return backoff;
+    }
+
+    case CELL_SIM_WAIT:
+        // With USIM_CD wired the module reports insertion itself, so waiting
+        // costs nothing and a reset would only throw away a working session.
+        if (!cellModem->hasSimHotplug() && simAbsent && (uint32_t)(now - simWaitSince) >= simResetBackoff())
+            stepSimReset();
+        else
+            stepSimWait();
+        break;
+
+    case CELL_REG_WAIT:
+        stepRegWait();
+        break;
+
+    case CELL_BEARER_UP:
+        // Sub-steps bearerStep through SHUT/CSTT/CIICR/CIFSR; a successful CIFSR
+        // moves cellState on to CELL_IP_UP.
+        stepBearer();
+        break;
+
+    case CELL_IP_UP:
+        if (!cellRtcSeeded) {
+            cellBusy = true;
+            cellModem->submit("AT+CCLK?", 5000, [](ATResult r, const String &resp) {
+                cellCommandDone(r);
+                if (r == ATResult::Ok && setRtcFromCclk(resp))
+                    cellRtcSeeded = true;
+            });
+        } else {
+            // Liveness plus registration drop detection.
+            cellBusy = true;
+            cellModem->submit("AT+CEREG?", 5000, [](ATResult r, const String &resp) {
+                cellCommandDone(r);
+                if (r != ATResult::Ok)
+                    return;
+                int stat = parseCeregStat(resp.c_str());
+                if (stat != 1 && stat != 5) {
+                    LOG_WARN("Cell registration lost (CEREG %d)", stat);
+                    cellLocalIP = "";
+                    setCellState(CELL_REG_WAIT);
+                }
+            });
+        }
+        break;
+    }
+
+    return CELL_POLL_MS;
+}
+
+bool initCellular()
+{
+    if (cellEvent)
+        return true;
+
+    initCellModem();
+    cellLastResponse = millis();
+    setCellState(CELL_BOOTING);
+    cellEvent = new Periodic("cellConnect", reconnectCell);
+    return true;
+}
+
+#endif

--- a/src/mesh/cell/cellBearer.cpp
+++ b/src/mesh/cell/cellBearer.cpp
@@ -4,7 +4,7 @@
 
 #include "concurrency/Periodic.h"
 #include "gps/RTC.h"
-#include "mesh/cell/ATModem.h"
+#include "mesh/cell/cellDiag.h"
 #include "mesh/cell/cellDiagParse.h"
 #include "mesh/cell/cellModem.h"
 #if HAS_SCREEN
@@ -88,6 +88,11 @@ static void setCellState(CellState next)
         simAbsent = false; // until the next CPIN? says otherwise
     }
 
+    // No sweep runs below REG_WAIT, so the readings would otherwise keep
+    // rendering as though current after a SIM pull or a modem power-cycle.
+    if (next != CELL_REG_WAIT && next != CELL_BEARER_UP && next != CELL_IP_UP)
+        cellDiagInvalidate();
+
 #if HAS_SCREEN
     // The Cellular frame redraws on the UI's own cadence, so without this a transition sits
     // unrendered - most visibly the toggle, where the frame keeps claiming BEARER_UP after power-down.
@@ -96,8 +101,9 @@ static void setCellState(CellState next)
 #endif
 }
 
-// Common tail for every bring-up callback: note liveness and clear the in-flight flag.
-static void cellCommandDone(ATResult r)
+// Common tail for every bring-up callback: note liveness and clear the in-flight
+// flag. Shared with the diagnostic sweep, which takes part in both.
+void cellCommandDone(ATResult r)
 {
     cellBusy = false;
     if (r != ATResult::Timeout)
@@ -392,7 +398,14 @@ static int32_t reconnectCell()
         break;
 
     case CELL_REG_WAIT:
-        stepRegWait();
+        // Signal readings matter most while registration is not happening, so the sweep
+        // gets a tick here too - at the cost of noticing registration one poll later.
+        if (cellDiagDue()) {
+            cellBusy = true;
+            serviceCellDiag();
+        } else {
+            stepRegWait();
+        }
         break;
 
     case CELL_BEARER_UP:
@@ -409,6 +422,10 @@ static int32_t reconnectCell()
                 if (r == ATResult::Ok && setRtcFromCclk(resp))
                     cellRtcSeeded = true;
             });
+        } else if (cellDiagDue()) {
+            // One diagnostic command per tick, so only ever one is in flight.
+            cellBusy = true;
+            serviceCellDiag();
         } else {
             // Liveness plus registration drop detection.
             cellBusy = true;

--- a/src/mesh/cell/cellBearer.cpp
+++ b/src/mesh/cell/cellBearer.cpp
@@ -2,8 +2,10 @@
 
 #if HAS_CELLULAR
 
+#include "NodeDB.h"
 #include "concurrency/Periodic.h"
 #include "gps/RTC.h"
+#include "mesh/MeshService.h"
 #include "mesh/cell/cellDiag.h"
 #include "mesh/cell/cellDiagParse.h"
 #include "mesh/cell/cellModem.h"
@@ -27,7 +29,7 @@ static CellState cellState = CELL_OFF;
 static String cellLocalIP;
 static bool cellBusy = false;      // a bring-up command is in flight
 static bool cellRtcSeeded = false; // AT+CCLK? has set the RTC this session
-static bool cellEnabled = true;    // cleared by the UI toggle, not persisted
+static bool cellEnabled = false;   // seeded from config.network.cell_enabled in initCellular()
 static uint8_t cellFailCount = 0;
 static uint32_t cellLastResponse = 0;
 
@@ -319,22 +321,24 @@ void setCellularEnabled(bool enabled)
     if (enabled == cellEnabled)
         return;
     cellEnabled = enabled;
-
-    if (!cellModem) // toggled before initCellular(), nothing to power
-        return;
+    config.network.cell_enabled = enabled;
+    service->reloadConfig(SEGMENT_CONFIG);
 
     cellLocalIP = "";
     cellRtcSeeded = false;
     cellBusy = false;
 
     if (enabled) {
-        cellModem->powerUp();
+        if (cellModem) // already started once, resume from OFF
+            cellModem->powerUp();
+        else // never started - cell_enabled was false at boot
+            initCellModem();
         cellLastResponse = millis();
         cellFailCount = 0;
         simAbsentLogged = false;
         simResetCount = 0;
         setCellState(CELL_BOOTING);
-    } else {
+    } else if (cellModem) {
         cellModem->powerOff();
         setCellState(CELL_OFF);
     }
@@ -452,9 +456,12 @@ bool initCellular()
     if (cellEvent)
         return true;
 
-    initCellModem();
-    cellLastResponse = millis();
-    setCellState(CELL_BOOTING);
+    cellEnabled = config.network.cell_enabled;
+    if (cellEnabled) {
+        initCellModem();
+        cellLastResponse = millis();
+        setCellState(CELL_BOOTING);
+    }
     cellEvent = new Periodic("cellConnect", reconnectCell);
     return true;
 }

--- a/src/mesh/cell/cellBearer.cpp
+++ b/src/mesh/cell/cellBearer.cpp
@@ -6,6 +6,7 @@
 #include "concurrency/Periodic.h"
 #include "gps/RTC.h"
 #include "mesh/MeshService.h"
+#include "mesh/Throttle.h"
 #include "mesh/cell/cellDiag.h"
 #include "mesh/cell/cellDiagParse.h"
 #include "mesh/cell/cellModem.h"
@@ -80,6 +81,11 @@ bool isCellularAvailable()
 
 static void setCellState(CellState next)
 {
+    // A bring-up command queued before setCellularEnabled(false) can still complete
+    // and reach here; do not let a stale callback revive the state machine after
+    // the modem has been told to power off.
+    if (!cellEnabled && next != CELL_OFF)
+        return;
     if (next == cellState)
         return;
     LOG_INFO("Cell state %s -> %s", getCellStateName(cellState), getCellStateName(next));
@@ -359,7 +365,7 @@ static int32_t reconnectCell()
     // pulse is also mandatory after powerOff(), which leaves the module off.
     bool silent =
         (cellState == CELL_SIM_WAIT || cellState == CELL_REG_WAIT || cellState == CELL_BEARER_UP || cellState == CELL_IP_UP) &&
-        (int32_t)(now - cellLastResponse) > (int32_t)CELL_SILENCE_MS;
+        !Throttle::isWithinTimespanMs(cellLastResponse, CELL_SILENCE_MS);
     if (cellModem->getState() == ATModem::FAILED || silent) {
         cellModem->restart();
         cellLocalIP = "";
@@ -395,7 +401,7 @@ static int32_t reconnectCell()
     case CELL_SIM_WAIT:
         // With USIM_CD wired the module reports insertion itself, so waiting
         // costs nothing and a reset would only throw away a working session.
-        if (!cellModem->hasSimHotplug() && simAbsent && (uint32_t)(now - simWaitSince) >= simResetBackoff())
+        if (!cellModem->hasSimHotplug() && simAbsent && !Throttle::isWithinTimespanMs(simWaitSince, simResetBackoff()))
             stepSimReset();
         else
             stepSimWait();

--- a/src/mesh/cell/cellBearer.h
+++ b/src/mesh/cell/cellBearer.h
@@ -5,17 +5,6 @@
 
 #if HAS_CELLULAR
 
-// Optional: with no CELL_APN the bearer sends an empty AT+CSTT and the network
-// picks the subscription default. Belongs in NetworkConfig once protobufs land.
-#ifdef CELL_APN
-#ifndef CELL_APN_USER
-#define CELL_APN_USER ""
-#endif
-#ifndef CELL_APN_PASS
-#define CELL_APN_PASS ""
-#endif
-#endif
-
 enum CellState { CELL_OFF, CELL_BOOTING, CELL_SIM_WAIT, CELL_REG_WAIT, CELL_BEARER_UP, CELL_IP_UP, CELL_FAILED };
 
 // Power up the modem and start the bearer state machine.
@@ -30,8 +19,8 @@ const char *getCellStateName(CellState s);
 // Assigned IPv4 address, empty string until the bearer is up.
 const String &getCellLocalIP();
 
-// Runtime power state of the modem, not persisted: a reboot brings it back up. Only meaningful
-// with PIN_MODEM_PWRKEY or PIN_MODEM_EN wired - without either, setCellularEnabled() refuses to act.
+// Backed by config.network.cell_enabled; setCellularEnabled() persists the change. Only
+// meaningful with PIN_MODEM_PWRKEY or PIN_MODEM_EN wired - without either, it refuses to act.
 bool isCellularEnabled();
 void setCellularEnabled(bool enabled);
 

--- a/src/mesh/cell/cellBearer.h
+++ b/src/mesh/cell/cellBearer.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "configuration.h"
+#include <Arduino.h>
+
+#if HAS_CELLULAR
+
+// Optional: with no CELL_APN the bearer sends an empty AT+CSTT and the network
+// picks the subscription default. Belongs in NetworkConfig once protobufs land.
+#ifdef CELL_APN
+#ifndef CELL_APN_USER
+#define CELL_APN_USER ""
+#endif
+#ifndef CELL_APN_PASS
+#define CELL_APN_PASS ""
+#endif
+#endif
+
+enum CellState { CELL_OFF, CELL_BOOTING, CELL_SIM_WAIT, CELL_REG_WAIT, CELL_BEARER_UP, CELL_IP_UP, CELL_FAILED };
+
+// Power up the modem and start the bearer state machine.
+bool initCellular();
+
+// True once a PDP context is active and an IPv4 address is assigned.
+bool isCellularAvailable();
+
+CellState getCellState();
+const char *getCellStateName(CellState s);
+
+// Assigned IPv4 address, empty string until the bearer is up.
+const String &getCellLocalIP();
+
+// Runtime power state of the modem, not persisted: a reboot brings it back up. Only meaningful
+// with PIN_MODEM_PWRKEY or PIN_MODEM_EN wired - without either, setCellularEnabled() refuses to act.
+bool isCellularEnabled();
+void setCellularEnabled(bool enabled);
+
+#endif

--- a/src/mesh/cell/cellDiag.cpp
+++ b/src/mesh/cell/cellDiag.cpp
@@ -2,6 +2,7 @@
 
 #if HAS_CELLULAR
 
+#include "mesh/Throttle.h"
 #include "mesh/cell/cellDiagParse.h"
 #include <string.h>
 
@@ -26,7 +27,7 @@ enum {
     STEP_VBAT,
 };
 static uint8_t sweepStep = 0;
-static uint32_t nextSweepMs = 0;
+static uint32_t lastSweepMs = 0; // 0 means "never swept", which is always due
 
 const CellDiag &getCellDiag()
 {
@@ -35,14 +36,14 @@ const CellDiag &getCellDiag()
 
 bool cellDiagDue()
 {
-    return sweepStep != 0 || (int32_t)(millis() - nextSweepMs) >= 0;
+    return sweepStep != 0 || lastSweepMs == 0 || !Throttle::isWithinTimespanMs(lastSweepMs, CELL_DIAG_INTERVAL_MS);
 }
 
 void cellDiagInvalidate()
 {
     diag = CellDiag();
     sweepStep = 0;
-    nextSweepMs = millis(); // sweep as soon as a state that polls is reached
+    lastSweepMs = 0; // sweep as soon as a state that polls is reached
 }
 
 static bool worthLogging()
@@ -62,7 +63,7 @@ static void finishSweep()
 {
     diag.lastUpdatedMs = millis();
     sweepStep = 0;
-    nextSweepMs = diag.lastUpdatedMs + CELL_DIAG_INTERVAL_MS;
+    lastSweepMs = diag.lastUpdatedMs;
 
     if (!worthLogging())
         return;

--- a/src/mesh/cell/cellDiag.cpp
+++ b/src/mesh/cell/cellDiag.cpp
@@ -1,0 +1,170 @@
+#include "mesh/cell/cellDiag.h"
+
+#if HAS_CELLULAR
+
+#include "mesh/cell/cellDiagParse.h"
+#include <string.h>
+
+#define CELL_DIAG_INTERVAL_MS 30000
+
+// Smallest RSRP change worth a log line, so a parked modem stays quiet.
+#define CELL_DIAG_RSRP_DELTA_DB 3
+
+static CellDiag diag;
+static CellDiag lastLogged;
+static bool everLogged = false;
+
+// 0 when no sweep is in progress, otherwise the current step. Fetching the operator takes up
+// to two round trips: a name is tried first, falling back to the numeric MCC/MNC only on an empty result.
+enum {
+    STEP_CESQ = 1,
+    STEP_COPS_SET_NAME,
+    STEP_COPS_QUERY_NAME,
+    STEP_COPS_SET_NUMERIC,
+    STEP_COPS_QUERY_NUMERIC,
+    STEP_BAND,
+    STEP_VBAT,
+};
+static uint8_t sweepStep = 0;
+static uint32_t nextSweepMs = 0;
+
+const CellDiag &getCellDiag()
+{
+    return diag;
+}
+
+bool cellDiagDue()
+{
+    return sweepStep != 0 || (int32_t)(millis() - nextSweepMs) >= 0;
+}
+
+void cellDiagInvalidate()
+{
+    diag = CellDiag();
+    sweepStep = 0;
+    nextSweepMs = millis(); // sweep as soon as a state that polls is reached
+}
+
+static bool worthLogging()
+{
+    if (!everLogged)
+        return true;
+    if (diag.rsrpValid != lastLogged.rsrpValid || diag.bandValid != lastLogged.bandValid)
+        return true;
+    if (diag.rsrpValid && abs(diag.rsrp - lastLogged.rsrp) >= CELL_DIAG_RSRP_DELTA_DB)
+        return true;
+    if (diag.bandValid && (diag.band != lastLogged.band || diag.act != lastLogged.act))
+        return true;
+    return strcmp(diag.operatorName, lastLogged.operatorName) != 0;
+}
+
+static void finishSweep()
+{
+    diag.lastUpdatedMs = millis();
+    sweepStep = 0;
+    nextSweepMs = diag.lastUpdatedMs + CELL_DIAG_INTERVAL_MS;
+
+    if (!worthLogging())
+        return;
+
+    char signal[32] = "signal n/a";
+    if (diag.rsrpValid)
+        snprintf(signal, sizeof(signal), "RSRP %d dBm RSRQ %.1f dB", diag.rsrp, diag.rsrq);
+
+    char band[24] = "";
+    if (diag.bandValid)
+        snprintf(band, sizeof(band), " band %u AcT %u", (unsigned)diag.band, (unsigned)diag.act);
+
+    char vbat[24] = "";
+    if (diag.vbatValid)
+        snprintf(vbat, sizeof(vbat), " VBAT %umV", (unsigned)diag.vbatMv);
+
+    LOG_INFO("Cell diag: %s%s%s operator %s", signal, band, vbat, diag.operatorName[0] ? diag.operatorName : "unknown");
+
+    lastLogged = diag;
+    everLogged = true;
+}
+
+void serviceCellDiag()
+{
+    if (sweepStep == 0)
+        sweepStep = STEP_CESQ;
+
+    switch (sweepStep) {
+    case STEP_CESQ:
+        cellModem->submit("AT+CESQ", 5000, [](ATResult r, const String &resp) {
+            cellCommandDone(r);
+            diag.rsrpValid = (r == ATResult::Ok) && parseCesq(resp.c_str(), &diag.rsrp, &diag.rsrq);
+            sweepStep = STEP_COPS_SET_NAME;
+        });
+        break;
+
+    case STEP_COPS_SET_NAME:
+        cellModem->submit("AT+COPS=3,0", 5000, [](ATResult r, const String &resp) {
+            cellCommandDone(r);
+            sweepStep = STEP_COPS_QUERY_NAME;
+        });
+        break;
+
+    case STEP_COPS_QUERY_NAME:
+        cellModem->submit("AT+COPS?", 5000, [](ATResult r, const String &resp) {
+            cellCommandDone(r);
+            // A network absent from the modem's PLMN table answers with an empty name;
+            // fall back to the numeric MCC/MNC rather than showing nothing.
+            if (r == ATResult::Ok && parseCopsName(resp.c_str(), diag.operatorName, sizeof(diag.operatorName)))
+                sweepStep = STEP_BAND;
+            else
+                sweepStep = STEP_COPS_SET_NUMERIC;
+        });
+        break;
+
+    case STEP_COPS_SET_NUMERIC:
+        cellModem->submit("AT+COPS=3,2", 5000, [](ATResult r, const String &resp) {
+            cellCommandDone(r);
+            sweepStep = STEP_COPS_QUERY_NUMERIC;
+        });
+        break;
+
+    case STEP_COPS_QUERY_NUMERIC:
+        cellModem->submit("AT+COPS?", 5000, [](ATResult r, const String &resp) {
+            cellCommandDone(r);
+            if (r != ATResult::Ok || !parseCopsNumeric(resp.c_str(), diag.operatorName, sizeof(diag.operatorName)))
+                diag.operatorName[0] = '\0';
+            sweepStep = STEP_BAND;
+        });
+        break;
+
+    case STEP_BAND: {
+        bool asked = cellModem->queryBand([](ATResult r, bool valid, uint8_t band, uint8_t act) {
+            cellCommandDone(r);
+            diag.bandValid = valid;
+            diag.band = band;
+            diag.act = act;
+            sweepStep = STEP_VBAT;
+        });
+        // A modem with no band reporting skips the step rather than stalling.
+        if (!asked) {
+            diag.bandValid = false;
+            sweepStep = STEP_VBAT;
+            serviceCellDiag();
+        }
+        break;
+    }
+
+    case STEP_VBAT: {
+        bool asked = cellModem->queryBatteryMv([](ATResult r, bool valid, uint16_t mv) {
+            cellCommandDone(r);
+            diag.vbatValid = valid;
+            diag.vbatMv = mv;
+            finishSweep();
+        });
+        if (!asked) {
+            diag.vbatValid = false;
+            finishSweep();
+        }
+        break;
+    }
+    }
+}
+
+#endif

--- a/src/mesh/cell/cellDiag.h
+++ b/src/mesh/cell/cellDiag.h
@@ -22,6 +22,7 @@ struct CellDiag {
     uint32_t lastUpdatedMs = 0;
 };
 
+// Latest readings, whatever the sweep has gathered so far.
 const CellDiag &getCellDiag();
 
 // Advance the diagnostic sweep by one command. Called from reconnectCell() where a bring-up

--- a/src/mesh/cell/cellDiag.h
+++ b/src/mesh/cell/cellDiag.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "configuration.h"
+
+#if HAS_CELLULAR
+
+#include "mesh/cell/ATModem.h"
+#include <Arduino.h>
+
+// Modem health, refreshed by a periodic sweep of the diagnostic AT commands. Every field carries
+// its own validity flag: a modem that is registered but answers CBC with ERROR still has a usable RSRP.
+struct CellDiag {
+    int16_t rsrp = 0; // dBm
+    float rsrq = 0;   // dB
+    uint8_t band = 0; // E-UTRA band number
+    uint8_t act = 0;  // access technology, 7 = E-UTRAN
+    uint16_t vbatMv = 0;
+    char operatorName[24] = {0}; // PLMN name, or the numeric MCC/MNC when unresolved
+    bool rsrpValid = false;
+    bool bandValid = false;
+    bool vbatValid = false;
+    uint32_t lastUpdatedMs = 0;
+};
+
+const CellDiag &getCellDiag();
+
+// Advance the diagnostic sweep by one command. Called from reconnectCell() where a bring-up
+// command would otherwise be issued, so only one AT command is ever in flight.
+void serviceCellDiag();
+
+// True when a sweep is due; the caller uses this to decide whether to spend
+// this tick on diagnostics instead of its own liveness poll.
+bool cellDiagDue();
+
+// Discard every reading and abandon any sweep in progress. Called when the link drops below
+// REG_WAIT, where no sweep runs: without this the last readings would keep rendering as though current.
+void cellDiagInvalidate();
+
+// Implemented in cellBearer.cpp: notes modem liveness and releases the
+// single-command-in-flight flag. Shared so diagnostics take part in both.
+void cellCommandDone(ATResult r);
+
+#endif

--- a/src/mesh/cell/cellDiagParse.cpp
+++ b/src/mesh/cell/cellDiagParse.cpp
@@ -1,0 +1,194 @@
+#include "mesh/cell/cellDiagParse.h"
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Locate the line carrying prefix and return the first character after the
+// prefix and its colon, skipping spaces. Null when no such line exists.
+static const char *findLine(const char *resp, const char *prefix)
+{
+    if (!resp || !prefix)
+        return nullptr;
+
+    size_t plen = strlen(prefix);
+    const char *p = resp;
+    while (*p) {
+        while (*p == ' ' || *p == '\t')
+            p++;
+        if (strncmp(p, prefix, plen) == 0) {
+            const char *q = p + plen;
+            while (*q == ' ')
+                q++;
+            if (*q == ':') {
+                q++;
+                while (*q == ' ')
+                    q++;
+                return q;
+            }
+        }
+        while (*p && *p != '\n')
+            p++;
+        if (*p)
+            p++;
+    }
+    return nullptr;
+}
+
+// Copy comma-separated field idx out of a single line, unquoted and trimmed.
+static bool field(const char *line, int idx, char *buf, size_t bufLen)
+{
+    if (!line || bufLen == 0)
+        return false;
+
+    const char *p = line;
+    for (int i = 0; i < idx; i++) {
+        while (*p && *p != ',' && *p != '\r' && *p != '\n')
+            p++;
+        if (*p != ',')
+            return false;
+        p++;
+    }
+
+    while (*p == ' ')
+        p++;
+
+    const char *end = p;
+    while (*end && *end != ',' && *end != '\r' && *end != '\n')
+        end++;
+    while (end > p && (end[-1] == ' ' || end[-1] == '\t'))
+        end--;
+
+    if (end - p >= 2 && *p == '"' && end[-1] == '"') {
+        p++;
+        end--;
+    }
+
+    size_t len = (size_t)(end - p);
+    if (len == 0 || len >= bufLen)
+        return false;
+    memcpy(buf, p, len);
+    buf[len] = '\0';
+    return true;
+}
+
+// Field idx as a non-negative integer, or -1 when absent or not all digits.
+static long intField(const char *line, int idx)
+{
+    char buf[16];
+    if (!field(line, idx, buf, sizeof(buf)))
+        return -1;
+    for (const char *c = buf; *c; c++)
+        if (!isdigit((unsigned char)*c))
+            return -1;
+    return strtol(buf, nullptr, 10);
+}
+
+bool parseCesq(const char *resp, int16_t *rsrpDbm, float *rsrqDb)
+{
+    const char *line = findLine(resp, "+CESQ");
+    if (!line)
+        return false;
+
+    long rsrq = intField(line, 4);
+    long rsrp = intField(line, 5);
+    if (rsrq < 0 || rsrp < 0 || rsrq == 255 || rsrp == 255)
+        return false;
+
+    if (rsrpDbm)
+        *rsrpDbm = (int16_t)(-140 + rsrp);
+    if (rsrqDb)
+        *rsrqDb = -20.0f + 0.5f * (float)rsrq;
+    return true;
+}
+
+int parseCeregStat(const char *resp)
+{
+    const char *line = findLine(resp, "+CEREG");
+    if (!line)
+        return -1;
+    return (int)intField(line, 1);
+}
+
+bool parseBandInd(const char *resp, uint8_t *band, uint8_t *act)
+{
+    const char *line = findLine(resp, "*BANDIND");
+    if (!line)
+        return false;
+
+    long b = intField(line, 1);
+    long a = intField(line, 2);
+    if (b < 0 || b > 255 || a < 0 || a > 255)
+        return false;
+
+    if (band)
+        *band = (uint8_t)b;
+    if (act)
+        *act = (uint8_t)a;
+    return true;
+}
+
+bool parseCbcMillivolts(const char *resp, uint16_t *mv)
+{
+    const char *line = findLine(resp, "+CBC");
+    if (!line)
+        return false;
+
+    // SIMCom answers <bcs>,<bcl>,<mV>; the Air780E answers with the millivolts
+    // alone. Accept either rather than silently dropping the reading.
+    long v = intField(line, 2);
+    if (v < 0)
+        v = intField(line, 0);
+
+    // The module runs from 3.4-4.2 V; anything outside a generous window around
+    // that is a different encoding, not a reading to display.
+    if (v < 2000 || v > 5000)
+        return false;
+
+    if (mv)
+        *mv = (uint16_t)v;
+    return true;
+}
+
+bool parseCopsNumeric(const char *resp, char *out, size_t outLen)
+{
+    const char *line = findLine(resp, "+COPS");
+    if (!line || !out || outLen == 0)
+        return false;
+
+    if (intField(line, 1) != 2) // format 2 is the numeric MCC/MNC
+        return false;
+
+    char buf[16];
+    if (!field(line, 2, buf, sizeof(buf)))
+        return false;
+    for (const char *c = buf; *c; c++)
+        if (!isdigit((unsigned char)*c))
+            return false;
+    if (strlen(buf) >= outLen)
+        return false;
+
+    strcpy(out, buf);
+    return true;
+}
+
+bool parseSysConfig(const char *resp, uint8_t *mode, uint8_t *acqorder, uint8_t *srvdomain)
+{
+    const char *line = findLine(resp, "^SYSCONFIG");
+    if (!line)
+        return false;
+
+    long m = intField(line, 0);
+    long a = intField(line, 1);
+    long s = intField(line, 3);
+    if (m < 0 || m > 255 || a < 0 || a > 255 || s < 0 || s > 255)
+        return false;
+
+    if (mode)
+        *mode = (uint8_t)m;
+    if (acqorder)
+        *acqorder = (uint8_t)a;
+    if (srvdomain)
+        *srvdomain = (uint8_t)s;
+    return true;
+}

--- a/src/mesh/cell/cellDiagParse.cpp
+++ b/src/mesh/cell/cellDiagParse.cpp
@@ -150,6 +150,19 @@ bool parseCbcMillivolts(const char *resp, uint16_t *mv)
     return true;
 }
 
+bool parseCopsName(const char *resp, char *out, size_t outLen)
+{
+    const char *line = findLine(resp, "+COPS");
+    if (!line || !out || outLen == 0)
+        return false;
+
+    long format = intField(line, 1);
+    if (format != 0 && format != 1) // only the alphanumeric formats carry a name
+        return false;
+
+    return field(line, 2, out, outLen);
+}
+
 bool parseCopsNumeric(const char *resp, char *out, size_t outLen)
 {
     const char *line = findLine(resp, "+COPS");

--- a/src/mesh/cell/cellDiagParse.cpp
+++ b/src/mesh/cell/cellDiagParse.cpp
@@ -92,7 +92,9 @@ bool parseCesq(const char *resp, int16_t *rsrpDbm, float *rsrqDb)
 
     long rsrq = intField(line, 4);
     long rsrp = intField(line, 5);
-    if (rsrq < 0 || rsrp < 0 || rsrq == 255 || rsrp == 255)
+    // 3GPP TS 27.007: <rsrq> is 0-34, <rsrp> is 0-97; 255 means not known or not
+    // detectable, and anything else outside range is not valid signal data either.
+    if (rsrq < 0 || rsrq > 34 || rsrp < 0 || rsrp > 97)
         return false;
 
     if (rsrpDbm)

--- a/src/mesh/cell/cellDiagParse.h
+++ b/src/mesh/cell/cellDiagParse.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+// Parsers for the modem's diagnostic responses. Kept free of Arduino types and of HAS_CELLULAR
+// so the native test suite can link them; each takes a whole response and locates the expected-prefix line.
+
+// +CESQ: <rxlev>,<ber>,<rscp>,<ecno>,<rsrq>,<rsrp>. False when either LTE field
+// reads 255 (not available) or the line is malformed.
+bool parseCesq(const char *resp, int16_t *rsrpDbm, float *rsrqDb);
+
+// +CEREG: <n>,<stat>[,...] - 1 home, 5 roaming. Returns -1 when unparseable.
+int parseCeregStat(const char *resp);
+
+// *BANDIND: <n>,<band>,<AcT> - AcT 7 is E-UTRAN.
+bool parseBandInd(const char *resp, uint8_t *band, uint8_t *act);
+
+// +CBC: <bcs>,<bcl>,<mV> - modem VBAT, not the host battery.
+bool parseCbcMillivolts(const char *resp, uint16_t *mv);
+
+// +COPS: <mode>,<format>,"<oper>"[,<AcT>]. Only accepts format 2, the numeric
+// MCC/MNC; the test unit's PLMN name table is incomplete, so a name is refused
+// rather than shown.
+bool parseCopsNumeric(const char *resp, char *out, size_t outLen);
+
+// ^SYSCONFIG: <mode>,<acqorder>,<roam>,<srvdomain>. Deliberately does not report <roam> - callers
+// read this back only to preserve mode/acqorder/srvdomain across a roaming-only rewrite.
+bool parseSysConfig(const char *resp, uint8_t *mode, uint8_t *acqorder, uint8_t *srvdomain);

--- a/src/mesh/cell/cellDiagParse.h
+++ b/src/mesh/cell/cellDiagParse.h
@@ -19,9 +19,12 @@ bool parseBandInd(const char *resp, uint8_t *band, uint8_t *act);
 // +CBC: <bcs>,<bcl>,<mV> - modem VBAT, not the host battery.
 bool parseCbcMillivolts(const char *resp, uint16_t *mv);
 
+// +COPS: <mode>,<format>,"<oper>"[,<AcT>]. Accepts format 0 or 1, the long or short PLMN
+// name; false when the format is numeric or the name is absent (no entry in the modem's PLMN table).
+bool parseCopsName(const char *resp, char *out, size_t outLen);
+
 // +COPS: <mode>,<format>,"<oper>"[,<AcT>]. Only accepts format 2, the numeric
-// MCC/MNC; the test unit's PLMN name table is incomplete, so a name is refused
-// rather than shown.
+// MCC/MNC. Fallback for when parseCopsName finds no name.
 bool parseCopsNumeric(const char *resp, char *out, size_t outLen);
 
 // ^SYSCONFIG: <mode>,<acqorder>,<roam>,<srvdomain>. Deliberately does not report <roam> - callers

--- a/src/mesh/cell/cellModem.cpp
+++ b/src/mesh/cell/cellModem.cpp
@@ -1,0 +1,25 @@
+#include "mesh/cell/cellModem.h"
+
+#if HAS_CELLULAR
+
+#include "mesh/cell/ATModem.h"
+
+#if defined(USE_EC618)
+#include "mesh/cell/EC618Modem.h"
+#else
+#error "HAS_CELLULAR is set, but no modem driver (USE_EC618) is selected."
+#endif
+
+void initCellModem()
+{
+    if (cellModem)
+        return;
+
+#if defined(USE_EC618)
+    cellModem = new EC618Modem();
+#endif
+
+    cellModem->start();
+}
+
+#endif

--- a/src/mesh/cell/cellModem.h
+++ b/src/mesh/cell/cellModem.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "configuration.h"
+
+#if HAS_CELLULAR
+
+// Create the modem thread for the driver selected at build time, and start the
+// power-on sequence.
+void initCellModem();
+
+#endif

--- a/src/mesh/generated/meshtastic/admin.pb.h
+++ b/src/mesh/generated/meshtastic/admin.pb.h
@@ -186,7 +186,7 @@ typedef struct _meshtastic_LockdownAuth {
  token at unlock time: the client-supplied boots_remaining when
  non-zero, otherwise the firmware default (TOKEN_DEFAULT_BOOTS).
  Note that boots_remaining == 0 in this message means "use firmware
- default", NOT "zero boots" - a client computing the ceiling for
+ default", NOT "zero boots" — a client computing the ceiling for
  display should mirror that resolution rather than multiplying the
  raw request value.
 
@@ -196,7 +196,7 @@ typedef struct _meshtastic_LockdownAuth {
 
  Uses millis() (CPU uptime), not wall-clock time, so the cap is
  immune to GPS spoofing, RTC backup-battery removal, and Faraday
- cage isolation - none of those move the uptime counter. The only
+ cage isolation — none of those move the uptime counter. The only
  way to reset the session clock is a reboot, which costs a boot
  from the on-flash, HMAC-bound counter. */
     uint32_t max_session_seconds;
@@ -213,7 +213,7 @@ typedef struct _meshtastic_LockdownAuth {
 
  NOT reversed by this operation: APPROTECT. Once the debug port
  lockout has been burned (on silicon where it is effective) it is
- permanent - disabling lockdown decrypts your data and removes the
+ permanent — disabling lockdown decrypts your data and removes the
  access gates, but the SWD/JTAG port stays locked for the life of
  the device (recoverable only via a full chip erase over a debug
  probe, which destroys all data). Clients should make this

--- a/src/mesh/generated/meshtastic/atak.pb.h
+++ b/src/mesh/generated/meshtastic/atak.pb.h
@@ -332,7 +332,7 @@ typedef enum _meshtastic_CotType {
     /* y-: TAKTALK room/membership broadcast. Payload carried via the
  TakTalkRoomData typed variant (sender_callsign, room_id, room_name,
  participants). The CoT type literally has a trailing dash and no
- second atom - not a typo. */
+ second atom — not a typo. */
     meshtastic_CotType_CotType_y = 126
 } meshtastic_CotType;
 
@@ -380,7 +380,7 @@ typedef enum _meshtastic_DrawnShape_Kind {
     /* u-r-b-bullseye: Bullseye ring with range rings and bearing reference */
     meshtastic_DrawnShape_Kind_Kind_Bullseye = 7,
     /* u-d-c-e: Ellipse with distinct major/minor axes (same storage as
- Kind_Circle - uses major_cm/minor_cm/angle_deg - but receivers
+ Kind_Circle — uses major_cm/minor_cm/angle_deg — but receivers
  render it as a non-circular ellipse rather than a round circle). */
     meshtastic_DrawnShape_Kind_Kind_Ellipse = 8,
     /* u-d-v: 2D vehicle outline drawn on the map. Vertices carry the
@@ -400,7 +400,7 @@ typedef enum _meshtastic_DrawnShape_Kind {
  end of parse; builder uses it to decide which of <strokeColor> /
  <fillColor> to emit in the reconstructed XML. */
 typedef enum _meshtastic_DrawnShape_StyleMode {
-    /* Unspecified - receiver infers from which color fields are non-zero. */
+    /* Unspecified — receiver infers from which color fields are non-zero. */
     meshtastic_DrawnShape_StyleMode_StyleMode_Unspecified = 0,
     /* Stroke only. No <fillColor> in the source XML. Used for polylines,
  ranging lines, bullseye rings. */
@@ -417,7 +417,7 @@ typedef enum _meshtastic_DrawnShape_StyleMode {
  alone is ambiguous (e.g. a-u-G could be a 2525 symbol or a custom icon
  depending on the iconset path). */
 typedef enum _meshtastic_Marker_Kind {
-    /* Unspecified - fall back to TAKPacketV2.cot_type_id */
+    /* Unspecified — fall back to TAKPacketV2.cot_type_id */
     meshtastic_Marker_Kind_Kind_Unspecified = 0,
     /* b-m-p-s-m: Spot map marker */
     meshtastic_Marker_Kind_Kind_Spot = 1,
@@ -680,10 +680,10 @@ typedef struct _meshtastic_AircraftTrack {
  hundred meters of the anchor has per-vertex deltas in the ±10^4 range.
  Under sint32+zigzag those encode as 2 bytes each (tag+varint), versus the
  4 bytes that sfixed32 would always require. At 32 vertices that is ~128
- bytes of savings - the difference between fitting under the LoRa MTU or
+ bytes of savings — the difference between fitting under the LoRa MTU or
  not. Absolute coordinates (values ~10^9) would cost sint32 varint 5 bytes
  per field, which is why TAKPacketV2's top-level latitude_i / longitude_i
- stay sfixed32 - only small values win with sint32. */
+ stay sfixed32 — only small values win with sint32. */
 typedef struct _meshtastic_CotGeoPoint {
     /* Latitude delta from TAKPacketV2.latitude_i, in 1e-7 degree units.
  Add to the enclosing event's latitude_i to recover the absolute latitude. */
@@ -791,7 +791,7 @@ typedef struct _meshtastic_Marker {
 
  Covers CoT type u-rb-a. The anchor position is on
  TAKPacketV2.latitude_i/longitude_i; the target endpoint is carried as a
- CotGeoPoint - same delta-from-anchor encoding used by DrawnShape.vertices
+ CotGeoPoint — same delta-from-anchor encoding used by DrawnShape.vertices
  so a self-anchored RAB (common case) encodes in zero bytes. */
 typedef struct _meshtastic_RangeAndBearing {
     /* Target/anchor endpoint (delta-encoded from TAKPacketV2.latitude_i/longitude_i). */
@@ -899,12 +899,12 @@ typedef struct _meshtastic_CasevacReport {
  same as the envelope callsign but ATAK sometimes carries a distinct
  ops-number here. */
     pb_callback_t title;
-    /* Primary medline free-text - the single most clinically important line
+    /* Primary medline free-text — the single most clinically important line
  on a MEDLINE form (e.g. "2 urgent litter patients, smoke on approach").
  MUST be preserved under MTU pressure as long as any casevac is sent. */
     pb_callback_t medline_remarks;
     /* Line 3 (newer ATAK format): patient counts by precedence level.
- Coexists with the enum-style `precedence` field (tag 1) - older ATAK
+ Coexists with the enum-style `precedence` field (tag 1) — older ATAK
  emits a single enum, newer ATAK emits these counts, and both can be
  set simultaneously. Senders populate whichever style(s) the source
  XML had; receivers prefer counts when non-zero. */
@@ -946,19 +946,19 @@ typedef struct _meshtastic_CasevacReport {
  (e.g. "Primary HLZ is soccer field"). */
     pb_callback_t hlz_remarks;
     /* Per-patient clinical records. Each entry is one patient's ZMIST card
- (Zap number / Mechanism / Injuries / Signs / Treatment). Repeatable -
+ (Zap number / Mechanism / Injuries / Signs / Treatment). Repeatable —
  a mass-casualty event can carry 1-6 entries in practice, limited by
  the 237 B LoRa MTU. */
     pb_callback_t zmist;
 } meshtastic_CasevacReport;
 
-/* Per-patient clinical summary record - one entry per patient in a CASEVAC.
+/* Per-patient clinical summary record — one entry per patient in a CASEVAC.
  Maps directly to ATAK's <zMist> child element inside <zMistsMap>.
  All fields are optional free-text; senders populate what they have. */
 typedef struct _meshtastic_ZMistEntry {
     /* Patient identifier / sequence label (e.g. "ZMIST-1", "ZMIST-2"). */
     pb_callback_t title;
-    /* Zap number - unique patient tracking ID (often a terse code like
+    /* Zap number — unique patient tracking ID (often a terse code like
  "Gunshot" or a serial). */
     pb_callback_t z;
     /* Mechanism of injury (e.g. "Penetrating trauma", "Blast injury"). */
@@ -997,7 +997,7 @@ typedef struct _meshtastic_EmergencyAlert {
  creation time; the fields below carry structured metadata the raw-detail
  fallback currently loses.
 
- Fields are deliberately lean - this variant is closer to the MTU ceiling
+ Fields are deliberately lean — this variant is closer to the MTU ceiling
  than the others, so every string is capped in options. */
 typedef struct _meshtastic_TaskRequest {
     /* Short tag for the task category (e.g. "engage", "observe", "recon",
@@ -1017,7 +1017,7 @@ typedef struct _meshtastic_TaskRequest {
 
 /* Weather annotation from <environment> CoT detail element.
 
- Attaches to any TAKPacketV2 regardless of payload_variant - an Aircraft,
+ Attaches to any TAKPacketV2 regardless of payload_variant — an Aircraft,
  PLI, or Marker can all carry observed conditions at the emitting station.
  ATAK-CIV ships an XSD for <environment> but no dedicated handler, so the
  element round-trips through the generic detail pipeline; this message
@@ -1026,7 +1026,7 @@ typedef struct _meshtastic_TaskRequest {
  Target wire cost: ~6-8 bytes compressed with a fully populated instance.
 
  Named `TAKEnvironment` (not just `Environment`) because the bare name
- collides with `SwiftUI.Environment` - every SwiftUI view in a consuming
+ collides with `SwiftUI.Environment` — every SwiftUI view in a consuming
  iOS app uses the `@Environment` property wrapper, and importing the
  generated proto module would make `Environment` ambiguous in every one
  of those files. The `TAK` prefix matches the convention used by the
@@ -1055,7 +1055,7 @@ typedef struct _meshtastic_TAKEnvironment {
  The receiving ATAK client restores those from its own defaults, same as
  every other CoT carried over Meshtastic today.
 
- Attaches to any TAKPacketV2 - a PLI with a sensor on the operator's head,
+ Attaches to any TAKPacketV2 — a PLI with a sensor on the operator's head,
  an Aircraft with a FLIR turret, a Marker dropped on a UAV.
  Target wire cost: ~7-14 bytes compressed (dominated by model string). */
 typedef struct _meshtastic_SensorFov {
@@ -1065,30 +1065,30 @@ typedef struct _meshtastic_SensorFov {
  SensorDetailHandler default (270°) and save varint bytes over centi-deg. */
     uint32_t azimuth_deg;
     /* Maximum range of the cone in meters.
- Optional - if unset, receivers should use the ATAK-CIV default of 100m. */
+ Optional — if unset, receivers should use the ATAK-CIV default of 100m. */
     bool has_range_m;
     uint32_t range_m;
     /* Horizontal field of view in whole degrees (cone's angular width).
  ATAK-CIV default is 45°. */
     uint32_t fov_horizontal_deg;
     /* Vertical field of view in whole degrees. ATAK-CIV default is 45°.
- Optional - a value of 0 means "not set / use horizontal FOV". */
+ Optional — a value of 0 means "not set / use horizontal FOV". */
     uint32_t fov_vertical_deg;
     /* Elevation angle in whole degrees. Positive = up, negative = down.
  Range -90 to +90. sint32 for varint efficiency on small negatives. */
     int32_t elevation_deg;
     /* Roll (camera tilt) in whole degrees, -180 to +180.
- Optional - use 0 if the sensor doesn't track roll. */
+ Optional — use 0 if the sensor doesn't track roll. */
     int32_t roll_deg;
     /* Free-form device model identifier, e.g. "FLIR-Boson-640", "SEEK".
- Optional - empty string means "unknown model" (ATAK-CIV default). */
+ Optional — empty string means "unknown model" (ATAK-CIV default). */
     pb_callback_t model;
 } meshtastic_SensorFov;
 
 /* TAKTALK chat message payload (CoT type m-t-t).
 
  TAKTALK is an ATAK plugin for voice + text team messaging. The voice
- audio stream goes over UDP/RTP and is NOT carried by the mesh - only
+ audio stream goes over UDP/RTP and is NOT carried by the mesh — only
  the text envelope (this message) is. `from_voice` marks messages sent
  via push-to-talk speech-to-text so receivers can render a mic icon
  next to the text.
@@ -1122,7 +1122,7 @@ typedef struct _meshtastic_TakTalkMessage {
  Announces a TAKTALK chatroom's friendly name and roster so peers can
  resolve room UUIDs (used in TakTalkMessage.chatroom_id and
  GeoChat.room_id) to a display name and participant list. Not a chat
- message itself - these events are emitted by TAKTALK when rooms are
+ message itself — these events are emitted by TAKTALK when rooms are
  created or memberships change. */
 typedef struct _meshtastic_TakTalkRoomData {
     /* Callsign of the device broadcasting the room state (typically the
@@ -1161,7 +1161,7 @@ typedef struct _meshtastic_Marti {
  primary-vs-cc distinction the same way ATAK does.
 
  If dest_callsign is [TAKPacketV2.callsign] (self-addressed, unusual but
- legal - e.g. ATAK echoing back to its own room), the builder still emits
+ legal — e.g. ATAK echoing back to its own room), the builder still emits
  the element so loopback shapes round-trip cleanly. */
     pb_callback_t dest_callsign;
 } meshtastic_Marti;

--- a/src/mesh/generated/meshtastic/config.pb.cpp
+++ b/src/mesh/generated/meshtastic/config.pb.cpp
@@ -6,7 +6,7 @@
 #error Regenerate this file with the current version of nanopb generator.
 #endif
 
-PB_BIND(meshtastic_Config, meshtastic_Config, AUTO)
+PB_BIND(meshtastic_Config, meshtastic_Config, 2)
 
 
 PB_BIND(meshtastic_Config_DeviceConfig, meshtastic_Config_DeviceConfig, AUTO)
@@ -18,7 +18,7 @@ PB_BIND(meshtastic_Config_PositionConfig, meshtastic_Config_PositionConfig, AUTO
 PB_BIND(meshtastic_Config_PowerConfig, meshtastic_Config_PowerConfig, AUTO)
 
 
-PB_BIND(meshtastic_Config_NetworkConfig, meshtastic_Config_NetworkConfig, AUTO)
+PB_BIND(meshtastic_Config_NetworkConfig, meshtastic_Config_NetworkConfig, 2)
 
 
 PB_BIND(meshtastic_Config_NetworkConfig_IpV4Config, meshtastic_Config_NetworkConfig_IpV4Config, AUTO)

--- a/src/mesh/generated/meshtastic/config.pb.h
+++ b/src/mesh/generated/meshtastic/config.pb.h
@@ -554,6 +554,18 @@ typedef struct _meshtastic_Config_NetworkConfig {
     uint32_t enabled_protocols;
     /* Enable/Disable ipv6 support */
     bool ipv6_enabled;
+    /* Enable Cellular (modem) networking */
+    bool cell_enabled;
+    /* APN to use when bringing up the cellular PDP context. Empty string asks for the
+ subscription default. */
+    char cell_apn[101];
+    /* Username for the cellular APN, if required */
+    char cell_apn_user[65];
+    /* Password for the cellular APN, if required */
+    char cell_apn_pass[65];
+    /* Allow the cellular modem to register on a roaming network. Disabled restricts
+ registration to the home network only. */
+    bool cell_roaming_enabled;
 } meshtastic_Config_NetworkConfig;
 
 /* Display Config */
@@ -833,7 +845,7 @@ extern "C" {
 #define meshtastic_Config_DeviceConfig_init_default {_meshtastic_Config_DeviceConfig_Role_MIN, 0, 0, 0, _meshtastic_Config_DeviceConfig_RebroadcastMode_MIN, 0, 0, 0, 0, "", 0, _meshtastic_Config_DeviceConfig_BuzzerMode_MIN}
 #define meshtastic_Config_PositionConfig_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, _meshtastic_Config_PositionConfig_GpsMode_MIN}
 #define meshtastic_Config_PowerConfig_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0}
-#define meshtastic_Config_NetworkConfig_init_default {0, "", "", "", 0, _meshtastic_Config_NetworkConfig_AddressMode_MIN, false, meshtastic_Config_NetworkConfig_IpV4Config_init_default, "", 0, 0}
+#define meshtastic_Config_NetworkConfig_init_default {0, "", "", "", 0, _meshtastic_Config_NetworkConfig_AddressMode_MIN, false, meshtastic_Config_NetworkConfig_IpV4Config_init_default, "", 0, 0, 0, "", "", "", 0}
 #define meshtastic_Config_NetworkConfig_IpV4Config_init_default {0, 0, 0, 0}
 #define meshtastic_Config_DisplayConfig_init_default {0, _meshtastic_Config_DisplayConfig_DeprecatedGpsCoordinateFormat_MIN, 0, 0, 0, _meshtastic_Config_DisplayConfig_DisplayUnits_MIN, _meshtastic_Config_DisplayConfig_OledType_MIN, _meshtastic_Config_DisplayConfig_DisplayMode_MIN, 0, 0, _meshtastic_Config_DisplayConfig_CompassOrientation_MIN, 0, 0, 0}
 #define meshtastic_Config_LoRaConfig_init_default {0, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, 0, 0, 0, 0, _meshtastic_Config_LoRaConfig_RegionCode_MIN, 0, 0, 0, 0, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, _meshtastic_Config_LoRaConfig_FEM_LNA_Mode_MIN, 0}
@@ -844,7 +856,7 @@ extern "C" {
 #define meshtastic_Config_DeviceConfig_init_zero {_meshtastic_Config_DeviceConfig_Role_MIN, 0, 0, 0, _meshtastic_Config_DeviceConfig_RebroadcastMode_MIN, 0, 0, 0, 0, "", 0, _meshtastic_Config_DeviceConfig_BuzzerMode_MIN}
 #define meshtastic_Config_PositionConfig_init_zero {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, _meshtastic_Config_PositionConfig_GpsMode_MIN}
 #define meshtastic_Config_PowerConfig_init_zero  {0, 0, 0, 0, 0, 0, 0, 0, 0}
-#define meshtastic_Config_NetworkConfig_init_zero {0, "", "", "", 0, _meshtastic_Config_NetworkConfig_AddressMode_MIN, false, meshtastic_Config_NetworkConfig_IpV4Config_init_zero, "", 0, 0}
+#define meshtastic_Config_NetworkConfig_init_zero {0, "", "", "", 0, _meshtastic_Config_NetworkConfig_AddressMode_MIN, false, meshtastic_Config_NetworkConfig_IpV4Config_init_zero, "", 0, 0, 0, "", "", "", 0}
 #define meshtastic_Config_NetworkConfig_IpV4Config_init_zero {0, 0, 0, 0}
 #define meshtastic_Config_DisplayConfig_init_zero {0, _meshtastic_Config_DisplayConfig_DeprecatedGpsCoordinateFormat_MIN, 0, 0, 0, _meshtastic_Config_DisplayConfig_DisplayUnits_MIN, _meshtastic_Config_DisplayConfig_OledType_MIN, _meshtastic_Config_DisplayConfig_DisplayMode_MIN, 0, 0, _meshtastic_Config_DisplayConfig_CompassOrientation_MIN, 0, 0, 0}
 #define meshtastic_Config_LoRaConfig_init_zero   {0, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, 0, 0, 0, 0, _meshtastic_Config_LoRaConfig_RegionCode_MIN, 0, 0, 0, 0, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, _meshtastic_Config_LoRaConfig_FEM_LNA_Mode_MIN, 0}
@@ -901,6 +913,11 @@ extern "C" {
 #define meshtastic_Config_NetworkConfig_rsyslog_server_tag 9
 #define meshtastic_Config_NetworkConfig_enabled_protocols_tag 10
 #define meshtastic_Config_NetworkConfig_ipv6_enabled_tag 11
+#define meshtastic_Config_NetworkConfig_cell_enabled_tag 12
+#define meshtastic_Config_NetworkConfig_cell_apn_tag 13
+#define meshtastic_Config_NetworkConfig_cell_apn_user_tag 14
+#define meshtastic_Config_NetworkConfig_cell_apn_pass_tag 15
+#define meshtastic_Config_NetworkConfig_cell_roaming_enabled_tag 16
 #define meshtastic_Config_DisplayConfig_screen_on_secs_tag 1
 #define meshtastic_Config_DisplayConfig_gps_format_tag 2
 #define meshtastic_Config_DisplayConfig_auto_screen_carousel_secs_tag 3
@@ -1038,7 +1055,12 @@ X(a, STATIC,   SINGULAR, UENUM,    address_mode,      7) \
 X(a, STATIC,   OPTIONAL, MESSAGE,  ipv4_config,       8) \
 X(a, STATIC,   SINGULAR, STRING,   rsyslog_server,    9) \
 X(a, STATIC,   SINGULAR, UINT32,   enabled_protocols,  10) \
-X(a, STATIC,   SINGULAR, BOOL,     ipv6_enabled,     11)
+X(a, STATIC,   SINGULAR, BOOL,     ipv6_enabled,     11) \
+X(a, STATIC,   SINGULAR, BOOL,     cell_enabled,     12) \
+X(a, STATIC,   SINGULAR, STRING,   cell_apn,         13) \
+X(a, STATIC,   SINGULAR, STRING,   cell_apn_user,    14) \
+X(a, STATIC,   SINGULAR, STRING,   cell_apn_pass,    15) \
+X(a, STATIC,   SINGULAR, BOOL,     cell_roaming_enabled,  16)
 #define meshtastic_Config_NetworkConfig_CALLBACK NULL
 #define meshtastic_Config_NetworkConfig_DEFAULT NULL
 #define meshtastic_Config_NetworkConfig_ipv4_config_MSGTYPE meshtastic_Config_NetworkConfig_IpV4Config
@@ -1149,12 +1171,12 @@ extern const pb_msgdesc_t meshtastic_Config_SessionkeyConfig_msg;
 #define meshtastic_Config_DisplayConfig_size     36
 #define meshtastic_Config_LoRaConfig_size        91
 #define meshtastic_Config_NetworkConfig_IpV4Config_size 20
-#define meshtastic_Config_NetworkConfig_size     204
+#define meshtastic_Config_NetworkConfig_size     443
 #define meshtastic_Config_PositionConfig_size    62
 #define meshtastic_Config_PowerConfig_size       52
 #define meshtastic_Config_SecurityConfig_size    180
 #define meshtastic_Config_SessionkeyConfig_size  0
-#define meshtastic_Config_size                   207
+#define meshtastic_Config_size                   446
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/mesh/generated/meshtastic/deviceonly.pb.h
+++ b/src/mesh/generated/meshtastic/deviceonly.pb.h
@@ -455,7 +455,7 @@ extern const pb_msgdesc_t meshtastic_BackupPreferences_msg;
 /* Maximum encoded size of messages (where known) */
 /* meshtastic_NodeDatabase_size depends on runtime parameters */
 #define MESHTASTIC_MESHTASTIC_DEVICEONLY_PB_H_MAX_SIZE meshtastic_BackupPreferences_size
-#define meshtastic_BackupPreferences_size        2740
+#define meshtastic_BackupPreferences_size        2989
 #define meshtastic_ChannelFile_size              718
 #define meshtastic_DeviceState_size              1944
 #define meshtastic_NodeEnvironmentEntry_size     170

--- a/src/mesh/generated/meshtastic/localonly.pb.h
+++ b/src/mesh/generated/meshtastic/localonly.pb.h
@@ -211,8 +211,8 @@ extern const pb_msgdesc_t meshtastic_LocalModuleConfig_msg;
 
 /* Maximum encoded size of messages (where known) */
 #define MESHTASTIC_MESHTASTIC_LOCALONLY_PB_H_MAX_SIZE meshtastic_LocalModuleConfig_size
-#define meshtastic_LocalConfig_size              759
-#define meshtastic_LocalModuleConfig_size        1126
+#define meshtastic_LocalConfig_size              998
+#define meshtastic_LocalModuleConfig_size        1136
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -1112,10 +1112,8 @@ typedef struct _meshtastic_MeshPacket {
     meshtastic_MeshPacket_Priority priority;
     /* rssi of received packet. Only sent to phone for dispay purposes.
  Explicit presence: rssi 0 is a legitimate reading on some radios (SX126x can report exactly
- 0 dBm; SX127x's formula can even go positive), so implicit-presence proto3 made an unset
- value indistinguishable from a measured one. has_rx_rssi disambiguates; a replayed packet
- built from history the device never restored an RSSI for should leave this field absent
- rather than emitting 0. */
+ 0 dBm; SX127x's formula can even go positive). has_rx_rssi disambiguates; a replayed packet
+ built from history should leave this field absent rather than emitting 0. */
     bool has_rx_rssi;
     int32_t rx_rssi;
     /* Describe if this message is delayed */
@@ -1269,15 +1267,15 @@ typedef struct _meshtastic_LockdownStatus {
     /* Current lockdown state being reported. */
     meshtastic_LockdownStatus_State state;
     /* For LOCKED: machine-readable reason. Known values:
-   "needs_auth"        - storage already unlocked, client must auth
-   "token_missing"     - no boot token on flash
-   "token_expired"     - boot token wall-clock TTL elapsed
-   "token_boots_zero"  - boot token boot-count TTL exhausted
-   "token_hmac_fail"   - token tampered or wrong device
-   "token_dek_fail"    - token DEK decrypt failed
-   "token_wrong_size"  - token file corrupted
-   "token_bad_magic"   - token file corrupted
-   "not_provisioned"   - should generally use NEEDS_PROVISION state instead
+   "needs_auth"        — storage already unlocked, client must auth
+   "token_missing"     — no boot token on flash
+   "token_expired"     — boot token wall-clock TTL elapsed
+   "token_boots_zero"  — boot token boot-count TTL exhausted
+   "token_hmac_fail"   — token tampered or wrong device
+   "token_dek_fail"    — token DEK decrypt failed
+   "token_wrong_size"  — token file corrupted
+   "token_bad_magic"   — token file corrupted
+   "not_provisioned"   — should generally use NEEDS_PROVISION state instead
  Other values may be added; clients should treat unknown values as
  "locked, ask for passphrase". */
     char lock_reason[32];
@@ -1417,6 +1415,8 @@ typedef struct _meshtastic_DeviceMetadata {
     /* Indicates whether this firmware build includes XEdDSA packet signature verification.
  This is a read-only capability and must be false when XEdDSA is not compiled in. */
     bool has_xeddsa;
+    /* Indicates that the device has a cellular (modem) peripheral */
+    bool hasCellular;
 } meshtastic_DeviceMetadata;
 
 /* A distinct set of legal modem presets shared by one or more LoRa regions.
@@ -1765,7 +1765,7 @@ extern "C" {
 #define meshtastic_Compressed_init_default       {_meshtastic_PortNum_MIN, {0, {0}}}
 #define meshtastic_NeighborInfo_init_default     {0, 0, 0, 0, {meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default}}
 #define meshtastic_Neighbor_init_default         {0, 0, 0, 0}
-#define meshtastic_DeviceMetadata_init_default   {"", 0, 0, 0, 0, 0, _meshtastic_Config_DeviceConfig_Role_MIN, 0, _meshtastic_HardwareModel_MIN, 0, 0, 0, 0}
+#define meshtastic_DeviceMetadata_init_default   {"", 0, 0, 0, 0, 0, _meshtastic_Config_DeviceConfig_Role_MIN, 0, _meshtastic_HardwareModel_MIN, 0, 0, 0, 0, 0}
 #define meshtastic_LoRaPresetGroup_init_default  {0, {_meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN}, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, 0}
 #define meshtastic_LoRaRegionPresets_init_default {_meshtastic_Config_LoRaConfig_RegionCode_MIN, 0}
 #define meshtastic_LoRaRegionPresetMap_init_default {0, {meshtastic_LoRaPresetGroup_init_default, meshtastic_LoRaPresetGroup_init_default, meshtastic_LoRaPresetGroup_init_default, meshtastic_LoRaPresetGroup_init_default, meshtastic_LoRaPresetGroup_init_default, meshtastic_LoRaPresetGroup_init_default, meshtastic_LoRaPresetGroup_init_default, meshtastic_LoRaPresetGroup_init_default}, 0, {meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default}}
@@ -1804,7 +1804,7 @@ extern "C" {
 #define meshtastic_Compressed_init_zero          {_meshtastic_PortNum_MIN, {0, {0}}}
 #define meshtastic_NeighborInfo_init_zero        {0, 0, 0, 0, {meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero}}
 #define meshtastic_Neighbor_init_zero            {0, 0, 0, 0}
-#define meshtastic_DeviceMetadata_init_zero      {"", 0, 0, 0, 0, 0, _meshtastic_Config_DeviceConfig_Role_MIN, 0, _meshtastic_HardwareModel_MIN, 0, 0, 0, 0}
+#define meshtastic_DeviceMetadata_init_zero      {"", 0, 0, 0, 0, 0, _meshtastic_Config_DeviceConfig_Role_MIN, 0, _meshtastic_HardwareModel_MIN, 0, 0, 0, 0, 0}
 #define meshtastic_LoRaPresetGroup_init_zero     {0, {_meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN}, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, 0}
 #define meshtastic_LoRaRegionPresets_init_zero   {_meshtastic_Config_LoRaConfig_RegionCode_MIN, 0}
 #define meshtastic_LoRaRegionPresetMap_init_zero {0, {meshtastic_LoRaPresetGroup_init_zero, meshtastic_LoRaPresetGroup_init_zero, meshtastic_LoRaPresetGroup_init_zero, meshtastic_LoRaPresetGroup_init_zero, meshtastic_LoRaPresetGroup_init_zero, meshtastic_LoRaPresetGroup_init_zero, meshtastic_LoRaPresetGroup_init_zero, meshtastic_LoRaPresetGroup_init_zero}, 0, {meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero}}
@@ -2008,6 +2008,7 @@ extern "C" {
 #define meshtastic_DeviceMetadata_hasPKC_tag     11
 #define meshtastic_DeviceMetadata_excluded_modules_tag 12
 #define meshtastic_DeviceMetadata_has_xeddsa_tag 14
+#define meshtastic_DeviceMetadata_hasCellular_tag 15
 #define meshtastic_LoRaPresetGroup_presets_tag   1
 #define meshtastic_LoRaPresetGroup_default_preset_tag 2
 #define meshtastic_LoRaPresetGroup_licensed_only_tag 3
@@ -2427,7 +2428,8 @@ X(a, STATIC,   SINGULAR, UENUM,    hw_model,          9) \
 X(a, STATIC,   SINGULAR, BOOL,     hasRemoteHardware,  10) \
 X(a, STATIC,   SINGULAR, BOOL,     hasPKC,           11) \
 X(a, STATIC,   SINGULAR, UINT32,   excluded_modules,  12) \
-X(a, STATIC,   SINGULAR, BOOL,     has_xeddsa,       14)
+X(a, STATIC,   SINGULAR, BOOL,     has_xeddsa,       14) \
+X(a, STATIC,   SINGULAR, BOOL,     hasCellular,      15)
 #define meshtastic_DeviceMetadata_CALLBACK NULL
 #define meshtastic_DeviceMetadata_DEFAULT NULL
 
@@ -2576,7 +2578,7 @@ extern const pb_msgdesc_t meshtastic_ChunkedPayloadResponse_msg;
 #define meshtastic_ClientNotification_size       482
 #define meshtastic_Compressed_size               239
 #define meshtastic_Data_size                     335
-#define meshtastic_DeviceMetadata_size           56
+#define meshtastic_DeviceMetadata_size           58
 #define meshtastic_DuplicatedPublicKey_size      0
 #define meshtastic_FileInfo_size                 236
 #define meshtastic_FromRadio_size                510

--- a/src/mesh/generated/meshtastic/mesh_beacon.pb.h
+++ b/src/mesh/generated/meshtastic/mesh_beacon.pb.h
@@ -15,7 +15,7 @@
 /* Payload for MESH_BEACON_APP packets.
  Periodically broadcast by nodes in beacon mode.
  Listeners deliver the text message to the local inbox and cache any offered
- channel/preset for the client app to act on - the firmware never auto-applies them. */
+ channel/preset for the client app to act on — the firmware never auto-applies them. */
 typedef struct _meshtastic_MeshBeacon {
     /* Human-readable beacon message. Max 100 bytes enforced by firmware on send. */
     char message[101];

--- a/src/mesh/generated/meshtastic/module_config.pb.h
+++ b/src/mesh/generated/meshtastic/module_config.pb.h
@@ -406,6 +406,11 @@ typedef struct _meshtastic_ModuleConfig_TelemetryConfig {
     bool device_telemetry_enabled;
     /* Enable/Disable the air quality telemetry measurement module on-device display */
     bool air_quality_screen_enabled;
+    /* Enable/disable Cellular (modem) diagnostic metrics */
+    bool cellular_measurement_enabled;
+    /* Interval in seconds of how often we should try to send our
+ cellular diagnostic metrics to the mesh */
+    uint32_t cellular_update_interval;
 } meshtastic_ModuleConfig_TelemetryConfig;
 
 /* Canned Messages Module Config */
@@ -497,7 +502,7 @@ typedef struct _meshtastic_ModuleConfig_MeshBeaconConfig {
     /* Single-target TX channel: channel settings (name + PSK) to send beacons on.
  If unset, beacons go out on the primary channel. Used only when broadcast_targets is empty.
  NOTE: the single-target path embeds the ChannelSettings inline here, whereas a
- broadcast_targets entry references a channel-table slot by channel_index instead - see
+ broadcast_targets entry references a channel-table slot by channel_index instead — see
  BroadcastTarget. The two paths are equal, first-class options; only this representation differs. */
     bool has_broadcast_on_channel;
     meshtastic_ChannelSettings broadcast_on_channel;
@@ -514,7 +519,7 @@ typedef struct _meshtastic_ModuleConfig_MeshBeaconConfig {
  each temporarily switching the radio to that entry's preset/region/channel.
  When empty, the broadcaster uses the scalar broadcast_on_preset / broadcast_on_region /
  broadcast_on_channel fields instead (the single-target path).
- Single- and multi-target are equal, first-class options - neither is preferred or
+ Single- and multi-target are equal, first-class options — neither is preferred or
  deprecated. They differ only in how the TX channel is named: broadcast_on_channel embeds a
  ChannelSettings inline, while a target references an existing channel-table slot by
  channel_index (see BroadcastTarget). */
@@ -680,7 +685,7 @@ extern "C" {
 #define meshtastic_ModuleConfig_ExternalNotificationConfig_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_StoreForwardConfig_init_default {0, 0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_RangeTestConfig_init_default {0, 0, 0, 0}
-#define meshtastic_ModuleConfig_TelemetryConfig_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+#define meshtastic_ModuleConfig_TelemetryConfig_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_CannedMessageConfig_init_default {0, 0, 0, 0, _meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_MIN, _meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_MIN, _meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_MIN, 0, 0, "", 0}
 #define meshtastic_ModuleConfig_AmbientLightingConfig_init_default {0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_StatusMessageConfig_init_default {""}
@@ -701,7 +706,7 @@ extern "C" {
 #define meshtastic_ModuleConfig_ExternalNotificationConfig_init_zero {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_StoreForwardConfig_init_zero {0, 0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_RangeTestConfig_init_zero {0, 0, 0, 0}
-#define meshtastic_ModuleConfig_TelemetryConfig_init_zero {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+#define meshtastic_ModuleConfig_TelemetryConfig_init_zero {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_CannedMessageConfig_init_zero {0, 0, 0, 0, _meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_MIN, _meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_MIN, _meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_MIN, 0, 0, "", 0}
 #define meshtastic_ModuleConfig_AmbientLightingConfig_init_zero {0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_StatusMessageConfig_init_zero {""}
@@ -800,6 +805,8 @@ extern "C" {
 #define meshtastic_ModuleConfig_TelemetryConfig_health_screen_enabled_tag 13
 #define meshtastic_ModuleConfig_TelemetryConfig_device_telemetry_enabled_tag 14
 #define meshtastic_ModuleConfig_TelemetryConfig_air_quality_screen_enabled_tag 15
+#define meshtastic_ModuleConfig_TelemetryConfig_cellular_measurement_enabled_tag 16
+#define meshtastic_ModuleConfig_TelemetryConfig_cellular_update_interval_tag 17
 #define meshtastic_ModuleConfig_CannedMessageConfig_rotary1_enabled_tag 1
 #define meshtastic_ModuleConfig_CannedMessageConfig_inputbroker_pin_a_tag 2
 #define meshtastic_ModuleConfig_CannedMessageConfig_inputbroker_pin_b_tag 3
@@ -1038,7 +1045,9 @@ X(a, STATIC,   SINGULAR, BOOL,     health_measurement_enabled,  11) \
 X(a, STATIC,   SINGULAR, UINT32,   health_update_interval,  12) \
 X(a, STATIC,   SINGULAR, BOOL,     health_screen_enabled,  13) \
 X(a, STATIC,   SINGULAR, BOOL,     device_telemetry_enabled,  14) \
-X(a, STATIC,   SINGULAR, BOOL,     air_quality_screen_enabled,  15)
+X(a, STATIC,   SINGULAR, BOOL,     air_quality_screen_enabled,  15) \
+X(a, STATIC,   SINGULAR, BOOL,     cellular_measurement_enabled,  16) \
+X(a, STATIC,   SINGULAR, UINT32,   cellular_update_interval,  17)
 #define meshtastic_ModuleConfig_TelemetryConfig_CALLBACK NULL
 #define meshtastic_ModuleConfig_TelemetryConfig_DEFAULT NULL
 
@@ -1173,7 +1182,7 @@ extern const pb_msgdesc_t meshtastic_RemoteHardwarePin_msg;
 #define meshtastic_ModuleConfig_StatusMessageConfig_size 81
 #define meshtastic_ModuleConfig_StoreForwardConfig_size 24
 #define meshtastic_ModuleConfig_TAKConfig_size   4
-#define meshtastic_ModuleConfig_TelemetryConfig_size 50
+#define meshtastic_ModuleConfig_TelemetryConfig_size 60
 #define meshtastic_ModuleConfig_TrafficManagementConfig_size 30
 #define meshtastic_ModuleConfig_size             328
 #define meshtastic_RemoteHardwarePin_size        21

--- a/src/mesh/generated/meshtastic/telemetry.pb.cpp
+++ b/src/mesh/generated/meshtastic/telemetry.pb.cpp
@@ -30,6 +30,9 @@ PB_BIND(meshtastic_HealthMetrics, meshtastic_HealthMetrics, AUTO)
 PB_BIND(meshtastic_HostMetrics, meshtastic_HostMetrics, 2)
 
 
+PB_BIND(meshtastic_CellularMetrics, meshtastic_CellularMetrics, AUTO)
+
+
 PB_BIND(meshtastic_Telemetry, meshtastic_Telemetry, 2)
 
 

--- a/src/mesh/generated/meshtastic/telemetry.pb.h
+++ b/src/mesh/generated/meshtastic/telemetry.pb.h
@@ -445,6 +445,28 @@ typedef struct _meshtastic_HostMetrics {
     char user_string[200];
 } meshtastic_HostMetrics;
 
+/* Cellular (modem) diagnostic metrics */
+typedef struct _meshtastic_CellularMetrics {
+    /* Reference Signal Received Power, in dBm */
+    bool has_rsrp;
+    int32_t rsrp;
+    /* Reference Signal Received Quality, in dB */
+    bool has_rsrq;
+    float rsrq;
+    /* E-UTRA band number */
+    bool has_band;
+    uint32_t band;
+    /* Access technology, 7 = E-UTRAN */
+    bool has_access_tech;
+    uint32_t access_tech;
+    /* Modem supply voltage, in millivolts */
+    bool has_modem_voltage_mv;
+    uint32_t modem_voltage_mv;
+    /* PLMN operator name, or the numeric MCC/MNC when unresolved */
+    bool has_operator_name;
+    char operator_name[24];
+} meshtastic_CellularMetrics;
+
 /* Types of Measurements the telemetry module is equipped to handle */
 typedef struct _meshtastic_Telemetry {
     /* Seconds since 1970 - or 0 for unknown/unset */
@@ -467,6 +489,8 @@ typedef struct _meshtastic_Telemetry {
         meshtastic_HostMetrics host_metrics;
         /* Traffic management statistics */
         meshtastic_TrafficManagementStats traffic_management_stats;
+        /* Cellular (modem) diagnostic metrics */
+        meshtastic_CellularMetrics cellular_metrics;
     } variant;
 } meshtastic_Telemetry;
 
@@ -519,6 +543,7 @@ extern "C" {
 
 
 
+
 /* Initializer values for message structs */
 #define meshtastic_DeviceMetrics_init_default    {false, 0, false, 0, false, 0, false, 0, false, 0}
 #define meshtastic_EnvironmentMetrics_init_default {false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0}}
@@ -528,6 +553,7 @@ extern "C" {
 #define meshtastic_TrafficManagementStats_init_default {0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_HealthMetrics_init_default    {false, 0, false, 0, false, 0}
 #define meshtastic_HostMetrics_init_default      {0, 0, 0, false, 0, false, 0, 0, 0, 0, false, ""}
+#define meshtastic_CellularMetrics_init_default  {false, 0, false, 0, false, 0, false, 0, false, 0, false, ""}
 #define meshtastic_Telemetry_init_default        {0, 0, {meshtastic_DeviceMetrics_init_default}}
 #define meshtastic_Nau7802Config_init_default    {0, 0}
 #define meshtastic_SEN5XState_init_default       {0, 0, 0, false, 0, false, 0, false, 0}
@@ -539,6 +565,7 @@ extern "C" {
 #define meshtastic_TrafficManagementStats_init_zero {0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_HealthMetrics_init_zero       {false, 0, false, 0, false, 0}
 #define meshtastic_HostMetrics_init_zero         {0, 0, 0, false, 0, false, 0, 0, 0, 0, false, ""}
+#define meshtastic_CellularMetrics_init_zero     {false, 0, false, 0, false, 0, false, 0, false, 0, false, ""}
 #define meshtastic_Telemetry_init_zero           {0, 0, {meshtastic_DeviceMetrics_init_zero}}
 #define meshtastic_Nau7802Config_init_zero       {0, 0}
 #define meshtastic_SEN5XState_init_zero          {0, 0, 0, false, 0, false, 0, false, 0}
@@ -647,6 +674,12 @@ extern "C" {
 #define meshtastic_HostMetrics_load5_tag         7
 #define meshtastic_HostMetrics_load15_tag        8
 #define meshtastic_HostMetrics_user_string_tag   9
+#define meshtastic_CellularMetrics_rsrp_tag      1
+#define meshtastic_CellularMetrics_rsrq_tag      2
+#define meshtastic_CellularMetrics_band_tag      3
+#define meshtastic_CellularMetrics_access_tech_tag 4
+#define meshtastic_CellularMetrics_modem_voltage_mv_tag 5
+#define meshtastic_CellularMetrics_operator_name_tag 6
 #define meshtastic_Telemetry_time_tag            1
 #define meshtastic_Telemetry_device_metrics_tag  2
 #define meshtastic_Telemetry_environment_metrics_tag 3
@@ -656,6 +689,7 @@ extern "C" {
 #define meshtastic_Telemetry_health_metrics_tag  7
 #define meshtastic_Telemetry_host_metrics_tag    8
 #define meshtastic_Telemetry_traffic_management_stats_tag 9
+#define meshtastic_Telemetry_cellular_metrics_tag 10
 #define meshtastic_Nau7802Config_zeroOffset_tag  1
 #define meshtastic_Nau7802Config_calibrationFactor_tag 2
 #define meshtastic_SEN5XState_last_cleaning_time_tag 1
@@ -801,6 +835,16 @@ X(a, STATIC,   OPTIONAL, STRING,   user_string,       9)
 #define meshtastic_HostMetrics_CALLBACK NULL
 #define meshtastic_HostMetrics_DEFAULT NULL
 
+#define meshtastic_CellularMetrics_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, INT32,    rsrp,              1) \
+X(a, STATIC,   OPTIONAL, FLOAT,    rsrq,              2) \
+X(a, STATIC,   OPTIONAL, UINT32,   band,              3) \
+X(a, STATIC,   OPTIONAL, UINT32,   access_tech,       4) \
+X(a, STATIC,   OPTIONAL, UINT32,   modem_voltage_mv,   5) \
+X(a, STATIC,   OPTIONAL, STRING,   operator_name,     6)
+#define meshtastic_CellularMetrics_CALLBACK NULL
+#define meshtastic_CellularMetrics_DEFAULT NULL
+
 #define meshtastic_Telemetry_FIELDLIST(X, a) \
 X(a, STATIC,   SINGULAR, FIXED32,  time,              1) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (variant,device_metrics,variant.device_metrics),   2) \
@@ -810,7 +854,8 @@ X(a, STATIC,   ONEOF,    MESSAGE,  (variant,power_metrics,variant.power_metrics)
 X(a, STATIC,   ONEOF,    MESSAGE,  (variant,local_stats,variant.local_stats),   6) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (variant,health_metrics,variant.health_metrics),   7) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (variant,host_metrics,variant.host_metrics),   8) \
-X(a, STATIC,   ONEOF,    MESSAGE,  (variant,traffic_management_stats,variant.traffic_management_stats),   9)
+X(a, STATIC,   ONEOF,    MESSAGE,  (variant,traffic_management_stats,variant.traffic_management_stats),   9) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (variant,cellular_metrics,variant.cellular_metrics),  10)
 #define meshtastic_Telemetry_CALLBACK NULL
 #define meshtastic_Telemetry_DEFAULT NULL
 #define meshtastic_Telemetry_variant_device_metrics_MSGTYPE meshtastic_DeviceMetrics
@@ -821,6 +866,7 @@ X(a, STATIC,   ONEOF,    MESSAGE,  (variant,traffic_management_stats,variant.tra
 #define meshtastic_Telemetry_variant_health_metrics_MSGTYPE meshtastic_HealthMetrics
 #define meshtastic_Telemetry_variant_host_metrics_MSGTYPE meshtastic_HostMetrics
 #define meshtastic_Telemetry_variant_traffic_management_stats_MSGTYPE meshtastic_TrafficManagementStats
+#define meshtastic_Telemetry_variant_cellular_metrics_MSGTYPE meshtastic_CellularMetrics
 
 #define meshtastic_Nau7802Config_FIELDLIST(X, a) \
 X(a, STATIC,   SINGULAR, INT32,    zeroOffset,        1) \
@@ -846,6 +892,7 @@ extern const pb_msgdesc_t meshtastic_LocalStats_msg;
 extern const pb_msgdesc_t meshtastic_TrafficManagementStats_msg;
 extern const pb_msgdesc_t meshtastic_HealthMetrics_msg;
 extern const pb_msgdesc_t meshtastic_HostMetrics_msg;
+extern const pb_msgdesc_t meshtastic_CellularMetrics_msg;
 extern const pb_msgdesc_t meshtastic_Telemetry_msg;
 extern const pb_msgdesc_t meshtastic_Nau7802Config_msg;
 extern const pb_msgdesc_t meshtastic_SEN5XState_msg;
@@ -859,6 +906,7 @@ extern const pb_msgdesc_t meshtastic_SEN5XState_msg;
 #define meshtastic_TrafficManagementStats_fields &meshtastic_TrafficManagementStats_msg
 #define meshtastic_HealthMetrics_fields &meshtastic_HealthMetrics_msg
 #define meshtastic_HostMetrics_fields &meshtastic_HostMetrics_msg
+#define meshtastic_CellularMetrics_fields &meshtastic_CellularMetrics_msg
 #define meshtastic_Telemetry_fields &meshtastic_Telemetry_msg
 #define meshtastic_Nau7802Config_fields &meshtastic_Nau7802Config_msg
 #define meshtastic_SEN5XState_fields &meshtastic_SEN5XState_msg
@@ -866,6 +914,7 @@ extern const pb_msgdesc_t meshtastic_SEN5XState_msg;
 /* Maximum encoded size of messages (where known) */
 #define MESHTASTIC_MESHTASTIC_TELEMETRY_PB_H_MAX_SIZE meshtastic_Telemetry_size
 #define meshtastic_AirQualityMetrics_size        150
+#define meshtastic_CellularMetrics_size          59
 #define meshtastic_DeviceMetrics_size            27
 #define meshtastic_EnvironmentMetrics_size       161
 #define meshtastic_HealthMetrics_size            11

--- a/src/modules/Modules.cpp
+++ b/src/modules/Modules.cpp
@@ -66,7 +66,7 @@
 #if HAS_TELEMETRY
 #include "modules/Telemetry/DeviceTelemetry.h"
 #endif
-#if HAS_TELEMETRY && HAS_CELLULAR
+#if HAS_TELEMETRY && HAS_CELLULAR && !MESHTASTIC_EXCLUDE_CELLULAR_TELEMETRY
 #include "modules/Telemetry/CellularTelemetry.h"
 #endif
 #if HAS_SENSOR && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
@@ -223,7 +223,7 @@ void setupModules()
 #if HAS_TELEMETRY
     new DeviceTelemetryModule();
 #endif
-#if HAS_TELEMETRY && HAS_CELLULAR
+#if HAS_TELEMETRY && HAS_CELLULAR && !MESHTASTIC_EXCLUDE_CELLULAR_TELEMETRY
     if (moduleConfig.has_telemetry && moduleConfig.telemetry.cellular_measurement_enabled) {
         new CellularTelemetryModule();
     }

--- a/src/modules/Modules.cpp
+++ b/src/modules/Modules.cpp
@@ -66,6 +66,9 @@
 #if HAS_TELEMETRY
 #include "modules/Telemetry/DeviceTelemetry.h"
 #endif
+#if HAS_TELEMETRY && HAS_CELLULAR
+#include "modules/Telemetry/CellularTelemetry.h"
+#endif
 #if HAS_SENSOR && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
 #include "main.h"
 #include "modules/Telemetry/EnvironmentTelemetry.h"
@@ -219,6 +222,11 @@ void setupModules()
 #endif
 #if HAS_TELEMETRY
     new DeviceTelemetryModule();
+#endif
+#if HAS_TELEMETRY && HAS_CELLULAR
+    if (moduleConfig.has_telemetry && moduleConfig.telemetry.cellular_measurement_enabled) {
+        new CellularTelemetryModule();
+    }
 #endif
 #if HAS_TELEMETRY && HAS_SENSOR && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
     if (moduleConfig.has_telemetry &&

--- a/src/modules/Telemetry/CellularTelemetry.cpp
+++ b/src/modules/Telemetry/CellularTelemetry.cpp
@@ -93,7 +93,9 @@ bool CellularTelemetryModule::getCellularTelemetry(meshtastic_Telemetry *m)
         m->variant.cellular_metrics.has_access_tech = true;
         m->variant.cellular_metrics.access_tech = diag.act;
         m->variant.cellular_metrics.has_operator_name = true;
-        strncpy(m->variant.cellular_metrics.operator_name, diag.operatorName, sizeof(m->variant.cellular_metrics.operator_name));
+        strncpy(m->variant.cellular_metrics.operator_name, diag.operatorName,
+                sizeof(m->variant.cellular_metrics.operator_name) - 1);
+        m->variant.cellular_metrics.operator_name[sizeof(m->variant.cellular_metrics.operator_name) - 1] = '\0';
     }
     if (diag.vbatValid) {
         m->variant.cellular_metrics.has_modem_voltage_mv = true;

--- a/src/modules/Telemetry/CellularTelemetry.cpp
+++ b/src/modules/Telemetry/CellularTelemetry.cpp
@@ -1,0 +1,127 @@
+#include "CellularTelemetry.h"
+
+#if HAS_CELLULAR
+
+#include "../mesh/generated/meshtastic/telemetry.pb.h"
+#include "Default.h"
+#include "MeshService.h"
+#include "NodeDB.h"
+#include "TransmitHistory.h"
+#include "configuration.h"
+#include "gps/RTC.h"
+#include "main.h"
+#include "mesh/cell/cellDiag.h"
+
+static constexpr uint16_t TX_HISTORY_KEY_CELLULAR_TELEMETRY = 0x8006;
+
+int32_t CellularTelemetryModule::runOnce()
+{
+    uint32_t lastTelemetry = transmitHistory ? transmitHistory->getLastSentToMeshMillis(TX_HISTORY_KEY_CELLULAR_TELEMETRY) : 0;
+    if (((lastTelemetry == 0) ||
+         ((millis() - lastTelemetry) >= Default::getConfiguredOrDefaultMsScaled(moduleConfig.telemetry.cellular_update_interval,
+                                                                                default_telemetry_broadcast_interval_secs,
+                                                                                numOnlineNodes, TrafficType::TELEMETRY))) &&
+        airTime->isTxAllowedChannelUtil(true) && airTime->isTxAllowedAirUtil()) {
+        if (sendTelemetry() && transmitHistory)
+            transmitHistory->setLastSentToMesh(TX_HISTORY_KEY_CELLULAR_TELEMETRY);
+    } else if (service->isToPhoneQueueEmpty()) {
+        // Just send to phone when it's not our time to send to mesh yet
+        if (lastSentToPhone == 0 || (millis() - lastSentToPhone) >= sendToPhoneIntervalMs) {
+            sendTelemetry(NODENUM_BROADCAST, true);
+            lastSentToPhone = millis();
+        }
+    }
+    return sendToPhoneIntervalMs;
+}
+
+bool CellularTelemetryModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_Telemetry *t)
+{
+    if (t->which_variant == meshtastic_Telemetry_cellular_metrics_tag)
+        nodeDB->updateTelemetry(getFrom(&mp), *t, RX_SRC_RADIO);
+    return false; // Let others look at this message also if they want
+}
+
+meshtastic_MeshPacket *CellularTelemetryModule::allocReply()
+{
+    if (currentRequest) {
+        if (isMultiHopBroadcastRequest() && !isSensorOrRouterRole()) {
+            ignoreRequest = true;
+            return NULL;
+        }
+        auto req = *currentRequest;
+        const auto &p = req.decoded;
+        meshtastic_Telemetry scratch;
+        meshtastic_Telemetry *decoded = NULL;
+        memset(&scratch, 0, sizeof(scratch));
+        if (pb_decode_from_bytes(p.payload.bytes, p.payload.size, &meshtastic_Telemetry_msg, &scratch)) {
+            decoded = &scratch;
+        } else {
+            LOG_ERROR("Error decoding CellularTelemetry module!");
+            return NULL;
+        }
+        if (decoded->which_variant == meshtastic_Telemetry_cellular_metrics_tag) {
+            meshtastic_Telemetry m = meshtastic_Telemetry_init_zero;
+            if (getCellularTelemetry(&m)) {
+                LOG_INFO("Cellular telemetry reply to request");
+                return allocDataProtobuf(m);
+            }
+            return NULL;
+        }
+    }
+    return NULL;
+}
+
+bool CellularTelemetryModule::getCellularTelemetry(meshtastic_Telemetry *m)
+{
+    const CellDiag &diag = getCellDiag();
+    if (!diag.rsrpValid && !diag.bandValid && !diag.vbatValid)
+        return false;
+
+    m->time = getTime();
+    m->which_variant = meshtastic_Telemetry_cellular_metrics_tag;
+    m->variant.cellular_metrics = meshtastic_CellularMetrics_init_zero;
+
+    if (diag.rsrpValid) {
+        m->variant.cellular_metrics.has_rsrp = true;
+        m->variant.cellular_metrics.rsrp = diag.rsrp;
+        m->variant.cellular_metrics.has_rsrq = true;
+        m->variant.cellular_metrics.rsrq = diag.rsrq;
+    }
+    if (diag.bandValid) {
+        m->variant.cellular_metrics.has_band = true;
+        m->variant.cellular_metrics.band = diag.band;
+        m->variant.cellular_metrics.has_access_tech = true;
+        m->variant.cellular_metrics.access_tech = diag.act;
+        m->variant.cellular_metrics.has_operator_name = true;
+        strncpy(m->variant.cellular_metrics.operator_name, diag.operatorName, sizeof(m->variant.cellular_metrics.operator_name));
+    }
+    if (diag.vbatValid) {
+        m->variant.cellular_metrics.has_modem_voltage_mv = true;
+        m->variant.cellular_metrics.modem_voltage_mv = diag.vbatMv;
+    }
+    return true;
+}
+
+bool CellularTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
+{
+    meshtastic_Telemetry m = meshtastic_Telemetry_init_zero;
+    if (!getCellularTelemetry(&m))
+        return false;
+
+    meshtastic_MeshPacket *p = allocDataProtobuf(m);
+    if (!p)
+        return false;
+    p->to = dest;
+    p->decoded.want_response = false;
+    p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
+
+    nodeDB->updateTelemetry(nodeDB->getNodeNum(), m, RX_SRC_LOCAL);
+    if (phoneOnly) {
+        service->sendToPhone(p);
+    } else {
+        service->sendToMesh(p, RX_SRC_LOCAL, true);
+    }
+    return true;
+}
+
+#endif

--- a/src/modules/Telemetry/CellularTelemetry.h
+++ b/src/modules/Telemetry/CellularTelemetry.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "configuration.h"
+
+#if HAS_CELLULAR
+
+#include "../mesh/generated/meshtastic/telemetry.pb.h"
+#include "BaseTelemetryModule.h"
+#include "NodeDB.h"
+#include "ProtobufModule.h"
+
+class CellularTelemetryModule : private concurrency::OSThread,
+                                public BaseTelemetryModule,
+                                public ProtobufModule<meshtastic_Telemetry>
+{
+    CallbackObserver<CellularTelemetryModule, const meshtastic::Status *> nodeStatusObserver =
+        CallbackObserver<CellularTelemetryModule, const meshtastic::Status *>(this, &CellularTelemetryModule::handleStatusUpdate);
+
+  public:
+    CellularTelemetryModule()
+        : concurrency::OSThread("CellularTelemetry"),
+          ProtobufModule("CellularTelemetry", meshtastic_PortNum_TELEMETRY_APP, &meshtastic_Telemetry_msg)
+    {
+        nodeStatusObserver.observe(&nodeStatus->onNewStatus);
+        setIntervalFromNow(10 * 1000);
+    }
+    virtual bool wantUIFrame() override { return false; }
+
+  protected:
+    // Handles an incoming message; true if handled and other handlers should be skipped.
+    virtual bool handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_Telemetry *p) override;
+    virtual int32_t runOnce() override;
+    // Fills m with cellular diagnostic telemetry; false if nothing valid is available yet.
+    bool getCellularTelemetry(meshtastic_Telemetry *m);
+    virtual meshtastic_MeshPacket *allocReply() override;
+    bool sendTelemetry(NodeNum dest = NODENUM_BROADCAST, bool phoneOnly = false);
+
+  private:
+    uint32_t sendToPhoneIntervalMs = SECONDS_IN_MINUTE * 1000; // Send to phone every minute
+    uint32_t lastSentToPhone = 0;
+};
+
+#endif

--- a/src/modules/Telemetry/CellularTelemetry.h
+++ b/src/modules/Telemetry/CellularTelemetry.h
@@ -9,6 +9,8 @@
 #include "NodeDB.h"
 #include "ProtobufModule.h"
 
+// Sends the cellDiag sweep (RSRP/RSRQ/band/operator/modem VBAT) as Telemetry.cellular_metrics,
+// on the mesh at the configured interval and to the phone whenever there's nothing else to send.
 class CellularTelemetryModule : private concurrency::OSThread,
                                 public BaseTelemetryModule,
                                 public ProtobufModule<meshtastic_Telemetry>

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -694,10 +694,16 @@ bool MQTT::isValidConfig(const meshtastic_ModuleConfig_MQTTConfig &config, MQTTC
         // which mutates the module's isConnected state. This only checks if the server
         // is reachable - it does not establish an MQTT session.
         // Settings are always saved regardless of the result.
-        // Skipped on cellular: the AT socket API gives one socket, so a probe
-        // would tear down the live MQTT connection.
-#if !HAS_CELLULAR
-        if (isConnectedToNetwork()) {
+        // Skipped while cellular is the active transport: the AT socket API gives
+        // one socket, so a probe would tear down the live MQTT connection. Most
+        // cellular-capable boards also compile WiFi/Ethernet, so this is a runtime
+        // check rather than a compile-time one - the probe still runs there when
+        // cellular isn't what the node is actually connected over.
+        bool cellIsActive = false;
+#if HAS_CELLULAR
+        cellIsActive = isCellularAvailable();
+#endif
+        if (!cellIsActive && isConnectedToNetwork()) {
             MQTTClient testClient;
             if (!testClient.connect(parsed.serverAddr.c_str(), parsed.serverPort)) {
                 const char *warning = "Could not reach the MQTT server. Settings will be saved, but please verify the server "
@@ -716,7 +722,6 @@ bool MQTT::isValidConfig(const meshtastic_ModuleConfig_MQTTConfig &config, MQTTC
             }
             testClient.stop();
         }
-#endif
 #else
         const char *warning = "Invalid MQTT config: proxy_to_client_enabled must be enabled on nodes that do not have a network";
         LOG_ERROR(warning);

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -301,31 +301,40 @@ bool connectPubSub(const PubSubConfig &config, PubSubClient &pubSub, Client &cli
 }
 #endif
 
-inline bool isConnectedToNetwork()
+enum class NetTransport { NONE, PRIMARY, CELLULAR };
+
+/// Which transport (if any) is currently reachable, in preference order: the IP-stack
+/// transports are cheaper/faster than the modem's AT socket, so cellular is the fallback.
+inline NetTransport activeTransport()
 {
+#if defined(ARCH_PORTDUINO)
+    return NetTransport::PRIMARY;
+#else
 #ifdef USE_WS5500
     if (ETH.connected())
-        return true;
+        return NetTransport::PRIMARY;
 #elif defined(USE_CH390D)
     if (CH390.isConnected())
-        return true;
+        return NetTransport::PRIMARY;
+#endif
+#if HAS_WIFI
+    if (WiFi.isConnected())
+        return NetTransport::PRIMARY;
+#elif HAS_ETHERNET
+    if (Ethernet.linkStatus() == LinkON)
+        return NetTransport::PRIMARY;
 #endif
 #if HAS_CELLULAR
-    // Cellular coexists with WiFi/Ethernet rather than excluding them, so check
-    // it independently before falling through to the primary transport below.
     if (isCellularAvailable())
-        return true;
+        return NetTransport::CELLULAR;
 #endif
+    return NetTransport::NONE;
+#endif // ARCH_PORTDUINO
+}
 
-#if HAS_WIFI
-    return WiFi.isConnected();
-#elif HAS_ETHERNET
-    return Ethernet.linkStatus() == LinkON;
-#elif defined(ARCH_PORTDUINO)
-    return true;
-#else
-    return false;
-#endif
+inline bool isConnectedToNetwork()
+{
+    return activeTransport() != NetTransport::NONE;
 }
 
 /** return true if we have a channel that wants uplink/downlink or map reporting is enabled
@@ -445,39 +454,32 @@ bool MQTT::isConnectedDirectly()
 #endif
 }
 
+#if HAS_CELLULAR
+CellClient *MQTT::cellClient()
+{
+#if MQTT_HAS_SECONDARY_CELL
+    return &mqttClientCell;
+#else
+    return mqttClient.get(); // MQTTClient IS CellClient here
+#endif
+}
+#endif
+
 #if HAS_NETWORKING
 Client *MQTT::activeClient()
 {
-#if defined(ARCH_PORTDUINO)
-    return mqttClient.get();
-#else
-    // Ordered by preference: the IP-stack transports are cheaper and faster
-    // than the modem's AT socket, so cellular is the fallback.
-#ifdef USE_WS5500
-    if (ETH.connected())
+    switch (activeTransport()) {
+    case NetTransport::PRIMARY:
         return mqttClient.get();
-#elif defined(USE_CH390D)
-    if (CH390.isConnected())
-        return mqttClient.get();
-#endif
-#if HAS_WIFI
-    if (WiFi.isConnected())
-        return mqttClient.get();
-#elif HAS_ETHERNET
-    if (Ethernet.linkStatus() == LinkON)
-        return mqttClient.get();
-#endif
+    case NetTransport::CELLULAR:
 #if HAS_CELLULAR
-    if (isCellularAvailable()) {
-#if MQTT_HAS_SECONDARY_CELL
-        return &mqttClientCell;
+        return cellClient();
 #else
-        return mqttClient.get();
+        return nullptr;
 #endif
+    default:
+        return nullptr;
     }
-#endif
-    return nullptr;
-#endif // ARCH_PORTDUINO
 }
 #endif // HAS_NETWORKING
 
@@ -555,23 +557,18 @@ void MQTT::reconnect()
 #endif
 #if MQTT_TLS_POSSIBLE
 #if HAS_CELLULAR
-#if MQTT_HAS_SECONDARY_CELL
-        CellClient *cellClientPtr = &mqttClientCell;
-#else
-        CellClient *cellClientPtr = mqttClient.get(); // MQTTClient IS CellClient here
-#endif
-        const bool usedCell = (clientConnection == static_cast<Client *>(cellClientPtr));
+        // Cellular negotiates TLS in-place via AT+CIPSSL - no separate secure client
+        // type like WiFiClientSecure is needed, so clientConnection stays as-is.
+        if (clientConnection == static_cast<Client *>(cellClient()))
+            cellClient()->setTlsEnabled(moduleConfig.mqtt.tls_enabled);
 #endif
         if (moduleConfig.mqtt.tls_enabled) {
-            bool handled = false;
 #if HAS_CELLULAR
-            // Cellular negotiates TLS in-place via AT+CIPSSL - no separate secure client
-            // type like WiFiClientSecure is needed, so clientConnection stays as-is.
-            if (usedCell) {
-                cellClientPtr->setTlsEnabled(true);
+            bool handled = (clientConnection == static_cast<Client *>(cellClient()));
+            if (handled)
                 LOG_INFO("Use TLS-encrypted cellular session");
-                handled = true;
-            }
+#else
+            bool handled = false;
 #endif
 #if MQTT_SUPPORTS_TLS
             // WiFiClientSecure needs the WiFi/netif stack initialized, so this must
@@ -589,10 +586,6 @@ void MQTT::reconnect()
             }
         } else {
             LOG_INFO("Use non-TLS-encrypted session");
-#if HAS_CELLULAR
-            if (usedCell)
-                cellClientPtr->setTlsEnabled(false);
-#endif
         }
 #endif // MQTT_TLS_POSSIBLE
         if (connectPubSub(ps_config, pubSub, *clientConnection)) {

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -26,6 +26,9 @@
 #if HAS_ETHERNET && defined(USE_CH390D)
 #include "ESP32_CH390.h"
 #endif // USE_CH390D
+#if HAS_CELLULAR
+#include "mesh/cell/cellBearer.h"
+#endif // HAS_CELLULAR
 #include "Default.h"
 #include <Throttle.h>
 #include <assert.h>
@@ -308,15 +311,22 @@ inline bool isConnectedToNetwork()
         return true;
 #endif
 
+    // Transports coexist rather than exclude each other, so test each one that
+    // is compiled in - a board can have cellular up while WiFi is down.
+    bool connected = false;
 #if HAS_WIFI
-    return WiFi.isConnected();
-#elif HAS_ETHERNET
-    return Ethernet.linkStatus() == LinkON;
-#elif defined(ARCH_PORTDUINO)
-    return true;
-#else
-    return false;
+    connected = connected || WiFi.isConnected();
 #endif
+#if HAS_ETHERNET && !defined(USE_WS5500) && !defined(USE_CH390D)
+    connected = connected || (Ethernet.linkStatus() == LinkON);
+#endif
+#if HAS_CELLULAR
+    connected = connected || isCellularAvailable();
+#endif
+#if defined(ARCH_PORTDUINO)
+    connected = true;
+#endif
+    return connected;
 }
 
 /** return true if we have a channel that wants uplink/downlink or map reporting is enabled
@@ -436,6 +446,42 @@ bool MQTT::isConnectedDirectly()
 #endif
 }
 
+#if HAS_NETWORKING
+Client *MQTT::activeClient()
+{
+#if defined(ARCH_PORTDUINO)
+    return mqttClient.get();
+#else
+    // Ordered by preference: the IP-stack transports are cheaper and faster
+    // than the modem's AT socket, so cellular is the fallback.
+#ifdef USE_WS5500
+    if (ETH.connected())
+        return mqttClient.get();
+#elif defined(USE_CH390D)
+    if (CH390.isConnected())
+        return mqttClient.get();
+#endif
+#if HAS_WIFI
+    if (WiFi.isConnected())
+        return mqttClient.get();
+#elif HAS_ETHERNET
+    if (Ethernet.linkStatus() == LinkON)
+        return mqttClient.get();
+#endif
+#if HAS_CELLULAR
+    if (isCellularAvailable()) {
+#if MQTT_HAS_SECONDARY_CELL
+        return &mqttClientCell;
+#else
+        return mqttClient.get();
+#endif
+    }
+#endif
+    return nullptr;
+#endif // ARCH_PORTDUINO
+}
+#endif // HAS_NETWORKING
+
 bool MQTT::publish(const char *topic, const char *payload, bool retained)
 {
     if (moduleConfig.mqtt.proxy_to_client_enabled) {
@@ -499,9 +545,22 @@ void MQTT::reconnect()
         }
 #if HAS_NETWORKING
         const PubSubConfig ps_config(moduleConfig.mqtt);
-        MQTTClient *clientConnection = mqttClient.get();
+        Client *clientConnection = activeClient();
+        if (!clientConnection) {
+            LOG_WARN("No network transport is up for MQTT");
+            return;
+        }
+#if HAS_WIFI && !defined(ARCH_PORTDUINO)
+        // Captured before the TLS swap below moves clientConnection.
+        const bool usedWiFi = clientConnection == mqttClient.get();
+#endif
 #if MQTT_SUPPORTS_TLS
         if (moduleConfig.mqtt.tls_enabled) {
+            // Only the IP-stack clients can do TLS; the AT socket API cannot.
+            if (clientConnection != mqttClient.get()) {
+                LOG_ERROR("TLS is not supported on the active transport");
+                return;
+            }
             mqttClientTLS.setInsecure();
             LOG_INFO("Use TLS-encrypted session");
             clientConnection = &mqttClientTLS;
@@ -513,7 +572,16 @@ void MQTT::reconnect()
             enabled = true; // Start running background process again
             runASAP = true;
             reconnectCount = 0;
-            isMqttServerAddressPrivate = isPrivateIpAddress(clientConnection->remoteIP());
+#if HAS_WIFI || HAS_ETHERNET
+            // remoteIP() is not part of the Arduino Client interface, so only
+            // the IP-stack transports can refine what the address parse found.
+            if (clientConnection == mqttClient.get())
+                isMqttServerAddressPrivate = isPrivateIpAddress(mqttClient->remoteIP());
+#if MQTT_SUPPORTS_TLS
+            else if (clientConnection == &mqttClientTLS)
+                isMqttServerAddressPrivate = isPrivateIpAddress(mqttClientTLS.remoteIP());
+#endif
+#endif
             isConnected = true;
             publishNodeInfo();
             sendSubscriptions();
@@ -525,11 +593,14 @@ void MQTT::reconnect()
 #if defined(USE_WS5500) || defined(USE_CH390D)
                 LOG_WARN("MQTT connect failed repeatedly; waiting for Ethernet reconnect");
 #else
-                needReconnect = true;
-                if (wifiReconnect) {
-                    wifiReconnect->setIntervalFromNow(0);
-                } else {
-                    LOG_WARN("MQTT connect failed repeatedly, but WiFi reconnect is unavailable");
+                // Only bounce WiFi when WiFi is what carried the failed attempt.
+                if (usedWiFi) {
+                    needReconnect = true;
+                    if (wifiReconnect) {
+                        wifiReconnect->setIntervalFromNow(0);
+                    } else {
+                        LOG_WARN("MQTT connect failed repeatedly, but WiFi reconnect is unavailable");
+                    }
                 }
 #endif
                 reconnectCount = 0;
@@ -623,6 +694,9 @@ bool MQTT::isValidConfig(const meshtastic_ModuleConfig_MQTTConfig &config, MQTTC
         // which mutates the module's isConnected state. This only checks if the server
         // is reachable - it does not establish an MQTT session.
         // Settings are always saved regardless of the result.
+        // Skipped on cellular: the AT socket API gives one socket, so a probe
+        // would tear down the live MQTT connection.
+#if !HAS_CELLULAR
         if (isConnectedToNetwork()) {
             MQTTClient testClient;
             if (!testClient.connect(parsed.serverAddr.c_str(), parsed.serverPort)) {
@@ -642,6 +716,7 @@ bool MQTT::isValidConfig(const meshtastic_ModuleConfig_MQTTConfig &config, MQTTC
             }
             testClient.stop();
         }
+#endif
 #else
         const char *warning = "Invalid MQTT config: proxy_to_client_enabled must be enabled on nodes that do not have a network";
         LOG_ERROR(warning);

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -553,20 +553,48 @@ void MQTT::reconnect()
         // Captured before the TLS swap below moves clientConnection.
         const bool usedWiFi = clientConnection == mqttClient.get();
 #endif
-#if MQTT_SUPPORTS_TLS
+#if MQTT_TLS_POSSIBLE
+#if HAS_CELLULAR
+#if MQTT_HAS_SECONDARY_CELL
+        CellClient *cellClientPtr = &mqttClientCell;
+#else
+        CellClient *cellClientPtr = mqttClient.get(); // MQTTClient IS CellClient here
+#endif
+        const bool usedCell = (clientConnection == static_cast<Client *>(cellClientPtr));
+#endif
         if (moduleConfig.mqtt.tls_enabled) {
-            // Only the IP-stack clients can do TLS; the AT socket API cannot.
-            if (clientConnection != mqttClient.get()) {
+            bool handled = false;
+#if HAS_CELLULAR
+            // Cellular negotiates TLS in-place via AT+CIPSSL - no separate secure client
+            // type like WiFiClientSecure is needed, so clientConnection stays as-is.
+            if (usedCell) {
+                cellClientPtr->setTlsEnabled(true);
+                LOG_INFO("Use TLS-encrypted cellular session");
+                handled = true;
+            }
+#endif
+#if MQTT_SUPPORTS_TLS
+            // WiFiClientSecure needs the WiFi/netif stack initialized, so this must
+            // never run while cellular (handled above) is what's actually active.
+            if (!handled && clientConnection == mqttClient.get()) {
+                mqttClientTLS.setInsecure();
+                LOG_INFO("Use TLS-encrypted session");
+                clientConnection = &mqttClientTLS;
+                handled = true;
+            }
+#endif
+            if (!handled) {
                 LOG_ERROR("TLS is not supported on the active transport");
                 return;
             }
-            mqttClientTLS.setInsecure();
-            LOG_INFO("Use TLS-encrypted session");
-            clientConnection = &mqttClientTLS;
         } else {
             LOG_INFO("Use non-TLS-encrypted session");
-        }
+#if HAS_CELLULAR
+            if (usedCell)
+                cellClientPtr->setTlsEnabled(false);
 #endif
+        }
+#endif // MQTT_TLS_POSSIBLE
         if (connectPubSub(ps_config, pubSub, *clientConnection)) {
             enabled = true; // Start running background process again
             runASAP = true;
@@ -684,7 +712,7 @@ bool MQTT::isValidConfig(const meshtastic_ModuleConfig_MQTTConfig &config, MQTTC
     if (config.enabled && !config.proxy_to_client_enabled) {
 #if HAS_NETWORKING
         if (config.tls_enabled) {
-#if !MQTT_SUPPORTS_TLS
+#if !MQTT_TLS_POSSIBLE
             LOG_ERROR("Invalid MQTT config: tls_enabled is not supported on this node");
             return false;
 #endif

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -714,16 +714,10 @@ bool MQTT::isValidConfig(const meshtastic_ModuleConfig_MQTTConfig &config, MQTTC
         // which mutates the module's isConnected state. This only checks if the server
         // is reachable - it does not establish an MQTT session.
         // Settings are always saved regardless of the result.
-        // Skipped while cellular is the active transport: the AT socket API gives
-        // one socket, so a probe would tear down the live MQTT connection. Most
-        // cellular-capable boards also compile WiFi/Ethernet, so this is a runtime
-        // check rather than a compile-time one - the probe still runs there when
-        // cellular isn't what the node is actually connected over.
-        bool cellIsActive = false;
-#if HAS_CELLULAR
-        cellIsActive = isCellularAvailable();
-#endif
-        if (!cellIsActive && isConnectedToNetwork()) {
+        // Skipped when cellular is the active transport - the AT socket API only
+        // exposes one socket, and a probe here would tear down the live MQTT link.
+        NetTransport transport = activeTransport();
+        if (transport != NetTransport::CELLULAR && transport != NetTransport::NONE) {
             MQTTClient testClient;
             if (!testClient.connect(parsed.serverAddr.c_str(), parsed.serverPort)) {
                 const char *warning = "Could not reach the MQTT server. Settings will be saved, but please verify the server "

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -310,23 +310,22 @@ inline bool isConnectedToNetwork()
     if (CH390.isConnected())
         return true;
 #endif
-
-    // Transports coexist rather than exclude each other, so test each one that
-    // is compiled in - a board can have cellular up while WiFi is down.
-    bool connected = false;
-#if HAS_WIFI
-    connected = connected || WiFi.isConnected();
-#endif
-#if HAS_ETHERNET && !defined(USE_WS5500) && !defined(USE_CH390D)
-    connected = connected || (Ethernet.linkStatus() == LinkON);
-#endif
 #if HAS_CELLULAR
-    connected = connected || isCellularAvailable();
+    // Cellular coexists with WiFi/Ethernet rather than excluding them, so check
+    // it independently before falling through to the primary transport below.
+    if (isCellularAvailable())
+        return true;
 #endif
-#if defined(ARCH_PORTDUINO)
-    connected = true;
+
+#if HAS_WIFI
+    return WiFi.isConnected();
+#elif HAS_ETHERNET
+    return Ethernet.linkStatus() == LinkON;
+#elif defined(ARCH_PORTDUINO)
+    return true;
+#else
+    return false;
 #endif
-    return connected;
 }
 
 /** return true if we have a channel that wants uplink/downlink or map reporting is enabled

--- a/src/mqtt/MQTT.h
+++ b/src/mqtt/MQTT.h
@@ -117,6 +117,10 @@ class MQTT : private concurrency::OSThread
 
     /// Client for whichever transport is up, or nullptr when none is.
     Client *activeClient();
+#if HAS_CELLULAR
+    /// The single cellular Client, whether it's the primary transport or a secondary alongside WiFi/Ethernet.
+    CellClient *cellClient();
+#endif
 #endif
 
     std::string cryptTopic = "/2/e/"; // msh/2/e/CHANNELID/NODEID

--- a/src/mqtt/MQTT.h
+++ b/src/mqtt/MQTT.h
@@ -100,6 +100,10 @@ class MQTT : private concurrency::OSThread
 // its own client whenever one of those is the primary transport.
 #define MQTT_HAS_SECONDARY_CELL (HAS_CELLULAR && (HAS_WIFI || HAS_ETHERNET))
 
+// Whether tls_enabled could be honored on some transport - WiFi's WiFiClientSecure,
+// or cellular's AT+CIPSSL, checked live per connection rather than by this macro.
+#define MQTT_TLS_POSSIBLE (MQTT_SUPPORTS_TLS || HAS_CELLULAR)
+
 #if HAS_NETWORKING
     std::unique_ptr<MQTTClient> mqttClient;
 #if MQTT_SUPPORTS_TLS

--- a/src/mqtt/MQTT.h
+++ b/src/mqtt/MQTT.h
@@ -15,6 +15,9 @@
 #if HAS_ETHERNET && !defined(USE_WS5500) && !defined(USE_CH390D)
 #include <EthernetClient.h>
 #endif
+#if HAS_CELLULAR
+#include "mesh/cell/CellClient.h"
+#endif
 
 #if HAS_NETWORKING
 #include <PubSubClient.h>
@@ -77,6 +80,8 @@ class MQTT : private concurrency::OSThread
 #ifndef PIO_UNIT_TESTING
   private:
 #endif
+// The primary transport's client type. Boards carrying a second link keep an
+// extra client below and choose between them at connect time.
 #if HAS_WIFI
     using MQTTClient = WiFiClient;
 #if __has_include(<WiFiClientSecure.h>)
@@ -85,17 +90,29 @@ class MQTT : private concurrency::OSThread
 #endif
 #elif HAS_ETHERNET
     using MQTTClient = EthernetClient;
+#elif HAS_CELLULAR
+    using MQTTClient = CellClient;
 #else
     using MQTTClient = void;
 #endif
+
+// Cellular coexists with WiFi/Ethernet instead of replacing them, so it needs
+// its own client whenever one of those is the primary transport.
+#define MQTT_HAS_SECONDARY_CELL (HAS_CELLULAR && (HAS_WIFI || HAS_ETHERNET))
 
 #if HAS_NETWORKING
     std::unique_ptr<MQTTClient> mqttClient;
 #if MQTT_SUPPORTS_TLS
     MQTTClientTLS mqttClientTLS;
 #endif
+#if MQTT_HAS_SECONDARY_CELL
+    CellClient mqttClientCell;
+#endif
     PubSubClient pubSub;
     explicit MQTT(std::unique_ptr<MQTTClient> mqttClient);
+
+    /// Client for whichever transport is up, or nullptr when none is.
+    Client *activeClient();
 #endif
 
     std::string cryptTopic = "/2/e/"; // msh/2/e/CHANNELID/NODEID

--- a/test/test_cell_diag/test_main.cpp
+++ b/test/test_cell_diag/test_main.cpp
@@ -1,0 +1,245 @@
+// Unit tests for the cellular diagnostic response parsers in src/mesh/cell/cellDiagParse.cpp.
+// Response text is taken from an Air780E running V1179.
+#include "Arduino.h"
+#include "TestUtil.h"
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <unity.h>
+
+// Forward-declared rather than included so the test does not pull in
+// configuration.h and the HAS_CELLULAR guard. Defined in cellDiagParse.cpp.
+bool parseCesq(const char *resp, int16_t *rsrpDbm, float *rsrqDb);
+int parseCeregStat(const char *resp);
+bool parseBandInd(const char *resp, uint8_t *band, uint8_t *act);
+bool parseCbcMillivolts(const char *resp, uint16_t *mv);
+bool parseCopsName(const char *resp, char *out, size_t outLen);
+bool parseCopsNumeric(const char *resp, char *out, size_t outLen);
+bool parseSysConfig(const char *resp, uint8_t *mode, uint8_t *acqorder, uint8_t *srvdomain);
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// --- AT+CESQ ---
+
+void test_cesq_typical()
+{
+    // rxlev,ber,rscp,ecno,rsrq,rsrp - only the last two carry LTE readings.
+    int16_t rsrp = 0;
+    float rsrq = 0;
+    TEST_ASSERT_TRUE(parseCesq("+CESQ: 99,99,255,255,20,45", &rsrp, &rsrq));
+    TEST_ASSERT_EQUAL_INT16(-95, rsrp);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, -10.0f, rsrq);
+}
+
+void test_cesq_not_available()
+{
+    // 255 in either LTE field means no reading, not a very good one.
+    int16_t rsrp = 0;
+    float rsrq = 0;
+    TEST_ASSERT_FALSE(parseCesq("+CESQ: 99,99,255,255,255,255", &rsrp, &rsrq));
+    TEST_ASSERT_FALSE(parseCesq("+CESQ: 99,99,255,255,255,45", &rsrp, &rsrq));
+    TEST_ASSERT_FALSE(parseCesq("+CESQ: 99,99,255,255,20,255", &rsrp, &rsrq));
+}
+
+void test_cesq_boundaries()
+{
+    int16_t rsrp = 0;
+    float rsrq = 0;
+    TEST_ASSERT_TRUE(parseCesq("+CESQ: 99,99,255,255,0,0", &rsrp, &rsrq));
+    TEST_ASSERT_EQUAL_INT16(-140, rsrp);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, -20.0f, rsrq);
+
+    TEST_ASSERT_TRUE(parseCesq("+CESQ: 99,99,255,255,34,97", &rsrp, &rsrq));
+    TEST_ASSERT_EQUAL_INT16(-43, rsrp);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, -3.0f, rsrq);
+}
+
+void test_cesq_multiline_response()
+{
+    // The parser is handed a whole response, which may carry other lines.
+    int16_t rsrp = 0;
+    TEST_ASSERT_TRUE(parseCesq("+CIEV: 1\n+CESQ: 99,99,255,255,20,45", &rsrp, nullptr));
+    TEST_ASSERT_EQUAL_INT16(-95, rsrp);
+}
+
+void test_cesq_malformed()
+{
+    int16_t rsrp = 0;
+    float rsrq = 0;
+    TEST_ASSERT_FALSE(parseCesq("", &rsrp, &rsrq));
+    TEST_ASSERT_FALSE(parseCesq("ERROR", &rsrp, &rsrq));
+    TEST_ASSERT_FALSE(parseCesq("+CESQ:", &rsrp, &rsrq));
+    TEST_ASSERT_FALSE(parseCesq("+CESQ: 99,99,255,255", &rsrp, &rsrq)); // truncated
+    TEST_ASSERT_FALSE(parseCesq("+CESQ: 99,99,255,255,20,xx", &rsrp, &rsrq));
+    TEST_ASSERT_FALSE(parseCesq(nullptr, &rsrp, &rsrq));
+}
+
+// --- AT+CEREG? ---
+
+void test_cereg_states()
+{
+    TEST_ASSERT_EQUAL_INT(1, parseCeregStat("+CEREG: 2,1"));
+    TEST_ASSERT_EQUAL_INT(2, parseCeregStat("+CEREG: 2,2"));
+    TEST_ASSERT_EQUAL_INT(5, parseCeregStat("+CEREG: 2,5,\"1A2B\",\"01234567\",7"));
+}
+
+void test_cereg_malformed()
+{
+    TEST_ASSERT_EQUAL_INT(-1, parseCeregStat("+CEREG: 2"));
+    TEST_ASSERT_EQUAL_INT(-1, parseCeregStat("+CEREG:"));
+    TEST_ASSERT_EQUAL_INT(-1, parseCeregStat("OK"));
+    TEST_ASSERT_EQUAL_INT(-1, parseCeregStat(""));
+}
+
+// --- AT*BANDIND? ---
+
+void test_bandind_typical()
+{
+    uint8_t band = 0, act = 0;
+    TEST_ASSERT_TRUE(parseBandInd("*BANDIND: 1,3,7", &band, &act));
+    TEST_ASSERT_EQUAL_UINT8(3, band);
+    TEST_ASSERT_EQUAL_UINT8(7, act); // 7 = E-UTRAN
+}
+
+void test_bandind_spaces_after_commas()
+{
+    // The V1179 answers "*BANDIND: 0, 1, 7" - padded, unlike every other response.
+    uint8_t band = 0, act = 0;
+    TEST_ASSERT_TRUE(parseBandInd("*BANDIND: 0, 1, 7", &band, &act));
+    TEST_ASSERT_EQUAL_UINT8(1, band);
+    TEST_ASSERT_EQUAL_UINT8(7, act);
+}
+
+void test_bandind_malformed()
+{
+    uint8_t band = 0, act = 0;
+    TEST_ASSERT_FALSE(parseBandInd("*BANDIND: 1,3", &band, &act));
+    TEST_ASSERT_FALSE(parseBandInd("+BANDIND: 1,3,7", &band, &act)); // wrong prefix
+    TEST_ASSERT_FALSE(parseBandInd("*BANDIND: 1,3,999", &band, &act));
+    TEST_ASSERT_FALSE(parseBandInd("", &band, &act));
+}
+
+// --- AT+CBC ---
+
+void test_cbc_three_field_simcom_form()
+{
+    uint16_t mv = 0;
+    TEST_ASSERT_TRUE(parseCbcMillivolts("+CBC: 0,75,3912", &mv));
+    TEST_ASSERT_EQUAL_UINT16(3912, mv);
+}
+
+void test_cbc_single_field_air780e_form()
+{
+    // The Air780E answers with the millivolts alone, not <bcs>,<bcl>,<mV>.
+    // Observed on V1179; reading field 2 alone dropped VBAT entirely.
+    uint16_t mv = 0;
+    TEST_ASSERT_TRUE(parseCbcMillivolts("+CBC: 4607", &mv));
+    TEST_ASSERT_EQUAL_UINT16(4607, mv);
+}
+
+void test_cbc_implausible_rejected()
+{
+    // A reading outside a generous window around the module's 3.4-4.2 V range
+    // is a different encoding, not a voltage to display.
+    uint16_t mv = 0;
+    TEST_ASSERT_FALSE(parseCbcMillivolts("+CBC: 0,75,39", &mv));
+    TEST_ASSERT_FALSE(parseCbcMillivolts("+CBC: 0,75,39120", &mv));
+    TEST_ASSERT_FALSE(parseCbcMillivolts("+CBC: 0,75", &mv));
+    TEST_ASSERT_FALSE(parseCbcMillivolts("", &mv));
+}
+
+// --- AT+COPS? ---
+
+void test_cops_numeric()
+{
+    char oper[12] = {0};
+    TEST_ASSERT_TRUE(parseCopsNumeric("+COPS: 0,2,\"52501\",7", oper, sizeof(oper)));
+    TEST_ASSERT_EQUAL_STRING("52501", oper);
+}
+
+void test_cops_name_long_and_short()
+{
+    char oper[24] = {0};
+    TEST_ASSERT_TRUE(parseCopsName("+COPS: 0,0,\"CHN-UNICOM\",7", oper, sizeof(oper)));
+    TEST_ASSERT_EQUAL_STRING("CHN-UNICOM", oper);
+    TEST_ASSERT_TRUE(parseCopsName("+COPS: 0,1,\"unicom\",7", oper, sizeof(oper)));
+    TEST_ASSERT_EQUAL_STRING("unicom", oper);
+}
+
+void test_cops_name_numeric_format_refused()
+{
+    // Format 2 is the numeric MCC/MNC, not a name.
+    char oper[24] = {0};
+    TEST_ASSERT_FALSE(parseCopsName("+COPS: 0,2,\"52501\",7", oper, sizeof(oper)));
+}
+
+void test_cops_not_registered()
+{
+    char oper[24] = {0};
+    TEST_ASSERT_FALSE(parseCopsName("+COPS: 0", oper, sizeof(oper)));
+    TEST_ASSERT_FALSE(parseCopsName("+COPS: 0,0", oper, sizeof(oper)));
+    TEST_ASSERT_FALSE(parseCopsName("", oper, sizeof(oper)));
+    TEST_ASSERT_FALSE(parseCopsNumeric("+COPS: 0", oper, sizeof(oper)));
+    TEST_ASSERT_FALSE(parseCopsNumeric("+COPS: 0,2", oper, sizeof(oper)));
+    TEST_ASSERT_FALSE(parseCopsNumeric("", oper, sizeof(oper)));
+}
+
+void test_cops_output_buffer_too_small()
+{
+    char oper[4] = {0};
+    TEST_ASSERT_FALSE(parseCopsName("+COPS: 0,0,\"CHN-UNICOM\",7", oper, sizeof(oper)));
+    TEST_ASSERT_EQUAL_STRING("", oper); // left untouched on failure
+    TEST_ASSERT_FALSE(parseCopsNumeric("+COPS: 0,2,\"52501\",7", oper, sizeof(oper)));
+    TEST_ASSERT_EQUAL_STRING("", oper);
+}
+
+// --- AT^SYSCONFIG ---
+
+void test_sysconfig_typical()
+{
+    uint8_t mode = 0, acqorder = 0, srvdomain = 0;
+    TEST_ASSERT_TRUE(parseSysConfig("^SYSCONFIG: 2,0,1,3", &mode, &acqorder, &srvdomain));
+    TEST_ASSERT_EQUAL_UINT8(2, mode);
+    TEST_ASSERT_EQUAL_UINT8(0, acqorder);
+    TEST_ASSERT_EQUAL_UINT8(3, srvdomain);
+}
+
+void test_sysconfig_malformed()
+{
+    uint8_t mode = 0, acqorder = 0, srvdomain = 0;
+    TEST_ASSERT_FALSE(parseSysConfig("^SYSCONFIG: 2,0,1", &mode, &acqorder, &srvdomain));   // missing srvdomain
+    TEST_ASSERT_FALSE(parseSysConfig("+SYSCONFIG: 2,0,1,3", &mode, &acqorder, &srvdomain)); // wrong prefix
+    TEST_ASSERT_FALSE(parseSysConfig("", &mode, &acqorder, &srvdomain));
+}
+
+// --- Unity lifecycle ---
+
+void setup()
+{
+    initializeTestEnvironment();
+    UNITY_BEGIN();
+    RUN_TEST(test_cesq_typical);
+    RUN_TEST(test_cesq_not_available);
+    RUN_TEST(test_cesq_boundaries);
+    RUN_TEST(test_cesq_multiline_response);
+    RUN_TEST(test_cesq_malformed);
+    RUN_TEST(test_cereg_states);
+    RUN_TEST(test_cereg_malformed);
+    RUN_TEST(test_bandind_typical);
+    RUN_TEST(test_bandind_spaces_after_commas);
+    RUN_TEST(test_bandind_malformed);
+    RUN_TEST(test_cbc_three_field_simcom_form);
+    RUN_TEST(test_cbc_single_field_air780e_form);
+    RUN_TEST(test_cbc_implausible_rejected);
+    RUN_TEST(test_cops_numeric);
+    RUN_TEST(test_cops_name_long_and_short);
+    RUN_TEST(test_cops_name_numeric_format_refused);
+    RUN_TEST(test_cops_not_registered);
+    RUN_TEST(test_cops_output_buffer_too_small);
+    RUN_TEST(test_sysconfig_typical);
+    RUN_TEST(test_sysconfig_malformed);
+    exit(UNITY_END());
+}
+
+void loop() {}

--- a/test/test_cell_diag/test_main.cpp
+++ b/test/test_cell_diag/test_main.cpp
@@ -55,6 +55,16 @@ void test_cesq_boundaries()
     TEST_ASSERT_FLOAT_WITHIN(0.01f, -3.0f, rsrq);
 }
 
+void test_cesq_out_of_range()
+{
+    // <rsrq> is valid 0-34 and <rsrp> is valid 0-97; anything above that is not
+    // the 255 "not known" sentinel either, and must not be reported as a reading.
+    int16_t rsrp = 0;
+    float rsrq = 0;
+    TEST_ASSERT_FALSE(parseCesq("+CESQ: 99,99,255,255,35,45", &rsrp, &rsrq));
+    TEST_ASSERT_FALSE(parseCesq("+CESQ: 99,99,255,255,20,98", &rsrp, &rsrq));
+}
+
 void test_cesq_multiline_response()
 {
     // The parser is handed a whole response, which may carry other lines.
@@ -222,6 +232,7 @@ void setup()
     RUN_TEST(test_cesq_typical);
     RUN_TEST(test_cesq_not_available);
     RUN_TEST(test_cesq_boundaries);
+    RUN_TEST(test_cesq_out_of_range);
     RUN_TEST(test_cesq_multiline_response);
     RUN_TEST(test_cesq_malformed);
     RUN_TEST(test_cereg_states);

--- a/variants/esp32s3/t-deck-pro-v1_1/variant.h
+++ b/variants/esp32s3/t-deck-pro-v1_1/variant.h
@@ -95,8 +95,10 @@
 // Internally the TTGO module hooks the SX1262-DIO2 in to control the TX/RX switch (which is the default for the sx1262interface
 // code)
 
-#define MODEM_POWER_EN 41
-#define MODEM_PWRKEY 40
+#define PIN_MODEM_EN 41
+#define PIN_MODEM_PWRKEY 40
+// Keeps the boot-time write LOW, unchanged from before.
+#define MODEM_PWRKEY_VALUE HIGH
 #define MODEM_RST 9
 #define MODEM_RI 7
 #define MODEM_DTR 8

--- a/variants/esp32s3/t-deck-pro/variant.h
+++ b/variants/esp32s3/t-deck-pro/variant.h
@@ -92,8 +92,10 @@
 // Internally the TTGO module hooks the SX1262-DIO2 in to control the TX/RX switch (which is the default for the sx1262interface
 // code)
 
-#define MODEM_POWER_EN 41
-#define MODEM_PWRKEY 40
+#define PIN_MODEM_EN 41
+#define PIN_MODEM_PWRKEY 40
+// Keeps the boot-time write LOW, unchanged from before.
+#define MODEM_PWRKEY_VALUE HIGH
 #define MODEM_RST 9
 #define MODEM_RI 7
 #define MODEM_DTR 8


### PR DESCRIPTION
## Summary

Adds the Air780E (EC618) as a new network interface for the MQTT client: an AT-command driver (`ATModem`/`EC618Modem`), a bearer/link-state machine (`cellBearer`), an Arduino `Client` for MQTT (`CellClient`) with TLS terminated by the modem itself via `AT+CIPSSL`, diagnostics (`cellDiag`) on a UI screen and as `CellularMetrics` telemetry, and a System Action toggle to power the modem on/off without a reboot. Config lives in `NetworkConfig` protobuf fields, mirroring `wifi_*`.

Named `cell*`/`HAS_CELLULAR` rather than `air780e*` so another EC618-family module or vendor can slot in later.

## What's included

- **Modem driver** (`src/mesh/cell/`): `ATModem`/`EC618Modem` (UART framing, AT dialect, TLS via `AT+CIPSSL`), `cellBearer` (link state machine), `CellClient` (single-socket IPv4 `Client`), `cellDiag`/`cellDiagParse` (signal/registration/battery sweep + parsers).
- **Network integration**: `HAS_CELLULAR` arm in `MQTT.{h,cpp}`'s client typedef, `isConnectedToNetwork()`, and `reconnect()`'s TLS branch; `CellularTelemetry` module sends `cellDiag` output as `Telemetry.cellular_metrics`.
- **Device UI**: Cellular System Action toggle and screen frame (`MenuHandler.{h,cpp}`).
- **Config/protobufs**: new `NetworkConfig` fields, `DeviceMetadata.hasCellular`, `Telemetry.CellularMetrics` (see Protobufs below).
- **Variants**: renamed T-Deck-Pro's `MODEM_POWER_EN`/`MODEM_PWRKEY` to this driver's `PIN_MODEM_*` naming - no behavior change.
- **Tests**: `test/test_cell_diag/`, 21 cases over the diagnostics parsers.

## Known limitations

- No listening sockets (`AT+CIPSTART` is outbound-only) - phone API server, web server, UDP multicast excluded.
- IPv4 only on the socket API.
- Power cycling an unresponsive modem requires `PIN_MODEM_EN` wired.

## Needs testing

- SIM hot-insert detection (`MODEM_SIM_HOTPLUG`) - bench module has no `USIM_CD` wired.

## PWRKEY / EN wiring

| PWRKEY | EN  | Power-on                 | Power-off                                     | SIM re-detect   | Recovers a hung modem? |
| ------ | --- | ------------------------ | ---------------------------------------------- | ---------------- | ------------------------ |
| No     | No  | Auto-boot only           | Not possible                                  | `AT+RESET` only | No                     |
| Yes    | No  | PWRKEY pulse             | Soft shutdown                                 | `AT+RESET`      | No                     |
| No     | Yes | EN assert, auto-boot     | EN de-assert (regulator off)                  | EN cycle        | Yes                    |
| Yes    | Yes | EN assert → PWRKEY pulse | Soft shutdown -> EN de-assert (regulator off) | EN cycle        | Yes - recommended      |

## Troubleshooting

Frequent hangs or resets are likely brownout (caused by multiple back-to-back TX bursts sagging the supply) - rule out power stability before suspecting a modem firmware bug:

- Confirm headroom for ~2A TX spikes, not just ~1A sustained.
- Use a high-current source (e.g. a LiPo cell) on short wires, or add bulk capacitance near the modem.
- Wire both PWRKEY and EN if unsure - only that combination self-recovers from a hang.

**VIN vs VBAT:** VBAT is 3.3-4.3V; the VIN pin is regulated from a wider range (check product info for voltage range), and that regulator is controlled by the `EN` pin.

## Build-time configuration

`build_flags` only - no in-tree board ships this modem yet. Required: `HAS_CELLULAR=1`, `USE_EC618`, `PIN_MODEM_TX`/`PIN_MODEM_RX`. `PIN_MODEM_PWRKEY`/`PIN_MODEM_EN` optional (see wiring table). Full macro list and defaults in `ATModem.h`/`EC618Modem.h`.

## Protobufs

From [meshtastic/protobufs#1030](https://github.com/meshtastic/protobufs/pull/1030) (not yet merged): `NetworkConfig.cell_enabled`/`cell_apn`/`cell_apn_user`/`cell_apn_pass`/`cell_roaming_enabled`, `DeviceMetadata.hasCellular`, `Telemetry.cellular_metrics` (new `CellularMetrics` message: rsrp/rsrq/band/access_tech/modem_voltage_mv/operator_name, all proto3-optional), and `TelemetryConfig.cellular_measurement_enabled`/`cellular_update_interval`.

Until #1030 merges, the submodule is pinned to the fork's commit instead (same technique as [meshtastic/firmware#10755](https://github.com/meshtastic/firmware/pull/10755)) - `.gitmodules` unchanged, forks share object storage with upstream. No extra setup needed to check out this PR.

## Testing

Bring-up used a stock Heltec V3 with the modem wired to its exposed header (no in-tree board ships this modem). Append to `variants/esp32s3/heltec_v3/platformio.ini` to reproduce:

```ini
; Bring-up setup for the Air780E modem - not a real variant. Serial2 keeps
; Serial1 free for GPS. See the PR description for wiring/config details.
; Wire a high-current 5V or 4.2V source (e.g. a power-path-switched VBUS) to
; the module's VIN/5V input. Check its datasheet for VIN range - see PR notes.
[env:heltec-v3-air780e]
extends = env:heltec-v3
board_level = extra
build_flags =
  ${env:heltec-v3.build_flags}
  -DHAS_CELLULAR=1
  -DUSE_EC618
  -DPIN_MODEM_EN=4
  -DPIN_MODEM_PWRKEY=5
  -DPIN_MODEM_RX=6
  -DPIN_MODEM_TX=7
  -DMODEM_SERIAL=Serial2
```

Done:

- `heltec-v3-air780e` (`HAS_CELLULAR=1`) and `heltec-v3` (`HAS_CELLULAR=0`) both build-verify clean.
- `t-deck-pro`, `t-deck-pro-v1_1`, `tbeam`: build-verified only.
- Native suite in Docker: 864/866 pass; the 2 failures (`test_packet_signing` `B11`/`B12`) predate this branch.
- Bench setup: modem powers on, attaches, gets an IP, publishes MQTT with and without TLS; diagnostics sweep confirmed on-screen; System Action toggle verified powering the modem off and back on.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3 - stock `heltec-v3` and the `heltec-v3-air780e` bring-up setup, both on hardware
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam - build-verified only
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below): LilyGo T-Deck-Pro / T-Deck-Pro v1.1 - build-verified only (renamed `PIN_MODEM_*` macros, no behavior change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cellular modem connectivity with power control, roaming, sockets, TLS, and MQTT transport.
  * Added support for EC618-based modems.
  * Added a Cellular status screen showing signal, network, IP, operator, band, and voltage.
  * Added cellular diagnostics and optional telemetry sharing over mesh or phone connections.
  * Added automatic fallback to cellular when Wi-Fi or Ethernet is unavailable.

* **Bug Fixes**
  * Improved syslog support for applicable network transports.
  * Improved modem power-control configuration across supported devices.

* **Tests**
  * Added coverage for cellular diagnostic response parsing and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
