### PR TITLE
docs(nexthop): correct stale createNewIdentity() description

### DIFF
--- a/docs/nexthop-routing-reliability.md
+++ b/docs/nexthop-routing-reliability.md
@@ -127,7 +127,8 @@ meshes, efficiency _is_ reliability.
 ### Note: pubkey-derived node numbers (develop / 2.8) - does not change the plan
 
 develop derives the node number from the public key:
-`my_node_num = crc32Buffer(public_key)`, set in `NodeDB::createNewIdentity()`
+`my_node_num = crc32Buffer(config.security.public_key.bytes, config.security.public_key.size)`,
+set in `NodeDB::createNewIdentity()`
 (`src/mesh/NodeDB.cpp`) and re-derived there on every key change. This **reinforces** the
 plan rather than changing it:
 
@@ -137,8 +138,9 @@ plan rather than changing it:
   renumber a node to dodge a conflict; now the number is fixed by the key, so a last-byte
   collision **cannot be resolved operationally by renumbering** → M1/M2/M3 become _more_
   necessary.
-- **Resolver gets cleaner inputs.** Stable node numbers keep a learned byte bound to one
-  identity (good for M3 freshness). `NodeDB::createNewIdentity()` retires the old entry by
+- **Resolver gets cleaner inputs.** A learned byte stays associated with the same identity
+  over time (good for M3 freshness) - it does not identify that identity uniquely, since
+  256 node numbers share each byte. `NodeDB::createNewIdentity()` retires the old entry by
   calling `removeNodeByNum()` on it outright. (The earlier "flag it **ignored**, clear its
   pubkey" approach was dropped: it left a keyless ghost of our own former identity that
   survived cleanup/eviction, was still streamed to clients, and made any DM/admin aimed at

--- a/docs/nexthop-routing-reliability.md
+++ b/docs/nexthop-routing-reliability.md
@@ -127,8 +127,8 @@ meshes, efficiency _is_ reliability.
 ### Note: pubkey-derived node numbers (develop / 2.8) - does not change the plan
 
 develop derives the node number from the public key:
-`my_node_num = crc32Buffer(public_key)` (`src/mesh/NodeDB.cpp:481`), re-derived on key
-change in `createNewIdentity()` (`src/mesh/NodeDB.cpp:3113`). This **reinforces** the
+`my_node_num = crc32Buffer(public_key)`, set in `NodeDB::createNewIdentity()`
+(`src/mesh/NodeDB.cpp`) and re-derived there on every key change. This **reinforces** the
 plan rather than changing it:
 
 - **Birthday problem unchanged and now textbook-exact.** CRC32 mixes well → the last
@@ -138,9 +138,14 @@ plan rather than changing it:
   collision **cannot be resolved operationally by renumbering** → M1/M2/M3 become _more_
   necessary.
 - **Resolver gets cleaner inputs.** Stable node numbers keep a learned byte bound to one
-  identity (good for M3 freshness). `createNewIdentity()` retires the old entry by marking
-  it **ignored** and clearing its pubkey (`src/mesh/NodeDB.cpp:3123-3125`), which M1's
-  candidate gate already skips - so key rotation can't pollute resolution.
+  identity (good for M3 freshness). `NodeDB::createNewIdentity()` retires the old entry by
+  calling `removeNodeByNum()` on it outright. (The earlier "flag it **ignored**, clear its
+  pubkey" approach was dropped: it left a keyless ghost of our own former identity that
+  survived cleanup/eviction, was still streamed to clients, and made any DM/admin aimed at
+  it fail forever with `PKI_SEND_FAIL_PUBLIC_KEY`.) Removal is **stronger** than the
+  ignored-flag behavior this bullet used to rely on: the row is gone from `meshNodes`
+  entirely, so M1's linear pass never sees it as a candidate at all and does not depend on
+  the `nodeInfoLiteIsIgnored` gate firing - key rotation still can't pollute resolution.
 - **No wire-free disambiguation unlocked.** A receiver still gets only 1 byte and cannot
   recover which full node number a colliding value meant - so "detect ambiguity → flood"
   remains the correct strategy.


### PR DESCRIPTION
`docs/nexthop-routing-reliability.md` stated that `createNewIdentity()` "retires the old entry by marking it **ignored** and clearing its pubkey", citing `src/mesh/NodeDB.cpp:3123-3125`.

Both halves are stale:

1. `createNewIdentity()` now calls `removeNodeByNum()` outright. The in-code comment explains why the ignored-flag approach was dropped: it left a keyless ghost of the node's own former identity that survived cleanup and eviction, was still streamed to clients, and made any DM or admin message aimed at it fail permanently with `PKI_SEND_FAIL_PUBLIC_KEY`.
2. The cited line numbers no longer point at that code.

This matters because the doc's mitigation reasoning rested on M1's candidate gate skipping *ignored* entries — a mechanism that no longer exists.

**Removal makes the claim stronger, not weaker.** The old wording depended on the `nodeInfoLiteIsIgnored` branch firing during the resolver's scan. `removeNodeByNum()` compacts the row out of `meshNodes` entirely — plus `eraseNodeSatellites()`, `warmStore.remove()` and `purgeNode()` — so the old identity is not in the scanned array at all.

Cites the function rather than line numbers, since those rot.

### Also verified, left unchanged

- "Node numbers are now immutable / identity-bound … cannot be resolved operationally by renumbering" — still accurate. `pickNewNodeNum()` still rerolls on conflict, but it runs before `createNewIdentity()` overwrites `my_node_num` with the key-derived value, so for any key-holding node the derived number wins.
- "CRC32 … uniformly distributed over 256 values" vs "255 buckets" elsewhere is not a contradiction: 256 is the raw CRC byte, 255 is after `getLastByteOfNodeNum()`'s `0x00`→`0xFF` projection.

Docs-only; no file under `src/` or `test/` touched.

## Validation

- Compile-checked on `heltec-v4` (ESP32-S3) against a clean baseline build of the same environment.
- All 11 fixes from this review merge without conflict and the combined tree compiles on both `heltec-v4` and `seeed-xiao-s3`.
- **Native unit tests were not run locally** — the harness is Linux-only (`bin/run-tests.sh` refuses off-Linux) and `bin/test-native-docker.sh` needs Docker, which was unavailable on the dev host. Relying on CI for the native suite.
- **No on-hardware validation yet.**

Found during an adversarial review of deriving `NodeNum` from the node public key. Filed as a draft for maintainer judgement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how node numbers are derived from public keys.
  * Documented that identity changes re-derive node numbers.
  * Explained that old identity entries are fully removed during key rotation, preventing stale entries from appearing in resolution or client-visible state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Integration test on hardware

This fix was included in an integration branch of all 11 review fixes (merged with **no conflicts**) and flashed to two boards from erased flash:

- **Seeed XIAO ESP32-S3** and **Heltec V4**, both `2.8.0.684f6b1`

Result: both booted, LoRa init OK, region set applied, config persisted across power-cycle, and the two nodes discovered and verified each other over the air.

| Check | XIAO | Heltec |
|---|---|---|
| Fresh boot, `region UNSET`, MAC-derived node num | `0x1dd29d30` | `0xb29fb324` |
| After region set (no reboot), `my_node_num == crc32(public_key)` | `0x4dc9fb0f` ✔ | `0xd71bb46a` ✔ |
| Node number survives power-cycle | ✔ | ✔ |
| Peer sees and verifies the other node | ✔ | ✔ |

Every config write in that sequence goes through `SafeFile` → `saveProto()`, and all of them succeeded, persisted across reboot, and triggered no spurious `fsFormat()`.
