### PR TITLE
fix(graphics): make on-screen keyboard lifecycle safe and RAII-managed

### DIFF
--- a/src/graphics/VirtualKeyboard.cpp
+++ b/src/graphics/VirtualKeyboard.cpp
@@ -666,7 +666,13 @@ void VirtualKeyboard::handleLongPress()
         break;
     case VK_ESC:
         if (onTextEntered) {
-            onTextEntered("");
+            // Copy-and-clear before invoking, like handlePress/submitText: the callback can
+            // destroy this keyboard (OnScreenKeyboardModule::stop), so the member must not be
+            // the std::function still executing on the stack.
+            std::function<void(const std::string &)> callback = onTextEntered;
+            onTextEntered = nullptr;
+            inputText = "";
+            callback("");
         }
         break;
     default:

--- a/src/modules/OnScreenKeyboardModule.cpp
+++ b/src/modules/OnScreenKeyboardModule.cpp
@@ -18,22 +18,12 @@ OnScreenKeyboardModule &OnScreenKeyboardModule::instance()
     return inst;
 }
 
-OnScreenKeyboardModule::~OnScreenKeyboardModule()
-{
-    if (keyboard) {
-        delete keyboard;
-        keyboard = nullptr;
-    }
-}
+OnScreenKeyboardModule::~OnScreenKeyboardModule() = default;
 
 void OnScreenKeyboardModule::start(const char *header, const char *initialText, uint32_t durationMs,
                                    std::function<void(const std::string &)> cb)
 {
-    if (keyboard) {
-        delete keyboard;
-        keyboard = nullptr;
-    }
-    keyboard = new VirtualKeyboard();
+    keyboard = std::make_unique<VirtualKeyboard>();
     callback = cb;
     if (header)
         keyboard->setHeader(header);
@@ -50,7 +40,7 @@ void OnScreenKeyboardModule::start(const char *header, const char *initialText, 
     });
 
     // Maintain legacy compatibility hooks
-    NotificationRenderer::virtualKeyboard = keyboard;
+    NotificationRenderer::virtualKeyboard = keyboard.get();
     NotificationRenderer::textInputCallback = callback;
 }
 
@@ -58,10 +48,7 @@ void OnScreenKeyboardModule::stop(bool callEmptyCallback)
 {
     auto cb = callback;
     callback = nullptr;
-    if (keyboard) {
-        delete keyboard;
-        keyboard = nullptr;
-    }
+    keyboard.reset();
     // Keep NotificationRenderer legacy pointers in sync
     NotificationRenderer::virtualKeyboard = nullptr;
     NotificationRenderer::textInputCallback = nullptr;
@@ -74,7 +61,7 @@ void OnScreenKeyboardModule::handleInput(const InputEvent &event)
     if (!keyboard)
         return;
 
-    if (processVirtualKeyboardInput(event, keyboard))
+    if (processVirtualKeyboardInput(event, keyboard.get()))
         return;
 
     if (event.inputEvent == INPUT_BROKER_CANCEL)

--- a/src/modules/OnScreenKeyboardModule.h
+++ b/src/modules/OnScreenKeyboardModule.h
@@ -7,6 +7,7 @@
 #include "graphics/VirtualKeyboard.h"
 #include <OLEDDisplay.h>
 #include <functional>
+#include <memory>
 #include <string>
 
 namespace graphics
@@ -34,7 +35,7 @@ class OnScreenKeyboardModule
     void onSubmit(const std::string &text);
     void onCancel();
 
-    VirtualKeyboard *keyboard = nullptr;
+    std::unique_ptr<VirtualKeyboard> keyboard;
     std::function<void(const std::string &)> callback;
 };
 


### PR DESCRIPTION
From the memory audit — one latent use-after-free hazard plus the ownership cleanup that pairs with it.

## VirtualKeyboard: delete-during-callback on long-press ESC

`handleLongPress`'s `VK_ESC` case invoked the member `onTextEntered` **directly**. That callback routes (via `OnScreenKeyboardModule`'s lambda) to `onCancel()` → `stop(true)` → destroying the `VirtualKeyboard` — including the `std::function` member whose invocation is still on the stack. `handlePress`'s ESC case and `submitText()` both deliberately copy-and-clear the callback before invoking to survive exactly this (`CannedMessageModule` documents the same hazard class and defers cleanup). Today the executing lambda happens not to touch freed state after the delete, so it narrowly works — but any change to the lambda or `std::function` internals turns it into a real use-after-free. Mirror the copy-and-clear.

## OnScreenKeyboardModule: keyboard → unique_ptr

The keyboard was manually managed at three sites (destructor, delete-then-new in `start()`, delete in `stop()`) on a repeated open/close path. `unique_ptr` removes all three; the `NotificationRenderer` legacy hook takes a non-owning `.get()` (it never deletes — its own comment says the module frees the keyboard).

## Testing

`trunk fmt` clean; native-macos integration build passes locally (module + renderer compile there).