### PR TITLE
fix(SafeFile): remove a stale .tmp before opening it for write

### DIFF
--- a/src/SafeFile.cpp
+++ b/src/SafeFile.cpp
@@ -18,7 +18,12 @@ static File openFile(const char *filename, bool fullAtomic)
     // write must go first. exists() guards it: a bare remove() of a missing file logs on Portduino.
     if (FSCom.exists(filenameTmp.c_str())) {
         LOG_DEBUG("Remove stale %s", filenameTmp.c_str());
-        FSCom.remove(filenameTmp.c_str());
+        // Opening anyway would append to the stale bytes, and the XOR readback is 8 bits wide, so
+        // polluted content has a real chance of verifying and being renamed over the good file.
+        if (!FSCom.remove(filenameTmp.c_str())) {
+            LOG_ERROR("Can't remove stale %s", filenameTmp.c_str());
+            return File();
+        }
     }
 
     // clear any previous LFS errors

--- a/src/SafeFile.cpp
+++ b/src/SafeFile.cpp
@@ -14,10 +14,14 @@ static File openFile(const char *filename, bool fullAtomic)
     String filenameTmp = filename;
     filenameTmp += ".tmp";
 
-    // FIXME: If we are doing a full atomic write, we may need to remove the old tmp file now
-    // if (fullAtomic) {
-    //     FSCom.remove(filename);
-    // }
+    // FILE_O_WRITE appends rather than truncates on Adafruit_LittleFS (nRF52) and STM32 LittleFS, so a tmp
+    // file left behind by an interrupted write must go before we open. Otherwise we append to the stale
+    // bytes, and because the hash only covers what we write, the readback in close() mismatches on this and
+    // every later save. Guard with exists() - a bare remove() logs on Portduino when there is nothing there.
+    if (FSCom.exists(filenameTmp.c_str())) {
+        LOG_WARN("Remove stale %s", filenameTmp.c_str());
+        FSCom.remove(filenameTmp.c_str());
+    }
 
     // clear any previous LFS errors
     return FSCom.open(filenameTmp.c_str(), FILE_O_WRITE);

--- a/src/SafeFile.cpp
+++ b/src/SafeFile.cpp
@@ -14,12 +14,10 @@ static File openFile(const char *filename, bool fullAtomic)
     String filenameTmp = filename;
     filenameTmp += ".tmp";
 
-    // FILE_O_WRITE appends rather than truncates on Adafruit_LittleFS (nRF52) and STM32 LittleFS, so a tmp
-    // file left behind by an interrupted write must go before we open. Otherwise we append to the stale
-    // bytes, and because the hash only covers what we write, the readback in close() mismatches on this and
-    // every later save. Guard with exists() - a bare remove() logs on Portduino when there is nothing there.
+    // FILE_O_WRITE appends on Adafruit_LittleFS (nRF52) and STM32 LittleFS, so a tmp left by an interrupted
+    // write must go first. exists() guards it: a bare remove() of a missing file logs on Portduino.
     if (FSCom.exists(filenameTmp.c_str())) {
-        LOG_WARN("Remove stale %s", filenameTmp.c_str());
+        LOG_DEBUG("Remove stale %s", filenameTmp.c_str());
         FSCom.remove(filenameTmp.c_str());
     }
 

--- a/test/test_safefile/test_main.cpp
+++ b/test/test_safefile/test_main.cpp
@@ -101,7 +101,8 @@ void test_save_replaces_previous_contents(void)
 }
 
 // The premise of the suite, asserted rather than assumed: this host truncates on FILE_O_WRITE.
-// If it ever fails, the host has gained the append behaviour and the tests above become real.
+// Portduino only, since it is false by design on the append-on-write backends the fix is aimed at.
+#ifdef ARCH_PORTDUINO
 void test_write_open_truncates_on_this_host(void)
 {
     writeRaw(kFile, "AAAAAAAA");
@@ -109,6 +110,7 @@ void test_write_open_truncates_on_this_host(void)
 
     TEST_ASSERT_EQUAL_STRING("B", readAll(kFile).c_str());
 }
+#endif
 
 #endif // FSCom
 
@@ -123,7 +125,9 @@ void setup()
     RUN_TEST(test_stale_tmp_is_not_appended_to_when_not_full_atomic);
     RUN_TEST(test_completed_save_leaves_no_tmp);
     RUN_TEST(test_save_replaces_previous_contents);
+#ifdef ARCH_PORTDUINO
     RUN_TEST(test_write_open_truncates_on_this_host);
