### PR TITLE
fix(stm32wl): reset instead of hanging on faults

### DIFF
--- a/src/platform/stm32wl/main-stm32wl.cpp
+++ b/src/platform/stm32wl/main-stm32wl.cpp
@@ -58,8 +58,10 @@ __attribute__((constructor(101), used)) static void earlyBootCheck(void)
     SCB->VTOR = SYS_MEM_BASE;
     __set_MSP(*(volatile uint32_t *)SYS_MEM_BASE);
     ((void (*)(void))(*(volatile uint32_t *)(SYS_MEM_BASE + 4)))();
-    while (1)
-        ;
+    // Should never be reached: the bootloader ROM does not return. A bare reset
+    // (rather than returning normally) avoids unwinding through this function's
+    // epilogue, which would restore registers relative to the now-repointed MSP.
+    NVIC_SystemReset();
 }
 
 void enterDfuMode()
@@ -171,12 +173,14 @@ void cpuDeepSleep(uint32_t msecToWake)
 
 // Hacks to force more code and data out.
 
+// Forward declaration; defined below alongside the other fault-reporting helpers.
+static void debug_printf(const char *format, ...);
+
 // By default __assert_func uses fiprintf which pulls in stdio.
-extern "C" void __wrap___assert_func(const char *, int, const char *, const char *)
+extern "C" void __wrap___assert_func(const char *file, int line, const char *func, const char *failedexpr)
 {
-    while (true)
-        ;
-    return;
+    debug_printf("assert: %s:%d in %s: %s\r\n", file, line, func, failedexpr);
+    HAL_NVIC_SystemReset();
 }
 
 // By default strerror has a lot of strings we probably don't use. Make it return an empty string instead.
@@ -233,34 +237,6 @@ static void debug_printf(const char *format, ...)
     uart_debug_write((uint8_t *)hardfault_message_buffer, min((unsigned int)length, sizeof(hardfault_message_buffer) - 1));
 }
 
-// N picked by guessing
-#define DOT_TIME 1200000
-static void dot()
-{
-    digitalWrite(LED_POWER, LED_STATE_ON);
-    for (volatile int i = 0; i < DOT_TIME; i++) { /* busy wait */
-    }
-    digitalWrite(LED_POWER, LED_STATE_OFF);
-    for (volatile int i = 0; i < DOT_TIME; i++) { /* busy wait */
-    }
-}
-
-static void dash()
-{
-    digitalWrite(LED_POWER, LED_STATE_ON);
-    for (volatile int i = 0; i < (DOT_TIME * 3); i++) { /* busy wait */
-    }
-    digitalWrite(LED_POWER, LED_STATE_OFF);
-    for (volatile int i = 0; i < DOT_TIME; i++) { /* busy wait */
-    }
-}
-
-static void space()
-{
-    for (volatile int i = 0; i < (DOT_TIME * 3); i++) { /* busy wait */
-    }
-}
-
 // Disable optimizations for this function so "frame" argument
 // does not get optimized away
 extern "C" __attribute__((optimize("O0"))) void HardFault_Handler_C(sContextStateFrame *frame)
@@ -277,17 +253,5 @@ extern "C" __attribute__((optimize("O0"))) void HardFault_Handler_C(sContextStat
 
     HALT_IF_DEBUGGING();
 
-    // blink SOS forever
-    while (1) {
-        dot();
-        dot();
-        dot();
-        dash();
-        dash();
-        dash();
-        dot();
-        dot();
-        dot();
-        space();
-    }
+    HAL_NVIC_SystemReset();
 }

--- a/src/platform/stm32wl/main-stm32wl.cpp
+++ b/src/platform/stm32wl/main-stm32wl.cpp
@@ -18,20 +18,9 @@ static bool stm32wlRtcValid = false;
 #endif
 
 // ─── Bootloader redirect ──────────────────────────────────────────────────────
