### PR TITLE
fix(nimble): stop leaking BLE2904 descriptor on BLE re-setup

### DIFF
--- a/src/nimble/NimbleBluetooth.cpp
+++ b/src/nimble/NimbleBluetooth.cpp
@@ -1025,13 +1025,16 @@ void NimbleBluetooth::setupService()
 
     // Setup the battery service
     BLEService *batteryService = bleServer->createService(BLEUUID((uint16_t)0x180f)); // 0x180F is the Battery Service
-    BLE2904 *batteryLevelDescriptor = new BLE2904();
-    batteryLevelDescriptor->setFormat(BLE2904::FORMAT_UINT8);
-    batteryLevelDescriptor->setNamespace(1);
-    batteryLevelDescriptor->setUnit(0x27ad);
+    // Static like the callback objects above: setupService() re-runs on every BLE re-enable, and
+    // the framework never frees descriptors (~BLECharacteristic is empty), so a heap allocation
+    // here leaks one BLE2904 per cycle.
+    static BLE2904 batteryLevelDescriptor;
+    batteryLevelDescriptor.setFormat(BLE2904::FORMAT_UINT8);
+    batteryLevelDescriptor.setNamespace(1);
+    batteryLevelDescriptor.setUnit(0x27ad);
     BatteryCharacteristic = batteryService->createCharacteristic( // 0x2A19 is the Battery Level characteristic)
         (uint16_t)0x2a19, BLECharacteristic::PROPERTY_READ | BLECharacteristic::PROPERTY_NOTIFY);
-    BatteryCharacteristic->addDescriptor(batteryLevelDescriptor);
+    BatteryCharacteristic->addDescriptor(&batteryLevelDescriptor);
     // Seed an initial 0-100 level so an early read of 0x2A19 returns a valid value.
     uint8_t initialLevel = (powerStatus && powerStatus->getHasBattery()) ? powerStatus->getBatteryChargePercent() : 0;
     if (initialLevel > 100)


### PR DESCRIPTION
`setupService()` re-runs on every Bluetooth re-enable cycle (its own comments note the characteristics are new each cycle, and `setup()` explicitly clears teardown guards to support same-boot re-init). Every callback object in the function is deliberately function-local `static` to survive those re-runs — the battery level `BLE2904` was the one remaining heap allocation.

Nothing ever frees a descriptor: in the Arduino BLE library, `BLEDevice::deinit()` only deletes the server/advertising/scan objects and `~BLECharacteristic` has an empty body, so each re-setup leaked one `BLE2904` (today that's one per boot since `deinit` is only called before deep sleep, but any same-boot disable→enable cycle leaks one per cycle).

Make the descriptor `static` to match the surrounding pattern; its format/namespace/unit fields are (re)set on every pass and `addDescriptor()` re-binds it to the fresh characteristic.

`trunk fmt` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth service reinitialization by reducing repeated descriptor allocations.
  * Preserved existing battery-level descriptor behavior across reconnects and reinitializations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->