### PR TITLE
fix(security): restore implicit ACK for opaque relays of our own PKI DMs

### DIFF
--- a/src/mesh/ReliableRouter.cpp
+++ b/src/mesh/ReliableRouter.cpp
@@ -53,7 +53,7 @@ ErrorCode ReliableRouter::send(meshtastic_MeshPacket *p)
     return result;
 }
 
-bool ReliableRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
+void ReliableRouter::handleOwnRebroadcastImplicitAck(const meshtastic_MeshPacket *p)
 {
     // Note: do not use getFrom() here, because we want to ignore messages sent from phone
     if (p->from == getNodeNum()) {
@@ -81,6 +81,16 @@ bool ReliableRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
             LOG_DEBUG("Didn't find pending packet");
         }
     }
+}
+
+void ReliableRouter::noteOpaqueOwnRebroadcast(const meshtastic_MeshPacket *p)
+{
+    handleOwnRebroadcastImplicitAck(p);
+}
+
+bool ReliableRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
+{
+    handleOwnRebroadcastImplicitAck(p);
 
     /* At this point we have already deleted the pending retransmission if this packet was an (implicit) ACK to it.
        Now for all other pending retransmissions, we have to add the airtime of this received packet to the retransmission timer,

--- a/src/mesh/ReliableRouter.h
+++ b/src/mesh/ReliableRouter.h
@@ -32,9 +32,15 @@ class ReliableRouter : public NextHopRouter
      */
     virtual bool shouldFilterReceived(const meshtastic_MeshPacket *p) override;
 
+    /** Same implicit-ACK match as shouldFilterReceived, usable on undecodable (opaque) traffic too. */
+    virtual void noteOpaqueOwnRebroadcast(const meshtastic_MeshPacket *p) override;
+
   private:
     /**
      * Should this packet be ACKed with a want_ack for reliable delivery?
      */
     bool shouldSuccessAckWithWantAck(const meshtastic_MeshPacket *p);
+
+    /** Implicit-ACK/cancel-retransmission match; only reads the plaintext (from, id) header. */
+    void handleOwnRebroadcastImplicitAck(const meshtastic_MeshPacket *p);
 };

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -1612,6 +1612,9 @@ void Router::perhapsHandleReceived(meshtastic_MeshPacket *p)
     }
     if (authVerdict == RoutingAuthVerdict::OPAQUE_RELAY_ONLY) {
         relayOpaquePacket(p);
+        // Own outgoing PKI DMs always classify as opaque (we're not the recipient), but the plaintext
+        // header still lets us implicit-ACK them without admitting the packet to routing/history state.
+        noteOpaqueOwnRebroadcast(p);
         packetPool.release(p);
         return;
     }

--- a/src/mesh/Router.h
+++ b/src/mesh/Router.h
@@ -137,6 +137,9 @@ class Router : protected concurrency::OSThread, protected PacketHistory
     /** Relay an opaque packet without admitting it to local routing/history state. */
     virtual bool relayOpaquePacket(const meshtastic_MeshPacket *) { return false; }
 
