### PR TITLE
fix(MeshService): don't read decoded.portnum on encrypted packets; let ROUTING_APP evict

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -495,8 +495,12 @@ void MeshService::sendToPhone(meshtastic_MeshPacket *p)
 #endif
 
     if (toPhoneQueue.numFree() == 0) {
-        if (isDecoded && (p->decoded.portnum == meshtastic_PortNum_TEXT_MESSAGE_APP ||
-                          p->decoded.portnum == meshtastic_PortNum_RANGE_TEST_APP)) {
+        // ROUTING_APP carries the delivery verdict for a message the phone is already tracking - an
+        // ACK or a MAX_RETRANSMIT NAK. Dropping it strands that message in "sending" forever, since
+        // a client cannot infer anything from a NAK that never arrives.
+        if (isDecoded &&
+            (p->decoded.portnum == meshtastic_PortNum_TEXT_MESSAGE_APP ||
+             p->decoded.portnum == meshtastic_PortNum_RANGE_TEST_APP || p->decoded.portnum == meshtastic_PortNum_ROUTING_APP)) {
             LOG_WARN("ToPhone queue full, discard oldest");
             meshtastic_MeshPacket *d = toPhoneQueue.dequeuePtr(0);
             if (d)

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -476,9 +476,16 @@ void MeshService::sendToPhone(meshtastic_MeshPacket *p)
         return;
     }
 
+    // `decoded` and `encrypted` are a union, and meshtastic_Data::portnum overlays the encrypted
+    // arm's `size` field. perhapsDecode() above deliberately lets undecryptable packets through, so
+    // reading decoded.portnum on one of those returns the ciphertext length - and TEXT_MESSAGE_APP
+    // (1) and RANGE_TEST_APP (66) are both ordinary payload sizes. Only trust portnum once the
+    // packet has actually decoded.
+    const bool isDecoded = p->which_payload_variant == meshtastic_MeshPacket_decoded_tag;
+
 #ifdef ARCH_ESP32
 #if !MESHTASTIC_EXCLUDE_STOREFORWARD
-    if (moduleConfig.store_forward.enabled && storeForwardModule->isServer() &&
+    if (moduleConfig.store_forward.enabled && storeForwardModule->isServer() && isDecoded &&
         p->decoded.portnum == meshtastic_PortNum_TEXT_MESSAGE_APP) {
         releaseToPool(p); // Copy is already stored in StoreForward history
         fromNum++;        // Notify observers for packet from radio
@@ -488,8 +495,8 @@ void MeshService::sendToPhone(meshtastic_MeshPacket *p)
 #endif
 
     if (toPhoneQueue.numFree() == 0) {
-        if (p->decoded.portnum == meshtastic_PortNum_TEXT_MESSAGE_APP ||
-            p->decoded.portnum == meshtastic_PortNum_RANGE_TEST_APP) {
+        if (isDecoded && (p->decoded.portnum == meshtastic_PortNum_TEXT_MESSAGE_APP ||
+                          p->decoded.portnum == meshtastic_PortNum_RANGE_TEST_APP)) {
             LOG_WARN("ToPhone queue full, discard oldest");
             meshtastic_MeshPacket *d = toPhoneQueue.dequeuePtr(0);
             if (d)

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -476,11 +476,8 @@ void MeshService::sendToPhone(meshtastic_MeshPacket *p)
         return;
     }
 
-    // `decoded` and `encrypted` are a union, and meshtastic_Data::portnum overlays the encrypted
-    // arm's `size` field. perhapsDecode() above deliberately lets undecryptable packets through, so
-    // reading decoded.portnum on one of those returns the ciphertext length - and TEXT_MESSAGE_APP
-    // (1) and RANGE_TEST_APP (66) are both ordinary payload sizes. Only trust portnum once the
-    // packet has actually decoded.
+    // portnum overlays the encrypted arm of the union, so on an undecryptable packet it reads back
+    // as ciphertext length. Only trust it once the packet has actually decoded.
     const bool isDecoded = p->which_payload_variant == meshtastic_MeshPacket_decoded_tag;
 
 #ifdef ARCH_ESP32
@@ -495,9 +492,8 @@ void MeshService::sendToPhone(meshtastic_MeshPacket *p)
 #endif
 
     if (toPhoneQueue.numFree() == 0) {
-        // ROUTING_APP carries the delivery verdict for a message the phone is already tracking - an
-        // ACK or a MAX_RETRANSMIT NAK. Dropping it strands that message in "sending" forever, since
-        // a client cannot infer anything from a NAK that never arrives.
+        // ROUTING_APP is the delivery verdict for a message the phone is already tracking, so
+        // dropping it strands that message in "sending" forever.
         if (isDecoded &&
             (p->decoded.portnum == meshtastic_PortNum_TEXT_MESSAGE_APP ||
              p->decoded.portnum == meshtastic_PortNum_RANGE_TEST_APP || p->decoded.portnum == meshtastic_PortNum_ROUTING_APP)) {


### PR DESCRIPTION
`MeshService::sendToPhone()` runs `perhapsDecode(p)` and then lets packets we could not decrypt carry
on, so the phone can try its own key. The comment above the call says as much. Two checks further
down then read `p->decoded.portnum` without testing `which_payload_variant` first: the StoreForward
check at `MeshService.cpp:481` and the `toPhoneQueue` eviction check at `:491`.

`decoded` and `encrypted` are a union, both at offset 12. `meshtastic_Data::portnum` is the first
member of one arm and `pb_size_t size` is the first member of the other, so on a still-encrypted
packet that read lands on the encrypted arm.

What it yields depends on enum width. Measured on this tree, `sizeof(pb_size_t)` is 2 and
`sizeof(meshtastic_PortNum)` is 4. On nRF52 and RP2040, where the ARM EABI gives short enums,
portnum is 2 bytes and the read is exactly `encrypted.size`. On ESP32 and native it is a 4 byte
load, so the low half is `size` and the high half is the first two ciphertext bytes.

`TEXT_MESSAGE_APP` is 1 and `RANGE_TEST_APP` is 66, and 66 bytes is an ordinary DM payload. On the
short enum targets ordinary traffic compares equal on ciphertext length alone. On ESP32 it also
needs the first two ciphertext bytes to be zero, so there it is a latent misread rather than
something you hit routinely.

Either way the value is not a portnum, so the queue-full eviction decision gets made on ciphertext.
The StoreForward case is the weaker of the two, since that block is `#ifdef ARCH_ESP32` and ESP32 is
the 4 byte platform.

The first commit gates both reads on `which_payload_variant`.

The second commit adds `ROUTING_APP` to the portnums allowed to evict when `toPhoneQueue` is full.
Today only `TEXT_MESSAGE_APP` and `RANGE_TEST_APP` evict and everything else is dropped outright.
`ROUTING_APP` carries the delivery verdict for a message the phone is already tracking, the ACK or
the `MAX_RETRANSMIT` NAK, and there is no retry and no second copy. Dropping it leaves that message
sitting in "sending" with nothing left to resolve it.

Both changes are in one PR because they are the same six lines and would conflict as separate
branches. Happy to split them if you would rather review them apart.

Things you may want to push back on:

The union guard changes behaviour for encrypted packets at both sites, in opposite directions. At
the StoreForward check they stop being released and now reach the phone. At the queue-full check
they take the drop path consistently instead of evicting depending on ciphertext.

The eviction change moves the loss rather than removing it. `dequeuePtr(0)` drops the oldest entry,
which under sustained pressure could be another `ROUTING_APP`. A priority-aware eviction policy
would be the real answer and is a bigger change than I wanted to make here.

I did not go looking for the same union pattern elsewhere in the tree. There may well be more of it.

Testing: builds clean on `heltec-v4` and `seeed-xiao-s3`. Full native suite via
`pio test -e native-macos` matches a same-commit baseline. No new unit test, though
`test/support/MockMeshService.h` already subclasses `MeshService` so the queue-full branch is
reachable natively if you want one before merge. Neither defect was reproduced at runtime; the
aliasing comes from the generated headers and the measured type sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other: compile-only on Heltec V4 and Seeed XIAO ESP32-S3
