### PR TITLE
fix(Radio): reject bogus coding rate and length readbacks on RX

### DIFF
--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -616,6 +616,13 @@ void RadioLibInterface::handleReceiveInterrupt()
     // read the number of actually received bytes
     size_t length = iface->getPacketLength();
 
+    // Some drivers report this as a 16 bit value, so a bad readback can overrun radioBuffer in readData()
+    if (length > sizeof(radioBuffer)) {
+        LOG_ERROR("Ignore rx packet, bad length %u", (unsigned int)length);
+        rxBad++;
+        return;
+    }
+
     uint32_t rxMsec = getPacketTime(length, true);
 
 #ifndef DISABLE_WELCOME_UNSET

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -341,7 +341,7 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
                 // Raw 0 is reserved and >7 is either undefined or an LR2021-only convolutional rate no
                 // Meshtastic peer can send. calculateTimeOnAir() would multiply by it unchecked.
                 if (rxCR < 1 || rxCR > 7) {
-                    LOG_WARN("Bogus RX coding rate %u from radio, use configured %u", rxCR, dr.lora.codingRate);
+                    LOG_WARN("Bogus RX coding rate %d from radio, use configured %d", rxCR, dr.lora.codingRate);
                 } else {
                     // Go from raw header value to denominator
                     if (rxCR < 5) {

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -331,23 +331,29 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
     template <typename T> uint32_t computePacketTime(T &lora, uint32_t pl, bool received)
     {
         if (received) {
-            // First get the actual coding rate and CRC status from the received packet
-            uint8_t rxCR;
-            bool hasCRC;
-            lora.getLoRaRxHeaderInfo(&rxCR, &hasCRC);
-            // Go from raw header value to denominator
-            if (rxCR < 5) {
-                rxCR += 4;
-            } else if (rxCR == 7) {
-                rxCR = 8;
-            }
-
             // Received packet configuration must be the same as configured, except for coding rate and CRC
             DataRate_t dr = getDataRate();
-            dr.lora.codingRate = rxCR;
-
             PacketConfig_t pc = getPacketConfig();
-            pc.lora.crcEnabled = hasCRC;
+
+            uint8_t rxCR = 0;
+            bool hasCRC = true;
+            if (lora.getLoRaRxHeaderInfo(&rxCR, &hasCRC) == RADIOLIB_ERR_NONE) {
+                // Raw 0 is reserved and >7 is either undefined or an LR2021-only convolutional rate no
+                // Meshtastic peer can send. calculateTimeOnAir() would multiply by it unchecked.
+                if (rxCR < 1 || rxCR > 7) {
+                    LOG_WARN("Bogus RX coding rate %u from radio, use configured %u", rxCR, dr.lora.codingRate);
+                } else {
+                    // Go from raw header value to denominator
+                    if (rxCR < 5) {
+                        rxCR += 4;
+                    } else if (rxCR == 7) {
+                        rxCR = 8;
+                    }
+
+                    dr.lora.codingRate = rxCR;
+                    pc.lora.crcEnabled = hasCRC;
+                }
+            }
 
             return lora.calculateTimeOnAir(modemType, dr, pc, pl) / 1000;
         }


### PR DESCRIPTION
computePacketTime() discarded the return code of getLoRaRxHeaderInfo(), left rxCR uninitialized, and normalized only raw values 0-4 and 7. Raw 8-15 passed through as the coding rate denominator, which calculateTimeOnAir() multiplies the symbol count by without a range check, so a bad readback inflated logged RX airtime and channel utilization.

RadioLib reads this field as 3 bits for LR11x0 but 4 bits for LR2021, which per LR2021 datasheet Rev 1.1 Table 9-13 is correct, so only LR2021 boards can report a raw value above 7. On a Mesh-Tracker-X1 receiving 240 byte packets at SF7 / BW 62.5 kHz, a true 774 ms was logged as 1204 ms at raw 8 and 2208 ms at raw 15, driving reported channel utilization to 283 percent and suppressing transmits.

Check the return code and validate the raw value before normalizing it. Per Table 9-4 raw 0 is reserved and raw 8 and 9 are LR2021 only convolutional rates, so accept 1 to 7 and otherwise keep the configured coding rate.

Also reject a reported packet length larger than radioBuffer. LR2021::getPacketLength() returns uint16_t where LR11x0 returns uint8_t, so the same bad readback can exceed the buffer readData() fills.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of oversized radio packets by safely discarding invalid data instead of attempting to process it.
  - Improved packet timing calculations when radio header metadata is missing or invalid.
  - Added validation for received coding-rate information and preserved configured defaults when reliable metadata is unavailable.
  - Invalid receptions are now recorded and logged more consistently for improved reliability and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->