### PR TITLE
feat(lora): state a pinned userPrefs preset as the unset region's intent

### DIFF
--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -746,18 +746,8 @@ void getRegionPresetMap(meshtastic_LoRaRegionPresetMap &map)
     }
 
 #ifdef USERPREFS_LORACONFIG_MODEM_PRESET
-    // A vendor build pins a preset in installDefaultConfig() and ships with the region still
-    // UNSET, so its nodes reach the user in a state stock firmware never produces: a preset
-    // that is deliberate rather than the LONG_FAST placeholder a default install leaves
-    // behind. Nothing on the wire told the two apart, so clients treated every unset-region
-    // node as factory-fresh and overwrote the preset the moment a region was picked.
-    //
-    // Advertising the pinned preset as UNSET's sole entry is that missing statement of
-    // intent. It is NOT enforcement: supportsPreset() accepts any known preset while the
-    // region is unset, and the radio is held silent either way, so the device will still
-    // honour whatever the user or an admin sets. A stock build emits no UNSET entry at all,
-    // which every client already reads as "unconstrained" - so this is inert unless a build
-    // actually pins a preset.
+    // A pinned preset is a statement of intent, not enforcement: supportsPreset() still accepts any
+    // known preset while unset. Stock builds emit no UNSET entry, which clients read as unconstrained.
     if (map.groups_count < maxGroups && map.region_groups_count < maxRegions) {
         const RegionInfo *unset = getRegion(meshtastic_Config_LoRaConfig_RegionCode_UNSET);
         meshtastic_LoRaPresetGroup &grp = map.groups[map.groups_count];
@@ -770,8 +760,7 @@ void getRegionPresetMap(meshtastic_LoRaRegionPresetMap &map)
         rg.region = unset->code;
         rg.group_index = (uint8_t)map.groups_count++;
     } else {
-        // Losing this entry only costs the intent signal - clients fall back to treating
-        // UNSET as unconstrained - but it must not be silent.
+        // Costs only the intent signal - clients fall back to unconstrained - but must not be silent.
         LOG_ERROR("Region preset map full; UNSET intent omitted");
     }
 #endif

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -744,6 +744,37 @@ void getRegionPresetMap(meshtastic_LoRaRegionPresetMap &map)
         rg.region = r->code;
         rg.group_index = (uint8_t)gi;
     }
