### PR TITLE
fix(eth): free partially initialized TLS contexts on init failure

### DIFF
--- a/src/mesh/eth/ethTlsApiServer.cpp
+++ b/src/mesh/eth/ethTlsApiServer.cpp
@@ -61,10 +61,8 @@ static mbedtls_ssl_config sslConf;
 static mbedtls_ssl_context ssl;
 static bool tlsReady = false;
 
-// Free all four contexts together. Safe to call on init-but-unpopulated contexts, which is
-// what makes it usable from initTlsContext's failure paths: without this, a parse/setup
-// failure strands the already-parsed cert/key material forever, because deInit's cleanup is
-// guarded by tlsReady, which is only set after full success.
+// Free all TLS contexts, including partially initialized ones - initTlsContext's failure
+// paths must use this, because deInit's cleanup only runs once tlsReady is set.
 static void freeTlsContexts()
 {
     mbedtls_ssl_free(&ssl);

--- a/src/mesh/eth/ethTlsApiServer.cpp
+++ b/src/mesh/eth/ethTlsApiServer.cpp
@@ -61,6 +61,18 @@ static mbedtls_ssl_config sslConf;
 static mbedtls_ssl_context ssl;
 static bool tlsReady = false;
 
+// Free all four contexts together. Safe to call on init-but-unpopulated contexts, which is
+// what makes it usable from initTlsContext's failure paths: without this, a parse/setup
+// failure strands the already-parsed cert/key material forever, because deInit's cleanup is
+// guarded by tlsReady, which is only set after full success.
+static void freeTlsContexts()
+{
+    mbedtls_ssl_free(&ssl);
+    mbedtls_ssl_config_free(&sslConf);
+    mbedtls_pk_free(&pkKey);
+    mbedtls_x509_crt_free(&certChain);
+}
+
 // Adapter: route mbedtls_ssl_set_bio() through the EthernetClient instance
 // that runOnce() is currently servicing. The void* ctx we hand mbedtls is a
 // pointer to the EthernetClient.
@@ -243,12 +255,14 @@ class EthTlsApiServerThread : public concurrency::OSThread
         ret = mbedtls_x509_crt_parse_der(&certChain, cert.certDer.data(), cert.certDer.size());
         if (ret != 0) {
             LOG_ERROR("ETH TLS: x509_crt_parse_der failed -0x%04x", -ret);
+            freeTlsContexts();
             return false;
         }
 
         ret = mbedtls_pk_parse_key(&pkKey, cert.keyDer.data(), cert.keyDer.size(), nullptr, 0, picoRand, nullptr);
         if (ret != 0) {
             LOG_ERROR("ETH TLS: pk_parse_key failed -0x%04x", -ret);
+            freeTlsContexts();
             return false;
         }
 
@@ -256,6 +270,7 @@ class EthTlsApiServerThread : public concurrency::OSThread
                                           MBEDTLS_SSL_PRESET_DEFAULT);
         if (ret != 0) {
             LOG_ERROR("ETH TLS: ssl_config_defaults failed -0x%04x", -ret);
+            freeTlsContexts();
             return false;
         }
 
@@ -272,12 +287,14 @@ class EthTlsApiServerThread : public concurrency::OSThread
         ret = mbedtls_ssl_conf_own_cert(&sslConf, &certChain, &pkKey);
         if (ret != 0) {
             LOG_ERROR("ETH TLS: conf_own_cert failed -0x%04x", -ret);
+            freeTlsContexts();
             return false;
         }
 
         ret = mbedtls_ssl_setup(&ssl, &sslConf);
         if (ret != 0) {
             LOG_ERROR("ETH TLS: ssl_setup failed -0x%04x", -ret);
+            freeTlsContexts();
             return false;
         }
 
@@ -340,10 +357,7 @@ void deInitEthTlsApiServer()
         tlsServer = nullptr;
     }
     if (tlsReady) {
-        mbedtls_ssl_free(&ssl);
-        mbedtls_ssl_config_free(&sslConf);
-        mbedtls_pk_free(&pkKey);
-        mbedtls_x509_crt_free(&certChain);
+        freeTlsContexts();
         tlsReady = false;
     }
 }


### PR DESCRIPTION
`initTlsContext()` inits four mbedtls contexts (`certChain`, `pkKey`, `sslConf`, `ssl`) and populates them step by step. Every failure return (`x509_crt_parse_der`, `pk_parse_key`, `ssl_config_defaults`, `conf_own_cert`, `ssl_setup`) returned `false` without freeing what the earlier steps had already allocated — e.g. a successfully parsed cert chain when the key parse fails.

Because `tlsReady` is only set after full success, the cleanup in `deInitEthTlsApiServer()` is guarded by `if (tlsReady)` and can never reclaim that partial state; `runOnce()` then hard-fails (`INT32_MAX`) with the parsed X.509/key material stranded for the life of the process. The same failure is reachable on the cert-regeneration path (DHCP lease change bumps the cert generation → deInit → re-init).

Fix: factor the four frees into a `freeTlsContexts()` helper — mbedtls free functions are safe on init-but-unpopulated contexts — and call it from every `initTlsContext` failure return. `deInitEthTlsApiServer()` now uses the same helper under its existing `tlsReady` guard.

No behavior change on the success path. `trunk fmt` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS resource cleanup when server initialization encounters an error.
  * Ensured TLS certificates, keys, configurations, and connection contexts are released during shutdown.
  * Reduced the risk of resource leaks and improves server stability after failed setup attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->