### PR TITLE
feat(nodedb): ratchet satellite caps down under megamesh pressure

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -100,7 +100,7 @@ int MeshService::handleFromRadio(const meshtastic_MeshPacket *mp)
         //  ignore our request for its NodeInfo
     } else if (mp->which_payload_variant == meshtastic_MeshPacket_decoded_tag &&
                !nodeInfoLiteHasUser(nodeDB->getMeshNode(mp->from)) && nodeInfoModule && !isPreferredRebroadcaster &&
-               !nodeDB->isFull()) {
+               !nodeDB->isPassiveFillOnly()) {
         if (airTime->isTxAllowedChannelUtil(true)) {
             const int8_t hopsUsed = getHopsAway(*mp, config.lora.hop_limit);
             if (hopsUsed > (int32_t)(config.lora.hop_limit + 2)) {

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -28,6 +28,7 @@
 #include "mesh/generated/meshtastic/deviceonly_legacy.pb.h"
 #include "meshUtils.h"
 #include "modules/NeighborInfoModule.h"
+#include "modules/NodeDBScalingModule.h"
 #include "target_specific.h"
 #if HAS_VARIABLE_HOPS
 #include "modules/HopScalingModule.h"
@@ -728,12 +729,12 @@ template <typename Map> bool evictStalestSatellite(NodeDB &db, Map &map)
     return true;
 }
 
-// Keep `map` within MAX_SATELLITE_NODES ahead of inserting `incoming` (the
-// tier-1/tier-2 split: only the freshest MAX_SATELLITE_NODES nodes carry
-// satellite payloads). Caller holds satelliteMutex.
-template <typename Map> void evictSatelliteOverCap(NodeDB &db, Map &map, NodeNum incoming)
+// Keep `map` within `cap` ahead of inserting `incoming` (the tier-1/tier-2 split: only the
+// freshest `cap` nodes carry satellite payloads). `cap` is the effective, possibly
+// ratcheted-down cap, not MAX_SATELLITE_NODES. Caller holds satelliteMutex.
+template <typename Map> void evictSatelliteOverCap(NodeDB &db, Map &map, NodeNum incoming, uint16_t cap)
 {
-    if (map.size() < MAX_SATELLITE_NODES || map.count(incoming))
+    if (map.size() < cap || map.count(incoming))
         return;
     evictStalestSatellite(db, map);
 }
@@ -1820,7 +1821,7 @@ void NodeDB::setNodeStatus(NodeNum n, const meshtastic_StatusMessage &status)
     (void)status;
 #else
     concurrency::LockGuard guard(&satelliteMutex);
-    evictSatelliteOverCap(*this, nodeStatus, n);
+    evictSatelliteOverCap(*this, nodeStatus, n, nodeDBEnvironmentCap());
     nodeStatus[n] = status;
 #endif
 }
@@ -1832,7 +1833,7 @@ void NodeDB::touchNodePositionTime(NodeNum n, uint32_t time)
     (void)time;
 #else
     concurrency::LockGuard guard(&satelliteMutex);
-    evictSatelliteOverCap(*this, nodePositions, n);
+    evictSatelliteOverCap(*this, nodePositions, n, nodeDBSatelliteCap());
     nodePositions[n].time = time;
 #endif
 }