+#endif
 #endif
     exit(UNITY_END());
 }

--- a/test/test_safefile/test_main.cpp
+++ b/test/test_safefile/test_main.cpp
@@ -1,0 +1,131 @@
+// Covers SafeFile's write-tmp / readback / rename-over path, on both the fullAtomic and the
+// !fullAtomic construction. See the commit message for why these cannot go red on this host.
+#include "MeshTypes.h"
+#include "TestUtil.h"
+// FSCommon.h is what defines FSCom, so it has to be included before anything tests for it.
+#include "FSCommon.h"
+#include "SPILock.h"
+#include "SafeFile.h"
+#include <cstring>
+#include <string>
+#include <unity.h>
+
+#ifdef FSCom
+
+// Built through FSCom rather than host fopen(): PortduinoFS confines paths to its own mountpoint, so
+// the same API is the only way the test stays agnostic about where that mountpoint is.
+static const char *kRoot = "/test_safefile";
+static const char *kFile = "/test_safefile/pref.dat";
+static const char *kTmp = "/test_safefile/pref.dat.tmp";
+
+static void writeRaw(const char *path, const char *payload)
+{
+    File f = FSCom.open(path, FILE_O_WRITE);
+    TEST_ASSERT_TRUE_MESSAGE(f, path);
+    f.write((const uint8_t *)payload, strlen(payload));
+    f.close();
+}
+
+static std::string readAll(const char *path)
+{
+    std::string out;
+    File f = FSCom.open(path, FILE_O_READ);
+    if (!f)
+        return out;
+    int c;
+    while ((c = f.read()) >= 0)
+        out.push_back((char)c);
+    f.close();
+    return out;
+}
+
+static void saveThrough(bool fullAtomic, const char *payload)
+{
+    auto f = SafeFile(kFile, fullAtomic);
+    f.write((const uint8_t *)payload, strlen(payload));
+    TEST_ASSERT_TRUE(f.close());
+}
+
+void setUp(void)
+{
+    rmDir(kRoot);
+    FSCom.mkdir(kRoot);
+}
+
+void tearDown(void)
+{
+    // Leave nothing behind: the sandbox is per suite, but an undeclared write is still a finding.
+    rmDir(kRoot);
+}
+
+// A .tmp surviving a reset between close() and renameFile() must not contribute a byte to the
+// next save.
+void test_stale_tmp_is_not_appended_to(void)
+{
+    writeRaw(kTmp, "STALESTALESTALE");
+
+    saveThrough(true, "NEW");
+
+    TEST_ASSERT_EQUAL_STRING("NEW", readAll(kFile).c_str());
+}
+
+// fullAtomic decides whether the real file is nuked up front; it has no bearing on the .tmp, which
+// both paths open with the same FILE_O_WRITE. This is why the remove must not be scoped to it.
+void test_stale_tmp_is_not_appended_to_when_not_full_atomic(void)
+{
+    writeRaw(kTmp, "STALESTALESTALE");
+
+    saveThrough(false, "NEW");
+
+    TEST_ASSERT_EQUAL_STRING("NEW", readAll(kFile).c_str());
+}
+
+// A stale .tmp must not survive the save either, or the next one inherits it again.
+void test_completed_save_leaves_no_tmp(void)
+{
+    writeRaw(kTmp, "STALE");
+
+    saveThrough(true, "NEW");
+
+    TEST_ASSERT_FALSE(FSCom.exists(kTmp));
+}
+
+// The rename is an overwrite, not an append onto the previous generation of the real file.
+void test_save_replaces_previous_contents(void)
+{
+    writeRaw(kFile, "OLDOLDOLDOLDOLD");
+
+    saveThrough(true, "NEW");
+
+    TEST_ASSERT_EQUAL_STRING("NEW", readAll(kFile).c_str());
+}
+
+// The premise of the suite, asserted rather than assumed: this host truncates on FILE_O_WRITE.
+// If it ever fails, the host has gained the append behaviour and the tests above become real.
+void test_write_open_truncates_on_this_host(void)
+{
+    writeRaw(kFile, "AAAAAAAA");
+    writeRaw(kFile, "B");
+
+    TEST_ASSERT_EQUAL_STRING("B", readAll(kFile).c_str());
+}
+
+#endif // FSCom
+
+void setup()
+{
+    initializeTestEnvironment();
+    // SafeFile takes spiLock on every open; main.cpp does this, and nothing in the test harness does.
+    initSPI();
+    UNITY_BEGIN();
+#ifdef FSCom
+    RUN_TEST(test_stale_tmp_is_not_appended_to);
+    RUN_TEST(test_stale_tmp_is_not_appended_to_when_not_full_atomic);
+    RUN_TEST(test_completed_save_leaves_no_tmp);
+    RUN_TEST(test_save_replaces_previous_contents);
+    RUN_TEST(test_write_open_truncates_on_this_host);
+#endif
+    exit(UNITY_END());
+}
+
+void loop() {}


