### PR TITLE
Correct for awake time in AQ telemetry

### DIFF
--- a/src/modules/Telemetry/AirQualityTelemetry.cpp
+++ b/src/modules/Telemetry/AirQualityTelemetry.cpp
@@ -208,6 +208,10 @@ int32_t AirQualityTelemetryModule::runOnce()
 
             if (!sensor->isActive()) {
                 LOG_DEBUG("Waking up: %s", sensor->sensorName);
+                awakeAheadOfTimeMs = max(awakeAheadOfTimeMs, sensor->wakeUpTimeMs());
+                // LOG_DEBUG("Woke up ahead of time %d for %s", awakeAheadOfTimeMs, sensor->sensorName);
+                startAirQualityTelemetryCycle = millis();
+                // TODO multiple sensors with different wake up times collide
                 return sensor->wakeUp();
             }
 
@@ -219,7 +223,6 @@ int32_t AirQualityTelemetryModule::runOnce()
         }
 
         bool telemetryDue = (lastTelemetry == 0) || !Throttle::isWithinTimespanMs(lastTelemetry, telemetryIntervalMs);
-
         bool phoneDue = (lastSentToPhone == 0) || !Throttle::isWithinTimespanMs(lastSentToPhone, sendToPhoneIntervalMs);
 
         if (telemetryDue && telemetryAllowed) {
@@ -228,10 +231,22 @@ int32_t AirQualityTelemetryModule::runOnce()
             if (transmitHistory) {
                 transmitHistory->setLastSentToMesh(TX_HISTORY_KEY_AIR_QUALITY_TELEMETRY);
             }
+            // Correct the awake time, trimming to 0
+            const unsigned long elapsed = millis() - startAirQualityTelemetryCycle;
+            awakeAheadOfTimeMs = elapsed >= awakeAheadOfTimeMs ? 0 : awakeAheadOfTimeMs - elapsed;
+            // LOG_DEBUG("Time to publish. Correcting ahead of time by: %d", awakeAheadOfTimeMs);
         } else if (phoneDue && phoneAllowed) {
             // Mesh transmission isn't due yet, but we can still update the phone.
             sendTelemetry(NODENUM_BROADCAST, true);
             lastSentToPhone = millis();
+            // Correct the awake time, trimming to 0
+            const unsigned long elapsed = millis() - startAirQualityTelemetryCycle;
+            awakeAheadOfTimeMs = elapsed >= awakeAheadOfTimeMs ? 0 : awakeAheadOfTimeMs - elapsed;
+            // LOG_DEBUG("Time to publish. Correcting ahead of time by: %d", awakeAheadOfTimeMs);
+        } else {
+            // if for some reason we end up here after waking up, but not able to send, then reset
+            // the counter
+            awakeAheadOfTimeMs = 0;
         }
 
         // Send to sleep sensors that can be to save power
@@ -253,7 +268,11 @@ int32_t AirQualityTelemetryModule::runOnce()
         // mistime the pending deep sleep
         return FIVE_SECONDS_MS;
     }
-    return min(sendToPhoneIntervalMs, result);
+    uint32_t correctedIntervalMs = sendToPhoneIntervalMs + awakeAheadOfTimeMs;
+    awakeAheadOfTimeMs = 0;
+    startAirQualityTelemetryCycle = 0;
+    LOG_DEBUG("Correctied interval in ms: %d", correctedIntervalMs);
+    return min(correctedIntervalMs, result);
 }
 
 bool AirQualityTelemetryModule::wantUIFrame()

--- a/src/modules/Telemetry/AirQualityTelemetry.cpp
+++ b/src/modules/Telemetry/AirQualityTelemetry.cpp
@@ -271,7 +271,7 @@ int32_t AirQualityTelemetryModule::runOnce()
     uint32_t correctedIntervalMs = sendToPhoneIntervalMs + awakeAheadOfTimeMs;
     awakeAheadOfTimeMs = 0;
     startAirQualityTelemetryCycle = 0;
-    LOG_DEBUG("Correctied interval in ms: %d", correctedIntervalMs);
+    LOG_DEBUG("Corrected interval in ms: %d", correctedIntervalMs);
     return min(correctedIntervalMs, result);
 }
 

--- a/src/modules/Telemetry/AirQualityTelemetry.cpp
+++ b/src/modules/Telemetry/AirQualityTelemetry.cpp
@@ -271,7 +271,7 @@ int32_t AirQualityTelemetryModule::runOnce()
     uint32_t correctedIntervalMs = sendToPhoneIntervalMs + awakeAheadOfTimeMs;
     awakeAheadOfTimeMs = 0;
     startAirQualityTelemetryCycle = 0;
-    LOG_DEBUG("Corrected interval in ms: %d", correctedIntervalMs);
+    LOG_DEBUG("Corrected interval in ms: %u", correctedIntervalMs);
     return min(correctedIntervalMs, result);
 }
 

