### PR TITLE
fix(lora): skip DIO detach when no ISR is attached

### DIFF
--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -318,7 +318,7 @@ template <typename T> bool LR11x0Interface<T>::reconfigure()
     return true;
 }
 
-template <typename T> void LR11x0Interface<T>::disableInterrupt()
+template <typename T> void LR11x0Interface<T>::clearRadioIsr()
 {
     lora.clearIrqAction();
 }

--- a/src/mesh/LR11x0Interface.h
+++ b/src/mesh/LR11x0Interface.h
@@ -47,12 +47,12 @@ template <class T> class LR11x0Interface : public RadioLibInterface
     /**
      * Glue functions called from ISR land
      */
-    virtual void disableInterrupt() override;
+    virtual void clearRadioIsr() override;
 
     /**
      * Enable a particular ISR callback glue function
      */
-    virtual void enableInterrupt(void (*callback)()) { lora.setIrqAction(callback); }
+    virtual void setRadioIsr(void (*callback)()) override { lora.setIrqAction(callback); }
 
     /** can we detect a LoRa preamble on the current channel? */
     virtual bool isChannelActive() override;

--- a/src/mesh/LR20x0Interface.cpp
+++ b/src/mesh/LR20x0Interface.cpp
@@ -323,7 +323,7 @@ template <typename T> bool LR20x0Interface<T>::reconfigure()
     return success;
 }
 
-template <typename T> void LR20x0Interface<T>::disableInterrupt()
+template <typename T> void LR20x0Interface<T>::clearRadioIsr()
 {
     lora.clearIrqAction();
 }

--- a/src/mesh/LR20x0Interface.h
+++ b/src/mesh/LR20x0Interface.h
@@ -42,12 +42,12 @@ template <class T> class LR20x0Interface : public RadioLibInterface
     /**
      * Glue functions called from ISR land
      */
-    virtual void disableInterrupt() override;
+    virtual void clearRadioIsr() override;
 
     /**
      * Enable a particular ISR callback glue function
      */
-    virtual void enableInterrupt(void (*callback)()) { lora.setIrqAction(callback); }
+    virtual void setRadioIsr(void (*callback)()) override { lora.setIrqAction(callback); }
 
     /** can we detect a LoRa preamble on the current channel? */
     virtual bool isChannelActive() override;

--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -201,7 +201,7 @@ bool RF95Interface::init()
     return res == RADIOLIB_ERR_NONE;
 }
 
-void RF95Interface::disableInterrupt()
+void RF95Interface::clearRadioIsr()
 {
     lora->clearDio0Action();
 }

--- a/src/mesh/RF95Interface.h
+++ b/src/mesh/RF95Interface.h
@@ -35,14 +35,14 @@ class RF95Interface : public RadioLibInterface
     /**
      * Glue functions called from ISR land
      */
-    virtual void disableInterrupt() override;
+    virtual void clearRadioIsr() override;
 
     int16_t getCurrentRSSI() override;
 
     /**
      * Enable a particular ISR callback glue function
      */
-    virtual void enableInterrupt(void (*callback)()) { lora->setDio0Action(callback, RISING); }
+    virtual void setRadioIsr(void (*callback)()) override { lora->setDio0Action(callback, RISING); }
 
     /** can we detect a LoRa preamble on the current channel? */
     virtual bool isChannelActive() override;

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -99,8 +99,8 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
     /// are _trying_ to receive a packet currently (note - we might just be waiting for one)
     bool isReceiving = false;
 
-    /// is the radio IRQ handler currently armed? (cleared from ISR context, hence volatile)
-    volatile bool isrAttached = false;
+    /// has the radio IRQ ever been armed? latches true and is never cleared, so ISR context only reads it
+    volatile bool isrEverArmed = false;
 
   protected:
     // Noise floor tracking - rolling window of samples.
@@ -148,14 +148,13 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
     /**
      * Glue functions called from ISR land
      *
-     * Skip the detach if nothing is attached: the first setStandby() runs before any
+     * Skip the detach until the IRQ has been armed once: the first setStandby() runs before any
      * enableInterrupt(), and ESP-IDF logs "GPIO isr service is not installed" for that call.
      */
     void disableInterrupt()
     {
-        if (!isrAttached)
+        if (!isrEverArmed)
             return;
-        isrAttached = false;
         clearRadioIsr();
     }
 
@@ -164,8 +163,8 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
      */
     void enableInterrupt(void (*callback)())
     {
-        // Mark attached before arming, so an ISR firing right away still detaches.
-        isrAttached = true;
+        // Latch before arming: the ISR can fire the moment the handler is installed.
+        isrEverArmed = true;
         setRadioIsr(callback);
     }
 

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -99,6 +99,9 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
     /// are _trying_ to receive a packet currently (note - we might just be waiting for one)
     bool isReceiving = false;
 
+    /// is the radio IRQ handler currently armed? (cleared from ISR context, hence volatile)
+    volatile bool isrAttached = false;
+
   protected:
     // Noise floor tracking - rolling window of samples.
     static const uint8_t NOISE_FLOOR_SAMPLES = 20;
