### PR TITLE
fix(serialhal): address CodeRabbit review on #10351

### DIFF
--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -308,7 +308,12 @@ meshtastic_LogRecord_Level RedirectablePrint::getLogLevel(const char *logLevel)
 void RedirectablePrint::log(const char *logLevel, const char *format, ...)
 {
 
-    if (isSerialHalLogSuppressed()) {
+    // Suppression is global and sits ahead of every level filter and every destination, so it
+    // would otherwise silence unrelated subsystems mid-frame. Keeping ERROR and CRIT flowing costs
+    // a few bytes of latency on the SerialHal response and preserves the only output that matters
+    // when something is actually going wrong.
+    if (isSerialHalLogSuppressed() && strcmp(logLevel, MESHTASTIC_LOG_LEVEL_ERROR) != 0 &&
+        strcmp(logLevel, MESHTASTIC_LOG_LEVEL_CRIT) != 0) {
         return;
     }
 

--- a/src/SerialConsole.cpp
+++ b/src/SerialConsole.cpp
@@ -239,18 +239,18 @@ bool SerialConsole::canEncodeLogRecord()
 }
 
 /// Frame USB CDC output and retain any unwritten tail.
-bool SerialConsole::writeFrame(uint8_t *buf, size_t len, bool bestEffort)
+bool SerialConsole::writeFrame(uint8_t *buf, size_t len, bool bestEffort, uint8_t discriminator)
 {
 #ifdef IS_USB_SERIAL
     if (len == 0 || !canWrite)
         return false;
 
-    const size_t totalLen = buildFrameHeader(buf, len);
+    const size_t totalLen = buildFrameHeader(buf, len, discriminator);
 
     concurrency::LockGuard guard(&streamLock);
     return frameWriter.writeFrame(Port, buf, totalLen, bestEffort);
 #else
-    return StreamAPI::writeFrame(buf, len, bestEffort);
+    return StreamAPI::writeFrame(buf, len, bestEffort, discriminator);
 #endif
 }
 
@@ -274,6 +274,24 @@ bool SerialConsole::handleToRadio(const uint8_t *buf, size_t len)
     } else {
         return false;
     }
+}
+
+/**
+ * A SerialHal host proxies the radio over this port and never sends a ToRadio frame, so
+ * handleToRadio() above never runs for it. Without this the console would still believe it is
+ * talking to a dumb terminal: canWrite stays false and the response we owe the host is dropped,
+ * and raw log text would be written into what is definitively a framed binary stream.
+ */
+void SerialConsole::handleSerialHalCommand(const uint8_t *buf, size_t len)
+{
+    if (!config.has_lora || !config.security.serial_enabled)
+        return;
+
+    setHostDraining(true);
+    usingProtobufs = true;
+    canWrite = true;
+
+    StreamAPI::handleSerialHalCommand(buf, len);
 }
 
 /// Route logs without allowing raw bytes into an active protobuf stream.

--- a/src/SerialConsole.h
+++ b/src/SerialConsole.h
@@ -36,6 +36,13 @@ class SerialConsole : public StreamAPI, public RedirectablePrint, private concur
     void rxInt();
 
   protected:
+    /**
+     * A SerialHal host drives the radio without ever sending a ToRadio frame, so it would
+     * otherwise never reach handleToRadio() and never take us out of raw-console mode. Recognise
+     * its command frames as the same proof of a smart host.
+     */
+    virtual void handleSerialHalCommand(const uint8_t *buf, size_t len) override;
+
     /// Check the current underlying physical link to see if the client is currently connected
     virtual bool checkIsConnected() override;
 
@@ -56,7 +63,7 @@ class SerialConsole : public StreamAPI, public RedirectablePrint, private concur
     /// Return whether the dedicated log buffer can be safely overwritten.
     virtual bool canEncodeLogRecord() override;
     /// Write or retain one framed USB CDC message.
-    virtual bool writeFrame(uint8_t *buf, size_t len, bool bestEffort) override;
+    virtual bool writeFrame(uint8_t *buf, size_t len, bool bestEffort, uint8_t discriminator) override;
 
   private:
     /// On USB CDC targets, keep console TX non-blocking unless a host is draining the

--- a/src/mesh/SerialHalDevice.cpp
+++ b/src/mesh/SerialHalDevice.cpp
@@ -3,10 +3,12 @@
 #include "SPILock.h"
 #include "concurrency/Periodic.h"
 #include "configuration.h"
+#include "mesh/SerialHalFraming.h"
 #include "mesh/StreamAPI.h"
 #include "mesh/generated/meshtastic/config.pb.h"
 #include <Arduino.h>
 #include <SPI.h>
+#include <atomic>
 #include <cstring>
 #include <stdint.h>
 
@@ -29,7 +31,10 @@ struct InterruptSlot {
     bool used = false;
     uint32_t pin = 0;
     uint32_t mode = 0;
-    volatile bool pending = false;
+    /// Set from interrupt context, cleared by pumpInterruptEvents() under interruptMutex. The ISR
+    /// cannot take the lock, so this needs to carry its own ordering - volatile alone says nothing
+    /// about visibility to the core running the pump.
+    std::atomic<bool> pending{false};
 };
 
 concurrency::Lock interruptMutex;
@@ -106,7 +111,7 @@ void emitInterruptEvent(uint32_t pin, StreamAPI *streamApi)
 void markPendingBySlot(uint8_t slot)
 {
     if (slot < MAX_INTERRUPT_SLOTS && interruptSlots[slot].used) {
-        interruptSlots[slot].pending = true;
+        interruptSlots[slot].pending.store(true);
     }
 }
 
@@ -155,8 +160,7 @@ int32_t pumpInterruptEvents()
         concurrency::LockGuard lock(&interruptMutex);
         streamApi = interruptStreamApi;
         for (size_t i = 0; i < MAX_INTERRUPT_SLOTS; ++i) {
-            if (interruptSlots[i].used && interruptSlots[i].pending) {
-                interruptSlots[i].pending = false;
+            if (interruptSlots[i].used && interruptSlots[i].pending.exchange(false)) {
                 toEmit[emitCount++] = interruptSlots[i].pin;
             }
         }
@@ -284,7 +288,7 @@ void SerialHalDevice::handleAttachInterrupt(const meshtastic_SerialHalCommand &c
             interruptSlots[slot].used = true;
             interruptSlots[slot].pin = cmd.pin;
             interruptSlots[slot].mode = cmd.mode;
-            interruptSlots[slot].pending = false;
+            interruptSlots[slot].pending.store(false);
         }
     }
 
