### PR TITLE
fix(serial): drop blank and line-noise text messages in TEXTMSG mode

### DIFF
--- a/src/meshUtils.cpp
+++ b/src/meshUtils.cpp
@@ -134,6 +134,45 @@ size_t pb_string_length(const char *str, size_t max_len)
     return len;
 }
 
+size_t utf8SequenceLength(const char *buf, size_t remaining)
+{
+    if (!buf || remaining == 0)
+        return 0;
+
+    const uint8_t lead = (uint8_t)buf[0];
+    size_t seqLen;
+    uint32_t minCodepoint; // anything below this is an overlong encoding of a shorter sequence
+    if (lead <= 0x7F) {
+        return 1;
+    } else if ((lead & 0xE0) == 0xC0) {
+        seqLen = 2;
+        minCodepoint = 0x80;
+    } else if ((lead & 0xF0) == 0xE0) {
+        seqLen = 3;
+        minCodepoint = 0x800;
+    } else if ((lead & 0xF8) == 0xF0) {
+        seqLen = 4;
+        minCodepoint = 0x10000;
+    } else {
+        return 0; // continuation byte with no lead, or a 5-byte-or-longer form
+    }
+
+    if (seqLen > remaining)
+        return 0;
+
+    uint32_t codepoint = lead & (seqLen == 2 ? 0x1F : (seqLen == 3 ? 0x0F : 0x07));
+    for (size_t i = 1; i < seqLen; i++) {
+        if (((uint8_t)buf[i] & 0xC0) != 0x80)
+            return 0;
+        codepoint = (codepoint << 6) | ((uint8_t)buf[i] & 0x3F);
+    }
+
+    if (codepoint < minCodepoint || codepoint > 0x10FFFF || (codepoint >= 0xD800 && codepoint <= 0xDFFF))
+        return 0;
+
+    return seqLen;
+}
+
 bool sanitizeUtf8(char *buf, size_t bufSize)
 {
     if (!buf || bufSize == 0)
@@ -147,76 +186,14 @@ bool sanitizeUtf8(char *buf, size_t bufSize)
     size_t len = strlen(buf);
 
     while (i < len) {
-        uint8_t b = (uint8_t)buf[i];
-
-        // Determine expected sequence length from lead byte
-        size_t seqLen;
-        uint32_t minCodepoint;
-        if (b <= 0x7F) {
-            // ASCII - valid single byte
-            i++;
-            continue;
-        } else if ((b & 0xE0) == 0xC0) {
-            seqLen = 2;
-            minCodepoint = 0x80; // Reject overlong
-        } else if ((b & 0xF0) == 0xE0) {
-            seqLen = 3;
-            minCodepoint = 0x800;
-        } else if ((b & 0xF8) == 0xF0) {
-            seqLen = 4;
-            minCodepoint = 0x10000;
-        } else {
-            // Invalid lead byte (0x80-0xBF or 0xF8+)
+        size_t seqLen = utf8SequenceLength(buf + i, len - i);
+        if (seqLen == 0) {
+            // Replace only this byte; the rest of a malformed sequence is caught on later iterations
             buf[i] = '?';
             replaced = true;
             i++;
-            continue;
-        }
-
-        // Check that we have enough bytes remaining
-        if (i + seqLen > len) {
-            // Truncated sequence at end of string - replace remaining bytes
-            for (size_t j = i; j < len; j++) {
-                buf[j] = '?';
-            }
-            replaced = true;
-            break;
-        }
-
-        // Validate continuation bytes (must be 10xxxxxx)
-        bool valid = true;
-        for (size_t j = 1; j < seqLen; j++) {
-            if (((uint8_t)buf[i + j] & 0xC0) != 0x80) {
-                valid = false;
-                break;
-            }
-        }
-
-        if (valid) {
-            // Decode codepoint to check for overlong encodings and surrogates
-            uint32_t cp = 0;
-            if (seqLen == 2)
-                cp = b & 0x1F;
-            else if (seqLen == 3)
-                cp = b & 0x0F;
-            else
-                cp = b & 0x07;
-            for (size_t j = 1; j < seqLen; j++)
-                cp = (cp << 6) | ((uint8_t)buf[i + j] & 0x3F);
-
-            if (cp < minCodepoint || cp > 0x10FFFF || (cp >= 0xD800 && cp <= 0xDFFF)) {
-                // Overlong encoding, out of Unicode range, or surrogate half
-                valid = false;
-            }
-        }
-
-        if (valid) {
+        } else {
             i += seqLen;
-        } else {
-            // Replace only the lead byte; continuation bytes will be caught on next iteration
-            buf[i] = '?';
-            replaced = true;
-            i++;
         }
     }
 

--- a/src/meshUtils.h
+++ b/src/meshUtils.h
@@ -70,6 +70,11 @@ const std::string vformat(const char *const zcFormat, ...);
 // Get actual string length for nanopb char array fields.
 size_t pb_string_length(const char *str, size_t max_len);
 
+// Length of the UTF-8 sequence starting at buf, or 0 if it is not a valid one: a bad lead byte,
+// missing or malformed continuation bytes, an overlong encoding, a surrogate half, a codepoint
+// above U+10FFFF, or a sequence that runs past `remaining` bytes.
+size_t utf8SequenceLength(const char *buf, size_t remaining);
+
 // Sanitize a fixed-size char buffer in-place by replacing invalid UTF-8 sequences with '?'.
 // Ensures the result is null-terminated within bufSize. Returns true if any bytes were replaced.
 bool sanitizeUtf8(char *buf, size_t bufSize);

--- a/src/meshUtils.h
+++ b/src/meshUtils.h
@@ -70,9 +70,8 @@ const std::string vformat(const char *const zcFormat, ...);
 // Get actual string length for nanopb char array fields.
 size_t pb_string_length(const char *str, size_t max_len);
 
-// Length of the UTF-8 sequence starting at buf, or 0 if it is not a valid one: a bad lead byte,
-// missing or malformed continuation bytes, an overlong encoding, a surrogate half, a codepoint
-// above U+10FFFF, or a sequence that runs past `remaining` bytes.
+// Length of the valid UTF-8 sequence starting at buf, or 0 if there is none - bad lead byte, bad
+// continuation, overlong, surrogate half, above U+10FFFF, or running past `remaining` bytes.
 size_t utf8SequenceLength(const char *buf, size_t remaining);
 
 // Sanitize a fixed-size char buffer in-place by replacing invalid UTF-8 sequences with '?'.

--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -6,6 +6,7 @@
 #include "Router.h"
 #include "configuration.h"
 #include "gps/RTC.h"
+#include "meshUtils.h"
 #include <Arduino.h>
 #include <Throttle.h>
 
@@ -71,6 +72,38 @@ bool serialConfigIsValid(const meshtastic_ModuleConfig_SerialConfig &config)
     }
 
     return true;
+}
+
+size_t sanitizeTextMessagePayload(char *buf, size_t size)
+{
+    if (!buf)
+        return 0;
+
+    size_t out = 0;
+    for (size_t i = 0; i < size;) {
+        const size_t seqLen = utf8SequenceLength(buf + i, size - i);
+        const uint8_t b = (uint8_t)buf[i];
+        const bool isControl = (b < 0x20 || b == 0x7F) && b != '\n' && b != '\t';
+        if (seqLen == 0 || isControl) {
+            i++; // line noise or a control character - drop the byte
+            continue;
+        }
+        for (size_t j = 0; j < seqLen; j++)
+            buf[out++] = buf[i + j];
+        i += seqLen;
+    }
+
+    // Trim the whitespace a terminal wraps a line in; whitespace alone is not worth a packet
+    size_t start = 0;
+    while (start < out && (buf[start] == ' ' || buf[start] == '\t' || buf[start] == '\n'))
+        start++;
+    while (out > start && (buf[out - 1] == ' ' || buf[out - 1] == '\t' || buf[out - 1] == '\n'))
+        out--;
+
+    if (start > 0)
+        memmove(buf, buf + start, out - start);
+
+    return out - start;
 }
 
 #if (defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040) || defined(ARCH_STM32WL)) &&                             \