@@ -1861,35 +1862,41 @@ bool NodeDB::enforceSatelliteCaps()
 {
     concurrency::LockGuard guard(&satelliteMutex);
     bool trimmedAny = false;
-    auto trim = [this, &trimmedAny](auto &map, const char *name) {
+    auto trim = [this, &trimmedAny](auto &map, const char *name, uint16_t cap) {
         const size_t before = map.size();
-        while (map.size() > MAX_SATELLITE_NODES) {
+        while (map.size() > cap) {
             if (!evictStalestSatellite(*this, map))
                 break;
         }
         if (map.size() != before) {
             trimmedAny = true;
-            LOG_MIGRATION("Trimmed %s satellites %u -> %u (cap %d)", name, (unsigned)before, (unsigned)map.size(),
-                          MAX_SATELLITE_NODES);
+            LOG_MIGRATION("Trimmed %s satellites %u -> %u (cap %u)", name, (unsigned)before, (unsigned)map.size(), (unsigned)cap);
         }
     };
+    // Position and telemetry share the UI-facing cap; environment and status take the
+    // deeper one (bigger entries, no map/list reader). See NodeDBScalingModule.h.
+    const uint16_t satCap = nodeDBSatelliteCap();
+    const uint16_t envCap = nodeDBEnvironmentCap();
 #if !MESHTASTIC_EXCLUDE_POSITIONDB
-    trim(nodePositions, "position");
+    trim(nodePositions, "position", satCap);
 #endif
 
 #if !MESHTASTIC_EXCLUDE_TELEMETRYDB
-    trim(nodeTelemetry, "telemetry");
+    trim(nodeTelemetry, "telemetry", satCap);
 #endif
 
 #if !MESHTASTIC_EXCLUDE_ENVIRONMENTDB
-    trim(nodeEnvironment, "environment");
+    trim(nodeEnvironment, "environment", envCap);
 #endif
 
 #if !MESHTASTIC_EXCLUDE_STATUSDB
-    trim(nodeStatus, "status");
+    trim(nodeStatus, "status", envCap);
 #endif
 
-    (void)trim; // all four maps may be compiled out
+    // all four maps may be compiled out (STM32WL), leaving these with no reader
+    (void)trim;
+    (void)satCap;
+    (void)envCap;
 
     // Approximate satellite heap usage: each std::map entry is one rb-tree node,
     // value_type plus ~44 B of node overhead (parent/left/right pointers, color,
@@ -3389,7 +3396,7 @@ void NodeDB::updatePosition(uint32_t nodeId, const meshtastic_Position &p, RxSou
 #else
     {
         concurrency::LockGuard guard(&satelliteMutex);
-        evictSatelliteOverCap(*this, nodePositions, nodeId);
+        evictSatelliteOverCap(*this, nodePositions, nodeId, nodeDBSatelliteCap());
         meshtastic_PositionLite &slot = nodePositions[nodeId]; // creates default-zero entry if missing
 
         if (src == RX_SRC_LOCAL) {
@@ -3447,7 +3454,7 @@ void NodeDB::updateTelemetry(uint32_t nodeId, const meshtastic_Telemetry &t, RxS
         }
 #if !MESHTASTIC_EXCLUDE_TELEMETRYDB
         concurrency::LockGuard guard(&satelliteMutex);
-        evictSatelliteOverCap(*this, nodeTelemetry, nodeId);
+        evictSatelliteOverCap(*this, nodeTelemetry, nodeId, nodeDBSatelliteCap());
         nodeTelemetry[nodeId] = t.variant.device_metrics;
 #endif
 
@@ -3459,7 +3466,7 @@ void NodeDB::updateTelemetry(uint32_t nodeId, const meshtastic_Telemetry &t, RxS
         }
 #if !MESHTASTIC_EXCLUDE_ENVIRONMENTDB
         concurrency::LockGuard guard(&satelliteMutex);
-        evictSatelliteOverCap(*this, nodeEnvironment, nodeId);
+        evictSatelliteOverCap(*this, nodeEnvironment, nodeId, nodeDBEnvironmentCap());
         nodeEnvironment[nodeId] = t.variant.environment_metrics;
 #endif
 
@@ -3979,6 +3986,11 @@ bool NodeDB::isFull()
     return (numMeshNodes >= MAX_NUM_NODES) || (memGet.getFreeHeap() < MINIMUM_SAFE_FREE_HEAP);
 }
 
+bool NodeDB::isPassiveFillOnly()
+{
+    return (numMeshNodes >= NODEDB_BASELINE_NODES) || (memGet.getFreeHeap() < MINIMUM_SAFE_FREE_HEAP);
+}
+
 uint32_t NodeDB::hotNodeLastHeard(NodeNum n) const
 {
     for (int i = 0; i < numMeshNodes; i++)
@@ -4241,6 +4253,7 @@ meshtastic_NodeInfoLite *NodeDB::getOrCreateMeshNode(NodeNum n)
                     meshNodes->at(i) = meshNodes->at(i + 1);
                 }
                 (numMeshNodes)--;
+                hotEvictions++;
             }
         }
         // Don't append past the end of the vector. The protected-node cap

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -2136,7 +2136,7 @@ LoadFileResult NodeDB::loadProto(const char *filename, size_t protoSize, size_t 
 #if WARM_NODE_COUNT > 0
 void NodeDB::demoteOldestHotNodesToWarm()
 {
-    const int keep = MAX_NUM_NODES;
+    const int keep = effectiveMaxNodes();
     if (numMeshNodes <= keep)
         return;
 
@@ -2178,7 +2178,7 @@ void NodeDB::nodeDBSelfCare()
         return;
 
     const NodeNum self = getNodeNum();
-    const bool nodesOverCap = numMeshNodes > MAX_NUM_NODES;
+    const bool nodesOverCap = numMeshNodes > effectiveMaxNodes();
 
     // Confirm self is present and its key matches what we just (re)derived. A
     // non-empty DB that doesn't contain us means a foreign/over-cap or corrupt
@@ -2203,16 +2203,25 @@ void NodeDB::nodeDBSelfCare()
         demoteOldestHotNodesToWarm(); // demotes oldest NON-self overflow; index 0 (us) left in place
 #endif
 
-    if (numMeshNodes > MAX_NUM_NODES) {
-        LOG_WARN("NodeDB self-care: %d over cap %d, truncating", numMeshNodes, MAX_NUM_NODES);
-        numMeshNodes = MAX_NUM_NODES;
+    if (numMeshNodes > effectiveMaxNodes()) {
+        LOG_WARN("NodeDB self-care: %d over cap %d, truncating", numMeshNodes, (int)effectiveMaxNodes());
+        numMeshNodes = effectiveMaxNodes();
     }
     // Normalise the backing store to the hot cap so getOrCreateMeshNode always
     // has spare slots to append into (it indexes meshNodes->at(numMeshNodes++)).
-    meshNodes->resize(MAX_NUM_NODES);
-    memaudit::set("nodedb", MAX_NUM_NODES * sizeof(meshtastic_NodeInfoLite));
+    hotCapacity = effectiveMaxNodes(); // pin the live cap to what we are about to allocate
+    meshNodes->resize(hotCapacity);
+    memaudit::set("nodedb", (size_t)hotCapacity * sizeof(meshtastic_NodeInfoLite));
 
     const bool satsTrimmed = enforceSatelliteCaps();
+
+    // Boot report: what the store holds, what it may hold, and where the handshake gate sits.
+    LOG_INFO("NodeDB: %d nodes, cap %d (base %d, +%u ratchet), passive-fill above %d", numMeshNodes, (int)effectiveMaxNodes(),
+             (int)MAX_NUM_NODES, nodeDBBonusNodes(), (int)NODEDB_BASELINE_NODES);
+    // Dedup history is pinned to the baseline by design; log the ratio so a field log shows
+    // how thin it has become rather than leaving it to be inferred (mesh-pb-constants.h).
+    LOG_DEBUG("NodeDB: dedup history %u records for cap %d (%u%% of 2x)", (unsigned)PACKETHISTORY_MAX, (int)effectiveMaxNodes(),
+              (unsigned)((uint32_t)PACKETHISTORY_MAX * 50u / (effectiveMaxNodes() ? effectiveMaxNodes() : 1)));
 
     // Ensure self exists, sits at index 0, and carries current owner info - after
     // any demotion has freed a slot. Covers the foreign/fixture case where the
@@ -2382,7 +2391,7 @@ void NodeDB::loadFromDisk()
     } disarm{*this};
 
     // Avoid push_back's power-of-2 capacity growth wasting RAM at small N.
-    nodeDatabase.nodes.reserve(MAX_NUM_NODES);
+    nodeDatabase.nodes.reserve(effectiveMaxNodes());
 
     auto state = loadProto(nodeDatabaseFileName, getMaxNodesAllocatedSize(), sizeof(meshtastic_NodeDatabase),
                            &meshtastic_NodeDatabase_msg, &nodeDatabase);
@@ -3511,7 +3520,7 @@ void NodeDB::addFromContact(meshtastic_SharedContact contact)
         // public key copied above - an ignored peer keeps a usable identity
         // (a verifiable target) rather than a bare node number.
         if (!setProtectedFlag(info, NODEINFO_BITFIELD_IS_IGNORED_MASK, true))
-            LOG_WARN(PROTECTED_CAP_WARN_FMT, "ignore", contact.node_num, MAX_NUM_NODES - 2);
+            LOG_WARN(PROTECTED_CAP_WARN_FMT, "ignore", contact.node_num, (int)effectiveMaxNodes() - 2);
         nodeInfoLiteSetBit(info, NODEINFO_BITFIELD_IS_FAVORITE_MASK, false);
         eraseNodeSatellites(contact.node_num);
 #if HAS_SCREEN || defined(MESHTASTIC_INCLUDE_NICHE_GRAPHICS)
@@ -3538,7 +3547,7 @@ void NodeDB::addFromContact(meshtastic_SharedContact contact)
             // If the protected cap refuses the favorite, fall back to a heard-now stamp so the
             // contact still isn't the first eviction victim.
             if (!setProtectedFlag(info, NODEINFO_BITFIELD_IS_FAVORITE_MASK, true)) {
-                LOG_WARN(PROTECTED_CAP_WARN_FMT, "favorite", contact.node_num, MAX_NUM_NODES - 2);
+                LOG_WARN(PROTECTED_CAP_WARN_FMT, "favorite", contact.node_num, (int)effectiveMaxNodes() - 2);
                 stampContactHeardNow(info);
             }
         }
@@ -3546,7 +3555,7 @@ void NodeDB::addFromContact(meshtastic_SharedContact contact)
         // As the clients will begin sending the contact with DMs, we want to strictly check if the node is manually verified
         if (contact.manually_verified) {
             if (!setProtectedFlag(info, NODEINFO_BITFIELD_IS_KEY_MANUALLY_VERIFIED_MASK, true))
-                LOG_WARN(PROTECTED_CAP_WARN_FMT, "verify", contact.node_num, MAX_NUM_NODES - 2);
+                LOG_WARN(PROTECTED_CAP_WARN_FMT, "verify", contact.node_num, (int)effectiveMaxNodes() - 2);
         }
         // Mark the node's key as manually verified to indicate trustworthiness.
         updateGUIforNode = info;
@@ -3769,7 +3778,7 @@ bool NodeDB::setProtectedFlag(meshtastic_NodeInfoLite *node, uint32_t mask, bool
     // protected set, so it's always allowed. A newly-protected node is refused
     // once the protected set has reached MAX_NUM_NODES-2, leaving two evictable
     // slots so getOrCreateMeshNode can always make room.
-    if (nodeInfoLiteIsProtected(node) || numProtectedNodes() < MAX_NUM_NODES - 2) {
+    if (nodeInfoLiteIsProtected(node) || numProtectedNodes() < (int)effectiveMaxNodes() - 2) {
         nodeInfoLiteSetBit(node, mask, true);
         return true;
     }
@@ -3788,7 +3797,7 @@ bool NodeDB::set_favorite(bool is_favorite, uint32_t nodeId)
         saveNodeDatabaseToDisk();
         return true;
     }
-    LOG_WARN(PROTECTED_CAP_WARN_FMT, "favorite", nodeId, MAX_NUM_NODES - 2);
+    LOG_WARN(PROTECTED_CAP_WARN_FMT, "favorite", nodeId, (int)effectiveMaxNodes() - 2);
     return false;
 }
 
@@ -3981,9 +3990,58 @@ bool NodeDB::resolveUniqueLastByte(uint8_t lastByte, bool requireDirectNeighbor,
 }
 
 // returns true if the maximum number of nodes is reached or we are running low on memory
+pb_size_t NodeDB::effectiveMaxNodes() const
+{
+    return hotCapacity ? hotCapacity : (pb_size_t)MAX_NUM_NODES;
+}
+
+pb_size_t NodeDB::desiredMaxNodes() const
+{
+    const uint32_t total = (uint32_t)MAX_NUM_NODES + nodeDBBonusNodes();
+    return (pb_size_t)((total > NODEDB_MIGRATION_LOAD_CEILING) ? NODEDB_MIGRATION_LOAD_CEILING : total);
+}
+
+void NodeDB::applyHotStoreCapacity()
+{
+    if (!meshNodes)
+        return;
+
+    const pb_size_t target = desiredMaxNodes();
+    const pb_size_t live = effectiveMaxNodes();
+    if (target == live && meshNodes->size() == target)
+        return;
+
+    if (target > live) {
+        // Growing the vector reallocates, so old and new buffers are live at once. Demand the new
+        // one plus a margin before trying - declining the extra slots costs only capacity, while
+        // getting this wrong on a 99%-heap part costs the boot.
+        const size_t needed = (size_t)target * sizeof(meshtastic_NodeInfoLite);
+        if (memGet.getFreeHeap() < needed + NODEDB_GROWTH_HEAP_MARGIN) {
+            LOG_WARN("NodeDB: decline grow %d->%d, %u B free", (int)live, (int)target, (unsigned)memGet.getFreeHeap());
+            return; // hotCapacity untouched: the cap keeps matching what is actually allocated
+        }
+        meshNodes->resize(target);
+        hotCapacity = target;
+        LOG_INFO("NodeDB: hot store %d -> %d slots (+%u ratchet)", (int)live, (int)target, nodeDBBonusNodes());
+    } else {
+        // Handing capacity back: the overflow keeps its key in the warm tier rather than vanishing.
+        hotCapacity = target;
+        if (numMeshNodes > target) {
+#if WARM_NODE_COUNT > 0
+            demoteOldestHotNodesToWarm();
+#endif
+            if (numMeshNodes > target)
+                numMeshNodes = target;
+        }
+        meshNodes->resize(target);
+        LOG_INFO("NodeDB: hot store %d -> %d slots, %d held", (int)live, (int)target, numMeshNodes);
+    }
+    memaudit::set("nodedb", (size_t)target * sizeof(meshtastic_NodeInfoLite));
+}
+
 bool NodeDB::isFull()
 {
-    return (numMeshNodes >= MAX_NUM_NODES) || (memGet.getFreeHeap() < MINIMUM_SAFE_FREE_HEAP);
+    return (numMeshNodes >= effectiveMaxNodes()) || (memGet.getFreeHeap() < MINIMUM_SAFE_FREE_HEAP);
 }
 
 bool NodeDB::isPassiveFillOnly()
@@ -4260,7 +4318,7 @@ meshtastic_NodeInfoLite *NodeDB::getOrCreateMeshNode(NodeNum n)
         // (numProtectedNodes() <= MAX_NUM_NODES-2) means the eviction above frees
         // a slot in normal operation; this guards the legacy case of a pre-cap
         // database that is full of protected nodes - refuse rather than overrun.
-        if (numMeshNodes >= MAX_NUM_NODES)
+        if (numMeshNodes >= effectiveMaxNodes())
             return NULL;
         // Pre-size before append when run before nodeDBSelfCare() (boot keygen); else at() aborts on nRF52.
         if (static_cast<size_t>(numMeshNodes) >= meshNodes->size())

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -432,8 +432,8 @@ NodeDB::NodeDB()
     // likewise - we always want the app requirements to come from the running appload
     myNodeInfo.min_app_version = 30200; // format is Mmmss (where M is 1+the numeric major number. i.e. 30200 means 2.2.00
 
-    // likewise the edition: it lives in persisted devicestate, so a vanilla install must
-    // overwrite the previous event build's value. Before the CRC compare, so the change persists.
+    // likewise the edition: it lives in persisted devicestate, so a vanilla install must overwrite
+    // the previous event build's value. Before the CRC compare, so the change persists.
 #ifdef USERPREFS_FIRMWARE_EDITION
     myNodeInfo.firmware_edition = USERPREFS_FIRMWARE_EDITION;
 #else
@@ -729,9 +729,8 @@ template <typename Map> bool evictStalestSatellite(NodeDB &db, Map &map)
     return true;
 }
 
-// Keep `map` within `cap` ahead of inserting `incoming` (the tier-1/tier-2 split: only the
-// freshest `cap` nodes carry satellite payloads). `cap` is the effective, possibly
-// ratcheted-down cap, not MAX_SATELLITE_NODES. Caller holds satelliteMutex.
+// Keep `map` within `cap` ahead of inserting `incoming`: only the freshest `cap` nodes carry
+// satellite payloads. `cap` is the effective one, not MAX_SATELLITE_NODES. Caller holds the mutex.
 template <typename Map> void evictSatelliteOverCap(NodeDB &db, Map &map, NodeNum incoming, uint16_t cap)
 {
     if (map.size() < cap || map.count(incoming))
@@ -1873,8 +1872,7 @@ bool NodeDB::enforceSatelliteCaps()
             LOG_MIGRATION("Trimmed %s satellites %u -> %u (cap %u)", name, (unsigned)before, (unsigned)map.size(), (unsigned)cap);
         }
     };
-    // Position and telemetry share the UI-facing cap; environment and status take the
-    // deeper one (bigger entries, no map/list reader). See NodeDBScalingModule.h.
+    // Position and telemetry share the UI-facing cap; environment and status take the deeper one.
     const uint16_t satCap = nodeDBSatelliteCap();
     const uint16_t envCap = nodeDBEnvironmentCap();
 #if !MESHTASTIC_EXCLUDE_POSITIONDB
@@ -2215,11 +2213,10 @@ void NodeDB::nodeDBSelfCare()
 
     const bool satsTrimmed = enforceSatelliteCaps();
 
-    // Boot report: what the store holds, what it may hold, and where the handshake gate sits.
     LOG_INFO("NodeDB: %d nodes, cap %d (base %d, +%u ratchet), passive-fill above %d", numMeshNodes, (int)effectiveMaxNodes(),
              (int)MAX_NUM_NODES, nodeDBBonusNodes(), (int)NODEDB_BASELINE_NODES);
-    // Dedup history is pinned to the baseline by design; log the ratio so a field log shows
-    // how thin it has become rather than leaving it to be inferred (mesh-pb-constants.h).
+    // Dedup history is pinned to the baseline by design; log the ratio so a field log shows how
+    // thin it has become rather than leaving it to be inferred (mesh-pb-constants.h).
     LOG_DEBUG("NodeDB: dedup history %u records for cap %d (%u%% of 2x)", (unsigned)PACKETHISTORY_MAX, (int)effectiveMaxNodes(),
               (unsigned)((uint32_t)PACKETHISTORY_MAX * 50u / (effectiveMaxNodes() ? effectiveMaxNodes() : 1)));
 
@@ -3520,7 +3517,7 @@ void NodeDB::addFromContact(meshtastic_SharedContact contact)
         // public key copied above - an ignored peer keeps a usable identity
         // (a verifiable target) rather than a bare node number.
         if (!setProtectedFlag(info, NODEINFO_BITFIELD_IS_IGNORED_MASK, true))
-            LOG_WARN(PROTECTED_CAP_WARN_FMT, "ignore", contact.node_num, (int)effectiveMaxNodes() - 2);
+            LOG_WARN(PROTECTED_CAP_WARN_FMT, "ignore", contact.node_num, MAX_NUM_NODES - 2);
         nodeInfoLiteSetBit(info, NODEINFO_BITFIELD_IS_FAVORITE_MASK, false);
         eraseNodeSatellites(contact.node_num);
 #if HAS_SCREEN || defined(MESHTASTIC_INCLUDE_NICHE_GRAPHICS)
@@ -3547,7 +3544,7 @@ void NodeDB::addFromContact(meshtastic_SharedContact contact)
             // If the protected cap refuses the favorite, fall back to a heard-now stamp so the
             // contact still isn't the first eviction victim.
             if (!setProtectedFlag(info, NODEINFO_BITFIELD_IS_FAVORITE_MASK, true)) {
-                LOG_WARN(PROTECTED_CAP_WARN_FMT, "favorite", contact.node_num, (int)effectiveMaxNodes() - 2);
+                LOG_WARN(PROTECTED_CAP_WARN_FMT, "favorite", contact.node_num, MAX_NUM_NODES - 2);
                 stampContactHeardNow(info);
             }
         }
@@ -3555,7 +3552,7 @@ void NodeDB::addFromContact(meshtastic_SharedContact contact)
         // As the clients will begin sending the contact with DMs, we want to strictly check if the node is manually verified
         if (contact.manually_verified) {
             if (!setProtectedFlag(info, NODEINFO_BITFIELD_IS_KEY_MANUALLY_VERIFIED_MASK, true))
-                LOG_WARN(PROTECTED_CAP_WARN_FMT, "verify", contact.node_num, (int)effectiveMaxNodes() - 2);
+                LOG_WARN(PROTECTED_CAP_WARN_FMT, "verify", contact.node_num, MAX_NUM_NODES - 2);
         }
         // Mark the node's key as manually verified to indicate trustworthiness.
         updateGUIforNode = info;
@@ -3774,11 +3771,9 @@ bool NodeDB::setProtectedFlag(meshtastic_NodeInfoLite *node, uint32_t mask, bool
         nodeInfoLiteSetBit(node, mask, false);
         return true;
     }
-    // Adding a flag to a node that is already protected doesn't grow the
-    // protected set, so it's always allowed. A newly-protected node is refused
-    // once the protected set has reached MAX_NUM_NODES-2, leaving two evictable
-    // slots so getOrCreateMeshNode can always make room.
-    if (nodeInfoLiteIsProtected(node) || numProtectedNodes() < (int)effectiveMaxNodes() - 2) {
+    // Flagging an already-protected node doesn't grow the set, so it's always allowed. The cap is
+    // MAX_NUM_NODES-2, never the ratcheted one: warm rehydration cannot restore these flags.
+    if (nodeInfoLiteIsProtected(node) || numProtectedNodes() < MAX_NUM_NODES - 2) {
         nodeInfoLiteSetBit(node, mask, true);
         return true;
     }
@@ -3797,7 +3792,7 @@ bool NodeDB::set_favorite(bool is_favorite, uint32_t nodeId)
         saveNodeDatabaseToDisk();
         return true;
     }
-    LOG_WARN(PROTECTED_CAP_WARN_FMT, "favorite", nodeId, (int)effectiveMaxNodes() - 2);
+    LOG_WARN(PROTECTED_CAP_WARN_FMT, "favorite", nodeId, MAX_NUM_NODES - 2);
     return false;
 }
 