@@ -144,13 +147,27 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
 
     /**
      * Glue functions called from ISR land
+     *
+     * Skip the detach if nothing is attached: the first setStandby() runs before any
+     * enableInterrupt(), and ESP-IDF logs "GPIO isr service is not installed" for that call.
      */
-    virtual void disableInterrupt() = 0;
+    void disableInterrupt()
+    {
+        if (!isrAttached)
+            return;
+        isrAttached = false;
+        clearRadioIsr();
+    }
 
     /**
      * Enable a particular ISR callback glue function
      */
-    virtual void enableInterrupt(void (*)()) = 0;
+    void enableInterrupt(void (*callback)())
+    {
+        // Mark attached before arming, so an ISR firing right away still detaches.
+        isrAttached = true;
+        setRadioIsr(callback);
+    }
 
     /**
      * Poll as a backup to catch missed edge-triggered interrupts.
@@ -299,6 +316,10 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
      * Add SNR data to received messages
      */
     virtual void addReceiveMetadata(meshtastic_MeshPacket *mp) = 0;
+
+    /** Chip specific arm/disarm of the radio IRQ; call enableInterrupt()/disableInterrupt() instead */
+    virtual void setRadioIsr(void (*callback)()) = 0;
+    virtual void clearRadioIsr() = 0;
 
     /**
      * Subclasses must override, implement and then call into this base class implementation

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -250,7 +250,7 @@ template <typename T> int16_t SX126xInterface<T>::getCurrentRSSI()
     return (int16_t)round(rssi);
 }
 
-template <typename T> void SX126xInterface<T>::enableInterrupt(void (*callback)())
+template <typename T> void SX126xInterface<T>::setRadioIsr(void (*callback)())
 {
 #ifdef LORA_DIO1_SOFTWARE_POLL
     irqPollingActive = true;
@@ -261,7 +261,7 @@ template <typename T> void SX126xInterface<T>::enableInterrupt(void (*callback)(
 #endif
 }
 
-template <typename T> void SX126xInterface<T>::disableInterrupt()
+template <typename T> void SX126xInterface<T>::clearRadioIsr()
 {
 #ifdef LORA_DIO1_SOFTWARE_POLL
     irqPollingActive = false;

--- a/src/mesh/SX126xInterface.h
+++ b/src/mesh/SX126xInterface.h
@@ -47,12 +47,12 @@ template <class T> class SX126xInterface : public RadioLibInterface
     /**
      * Glue functions called from ISR land
      */
-    virtual void disableInterrupt() override;
+    virtual void clearRadioIsr() override;
 
     /**
      * Enable a particular ISR callback glue function
      */
-    virtual void enableInterrupt(void (*callback)()) override;
+    virtual void setRadioIsr(void (*callback)()) override;
 
 #ifdef LORA_DIO1_SOFTWARE_POLL
     void handleSoftwareLoraIrqPoll() override;

--- a/src/mesh/SX128xInterface.cpp
+++ b/src/mesh/SX128xInterface.cpp
@@ -156,7 +156,7 @@ template <typename T> bool SX128xInterface<T>::reconfigure()
     return true;
 }
 
-template <typename T> void SX128xInterface<T>::disableInterrupt()
+template <typename T> void SX128xInterface<T>::clearRadioIsr()
 {
     lora.clearDio1Action();
 }

--- a/src/mesh/SX128xInterface.h
+++ b/src/mesh/SX128xInterface.h
@@ -43,12 +43,12 @@ template <class T> class SX128xInterface : public RadioLibInterface
     /**
      * Glue functions called from ISR land
      */
-    virtual void disableInterrupt() override;
+    virtual void clearRadioIsr() override;
 
     /**
      * Enable a particular ISR callback glue function
      */
-    virtual void enableInterrupt(void (*callback)()) { lora.setDio1Action(callback); }
+    virtual void setRadioIsr(void (*callback)()) override { lora.setDio1Action(callback); }
 
     /** can we detect a LoRa preamble on the current channel? */
     virtual bool isChannelActive() override;


### PR DESCRIPTION
The first `startReceive()` -> `setStandby()` -> `disableInterrupt()` runs before any `enableInterrupt()`, so RadioLib detaches a never-attached GPIO and ESP-IDF logs `gpio_isr_handler_remove(): GPIO isr service is not installed`.

`RadioLibInterface` now tracks whether the IRQ is armed and skips the detach when it is not. Chip drivers implement `setRadioIsr()`/`clearRadioIsr()`; the `enableInterrupt()`/`disableInterrupt()` call sites are unchanged. Applies to SX126x, SX128x, LR11x0, LR20x0 and RF95.

Fixes #11371

Compile checked with `native-windows`. Not verified on hardware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized radio interrupt setup and clearing across supported radio hardware.
  * Improved interrupt lifecycle handling so clearing an interrupt is safely ignored when no interrupt is attached.
  * Preserved existing callback registration and radio interrupt behavior across LR11x0, LR20x0, RF95, SX126x, and SX128x devices.
  * Updated interface naming for clearer, more consistent radio ISR management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->