### PR TITLE
fix(MQTT): stop reporting delivery from our own gateway echo

### DIFF
--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -1766,6 +1766,10 @@ PhoneAPI::LocalAdminGate PhoneAPI::classifyLocalAdminPacket(const meshtastic_Mes
  */
 bool PhoneAPI::handleToRadioPacket(meshtastic_MeshPacket &p)
 {
+    // Clients don't get to name the transport they arrived on, the same way they don't get to assign
+    // `from`. PacketAPI already stamps its own ingress; this is the path that did not.
+    p.transport_mechanism = meshtastic_MeshPacket_TransportMechanism_TRANSPORT_INTERNAL;
+
     printPacket("PACKET FROM PHONE", &p);
 
 #if defined(MESHTASTIC_ENCRYPTED_STORAGE) && defined(MESHTASTIC_PHONEAPI_ACCESS_CONTROL)

--- a/src/mesh/ReliableRouter.cpp
+++ b/src/mesh/ReliableRouter.cpp
@@ -160,9 +160,7 @@ void ReliableRouter::sniffReceived(const meshtastic_MeshPacket *p, const meshtas
         PacketId nakId = (c && c->error_reason != meshtastic_Routing_Error_NONE) ? p->decoded.request_id : 0;
 
         // We intentionally don't check wasSeenRecently, because it is harmless to delete non existent retransmission records
-        if ((ackId || nakId) &&
-            // Implicit ACKs from MQTT should not stop retransmissions
-            !(isFromUs(p) && p->transport_mechanism == meshtastic_MeshPacket_TransportMechanism_TRANSPORT_MQTT)) {
+        if (ackId || nakId) {
             LOG_DEBUG("Received a %s for 0x%08x, stopping retransmissions", ackId ? "ACK" : "NAK", ackId);
             if (ackId) {
                 stopRetransmission(p->to, ackId);

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -116,19 +116,8 @@ inline void onReceiveProto(char *topic, byte *payload, size_t length)
     // Generate node ID from nodenum for comparison
     std::string nodeId = nodeDB->getNodeId();
     if (strcmp(e.gateway_id, nodeId.c_str()) == 0) {
-        // Our own packet, echoed back off our own gateway topic. That round trip proves the broker
-        // received and returned it. It does not show that any node on the mesh heard it, which is
-        // what an ACK delivered to the phone says.
-        //
-        // This used to synthesise a local ROUTING ACK here, on the reasoning that getting our own
-        // packet back means at least one node received it, "then we'll stop our retransmissions".
-        // Those retransmissions are not in fact stopped: ReliableRouter::sniffReceived() exempts
-        // MQTT-sourced implicit ACKs from stopRetransmission() precisely because the echo is not
-        // delivery evidence. So the ACK reached the phone as a delivery confirmation while the radio
-        // carried on retrying, and if the message really was undeliverable the phone was told
-        // "delivered" and then, one full retry ladder later, MAX_RETRANSMIT.
-        //
-        // Drop the ACK rather than the exemption. See the PR discussion for the other direction.
+        // Our own packet back off our own gateway proves the broker returned it, not that the mesh
+        // heard it, so no ACK is minted here. See the commit message.
         if (!isFromUs(e.packet)) {
             LOG_INFO("Ignore downlink msg we sent");
         }

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -116,17 +116,20 @@ inline void onReceiveProto(char *topic, byte *payload, size_t length)
     // Generate node ID from nodenum for comparison
     std::string nodeId = nodeDB->getNodeId();
     if (strcmp(e.gateway_id, nodeId.c_str()) == 0) {
-        // Generate an implicit ACK towards ourselves (handled and processed only locally!) for this message.
-        // We do this because packets are not rebroadcasted back into MQTT anymore and we assume that at least one node
-        // receives it when we get our own packet back. Then we'll stop our retransmissions.
-        if (isFromUs(e.packet)) {
-            auto pAck = routingModule->allocAckNak(meshtastic_Routing_Error_NONE, getFrom(e.packet), e.packet->id, ch.index);
-            if (!pAck)
-                return;
-            pAck->transport_mechanism = meshtastic_MeshPacket_TransportMechanism_TRANSPORT_MQTT;
-            if (router->sendLocal(pAck) == ERRNO_SHOULD_RELEASE)
-                packetPool.release(pAck);
-        } else {
+        // Our own packet, echoed back off our own gateway topic. That round trip proves the broker
+        // received and returned it. It does not show that any node on the mesh heard it, which is
+        // what an ACK delivered to the phone says.
+        //
+        // This used to synthesise a local ROUTING ACK here, on the reasoning that getting our own
+        // packet back means at least one node received it, "then we'll stop our retransmissions".
+        // Those retransmissions are not in fact stopped: ReliableRouter::sniffReceived() exempts
+        // MQTT-sourced implicit ACKs from stopRetransmission() precisely because the echo is not
+        // delivery evidence. So the ACK reached the phone as a delivery confirmation while the radio
+        // carried on retrying, and if the message really was undeliverable the phone was told
+        // "delivered" and then, one full retry ladder later, MAX_RETRANSMIT.
+        //
+        // Drop the ACK rather than the exemption. See the PR discussion for the other direction.
+        if (!isFromUs(e.packet)) {
             LOG_INFO("Ignore downlink msg we sent");
         }
         return;

--- a/test/test_event_channel_phone_api/test_main.cpp
+++ b/test/test_event_channel_phone_api/test_main.cpp
@@ -250,12 +250,26 @@ static void test_event_position_ingress_does_not_poison_retry_state()
 #endif
 }
 
+// A client must not be able to name the transport its packet arrived on. Several routing decisions
+// read transport_mechanism as evidence of how a packet reached us, so an unscrubbed value is trusted.
+static void test_toradio_transport_mechanism_is_not_client_settable()
+{
+    auto forged = makePositionToRadio(FOLLOWUP_PACKET_ID, PRIVATE_CHANNEL);
+    forged.packet.transport_mechanism = meshtastic_MeshPacket_TransportMechanism_TRANSPORT_MQTT;
+
+    TEST_ASSERT_TRUE(sendToRadio(forged));
+    TEST_ASSERT_EQUAL(1, mockRouter->sentPackets.size());
+    TEST_ASSERT_EQUAL(meshtastic_MeshPacket_TransportMechanism_TRANSPORT_INTERNAL,
+                      mockRouter->sentPackets[0].transport_mechanism);
+}
+
 extern "C" {
 void setup()
 {
     initializeTestEnvironment();
     UNITY_BEGIN();
     RUN_TEST(test_event_position_ingress_does_not_poison_retry_state);
+    RUN_TEST(test_toradio_transport_mechanism_is_not_client_settable);
     exit(UNITY_END());
 }
 

--- a/test/test_mqtt/MQTT.cpp
+++ b/test/test_mqtt/MQTT.cpp
@@ -752,21 +752,18 @@ void test_receiveIgnoresOwnPublishedMessages(void)
     TEST_ASSERT_TRUE(mockRoutingModule->ackNacks_.empty());
 }
 
-// Considers receiving one of our packets an acknowledgement of it being sent.
-void test_receiveAcksOwnSentMessages(void)
+// Our own packet back off our own gateway is not evidence the mesh heard it, so nothing is minted.
+// getForPhone() is the assertion that bites: the old ACK reached the phone through sendLocal().
+void test_receiveDoesNotAckOwnSentMessages(void)
 {
     meshtastic_MeshPacket p = decoded;
     p.from = myNodeInfo.my_node_num;
 
     unitTest->publish(&p, nodeDB->getNodeId().c_str());
 
-    // FIXME: Better assertion for this test
-    // TEST_ASSERT_TRUE(mockRouter->packets_.empty());
-    // TEST_ASSERT_EQUAL(1, mockRoutingModule->ackNacks_.size());
-    // const auto &[err, to, idFrom, chIndex, hopLimit] = mockRoutingModule->ackNacks_.front();
-    // TEST_ASSERT_EQUAL(meshtastic_Routing_Error_NONE, err);
-    // TEST_ASSERT_EQUAL(myNodeInfo.my_node_num, to);
-    // TEST_ASSERT_EQUAL(p.id, idFrom);
+    TEST_ASSERT_TRUE(mockRouter->packets_.empty());
+    TEST_ASSERT_TRUE(mockRoutingModule->ackNacks_.empty());
+    TEST_ASSERT_NULL(mockMeshService->getForPhone());
 }
 
 // Should ignore our own messages from MQTT that were heard by other nodes.
@@ -1274,7 +1271,7 @@ void setup()
     RUN_TEST(test_receiveWithoutChannelDownlink);
     RUN_TEST(test_receiveEncryptedPKITopicToUs);
     RUN_TEST(test_receiveIgnoresOwnPublishedMessages);
-    RUN_TEST(test_receiveAcksOwnSentMessages);
+    RUN_TEST(test_receiveDoesNotAckOwnSentMessages);
     RUN_TEST(test_receiveIgnoresSentMessagesFromOthers);
     RUN_TEST(test_receiveIgnoresDecodedWhenEncryptionEnabled);
     RUN_TEST(test_receiveIgnoresDecodedAdminApp);


### PR DESCRIPTION
Two places in the tree disagree about what the self-gateway MQTT echo means, and the disagreement is
visible to the user.

`MQTT.cpp` synthesised a local ROUTING ACK when our own packet came back off our own gateway topic.
Its comment gives the reasoning: getting the packet back means at least one node received it, "then
we'll stop our retransmissions".

`ReliableRouter::sniffReceived()` says the opposite. It exempts MQTT-sourced implicit ACKs from
`stopRetransmission()`, with the comment "Implicit ACKs from MQTT should not stop retransmissions".
So the retransmissions the MQTT comment describes stopping are never actually stopped.

Both cannot be right. The exemption is the one that matches the facts: the echo proves the broker
received the packet and sent it back, and says nothing about whether any node on the mesh heard it.
Our own gateway is specifically the node that cannot be evidence of that.

What the user sees from the disagreement is a phone told "delivered" while the radio is still
retrying, and then told `MAX_RETRANSMIT` a full retry ladder later if the message really was
undeliverable.

This drops the ACK, and the exemption goes with it.

### Why the exemption goes too

That ACK was its only firmware producer. The other writer of `TRANSPORT_MQTT` is the third-party
downlink path a few lines below, which returns early on `isFromUs()`; LoRa, UDP and PacketAPI each
stamp their own transport; and StoreForward preserves the field through its history but never sets
`decoded.request_id` on replay, so it cannot reach the `ackId || nakId` gate.

It was not literally unreachable, and the difference is worth stating plainly. `transport_mechanism`
is `MeshPacket` field 21 and rides in on `ToRadio` like any other field. `MeshService::handleToRadio`
scrubs `from`, `next_hop` and `relay_node`, each with a "we don't let clients assign X" comment, but
not this one, so a local client could hand us a self-addressed packet carrying `TRANSPORT_MQTT` and
reach this line. The guard was never a defence there: that client got the identical effect by leaving
the field at zero, since the guard only exempted MQTT-*marked* packets.

So the third commit closes that properly. `PacketAPI`, the sibling `ToRadio` ingress, already stamps
`TRANSPORT_API` before handing the packet over; `PhoneAPI` was the path with no stamp. It now stamps
`TRANSPORT_INTERNAL`, which is what a well-behaved client sends today, so compliant clients see no
change.

That is worth more than the guard was. The field is read as evidence of how a packet reached us:
`FloodingRouter`'s dupe-cancel, `ReliableRouter`'s rebroadcast gate, `NextHopRouter`'s dupe handling
and `NodeDB`'s `hops_away` and SNR bookkeeping all key off `TRANSPORT_LORA`, and `PositionModule`
gates own-position updates on the value. Forging `TRANSPORT_LORA` was the more interesting case, and
it is closed too. Stamped in `PhoneAPI` rather than at the `MeshService::handleToRadio` choke point so
`PacketAPI` keeps its own `TRANSPORT_API`, which `PositionModule` distinguishes.

Nothing in the retry ladder changes either way, because the exemption already prevented this ACK from
affecting it. What goes away is the false delivery report.

Real end-to-end ACKs are untouched. An ACK from the recipient relayed back through someone else's
gateway carries the recipient's node number in `from`, so `isFromUs(p)` was already false and the
exemption never applied to it. It still stops retransmissions and still reaches the phone, subject as
before to `ignore_mqtt` and to ordinary dupe suppression if the ACK was also heard over LoRa.

### The other direction

Honouring the MQTT comment instead, by letting the echo stop retransmissions, is the alternative and
I do not think it is the right one. It would end the retries on evidence that does not support them:
a node whose LoRa neighbours all missed the packet would stop trying as soon as the broker echoed it
back. But it is a coherent position if the intent was that MQTT connectivity substitutes for mesh
delivery, and that is a call about intended MQTT semantics rather than something to settle from
outside the project. Hence draft.

Worth knowing if you take this direction: a node whose traffic reaches the mesh only via MQTT loses
this signal, but not every signal. Where the recipient's side has a gateway on the same broker their
real ACK still comes back and still confirms. What goes away is the case where no ACK can return,
which is the same case where the echo was reporting a delivery that had not happened. There is also
no marker distinguishing an implicit ACK from a real one on the wire, so a client cannot presently
tell them apart either way, which is a separate gap.

### Tests

`test_receiveAcksOwnSentMessages` was named and documented for the behaviour this PR removes, and
every assertion in it was commented out behind a `FIXME`, so it passed in either direction. It is
renamed and given assertions that bite. `getForPhone()` is the one that does the work: the old ACK
went through neither `MockRoutingModule::sendAckNak` (the code called `allocAckNak` directly) nor
`MockRouter::enqueueReceivedMessage`, so the two commented-out assertions would have failed on
develop as well. It did reach the phone queue via `sendLocal()`.

`test_toradio_transport_mechanism_is_not_client_settable` forges `TRANSPORT_MQTT` through the real
`StreamAPI` `ToRadio` path and asserts what reaches `Router::send`.

Both were checked against a tree without their fix: the first fails on develop at the `getForPhone`
assertion, the second fails with `Expected 0 Was 5`.

Related: I have a separate PR for `ignore_mqtt` not being honoured on this same branch of
`onReceiveProto()`. It is independent of which direction you pick here, though if this lands it
covers that case too and I would close the other one.

Merges cleanly with #11477, which adds a branch inside the same if/else a few lines below; checked
with `git merge-tree`, no conflict. Worth reviewing alongside #11478 rather than separately: each
argues its own transport check is individually dead, and after both there is no `transport_mechanism`
check left anywhere on the stop-retransmissions path.

Testing: builds clean on `heltec-v4` and `seeed-xiao-s3`, 171/171 across `test_mqtt`,
`test_nexthop_routing`, `test_packet_signing` and `test_event_channel_phone_api` on `native-macos`.
Not exercised against a live broker, since I have no MQTT setup here; the contradiction is from
reading the two call sites and the exemption condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other: compile-only on Heltec V4 and Seeed XIAO ESP32-S3
