### PR TITLE
fix(mesh): dedup opaque relays to prevent an undecryptable-frame broadcast storm

### DIFF
--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -45,7 +45,7 @@ bool NextHopRouter::relayOpaquePacket(const meshtastic_MeshPacket *p)
     // always relayed so reliable opaque unicast still propagates (mirrors FloodingRouter's isRepeated).
     const bool isOriginatorTx = p->hop_start > 0 && p->hop_start == p->hop_limit;
     if (opaqueWasSeenRecently(getFrom(p), p->id) && !isOriginatorTx) {
-        LOG_WARN("Drop duplicate opaque relay from 0x%08x id %u", getFrom(p), p->id);
+        LOG_TRACE("Drop duplicate opaque relay from 0x%08x id 0x%08x", getFrom(p), p->id);
         return false;
     }
 

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -37,6 +37,18 @@ bool NextHopRouter::relayOpaquePacket(const meshtastic_MeshPacket *p)
         (p->next_hop != NO_NEXT_HOP_PREFERENCE && p->next_hop != nodeDB->getLastByteOfNodeNum(getNodeNum())))
         return false;
 
+    // Dedup opaque relays. Opaque frames deliberately never enter PacketHistory (so unauthenticated
+    // traffic can't influence routing/ACK/next-hop) - but with NO dedup at all, a dense mesh re-relays
+    // every copy of every frame, multiplying at each hop into an unbounded broadcast storm ("let hop
+    // exhaustion bound it" caps depth, not count). Suppress duplicate opaque rebroadcasts with a small,
+    // routing-isolated seen-set. Genuine originator (re)transmissions (hop_start == hop_limit) are
+    // always relayed so reliable opaque unicast still propagates (mirrors FloodingRouter's isRepeated).
+    const bool isOriginatorTx = p->hop_start > 0 && p->hop_start == p->hop_limit;
+    if (opaqueWasSeenRecently(getFrom(p), p->id) && !isOriginatorTx) {
+        LOG_WARN("Drop duplicate opaque relay from 0x%08x id %u", getFrom(p), p->id);
+        return false;
+    }
+
     meshtastic_MeshPacket *relay = packetPool.allocCopy(*p);
     if (!relay)
         return false;
@@ -51,6 +63,24 @@ bool NextHopRouter::relayOpaquePacket(const meshtastic_MeshPacket *p)
     if (res == ERRNO_SHOULD_RELEASE)
         packetPool.release(relay);
     return res == ERRNO_OK;
+}
+
+// Isolated dedup for opaque relays (see relayOpaquePacket). Returns true if (from,id) is already in the
+// ring; otherwise records it (round-robin eviction) and returns false. A separate table from
+// PacketHistory on purpose: opaque frames must never influence routing/ACK/next-hop. No timestamps -
+// a stale (from,id) can't false-match a later packet because ids are effectively random.
+bool NextHopRouter::opaqueWasSeenRecently(NodeNum from, PacketId id)
+{
+    for (uint8_t i = 0; i < OPAQUE_SEEN_MAX; i++) {
+        if (opaqueSeen[i].sender == from && opaqueSeen[i].id == id)
+            return true;
+    }
+    // Not seen: record it, overwriting the oldest-written slot (FIFO). Empty slots hold id 0, which a
+    // real entry never has (relayOpaquePacket drops id 0), so they simply never match above.
+    opaqueSeen[opaqueSeenNext].sender = from;
+    opaqueSeen[opaqueSeenNext].id = id;
+    opaqueSeenNext = (uint8_t)((opaqueSeenNext + 1) % OPAQUE_SEEN_MAX);
+    return false;
 }
 
 PendingPacket::PendingPacket(meshtastic_MeshPacket *p, uint8_t numRetransmissions)

--- a/src/mesh/NextHopRouter.h
+++ b/src/mesh/NextHopRouter.h
@@ -124,7 +124,7 @@ class NextHopRouter : public FloodingRouter
     constexpr static uint32_t ROUTE_TTL_MSEC = 30UL * 60 * 1000; // re-discover a route unconfirmed for 30 min
     constexpr static uint8_t ROUTE_FAILURE_THRESHOLD = 3;        // consecutive un-ACKed directed deliveries -> dead
 
