### PR TITLE
fix(detectionsensor): release unsent packets when refused on public channel

### DIFF
--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -128,11 +128,10 @@ int32_t DetectionSensorModule::runOnce()
 void DetectionSensorModule::sendDetectionMessage()
 {
     LOG_DEBUG("Detected event observed. Send message");
-    char *message = new char[40];
-    sprintf(message, "%s detected", moduleConfig.detection_sensor.name);
+    char message[40];
+    snprintf(message, sizeof(message), "%s detected", moduleConfig.detection_sensor.name);
     meshtastic_MeshPacket *p = allocDataPacket();
     if (!p) {
-        delete[] message;
         return;
     }
     p->want_ack = false;
@@ -147,18 +146,18 @@ void DetectionSensorModule::sendDetectionMessage()
     if (!channels.isDefaultChannel(0)) {
         LOG_INFO("Send message id=%d, dest=%x, msg=%.*s", p->id, p->to, p->decoded.payload.size, p->decoded.payload.bytes);
         service->sendToMesh(p);
-    } else
+    } else {
         LOG_ERROR("Message not allow on Public channel");
-    delete[] message;
+        packetPool.release(p);
+    }
 }
 
 void DetectionSensorModule::sendCurrentStateMessage(bool state)
 {
-    char *message = new char[40];
-    sprintf(message, "%s state: %i", moduleConfig.detection_sensor.name, state);
+    char message[40];
+    snprintf(message, sizeof(message), "%s state: %i", moduleConfig.detection_sensor.name, state);
     meshtastic_MeshPacket *p = allocDataPacket();
     if (!p) {
-        delete[] message;
         return;
     }
     p->want_ack = false;
@@ -168,9 +167,10 @@ void DetectionSensorModule::sendCurrentStateMessage(bool state)
     if (!channels.isDefaultChannel(0)) {
         LOG_INFO("Send message id=%d, dest=%x, msg=%.*s", p->id, p->to, p->decoded.payload.size, p->decoded.payload.bytes);
         service->sendToMesh(p);
-    } else
+    } else {
         LOG_ERROR("Message not allow on Public channel");
-    delete[] message;
+        packetPool.release(p);
+    }
 }
 
 bool DetectionSensorModule::hasDetectionEvent()


### PR DESCRIPTION
## Why

Both `sendDetectionMessage()` and `sendCurrentStateMessage()` allocate a `MeshPacket` from `packetPool` and then, when the node's primary channel is the default/public channel, hit an `else` branch that only logs — the packet is neither handed to `service->sendToMesh()` nor released. Every refused send permanently leaks one entry from the fixed-size packet pool.

The heartbeat path makes this worse: with `state_broadcast_secs > 0`, `sendCurrentStateMessage()` fires on a periodic timer, so a detection-sensor node left on the default channel drains the pool at a steady rate until packet allocation fails device-wide.

## What

- Release the packet back to `packetPool` in the refusal branch of both functions (same pattern as `PositionModule`).
- Replace the per-message `new char[40]` scratch buffer with a stack buffer and `snprintf`, which also removes the manual `delete[]` on every exit path. `detection_sensor.name` is bounded (20 bytes) so 40 bytes remains sufficient.

## Testing

- Verified `packetPool` is in scope via `MeshService.h` → `MeshTypes.h`.
- `trunk fmt` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when sending detection and current-state messages.
  * Prevented rejected public-channel packets from being retained, reducing the risk of resource exhaustion.
  * Added safer message formatting to avoid oversized or malformed messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->