### PR TITLE
fix(nrf54l15): don't write past String buffer when a grow fails

### DIFF
--- a/src/platform/nrf54l15/Arduino.h
+++ b/src/platform/nrf54l15/Arduino.h
@@ -601,6 +601,8 @@ class String
     {
         // reserve() keeps the old (smaller) buffer on OOM, so a failed grow must abort the
         // write: memcpy'ing n >= _cap bytes would overflow into adjacent heap.
+        if (n + 1 == 0)
+            return; // n + 1 would wrap
         if (n >= _cap && !reserve(n + 1))
             return;
         if (_buf) {
@@ -614,6 +616,8 @@ class String
         if (!s || n == 0)
             return;
         unsigned newlen = _len + n;
+        if (newlen < _len || newlen + 1 == 0)
+            return; // length arithmetic wrapped
         if (newlen >= _cap && !reserve(newlen + 1))
             return; // OOM: keep the existing content intact instead of writing past the buffer
         if (_buf) {
@@ -624,6 +628,8 @@ class String
     }
     bool reserve(unsigned int n)
     {
+        if (n == 0)
+            return false;
         char *b = (char *)realloc(_buf, n);
         if (b) {
             _buf = b;

--- a/src/platform/nrf54l15/Arduino.h
+++ b/src/platform/nrf54l15/Arduino.h
@@ -599,8 +599,10 @@ class String
 
     void assign(const char *s, unsigned int n)
     {
-        if (n >= _cap)
-            reserve(n + 1);
+        // reserve() keeps the old (smaller) buffer on OOM, so a failed grow must abort the
+        // write: memcpy'ing n >= _cap bytes would overflow into adjacent heap.
+        if (n >= _cap && !reserve(n + 1))
+            return;
         if (_buf) {
             memcpy(_buf, s, n);
             _buf[n] = 0;
@@ -612,21 +614,23 @@ class String
         if (!s || n == 0)
             return;
         unsigned newlen = _len + n;
-        if (newlen >= _cap)
-            reserve(newlen + 1);
+        if (newlen >= _cap && !reserve(newlen + 1))
+            return; // OOM: keep the existing content intact instead of writing past the buffer
         if (_buf) {
             memcpy(_buf + _len, s, n);
             _len = newlen;
             _buf[_len] = 0;
         }
     }
-    void reserve(unsigned int n)
+    bool reserve(unsigned int n)
     {
         char *b = (char *)realloc(_buf, n);
         if (b) {
             _buf = b;
             _cap = n;
+            return true;
         }
+        return false;
     }
 };
 


### PR DESCRIPTION
In the nRF54L15 `String` shim, `reserve()` handles `realloc` failure correctly (keeps the old buffer/capacity) — but it returned `void`, and both callers ignored the outcome:

- `assign(s, n)`: after a failed grow, `_buf` is still the old smaller buffer and the `if (_buf)` guard passes, so `memcpy(_buf, s, n)` with `n >= _cap` writes up to `n+1-_cap` bytes past the allocation.
- `concat(s, n)`: identical pattern at `memcpy(_buf + _len, s, n)`.

On this Zephyr target malloc failure is a realistic condition, and the failure mode was silent heap corruption rather than a clean truncation.

Fix: `reserve()` returns `bool`; `assign`/`concat` leave the string unchanged when the grow fails.

`trunk fmt` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved string handling when memory allocation fails.
  * String assignment and concatenation now preserve existing content instead of leaving it partially modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->