-    constexpr static uint8_t OPAQUE_SEEN_MAX = 32; // opaque-relay dedup slots (see relayOpaquePacket); ~12B/slot -> ~384B
+    constexpr static uint8_t OPAQUE_SEEN_MAX = 32; // opaque-relay dedup slots (see relayOpaquePacket); ~8B/slot -> ~256B
 
   protected:
     /**

--- a/src/mesh/NextHopRouter.h
+++ b/src/mesh/NextHopRouter.h
@@ -124,6 +124,8 @@ class NextHopRouter : public FloodingRouter
     constexpr static uint32_t ROUTE_TTL_MSEC = 30UL * 60 * 1000; // re-discover a route unconfirmed for 30 min
     constexpr static uint8_t ROUTE_FAILURE_THRESHOLD = 3;        // consecutive un-ACKed directed deliveries -> dead
 
+    constexpr static uint8_t OPAQUE_SEEN_MAX = 32; // opaque-relay dedup slots (see relayOpaquePacket); ~12B/slot -> ~384B
+
   protected:
     /**
      * Pending retransmissions
@@ -136,6 +138,21 @@ class NextHopRouter : public FloodingRouter
     RouteHealth routeHealth[ROUTE_HEALTH_MAX] = {};
 
     /**
+     * Recently-seen opaque (undecryptable) frames, keyed on the outer (from,id) header. A second,
+     * isolated PacketHistory-style dedup: it bounds broadcast amplification of frames we can't decrypt
+     * WITHOUT admitting them to the real PacketHistory/NodeDB, so unauthenticated traffic can never
+     * influence routing / ACK / next-hop decisions. Fixed-size ring, round-robin (FIFO) eviction, no
+     * timestamps (a stale (from,id) can't false-match: packet ids are effectively random, and a real
+     * entry never has id 0 - relayOpaquePacket drops id 0 before this). RAM-only.
+     */
+    struct OpaqueSeen {
+        NodeNum sender = 0;
+        PacketId id = 0; // 0 == empty/unused slot
+    };
+    OpaqueSeen opaqueSeen[OPAQUE_SEEN_MAX] = {};
+    uint8_t opaqueSeenNext = 0; // ring write cursor (round-robin eviction)
+
+    /**
      * Should this incoming filter be dropped?
      *
      * Called immediately on reception, before any further processing.
@@ -143,6 +160,9 @@ class NextHopRouter : public FloodingRouter
      */
     virtual bool shouldFilterReceived(const meshtastic_MeshPacket *p) override;
     bool relayOpaquePacket(const meshtastic_MeshPacket *p) override;
+    // Dedup helper for relayOpaquePacket: true if (from,id) is already recorded; otherwise records it
+    // (round-robin eviction) and returns false. Pure function of the table - no clock.
+    bool opaqueWasSeenRecently(NodeNum from, PacketId id);
 
     /**
      * Look for packets we need to relay


### PR DESCRIPTION
## Problem

`NextHopRouter::relayOpaquePacket()` relays frames a node can't decrypt ("opaque" traffic), but deliberately keeps them out of `PacketHistory` — from the packet-authenticity policy work (`d6b12ea3f`), so a spoofer can't poison next-hop learning / ACK matching with forged `(from,id)`/`relay_node`. The comment says *"never admitted to PacketHistory … let hop exhaustion bound it."*

The catch: `PacketHistory` admission was also the **only deduplication** for opaque relays. With none, a node re-relays **every copy** of an opaque frame it hears, and the copy count **multiplies at each hop** — hop exhaustion bounds the *depth* (`hop_limit`), not the *count*. On a dense mesh this is unbounded broadcast amplification / a DoS surface: any node keying up on a shared RF frequency with a channel the others lack can saturate the mesh.

## Evidence

On a mixed-channel mesh (nodes sharing a frequency but not a channel key), a single `NextHopRouter` node was observed:

- relaying **one** undecryptable broadcast `(from,id)` **23 times** — once per overheard copy, from every upstream relayer;
- `TX queue is full` continuously → congestion collapse;
- meanwhile **decodable** traffic on the same node deduped correctly (`Ignore dupe` + `cancelSending`); only the **opaque** frames (`encrypted`, `No channel found for decoding`) stormed.

Ruled out: eviction (only ~24 unique `(from,id)` vs a 240-entry `PacketHistory`) and the hop-limit-upgrade path (`Processing upgraded packet: 0`). It's purely the missing dedup on the opaque path.

## Fix

Add a small, **isolated** `(from,id)` seen-set, checked in `relayOpaquePacket()` before it rebroadcasts:

- A second `PacketHistory`-style table (fixed 32-slot ring, round-robin eviction) that **only** suppresses duplicate opaque rebroadcasts. It never feeds routing / ACK / next-hop decisions, so the security intent — keeping opaque frames out of the trusted `PacketHistory` — is preserved.
- Genuine originator (re)transmissions (`hop_start == hop_limit`) are always relayed, so reliable opaque unicast still propagates — mirrors the existing `isRepeated` carve-out in `shouldFilterReceived()`.

Opaque relays are now bounded to ~1 per node per `(from,id)`, matching decodable traffic and the pre-`relayOpaquePacket` behaviour — without re-poisoning `PacketHistory`.

## Notes

- The table is a fixed 32 slots for simplicity; it comfortably covers the observed working set. A mesh with >32 simultaneous opaque `(from,id)` in flight would thrash and let some dupes through — a one-line bump, or a `PACKETHISTORY_MAX`-sized allocation, if that ever shows up.
- Separately: `relayOpaquePacket()` sends via `Router::send()` (one-shot, no per-hop retransmission), so multi-hop *opaque unicast* reliability is weaker than pre-policy. That's out of scope here and would be its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate opaque packets from being relayed repeatedly.
  * Preserved legitimate retransmissions from the original sender.
  * Added bounded tracking to avoid unbounded memory usage while filtering duplicates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->