### PR TITLE
fix(NodeDB): repair the USERPREFS_FIXED_GPS build path

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -638,10 +638,11 @@ NodeDB::NodeDB()
 #if !MESHTASTIC_EXCLUDE_POSITIONDB
         {
             concurrency::LockGuard guard(&satelliteMutex);
-            nodePositions[info->num] = TypeConversions::ConvertToPositionLite(fixedGPS);
+            nodePositions[getNodeNum()] = TypeConversions::ConvertToPositionLite(fixedGPS);
         }
 #endif
-        nodeDB->setLocalPosition(fixedGPS);
+        // Call the member directly: the global nodeDB is still null until our ctor returns.
+        setLocalPosition(fixedGPS);
         config.position.fixed_position = true;
 #endif
     }


### PR DESCRIPTION
The `USERPREFS_FIXED_GPS` block in the `NodeDB` constructor has two defects:

1. **It does not compile.** `nodePositions[info->num]` references `info`, which is not declared in that scope — no local, no member, no global. Any vendor build setting `USERPREFS_FIXED_GPS` + `_LAT` + `_LON` fails with `'info' was not declared in this scope`.
2. **Null pointer on variants where the first line is preprocessed out.** The next statement calls `nodeDB->setLocalPosition(...)` via the *global* `nodeDB`, which is null until `new NodeDB()` returns. Another line in the same constructor already calls the member directly and correctly.

Stock builds are unaffected — no in-tree config sets the flag — but the documented fixed-GPS user-prefs feature is broken as written.

### Provenance

Two separate regressions, not one:

- The `info->position` → `nodePositions[info->num]` rewrite landed in 94bb21ecc, but `info` was still declared then, so it compiled. The declaration was moved into `nodeDBSelfCare()` later by **79a7dcc46 (#10705)** — that is the commit that broke the build.
- The null-`nodeDB` call predates both; it arrived with the feature in **d4d89447b (#5341)**.

### Compile-testing this

The block is behind a flag no in-tree config sets, so a normal build does not exercise it:

```bash
PLATFORMIO_BUILD_FLAGS='-DUSERPREFS_FIXED_GPS=1 -DUSERPREFS_FIXED_GPS_LAT=48.85873920 -DUSERPREFS_FIXED_GPS_LON=2.294508368 -DUSERPREFS_FIXED_GPS_ALT=0' pio run -e native-macos
```

Add `-DMESHTASTIC_EXCLUDE_POSITIONDB=1` to exercise the STM32WL path instead.

### Related issue, not fixed here

This block only fires on `reboot_count == 1`, when a factory-fresh device still has `region == UNSET` — so keygen is suppressed and the fixed position is written under the **MAC-derived** node number. When the user later sets a region, `createNewIdentity()` → `removeNodeByNum()` → `eraseNodeSatellites()` deletes it, while `config.position.fixed_position` stays true: fixed-position mode enabled with no coordinates. Not fixable inside this block.

## Validation

- Compile-checked on `heltec-v4` (ESP32-S3) against a clean baseline build of the same environment.
- All 11 fixes from this review merge without conflict and the combined tree compiles on both `heltec-v4` and `seeed-xiao-s3`.
- **Native unit tests were not run locally** — the harness is Linux-only (`bin/run-tests.sh` refuses off-Linux) and `bin/test-native-docker.sh` needs Docker, which was unavailable on the dev host. Relying on CI for the native suite.
- **No on-hardware validation yet.**

Found during an adversarial review of deriving `NodeNum` from the node public key. Filed as a draft for maintainer judgement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Verified with the flag enabled

The block this fixes is behind `USERPREFS_FIXED_GPS`, which no in-tree config sets — so an ordinary build never compiles it. Built both trees with the flag to confirm the defect and the fix:

```
FAIL  review-base (stock)   src/mesh/NodeDB.cpp:641:27: error: 'info' was not declared in this scope
PASS  this branch
```

Command used (`heltec-v4`, ESP32-S3):

```bash
PLATFORMIO_BUILD_FLAGS='-DUSERPREFS_FIXED_GPS=1 -DUSERPREFS_FIXED_GPS_LAT=48.85873920 -DUSERPREFS_FIXED_GPS_LON=2.294508368 -DUSERPREFS_FIXED_GPS_ALT=0' pio run -e heltec-v4
```

The second defect (the null global `nodeDB` on `MESHTASTIC_EXCLUDE_POSITIONDB` variants) is not reachable on this target and remains verified by inspection.
