### PR TITLE
Update earlephilhower/arduino-pico to 6.0.0 on rp2350 as well

### DIFF
--- a/variants/rp2350/rp2350.ini
+++ b/variants/rp2350/rp2350.ini
@@ -7,7 +7,7 @@ platform =
 extends = arduino_base
 platform_packages =
   # TODO renovate
-  arduino-pico@https://github.com/earlephilhower/arduino-pico/releases/download/5.7.0/rp2040-5.7.0.zip
+  arduino-pico@https://github.com/earlephilhower/arduino-pico/releases/download/6.0.0/rp2040-6.0.0.zip
 
 board_build.core = earlephilhower
 board_build.filesystem_size = 0.5m


### PR DESCRIPTION
follow-up for #11351, bump arduino-pico to 6.0.0 on RP2350 platform as well.
## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] Wiznet W5500-EVB-Pico2 (paired with Wio-SX1262)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `arduino-pico` package for RP2350 targets to version 6.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->