@@ -292,7 +325,10 @@ int32_t SerialModule::runOnce()
                 while (serialInstance->available()) {
                     serialPayloadSize = serialInstance->readBytes(serialBytes, meshtastic_Constants_DATA_PAYLOAD_LEN);
 #endif
-                    serialModuleRadio->sendPayload();
+                    if (moduleConfig.serial.mode == meshtastic_ModuleConfig_SerialConfig_Serial_Mode_TEXTMSG)
+                        serialPayloadSize = sanitizeTextMessagePayload(serialBytes, serialPayloadSize);
+                    if (serialPayloadSize > 0)
+                        serialModuleRadio->sendPayload();
                 }
             }
 #endif

--- a/src/modules/SerialModule.h
+++ b/src/modules/SerialModule.h
@@ -13,6 +13,12 @@
 // SerialModule itself does not exist. Logs and notifies the client on rejection.
 bool serialConfigIsValid(const meshtastic_ModuleConfig_SerialConfig &config);
 
+// Compact a TEXTMSG payload in place to what is worth putting on the mesh, returning the length to
+// send, 0 meaning "send nothing" - so a bare ENTER or line noise on a floating RX pin sends no
+// message. Outside the architecture guard for the same reason as above: no serial hardware, so it
+// can be tested natively.
+size_t sanitizeTextMessagePayload(char *buf, size_t size);
+
 #if (defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040) || defined(ARCH_STM32WL)) &&                             \
     !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
 

