### PR TITLE
perf(crypto): stop heap-allocating a cipher object per packet

### DIFF
--- a/src/mesh/CryptoEngine.cpp
+++ b/src/mesh/CryptoEngine.cpp
@@ -403,11 +403,8 @@ void CryptoEngine::decrypt(uint32_t fromNode, uint64_t packetId, size_t numBytes
 // Generic implementation of AES-CTR encryption.
 void CryptoEngine::encryptAESCtr(CryptoKey _key, uint8_t *_nonce, size_t numBytes, uint8_t *bytes)
 {
-    // Allocated once on first use instead of per packet: this runs for every encrypted send and
-    // every channel decrypt attempt, and the churn fragments small heaps. Reuse is safe for the
-    // same reason the static scratch buffer below is - all callers serialize under cryptLock -
-    // and setKey/setIV reinitialize the full cipher state each call. Lazy heap singletons (not
-    // static objects) so platforms that override this method never reserve the RAM.
+    // Reused instead of reallocated per packet: safe because all callers hold cryptLock and setKey/setIV reset the
+    // full cipher state. Lazy so overriding platforms reserve nothing; key material now lives until the next call.
     static CTR<AES128> *ctr128 = nullptr;
     static CTR<AES256> *ctr256 = nullptr;
     CTRCommon *ctr;

--- a/src/mesh/CryptoEngine.cpp
+++ b/src/mesh/CryptoEngine.cpp
@@ -403,11 +403,23 @@ void CryptoEngine::decrypt(uint32_t fromNode, uint64_t packetId, size_t numBytes
 // Generic implementation of AES-CTR encryption.
 void CryptoEngine::encryptAESCtr(CryptoKey _key, uint8_t *_nonce, size_t numBytes, uint8_t *bytes)
 {
-    std::unique_ptr<CTRCommon> ctr;
-    if (_key.length == 16)
-        ctr = std::unique_ptr<CTRCommon>(new CTR<AES128>());
-    else
-        ctr = std::unique_ptr<CTRCommon>(new CTR<AES256>());
+    // Allocated once on first use instead of per packet: this runs for every encrypted send and
+    // every channel decrypt attempt, and the churn fragments small heaps. Reuse is safe for the
+    // same reason the static scratch buffer below is - all callers serialize under cryptLock -
+    // and setKey/setIV reinitialize the full cipher state each call. Lazy heap singletons (not
+    // static objects) so platforms that override this method never reserve the RAM.
+    static CTR<AES128> *ctr128 = nullptr;
+    static CTR<AES256> *ctr256 = nullptr;
+    CTRCommon *ctr;
+    if (_key.length == 16) {
+        if (!ctr128)
+            ctr128 = new CTR<AES128>();
+        ctr = ctr128;
+    } else {
+        if (!ctr256)
+            ctr256 = new CTR<AES256>();
+        ctr = ctr256;
+    }
     ctr->setKey(_key.bytes, _key.length);
     static uint8_t scratch[MAX_BLOCKSIZE];
     memcpy(scratch, bytes, numBytes);


### PR DESCRIPTION
From the memory audit — the last hot-path allocation-churn item.

`CryptoEngine::encryptAESCtr()` heap-allocated a fresh `CTR<AES128>`/`CTR<AES256>` on **every call**: once per encrypted transmit (`perhapsEncode` → `encryptPacket`) and once per channel decrypt attempt on every received encrypted packet (`perhapsDecode` loops channels). The `unique_ptr` meant no leak, but on the platforms that use this base implementation — STM32WL, RP2040, nRF54L15, portduino — it's steady malloc/free churn that fragments small heaps. (ESP32 and nRF52 override this method with their own engines and are unaffected.)

Reuse lazily-created singletons instead:

- Safety: every caller serializes under `cryptLock` (`Router::perhapsDecode`/`perhapsEncode`) — the function already depends on that via its `static uint8_t scratch` buffer — and `setKey`/`setIV`/`setCounterSize` reinitialize the full cipher state per call, in the same order as before.
- Footprint: lazy heap pointers rather than function-local static objects, so platforms that never call the base implementation don't reserve BSS for two cipher contexts.

`trunk fmt` clean; native test suite run against the integration branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved encryption efficiency by reusing AES-128 and AES-256 encryption resources.
  * Reduced overhead when processing multiple encrypted packets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->