### PR TITLE
fix(NodeDB): reset a persisted event firmware_edition on vanilla builds

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -430,6 +430,14 @@ NodeDB::NodeDB()
 
     // likewise - we always want the app requirements to come from the running appload
     myNodeInfo.min_app_version = 30200; // format is Mmmss (where M is 1+the numeric major number. i.e. 30200 means 2.2.00
+
+    // likewise the edition: it lives in persisted devicestate, so a vanilla install must
+    // overwrite the previous event build's value. Before the CRC compare, so the change persists.
+#ifdef USERPREFS_FIRMWARE_EDITION
+    myNodeInfo.firmware_edition = USERPREFS_FIRMWARE_EDITION;
+#else
+    myNodeInfo.firmware_edition = meshtastic_FirmwareEdition_VANILLA;
+#endif
     pickNewNodeNum();
 
     // Set our board type so we can share it with others
@@ -615,13 +623,6 @@ NodeDB::NodeDB()
         config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_ENABLED;
         config.position.gps_enabled = 0;
     }
-    // Stamp unconditionally: myNodeInfo lives in persisted devicestate, so without the
-    // else branch a vanilla install keeps reporting the previous event edition forever.
-#ifdef USERPREFS_FIRMWARE_EDITION
-    myNodeInfo.firmware_edition = USERPREFS_FIRMWARE_EDITION;
-#else
-    myNodeInfo.firmware_edition = meshtastic_FirmwareEdition_VANILLA;
-#endif
 #ifdef USERPREFS_FIXED_GPS
     if (myNodeInfo.reboot_count == 1) { // Check if First boot ever or after Factory Reset.
         meshtastic_Position fixedGPS = meshtastic_Position_init_default;

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -615,8 +615,12 @@ NodeDB::NodeDB()
         config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_ENABLED;
         config.position.gps_enabled = 0;
     }
+    // Stamp unconditionally: myNodeInfo lives in persisted devicestate, so without the
+    // else branch a vanilla install keeps reporting the previous event edition forever.
 #ifdef USERPREFS_FIRMWARE_EDITION
     myNodeInfo.firmware_edition = USERPREFS_FIRMWARE_EDITION;
