### PR TITLE
fix(Router): never return ERRNO_SHOULD_RELEASE after abortSendAndNak

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -545,12 +545,8 @@ ErrorCode Router::send(meshtastic_MeshPacket *p)
             packetPool.release(p_decoded);
             p->channel = 0; // Reset the channel to 0, so we don't use the failing hash again
             abortSendAndNak(encodeResult, p);
-            // abortSendAndNak() has already released p, so we must never hand back a value the
-            // caller reads as ERRNO_SHOULD_RELEASE - it would release the packet a second time.
-            // meshtastic_Routing_Error and ErrorCode share this one return channel and their
-            // numbering overlaps (PKI_UNKNOWN_PUBKEY == ERRNO_SHOULD_RELEASE == 35,
-            // PKI_FAILED == ERRNO_DISABLED == 34, BAD_REQUEST == ERRNO_UNKNOWN == 32).
-            // ERRNO_SHOULD_RELEASE is the only one any caller actually compares against.
+            // abortSendAndNak() already released p, and Routing_Error shares this return channel with
+            // ErrorCode: PKI_UNKNOWN_PUBKEY is 35, so returning it raw would free the packet twice.
             static_assert((int)meshtastic_Routing_Error_PKI_UNKNOWN_PUBKEY == ERRNO_SHOULD_RELEASE,
                           "Routing_Error/ERRNO overlap changed; re-check the guard below");
             if ((int)encodeResult == ERRNO_SHOULD_RELEASE)

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -545,7 +545,17 @@ ErrorCode Router::send(meshtastic_MeshPacket *p)
             packetPool.release(p_decoded);
             p->channel = 0; // Reset the channel to 0, so we don't use the failing hash again
             abortSendAndNak(encodeResult, p);
-            return encodeResult; // FIXME - this isn't a valid ErrorCode
+            // abortSendAndNak() has already released p, so we must never hand back a value the
+            // caller reads as ERRNO_SHOULD_RELEASE - it would release the packet a second time.
+            // meshtastic_Routing_Error and ErrorCode share this one return channel and their
+            // numbering overlaps (PKI_UNKNOWN_PUBKEY == ERRNO_SHOULD_RELEASE == 35,
+            // PKI_FAILED == ERRNO_DISABLED == 34, BAD_REQUEST == ERRNO_UNKNOWN == 32).
+            // ERRNO_SHOULD_RELEASE is the only one any caller actually compares against.
+            static_assert((int)meshtastic_Routing_Error_PKI_UNKNOWN_PUBKEY == ERRNO_SHOULD_RELEASE,
+                          "Routing_Error/ERRNO overlap changed; re-check the guard below");
+            if ((int)encodeResult == ERRNO_SHOULD_RELEASE)
+                return ERRNO_UNKNOWN;
+            return encodeResult;
         }
 #if !MESHTASTIC_EXCLUDE_MQTT
         // Only publish to MQTT if we're the original transmitter of the packet


### PR DESCRIPTION
`Router::send()` calls `abortSendAndNak()` on the encode failure path, which releases the packet, and
then returns the raw `meshtastic_Routing_Error`. There is already a FIXME on that line saying it
isn't a valid ErrorCode. The problem is a little sharper than that: `meshtastic_Routing_Error` and
`ErrorCode` share the return channel and their numbering overlaps.

```
  NONE                0   /  ERRNO_OK              0     (harmless, both mean success)
  BAD_REQUEST        32   /  ERRNO_UNKNOWN        32
  NOT_AUTHORIZED     33   /  ERRNO_NO_INTERFACES  33
  PKI_FAILED         34   /  ERRNO_DISABLED       34
  PKI_UNKNOWN_PUBKEY 35   /  ERRNO_SHOULD_RELEASE 35
```

Callers release on `ERRNO_SHOULD_RELEASE` at 12 textual sites across four files: `NextHopRouter.cpp`
x7 (two behind `NEXTHOP_EARLY_FLOOD_ON_UNVERIFIED`, so 5 in a default build), `MeshService.cpp` x3,
`RoutingModule.cpp` and `MQTT.cpp`. If `Router::send` ever returned 35 from here it would be a use
after free read followed by a double free of a packet `abortSendAndNak()` already released.

It doesn't today, for two reasons that are each one commit from changing. `perhapsEncode()` only
returns `TOO_LARGE`, `NO_CHANNEL`, `PKI_FAILED` and `PKI_SEND_FAIL_PUBLIC_KEY`, never
`PKI_UNKNOWN_PUBKEY`, even though that value exists for exactly the condition those PKI paths hit and
`ReliableRouter` already sends it as a NAK elsewhere. And of the overlapping values only
`ERRNO_SHOULD_RELEASE` is ever compared against: every `ERRNO_DISABLED`, `ERRNO_NO_INTERFACES` and
`ERRNO_UNKNOWN` in `src/` is a return, never a comparison. So `PKI_FAILED == ERRNO_DISABLED`, which
`perhapsEncode` does reach, has nothing in firmware to misread it. It isn't completely unobserved
though, since `MeshService::sendToMesh` forwards the value into `QueueStatus.res`, so a `PKI_FAILED`
encode already reaches the client as 34, the same number a disabled interface reports.

The change guards the one value that is actually consumed and `static_assert`s the overlap so the
guard can't rot silently if either enum is renumbered. The assert deliberately asserts that the
collision exists. Writing it the obvious way, asserting no `Routing_Error` collides with any
`ERRNO_*`, would fail to compile today because four of them already do.

Worth knowing the guard is pointwise rather than structural. `Router.cpp` has other
release-then-return-`Routing_Error` sites in the same path. None of those values collides with
`ERRNO_SHOULD_RELEASE` so none is a live hazard, but this doesn't make the pattern safe in general. I
left both enums alone: `Routing_Error` is on the wire and `ErrorCode`'s values are picked to dodge
`RH_ROUTER_ERROR_UNABLE_TO_DELIVER`, so splitting the channel properly is a bigger job and belongs to
whoever wants to retire that FIXME.

Testing: builds clean on `heltec-v4` and `seeed-xiao-s3`, 182/182 across `test_packet_signing`,
`test_crypto`, `test_mqtt` and `test_nexthop_routing`. Nothing to reproduce at runtime, since the
guarded path is unreachable today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other: compile-only on Heltec V4 and Seeed XIAO ESP32-S3
