### PR TITLE
nrf54l15: fix BLE phone-API bootstrap (sleep clock, adv restart, ToRadio race, reboot)

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -854,7 +854,9 @@ void Power::reboot()
     notifyReboot.notifyObservers(NULL);
 #if defined(ARCH_ESP32)
     ESP.restart();
-#elif defined(ARCH_NRF52)
+#elif defined(ARCH_NRF52) || defined(ARCH_NRF54L15)
+    // On nRF54L15 the Arduino shim maps NVIC_SystemReset to
+    // sys_reboot(SYS_REBOOT_COLD).
     NVIC_SystemReset();
 #elif defined(ARCH_RP2040)
     rp2040.reboot();

--- a/src/platform/nrf54l15/NRF54L15Bluetooth.cpp
+++ b/src/platform/nrf54l15/NRF54L15Bluetooth.cpp
@@ -316,6 +316,19 @@ BT_GATT_SERVICE_DEFINE(mesh_svc, BT_GATT_PRIMARY_SERVICE(&mesh_svc_uuid.uuid),
 
 static void start_advertising()
 {
+    // MAX_CONN=1: while a central is connected there is no free connection
+    // object for a new connectable advertiser, and issuing the
+    // SET_ADV_PARAM/adv-data HCI sequence mid-connection (e.g. from a
+    // PowerFSM state re-enter) needlessly pokes the controller. Advertising
+    // restarts via adv_restart_work after the disconnect callback.
+    {
+        struct bt_conn *conn = acquire_active_conn();
+        if (conn) {
+            bt_conn_unref(conn);
+            return;
+        }
+    }
+
     // IMPORTANT: BT_DATA_BYTES() uses C99 compound literals that GCC C++ treats
     // as temporaries; with -Os the compiler may elide writes, leaving stack
     // uninitialized.  Use static const arrays for stable data (flags, UUID)
@@ -765,7 +778,12 @@ void NRF54L15Bluetooth::startDisabled()
 void NRF54L15Bluetooth::resumeAdvertising()
 {
     ble_enabled = true;
-    start_advertising();
+    // PowerFSM transitions can land here from BT stack callback context
+    // (e.g. EVENT_BLUETOOTH_PAIR is fired inside auth_passkey_display on the
+    // BT RX thread) and while a central is connected. Never issue synchronous
+    // HCI advertising commands from that context - defer to the system
+    // workqueue exactly like the disconnect path does.
+    k_work_submit(&adv_restart_work);
 }
 
 void NRF54L15Bluetooth::clearBonds()

--- a/src/platform/nrf54l15/NRF54L15Bluetooth.cpp
+++ b/src/platform/nrf54l15/NRF54L15Bluetooth.cpp
@@ -604,6 +604,20 @@ class BleDeferredThread : public concurrency::OSThread
         k_mutex_unlock(&pendingToRadioMutex);
         if (have_pending && phoneAPI) {
             phoneAPI->handleToRadio(buf, n);
+            // The phone reads fromRadio immediately after writing ToRadio.
+            // Because handleToRadio ran up to a poll interval later on this
+            // thread, that eager read raced ahead and saw an empty queue; the
+            // iOS app then waits for a fromNum notification before reading
+            // again and gives up ~30 s after its config request. Now that any
+            // responses are queued, kick the subscribed client so it re-reads
+            // right away.
+            if (fromnum_ccc_val & BT_GATT_CCC_NOTIFY) {
+                struct bt_conn *kick = acquire_active_conn();
+                if (kick) {
+                    bt_gatt_notify(kick, &mesh_svc.attrs[FROMNUM_ATTR_IDX], &fromNumValue, sizeof(fromNumValue));
+                    bt_conn_unref(kick);
+                }
+            }
         }
 
         // Take a reference to active_conn so it can't be freed underneath us

--- a/zephyr/prj.conf
+++ b/zephyr/prj.conf
@@ -84,9 +84,17 @@ CONFIG_LOG_BACKEND_RTT_MODE_BLOCK=n
 CONFIG_LOG_BACKEND_RTT_MODE_OVERWRITE=y
 CONFIG_LOG_BACKEND_RTT_OUTPUT_BUFFER_SIZE=256
 
-# ── LFXO clock source — use RC oscillator to avoid ~2s crystal stabilization
-# disrupting the GRTC timer and hanging k_sleep
-CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC=y
+# ── 32.768 kHz sleep clock: keep the board-default crystal (LFXO) ───────────
+# The BLE link layer schedules every connection/advertising event from this
+# clock. Running it from the calibrated RC oscillator (a previous workaround
+# for slow crystal start-up) wedges the nRF54L15 software controller
+# mid-connection: the peripheral progressively misses connection events, the
+# host stops receiving Number-of-Completed-Packets (ATT TX stalls after
+# BT_BUF_ACL_TX_COUNT unacked PDUs), disconnect events are lost, and HCI
+# commands time out ("Controller unresponsive"). Verified by a controlled
+# A/B/A on XIAO nRF54L15: identical firmware passes the full phone-API
+# bootstrap on LFXO and fails right after the ATT MTU exchange on the RC
+# oscillator. Do not set CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC here.
 
 # ── Stack sizes — Meshtastic setup() is heavy (RadioLib, NodeDB, printf) ──────
 # bt_enable() called from nrf54l15Setup() needs >8KB.
@@ -203,19 +211,11 @@ CONFIG_BT_KEYS_OVERWRITE_OLDEST=y
 # service; disabling it is required before BT_GATT_CACHING can be disabled.
 CONFIG_BT_GATT_SERVICE_CHANGED=n
 CONFIG_BT_GATT_CACHING=n
-# Disable automatic PHY update (1M→2M) after connection.
-# The nRF54L15 SW-LL fails the LL_PHY_REQ/RSP exchange and disconnects
-# exactly 1.786s after connection — before any ATT/GATT operations.
-CONFIG_BT_AUTO_PHY_UPDATE=n
-# ATT/GATT/L2CAP debug logging — see exactly what happens after connection
-CONFIG_BT_ATT_LOG_LEVEL_DBG=y
-CONFIG_BT_GATT_LOG_LEVEL_DBG=y
-CONFIG_BT_SMP_LOG_LEVEL_DBG=y
-# L2CAP DBG: shows recv on fixed ATT channel — confirms whether iOS sends any data
-CONFIG_BT_L2CAP_LOG_LEVEL_DBG=y
-# Keep bt_conn at INF — DBG floods RTT buffer every ~150µs (tx_processor loop),
-# overwriting all ATT/GATT messages before they can be read.
-# Connection events (connected/disconnected) are logged at INF level.
+# BT subsystem logging at INF. The earlier PHY-update disconnects and ATT
+# stalls were symptoms of the RC sleep clock (see the LFXO note above); with
+# the crystal clock the full bootstrap passes with PHY update, 2M and DLE at
+# their defaults, so neither the DBG log levels nor those workarounds are
+# needed anymore.
 CONFIG_BT_CONN_LOG_LEVEL_INF=y
 # Keep HCI logs at INF to save RAM (log thread processing buffers, etc.).
 # (Earlier DBG was used to diagnose the hci_acl → L2CAP stall — fix applied.)
@@ -255,12 +255,6 @@ CONFIG_BT_CONN_TX_NOTIFY_WQ_STACK_SIZE=2048
 # transition time → `new char[]` in RedirectablePrint::log returned NULL →
 # libstdc++ called abort() from main thread.  Shrinking both RTT buffers to
 # 4 KB (above) frees ~40 KB of BSS for the heap and resolves it.
-#
-# DLE stays off (BT_DATA_LEN_UPDATE=n below): the LLCP remote table at
-# ull_llcp_remote.c:878 is guarded by #ifdef CONFIG_BT_CTLR_DATA_LENGTH, so
-# the controller answers iOS's LL_LENGTH_REQ with LL_UNKNOWN_RSP and falls
-# back to 27-byte LL PDUs.  The host reassembles LL PDUs into L2CAP frames
-# up to BT_BUF_ACL_RX_SIZE before dispatching to ATT.
 CONFIG_BT_L2CAP_TX_MTU=247
 # Server ATT MTU = BUF_ACL_RX_SIZE - 4 = 247 (matches L2CAP_TX_MTU)
 CONFIG_BT_BUF_ACL_RX_SIZE=251
@@ -291,9 +285,6 @@ CONFIG_BT_CTLR_CONN_PARAM_REQ=y
 # SW-LL is mid-procedure, a simultaneous host-initiated HCI_LE_Connection_Update
 # creates an LL collision. Disabling the auto-update avoids the collision entirely.
 CONFIG_BT_GAP_AUTO_UPDATE_CONN_PARAMS=n
-# Disable optional LL procedures (belt-and-suspenders while debugging):
-# BT_PHY_UPDATE=n + BT_CTLR_PHY_2M=n: no PHY update procedure → iOS doesn't attempt LL_PHY_REQ
-# BT_DATA_LEN_UPDATE=n: no DLE → controller sends LL_UNKNOWN_RSP to LL_LENGTH_REQ
-CONFIG_BT_CTLR_PHY_2M=n
-CONFIG_BT_PHY_UPDATE=n
-CONFIG_BT_DATA_LEN_UPDATE=n
+# 2M PHY, PHY update and data length extension stay at their defaults
+# (enabled): with the crystal sleep clock (see top of file) the full iOS and
+# macOS phone-API bootstrap passes with all three active.


### PR DESCRIPTION
Four fixes that take the nRF54L15 port from "phone app stalls while
connecting" to a working, encrypted, bonded phone-API session. All verified
on a Seeed XIAO nRF54L15 Sense + Wio-SX1262 against the iOS app and a macOS
CoreBluetooth test client. One commit per fix:

**1. Run the BLE sleep clock from the crystal; drop the workarounds that
were masking it.** The RC sleep clock (`CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC`,
originally a workaround for slow LFXO start-up) wedges the software link
layer mid-connection: missed connection events, lost disconnect events (the
"zombie connection" behavior this port's watchdog exists for), no
Number-of-Completed-Packets — so host ATT TX stalls after exactly
`BT_BUF_ACL_TX_COUNT` (3) unacked PDUs, which is the long-observed "phone
stops right after service discovery" signature — and eventually
`Controller unresponsive` HCI timeouts.

Evidence: controlled A/B/A on the same board, same central, minutes apart —
identical firmware **passes** the complete bootstrap (discovery, CCC
subscriptions, want_config, 40+ packet config stream, stable hold, clean
disconnect) on LFXO, **fails** right after the ATT MTU exchange on the RC
clock, and passes again after reverting to LFXO. The crystal boots cleanly;
the start-up hang the RC switch was meant to avoid did not reproduce across
dozens of boots. With the clock fixed, the 2M-PHY / PHY-update /
data-length-extension disables (workarounds for symptoms of the same wedge)
are removed — the full bootstrap passes with all three at their defaults —
and the ATT/GATT/SMP/L2CAP DBG log levels return to INF.

**2. Never start advertising from BT callback context or mid-connection.**
PowerFSM transitions can call `resumeAdvertising()` from BT stack callback
context (`EVENT_BLUETOOTH_PAIR` fires inside `auth_passkey_display` on the
BT RX thread) and while a central holds the only connection object
(`BT_MAX_CONN=1`). Issuing the synchronous SET_ADV_PARAM/adv-data HCI
sequence from there stalled secure pairing right after the PIN was
displayed. Defer to the system workqueue exactly like the disconnect path
already does.

**3. Notify fromNum after deferred ToRadio processing.** The phone reads
fromRadio immediately after writing ToRadio, but BleDeferredThread processes
the write up to a poll interval later, so the eager read races ahead and
sees an empty queue; the iOS app then waits for a fromNum notification that
never comes and abandons the link ~30 s after its config request. Kick the
subscribed client once the deferred `handleToRadio()` has queued responses.

**4. Implement `Power::reboot()`.** It had no `ARCH_NRF54L15` branch, so
admin- and config-driven reboots logged the FIXME fallback and never reset
the device — config changes requiring a restart were silently not applied.

After these four: encrypted fixed-PIN pairing completes (SC passkey entry,
security level 4), bonds persist across reboots (reconnect with no PIN
prompt), the config stream starts ~400 ms after want_config, and multi-hour
sessions run without controller wedges.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)

Tested extensively on a Seeed XIAO nRF54L15 Sense + Wio-SX1262 (iOS app +
macOS CoreBluetooth client): pairing, bonding, config streams, and LoRa
mesh operation alongside BLE. Every changed line is in nRF54L15-only files
(`src/platform/nrf54l15/`, `zephyr/prj.conf`) or `src/Power.cpp` inside an
`ARCH_NRF54L15` guard, so regressions on the listed devices are not
possible by construction.