@@ -4012,9 +4007,8 @@ void NodeDB::applyHotStoreCapacity()
         return;
 
     if (target > live) {
-        // Growing the vector reallocates, so old and new buffers are live at once. Demand the new
-        // one plus a margin before trying - declining the extra slots costs only capacity, while
-        // getting this wrong on a 99%-heap part costs the boot.
+        // Both buffers are live across the reallocation, so demand the new one plus a margin:
+        // declining costs only capacity, getting it wrong on a 99%-heap part costs the boot.
         const size_t needed = (size_t)target * sizeof(meshtastic_NodeInfoLite);
         if (memGet.getFreeHeap() < needed + NODEDB_GROWTH_HEAP_MARGIN) {
             LOG_WARN("NodeDB: decline grow %d->%d, %u B free", (int)live, (int)target, (unsigned)memGet.getFreeHeap());
@@ -4025,13 +4019,13 @@ void NodeDB::applyHotStoreCapacity()
         LOG_INFO("NodeDB: hot store %d -> %d slots (+%u ratchet)", (int)live, (int)target, nodeDBBonusNodes());
     } else {
         // Handing capacity back: the overflow keeps its key in the warm tier rather than vanishing.
+        // hotCapacity first - demoteOldestHotNodesToWarm() keeps effectiveMaxNodes() entries.
         hotCapacity = target;
         if (numMeshNodes > target) {
 #if WARM_NODE_COUNT > 0
             demoteOldestHotNodesToWarm();
 #endif
-            if (numMeshNodes > target)
-                numMeshNodes = target;
+            numMeshNodes = std::min(numMeshNodes, target); // whatever the warm tier could not take
         }
         meshNodes->resize(target);
         LOG_INFO("NodeDB: hot store %d -> %d slots, %d held", (int)live, (int)target, numMeshNodes);

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -28,9 +28,8 @@
 /// them still decodes here; the excess is trimmed after load.
 static constexpr size_t NODEDB_MIGRATION_LOAD_CEILING = 250;
 
-/// Heap that must remain free *after* a hot-store growth allocation before we attempt it. Growing
-/// the vector reallocates, so old and new buffers coexist briefly; on the RAM-tightest parts that
-/// transient is the whole risk. Declining the extra slots costs nothing but capacity.
+/// Heap that must stay free after a hot-store growth allocation. The vector reallocates, so both
+/// buffers coexist briefly; declining the extra slots costs nothing but capacity.
 static constexpr size_t NODEDB_GROWTH_HEAP_MARGIN = 8 * 1024;
 
 #if !defined(MESHTASTIC_EXCLUDE_PKI)
@@ -277,8 +276,8 @@ class NodeDB
     Observable<const meshtastic::NodeStatus *> newStatus;
     pb_size_t numMeshNodes;
 
-    /// Hot-store evictions since boot. Free-running; read as a delta, never as a rate.
-    /// NodeDBScalingModule uses it as the "the squeeze is on us" signal.
+    /// Hot-store evictions since boot; free-running, read as a delta. NodeDBScalingModule
+    /// uses it as the "the squeeze is on us" signal.
     uint32_t hotEvictions = 0;
 
     // Satellite per-NodeNum maps. std::map avoids unordered_map's bucket-array
@@ -557,36 +556,27 @@ class NodeDB
                (loadCeiling * meshtastic_NodeEnvironmentEntry_size) + (loadCeiling * meshtastic_NodeStatusEntry_size);
     }
 
-    /// The hot store's live capacity. This only ever reports slots that are actually backed by
-    /// allocated storage: applyHotStoreCapacity() raises it after a successful resize and never
-    /// when growth was declined, so no caller can be tempted to append past the buffer (in
-    /// particular getOrCreateMeshNode's grow-by-one fallback, which runs on the packet path).
-    /// Equals MAX_NUM_NODES when unpressured or when the scaling module is compiled out.
+    /// The hot store's live capacity, only ever reporting slots that are actually allocated -
+    /// so no caller (notably getOrCreateMeshNode) can be tempted to append past the buffer.
     pb_size_t effectiveMaxNodes() const;
 
-    /// What the ratchet would like the capacity to be: baseline + funded slots, clamped to
-    /// NODEDB_MIGRATION_LOAD_CEILING so a file we write stays inside the decode allowance every
-    /// build already grants. Only applyHotStoreCapacity() should act on this.
+    /// What the ratchet would like the capacity to be: baseline + funded slots, clamped to the
+    /// decode ceiling. Only applyHotStoreCapacity() should act on this.
     pb_size_t desiredMaxNodes() const;
 
-    /// Resize the hot store to effectiveMaxNodes(). Growth is refused unless the heap can carry the
-    /// new allocation alongside the old one; shrinking demotes the overflow into the warm tier
-    /// first. Call only from the main loop - never from a packet path.
+    /// Resize the hot store to desiredMaxNodes(); growth is heap-guarded and may be declined,
+    /// shrinking demotes the overflow to warm first. Main loop only, never a packet path.
     void applyHotStoreCapacity();
 
     // returns true if the maximum number of nodes is reached or we are running low on memory
     bool isFull();
 
-    /// True once the hot store holds NODEDB_BASELINE_NODES entries (or heap is low): the
-    /// point at which we stop *actively* introducing ourselves to newly-heard nodes and let
-    /// any remaining capacity fill passively from observed traffic. Distinct from isFull()
-    /// so that granting a larger hot store never grants more handshake airtime with it.
+    /// True once the store holds NODEDB_BASELINE_NODES entries: we stop actively introducing
+    /// ourselves, so granting a larger hot store never grants more handshake airtime with it.
     bool isPassiveFillOnly();
 
-    /// Trim each satellite map down to its current effective cap (nodeDBSatelliteCap() /
-    /// nodeDBEnvironmentCap()), dropping the stalest entries. Used after loading files
-    /// written before the caps existed or by a build with larger ones, and by
-    /// NodeDBScalingModule when it ratchets a cap down. Returns true iff anything was trimmed.
+    /// Trim each satellite map to its current effective cap, dropping the stalest entries.
+    /// Returns true iff anything was trimmed.
     bool enforceSatelliteCaps();
 
     void clearLocalPosition();
@@ -683,8 +673,8 @@ class NodeDB
     // enough room to create it safely at boot. A later boot retries the check.
     bool eventProfileStorageUnavailable = false;
 #endif
-    /// Backed hot-store capacity; 0 until first set, meaning "the platform baseline".
-    /// Raised only by a successful applyHotStoreCapacity() resize.
+    /// Backed hot-store capacity; 0 means "the platform baseline". Raised only by a
+    /// successful applyHotStoreCapacity() resize.
     pb_size_t hotCapacity = 0;
     uint32_t lastNodeDbSave = 0;     // when we last saved our db to flash
     uint32_t lastFullEvictionMs = 0; // when we last evicted to admit a new node, once the db is full

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -28,6 +28,11 @@
 /// them still decodes here; the excess is trimmed after load.
 static constexpr size_t NODEDB_MIGRATION_LOAD_CEILING = 250;
 
+/// Heap that must remain free *after* a hot-store growth allocation before we attempt it. Growing
+/// the vector reallocates, so old and new buffers coexist briefly; on the RAM-tightest parts that
+/// transient is the whole risk. Declining the extra slots costs nothing but capacity.
+static constexpr size_t NODEDB_GROWTH_HEAP_MARGIN = 8 * 1024;
+
 #if !defined(MESHTASTIC_EXCLUDE_PKI)
 // E3B0C442 is the blank hash
 static const uint8_t LOW_ENTROPY_HASHES[][32] = {
@@ -552,6 +557,23 @@ class NodeDB
                (loadCeiling * meshtastic_NodeEnvironmentEntry_size) + (loadCeiling * meshtastic_NodeStatusEntry_size);
     }
 
+    /// The hot store's live capacity. This only ever reports slots that are actually backed by
+    /// allocated storage: applyHotStoreCapacity() raises it after a successful resize and never
+    /// when growth was declined, so no caller can be tempted to append past the buffer (in
+    /// particular getOrCreateMeshNode's grow-by-one fallback, which runs on the packet path).
+    /// Equals MAX_NUM_NODES when unpressured or when the scaling module is compiled out.
+    pb_size_t effectiveMaxNodes() const;
+
+    /// What the ratchet would like the capacity to be: baseline + funded slots, clamped to
+    /// NODEDB_MIGRATION_LOAD_CEILING so a file we write stays inside the decode allowance every
+    /// build already grants. Only applyHotStoreCapacity() should act on this.
+    pb_size_t desiredMaxNodes() const;
+
+    /// Resize the hot store to effectiveMaxNodes(). Growth is refused unless the heap can carry the
+    /// new allocation alongside the old one; shrinking demotes the overflow into the warm tier
+    /// first. Call only from the main loop - never from a packet path.
+    void applyHotStoreCapacity();
+
     // returns true if the maximum number of nodes is reached or we are running low on memory
     bool isFull();
 
@@ -661,6 +683,9 @@ class NodeDB
     // enough room to create it safely at boot. A later boot retries the check.
     bool eventProfileStorageUnavailable = false;
 #endif
+    /// Backed hot-store capacity; 0 until first set, meaning "the platform baseline".
+    /// Raised only by a successful applyHotStoreCapacity() resize.
+    pb_size_t hotCapacity = 0;
     uint32_t lastNodeDbSave = 0;     // when we last saved our db to flash
     uint32_t lastFullEvictionMs = 0; // when we last evicted to admit a new node, once the db is full
     uint32_t lastBackupAttempt = 0;  // when we last tried a backup automatically or manually

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -272,6 +272,10 @@ class NodeDB
     Observable<const meshtastic::NodeStatus *> newStatus;
     pb_size_t numMeshNodes;
 
+    /// Hot-store evictions since boot. Free-running; read as a delta, never as a rate.
+    /// NodeDBScalingModule uses it as the "the squeeze is on us" signal.
+    uint32_t hotEvictions = 0;
+
     // Satellite per-NodeNum maps. std::map avoids unordered_map's bucket-array
     // preallocation; O(log N) lookup is fine at these sizes.
 #if !MESHTASTIC_EXCLUDE_POSITIONDB
@@ -551,6 +555,18 @@ class NodeDB
     // returns true if the maximum number of nodes is reached or we are running low on memory
     bool isFull();
 
+    /// True once the hot store holds NODEDB_BASELINE_NODES entries (or heap is low): the
+    /// point at which we stop *actively* introducing ourselves to newly-heard nodes and let
+    /// any remaining capacity fill passively from observed traffic. Distinct from isFull()
+    /// so that granting a larger hot store never grants more handshake airtime with it.
+    bool isPassiveFillOnly();
+
+    /// Trim each satellite map down to its current effective cap (nodeDBSatelliteCap() /
+    /// nodeDBEnvironmentCap()), dropping the stalest entries. Used after loading files
+    /// written before the caps existed or by a build with larger ones, and by
+    /// NodeDBScalingModule when it ratchets a cap down. Returns true iff anything was trimmed.
+    bool enforceSatelliteCaps();
+
     void clearLocalPosition();
 
     void setLocalPosition(meshtastic_Position position, bool timeOnly = false)
@@ -695,11 +711,6 @@ class NodeDB
 
     /// purge db entries without user info
     void cleanupMeshDB();
-
-    /// Trim each satellite map down to MAX_SATELLITE_NODES, dropping the
-    /// stalest entries (used after loading files written before the cap, or by
-    /// a build with a larger cap). Returns true iff anything was trimmed.
-    bool enforceSatelliteCaps();
 
     /// Node-DB self-care; call only once identity is established (getNodeNum()
     /// valid). Confirms self is present, trims/demotes only NON-self overflow, and

--- a/src/mesh/mesh-pb-constants.h
+++ b/src/mesh/mesh-pb-constants.h
@@ -125,6 +125,16 @@ static inline int get_max_num_nodes()
 #endif                    // platform
 #endif                    // MAX_NUM_NODES
 
+/// Hot-store occupancy above which we stop *actively* introducing ourselves to
+/// newly-heard nodes (MeshService's "heard a new node, send NodeInfo and ask for
+/// a reply"). Deliberately the platform's baseline cap, not MAX_NUM_NODES: any
+/// capacity granted above this baseline is to be filled passively from observed
+/// traffic, so a larger hot store never buys extra handshake airtime. Pin this to
+/// the unexpanded value if MAX_NUM_NODES ever flexes upward at runtime.
+#ifndef NODEDB_BASELINE_NODES
+#define NODEDB_BASELINE_NODES MAX_NUM_NODES
+#endif
+
 /// Packet-history capacity: 2x the hot store so dedup/relayer state survives a
 /// full mesh, floored at 100. Shared by PacketHistory's constructor clamp and
 /// the boot-cache budget assert below so the two cannot drift.
@@ -141,6 +151,8 @@ static inline int get_max_num_nodes()
 /// NodeInfoLite header. RAM-bound (the maps are internal-SRAM, not PSRAM), so
 /// flash-rich hosts get a cap >= their hot store (satellites for every node, as
 /// before the cap existed) while constrained parts stay at 40.
+/// This is the *unpressured* cap: NodeDBScalingModule ratchets the effective caps
+/// down from here in a megamesh (modules/NodeDBScalingModule.h).
 #ifndef MAX_SATELLITE_NODES
 #if MESHTASTIC_MEM_CLASS >= MEM_CLASS_LARGE
 #define MAX_SATELLITE_NODES 250
@@ -199,6 +211,17 @@ static inline int get_max_num_nodes()
 
 #ifndef HAS_VARIABLE_HOPS
 #define HAS_VARIABLE_HOPS 1
+#endif
+
+// NodeDBScalingModule - ratchets the satellite caps down under megamesh pressure.
+// Needs HopScalingModule's population estimate as its input signal, and has nothing
+// to trade on TINY parts (satellite DBs already compiled out there).
+#ifndef HAS_NODEDB_SCALING
+#if MESHTASTIC_MEM_CLASS <= MEM_CLASS_TINY || !HAS_VARIABLE_HOPS
+#define HAS_NODEDB_SCALING 0
+#else
+#define HAS_NODEDB_SCALING 1
+#endif
 #endif
 
 // Cache size for traffic management (number of nodes to track)

--- a/src/mesh/mesh-pb-constants.h
+++ b/src/mesh/mesh-pb-constants.h
@@ -135,9 +135,19 @@ static inline int get_max_num_nodes()
 #define NODEDB_BASELINE_NODES MAX_NUM_NODES
 #endif
 
-/// Packet-history capacity: 2x the hot store so dedup/relayer state survives a
-/// full mesh, floored at 100. Shared by PacketHistory's constructor clamp and
-/// the boot-cache budget assert below so the two cannot drift.
+/// Packet-history capacity: 2x the *baseline* hot store so dedup/relayer state
+/// survives a full mesh, floored at 100. Shared by PacketHistory's constructor
+/// clamp and the boot-cache budget assert below so the two cannot drift.
+///
+/// Deliberately keyed to MAX_NUM_NODES and NOT to NodeDB::effectiveMaxNodes():
+/// when NodeDBScalingModule ratchets extra hot-store slots into being, this stays
+/// where it is. That is an accepted trade, not an oversight. Growing it would cost
+/// 20 B per added record on the same heap the growth guard is protecting (nRF52840
+/// runs its ~115 KB arena at 99%), and PacketHistory allocates its array once in
+/// the constructor, so it cannot grow later without new machinery. The cost is that
+/// the ratio falls below 2x while the ratchet is engaged - dedup records are evicted
+/// sooner relative to mesh size. Eviction is LRU, so this degrades rather than fails.
+/// If you ever wire this to the effective cap, re-check MESHTASTIC_BOOT_CACHE_BUDGET.
 #ifndef PACKETHISTORY_MAX
 #if defined(ARCH_STM32WL)
 #define PACKETHISTORY_MAX (MAX_NUM_NODES * 2) // 20 entries for 10-node STM32WL

--- a/src/mesh/mesh-pb-constants.h
+++ b/src/mesh/mesh-pb-constants.h
@@ -125,12 +125,8 @@ static inline int get_max_num_nodes()
 #endif                    // platform
 #endif                    // MAX_NUM_NODES
 
-/// Hot-store occupancy above which we stop *actively* introducing ourselves to
-/// newly-heard nodes (MeshService's "heard a new node, send NodeInfo and ask for
-/// a reply"). Deliberately the platform's baseline cap, not MAX_NUM_NODES: any
-/// capacity granted above this baseline is to be filled passively from observed
-/// traffic, so a larger hot store never buys extra handshake airtime. Pin this to
-/// the unexpanded value if MAX_NUM_NODES ever flexes upward at runtime.
+/// Occupancy above which we stop *actively* introducing ourselves to newly-heard
+/// nodes: capacity above this baseline is filled passively, buying no extra airtime.
 #ifndef NODEDB_BASELINE_NODES
 #define NODEDB_BASELINE_NODES MAX_NUM_NODES
 #endif
@@ -139,15 +135,8 @@ static inline int get_max_num_nodes()
 /// survives a full mesh, floored at 100. Shared by PacketHistory's constructor
 /// clamp and the boot-cache budget assert below so the two cannot drift.
 ///
-/// Deliberately keyed to MAX_NUM_NODES and NOT to NodeDB::effectiveMaxNodes():
-/// when NodeDBScalingModule ratchets extra hot-store slots into being, this stays
-/// where it is. That is an accepted trade, not an oversight. Growing it would cost
-/// 20 B per added record on the same heap the growth guard is protecting (nRF52840
-/// runs its ~115 KB arena at 99%), and PacketHistory allocates its array once in
-/// the constructor, so it cannot grow later without new machinery. The cost is that
-/// the ratio falls below 2x while the ratchet is engaged - dedup records are evicted
-/// sooner relative to mesh size. Eviction is LRU, so this degrades rather than fails.
-/// If you ever wire this to the effective cap, re-check MESHTASTIC_BOOT_CACHE_BUDGET.
+/// Keyed to MAX_NUM_NODES, never NodeDB::effectiveMaxNodes(): the ratio is allowed to fall below
+/// 2x while the ratchet is engaged. Re-check MESHTASTIC_BOOT_CACHE_BUDGET if you rewire it.
 #ifndef PACKETHISTORY_MAX
 #if defined(ARCH_STM32WL)
 #define PACKETHISTORY_MAX (MAX_NUM_NODES * 2) // 20 entries for 10-node STM32WL
@@ -223,9 +212,8 @@ static inline int get_max_num_nodes()
 #define HAS_VARIABLE_HOPS 1
 #endif
 
-// NodeDBScalingModule - ratchets the satellite caps down under megamesh pressure.
-// Needs HopScalingModule's population estimate as its input signal, and has nothing
-// to trade on TINY parts (satellite DBs already compiled out there).
+// NodeDBScalingModule - ratchets the satellite caps down under megamesh pressure. Needs
+// HopScalingModule's estimate, and has nothing to trade on TINY parts (no satellite DBs).
 #ifndef HAS_NODEDB_SCALING
 #if MESHTASTIC_MEM_CLASS <= MEM_CLASS_TINY || !HAS_VARIABLE_HOPS
 #define HAS_NODEDB_SCALING 0

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -526,8 +526,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
                 if (screen)
                     screen->setFrames(graphics::Screen::FOCUS_PRESERVE); // <-- Rebuild screens
             } else if (mp.from == 0) { // local request from the phone - tell the user why it didn't take
-                sendWarning(NodeDB::PROTECTED_CAP_WARN_FMT, "favorite", r->set_favorite_node,
-                            (int)nodeDB->effectiveMaxNodes() - 2);
+                sendWarning(NodeDB::PROTECTED_CAP_WARN_FMT, "favorite", r->set_favorite_node, MAX_NUM_NODES - 2);
             } else {
                 LOG_WARN("Remote set_favorite_node for 0x%08x refused: protected-node cap", r->set_favorite_node);
             }
