### PR TITLE
fix(mesh): plug pooled-object and driver leaks in core paths

### DIFF
--- a/src/MessageStore.cpp
+++ b/src/MessageStore.cpp
@@ -42,6 +42,10 @@ static inline void resetMessagePool()
 // If not enough space remains, wrap around (ring buffer style)
 static inline uint16_t storeTextInPool(const char *src, size_t len)
 {
+    // Pool allocation can fail at boot; getTextFromPool() already maps offset 0 to "" in that case
+    if (!g_messagePool)
+        return 0;
+
     if (len >= MAX_MESSAGE_SIZE)
         len = MAX_MESSAGE_SIZE - 1;
 

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -353,6 +353,8 @@ ErrorCode MeshService::sendQueueStatusToPhone(const meshtastic_QueueStatus &qs, 
     lastQueueStatus = *copied;
 
     res = toPhoneQueueStatusQueue.enqueue(copied, 0);
+    if (!res)
+        releaseQueueStatusToPool(copied);
     fromNum++;
 
     return res ? ERRNO_OK : ERRNO_UNKNOWN;

--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -129,7 +129,8 @@ bool RF95Interface::init()
 
     limitPower(RF95_MAX_POWER);
 
-    iface = lora = new RadioLibRF95(&module);
+    lora.reset(new RadioLibRF95(&module));
+    iface = lora.get();
 
 #ifdef RF95_TCXO
     pinMode(RF95_TCXO, OUTPUT);

--- a/src/mesh/RF95Interface.h
+++ b/src/mesh/RF95Interface.h
@@ -4,12 +4,18 @@
 #include "RadioLibInterface.h"
 #include "RadioLibRF95.h"
 
+#include <memory>
+
 /**
  * Our new not radiohead adapter for RF95 style radios
  */
 class RF95Interface : public RadioLibInterface
 {
-    RadioLibRF95 *lora = NULL; // Either a RFM95 or RFM96 depending on what was stuffed on this board
+    // Either a RFM95 or RFM96 depending on what was stuffed on this board.
+    // Owned here; every other radio interface holds its driver by value, but this one is
+    // constructed in init(), so unique_ptr keeps it from leaking when init() fails and the
+    // interface is destroyed.
+    std::unique_ptr<RadioLibRF95> lora;
 
   public:
     RF95Interface(LockingArduinoHal *hal, RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst,


### PR DESCRIPTION
Three small memory fixes in core mesh paths:

## MeshService::sendQueueStatusToPhone — pool slot lost on enqueue failure

The function allocates from the 4-slot `staticQueueStatusPool`, then returns without releasing when `toPhoneQueueStatusQueue.enqueue()` fails. Its two siblings in the same file (`sendMqttMessageToClientProxy`, `sendClientNotification`) both release on exactly this failure. The full-queue guard makes the failure impossible single-threaded, but the numFree/dequeue/enqueue sequence is not atomic and this path runs concurrently from the main loop and (on nRF52) the Bluefruit BLE write callback (`NRF52Bluetooth.cpp` `onToRadioWrite` → `handleToRadio` → `sendToMesh` → `sendQueueStatusToPhone`). Each occurrence permanently loses a pool slot; after four, QueueStatus to the phone is dead until reboot.

## MessageStore::storeTextInPool — write through null pool pointer

`resetMessagePool()` leaves `g_messagePool` null when the boot `malloc` fails; the read side (`getTextFromPool`) guards for that, but the write side memcpy'd through the null pointer on every stored text message. Now returns offset 0, which the read side already maps to `""`.

## RF95Interface — driver leaked when radio probe fails

`init()` does `lora = new RadioLibRF95(&module)` with no destructor anywhere in the class. When `init()` then fails (e.g. `begin()` returns `CHIP_NOT_FOUND` while probing), `initLoRa()` destroys the interface via `unique_ptr<RadioInterface>` and the driver object leaks. Hold it in a `unique_ptr` — every other radio interface holds its driver by value, so this is the only one that needed it. `iface` remains a non-owning alias (`~RadioLibInterface` does not delete it).

## Testing

- `trunk fmt` clean; native test suite run planned across the fix series before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when message storage allocation fails.
  * Prevented queue-status resources from remaining allocated when delivery fails.
  * Improved radio driver ownership and lifecycle management for more reliable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->