### PR TITLE
fix(NodeDB): stop logging the raw identity private key

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -985,7 +985,8 @@ void NodeDB::installDefaultConfig(bool preserveKey = false)
     if (shouldPreserveKey) {
         config.security.private_key.size = 32;
         memcpy(config.security.private_key.bytes, private_key_temp, config.security.private_key.size);
-        printBytes("Restored key", config.security.private_key.bytes, config.security.private_key.size);
+        // Never log the key bytes: debug logs get pasted into public bug reports.
+        LOG_DEBUG("Restored preserved private key");
     } else {
         config.security.private_key.size = 0;
     }


### PR DESCRIPTION
`installDefaultConfig()` logged the raw 32-byte X25519 identity **private key** via `printBytes("Restored key", ...)`.

Serial/BLE debug logs are routinely captured, pasted into bug reports, and shared publicly. A leaked identity private key lets anyone impersonate the node and decrypt its PKI direct messages.

Replaced with a byte-free confirmation. The restore-vs-no-restore signal is the genuinely useful diagnostic on this path and costs nothing to keep; the bytes were never what made the line useful. Log level is unchanged — `printBytes()` logs at `LOG_DEBUG` internally, so `LOG_DEBUG` is the faithful match.

A hash or truncated prefix was deliberately **not** used as a compromise: a prefix still leaks key material and a hash is a confirmation oracle.

### Sweep

Checked every `printBytes` call and every `LOG_*` touching `private_key` / `psk` / `privateKey`. Public-key logging (`"Incoming Pubkey"`, `"Saved Pubkey"`) is left alone — those are broadcast to the mesh by design.

**Two further sites found and deliberately left for maintainer judgement**, since removing a deliberately-added debugging aid is a debuggability-vs-security tradeoff rather than a clear bug:

- `AdminModule.cpp` logs the **admin session passkey in full** (8 of 8 bytes), including the expected server-side value — a complete credential dump, mitigated only by the 300 s validity window.
- `CryptoEngine.cpp` logs the first 8 of 32 bytes of the derived `shared_key`. Worth noting it is *not* ephemeral — the PKI shared secret is static per node pair — though the truncation leaves ~2^192 work.

Happy to follow up on either if wanted.

## Validation

- Compile-checked on `heltec-v4` (ESP32-S3) against a clean baseline build of the same environment.
- All 11 fixes from this review merge without conflict and the combined tree compiles on both `heltec-v4` and `seeed-xiao-s3`.
- **Native unit tests were not run locally** — the harness is Linux-only (`bin/run-tests.sh` refuses off-Linux) and `bin/test-native-docker.sh` needs Docker, which was unavailable on the dev host. Relying on CI for the native suite.
- **No on-hardware validation yet.**

Found during an adversarial review of deriving `NodeNum` from the node public key. Filed as a draft for maintainer judgement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Privacy**
  * Private-key restoration no longer logs sensitive key material.
  * Restoration now reports only a generic debug message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Integration test on hardware

This fix was included in an integration branch of all 11 review fixes (merged with **no conflicts**) and flashed to two boards from erased flash:

- **Seeed XIAO ESP32-S3** and **Heltec V4**, both `2.8.0.684f6b1`

Result: both booted, LoRa init OK, region set applied, config persisted across power-cycle, and the two nodes discovered and verified each other over the air.

| Check | XIAO | Heltec |
|---|---|---|
| Fresh boot, `region UNSET`, MAC-derived node num | `0x1dd29d30` | `0xb29fb324` |
| After region set (no reboot), `my_node_num == crc32(public_key)` | `0x4dc9fb0f` ✔ | `0xd71bb46a` ✔ |
| Node number survives power-cycle | ✔ | ✔ |
| Peer sees and verifies the other node | ✔ | ✔ |

Every config write in that sequence goes through `SafeFile` → `saveProto()`, and all of them succeeded, persisted across reboot, and triggered no spurious `fsFormat()`.

**Specific to this PR:** verified in the built artifact, not just the source. The flashed integration firmware contains **0** occurrences of the byte-dumping `"Restored key"` string and **1** occurrence of the byte-free replacement. Source ground truth: `review-base` has 1 `printBytes("Restored key", …)`, the fixed tree has 0.