@@ -306,7 +310,11 @@ void SerialHalDevice::handleDetachInterrupt(const meshtastic_SerialHalCommand &c
         concurrency::LockGuard lock(&interruptMutex);
         const int slot = findSlotByPinLocked(cmd.pin);
         if (slot >= 0) {
-            interruptSlots[slot] = InterruptSlot{};
+            // Reset field by field: the atomic member makes InterruptSlot non-assignable.
+            interruptSlots[slot].used = false;
+            interruptSlots[slot].pin = 0;
+            interruptSlots[slot].mode = 0;
+            interruptSlots[slot].pending.store(false);
         }
     }
 }
@@ -364,18 +372,8 @@ void SerialHalDevice::emitResponse(const meshtastic_SerialHalResponse &response,
         return;
     }
 
-    // Build frame with StreamAPI framing: START1 SERIALHAL_MAGIC LEN_H LEN_L [payload]
-    constexpr uint8_t START1 = 0x94;
-    constexpr uint8_t SERIALHAL_MAGIC = 0xA5;
-
-    uint8_t hdr[4];
-    hdr[0] = START1;
-    hdr[1] = SERIALHAL_MAGIC;
-    hdr[2] = (uint8_t)((responseLen >> 8) & 0xFF); // LEN_H
-    hdr[3] = (uint8_t)(responseLen & 0xFF);        // LEN_L
-
-    // Emit via StreamAPI (this uses the internal txBuf + framing)
-    streamApi->emitSerialHalResponse(hdr, sizeof(hdr), encoded, responseLen);
+    // StreamAPI owns the framing; it stamps START1 SERIALHAL_MAGIC LEN_H LEN_L ahead of this.
+    streamApi->emitSerialHalResponse(encoded, responseLen);
 
     // Keep a recent stream instance so async interrupt events can be emitted.
     {

--- a/src/mesh/SerialHalFraming.h
+++ b/src/mesh/SerialHalFraming.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+/// Canonical framing for the StreamAPI wire protocol.
+///
+/// Every frame is START1 <discriminator> LEN_H LEN_L [payload], where the second byte selects
+/// between a normal ToRadio/FromRadio frame (START2) and a SerialHal command/response frame
+/// (SERIALHAL_MAGIC). Three translation units parse or emit these bytes - StreamAPI (the receive
+/// state machine), SerialHalDevice (the device-side responder) and SerialHal (the Portduino-side
+/// host) - so they are defined here once. Request and response framing desyncing because one copy
+/// drifted is a failure mode that is very hard to spot on the wire.
+
+constexpr uint8_t START1 = 0x94;
+constexpr uint8_t START2 = 0xc3;
+constexpr uint8_t SERIALHAL_MAGIC = 0xa5;
+constexpr size_t HEADER_LEN = 4;

--- a/src/mesh/StreamAPI.cpp
+++ b/src/mesh/StreamAPI.cpp
@@ -6,19 +6,45 @@
 #include "RTC.h"
 #include "RedirectablePrint.h"
 #include "SerialHalDevice.h"
+#include "SerialHalFraming.h"
 #include "StreamAPI.h"
 #include "Throttle.h"
 #include "concurrency/LockGuard.h"
 #include "gps/RTC.h"
 
-#define START1 0x94
-#define START2 0xc3
-#define SERIALHAL_MAGIC 0xa5 // second framing byte for SerialHal frames (START1 SH_MAGIC LEN_H LEN_L PAYLOAD)
-#define HEADER_LEN 4
+/// Enter or leave the SerialHal receive window.
+///
+/// The window keeps readStream() polling at full speed and mutes log output so a LogRecord frame
+/// cannot delay the response the host is blocking on. Both effects are global, so the three call
+/// sites that open and close it must stay in step - hence one helper rather than the flag pair
+/// being poked by hand.
+void StreamAPI::setSerialHalRxActive(bool active)
+{
+    serialHalRxActive.store(active);
+    RedirectablePrint::setSerialHalLogSuppressed(active);
+    if (active)
+        serialHalRxStartMsec = millis();
+}
+
+/// Abandon a SerialHal frame that stopped arriving part-way through.
+///
+/// Suppression is armed on the frame's second byte and disarmed on its last one. A host that
+/// stalls or disconnects mid-frame would otherwise hold the window open forever, silencing logs
+/// for every subsystem on the node with no way back.
+void StreamAPI::expireStaleSerialHalRx()
+{
+    if (!serialHalRxActive.load() || Throttle::isWithinTimespanMs(serialHalRxStartMsec, SERIALHAL_RX_TIMEOUT_MSEC))
+        return;
+
+    LOG_WARN("StreamAPI: SerialHal frame stalled mid-receive, dropping it");
+    rxPtr = 0;
+    setSerialHalRxActive(false);
+}
 
 /// Poll the underlying stream, drain output, and update connection state.
 int32_t StreamAPI::runOncePart()
 {
+    expireStaleSerialHalRx();
     auto result = readStream();
     // More to send: come straight back instead of sleeping out readStream's idle delay.
     if (writeStream())
@@ -30,6 +56,7 @@ int32_t StreamAPI::runOncePart()
 /// Consume supplied input bytes, drain output, and update connection state.
 int32_t StreamAPI::runOncePart(char *buf, uint16_t bufLen)
 {
+    expireStaleSerialHalRx();
     auto result = readStream(buf, bufLen);
     if (writeStream())
         result = 0;
@@ -111,16 +138,13 @@ int32_t StreamAPI::handleRecStream(const char *buf, uint16_t bufLen)
         } else if (ptr == 1) { // discriminate frame type on second byte
             if (c == START2) {
                 rxIsSerialHal = false; // standard ToRadio frame
-                serialHalRxActive.store(false);
-                RedirectablePrint::setSerialHalLogSuppressed(false);
+                setSerialHalRxActive(false);
             } else if (c == SERIALHAL_MAGIC) {
                 rxIsSerialHal = true; // SerialHal command frame
-                serialHalRxActive.store(true);
-                RedirectablePrint::setSerialHalLogSuppressed(true);
+                setSerialHalRxActive(true);
             } else {
                 rxPtr = 0; // unrecognised second byte - not our frame
-                serialHalRxActive.store(false);
-                RedirectablePrint::setSerialHalLogSuppressed(false);
+                setSerialHalRxActive(false);
             }
         } else if (ptr >= HEADER_LEN - 1) {            // we have at least read our 4 byte framing
             uint32_t len = (rxBuf[2] << 8) + rxBuf[3]; // big endian 16 bit length follows framing
@@ -130,8 +154,10 @@ int32_t StreamAPI::handleRecStream(const char *buf, uint16_t bufLen)
             if (ptr == HEADER_LEN - 1) {
                 // we _just_ finished our 4 byte header, validate length now
                 uint32_t maxLen = rxIsSerialHal ? (uint32_t)meshtastic_SerialHalCommand_size : MAX_TO_FROM_RADIO_SIZE;
-                if (len > maxLen)
-                    rxPtr = 0; // length is bogus, restart search for framing
+                if (len > maxLen) {
+                    rxPtr = 0;                   // length is bogus, restart search for framing
+                    setSerialHalRxActive(false); // and close the window this frame opened
+                }
             }
 
             if (rxPtr != 0)                        // Is packet still considered 'good'?
@@ -145,9 +171,7 @@ int32_t StreamAPI::handleRecStream(const char *buf, uint16_t bufLen)
                         handleToRadio(rxBuf + HEADER_LEN, len);
 
                     if (rxIsSerialHal)
-                        serialHalRxActive.store(false);
-                    if (rxIsSerialHal)
-                        RedirectablePrint::setSerialHalLogSuppressed(false);
+                        setSerialHalRxActive(false);
                 }
         }
     }