@@ -563,7 +562,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
                     screen->setFrames(graphics::Screen::FOCUS_PRESERVE);
 #endif
             } else if (mp.from == 0) { // local request from the phone - tell the user why it didn't take
-                sendWarning(NodeDB::PROTECTED_CAP_WARN_FMT, "ignore", r->set_ignored_node, (int)nodeDB->effectiveMaxNodes() - 2);
+                sendWarning(NodeDB::PROTECTED_CAP_WARN_FMT, "ignore", r->set_ignored_node, MAX_NUM_NODES - 2);
             } else {
                 LOG_WARN("Remote set_ignored_node for 0x%08x refused: protected-node cap", r->set_ignored_node);
             }

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -526,7 +526,8 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
                 if (screen)
                     screen->setFrames(graphics::Screen::FOCUS_PRESERVE); // <-- Rebuild screens
             } else if (mp.from == 0) { // local request from the phone - tell the user why it didn't take
-                sendWarning(NodeDB::PROTECTED_CAP_WARN_FMT, "favorite", r->set_favorite_node, MAX_NUM_NODES - 2);
+                sendWarning(NodeDB::PROTECTED_CAP_WARN_FMT, "favorite", r->set_favorite_node,
+                            (int)nodeDB->effectiveMaxNodes() - 2);
             } else {
                 LOG_WARN("Remote set_favorite_node for 0x%08x refused: protected-node cap", r->set_favorite_node);
             }
@@ -562,7 +563,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
                     screen->setFrames(graphics::Screen::FOCUS_PRESERVE);
 #endif
             } else if (mp.from == 0) { // local request from the phone - tell the user why it didn't take
-                sendWarning(NodeDB::PROTECTED_CAP_WARN_FMT, "ignore", r->set_ignored_node, MAX_NUM_NODES - 2);
+                sendWarning(NodeDB::PROTECTED_CAP_WARN_FMT, "ignore", r->set_ignored_node, (int)nodeDB->effectiveMaxNodes() - 2);
             } else {
                 LOG_WARN("Remote set_ignored_node for 0x%08x refused: protected-node cap", r->set_ignored_node);
             }

--- a/src/modules/Modules.cpp
+++ b/src/modules/Modules.cpp
@@ -50,6 +50,7 @@
 #if HAS_VARIABLE_HOPS
 #include "modules/HopScalingModule.h"
 #endif
+#include "modules/NodeDBScalingModule.h"
 #include "modules/TextMessageModule.h"
 #if !MESHTASTIC_EXCLUDE_TRACEROUTE
 #include "modules/TraceRouteModule.h"
@@ -141,6 +142,11 @@ void setupModules()
 
 #if HAS_VARIABLE_HOPS
     hopScalingModule = new HopScalingModule();
+#endif
+
+#if HAS_NODEDB_SCALING
+    // After HopScalingModule: it reads that module's population estimate.
+    nodeDBScalingModule = new NodeDBScalingModule();
 #endif
 
 #if !MESHTASTIC_EXCLUDE_ADMIN

--- a/src/modules/NodeDBScalingModule.cpp
+++ b/src/modules/NodeDBScalingModule.cpp
@@ -46,9 +46,8 @@ uint8_t NodeDBScalingModule::stepForPopulation(uint16_t population)
 
 uint32_t NodeDBScalingModule::freedFlashBytes(uint16_t satCap, uint16_t envCap)
 {
-    // Price the trade in the same currency that sizes MAX_NUM_NODES: worst-case encoded bytes
-    // in nodes.proto. Position and telemetry ride the satellite cap, environment and status the
-    // bulk one, matching how enforceSatelliteCaps() trims them.
+    // Priced in the currency that sizes MAX_NUM_NODES: worst-case encoded bytes in nodes.proto,
+    // split across the two caps exactly as enforceSatelliteCaps() trims them.
     const uint16_t satDropped = (satCap < MAX_SATELLITE_NODES) ? (uint16_t)(MAX_SATELLITE_NODES - satCap) : 0;
     const uint16_t envDropped = (envCap < MAX_SATELLITE_NODES) ? (uint16_t)(MAX_SATELLITE_NODES - envCap) : 0;
     return (uint32_t)satDropped * (meshtastic_NodePositionEntry_size + meshtastic_NodeTelemetryEntry_size) +
@@ -106,12 +105,13 @@ void NodeDBScalingModule::evaluate(uint16_t population, bool underPressure)
     const uint8_t warranted = stepForPopulation(population);
 
     if (warranted > step) {
-        // Population alone is not enough: a node parked beside a busy repeater hears a big
-        // mesh without its own store ever being squeezed. Require evidence of the squeeze.
-        if (underPressure) {
-            quietEvaluations = 0;
+        // A population that warrants *more* ratchet voids any release run in progress, whether
+        // or not we act on it - otherwise quiet hours accumulate across a busy spell between them.
+        quietEvaluations = 0;
+        // Population alone is not enough to descend: a node parked beside a busy repeater hears a
+        // big mesh without its own store ever being squeezed. Require evidence of the squeeze.
+        if (underPressure)
             setStep(step + 1);
-        }
         return;
     }
 

--- a/src/modules/NodeDBScalingModule.cpp
+++ b/src/modules/NodeDBScalingModule.cpp
@@ -20,6 +20,7 @@ NodeDBScalingModule *nodeDBScalingModule = nullptr;
 NodeDBScalingModule::NodeDBScalingModule() : concurrency::OSThread("NodeDBScaling")
 {
     refreshCaps();
+    logLadder();
     setIntervalFromNow(INITIAL_DELAY_MS);
 }
 
@@ -43,10 +44,39 @@ uint8_t NodeDBScalingModule::stepForPopulation(uint16_t population)
     return warranted;
 }
 
+uint32_t NodeDBScalingModule::freedFlashBytes(uint16_t satCap, uint16_t envCap)
+{
+    // Price the trade in the same currency that sizes MAX_NUM_NODES: worst-case encoded bytes
+    // in nodes.proto. Position and telemetry ride the satellite cap, environment and status the
+    // bulk one, matching how enforceSatelliteCaps() trims them.
+    const uint16_t satDropped = (satCap < MAX_SATELLITE_NODES) ? (uint16_t)(MAX_SATELLITE_NODES - satCap) : 0;
+    const uint16_t envDropped = (envCap < MAX_SATELLITE_NODES) ? (uint16_t)(MAX_SATELLITE_NODES - envCap) : 0;
+    return (uint32_t)satDropped * (meshtastic_NodePositionEntry_size + meshtastic_NodeTelemetryEntry_size) +
+           (uint32_t)envDropped * (meshtastic_NodeEnvironmentEntry_size + meshtastic_NodeStatusEntry_size);
+}
+
+uint16_t NodeDBScalingModule::bonusForCaps(uint16_t satCap, uint16_t envCap)
+{
+    return (uint16_t)(freedFlashBytes(satCap, envCap) / meshtastic_NodeInfoLite_size);
+}
+
 void NodeDBScalingModule::refreshCaps()
 {
     satelliteCap = capForPct(STEPS[step].satellitePct, UI_SATELLITE_FLOOR);
     environmentCap = capForPct(STEPS[step].bulkPct, BULK_FLOOR);
+    bonusNodes = bonusForCaps(satelliteCap, environmentCap);
+}
+
+void NodeDBScalingModule::logLadder() const
+{
+    LOG_INFO("NodeDB scaling: base sats %d, hot store %d (passive-fill above %d)", MAX_SATELLITE_NODES, (int)MAX_NUM_NODES,
+             (int)NODEDB_BASELINE_NODES);
+    for (uint8_t i = 0; i < STEP_COUNT; i++) {
+        const uint16_t sat = capForPct(STEPS[i].satellitePct, UI_SATELLITE_FLOOR);
+        const uint16_t env = capForPct(STEPS[i].bulkPct, BULK_FLOOR);
+        LOG_DEBUG("  step %u: pop>=%u sats %u env %u frees %uB -> +%u nodes", i, STEPS[i].enterPopulation, sat, env,
+                  (unsigned)freedFlashBytes(sat, env), bonusForCaps(sat, env));
+    }
 }
 
 void NodeDBScalingModule::setStep(uint8_t newStep)
@@ -61,11 +91,14 @@ void NodeDBScalingModule::setStep(uint8_t newStep)
 
     step = newStep;
     refreshCaps();
-    LOG_INFO("NodeDB scaling: step %u - satellites %u, environment/status %u (of %d)", step, satelliteCap, environmentCap,
-             MAX_SATELLITE_NODES);
+    LOG_INFO("NodeDB scaling: step %u - sats %u, env/status %u (of %d), +%u nodes", step, satelliteCap, environmentCap,
+             MAX_SATELLITE_NODES, bonusNodes);
     // Descending must reclaim immediately; ascending is a no-op here and refills from traffic.
-    if (nodeDB)
+    if (nodeDB) {
         nodeDB->enforceSatelliteCaps();
+        // Spend (or hand back) the freed budget. Growth is heap-guarded and may decline.
+        nodeDB->applyHotStoreCapacity();
+    }
 }
 
 void NodeDBScalingModule::evaluate(uint16_t population, bool underPressure)
@@ -132,6 +165,11 @@ uint16_t nodeDBEnvironmentCap()
     return nodeDBScalingModule ? nodeDBScalingModule->getEnvironmentCap() : (uint16_t)MAX_SATELLITE_NODES;
 }
 
+uint16_t nodeDBBonusNodes()
+{
+    return nodeDBScalingModule ? nodeDBScalingModule->getBonusNodes() : 0;
+}
+
 #else // HAS_NODEDB_SCALING
 
 uint16_t nodeDBSatelliteCap()
@@ -142,6 +180,11 @@ uint16_t nodeDBSatelliteCap()
 uint16_t nodeDBEnvironmentCap()
 {
     return MAX_SATELLITE_NODES;
+}
+
+uint16_t nodeDBBonusNodes()
+{
+    return 0;
 }
 
 #endif // HAS_NODEDB_SCALING

