### PR TITLE
refactor(inkhud): make tile and framebuffer ownership explicit

### DIFF
--- a/src/graphics/niche/Drivers/EInk/GDEW0102T4.cpp
+++ b/src/graphics/niche/Drivers/EInk/GDEW0102T4.cpp
@@ -163,7 +163,7 @@ void GDEW0102T4::writeOldImage()
 
     // FAST refresh uses differential data (previous frame as old image).
     if (previousBuffer) {
-        writeImage(0x10, previousBuffer);
+        writeImage(0x10, previousBuffer.get());
     } else {
         writeImage(0x10, buffer);
     }

--- a/src/graphics/niche/Drivers/EInk/UC8175.cpp
+++ b/src/graphics/niche/Drivers/EInk/UC8175.cpp
@@ -33,9 +33,9 @@ void UC8175::begin(SPIClass *spi, uint8_t pin_dc, uint8_t pin_cs, uint8_t pin_bu
     }
 
     if (!previousBuffer) {
-        previousBuffer = new uint8_t[bufferSize];
+        previousBuffer.reset(new uint8_t[bufferSize]);
         if (previousBuffer)
-            memset(previousBuffer, 0xFF, bufferSize);
+            memset(previousBuffer.get(), 0xFF, bufferSize);
     }
 }
 
@@ -44,7 +44,7 @@ void UC8175::update(uint8_t *imageData, UpdateTypes type)
     buffer = imageData;
     updateType = (type == UpdateTypes::UNSPECIFIED) ? UpdateTypes::FULL : type;
 
-    if (updateType == FAST && hasPreviousBuffer && previousBuffer && memcmp(previousBuffer, buffer, bufferSize) == 0)
+    if (updateType == FAST && hasPreviousBuffer && previousBuffer && memcmp(previousBuffer.get(), buffer, bufferSize) == 0)
         return;
 
     reset();
@@ -60,7 +60,7 @@ void UC8175::update(uint8_t *imageData, UpdateTypes type)
     sendCommand(0x12); // Display refresh.
 
     if (previousBuffer) {
-        memcpy(previousBuffer, buffer, bufferSize);
+        memcpy(previousBuffer.get(), buffer, bufferSize);
         hasPreviousBuffer = true;
     }
 
@@ -164,7 +164,7 @@ void UC8175::writeImage(uint8_t command, const uint8_t *image)
 void UC8175::writeOldImage()
 {
     if (updateType == FAST && previousBuffer)
-        writeImage(0x10, previousBuffer);
+        writeImage(0x10, previousBuffer.get());
     else
         writeImage(0x10, buffer);
 }

--- a/src/graphics/niche/Drivers/EInk/UC8175.h
+++ b/src/graphics/niche/Drivers/EInk/UC8175.h
@@ -6,6 +6,8 @@
 
 #include "configuration.h"
 
+#include <memory>
+
 #include "./EInk.h"
 
 namespace NicheGraphics::Drivers
@@ -45,7 +47,7 @@ class UC8175 : public EInk
     uint16_t bufferRowSize = 0;
     uint32_t bufferSize = 0;
     uint8_t *buffer = nullptr;
-    uint8_t *previousBuffer = nullptr;
+    std::unique_ptr<uint8_t[]> previousBuffer;
     bool hasPreviousBuffer = false;
     UpdateTypes updateType = UpdateTypes::UNSPECIFIED;
 

--- a/src/graphics/niche/InkHUD/Renderer.cpp
+++ b/src/graphics/niche/InkHUD/Renderer.cpp
@@ -41,7 +41,7 @@ void InkHUD::Renderer::setDriver(Drivers::EInk *driver)
     imageBufferHeight = driver->height;
 
     // Allocate the image buffer
-    imageBuffer = new uint8_t[imageBufferWidth * imageBufferHeight];
+    imageBuffer = std::make_unique<uint8_t[]>(imageBufferWidth * imageBufferHeight);
 }
 
 // Set the target number of FAST display updates in a row, before a FULL update is used for display health
@@ -236,7 +236,7 @@ void InkHUD::Renderer::render(bool async)
 
         // Tell display to begin process of drawing new image
         LOG_INFO("Updating display");
-        driver->update(imageBuffer, updateType);
+        driver->update(imageBuffer.get(), updateType);
 
         // If not async, wait here until the update is complete
         if (!async)
@@ -260,7 +260,7 @@ void InkHUD::Renderer::render(bool async)
 // rather than rendering selectively, and manually blanking a portion of the display
 void InkHUD::Renderer::clearBuffer()
 {
-    memset(imageBuffer, 0xFF, imageBufferHeight * imageBufferWidth);
+    memset(imageBuffer.get(), 0xFF, imageBufferHeight * imageBufferWidth);
 }
 
 // Manually clear the pixels below a tile
