### PR TITLE
Request a current GPS position for the map

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1388,25 +1388,23 @@ bool GPS::requestPositionUpdate()
         return false;
     }
 
+    if (hasPositionUpdateRequest &&
+        Throttle::isWithinTimespanMs(lastPositionUpdateRequest, GPS_POSITION_UPDATE_REQUEST_INTERVAL_MS)) {
+        LOG_DEBUG("GPS request cooldown");
+        if (hasValidLocation && positionModule->sendOurPositionToPhone())
+            forwardPositionToPhone = false;
+        return true;
+    }
+
     forwardPositionToPhone = true;
+    hasPositionUpdateRequest = true;
+    lastPositionUpdateRequest = millis();
     if (!enabled) {
         LOG_INFO("GPS request: enable");
-        lastPositionUpdateRequest = millis();
         enable();
     } else if (powerState != GPS_ACTIVE) {
-        if (lastPositionUpdateRequest != 0 &&
-            Throttle::isWithinTimespanMs(lastPositionUpdateRequest, GPS_POSITION_UPDATE_REQUEST_INTERVAL_MS)) {
-            LOG_DEBUG("GPS request cooldown");
-            if (hasValidLocation)
-                positionModule->sendOurPositionToPhone();
-            forwardPositionToPhone = false;
-            return true;
-        }
         LOG_INFO("GPS request");
-        lastPositionUpdateRequest = millis();
         up();
-    } else {
-        lastPositionUpdateRequest = millis();
     }
     setIntervalFromNow(0);
     return true;
@@ -1588,7 +1586,10 @@ int32_t GPS::runOnce()
                 LOG_DEBUG("hasValidLocation RISING EDGE");
             }
 #endif
