### PR TITLE
Fix NodeDB loadFromDisk to replace store instead of appending

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -161,15 +161,6 @@ lint:
         - test/test_airtime/test_main.cpp
         - test/test_throttle/test_main.cpp
         - test/test_uptime_clock/test_main.cpp
-    # Same detector, different trigger: Lob's key shape is a short word, an
-    # underscore and exactly 35 further name characters, so any test function
-    # whose name runs 35 characters past "test_" matches. Two in this file do -
-    # naming them here would trip the detector on this file too. The reported
-    # "secret" is the function name itself, and the alternative is padding
-    # identifiers to dodge a character count.
-    - linters: [trufflehog]
-      paths:
-        - test/test_nodedb_blocked/test_main.cpp
 runtimes:
   enabled:
     - python@3.14.4

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -161,6 +161,15 @@ lint:
         - test/test_airtime/test_main.cpp
         - test/test_throttle/test_main.cpp
         - test/test_uptime_clock/test_main.cpp
+    # Same detector, different trigger: Lob's key shape is a short word, an
+    # underscore and exactly 35 further name characters, so any test function
+    # whose name runs 35 characters past "test_" matches. Two in this file do -
+    # naming them here would trip the detector on this file too. The reported
+    # "secret" is the function name itself, and the alternative is padding
+    # identifiers to dodge a character count.
+    - linters: [trufflehog]
+      paths:
+        - test/test_nodedb_blocked/test_main.cpp
 runtimes:
   enabled:
     - python@3.14.4

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -2369,6 +2369,12 @@ void NodeDB::loadFromDisk()
         ~Disarm() { self.disarmNodeDatabaseDecodeTargets(); }
     } disarm{*this};
 
+    // loadProto() skips its destination memset for this struct (std::vector members), so reset it
+    // here: the nodes callback only push_back()s and nodeDatabase is a global, so a second load
+    // appended to the first, and a stale version skipped installDefaultNodeDatabase().
+    nodeDatabase.nodes.clear();
+    numMeshNodes = 0;
+    nodeDatabase.version = 0;
     // Avoid push_back's power-of-2 capacity growth wasting RAM at small N.
     nodeDatabase.nodes.reserve(MAX_NUM_NODES);
 

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -2363,6 +2363,17 @@ void NodeDB::loadFromDisk()
     {
         concurrency::LockGuard guard(&satelliteMutex);
         armNodeDatabaseDecodeTargets();
+        // Where a satellite DB is compiled out there is no map to arm, so the decode callback falls
+        // through to the vector and push_back()s into it. Reset those the same way the save path
+        // does on its way out, so no build can carry entries from one load into the next.
+        nodeDatabase.positions.clear();
+        nodeDatabase.positions.shrink_to_fit();
+        nodeDatabase.telemetry.clear();
+        nodeDatabase.telemetry.shrink_to_fit();
+        nodeDatabase.environment.clear();
+        nodeDatabase.environment.shrink_to_fit();
+        nodeDatabase.status.clear();
+        nodeDatabase.status.shrink_to_fit();
     }
     struct Disarm {
         NodeDB &self;

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -2052,6 +2052,13 @@ void NodeDB::pickNewNodeNum()
     myNodeInfo.my_node_num = nodeNum;
 }
 
+/// Both NodeDatabase descriptors decode into structs holding std::vector members, which a memset
+/// would leave in an undefined state; their callers reset the destination themselves instead.
+static inline bool destinationHasVectorMembers(const pb_msgdesc_t *fields)
+{
+    return fields == &meshtastic_NodeDatabase_msg || fields == &meshtastic_NodeDatabase_Legacy_msg;
+}
+
 /** Load a protobuf from a file, return LoadFileResult */
 LoadFileResult NodeDB::loadProto(const char *filename, size_t protoSize, size_t objSize, const pb_msgdesc_t *fields,
                                  void *dest_struct)