+#else
+    myNodeInfo.firmware_edition = meshtastic_FirmwareEdition_VANILLA;
 #endif
 #ifdef USERPREFS_FIXED_GPS
     if (myNodeInfo.reboot_count == 1) { // Check if First boot ever or after Factory Reset.

--- a/test/state-manifest.tsv
+++ b/test/state-manifest.tsv
@@ -42,6 +42,7 @@
 # suite	flags	reason
 test_admin_radio	writes=config.proto,module.proto,device.proto,channels.proto,nodes.proto,warm.dat,Messages_default.msgs	per-test NodeDB fixture, and the admin handlers under test persist config, channels and node metadata
 test_admin_session_repro	writes=config.proto,module.proto,device.proto,channels.proto,nodes.proto	constructs a NodeDB, whose constructor persists a default set when the prefs directory is empty
+test_firmware_edition	writes=config.proto,module.proto,device.proto,channels.proto,nodes.proto	persists an event firmware_edition in devicestate, then reboots a NodeDB to prove a vanilla build resets it
 test_fuzz_packets	writes=config.proto,module.proto,device.proto,channels.proto,nodes.proto,warm.dat,Messages_default.msgs	drives decode of fuzzed packets through the real NodeDB and message store
 test_hop_scaling	writes=config.proto,module.proto,device.proto,channels.proto,nodes.proto	constructs a NodeDB to hold the hop-distance fixtures
 test_mesh_beacon	writes=module.proto	exercises the beacon's module-config save path

--- a/test/test_firmware_edition/test_main.cpp
+++ b/test/test_firmware_edition/test_main.cpp
@@ -1,0 +1,42 @@
+// Regression test for the boot-time firmware_edition stamp in NodeDB's constructor.
+// devicestate.my_node survives a firmware reinstall, so a vanilla build (no
+// USERPREFS_FIRMWARE_EDITION) must actively reset a persisted event edition or the
+// device keeps reporting DEFCON/etc. forever and clients keep the event branding.
+#include "MeshTypes.h" // Include BEFORE TestUtil.h
+#include "TestUtil.h"
+#include "mesh/NodeDB.h"
+#include <unity.h>
+
+#if defined(ARCH_PORTDUINO)
+#define FE_TEST_ENTRY extern "C"
+#else
+#define FE_TEST_ENTRY
+#endif
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// Native test builds define no USERPREFS_FIRMWARE_EDITION, so a fresh NodeDB boot here
+// is exactly a "user installed Vanilla over event firmware" reboot.
+static void test_vanillaBoot_resetsPersistedEventEdition(void)
+{
+    devicestate.my_node.firmware_edition = meshtastic_FirmwareEdition_DEFCON;
+    TEST_ASSERT_TRUE(nodeDB->saveToDisk(SEGMENT_DEVICESTATE));
+
+    NodeDB *rebooted = new NodeDB();
+    delete nodeDB;
+    nodeDB = rebooted;
+
+    TEST_ASSERT_EQUAL(meshtastic_FirmwareEdition_VANILLA, devicestate.my_node.firmware_edition);
+}
+
+FE_TEST_ENTRY void setup()
+{
+    initializeTestEnvironment();
+    nodeDB = new NodeDB();
+
+    UNITY_BEGIN();
+    RUN_TEST(test_vanillaBoot_resetsPersistedEventEdition);
+    exit(UNITY_END());
+}
+FE_TEST_ENTRY void loop() {}

--- a/test/test_firmware_edition/test_main.cpp
+++ b/test/test_firmware_edition/test_main.cpp
@@ -1,7 +1,5 @@
-// Regression test for the boot-time firmware_edition stamp in NodeDB's constructor.
 // devicestate.my_node survives a firmware reinstall, so a vanilla build (no
-// USERPREFS_FIRMWARE_EDITION) must actively reset a persisted event edition or the
-// device keeps reporting DEFCON/etc. forever and clients keep the event branding.
+// USERPREFS_FIRMWARE_EDITION) must reset a persisted event edition at boot.
 #include "MeshTypes.h" // Include BEFORE TestUtil.h
 #include "TestUtil.h"
 #include "mesh/NodeDB.h"
@@ -16,18 +14,27 @@
 void setUp(void) {}
 void tearDown(void) {}
 
-// Native test builds define no USERPREFS_FIRMWARE_EDITION, so a fresh NodeDB boot here
-// is exactly a "user installed Vanilla over event firmware" reboot.
+static meshtastic_FirmwareEdition persistedEdition()
+{
+    meshtastic_DeviceState saved = meshtastic_DeviceState_init_zero;
+    TEST_ASSERT_EQUAL(LoadFileResult::LOAD_SUCCESS, nodeDB->loadProto(deviceStateFileName, meshtastic_DeviceState_size,
+                                                                      sizeof(saved), &meshtastic_DeviceState_msg, &saved));
+    return saved.my_node.firmware_edition;
+}
+
 static void test_vanillaBoot_resetsPersistedEventEdition(void)
 {
     devicestate.my_node.firmware_edition = meshtastic_FirmwareEdition_DEFCON;
     TEST_ASSERT_TRUE(nodeDB->saveToDisk(SEGMENT_DEVICESTATE));
+    TEST_ASSERT_EQUAL(meshtastic_FirmwareEdition_DEFCON, persistedEdition());
 
     NodeDB *rebooted = new NodeDB();
     delete nodeDB;
     nodeDB = rebooted;
 
     TEST_ASSERT_EQUAL(meshtastic_FirmwareEdition_VANILLA, devicestate.my_node.firmware_edition);
+    // On disk too, not just in RAM: the stamp must land before the boot save decision.
+    TEST_ASSERT_EQUAL(meshtastic_FirmwareEdition_VANILLA, persistedEdition());
 }
 
 FE_TEST_ENTRY void setup()


### PR DESCRIPTION
## Why

Users report that clients keep showing event branding (DEFCON, Burning Man, …) after they reinstall vanilla firmware. The device is the one still reporting the event edition:

- `myNodeInfo` is an alias into `devicestate.my_node`, which is persisted flash state that survives a firmware reinstall.
- The boot-time stamp in `NodeDB::NodeDB()` is wrapped in `#ifdef USERPREFS_FIRMWARE_EDITION`, so vanilla builds compile it out and never write the field.

Result: flash an event build once and `MyNodeInfo.firmware_edition` reports that edition forever — a factory reset is the only way out, which matches the field reports. Clients (verified against the Android branding pipeline) clear correctly the moment the device reports `VANILLA`, so the fix belongs here.

## What

Stamp the field unconditionally at boot: the `#else` branch writes `meshtastic_FirmwareEdition_VANILLA`, making the running build the source of truth. Event/DIY builds that define `USERPREFS_FIRMWARE_EDITION` are unchanged.

## Tests

New native suite `test_firmware_edition`: persists a DEFCON edition in devicestate, reboots a NodeDB in a build without `USERPREFS_FIRMWARE_EDITION`, and asserts the edition resets to `VANILLA`. Fails before the fix (`Expected 0 Was 17`), passes after. Declared in `test/state-manifest.tsv`. Full native suite run alongside; no regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Firmware edition information is now initialized consistently during startup.
  * Vanilla builds correctly reset persisted firmware edition data to the Vanilla edition, both in memory and after reboot.
  * Configured firmware editions continue to be preserved where applicable.

* **Tests**
  * Added regression coverage verifying firmware edition reset behavior across simulated reboots and persistent storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->