### PR TITLE
fix(ReliableRouter): keep the retry across a duty-cycle rejection

### DIFF
--- a/src/mesh/ReliableRouter.cpp
+++ b/src/mesh/ReliableRouter.cpp
@@ -170,6 +170,14 @@ void ReliableRouter::sniffReceived(const meshtastic_MeshPacket *p, const meshtas
                 // so clear its failure count and refresh freshness (keeps a good route pinned).
                 if (!isBroadcast(getFrom(p)))
                     noteRouteSuccess(getFrom(p), millis());
+            } else if (c && c->error_reason == meshtastic_Routing_Error_DUTY_CYCLE_LIMIT && isFromUs(p)) {
+                // Our own duty-cycle rejection, looped back. Router::send() aborts the packet and NAKs
+                // it to us, and deliverLocal() runs that inline because doRetransmissions() and
+                // ReliableRouter::send() both run with handleDepth == 0. ReliableRouter::send()
+                // deliberately keeps the pending record for this error so the retry can go out once
+                // the window clears; erasing it here would defeat that before send() ever inspects
+                // its result. The client still gets the NAK, it just is not the final word.
+                LOG_DEBUG("Duty cycle NAK for 0x%08x, keep retransmissions", nakId);
             } else {
                 stopRetransmission(p->to, nakId);
             }

--- a/src/mesh/ReliableRouter.cpp
+++ b/src/mesh/ReliableRouter.cpp
@@ -171,12 +171,8 @@ void ReliableRouter::sniffReceived(const meshtastic_MeshPacket *p, const meshtas
                 if (!isBroadcast(getFrom(p)))
                     noteRouteSuccess(getFrom(p), millis());
             } else if (c && c->error_reason == meshtastic_Routing_Error_DUTY_CYCLE_LIMIT && isFromUs(p)) {
-                // Our own duty-cycle rejection, looped back. Router::send() aborts the packet and NAKs
-                // it to us, and deliverLocal() runs that inline because doRetransmissions() and
-                // ReliableRouter::send() both run with handleDepth == 0. ReliableRouter::send()
-                // deliberately keeps the pending record for this error so the retry can go out once
-                // the window clears; erasing it here would defeat that before send() ever inspects
-                // its result. The client still gets the NAK, it just is not the final word.
+                // Our own duty-cycle rejection, looped straight back inline. send() keeps the pending
+                // record for this error on purpose, so erasing it here would undo that carve-out.
                 LOG_DEBUG("Duty cycle NAK for 0x%08x, keep retransmissions", nakId);
             } else {
                 stopRetransmission(p->to, nakId);

--- a/test/test_packet_signing/test_main.cpp
+++ b/test/test_packet_signing/test_main.cpp
@@ -183,11 +183,8 @@ class AuthPipelineRouter : public ReliableRouter
     }
 };
 
-// Counting the call is not enough to model sendAckNak(). In the firmware it continues into
-// router->sendLocal(), and a NAK addressed to ourselves reaches deliverLocal(), which delivers inline
-// whenever handleDepth is 0. ReliableRouter::sniffReceived() then acts on that NAK while the original
-// caller is still mid-send. A stub that only counts cannot show whether a pending record survives
-// that, so drive the loopback for error NAKs the way the firmware does.
+// A stub that only counts the call cannot show whether a pending record survives, since the real
+// sendAckNak() loops a self-addressed NAK back into sniffReceived() inline. So drive that loopback.
 class AuthPipelineRoutingModule : public RoutingModule
 {
   public:

--- a/test/test_packet_signing/test_main.cpp
+++ b/test/test_packet_signing/test_main.cpp
@@ -174,6 +174,7 @@ class AuthPipelineRouter : public ReliableRouter
         return entry ? entry->nextTxMsec : 0;
     }
     size_t pendingCount() const { return pending.size(); }
+    void sniff(const meshtastic_MeshPacket *p, const meshtastic_Routing *c) { ReliableRouter::sniffReceived(p, c); }
     void clearPending()
     {
         for (auto &entry : pending)
@@ -182,10 +183,38 @@ class AuthPipelineRouter : public ReliableRouter
     }
 };
 
