### PR TITLE
refactor(led): generalize LED_LORA init from ThinkNode-M7

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -392,6 +392,11 @@ void setup()
     digitalWrite(LED_NOTIFICATION, HIGH ^ LED_STATE_ON);
 #endif
 
+#ifdef LED_LORA
+    pinMode(LED_LORA, OUTPUT);
+    digitalWrite(LED_LORA, HIGH ^ LED_STATE_ON);
+#endif
+
 #ifdef WIFI_LED
     pinMode(WIFI_LED, OUTPUT);
     digitalWrite(WIFI_LED, HIGH ^ WIFI_STATE_ON);

--- a/variants/esp32s3/ELECROW-ThinkNode-M7/variant.cpp
+++ b/variants/esp32s3/ELECROW-ThinkNode-M7/variant.cpp
@@ -5,6 +5,4 @@ void initVariant()
 {
     pinMode(LED_PAIRING, OUTPUT);
     digitalWrite(LED_PAIRING, !LED_STATE_ON); // Turn off the LED to start
-    pinMode(LED_LORA, OUTPUT);
-    digitalWrite(LED_LORA, !LED_STATE_ON); // Turn off the LED to start
 }


### PR DESCRIPTION
Moves LED_LORA pin initialization out of ELECROW-ThinkNode-M7's initVariant() and into the shared setup() in src/main.cpp, guarded by #ifdef LED_LORA, matching the existing pattern used for LED_NOTIFICATION and WIFI_LED. Any board that defines LED_LORA now gets it initialized without needing its own initVariant() boilerplate.

#11384 depends on this merging first, since the new Nucleo-WL55JC variant defines LED_LORA and relies on this generalized init rather than adding its own.

(Split out of #11384 at @caveman99's request — this refactor is unrelated to that PR's board addition and stands on its own.)

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] ELECROW ThinkNode-M7 (build-verified only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization of the optional LoRa LED indicator.
  * Ensured the indicator starts in its inactive state when enabled.
  * Preserved pairing LED behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->