### PR TITLE
fix(ReliableRouter): drop the dead transport gate on the implicit ACK

### DIFF
--- a/src/mesh/ReliableRouter.cpp
+++ b/src/mesh/ReliableRouter.cpp
@@ -69,12 +69,24 @@ bool ReliableRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
             LOG_DEBUG("Generate implicit ack");
             // NOTE: we do NOT check p->wantAck here because p is the INCOMING rebroadcast and that packet is not expected to be
             // marked as wantAck
+            // This call already ends the retransmissions, so nothing follows it here. sendAckNak()
+            // reaches router->sendLocal(), and the ACK is addressed to us, so deliverLocal() takes
+            // it. deliverLocal() only defers when handleDepth > 0, and we are called from
+            // perhapsHandleReceived() before handleReceived() raises it, so the delivery runs inline
+            // on this stack. sniffReceived() then sees an ACK for this packet's id and calls
+            // stopRetransmission() itself.
+            //
+            // There used to be a `if (transport_mechanism == TRANSPORT_LORA) stopRetransmission(key)`
+            // below, meant to keep retrying when a rebroadcast reached us by some other transport.
+            // It could not work: by the time it ran the record was already gone, whatever the
+            // transport. It was also unreachable in the sense that mattered, since no non-LoRa
+            // transport delivers our own packets back to this function - MQTT returns early for
+            // self-origin envelopes and UDP multicast drops them on ingress.
+            //
+            // If a transport is ever added that can land here, that intent needs implementing where
+            // it can take effect, i.e. as an exemption in sniffReceived() keyed off the ACK's own
+            // transport_mechanism, which is the pattern MQTT's implicit ACK already uses.
             sendAckNak(meshtastic_Routing_Error_NONE, getFrom(p), p->id, old->packet->channel);
-
-            // Only stop retransmissions if the rebroadcast came via LoRa
-            if (p->transport_mechanism == meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA) {
-                stopRetransmission(key);
-            }
         } else {
             LOG_DEBUG("Didn't find pending packet");
         }


### PR DESCRIPTION
`ReliableRouter::shouldFilterReceived()` ended the implicit-ACK block with

```c
    // Only stop retransmissions if the rebroadcast came via LoRa
    if (p->transport_mechanism == meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA) {
        stopRetransmission(key);
    }
```

which reads as though a rebroadcast arriving by some other transport leaves the retries running. It
does not, for two independent reasons.

The `sendAckNak()` on the line above has already ended them. It reaches `router->sendLocal()`, the
ACK is addressed to us, so `deliverLocal()` takes it, and `deliverLocal()` only defers when
`handleDepth > 0`. This function is called from `perhapsHandleReceived()`, which runs before
`handleReceived()` raises `handleDepth`, so the delivery happens inline on the same stack and
`sniffReceived()` calls `stopRetransmission()` for the id itself. By the time the gate ran, the
record was gone regardless of transport.

The case it guards against also cannot occur today. No non-LoRa transport delivers our own packets
back to this function: MQTT returns early for self-origin envelopes, and UDP multicast drops them on
ingress.

This replaces the gate with a note recording where the record actually gets erased, and where the
intent would have to live if a transport that can reach here is ever added: an exemption in
`sniffReceived()` keyed off the ACK's own `transport_mechanism`, which is what MQTT's implicit ACK
already does. No behaviour change.

I chose not to build that machinery now, since it would be guarding a path with no caller. If you
would rather have the intent implemented than removed, say so and I will move it rather than delete
it.

### Related

This is the third place where the same inline loopback is the root cause. `sendAckNak()` re-entering
the router while `handleDepth` is 0 also means `doRetransmissions()` can keep using a pending record
that the loopback has freed, and it defeats `ReliableRouter::send()`'s duty-cycle carve-out. Both are
separate PRs. Individually they look like three unrelated small things; the common factor is that the
loopback is synchronous in more places than the code appears to expect.

Testing: builds clean on `heltec-v4` and `seeed-xiao-s3`, 169/169 across `test_packet_signing`,
`test_nexthop_routing` and `test_mqtt`. Nothing to exercise at runtime, since the change removes
unreachable code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other: compile-only on Heltec V4 and Seeed XIAO ESP32-S3
