### PR TITLE
feat(stm32wl): add ST Nucleo-WL55JC variant

### DIFF
--- a/variants/stm32/nucleo_wl55jc/platformio.ini
+++ b/variants/stm32/nucleo_wl55jc/platformio.ini
@@ -1,0 +1,23 @@
+; ST Nucleo-WL55JC dev board
+; https://www.st.com/en/evaluation-tools/nucleo-wl55jc.html
+[env:nucleo_wl55jc]
+extends = stm32_base
+board = nucleo_wl55jc
+board_level = pr
+board_upload.maximum_size = 247808 ; reserve the last 14KB for filesystem
+build_flags =
+  ${stm32_base.build_flags}
+  -Ivariants/stm32/nucleo_wl55jc
+  -DPRIVATE_HW
+  -DENABLE_HWSERIAL2
+  -DHAS_GPS=1
+  -DGPS_SERIAL_PORT=Serial2 ; Default Serial object is used for onboard ST-Link VCP
+  -DHAS_SENSOR=1
+lib_deps =
+  ${stm32_base.lib_deps}
+  # renovate: datasource=github-tags depName=STM32RTC packageName=stm32duino/STM32RTC
+  https://github.com/stm32duino/STM32RTC/archive/refs/tags/1.9.0.zip
+  # renovate: datasource=github-tags depName=STM32LowPower packageName=stm32duino/STM32LowPower
+  https://github.com/stm32duino/STM32LowPower/archive/refs/tags/1.5.0.zip
+
+upload_port = stlink

--- a/variants/stm32/nucleo_wl55jc/rfswitch.h
+++ b/variants/stm32/nucleo_wl55jc/rfswitch.h
@@ -1,0 +1,9 @@
+// Canonical RF switch macros from variant_NUCLEO_WL55JC1.h
+// UM2592 S6.6.3: RF overview
+static const RADIOLIB_PIN_TYPE rfswitch_pins[5] = {LORAWAN_RFSWITCH_PINS, RADIOLIB_NC, RADIOLIB_NC};
+
+static const Module::RfSwitchMode_t rfswitch_table[5] = {{STM32WLx::MODE_IDLE, {LORAWAN_RFSWITCH_OFF_VALUES}},
+                                                         {STM32WLx::MODE_RX, {LORAWAN_RFSWITCH_RX_VALUES}},
+                                                         {STM32WLx::MODE_TX_LP, {LORAWAN_RFSWITCH_RFO_LP_VALUES}},
+                                                         {STM32WLx::MODE_TX_HP, {LORAWAN_RFSWITCH_RFO_HP_VALUES}},
+                                                         END_OF_MODE_TABLE};

--- a/variants/stm32/nucleo_wl55jc/variant.h
+++ b/variants/stm32/nucleo_wl55jc/variant.h
@@ -1,0 +1,59 @@
+/*
+ST Nucleo-WL55JC (MB1389)
+https://www.st.com/en/evaluation-tools/nucleo-wl55jc.html
+*/
+
+#ifndef _VARIANT_NUCLEO_WL55JC_
+#define _VARIANT_NUCLEO_WL55JC_
+
+#define USE_STM32WLx
+
+// Pin mappings from UM2592: User Manual, STM32WL Nucleo-64 board (MB1389)
+// https://www.st.com/resource/en/user_manual/um2592-stm32wl-nucleo64-board-mb1389-stmicroelectronics.pdf
+
+// Human-readable pin macros from variant_NUCLEO_WL55JC1.h
+
+// UM2592 S6.6.1: LEDs
+#define LED_POWER LED_GREEN
+#define LED_STATE_ON 1
+#define LED_LORA LED_RED
+#define LED_NOTIFICATION LED_BLUE
+
+// UM2592 S6.6.2: Push-buttons
+#define BUTTON_PIN B1_BTN // WKUP1-capable
+#define BUTTON_NEED_PULLUP
+#define ALT_BUTTON_PIN B2_BTN
+#define CANCEL_BUTTON_PIN B3_BTN
+#define CANCEL_BUTTON_ACTIVE_LOW true
+#define CANCEL_BUTTON_ACTIVE_PULLUP true
+
+// UM2592 S7.4: Arduino UNO R3 connectors - SPI
+// Arduino UNO R3 header: CS/D10, MOSI/D11, MISO/D12, SCK/D13
+#define PIN_SPI_MOSI PA7
+#define PIN_SPI_MISO PA6
+#define PIN_SPI_SCK PA5
+
+// UM2592 S7.4: Arduino UNO R3 connectors - UART (GPS, etc.)
+// Arduino UNO R3 header: RX/D0, TX/D1
+#define PIN_SERIAL2_TX PB6
+#define PIN_SERIAL2_RX PB7
+
+// UM2592 S7.4: Arduino UNO R3 connectors - I2C
+// Arduino UNO R3 header: SDA/D14, SCL/D15
+#define PIN_WIRE_SDA PA11
+#define PIN_WIRE_SCL PA12
+
+// RM0453 S18.10: Battery voltage monitoring
+// Internal VBAT ADC channel; VBAT bridged to VDD_SYS by SB21
+#define BATTERY_PIN AVBAT
+#define ADC_MULTIPLIER (1.01f * 3)
+
+// UM2592 S6.5.2: LSE clock
+#define HAS_LSE 1
+#define STM32WL_LSE_DRIVE RCC_LSEDRIVE_LOW
+
+// UM2592 S6.5.1: HSE clock (used for sub-GHz radio as well)
+// NDK NT2016SF-32M-END5875A
+#define SX126X_DIO3_TCXO_VOLTAGE 1.7
+
+#endif


### PR DESCRIPTION
STM32 Nucleo-64 development board with STM32WL55JC MCU, SMPS, supports Arduino and ST morpho connectivity.

https://www.st.com/en/evaluation-tools/nucleo-wl55jc.html

I am actually thinking this board should be the first candidate for STM32WL to be promoted to a release-level board, but what do you think?

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] ST NUCLEO-WL55JC1 (MB1389E-02)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the STM32 Nucleo-WL55JC board, including connectivity, battery monitoring, clock, LED, button, and radio configuration.
  - Added RF switch modes for idle, receive, low-power transmit, and high-power transmit operation.
- **Bug Fixes**
  - Improved initialization of the optional LoRa status LED on compatible boards.
  - Prevented duplicate LoRa LED configuration during board startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->