-            if (updateInterval <= GPS_UPDATE_ALWAYS_ON_THRESHOLD_MS) {
+            if (forwardPositionToPhone) {
+                hasValidLocation = true;
+                shouldPublish = true;
+            } else if (updateInterval <= GPS_UPDATE_ALWAYS_ON_THRESHOLD_MS) {
                 hasValidLocation = true;
                 shouldPublish = true;
             } else if (!hasValidLocation || prev_fixQual == 0 || (fixHoldEnds + GPS_THREAD_INTERVAL) < millis()) {

--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -76,6 +76,7 @@ static struct uBloxGnssModelInfo {
 
 #define GPS_SOL_EXPIRY_MS 5000 // in millis. give 1 second time to combine different sentences. NMEA Frequency isn't higher anyway
 #define NMEA_MSG_GXGSA "GNGSA" // GSA message (GPGSA, GNGSA etc)
+static constexpr uint32_t GPS_POSITION_UPDATE_REQUEST_INTERVAL_MS = 10 * 1000UL;
 
 namespace
 {
@@ -1380,6 +1381,37 @@ void GPS::up()
     setPowerState(GPS_ACTIVE);
 }
 
+bool GPS::requestPositionUpdate()
+{
+    if (!GPSInitFinished || config.position.fixed_position ||
+        config.position.gps_mode != meshtastic_Config_PositionConfig_GpsMode_ENABLED) {
+        return false;
+    }
+
+    forwardPositionToPhone = true;
+    if (!enabled) {
+        LOG_INFO("GPS request: enable");
+        lastPositionUpdateRequest = millis();
+        enable();
+    } else if (powerState != GPS_ACTIVE) {
+        if (lastPositionUpdateRequest != 0 &&
+            Throttle::isWithinTimespanMs(lastPositionUpdateRequest, GPS_POSITION_UPDATE_REQUEST_INTERVAL_MS)) {
+            LOG_DEBUG("GPS request cooldown");
+            if (hasValidLocation)
+                positionModule->sendOurPositionToPhone();
+            forwardPositionToPhone = false;
+            return true;
+        }
+        LOG_INFO("GPS request");
+        lastPositionUpdateRequest = millis();
+        up();
+    } else {
+        lastPositionUpdateRequest = millis();
+    }
+    setIntervalFromNow(0);
+    return true;
+}
+
 // We've finished a GPS search cycle (lock or timeout). Enter a low power state, potentially.
 void GPS::down()
 {
@@ -1449,7 +1481,12 @@ void GPS::publishUpdate()
         const meshtastic::GPSStatus status = meshtastic::GPSStatus(hasValidLocation, isConnected(), isPowerSaving(), p, gotTime);
         newStatus.notifyObservers(&status);
         if (config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED) {
-            positionModule->handleNewPosition();
+            if (forwardPositionToPhone && hasValidLocation) {
+                forwardPositionToPhone = false;
+                positionModule->sendOurPositionToPhone();
+            } else if (!forwardPositionToPhone) {
+                positionModule->handleNewPosition();
+            }
         }
     }
 }
@@ -1570,6 +1607,7 @@ int32_t GPS::runOnce()
         bool tooLong = scheduling.searchedTooLong();
         if (tooLong && !gotLoc) {
             LOG_WARN("Can't publish valid location: no GPS lock in time");
+            forwardPositionToPhone = false;
             // we didn't get a location during this ack window, therefore declare loss of lock
             if (hasValidLocation) {
                 p = meshtastic_Position_init_default;

--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1607,7 +1607,6 @@ int32_t GPS::runOnce()
         bool tooLong = scheduling.searchedTooLong();
         if (tooLong && !gotLoc) {
             LOG_WARN("Can't publish valid location: no GPS lock in time");
-            forwardPositionToPhone = false;
             // we didn't get a location during this ack window, therefore declare loss of lock
             if (hasValidLocation) {
                 p = meshtastic_Position_init_default;
@@ -1634,6 +1633,9 @@ int32_t GPS::runOnce()
             if (tooLong || holdExpired) {
                 down();
             }
+
+            if (tooLong && !gotLoc)
+                forwardPositionToPhone = false;
 
 #ifdef GPS_DEBUG
         } else if (fixHoldEnds != 0) {

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -216,6 +216,7 @@ class GPS : private concurrency::OSThread
 
     bool shouldPublish = false; // If we've changed GPS state, this will force a publish the next loop()
     bool forwardPositionToPhone = false;
+    bool hasPositionUpdateRequest = false;
     uint32_t lastPositionUpdateRequest = 0;
 
     bool hasGPS = false; // Do we have a GPS we are talking to

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -135,6 +135,9 @@ class GPS : private concurrency::OSThread
     // Wake the GPS hardware - ready for an update
     void up();
 
+    // Schedule an immediate GPS sampling cycle without changing configured intervals.
+    bool requestPositionUpdate();
+
     // Let the GPS hardware save power between updates
     void down();
 
@@ -212,6 +215,8 @@ class GPS : private concurrency::OSThread
     bool hasValidLocation = false; // default to false, until we complete our first read
 
     bool shouldPublish = false; // If we've changed GPS state, this will force a publish the next loop()
+    bool forwardPositionToPhone = false;
+    uint32_t lastPositionUpdateRequest = 0;
 
     bool hasGPS = false; // Do we have a GPS we are talking to
 

--- a/src/mesh/generated/meshtastic/admin.pb.h
+++ b/src/mesh/generated/meshtastic/admin.pb.h
@@ -459,10 +459,6 @@ typedef struct _meshtastic_AdminMessage {
         meshtastic_SharedContact add_contact;
         /* Initiate or respond to a key verification request */
         meshtastic_KeyVerificationAdmin key_verification;
-        /* Request an immediate GPS sampling cycle. This does not change the
-     configured GPS or position broadcast intervals. Requests received
-     within 10 seconds are coalesced and use the most recent fix. */
-        bool request_position_update;
         /* Tell the node to factory reset config everything; all device state and configuration will be returned to factory defaults and BLE bonds will be cleared. */
         int32_t factory_reset_device;
         /* Tell the node to reboot into the OTA Firmware in this many seconds (or <0 to cancel reboot)
@@ -671,7 +667,6 @@ extern "C" {
 #define meshtastic_AdminMessage_commit_edit_settings_tag 65
 #define meshtastic_AdminMessage_add_contact_tag  66
 #define meshtastic_AdminMessage_key_verification_tag 67
-#define meshtastic_AdminMessage_request_position_update_tag 70
 #define meshtastic_AdminMessage_factory_reset_device_tag 94
 #define meshtastic_AdminMessage_reboot_ota_seconds_tag 95
 #define meshtastic_AdminMessage_exit_simulator_tag 96
@@ -734,7 +729,6 @@ X(a, STATIC,   ONEOF,    BOOL,     (payload_variant,begin_edit_settings,begin_ed
 X(a, STATIC,   ONEOF,    BOOL,     (payload_variant,commit_edit_settings,commit_edit_settings),  65) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,add_contact,add_contact),  66) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,key_verification,key_verification),  67) \
-X(a, STATIC,   ONEOF,    BOOL,     (payload_variant,request_position_update,request_position_update),  70) \
 X(a, STATIC,   ONEOF,    INT32,    (payload_variant,factory_reset_device,factory_reset_device),  94) \
 X(a, STATIC,   ONEOF,    INT32,    (payload_variant,reboot_ota_seconds,reboot_ota_seconds),  95) \
 X(a, STATIC,   ONEOF,    BOOL,     (payload_variant,exit_simulator,exit_simulator),  96) \

--- a/src/mesh/generated/meshtastic/admin.pb.h
+++ b/src/mesh/generated/meshtastic/admin.pb.h
@@ -459,6 +459,10 @@ typedef struct _meshtastic_AdminMessage {
         meshtastic_SharedContact add_contact;
         /* Initiate or respond to a key verification request */
         meshtastic_KeyVerificationAdmin key_verification;
+        /* Request an immediate GPS sampling cycle. This does not change the
+     configured GPS or position broadcast intervals. Requests received
+     within 10 seconds are coalesced and use the most recent fix. */
+        bool request_position_update;
         /* Tell the node to factory reset config everything; all device state and configuration will be returned to factory defaults and BLE bonds will be cleared. */
         int32_t factory_reset_device;
         /* Tell the node to reboot into the OTA Firmware in this many seconds (or <0 to cancel reboot)
@@ -667,6 +671,7 @@ extern "C" {
 #define meshtastic_AdminMessage_commit_edit_settings_tag 65
 #define meshtastic_AdminMessage_add_contact_tag  66
 #define meshtastic_AdminMessage_key_verification_tag 67
+#define meshtastic_AdminMessage_request_position_update_tag 70
 #define meshtastic_AdminMessage_factory_reset_device_tag 94
 #define meshtastic_AdminMessage_reboot_ota_seconds_tag 95
 #define meshtastic_AdminMessage_exit_simulator_tag 96
@@ -729,6 +734,7 @@ X(a, STATIC,   ONEOF,    BOOL,     (payload_variant,begin_edit_settings,begin_ed
 X(a, STATIC,   ONEOF,    BOOL,     (payload_variant,commit_edit_settings,commit_edit_settings),  65) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,add_contact,add_contact),  66) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,key_verification,key_verification),  67) \
+X(a, STATIC,   ONEOF,    BOOL,     (payload_variant,request_position_update,request_position_update),  70) \
 X(a, STATIC,   ONEOF,    INT32,    (payload_variant,factory_reset_device,factory_reset_device),  94) \
 X(a, STATIC,   ONEOF,    INT32,    (payload_variant,reboot_ota_seconds,reboot_ota_seconds),  95) \
 X(a, STATIC,   ONEOF,    BOOL,     (payload_variant,exit_simulator,exit_simulator),  96) \

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -687,6 +687,20 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         handleSendInputEvent(r->send_input_event);
         break;
     }
+    case meshtastic_AdminMessage_request_position_update_tag: {
+#if !MESHTASTIC_EXCLUDE_GPS
+        if (gps && gps->requestPositionUpdate()) {
+            LOG_INFO("GPS update requested");
+        } else {
+            LOG_WARN("GPS update unavailable");
+            myReply = allocErrorResponse(meshtastic_Routing_Error_BAD_REQUEST, &mp);
+        }
+#else
+        LOG_WARN("GPS unavailable");
+        myReply = allocErrorResponse(meshtastic_Routing_Error_BAD_REQUEST, &mp);
+#endif
+        break;
+    }
 #ifdef ARCH_PORTDUINO
     case meshtastic_AdminMessage_exit_simulator_tag:
         LOG_INFO("Exiting simulator");

--- a/src/modules/PositionModule.h
+++ b/src/modules/PositionModule.h
@@ -36,6 +36,9 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
     void sendOurPosition(NodeNum dest, bool wantReplies = false, uint8_t channel = 0);
     void sendOurPosition();
 
+    // Streams our own position to the connected phone/UI without touching the mesh.
+    bool sendOurPositionToPhone();
+
     void handleNewPosition();
 
     // Pure broadcast-policy helpers, split out so they're unit-testable without the module.
@@ -70,10 +73,6 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
 
   private:
     meshtastic_MeshPacket *allocPositionPacket(uint32_t atPrecision);
-    // Streams our own position to the connected phone/UI at full precision without touching the
-    // mesh. Keeps the local view alive now that mesh position sharing is opt-in. Returns true
-    // only when a packet was handed to the phone queue.
-    bool sendOurPositionToPhone();
     bool hasSentPositionToPhone = false;
     uint32_t lastPhoneSendMs = 0;
     static constexpr uint32_t sendToPhoneIntervalMs = 60 * 1000; // Matches telemetry's local cadence

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -29,6 +29,7 @@
 #include <unity.h>
 #include <vector>
 
+#include "meshtastic/admin.pb.h"
 #include "meshtastic/config.pb.h"
 #include "support/AdminModuleTestShim.h"
 
@@ -52,6 +53,22 @@ class MockMeshService : public MeshService
 };
 
 static MockMeshService *mockMeshService;
+
+static void test_request_position_update_admin_message_round_trip()
+{
+    meshtastic_AdminMessage request = meshtastic_AdminMessage_init_zero;
+    request.which_payload_variant = meshtastic_AdminMessage_request_position_update_tag;
+    request.request_position_update = true;
+
+    uint8_t bytes[16];
+    size_t size = pb_encode_to_bytes(bytes, sizeof(bytes), &meshtastic_AdminMessage_msg, &request);
+    TEST_ASSERT_GREATER_THAN(0, size);
+
+    meshtastic_AdminMessage decoded = meshtastic_AdminMessage_init_zero;
+    TEST_ASSERT_TRUE(pb_decode_from_bytes(bytes, size, &meshtastic_AdminMessage_msg, &decoded));
+    TEST_ASSERT_EQUAL(meshtastic_AdminMessage_request_position_update_tag, decoded.which_payload_variant);
+    TEST_ASSERT_TRUE(decoded.request_position_update);
+}
 
 // -----------------------------------------------------------------------
 // getRegion() tests
@@ -1882,6 +1899,8 @@ void setup()
     initializeTestEnvironment();
 
     UNITY_BEGIN();
+
+    RUN_TEST(test_request_position_update_admin_message_round_trip);
 
     // getRegion()
     RUN_TEST(test_handleSetOwner_persistsLicensedChannelSanitation);

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -54,7 +54,7 @@ class MockMeshService : public MeshService
 
 static MockMeshService *mockMeshService;
 
-static void test_request_position_update_admin_message_round_trip()
+static void testRequestPositionUpdateAdminMessageRoundTrip()
 {
     meshtastic_AdminMessage request = meshtastic_AdminMessage_init_zero;
     request.which_payload_variant = meshtastic_AdminMessage_request_position_update_tag;
@@ -1564,6 +1564,17 @@ static void sendAdmin(meshtastic_AdminMessage &m)
     testAdmin->handleReceivedProtobuf(mp, &m);
 }
 
+static void testRequestPositionUpdateRejectsUnavailableGps()
+{
+    meshtastic_AdminMessage request = meshtastic_AdminMessage_init_zero;
+    request.which_payload_variant = meshtastic_AdminMessage_request_position_update_tag;
+    request.request_position_update = true;
+
+    sendAdmin(request);
+    TEST_ASSERT_NOT_NULL(testAdmin->reply());
+    testAdmin->drainReply();
+}
+
 static void sendSetChannel(const meshtastic_Channel &ch)
 {
     meshtastic_AdminMessage m = meshtastic_AdminMessage_init_zero;
@@ -1900,7 +1911,8 @@ void setup()
 
     UNITY_BEGIN();
 
-    RUN_TEST(test_request_position_update_admin_message_round_trip);
+    RUN_TEST(testRequestPositionUpdateAdminMessageRoundTrip);
+    RUN_TEST(testRequestPositionUpdateRejectsUnavailableGps);
 
     // getRegion()
     RUN_TEST(test_handleSetOwner_persistsLicensedChannelSanitation);

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -31,6 +31,7 @@
 
 #include "meshtastic/admin.pb.h"
 #include "meshtastic/config.pb.h"
+#include "meshtastic/routing.pb.h"
 #include "support/AdminModuleTestShim.h"
 
 // hash() is a file-scope function in RadioInterface.cpp; link it in for slot-formula tests
@@ -1571,7 +1572,15 @@ static void testRequestPositionUpdateRejectsUnavailableGps()
     request.request_position_update = true;
 
     sendAdmin(request);
-    TEST_ASSERT_NOT_NULL(testAdmin->reply());
+    meshtastic_MeshPacket *reply = testAdmin->reply();
+    TEST_ASSERT_NOT_NULL(reply);
+    TEST_ASSERT_EQUAL(meshtastic_PortNum_ROUTING_APP, reply->decoded.portnum);
+
+    meshtastic_Routing response = meshtastic_Routing_init_zero;
+    TEST_ASSERT_TRUE(
+        pb_decode_from_bytes(reply->decoded.payload.bytes, reply->decoded.payload.size, &meshtastic_Routing_msg, &response));
+    TEST_ASSERT_EQUAL(meshtastic_Routing_error_reason_tag, response.which_variant);
+    TEST_ASSERT_EQUAL(meshtastic_Routing_Error_BAD_REQUEST, response.error_reason);
     testAdmin->drainReply();
 }
 


### PR DESCRIPTION
## Summary

Adds authenticated AdminMessage handling for an on-demand GPS sample and forwards the resulting local position to the connected client without broadcasting it over the mesh. Requests are coalesced for 10 seconds.

Depends on protobuf PR #1032.

## Testing

- `trunk fmt`