@@ -2073,7 +2080,7 @@ LoadFileResult NodeDB::loadProto(const char *filename, size_t protoSize, size_t 
         if (EncryptedStorage::readAndDecrypt(filename, decBuf.get(), protoSize, decLen)) {
             LOG_INFO("Load encrypted %s", filename);
             pb_istream_t stream = pb_istream_from_buffer(decBuf.get(), decLen);
-            if (fields != &meshtastic_NodeDatabase_msg)
+            if (!destinationHasVectorMembers(fields))
                 memset(dest_struct, 0, objSize);
             if (!pb_decode(&stream, fields, dest_struct)) {
                 LOG_ERROR("Can't decode protobuf %s", PB_GET_ERROR(&stream));
@@ -2100,8 +2107,7 @@ LoadFileResult NodeDB::loadProto(const char *filename, size_t protoSize, size_t 
     if (f) {
         LOG_INFO("Load %s", filename);
         pb_istream_t stream = {&readcb, &f, protoSize};
-        if (fields != &meshtastic_NodeDatabase_msg &&
-            fields != &meshtastic_NodeDatabase_Legacy_msg) // both NodeDatabase descriptors contain std::vector members
+        if (!destinationHasVectorMembers(fields))
             memset(dest_struct, 0, objSize);
         if (!pb_decode(&stream, fields, dest_struct)) {
             LOG_ERROR("Can't decode protobuf %s", PB_GET_ERROR(&stream));
@@ -2383,8 +2389,8 @@ void NodeDB::loadFromDisk()
     // loadProto() skips its destination memset for this struct (std::vector members), so reset it
     // here: the nodes callback only push_back()s and nodeDatabase is a global, so a second load
     // appended to the first, and a stale version skipped installDefaultNodeDatabase().
+    numMeshNodes = 0; // before the clear: the old count against an emptied vector reads past the end
     nodeDatabase.nodes.clear();
-    numMeshNodes = 0;
     nodeDatabase.version = 0;
     // Avoid push_back's power-of-2 capacity growth wasting RAM at small N.
     nodeDatabase.nodes.reserve(MAX_NUM_NODES);

--- a/test/README.md
+++ b/test/README.md
@@ -220,6 +220,14 @@ So: `exit(UNITY_END())` in **every** `setup()` branch, including the `#else` of 
 
 Wrap the entire test body in the same `#if` guard the module uses (e.g. `#if HAS_VARIABLE_HOPS`, `#if !MESHTASTIC_EXCLUDE_GPS`). When the feature is disabled, the `#else` branch produces an empty passing suite.
 
+### 5. Don't Name a Test Exactly 35 Characters Past `test_`
+
+Trunk runs `trufflehog`, whose Lob detector matches `test_` followed by exactly 35 further identifier characters and reports the function name as a verified secret. It only fires on files a PR touches, so an offending name can sit on `develop` for months and then fail CI in an unrelated change. Longer or shorter both pass - only 35 matches. Check with:
+
+```sh
+grep -oE '\b(test|live)_[a-zA-Z0-9_]{35}\b' test/<suite>/test_main.cpp
+```
+
 ## Common Patterns
 
 ### MockNodeDB

--- a/test/README.md
+++ b/test/README.md
@@ -258,6 +258,39 @@ static MockNodeDB *mockNodeDB = nullptr;
 
 Set `nodeDB = mockNodeDB;` in `setUp()`.
 
+### Save/Load With a Mock NodeDB
+
+**A new `NodeDB` subclass is not a new node database.** The hot store is not a member of the
+object: it lives in `nodeDatabase`, a file-scope global in `src/mesh/NodeDB.cpp`, which
+`meshNodes` points into and `numMeshNodes` indexes. `new MockNodeDB()` runs the real
+constructor, so it runs `loadFromDisk()` and reads `/prefs/nodes.proto` out of the suite's
+scratch `$HOME`. What you get back is whatever the previous test left on disk - and, before
+the vector clear in `loadFromDisk()`, whatever the previous test left in RAM as well, with
+the file's rows appended to it. That defect is fixed, but the ownership it exposed is
+permanent: **the store outlives your fixture.** Rules that follow from it:
+
+- **Decide whether your mock owns the real store or a private one, and don't mix.** The
+  `testNodes` pattern above re-points `meshNodes` at a vector the mock owns, which is fine
+  for pure in-RAM tests. It is not fine if you also call the persistence paths:
+  `saveNodeDatabaseToDisk()` encodes `nodeDatabase.nodes`, not `testNodes`, so you would
+  assert on one store and persist another. A suite that exercises persistence should drive
+  the real store instead - `meshNodes->clear(); numMeshNodes = 0;` then push into it, as
+  `test/test_nodedb_blocked/test_main.cpp`'s shim does.
+- **Arm the keypair gate, every time.** `saveNodeDatabaseToDisk()` logs _"Skip NodeDB without
+  key"_ and returns `true` - success, no write - until `owner.public_key.size == 32` or
+  `owner.is_licensed`. A test that means to write `nodes.proto` must set one. Re-arm before
+  **each** save: `owner` is a reference into `devicestate`, which `loadFromDisk()` reloads,
+  so a load silently disarms the next save. A "passing" round-trip that never wrote the file
+  is the failure mode this produces.
+- **`loadFromDisk()` is not scoped to the node DB.** It also reloads `devicestate`, `config`,
+  `channelFile`, `moduleConfig` and the warm tier. Treat a call to it as resetting all of
+  them, and restore anything your suite depends on afterwards.
+- **Delete `/prefs/nodes.proto` in `setUp()`** if you want "fresh NodeDB" to mean it. Cheap,
+  local, and it makes the intent visible - see §1 of the shared-state rules above.
+- **Round-trip across at least two cycles.** One cycle of an append-instead-of-replace bug
+  yields a number that looks plausible (3 nodes became 6); it is the _doubling_ that
+  identifies it. Assert the count is unchanged after two or three save/load cycles, not one.
+
 ### Test Shim (Exposing Protected/Private Members)
 
 Subclass the module under test to make protected methods callable and private members writable:
@@ -370,13 +403,17 @@ If your suite touches globals the code under test writes - `nodeDB`, `config`, `
 ```cpp
 void setUp(void) {
     // ...
-    replaceAdminRadioGlobals();   // saves the globals, installs a fresh NodeDB
+    replaceAdminRadioGlobals();   // drops nodes.proto, saves the globals, installs a fresh NodeDB
 }
 void tearDown(void) {
     restoreAdminRadioGlobals();   // restores them, deletes the NodeDB, re-runs initRegion()
     // ...
 }
 ```
+
+The `nodes.proto` delete is part of the fixture, not decoration: the constructor loads that file, so a
+replacement `NodeDB` built while the previous test's store is still on disk starts from that store. See
+_Save/Load With a Mock NodeDB_ above.
 
 A fresh `NodeDB` per test costs real time (`loadFromDisk()` plus, when the region is set, key generation) - in that suite roughly 7% of a ~7½-minute run. Pay it. If a test genuinely needs to observe the previous test's state, that is what `state=per-suite` in `test/state-manifest.tsv` is for; say so there rather than achieving it by omission.
 

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -1011,6 +1011,10 @@ static void replaceAdminRadioGlobals()
     savedOwner = owner;
     savedConfig = config;
     savedChannelFile = channelFile;
+    // A "fresh" NodeDB is only fresh if the file its constructor loads is gone: the admin handlers
+    // under test persist node metadata, so without this each test starts from the previous test's
+    // saved store rather than an empty one, and the suite drifts into testing something else.
+    FSCom.remove(nodeDatabaseFileName);
     replacementNodeDB = new NodeDB();
     nodeDB = replacementNodeDB;
 }

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -1011,10 +1011,11 @@ static void replaceAdminRadioGlobals()
     savedOwner = owner;
     savedConfig = config;
     savedChannelFile = channelFile;
-    // A "fresh" NodeDB is only fresh if the file its constructor loads is gone: the admin handlers
+    // A "fresh" NodeDB is only fresh if both files its constructor loads are gone: the admin handlers
     // under test persist node metadata, so without this each test starts from the previous test's
     // saved store rather than an empty one, and the suite drifts into testing something else.
     FSCom.remove(nodeDatabaseFileName);
+    FSCom.remove("/prefs/warm.dat");
     replacementNodeDB = new NodeDB();
     nodeDB = replacementNodeDB;
 }

--- a/test/test_mesh_module/test_main.cpp
+++ b/test/test_mesh_module/test_main.cpp
@@ -329,9 +329,10 @@ void setUp(void)
     owner = meshtastic_User_init_zero;
     myNodeInfo.my_node_num = LOCAL_NODE;
 
-    // MockNodeDB is an empty subclass, so this suite drives the real node store. Drop the file the
+    // MockNodeDB is an empty subclass, so this suite drives the real node store. Drop both files the
     // constructor loads, or each test starts from whatever the previous test's saves left on disk.
     FSCom.remove(nodeDatabaseFileName);
+    FSCom.remove("/prefs/warm.dat");
     mockNodeDB = new MockNodeDB();
     nodeDB = mockNodeDB;
     myNodeInfo.my_node_num = LOCAL_NODE;

--- a/test/test_mesh_module/test_main.cpp
+++ b/test/test_mesh_module/test_main.cpp
@@ -3,6 +3,7 @@
 #include "TestUtil.h"
 #include <unity.h>
 
+#include "FSCommon.h" // FSCom, for the per-test nodes.proto drop in setUp
 #include "configuration.h"
 #include "mesh/CryptoEngine.h"
 #include "mesh/MeshService.h"
@@ -328,6 +329,9 @@ void setUp(void)
     owner = meshtastic_User_init_zero;
     myNodeInfo.my_node_num = LOCAL_NODE;
 
+    // MockNodeDB is an empty subclass, so this suite drives the real node store. Drop the file the
+    // constructor loads, or each test starts from whatever the previous test's saves left on disk.
+    FSCom.remove(nodeDatabaseFileName);
     mockNodeDB = new MockNodeDB();
     nodeDB = mockNodeDB;
     myNodeInfo.my_node_num = LOCAL_NODE;

--- a/test/test_nodedb_blocked/test_main.cpp
+++ b/test/test_nodedb_blocked/test_main.cpp
@@ -13,6 +13,7 @@
 // The migration demotes overflow into the warm tier, so these tests need it.
 #if WARM_NODE_COUNT > 0
 
+#include "FSCommon.h" // FSCom, for the persistence round-trip tests
 #include "mesh/NodeDB.h"
 #include <cstring>
 
@@ -25,6 +26,10 @@ class NodeDBTestShim : public NodeDB
   public:
     void runDemote() { demoteOldestHotNodesToWarm(); }
     void runCleanup() { cleanupMeshDB(); }
+    // The persistence pair the NodeDB constructor runs. Private in NodeDB; reachable
+    // here through the `friend class NodeDBTestShim` declaration.
+    void runLoad() { loadFromDisk(); }
+    bool runSave() { return saveNodeDatabaseToDisk(); }
     void stampUntrusted(NodeNum num, uint32_t uptimeSecs) { recordHeardWhileClockUntrusted(num, uptimeSecs); }
 
     // Read back the role + protected category the warm tier cached for a node.
@@ -71,6 +76,16 @@ bool warmHasKey(NodeNum n)
 {
     meshtastic_NodeInfoLite_public_key_t k = {0, {0}};
     return db->copyPublicKey(n, k) && k.size == 32;
+}
+
+// saveNodeDatabaseToDisk() returns early - "Skip NodeDB without key" - until this node
+// has a PKI keypair, so a test that means to write nodes.proto has to supply one. It has
+// to be re-armed before *every* save, because `owner` is a reference into devicestate,
+// which loadFromDisk() reloads from disk underneath it.
+void armSaveGate()
+{
+    owner.public_key.size = 32;
+    memset(owner.public_key.bytes, 0x5A, sizeof(owner.public_key.bytes));
 }
 
 } // namespace
@@ -280,6 +295,118 @@ static void test_removeNodeByNum_presentNodeOnFullDb(void)
     TEST_ASSERT_NOT_NULL(db->getMeshNode(8000 + MAX_NUM_NODES - 1)); // survivors kept
 }
 
+// A save/load cycle must *replace* the in-RAM store, not add to it.
+//
+// loadProto() memsets every proto's destination clear before decoding except the two
+// NodeDatabase descriptors, which hold std::vector members that memset would corrupt.
+// Nothing took over that job, the nodes decode callback only push_back()s, and
+// `nodeDatabase` is a file-scope global that outlives any one NodeDB - so every load
+// appended the file's rows to whatever was already in RAM, and each cycle doubled the
+// store: 1 -> 2 -> 4 -> ... -> MAX_NUM_NODES copies of one node number. Duplicates that
+// are ignored (blocked) survive cleanupMeshDB() by design, which is what let a fixture
+// reach a full DB of protected rows and take the NULL branch tested further down.
+//
+// Two nearby paths got this right and are the reason the gap was easy to miss:
+// armNodeDatabaseDecodeTargets(), called immediately before the load, clears the
+// satellite maps, and migrateLegacyNodeDatabase() clears the vector before it fills it.
+// Only the current-version path did not.
+//
+// It is not test-only. reloadFromDisk() calls loadFromDisk() a second time in one process
+// after an encrypted-storage unlock, and the locked boot returns early from it having run
+// installDefaultNodeDatabase() - so the reload decoded the real store on top of
+// MAX_NUM_NODES zeroed rows, went over cap, and nodeDBSelfCare() truncated and rewrote
+// nodes.proto with cleanupMeshDB() never running on that path.
+static void test_saveThenLoad_doesNotAccumulateNodes(void)
+{
+    db->clearHot();
+    db->seedSelf();
+    db->push(0x0A000001, /*last_heard=*/100, false, false, /*withUser=*/true, /*withKey=*/false);
+    db->push(0x0A000002, /*last_heard=*/200, false, false, /*withUser=*/true, /*withKey=*/false);
+    const int expected = (int)db->getNumMeshNodes();
+    TEST_ASSERT_EQUAL_INT(3, expected); // self + two
+
+    // Three cycles, because one cycle of the old defect only produced a plausible-looking
+    // 6: the signature is that it keeps doubling.
+    for (int cycle = 0; cycle < 3; cycle++) {
+        armSaveGate();
+        TEST_ASSERT_TRUE(db->runSave());
+        db->runLoad();
+        TEST_ASSERT_EQUAL_INT_MESSAGE(expected, (int)db->getNumMeshNodes(),
+                                      "a save/load cycle must round-trip the store, not append to it");
+    }
+    TEST_ASSERT_NOT_NULL(db->getMeshNode(0x0A000001));
+    TEST_ASSERT_NOT_NULL(db->getMeshNode(0x0A000002));
+}
+
+// The other half of the same defect: with nothing resetting the destination, an absent or
+// undecodable nodes.proto left the previous contents in RAM *and* kept the version that
+// was decoded last time, so the install-defaults path was skipped and a "fresh" NodeDB
+// silently inherited the old store.
+static void test_loadFromDisk_absentFileDoesNotInheritStaleNodes(void)
+{
+    db->clearHot();
+    db->seedSelf();
+    db->push(0x0B000001, /*last_heard=*/100, false, false, /*withUser=*/true, /*withKey=*/false);
+    armSaveGate();
+    TEST_ASSERT_TRUE(db->runSave());
+
+    FSCom.remove(nodeDatabaseFileName);
+    db->runLoad();
+
+    TEST_ASSERT_EQUAL_INT(0, (int)db->getNumMeshNodes());
+    TEST_ASSERT_NULL(db->getMeshNode(0x0B000001));
+    TEST_ASSERT_NULL(db->getMeshNode(0x0BADF00D)); // not even self survives an empty store
+
+    // Leave the file the suite declares in state-manifest.tsv on disk for the next test.
+    armSaveGate();
+    TEST_ASSERT_TRUE(db->runSave());
+}
+
+// The NULL return in getOrCreateMeshNode(): a store at MAX_NUM_NODES whose every
+// non-self row is protected has no eviction candidate, so admission must be refused
+// rather than appending past the cap. setProtectedFlag() holds numProtectedNodes() to
+// MAX_NUM_NODES-2 at runtime, so only a pre-cap or externally written nodes.proto can
+// reach this shape - which is why the guard is not dead code, and why it is asserted
+// here rather than assumed.
+static void test_getOrCreateMeshNode_refusesWhenFullAndEveryCandidateProtected(void)
+{
+    db->clearHot();
+    db->seedSelf();
+    for (int i = 1; i < MAX_NUM_NODES; i++)
+        db->push(0x0C000000 + i, /*last_heard=*/i, /*favorite=*/false, /*ignored=*/true, /*withUser=*/true, /*withKey=*/false);
+    TEST_ASSERT_EQUAL_INT(MAX_NUM_NODES, (int)db->getNumMeshNodes());
+    TEST_ASSERT_EQUAL_INT(MAX_NUM_NODES - 1, db->numProtectedNodes()); // past the runtime cap, on purpose
+
+    TEST_ASSERT_NULL(db->getOrCreateMeshNode(0x0CFFFFFF));
+
+    TEST_ASSERT_EQUAL_INT(MAX_NUM_NODES, (int)db->getNumMeshNodes());         // nothing appended
+    TEST_ASSERT_EQUAL_UINT32(MAX_NUM_NODES, (uint32_t)db->meshNodes->size()); // and no growth past the cap
+    TEST_ASSERT_NOT_NULL(db->getMeshNode(0x0C000001));                        // refusal evicted nobody
+    TEST_ASSERT_NOT_NULL(db->getMeshNode(0x0BADF00D));
+}
+
+// Complement, and the reason the cap is MAX_NUM_NODES-2: with the protected limit
+// honoured, a full store still admits a new node - the guard above can only fire on a
+// store that never went through setProtectedFlag().
+static void test_getOrCreateMeshNode_admitsAtCapWhenProtectedLimitHonoured(void)
+{
+    db->clearHot();
+    db->seedSelf();
+    for (int i = 1; i <= MAX_NUM_NODES - 2; i++)
+        db->push(0x0D000000 + i, /*last_heard=*/1000 + i, /*favorite=*/true, false, /*withUser=*/true, /*withKey=*/false);
+    db->push(0x0DFFFF01, /*last_heard=*/1, false, false, /*withUser=*/true, /*withKey=*/false); // the evictable row
+    TEST_ASSERT_EQUAL_INT(MAX_NUM_NODES, (int)db->getNumMeshNodes());
+    TEST_ASSERT_EQUAL_INT(MAX_NUM_NODES - 2, db->numProtectedNodes());
+
+    meshtastic_NodeInfoLite *fresh = db->getOrCreateMeshNode(0x0DFFFF02);
+
+    TEST_ASSERT_NOT_NULL(fresh);
+    TEST_ASSERT_EQUAL_UINT32(0x0DFFFF02, fresh->num);
+    TEST_ASSERT_NULL(db->getMeshNode(0x0DFFFF01));                    // the one evictable row was the victim
+    TEST_ASSERT_NOT_NULL(db->getMeshNode(0x0D000001));                // no favourite was touched
+    TEST_ASSERT_EQUAL_INT(MAX_NUM_NODES, (int)db->getNumMeshNodes()); // still exactly at the cap
+}
+
 NDB_TEST_ENTRY void setup()
 {
     initializeTestEnvironment();
@@ -296,6 +423,10 @@ NDB_TEST_ENTRY void setup()
     RUN_TEST(test_protectedCap_refusesBeyondLimit);
     RUN_TEST(test_removeNodeByNum_absentNodeOnFullDb);
     RUN_TEST(test_removeNodeByNum_presentNodeOnFullDb);
+    RUN_TEST(test_saveThenLoad_doesNotAccumulateNodes);
+    RUN_TEST(test_loadFromDisk_absentFileDoesNotInheritStaleNodes);
+    RUN_TEST(test_getOrCreateMeshNode_refusesWhenFullAndEveryCandidateProtected);
+    RUN_TEST(test_getOrCreateMeshNode_admitsAtCapWhenProtectedLimitHonoured);
     exit(UNITY_END());
 }
 NDB_TEST_ENTRY void loop() {}

--- a/test/test_nodedb_blocked/test_main.cpp
+++ b/test/test_nodedb_blocked/test_main.cpp
@@ -264,7 +264,7 @@ static void test_protectedCap_refusesBeyondLimit(void)
 
 // removeNodeByNum() compacts survivors down and clears the slots that leaves free. A full
 // store with no matching node frees none, so there is nothing past the last node to clear.
-static void test_removeNodeByNum_absentNodeOnFullDb(void)
+static void test_removeNodeByNum_absentNodeFullDb(void)
 {
     db->seedSelf();
     for (int i = 1; i < MAX_NUM_NODES; i++) // fill to MAX_NUM_NODES total (incl. self)
@@ -281,7 +281,7 @@ static void test_removeNodeByNum_absentNodeOnFullDb(void)
 
 // Control for the above: a matching node on a full store is still removed, the survivors
 // compact down, and the freed tail slot is cleared.
-static void test_removeNodeByNum_presentNodeOnFullDb(void)
+static void test_removeNodeByNum_presentNodeFullDb(void)
 {
     db->seedSelf();
     for (int i = 1; i < MAX_NUM_NODES; i++)
@@ -316,7 +316,7 @@ static void test_removeNodeByNum_presentNodeOnFullDb(void)
 // installDefaultNodeDatabase() - so the reload decoded the real store on top of
 // MAX_NUM_NODES zeroed rows, went over cap, and nodeDBSelfCare() truncated and rewrote
 // nodes.proto with cleanupMeshDB() never running on that path.
-static void test_saveThenLoad_doesNotAccumulateNodes(void)
+static void test_saveThenLoad_doesNotAccumulate(void)
 {
     db->clearHot();
     db->seedSelf();
@@ -421,9 +421,9 @@ NDB_TEST_ENTRY void setup()
     RUN_TEST(test_eviction_prefersCurrentBootStampOverPost2038Epoch);
     RUN_TEST(test_ignored_survivesEvictionAndCleanup);
     RUN_TEST(test_protectedCap_refusesBeyondLimit);
-    RUN_TEST(test_removeNodeByNum_absentNodeOnFullDb);
-    RUN_TEST(test_removeNodeByNum_presentNodeOnFullDb);
-    RUN_TEST(test_saveThenLoad_doesNotAccumulateNodes);
+    RUN_TEST(test_removeNodeByNum_absentNodeFullDb);
+    RUN_TEST(test_removeNodeByNum_presentNodeFullDb);
+    RUN_TEST(test_saveThenLoad_doesNotAccumulate);
     RUN_TEST(test_loadFromDisk_absentFileDoesNotInheritStaleNodes);
     RUN_TEST(test_getOrCreateMeshNode_refusesWhenFullAndEveryCandidateProtected);
     RUN_TEST(test_getOrCreateMeshNode_admitsAtCapWhenProtectedLimitHonoured);

--- a/test/test_nodedb_blocked/test_main.cpp
+++ b/test/test_nodedb_blocked/test_main.cpp
@@ -357,8 +357,10 @@ static void test_loadFromDisk_absentFileDoesNotInheritStaleNodes(void)
     TEST_ASSERT_NULL(db->getMeshNode(0x0B000001));
     TEST_ASSERT_NULL(db->getMeshNode(0x0BADF00D)); // not even self survives an empty store
 
-    // Leave the file the suite declares in state-manifest.tsv on disk for the next test.
+    // Leave the file state-manifest.tsv declares on disk. clearHot() first: the defaults the absent
+    // file installed leave MAX_NUM_NODES zeroed rows in the vector the encode walks.
     armSaveGate();
+    db->clearHot();
     TEST_ASSERT_TRUE(db->runSave());
 }
 


### PR DESCRIPTION
This pull request fixes a long-standing bug in the NodeDB persistence logic, where loading the node database from disk would append to the in-memory store rather than replacing it, causing node entries to accumulate across loads. It also updates the test infrastructure and documentation to ensure test isolation and clarify NodeDB state management. Several new and improved tests are added to verify correct behavior, and the test setup is hardened to guarantee a clean state for each test.

**Persistence and NodeDB State Management**

* Fixed a bug where `loadFromDisk()` did not clear the in-memory node database before loading from disk, resulting in duplicate entries after multiple load cycles. Now, all relevant `std::vector` members and counters in `nodeDatabase` are cleared before loading.
* Added the helper function `destinationHasVectorMembers()` to prevent `memset` on protobuf structs with `std::vector` members, avoiding undefined behavior. [[1]](diffhunk://#diff-d3ca504aa401bdfaa42fcd99349d867b504756a86721afbbb46482909e8b1001R2055-R2061) [[2]](diffhunk://#diff-d3ca504aa401bdfaa42fcd99349d867b504756a86721afbbb46482909e8b1001L2076-R2083) [[3]](diffhunk://#diff-d3ca504aa401bdfaa42fcd99349d867b504756a86721afbbb46482909e8b1001L2103-R2110)

**Test Infrastructure and Isolation**

* Updated test fixtures (`setUp` in various test suites) to always remove both `nodes.proto` and `warm.dat` before constructing a new `NodeDB`, ensuring tests do not inherit persisted state from previous runs. [[1]](diffhunk://#diff-dce01576acb7598ec197d0732dba7894a08f8656a5bdd86b78986787f35dbb60R1014-R1018) [[2]](diffhunk://#diff-57fa3d226cfe5721a368f0c9fd8119e7cdd5524465cca95d75efcbf3886ae1bcR332-R335)
* Improved documentation in `test/README.md` to explain NodeDB ownership, persistence, and best practices for test isolation, including a new section on handling save/load with mocks. [[1]](diffhunk://#diff-5de36acd90308dc62abf7855a686ee7052ffb6e762c756fd735fb0c9fbd9595dR269-R301) [[2]](diffhunk://#diff-5de36acd90308dc62abf7855a686ee7052ffb6e762c756fd735fb0c9fbd9595dL373-R425)
* Added a warning about test names that can trigger false positives in secret scanning tools.

**Testing and Verification**

* Added new tests to verify that save/load cycles do not accumulate nodes, that absent or undecodable files do not leave stale nodes in memory, and that node admission and eviction logic works correctly at capacity. [[1]](diffhunk://#diff-38094f6f0c9434ab24df8074860151c7182f0261a81fda1eabe9bb534796311fR298-R411) [[2]](diffhunk://#diff-38094f6f0c9434ab24df8074860151c7182f0261a81fda1eabe9bb534796311fL297-R431)
* Refactored test utility code, e.g., adding `armSaveGate()` to ensure the persistence gate is properly armed for each save, and exposing `runLoad()`/`runSave()` in the test shim. [[1]](diffhunk://#diff-38094f6f0c9434ab24df8074860151c7182f0261a81fda1eabe9bb534796311fR29-R32) [[2]](diffhunk://#diff-38094f6f0c9434ab24df8074860151c7182f0261a81fda1eabe9bb534796311fR81-R90)

**Test Naming and Maintenance**

* Renamed tests for clarity and to avoid secret scanning false positives. [[1]](diffhunk://#diff-38094f6f0c9434ab24df8074860151c7182f0261a81fda1eabe9bb534796311fL252-R267) [[2]](diffhunk://#diff-38094f6f0c9434ab24df8074860151c7182f0261a81fda1eabe9bb534796311fL269-R284)

**Test Suite Consistency**

* Included `FSCommon.h` where needed for file operations in tests. [[1]](diffhunk://#diff-57fa3d226cfe5721a368f0c9fd8119e7cdd5524465cca95d75efcbf3886ae1bcR6) [[2]](diffhunk://#diff-38094f6f0c9434ab24df8074860151c7182f0261a81fda1eabe9bb534796311fR16)

These changes together ensure that the NodeDB hot store is always correctly replaced on load, tests are reliably isolated, and persistence logic is robustly verified.



## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repeated database loads so stale node data and version information are cleared before reloading.
  * Improved handling when optional satellite databases are unavailable.
  * Ensured fresh database states when replacing or recreating stored node data.

* **Tests**
  * Added coverage for persistence round trips, missing files, stale data, and node admission limits.
  * Added guidance for reliable persistence testing and fixture cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->