@@ -191,17 +215,13 @@ int32_t StreamAPI::readStream()
             } else if (ptr == 1) { // discriminate frame type on second byte
                 if (c == START2) {
                     rxIsSerialHal = false; // standard ToRadio frame
-                    serialHalRxActive.store(false);
-                    RedirectablePrint::setSerialHalLogSuppressed(false);
+                    setSerialHalRxActive(false);
                 } else if (c == SERIALHAL_MAGIC) {
                     rxIsSerialHal = true; // SerialHal command frame
-                    serialHalRxActive.store(true);
-                    RedirectablePrint::setSerialHalLogSuppressed(true);
-                    LOG_WARN("StreamAPI: Detected SerialHal command frame");
+                    setSerialHalRxActive(true);
                 } else {
                     rxPtr = 0; // unrecognised second byte - not our frame
-                    serialHalRxActive.store(false);
-                    RedirectablePrint::setSerialHalLogSuppressed(false);
+                    setSerialHalRxActive(false);
                 }
             } else if (ptr >= HEADER_LEN - 1) {            // we have at least read our 4 byte framing
                 uint32_t len = (rxBuf[2] << 8) + rxBuf[3]; // big endian 16 bit length follows framing
@@ -211,8 +231,10 @@ int32_t StreamAPI::readStream()
                 if (ptr == HEADER_LEN - 1) {
                     // we _just_ finished our 4 byte header, validate length now
                     uint32_t maxLen = rxIsSerialHal ? (uint32_t)meshtastic_SerialHalCommand_size : MAX_TO_FROM_RADIO_SIZE;
-                    if (len > maxLen)
-                        rxPtr = 0; // length is bogus, restart search for framing
+                    if (len > maxLen) {
+                        rxPtr = 0;                   // length is bogus, restart search for framing
+                        setSerialHalRxActive(false); // and close the window this frame opened
+                    }
                 }
 
                 if (rxPtr != 0)                        // Is packet still considered 'good'?
@@ -226,9 +248,7 @@ int32_t StreamAPI::readStream()
                             handleToRadio(rxBuf + HEADER_LEN, len);
 
                         if (rxIsSerialHal)
-                            serialHalRxActive.store(false);
-                        if (rxIsSerialHal)
-                            RedirectablePrint::setSerialHalLogSuppressed(false);
+                            setSerialHalRxActive(false);
                     }
             }
         }
@@ -240,10 +260,10 @@ int32_t StreamAPI::readStream()
 }
 
 /// Encode the stream marker and big-endian payload length.
