### PR TITLE
Fix the IFDEF guard causing OLED_TINY failures

### DIFF
--- a/src/graphics/draw/DebugRenderer.cpp
+++ b/src/graphics/draw/DebugRenderer.cpp
@@ -299,8 +299,8 @@ void drawLoRaFocused(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x,
 
         display->drawString(starting_position + chUtil_x + chutil_bar_width + extraoffset, getTextPositions(display)[line++],
                             chUtilPercentage);
-#endif
     }
+#endif
     graphics::drawCommonFooter(display, x, y);
 }
 


### PR DESCRIPTION
Fix the IFDEF guard causing OLED_TINY failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected footer rendering behavior in the focused LoRa display view, ensuring the common footer appears consistently on supported screen configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->