### PR TITLE
fix(serial): don't sleep forever with pending PhoneAPI output on UART consoles

### DIFF
--- a/src/SerialConsole.cpp
+++ b/src/SerialConsole.cpp
@@ -125,9 +125,8 @@ int32_t SerialConsole::runOnce()
 
     int32_t delay = runOncePart();
 #if defined(SERIAL_HAS_ON_RECEIVE) || defined(CONFIG_IDF_TARGET_ESP32S2)
-    // Only rxInt()/onNowHasData() end the idle sleep, and neither fires for "TX space
-    // freed": the bounded drain (#11164) can leave queued output behind with no RX
-    // pending, so an unbounded sleep here would strand the rest of a config dump.
+    // Nothing wakes the idle sleep for "TX space freed" or a bounded-drain remainder
+    // (#11164), so keep polling while the API holds undelivered output.
     if (hasPendingOutput())
         return delay < 25 ? delay : 25; // 0 continues a budget slice; else short-poll TX drain
     return Port.available() ? delay : INT32_MAX;

--- a/src/SerialConsole.cpp
+++ b/src/SerialConsole.cpp
@@ -125,6 +125,11 @@ int32_t SerialConsole::runOnce()
 
     int32_t delay = runOncePart();
 #if defined(SERIAL_HAS_ON_RECEIVE) || defined(CONFIG_IDF_TARGET_ESP32S2)
+    // Only rxInt()/onNowHasData() end the idle sleep, and neither fires for "TX space
+    // freed": the bounded drain (#11164) can leave queued output behind with no RX
+    // pending, so an unbounded sleep here would strand the rest of a config dump.
+    if (hasPendingOutput())
+        return delay < 25 ? delay : 25; // 0 continues a budget slice; else short-poll TX drain
     return Port.available() ? delay : INT32_MAX;
 #elif defined(IS_USB_SERIAL)
     return HWCDC::isPlugged() ? delay : (1000 * 20);
@@ -209,6 +214,17 @@ bool SerialConsole::finishPendingFrame()
     return frameWriter.finishPendingFrame(Port);
 #else
     return true;
+#endif
+}
+
+/// Report a retained USB CDC frame awaiting TX space.
+bool SerialConsole::hasRetainedFrame()
+{
+#ifdef IS_USB_SERIAL
+    concurrency::LockGuard guard(&streamLock);
+    return !frameWriter.isIdle();
+#else
+    return false;
 #endif
 }
 

--- a/src/SerialConsole.h
+++ b/src/SerialConsole.h
@@ -51,6 +51,8 @@ class SerialConsole : public StreamAPI, public RedirectablePrint, private concur
 
     /// Continue retained USB CDC output before PhoneAPI advances.
     virtual bool finishPendingFrame() override;
+    /// Report a retained USB CDC frame awaiting TX space.
+    virtual bool hasRetainedFrame() override;
     /// Return whether the dedicated log buffer can be safely overwritten.
     virtual bool canEncodeLogRecord() override;
     /// Write or retain one framed USB CDC message.

--- a/src/mesh/StreamAPI.cpp
+++ b/src/mesh/StreamAPI.cpp
@@ -33,6 +33,12 @@ int32_t StreamAPI::runOncePart(char *buf, uint16_t bufLen)
     return result;
 }
 
+/// Report undelivered output so idle-sleep decisions keep the drain alive.
+bool StreamAPI::hasPendingOutput()
+{
+    return canWrite && (hasRetainedFrame() || available());
+}
+
 /**
  * Read any rx chars from the link and call handleRecStream
  */

--- a/src/mesh/StreamAPI.h
+++ b/src/mesh/StreamAPI.h
@@ -57,9 +57,8 @@ class StreamAPI : public PhoneAPI
     virtual int32_t runOncePart();
     virtual int32_t runOncePart(char *buf, uint16_t bufLen);
 
