### PR TITLE
fix(MQTT): don't let a disabled channel gate downlink, PKI, or uplink

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -85,6 +85,32 @@ inline bool shouldDropMqttDownlink(const meshtastic_MeshPacket &packet)
     return false;
 }
 
+// A channel only counts for MQTT if it is actually usable, the same test Channels::anyMqttEnabled()
+// applies. getByName() ignores role, so a disabled slot that kept its settings answers for a channel
+// the user turned off. First match wins: duplicate global ids are legal, since any two blank-named
+// slots resolve to the same preset name.
+inline bool channelWantsDownlink(ChannelIndex i)
+{
+    const meshtastic_Channel &c = channels.getByIndex(i);
+    return c.role != meshtastic_Channel_Role_DISABLED && c.has_settings && c.settings.downlink_enabled;
+}
+
+inline int resolveDownlinkChannel(const char *channelId)
+{
+    for (ChannelIndex i = 0; i < channels.getNumChannels(); i++)
+        if (channelWantsDownlink(i) && strcmp(channels.getGlobalId(i), channelId) == 0)
+            return (int)i;
+    return -1;
+}
+
+inline bool anyChannelWantsDownlink()
+{
+    for (ChannelIndex i = 0; i < channels.getNumChannels(); i++)
+        if (channelWantsDownlink(i))
+            return true;
+    return false;
+}
+
 inline void onReceiveProto(char *topic, byte *payload, size_t length)
 {
     const DecodedServiceEnvelope e(payload, length);
@@ -93,26 +119,18 @@ inline void onReceiveProto(char *topic, byte *payload, size_t length)
         return;
     }
 