+
+#ifdef USERPREFS_LORACONFIG_MODEM_PRESET
+    // A vendor build pins a preset in installDefaultConfig() and ships with the region still
+    // UNSET, so its nodes reach the user in a state stock firmware never produces: a preset
+    // that is deliberate rather than the LONG_FAST placeholder a default install leaves
+    // behind. Nothing on the wire told the two apart, so clients treated every unset-region
+    // node as factory-fresh and overwrote the preset the moment a region was picked.
+    //
+    // Advertising the pinned preset as UNSET's sole entry is that missing statement of
+    // intent. It is NOT enforcement: supportsPreset() accepts any known preset while the
+    // region is unset, and the radio is held silent either way, so the device will still
+    // honour whatever the user or an admin sets. A stock build emits no UNSET entry at all,
+    // which every client already reads as "unconstrained" - so this is inert unless a build
+    // actually pins a preset.
+    if (map.groups_count < maxGroups && map.region_groups_count < maxRegions) {
+        const RegionInfo *unset = getRegion(meshtastic_Config_LoRaConfig_RegionCode_UNSET);
+        meshtastic_LoRaPresetGroup &grp = map.groups[map.groups_count];
+        grp.presets_count = 1;
+        grp.presets[0] = USERPREFS_LORACONFIG_MODEM_PRESET;
+        grp.default_preset = USERPREFS_LORACONFIG_MODEM_PRESET;
+        grp.licensed_only = unset->profile->licensedOnly;
+
+        meshtastic_LoRaRegionPresets &rg = map.region_groups[map.region_groups_count++];
+        rg.region = unset->code;
+        rg.group_index = (uint8_t)map.groups_count++;
+    } else {
+        // Losing this entry only costs the intent signal - clients fall back to treating
+        // UNSET as unconstrained - but it must not be silent.
+        LOG_ERROR("Region preset map full; UNSET intent omitted");
+    }
+#endif
 }
 
 /**

--- a/test/test_radio/test_main.cpp
+++ b/test/test_radio/test_main.cpp
@@ -292,9 +292,7 @@ static size_t countKnownRegions()
 
 // Every region in the firmware table (except the UNSET sentinel) must appear
 // exactly once in the map, and all counts must stay within the mesh.options bounds
-// (exceeding them would mean nanopb silently truncates the wire message). A build that
-// pins a preset in userPrefs adds one more entry for UNSET - see
-// test_regionPresetMap_unsetCarriesUserprefsIntent.
+// (exceeding them would mean nanopb silently truncates the wire message).
 static void test_regionPresetMap_coversAllRegionsWithinBounds()
 {
     meshtastic_LoRaRegionPresetMap map;
@@ -341,9 +339,7 @@ static void test_regionPresetMap_matchesRegionTable()
         const RegionInfo *r = getRegion(code);
 
 #ifdef USERPREFS_LORACONFIG_MODEM_PRESET
-        // UNSET's entry states the build's pinned preset rather than mirroring PROFILE_UNDEF,
-        // so the table comparisons below do not apply to it. Covered instead by
-        // test_regionPresetMap_unsetCarriesUserprefsIntent.
+        // UNSET states the pinned preset, not PROFILE_UNDEF's list, so the table checks below don't apply.
         if (code == meshtastic_Config_LoRaConfig_RegionCode_UNSET)
             continue;
 #endif
@@ -387,10 +383,8 @@ static void test_regionPresetMap_matchesRegionTable()
     }
 }
 
-// UNSET is in the map only when the build pins a preset in userPrefs, and then it states
-// exactly that preset - a statement of intent a client can distinguish from the LONG_FAST
-// placeholder a stock install leaves behind. A stock build leaves UNSET out entirely, which
-// clients read as "unconstrained".
+// UNSET appears only when the build pins a preset, and then states exactly that preset.
+// A stock build leaves it out entirely, which clients read as "unconstrained".
 static void test_regionPresetMap_unsetCarriesUserprefsIntent()
 {
     meshtastic_LoRaRegionPresetMap map;

--- a/test/test_radio/test_main.cpp
+++ b/test/test_radio/test_main.cpp
@@ -292,13 +292,19 @@ static size_t countKnownRegions()
 
 // Every region in the firmware table (except the UNSET sentinel) must appear
 // exactly once in the map, and all counts must stay within the mesh.options bounds
-// (exceeding them would mean nanopb silently truncates the wire message).
+// (exceeding them would mean nanopb silently truncates the wire message). A build that
+// pins a preset in userPrefs adds one more entry for UNSET - see
+// test_regionPresetMap_unsetCarriesUserprefsIntent.
 static void test_regionPresetMap_coversAllRegionsWithinBounds()
 {
     meshtastic_LoRaRegionPresetMap map;
     getRegionPresetMap(map);
 
+#ifdef USERPREFS_LORACONFIG_MODEM_PRESET
+    const size_t known = countKnownRegions() + 1; // + the UNSET intent entry
+#else
     const size_t known = countKnownRegions();
+#endif
     TEST_ASSERT_EQUAL_UINT((unsigned)known, (unsigned)map.region_groups_count);
 
     // Bounds derived from the generated nanopb arrays (mesh.options max_count), so
@@ -333,6 +339,14 @@ static void test_regionPresetMap_matchesRegionTable()
 
         const meshtastic_LoRaPresetGroup &grp = map.groups[gi];
         const RegionInfo *r = getRegion(code);
+
+#ifdef USERPREFS_LORACONFIG_MODEM_PRESET
+        // UNSET's entry states the build's pinned preset rather than mirroring PROFILE_UNDEF,
+        // so the table comparisons below do not apply to it. Covered instead by
+        // test_regionPresetMap_unsetCarriesUserprefsIntent.
+        if (code == meshtastic_Config_LoRaConfig_RegionCode_UNSET)
+            continue;
+#endif
 
         // Group's list is non-empty and within the generated array bound.
         const size_t maxPresets = sizeof(grp.presets) / sizeof(grp.presets[0]);
@@ -371,6 +385,38 @@ static void test_regionPresetMap_matchesRegionTable()
         // Licensed flag matches the region's profile.
         TEST_ASSERT_EQUAL(r->profile->licensedOnly, grp.licensed_only);
     }
+}
+
+// UNSET is in the map only when the build pins a preset in userPrefs, and then it states
+// exactly that preset - a statement of intent a client can distinguish from the LONG_FAST
+// placeholder a stock install leaves behind. A stock build leaves UNSET out entirely, which
+// clients read as "unconstrained".
+static void test_regionPresetMap_unsetCarriesUserprefsIntent()
+{
+    meshtastic_LoRaRegionPresetMap map;
+    getRegionPresetMap(map);
+
+    const meshtastic_LoRaPresetGroup *grp = nullptr;
+    for (pb_size_t i = 0; i < map.region_groups_count; i++)
+        if (map.region_groups[i].region == meshtastic_Config_LoRaConfig_RegionCode_UNSET)
+            grp = &map.groups[map.region_groups[i].group_index];
+
+#ifdef USERPREFS_LORACONFIG_MODEM_PRESET
+    const meshtastic_Config_LoRaConfig_ModemPreset pinned = USERPREFS_LORACONFIG_MODEM_PRESET;
+    TEST_ASSERT_NOT_NULL_MESSAGE(grp, "a build that pins a preset must state it for UNSET");
+    TEST_ASSERT_EQUAL_UINT_MESSAGE(1, (unsigned)grp->presets_count, "the pinned preset is the sole entry");
+    TEST_ASSERT_EQUAL(pinned, grp->presets[0]);
+    TEST_ASSERT_EQUAL(pinned, grp->default_preset);
+    TEST_ASSERT_FALSE_MESSAGE(grp->licensed_only, "UNSET is not a licensed-only region");
+
+    // Stating intent must not narrow what the device accepts: the firmware still takes any
+    // real preset while the region is unset (#11496), so the map cannot become enforcement.
+    const RegionInfo *unset = getRegion(meshtastic_Config_LoRaConfig_RegionCode_UNSET);
+    TEST_ASSERT_TRUE(unset->supportsPreset(meshtastic_Config_LoRaConfig_ModemPreset_LONG_FAST));
+    TEST_ASSERT_TRUE(unset->supportsPreset(meshtastic_Config_LoRaConfig_ModemPreset_SHORT_TURBO));
+#else
+    TEST_ASSERT_NULL_MESSAGE(grp, "a stock build must leave UNSET out of the map entirely");
+#endif
 }
 
 void setUp(void)
@@ -422,6 +468,7 @@ void setup()
     RUN_TEST(test_clampConfigLora_mediumTurboValidForUS);
     RUN_TEST(test_regionPresetMap_coversAllRegionsWithinBounds);
     RUN_TEST(test_regionPresetMap_matchesRegionTable);
+    RUN_TEST(test_regionPresetMap_unsetCarriesUserprefsIntent);
     exit(UNITY_END());
 }
 


### PR DESCRIPTION
Fixes #11506.

A vendor/community build can pin a modem preset with `USERPREFS_LORACONFIG_MODEM_PRESET` while leaving `USERPREFS_CONFIG_LORA_REGION` unset, so the user still picks their own region. Both `NodeDB::installDefaultConfig()` and `Channels::initDefaultLoraConfig()` apply the pin, so a fresh flash comes up as **region `UNSET` + the pinned preset**.

A stock install comes up as **region `UNSET` + the `LONG_FAST` placeholder**, and nothing in `FromRadio` separated the two. Clients therefore treat every unset-region node as factory-fresh and replace its preset with the region default the moment the user picks a region — so a mesh pinned to `SHORT_TURBO` loses each new node to `LONG_FAST` or `LONG_TURBO`, silently. Filed against the clients as meshtastic/Meshtastic-Android#6704 and meshtastic/Meshtastic-Apple#2273; neither can fix it without a signal from us.

## Change

`getRegionPresetMap()` emits an `UNSET` entry when, and only when, the build pins a preset, stating that preset as both the group's sole entry and its `default_preset`.

| Build | `UNSET` in `region_groups` | Client reads |
| --- | --- | --- |
| Stock | absent | unconstrained, preset is a placeholder |
| Pinned | present, single preset | the build intends this preset |

Stock builds are unchanged on the wire, so this is inert unless a build actually pins a preset.

**Intent, not enforcement.** Since #11496 `supportsPreset()` accepts any known preset while the region is unset, and the radio is held silent either way, so the device still honours whatever the user or an admin sets. The map does not narrow that, and the test asserts it.

Costs one group slot and one region slot on pinned builds only (6→7 of `max_count:8`, 34→35 of 38). Exhaustion is logged and degrades to the existing unconstrained behaviour.

## Testing

`./bin/run-tests.sh -e native -f test_radio` — 22/22 green in **both** build shapes, since the `#ifdef` means one run only covers one of them:

- **Stock** — `test_regionPresetMap_unsetCarriesUserprefsIntent` asserts `UNSET` is absent from the map entirely.
- **Pinned** — with `USERPREFS_LORACONFIG_MODEM_PRESET` set to `SHORT_TURBO` in `userPrefs.jsonc` and a full rebuild: asserts the single-preset `UNSET` group, its default, and that `supportsPreset()` still accepts other real presets while unset.

`test_regionPresetMap_coversAllRegionsWithinBounds` and `_matchesRegionTable` are updated for the extra entry on pinned builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for builds with a pinned modem preset, exposing it through the `UNSET` region option.
  * The pinned preset is used as both the default and only available choice.

* **Bug Fixes**
  * Improved handling when the region preset map reaches capacity, preventing invalid entries from being advertised.

* **Tests**
  * Added coverage confirming pinned-preset behavior and ensuring standard builds continue to omit the `UNSET` option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->