--- a/src/modules/NodeDBScalingModule.cpp
+++ b/src/modules/NodeDBScalingModule.cpp
@@ -1,0 +1,147 @@
+#include "NodeDBScalingModule.h"
+
+#if HAS_NODEDB_SCALING
+
+#include "HopScalingModule.h"
+#include "NodeDB.h"
+
+namespace
+{
+// First evaluation is deferred past HopScalingModule's warm-start load and its first hourly
+// rollover, which is what publishes the population estimate we read.
+constexpr uint32_t INITIAL_DELAY_MS = 15 * 60 * 1000UL;
+constexpr uint32_t RUN_INTERVAL_MS = 60 * 60 * 1000UL;
+// Retry sooner while the population estimate is still unavailable (no rollover yet).
+constexpr uint32_t RETRY_INTERVAL_MS = 5 * 60 * 1000UL;
+} // namespace
+
+NodeDBScalingModule *nodeDBScalingModule = nullptr;
+
+NodeDBScalingModule::NodeDBScalingModule() : concurrency::OSThread("NodeDBScaling")
+{
+    refreshCaps();
+    setIntervalFromNow(INITIAL_DELAY_MS);
+}
+
+uint16_t NodeDBScalingModule::capForPct(uint8_t pct, uint16_t floor)
+{
+    uint32_t cap = ((uint32_t)MAX_SATELLITE_NODES * pct) / 100u;
+    if (cap < floor)
+        cap = floor;
+    if (cap > (uint32_t)MAX_SATELLITE_NODES)
+        cap = MAX_SATELLITE_NODES; // a floor must never raise the cap above the unpressured one
+    return (uint16_t)cap;
+}
+
+uint8_t NodeDBScalingModule::stepForPopulation(uint16_t population)
+{
+    uint8_t warranted = 0;
+    for (uint8_t i = 1; i < STEP_COUNT; i++) {
+        if (population >= STEPS[i].enterPopulation)
+            warranted = i;
+    }
+    return warranted;
+}
+
+void NodeDBScalingModule::refreshCaps()
+{
+    satelliteCap = capForPct(STEPS[step].satellitePct, UI_SATELLITE_FLOOR);
+    environmentCap = capForPct(STEPS[step].bulkPct, BULK_FLOOR);
+}
+
+void NodeDBScalingModule::setStep(uint8_t newStep)
+{
+    if (newStep > MAX_STEP)
+        newStep = MAX_STEP;
+    // An explicit step change restarts the hysteresis run either way: a release run counted
+    // against the step we just left says nothing about the one we just entered.
+    quietEvaluations = 0;
+    if (newStep == step)
+        return;
+
+    step = newStep;
+    refreshCaps();
+    LOG_INFO("NodeDB scaling: step %u - satellites %u, environment/status %u (of %d)", step, satelliteCap, environmentCap,
+             MAX_SATELLITE_NODES);
+    // Descending must reclaim immediately; ascending is a no-op here and refills from traffic.
+    if (nodeDB)
+        nodeDB->enforceSatelliteCaps();
+}
+
+void NodeDBScalingModule::evaluate(uint16_t population, bool underPressure)
+{
+    const uint8_t warranted = stepForPopulation(population);
+
+    if (warranted > step) {
+        // Population alone is not enough: a node parked beside a busy repeater hears a big
+        // mesh without its own store ever being squeezed. Require evidence of the squeeze.
+        if (underPressure) {
+            quietEvaluations = 0;
+            setStep(step + 1);
+        }
+        return;
+    }
+
+    if (step == 0)
+        return;
+
+    // Release only once the population has fallen clear of the band around this step's own
+    // entry threshold, and stayed there.
+    const uint32_t releaseBelow = ((uint32_t)STEPS[step].enterPopulation * RELEASE_PCT) / 100u;
+    if (population >= releaseBelow) {
+        quietEvaluations = 0;
+        return;
+    }
+
+    if (++quietEvaluations >= QUIET_HOURS_PER_STEP) {
+        quietEvaluations = 0;
+        setStep(step - 1);
+    }
+}
+
+uint16_t NodeDBScalingModule::currentPopulationEstimate()
+{
+    if (!hopScalingModule)
+        return 0;
+    // Already scaled by the filtering denominator, and only counts nodes seen in the last
+    // 13 h - the hysteresis we would otherwise have to build ourselves.
+    return hopScalingModule->getLastPerHopCounts().total;
+}
+
+int32_t NodeDBScalingModule::runOnce()
+{
+    const uint16_t population = currentPopulationEstimate();
+    if (population == 0)
+        return RETRY_INTERVAL_MS; // no rollover yet; hold the current step rather than release it
+
+    const uint32_t evictions = nodeDB ? nodeDB->hotEvictions : 0;
+    const bool underPressure = (nodeDB && nodeDB->isFull()) || evictions != lastEvictionCount;
+    lastEvictionCount = evictions;
+
+    evaluate(population, underPressure);
+    return RUN_INTERVAL_MS;
+}
+
+uint16_t nodeDBSatelliteCap()
+{
+    return nodeDBScalingModule ? nodeDBScalingModule->getSatelliteCap() : (uint16_t)MAX_SATELLITE_NODES;
+}
+
+uint16_t nodeDBEnvironmentCap()
+{
+    return nodeDBScalingModule ? nodeDBScalingModule->getEnvironmentCap() : (uint16_t)MAX_SATELLITE_NODES;
+}
+
+#else // HAS_NODEDB_SCALING
+
+uint16_t nodeDBSatelliteCap()
+{
+    return MAX_SATELLITE_NODES;
+}
+
+uint16_t nodeDBEnvironmentCap()
+{
+    return MAX_SATELLITE_NODES;
+}
+
+#endif // HAS_NODEDB_SCALING

--- a/src/modules/NodeDBScalingModule.h
+++ b/src/modules/NodeDBScalingModule.h
@@ -1,0 +1,151 @@
+#pragma once
+
+#include "concurrency/OSThread.h"
+#include "configuration.h"
+#include "mesh/mesh-pb-constants.h"
+#include <cstdint>
+
+/**
+ * NodeDBScalingModule: ratchets the NodeDB satellite caps down under megamesh pressure.
+ *
+ * The problem: on a constrained part the satellite stores (position / telemetry /
+ * environment / status) cost ~452 B RAM and 336 B flash per node at their worst, against
+ * 100 B / 112 B for the NodeInfoLite header itself. In a mesh large enough to churn the
+ * hot store, that budget is better spent on identities than on stale payloads for nodes
+ * we will not see again.
+ *
+ * The policy: a step ladder, one step per hourly evaluation, driven by HopScalingModule's
+ * population estimate and gated on evidence that the pressure is actually on *us* (a full
+ * hot store, or evictions since the last evaluation). Descending is fast (one step per
+ * hour while the population warrants it); ascending needs QUIET_HOURS_PER_STEP consecutive
+ * quiet hours per step, so a mesh that briefly quietens does not thrash the caps.
+ *
+ * Ladder (percentages of MAX_SATELLITE_NODES, i.e. of 40 on a constrained part):
+ *
+ *   step  population  satellites (pos/tel)  bulk (env/status)
+ *   ----  ----------  --------------------  -----------------
+ *     0            -              40 (100%)          40 (100%)
+ *     1         >=200              24  (60%)          24  (60%)
+ *     2         >=400              16  (40%)          16  (40%)
+ *     3         >=800               8  (20%)           8  (20%)
+ *     4        >=1500               8  (20%)           4  (10%)
+ *
+ * Position and telemetry share a ladder because the on-device UI reads both (distance,
+ * bearing, battery column). Environment and status get the extra step because
+ * EnvironmentMetrics is the elephant - 196 B RAM / 170 B flash per entry, 4-5x anything
+ * else - and is the least useful thing to persist in a megamesh.
+ *
+ * UI floor: satellite entries feed the local display, so builds that draw a map or a node
+ * list keep an absolute minimum of them regardless of how far the ladder descends
+ * (UI_SATELLITE_FLOOR below). A headless router has no such reader and ratchets freely.
+ *
+ * No persistence: the step is re-derived on the first evaluation after boot from
+ * HopScalingModule's own warm-started estimate, so a reboot costs at most one startup
+ * delay of over-capacity, not a state file.
+ */
+
+#if HAS_NODEDB_SCALING
+
+/// Absolute minimum satellite entries kept for builds whose UI reads them. InkHUD's map
+/// applet draws every node with a position, so it needs more than a node list that only
+/// resolves distance for the row in view; a headless build reads none of it.
+#ifndef NODEDB_SCALING_UI_SATELLITE_FLOOR
+#if defined(MESHTASTIC_INCLUDE_INKHUD)
+#define NODEDB_SCALING_UI_SATELLITE_FLOOR 12
+#elif HAS_SCREEN
+#define NODEDB_SCALING_UI_SATELLITE_FLOOR 8
+#else
+#define NODEDB_SCALING_UI_SATELLITE_FLOOR 4
+#endif
+#endif
+
+class NodeDBScalingModule : private concurrency::OSThread
+{
+  public:
+    // -----------------------------------------------------------------------
+    // Ladder
+    // -----------------------------------------------------------------------
+    struct Step {
+        uint16_t enterPopulation; ///< estimated mesh population at or above which this step applies
+        uint8_t satellitePct;     ///< percent of MAX_SATELLITE_NODES kept for position + telemetry
+        uint8_t bulkPct;          ///< percent of MAX_SATELLITE_NODES kept for environment + status
+    };
+
+    static constexpr Step STEPS[] = {
+        {0, 100, 100}, {200, 60, 60}, {400, 40, 40}, {800, 20, 20}, {1500, 20, 10},
+    };
+    static constexpr uint8_t STEP_COUNT = sizeof(STEPS) / sizeof(STEPS[0]);
+    static constexpr uint8_t MAX_STEP = STEP_COUNT - 1;
+
+    /// A step is released (ratcheted back up) only once the population drops below this
+    /// percentage of the step's own entry threshold - the hysteresis band that stops a
+    /// mesh hovering at ~200 nodes from stepping down and up every hour.
+    static constexpr uint8_t RELEASE_PCT = 75;
+
+    /// Consecutive quiet evaluations required to release one step. Descent is one step per
+    /// evaluation; ascent is deliberately six times slower.
+    static constexpr uint8_t QUIET_HOURS_PER_STEP = 6;
+
+    // -----------------------------------------------------------------------
+    // Floors
+    // -----------------------------------------------------------------------
+    /// Absolute minimum satellite entries kept for builds whose UI reads them; see the
+    /// NODEDB_SCALING_UI_SATELLITE_FLOOR block above this class.
+    static constexpr uint16_t UI_SATELLITE_FLOOR = NODEDB_SCALING_UI_SATELLITE_FLOOR;
+
+    /// Environment and status have no map/list reader to starve, so they floor low
+    /// everywhere - just enough to keep the nearest few sensor nodes.
+    static constexpr uint16_t BULK_FLOOR = 4;
+
+    NodeDBScalingModule();
+    ~NodeDBScalingModule() = default;
+
+    // -----------------------------------------------------------------------
+    // Published caps - read by NodeDB's satellite eviction paths
+    // -----------------------------------------------------------------------
+    uint16_t getSatelliteCap() const { return satelliteCap; }
+    uint16_t getEnvironmentCap() const { return environmentCap; }
+    uint8_t getStep() const { return step; }
+
+    /// Apply a step directly. Recomputes the caps and, when the step moved, trims the
+    /// satellite maps to match. Public for tests and for a future admin override.
+    void setStep(uint8_t newStep);
+
+    /// One evaluation of the ladder against the supplied signals. Separated from runOnce()
+    /// so tests can drive it without a clock or a live HopScalingModule.
+    /// @param population estimated mesh population (HopScalingModule's scaled total)
+    /// @param underPressure true when the hot store is full or has evicted since the last call
+    void evaluate(uint16_t population, bool underPressure);
+
+    /// Ladder lookup: the step this population alone warrants, before hysteresis.
+    static uint8_t stepForPopulation(uint16_t population);
+
+    /// Percentage of MAX_SATELLITE_NODES, floored. Exposed for tests.
+    static uint16_t capForPct(uint8_t pct, uint16_t floor);
+
+  protected:
+    int32_t runOnce() override;
+
+  private:
+    /// Recompute satelliteCap / environmentCap from the current step.
+    void refreshCaps();
+
+    /// Read the current population estimate from HopScalingModule, or 0 when it has none yet.
+    static uint16_t currentPopulationEstimate();
+
+    uint8_t step = 0;
+    uint8_t quietEvaluations = 0; ///< consecutive evaluations that warranted a release
+    uint16_t satelliteCap = MAX_SATELLITE_NODES;
+    uint16_t environmentCap = MAX_SATELLITE_NODES;
+    uint32_t lastEvictionCount = 0; ///< NodeDB::hotEvictions at the previous evaluation
+};
+
+extern NodeDBScalingModule *nodeDBScalingModule;
+
+#endif // HAS_NODEDB_SCALING
+
+/// Effective per-map satellite caps. Both fall back to the compile-time
+/// MAX_SATELLITE_NODES when the module is compiled out or not yet constructed, so NodeDB
+/// can call them at any point in boot.
+uint16_t nodeDBSatelliteCap();
+uint16_t nodeDBEnvironmentCap();

--- a/src/modules/NodeDBScalingModule.h
+++ b/src/modules/NodeDBScalingModule.h
@@ -8,54 +8,35 @@
 /**
  * NodeDBScalingModule: ratchets the NodeDB satellite caps down under megamesh pressure.
  *
- * The problem: on a constrained part the satellite stores (position / telemetry /
- * environment / status) cost ~452 B RAM and 336 B flash per node at their worst, against
- * 100 B / 112 B for the NodeInfoLite header itself. In a mesh large enough to churn the
- * hot store, that budget is better spent on identities than on stale payloads for nodes
- * we will not see again.
+ * Satellite payloads (position / telemetry / environment / status) cost ~452 B RAM and 336 B
+ * flash per node against 100 B / 112 B for the NodeInfoLite header, so once the mesh is large
+ * enough to churn the hot store that budget buys more identities than stale payloads. The freed
+ * flash is spent on hot-store slots (NodeDB::applyHotStoreCapacity), filled passively from
+ * observed traffic so a larger store never buys extra handshake airtime.
  *
- * The policy: a step ladder, one step per hourly evaluation, driven by HopScalingModule's
- * population estimate and gated on evidence that the pressure is actually on *us* (a full
- * hot store, or evictions since the last evaluation). Descending is fast (one step per
- * hour while the population warrants it); ascending needs QUIET_HOURS_PER_STEP consecutive
- * quiet hours per step, so a mesh that briefly quietens does not thrash the caps.
+ *   step  population  sat (pos/tel)  bulk (env/status)
+ *   ----  ----------  -------------  -----------------
+ *      0           -      40 (100%)          40 (100%)
+ *      1       >=200      24  (60%)          24  (60%)
+ *      2       >=400      16  (40%)          16  (40%)
+ *      3       >=800       8  (20%)           8  (20%)
+ *      4      >=1500       8  (20%)           4  (10%)
  *
- * Ladder (percentages of MAX_SATELLITE_NODES, i.e. of 40 on a constrained part):
+ * Percentages are of MAX_SATELLITE_NODES (40 on a constrained part). Env/status ratchet one step
+ * deeper: EnvironmentMetrics is 4-5x any other entry and the least useful thing to persist, while
+ * position and telemetry both feed the on-device UI and keep a floor for it. Descent is one step
+ * per hourly evaluation and needs evidence the squeeze is on us (full hot store, or an eviction
+ * since the last evaluation); ascent needs QUIET_HOURS_PER_STEP consecutive quiet evaluations.
+ * The step is not persisted - it re-derives from HopScalingModule's warm-started estimate.
  *
- *   step  population  satellites (pos/tel)  bulk (env/status)
- *   ----  ----------  --------------------  -----------------
- *     0            -              40 (100%)          40 (100%)
- *     1         >=200              24  (60%)          24  (60%)
- *     2         >=400              16  (40%)          16  (40%)
- *     3         >=800               8  (20%)           8  (20%)
- *     4        >=1500               8  (20%)           4  (10%)
- *
- * Position and telemetry share a ladder because the on-device UI reads both (distance,
- * bearing, battery column). Environment and status get the extra step because
- * EnvironmentMetrics is the elephant - 196 B RAM / 170 B flash per entry, 4-5x anything
- * else - and is the least useful thing to persist in a megamesh.
- *
- * UI floor: satellite entries feed the local display, so builds that draw a map or a node
- * list keep an absolute minimum of them regardless of how far the ladder descends
- * (UI_SATELLITE_FLOOR below). A headless router has no such reader and ratchets freely.
- *
- * No persistence: the step is re-derived on the first evaluation after boot from
- * HopScalingModule's own warm-started estimate, so a reboot costs at most one startup
- * delay of over-capacity, not a state file.
- *
- * Accepted trade - packet history does not follow the growth. PACKETHISTORY_MAX is
- * 2x the *baseline* hot store and stays there while the ratchet is engaged, so dedup
- * coverage per node falls (on nRF52840: 240 records against up to 225 slots, ~1.1x
- * rather than 2x). Growing it would spend heap - the resource the growth guard exists
- * to protect - to buy back a property that degrades gracefully, since eviction is LRU.
- * See the PACKETHISTORY_MAX comment in mesh-pb-constants.h.
+ * Accepted trade: PACKETHISTORY_MAX stays sized from the baseline hot store, so dedup coverage
+ * per node thins while the ratchet is engaged. See its comment in mesh-pb-constants.h.
  */
 
 #if HAS_NODEDB_SCALING
 
