### PR TITLE
fix(bin): repair the Windows device-install and device-update scripts

### DIFF
--- a/bin/device-install.bat
+++ b/bin/device-install.bat
@@ -112,7 +112,7 @@ IF EXIST !METAFILE! (
 
 CALL :LOG_MESSAGE DEBUG "Determine the correct esptool command to use..."
 IF NOT "__%PYTHON%__"=="____" (
-    SET "ESPTOOL_CMD=!PYTHON! -m esptool"
+    SET "ESPTOOL_CMD="!PYTHON!" -m esptool"
     CALL :LOG_MESSAGE DEBUG "Python interpreter supplied."
 ) ELSE (
     CALL :LOG_MESSAGE DEBUG "Python interpreter NOT supplied. Looking for esptool..."
@@ -127,7 +127,9 @@ IF NOT "__%PYTHON%__"=="____" (
 )
 
 CALL :LOG_MESSAGE DEBUG "Checking esptool command !ESPTOOL_CMD!..."
-!ESPTOOL_CMD! >nul 2>&1
+@REM %VAR% not !VAR!: cmd will not split a delayed-expanded command token that
+@REM carries a path, so the "python -m esptool" form never starts.
+%ESPTOOL_CMD% >nul 2>&1
 IF %ERRORLEVEL% EQU 9009 (
     @REM 9009 = command not found on Windows
     CALL :LOG_MESSAGE ERROR "esptool not found: !ESPTOOL_CMD!"
@@ -214,7 +216,7 @@ EXIT /B %ERRORLEVEL%
 @REM Example:: CALL :RUN_ESPTOOL 115200 write_flash 0x10000 "firmwarefile.bin"
 IF %DEBUG% EQU 1 CALL :LOG_MESSAGE DEBUG "About to run command: !ESPTOOL_CMD! --baud %~1 %~2 %~3 %~4"
 CALL :RESET_ERROR
-!ESPTOOL_CMD! --baud %~1 %~2 %~3 %~4
+%ESPTOOL_CMD% --baud %~1 %~2 %~3 %~4
 IF %BPS_RESET% EQU 1 GOTO :eof
 IF %ERRORLEVEL% NEQ 0 (
     CALL :LOG_MESSAGE ERROR "Error running command: !ESPTOOL_CMD! --baud %~1 %~2 %~3 %~4"

--- a/bin/device-install.bat
+++ b/bin/device-install.bat
@@ -70,7 +70,8 @@ IF "__!FILENAME!__"=="____" (
         CALL :LOG_MESSAGE ERROR "Filename containing spaces are not supported."
         GOTO help
     )
-    IF NOT "__!FILENAME:.factory.bin=!__"=="__!FILENAME!__" (
+    @REM Unchanged after stripping means the suffix was absent.
+    IF "__!FILENAME:.factory.bin=!__"=="__!FILENAME!__" (
         CALL :LOG_MESSAGE ERROR "Filename must be a firmware-*.factory.bin file."
         GOTO help
     )
@@ -132,6 +133,21 @@ IF %ERRORLEVEL% EQU 9009 (
     CALL :LOG_MESSAGE ERROR "esptool not found: !ESPTOOL_CMD!"
     EXIT /B 1
 )
+
+@REM esptool v5 renamed subcommands to dashes; older versions only take underscores.
+@REM Probe here: the --debug and --port rewrites below leave ESPTOOL_CMD unusable.
+SET "ESPTOOL_WRITE_FLASH=write_flash"
+SET "ESPTOOL_ERASE_FLASH=erase_flash"
+SET "ESPTOOL_READ_FLASH_STATUS=read_flash_status"
+%ESPTOOL_CMD% 2>&1 | findstr /C:"write-flash" >nul
+IF !ERRORLEVEL! EQU 0 (
+    SET "ESPTOOL_WRITE_FLASH=write-flash"
+    SET "ESPTOOL_ERASE_FLASH=erase-flash"
+    SET "ESPTOOL_READ_FLASH_STATUS=read-flash-status"
+)
+CALL :RESET_ERROR
+CALL :LOG_MESSAGE DEBUG "Using esptool write command: !ESPTOOL_WRITE_FLASH!"
+
 IF %DEBUG% EQU 1 (
     CALL :LOG_MESSAGE DEBUG "Skipping ESPTOOL_CMD steps."
     SET "ESPTOOL_CMD=REM !ESPTOOL_CMD!"
@@ -148,7 +164,7 @@ CALL :LOG_MESSAGE INFO "Using esptool baud: !ESPTOOL_BAUD!."
 
 IF %BPS_RESET% EQU 1 (
     @REM Attempt to change mode via 1200bps Reset.
-    CALL :RUN_ESPTOOL 1200 --after no_reset read_flash_status
+    CALL :RUN_ESPTOOL 1200 --after no_reset !ESPTOOL_READ_FLASH_STATUS!
     GOTO eof
 )
 
@@ -174,14 +190,14 @@ IF NOT EXIST !SPIFFS_FILENAME! CALL :LOG_MESSAGE ERROR "File does not exist: "!S
 
 @REM Flashing operations.
 CALL :LOG_MESSAGE INFO "Trying to flash "!FILENAME!", but first erasing and writing system information..."
-CALL :RUN_ESPTOOL !ESPTOOL_BAUD! erase_flash || GOTO eof
-CALL :RUN_ESPTOOL !ESPTOOL_BAUD! write_flash 0x00 "!FILENAME!" || GOTO eof
+CALL :RUN_ESPTOOL !ESPTOOL_BAUD! !ESPTOOL_ERASE_FLASH! || GOTO eof
+CALL :RUN_ESPTOOL !ESPTOOL_BAUD! !ESPTOOL_WRITE_FLASH! 0x00 "!FILENAME!" || GOTO eof
 
 CALL :LOG_MESSAGE INFO "Trying to flash BLEOTA "!OTA_FILENAME!" at OTA_OFFSET !OTA_OFFSET!..."
-CALL :RUN_ESPTOOL !ESPTOOL_BAUD! write_flash !OTA_OFFSET! "!OTA_FILENAME!" || GOTO eof
+CALL :RUN_ESPTOOL !ESPTOOL_BAUD! !ESPTOOL_WRITE_FLASH! !OTA_OFFSET! "!OTA_FILENAME!" || GOTO eof
 
 CALL :LOG_MESSAGE INFO "Trying to flash SPIFFS "!SPIFFS_FILENAME!" at SPIFFS_OFFSET !SPIFFS_OFFSET!..."
-CALL :RUN_ESPTOOL !ESPTOOL_BAUD! write_flash !SPIFFS_OFFSET! "!SPIFFS_FILENAME!" || GOTO eof
+CALL :RUN_ESPTOOL !ESPTOOL_BAUD! !ESPTOOL_WRITE_FLASH! !SPIFFS_OFFSET! "!SPIFFS_FILENAME!" || GOTO eof
 
 CALL :LOG_MESSAGE INFO "Script complete!."
 

--- a/bin/device-install.bat
+++ b/bin/device-install.bat
@@ -70,8 +70,7 @@ IF "__!FILENAME!__"=="____" (
         CALL :LOG_MESSAGE ERROR "Filename containing spaces are not supported."
         GOTO help
     )
-    @REM Unchanged after stripping means the suffix was absent.
-    IF "__!FILENAME:.factory.bin=!__"=="__!FILENAME!__" (
+    IF /I NOT "!FILENAME:~-12!"==".factory.bin" (
         CALL :LOG_MESSAGE ERROR "Filename must be a firmware-*.factory.bin file."
         GOTO help
     )
@@ -130,8 +129,10 @@ CALL :LOG_MESSAGE DEBUG "Checking esptool command !ESPTOOL_CMD!..."
 @REM %VAR% not !VAR!: cmd will not split a delayed-expanded command token that
 @REM carries a path, so the "python -m esptool" form never starts.
 %ESPTOOL_CMD% >nul 2>&1
-IF %ERRORLEVEL% EQU 9009 (
-    @REM 9009 = command not found on Windows
+SET "ESPTOOL_EXIT=!ERRORLEVEL!"
+@REM 9009 = command not found, 3 = bad path from -P. Both mean unusable.
+IF !ESPTOOL_EXIT! EQU 3 SET "ESPTOOL_EXIT=9009"
+IF !ESPTOOL_EXIT! EQU 9009 (
     CALL :LOG_MESSAGE ERROR "esptool not found: !ESPTOOL_CMD!"
     EXIT /B 1
 )

--- a/bin/device-update.bat
+++ b/bin/device-update.bat
@@ -90,7 +90,7 @@ IF NOT "__!FILENAME:.factory.bin=!__"=="__!FILENAME!__" (
 
 CALL :LOG_MESSAGE DEBUG "Determine the correct esptool command to use..."
 IF NOT "__%PYTHON%__"=="____" (
-    SET "ESPTOOL_CMD=""!PYTHON!"" -m esptool"
+    SET "ESPTOOL_CMD="!PYTHON!" -m esptool"
     CALL :LOG_MESSAGE DEBUG "Python interpreter supplied."
 ) ELSE (
     CALL :LOG_MESSAGE DEBUG "Python interpreter NOT supplied. Looking for esptool..."
@@ -105,7 +105,9 @@ IF NOT "__%PYTHON%__"=="____" (
 )
 
 CALL :LOG_MESSAGE DEBUG "Checking esptool command !ESPTOOL_CMD!..."
-!ESPTOOL_CMD! >nul 2>&1
+@REM %VAR% not !VAR!: cmd will not split a delayed-expanded command token that
+@REM carries a path, so the "python -m esptool" form never starts.
+%ESPTOOL_CMD% >nul 2>&1
 CALL :LOG_MESSAGE DEBUG "esptool exit code: %ERRORLEVEL%"
 IF %ERRORLEVEL% EQU 9009 (
     @REM 9009 = command not found on Windows
@@ -166,7 +168,7 @@ EXIT /B %ERRORLEVEL%
 @REM Example:: CALL :RUN_ESPTOOL 115200 write-flash 0x10000 "firmwarefile.bin"
 IF %DEBUG% EQU 1 CALL :LOG_MESSAGE DEBUG "About to run command: !ESPTOOL_CMD! --baud %~1 %~2 %~3 %~4"
 CALL :RESET_ERROR
-!ESPTOOL_CMD! --baud %~1 %~2 %~3 %~4
+%ESPTOOL_CMD% --baud %~1 %~2 %~3 %~4
 IF %CHANGE_MODE% EQU 1 GOTO :eof
 IF %ERRORLEVEL% NEQ 0 (
     CALL :LOG_MESSAGE ERROR "Error running command: !ESPTOOL_CMD! --baud %~1 %~2 %~3 %~4"

--- a/bin/device-update.bat
+++ b/bin/device-update.bat
@@ -112,6 +112,21 @@ IF %ERRORLEVEL% EQU 9009 (
     CALL :LOG_MESSAGE ERROR "esptool not found: !ESPTOOL_CMD!"
     EXIT /B 1
 )
+
+@REM esptool v5 renamed subcommands to dashes; older versions only take underscores.
+@REM Probe here: the --debug and --port rewrites below leave ESPTOOL_CMD unusable.
+SET "ESPTOOL_WRITE_FLASH=write_flash"
+SET "ESPTOOL_ERASE_FLASH=erase_flash"
+SET "ESPTOOL_READ_FLASH_STATUS=read_flash_status"
+%ESPTOOL_CMD% 2>&1 | findstr /C:"write-flash" >nul
+IF !ERRORLEVEL! EQU 0 (
+    SET "ESPTOOL_WRITE_FLASH=write-flash"
+    SET "ESPTOOL_ERASE_FLASH=erase-flash"
+    SET "ESPTOOL_READ_FLASH_STATUS=read-flash-status"
+)
+CALL :RESET_ERROR
+CALL :LOG_MESSAGE DEBUG "Using esptool write command: !ESPTOOL_WRITE_FLASH!"
+
 IF %DEBUG% EQU 1 (
     CALL :LOG_MESSAGE DEBUG "Skipping ESPTOOL_CMD steps."
     SET "ESPTOOL_CMD=REM !ESPTOOL_CMD!"
@@ -128,13 +143,13 @@ CALL :LOG_MESSAGE INFO "Using esptool baud: !ESPTOOL_BAUD!."
 
 IF %CHANGE_MODE% EQU 1 (
     @REM Attempt to change mode via 1200bps Reset.
-    CALL :RUN_ESPTOOL !RESET_BAUD! --after no_reset read_flash_status
+    CALL :RUN_ESPTOOL !RESET_BAUD! --after no_reset !ESPTOOL_READ_FLASH_STATUS!
     GOTO eof
 )
 
 @REM Flashing operations.
 CALL :LOG_MESSAGE INFO "Trying to flash update "!FILENAME!" at OFFSET !UPDATE_OFFSET!..."
-CALL :RUN_ESPTOOL !ESPTOOL_BAUD! write-flash !UPDATE_OFFSET! "!FILENAME!" || GOTO eof
+CALL :RUN_ESPTOOL !ESPTOOL_BAUD! !ESPTOOL_WRITE_FLASH! !UPDATE_OFFSET! "!FILENAME!" || GOTO eof
 
 CALL :LOG_MESSAGE INFO "Script complete!."
 

--- a/bin/device-update.bat
+++ b/bin/device-update.bat
@@ -108,9 +108,11 @@ CALL :LOG_MESSAGE DEBUG "Checking esptool command !ESPTOOL_CMD!..."
 @REM %VAR% not !VAR!: cmd will not split a delayed-expanded command token that
 @REM carries a path, so the "python -m esptool" form never starts.
 %ESPTOOL_CMD% >nul 2>&1
-CALL :LOG_MESSAGE DEBUG "esptool exit code: %ERRORLEVEL%"
-IF %ERRORLEVEL% EQU 9009 (
-    @REM 9009 = command not found on Windows
+SET "ESPTOOL_EXIT=!ERRORLEVEL!"
+CALL :LOG_MESSAGE DEBUG "esptool exit code: !ESPTOOL_EXIT!"
+@REM 9009 = command not found, 3 = bad path from -P. Both mean unusable.
+IF !ESPTOOL_EXIT! EQU 3 SET "ESPTOOL_EXIT=9009"
+IF !ESPTOOL_EXIT! EQU 9009 (
     CALL :LOG_MESSAGE ERROR "esptool not found: !ESPTOOL_CMD!"
     EXIT /B 1
 )


### PR DESCRIPTION
Fixes #8156

- `device-install.bat` rejected every valid `firmware-*.factory.bin` name. The substring-strip comparison was negated, so it errored when the suffix was present.
- `device-install.bat` hardcoded the esptool v4 subcommand names. Both scripts now probe the help output once and pick the underscore or dash spelling, mirroring `bin/device-install.sh`.
- `device-update.bat` mixed the v5 `write-flash` with the v4 `read_flash_status`, so it worked fully on neither version. Not previously reported.
- `-P <python>` never worked in either script. cmd does not split a delayed-expanded command token carrying a path into program and arguments, so it exited 9009 as `esptool not found`. `device-update.bat` also doubled the quotes around the interpreter. Paths with spaces work now too.

Tested on Windows cmd.exe against esptool 4.8.1 and 5.3.1, with and without `-P`. No hardware, so offsets are unverified; they are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firmware installation and update reliability when using Python-based flashing tools.
  * Added validation to ensure installation files use the expected factory firmware format.
  * Improved handling of paths containing spaces and clearer startup error processing.
* **Compatibility**
  * Added support for different command naming conventions across flashing tool versions.
  * Reset, erase, status, and flashing operations now adapt automatically to the detected tool version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->