### PR TITLE
fix(platform): OOM null-write in stm32wl File and exception leak in portduino GPIO init

### DIFF
--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -845,10 +845,10 @@ int initGPIOPin(int pinNum, const std::string &gpioChipName, int line)
     std::string gpio_name = "GPIO" + std::to_string(pinNum);
     std::cout << "Initializing " << gpio_name << " on chip " << gpioChipName << std::endl;
     try {
-        GPIOPin *csPin;
-        csPin = new LinuxGPIOPin(pinNum, gpioChipName.c_str(), line, gpio_name.c_str());
+        auto csPin = std::make_unique<LinuxGPIOPin>(pinNum, gpioChipName.c_str(), line, gpio_name.c_str());
         csPin->setSilent();
-        gpioBind(csPin);
+        gpioBind(csPin.get());
+        csPin.release(); // owned by the gpio table from here on
         return ERRNO_OK;
     } catch (...) {
         const std::type_info *t = abi::__cxa_current_exception_type();

--- a/src/platform/stm32wl/STM32_LittleFS_File.cpp
+++ b/src/platform/stm32wl/STM32_LittleFS_File.cpp
@@ -100,10 +100,17 @@ bool File::_open_dir(char const *filepath)
         return false;
     }
 
-    _is_dir = true;
-
     _dir_path = (char *)rtos_malloc(strlen(filepath) + 1);
+    if (!_dir_path) {
+        // match the _dir failure path above: don't leave a half-open dir behind
+        lfs_dir_close(_fs->_getFS(), _dir);
+        rtos_free(_dir);
+        _dir = NULL;
+        return false;
+    }
     strcpy(_dir_path, filepath);
+
+    _is_dir = true;
 
     return true;
 }


### PR DESCRIPTION
Two small platform-layer fixes from a memory audit:

## stm32wl `File::_open_dir` — unchecked malloc + strcpy

The `_dir_path` allocation was the only unchecked `rtos_malloc` in the file (both `_file` and `_dir` are checked), and it's followed immediately by `strcpy`, so OOM became a NULL write. Worse, the object was left half-initialized — dir open, `_is_dir` already true, null path — and `openNextFile()` would later call `strlen(NULL)`. Now checked, unwinding the already-opened dir exactly like the `_dir` failure path above it; `_is_dir` is only set once the state is complete.

## portduino `initGPIOPin` — pin object lost on exception

The body is wrapped in `try/catch(...)`; if `setSilent()` or `gpioBind()` threw after `new LinuxGPIOPin(...)`, the catch block logged and returned with the object unreachable. Hold it in a `unique_ptr` and `release()` only after `gpioBind` has registered it.

(A third candidate from the audit — the dropped `new BQ25713()` pointer in `main-nrf52.cpp` — was left alone: no in-tree variant defines `BQ25703A_ADDR`, so the change couldn't be compile-verified.)

`trunk fmt` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when initializing Linux GPIO pins.
  * Added safer handling for directory path allocation failures, ensuring resources are properly released and directory state remains consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->