### PR TITLE
fix(MQTT): honour ignore_mqtt for the self-gateway implicit ACK

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -113,6 +113,14 @@ inline void onReceiveProto(char *topic, byte *payload, size_t length)
     if (strcmp(e.channel_id, "PKI") == 0 && !anyChannelHasDownlink) {
         return;
     }
+    // ignore_mqtt lives in shouldDropMqttDownlink(), which is only reached further down. The
+    // self-gateway branch below returns before that, so check it here or a user who has opted out of
+    // MQTT-sourced traffic still gets MQTT-driven ACKs for their own messages.
+    if (config.lora.ignore_mqtt) {
+        LOG_INFO("Drop MQTT ignore_mqtt");
+        return;
+    }
+
     // Generate node ID from nodenum for comparison
     std::string nodeId = nodeDB->getNodeId();
     if (strcmp(e.gateway_id, nodeId.c_str()) == 0) {

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -113,9 +113,8 @@ inline void onReceiveProto(char *topic, byte *payload, size_t length)
     if (strcmp(e.channel_id, "PKI") == 0 && !anyChannelHasDownlink) {
         return;
     }
-    // ignore_mqtt lives in shouldDropMqttDownlink(), which is only reached further down. The
-    // self-gateway branch below returns before that, so check it here or a user who has opted out of
-    // MQTT-sourced traffic still gets MQTT-driven ACKs for their own messages.
+    // The self-gateway branch below returns before shouldDropMqttDownlink() ever runs, so check
+    // ignore_mqtt here or a user who opted out of MQTT still gets MQTT-driven ACKs.
     if (config.lora.ignore_mqtt) {
         LOG_INFO("Drop MQTT ignore_mqtt");
         return;


### PR DESCRIPTION
`config.lora.ignore_mqtt` is checked inside `shouldDropMqttDownlink()`, which `onReceiveProto()` only
reaches further down the function. The self-gateway branch returns before that, so when we receive
our own packet back from our own gateway topic we synthesise a local ROUTING ACK regardless of the
setting.

The effect is that a user who has explicitly opted out of MQTT-sourced traffic still has their own
message deliveries confirmed by MQTT. That matters more than it first sounds, because `ignore_mqtt`
is set automatically for duty-cycle-limited regions in `AdminModule`, so EU nodes end up with it
without having asked.

The change checks it before the self-gateway branch.

Only the `ignore_mqtt` predicate is hoisted, not the whole of `shouldDropMqttDownlink()`. The other
three checks in there are keyed on `packet.from`, which on this path is our own node number, so
moving them would only change behaviour for a node that has somehow ignored itself.

While looking at this I also considered gating the implicit ACK on `e.packet->want_ack`, since the
branch currently fires for any echoed packet of ours whether or not an ACK was asked for. That turns
out to be wrong and is deliberately not in this PR: `Router::send` clears `want_ack` for broadcasts
at `Router.cpp:472-474`, before the MQTT uplink at `:553`, so a reliable broadcast that
`ReliableRouter` is tracking comes back with the flag already false. Gating on it would suppress the
implicit ACK for exactly the case that needs it. The question the code actually wants to ask is
whether a pending retransmission exists for the id, which is what the comment above the branch
describes, but `findPendingPacket` is protected on `NextHopRouter` and not reachable from
`MQTT.cpp`. Adding an accessor for it seemed like your call rather than mine.

Testing: builds clean on `heltec-v4` and `seeed-xiao-s3`, 169/169 across `test_mqtt`,
`test_nexthop_routing` and `test_packet_signing`. Not exercised against a live broker; I have no MQTT
setup here, so the control flow is from reading `onReceiveProto()` and the placement of the
`shouldDropMqttDownlink()` call relative to the self-gateway return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other: compile-only on Heltec V4 and Seeed XIAO ESP32-S3