--- a/src/modules/SerialModule.h
+++ b/src/modules/SerialModule.h
@@ -13,10 +13,8 @@
 // SerialModule itself does not exist. Logs and notifies the client on rejection.
 bool serialConfigIsValid(const meshtastic_ModuleConfig_SerialConfig &config);
 
-// Compact a TEXTMSG payload in place to what is worth putting on the mesh, returning the length to
-// send, 0 meaning "send nothing" - so a bare ENTER or line noise on a floating RX pin sends no
-// message. Outside the architecture guard for the same reason as above: no serial hardware, so it
-// can be tested natively.
+// Compact a TEXTMSG payload in place to what is worth sending and return its length; 0 means send
+// nothing, so a bare ENTER or noise on a floating RX pin produces no message.
 size_t sanitizeTextMessagePayload(char *buf, size_t size);
 
 #if (defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040) || defined(ARCH_STM32WL)) &&                             \

--- a/test/test_serial/SerialModule.cpp
+++ b/test/test_serial/SerialModule.cpp
@@ -124,7 +124,6 @@ void test_serialConfigVariousModesWithoutOverrideAreValid(void)
 
 // --- TEXTMSG payload sanitizing ---
 
-// Test that a bare carriage return / newline yields nothing to send.
 void test_textMsgCrLfOnlyIsNotSent(void)
 {
     char buf[8] = "\r\n";
@@ -132,7 +131,6 @@ void test_textMsgCrLfOnlyIsNotSent(void)
     TEST_ASSERT_EQUAL_size_t(0, sanitizeTextMessagePayload(buf, 2));
 }
 
-// Test that a payload of only spaces and tabs yields nothing to send.
 void test_textMsgWhitespaceOnlyIsNotSent(void)
 {
     char buf[16] = "  \t \r\n";
@@ -140,7 +138,7 @@ void test_textMsgWhitespaceOnlyIsNotSent(void)
     TEST_ASSERT_EQUAL_size_t(0, sanitizeTextMessagePayload(buf, 6));
 }
 