-    /// True while undelivered output remains: a transport-retained frame or queued PhoneAPI
-    /// data. writeStream() stops mid-dump at STREAM_WRITE_BUDGET_MSEC, so callers whose idle
-    /// sleep is woken only by RX activity must keep polling while this holds (see #11164).
+    /// True while undelivered output remains (retained frame or queued PhoneAPI data); callers
+    /// woken only by RX activity must keep polling while set, as drains stop mid-dump (#11164).
     bool hasPendingOutput();
 
     /// Check the current underlying physical link to see if the client is currently connected

--- a/src/mesh/StreamAPI.h
+++ b/src/mesh/StreamAPI.h
@@ -57,6 +57,11 @@ class StreamAPI : public PhoneAPI
     virtual int32_t runOncePart();
     virtual int32_t runOncePart(char *buf, uint16_t bufLen);
 
+    /// True while undelivered output remains: a transport-retained frame or queued PhoneAPI
+    /// data. writeStream() stops mid-dump at STREAM_WRITE_BUDGET_MSEC, so callers whose idle
+    /// sleep is woken only by RX activity must keep polling while this holds (see #11164).
+    bool hasPendingOutput();
+
     /// Check the current underlying physical link to see if the client is currently connected
     virtual bool checkIsConnected() override = 0;
 
@@ -104,6 +109,8 @@ class StreamAPI : public PhoneAPI
 
     /// Complete retained transport output before dequeuing another PhoneAPI packet.
     virtual bool finishPendingFrame() { return true; }
+    /// Return whether the transport retains an incomplete frame awaiting TX space.
+    virtual bool hasRetainedFrame() { return false; }
     /// Return whether the dedicated log buffer is available for encoding.
     virtual bool canEncodeLogRecord() { return true; }
     /// Frame and write a payload, optionally using best-effort admission.

--- a/test/test_stream_api/test_main.cpp
+++ b/test/test_stream_api/test_main.cpp
@@ -147,6 +147,26 @@ class PhoneAPITestShim : public PhoneAPI
     bool checkIsConnected() override { return true; }
 };
 
+/// Exposes the hasPendingOutput() inputs used by idle-sleep gating.
+class PendingOutputStreamAPI : public StreamAPI
+{
+  public:
+    /// Construct the shim over a scripted stream.
+    explicit PendingOutputStreamAPI(Stream *stream) : StreamAPI(stream) {}
+
+    /// Keep connection-timeout handling inactive during tests.
+    bool checkIsConnected() override { return true; }
+
+    /// Set the transport-writability gate normally controlled by first client contact.
+    void setCanWrite(bool value) { canWrite = value; }
+
+    bool retainedFrame = false;
+
+  protected:
+    /// Report the scripted retained-frame state.
+    bool hasRetainedFrame() override { return retainedFrame; }
+};
+
 /// Exposes framed-log hooks and records best-effort writes.
 class LogHookStreamAPI : public StreamAPI
 {
@@ -538,7 +558,7 @@ static void queuePendingTimePlaceholderPacket(NodeNum from, uint32_t placeholder
     service->sendToPhone(packetPool.allocCopy(pending));
 }
 
-static void startHandshake(PhoneAPITestShim &api)
+static void startHandshake(PhoneAPI &api)
 {
     meshtastic_ToRadio request = meshtastic_ToRadio_init_zero;
     request.which_payload_variant = meshtastic_ToRadio_want_config_id_tag;
@@ -564,6 +584,62 @@ static bool drainHandshakeForPacketFrom(PhoneAPITestShim &api, NodeNum from, mes
         }
     }
     return false;
+}
+
+/// Swaps in a scratch NodeDB for the config-dump stream, restoring the prior one on
+/// destruction (Unity asserts longjmp out, so cleanup cannot sit at the end of a test).
+class ScopedNodeDB
+{
+  public:
+    /// Install the scoped NodeDB.
+    ScopedNodeDB() : previous(nodeDB) { nodeDB = &instance; }
+    /// Restore the prior NodeDB.
+    ~ScopedNodeDB() { nodeDB = previous; }
+
+  private:
+    NodeDB instance;
+    NodeDB *previous;
+};
+
+// The #11164 bounded drain can end a dispatch with config frames still queued and no RX
+// pending. SerialConsole::runOnce gates its INT32_MAX idle sleep on hasPendingOutput(),
+// so this pins the contract: pending while queued or retained, clear once drained, and
+// always gated off while the transport is not yet writable.
+static void test_stream_api_pending_output_tracks_queue_and_retained_frame(void)
+{
+    ScopedMeshService scopedService;
+    ScopedNodeDB scopedNodeDB;
+    ScriptedStream stream;
+    PendingOutputStreamAPI api(&stream);
+
+    // Nothing queued and no client yet: an idle console must be allowed to sleep.
+    TEST_ASSERT_FALSE(api.hasPendingOutput());
+
+    // A client that has not yet spoken (canWrite false) must not force polling,
+    // even with a full config dump queued behind the gate.
+    startHandshake(api);
+    api.setCanWrite(false);
+    TEST_ASSERT_FALSE(api.hasPendingOutput());
+
+    // Once writable, the queued dump is pending output until fully drained.
+    api.setCanWrite(true);
+    TEST_ASSERT_TRUE(api.hasPendingOutput());
+    unsigned drained = 0;
+    for (unsigned i = 0; i < 512 && api.hasPendingOutput(); ++i) {
+        uint8_t responseBytes[meshtastic_FromRadio_size];
+        if (api.getFromRadio(responseBytes) != 0)
+            drained++;
+    }
+    TEST_ASSERT_GREATER_THAN_UINT(0, drained);
+    TEST_ASSERT_FALSE_MESSAGE(api.hasPendingOutput(), "pending output must clear once the dump is drained");
+
+    // A transport-retained partial frame alone keeps the drain alive.
+    api.retainedFrame = true;
+    TEST_ASSERT_TRUE(api.hasPendingOutput());
+    api.retainedFrame = false;
+    TEST_ASSERT_FALSE(api.hasPendingOutput());
+
+    api.close();
 }
 
 /// Swaps in a scratch NodeDB and the injected clock, restoring both plus the RTC on destruction.