+    /** An opaque packet's plaintext (from, id) header can still match our own pending retransmissions. */
+    virtual void noteOpaqueOwnRebroadcast(const meshtastic_MeshPacket *) {}
+
     /**
      * Determine if hop_limit should be decremented for a relay operation.
      * Returns false (preserve hop_limit) only if all conditions are met:

--- a/test/test_packet_signing/test_main.cpp
+++ b/test/test_packet_signing/test_main.cpp
@@ -1573,6 +1573,44 @@ void test_C16_reliable_broadcast_keeps_three_total_attempts(void)
     TEST_ASSERT_EQUAL_UINT8(3, pipelineRouter->pendingTotalAttempts(LOCAL_NODE, p.id));
 }
 
+// A relay of our own outgoing PKI DM never decrypts for us (we're not the recipient), so it always
+// classifies as opaque. It must still generate the implicit ACK and cancel the retransmission from
+// its plaintext (from, id) header alone, without being admitted to history, modules, or MQTT.
+void test_C17_opaque_own_rebroadcast_still_generates_implicit_ack(void)
+{
+    setPolicy(meshtastic_Config_SecurityConfig_PacketSignaturePolicy_PACKET_SIGNATURE_POLICY_STRICT);
+    const PacketId id = 0xC17C17C1;
+    meshtastic_MeshPacket prior = makeDecoded(LOCAL_NODE, REMOTE_NODE, meshtastic_PortNum_TEXT_MESSAGE_APP, SMALL_PAYLOAD);
+    prior.id = id;
+    prior.channel = 0;
+    pipelineRouter->addPending(prior, Time::getMillis() + 3600000UL);
+    TEST_ASSERT_EQUAL(1, pipelineRouter->pendingCount());
+
+    meshtastic_MeshPacket relayed = meshtastic_MeshPacket_init_zero;
+    relayed.from = LOCAL_NODE;
+    relayed.to = REMOTE_NODE;
+    relayed.id = id;
+    relayed.channel = 0xFE; // no configured channel matches, so decode is opaque, not a failure
+    relayed.hop_limit = 2;
+    relayed.hop_start = 3;
+    relayed.transport_mechanism = meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA;
+    relayed.which_payload_variant = meshtastic_MeshPacket_encrypted_tag;
+    relayed.encrypted.size = 16;
+    memset(relayed.encrypted.bytes, 0xA5, relayed.encrypted.size);
+
+    TEST_ASSERT_EQUAL(static_cast<int>(RoutingAuthVerdict::OPAQUE_RELAY_ONLY), static_cast<int>(passesRoutingAuthGate(&relayed)));
+    runPipelineIngress(relayed);
+
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(1, pipelineRouting->ackCalls,
+                                     "overhearing our own relayed DM must still generate an implicit ACK");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(0, pipelineRouter->pendingCount(),
+                                     "the implicit ACK must cancel our pending retransmission");
+    TEST_ASSERT_EQUAL(0, pipelineModule->calls);
+    TEST_ASSERT_EQUAL(0, pipelineMqtt->queueSize());
+    TEST_ASSERT_NULL(pipelineService->getForPhone());
+    TEST_ASSERT_FALSE(pipelineRouter->historyContains(&relayed));
+}
+
 // C5: the packet survives (C4) but the identity claim inside it must not land - the pubkey guard
 // can't tell a signer from an impersonator replaying its (public) key. Only the write is refused.
 void test_N5_unsigned_unicast_nodeinfo_from_signer_does_not_change_name(void)
@@ -2150,6 +2188,7 @@ void setup()
     RUN_TEST(test_C14_duty_cycle_limited_reliable_send_remains_pending);
     RUN_TEST(test_C15_reliable_unicast_tracks_five_total_attempts);
     RUN_TEST(test_C16_reliable_broadcast_keeps_three_total_attempts);
+    RUN_TEST(test_C17_opaque_own_rebroadcast_still_generates_implicit_ack);
     printf("\n=== Group N: NodeInfoModule authentication ===\n");
     RUN_TEST(test_N1_unsigned_nodeinfo_from_signer_dropped);
     RUN_TEST(test_N2_signed_nodeinfo_from_signer_not_dropped);


### PR DESCRIPTION
## Summary

#10967 ("feat(security): enforce packet authenticity policies") added a `passesRoutingAuthGate()` step ahead of `shouldFilterReceived()`. Packets that decode as `DECODE_OPAQUE` are routed straight to `relayOpaquePacket()` and returned early — they never reach `shouldFilterReceived()` at all.

That's the right call for genuinely unauthenticated third-party traffic: we shouldn't admit packets we can't make sense of to `PacketHistory`, module dispatch, MQTT, or the NextHop/Flooding dedup state.

But it also silently swallows a case that isn't third-party traffic: **a relay of our own outgoing PKI DM**. The originating node is never the recipient, so it can never PKI-decrypt its own DM — from its own point of view that packet always decodes as opaque. Before #10967, every packet (opaque or not) reached `shouldFilterReceived()`, whose `p->from == getNodeNum()` check would match the rebroadcast against our own pending-retransmission map and generate the implicit ACK / cancel the retransmission. After #10967, opaque packets never reach that check, so **every PKI DM now pays its full retry cost even when a relay has already carried it onward** — the implicit-ACK optimization (and the "stop retransmitting once someone relays it" behavior) is gone specifically for PKI DMs.

## Fix

Rather than widening the opaque-relay path itself (which would reopen the unauthenticated-traffic surface #10967 closed — `shouldFilterReceived()`'s NextHop/Flooding paths do real `stopRetransmission`/dedup/history work keyed only on the plaintext header), this adds a narrow, purpose-built hook:

- `Router::noteOpaqueOwnRebroadcast()` — new virtual, no-op by default.
- `ReliableRouter::noteOpaqueOwnRebroadcast()` — overrides it, calling a new `handleOwnRebroadcastImplicitAck()` helper extracted from the existing `p->from == getNodeNum()` block in `ReliableRouter::shouldFilterReceived()`. Same check, same plaintext-header-only authentication boundary that's always backed it, broadcast or unicast.
- `Router::perhapsHandleReceived()` calls this new hook for `OPAQUE_RELAY_ONLY` packets, right after `relayOpaquePacket()`.

The packet itself still never touches `PacketHistory`, modules, MQTT, or the NextHop/Flooding dedup logic — only the implicit-ACK match, exactly as it worked before #10967.

## Testing

- Added `test_C17_opaque_own_rebroadcast_still_generates_implicit_ack` alongside the existing `test_C*` opaque/authenticity group, covering both the restored implicit ACK/retransmission-cancel and the continued absence of history/module/MQTT admission.
- `./bin/run-tests.sh` — full suite green (58/58 suites).
- `./bin/run-tests.sh -f test_packet_signing`, `-f test_nexthop_routing`, `-f test_mqtt` — all clean.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)

Tested on a Seeed Studio Wio Tracker L1 only — sending a PKI DM and observing the retransmission get canceled once a relay is overheard, matching pre-#10967 behavior. Not yet tested against any other hardware target; the change is router-logic-only (no platform-specific code), but independent confirmation on other boards is welcome before merge.