--- a/src/modules/Telemetry/AirQualityTelemetry.cpp
+++ b/src/modules/Telemetry/AirQualityTelemetry.cpp
@@ -208,9 +208,9 @@ int32_t AirQualityTelemetryModule::runOnce()
 
             if (!sensor->isActive()) {
                 LOG_DEBUG("Waking up: %s", sensor->sensorName);
+                if (awakeAheadOfTimeMs == 0)
+                    startAirQualityTelemetryCycle = millis();
                 awakeAheadOfTimeMs = max(awakeAheadOfTimeMs, sensor->wakeUpTimeMs());
-                // LOG_DEBUG("Woke up ahead of time %d for %s", awakeAheadOfTimeMs, sensor->sensorName);
-                startAirQualityTelemetryCycle = millis();
                 // TODO multiple sensors with different wake up times collide
                 return sensor->wakeUp();
             }

--- a/src/modules/Telemetry/AirQualityTelemetry.cpp
+++ b/src/modules/Telemetry/AirQualityTelemetry.cpp
@@ -226,23 +226,28 @@ int32_t AirQualityTelemetryModule::runOnce()
         bool phoneDue = (lastSentToPhone == 0) || !Throttle::isWithinTimespanMs(lastSentToPhone, sendToPhoneIntervalMs);
 
         if (telemetryDue && telemetryAllowed) {
-            sendTelemetry();
-
-            if (transmitHistory) {
-                transmitHistory->setLastSentToMesh(TX_HISTORY_KEY_AIR_QUALITY_TELEMETRY);
+            if (sendTelemetry()) {
+                if (transmitHistory) {
+                    transmitHistory->setLastSentToMesh(TX_HISTORY_KEY_AIR_QUALITY_TELEMETRY);
+                }
+                // Correct the awake time, trimming to 0
+                const unsigned long elapsed = millis() - startAirQualityTelemetryCycle;
+                awakeAheadOfTimeMs = elapsed >= awakeAheadOfTimeMs ? 0 : awakeAheadOfTimeMs - elapsed;
+                // LOG_DEBUG("Time to publish. Correcting ahead of time by: %d", awakeAheadOfTimeMs);
+            } else {
+                awakeAheadOfTimeMs = 0;
             }
-            // Correct the awake time, trimming to 0
-            const unsigned long elapsed = millis() - startAirQualityTelemetryCycle;
-            awakeAheadOfTimeMs = elapsed >= awakeAheadOfTimeMs ? 0 : awakeAheadOfTimeMs - elapsed;
-            // LOG_DEBUG("Time to publish. Correcting ahead of time by: %d", awakeAheadOfTimeMs);
         } else if (phoneDue && phoneAllowed) {
             // Mesh transmission isn't due yet, but we can still update the phone.
-            sendTelemetry(NODENUM_BROADCAST, true);
-            lastSentToPhone = millis();
-            // Correct the awake time, trimming to 0
-            const unsigned long elapsed = millis() - startAirQualityTelemetryCycle;
-            awakeAheadOfTimeMs = elapsed >= awakeAheadOfTimeMs ? 0 : awakeAheadOfTimeMs - elapsed;
-            // LOG_DEBUG("Time to publish. Correcting ahead of time by: %d", awakeAheadOfTimeMs);
+            if (sendTelemetry(NODENUM_BROADCAST, true)) {
+                lastSentToPhone = millis();
+                // Correct the awake time, trimming to 0
+                const unsigned long elapsed = millis() - startAirQualityTelemetryCycle;
+                awakeAheadOfTimeMs = elapsed >= awakeAheadOfTimeMs ? 0 : awakeAheadOfTimeMs - elapsed;
+                // LOG_DEBUG("Time to publish. Correcting ahead of time by: %d", awakeAheadOfTimeMs);
+            } else {
+                awakeAheadOfTimeMs = 0;
+            }
         } else {
             // if for some reason we end up here after waking up, but not able to send, then reset
             // the counter
@@ -268,6 +273,8 @@ int32_t AirQualityTelemetryModule::runOnce()
         // mistime the pending deep sleep
         return FIVE_SECONDS_MS;
     }
+
+    // Update next interval if we were ahead
     uint32_t correctedIntervalMs = sendToPhoneIntervalMs + awakeAheadOfTimeMs;
     awakeAheadOfTimeMs = 0;
     startAirQualityTelemetryCycle = 0;

--- a/src/modules/Telemetry/AirQualityTelemetry.h
+++ b/src/modules/Telemetry/AirQualityTelemetry.h
@@ -66,6 +66,8 @@ class AirQualityTelemetryModule : private concurrency::OSThread,
 
   private:
     bool firstTime = true;
+    int32_t awakeAheadOfTimeMs = 0;
+    int32_t startAirQualityTelemetryCycle = 0;
     meshtastic_MeshPacket *lastMeasurementPacket;
     uint32_t sendToPhoneIntervalMs = SECONDS_IN_MINUTE * 1000; // Send to phone every minute
     // uint32_t sendToPhoneIntervalMs = 1000; // Send to phone every minute


### PR DESCRIPTION
In AirQualityTelemetry module we can have sensors that wake up ahead of time to warm up. Some sensors require 15s, while others require more, depending on the conditions after 15s. This PR tries to make AQTelemetry module intervals constant, so that no matter when the sensor wakes up (ahead of time by X seconds, with a conditional exit before that time), we always keep the AQ telemetry module interval constant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved air-quality telemetry scheduling by accurately accounting for processing time during telemetry cycles.
  - Preserved the configured wake-ahead interval after mesh or phone transmissions.
  - Reset wake-ahead timing when no transmission occurs, improving consistency in subsequent cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->