### PR TITLE
Fixed GPS icon alignment for all OLEDs

### DIFF
--- a/src/graphics/draw/UIRenderer.cpp
+++ b/src/graphics/draw/UIRenderer.cpp
@@ -543,7 +543,7 @@ void UIRenderer::drawGps(OLEDDisplay *display, int16_t x, int16_t y, const mesht
     if (currentResolution == ScreenResolution::High) {
         NodeListRenderer::drawScaledXBitmap16x16(x, y - 2, imgGPS_width, imgGPS_height, imgGPS, display);
     } else {
-        display->drawXbm(x + 1, y + 1, imgGPS_width, imgGPS_height, imgGPS);
+        display->drawXbm(x + 1, y + 3, imgGPS_width, imgGPS_height, imgGPS);
     }
 
     display->drawString(x + textOffset, y, textString);


### PR DESCRIPTION
From #11342 it appears the GPS alignment was shifted two pixels up incorrectly. This PR fixes that.

Tested on Meshnology W12 and Wio Tracker L1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the low-resolution GPS icon’s vertical positioning for improved visual alignment.
  * High-resolution GPS rendering and GPS text placement remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->