@@ -312,7 +312,7 @@ void InkHUD::Renderer::clearTile(Tile *t)
 
     // Clear the pixels
     if (xStart == 0 && xEnd == driver->width) { // full width box is easier to clear
-        memset(imageBuffer + (yStart * imageBufferWidth), 0xFF, (yEnd - yStart) * imageBufferWidth);
+        memset(imageBuffer.get() + (yStart * imageBufferWidth), 0xFF, (yEnd - yStart) * imageBufferWidth);
     } else {
         const uint16_t byteStart = (xStart / 8) + 1;
         const uint16_t byteEnd = xEnd / 8;
@@ -324,7 +324,7 @@ void InkHUD::Renderer::clearTile(Tile *t)
 
             // Set the continuous bytes
             if (byteStart < byteEnd)
-                memset(imageBuffer + i + byteStart, 0xFF, byteEnd - byteStart);
+                memset(imageBuffer.get() + i + byteStart, 0xFF, byteEnd - byteStart);
 
             // Set the trailing byte
             if (byteEnd != imageBufferWidth)

--- a/src/graphics/niche/InkHUD/Renderer.h
+++ b/src/graphics/niche/InkHUD/Renderer.h
@@ -14,6 +14,8 @@ Orchestrates updating of the display image
 
 #include "configuration.h"
 
+#include <memory>
+
 #include "./DisplayHealth.h"
 #include "./InkHUD.h"
 #include "./Persistence.h"
@@ -76,7 +78,7 @@ class Renderer : protected concurrency::OSThread
     Drivers::EInk *driver = nullptr; // Interacts with your variants display hardware
     DisplayHealth displayHealth;     // Manages display health by controlling type of update
 
-    uint8_t *imageBuffer = nullptr; // Fed into driver
+    std::unique_ptr<uint8_t[]> imageBuffer; // Fed into driver
     uint16_t imageBufferHeight = 0;
     uint16_t imageBufferWidth = 0;
     uint32_t imageBufferSize = 0; // Bytes

--- a/src/graphics/niche/InkHUD/Tile.cpp
+++ b/src/graphics/niche/InkHUD/Tile.cpp
@@ -40,6 +40,20 @@ InkHUD::Tile::Tile()
     Tile::highlightShown = false;
 }
 
