### PR TITLE
refactor(graphics): unique_ptr ownership for display buffers

### DIFF
--- a/src/graphics/BaseUIEInkDisplay.cpp
+++ b/src/graphics/BaseUIEInkDisplay.cpp
@@ -22,7 +22,8 @@ BaseUIEInkDisplay::BaseUIEInkDisplay(Drivers::EInk *driver, uint8_t rotation) : 
     // Panel-native row-major buffer
     panelRowBytes = ((driver->width - 1) / 8) + 1;
     panelBufferSize = panelRowBytes * driver->height;
-    panelBuffer = std::make_unique<uint8_t[]>(panelBufferSize);
+    // plain new (no value-init): the memset below fills the buffer anyway
+    panelBuffer.reset(new uint8_t[panelBufferSize]);
     memset(panelBuffer.get(), 0xFF, panelBufferSize); // All white
 }
 

--- a/src/graphics/BaseUIEInkDisplay.cpp
+++ b/src/graphics/BaseUIEInkDisplay.cpp
@@ -22,13 +22,8 @@ BaseUIEInkDisplay::BaseUIEInkDisplay(Drivers::EInk *driver, uint8_t rotation) : 
     // Panel-native row-major buffer
     panelRowBytes = ((driver->width - 1) / 8) + 1;
     panelBufferSize = panelRowBytes * driver->height;
-    panelBuffer = new uint8_t[panelBufferSize];
-    memset(panelBuffer, 0xFF, panelBufferSize); // All white
-}
-
-BaseUIEInkDisplay::~BaseUIEInkDisplay()
-{
-    delete[] panelBuffer;
+    panelBuffer = std::make_unique<uint8_t[]>(panelBufferSize);
+    memset(panelBuffer.get(), 0xFF, panelBufferSize); // All white
 }
 
 bool BaseUIEInkDisplay::connect()
@@ -106,7 +101,7 @@ bool BaseUIEInkDisplay::commit(Drivers::EInk::UpdateTypes type, bool blocking)
     if (type == Drivers::EInk::UpdateTypes::FAST && !driver->supports(Drivers::EInk::UpdateTypes::FAST))
         type = Drivers::EInk::UpdateTypes::FULL;
 
-    driver->update(panelBuffer, type);
+    driver->update(panelBuffer.get(), type);
 
     if (blocking)
         driver->await();
