### PR TITLE
fix(test): make the native-windows test suite build and run

### DIFF
--- a/test/TestUtil.cpp
+++ b/test/TestUtil.cpp
@@ -63,6 +63,20 @@ void testStateCheckpoint(const char *, const char *) {}
 namespace
 {
 
+/// MinGW-w64 has no lstat(): Windows has no POSIX symlink stat, and nothing in a test sandbox
+/// creates a symlink, so stat() sees the same thing for every entry walk() can reach.
+#ifdef _WIN32
+inline int lstatCompat(const char *path, struct stat *st)
+{
+    return stat(path, st);
+}
+#else
+inline int lstatCompat(const char *path, struct stat *st)
+{
+    return lstat(path, st);
+}
+#endif
+
 /// Content fingerprint, used only to answer "did this file change?". FNV-1a rather than a real
 /// digest because the answer is a boolean and the files are a few KB of protobuf; nothing here
 /// records a hash as an expected value, which is what would make this a snapshot test.
@@ -96,7 +110,7 @@ void walk(const std::string &root, const std::string &rel, std::map<std::string,
         const std::string childRel = rel.empty() ? std::string(e->d_name) : rel + "/" + e->d_name;
         const std::string childPath = root + "/" + childRel;
         struct stat st;
-        if (lstat(childPath.c_str(), &st) != 0)
+        if (lstatCompat(childPath.c_str(), &st) != 0)
             continue;
         if (S_ISDIR(st.st_mode))
             walk(root, childRel, out);

--- a/test/test_default/test_main.cpp
+++ b/test/test_default/test_main.cpp
@@ -277,6 +277,10 @@ void test_trafficType_overflowSaturates()
     TEST_ASSERT_EQUAL_UINT32(static_cast<uint32_t>(INT32_MAX), res);
 }
 
+// Required by Unity: PlatformIO's weak defaults do not link on MinGW (PE-COFF weak externals).
+void setUp(void) {}
+void tearDown(void) {}
+
 void setup()
 {
     // Small delay to match other test mains

--- a/test/test_fscommon_getfiles/test_main.cpp
+++ b/test/test_fscommon_getfiles/test_main.cpp
@@ -112,6 +112,9 @@ void test_getfiles_depth_limit(void)
 
 // 4. A path that will not fit meshtastic_FileInfo::file_name is dropped, not truncated into the
 //    manifest, and the drop is reported.
+// Not built on Windows: any path long enough to overrun the 228-byte file_name also exceeds the
+// 260-byte MAX_PATH, so the tree is never created and there is nothing to drop.
+#ifndef _WIN32
 void test_getfiles_rejects_overlong_path(void)
 {
     // file_name is 228 bytes; build a nested path that overruns it while each component stays
@@ -148,6 +151,7 @@ void test_getfiles_rejects_overlong_path(void)
         *strrchr(dir, '/') = '\0';
     }
 }
+#endif
 
 // 5. pathEndsWithDot() - no entry in the manifest may end in '.', which is how the walk filters the
 //    "." and ".." pseudo-entries some backends return.
@@ -231,7 +235,9 @@ void setup()
     RUN_TEST(test_getfiles_respects_max_count);
     RUN_TEST(test_getfiles_unlimited_when_under_cap);
     RUN_TEST(test_getfiles_depth_limit);
+#ifndef _WIN32
     RUN_TEST(test_getfiles_rejects_overlong_path);
+#endif
     RUN_TEST(test_getfiles_skips_dot_entries);
     RUN_TEST(test_getfiles_reports_sizes);
     RUN_TEST(test_getfiles_missing_dir_is_empty);

--- a/test/test_http_content_handler/test_main.cpp
+++ b/test/test_http_content_handler/test_main.cpp
@@ -8,6 +8,10 @@ static void test_placeholder()
 }
 
 extern "C" {
+// Required by Unity: PlatformIO's weak defaults do not link on MinGW (PE-COFF weak externals).
+void setUp(void) {}
+void tearDown(void) {}
+
 void setup()
 {
     initializeTestEnvironment();

--- a/test/test_meshpacket_serializer/test_serializer.cpp
+++ b/test/test_meshpacket_serializer/test_serializer.cpp
@@ -23,6 +23,10 @@ void test_timestamp_present_when_has_rx_time();
 void test_timestamp_zeroed_when_rx_time_absent();
 void test_encrypted_timestamp_zeroed_when_rx_time_absent();
 
+// Required by Unity: PlatformIO's weak defaults do not link on MinGW (PE-COFF weak externals).
+void setUp(void) {}
+void tearDown(void) {}
+
 void setup()
 {
     UNITY_BEGIN();

--- a/test/test_mqtt/MQTT.cpp
+++ b/test/test_mqtt/MQTT.cpp
@@ -17,7 +17,13 @@
 #include <PubSubClient.h>
 #include <WiFiClient.h>
 
+// htonl() for remoteIP() below. MinGW has no <arpa/inet.h>; the byte-order helpers live in
+// winsock2.h, which must precede any <windows.h> the Arduino shims pull in.
+#ifdef _WIN32
+#include <winsock2.h>
+#else
 #include <arpa/inet.h>
+#endif
 
 #include <algorithm>
 #include <list>

--- a/test/test_serial/SerialModule.cpp
+++ b/test/test_serial/SerialModule.cpp
@@ -2,6 +2,11 @@
 #include "TestUtil.h"
 #include <unity.h>
 
+// Required by Unity: PlatformIO's weak defaults do not link on MinGW (PE-COFF weak externals).
+// Outside the guard below so both the portduino and the stub setup() get them.
+void setUp(void) {}
+void tearDown(void) {}
+
 #ifdef ARCH_PORTDUINO
 #include "configuration.h"
 

--- a/variants/native/portduino.ini
+++ b/variants/native/portduino.ini
@@ -57,6 +57,9 @@ build_flags_common =
   -std=gnu17
   -std=gnu++17
   -DMAX_TFT_COLOR_REGIONS=64
+  ; Unity omits double support unless asked, compiling TEST_ASSERT_DOUBLE_* into an
+  ; unconditional "Unity Double Precision Disabled" failure (test_gps_update_scheduling).
+  -DUNITY_INCLUDE_DOUBLE
 
 build_flags =
   ${portduino_base.build_flags_common}

--- a/variants/native/portduino/platformio.ini
+++ b/variants/native/portduino/platformio.ini
@@ -332,9 +332,6 @@ build_flags = ${portduino_base.build_flags_common}
   ; screen renderer; EXCLUDE_SCREEN gates the `screen->...` hooks in the sensors.
   -DHAS_SCREEN=0
   -DMESHTASTIC_EXCLUDE_SCREEN=1
-  ; Unity excludes double assertions unless asked; without this TEST_ASSERT_DOUBLE_* compiles to
-  ; an unconditional "Unity Double Precision Disabled" failure (test_gps_update_scheduling).
-  -DUNITY_INCLUDE_DOUBLE
   !pkg-config --cflags --libs openssl --silence-errors || :
 build_unflags =
   -fPIC ; ignored on Windows, where all code is position-independent

--- a/variants/native/portduino/platformio.ini
+++ b/variants/native/portduino/platformio.ini
@@ -332,6 +332,9 @@ build_flags = ${portduino_base.build_flags_common}
   ; screen renderer; EXCLUDE_SCREEN gates the `screen->...` hooks in the sensors.
   -DHAS_SCREEN=0
   -DMESHTASTIC_EXCLUDE_SCREEN=1
+  ; Unity excludes double assertions unless asked; without this TEST_ASSERT_DOUBLE_* compiles to
+  ; an unconditional "Unity Double Precision Disabled" failure (test_gps_update_scheduling).
+  -DUNITY_INCLUDE_DOUBLE
   !pkg-config --cflags --libs openssl --silence-errors || :
 build_unflags =
   -fPIC ; ignored on Windows, where all code is position-independent


### PR DESCRIPTION
`pio test -e native-windows` failed all 53 suites at the build stage. Five independent causes, all Windows-only, plus one Unity configuration gap that turned out not to be Windows-specific at all.

## Causes

**`lstat()` in `test/TestUtil.cpp`.** MinGW-w64 does not provide it. The state-checkpoint walk added in #11322 is fenced with `ARCH_PORTDUINO`, which `native-windows` also satisfies, so the file failed to compile and took every suite with it. This is the regression that broke the Windows runner; the others were masked behind it. Routed through a `stat()` shim on `_WIN32`.

**Missing `setUp`/`tearDown` in four suites.** `test_default`, `test_http_content_handler`, `test_meshpacket_serializer` and `test_serial` define neither and relied on the weak defaults PlatformIO emits in its generated `unity_config.c`. Those defaults are enabled on MinGW, but GCC lowers a weak definition on PE-COFF to a weak external:

```
0000000000000000 T .weak.setUp.unityOutputStart
                 w setUp
```

`setUp` stays undefined (`w`) with a renamed alternate, rather than ELF's weak definition (`W`), so it does not satisfy `unity.c`'s strong reference and the link fails. Defined explicitly, as the other 49 suites already do.

**`<arpa/inet.h>` in `test_mqtt`.** Absent on MinGW; included only for `htonl()`. Uses `winsock2.h` there.

**`UNITY_INCLUDE_DOUBLE` was never defined anywhere.** Unity omits double support unless asked, so `TEST_ASSERT_DOUBLE_*` compiles into an unconditional "Unity Double Precision Disabled" failure. This is not Windows-specific. Verified on Debian with gcc, against the Linux env's own Unity 2.6.1 and PlatformIO's generated `native` `unity_config`:

```
UNITY_INCLUDE_DOUBLE : NOT defined
UNITY_EXCLUDE_DOUBLE : defined
test_double_within:FAIL: Unity Double Precision Disabled
```

The macro appears nowhere in the repo, the ini files, `test_native.yml`, or PlatformIO's Unity runner, which adds only `UNITY_INCLUDE_CONFIG_H`. It is therefore defined in `portduino_base.build_flags_common`, which every native env resolves: `native`, `native-tft`, `native-fb`, `native-tft-debug`, `coverage`, `coverage-event-policy`, `native-macos`, `native-windows`, `native-wasm`.

**`test_getfiles_rejects_overlong_path`.** Excluded on `_WIN32`. Overrunning the 228-byte `file_name` needs at least 229 bytes below the portduino root, and that root is already about 34 bytes, so every qualifying path passes the 260-byte `MAX_PATH`. The nested `mkdir()` fails, the file is never created, and `getFiles()` has nothing to drop. No component layout satisfies both limits.

## Verification

Full `pio test -e native-windows` on Windows 11 / UCRT64 gcc 16.1.0, before and after:

| | Before | After |
| --- | --- | --- |
| Suites built and run | 46 of 53 | 53 of 53 |
| Test cases | 839 | 938 |
| Failed | 2, plus 7 suites that never built | 1 |

## Scope

Every guard is `_WIN32`-only except `UNITY_INCLUDE_DOUBLE`, which now applies to all native envs and **does change Linux and macOS**: `TEST_ASSERT_DOUBLE_*` becomes a real comparison instead of a stub that always fails. `test_gps_update_scheduling` is the only suite in the repo using those macros, and its arithmetic is integer-based and bit-identical across platforms, so it should pass wherever it runs.

Worth flagging for review: that suite currently reports PASSED on CI in 0.03 seconds while emitting no Unity output at all, so its assertions appear never to execute there. That is a separate issue and is not addressed here.

No CI job currently compiles the test tree for `native-windows`: `test_native.yml` runs on Ubuntu against `-e coverage`, and `build_windows_bin.yml` runs `pio run`, never `pio test`. That is why the `lstat` regression stood for a week.

## Known limitation

`test_fscommon_getfiles` still fails in a full run, for a cause outside this change: `VFSImpl::rmdir()` in framework-portduino calls `unlink()`, which cannot remove a directory, so the tree its depth-limit case creates survives `setUp()`'s `rmDir()` and makes `getFiles()` report a spurious depth truncation. Fixed by meshtastic/framework-portduino#77; once that lands and the platform pin picks it up, the suite goes green on Windows with no further change here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform directory traversal and network byte-order handling for Windows builds.
  * Excluded unsupported long-path tests on Windows.

* **Tests**
  * Improved test compatibility with MinGW by adding required test lifecycle hooks.
  * Enabled double-precision assertions for GPS scheduling tests.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->