+InkHUD::Tile::~Tile()
+{
+    // Break the reciprocal Tile<->Applet link, so an applet orphaned by a layout rebuild is not
+    // left holding a dangling pointer to this tile
+    if (assignedApplet && assignedApplet->getTile() == this)
+        assignedApplet->setTile(nullptr);
+
+    // Same for the pending-highlight target
+    if (Tile::highlightTarget == this) {
+        Tile::highlightTarget = nullptr;
+        Tile::highlightShown = false;
+    }
+}
+
 InkHUD::Tile::Tile(int16_t left, int16_t top, uint16_t width, uint16_t height)
 {
     assert(width > 0 && height > 0);

--- a/src/graphics/niche/InkHUD/Tile.h
+++ b/src/graphics/niche/InkHUD/Tile.h
@@ -25,6 +25,7 @@ class Tile
   public:
     Tile();
     Tile(int16_t left, int16_t top, uint16_t width, uint16_t height);
+    ~Tile();
 
     void setRegion(uint8_t layoutSize, uint8_t tileIndex);                      // Assign region automatically, based on layout
     void setRegion(int16_t left, int16_t top, uint16_t width, uint16_t height); // Assign region manually

--- a/src/graphics/niche/InkHUD/WindowManager.cpp
+++ b/src/graphics/niche/InkHUD/WindowManager.cpp
@@ -539,7 +539,7 @@ std::vector<InkHUD::Tile *> InkHUD::WindowManager::getEmptyTiles()
     for (auto &t : userTiles) {
         Applet *a = t->getAssignedApplet();
         if (!a || !a->isActive())
-            empty.push_back(t);
+            empty.push_back(t.get());
     }
 
     return empty;

--- a/src/graphics/niche/InkHUD/WindowManager.cpp
+++ b/src/graphics/niche/InkHUD/WindowManager.cpp
@@ -100,7 +100,7 @@ void InkHUD::WindowManager::nextTile()
     refocusTile();
 
     if (menuWasOpen)
-        menu->show(userTiles.at(settings->userTiles.focused));
+        menu->show(userTiles.at(settings->userTiles.focused).get());
 
     // Ask the tile to draw an indicator showing which tile is now focused
     // Requests a render
@@ -132,7 +132,7 @@ void InkHUD::WindowManager::prevTile()
     refocusTile();
 
     if (menuWasOpen)
-        menu->show(userTiles.at(settings->userTiles.focused));
+        menu->show(userTiles.at(settings->userTiles.focused).get());
 
     // Ask the tile to draw an indicator showing which tile is now focused
     // Requests a render
@@ -153,7 +153,7 @@ bool InkHUD::WindowManager::selectTileAt(uint16_t x, uint16_t y)
     const int32_t ty = y;
 
     for (uint8_t i = 0; i < userTiles.size(); i++) {
-        Tile *tile = userTiles.at(i);
+        Tile *tile = userTiles.at(i).get();
 
         const int32_t left = tile->getLeft();
         const int32_t top = tile->getTop();
@@ -179,7 +179,7 @@ bool InkHUD::WindowManager::selectTileAt(uint16_t x, uint16_t y)
 void InkHUD::WindowManager::openMenu()
 {
     MenuApplet *menu = (MenuApplet *)inkhud->getSystemApplet("Menu");
-    menu->show(userTiles.at(settings->userTiles.focused));
+    menu->show(userTiles.at(settings->userTiles.focused).get());
 }
 
 // Show touch-only app switcher on the focused tile
@@ -190,7 +190,7 @@ void InkHUD::WindowManager::openAppSwitcher()
 
     AppSwitcherApplet *switcher = static_cast<AppSwitcherApplet *>(inkhud->getSystemApplet("AppSwitcher"));
     if (switcher) {
-        switcher->show(userTiles.at(settings->userTiles.focused));
+        switcher->show(userTiles.at(settings->userTiles.focused).get());
     }
 }
 
@@ -235,7 +235,7 @@ void InkHUD::WindowManager::closeKeyboard()
 // Applets available for this must be activated, and not already displayed on another tile
 void InkHUD::WindowManager::nextApplet()
 {
-    Tile *t = userTiles.at(settings->userTiles.focused);
+    Tile *t = userTiles.at(settings->userTiles.focused).get();
 
     // Abort if zero applets available
     // nullptr means WindowManager::refocusTile determined that there were no available applets
@@ -284,7 +284,7 @@ void InkHUD::WindowManager::nextApplet()
 // Applets available for this must be activated, and not already displayed on another tile
 void InkHUD::WindowManager::prevApplet()
 {
-    Tile *t = userTiles.at(settings->userTiles.focused);
+    Tile *t = userTiles.at(settings->userTiles.focused).get();
 
     // Abort if zero applets available
     // nullptr means WindowManager::refocusTile determined that there were no available applets
@@ -356,7 +356,7 @@ bool InkHUD::WindowManager::showApplet(uint8_t appletIndex)
     }
 
     // Otherwise replace the focused tile's applet.
-    Tile *focused = userTiles.at(settings->userTiles.focused);
+    Tile *focused = userTiles.at(settings->userTiles.focused).get();
     Applet *current = focused->getAssignedApplet();
     if (current && current != target)
         current->sendToBackground();
@@ -430,7 +430,7 @@ void InkHUD::WindowManager::changeLayout()
     // - its assignment was cleared (assignUserAppletsToTiles)
     MenuApplet *menu = (MenuApplet *)inkhud->getSystemApplet("Menu");
     if (menu->isForeground()) {
-        Tile *ft = userTiles.at(settings->userTiles.focused);
+        Tile *ft = userTiles.at(settings->userTiles.focused).get();
         menu->show(ft);
     }
 
@@ -480,7 +480,7 @@ void InkHUD::WindowManager::changeActivatedApplets()
     // Restore menu
     // - its assignment was cleared (assignUserAppletsToTiles)
     if (menu->isForeground()) {
-        Tile *ft = userTiles.at(settings->userTiles.focused);
+        Tile *ft = userTiles.at(settings->userTiles.focused).get();
         menu->show(ft);
     }
 
@@ -510,10 +510,10 @@ void InkHUD::WindowManager::autoshow()
             && !a->isForeground()                 // Not yet foreground
             && settings->userApplets.autoshow[i]) // User permits this applet to autoshow
         {
-            Tile *t = userTiles.at(settings->userTiles.focused); // Get focused tile
-            t->getAssignedApplet()->sendToBackground();          // Background whichever applet is already on the tile
-            t->assignApplet(a);                                  // Assign our new applet to tile
-            a->bringToForeground();                              // Foreground our new applet
+            Tile *t = userTiles.at(settings->userTiles.focused).get(); // Get focused tile
+            t->getAssignedApplet()->sendToBackground();                // Background whichever applet is already on the tile
+            t->assignApplet(a);                                        // Assign our new applet to tile
+            a->bringToForeground();                                    // Foreground our new applet
 
             // Check if autoshown applet shows the same information as notification intended to
             // In this case, we can dismiss the notification before it is shown
@@ -536,7 +536,7 @@ std::vector<InkHUD::Tile *> InkHUD::WindowManager::getEmptyTiles()
 {
     std::vector<Tile *> empty;
 
-    for (Tile *t : userTiles) {
+    for (auto &t : userTiles) {
         Applet *a = t->getAssignedApplet();
         if (!a || !a->isActive())
             empty.push_back(t);
@@ -673,16 +673,12 @@ void InkHUD::WindowManager::createUserApplets()
 // The amount of these is controlled by the user, via "layout" option in the InkHUD menu
 void InkHUD::WindowManager::createUserTiles()
 {
-    // Delete any tiles which currently exist
-    for (Tile *t : userTiles)
-        delete t;
+    // Delete any tiles which currently exist (~Tile breaks the link with any orphaned applet)
     userTiles.clear();
 
     // Create new tiles
-    for (uint8_t i = 0; i < settings->userTiles.count; i++) {
-        Tile *t = new Tile;
-        userTiles.push_back(t);
-    }
+    for (uint8_t i = 0; i < settings->userTiles.count; i++)
+        userTiles.push_back(std::make_unique<Tile>());
 }
 
 // Calculate the display region occupied by each tile
@@ -703,7 +699,7 @@ void InkHUD::WindowManager::assignUserAppletsToTiles()
 {
     // Each user tile
     for (uint8_t i = 0; i < userTiles.size(); i++) {
-        Tile *t = userTiles.at(i);
+        Tile *t = userTiles.at(i).get();
 
         // Check whether tile can display the previously shown applet again
         uint8_t oldIndex = settings->userTiles.displayedUserApplet[i]; // Previous index in WindowManager::userApplets
@@ -747,7 +743,7 @@ void InkHUD::WindowManager::refocusTile()
     // Give "focused tile" a valid applet
     // - scan for another valid applet, which we can addSubstitution
     // - reason: nextApplet() won't cycle if no applet is assigned
-    Tile *focusedTile = userTiles.at(settings->userTiles.focused);
+    Tile *focusedTile = userTiles.at(settings->userTiles.focused).get();
     if (!focusedTile->getAssignedApplet()) {
         // Search for available applets
         for (uint8_t i = 0; i < inkhud->userApplets.size(); i++) {
@@ -778,7 +774,7 @@ void InkHUD::WindowManager::findOrphanApplets()
         // Check each tile, to see if anyone claims this applet
         bool foundOwner = false;
         for (uint8_t it = 0; it < userTiles.size(); it++) {
-            Tile *t = userTiles.at(it);
+            Tile *t = userTiles.at(it).get();
             // A tile claims this applet: not orphaned
             if (t->getAssignedApplet() == a) {
                 foundOwner = true;

--- a/src/graphics/niche/InkHUD/WindowManager.h
+++ b/src/graphics/niche/InkHUD/WindowManager.h
@@ -10,6 +10,8 @@ Responsible for managing which applets are shown, and their sizes / positions
 
 #include "configuration.h"
 
+#include <memory>
+
 #include "./Applets/System/Notification/Notification.h" // The notification object, not the applet
 #include "./InkHUD.h"
 #include "./Persistence.h"
@@ -69,7 +71,8 @@ class WindowManager
 
     void findOrphanApplets(); // Find any applets left-behind when layout changes
 
-    std::vector<Tile *> userTiles; // Tiles which can host user applets
+    std::vector<std::unique_ptr<Tile>>
+        userTiles; // Tiles which can host user applets (owned here; applets hold raw back-pointers)
     bool keyboardOpen = false;
 
     // For convenience


### PR DESCRIPTION
Follow-up to the memory-audit fix series — this one is a no-behavior-change ownership cleanup in NicheGraphics/InkHUD.

## `userTiles` → `std::vector<std::unique_ptr<Tile>>`

`createUserTiles()` is a genuinely repeated runtime path (every rotation change, tile-count change, and on-screen keyboard open/close) and contained the only manual delete/new cycle in the subsystem. The pairing was correct, but only by convention — any future early return in the rebuild sequence would have leaked. Applets keep raw non-owning back-pointers, as before.

## `~Tile()` breaks the reciprocal Tile↔Applet link

`Tile::assignApplet()` creates a two-way link, but deleting a tile left the applet's `assignedTile` dangling until `findOrphanApplets()` happened to relink it. There's a latent hazard behind that: `AppSwitcherApplet` borrows a user tile while foreground, and only the Menu applet is restored after a rebuild — today unreachable (AppSwitcher locks input while shown), but the invariant was undocumented. The destructor now clears the applet's back-pointer and the static `highlightTarget` when they point at the dying tile.

## `Renderer::imageBuffer` / `UC8175::previousBuffer` → `unique_ptr<uint8_t[]>`

One-time setup allocations that live for the process lifetime — not leaks, just self-documenting ownership now.

## Testing

`trunk fmt` clean; building the t114 InkHUD target locally alongside CI.