### PR TITLE
Do not build nucleo_wl55jc upon PR

### DIFF
--- a/variants/stm32/nucleo_wl55jc/platformio.ini
+++ b/variants/stm32/nucleo_wl55jc/platformio.ini
@@ -3,7 +3,7 @@
 [env:nucleo_wl55jc]
 extends = stm32_base
 board = nucleo_wl55jc
-board_level = pr
+board_level = extra
 board_upload.maximum_size = 247808 ; reserve the last 14KB for filesystem
 build_flags =
   ${stm32_base.build_flags}


### PR DESCRIPTION
Addendum to #11384
Don't build `nucleo_wl55jc` upon PR or release. It's a niche devkit not a PR canary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the Nucleo-WL55JC build environment setting to use the extra board level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->