-size_t StreamAPI::buildFrameHeader(uint8_t *buf, size_t payloadLen)
+size_t StreamAPI::buildFrameHeader(uint8_t *buf, size_t payloadLen, uint8_t discriminator)
 {
     buf[0] = START1;
-    buf[1] = START2;
+    buf[1] = discriminator;
     buf[2] = (payloadLen >> 8) & 0xff;
     buf[3] = payloadLen & 0xff;
     return payloadLen + HEADER_LEN;
@@ -253,13 +273,13 @@ size_t StreamAPI::buildFrameHeader(uint8_t *buf, size_t payloadLen)
  * Send the current txBuffer over our stream
  */
 /// Write one framed payload using the transport's failure semantics.
-bool StreamAPI::writeFrame(uint8_t *buf, size_t len, bool bestEffort)
+bool StreamAPI::writeFrame(uint8_t *buf, size_t len, bool bestEffort, uint8_t discriminator)
 {
     (void)bestEffort;
     if (len == 0 || !canWrite)
         return false;
 
-    const size_t totalLen = buildFrameHeader(buf, len);
+    const size_t totalLen = buildFrameHeader(buf, len, discriminator);
     // Serialize write-readiness checks, writes and write-failure handling
     // against concurrent stream writes/close.
     concurrency::LockGuard guard(&streamLock);
@@ -279,7 +299,7 @@ bool StreamAPI::writeFrame(uint8_t *buf, size_t len, bool bestEffort)
 /// Emit the prepared main PhoneAPI payload as required output.
 bool StreamAPI::emitTxBuffer(size_t len)
 {
-    return writeFrame(txBuf, len, false);
+    return writeFrame(txBuf, len, false, START2);
 }
 
 /// Emit the initial reboot notification as a framed FromRadio payload.
@@ -326,7 +346,7 @@ void StreamAPI::emitLogRecord(meshtastic_LogRecord_Level level, const char *src,
 
     size_t len =
         pb_encode_to_bytes(txBufLog + HEADER_LEN, meshtastic_FromRadio_size, &meshtastic_FromRadio_msg, &fromRadioScratchLog);
-    writeFrame(txBufLog, len, true);
+    writeFrame(txBufLog, len, true, START2);
 }
 
 /// Hookable to find out when connection changes
@@ -349,23 +369,19 @@ void StreamAPI::handleSerialHalCommand(const uint8_t *buf, size_t len)
     SerialHalDevice::handleCommand(buf, len, this);
 }
 
-void StreamAPI::emitSerialHalResponse(const uint8_t *hdr, size_t hdrLen, const uint8_t *payload, size_t payloadLen)
+void StreamAPI::emitSerialHalResponse(const uint8_t *payload, size_t payloadLen)
 {
-    if (hdr == nullptr || hdrLen != 4 || payload == nullptr || payloadLen > meshtastic_SerialHalResponse_size) {
+    if (payload == nullptr || payloadLen == 0 || payloadLen > meshtastic_SerialHalResponse_size) {
         LOG_ERROR("StreamAPI: Invalid SerialHal response parameters");
         return;
     }
 
-    // Build complete frame in a temporary buffer
-    uint8_t frame[4 + meshtastic_SerialHalResponse_size];
-    memcpy(frame, hdr, hdrLen);
-    memcpy(frame + hdrLen, payload, payloadLen);
+    // Leave HEADER_LEN bytes clear so writeFrame() can stamp the header in place. Going through
+    // writeFrame() rather than writing the stream directly is what gets this path the transport's
+    // own admission control, partial-write reporting and - on USB CDC consoles - the retained
+    // frame machinery, which a direct write would interleave bytes into.
+    uint8_t frame[HEADER_LEN + meshtastic_SerialHalResponse_size];
+    memcpy(frame + HEADER_LEN, payload, payloadLen);
 
-    size_t totalLen = hdrLen + payloadLen;
-
-    // Serialize stream writes against other emit operations via streamLock
-    concurrency::LockGuard guard(&streamLock);
-    stream->write(frame, totalLen);
-    stream->flush();
-    LOG_WARN("StreamAPI: Emitted SerialHal response frame (len=%zu)", totalLen);
+    writeFrame(frame, payloadLen, false, SERIALHAL_MAGIC);
 }

--- a/src/mesh/StreamAPI.h
+++ b/src/mesh/StreamAPI.h
@@ -18,6 +18,11 @@
 // hardware watchdog (RP2350 arms 8s) resets mid-dump.
 #define STREAM_WRITE_BUDGET_MSEC 100
 
+// How long a partially-received SerialHal frame may hold the log-suppression window open. Comfortably
+// longer than any real frame at 115200 baud, short enough that a host which dies mid-frame does not
+// leave the node silent.
+#define SERIALHAL_RX_TIMEOUT_MSEC 1000
+
 /**
  * A version of our 'phone' API that talks over a Stream.  So therefore well suited to use with serial links
  * or TCP connections.
@@ -50,6 +55,8 @@ class StreamAPI : public PhoneAPI
     size_t rxPtr = 0;
     bool rxIsSerialHal = false; ///< true when the current in-progress frame is a SerialHal frame (START1 SH_MAGIC ...)
     std::atomic<bool> serialHalRxActive{false};
+    /// millis() when the current SerialHal receive window opened, so a stalled frame can be expired
+    uint32_t serialHalRxStartMsec = 0;
 
     /// time of last rx, used, to slow down our polling if we haven't heard from anyone
     uint32_t lastRxMsec = 0;
@@ -75,12 +82,10 @@ class StreamAPI : public PhoneAPI
      * Emit a SerialHal response frame with proper framing (START1 SERIALHAL_MAGIC LEN_H LEN_L payload).
      * Called by SerialHalDevice to send responses back to the host.
      *
-     * @param hdr     4-byte header (START1 SERIALHAL_MAGIC LEN_H LEN_L)
-     * @param hdrLen  Length of header (should be 4)
      * @param payload Encoded SerialHalResponse protobuf payload
      * @param payloadLen Length of payload
      */
-    void emitSerialHalResponse(const uint8_t *hdr, size_t hdrLen, const uint8_t *payload, size_t payloadLen);
+    void emitSerialHalResponse(const uint8_t *payload, size_t payloadLen);
 
   private:
     /**
@@ -89,6 +94,11 @@ class StreamAPI : public PhoneAPI
     int32_t readStream();
     int32_t readStream(const char *buf, uint16_t bufLen);
     int32_t handleRecStream(const char *buf, uint16_t bufLen);
+
+    /// Open or close the SerialHal receive window (fast polling + log suppression) as one unit.
+    void setSerialHalRxActive(bool active);
+    /// Drop a SerialHal frame that stopped arriving, so it cannot wedge log suppression on.
+    void expireStaleSerialHalRx();
 
     /// Emit a slice of pending output. True asks the caller to come straight back; false covers
     /// both a drained queue and backpressure, so it does not mean the queue is empty.
@@ -127,8 +137,12 @@ class StreamAPI : public PhoneAPI
     /// Let transports recover from or close after an incomplete write.
     virtual void onFrameWriteFailed(size_t frameLen, size_t writtenLen) {}
 
-    /// Fill in the 4-byte 0x94C3 length header; returns the total frame length.
-    static size_t buildFrameHeader(uint8_t *buf, size_t payloadLen);
+    /// Fill in the 4-byte framing + length header; returns the total frame length. The
+    /// discriminator is the frame's second byte and selects its type: START2 for FromRadio,
+    /// SERIALHAL_MAGIC for a SerialHal response (see mesh/SerialHalFraming.h). It has no default
+    /// so this header does not have to pull the framing constants into every translation unit -
+    /// configuration.h reaches StreamAPI.h, so that would be all of them.
+    static size_t buildFrameHeader(uint8_t *buf, size_t payloadLen, uint8_t discriminator);
 
     /// Complete retained transport output before dequeuing another PhoneAPI packet.
     virtual bool finishPendingFrame() { return true; }
@@ -136,8 +150,9 @@ class StreamAPI : public PhoneAPI
     virtual bool hasRetainedFrame() { return false; }
     /// Return whether the dedicated log buffer is available for encoding.
     virtual bool canEncodeLogRecord() { return true; }
-    /// Frame and write a payload, optionally using best-effort admission.
-    virtual bool writeFrame(uint8_t *buf, size_t len, bool bestEffort);
+    /// Frame and write a payload, optionally using best-effort admission. `buf` must have
+    /// HEADER_LEN bytes of room ahead of the payload for the header this stamps in.
+    virtual bool writeFrame(uint8_t *buf, size_t len, bool bestEffort, uint8_t discriminator);
 
     concurrency::Lock streamLock;
 

--- a/src/platform/portduino/SerialHal.cpp
+++ b/src/platform/portduino/SerialHal.cpp
@@ -1,5 +1,6 @@
 #include "platform/portduino/SerialHal.h"
 
+#include "mesh/SerialHalFraming.h"
 #include "mesh/mesh-pb-constants.h"
 #include "platform/portduino/PortduinoGlue.h"
 #include <cerrno>
@@ -15,10 +16,13 @@
 
 namespace
 {
-constexpr uint8_t START1 = 0x94;
-constexpr uint8_t SERIALHAL_MAGIC = 0xA5;
-constexpr size_t HEADER_SIZE = 4; // START1 + SERIALHAL_MAGIC + LEN_H + LEN_L
-constexpr uint8_t START2 = 0xC3;  // second byte of a normal FromRadio frame
+/// True while the calling thread is executing one of SerialHal's own worker loops.
+///
+/// A RadioLib interrupt callback runs on interruptThread and is free to call back into the HAL. If
+/// that path reaches openPort() it would call closePort() -> stopReaderThread() -> join() on the
+/// very thread doing the joining, which is undefined behaviour. Worker threads therefore decline
+/// to recycle the port and let the request fail instead.
+thread_local bool inHalWorkerThread = false;
 
 speed_t toTermiosBaud(uint32_t baud)
 {
@@ -61,15 +65,36 @@ SerialHal::~SerialHal()
 
 bool SerialHal::openPort()
 {
-    closePort();
-    fd = ::open(device.c_str(), O_RDWR | O_NOCTTY | O_SYNC);
-    if (fd < 0) {
+    if (inHalWorkerThread) {
+        // Recycling the port from here would join this very thread. Fail the request; the next
+        // call from the radio thread will reopen.
+        return false;
+    }
+    std::lock_guard<std::mutex> guard(fdMutex);
+    return openPortLocked();
+}
+
+void SerialHal::closePort()
+{
+    if (inHalWorkerThread) {
+        return;
+    }
+    std::lock_guard<std::mutex> guard(fdMutex);
+    closePortLocked();
+}
+
+bool SerialHal::openPortLocked()
+{
+    closePortLocked();
+    const int opened = ::open(device.c_str(), O_RDWR | O_NOCTTY | O_SYNC);
+    fd.store(opened);
+    if (opened < 0) {
         return false;
     }
 
     termios tty = {};
-    if (tcgetattr(fd, &tty) != 0) {
-        closePort();
+    if (tcgetattr(opened, &tty) != 0) {
+        closePortLocked();
         return false;
     }
 
@@ -87,29 +112,30 @@ bool SerialHal::openPort()
     tty.c_cflag &= ~CSTOPB;
     tty.c_cflag &= ~CRTSCTS;
 
-    if (tcsetattr(fd, TCSANOW, &tty) != 0) {
-        closePort();
+    if (tcsetattr(opened, TCSANOW, &tty) != 0) {
+        closePortLocked();
         return false;
     }
 
-    tcflush(fd, TCIOFLUSH);
+    tcflush(opened, TCIOFLUSH);
     inError = false;
     startReaderThread();
     return true;
 }
 
-void SerialHal::closePort()
+void SerialHal::closePortLocked()
 {
+    // Threads first: both worker loops read fd directly, so they must be gone before it closes.
     stopReaderThread();
-    if (fd >= 0) {
-        ::close(fd);
-        fd = -1;
+    const int current = fd.exchange(-1);
+    if (current >= 0) {
+        ::close(current);
     }
 }
 
 void SerialHal::setTransportError(const char *msg)
 {
-    if (!inError.load() || !hasWarned) {
+    if (!inError.load() || !hasWarned.load()) {
         LOG_ERROR("SerialHal: %s (%s)", msg, device.c_str());
     }
     inError = true;
@@ -119,11 +145,12 @@ void SerialHal::setTransportError(const char *msg)
 
 bool SerialHal::waitForReadable(int timeout)
 {
-    if (fd < 0) {
+    const int current = fd.load();
+    if (current < 0) {
         return false;
     }
     pollfd pfd = {};
-    pfd.fd = fd;
+    pfd.fd = current;
     pfd.events = POLLIN;
     int ret = poll(&pfd, 1, timeout);
     return ret > 0 && (pfd.revents & POLLIN);
@@ -131,9 +158,13 @@ bool SerialHal::waitForReadable(int timeout)
 
 bool SerialHal::writeAll(const uint8_t *data, size_t len)
 {
+    const int current = fd.load();
+    if (current < 0) {
+        return false;
+    }
     size_t off = 0;
     while (off < len) {
-        ssize_t rc = ::write(fd, data + off, len - off);
+        ssize_t rc = ::write(current, data + off, len - off);
         if (rc < 0) {
             if (errno == EINTR) {
                 continue;
@@ -147,6 +178,10 @@ bool SerialHal::writeAll(const uint8_t *data, size_t len)
 
 bool SerialHal::readExact(uint8_t *data, size_t len)
 {
+    const int current = fd.load();
+    if (current < 0) {
+        return false;
+    }
     size_t off = 0;
     auto start = std::chrono::steady_clock::now();
     while (off < len) {
@@ -156,7 +191,7 @@ bool SerialHal::readExact(uint8_t *data, size_t len)
         if (remaining <= 0 || !waitForReadable(remaining)) {
             return false;
         }
-        ssize_t rc = ::read(fd, data + off, len - off);
+        ssize_t rc = ::read(current, data + off, len - off);
         if (rc < 0) {
             if (errno == EINTR) {
                 continue;
@@ -171,25 +206,20 @@ bool SerialHal::readExact(uint8_t *data, size_t len)
     return true;
 }
 
-uint16_t SerialHal::crc16(const uint8_t *data, size_t len) const
+uint16_t SerialHal::nextTransactionId()
 {
-    uint16_t crc = 0xFFFF;
-    for (size_t i = 0; i < len; ++i) {
-        crc ^= ((uint16_t)data[i] << 8);
-        for (int bit = 0; bit < 8; ++bit) {
-            if (crc & 0x8000) {
-                crc = (uint16_t)((crc << 1) ^ 0x1021);
-            } else {
-                crc = (uint16_t)(crc << 1);
-            }
-        }
+    uint16_t id = txId.fetch_add(1);
+    if (id == 0) {
+        // The counter wrapped onto the value readerLoop() treats as an unsolicited interrupt
+        // event, so this request would never be matched. Take the next one instead.
+        id = txId.fetch_add(1);
     }
-    return crc;
+    return id;
 }
 
 bool SerialHal::sendRequest(const meshtastic_SerialHalCommand &cmd, meshtastic_SerialHalResponse *response)
 {
-    if (fd < 0 && !openPort()) {
+    if (fd.load() < 0 && !openPort()) {
         setTransportError("serial open failed");
         return false;
     }
@@ -204,17 +234,26 @@ bool SerialHal::sendRequest(const meshtastic_SerialHalCommand &cmd, meshtastic_S
 
     // Build frame with StreamAPI canonical framing: START1 SERIALHAL_MAGIC LEN_H LEN_L [payload]
     std::vector<uint8_t> frame;
-    frame.resize(HEADER_SIZE + payloadLen);
+    frame.resize(HEADER_LEN + payloadLen);
 
     frame[0] = START1;
     frame[1] = SERIALHAL_MAGIC;
     frame[2] = (uint8_t)((payloadLen >> 8) & 0xFF); // LEN_H (big-endian)
     frame[3] = (uint8_t)(payloadLen & 0xFF);        // LEN_L
-    memcpy(frame.data() + HEADER_SIZE, encoded, payloadLen);
+    memcpy(frame.data() + HEADER_LEN, encoded, payloadLen);
+
+    // Claim the id before the bytes go out, so a reply that comes back immediately is not
+    // mistaken by the reader for a late response to an abandoned request.
+    {
+        std::lock_guard<std::mutex> lock(stateMutex);
+        inFlight.insert(cmd.transaction_id);
+    }
 
     {
         std::lock_guard<std::mutex> writeGuard(writeMutex);
         if (!writeAll(frame.data(), frame.size())) {
+            std::lock_guard<std::mutex> lock(stateMutex);
+            inFlight.erase(cmd.transaction_id);
             setTransportError("serial write failed");
             return false;
         }
@@ -225,7 +264,14 @@ bool SerialHal::sendRequest(const meshtastic_SerialHalCommand &cmd, meshtastic_S
         std::unique_lock<std::mutex> lock(stateMutex);
         const auto timeout = std::chrono::milliseconds(timeoutMs);
         const bool arrived = responseCv.wait_for(lock, timeout, [&]() { return pendingResponses.count(cmd.transaction_id) > 0; });
+
+        inFlight.erase(cmd.transaction_id);
         if (!arrived) {
+            // Drop anything cached for this id as well: transaction ids are 16 bits and get
+            // reused, so a stale entry left here would later satisfy an unrelated caller.
+            pendingResponses.erase(cmd.transaction_id);
+            lock.unlock();
+
             setTransportError("serial response timeout");
             LOG_WARN("SerialHal: response timeout for transaction_id %u, cmd type %u", cmd.transaction_id, cmd.type);
             return false;
@@ -235,10 +281,18 @@ bool SerialHal::sendRequest(const meshtastic_SerialHalCommand &cmd, meshtastic_S
         pendingResponses.erase(cmd.transaction_id);
     }
 
-    if (got.result != meshtastic_SerialHalResponse_Result_OK) {
-        setTransportError("serial response reported error");
-        LOG_WARN("SerialHal: response error: %s, %u, %u", got.error, cmd.type, cmd.data.size);
+    // A reply arrived, so the link itself is healthy - clear any transport latch before looking at
+    // what the device actually said.
+    inError = false;
+    hasWarned = false;
 
+    if (got.result != meshtastic_SerialHalResponse_Result_OK) {
+        // An application-level refusal (bad pin, unsupported command, device not in
+        // serial_hal_only mode) says nothing about the transport. Latching inError here would be
+        // terminal: checkError() gates every public entry point and sendRequest() is the only
+        // thing that clears the latch, so one bad command would disable the HAL for the life of
+        // the process.
+        LOG_WARN("SerialHal: response error: %s, cmd type %u, response data size %u", got.error, cmd.type, got.data.size);
         return false;
     }
 
@@ -246,8 +300,6 @@ bool SerialHal::sendRequest(const meshtastic_SerialHalCommand &cmd, meshtastic_S
         *response = got;
     }
 
-    inError = false;
-    hasWarned = false;
     return true;
 }
 
@@ -258,7 +310,7 @@ void SerialHal::pinMode(uint32_t pin, uint32_t mode)
     }
 
     meshtastic_SerialHalCommand cmd = meshtastic_SerialHalCommand_init_zero;
-    cmd.transaction_id = txId.fetch_add(1);
+    cmd.transaction_id = nextTransactionId();
     cmd.type = meshtastic_SerialHalCommand_Type_PIN_MODE;
     cmd.pin = pin;
     cmd.mode = mode;
@@ -274,7 +326,7 @@ void SerialHal::digitalWrite(uint32_t pin, uint32_t value)
     }
 
     meshtastic_SerialHalCommand cmd = meshtastic_SerialHalCommand_init_zero;
-    cmd.transaction_id = txId.fetch_add(1);
+    cmd.transaction_id = nextTransactionId();
     cmd.type = meshtastic_SerialHalCommand_Type_DIGITAL_WRITE;
     cmd.pin = pin;
     cmd.value = value;
@@ -290,7 +342,7 @@ uint32_t SerialHal::digitalRead(uint32_t pin)
     }
 
     meshtastic_SerialHalCommand cmd = meshtastic_SerialHalCommand_init_zero;
-    cmd.transaction_id = txId.fetch_add(1);
+    cmd.transaction_id = nextTransactionId();
     cmd.type = meshtastic_SerialHalCommand_Type_DIGITAL_READ;
     cmd.pin = pin;
 
@@ -313,7 +365,7 @@ void SerialHal::attachInterrupt(uint32_t interruptNum, void (*interruptCb)(void)
     }
 
     meshtastic_SerialHalCommand cmd = meshtastic_SerialHalCommand_init_zero;
-    cmd.transaction_id = txId.fetch_add(1);
+    cmd.transaction_id = nextTransactionId();
     cmd.type = meshtastic_SerialHalCommand_Type_ATTACH_INTERRUPT;
     cmd.pin = interruptNum;
     cmd.mode = mode;
@@ -334,7 +386,7 @@ void SerialHal::detachInterrupt(uint32_t interruptNum)
     }
 
     meshtastic_SerialHalCommand cmd = meshtastic_SerialHalCommand_init_zero;
-    cmd.transaction_id = txId.fetch_add(1);
+    cmd.transaction_id = nextTransactionId();
     cmd.type = meshtastic_SerialHalCommand_Type_DETACH_INTERRUPT;
     cmd.pin = interruptNum;
 
@@ -395,16 +447,26 @@ void SerialHal::spiTransfer(uint8_t *out, size_t len, uint8_t *in)
     }
 
     meshtastic_SerialHalCommand cmd = meshtastic_SerialHalCommand_init_zero;
-    cmd.transaction_id = txId.fetch_add(1);
+    cmd.transaction_id = nextTransactionId();
     cmd.type = meshtastic_SerialHalCommand_Type_SPI_TRANSFER;
 
     const size_t maxTx = sizeof(cmd.data.bytes);
-    const size_t txLen = len < maxTx ? len : maxTx;
-    cmd.data.size = txLen;
+    if (len > maxTx) {
+        // Quietly sending a short transfer would leave the radio's registers in a state neither
+        // side can reason about. RadioLib stays well inside a LoRa payload today, so this is a
+        // guard against a future caller rather than a limit we expect to reach.
+        LOG_ERROR("SerialHal: SPI transfer of %u bytes exceeds the %u byte frame payload limit", (unsigned)len, (unsigned)maxTx);
+        if (in != nullptr) {
+            memset(in, 0, len);
+        }
+        return;
+    }
+
+    cmd.data.size = len;
     if (out != nullptr) {
-        memcpy(cmd.data.bytes, out, txLen);
+        memcpy(cmd.data.bytes, out, len);
     } else {
-        memset(cmd.data.bytes, 0, txLen);
+        memset(cmd.data.bytes, 0, len);
     }
 
     meshtastic_SerialHalResponse response = meshtastic_SerialHalResponse_init_zero;
@@ -424,9 +486,8 @@ void SerialHal::spiTransfer(uint8_t *out, size_t len, uint8_t *in)
 bool SerialHal::checkError()
 {
     if (inError.load()) {
-        if (!hasWarned) {
+        if (!hasWarned.exchange(true)) {
             LOG_ERROR("SerialHal in_error detected");
-            hasWarned = true;
         }
         portduino_status.LoRa_in_error = true;
         return true;
@@ -435,18 +496,23 @@ bool SerialHal::checkError()
     return false;
 }
 
-bool SerialHal::readFrame(std::vector<uint8_t> &payload, int firstByteTimeoutMs)
+bool SerialHal::readFrame(std::vector<uint8_t> &payload)
 {
     payload.clear();
+
+    const int current = fd.load();
+    if (current < 0) {
+        return false;
+    }
 
     // Loop so that normal FromRadio frames (START1 START2 ...) emitted by the
     // device on the same serial port are drained and discarded rather than
     // causing the byte stream to desync.
     for (;;) {
-        uint8_t hdr[HEADER_SIZE] = {0};
+        uint8_t hdr[HEADER_LEN] = {0};
         for (;;) {
 
-            ssize_t rc = ::read(fd, &hdr[0], 1);
+            ssize_t rc = ::read(current, &hdr[0], 1);
             if (rc < 0) {
                 if (errno == EINTR) {
                     continue;
@@ -461,7 +527,7 @@ bool SerialHal::readFrame(std::vector<uint8_t> &payload, int firstByteTimeoutMs)
             }
         }
 
-        if (!readExact(hdr + 1, HEADER_SIZE - 1)) {
+        if (!readExact(hdr + 1, HEADER_LEN - 1)) {
             return false;
         }
 
@@ -497,9 +563,10 @@ bool SerialHal::readFrame(std::vector<uint8_t> &payload, int firstByteTimeoutMs)
 
 void SerialHal::readerLoop()
 {
+    inHalWorkerThread = true;
     readerRunning = true;
     while (!readerStopRequested.load()) {
-        if (fd < 0) {
+        if (fd.load() < 0) {
             break;
         }
 
@@ -508,7 +575,7 @@ void SerialHal::readerLoop()
         }
 
         std::vector<uint8_t> payload;
-        if (!readFrame(payload, 40)) {
+        if (!readFrame(payload)) {
             continue;
         }
 
@@ -534,6 +601,13 @@ void SerialHal::readerLoop()
 
         {
             std::lock_guard<std::mutex> lock(stateMutex);
+            if (inFlight.count(resp.transaction_id) == 0) {
+                // Nobody is waiting on this id - it is a reply to a request that already timed
+                // out. Caching it would grow the map without bound and, once the 16-bit id wraps,
+                // hand stale data to a future caller.
+                LOG_DEBUG("SerialHal: dropping unmatched response for transaction_id %u", resp.transaction_id);
+                continue;
+            }
             pendingResponses[resp.transaction_id] = resp;
         }
         responseCv.notify_all();
@@ -543,6 +617,7 @@ void SerialHal::readerLoop()
 
 void SerialHal::interruptDispatchLoop()
 {
+    inHalWorkerThread = true;
     interruptDispatcherRunning = true;
     while (!readerStopRequested.load()) {
         uint32_t pin = 0;

--- a/src/platform/portduino/SerialHal.h
+++ b/src/platform/portduino/SerialHal.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #define SERIAL_PI_INPUT (0)
@@ -57,27 +58,34 @@ class SerialHal : public RadioLibHal
   private:
     bool openPort();
     void closePort();
+    bool openPortLocked();
+    void closePortLocked();
     bool sendRequest(const meshtastic_SerialHalCommand &cmd, meshtastic_SerialHalResponse *response);
     bool writeAll(const uint8_t *data, size_t len);
     bool readExact(uint8_t *data, size_t len);
     bool waitForReadable(int timeoutMs);
-    bool readFrame(std::vector<uint8_t> &payload, int firstByteTimeoutMs);
+    bool readFrame(std::vector<uint8_t> &payload);
     void readerLoop();
     void interruptDispatchLoop();
     void startReaderThread();
     void stopReaderThread();
 
-    uint16_t crc16(const uint8_t *data, size_t len) const;
+    /// Hand out the next request id, stepping over 0 (reserved for unsolicited interrupt events).
+    uint16_t nextTransactionId();
     void setTransportError(const char *msg);
 
     std::string device;
     uint32_t baud;
     uint32_t timeoutMs;
-    int fd = -1;
-    bool hasWarned = false;
+    /// Atomic because the reader thread polls it while the radio thread can be opening or closing
+    /// the port. The lifecycle transitions themselves are serialized by fdMutex.
+    std::atomic<int> fd{-1};
+    std::atomic<bool> hasWarned{false};
     std::atomic<bool> inError{false};
     std::atomic<uint16_t> txId{1};
 
+    /// Serializes openPort()/closePort() so two callers cannot tear down the port at once. The
+    /// worker threads never take it, so stopReaderThread() can join while holding it.
     std::mutex fdMutex;
     std::mutex writeMutex;
     std::mutex stateMutex;
@@ -94,6 +102,10 @@ class SerialHal : public RadioLibHal
 
     std::unordered_map<uint32_t, void (*)(void)> interruptCallbacks;
     std::unordered_map<uint16_t, meshtastic_SerialHalResponse> pendingResponses;
+    /// Request ids a caller is currently blocked on. The reader drops anything not listed here, so
+    /// a reply that arrives after its caller gave up cannot be handed to a later request once the
+    /// 16-bit id wraps around.
+    std::unordered_set<uint16_t> inFlight;
 };
 
 #endif


### PR DESCRIPTION
Targets `serialHal` (#10351), not `develop`. Each CodeRabbit finding on that PR was checked against the branch head (`72aaeca`); this implements the eight that held up and explains the one that did not.

## Findings addressed

**The critical one — application errors permanently disabled the HAL.** `SerialHal::sendRequest()` called `setTransportError()` for any non-OK device result, latching `inError`. Since `checkError()` gates all six public entry points and `sendRequest()` is the only thing that clears the latch, no later call could ever reach the code that would recover it. One refusal disabled the radio for the life of the process, indistinguishable from a dead link. It is reachable on the *first* command: a device without `config.lora.serial_hal_only` replies `UNSUPPORTED` to everything. Application-level results are now reported without poisoning the transport, and a reply arriving at all clears the latch, since it proves the link works.

**Stale responses and transaction-id reuse.** A timed-out request left its entry in `pendingResponses` forever. `txId` is 16-bit, so after wrapping, that stale entry would satisfy an unrelated caller. In-flight ids are now tracked, the reader drops replies nobody is waiting for, the timeout path erases its own entry, and id allocation steps over `0` — which `readerLoop()` reserves for unsolicited interrupt events, so a wrapped request would otherwise have always timed out.

**Port state was unsynchronised.** `fd` and `hasWarned` are now atomic and the declared-but-unused `fdMutex` serializes `openPort()`/`closePort()`. Related, and worse than the review described: a HAL callback dispatched from `interruptThread` reaching `openPort()` would run `closePort()` → `stopReaderThread()` → `join()` on the calling thread. The worker loops now decline to recycle the port.

**`emitSerialHalResponse()` bypassed `writeFrame()`.** It ignored `canWrite`, never checked how many bytes were written, and on USB CDC consoles wrote straight past the retained-frame machinery it can interleave bytes into. CodeRabbit's suggested patch cannot be applied as written — `buildFrameHeader()` unconditionally stamps `START2` over byte 1, so routing through `writeFrame()` would overwrite the `0xA5` magic and the host would drain the response as a FromRadio frame and discard it. Instead `buildFrameHeader()`/`writeFrame()` now take the discriminator byte, which lets the SerialHal path reuse them intact.

That gate then exposed a second problem: `SerialConsole` starts with `canWrite = false` and only flips it in `handleToRadio()`. A SerialHal host drives the radio without ever sending a ToRadio frame, so the gate would have swallowed every response. `SerialConsole` now treats a SerialHal command frame as the same proof of a smart host.

**Global log suppression.** `RedirectablePrint::log()` returned ahead of all level filtering and every destination, so an in-flight frame silenced `LOG_ERROR` from every subsystem. It was armed on a frame's second byte and disarmed only on its last, so a host stalling mid-frame wedged it indefinitely, and the bogus-length reset path never cleared it. Errors now pass through, that reset path closes the window, and a stalled frame expires after `SERIALHAL_RX_TIMEOUT_MSEC`. Protobuf log frames are still held back by the existing `serialHalRxActive` check in `emitLogRecord()`, so letting errors through puts nothing new on the wire mid-transaction.

**Smaller items.** Oversized SPI transfers are rejected rather than silently truncated and zero-filled (not reachable today — RadioLib stays well inside the 512-byte field — so this is a guard). The unused `crc16()` is deleted. `InterruptSlot::pending` is `std::atomic<bool>` rather than `volatile`. The framing bytes move from three copies into `src/mesh/SerialHalFraming.h`.

## Finding not applied

`#if !ARCH_PORTDUINO` (`SerialHalDevice.cpp:320`) is fine. CodeRabbit assumed a bare `-DARCH_PORTDUINO`, but `src/platform/portduino/architecture.h:3` defines it as `1`, and `#if ARCH_PORTDUINO` / `#if !ARCH_PORTDUINO` is already used in `TelemetrySensor.h`, `RedirectablePrint.cpp` and `Modules.cpp`. Its own probe only failed on the `empty_define` case, which does not occur here.

## Not addressed

Out of scope for a review-response PR, but worth knowing about:

- `interruptStreamApi` (`SerialHalDevice.cpp`) caches a raw `StreamAPI*` with no invalidation on destruction.
- `isr0`..`isr7` are not `IRAM_ATTR`, which is a risk on ESP32 during flash operations.
- `readStream()` and `handleRecStream()` carry two copies of the same framing state machine; both were extended by #10351 and both had to be edited in step here.

## Testing

Verification here was limited by the sandbox: this environment's network policy blocks the PlatformIO registry and GitHub archive downloads, so a full `pio run -e native` link could not complete. I mirrored the platform, framework and 88 library dependencies over git to get a working toolchain, then compiled with the real build's flags:

- All five changed translation units pass `-fsyntax-only` under the native env's exact flags.
- Swept all 24 TUs referencing `StreamAPI`/`PhoneAPI`/`writeFrame`/`RedirectablePrint`/`SerialHal`, before and after the change. Identical results — the 8 that fail are pre-existing and fail on unmirrored platform SDKs (nimble, nrf52, wasm), not on this diff.
- Checked that `START1`/`START2`/`HEADER_LEN` do not collide anywhere in `src/`, the installed libdeps or the framework. To keep that safe on the platforms I could not compile, the new header is not included from `StreamAPI.h` — the discriminator parameters deliberately have no default so the constants stay out of every TU that `configuration.h` reaches.
- `trunk`'s clang-format config applied; `--dry-run -Werror` is clean.

**No hardware testing.** The behavioural changes need it, particularly: a device *without* `serial_hal_only` set (finding 1's repro — the HAL should now keep working after the first `UNSUPPORTED` instead of latching off), response delivery on a USB CDC board via the retained-frame path, and that errors reaching the console mid-transaction do not disturb framing.

---
_Generated by [Claude Code](https://claude.ai/code/session_0157ZWRSq9ng5wzBZodg6pkb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added framed SerialHAL communication for supported serial connections.
  * Added automatic handling of SerialHAL commands and responses.
  * Added timeout handling for incomplete serial messages.

* **Bug Fixes**
  * Improved reliability when serial connections restart or encounter stale responses.
  * Prevented oversized SPI payloads from being silently truncated.
  * Reduced unnecessary logging while serial-HAL suppression is active.
  * Improved synchronization for serial interrupts and background processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->