### PR TITLE
fix(power): let a configured INA outrank the board's charge-status pin

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -594,13 +594,8 @@ class AnalogBatteryLevel : public HasBatteryLevel
             return (rak9154Sensor.isCharging()) ? OptTrue : OptFalse;
         }
 #endif
-#if defined(ELECROW_ThinkNode_M6)
-        return digitalRead(EXT_CHRG_DETECT) == EXT_CHRG_DETECT_VALUE || isVbusIn();
-#elif defined(EXT_CHRG_DETECT)
-        return digitalRead(EXT_CHRG_DETECT) == EXT_CHRG_DETECT_VALUE;
-#elif defined(BATTERY_CHARGING_INV)
-        return !digitalRead(BATTERY_CHARGING_INV);
-#else
+        // A configured INA outranks the board's own charge-status pin, as it does BATTERY_PIN in
+        // getBattVoltage(): an external charger leaves that pin idle, reading "not charging" forever.
 #if HAS_TELEMETRY && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR && !defined(DISABLE_INA_CHARGING_DETECTION)
         if (hasINA()) {
             // get current flow from INA sensor - negative value means power flowing
@@ -613,6 +608,16 @@ class AnalogBatteryLevel : public HasBatteryLevel
             return getINACurrent() < 0;
 #endif
         }
+#endif
+#if defined(ELECROW_ThinkNode_M6)
+        return digitalRead(EXT_CHRG_DETECT) == EXT_CHRG_DETECT_VALUE || isVbusIn();
+#elif defined(EXT_CHRG_DETECT)
+        return digitalRead(EXT_CHRG_DETECT) == EXT_CHRG_DETECT_VALUE;
+#elif defined(BATTERY_CHARGING_INV)
+        return !digitalRead(BATTERY_CHARGING_INV);
+#else
+#if HAS_TELEMETRY && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR && !defined(DISABLE_INA_CHARGING_DETECTION)
+        // No charge-status pin and no INA: infer from battery presence plus external power.
         return isBatteryConnect() && isVbusIn();
 #endif
 #endif

--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -684,6 +684,9 @@ class AnalogBatteryLevel : public HasBatteryLevel
         } else if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_INA226].first ==
                    config.power.device_battery_ina_address) {
             return ina226Sensor.getCurrentMa();
+        } else if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_INA260].first ==
+                   config.power.device_battery_ina_address) {
+            return ina260Sensor.getCurrentMa();
         } else if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_INA3221].first ==
                    config.power.device_battery_ina_address) {
             return ina3221Sensor.getCurrentMa();

--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -691,30 +691,29 @@ class AnalogBatteryLevel : public HasBatteryLevel
         return 0;
     }
 
+    // Open the sensor if it isn't open yet, then report whether it is actually running. runOnce()
+    // answers with a poll interval, so only isRunning() tells us the device replied.
+    static bool sensorReady(TelemetrySensor &sensor)
+    {
+        if (!sensor.isInitialized())
+            sensor.runOnce();
+        return sensor.isRunning();
+    }
+
     bool hasINA()
     {
-        if (!config.power.device_battery_ina_address) {
+        const uint8_t inaAddress = config.power.device_battery_ina_address;
+        if (!inaAddress) {
             return false;
         }
-        if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_INA219].first == config.power.device_battery_ina_address) {
-            if (!ina219Sensor.isInitialized())
-                return ina219Sensor.runOnce() > 0;
-            return ina219Sensor.isRunning();
-        } else if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_INA226].first ==
-                   config.power.device_battery_ina_address) {
-            if (!ina226Sensor.isInitialized())
-                return ina226Sensor.runOnce() > 0;
-            return ina226Sensor.isRunning();
-        } else if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_INA260].first ==
-                   config.power.device_battery_ina_address) {
-            if (!ina260Sensor.isInitialized())
-                return ina260Sensor.runOnce() > 0;
-            return ina260Sensor.isRunning();
-        } else if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_INA3221].first ==
-                   config.power.device_battery_ina_address) {
-            if (!ina3221Sensor.isInitialized())
-                return ina3221Sensor.runOnce() > 0;
-            return ina3221Sensor.isRunning();
+        if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_INA219].first == inaAddress) {
+            return sensorReady(ina219Sensor);
+        } else if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_INA226].first == inaAddress) {
+            return sensorReady(ina226Sensor);
+        } else if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_INA260].first == inaAddress) {
+            return sensorReady(ina260Sensor);
+        } else if (nodeTelemetrySensorsMap[meshtastic_TelemetrySensorType_INA3221].first == inaAddress) {
+            return sensorReady(ina3221Sensor);
         }
         return false;
     }

--- a/src/modules/Telemetry/Sensor/INA260Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/INA260Sensor.cpp
@@ -40,4 +40,9 @@ uint16_t INA260Sensor::getBusVoltageMv()
     return lround(ina260.readBusVoltage());
 }
 
+int16_t INA260Sensor::getCurrentMa()
+{
+    return lround(ina260.readCurrent());
+}
+
 #endif

--- a/src/modules/Telemetry/Sensor/INA260Sensor.h
+++ b/src/modules/Telemetry/Sensor/INA260Sensor.h
@@ -3,11 +3,12 @@
 #if HAS_TELEMETRY && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR && __has_include(<Adafruit_INA260.h>)
 
 #include "../mesh/generated/meshtastic/telemetry.pb.h"
+#include "CurrentSensor.h"
 #include "TelemetrySensor.h"
 #include "VoltageSensor.h"
 #include <Adafruit_INA260.h>
 
-class INA260Sensor : public TelemetrySensor, VoltageSensor
+class INA260Sensor : public TelemetrySensor, VoltageSensor, CurrentSensor
 {
   private:
     Adafruit_INA260 ina260 = Adafruit_INA260();
@@ -20,6 +21,7 @@ class INA260Sensor : public TelemetrySensor, VoltageSensor
     virtual int32_t runOnce() override;
     virtual bool getMetrics(meshtastic_Telemetry *measurement) override;
     virtual uint16_t getBusVoltageMv() override;
+    virtual int16_t getCurrentMa() override;
 };
 
 #endif


### PR DESCRIPTION
`AnalogBatteryLevel::isCharging()` picked its source with a preprocessor chain that put `EXT_CHRG_DETECT` / `BATTERY_CHARGING_INV` ahead of the INA current check, so on any board defining a charge-status pin the INA arm was compiled out entirely and `device_battery_ina_address` changed the reported voltage but never the charging state. The Xiao nRF52840 Kit started hitting this when #6930 gave the variant the onboard BQ25101 `~CHG` pin in 2.6.11: charge through an external charger and that pin sits idle, so the node reads "not charging" forever and the UI never shows the charging icon. This moves the INA check ahead of the pin arms, keeping the SGM41562 and RAK9154 checks first since those report real charger state; `hasINA()` is false unless a non-zero `device_battery_ina_address` matches a detected INA, so stock boards are unaffected and `DISABLE_INA_CHARGING_DETECTION` remains the per-board opt-out. The second commit stops `hasINA()` reading `runOnce()`'s poll interval as a success flag, which let a detected-but-unusable INA report as present.

Fixes #11485

Clod helped sort this one out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added current monitoring through the INA260 sensor, including milliamp readings.
  * Added support for T-Watch Ultra power-rail measurement and charging-LED configuration.
* **Bug Fixes**
  * Improved charging-status detection by prioritizing INA260 current readings, with GPIO, battery, and USB fallbacks.
  * Improved sensor readiness checks for more consistent charging information.
  * Prevented power-button event handling when the input system is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->