-    const meshtastic_Channel &ch = channels.getByName(e.channel_id);
-    // Find channel by channel_id and check downlink_enabled
-    if (!(strcmp(e.channel_id, "PKI") == 0 ||
-          (strcmp(e.channel_id, channels.getGlobalId(ch.index)) == 0 && ch.settings.downlink_enabled))) {
-        return;
+    // The PKI topic names no local channel, so it borrows the primary index for the stamps below.
+    ChannelIndex chIndex = channels.getPrimaryIndex();
+    if (strcmp(e.channel_id, "PKI") == 0) {
+        if (!anyChannelWantsDownlink())
+            return;
+    } else {
+        const int resolved = resolveDownlinkChannel(e.channel_id);
+        if (resolved < 0)
+            return;
+        chIndex = (ChannelIndex)resolved;
     }
 
-    bool anyChannelHasDownlink = false;
-    size_t numChan = channels.getNumChannels();
-    for (size_t i = 0; i < numChan; ++i) {
-        const auto &c = channels.getByIndex(i);
-        if (c.settings.downlink_enabled) {
-            anyChannelHasDownlink = true;
-            break;
-        }
-    }
-
-    if (strcmp(e.channel_id, "PKI") == 0 && !anyChannelHasDownlink) {
-        return;
-    }
     // Generate node ID from nodenum for comparison
     std::string nodeId = nodeDB->getNodeId();
     if (strcmp(e.gateway_id, nodeId.c_str()) == 0) {
@@ -120,7 +138,7 @@ inline void onReceiveProto(char *topic, byte *payload, size_t length)
         // We do this because packets are not rebroadcasted back into MQTT anymore and we assume that at least one node
         // receives it when we get our own packet back. Then we'll stop our retransmissions.
         if (isFromUs(e.packet)) {
-            auto pAck = routingModule->allocAckNak(meshtastic_Routing_Error_NONE, getFrom(e.packet), e.packet->id, ch.index);
+            auto pAck = routingModule->allocAckNak(meshtastic_Routing_Error_NONE, getFrom(e.packet), e.packet->id, chIndex);
             if (!pAck)
                 return;
             pAck->transport_mechanism = meshtastic_MeshPacket_TransportMechanism_TRANSPORT_MQTT;
@@ -170,7 +188,7 @@ inline void onReceiveProto(char *topic, byte *payload, size_t length)
             LOG_INFO("Ignore decoded admin packet");
             return;
         }
-        p->channel = ch.index;
+        p->channel = chIndex;
 #if !(MESHTASTIC_EXCLUDE_PKI) && !(MESHTASTIC_EXCLUDE_XEDDSA)
         // Already-decoded downlink skips perhapsDecode's crypto path entirely, so enforce the
         // signature policy here: verify a carried signature and apply unsigned-downgrade
@@ -544,10 +562,8 @@ void MQTT::sendSubscriptions()
 {
 #if HAS_NETWORKING
     bool hasDownlink = false;
-    size_t numChan = channels.getNumChannels();
-    for (size_t i = 0; i < numChan; i++) {
-        const auto &ch = channels.getByIndex(i);
-        if (ch.settings.downlink_enabled) {
+    for (ChannelIndex i = 0; i < channels.getNumChannels(); i++) {
+        if (channelWantsDownlink(i)) {
             hasDownlink = true;
             std::string topic = cryptTopic + channels.getGlobalId(i) + "/+";
             LOG_INFO("Subscribe to %s", topic.c_str());

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -111,6 +111,16 @@ inline bool anyChannelWantsDownlink()
     return false;
 }
 
+inline bool anyChannelWantsUplink()
+{
+    for (ChannelIndex i = 0; i < channels.getNumChannels(); i++) {
+        const meshtastic_Channel &c = channels.getByIndex(i);
+        if (c.role != meshtastic_Channel_Role_DISABLED && c.has_settings && c.settings.uplink_enabled)
+            return true;
+    }
+    return false;
+}
+
 inline void onReceiveProto(char *topic, byte *payload, size_t length)
 {
     const DecodedServiceEnvelope e(payload, length);
@@ -722,12 +732,9 @@ void MQTT::onSend(const meshtastic_MeshPacket &mp_encrypted, const meshtastic_Me
         return;
     }
 #endif
-    bool uplinkEnabled = false;
-    for (int i = 0; i <= 7; i++) {
-        if (channels.getByIndex(i).settings.uplink_enabled)
-            uplinkEnabled = true;
-    }
-    if (!uplinkEnabled)
+    // For a PKI packet this is the only uplink gate, since the per-channel check below is bypassed,
+    // so a disabled slot's stale uplink_enabled would publish DMs the user opted out of uplinking.
+    if (!anyChannelWantsUplink())
         return; // no channels have an uplink enabled
     auto &ch = channels.getByIndex(chIndex);
 

--- a/test/test_mqtt/MQTT.cpp
+++ b/test/test_mqtt/MQTT.cpp
@@ -733,6 +733,65 @@ void test_receiveWithoutChannelDownlink(void)
     TEST_ASSERT_TRUE(mockRouter->packets_.empty());
 }
 
+// A disabled channel keeps its name and downlink_enabled: ensureLicensedOperation() leaves an admin
+// channel in exactly that shape. It must not answer for a channel the user turned off.
+void test_receiveIgnoresDisabledChannelDownlink(void)
+{
+    channelFile.channels[1] = meshtastic_Channel{
+        .index = 1,
+        .has_settings = true,
+        .settings = {.name = "ghost", .downlink_enabled = true},
+        .role = meshtastic_Channel_Role_DISABLED,
+    };
+    channelFile.channels_count = 2;
+    channels.onConfigChanged();
+
+    unitTest->publish(&decoded, "!87654321", "ghost");
+
+    TEST_ASSERT_TRUE(mockRouter->packets_.empty());
+}
+
+// Nor may it be the thing that unlocks the PKI topic.
+void test_receiveIgnoresPkiWhenOnlyDisabledChannelHasDownlink(void)
+{
+    channelFile.channels[0].settings.downlink_enabled = false;
+    channelFile.channels[1] = meshtastic_Channel{
+        .index = 1,
+        .has_settings = true,
+        .settings = {.name = "ghost", .downlink_enabled = true},
+        .role = meshtastic_Channel_Role_DISABLED,
+    };
+    channelFile.channels_count = 2;
+    channels.onConfigChanged();
+    meshtastic_MeshPacket e = encrypted;
+    e.to = myNodeInfo.my_node_num;
+
+    unitTest->publish(&e, "!87654321", "PKI");
+
+    TEST_ASSERT_TRUE(mockRouter->packets_.empty());
+}
+
+// Two active slots can legitimately share a global id, since every blank name resolves to the preset
+// name. That must still deliver, resolved to the first match, not be rejected as ambiguous.
+void test_receiveAcceptsDownlinkWhenTwoChannelsShareAGlobalId(void)
+{
+    config.lora.use_preset = true; // blank names resolve to "LongFast"
+    channelFile.channels[0].settings.name[0] = '\0';
+    channelFile.channels[1] = meshtastic_Channel{
+        .index = 1,
+        .has_settings = true,
+        .settings = {.name = "", .downlink_enabled = true},
+        .role = meshtastic_Channel_Role_SECONDARY,
+    };
+    channelFile.channels_count = 2;
+    channels.onConfigChanged();
+
+    unitTest->publish(&decoded, "!87654321", "LongFast");
+
+    TEST_ASSERT_EQUAL(1, mockRouter->packets_.size());
+    TEST_ASSERT_EQUAL(0, mockRouter->packets_.front().channel);
+}
+
 // Test receiving an encrypted MeshPacket on the PKI topic.
 void test_receiveEncryptedPKITopicToUs(void)
 {
@@ -1278,6 +1337,9 @@ void setup()
     RUN_TEST(test_receiveTextVariantFromProxyIsNotReadAsBytes);
     RUN_TEST(test_receiveNoVariantFromProxyIsIgnored);
     RUN_TEST(test_receiveWithoutChannelDownlink);
+    RUN_TEST(test_receiveIgnoresDisabledChannelDownlink);
+    RUN_TEST(test_receiveIgnoresPkiWhenOnlyDisabledChannelHasDownlink);
+    RUN_TEST(test_receiveAcceptsDownlinkWhenTwoChannelsShareAGlobalId);
     RUN_TEST(test_receiveEncryptedPKITopicToUs);
     RUN_TEST(test_receiveIgnoresOwnPublishedMessages);
     RUN_TEST(test_receiveAcksOwnSentMessages);

--- a/test/test_mqtt/MQTT.cpp
+++ b/test/test_mqtt/MQTT.cpp
@@ -511,6 +511,28 @@ void test_explicitPkiPositionStillPublishesWithEventPolicy(void)
     TEST_ASSERT_EQUAL_STRING("msh/2/e/PKI/!12345678", pubsub->published_.front().first.c_str());
 }
 
+// A PKI packet skips the per-channel uplink check, so the "does any channel want uplink" scan is the
+// only gate it passes. A disabled slot's stale uplink_enabled must not be what opens it.
+void test_pkiNotUplinkedWhenOnlyDisabledChannelHasUplink(void)
+{
+    clearPublicationState();
+    channelFile.channels[0].settings.uplink_enabled = false;
+    channelFile.channels[1] = meshtastic_Channel{
+        .index = 1,
+        .has_settings = true,
+        .settings = {.name = "ghost", .uplink_enabled = true},
+        .role = meshtastic_Channel_Role_DISABLED,
+    };
+    channelFile.channels_count = 2;
+    channels.onConfigChanged();
+    meshtastic_MeshPacket encryptedPki = encrypted;
+    encryptedPki.pki_encrypted = true;
+
+    mqtt->onSend(encryptedPki, decoded, 0);
+
+    TEST_ASSERT_TRUE(pubsub->published_.empty());
+}
+
 // Verify that the decoded MeshPacket is proxied through the MeshService when encryption_enabled = false.
 void test_proxyToMeshServiceDecoded(void)
 {
@@ -1322,6 +1344,7 @@ void setup()
     RUN_TEST(test_eventPositionPublicationFollowsCompileTimePolicy);
     RUN_TEST(test_privatePositionStillPublishesWithEventPolicy);
     RUN_TEST(test_explicitPkiPositionStillPublishesWithEventPolicy);
+    RUN_TEST(test_pkiNotUplinkedWhenOnlyDisabledChannelHasUplink);
     RUN_TEST(test_proxyToMeshServiceDecoded);
     RUN_TEST(test_proxyToMeshServiceEncrypted);
     RUN_TEST(test_dontMqttMeOnPublicServer);


### PR DESCRIPTION
A disabled channel can still drive MQTT.

`MQTT.cpp` checks `downlink_enabled` / `uplink_enabled` in four places without checking that the channel is actually enabled. A slot with `role == DISABLED` keeps its settings, so if it still has an MQTT flag set it is treated as live.

**How a node gets into that state**

- iOS: setting a channel's role to "Disabled" in the editor sends the full settings block along with the role.
- CLI: `--ch-index N --ch-disable` flips the role and writes the channel back with its settings.
- Licensed mode: `ensureLicensedOperation()` disables the `admin` channel but only clears the PSK.

The firmware stores what the client sent, and `fixupChannel()` only scrubs when `has_settings` is false, so the state persists across reboots. Android and `--ch-del` send empty settings and are not affected.

**What goes wrong**

- The node subscribes to the disabled channel's topic and accepts downlink on it. The packet is stamped with the disabled slot's index, which has no key, so rebroadcast fails with `NO_CHANNEL` and the phone sees traffic on a channel the user turned off.
- A disabled slot on its own unlocks the PKI downlink topic.
- Uplink: for PKI packets the "any channel has uplink" scan in `onSend()` is the only gate. If the user turns uplink off on every active channel but a disabled slot still has it set, every PKI DM the node sends or relays is still published. Payload is encrypted; sender, recipient, packet id and timestamp are not.

**Fix**

All four checks now require `role != DISABLED && has_settings` as well as the flag, matching `Channels::anyMqttEnabled()`. Downlink channel lookup is first match by `getGlobalId()`, since duplicate ids are legal (blank names all resolve to the preset name) and rejecting them would drop downlink on stock configs.

One behaviour change: if a lower-index slot shares a name but has downlink off and a higher-index slot has it on, develop dropped the packet and this accepts it. That matches what `sendSubscriptions()` already subscribed to.

`ensureLicensedOperation()` leaving the settings behind is the root of the licensed case and could be fixed there separately.

**Tests**

Three new tests fail on develop: `test_receiveIgnoresDisabledChannelDownlink`, `test_receiveIgnoresPkiWhenOnlyDisabledChannelHasDownlink`, `test_pkiNotUplinkedWhenOnlyDisabledChannelHasUplink`. `test_receiveAcceptsDownlinkWhenTwoChannelsShareAGlobalId` pins the first-match behaviour.

Rebased on develop `585ce17f5`. `test_mqtt` passes on `native-macos`, `heltec-v4` builds. Not tested against a live broker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V4
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other: compile-only on Heltec V4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MQTT uplink and downlink routing now ignores disabled channels, even when uplink or downlink settings are enabled.
  * PKI-encrypted messages are no longer sent or unlocked through disabled channels.
  * Downlink subscriptions now include only usable channels.
  * Messages are routed correctly when multiple active channels share a blank global ID.

* **Tests**
  * Added coverage for disabled-channel routing, PKI handling, and duplicate channel identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->