-/// Absolute minimum satellite entries kept for builds whose UI reads them. InkHUD's map
-/// applet draws every node with a position, so it needs more than a node list that only
-/// resolves distance for the row in view; a headless build reads none of it.
+/// Minimum satellite entries kept for builds whose UI reads them: InkHUD's map applet draws every
+/// positioned node, a node list resolves only the row in view, a headless build reads none of it.
 #ifndef NODEDB_SCALING_UI_SATELLITE_FLOOR
 #if defined(MESHTASTIC_INCLUDE_INKHUD)
 #define NODEDB_SCALING_UI_SATELLITE_FLOOR 12
@@ -84,24 +65,20 @@ class NodeDBScalingModule : private concurrency::OSThread
     static constexpr uint8_t STEP_COUNT = sizeof(STEPS) / sizeof(STEPS[0]);
     static constexpr uint8_t MAX_STEP = STEP_COUNT - 1;
 
-    /// A step is released (ratcheted back up) only once the population drops below this
-    /// percentage of the step's own entry threshold - the hysteresis band that stops a
-    /// mesh hovering at ~200 nodes from stepping down and up every hour.
+    /// Release band: a step is given back only below this percentage of its own entry threshold,
+    /// so a mesh hovering at ~200 nodes does not step down and up every hour.
     static constexpr uint8_t RELEASE_PCT = 75;
 
-    /// Consecutive quiet evaluations required to release one step. Descent is one step per
-    /// evaluation; ascent is deliberately six times slower.
+    /// Consecutive quiet evaluations required to release one step; descent takes one.
     static constexpr uint8_t QUIET_HOURS_PER_STEP = 6;
 
     // -----------------------------------------------------------------------
     // Floors
     // -----------------------------------------------------------------------
-    /// Absolute minimum satellite entries kept for builds whose UI reads them; see the
-    /// NODEDB_SCALING_UI_SATELLITE_FLOOR block above this class.
+    /// Minimum kept for a UI that reads them; see NODEDB_SCALING_UI_SATELLITE_FLOOR above.
     static constexpr uint16_t UI_SATELLITE_FLOOR = NODEDB_SCALING_UI_SATELLITE_FLOOR;
 
-    /// Environment and status have no map/list reader to starve, so they floor low
-    /// everywhere - just enough to keep the nearest few sensor nodes.
+    /// Environment and status have no map/list reader to starve, so they floor low everywhere.
     static constexpr uint16_t BULK_FLOOR = 4;
 
     NodeDBScalingModule();
@@ -114,10 +91,8 @@ class NodeDBScalingModule : private concurrency::OSThread
     uint16_t getEnvironmentCap() const { return environmentCap; }
     uint8_t getStep() const { return step; }
 
-    /// Extra hot-store slots this step's satellite savings pay for, priced in worst-case
-    /// on-disk bytes (the budget that sizes MAX_NUM_NODES): freed satellite entry bytes
-    /// divided by meshtastic_NodeInfoLite_size. This is the funding only - NodeDB clamps the
-    /// resulting total to its decode ceiling and to what the heap can actually carry.
+    /// Hot-store slots this step's savings fund, priced in the worst-case on-disk bytes that size
+    /// MAX_NUM_NODES. Funding only - NodeDB clamps to its decode ceiling and to the live heap.
     uint16_t getBonusNodes() const { return bonusNodes; }
 
     /// Worst-case bytes reclaimed from nodes.proto at the given caps, and the slots they buy.
@@ -127,14 +102,13 @@ class NodeDBScalingModule : private concurrency::OSThread
     /// One-shot startup report: the ladder, and what each step would cost and fund.
     void logLadder() const;
 
-    /// Apply a step directly. Recomputes the caps and, when the step moved, trims the
-    /// satellite maps to match. Public for tests and for a future admin override.
+    /// Apply a step directly, trimming the satellite maps when it moved. Public for tests
+    /// and for a future admin override.
     void setStep(uint8_t newStep);
 
-    /// One evaluation of the ladder against the supplied signals. Separated from runOnce()
-    /// so tests can drive it without a clock or a live HopScalingModule.
-    /// @param population estimated mesh population (HopScalingModule's scaled total)
-    /// @param underPressure true when the hot store is full or has evicted since the last call
+    /// One ladder evaluation; split from runOnce() so tests need no clock or HopScalingModule.
+    /// @param population HopScalingModule's scaled total
+    /// @param underPressure hot store full, or evicted since the last call
     void evaluate(uint16_t population, bool underPressure);
 
     /// Ladder lookup: the step this population alone warrants, before hysteresis.
@@ -165,9 +139,8 @@ extern NodeDBScalingModule *nodeDBScalingModule;
 
 #endif // HAS_NODEDB_SCALING
 
-/// Effective per-map satellite caps. Both fall back to the compile-time
-/// MAX_SATELLITE_NODES when the module is compiled out or not yet constructed, so NodeDB
-/// can call them at any point in boot.
+/// Effective per-map satellite caps. Both fall back to MAX_SATELLITE_NODES when the module is
+/// compiled out or not yet constructed, so NodeDB can call them at any point in boot.
 uint16_t nodeDBSatelliteCap();
 uint16_t nodeDBEnvironmentCap();
 

--- a/src/modules/NodeDBScalingModule.h
+++ b/src/modules/NodeDBScalingModule.h
@@ -42,6 +42,13 @@
  * No persistence: the step is re-derived on the first evaluation after boot from
  * HopScalingModule's own warm-started estimate, so a reboot costs at most one startup
  * delay of over-capacity, not a state file.
+ *
+ * Accepted trade - packet history does not follow the growth. PACKETHISTORY_MAX is
+ * 2x the *baseline* hot store and stays there while the ratchet is engaged, so dedup
+ * coverage per node falls (on nRF52840: 240 records against up to 225 slots, ~1.1x
+ * rather than 2x). Growing it would spend heap - the resource the growth guard exists
+ * to protect - to buy back a property that degrades gracefully, since eviction is LRU.
+ * See the PACKETHISTORY_MAX comment in mesh-pb-constants.h.
  */
 
 #if HAS_NODEDB_SCALING
@@ -107,6 +114,19 @@ class NodeDBScalingModule : private concurrency::OSThread
     uint16_t getEnvironmentCap() const { return environmentCap; }
     uint8_t getStep() const { return step; }
 
+    /// Extra hot-store slots this step's satellite savings pay for, priced in worst-case
+    /// on-disk bytes (the budget that sizes MAX_NUM_NODES): freed satellite entry bytes
+    /// divided by meshtastic_NodeInfoLite_size. This is the funding only - NodeDB clamps the
+    /// resulting total to its decode ceiling and to what the heap can actually carry.
+    uint16_t getBonusNodes() const { return bonusNodes; }
+
+    /// Worst-case bytes reclaimed from nodes.proto at the given caps, and the slots they buy.
+    static uint32_t freedFlashBytes(uint16_t satCap, uint16_t envCap);
+    static uint16_t bonusForCaps(uint16_t satCap, uint16_t envCap);
+
+    /// One-shot startup report: the ladder, and what each step would cost and fund.
+    void logLadder() const;
+
     /// Apply a step directly. Recomputes the caps and, when the step moved, trims the
     /// satellite maps to match. Public for tests and for a future admin override.
     void setStep(uint8_t newStep);
@@ -137,6 +157,7 @@ class NodeDBScalingModule : private concurrency::OSThread
     uint8_t quietEvaluations = 0; ///< consecutive evaluations that warranted a release
     uint16_t satelliteCap = MAX_SATELLITE_NODES;
     uint16_t environmentCap = MAX_SATELLITE_NODES;
+    uint16_t bonusNodes = 0;
     uint32_t lastEvictionCount = 0; ///< NodeDB::hotEvictions at the previous evaluation
 };
 
@@ -149,3 +170,6 @@ extern NodeDBScalingModule *nodeDBScalingModule;
 /// can call them at any point in boot.
 uint16_t nodeDBSatelliteCap();
 uint16_t nodeDBEnvironmentCap();
+
+/// Extra hot-store slots funded by the satellite savings; 0 when unpressured or compiled out.
+uint16_t nodeDBBonusNodes();

--- a/test/state-manifest.tsv
+++ b/test/state-manifest.tsv
@@ -50,6 +50,7 @@ test_mesh_module	writes=config.proto,module.proto,device.proto,channels.proto,no
 test_mqtt	writes=config.proto,module.proto,device.proto,channels.proto,nodes.proto	constructs a NodeDB for node lookups in the MQTT paths
 test_nexthop_routing	writes=config.proto,module.proto,device.proto,channels.proto,nodes.proto	next-hop selection reads and updates the node DB
 test_nodedb_blocked	state=per-suite writes=config.proto,module.proto,device.proto,channels.proto,nodes.proto,warm.dat	saturates the DB with MAX_NUM_NODES-2 favourited nodes to test the protected cap; a later test's removeNodeByNum() persists that state, and the cap test depends on the fill from the test before it
+test_nodedb_scaling	writes=config.proto,module.proto,device.proto,channels.proto,nodes.proto	constructs a NodeDB so the satellite-cap ratchet has real maps and last_heard values to trim
 test_packet_signing	writes=config.proto,module.proto,device.proto,channels.proto,nodes.proto,warm.dat	needs a NodeDB holding both peers' keys for the PKI encode/decode paths
 test_pki_admin_fallback	writes=config.proto,module.proto,device.proto,channels.proto,nodes.proto	needs a NodeDB holding admin keys for the fallback paths
 test_stream_api	writes=config.proto,module.proto,device.proto,channels.proto,nodes.proto	drives real PhoneAPI handshakes, which read and persist config and the node DB

--- a/test/test_nodedb_scaling/test_main.cpp
+++ b/test/test_nodedb_scaling/test_main.cpp
@@ -41,6 +41,22 @@ class NodeDBTestShim : public NodeDB
         nodePositions[num] = pos;
         nodeEnvironment[num] = meshtastic_EnvironmentMetrics_init_zero;
     }
+
+    /// Bare hot-store rows, no satellites - for occupancy/gate tests.
+    void fillHot(pb_size_t count)
+    {
+        clearHot();
+        for (pb_size_t i = 0; i < count; i++) {
+            meshtastic_NodeInfoLite n = meshtastic_NodeInfoLite_init_zero;
+            n.num = 0x2000 + i;
+            n.last_heard = 1000 + i;
+            meshNodes->push_back(n);
+        }
+        numMeshNodes = count;
+        // Keep the backing store at the live cap, as production does after applyHotStoreCapacity().
+        if (meshNodes->size() < effectiveMaxNodes())
+            meshNodes->resize(effectiveMaxNodes());
+    }
 };
 
 namespace
@@ -243,6 +259,94 @@ void test_stepDownTrimsSatellitesOldestFirst()
     TEST_ASSERT_EQUAL_UINT32((uint32_t)satCap, (uint32_t)db->nodePositions.size());
 }
 
+// ---------------------------------------------------------------------------
+// Converting freed satellite budget into hot-store slots
+// ---------------------------------------------------------------------------
+
+// The funding is priced in worst-case on-disk bytes, so it must rise monotonically as the
+// ladder descends and be zero when unpressured.
+void test_bonusRisesWithEachStep()
+{
+    TEST_ASSERT_EQUAL_UINT32(0, NodeDBScalingModule::freedFlashBytes(MAX_SATELLITE_NODES, MAX_SATELLITE_NODES));
+    TEST_ASSERT_EQUAL_UINT16(0, NodeDBScalingModule::bonusForCaps(MAX_SATELLITE_NODES, MAX_SATELLITE_NODES));
+
+    uint16_t previous = 0;
+    for (uint8_t i = 1; i < NodeDBScalingModule::STEP_COUNT; i++) {
+        const uint16_t sat =
+            NodeDBScalingModule::capForPct(NodeDBScalingModule::STEPS[i].satellitePct, NodeDBScalingModule::UI_SATELLITE_FLOOR);
+        const uint16_t env =
+            NodeDBScalingModule::capForPct(NodeDBScalingModule::STEPS[i].bulkPct, NodeDBScalingModule::BULK_FLOOR);
+        const uint16_t bonus = NodeDBScalingModule::bonusForCaps(sat, env);
+        TEST_ASSERT_GREATER_THAN_UINT16(previous, bonus);
+        previous = bonus;
+    }
+}
+
+// A file we write must stay inside the decode allowance every build already grants, or a peer
+// or a downgrade could not read it back.
+void test_effectiveMaxNodesNeverExceedsDecodeCeiling()
+{
+    for (uint8_t i = 0; i < NodeDBScalingModule::STEP_COUNT; i++) {
+        mod->setStep(i);
+        TEST_ASSERT_LESS_OR_EQUAL_UINT32(NODEDB_MIGRATION_LOAD_CEILING, (uint32_t)db->effectiveMaxNodes());
+        TEST_ASSERT_GREATER_OR_EQUAL_UINT32((uint32_t)MAX_NUM_NODES, (uint32_t)db->effectiveMaxNodes());
+    }
+}
+
+// THE invariant: extra capacity is filled passively. The introduce-yourself handshake gate must
+// stay pinned to the baseline even while the store is allowed to grow past it.
+void test_passiveFillGateDoesNotFollowTheBonus()
+{
+    mod->setStep(NodeDBScalingModule::MAX_STEP);
+    db->applyHotStoreCapacity();
+
+    // Below baseline: still actively introducing ourselves.
+    db->fillHot(NODEDB_BASELINE_NODES - 1);
+    TEST_ASSERT_FALSE(db->isPassiveFillOnly());
+
+    // At baseline: gate closes, even though the store has room to keep growing.
+    db->fillHot(NODEDB_BASELINE_NODES);
+    TEST_ASSERT_TRUE(db->isPassiveFillOnly());
+    if (db->effectiveMaxNodes() > NODEDB_BASELINE_NODES)
+        TEST_ASSERT_FALSE(db->isFull()); // room remains, but only for passively-learned nodes
+}
+
+void test_capacityGrowsAndIsHandedBack()
+{
+    mod->setStep(0);
+    db->applyHotStoreCapacity();
+    const size_t base = db->meshNodes->size();
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)db->effectiveMaxNodes(), (uint32_t)base);
+
+    mod->setStep(NodeDBScalingModule::MAX_STEP);
+    db->applyHotStoreCapacity();
+    TEST_ASSERT_GREATER_OR_EQUAL_UINT32((uint32_t)base, (uint32_t)db->meshNodes->size());
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)db->effectiveMaxNodes(), (uint32_t)db->meshNodes->size());
+
+    // Mesh quietens: the slots go back, and the store is resized to match.
+    mod->setStep(0);
+    db->applyHotStoreCapacity();
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)base, (uint32_t)db->meshNodes->size());
+    TEST_ASSERT_LESS_OR_EQUAL_UINT32((uint32_t)base, (uint32_t)db->numMeshNodes);
+}
+
+// Accepted trade, guarded so it cannot drift: dedup history is sized from the BASELINE hot
+// store, never from the ratcheted cap. Wiring it to the effective cap would spend the heap the
+// growth guard exists to protect, and would silently blow MESHTASTIC_BOOT_CACHE_BUDGET.
+void test_dedupHistoryStaysPinnedToBaseline()
+{
+    const uint32_t fromBaseline = ((uint32_t)MAX_NUM_NODES * 2 > 100) ? (uint32_t)MAX_NUM_NODES * 2 : 100u;
+    TEST_ASSERT_EQUAL_UINT32(fromBaseline, (uint32_t)PACKETHISTORY_MAX);
+
+    // With the ratchet fully engaged the cap grows, but the history does not follow it - so the
+    // records-per-slot ratio is expected to fall below the nominal 2x.
+    mod->setStep(NodeDBScalingModule::MAX_STEP);
+    db->applyHotStoreCapacity();
+    TEST_ASSERT_EQUAL_UINT32(fromBaseline, (uint32_t)PACKETHISTORY_MAX);
+    if (db->effectiveMaxNodes() > MAX_NUM_NODES)
+        TEST_ASSERT_LESS_THAN_UINT32((uint32_t)db->effectiveMaxNodes() * 2u, (uint32_t)PACKETHISTORY_MAX);
+}
+
 } // namespace
 
 // Every test starts from an unpressured ladder; setStep() also clears the hysteresis run.