-// Test that a single line-noise byte, as seen on a floating RX pin at boot, yields nothing to send.
+// The floating RX pin at boot: one noise byte must not become a message.
 void test_textMsgLoneNoiseByteIsNotSent(void)
 {
     char buf[8] = "\xFF";
@@ -148,7 +146,6 @@ void test_textMsgLoneNoiseByteIsNotSent(void)
     TEST_ASSERT_EQUAL_size_t(0, sanitizeTextMessagePayload(buf, 1));
 }
 
-// Test that ordinary text passes through untouched.
 void test_textMsgPlainTextUnchanged(void)
 {
     char buf[16] = "hello";
@@ -157,7 +154,7 @@ void test_textMsgPlainTextUnchanged(void)
     TEST_ASSERT_EQUAL_MEMORY("hello", buf, 5);
 }
 
-// Test that surrounding whitespace is trimmed, including the trailing newline the terminal sends.
+// The CR/LF a terminal appends to the line goes with the surrounding whitespace.
 void test_textMsgSurroundingWhitespaceTrimmed(void)
 {
     char buf[16] = "  hello \r\n";
@@ -166,7 +163,6 @@ void test_textMsgSurroundingWhitespaceTrimmed(void)
     TEST_ASSERT_EQUAL_MEMORY("hello", buf, 5);
 }
 
-// Test that control characters are dropped from the middle of a message.
 void test_textMsgControlCharsStripped(void)
 {
     char buf[16] = "a\x01"
@@ -177,7 +173,7 @@ void test_textMsgControlCharsStripped(void)
     TEST_ASSERT_EQUAL_MEMORY("abc", buf, 3);
 }
 
-// Test that an embedded newline or tab survives, so multi-line input stays readable.
+// Interior newline and tab survive, so pasted multi-line input stays readable.
 void test_textMsgInteriorNewlineAndTabKept(void)
 {
     char buf[16] = "a\n\tb";
@@ -186,7 +182,7 @@ void test_textMsgInteriorNewlineAndTabKept(void)
     TEST_ASSERT_EQUAL_MEMORY("a\n\tb", buf, 4);
 }
 
-// Test that valid multi-byte UTF-8 is preserved, so non-ASCII text still sends.
+// Text in someone's own language must still send, so valid multi-byte UTF-8 survives.
 void test_textMsgValidUtf8Preserved(void)
 {
     // "café 🌍" - é is C3 A9, the globe is F0 9F 8C 8D
@@ -196,7 +192,6 @@ void test_textMsgValidUtf8Preserved(void)
     TEST_ASSERT_EQUAL_MEMORY("caf\xC3\xA9 \xF0\x9F\x8C\x8D", buf, 10);
 }
 
-// Test that invalid UTF-8 bytes are dropped while the surrounding text survives.
 void test_textMsgInvalidUtf8BytesDropped(void)
 {
     // 0xC3 without its continuation byte, then a bare continuation byte.
@@ -208,7 +203,6 @@ void test_textMsgInvalidUtf8BytesDropped(void)
     TEST_ASSERT_EQUAL_MEMORY("abc", buf, 3);
 }
 
-// Test that an empty read yields nothing to send.
 void test_textMsgEmptyPayloadIsNotSent(void)
 {
     char buf[8] = "";

--- a/test/test_serial/SerialModule.cpp
+++ b/test/test_serial/SerialModule.cpp
@@ -122,6 +122,100 @@ void test_serialConfigVariousModesWithoutOverrideAreValid(void)
     TEST_ASSERT_TRUE(serialConfigIsValid(config));
 }
 
