### PR TITLE
fix(NextHopRouter): guard the PendingPacket ctor and correct its docs

### DIFF
--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -53,6 +53,11 @@ bool NextHopRouter::relayOpaquePacket(const meshtastic_MeshPacket *p)
 
 PendingPacket::PendingPacket(meshtastic_MeshPacket *p, uint8_t numRetransmissions)
 {
+    // numRetransmissions is a total attempt count including the send the caller has already done, so
+    // zero has no meaning here and would wrap the subtraction below to 255, giving the record a
+    // near-endless retry budget. Every caller passes a constant of at least 2.
+    assert(numRetransmissions > 0);
+
     packet = p;
     this->numRetransmissions = numRetransmissions - 1; // We subtract one, because we assume the user just did the first send
 }

--- a/src/mesh/NextHopRouter.h
+++ b/src/mesh/NextHopRouter.h
@@ -31,12 +31,13 @@ struct GlobalPacketId {
  * A packet queued for retransmission
  */
 struct PendingPacket {
-    meshtastic_MeshPacket *packet;
+    meshtastic_MeshPacket *packet = nullptr;
 
     /** The next time we should try to retransmit this packet */
     uint32_t nextTxMsec = 0;
 
-    /** Starts at NUM_RETRANSMISSIONS -1 and counts down.  Once zero it will be removed from the list */
+    /** Starts at the ctor's numReTx argument minus one, since the first send has already happened, and
+     * counts down. Once zero the record is removed from the list. */
     uint8_t numRetransmissions = 0;
 
     PendingPacket() {}
@@ -74,9 +75,11 @@ class GlobalPacketIdHashFunction
 /*
   Router for direct messages, which only relays if it is the next hop for a packet. The next hop is set by the current
   relayer of a packet, which bases this on information from a previous successful delivery to the destination via flooding.
-  Namely, in the PacketHistory, we keep track of (up to 3) relayers of a packet. When the ACK is delivered back to us via a node
-  that also relayed the original packet, we use that node as next hop for the destination from then on. This makes sure that only
-  when there’s a two-way connection, we assign a next hop. Both the ReliableRouter and NextHopRouter will do retransmissions (the
+  Namely, in the PacketHistory, we keep track of (up to NUM_RELAYERS) relayers of a packet. When the ACK is delivered back to us
+  via a node that also relayed the original packet, we use that node as next hop for the destination from then on. That is
+  evidence of a two-way connection rather than proof of one: every input to the check is derived from frames we received, so it
+  establishes that we can hear the relayer, not that the relayer can hear us. Both the ReliableRouter and NextHopRouter will do
+  retransmissions (the
   NextHopRouter only 1 time). For the final retry, if no one actually relayed the packet, it will reset the next hop in order to
   fall back to the FloodingRouter again. Note that thus also intermediate hops will do a single retransmission if the intended
   next-hop didn’t relay, in order to fix changes in the middle of the route.


### PR DESCRIPTION
Four small things in `NextHopRouter`, none of which changes behaviour on any current code path.

`PendingPacket`'s constructor takes a total attempt count including the send the caller has already
done, and subtracts one. Zero has no meaning there and wraps to 255, handing the record a
near-endless retry budget. No caller passes it today, so this is an `assert` rather than a fix.

`PendingPacket::packet` was the only member without an in-class initializer, so a default-constructed
record held an indeterminate pointer.

The comment on `numRetransmissions` referred to `NUM_RETRANSMISSIONS`, which does not exist anywhere
in the tree. It now describes the constructor argument instead.

The class doc said `PacketHistory` tracks "up to 3" relayers. `NUM_RELAYERS` has been 6 for a while,
so the doc now names the constant rather than a number that can drift again.

The last change is the one worth a second look. The same doc said the ACK round trip "makes sure that
only when there's a two-way connection, we assign a next hop". That claims more than the check
supports. Every input to it comes from frames we received: `PacketHistory.relayed_by` is populated
from our own transmissions and from copies we heard, and the ACK's `relay_node` comes off a frame we
received. So the check establishes that we can hear the relayer, not that the relayer can hear us.
On a link that is asymmetric, and mixed TX power in a mesh makes that ordinary rather than exotic,
those are different statements. The wording matters because it is the stated justification for
trusting the learned hop, and reading it as a guarantee is how you end up not questioning a next hop
that cannot actually receive from you.

I have deliberately only softened the wording rather than proposing a change to the check itself. The
failure direction is one-sided and safe: a node can never install a next hop it has not heard, and
anything mislearned still delivers via the flood fallback. So this is a documentation correction, not
a bug report.

Testing: builds clean on `heltec-v4` and `seeed-xiao-s3`, targeted native suites unchanged. The
`assert` is on a path no caller reaches, so there is nothing to exercise at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other: compile-only on Heltec V4 and Seeed XIAO ESP32-S3
