### PR TITLE
fix(t-impulse-plus): enable 1200bps touch for nrfutil upload

### DIFF
--- a/boards/t-impulse-plus.json
+++ b/boards/t-impulse-plus.json
@@ -7,7 +7,10 @@
     "cpu": "cortex-m4",
     "extra_flags": "-DARDUINO_NRF52840_T_IMPULSE_PLUS -DNRF52840_XXAA",
     "f_cpu": "64000000L",
-    "hwids": [["0x239A", "0x8029"]],
+    "hwids": [
+      ["0x239A", "0x8029"],
+      ["0x239A", "0x00DA"]
+    ],
     "usb_product": "T-Impulse-Plus-nRF52840",
     "mcu": "nrf52840",
     "variant": "t-impulse-plus",
@@ -37,6 +40,8 @@
     "maximum_ram_size": 248832,
     "maximum_size": 815104,
     "require_upload_port": true,
+    "wait_for_upload_port": true,
+    "use_1200bps_touch": true,
     "speed": 115200,
     "protocol": "nrfutil",
     "protocols": [


### PR DESCRIPTION
Board was missing `use_1200bps_touch`, so uploads never switched the device into DFU and adafruit-nrfutil spoke the DFU protocol at the running application CDC, failing with "No data received on serial port".

Adds `use_1200bps_touch` and `wait_for_upload_port` to match the other nrf52840 nrfutil boards, plus the bootloader hwid `0x239A:0x00DA`.

Tested on LILYGO T-Impulse Plus hardware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional USB hardware variant.
  * Improved upload handling by waiting for the upload port and initiating the required connection step automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->