### PR TITLE
Add the PMU button handling to BPF

### DIFF
--- a/variants/esp32s3/t-beam-bpf/variant.h
+++ b/variants/esp32s3/t-beam-bpf/variant.h
@@ -67,4 +67,5 @@
 
 // PMU
 #define HAS_AXP2101
-// #define PMU_IRQ 4 // Leave disabled for now
+#define PMU_IRQ 4
+#define PMU_POWER_BUTTON_IS_CANCEL // maps a short click of the power button to a cancel action (turning off the screen)


### PR DESCRIPTION
makes the power button work as cancel, as other t-beam devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled power-management interrupt handling.
  * Short power-button presses now act as cancel actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->