+// Counting the call is not enough to model sendAckNak(). In the firmware it continues into
+// router->sendLocal(), and a NAK addressed to ourselves reaches deliverLocal(), which delivers inline
+// whenever handleDepth is 0. ReliableRouter::sniffReceived() then acts on that NAK while the original
+// caller is still mid-send. A stub that only counts cannot show whether a pending record survives
+// that, so drive the loopback for error NAKs the way the firmware does.
 class AuthPipelineRoutingModule : public RoutingModule
 {
   public:
-    void sendAckNak(meshtastic_Routing_Error, NodeNum, PacketId, ChannelIndex, uint8_t = 0, bool = false) override { ackCalls++; }
+    AuthPipelineRouter *target = nullptr;
+
+    void sendAckNak(meshtastic_Routing_Error err, NodeNum to, PacketId idFrom, ChannelIndex chIndex, uint8_t = 0,
+                    bool = false) override
+    {
+        ackCalls++;
+        if (target == nullptr || err == meshtastic_Routing_Error_NONE)
+            return;
+
+        meshtastic_MeshPacket nak = meshtastic_MeshPacket_init_zero;
+        nak.from = to;
+        nak.to = to;
+        nak.id = idFrom ^ 0x3C3C3C3C;
+        nak.channel = chIndex;
+        nak.which_payload_variant = meshtastic_MeshPacket_decoded_tag;
+        nak.decoded.portnum = meshtastic_PortNum_ROUTING_APP;
+        nak.decoded.request_id = idFrom;
+
+        meshtastic_Routing routing = meshtastic_Routing_init_zero;
+        routing.error_reason = err;
+
+        target->sniff(&nak, &routing);
+    }
+
     uint32_t ackCalls = 0;
 };
 
@@ -1916,6 +1945,7 @@ void setup()
     pipelineRouter->addInterface(std::move(pipelineRadioOwner));
     router = pipelineRouter;
     routingModule = pipelineRouting = new AuthPipelineRoutingModule();
+    pipelineRouting->target = pipelineRouter; // deliver NAKs back into the router, as sendLocal() does
     pipelineModule = new AuthPipelineModule();
     service = pipelineService = new MeshService();
     mqtt = pipelineMqtt = new AuthPipelineMqtt();


### PR DESCRIPTION
`ReliableRouter::send()` deliberately leaves the pending record in place when the send comes back
`DUTY_CYCLE_LIMIT`, on the reasoning in its own comment that the rejection may clear before the
scheduled retry:

```c
    if (retransmitting && result != ERRNO_OK && result != meshtastic_Routing_Error_DUTY_CYCLE_LIMIT)
        stopRetransmission(key);
```

That never worked. `Router::send()` aborts the packet on a duty-cycle rejection and NAKs it back to us
through `abortSendAndNak()` -> `sendLocal()` -> `deliverLocal()`. `deliverLocal()` only defers when
`handleDepth > 0`, and `ReliableRouter::send()` runs with `handleDepth` 0, so the NAK is delivered
inline. `sniffReceived()` sees an error NAK carrying the packet's id and calls
`stopRetransmission()`, erasing the record before `send()` ever reaches the line above.

So the retry the carve-out exists to preserve is gone by the time the check runs, and a duty-cycle
rejection is final in practice rather than transient.

The fix skips that `stopRetransmission()` for a self-addressed `DUTY_CYCLE_LIMIT` NAK. It is
locally generated and describes a condition that clears on its own, so it is the one NAK that should
not be the last word. The client still receives it.

Duty cycle applies where `dutyCycle < 100`: EU_433, EU_868, EU_866, EU_N_868, TH and UA_433.

### The test was green for the wrong reason

`test_C14_duty_cycle_limited_reliable_send_remains_pending` asserts exactly the behaviour that was
broken, and passed anyway. `AuthPipelineRoutingModule::sendAckNak()` counted the call and returned,
so nothing was ever delivered, so nothing erased the record, and `pendingCount() == 1` held for a
reason unrelated to what the test claims to check.

The second commit makes that stub deliver its NAKs the way `sendLocal()` does. With the stub fixed
and the source change reverted, C14 fails:

```
test_C14_duty_cycle_limited_reliable_send_remains_pending:
  Expected 1 Was 0. duty-cycle rejection must retain the retry for when airtime is available
```

which is the assertion it was written to make.

Worth flagging separately: the same synchronous loopback is why `doRetransmissions()` can use a
freed pending record, which is #11475. This one is the narrower behavioural half.

Rebased on develop `585ce17f5`. The NAK branch now sits inside the `ackProofPermitsAction()` gate from
#11877, which passes a self-originated NAK through, so the carve-out is unchanged. The routing stub
follows the `relaySource` parameter #10767 added to `sendAckNak()`. `test_packet_signing`,
`test_nexthop_routing` and `test_mesh_module` pass on `native-macos`; C14 still fails with the source
change reverted. Earlier hardware run on `heltec-v4` was at reduced power.

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [X] Heltec (Lora32) V4
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of duty-cycle-limited delivery failures so pending retransmissions are preserved instead of being stopped prematurely.
  - Added more reliable processing for locally generated negative acknowledgements, helping the router maintain accurate retransmission state and respond consistently when delivery is temporarily restricted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