@@ -735,6 +811,7 @@ void setup()
     RUN_TEST(test_lockdown_admin_gate_ignores_wire_from);
     RUN_TEST(test_lockdown_admin_gate_rejects_undecodable_admin);
     RUN_TEST(test_want_config_includes_status_message_module_config);
+    RUN_TEST(test_stream_api_pending_output_tracks_queue_and_retained_frame);
     RUN_TEST(test_time_given_at_handshake_start_reconciles_queued_packet);
     RUN_TEST(test_time_given_at_handshake_end_does_not_rewrite_already_sent_packet);
     RUN_TEST(test_node_heard_before_time_gets_last_heard_backfilled);

--- a/test/test_stream_api/test_main.cpp
+++ b/test/test_stream_api/test_main.cpp
@@ -586,29 +586,25 @@ static bool drainHandshakeForPacketFrom(PhoneAPITestShim &api, NodeNum from, mes
     return false;
 }
 
-/// Swaps in a scratch NodeDB for the config-dump stream, restoring the prior one on
-/// destruction (Unity asserts longjmp out, so cleanup cannot sit at the end of a test).
-class ScopedNodeDB
+// Scratch NodeDB for the config-dump stream; restored by tearDown() rather than RAII
+// because a failed TEST_ASSERT longjmps out of the test without running destructors.
+static NodeDB *scratchNodeDB = nullptr;
+static NodeDB *savedNodeDB = nullptr;
+
+/// Install a scratch NodeDB; tearDown() restores the previous one after any test outcome.
+static void installScratchNodeDB()
 {
-  public:
-    /// Install the scoped NodeDB.
-    ScopedNodeDB() : previous(nodeDB) { nodeDB = &instance; }
-    /// Restore the prior NodeDB.
-    ~ScopedNodeDB() { nodeDB = previous; }
+    savedNodeDB = nodeDB;
+    scratchNodeDB = new NodeDB();
+    nodeDB = scratchNodeDB;
+}
 