+// --- TEXTMSG payload sanitizing ---
+
+// Test that a bare carriage return / newline yields nothing to send.
+void test_textMsgCrLfOnlyIsNotSent(void)
+{
+    char buf[8] = "\r\n";
+
+    TEST_ASSERT_EQUAL_size_t(0, sanitizeTextMessagePayload(buf, 2));
+}
+
+// Test that a payload of only spaces and tabs yields nothing to send.
+void test_textMsgWhitespaceOnlyIsNotSent(void)
+{
+    char buf[16] = "  \t \r\n";
+
+    TEST_ASSERT_EQUAL_size_t(0, sanitizeTextMessagePayload(buf, 6));
+}
+
+// Test that a single line-noise byte, as seen on a floating RX pin at boot, yields nothing to send.
+void test_textMsgLoneNoiseByteIsNotSent(void)
+{
+    char buf[8] = "\xFF";
+
+    TEST_ASSERT_EQUAL_size_t(0, sanitizeTextMessagePayload(buf, 1));
+}
+
+// Test that ordinary text passes through untouched.
+void test_textMsgPlainTextUnchanged(void)
+{
+    char buf[16] = "hello";
+
+    TEST_ASSERT_EQUAL_size_t(5, sanitizeTextMessagePayload(buf, 5));
+    TEST_ASSERT_EQUAL_MEMORY("hello", buf, 5);
+}
+
+// Test that surrounding whitespace is trimmed, including the trailing newline the terminal sends.
+void test_textMsgSurroundingWhitespaceTrimmed(void)
+{
+    char buf[16] = "  hello \r\n";
+
+    TEST_ASSERT_EQUAL_size_t(5, sanitizeTextMessagePayload(buf, 10));
+    TEST_ASSERT_EQUAL_MEMORY("hello", buf, 5);
+}
+
+// Test that control characters are dropped from the middle of a message.
+void test_textMsgControlCharsStripped(void)
+{
+    char buf[16] = "a\x01"
+                   "b\x7F"
+                   "c";
+
+    TEST_ASSERT_EQUAL_size_t(3, sanitizeTextMessagePayload(buf, 5));
+    TEST_ASSERT_EQUAL_MEMORY("abc", buf, 3);
+}
+
+// Test that an embedded newline or tab survives, so multi-line input stays readable.
+void test_textMsgInteriorNewlineAndTabKept(void)
+{
+    char buf[16] = "a\n\tb";
+
+    TEST_ASSERT_EQUAL_size_t(4, sanitizeTextMessagePayload(buf, 4));
+    TEST_ASSERT_EQUAL_MEMORY("a\n\tb", buf, 4);
+}
+
+// Test that valid multi-byte UTF-8 is preserved, so non-ASCII text still sends.
+void test_textMsgValidUtf8Preserved(void)
+{
+    // "café 🌍" - é is C3 A9, the globe is F0 9F 8C 8D
+    char buf[24] = "caf\xC3\xA9 \xF0\x9F\x8C\x8D";
+
+    TEST_ASSERT_EQUAL_size_t(10, sanitizeTextMessagePayload(buf, 10));
+    TEST_ASSERT_EQUAL_MEMORY("caf\xC3\xA9 \xF0\x9F\x8C\x8D", buf, 10);
+}
+
+// Test that invalid UTF-8 bytes are dropped while the surrounding text survives.
+void test_textMsgInvalidUtf8BytesDropped(void)
+{
+    // 0xC3 without its continuation byte, then a bare continuation byte.
+    char buf[16] = "a\xC3"
+                   "b\x80"
+                   "c";
+
+    TEST_ASSERT_EQUAL_size_t(3, sanitizeTextMessagePayload(buf, 5));
+    TEST_ASSERT_EQUAL_MEMORY("abc", buf, 3);
+}
+
+// Test that an empty read yields nothing to send.
+void test_textMsgEmptyPayloadIsNotSent(void)
+{
+    char buf[8] = "";
+
+    TEST_ASSERT_EQUAL_size_t(0, sanitizeTextMessagePayload(buf, 0));
+}
+
 void setup()
 {
     initializeTestEnvironment();
@@ -137,6 +231,16 @@ void setup()
     RUN_TEST(test_serialConfigWithOverrideConsoleTextMsgModeIsInvalid);
     RUN_TEST(test_serialConfigWithOverrideConsoleProtoModeIsInvalid);
     RUN_TEST(test_serialConfigVariousModesWithoutOverrideAreValid);
+    RUN_TEST(test_textMsgCrLfOnlyIsNotSent);
+    RUN_TEST(test_textMsgWhitespaceOnlyIsNotSent);
+    RUN_TEST(test_textMsgLoneNoiseByteIsNotSent);
+    RUN_TEST(test_textMsgPlainTextUnchanged);
+    RUN_TEST(test_textMsgSurroundingWhitespaceTrimmed);
+    RUN_TEST(test_textMsgControlCharsStripped);
+    RUN_TEST(test_textMsgInteriorNewlineAndTabKept);
+    RUN_TEST(test_textMsgValidUtf8Preserved);
+    RUN_TEST(test_textMsgInvalidUtf8BytesDropped);
+    RUN_TEST(test_textMsgEmptyPayloadIsNotSent);
     exit(UNITY_END());
 }
 #else

