### PR TITLE
fix(raspihttp): build against OpenSSL 4.0's const X509 name getters

### DIFF
--- a/src/mesh/raspihttp/PiWebServer.cpp
+++ b/src/mesh/raspihttp/PiWebServer.cpp
@@ -357,13 +357,21 @@ int generate_self_signed_x509(EVP_PKEY *pkey, X509 **x509)
 
     X509_set_pubkey(*x509, pkey);
 
-    // SET Subject Name
-    X509_NAME *name = X509_get_subject_name(*x509);
-    X509_NAME_add_entry_by_txt(name, "C", MBSTRING_ASC, (unsigned char *)"DE", -1, -1, 0);
-    X509_NAME_add_entry_by_txt(name, "O", MBSTRING_ASC, (unsigned char *)"Meshtastic", -1, -1, 0);
-    X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, (unsigned char *)"meshtastic.local", -1, -1, 0);
-    // Selfsigned,  Issuer = Subject
-    X509_set_issuer_name(*x509, name);
+    // SET Subject Name. Build the name standalone instead of mutating the cert's own in place:
+    // OpenSSL 4.0 made X509_get_subject_name() return a const pointer, and the setters (which take
+    // a const name and copy it) are the spelling that compiles against every supported version.
+    X509_NAME *name = X509_NAME_new();
+    if (!name)
+        return -1;
+    if (X509_NAME_add_entry_by_txt(name, "C", MBSTRING_ASC, (unsigned char *)"DE", -1, -1, 0) != 1 ||
+        X509_NAME_add_entry_by_txt(name, "O", MBSTRING_ASC, (unsigned char *)"Meshtastic", -1, -1, 0) != 1 ||
+        X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, (unsigned char *)"meshtastic.local", -1, -1, 0) != 1 ||
+        // Selfsigned, Issuer = Subject
+        X509_set_subject_name(*x509, name) != 1 || X509_set_issuer_name(*x509, name) != 1) {
+        X509_NAME_free(name);
+        return -1;
+    }
+    X509_NAME_free(name);
 
     // Certificate signed with our privte key
     if (X509_sign(*x509, pkey, EVP_sha256()) <= 0)


### PR DESCRIPTION
`meshtasticd` fails to compile on Ubuntu 26.10 "Stonking":

```
src/mesh/raspihttp/PiWebServer.cpp:361:44: error: invalid conversion from 'const X509_NAME*' {aka 'const X509_name_st*'} to 'X509_NAME*' {aka 'X509_name_st*'} [-fpermissive]
  361 |     X509_NAME *name = X509_get_subject_name(*x509);
      |                       ~~~~~~~~~~~~~~~~~~~~~^~~~~~~
```

## Why

Not our bug — an upstream API break. Stonking ships **OpenSSL 4.0**, which const-qualified the return type of the X509 name getters:

| Branch | Declaration |
| --- | --- |
| `openssl-3.5`, `openssl-3.6` | `X509_NAME *X509_get_subject_name(const X509 *a);` |
| `openssl-4.0`, `master` | `const X509_NAME *X509_get_subject_name(const X509 *a);` |

`X509_get_issuer_name()` got the same treatment. `generate_self_signed_x509()` reached into the certificate for its own subject name and mutated it in place, so binding the result to a non-const `X509_NAME *` no longer compiles. Unlike `notBefore`/`notAfter`, there is no `X509_getm_subject_name()` mutable variant to fall back on — OpenSSL 4.0 removed the const-clean way to do it in place.

## What changed

Build the `X509_NAME` standalone and hand it to `X509_set_subject_name()` / `X509_set_issuer_name()` instead of `const_cast`-ing the const away. Both setters take a `const X509_NAME *` and copy it, and have done so on every OpenSSL from 1.1.0 through 4.0 — so this compiles everywhere without version guards.

Because the setters dup the name, ours is freed on both the success and failure paths. This also lets the three `X509_NAME_add_entry_by_txt()` calls be error-checked, which they weren't before; the caller already `X509_free()`s the partially built certificate when we return `-1` (from #11451), so the added error paths are covered.

`src/mesh/raspihttp/PiWebServer.cpp` is the only file under `src/` that includes any OpenSSL header, and this was its only affected call site.

## Testing

Compile verification of `generate_self_signed_x509()` in isolation, against real OpenSSL 3.x headers plus a shim reproducing the 4.0 const signature:

| | OpenSSL 3.x headers | 4.0 signature |
| --- | --- | --- |
| before | compiles | **reproduces the reported error** |
| after | compiles | compiles |

`trunk check` is clean on the changed file.

I do **not** have an Ubuntu 26.10 box, so I have not run a full `native`/`native-tft` build against a real OpenSSL 4.0 toolchain — help confirming that would be welcome. No hardware is involved; this file is Portduino/`meshtasticd` only.

One thing for reviewers to keep in mind: OpenSSL 4.0 is a major bump, and this only clears the in-tree breakage. If ulfius, gnutls, or Portduino itself haven't been rebuilt against 4.0, further errors may surface from those — they'd appear as different files in the build log, not this one.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)

Linux `meshtasticd` only — no embedded hardware is affected by this file. Verified at compile level as described above rather than at runtime; the generated self-signed certificate's contents are unchanged (same C/O/CN, same self-signed issuer == subject).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved self-signed certificate generation reliability.
  * Certificate creation now handles allocation and configuration failures safely, returning an error instead of proceeding with invalid certificate data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->