-//
-// Why .noinit + constructor instead of TAMP backup registers:
-//
-//   The STM32duino startup sequence initialises clocks which may call
-//   __HAL_RCC_BACKUPRESET_FORCE/RELEASE when configuring the LSE oscillator,
-//   wiping the entire backup domain (including TAMP->BKP0R) before setup()
-//   ever runs. The backup-register approach therefore cannot reliably survive
-//   a soft reset in this toolchain.
-//
-//   Solution: store the magic in a .noinit SRAM variable.
-//   - NVIC_SystemReset() does NOT clear SRAM.
-//   - The linker script skips zero-init for .noinit sections.
-//   - __attribute__((constructor)) fires before main()/HAL_Init(), so we can
-//     intercept and jump before anything disturbs peripheral state.
+// Uses .noinit SRAM instead of TAMP backup registers: STM32duino's clock init can wipe the
+// backup domain via __HAL_RCC_BACKUPRESET_FORCE/RELEASE before setup() runs, but .noinit
+// survives NVIC_SystemReset() and this constructor fires before HAL_Init() touches anything.
 
 #define BOOTLOADER_MAGIC 0xD00DB007UL
 #define SYS_MEM_BASE 0x1FFF0000UL
@@ -171,17 +160,7 @@ void cpuDeepSleep(uint32_t msecToWake)
 #endif
 }
 
-// Hacks to force more code and data out.
-
-// Forward declaration; defined below alongside the other fault-reporting helpers.
-static void debug_printf(const char *format, ...);
-
-// By default __assert_func uses fiprintf which pulls in stdio.
-extern "C" void __wrap___assert_func(const char *file, int line, const char *func, const char *failedexpr)
-{
-    debug_printf("assert: %s:%d in %s: %s\r\n", file, line, func, failedexpr);
-    HAL_NVIC_SystemReset();
-}
+// ─── Linker hacks to reduce code size ─────────────────────────────────────────
 
 // By default strerror has a lot of strings we probably don't use. Make it return an empty string instead.
 char empty = 0;
@@ -200,6 +179,8 @@ extern "C" void __wrap__tzset_unlocked_r(struct _reent *reent_ptr)
     return;
 }
 #endif
+
+// ─── Fault handling & recovery ────────────────────────────────────────────────
 
 // Taken from https://interrupt.memfault.com/blog/cortex-m-hardfault-debug
 typedef struct __attribute__((packed)) ContextStateFrame {
@@ -235,6 +216,13 @@ static void debug_printf(const char *format, ...)
     if (length < 0)
         return;
     uart_debug_write((uint8_t *)hardfault_message_buffer, min((unsigned int)length, sizeof(hardfault_message_buffer) - 1));
+}
+
+// By default __assert_func uses fiprintf which pulls in stdio.
+extern "C" void __wrap___assert_func(const char *file, int line, const char *func, const char *failedexpr)
+{
+    debug_printf("assert: %s:%d in %s: %s\r\n", file, line, func, failedexpr);
+    HAL_NVIC_SystemReset();
 }
 
 // Disable optimizations for this function so "frame" argument


### PR DESCRIPTION
Three places in `src/platform/stm32wl/main-stm32wl.cpp` hung the MCU forever on an unrecoverable condition instead of resetting, requiring a manual power cycle to recover:

- `HardFault_Handler_C` blinked SOS forever once no debugger was attached.
- `__wrap___assert_func` silently hung on an assert failure with no UART output at all.
- `earlyBootCheck`'s bootloader-jump fallback hung silently if the jump into the system-memory bootloader ROM didn't take.

This replaces all three with `HAL_NVIC_SystemReset()`/`NVIC_SystemReset()` (matching the reset call already used elsewhere in the file) so the device reboots on its own instead of bricking until someone finds it.

It also moves `__wrap___assert_func` next to `HardFault_Handler_C` under a new "Fault handling & recovery" banner comment (matching the existing "Bootloader redirect" banner), since it's now the same "print diagnostics, then reset" pattern as the rest of that section.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] RAK3172 — build-verified only
    - [x] Russell — build-verified only
    - [x] ST NUCLEO-WL55JC1 (cherry-picked #11384 for testing) - triggered `enterDfuMode()` over the admin API and confirmed via SWD register readback (PC and VTOR both within the `0x1FFF0000` system-memory region) that the device is actively in ROM bootloader
    - [x] ST NUCLEO-WL55JC1 - injected a real HardFault via SWD (corrupted the running PC to an invalid address) and confirmed `HardFault_Handler_C` printed the fault registers over the debug UART, correctly halted at `HALT_IF_DEBUGGING()` for the attached debugger, then called `HAL_NVIC_SystemReset()` on resume and the device rebooted back into the running app


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when the ROM bootloader unexpectedly returns by resetting the device.
  * Added detailed assertion diagnostics before resetting.
  * Updated HardFault handling to report fault information and reset instead of remaining stuck.
* **Documentation**
  * Clarified bootloader handoff behavior and SRAM persistence.
  * Updated section headings for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->