### PR TITLE
Fix SerialConsole handling of sliced stream

### DIFF
--- a/src/SerialConsole.cpp
+++ b/src/SerialConsole.cpp
@@ -125,6 +125,10 @@ int32_t SerialConsole::runOnce()
 
     int32_t delay = runOncePart();
 #if defined(SERIAL_HAS_ON_RECEIVE) || defined(CONFIG_IDF_TARGET_ESP32S2)
+    // runOncePart() returns 0 when writeStream() stopped at its slice budget with more queued;
+    // parking on INT32_MAX there strands the dump until the host happens to send a byte.
+    if (delay == 0)
+        return 0;
     return Port.available() ? delay : INT32_MAX;
 #elif defined(IS_USB_SERIAL)
     return HWCDC::isPlugged() ? delay : (1000 * 20);


### PR DESCRIPTION
Updates `SerialConsole` to pass through the continue-streaming indicator introduced with the stream slicing of #11164.

d89f3eb8f introduces slicing of the stream into 100ms chunks to prevent hardware watchdogs from treating long streams as stalls and restarting mid-stream. It returns a delay of 0 to tell the loop to immediately come back to the stream for more slices. The `SerialModule` and `ServerAPI` pass this through. However, the `SerialConsole` caller of `runOncePart` instead rewrites the delay to `INT32_MAX` if the host does not have any bytes waiting. This causes certain serial connections such as using the CLI to interact with an ESP32 node connected as a UART console to time out, since it's waiting for 24 days before getting the next slice.

Reproduction: `$ meshtastic --info` with a Heltec V3 flashed to `2.8.0.512154f` times out.

Full disclosure: Claude Code (Opus) helped me track this down.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serial console responsiveness by ensuring queued output is sent promptly without unnecessary delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->