--- a/test/test_utf8/test_main.cpp
+++ b/test/test_utf8/test_main.cpp
@@ -223,6 +223,51 @@ void test_clamp_long_name_fixes_partial_rune_at_cut()
     TEST_ASSERT_EQUAL_INT('?', buf[23]);
 }
 
+// --- utf8SequenceLength: the validity primitive both sanitizers share ---
+
+void test_sequence_length_ascii()
+{
+    TEST_ASSERT_EQUAL_size_t(1, utf8SequenceLength("a", 1));
+}
+
+void test_sequence_length_valid_2byte()
+{
+    TEST_ASSERT_EQUAL_size_t(2, utf8SequenceLength("\xC3\xA9", 2));
+}
+
+void test_sequence_length_valid_4byte()
+{
+    TEST_ASSERT_EQUAL_size_t(4, utf8SequenceLength("\xF0\x9F\x8C\x8D", 4));
+}
+
+void test_sequence_length_bare_continuation()
+{
+    TEST_ASSERT_EQUAL_size_t(0, utf8SequenceLength("\x80", 1));
+}
+
+void test_sequence_length_truncated()
+{
+    // A 2-byte lead with its continuation byte cut off by the end of the input
+    TEST_ASSERT_EQUAL_size_t(0, utf8SequenceLength("\xC3", 1));
+}
+
+void test_sequence_length_missing_continuation()
+{
+    TEST_ASSERT_EQUAL_size_t(0, utf8SequenceLength("\xC3z", 2));
+}
+
+void test_sequence_length_overlong()
+{
+    // C0 80 encodes U+0000 in two bytes
+    TEST_ASSERT_EQUAL_size_t(0, utf8SequenceLength("\xC0\x80", 2));
+}
+
+void test_sequence_length_surrogate_half()
+{
+    // ED A0 80 = U+D800
+    TEST_ASSERT_EQUAL_size_t(0, utf8SequenceLength("\xED\xA0\x80", 3));
+}
+
 void setup()
 {
     UNITY_BEGIN();
@@ -252,6 +297,16 @@ void setup()
     RUN_TEST(test_above_max_codepoint);
     RUN_TEST(test_waypoint_codepoint_encoding);
     RUN_TEST(test_waypoint_codepoint_rejects_invalid_scalars);
+
+    // utf8SequenceLength
+    RUN_TEST(test_sequence_length_ascii);
+    RUN_TEST(test_sequence_length_valid_2byte);
+    RUN_TEST(test_sequence_length_valid_4byte);
+    RUN_TEST(test_sequence_length_bare_continuation);
+    RUN_TEST(test_sequence_length_truncated);
+    RUN_TEST(test_sequence_length_missing_continuation);
+    RUN_TEST(test_sequence_length_overlong);
+    RUN_TEST(test_sequence_length_surrogate_half);
 
     // clampLongName
     RUN_TEST(test_clamp_long_name_short_unchanged);


### PR DESCRIPTION
Fixes #6444.

## What was wrong

In TEXTMSG mode the read loop in `SerialModule::runOnce()` forwarded whatever `readBytes()` returned straight into a mesh packet, with no check on length or content:

```cpp
while (serialInstance->available()) {
    serialPayloadSize = serialInstance->readBytes(serialBytes, meshtastic_Constants_DATA_PAYLOAD_LEN);
    serialModuleRadio->sendPayload();
}
```

Both symptoms in the issue follow from that directly:

- pressing ENTER in a terminal sends a message whose entire content is CR/LF;
- a node powering up with a floating RX pin - the "KNOWN PROBLEMS" note at the top of the same file - sends a byte of line noise as a text message.

## What changed

- **`sanitizeTextMessagePayload()`** (`src/modules/SerialModule.cpp`) compacts a TEXTMSG payload in place and returns the length worth sending. Control characters other than `\n` and `\t` are dropped, so are bytes that are not valid UTF-8, then surrounding whitespace is trimmed. Nothing left means nothing is sent. It sits outside the architecture guard next to `serialConfigIsValid()` for the same reason given there: it touches no serial hardware, so it can be tested on the native target.
- **The read loop** sanitizes only in TEXTMSG mode, so DEFAULT and SIMPLE stay byte-transparent for binary bridging. The length check applies to every mode - a zero-length read was never worth a packet either.
- **`utf8SequenceLength()`** (`src/meshUtils.cpp`) is the UTF-8 validity check `sanitizeUtf8()` already performed inline, extracted so both callers share one implementation. `sanitizeUtf8()` behaviour is unchanged: the existing `test_utf8` cases (truncated sequences, overlong encodings, surrogate halves, 5-byte forms, buffer-end truncation) all pass unmodified.

## One deviation from the report

The issue asks for non-ASCII characters to be rejected. This implements "must be valid UTF-8" instead, because a hard ASCII filter would stop people sending text in their own language over serial. Random line noise essentially never forms a valid UTF-8 sequence, so the reported symptom is still covered. Happy to tighten it to ASCII-only if you would rather follow the report literally.

Known limit either way: a noise byte that happens to land in printable ASCII is indistinguishable from a one-character message, so that one still goes out.

## Testing

- `test_serial` gains 10 cases for the new helper: CR/LF only, whitespace only, a lone `0xFF`, surrounding-whitespace trimming, control characters mid-message, interior newline/tab kept, valid multi-byte UTF-8 preserved, invalid UTF-8 dropped, plain text untouched, empty read.
- `test_utf8` gains 8 cases for the extracted primitive.
- Each new case was watched failing first against a stub helper, then passing against the implementation, with the pre-existing cases green throughout.
- `test_serial` 20/20 and `test_utf8` 30/30 under the sanitized `coverage` env.
- Full native suite in Docker on a macOS host: 862 cases, 858 passed. The two failures are `test_packet_signing` `test_B11_normal_unicast_still_uses_pki` and `test_B12_licensed_receiver_does_not_decrypt_pki`, which fail identically on an unmodified export of the parent commit, so they are pre-existing and unrelated. One suite (`test_traceroute_nexthop`) errored on an out-of-memory `cc1plus` kill inside my 2 GB container and passes 3/3 when run on its own.
- Cross-compiled `heltec-v3` to check the arch-guarded call site: SUCCESS.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)

I do not have a Meshtastic device, so the hardware boxes are deliberately unchecked: the behaviour is verified by the native unit tests and the `heltec-v3` build only, and the real UART path has not been exercised. A check from anyone with a TEXTMSG-configured node and a serial adapter would be very welcome - pressing ENTER should now send nothing, and a cold boot should no longer emit a stray message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Serial text messages are sanitized before transmission by removing invalid UTF-8, unsupported control characters, and surrounding whitespace.
  * Empty messages after sanitization are not transmitted.
  * Tabs, newlines, interior spacing, and valid UTF-8 content are preserved.

* **Bug Fixes**
  * Improved handling of truncated, malformed, overlong, and invalid Unicode sequences.

* **Tests**
  * Added coverage for UTF-8 validation and serial message sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->