-  private:
-    NodeDB instance;
-    NodeDB *previous;
-};
-
-// The #11164 bounded drain can end a dispatch with config frames still queued and no RX
-// pending. SerialConsole::runOnce gates its INT32_MAX idle sleep on hasPendingOutput(),
-// so this pins the contract: pending while queued or retained, clear once drained, and
-// always gated off while the transport is not yet writable.
+// SerialConsole::runOnce gates its INT32_MAX idle sleep on hasPendingOutput(): pending while
+// output is queued or retained (#11164 bounded drain), clear when drained or pre-contact.
 static void test_stream_api_pending_output_tracks_queue_and_retained_frame(void)
 {
     ScopedMeshService scopedService;
-    ScopedNodeDB scopedNodeDB;
+    installScratchNodeDB();
     ScriptedStream stream;
     PendingOutputStreamAPI api(&stream);
 
@@ -791,8 +787,15 @@ static void test_node_heard_during_first_uptime_second_gets_last_heard_backfille
 
 /// Unity per-test setup; fixtures are local to each test.
 void setUp(void) {}
-/// Unity per-test teardown; fixtures clean themselves up.
-void tearDown(void) {}
+/// Unity per-test teardown; restores state that a failed assert's longjmp would leak.
+void tearDown(void)
+{
+    if (scratchNodeDB) {
+        nodeDB = savedNodeDB;
+        delete scratchNodeDB;
+        scratchNodeDB = nullptr;
+    }
+}
 
 /// Initialize the native environment and run the stream regression suite.
 void setup()


### PR DESCRIPTION
## Symptom

On ESP32 boards with a UART console (e.g. Heltec V3 via CP2102), the serial config download stalls partway through the nodeinfo stream and never completes. Any inbound byte from the client (e.g. a heartbeat ToRadio) instantly resumes it. Deterministic on hardware since #11164 (2026-08-04); USB-CDC builds self-heal via their 20s poll and BLE is unaffected.

## Root cause

#11164 bounds each `writeStream()` slice to `STREAM_WRITE_BUDGET_MSEC`, so a config dump routinely ends a dispatch with output still queued. Under `SERIAL_HAS_ON_RECEIVE` (set arch-wide for ESP32), `SerialConsole::runOnce()` returns `Port.available() ? delay : INT32_MAX` — and the only wakeups from that sleep are `rxInt()` and `onNowHasData()`. Neither fires for "queued output remains" or "TX space freed", so the retained output sits forever.

## Fix

- New `StreamAPI::hasPendingOutput()`: `canWrite && (hasRetainedFrame() || PhoneAPI::available())`.
- New `hasRetainedFrame()` virtual (default false); `SerialConsole` reports `!frameWriter.isIdle()` on USB-CDC builds. This also covers the ESP32-S2 branch, which takes the same `INT32_MAX` path but can retain a partial frame under TX backpressure.
- `SerialConsole::runOnce()` returns `min(delay, 25)` while output is pending: 0 chains straight into the next budget slice, 25ms short-polls a retained frame until TX drains.

The #11164 write budget is untouched — each dispatch still returns to the scheduler, so the watchdog keeps getting fed on full dumps. With no client or a drained queue, `hasPendingOutput()` is false and the idle `INT32_MAX` sleep is unchanged.

## Verification

- Hardware A/B on Heltec V3: plain `meshtastic` Python `SerialInterface` connect fails on develop (`Timed out waiting for connection completion`, stream stops at exactly 41 frames); with this fix the full config download completes in 1.2–1.7s across 5 consecutive connects with no client-side keepalive. A raw frame pump counted 60 frames straight through to `config_complete_id` with no watchdog reset.
- New native regression test `test_stream_api_pending_output_tracks_queue_and_retained_frame` pins the `hasPendingOutput()` contract (pending while queued or retained, clear once drained, gated off before first client contact). `test_stream_api` is 18/18 green on both the Docker coverage env and native-macos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serial console polling so queued output is transmitted promptly instead of remaining delayed during idle waits.
  * Improved handling of partially transmitted USB console frames.
  * Added more reliable detection and draining of pending stream output.

* **Tests**
  * Added regression coverage for queued output, transport availability, complete draining, and partially transmitted frames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->