### PR TITLE
fix(rak4631): enable GPS power rail so GPS-off drops idle current

### DIFF
--- a/variants/nrf52840/rak4631/variant.h
+++ b/variants/nrf52840/rak4631/variant.h
@@ -226,16 +226,9 @@ SO GPIO 39/TXEN MAY NOT BE DEFINED FOR SUCCESSFUL OPERATION OF THE SX1262 - TG
 // #define INA3221_BAT_CH INA3221_CH2
 // #define INA3221_ENV_CH INA3221_CH1
 
-// enables 3.3V periphery like GPS or IO Module
-// Do not toggle this for GPS power savings
+// WisBlock 3V3_S (IO2): one rail for every slot (GPS, sensors, IO)
 #define PIN_3V3_EN (34)
 #define WB_IO2 PIN_3V3_EN
-
-// GPS EN only for finished products that accept cutting 3V3_S with GPS off.
-// Generic rak4631 / sensor bases keep this undefined so sensors on 3V3_S stay powered.
-#if defined(WISMESH_POCKET) || defined(WISMESH_REPEATER_MINI)
-#define PIN_GPS_EN PIN_3V3_EN
-#endif
 
 // RAK1910 GPS module
 // If using the wisblock GPS module and pluged into Port A on WisBlock base
@@ -244,7 +237,8 @@ SO GPIO 39/TXEN MAY NOT BE DEFINED FOR SUCCESSFUL OPERATION OF THE SX1262 - TG
 // Therefore must be 1 to keep peripherals powered
 // Power is on the controllable 3V3_S rail
 // #define PIN_GPS_RESET (34)
-// #define PIN_GPS_EN PIN_3V3_EN
+// Default ON so GPS-off actually drops idle current. Comment out to keep slot sensors powered with GPS disabled.
+#define PIN_GPS_EN PIN_3V3_EN
 #define PIN_GPS_PPS (17) // Pulse per second input from the GPS
 
 #define GPS_RX_PIN PIN_SERIAL1_RX


### PR DESCRIPTION
## Summary
- Define ``PIN_GPS_EN`` as ``PIN_3V3_EN`` for all RAK4631 builds so turning GPS off actually cuts the 3V3_S rail (the GPS-disabled idle-current reports).
- WisBlock bases share one IO2 / 3V3_S supply across every slot. The old default left ``PIN_GPS_EN`` undefined so sensors/IO stayed up when GPS was disabled; Pocket and Repeater Mini already opted in.
- Side effect: GPS-off also unpowers other slot modules. Comment out ``PIN_GPS_EN`` in ``variants/nrf52840/rak4631/variant.h`` if sensors must stay powered.
## Test plan
- [ ] Flash ``rak4631`` with GPS enabled, confirm fix and position.
- [ ] Disable GPS in config; confirm idle current drops vs previous firmware.
- [ ] On a base with a slot sensor, disable GPS and confirm that sensor/IO on 3V3_S also lose power (expected).
- [ ] WisMesh Pocket / Repeater Mini still behave as before (they already defined ``PIN_GPS_EN``).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GPS power control is now consistently linked to the shared 3V3 supply.
  * Disabling GPS power also turns off peripherals using the shared rail across supported board variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->