### PR TITLE
Actions: Add PIO caching to build-debian-src workflow

### DIFF
--- a/.github/workflows/build_debian_src.yml
+++ b/.github/workflows/build_debian_src.yml
@@ -21,6 +21,10 @@ permissions:
 jobs:
   build-debian-src:
     runs-on: ubuntu-24.04
+    # Only pushes to the default branch (develop) populate the cache; PR / merge_group runs
+    # restore it but never save, so they stop filling up the repo's Actions cache storage.
+    env:
+      SAVE_CACHE: ${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -58,6 +62,14 @@ jobs:
           BUILD_LOCATION: ${{ inputs.build_location }}
         id: version
 
+      - name: Restore PlatformIO cache
+        id: pio-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: meshtasticd/pio/core/.cache
+          key: |
+            pio-deb-src-${{ hashFiles('meshtasticd/platformio.ini', 'meshtasticd/variants/native/portduino.ini', 'meshtasticd/variants/native/portduino/platformio.ini') }}
+
       - name: Fetch libdeps, package debian source
         working-directory: meshtasticd
         run: debian/ci_pack_sdeb.sh
@@ -65,6 +77,18 @@ jobs:
           SERIES: ${{ inputs.series }}
           GPG_KEY_ID: ${{ steps.gpg.outputs.keyid || '' }}
           PKG_VERSION: ${{ steps.version.outputs.deb }}
+
+      - name: Extract cache from pio.tar
+        if: env.SAVE_CACHE == 'true' && steps.pio-cache.outputs.cache-hit != 'true'
+        run: tar -C meshtasticd -xf meshtasticd/pio.tar pio/core/.cache
+
+      - name: Save PlatformIO cache
+        if: env.SAVE_CACHE == 'true' && steps.pio-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: meshtasticd/pio/core/.cache
+          key: |
+            pio-deb-src-${{ hashFiles('meshtasticd/platformio.ini', 'meshtasticd/variants/native/portduino.ini', 'meshtasticd/variants/native/portduino/platformio.ini') }}
 
       - name: Store binaries as an artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Prevent a few more transient fails by caching `build-debian-src`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated build caching for more efficient build runs.
  * Build artifacts are now restored whenever available, while new cache data is saved only for eligible default-branch pushes.
  * This reduces unnecessary cache updates, avoids redundant work, and helps keep development builds consistent across automated runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->