### PR TITLE
fix(NodeDB): stop addFromContact() erasing a stored public key

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -3482,7 +3482,16 @@ void NodeDB::addFromContact(meshtastic_SharedContact contact)
         }
     }
     info->num = contact.node_num;
+    // CopyUserToNodeInfoLite assigns public_key unconditionally, and clients send add_contact before every
+    // DM - often from an entry that carries no key at all. A contact may still supply or update a full
+    // 32-byte key (that's what add_contact is for), but it must never *erase* a key we already hold, which
+    // would be persisted below and break subsequent DMs with PKI_SEND_FAIL_PUBLIC_KEY.
+    const meshtastic_NodeInfoLite_public_key_t storedKey = info->public_key;
     TypeConversions::CopyUserToNodeInfoLite(info, contact.user);
+    if (storedKey.size == 32 && info->public_key.size != 32) {
+        LOG_INFO("Contact 0x%08x has no key, keep the stored one", contact.node_num);
+        info->public_key = storedKey;
+    }
     if (contact.should_ignore) {
         // Block the contact and drop its rich satellite data, but keep the
         // public key copied above - an ignored peer keeps a usable identity


### PR DESCRIPTION
`addFromContact()` reaches `TypeConversions::CopyUserToNodeInfoLite()`, which assigns `public_key` unconditionally. So a `SharedContact` with `has_user` set and an **empty** `public_key` erases a peer's stored, XEdDSA-proven key — and the erasure is persisted. Subsequent DMs to that peer then fail with `PKI_SEND_FAIL_PUBLIC_KEY`.

Per the comment in the same function, clients send `add_contact` before **every** text-message DM, making this the highest-volume key-write path on the device and the only one with no protection against erasure.

Fix: refuse only the erasure. If the entry already holds a 32-byte key and the incoming contact carries an empty/short one, keep the stored key.

### Deliberately NOT changed

- **No first-key-wins pin.** `updateUser()`'s refuse-on-mismatch is *not* replicated here. `add_contact` exists to supply keys the radio never had and to update them (QR contact sharing); a blanket pin would break that documented flow. A valid 32-byte contact key still replaces a stored one exactly as today.
- **No node-number validation.** Reserved/broadcast/self node numbers are still accepted here — separate concern.
- **`CopyUserToNodeInfoLite` untouched.** It has several other callers; the guard is at the `addFromContact` call site only.

### Is an empty key ever an intentional "clear"?

No evidence for it, and the field shape argues against it: `public_key` is a **singular, non-optional** bytes field, so "absent" and "explicitly empty" are indistinguishable on the wire — a client that merely lacks a key looks identical to one requesting a clear. The one intentional key-clear that did exist on this path (the `should_ignore` branch) was **removed** in #10705 and replaced with a comment stating an ignored peer keeps a usable identity. `test_traffic_management` asserts the same merge rule elsewhere: a keyless identity must not erase a key already learned.

## Validation

- Compile-checked on `heltec-v4` (ESP32-S3) against a clean baseline build of the same environment.
- All 11 fixes from this review merge without conflict and the combined tree compiles on both `heltec-v4` and `seeed-xiao-s3`.
- **Native unit tests were not run locally** — the harness is Linux-only (`bin/run-tests.sh` refuses off-Linux) and `bin/test-native-docker.sh` needs Docker, which was unavailable on the dev host. Relying on CI for the native suite.
- **No on-hardware validation yet.**

Found during an adversarial review of deriving `NodeNum` from the node public key. Filed as a draft for maintainer judgement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing contact public keys when incoming contact information is incomplete.
  * Continued to accept and update contacts when a complete public key is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Integration test on hardware

This fix was included in an integration branch of all 11 review fixes (merged with **no conflicts**) and flashed to two boards from erased flash:

- **Seeed XIAO ESP32-S3** and **Heltec V4**, both `2.8.0.684f6b1`

Result: both booted, LoRa init OK, region set applied, config persisted across power-cycle, and the two nodes discovered and verified each other over the air.

| Check | XIAO | Heltec |
|---|---|---|
| Fresh boot, `region UNSET`, MAC-derived node num | `0x1dd29d30` | `0xb29fb324` |
| After region set (no reboot), `my_node_num == crc32(public_key)` | `0x4dc9fb0f` ✔ | `0xd71bb46a` ✔ |
| Node number survives power-cycle | ✔ | ✔ |
| Peer sees and verifies the other node | ✔ | ✔ |

Every config write in that sequence goes through `SafeFile` → `saveProto()`, and all of them succeeded, persisted across reboot, and triggered no spurious `fsFormat()`.


> [!NOTE]
> The integration run above is a **regression smoke test** — it proves this change does not break normal operation on real hardware. It does **not** exercise the specific defect fixed here, which needs a condition that cannot be induced with two bench nodes. That part remains verified by code inspection and, once CI runs, by the native suite.