@@ -277,6 +381,12 @@ NDB_TEST_ENTRY void setup()
 
     RUN_TEST(test_freeAccessorsTrackTheModule);
     RUN_TEST(test_stepDownTrimsSatellitesOldestFirst);
+
+    RUN_TEST(test_bonusRisesWithEachStep);
+    RUN_TEST(test_effectiveMaxNodesNeverExceedsDecodeCeiling);
+    RUN_TEST(test_passiveFillGateDoesNotFollowTheBonus);
+    RUN_TEST(test_capacityGrowsAndIsHandedBack);
+    RUN_TEST(test_dedupHistoryStaysPinnedToBaseline);
 
     exit(UNITY_END());
 }

--- a/test/test_nodedb_scaling/test_main.cpp
+++ b/test/test_nodedb_scaling/test_main.cpp
@@ -196,6 +196,25 @@ void test_quietRunIsResetByABusyEvaluation()
     TEST_ASSERT_EQUAL_UINT8(0, mod->getStep());
 }
 
+// A population warranting a deeper step voids the release run even with no pressure signal -
+// otherwise quiet hours from either side of a busy spell add up to an undeserved release.
+void test_highPopulationWithoutPressureVoidsTheQuietRun()
+{
+    mod->setStep(1); // entry 200, release below 150
+    for (uint8_t i = 0; i < NodeDBScalingModule::QUIET_HOURS_PER_STEP - 1; i++)
+        mod->evaluate(100, false);
+
+    mod->evaluate(500, /*underPressure=*/false); // warrants step 2, but nothing is squeezing us
+    TEST_ASSERT_EQUAL_UINT8(1, mod->getStep());
+
+    mod->evaluate(100, false); // would have been the sixth quiet hour had the run survived
+    TEST_ASSERT_EQUAL_UINT8(1, mod->getStep());
+
+    for (uint8_t i = 1; i < NodeDBScalingModule::QUIET_HOURS_PER_STEP; i++)
+        mod->evaluate(100, false);
+    TEST_ASSERT_EQUAL_UINT8(0, mod->getStep());
+}
+
 void test_ratchetIsSymmetricAcrossAFullCycle()
 {
     for (int i = 0; i < NodeDBScalingModule::MAX_STEP; i++)
@@ -330,6 +349,32 @@ void test_capacityGrowsAndIsHandedBack()
     TEST_ASSERT_LESS_OR_EQUAL_UINT32((uint32_t)base, (uint32_t)db->numMeshNodes);
 }
 
+// Protected-node admission is pinned to the BASELINE cap, never the ratcheted one: capacity is
+// handed back, and a round trip through the warm tier does not restore favorite/ignore/verified.
+void test_protectedCapIgnoresTheRatchetedCapacity()
+{
+    mod->setStep(NodeDBScalingModule::MAX_STEP);
+    db->applyHotStoreCapacity();
+
+    db->clearHot();
+    const pb_size_t grown = db->effectiveMaxNodes();
+    for (pb_size_t i = 0; i < grown; i++)
+        db->pushWithSatellites(0x3000 + i, 1000 + i);
+
+    int admitted = 0;
+    for (pb_size_t i = 0; i < grown; i++)
+        if (db->setProtectedFlag(&db->meshNodes->at(i), NODEINFO_BITFIELD_IS_FAVORITE_MASK, true))
+            admitted++;
+    TEST_ASSERT_EQUAL_INT(MAX_NUM_NODES - 2, admitted);
+    TEST_ASSERT_EQUAL_INT(admitted, db->numProtectedNodes());
+
+    // Hand the capacity back: the overflow demotes, but no favorite is among it.
+    mod->setStep(0);
+    db->applyHotStoreCapacity();
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)MAX_NUM_NODES, (uint32_t)db->effectiveMaxNodes());
+    TEST_ASSERT_EQUAL_INT(admitted, db->numProtectedNodes());
+}
+
 // Accepted trade, guarded so it cannot drift: dedup history is sized from the BASELINE hot
 // store, never from the ratcheted cap. Wiring it to the effective cap would spend the heap the
 // growth guard exists to protect, and would silently blow MESHTASTIC_BOOT_CACHE_BUDGET.
@@ -377,6 +422,7 @@ NDB_TEST_ENTRY void setup()
     RUN_TEST(test_releaseNeedsSustainedQuiet);
     RUN_TEST(test_populationInsideHysteresisBandHolds);
     RUN_TEST(test_quietRunIsResetByABusyEvaluation);
+    RUN_TEST(test_highPopulationWithoutPressureVoidsTheQuietRun);
     RUN_TEST(test_ratchetIsSymmetricAcrossAFullCycle);
 
     RUN_TEST(test_freeAccessorsTrackTheModule);
@@ -386,6 +432,7 @@ NDB_TEST_ENTRY void setup()
     RUN_TEST(test_effectiveMaxNodesNeverExceedsDecodeCeiling);
     RUN_TEST(test_passiveFillGateDoesNotFollowTheBonus);
     RUN_TEST(test_capacityGrowsAndIsHandedBack);
+    RUN_TEST(test_protectedCapIgnoresTheRatchetedCapacity);
     RUN_TEST(test_dedupHistoryStaysPinnedToBaseline);
 
     exit(UNITY_END());

--- a/test/test_nodedb_scaling/test_main.cpp
+++ b/test/test_nodedb_scaling/test_main.cpp
@@ -171,7 +171,7 @@ void test_releaseNeedsSustainedQuiet()
     TEST_ASSERT_EQUAL_UINT8(0, mod->getStep());
 }
 
