### PR TITLE
fix(NodeDB): only learn hops_away from genuine RF receptions

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -3719,9 +3719,14 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
         }
 #endif
 
-        // If hopStart was set and there wasn't someone messing with the limit in the middle, add hopsAway
+        // If hopStart was set and there wasn't someone messing with the limit in the middle, add hopsAway.
+        // Only from genuine RF receptions: for an MQTT- or UDP-sourced packet the hop fields describe the
+        // path to the *gateway*, not to us, so hops_away would be measuring someone else's distance. A
+        // gateway that heard the sender directly yields hops_away == 0 and a phantom "direct neighbour"
+        // that we have no RF path to at all - which NodeDB::resolveLastByte(requireDirectNeighbor=true)
+        // then trusts when picking a next hop.
         const int8_t hopsAway = getHopsAway(mp);
-        if (hopsAway >= 0) {
+        if (mp.transport_mechanism == meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA && hopsAway >= 0) {
             info->has_hops_away = true;
             info->hops_away = hopsAway;
         }

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -3720,11 +3720,8 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
 #endif
 
         // If hopStart was set and there wasn't someone messing with the limit in the middle, add hopsAway.
-        // Only from genuine RF receptions: for an MQTT- or UDP-sourced packet the hop fields describe the
-        // path to the *gateway*, not to us, so hops_away would be measuring someone else's distance. A
-        // gateway that heard the sender directly yields hops_away == 0 and a phantom "direct neighbour"
-        // that we have no RF path to at all - which NodeDB::resolveLastByte(requireDirectNeighbor=true)
-        // then trusts when picking a next hop.
+        // Only from RF: on an MQTT or UDP packet the hop fields measure the path to the gateway, so a
+        // gateway that heard the sender directly invents a direct neighbour we have no RF path to.
         const int8_t hopsAway = getHopsAway(mp);
         if (mp.transport_mechanism == meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA && hopsAway >= 0) {
             info->has_hops_away = true;


### PR DESCRIPTION
`NodeDB::updateFrom()` writes `has_hops_away` and `hops_away` with no transport gate. The two writes
ten lines above it in the same function are both gated: `snr` requires `TRANSPORT_LORA` and
`has_rx_rssi`, and the hop scaling histogram requires `TRANSPORT_LORA` and `!via_mqtt`.

For an MQTT or UDP sourced packet the hop fields describe the path to the gateway, not to us.
`Router::send()` stamps `hop_start = hop_limit` on everything it originates, and both ingress paths
copy `hop_start` and `hop_limit` verbatim (`MQTT.cpp:152`, `UdpMulticastHandler.h:75`), so
`getHopsAway()` returns a real non negative number and the write goes through.

When the gateway heard the sender directly, which is the usual case since gateways uplink their own
neighbours, that number is 0. We then hold a node marked as a direct neighbour that we have no RF
path to in either direction, carrying `has_hops_away` and `hops_away == 0` next to
`via_mqtt == true`. `NodeDB::resolveLastByte(byte, requireDirectNeighbor=true)` treats that as a
plausible relay and doesn't look at `via_mqtt`, so `NextHopRouter::getNextHop()` can hand out a
`next_hop` byte for a node that only exists to us over IP.

Most of the time this is self limiting: the phantom collides with a real neighbour's last byte,
`resolveLastByte` returns `Ambiguous` and the caller floods, which is degraded but safe. The case
that bites is a phantom that uniquely validates a stored `next_hop` whose real RF holder has gone, so
a DM gets unicast at a node that can't hear it.

Separately from routing, `hops_away` is just wrong data for non RF ingress. A node two hops from the
gateway is recorded as `hops_away` 2 for us, which isn't a fact about our topology at all. It is
surfaced to the phone and to MQTT JSON as well.

Gating on `TRANSPORT_LORA` matches the two adjacent writes.

I deliberately didn't gate on `via_mqtt`. UDP ingress never sets that bit and `:3688` overwrites it
on every update, so it isn't a reliable discriminator here.

One visible consequence: an MQTT only node now has no `hops_away` rather than a wrong one. That is
the intent, since `has_hops_away` exists so "unknown" is representable, but anything displaying
`hops_away` will notice. Nodes already carrying a phantom value keep it until their entry is next
updated from a real LoRa reception.

Testing: builds clean on `heltec-v4` and `seeed-xiao-s3`, 137/137 across `test_nodedb_blocked`,
`test_mqtt`, `test_nexthop_routing`, `test_traceroute_nexthop` and `test_type_conversions`. Not
reproduced at runtime, since that needs MQTT or UDP ingress feeding `updateFrom()` and I couldn't set
that up on a two node LoRa only bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other: compile-only on Heltec V4 and Seeed XIAO ESP32-S3
