### PR TITLE
fix(mesh): restore the implicit ACK for our own overheard PKI DMs

### DIFF
--- a/src/mesh/ReliableRouter.cpp
+++ b/src/mesh/ReliableRouter.cpp
@@ -53,34 +53,41 @@ ErrorCode ReliableRouter::send(meshtastic_MeshPacket *p)
     return result;
 }
 
-bool ReliableRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
+void ReliableRouter::perhapsGenerateImplicitAckForOwnOverheard(const meshtastic_MeshPacket *p)
 {
     // Note: do not use getFrom() here, because we want to ignore messages sent from phone
-    if (p->from == getNodeNum()) {
-        printPacket("Rx someone rebroadcasting for us", p);
+    if (p->from != getNodeNum())
+        return;
 
-        // We are seeing someone rebroadcast one of our broadcast attempts.
-        // If this is the first time we saw this, cancel any retransmissions we have queued up and generate an internal ack for
-        // the original sending process.
+    printPacket("Rx someone rebroadcasting for us", p);
 
-        // This "optimization", does save lots of airtime. For DMs, you also get a real ACK back
-        // from the intended recipient.
-        auto key = GlobalPacketId(getFrom(p), p->id);
-        auto old = findPendingPacket(key);
-        if (old) {
-            LOG_DEBUG("Generate implicit ack");
-            // NOTE: we do NOT check p->wantAck here because p is the INCOMING rebroadcast and that packet is not expected to be
-            // marked as wantAck
-            sendAckNak(meshtastic_Routing_Error_NONE, getFrom(p), p->id, old->packet->channel);
+    // We are seeing someone rebroadcast one of our transmissions. If this is the first time we saw
+    // this, cancel any retransmissions we have queued up and generate an internal ack for the
+    // original sending process. Header-only (from/id), so it works even for a packet we cannot
+    // decrypt - notably a PKI DM we originated, which is opaque to us when overheard.
 
-            // Only stop retransmissions if the rebroadcast came via LoRa
-            if (p->transport_mechanism == meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA) {
-                stopRetransmission(key);
-            }
-        } else {
-            LOG_DEBUG("Didn't find pending packet");
+    // This "optimization", does save lots of airtime. For DMs, you also get a real ACK back
+    // from the intended recipient.
+    auto key = GlobalPacketId(getFrom(p), p->id);
+    auto old = findPendingPacket(key);
+    if (old) {
+        LOG_DEBUG("Generate implicit ack");
+        // NOTE: we do NOT check p->wantAck here because p is the INCOMING rebroadcast and that packet is not expected to be
+        // marked as wantAck
+        sendAckNak(meshtastic_Routing_Error_NONE, getFrom(p), p->id, old->packet->channel);
+
+        // Only stop retransmissions if the rebroadcast came via LoRa
+        if (p->transport_mechanism == meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA) {
+            stopRetransmission(key);
         }
+    } else {
+        LOG_DEBUG("Didn't find pending packet");
     }
+}
+
+bool ReliableRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
+{
+    perhapsGenerateImplicitAckForOwnOverheard(p);
 
     /* At this point we have already deleted the pending retransmission if this packet was an (implicit) ACK to it.
        Now for all other pending retransmissions, we have to add the airtime of this received packet to the retransmission timer,

--- a/src/mesh/ReliableRouter.h
+++ b/src/mesh/ReliableRouter.h
@@ -32,6 +32,11 @@ class ReliableRouter : public NextHopRouter
      */
     virtual bool shouldFilterReceived(const meshtastic_MeshPacket *p) override;
 
+    /**
+     * Header-only implicit ACK for our own overheard rebroadcast (also usable before decode).
+     */
+    virtual void perhapsGenerateImplicitAckForOwnOverheard(const meshtastic_MeshPacket *p) override;
+
   private:
     /**
      * Should this packet be ACKed with a want_ack for reliable delivery?

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -1611,6 +1611,12 @@ void Router::perhapsHandleReceived(meshtastic_MeshPacket *p)
         return;
     }
     if (authVerdict == RoutingAuthVerdict::OPAQUE_RELAY_ONLY) {
+        // A packet we originated but cannot decrypt (a PKI DM we sent, overheard being rebroadcast)
+        // is opaque to us and would otherwise skip shouldFilterReceived entirely, so the implicit
+        // ACK that marks a DM "Delivered to mesh" never fires. The ACK is header-only (from/id), so
+        // generate it here from the still-encrypted packet before opaque relay.
+        if (isFromUs(p))
+            perhapsGenerateImplicitAckForOwnOverheard(p);
         relayOpaquePacket(p);
         packetPool.release(p);
         return;

--- a/src/mesh/Router.h
+++ b/src/mesh/Router.h
@@ -138,6 +138,14 @@ class Router : protected concurrency::OSThread, protected PacketHistory
     virtual bool relayOpaquePacket(const meshtastic_MeshPacket *) { return false; }
 
     /**
+     * Generate the implicit ACK for our own transmission overheard being rebroadcast, using header
+     * fields only (from/id). Split out of shouldFilterReceived() so it can also run when the auth
+     * gate short-circuits a packet we cannot decrypt (a PKI DM we originated is opaque to us, so
+     * without this the client never sees "Delivered to mesh" for DMs).
+     */
+    virtual void perhapsGenerateImplicitAckForOwnOverheard(const meshtastic_MeshPacket *) {}
+
+    /**
      * Determine if hop_limit should be decremented for a relay operation.
      * Returns false (preserve hop_limit) only if all conditions are met:
      * - It's NOT the first hop (first hop must always decrement)

--- a/test/test_nexthop_routing/test_main.cpp
+++ b/test/test_nexthop_routing/test_main.cpp
@@ -826,7 +826,7 @@ void test_reliableAckStopsNormalPendingTransmission(void)
 // cannot decode it. The routing auth gate classifies it opaque and returns before
 // shouldFilterReceived() runs, so the implicit ACK has to be reachable from the header alone -
 // otherwise the client never sees "Delivered to mesh" for a DM.
-void test_implicitAck_firesForUndecodableOwnOverheardPacket(void)
+void test_implicit_ack_for_opaque_own_packet(void)
 {
     auto original = makeBehaviorPacket(meshtastic_PortNum_TEXT_MESSAGE_APP, kLocalNode, kRemoteNode, 0, /*wantAck=*/true);
     reliableShim->seedRetry(original, NextHopRouter::NUM_RELIABLE_UNICAST_ATTEMPTS);
@@ -854,7 +854,7 @@ void test_implicitAck_firesForUndecodableOwnOverheardPacket(void)
 }
 
 // Someone else's traffic must never mint an ACK, even with a colliding id.
-void test_implicitAck_ignoresPacketsNotFromUs(void)
+void test_implicit_ack_ignores_foreign_packet(void)
 {
     auto original = makeBehaviorPacket(meshtastic_PortNum_TEXT_MESSAGE_APP, kLocalNode, kRemoteNode, 0, /*wantAck=*/true);
     reliableShim->seedRetry(original, NextHopRouter::NUM_RELIABLE_UNICAST_ATTEMPTS);
@@ -1102,8 +1102,8 @@ void setup()
     RUN_TEST(test_reliableAckStopsNormalPendingTransmission);
 
     printf("\n=== pending retransmission bookkeeping ===\n");
-    RUN_TEST(test_implicitAck_firesForUndecodableOwnOverheardPacket);
-    RUN_TEST(test_implicitAck_ignoresPacketsNotFromUs);
+    RUN_TEST(test_implicit_ack_for_opaque_own_packet);
+    RUN_TEST(test_implicit_ack_ignores_foreign_packet);
     RUN_TEST(test_pending_does_not_cancel_radio_queue_before_first_retry);
     RUN_TEST(test_pending_cancels_radio_queue_after_first_retry_for_any_budget);
     RUN_TEST(test_directed_hop_tracks_three_total_attempts);

--- a/test/test_nexthop_routing/test_main.cpp
+++ b/test/test_nexthop_routing/test_main.cpp
@@ -268,6 +268,8 @@ class ReliableRouterTestShim : public ReliableRouter
         ReliableRouter::sniffReceived(p, routing);
     }
 
+    void implicitAckForTest(const meshtastic_MeshPacket *p) { perhapsGenerateImplicitAckForOwnOverheard(p); }
+
     void clearPendingForTest()
     {
         while (!pending.empty())
@@ -820,6 +822,57 @@ void test_reliableAckStopsNormalPendingTransmission(void)
     TEST_ASSERT_EQUAL_UINT32(0, reliableShim->pendingCount());
 }
 
+// A PKI DM we originated is encrypted to the recipient, so when we overhear it being rebroadcast we
+// cannot decode it. The routing auth gate classifies it opaque and returns before
+// shouldFilterReceived() runs, so the implicit ACK has to be reachable from the header alone -
+// otherwise the client never sees "Delivered to mesh" for a DM.
+void test_implicitAck_firesForUndecodableOwnOverheardPacket(void)
+{
+    auto original = makeBehaviorPacket(meshtastic_PortNum_TEXT_MESSAGE_APP, kLocalNode, kRemoteNode, 0, /*wantAck=*/true);
+    reliableShim->seedRetry(original, NextHopRouter::NUM_RELIABLE_UNICAST_ATTEMPTS);
+    TEST_ASSERT_EQUAL_UINT32(1, reliableShim->pendingCount());
+    mockRoutingModule->ackNaks.clear();
+
+    // The overheard copy as it actually arrives: still encrypted, nothing decoded.
+    meshtastic_MeshPacket overheard = meshtastic_MeshPacket_init_zero;
+    overheard.from = kLocalNode;
+    overheard.to = kRemoteNode;
+    overheard.id = original.id;
+    overheard.channel = 0;
+    overheard.which_payload_variant = meshtastic_MeshPacket_encrypted_tag;
+    overheard.encrypted.size = 32;
+
+    reliableShim->implicitAckForTest(&overheard);
+
+    TEST_ASSERT_EQUAL_UINT32(1, mockRoutingModule->ackNaks.size());
+    const auto &ack = mockRoutingModule->ackNaks.front();
+    TEST_ASSERT_EQUAL(meshtastic_Routing_Error_NONE, std::get<0>(ack));
+    TEST_ASSERT_EQUAL_UINT32(kLocalNode, std::get<1>(ack)); // addressed to us -> reaches the phone
+    TEST_ASSERT_EQUAL_UINT32(original.id, std::get<2>(ack));
+
+    reliableShim->clearPendingForTest();
+}
+
+// Someone else's traffic must never mint an ACK, even with a colliding id.
+void test_implicitAck_ignoresPacketsNotFromUs(void)
+{
+    auto original = makeBehaviorPacket(meshtastic_PortNum_TEXT_MESSAGE_APP, kLocalNode, kRemoteNode, 0, /*wantAck=*/true);
+    reliableShim->seedRetry(original, NextHopRouter::NUM_RELIABLE_UNICAST_ATTEMPTS);
+    mockRoutingModule->ackNaks.clear();
+
+    meshtastic_MeshPacket foreign = meshtastic_MeshPacket_init_zero;
+    foreign.from = kRemoteNode;
+    foreign.to = kLocalNode;
+    foreign.id = original.id;
+    foreign.which_payload_variant = meshtastic_MeshPacket_encrypted_tag;
+    foreign.encrypted.size = 32;
+
+    reliableShim->implicitAckForTest(&foreign);
+
+    TEST_ASSERT_EQUAL_UINT32(0, mockRoutingModule->ackNaks.size());
+    reliableShim->clearPendingForTest();
+}
+
 void test_pending_does_not_cancel_radio_queue_before_first_retry(void)
 {
     MockRadioInterface *mockIface = installMockIface();
@@ -1049,6 +1102,8 @@ void setup()
     RUN_TEST(test_reliableAckStopsNormalPendingTransmission);
 
     printf("\n=== pending retransmission bookkeeping ===\n");
+    RUN_TEST(test_implicitAck_firesForUndecodableOwnOverheardPacket);
+    RUN_TEST(test_implicitAck_ignoresPacketsNotFromUs);
     RUN_TEST(test_pending_does_not_cancel_radio_queue_before_first_retry);
     RUN_TEST(test_pending_cancels_radio_queue_after_first_retry_for_any_budget);
     RUN_TEST(test_directed_hop_tracks_three_total_attempts);

--- a/test/test_nexthop_routing/test_main.cpp
+++ b/test/test_nexthop_routing/test_main.cpp
@@ -854,7 +854,7 @@ void test_implicit_ack_for_opaque_own_packet(void)
 }
 
 // Someone else's traffic must never mint an ACK, even with a colliding id.
-void test_implicit_ack_ignores_foreign_packet(void)
+void test_implicit_ack_ignores_foreign_pkt(void)
 {
     auto original = makeBehaviorPacket(meshtastic_PortNum_TEXT_MESSAGE_APP, kLocalNode, kRemoteNode, 0, /*wantAck=*/true);
     reliableShim->seedRetry(original, NextHopRouter::NUM_RELIABLE_UNICAST_ATTEMPTS);
@@ -1103,7 +1103,7 @@ void setup()
 
     printf("\n=== pending retransmission bookkeeping ===\n");
     RUN_TEST(test_implicit_ack_for_opaque_own_packet);
-    RUN_TEST(test_implicit_ack_ignores_foreign_packet);
+    RUN_TEST(test_implicit_ack_ignores_foreign_pkt);
     RUN_TEST(test_pending_does_not_cancel_radio_queue_before_first_retry);
     RUN_TEST(test_pending_cancels_radio_queue_after_first_retry_for_any_budget);
     RUN_TEST(test_directed_hop_tracks_three_total_attempts);


### PR DESCRIPTION
## Summary

DMs never reach the "Delivered to mesh" state. The client goes straight from *sending* to either *max retransmissions* or *delivered to recipient*, skipping the intermediate ack. Channel messages are unaffected.

The implicit ACK — the ROUTING_APP ack a node generates for itself when it overhears a neighbour rebroadcasting its own packet — is produced in `ReliableRouter::shouldFilterReceived()`. But `Router::perhapsHandleReceived()` runs the routing auth gate first and returns early for anything it cannot decode:

```cpp
const auto authVerdict = passesRoutingAuthGate(p);
if (authVerdict == RoutingAuthVerdict::OPAQUE_RELAY_ONLY) {
    relayOpaquePacket(p);
    packetPool.release(p);
    return;                 // <-- shouldFilterReceived() never runs
}
if (shouldFilterReceived(p)) { ... }
```

A DM we originate is PKI-encrypted **to the recipient**, and `perhapsDecode()` only attempts PKI decryption when `isToUs(p)`. When we overhear our own DM being relayed we are not the recipient, so we cannot decrypt it. PKI DMs also go out with `p->channel = 0` (`Router.cpp`, in `perhapsEncode`), which matches no channel hash, so the packet is classified `DECODE_OPAQUE` and takes the early return above. The implicit ACK is never generated.

Broadcasts on a PSK channel decode normally, reach `shouldFilterReceived()`, and still get their implicit ACK — which is exactly why channel messages look fine and only DMs show the symptom.

## Why it broke

The reorder landed in #10967 (`feat(security): enforce packet authenticity policies`), which moved decrypt/authenticate ahead of the Reliable/Flooding/NextHop filters so that stateful routing could not be driven by unauthenticated packets. That goal is right, and this PR does not change it. The side effect was that the implicit-ACK generator sits *behind* those filters, so every packet the gate cannot decode — including our own PKI DMs — now bypasses it. This is a latent regression that has been on `develop` since #10967; it is not new to the current nightly.

## Fix

The implicit ACK only ever needed the packet header (`from`, `id`) — never the decoded payload. Split it out of `shouldFilterReceived()` into `perhapsGenerateImplicitAckForOwnOverheard()` and call it from the opaque short-circuit as well, gated on `isFromUs(p)`.

- The decodable path is behaviour-identical: `shouldFilterReceived()` calls the extracted method first, then does exactly what it did before.
- The two call sites are mutually exclusive (opaque returns early), so there is no double-ACK.
- `REJECT` is deliberately left alone — that is malformed or policy-failed traffic and should not mint an ACK.

## Validation

Hardware A/B on a Heltec V3, `develop` @ `fb6a212` with `-D MESHTASTIC_ENABLE_FRAME_INJECTION=1`, injecting an opaque rebroadcast of a real in-flight PKI DM (same packet id, while its retransmission record is still pending):

**Before (unpatched `develop`)**
```
inject: RX from=0x432df608 to=0x3f8558c3 id=0x9aeadb27 ch=0 encrypted
No channel found for decoding, hash 0x0
                                            <- nothing further; no ACK to the client
```

**After (this PR)**
```
inject: RX from=0x432df608 to=0x3f8558c3 id=0xfeba1213 ch=0 encrypted
No channel found for decoding, hash 0x0
Rx someone rebroadcasting for us (id=0xfeba1213 fr=0x432df608 to=0x3f8558c3 ...)
Generate implicit ack
Delivering rx packet (... Portnum=5 requestId=0xfeba1213 ...)   <- reaches the client
```

The ACK is delivered as `from=<us> to=<us> ROUTING_APP error=NONE`, which is what clients render as "Delivered to mesh".

Two regression tests added to `test_nexthop_routing`:

- `test_implicitAck_firesForUndecodableOwnOverheardPacket` — an overheard copy with `which_payload_variant = encrypted_tag` (nothing decoded) still produces the ACK, addressed to us with the original packet id.
- `test_implicitAck_ignoresPacketsNotFromUs` — a foreign packet with a colliding id mints nothing.

`./bin/test-native-docker.sh -f test_nexthop_routing` → 48/48 pass.

## Notes for reviewers

- Reported in the field against the current nightly; the bisect points at #10967 rather than anything in this nightly, so the same symptom should be reproducible on any build since 2026-07-21.
- I could not reproduce the failure over the air here (no relaying neighbour in range), hence the frame-injection harness; the injected packet takes the identical `perhapsHandleReceived()` path as a real overheard rebroadcast.
- Worth a second opinion on whether `OPAQUE_RELAY_ONLY` is the only gate that needs this. `DECODE_FAILURE` → `REJECT` is intentionally excluded above, but if a real-world PKI DM can ever land in `DECODE_FAILURE` (e.g. `matchedChannel` true via a colliding channel hash), that case would still be missing its ACK.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delivery reliability for encrypted packets rebroadcast by the local device.
  * Added implicit acknowledgements when locally originated opaque packets cannot be decrypted.
  * Prevented unrelated packets with matching identifiers from generating acknowledgements.
  * Improved pending transmission handling for overheard rebroadcasts.
  * Enhanced acknowledgement handling for opaque encrypted direct messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->