@@ -151,7 +146,7 @@ Drivers::EInk::UpdateTypes BaseUIEInkDisplay::decide()
 
 uint32_t BaseUIEInkDisplay::repack()
 {
-    memset(panelBuffer, 0xFF, panelBufferSize); // start all-white
+    memset(panelBuffer.get(), 0xFF, panelBufferSize); // start all-white
 
     const uint16_t pw = driver->width;
     const uint16_t ph = driver->height;

--- a/src/graphics/BaseUIEInkDisplay.h
+++ b/src/graphics/BaseUIEInkDisplay.h
@@ -18,6 +18,7 @@ Replaces the per-board branching in EInkDisplay2 / EInkDynamicDisplay / EInkPara
 #include "graphics/eink/Drivers/EInk.h"
 
 #include <OLEDDisplay.h>
+#include <memory>
 
 namespace NicheGraphics
 {
@@ -37,7 +38,6 @@ class BaseUIEInkDisplay : public OLEDDisplay
     };
 
     BaseUIEInkDisplay(Drivers::EInk *driver, uint8_t rotation);
-    ~BaseUIEInkDisplay() override;
 
     // OLEDDisplay overrides
     bool connect() override;
@@ -71,7 +71,7 @@ class BaseUIEInkDisplay : public OLEDDisplay
 
     Drivers::EInk *driver = nullptr;
     uint8_t rotation = 0; // 0=0°, 1=90°CW, 2=180°, 3=270°CW
-    uint8_t *panelBuffer = nullptr;
+    std::unique_ptr<uint8_t[]> panelBuffer;
     uint32_t panelBufferSize = 0;
     uint16_t panelRowBytes = 0;
 

--- a/src/graphics/EInkParallelDisplay.cpp
+++ b/src/graphics/EInkParallelDisplay.cpp
@@ -22,7 +22,7 @@
 #define EPD_RESPONSIVE_MIN_MS 1000 // simple rate-limit (ms) for responsive updates
 #endif
 
-EInkParallelDisplay::EInkParallelDisplay(uint16_t width, uint16_t height, EpdRotation rot) : epaper(nullptr), rotation(rot)
+EInkParallelDisplay::EInkParallelDisplay(uint16_t width, uint16_t height, EpdRotation rot) : rotation(rot)
 {
     LOG_INFO("init EInkParallelDisplay");
     // Set dimensions in OLEDDisplay base class
@@ -42,19 +42,13 @@ EInkParallelDisplay::EInkParallelDisplay(uint16_t width, uint16_t height, EpdRot
     // allocate dirty pixel buffer same size as epaper buffers (rowBytes * height)
     size_t rowBytes = (this->displayWidth + 7) / 8;
     dirtyPixelsSize = rowBytes * this->displayHeight;
-    dirtyPixels = (uint8_t *)calloc(dirtyPixelsSize, 1);
+    dirtyPixels = std::make_unique<uint8_t[]>(dirtyPixelsSize);
     ghostPixelCount = 0;
 #endif
 }
 
 EInkParallelDisplay::~EInkParallelDisplay()
 {
-#ifdef EINK_LIMIT_GHOSTING_PX
-    if (dirtyPixels) {
-        free(dirtyPixels);
-        dirtyPixels = nullptr;
-    }
-#endif
     // If an async full update is running, wait for it to finish
     if (asyncFullRunning.load()) {
         // wait a short while for task to finish
@@ -67,8 +61,6 @@ EInkParallelDisplay::~EInkParallelDisplay()
             asyncTaskHandle = nullptr;
         }
     }
-
-    delete epaper;
 }
 
 /*
@@ -79,7 +71,7 @@ bool EInkParallelDisplay::connect()
     LOG_INFO("Do EPD init");
     int initRc = BBEP_SUCCESS;
     if (!epaper) {
-        epaper = new FASTEPD;
+        epaper.reset(new FASTEPD);
 #if defined(T5_S3_EPAPER_PRO_V1)
         initRc = epaper->initPanel(BB_PANEL_LILYGO_T5PRO, 28000000);
 #elif defined(T5_S3_EPAPER_PRO_V2)
@@ -407,7 +399,7 @@ void EInkParallelDisplay::resetGhostPixelTracking()
 {
     if (!dirtyPixels)
         return;
-    memset(dirtyPixels, 0, dirtyPixelsSize);
+    memset(dirtyPixels.get(), 0, dirtyPixelsSize);
     ghostPixelCount = 0;
 }
 #endif

--- a/src/graphics/EInkParallelDisplay.cpp
+++ b/src/graphics/EInkParallelDisplay.cpp
@@ -6,6 +6,7 @@
 #include "variant.h"
 #include <Arduino.h>
 #include <atomic>
+#include <new>
 #include <stdlib.h>
 #include <string.h>
 
@@ -42,7 +43,9 @@ EInkParallelDisplay::EInkParallelDisplay(uint16_t width, uint16_t height, EpdRot
     // allocate dirty pixel buffer same size as epaper buffers (rowBytes * height)
     size_t rowBytes = (this->displayWidth + 7) / 8;
     dirtyPixelsSize = rowBytes * this->displayHeight;
-    dirtyPixels = std::make_unique<uint8_t[]>(dirtyPixelsSize);
+    // nothrow + value-init keeps the old calloc semantics: zeroed buffer, and nullptr on OOM
+    // (the render paths null-check) instead of a bad_alloc crash
+    dirtyPixels.reset(new (std::nothrow) uint8_t[dirtyPixelsSize]());
     ghostPixelCount = 0;
 #endif
 }

--- a/src/graphics/EInkParallelDisplay.h
+++ b/src/graphics/EInkParallelDisplay.h
@@ -4,6 +4,7 @@
 
 #ifdef USE_EINK_PARALLELDISPLAY
 #include <OLEDDisplay.h>
+#include <memory>
 
 #include <atomic>
 #include <freertos/FreeRTOS.h>
@@ -38,7 +39,7 @@ class EInkParallelDisplay : public OLEDDisplay
 
   protected:
     uint32_t lastDrawMsec = 0;
-    FASTEPD *epaper;
+    std::unique_ptr<FASTEPD> epaper;
 
     // Set only when connect() fully succeeds; framebuffer-touching methods no-op while false.
     bool displayReady = false;
@@ -57,7 +58,7 @@ class EInkParallelDisplay : public OLEDDisplay
     void countGhostPixelsAndMaybePromote(int &newTop, int &newBottom, bool &forceFull);
 
     // per-bit dirty buffer (same format as epaper buffers): one bit == one pixel
-    uint8_t *dirtyPixels = nullptr;
+    std::unique_ptr<uint8_t[]> dirtyPixels;
     size_t dirtyPixelsSize = 0;
     uint32_t ghostPixelCount = 0;
     uint32_t ghostPixelLimit = EINK_LIMIT_GHOSTING_PX;

--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -1,6 +1,7 @@
 #include "configuration.h"
 #include "main.h"
 #include "memory/MemAudit.h"
+#include <new>
 #if USE_TFTDISPLAY
 
 #if ARCH_PORTDUINO
@@ -1223,15 +1224,6 @@ TFTDisplay::TFTDisplay(uint8_t address, int sda, int scl, OLEDDISPLAY_GEOMETRY g
 
 TFTDisplay::~TFTDisplay()
 {
-    // Clean up allocated line pixel buffer to prevent memory leak
-    if (linePixelBuffer != nullptr) {
-        free(linePixelBuffer);
-        linePixelBuffer = nullptr;
-    }
-    if (repaintChunkBuffer != nullptr) {
-        free(repaintChunkBuffer);
-        repaintChunkBuffer = nullptr;
-    }
     memaudit::set("display", 0);
 }
 
@@ -1283,7 +1275,7 @@ void TFTDisplay::display(bool fromBlank)
                 y_byteIndex = (y / 8) * displayWidth;
                 y_byteMask = (1 << (y & 7));
 
-                uint16_t *chunkRow = repaintChunkBuffer + (row * displayWidth);
+                uint16_t *chunkRow = repaintChunkBuffer.get() + (row * displayWidth);
 
                 // Step 1: fill the whole row with the default colors. No per-pixel
                 // region scan, so background pixels (the bulk of the screen) are O(1).
@@ -1312,9 +1304,9 @@ void TFTDisplay::display(bool fromBlank)
                 }
             }
 #if defined(HACKADAY_COMMUNICATOR)
-            tft->draw16bitBeRGBBitmap(0, yStart, repaintChunkBuffer, displayWidth, rowsThisChunk);
+            tft->draw16bitBeRGBBitmap(0, yStart, repaintChunkBuffer.get(), displayWidth, rowsThisChunk);
 #else
-            tft->pushImage(0, yStart, displayWidth, rowsThisChunk, repaintChunkBuffer);
+            tft->pushImage(0, yStart, displayWidth, rowsThisChunk, repaintChunkBuffer.get());
 #endif
         }
 
@@ -1656,8 +1648,8 @@ bool TFTDisplay::connect()
 #endif
     tft->fillScreen(getThemeDefaultOffColor());
 
-    if (this->linePixelBuffer == NULL) {
-        this->linePixelBuffer = (uint16_t *)malloc(sizeof(uint16_t) * displayWidth);
+    if (!this->linePixelBuffer) {
+        this->linePixelBuffer.reset(new (std::nothrow) uint16_t[displayWidth]);
 
         if (!this->linePixelBuffer) {
             LOG_ERROR("Not enough memory to create TFT line buffer");
@@ -1665,8 +1657,8 @@ bool TFTDisplay::connect()
         }
         memaudit::add("display", sizeof(uint16_t) * displayWidth);
     }
-    if (this->repaintChunkBuffer == NULL) {
-        this->repaintChunkBuffer = (uint16_t *)malloc(sizeof(uint16_t) * displayWidth * kFullRepaintChunkRows);
+    if (!this->repaintChunkBuffer) {
+        this->repaintChunkBuffer.reset(new (std::nothrow) uint16_t[displayWidth * kFullRepaintChunkRows]);
 
         if (!this->repaintChunkBuffer) {
             LOG_ERROR("Not enough memory to create TFT repaint chunk buffer");

--- a/src/graphics/TFTDisplay.h
+++ b/src/graphics/TFTDisplay.h
@@ -2,6 +2,7 @@
 
 #include <GpioLogic.h>
 #include <OLEDDisplay.h>
+#include <memory>
 
 /**
  * An adapter class that allows using the LovyanGFX library as if it was an OLEDDisplay implementation.
@@ -62,6 +63,6 @@ class TFTDisplay : public OLEDDisplay
     // Connect to the display
     virtual bool connect() override;
 
-    uint16_t *linePixelBuffer = nullptr;
-    uint16_t *repaintChunkBuffer = nullptr;
+    std::unique_ptr<uint16_t[]> linePixelBuffer;
+    std::unique_ptr<uint16_t[]> repaintChunkBuffer;
 };


### PR DESCRIPTION
Final ownership-cleanup PR from the memory audit series. No behavior change.

- **TFTDisplay**: `linePixelBuffer`/`repaintChunkBuffer` become `unique_ptr<uint16_t[]>`. The `new (std::nothrow)` allocation preserves the existing OOM log-and-fail path; the destructor's manual free block disappears (its `memaudit` bookkeeping stays).
- **BaseUIEInkDisplay**: `panelBuffer` becomes `unique_ptr<uint8_t[]>`; the user-written destructor is gone.
- **EInkParallelDisplay**: `epaper` and the ghosting `dirtyPixels` buffer become `unique_ptr` (`make_unique` zero-initializes, matching the old `calloc`); the destructor keeps only its async-task wait logic.

`trunk fmt` clean; native-macos integration build (TFTDisplay path) passes locally. E-ink targets covered by CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Improved automatic management of display memory buffers.
  * Reduced the risk of memory leaks and invalid cleanup during display operation and shutdown.
  * Improved handling when touchscreen hardware is unavailable or unsupported.
* **Compatibility**
  * Display rendering, buffer updates, and e-paper behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->