-void test_populationInsideHysteresisBandHolds()
+void test_populationInsideTheHysteresisBandHolds()
 {
     mod->setStep(1); // entry 200, release below 150: 175 is inside the band
     for (int i = 0; i < 20; i++)
@@ -420,7 +420,7 @@ NDB_TEST_ENTRY void setup()
     RUN_TEST(test_populationWithoutPressureDoesNotDescend);
     RUN_TEST(test_capsFollowTheStep);
     RUN_TEST(test_releaseNeedsSustainedQuiet);
-    RUN_TEST(test_populationInsideHysteresisBandHolds);
+    RUN_TEST(test_populationInsideTheHysteresisBandHolds);
     RUN_TEST(test_quietRunIsResetByABusyEvaluation);
     RUN_TEST(test_highPopulationWithoutPressureVoidsTheQuietRun);
     RUN_TEST(test_ratchetIsSymmetricAcrossAFullCycle);

--- a/test/test_nodedb_scaling/test_main.cpp
+++ b/test/test_nodedb_scaling/test_main.cpp
@@ -1,0 +1,298 @@
+// Tests for the megamesh satellite ratchet - src/modules/NodeDBScalingModule.cpp - and the
+// effective-cap plumbing it drives in NodeDB::enforceSatelliteCaps().
+#include "MeshTypes.h" // BEFORE TestUtil.h - provides MAX_SATELLITE_NODES via mesh-pb-constants.h
+#include "TestUtil.h"
+#include <unity.h>
+
+#if defined(ARCH_PORTDUINO)
+#define NDB_TEST_ENTRY extern "C"
+#else
+#define NDB_TEST_ENTRY
+#endif
+
+#if HAS_NODEDB_SCALING
+
+#include "mesh/NodeDB.h"
+#include "modules/NodeDBScalingModule.h"
+#include <cstring>
+
+// Subclass shim: lets a test own the hot store directly so the satellite trim has
+// last_heard values to rank against. Global scope to match `friend class NodeDBTestShim`.
+class NodeDBTestShim : public NodeDB
+{
+  public:
+    void clearHot()
+    {
+        meshNodes->clear();
+        numMeshNodes = 0;
+    }
+
+    /// Push a hot-store row and give it a position + environment satellite entry.
+    void pushWithSatellites(NodeNum num, uint32_t lastHeard)
+    {
+        meshtastic_NodeInfoLite n = meshtastic_NodeInfoLite_init_zero;
+        n.num = num;
+        n.last_heard = lastHeard;
+        meshNodes->push_back(n);
+        numMeshNodes = meshNodes->size();
+
+        meshtastic_PositionLite pos = meshtastic_PositionLite_init_zero;
+        pos.time = lastHeard;
+        nodePositions[num] = pos;
+        nodeEnvironment[num] = meshtastic_EnvironmentMetrics_init_zero;
+    }
+};
+
+namespace
+{
+
+NodeDBTestShim *db = nullptr;
+NodeDBScalingModule *mod = nullptr;
+
+constexpr uint16_t pctOfBase(uint8_t pct)
+{
+    return (uint16_t)(((uint32_t)MAX_SATELLITE_NODES * pct) / 100u);
+}
+
+// ---------------------------------------------------------------------------
+// Ladder lookup
+// ---------------------------------------------------------------------------
+
+void test_stepForPopulation_walksTheLadder()
+{
+    TEST_ASSERT_EQUAL_UINT8(0, NodeDBScalingModule::stepForPopulation(0));
+    TEST_ASSERT_EQUAL_UINT8(0, NodeDBScalingModule::stepForPopulation(199));
+    TEST_ASSERT_EQUAL_UINT8(1, NodeDBScalingModule::stepForPopulation(200));
+    TEST_ASSERT_EQUAL_UINT8(1, NodeDBScalingModule::stepForPopulation(399));
+    TEST_ASSERT_EQUAL_UINT8(2, NodeDBScalingModule::stepForPopulation(400));
+    TEST_ASSERT_EQUAL_UINT8(3, NodeDBScalingModule::stepForPopulation(800));
+    TEST_ASSERT_EQUAL_UINT8(4, NodeDBScalingModule::stepForPopulation(1500));
+    TEST_ASSERT_EQUAL_UINT8(4, NodeDBScalingModule::stepForPopulation(65535));
+}
+
+// The published ladder is 100/60/40/20 for satellites and 100/60/40/20/10 for the bulk
+// stores - i.e. 40-24-16-8 and 40-24-16-8-4 on a part whose base cap is 40.
+void test_ladderPercentagesMatchThePublishedSteps()
+{
+    static const uint8_t expectedSat[] = {100, 60, 40, 20, 20};
+    static const uint8_t expectedBulk[] = {100, 60, 40, 20, 10};
+    TEST_ASSERT_EQUAL_UINT8(5, NodeDBScalingModule::STEP_COUNT);
+    for (uint8_t i = 0; i < NodeDBScalingModule::STEP_COUNT; i++) {
+        TEST_ASSERT_EQUAL_UINT8(expectedSat[i], NodeDBScalingModule::STEPS[i].satellitePct);
+        TEST_ASSERT_EQUAL_UINT8(expectedBulk[i], NodeDBScalingModule::STEPS[i].bulkPct);
+    }
+}
+
+void test_capForPct_appliesFloorAndCeiling()
+{
+    // A percentage above the floor passes through unchanged.
+    TEST_ASSERT_EQUAL_UINT16(MAX_SATELLITE_NODES, NodeDBScalingModule::capForPct(100, 1));
+    TEST_ASSERT_EQUAL_UINT16(pctOfBase(60), NodeDBScalingModule::capForPct(60, 1));
+    // A floor raises a cap that fell below it...
+    TEST_ASSERT_EQUAL_UINT16(pctOfBase(20) + 5, NodeDBScalingModule::capForPct(20, pctOfBase(20) + 5));
+    // ...but never above the unpressured cap.
+    TEST_ASSERT_EQUAL_UINT16(MAX_SATELLITE_NODES, NodeDBScalingModule::capForPct(10, MAX_SATELLITE_NODES + 100));
+}
+
+// ---------------------------------------------------------------------------
+// Ratchet
+// ---------------------------------------------------------------------------
+
+void test_descendsOneStepPerEvaluation()
+{
+    // A population that warrants step 4 still only moves one step at a time.
+    mod->evaluate(2000, /*underPressure=*/true);
+    TEST_ASSERT_EQUAL_UINT8(1, mod->getStep());
+    mod->evaluate(2000, true);
+    TEST_ASSERT_EQUAL_UINT8(2, mod->getStep());
+    mod->evaluate(2000, true);
+    TEST_ASSERT_EQUAL_UINT8(3, mod->getStep());
+    mod->evaluate(2000, true);
+    TEST_ASSERT_EQUAL_UINT8(4, mod->getStep());
+    // ...and stops at the bottom of the ladder.
+    mod->evaluate(2000, true);
+    TEST_ASSERT_EQUAL_UINT8(NodeDBScalingModule::MAX_STEP, mod->getStep());
+}
+
+// Hearing a big mesh is not enough: the squeeze has to be on our own store.
+void test_populationWithoutPressureDoesNotDescend()
+{
+    for (int i = 0; i < 10; i++)
+        mod->evaluate(2000, /*underPressure=*/false);
+    TEST_ASSERT_EQUAL_UINT8(0, mod->getStep());
+}
+
+void test_capsFollowTheStep()
+{
+    TEST_ASSERT_EQUAL_UINT16(MAX_SATELLITE_NODES, mod->getSatelliteCap());
+    TEST_ASSERT_EQUAL_UINT16(MAX_SATELLITE_NODES, mod->getEnvironmentCap());
+
+    mod->setStep(1);
+    TEST_ASSERT_EQUAL_UINT16(pctOfBase(60), mod->getSatelliteCap());
+    TEST_ASSERT_EQUAL_UINT16(pctOfBase(60), mod->getEnvironmentCap());
+
+    // At the bottom the bulk stores are cut one step further than the UI-facing ones.
+    mod->setStep(NodeDBScalingModule::MAX_STEP);
+    TEST_ASSERT_GREATER_THAN_UINT16(mod->getEnvironmentCap(), mod->getSatelliteCap());
+
+    // Whatever the ladder says, the floors hold.
+    TEST_ASSERT_GREATER_OR_EQUAL_UINT16(NodeDBScalingModule::UI_SATELLITE_FLOOR, mod->getSatelliteCap());
+    TEST_ASSERT_GREATER_OR_EQUAL_UINT16(NodeDBScalingModule::BULK_FLOOR, mod->getEnvironmentCap());
+}
+
+// A step is only released after a sustained quiet spell, and only once the population has
+// fallen clear of the hysteresis band around the step's own entry threshold.
+void test_releaseNeedsSustainedQuiet()
+{
+    mod->setStep(1); // entry threshold 200, release below 150
+    const uint16_t quiet = 100;
+
+    for (uint8_t i = 0; i < NodeDBScalingModule::QUIET_HOURS_PER_STEP - 1; i++) {
+        mod->evaluate(quiet, /*underPressure=*/false);
+        TEST_ASSERT_EQUAL_UINT8(1, mod->getStep());
+    }
+    mod->evaluate(quiet, false);
+    TEST_ASSERT_EQUAL_UINT8(0, mod->getStep());
+}
+
+void test_populationInsideHysteresisBandHolds()
+{
+    mod->setStep(1); // entry 200, release below 150: 175 is inside the band
+    for (int i = 0; i < 20; i++)
+        mod->evaluate(175, /*underPressure=*/false);
+    TEST_ASSERT_EQUAL_UINT8(1, mod->getStep());
+}
+
+// One busy hour part-way through a quiet spell resets the count - no half-release.
+void test_quietRunIsResetByABusyEvaluation()
+{
+    mod->setStep(1);
+    for (uint8_t i = 0; i < NodeDBScalingModule::QUIET_HOURS_PER_STEP - 1; i++)
+        mod->evaluate(100, false);
+    mod->evaluate(250, /*underPressure=*/false); // warrants step 1: not a release, resets the run
+    TEST_ASSERT_EQUAL_UINT8(1, mod->getStep());
+
+    for (uint8_t i = 0; i < NodeDBScalingModule::QUIET_HOURS_PER_STEP - 1; i++) {
+        mod->evaluate(100, false);
+        TEST_ASSERT_EQUAL_UINT8(1, mod->getStep());
+    }
+    mod->evaluate(100, false);
+    TEST_ASSERT_EQUAL_UINT8(0, mod->getStep());
+}
+
+void test_ratchetIsSymmetricAcrossAFullCycle()
+{
+    for (int i = 0; i < NodeDBScalingModule::MAX_STEP; i++)
+        mod->evaluate(2000, true);
+    TEST_ASSERT_EQUAL_UINT8(NodeDBScalingModule::MAX_STEP, mod->getStep());
+
+    // Mesh goes quiet: every step comes back, one quiet run each.
+    for (uint8_t s = NodeDBScalingModule::MAX_STEP; s > 0; s--) {
+        for (uint8_t i = 0; i < NodeDBScalingModule::QUIET_HOURS_PER_STEP; i++)
+            mod->evaluate(0, false);
+    }
+    TEST_ASSERT_EQUAL_UINT8(0, mod->getStep());
+    TEST_ASSERT_EQUAL_UINT16(MAX_SATELLITE_NODES, mod->getSatelliteCap());
+    TEST_ASSERT_EQUAL_UINT16(MAX_SATELLITE_NODES, mod->getEnvironmentCap());
+}
+
+// ---------------------------------------------------------------------------
+// Cap plumbing into NodeDB
+// ---------------------------------------------------------------------------
+
+void test_freeAccessorsTrackTheModule()
+{
+    mod->setStep(0);
+    TEST_ASSERT_EQUAL_UINT16(MAX_SATELLITE_NODES, nodeDBSatelliteCap());
+    TEST_ASSERT_EQUAL_UINT16(MAX_SATELLITE_NODES, nodeDBEnvironmentCap());
+
+    mod->setStep(NodeDBScalingModule::MAX_STEP);
+    TEST_ASSERT_EQUAL_UINT16(mod->getSatelliteCap(), nodeDBSatelliteCap());
+    TEST_ASSERT_EQUAL_UINT16(mod->getEnvironmentCap(), nodeDBEnvironmentCap());
+}
+
+// Stepping down has to reclaim immediately, and has to reclaim the *stalest* entries -
+// the freshest nodes are the ones the UI still wants to draw.
+void test_stepDownTrimsSatellitesOldestFirst()
+{
+    db->clearHot();
+    // last_heard ascending with node number, so 0x1000 is the stalest.
+    for (uint16_t i = 0; i < MAX_SATELLITE_NODES; i++)
+        db->pushWithSatellites(0x1000 + i, 1000 + i);
+
+    mod->setStep(0);
+    db->enforceSatelliteCaps();
+    TEST_ASSERT_EQUAL_UINT16(MAX_SATELLITE_NODES, db->nodePositions.size());
+
+    mod->setStep(NodeDBScalingModule::MAX_STEP); // calls enforceSatelliteCaps() itself
+    const uint16_t satCap = mod->getSatelliteCap();
+    const uint16_t envCap = mod->getEnvironmentCap();
+    TEST_ASSERT_EQUAL_UINT16(satCap, db->nodePositions.size());
+    TEST_ASSERT_EQUAL_UINT16(envCap, db->nodeEnvironment.size());
+    TEST_ASSERT_LESS_THAN_UINT16(satCap, envCap); // bulk is cut harder than UI-facing
+
+    // The survivors are the freshest ones.
+    for (uint16_t i = 0; i < MAX_SATELLITE_NODES; i++) {
+        const bool shouldSurvive = i >= (MAX_SATELLITE_NODES - satCap);
+        TEST_ASSERT_EQUAL(shouldSurvive ? 1u : 0u, db->nodePositions.count(0x1000 + i));
+    }
+
+    // Ratcheting back up must not resurrect anything - the maps refill from live traffic only.
+    mod->setStep(0);
+    TEST_ASSERT_EQUAL_UINT16(MAX_SATELLITE_NODES, mod->getSatelliteCap());
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)satCap, (uint32_t)db->nodePositions.size());
+}
+
+} // namespace
+
+// Every test starts from an unpressured ladder; setStep() also clears the hysteresis run.
+void setUp(void)
+{
+    if (mod)
+        mod->setStep(0);
+}
+void tearDown(void) {}
+
+NDB_TEST_ENTRY void setup()
+{
+    initializeTestEnvironment();
+    db = new NodeDBTestShim();
+    nodeDB = db;
+    mod = new NodeDBScalingModule();
+    nodeDBScalingModule = mod;
+
+    UNITY_BEGIN();
+
+    RUN_TEST(test_stepForPopulation_walksTheLadder);
+    RUN_TEST(test_ladderPercentagesMatchThePublishedSteps);
+    RUN_TEST(test_capForPct_appliesFloorAndCeiling);
+
+    RUN_TEST(test_descendsOneStepPerEvaluation);
+    RUN_TEST(test_populationWithoutPressureDoesNotDescend);
+    RUN_TEST(test_capsFollowTheStep);
+    RUN_TEST(test_releaseNeedsSustainedQuiet);
+    RUN_TEST(test_populationInsideHysteresisBandHolds);
+    RUN_TEST(test_quietRunIsResetByABusyEvaluation);
+    RUN_TEST(test_ratchetIsSymmetricAcrossAFullCycle);
+
+    RUN_TEST(test_freeAccessorsTrackTheModule);
+    RUN_TEST(test_stepDownTrimsSatellitesOldestFirst);
+
+    exit(UNITY_END());
+}
+
+NDB_TEST_ENTRY void loop() {}
+
+#else // !HAS_NODEDB_SCALING
+
+void setUp(void) {}
+void tearDown(void) {}
+NDB_TEST_ENTRY void setup()
+{
+    initializeTestEnvironment();
+    UNITY_BEGIN();
+    exit(UNITY_END());
+}
+NDB_TEST_ENTRY void loop() {}
+
+#endif // HAS_NODEDB_SCALING


### PR DESCRIPTION
In a mesh large enough to churn the hot store, the per-node satellite payloads are the wrong thing to be spending memory on. Measured against NodeInfoLite's 100 B RAM / 112 B encoded, a node carrying all four satellites costs ~452 B RAM and 336 B flash - and EnvironmentMetrics alone is 196 B / 170 B of that, 4-5x every other entry and the least useful thing to persist for a node we will not see again.

NodeDBScalingModule turns MAX_SATELLITE_NODES into a step ladder driven by HopScalingModule's existing population estimate (already sampled, scaled and 13-hour hysteretic, so no new churn counter is needed). Position and telemetry share one ladder because the on-device UI reads both; environment and status get an extra step down. Descent is one step per hourly evaluation and is gated on evidence that the squeeze is on us - a full hot store or evictions since the last check - so a node parked beside a busy repeater in a small mesh does not ratchet on population alone. Release needs six consecutive quiet evaluations per step, and only once population falls below 75% of that step's own entry threshold. Nothing is persisted: the step is re-derived after boot from the histogram's own warm-started estimate.

Builds whose UI reads the satellites keep an absolute floor of entries - 12 for InkHUD, whose map applet draws every positioned node, 8 for other screens, 4 headless. Compiled out entirely on TINY parts and wherever HAS_VARIABLE_HOPS is off, since the population estimate is the module's only input.

Separately, the "heard a new node, introduce ourselves and ask for a reply" handshake in MeshService now gates on a new NodeDB::isPassiveFillOnly() keyed to NODEDB_BASELINE_NODES rather than on isFull(). The two are identical today. The point is the seam: once the hot store is allowed to flex above its baseline, the extra capacity fills passively from observed traffic, so a larger store cannot buy more handshake airtime than a small one - which the current isFull() gate would otherwise do, since a saturated node has that handshake permanently off and an unsaturated one does not.


## Converting the freed budget into node capacity

The reclaimed `nodes.proto` budget is now spent on hot-store slots. Figures are for **nRF52840 /
generic ESP32** (satellite base 40, hot-store baseline 120, `NodeInfoLite` 112 B encoded):

| step | population | pos/tel | env/status | flash freed | +nodes | hot cap | dedup ratio |
|---|---|---|---|---|---|---|---|
| 0 | — | 40 | 40 | 0 B | +0 | **120** | 2.00x |
| 1 | ≥200 | 24 | 24 | 5,376 B | +48 | **168** | 1.43x |
| 2 | ≥400 | 16 | 16 | 8,064 B | +72 | **192** | 1.25x |
| 3 | ≥800 | 8 | 8 | 10,752 B | +96 | **216** | 1.11x |
| 4 | ≥1500 | 8 | 4 | 11,788 B | +105 | **225** | 1.07x |

Five things worth knowing before reading the `+nodes` column as a promise:

**Flash is the currency, and worst case is the right column.** `MAX_NUM_NODES` is 120 on nRF52840
because a saturated worst-case `nodes.proto` (120 × 112 B of `NodeInfoLite` plus 40 satellite slots)
is ~26.9 KB against a 28,672 B LittleFS. A cap has to hold in the worst case — the failure mode is a
failed write, not a stale map. In those terms step 3 frees 37% of the whole filesystem.

**But the freed figures assume full satellite maps.** Environment and status supply most of the
reclaimed bytes and are the sparsest entries in practice (only sensor-bearing nodes create them), so
a typical device reclaims nearer 1.2–2.7 KB. The table is the ceiling a cap is safely sized against,
not a forecast of day-to-day savings.

**Growth can be declined.** `resize()` reallocates, so old and new buffers are briefly both live.
`applyHotStoreCapacity()` demands the new allocation plus an 8 KB margin and otherwise refuses, and
the reported cap only ever reflects storage actually allocated — so nothing can append past the
buffer, including `getOrCreateMeshNode`'s grow-by-one fallback on the packet path.

**The extra capacity is passive-fill only**, per the `isPassiveFillOnly()` seam above: a larger
store cannot buy more handshake airtime than a small one.

**Dedup coverage thins** — the last column. `PACKETHISTORY_MAX` stays sized from the 120-node
baseline by design; growing it would spend the very heap the growth guard protects, and
`PacketHistory` allocates its array once in the constructor. Eviction is LRU, so this degrades
rather than fails and the loss falls on the long tail — but it is a real cost, and some of the
airtime the ratchet reclaims is handed back as re-forwarded duplicates. The measurement that would
settle it is duplicate-rebroadcast rate at step 0 versus step 3 on a saturated node.

Totals are clamped to `NODEDB_MIGRATION_LOAD_CEILING` (250) so a file we write stays inside the
decode allowance every existing build already grants. On LARGE parts the ladder scales ×6.25 but
flash is not the binding constraint, so the clamp absorbs the bonus; on STM32WL the module is
compiled out entirely.

@h3lix1 could you try this out, please?

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Node database capacity now adjusts dynamically based on network conditions and available memory.
  - Additional node slots may be unlocked when storage capacity allows.
  - Satellite data limits adjust independently for position, telemetry, environment, and status information.
- **Improvements**
  - Node records are managed more efficiently under pressure, with safer trimming and eviction handling.
  - Automatic NodeInfo responses are reduced when the database is configured for passive filling.
  - Capacity changes now use safeguards to prevent abrupt oscillation or excessive growth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
