### PR TITLE
Add Seeed XIAO nRF54L15 Sense + Wio-SX1262 variant with GPS and IMU support

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -50,7 +50,7 @@ template <typename T, std::size_t N> std::size_t array_count(const T (&)[N])
 
 #if defined(SENSECAP_INDICATOR)
 UARTProxy *GPS::_serial_gps = nullptr; // assigned in createGps(), see there
-#elif defined(ARCH_NRF52)
+#elif defined(ARCH_NRF52) || defined(ARCH_NRF54L15)
 Uart *GPS::_serial_gps = &GPS_SERIAL_PORT;
 #elif defined(ARCH_ESP32) || defined(ARCH_PORTDUINO) || defined(ARCH_STM32)
 HardwareSerial *GPS::_serial_gps = &GPS_SERIAL_PORT;
@@ -676,7 +676,7 @@ bool GPS::verifyCachedProbePresence()
         return false;
     }
 
-#if defined(ARCH_NRF52) || defined(ARCH_PORTDUINO) || defined(ARCH_STM32)
+#if defined(ARCH_NRF52) || defined(ARCH_NRF54L15) || defined(ARCH_PORTDUINO) || defined(ARCH_STM32)
     _serial_gps->end();
     _serial_gps->begin(cachedProbeBaud);
 #elif defined(ARCH_RP2040)
