### PR TITLE
Fix unterminated MyNodeInfo.pio_env when APP_ENV is 40+ chars

### DIFF
--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -579,6 +579,9 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
         // app not to send locations on our behalf.
         fromRadioScratch.which_payload_variant = meshtastic_FromRadio_my_info_tag;
         strncpy(myNodeInfo.pio_env, optstr(APP_ENV), sizeof(myNodeInfo.pio_env));
+        // strncpy does not terminate when the source fills the buffer; a 40+ char
+        // APP_ENV would make nanopb reject the MyInfo encode ("unterminated string").
+        myNodeInfo.pio_env[sizeof(myNodeInfo.pio_env) - 1] = '\0';
         myNodeInfo.nodedb_count = static_cast<uint16_t>(nodeDB->getNumMeshNodes());
         fromRadioScratch.my_info = myNodeInfo;
 #ifdef MESHTASTIC_PHONEAPI_ACCESS_CONTROL


### PR DESCRIPTION
`strncpy` does not null-terminate when the source fills the destination. A
PlatformIO environment name of 40 or more characters (`pio_env` is
`char[40]`) leaves `pio_env` unterminated, nanopb aborts the whole MyInfo
encode with `Panic: can't encode protobuf reason='unterminated string'`,
`getFromRadio()` returns 0 bytes forever, and the client app never receives
any config after `want_config_id` — the BLE connection looks established but
the app hangs at "connecting" until it gives up.

Clients that receive a redacted MyInfo (`pio_env` cleared before encode
under `MESHTASTIC_PHONEAPI_ACCESS_CONTROL`) are unaffected, which makes the
failure look client-specific when it is not.

Observed on hardware with a 40-character environment name
(`xiao_nrf54l15_wio_sx1262_debug_uart_lfxo`): device-side UART logs showed
`FromRadio=STATE_SEND_MY_INFO` followed by the nanopb panic on every
fromRadio read; with this one-line fix the same build streams the full
config to the iOS app.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)

Tested on a Seeed XIAO nRF54L15 Sense + Wio-SX1262 (where the bug
reproduces). I don't have the listed devices to regression-test against,
but the change is a single null-termination after an existing `strncpy`
and only affects builds whose `APP_ENV` is ≥ 40 characters — all current
in-tree environment names are shorter, so released firmware behavior is
unchanged. Community testing welcome.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed malformed device information messages when the PlatformIO environment string reaches its maximum buffer length.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->