### PR TITLE
fix(stm32wl): smaller MAX_RX_TOPHONE and PACKETHISTORY_MAX on stm32wl

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -46,9 +46,8 @@
 // Live in-flight packet bytes are tracked under "pktpool(live)" in the MemAudit breakdown
 static MemoryDynamic<meshtastic_MeshPacket> dynamicPool("pktpool(live)");
 Allocator<meshtastic_MeshPacket> &packetPool = dynamicPool;
-#elif defined(ARCH_STM32WL) || defined(BOARD_HAS_PSRAM)
-// On STM32 and boards with PSRAM, there isn't enough heap left over for the rest of the firmware if we allocate this statically.
-// For now, make it dynamic again.
+#elif defined(BOARD_HAS_PSRAM)
+// On boards with PSRAM, there is enough heap for dynamic memory pools
 #define MAX_PACKETS                                                                                                              \
     (MAX_RX_TOPHONE + MAX_RX_FROMRADIO + 2 * MAX_TX_QUEUE +                                                                      \
      2) // max number of packets which can be in flight (either queued from reception or queued for sending)

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -46,8 +46,9 @@
 // Live in-flight packet bytes are tracked under "pktpool(live)" in the MemAudit breakdown
 static MemoryDynamic<meshtastic_MeshPacket> dynamicPool("pktpool(live)");
 Allocator<meshtastic_MeshPacket> &packetPool = dynamicPool;
-#elif defined(BOARD_HAS_PSRAM)
-// On boards with PSRAM, there is enough heap for dynamic memory pools
+#elif defined(ARCH_STM32WL) || defined(BOARD_HAS_PSRAM)
+// On STM32 and boards with PSRAM, there isn't enough heap left over for the rest of the firmware if we allocate this statically.
+// For now, make it dynamic again.
 #define MAX_PACKETS                                                                                                              \
     (MAX_RX_TOPHONE + MAX_RX_FROMRADIO + 2 * MAX_TX_QUEUE +                                                                      \
      2) // max number of packets which can be in flight (either queued from reception or queued for sending)

--- a/src/mesh/mesh-pb-constants.h
+++ b/src/mesh/mesh-pb-constants.h
@@ -26,7 +26,7 @@
 // FIXME - max_count is actually 32 but we save/load this as one long string of preencoded MeshPacket bytes - not a big array in
 // RAM #define MAX_RX_TOPHONE (member_size(DeviceState, receive_queue) / member_size(DeviceState, receive_queue[0]))
 #ifndef MAX_RX_TOPHONE
-#if defined(ARCH_ESP32) && !(defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S3))
+#if defined(ARCH_STM32WL) || (defined(ARCH_ESP32) && !(defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S3)))
 #define MAX_RX_TOPHONE 8
 #elif defined(NRF52840_XXAA)
 // Each slot is a ~340 B MeshPacket in the static pool (Router.cpp MAX_PACKETS_STATIC), so 32 slots
@@ -34,8 +34,6 @@
 // the 8 classic ESP32 has shipped with for years; drops start when a stalled phone/serial client has
 // 16 packets queued.
 #define MAX_RX_TOPHONE 16
-#elif defined(ARCH_STM32WL)
-#define MAX_RX_TOPHONE 8
 #elif MESHTASTIC_MEM_CLASS >= MEM_CLASS_MEDIUM || defined(ARCH_RP2040) || defined(CONFIG_IDF_TARGET_ESP32C3)
 // RP2040/RP2350 and ESP32-C3 keep their historical 32.
 #define MAX_RX_TOPHONE 32

--- a/src/mesh/mesh-pb-constants.h
+++ b/src/mesh/mesh-pb-constants.h
@@ -34,10 +34,10 @@
 // the 8 classic ESP32 has shipped with for years; drops start when a stalled phone/serial client has
 // 16 packets queued.
 #define MAX_RX_TOPHONE 16
-#elif MESHTASTIC_MEM_CLASS >= MEM_CLASS_MEDIUM || defined(ARCH_RP2040) || defined(CONFIG_IDF_TARGET_ESP32C3) ||                  \
-    defined(ARCH_STM32WL)
-// RP2040/RP2350, ESP32-C3 and STM32WL keep their historical 32 (no field pressure to cut them;
-// STM32WL's pool is dynamic, so the constant only bounds in-flight packets there).
+#elif defined(ARCH_STM32WL)
+#define MAX_RX_TOPHONE 8
+#elif MESHTASTIC_MEM_CLASS >= MEM_CLASS_MEDIUM || defined(ARCH_RP2040) || defined(CONFIG_IDF_TARGET_ESP32C3)
+// RP2040/RP2350 and ESP32-C3 keep their historical 32.
 #define MAX_RX_TOPHONE 32
 #else
 #define MAX_RX_TOPHONE 16 // unclassified small parts: fail safe-small
@@ -131,7 +131,11 @@ static inline int get_max_num_nodes()
 /// full mesh, floored at 100. Shared by PacketHistory's constructor clamp and
 /// the boot-cache budget assert below so the two cannot drift.
 #ifndef PACKETHISTORY_MAX
+#if defined(ARCH_STM32WL)
+#define PACKETHISTORY_MAX (MAX_NUM_NODES * 2) // 20 entries for 10-node STM32WL
+#else
 #define PACKETHISTORY_MAX (MAX_NUM_NODES * 2 > 100 ? (uint32_t)(MAX_NUM_NODES * 2) : (uint32_t)100)
+#endif
 #endif
 
 /// Per-map cap (position/telemetry/environment/status): only the freshest


### PR DESCRIPTION
Reducing MAX_RX_TOPHONE and PACKETHISTORY_MAX for stm32wl platform, guarded by ARCH_STM32WL,
to save/maintain some free RAM/heap while ensuring client connection via its serial working.

for MAX_RX_TO_PHONE it's fixed to 8 and it's open question that number is enough or not.
while PACKETHISTORY_MAX is tied to MAX_NUM_NODES which is currently set to 10 for stm32wl.

related PRs(to be added):
- #11223 

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] Seeed Wio-E5 (STM32WL)
    - [x]  Wiznet W5500-EVB-Pico2 (RP2350, paired with Wio-SX1262)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized packet handling for STM32WL devices by reducing the maximum queued packets and packet history size.
  * Helps lower memory usage while retaining support for the expected number of network nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->