@@ -1450,9 +1450,13 @@ bool shouldArmFixHold(bool hasValidLocation, uint8_t prevFixQual, uint32_t fixHo
 
 int32_t GPS::runOnce()
 {
-#if defined(SENSECAP_INDICATOR)
+#if defined(SENSECAP_INDICATOR) || defined(GPS_SKIP_PROBE)
     // No model probe on the bridged fake UART (the module only streams
-    // NMEA), but the user's GPS mode setting must still be honored
+    // NMEA), but the user's GPS mode setting must still be honored.
+    // GPS_SKIP_PROBE lets a variant opt into the same stream-only handling
+    // when its module's command channel is unavailable or unreliable (e.g.
+    // shield stacks where the GNSS reset/standby lines are shared with
+    // other peripherals).
     if (!GPSInitFinished) {
         if (!_serial_gps || config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_NOT_PRESENT) {
             LOG_INFO("GPS set to not-present. Skip probe");
@@ -1656,7 +1660,7 @@ GnssModel_t GPS::probe(int serialSpeed)
 
     switch (currentStep) {
     case 0: {
-#if defined(ARCH_NRF52) || defined(ARCH_PORTDUINO) || defined(ARCH_STM32)
+#if defined(ARCH_NRF52) || defined(ARCH_NRF54L15) || defined(ARCH_PORTDUINO) || defined(ARCH_STM32)
         _serial_gps->end();
         _serial_gps->begin(serialSpeed);
 #elif defined(ARCH_RP2040)
@@ -2028,7 +2032,7 @@ std::unique_ptr<GPS> GPS::createGps()
         _serial_gps->setPinout(new_gps->tx_gpio, new_gps->rx_gpio);
         _serial_gps->setFIFOSize(256);
         _serial_gps->begin(GPS_BAUDRATE);
-#elif defined(ARCH_NRF52)
+#elif defined(ARCH_NRF52) || defined(ARCH_NRF54L15)
         _serial_gps->setPins(new_gps->rx_gpio, new_gps->tx_gpio);
         _serial_gps->begin(GPS_BAUDRATE);
 #elif defined(ARCH_STM32)

--- a/src/platform/nrf54l15/Arduino.h
+++ b/src/platform/nrf54l15/Arduino.h
@@ -671,29 +671,43 @@ inline String Stream::readStringUntil(char)
 }
 
 // ── HardwareSerial ───────────────────────────────────────────────────────────
+//
+// A HardwareSerial constructed without a device stays a console shim:
+// write() goes to printk (RTT/console) and reads return nothing. When
+// constructed with a Zephyr UART device pointer (see Serial1 in
+// nrf54l15_arduino.cpp, bound to uart21 = XIAO D6/D7), begin() configures the
+// UART at the requested baud rate and starts interrupt-driven reception into
+// a ring buffer, which is what Meshtastic's GPS baud-probing state machine
+// needs.
 class HardwareSerial : public Stream
 {
   public:
-    void begin(unsigned long) {}
-    void begin(unsigned long, uint16_t) {}
-    void end() {}
+    HardwareSerial() {}
+    explicit HardwareSerial(const void *zephyr_uart_dev) : _udev(zephyr_uart_dev) {}
+    void begin(unsigned long baud);
+    void begin(unsigned long baud, uint16_t) { begin(baud); }
+    void end();
     void setPins(int rx, int tx) {}
     void setPinout(int tx, int rx) {}
     void setFIFOSize(size_t) {}
     void setRxBufferSize(size_t) {}
-    void begin(unsigned long baud, uint32_t config, int8_t rx = -1, int8_t tx = -1, bool invert = false) {}
-    int available() override { return 0; }
-    int read() override { return -1; }
-    int peek() override { return -1; }
+    void begin(unsigned long baud, uint32_t config, int8_t rx = -1, int8_t tx = -1, bool invert = false) { begin(baud); }
+    int available() override;
+    int read() override;
+    int peek() override;
     size_t write(uint8_t c) override;
     size_t write(const uint8_t *buf, size_t n) override;
     using Print::write; // un-hide base class write(const char*)
-    size_t readBytes(uint8_t *buf, size_t len) { return 0; }
-    size_t readBytes(char *buf, size_t len) { return 0; }
+    size_t readBytes(uint8_t *buf, size_t len);
+    size_t readBytes(char *buf, size_t len) { return readBytes((uint8_t *)buf, len); }
     operator bool() const { return true; }
     void flush() override {}
     String readString() { return String(); }
     String readStringUntil(char) { return String(); }
+
+  private:
+    const void *_udev = nullptr; // const struct device * (Zephyr UART), or nullptr for the console shim
+    void *_rx = nullptr;         // interrupt-driven RX ring-buffer state, allocated on first begin()
 };
 
 // Uart - nRF52 BSP alias for HardwareSerial (used by GPS.h when ARCH_NRF52)

--- a/src/platform/nrf54l15/nrf54l15_arduino.cpp
+++ b/src/platform/nrf54l15/nrf54l15_arduino.cpp
@@ -15,9 +15,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/uart.h>
 #include <zephyr/kernel.h>
+#include <zephyr/sys/ring_buffer.h>
 // ── Bluefruit singleton stub (satisfies NodeDB.cpp ARCH_NRF52 path) ──────────
 #include "bluefruit.h"
 BlueFruitClass Bluefruit;
@@ -34,8 +38,15 @@ TwoWire Wire;
 TwoWire Wire1;
 
 // ── HardwareSerial singletons ────────────────────────────────────────────────
+// Serial stays a console shim (printk). Serial1 is bound to uart21 (the XIAO
+// header UART, TX=P2.08/D6 RX=P2.07/D7) when the board enables it - this is
+// the GPS port. Serial2 has no hardware.
 HardwareSerial Serial;
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart21), okay)
+HardwareSerial Serial1(DEVICE_DT_GET(DT_NODELABEL(uart21)));
+#else
 HardwareSerial Serial1;
+#endif
 HardwareSerial Serial2;
 
 // ── Timing functions - C linkage to match extern "C" declarations ────────────
@@ -71,17 +82,137 @@ extern "C" void NVIC_SystemReset(void)
 }
 #pragma pop_macro("NVIC_SystemReset")
 
-// ── HardwareSerial::write ─────────────────────────────────────────────────────
+// ── HardwareSerial ───────────────────────────────────────────────────────────
+//
+// Console instances (_udev == nullptr) keep the historical printk behavior.
+// Device-backed instances (Serial1 → uart21) implement a real UART with
+// interrupt-driven RX into a ring buffer. Producer is the UART ISR, consumer
+// is the GPS thread; Zephyr's ring_buf is safe for that single-producer/
+// single-consumer pattern without extra locking.
+
+namespace
+{
+struct UartRxState {
+    struct ring_buf rb;
+    uint8_t storage[512]; // >2 NMEA sentences of headroom at 9600 baud
+};
+
+void hw_serial_rx_isr(const struct device *dev, void *user_data)
+{
+    auto *st = static_cast<UartRxState *>(user_data);
+    while (uart_irq_update(dev) && uart_irq_rx_ready(dev)) {
+        uint8_t chunk[32];
+        int n = uart_fifo_read(dev, chunk, sizeof(chunk));
+        if (n <= 0) {
+            break;
+        }
+        // On overflow ring_buf_put stores what fits and drops the rest;
+        // NMEA parsers resynchronize on the next '$' so this is acceptable.
+        ring_buf_put(&st->rb, chunk, (uint32_t)n);
+    }
+}
+} // namespace
+
+void HardwareSerial::begin(unsigned long baud)
+{
+    const struct device *dev = static_cast<const struct device *>(_udev);
+    if (!dev || !device_is_ready(dev)) {
+        return;
+    }
+
+    uart_irq_rx_disable(dev);
+
+    struct uart_config cfg = {};
+    cfg.baudrate = (uint32_t)baud;
+    cfg.parity = UART_CFG_PARITY_NONE;
+    cfg.stop_bits = UART_CFG_STOP_BITS_1;
+    cfg.data_bits = UART_CFG_DATA_BITS_8;
+    cfg.flow_ctrl = UART_CFG_FLOW_CTRL_NONE;
+    int err = uart_configure(dev, &cfg);
+    if (err != 0) {
+        // Requires CONFIG_UART_USE_RUNTIME_CONFIGURE; without it the port
+        // stays at the device tree's current-speed.
+        printk("HardwareSerial: uart_configure(%lu) failed: %d\n", baud, err);
+    }
+
+    if (!_rx) {
+        auto *st = new UartRxState();
+        ring_buf_init(&st->rb, sizeof(st->storage), st->storage);
+        uart_irq_callback_user_data_set(dev, hw_serial_rx_isr, st);
+        _rx = st;
+    } else {
+        // Re-begin during GPS baud probing: discard bytes from the old rate.
+        ring_buf_reset(&static_cast<UartRxState *>(_rx)->rb);
+    }
+    uart_irq_rx_enable(dev);
+}
+
+void HardwareSerial::end()
+{
+    const struct device *dev = static_cast<const struct device *>(_udev);
+    if (dev && device_is_ready(dev)) {
+        uart_irq_rx_disable(dev);
+    }
+}
+
+int HardwareSerial::available()
+{
+    auto *st = static_cast<UartRxState *>(_rx);
+    if (!st) {
+        return 0;
+    }
+    return (int)(ring_buf_capacity_get(&st->rb) - ring_buf_space_get(&st->rb));
+}
+
+int HardwareSerial::read()
+{
+    auto *st = static_cast<UartRxState *>(_rx);
+    uint8_t c;
+    if (!st || ring_buf_get(&st->rb, &c, 1) != 1) {
+        return -1;
+    }
+    return c;
+}
+
+int HardwareSerial::peek()
+{
+    auto *st = static_cast<UartRxState *>(_rx);
+    uint8_t c;
+    if (!st || ring_buf_peek(&st->rb, &c, 1) != 1) {
+        return -1;
+    }
+    return c;
+}
+
+size_t HardwareSerial::readBytes(uint8_t *buf, size_t len)
+{
+    auto *st = static_cast<UartRxState *>(_rx);
+    if (!st) {
+        return 0;
+    }
+    return ring_buf_get(&st->rb, buf, (uint32_t)len);
+}
+
 size_t HardwareSerial::write(uint8_t c)
 {
-    // TODO(nrf54l15 Phase 3): route through Zephyr UART / USB-CDC console
-    // For now use printk so we at least get something over RTT/UART0
+    const struct device *dev = static_cast<const struct device *>(_udev);
+    if (dev && device_is_ready(dev)) {
+        uart_poll_out(dev, c);
+        return 1;
+    }
+    // Console shim path: printk so output reaches RTT/UART0.
     printk("%c", (char)c);
     return 1;
 }
 
 size_t HardwareSerial::write(const uint8_t *buf, size_t n)
 {
+    const struct device *dev = static_cast<const struct device *>(_udev);
+    if (dev && device_is_ready(dev)) {
+        for (size_t i = 0; i < n; i++)
+            uart_poll_out(dev, buf[i]);
+        return n;
+    }
     for (size_t i = 0; i < n; i++)
         printk("%c", (char)buf[i]);
     return n;

--- a/variants/nrf54l15/xiao_nrf54l15_wio_sx1262/README.md
+++ b/variants/nrf54l15/xiao_nrf54l15_wio_sx1262/README.md
@@ -1,0 +1,29 @@
+# Seeed Studio XIAO nRF54L15 Sense + Wio-SX1262
+
+Meshtastic on the XIAO nRF54L15 Sense stacked with the Wio-SX1262 for XIAO
+(header pinout, standalone SKU 113010003) and, optionally, the L76K GNSS
+Module for Seeed Studio XIAO.
+
+| Function | XIAO pin | nRF54 GPIO |
+| --- | --- | --- |
+| SX1262 SCK / MISO / MOSI | D8 / D9 / D10 | P2.01 / P2.04 / P2.02 (spi00) |
+| SX1262 CS | D4 | P1.10 |
+| SX1262 DIO1 / BUSY / RESET | D1 / D3 / D2 | P1.05 / P1.07 / P1.06 |
+| SX1262 RF switch RX enable | D5 | P1.11 |
+| L76K UART (MCU TX / MCU RX) | D6 / D7 | P2.08 / P2.07 (uart21 = Serial1) |
+| L76K STANDBY | D0 | P1.04 |
+| LSM6DS3 IMU (on the Sense) | D11 / D12 | i2c30, address 0x6a |
+| Status LED (active low) | - | P2.00 |
+
+Notes:
+
+- DIO2 drives the TX side of the RF switch and DIO3 supplies the 1.8 V TCXO.
+- i2c22 is disabled in the board overlay because it would otherwise claim
+  D4/D5, which the radio uses; i2c30 on D11/D12 remains for the IMU and
+  external sensors.
+- The L76K shield shares its reset line with the radio's RESET on D2, which
+  makes the GNSS command channel unreliable, so the variant sets
+  GPS_SKIP_PROBE and parses the NMEA stream directly (default 9600 baud).
+- Flashing is via the onboard CMSIS-DAP probe (`pyocd`, target `nrf54l`).
+  The MCUboot secondary slot is reclaimed for LittleFS storage; OTA is not
+  provided.

--- a/variants/nrf54l15/xiao_nrf54l15_wio_sx1262/platformio.ini
+++ b/variants/nrf54l15/xiao_nrf54l15_wio_sx1262/platformio.ini
@@ -1,0 +1,54 @@
+[env:xiao_nrf54l15_wio_sx1262]
+# PRIVATE_HW (255) until an SKU-backed HardwareModel enum value is assigned.
+custom_meshtastic_hw_model = 255
+custom_meshtastic_hw_model_slug = XIAO_NRF54L15_WIO_SX1262
+custom_meshtastic_architecture = nrf54l15
+custom_meshtastic_actively_supported = false
+custom_meshtastic_support_level = 3
+custom_meshtastic_display_name = Seeed Studio XIAO nRF54L15 Sense + Wio-SX1262
+custom_meshtastic_tags = Seeed, DIY
+
+extends = nrf54l15_base
+board = seeed-xiao-nrf54l15
+board_level = extra
+debug_tool = cmsis-dap
+upload_protocol = cmsis-dap
+
+# prj-gps.conf enables the Zephyr UART pieces Serial1 needs for the L76K GNSS
+# shield (see zephyr/prj-gps.conf); the board overlay in zephyr/boards/ turns
+# on uart21 and frees D4/D5 for the Wio-SX1262.
+#
+# The CMAKE_GDB placeholder stops Zephyr's CMake from hanging while probing
+# PlatformIO's x86_64-only GDB on Apple Silicon hosts; it has no effect on
+# the firmware output.
+board_build.zephyr.cmake_extra_args =
+  -DCMAKE_GDB:FILEPATH=/usr/bin/false
+  -DEXTRA_CONF_FILE:STRING=prj-gps.conf
+
+build_flags = ${nrf54l15_base.build_flags}
+  -Ivariants/nrf54l15/xiao_nrf54l15_wio_sx1262
+  -DXIAO_NRF54L15_WIO_SX1262
+  -DMESHTASTIC_EXCLUDE_FILES_MANIFEST=1
+  # The nRF54 base filters out motion sources but currently leaves the generic
+  # magnetometer header enabled. This radio profile has no MMC5983MA attached.
+  -DMESHTASTIC_EXCLUDE_MAGNETOMETER=1
+  # The XIAO nRF54L15 Sense carries an LSM6DS3 IMU on i2c30 (address 0x6a).
+  # Undo the nrf54l15-base exclusion and re-add the motion sources below;
+  # BusIO/Unified-Sensor already build on this Arduino shim (BMP280 uses
+  # them).
+  -UMESHTASTIC_EXCLUDE_ACCELEROMETER
+  "-I.pio/libdeps/${PIOENV}/Adafruit LSM6DS/src"
+  # GPS on the XIAO header UART (uart21 = Serial1, D6 TX / D7 RX). Undo the
+  # nrf54l15-base exclusion; HAS_GPS is set in variant.h.
+  -UMESHTASTIC_EXCLUDE_GPS
+
+build_src_filter = ${nrf54l15_base.build_src_filter}
+  +<motion/MotionSensor.cpp>
+  +<motion/LSM6DS3Sensor.cpp>
+  # AccelerometerThread's BMX160 switch case is unguarded upstream; this file
+  # provides the stub constructor when Rak_BMX160.h is absent.
+  +<motion/BMX160Sensor.cpp>
+  +<../variants/nrf54l15/xiao_nrf54l15_wio_sx1262>
+
+lib_deps = ${nrf54l15_base.lib_deps}
+  https://github.com/adafruit/Adafruit_LSM6DS/archive/refs/tags/4.7.4.zip

--- a/variants/nrf54l15/xiao_nrf54l15_wio_sx1262/variant.cpp
+++ b/variants/nrf54l15/xiao_nrf54l15_wio_sx1262/variant.cpp
@@ -1,0 +1,6 @@
+#include "variant.h"
+
+void initVariant()
+{
+    // Peripheral pinmux and storage are configured by the Zephyr overlay.
+}

--- a/variants/nrf54l15/xiao_nrf54l15_wio_sx1262/variant.h
+++ b/variants/nrf54l15/xiao_nrf54l15_wio_sx1262/variant.h
@@ -1,0 +1,70 @@
+#pragma once
+
+/*
+ * Seeed Studio XIAO nRF54L15 Sense + Wio-SX1262 for XIAO.
+ *
+ * The Wio module's standard XIAO header wiring is:
+ *   D8  (P2.01 / pin 33) -> SCK
+ *   D9  (P2.04 / pin 36) -> MISO
+ *   D10 (P2.02 / pin 34) -> MOSI
+ *   D4  (P1.10 / pin 26) -> NSS / CS
+ *   D1  (P1.05 / pin 21) -> DIO1
+ *   D3  (P1.07 / pin 23) -> BUSY
+ *   D2  (P1.06 / pin 22) -> RESET
+ *   D5  (P1.11 / pin 27) -> RF_SW1 / RXEN
+ *
+ * Pin numbers below use Meshtastic's nRF54L15 Arduino shim convention:
+ * P0.n = n, P1.n = 16 + n, P2.n = 32 + n.
+ */
+
+#ifndef XIAO_NRF54L15_WIO_SX1262
+#define XIAO_NRF54L15_WIO_SX1262
+#endif
+
+#define USE_SX1262
+#define SX126X_CS 26
+#define SX126X_DIO1 21
+#define SX126X_BUSY 23
+#define SX126X_RESET 22
+#define SX126X_RXEN 27
+
+// The Wio-SX1262 uses DIO2 for its TX RF-switch path and DIO3 to supply the
+// module TCXO reference. RXEN stays on D5, as on Meshtastic's nRF52840 Wio kit.
+#define SX126X_DIO2_AS_RF_SWITCH
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8f
+#define SX126X_MAX_POWER 22
+#define REGULATORY_GAIN_LORA 7
+
+// The Sense board has one active-low status LED on P2.00. The stock nRF54L15
+// base profile has HAS_BUTTON=0, so D0 is left untouched for Wio add-ons.
+#define PIN_LED1 32
+#define LED_STATE_ON 0
+
+// Meshtastic's nRF54L15 TwoWire shim uses i2c30. On XIAO that is the free
+// D11/D12 bus (P0.03 SCL, P0.04 SDA); i2c22 is disabled in the overlay because
+// it would otherwise claim D4/D5, which are required by the Wio-SX1262.
+#define PIN_WIRE_SDA 4
+#define PIN_WIRE_SCL 3
+#define WIRE_INTERFACES_COUNT 1
+
+// GPS on the XIAO header UART: Serial1 is bound to Zephyr uart21
+// (TX = P2.08/D6, RX = P2.07/D7; enabled in the board overlay). Meshtastic
+// probes module type and baud rate at runtime, so no fixed model is declared.
+// GPS_RX_PIN/GPS_TX_PIN are required for NodeDB to default gps_mode to
+// ENABLED (undefined RX pin means "no GPS fitted"); the actual pin muxing is
+// owned by the device tree, and the shim's setPins() is a no-op.
+#define HAS_GPS 1
+#define GPS_RX_PIN 39 // P2.07 = D7
+#define GPS_TX_PIN 40 // P2.08 = D6
+// Seeed's "L76K GNSS Module for XIAO" shield routes the module's STANDBY
+// pin to D0 (P1.04) and the module stays asleep (UART silent) until it is
+// driven high. Matches the upstream seeed_xiao_nrf52840_kit variant; the
+// default GPS_STANDBY_ACTIVE=LOW polarity is correct for the L76K.
+#define PIN_GPS_STANDBY 20 // P1.04 = D0
+#define GPS_BAUDRATE 9600
+#define GPS_THREAD_INTERVAL 50
+// The L76K streams NMEA (RX path verified) but does not answer probe
+// commands on this stack - its reset line is shared with the Wio-SX1262's
+// RESET on D2, so the command channel is unreliable. Parse the stream
+// directly instead of requiring a successful model probe.
+#define GPS_SKIP_PROBE 1

--- a/zephyr/boards/xiao_nrf54l15_nrf54l15_cpuapp.overlay
+++ b/zephyr/boards/xiao_nrf54l15_nrf54l15_cpuapp.overlay
@@ -1,0 +1,42 @@
+/*
+ * XIAO nRF54L15 Sense + Wio-SX1262 Meshtastic overlay.
+ *
+ * The base XIAO DTS enables i2c22 on P1.10/P1.11 (D4/D5). The Wio-SX1262
+ * owns those pins for CS and RF_SW1, so leave i2c22 disabled. i2c30 remains
+ * available on D11/D12 for the Sense board's IMU and compatible peripherals.
+ */
+
+&i2c22 {
+    status = "disabled";
+};
+
+/*
+ * Keep SPI00 and its Seeed pinctrl assignments:
+ * P2.01 = SCK/D8, P2.02 = MOSI/D10, P2.04 = MISO/D9.
+ * RadioLib drives CS on D4 as a GPIO, so no hardware chip-select is declared.
+ */
+&spi00 {
+    status = "okay";
+};
+
+/*
+ * GPS on the XIAO header UART: uart21 with the Seeed pinctrl assignments
+ * TX = P2.08 (D6), RX = P2.07 (D7). The Arduino shim exposes this device as
+ * Serial1 for Meshtastic's GPS driver; the baud rate is reconfigured at
+ * runtime during GPS probing, so current-speed is only the initial value.
+ */
+&uart21 {
+    status = "okay";
+    current-speed = <9600>;
+};
+
+/*
+ * Meshtastic keeps configuration in LittleFS. Reclaim the unused secondary
+ * MCUboot slot for storage: 36 KiB -> 700 KiB. This profile is flashed through
+ * a debug probe and does not provide dual-bank MCUboot OTA updates.
+ */
+/delete-node/ &slot1_partition;
+
+&storage_partition {
+    reg = <0xb6000 0xaf000>;
+};

--- a/zephyr/prj-gps.conf
+++ b/zephyr/prj-gps.conf
@@ -1,0 +1,13 @@
+# GPS over the XIAO header UART (uart21, D6/D7 - see the board overlay).
+#
+# The Arduino shim's Serial1 uses the Zephyr interrupt-driven UART API with a
+# ring-buffered RX path. CONFIG_SERIAL here does NOT enable a UART console in
+# the normal profile: prj.conf keeps CONFIG_UART_CONSOLE=n, so logs stay on
+# RTT and uart21 belongs exclusively to the GPS.
+CONFIG_SERIAL=y
+CONFIG_UART_INTERRUPT_DRIVEN=y
+CONFIG_RING_BUFFER=y
+# Serial1.begin(baud) reconfigures the UART at runtime during GPS baud
+# probing; without this the driver returns -ENOTSUP and the port is stuck at
+# the device tree's current-speed.
+CONFIG_UART_USE_RUNTIME_CONFIGURE=y


### PR DESCRIPTION
New variant for the Seeed Studio XIAO nRF54L15 Sense stacked with the
Wio-SX1262 for XIAO (header pinout, standalone SKU 113010003) and,
optionally, the L76K GNSS Module for Seeed Studio XIAO. Registered as
PRIVATE_HW following the nrf54l15dk convention.

Pin map, board overlay (uart21 enabled, i2c22 freed for the radio's D4/D5,
MCUboot slot1 reclaimed for LittleFS), and hardware notes are in the
variant's README.

Platform work included, all device-tree- or arch-guarded so existing
targets (including nrf54l15dk) are unaffected:

- **Real `Serial1` in the nRF54L15 Arduino shim**: bound to Zephyr `uart21`
  (XIAO D6/D7) with interrupt-driven RX into a ring buffer, runtime baud
  reconfiguration for GPS probing, and poll-out TX. Console instances keep
  the existing printk behavior; the device binding is guarded by
  `DT_NODE_HAS_STATUS(..., okay)`, so builds that leave uart21 disabled
  compile identically.
- **`ARCH_NRF54L15` added to GPS.cpp's serial-port selection branches**
  (previously fell through to `#error Unsupported architecture!`).
- **`GPS_SKIP_PROBE`**: generalizes the existing `SENSECAP_INDICATOR`
  stream-only handling for variants whose GNSS command channel is
  unavailable. On this stack the L76K shield's reset line is shared with
  the radio's RESET on D2, so probe commands are unreliable while the NMEA
  stream itself is fine — the variant parses the stream directly at the
  module's default 9600 baud.
- **LSM6DS3 accelerometer** (on the Sense board, i2c30 @ 0x6a) enabled for
  wake-on-motion: motion sources re-added to the build and the Adafruit
  LSM6DS driver pulled in. `BMX160Sensor.cpp` is included for its stub
  constructor because AccelerometerThread's BMX160 switch case is not
  include-guarded.

Verified on hardware: BLE phone-API bootstrap (encrypted fixed-PIN pairing,
bond persistence across reboots), LoRa mesh TX/RX/relay on US LongFast,
LSM6DS3 detection and init, and GPS fixes (16+ satellites, PDOP ~1.0) from
the L76K.

BLE reliability on this board depends on #11471 (sleep-clock and phone-API
fixes); this PR builds independently of it.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)

Tested on the target hardware (XIAO nRF54L15 Sense + Wio-SX1262 + L76K).
All shared-code changes are behind `ARCH_NRF54L15`, a device-tree status
guard, or the new opt-in `GPS_SKIP_PROBE` define, so the listed devices
compile byte-identical firmware.
