### PR TITLE
fix(portduino): don't segfault writing the trace file

### DIFF
--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -302,13 +302,18 @@ void RedirectablePrint::log(const char *logLevel, const char *format, ...)
     // level trace is special, two possible ways to handle it.
     if (strcmp(logLevel, MESHTASTIC_LOG_LEVEL_TRACE) == 0) {
         if (portduino_config.traceFilename != "") {
+            // Format the message rather than assuming the first vararg is a string: not every
+            // LOG_TRACE call passes one, and reading a char* that isn't there segfaults. Sized for
+            // the worst-case packet JSON (233-byte payload escaped 6x, plus metadata ~= 1.7 KB).
+            char traceBuf[2048];
             va_list arg;
             va_start(arg, format);
+            vsnprintf(traceBuf, sizeof(traceBuf), format, arg);
+            va_end(arg);
             try {
-                traceFile << va_arg(arg, char *) << std::endl;
+                traceFile << traceBuf << std::endl;
             } catch (const std::ios_base::failure &e) {
             }
-            va_end(arg);
         }
         if (portduino_config.logoutputlevel < level_trace && strcmp(logLevel, MESHTASTIC_LOG_LEVEL_TRACE) == 0) {
             return;


### PR DESCRIPTION
Fixes #11490 — meshtasticd segfaults at boot when `Logging.TraceFile` is set.

### Root cause

`RedirectablePrint::log`'s portduino trace-file path took the **first variadic argument as a `char *`** and streamed it:

```c
traceFile << va_arg(arg, char *) << std::endl;
```

That held only while the tree's sole `LOG_TRACE` call sites were `LOG_TRACE("%s", <json>.c_str())`. #11391 demoted a batch of chatty `LOG_DEBUG` lines to `LOG_TRACE`, and one of them — `LOG_TRACE("Filesystem files:")` in `fsInit()` — passes **no varargs**. `va_arg` then returns a garbage stack value that `operator<<(ostream&, const char*)` dereferences, so the daemon dies during `setup()`. The surrounding `try/catch` only covers iostream exceptions, not the fault. This matches the reporter's backtrace (frames #2/#3) and their bisect: image #697 (`b8dee13`) fine, #698 (`5baad2e`, the #11391 merge) crashes. The same latent bug would fire for any `LOG_TRACE("… %u", someInt)`.

### Fix

Format the message with `vsnprintf` instead of assuming a string argument. Buffer is 2 KB: worst-case packet JSON is a 233-byte payload (`meshtastic_Constants_DATA_PAYLOAD_LEN`) escaped up to 6× as `\u00XX` plus ~325 bytes of metadata ≈ 1.7 KB. It deliberately isn't smaller — the trace file bypasses the console path's 512-byte `printBuf` truncation, so records are written untruncated today and shrinking the bound would corrupt JSONL for consumers.

Note: since #11391, trace-level chatter now lands in the trace file alongside packet JSON, so consumers should skip lines that don't parse as JSON. A dedicated packet-trace channel would separate the two cleanly; that's a follow-up rather than part of this fix.

### Testing

Reproduced and verified locally on native/portduino with `Logging: TraceFile:` configured:

- **Before**: SIGSEGV (exit 139) immediately after the boot banner, at `fsInit()`.
- **After**: boots through to `API server listen on TCP port 4403` and keeps running; the trace file receives correctly formatted lines (`Filesystem files:`, packet records, …).

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)

Linux native (portduino) — the only platform with this code path (`#if ARCH_PORTDUINO`); embedded targets are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBiZc9sfPrH1MZ2L3Fxgt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBiZc9sfPrH1MZ2L3Fxgt1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trace logging to correctly format messages with multiple or varied arguments.
  * Preserved newline formatting and exception handling when writing trace output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->