### PR DESCRIPTION
`SafeFile` writes to `<filename>.tmp`, verifies it by readback, then renames it over the real file. `openFile()` never removed a pre-existing `.tmp` — an unfinished `FIXME` — and `FILE_O_WRITE` **appends rather than truncates** on Adafruit_LittleFS (nRF52) and STM32 LittleFS.

So a `.tmp` left behind by a reset in the window between `close()` and `renameFile()` is appended to on the next save. The readback hash covers only the bytes just written, so it mismatches, `close()` returns false, and the tmp is left behind again — **the failure latches**, and every subsequent save of that file fails.

Today `saveProto()` discards `close()`'s result, so this is silent and permanent.

The remove is guarded with `exists()` because a bare `remove()` of a missing file logs on Portduino. The same guarded pattern is already used for this exact append trap in `xmodem.cpp`.

### Note on the original FIXME

Its commented-out body named the wrong path — `FSCom.remove(filename)`, the **real** file, not `filenameTmp`. Had it ever been uncommented it would have destroyed the good copy on every write.

### Per-platform check of the remove call

| Platform | Backend | `remove()` on missing file |
|---|---|---|
| nRF52 | Adafruit_LittleFS | `PRINT_LFS_ERR`, compiled out unless `CFG_DEBUG` |
| STM32WL | in-repo STM32_LittleFS | same |
| ESP32 | Arduino LittleFS | returns false, no log |
| RP2040 | earlephilhower LittleFS | `DEBUGV` only |
| Portduino | PortduinoFS | `log_e(...)` — the reason for the `exists()` guard |
| nRF54L15 | in-repo wrapper | returns false, no log |

`exists()` is available on every backend. Nothing errors; with the guard, nothing logs spuriously.

Nothing relies on tmp persistence: `grep -rn "\.tmp" src/` matches only `SafeFile.cpp`, and all 16 construction sites are construct → write → close within a single function.

## Validation

- Compile-checked on `heltec-v4` (ESP32-S3) against a clean baseline build of the same environment.
- All 11 fixes from this review merge without conflict and the combined tree compiles on both `heltec-v4` and `seeed-xiao-s3`.
- **Native unit tests were not run locally** — the harness is Linux-only (`bin/run-tests.sh` refuses off-Linux) and `bin/test-native-docker.sh` needs Docker, which was unavailable on the dev host. Relying on CI for the native suite.
- **No on-hardware validation yet.**

Found during an adversarial review of deriving `NodeNum` from the node public key. Filed as a draft for maintainer judgement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Integration test on hardware

This fix was included in an integration branch of all 11 review fixes (merged with **no conflicts**) and flashed to two boards from erased flash:

- **Seeed XIAO ESP32-S3** and **Heltec V4**, both `2.8.0.684f6b1`

Result: both booted, LoRa init OK, region set applied, config persisted across power-cycle, and the two nodes discovered and verified each other over the air.

| Check | XIAO | Heltec |
|---|---|---|
| Fresh boot, `region UNSET`, MAC-derived node num | `0x1dd29d30` | `0xb29fb324` |
| After region set (no reboot), `my_node_num == crc32(public_key)` | `0x4dc9fb0f` ✔ | `0xd71bb46a` ✔ |
| Node number survives power-cycle | ✔ | ✔ |
| Peer sees and verifies the other node | ✔ | ✔ |

Every config write in that sequence goes through `SafeFile` → `saveProto()`, and all of them succeeded, persisted across reboot, and triggered no spurious `fsFormat()`.

**Specific to this PR:** every configuration write in the sequence above exercised the modified `SafeFile::openFile()`. No stale `.tmp` was left behind and no save failed. The *failure* path (a `.tmp` surviving an interrupted write) was not artificially induced, so it remains verified by code inspection only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented stale temporary files from being appended to or retained during saves.
  - Saving now reliably replaces existing file contents.
  - Completed saves leave no temporary files behind.
  - File writes correctly truncate existing contents where supported.
  - File operations now fail safely when stale temporary files cannot be removed.

- **Tests**
  - Added coverage for temporary-file cleanup, save replacement behavior, write truncation, and cleanup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->