### PR TITLE
fix(NodeDB): propagate SafeFile write failures out of saveProto()

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -3021,6 +3021,10 @@ bool NodeDB::saveProto(const char *filename, size_t protoSize, const pb_msgdesc_
     if (!okay || !writeSucceeded) {
         LOG_ERROR("Can't write prefs");
     }
+
+    // pb_encode() only sees the byte stream, not the readback hash check, the tmp reopen or the
+    // rename - all of which SafeFile::close() reports. Propagate it so saveToDisk() can recover.
+    okay = okay && writeSucceeded;
 #else
     LOG_ERROR("Filesystem not implemented");
 #endif


### PR DESCRIPTION
> [!IMPORTANT]
> **Do not merge before #11428** (`SafeFile`: remove a stale `.tmp` before opening it for write). On nRF52/STM32WL, propagating write failures before stale `.tmp` files are cleaned converts a leftover temp file into a full `fsFormat()`. These are separate PRs by request; the ordering constraint is real.

`saveProto()` captured the result of `SafeFile::close()` into `writeSucceeded`, used it only in a `LOG_ERROR` condition, and returned `okay` — which reflects `pb_encode()` alone.

`pb_encode()` sees only the byte stream, so three failures were reported to callers as successful saves:

1. readback XOR hash mismatch — bytes read back differ from those written
2. the tmp file cannot be reopened for the readback pass
3. `renameFile(tmp, real)` fails — the atomic commit never happens

All three mean the write did not land. Open failure and disk-full **already** failed `pb_encode()` (`writecb` checks `write() == count`), so those are unchanged — the scope is narrower than "everything `close()` checks".

This re-enables the recovery in `saveToDisk()`, which was added alongside the readback verification in 66c41e683 (#4397) and has been unreachable for these cases ever since. `SafeFile.h` documents `close()` as returning false "so higher level code can handle failures", and the encrypted-storage branch of this same function already propagates it.

### Residual risk a maintainer should weigh

`saveToDisk()` formats the whole filesystem but only re-saves `saveWhat`. Most callers pass a single segment, so a single-segment save failure wipes the *other* segments' files — channels (including PSKs), moduleConfig, devicestate, nodes.proto — plus uiconfig, rtttl, canned messages and backups. Live values survive in RAM, but anything not re-saved before the next reboot returns as defaults.

This is not new behaviour introduced here; it is behaviour that becomes *reachable* for genuine flash failures. It cannot loop: `saveToDiskNoRetry` runs at most twice, one format, no recursion.

On Portduino, `RECORD_CRITICALERROR` with a `FLASH_CORRUPTION_*` code calls `exit(2)`, terminating meshtasticd.

## Validation

- Compile-checked on `heltec-v4` (ESP32-S3) against a clean baseline build of the same environment.
- All 11 fixes from this review merge without conflict and the combined tree compiles on both `heltec-v4` and `seeed-xiao-s3`.
- **Native unit tests were not run locally** — the harness is Linux-only (`bin/run-tests.sh` refuses off-Linux) and `bin/test-native-docker.sh` needs Docker, which was unavailable on the dev host. Relying on CI for the native suite.
- **No on-hardware validation yet.**

Found during an adversarial review of deriving `NodeNum` from the node public key. Filed as a draft for maintainer judgement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Integration test on hardware

This fix was included in an integration branch of all 11 review fixes (merged with **no conflicts**) and flashed to two boards from erased flash:

- **Seeed XIAO ESP32-S3** and **Heltec V4**, both `2.8.0.684f6b1`

Result: both booted, LoRa init OK, region set applied, config persisted across power-cycle, and the two nodes discovered and verified each other over the air.

| Check | XIAO | Heltec |
|---|---|---|
| Fresh boot, `region UNSET`, MAC-derived node num | `0x1dd29d30` | `0xb29fb324` |
| After region set (no reboot), `my_node_num == crc32(public_key)` | `0x4dc9fb0f` ✔ | `0xd71bb46a` ✔ |
| Node number survives power-cycle | ✔ | ✔ |
| Peer sees and verifies the other node | ✔ | ✔ |

Every config write in that sequence goes through `SafeFile` → `saveProto()`, and all of them succeeded, persisted across reboot, and triggered no spurious `fsFormat()`.

**Specific to this PR:** all saves in the sequence above returned success and persisted, confirming the propagation change does not produce false failures — the main regression risk, since a false failure would now trigger `fsFormat()`. The genuine failure conditions (readback hash mismatch, tmp reopen failure, rename failure) were not artificially induced and remain verified by inspection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved persistence reliability by detecting and reporting failures when saving data, reopening temporary files, verifying saved content, or completing file replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->