### PR TITLE
Fix out-of-bounds baud table read when GPS is re-enabled after failed probe

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -828,6 +828,9 @@ bool GPS::setup()
                 if (gnssModel != GNSS_MODEL_UNKNOWN) {
                     detectedBaud = rareSerialSpeeds[speedSelect];
                 } else if (currentStep == 0 && ++speedSelect == array_count(rareSerialSpeeds)) {
+                    // Reset so a runtime GPS re-enable does not index
+                    // rareSerialSpeeds[speedSelect] out of bounds.
+                    speedSelect = 0;
                     LOG_WARN("Give up GPS probe, set to %d", GPS_BAUDRATE);
                     return true;
                 }


### PR DESCRIPTION
When the probe scan exhausts `rareSerialSpeeds` and gives up, `speedSelect`
is left equal to `array_count(rareSerialSpeeds)`. If GPS is later re-enabled
at runtime (e.g. the user toggles `position.gps_mode` from the app),
`setup()` runs again with `probeTries` already at `GPS_PROBETRIES` and
indexes `rareSerialSpeeds[speedSelect]` past the end of the array, probing
garbage baud rates read from adjacent memory. Observed on hardware:

WARN | [GPS] No GNSS Module (baudrate 484401)
WARN | [GPS] No GNSS Module (baudrate 68673)
WARN | [GPS] No GNSS Module (baudrate 460269)

Fix: reset `speedSelect` before giving up, so a later re-enable restarts
the scan from the beginning of the table.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)

Reproduced and verified on a Seeed XIAO nRF54L15 Sense + Wio-SX1262 with an
L76K GNSS module: before the fix, disabling and re-enabling GPS from the app
after a failed scan produced the garbage-baud probes above; after the fix
the rescan walks the normal baud table. I don't have the listed devices, but
this code path only executes after a probe scan has fully failed *and* GPS
is re-enabled in the same boot — a state no device with a working, detected
GPS ever reaches, so regression risk on those targets is minimal. Community
testing welcome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GPS re-enablement after rare baud-rate detection attempts are exhausted.
  * Improved runtime stability by preventing invalid speed selection during GPS setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->