### PR TITLE
fix(TraceRoute): only learn a next hop from an RF-delivered reply

### DIFF
--- a/src/modules/TraceRouteModule.cpp
+++ b/src/modules/TraceRouteModule.cpp
@@ -307,10 +307,8 @@ void TraceRouteModule::updateNextHops(const meshtastic_MeshPacket &p, meshtastic
 
         // The route array is unauthenticated payload, so only learn from it when the node it names as our
         // next hop is the one that actually relayed this packet to us. Otherwise a forged response could
-        // point any node's next_hop anywhere. relay_node only corroborates an RF route when the packet
-        // actually arrived over RF: MQTT ingress zeroes it (so the NO_RELAY_NODE test below catches that),
-        // but UDP multicast ingress preserves the on-wire value while clearing pki_encrypted, rx_snr and
-        // rx_rssi, so a LAN peer's reply would otherwise satisfy this check with no RF evidence at all.
+        // point any node's next_hop anywhere. relay_node only corroborates that over RF: UDP ingress
+        // keeps the on-wire value, so a LAN peer would otherwise pass this with no RF evidence.
         if (p.transport_mechanism != meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA) {
             LOG_DEBUG("Ignore traceroute next-hop 0x%02x: non-RF transport %d", nextHopByte, p.transport_mechanism);
             return;

--- a/src/modules/TraceRouteModule.cpp
+++ b/src/modules/TraceRouteModule.cpp
@@ -307,8 +307,14 @@ void TraceRouteModule::updateNextHops(const meshtastic_MeshPacket &p, meshtastic
 
         // The route array is unauthenticated payload, so only learn from it when the node it names as our
         // next hop is the one that actually relayed this packet to us. Otherwise a forged response could
-        // point any node's next_hop anywhere. relay_node is 0 for MQTT-sourced packets, which cannot
-        // corroborate an RF route either.
+        // point any node's next_hop anywhere. relay_node only corroborates an RF route when the packet
+        // actually arrived over RF: MQTT ingress zeroes it (so the NO_RELAY_NODE test below catches that),
+        // but UDP multicast ingress preserves the on-wire value while clearing pki_encrypted, rx_snr and
+        // rx_rssi, so a LAN peer's reply would otherwise satisfy this check with no RF evidence at all.
+        if (p.transport_mechanism != meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA) {
+            LOG_DEBUG("Ignore traceroute next-hop 0x%02x: non-RF transport %d", nextHopByte, p.transport_mechanism);
+            return;
+        }
         if (p.relay_node == NO_RELAY_NODE || nextHopByte != p.relay_node) {
             LOG_DEBUG("Ignore traceroute next-hop 0x%02x, relayed by 0x%02x", nextHopByte, p.relay_node);
             return;

--- a/test/test_traceroute_nexthop/test_main.cpp
+++ b/test/test_traceroute_nexthop/test_main.cpp
@@ -149,9 +149,8 @@ void test_nexthop_ignored_without_a_relay(void)
     TEST_ASSERT_EQUAL_MESSAGE(0, mockNodeDB->nextHopOf(NODE_D), "no relay means no corroboration");
 }
 
-// UDP multicast ingress preserves the on-wire relay_node while clearing pki_encrypted, rx_snr and
-// rx_rssi, so relay_node alone cannot show the reply came off the radio. A LAN peer can name any
-// node in the route and set relay_node to match; only the transport check rejects it.
+// UDP ingress keeps the on-wire relay_node, so a LAN peer can name any node in the route and set
+// relay_node to match. Only the transport check rejects that.
 void test_nexthop_ignored_when_reply_arrived_over_udp(void)
 {
     meshtastic_RouteDiscovery r;

--- a/test/test_traceroute_nexthop/test_main.cpp
+++ b/test/test_traceroute_nexthop/test_main.cpp
@@ -75,6 +75,9 @@ static meshtastic_MeshPacket makeResponse(uint8_t relayByte, meshtastic_RouteDis
     p.which_payload_variant = meshtastic_MeshPacket_decoded_tag;
     p.decoded.portnum = meshtastic_PortNum_TRACEROUTE_APP;
     p.decoded.request_id = 0x9999; // non-zero marks this a response, which is what drives updateNextHops
+    // RadioInterface::deliverToReceiver() stamps this on every RF reception before the router sees the
+    // packet, so anything that reached a module off the radio carries it.
+    p.transport_mechanism = meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA;
     return p;
 }
 
@@ -146,6 +149,22 @@ void test_nexthop_ignored_without_a_relay(void)
     TEST_ASSERT_EQUAL_MESSAGE(0, mockNodeDB->nextHopOf(NODE_D), "no relay means no corroboration");
 }
 
+// UDP multicast ingress preserves the on-wire relay_node while clearing pki_encrypted, rx_snr and
+// rx_rssi, so relay_node alone cannot show the reply came off the radio. A LAN peer can name any
+// node in the route and set relay_node to match; only the transport check rejects it.
+void test_nexthop_ignored_when_reply_arrived_over_udp(void)
+{
+    meshtastic_RouteDiscovery r;
+    meshtastic_MeshPacket p = makeResponse(nodeDB->getLastByteOfNodeNum(RELAY_B), &r);
+    p.transport_mechanism = meshtastic_MeshPacket_TransportMechanism_TRANSPORT_MULTICAST_UDP;
+
+    shim->alterReceivedProtobuf(p, &r);
+
+    TEST_ASSERT_EQUAL_MESSAGE(0, mockNodeDB->nextHopOf(RELAY_B), "UDP reply must not set a next hop");
+    TEST_ASSERT_EQUAL_MESSAGE(0, mockNodeDB->nextHopOf(NODE_C), "UDP reply must not set a next hop");
+    TEST_ASSERT_EQUAL_MESSAGE(0, mockNodeDB->nextHopOf(NODE_D), "UDP reply must not set a next hop");
+}
+
 void setup()
 {
     delay(10);
@@ -156,6 +175,7 @@ void setup()
     RUN_TEST(test_nexthop_learned_when_route_matches_relay);
     RUN_TEST(test_nexthop_ignored_when_route_contradicts_relay);
     RUN_TEST(test_nexthop_ignored_without_a_relay);
+    RUN_TEST(test_nexthop_ignored_when_reply_arrived_over_udp);
     exit(UNITY_END());
 }
 


### PR DESCRIPTION
`maybeSetNextHop()` is guarded by an anti-forgery check. The route array is unauthenticated payload,
so we only trust it when the node it names as our next hop is the one that relayed the reply to us.
The comment justifies skipping the transport question with "relay_node is 0 for MQTT-sourced
packets".

That holds for MQTT, which allocates zeroed and never copies `relay_node`. It does not hold for UDP
multicast. `UdpMulticastHandler` sets `transport_mechanism`, clears `pki_encrypted`, and clears
`rx_snr` / `rx_rssi` / `has_rx_rssi`, but leaves `relay_node` at whatever the frame carried. So a
peer on the same LAN can send a traceroute reply whose route array names any node as our next hop,
set `relay_node` to match, and pass the check with no RF evidence behind it.

The route it installs also escapes the M3 route-health machinery. `maybeSetNextHop` writes
`NodeInfoLite.next_hop` and the TMM overflow cache directly and never calls `noteRouteLearned`, so
there is no `RouteHealth` record for the staleness or failure decay in `getNextHop()` to act on. It
sits there until something else overwrites it.

The fix gates on `TRANSPORT_LORA` before the `relay_node` comparison.

The alternative would be to clear `relay_node` on UDP ingress alongside the other RF-derived fields
it already clears, which fixes every consumer rather than just this one. I did not do that here:
`relay_node` also feeds PacketHistory relayer tracking and Router's `resolveUniqueLastByte` call, and
moving those in the same patch as a security gate seemed like a bad trade. Worth doing separately if
you agree with the direction.

The second commit covers this in `test_traceroute_nexthop`. Two changes there:

`makeResponse()` was building packets with `transport_mechanism` left at its zero value, which is
`TRANSPORT_INTERNAL`. Nothing off the radio looks like that, since
`RadioInterface::deliverToReceiver()` stamps `TRANSPORT_LORA` on every reception before the router
sees the packet, so the helper now sets it and the fixture models a real RF arrival.

The new case is the one the gate exists for: a UDP multicast reply naming RELAY_B in the route with a
matching `relay_node`. Revert the source change and it fails with "Expected 0 Was 11", meaning the
forged route installed a next hop.

Testing: builds clean on `heltec-v4` and `seeed-xiao-s3`, 102/102 across `test_traceroute_nexthop`,
`test_nexthop_routing` and `test_mqtt`. Not exercised against a real UDP peer, since my bench is two
LoRa nodes over USB, so the UDP field handling itself comes from reading `UdpMulticastHandler.h`
where the contrast between what it clears and what it leaves alone is explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other: compile-only on Heltec V4 and Seeed XIAO ESP32-S3
