### PR TITLE
feat: isolate T-Deck-Pro&Max touch hardware and input pipeline

### DIFF
--- a/src/graphics/TouchLayout.h
+++ b/src/graphics/TouchLayout.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "input/TouchTargetRegistry.h"
+
+namespace graphics
+{
+
+inline meshtastic::TouchRect touchExpandedRect(int left, int top, int width, int height, int margin)
+{
+    return {static_cast<int16_t>(left - margin), static_cast<int16_t>(top - margin),
+            static_cast<int16_t>(left + width + margin), static_cast<int16_t>(top + height + margin)};
+}
+
+} // namespace graphics

--- a/src/input/InputBroker.h
+++ b/src/input/InputBroker.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "configuration.h"
 #include "Observer.h"
 #include "concurrency/OSThread.h"
 #include "freertosinc.h"
@@ -55,6 +56,11 @@ typedef struct _InputEvent {
     unsigned char kbchar;
     uint16_t touchX;
     uint16_t touchY;
+#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
+    uint8_t touchTargetKind;
+    uint32_t touchTargetValue;
+    uint8_t touchTargetLongPress;
+#endif
 } InputEvent;
 
 class InputPollable

--- a/src/input/TouchGestureRecognizer.cpp
+++ b/src/input/TouchGestureRecognizer.cpp
@@ -1,0 +1,268 @@
+#include "configuration.h"
+
+#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
+
+#include "TouchGestureRecognizer.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace meshtastic {
+
+TouchGestureRecognizer::TouchGestureRecognizer(uint16_t width, uint16_t height) : width(width), height(height) {}
+
+int16_t TouchGestureRecognizer::median(const int16_t *values, uint8_t count)
+{
+    int16_t sorted[FILTER_SAMPLES] = {};
+    for (uint8_t i = 0; i < count; ++i)
+        sorted[i] = values[i];
+    std::sort(sorted, sorted + count);
+    if ((count & 1U) != 0)
+        return sorted[count / 2];
+    return static_cast<int16_t>((static_cast<int32_t>(sorted[count / 2 - 1]) + sorted[count / 2]) / 2);
+}
+
+bool TouchGestureRecognizer::acceptSample(int16_t rawX, int16_t rawY, int16_t &filteredX, int16_t &filteredY)
+{
+    if (rawX < 0 || rawY < 0 || rawX >= static_cast<int16_t>(width) || rawY >= static_cast<int16_t>(height))
+        return false;
+
+    if (pendingJump) {
+        const int16_t confirmX = static_cast<int16_t>(rawX - pendingX);
+        const int16_t confirmY = static_cast<int16_t>(rawY - pendingY);
+        if (std::abs(confirmX) <= 8 && std::abs(confirmY) <= 8) {
+            pendingJump = false;
+            confirmedJump = true;
+        } else {
+            pendingJump = false;
+            rejectedJump = true;
+        }
+    }
+    if (haveRaw && !confirmedJump) {
+        const int16_t dx = static_cast<int16_t>(rawX - lastRawX);
+        const int16_t dy = static_cast<int16_t>(rawY - lastRawY);
+        if (std::abs(dx) > MAX_JUMP || std::abs(dy) > MAX_JUMP) {
+            pendingJump = true;
+            pendingX = rawX;
+            pendingY = rawY;
+            return false;
+        }
+    }
+    confirmedJump = false;
+
+    haveRaw = true;
+    lastRawX = rawX;
+    lastRawY = rawY;
+    filterX[filterIndex] = rawX;
+    filterY[filterIndex] = rawY;
+    filterIndex = static_cast<uint8_t>((filterIndex + 1) % FILTER_SAMPLES);
+    if (filterCount < FILTER_SAMPLES)
+        ++filterCount;
+
+    const int16_t medianX = median(filterX, filterCount);
+    const int16_t medianY = median(filterY, filterCount);
+    if (!haveFiltered) {
+        filteredX = medianX;
+        filteredY = medianY;
+    } else {
+        filteredX = static_cast<int16_t>((static_cast<int32_t>(lastFilteredX) * 3 + medianX) / 4);
+        filteredY = static_cast<int16_t>((static_cast<int32_t>(lastFilteredY) * 3 + medianY) / 4);
+    }
+    lastFilteredX = filteredX;
+    lastFilteredY = filteredY;
+    haveFiltered = true;
+    return true;
+}
+
+TouchGesture TouchGestureRecognizer::directionFor(int16_t dx, int16_t dy) const
+{
+    const int16_t ax = static_cast<int16_t>(std::abs(dx));
+    const int16_t ay = static_cast<int16_t>(std::abs(dy));
+    if (ax == 0 && ay == 0)
+        return TouchGesture::None;
+    if (ax >= ay)
+        return dx < 0 ? TouchGesture::SwipeLeft : TouchGesture::SwipeRight;
+    return dy < 0 ? TouchGesture::SwipeUp : TouchGesture::SwipeDown;
+}
+
+bool TouchGestureRecognizer::lockDirection(int16_t dx, int16_t dy)
+{
+    const int16_t ax = static_cast<int16_t>(std::abs(dx));
+    const int16_t ay = static_cast<int16_t>(std::abs(dy));
+    const int16_t dominant = std::max(ax, ay);
+    const int16_t other = std::min(ax, ay);
+    if (dominant < LOCK_DISTANCE)
+        return false;
+    if (other != 0 && (dominant * 100 < (dominant + other) * 72 || dominant < static_cast<int16_t>(other * 1.4f)))
+        return false;
+    directionLocked = true;
+    lockedGesture = directionFor(dx, dy);
+    return true;
+}
+
+void TouchGestureRecognizer::emit(TouchGesture gesture, uint32_t duration, TouchGestureEvent &event)
+{
+    event.gesture = gesture;
+    event.x = lastX;
+    event.y = lastY;
+    event.duration = duration;
+}
+
+bool TouchGestureRecognizer::update(const TouchSample &sample, TouchGestureEvent &event, bool allowLongPress)
+{
+    event = {};
+    if (!sample.touched) {
+        if (pendingJump || rejectedJump) {
+            reset();
+            return false;
+        }
+        if (state == State::Tracking) {
+            const uint32_t duration = sample.timestamp - startTime;
+            if (stableSamples >= STABLE_SAMPLES_REQUIRED && !longPressRejected && !directionLocked &&
+                !pressMoved &&
+                (!allowLongPress || duration < LONG_PRESS_MS)) {
+                emit(TouchGesture::Tap, duration, event);
+                reset();
+                return true;
+            }
+            const bool horizontal = lockedGesture == TouchGesture::SwipeLeft || lockedGesture == TouchGesture::SwipeRight;
+            const int16_t peakAxisDistance = horizontal ? maxRawAbsX : maxRawAbsY;
+            if (directionLocked && peakAxisDistance >= SWIPE_DISTANCE) {
+                emit(lockedGesture, duration, event);
+                reset();
+                return true;
+            }
+        }
+        reset();
+        return false;
+    }
+
+    int16_t x = 0;
+    int16_t y = 0;
+    if (!acceptSample(sample.x, sample.y, x, y))
+        return false;
+
+    if (state == State::Idle) {
+        state = State::Tracking;
+        startTime = sample.timestamp;
+        startRawX = sample.x;
+        startRawY = sample.y;
+        lastX = x;
+        lastY = y;
+        stableSamples = 1;
+        return false;
+    }
+    if (state == State::Cancelled || state == State::LongPressed) {
+        lastX = x;
+        lastY = y;
+        return false;
+    }
+
+    if (stableSamples < STABLE_SAMPLES_REQUIRED)
+        ++stableSamples;
+
+    // Keep the gesture sum in the filtered coordinate space. A single noisy
+    // raw sample therefore cannot turn a stable press into a move.
+    const int16_t filteredDx = static_cast<int16_t>(x - lastX);
+    const int16_t filteredDy = static_cast<int16_t>(y - lastY);
+    gestureSumX += filteredDx;
+    gestureSumY += filteredDy;
+    const int32_t filteredDistance = std::max(std::abs(gestureSumX), std::abs(gestureSumY));
+    maxFilteredDistance = std::max(maxFilteredDistance, filteredDistance);
+    if (filteredDistance > TAP_DEAD_ZONE)
+        pressMoved = true;
+    lastX = x;
+    lastY = y;
+
+    const int16_t rawDx = static_cast<int16_t>(sample.x - startRawX);
+    const int16_t rawDy = static_cast<int16_t>(sample.y - startRawY);
+    maxRawDistance = std::max(maxRawDistance, static_cast<int16_t>(std::max(std::abs(rawDx), std::abs(rawDy))));
+    maxRawAbsX = std::max(maxRawAbsX, static_cast<int16_t>(std::abs(rawDx)));
+    maxRawAbsY = std::max(maxRawAbsY, static_cast<int16_t>(std::abs(rawDy)));
+
+    if (directionLocked) {
+        const bool horizontal = lockedGesture == TouchGesture::SwipeLeft || lockedGesture == TouchGesture::SwipeRight;
+        const int16_t axisDistance = horizontal ? std::abs(rawDx) : std::abs(rawDy);
+        const int16_t signedDistance = horizontal ? rawDx : rawDy;
+        const bool wrongWay = (lockedGesture == TouchGesture::SwipeLeft && signedDistance > 0) ||
+                              (lockedGesture == TouchGesture::SwipeRight && signedDistance < 0) ||
+                              (lockedGesture == TouchGesture::SwipeUp && signedDistance > 0) ||
+                              (lockedGesture == TouchGesture::SwipeDown && signedDistance < 0);
+        if (wrongWay && axisDistance > LOCK_DISTANCE)
+            state = State::Cancelled;
+    } else if (maxRawDistance >= LOCK_DISTANCE) {
+        lockDirection(rawDx, rawDy);
+    }
+
+    const uint32_t duration = sample.timestamp - startTime;
+    if (allowLongPress && duration >= LONG_PRESS_MS && stableSamples >= STABLE_SAMPLES_REQUIRED) {
+        if (maxFilteredDistance <= LONG_PRESS_MOVE) {
+            emit(TouchGesture::LongPress, duration, event);
+            state = State::LongPressed;
+            return true;
+        }
+        longPressRejected = true;
+        if (!directionLocked)
+            state = State::Cancelled;
+    }
+    return false;
+}
+
+void TouchGestureRecognizer::reset()
+{
+    state = State::Idle;
+    directionLocked = false;
+    pressMoved = false;
+    longPressRejected = false;
+    stableSamples = 0;
+    startTime = 0;
+    startRawX = 0;
+    startRawY = 0;
+    lastX = 0;
+    lastY = 0;
+    gestureSumX = 0;
+    gestureSumY = 0;
+    maxFilteredDistance = 0;
+    maxRawDistance = 0;
+    maxRawAbsX = 0;
+    maxRawAbsY = 0;
+    lockedGesture = TouchGesture::None;
+    haveRaw = false;
+    pendingJump = false;
+    rejectedJump = false;
+    confirmedJump = false;
+    lastRawX = 0;
+    lastRawY = 0;
+    pendingX = 0;
+    pendingY = 0;
+    filterCount = 0;
+    filterIndex = 0;
+    lastFilteredX = 0;
+    lastFilteredY = 0;
+    haveFiltered = false;
+}
+
+void TouchGestureRecognizer::cancel()
+{
+    state = State::Cancelled;
+    directionLocked = false;
+    longPressRejected = true;
+}
+
+bool TouchGestureRecognizer::transformCoordinates(int16_t &x, int16_t &y, uint16_t width, uint16_t height, bool flipScreen,
+                                                  int16_t offsetX, int16_t offsetY, float scaleX, float scaleY)
+{
+    if (width == 0 || height == 0)
+        return false;
+    const int32_t transformedX = static_cast<int32_t>(std::lround((x + offsetX) * scaleX));
+    const int32_t transformedY = static_cast<int32_t>(std::lround((y + offsetY) * scaleY));
+    if (transformedX < 0 || transformedY < 0 || transformedX >= width || transformedY >= height)
+        return false;
+    x = static_cast<int16_t>(flipScreen ? width - 1 - transformedX : transformedX);
+    y = static_cast<int16_t>(flipScreen ? height - 1 - transformedY : transformedY);
+    return true;
+}
+
+} // namespace meshtastic
+
+#endif // T_DECK_MAX || _VARIANT_T_DECK_PRO_V1_1

--- a/src/input/TouchGestureRecognizer.h
+++ b/src/input/TouchGestureRecognizer.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace meshtastic {
+
+struct TouchSample {
+    int16_t x;
+    int16_t y;
+    uint32_t timestamp;
+    bool touched;
+};
+
+enum class TouchGesture : uint8_t {
+    None,
+    Tap,
+    LongPress,
+    SwipeLeft,
+    SwipeRight,
+    SwipeUp,
+    SwipeDown,
+};
+
+struct TouchGestureEvent {
+    TouchGesture gesture = TouchGesture::None;
+    int16_t x = 0;
+    int16_t y = 0;
+    uint32_t duration = 0;
+};
+
+class TouchGestureRecognizer
+{
+  public:
+    TouchGestureRecognizer(uint16_t width, uint16_t height);
+
+    bool update(const TouchSample &sample, TouchGestureEvent &event, bool allowLongPress = true);
+    void reset();
+    void cancel();
+
+    static bool transformCoordinates(int16_t &x, int16_t &y, uint16_t width, uint16_t height, bool flipScreen,
+                                     int16_t offsetX = 0, int16_t offsetY = 0, float scaleX = 1.0f,
+                                     float scaleY = 1.0f);
+
+  private:
+    enum class State : uint8_t { Idle, Tracking, LongPressed, Cancelled };
+
+    static constexpr uint8_t FILTER_SAMPLES = 3;
+    static constexpr uint8_t STABLE_SAMPLES_REQUIRED = 3;
+    static constexpr int16_t MAX_JUMP = 80;
+    static constexpr int16_t TAP_DEAD_ZONE = 12;
+    static constexpr int16_t LOCK_DISTANCE = 20;
+    static constexpr int16_t SWIPE_DISTANCE = 38;
+    static constexpr int16_t LONG_PRESS_MOVE = 14;
+    static constexpr uint32_t LONG_PRESS_MS = 500;
+
+    bool acceptSample(int16_t rawX, int16_t rawY, int16_t &filteredX, int16_t &filteredY);
+    bool lockDirection(int16_t dx, int16_t dy);
+    TouchGesture directionFor(int16_t dx, int16_t dy) const;
+    void emit(TouchGesture gesture, uint32_t duration, TouchGestureEvent &event);
+    static int16_t median(const int16_t *values, uint8_t count);
+
+    uint16_t width;
+    uint16_t height;
+    State state = State::Idle;
+    bool directionLocked = false;
+    // Once filtered motion exceeds the tap dead zone, this press must not be
+    // converted back into a tap.
+    bool pressMoved = false;
+    bool longPressRejected = false;
+    uint8_t stableSamples = 0;
+    uint32_t startTime = 0;
+    int16_t startRawX = 0;
+    int16_t startRawY = 0;
+    int16_t lastX = 0;
+    int16_t lastY = 0;
+    int32_t gestureSumX = 0;
+    int32_t gestureSumY = 0;
+    int32_t maxFilteredDistance = 0;
+    int16_t maxRawDistance = 0;
+    int16_t maxRawAbsX = 0;
+    int16_t maxRawAbsY = 0;
+    TouchGesture lockedGesture = TouchGesture::None;
+    bool haveRaw = false;
+    bool pendingJump = false;
+    bool rejectedJump = false;
+    bool confirmedJump = false;
+    int16_t lastRawX = 0;
+    int16_t lastRawY = 0;
+    int16_t pendingX = 0;
+    int16_t pendingY = 0;
+    int16_t filterX[FILTER_SAMPLES] = {};
+    int16_t filterY[FILTER_SAMPLES] = {};
+    int16_t lastFilteredX = 0;
+    int16_t lastFilteredY = 0;
+    uint8_t filterCount = 0;
+    uint8_t filterIndex = 0;
+    bool haveFiltered = false;
+};
+
+} // namespace meshtastic

--- a/src/input/TouchScreenBase.cpp
+++ b/src/input/TouchScreenBase.cpp
@@ -1,8 +1,5 @@
 #include "TouchScreenBase.h"
 #include "configuration.h"
-#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
-#include "input/HapticFeedback.h"
-#endif
 #include "main.h"
 
 #if defined(RAK14014) && !defined(MESHTASTIC_EXCLUDE_CANNEDMESSAGES)
@@ -322,12 +319,7 @@ int32_t TouchScreenBase::runOnce()
 
 void TouchScreenBase::hapticFeedback()
 {
-#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
-#if defined(HAPTIC_FEEDBACK_PIN) || defined(HAS_DRV2605)
-    if (::hapticFeedback)
-        ::hapticFeedback->play(HapticEffect::NAVIGATION);
-#endif
-#else
+#if !defined(T_DECK_MAX) && !defined(_VARIANT_T_DECK_PRO_V1_1)
 #ifdef T_WATCH_S3
     drv.setWaveform(0, 75);
     drv.setWaveform(1, 0); // end waveform

--- a/src/input/TouchScreenBase.cpp
+++ b/src/input/TouchScreenBase.cpp
@@ -1,4 +1,8 @@
 #include "TouchScreenBase.h"
+#include "configuration.h"
+#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
+#include "input/HapticFeedback.h"
+#endif
 #include "main.h"
 
 #if defined(RAK14014) && !defined(MESHTASTIC_EXCLUDE_CANNEDMESSAGES)
@@ -9,8 +13,6 @@
 #define TIME_LONG_PRESS 400
 #endif
 
-// Touch sampling cadence (milliseconds).
-// Can be overridden by board variants for faster touch panels.
 #ifndef TOUCH_POLL_INTERVAL_IDLE
 #define TOUCH_POLL_INTERVAL_IDLE 100
 #endif
@@ -23,7 +25,6 @@
 #define TOUCH_POLL_INTERVAL_RELEASE 50
 #endif
 
-// Faster cadence used for keyboard-like tap-heavy UIs.
 #ifndef TOUCH_POLL_INTERVAL_ACTIVE_FAST
 #define TOUCH_POLL_INTERVAL_ACTIVE_FAST TOUCH_POLL_INTERVAL_ACTIVE
 #endif
@@ -32,8 +33,6 @@
 #define TOUCH_POLL_INTERVAL_RELEASE_FAST TOUCH_POLL_INTERVAL_RELEASE
 #endif
 
-// Ignore very short "finger lifted" glitches from noisy touch controllers.
-// A release is only accepted once we've seen no-touch for at least this duration.
 #ifndef TOUCH_RELEASE_GRACE_MS
 #define TOUCH_RELEASE_GRACE_MS 35
 #endif
@@ -48,15 +47,23 @@
 #endif
 
 TouchScreenBase::TouchScreenBase(const char *name, uint16_t width, uint16_t height)
-    : concurrency::OSThread(name), _display_width(width), _display_height(height), _first_x(0), _last_x(0), _first_y(0),
-      _last_y(0), _start(0), _lastTouchSeenMs(0), _tapped(false), _originName(name)
+#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
+    : concurrency::OSThread(name), _display_width(width), _display_height(height), _recognizer(width, height),
+      _targets(width, height), _originName(name)
+#else
+    : concurrency::OSThread(name), _display_width(width), _display_height(height), _originName(name)
+#endif
 {
 }
 
 void TouchScreenBase::init(bool hasTouch)
 {
     if (hasTouch) {
+#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
+        LOG_INFO("TouchScreen initialized: tap=12 lock=20 swipe=38 long=500ms stable=3");
+#else
         LOG_INFO("TouchScreen initialized %d %d", TOUCH_THRESHOLD_X, TOUCH_THRESHOLD_Y);
+#endif
         this->setInterval(TOUCH_POLL_INTERVAL_IDLE);
     } else {
         disable();
@@ -64,8 +71,143 @@ void TouchScreenBase::init(bool hasTouch)
     }
 }
 
+#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
+void TouchScreenBase::beginTouchFrame(uint32_t pageGeneration)
+{
+    _targets.beginFrame(pageGeneration);
+}
+
+void TouchScreenBase::markTouchFrameMapped()
+{
+    _targets.markFrameMapped();
+}
+
+bool TouchScreenBase::addTouchTarget(meshtastic::TouchRect rect, meshtastic::TouchTargetKind kind, uint32_t value,
+                                     input_broker_event tapAction, input_broker_event longPressAction)
+{
+    return _targets.add(rect, kind, value, tapAction, longPressAction);
+}
+
+void TouchScreenBase::publishTouchFrame()
+{
+    _targets.publishFrame();
+}
+#endif
+
 int32_t TouchScreenBase::runOnce()
 {
+#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
+    const uint32_t nowMs = millis();
+    if (nowMs - _lastRun < 20)
+        return 20;
+    _lastRun = nowMs;
+
+    TouchEvent e = {};
+    e.touchEvent = static_cast<char>(TOUCH_ACTION_NONE);
+    e.targetAction = INPUT_BROKER_NONE;
+    this->setInterval(TOUCH_POLL_INTERVAL_IDLE);
+
+    const bool fastTapMode = fastTapModeEnabled();
+    const bool allowLongPress = longPressEnabled();
+    int16_t x = _last_x;
+    int16_t y = _last_y;
+    const bool rawTouched = getTouch(x, y);
+    const bool validTouched = rawTouched && meshtastic::TouchGestureRecognizer::transformCoordinates(
+                                             x, y, _display_width, _display_height, config.display.flip_screen);
+    bool touched = validTouched;
+
+    if (touched) {
+        _lastTouchSeenMs = nowMs;
+        this->setInterval(fastTapMode ? TOUCH_POLL_INTERVAL_ACTIVE_FAST : TOUCH_POLL_INTERVAL_ACTIVE);
+    } else if (!rawTouched && _touchedOld && nowMs - _lastTouchSeenMs < TOUCH_RELEASE_GRACE_MS) {
+        touched = true;
+        this->setInterval(fastTapMode ? TOUCH_POLL_INTERVAL_ACTIVE_FAST : TOUCH_POLL_INTERVAL_ACTIVE);
+    } else {
+        this->setInterval(fastTapMode ? TOUCH_POLL_INTERVAL_RELEASE_FAST : TOUCH_POLL_INTERVAL_RELEASE);
+    }
+
+    meshtastic::TouchGestureEvent gestureEvent;
+    const bool emitted = _recognizer.update({x, y, nowMs, touched}, gestureEvent, allowLongPress);
+
+    if (touched) {
+        if (!_touchedOld) {
+            hapticFeedback();
+            _state = TOUCH_EVENT_OCCURRED;
+            _targetCaptureStarted = _targets.capture(x, y);
+        }
+        if (_targetCaptureStarted)
+            _targets.updateCapture(x, y);
+        _last_x = x;
+        _last_y = y;
+    } else {
+        _state = TOUCH_EVENT_CLEARED;
+    }
+    _touchedOld = touched;
+
+    if (emitted) {
+        switch (gestureEvent.gesture) {
+        case meshtastic::TouchGesture::SwipeLeft:
+            e.touchEvent = static_cast<char>(TOUCH_ACTION_LEFT);
+            break;
+        case meshtastic::TouchGesture::SwipeRight:
+            e.touchEvent = static_cast<char>(TOUCH_ACTION_RIGHT);
+            break;
+        case meshtastic::TouchGesture::SwipeUp:
+            e.touchEvent = static_cast<char>(TOUCH_ACTION_UP);
+            break;
+        case meshtastic::TouchGesture::SwipeDown:
+            e.touchEvent = static_cast<char>(TOUCH_ACTION_DOWN);
+            break;
+        case meshtastic::TouchGesture::Tap:
+            e.touchEvent = static_cast<char>(TOUCH_ACTION_TAP);
+            break;
+        case meshtastic::TouchGesture::LongPress:
+            e.touchEvent = static_cast<char>(TOUCH_ACTION_LONG_PRESS);
+            break;
+        default:
+            break;
+        }
+
+        _last_x = gestureEvent.x;
+        _last_y = gestureEvent.y;
+        if (gestureEvent.gesture == meshtastic::TouchGesture::Tap ||
+            gestureEvent.gesture == meshtastic::TouchGesture::LongPress) {
+            meshtastic::TouchTarget target{};
+            const bool targetCaptureStarted = _targetCaptureStarted;
+            const bool targetReleased =
+                _targets.release(_last_x, _last_y, gestureEvent.gesture == meshtastic::TouchGesture::LongPress, target);
+            _targetCaptureStarted = false;
+            if (targetReleased) {
+                e.targetAction = gestureEvent.gesture == meshtastic::TouchGesture::LongPress ? target.longPressAction
+                                                                                              : target.tapAction;
+                e.targetLongPress = gestureEvent.gesture == meshtastic::TouchGesture::LongPress;
+                if (target.kind != meshtastic::TouchTargetKind::LegacyFallback) {
+                    e.targetKind = static_cast<uint8_t>(target.kind);
+                    e.targetValue = target.value;
+                }
+            } else if (targetCaptureStarted) {
+                // A touch that leaves a registered target must not fall back to a generic tap.
+                e.touchEvent = static_cast<char>(TOUCH_ACTION_NONE);
+            }
+        } else {
+            _targets.cancelCapture();
+            _targetCaptureStarted = false;
+        }
+    } else if (!touched && (!rawTouched || !validTouched)) {
+        _targets.cancelCapture();
+        _targetCaptureStarted = false;
+    }
+
+    if (e.touchEvent != TOUCH_ACTION_NONE) {
+        e.source = this->_originName;
+        e.x = static_cast<uint16_t>(_last_x);
+        e.y = static_cast<uint16_t>(_last_y);
+        onEvent(e);
+    }
+
+    return interval;
+
+#else
     uint32_t nowMs = millis();
     if (nowMs - _lastRun < 20) { // suppress too fast consecutive runOnce() executions
         return 20;
@@ -77,10 +219,9 @@ int32_t TouchScreenBase::runOnce()
     const bool fastTapMode = fastTapModeEnabled();
     const bool allowLongPress = longPressEnabled();
 
-    // process touch events
     int16_t x, y;
     bool touched = getTouch(x, y);
-    if (x < 0 || y < 0) // T-deck can emit phantom touch events with a negative value when turning off the screen
+    if (x < 0 || y < 0)
         touched = false;
     if (touched) {
         _lastTouchSeenMs = millis();
@@ -88,7 +229,6 @@ int32_t TouchScreenBase::runOnce()
         _last_x = x;
         _last_y = y;
     } else if (_touchedOld && ((uint32_t)millis() - _lastTouchSeenMs) < TOUCH_RELEASE_GRACE_MS) {
-        // Treat brief no-touch samples as continuous touch to preserve long-press detection.
         touched = true;
     }
     if (touched != _touchedOld) {
@@ -105,40 +245,33 @@ int32_t TouchScreenBase::runOnce()
             y = _last_y;
             this->setInterval(fastTapMode ? TOUCH_POLL_INTERVAL_RELEASE_FAST : TOUCH_POLL_INTERVAL_RELEASE);
 
-            // compute distance
             int16_t dx = x - _first_x;
             int16_t dy = y - _first_y;
             uint16_t adx = abs(dx);
             uint16_t ady = abs(dy);
 
-            // swipe horizontal
             if (adx > ady && adx > TOUCH_THRESHOLD_X) {
-                if (0 > dx) { // swipe right to left
+                if (0 > dx) {
                     e.touchEvent = static_cast<char>(TOUCH_ACTION_LEFT);
                     LOG_DEBUG("action SWIPE: right to left");
-                } else { // swipe left to right
+                } else {
                     e.touchEvent = static_cast<char>(TOUCH_ACTION_RIGHT);
                     LOG_DEBUG("action SWIPE: left to right");
                 }
-            }
-            // swipe vertical
-            else if (ady > adx && ady > TOUCH_THRESHOLD_Y) {
-                if (0 > dy) { // swipe bottom to top
+            } else if (ady > adx && ady > TOUCH_THRESHOLD_Y) {
+                if (0 > dy) {
                     e.touchEvent = static_cast<char>(TOUCH_ACTION_UP);
                     LOG_DEBUG("action SWIPE: bottom to top");
-                } else { // swipe top to bottom
+                } else {
                     e.touchEvent = static_cast<char>(TOUCH_ACTION_DOWN);
                     LOG_DEBUG("action SWIPE: top to bottom");
                 }
-            }
-            // tap
-            else {
+            } else {
                 if (duration > 0 && (duration < TIME_LONG_PRESS || !allowLongPress)) {
-                    if (_tapped) {
+                    if (_tapped)
                         _tapped = false;
-                    } else {
+                    else
                         _tapped = true;
-                    }
                 } else {
                     _tapped = false;
                 }
@@ -148,7 +281,6 @@ int32_t TouchScreenBase::runOnce()
     _touchedOld = touched;
 
 #if defined RAK14014
-    // Speed up the processing speed of the keyboard in virtual keyboard mode
     auto state = cannedMessageModule->getRunState();
     if (state == CANNED_MESSAGE_RUN_STATE_FREETEXT) {
         if (_tapped) {
@@ -164,7 +296,6 @@ int32_t TouchScreenBase::runOnce()
         }
     }
 #else
-    // fire TAP event when no 2nd tap occurred within time
     if (_tapped) {
         _tapped = false;
         e.touchEvent = static_cast<char>(TOUCH_ACTION_TAP);
@@ -172,9 +303,7 @@ int32_t TouchScreenBase::runOnce()
     }
 #endif
 
-    // fire LONG_PRESS event without the need for release
     if (allowLongPress && touched && (time_t(millis()) - _start) > TIME_LONG_PRESS) {
-        // tricky: prevent reoccurring events and another touch event when releasing
         _start = millis() + 30000;
         e.touchEvent = static_cast<char>(TOUCH_ACTION_LONG_PRESS);
         LOG_DEBUG("action LONG PRESS(%d/%d)", _last_x, _last_y);
@@ -188,14 +317,22 @@ int32_t TouchScreenBase::runOnce()
     }
 
     return interval;
+#endif
 }
 
 void TouchScreenBase::hapticFeedback()
 {
+#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
+#if defined(HAPTIC_FEEDBACK_PIN) || defined(HAS_DRV2605)
+    if (::hapticFeedback)
+        ::hapticFeedback->play(HapticEffect::NAVIGATION);
+#endif
+#else
 #ifdef T_WATCH_S3
     drv.setWaveform(0, 75);
     drv.setWaveform(1, 0); // end waveform
     drv.go();
+#endif
 #endif
 }
 

--- a/src/input/TouchScreenBase.h
+++ b/src/input/TouchScreenBase.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#include "configuration.h"
 #include "InputBroker.h"
+#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
+#include "TouchGestureRecognizer.h"
+#include "TouchTargetRegistry.h"
+#endif
 #include "concurrency/OSThread.h"
 #include "mesh/NodeDB.h"
 #include "time.h"
@@ -10,6 +15,12 @@ typedef struct _TouchEvent {
     char touchEvent;
     uint16_t x;
     uint16_t y;
+#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
+    input_broker_event targetAction;
+    uint8_t targetKind;
+    uint32_t targetValue;
+    uint8_t targetLongPress;
+#endif
 } TouchEvent;
 
 class TouchScreenBase : public Observable<const InputEvent *>, public concurrency::OSThread
@@ -17,6 +28,13 @@ class TouchScreenBase : public Observable<const InputEvent *>, public concurrenc
   public:
     explicit TouchScreenBase(const char *name, uint16_t width, uint16_t height);
     void init(bool hasTouch);
+#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
+    void beginTouchFrame(uint32_t pageGeneration);
+    void markTouchFrameMapped();
+    bool addTouchTarget(meshtastic::TouchRect rect, meshtastic::TouchTargetKind kind, uint32_t value,
+                        input_broker_event tapAction, input_broker_event longPressAction = INPUT_BROKER_NONE);
+    void publishTouchFrame();
+#endif
 
   protected:
     enum TouchScreenBaseStateType { TOUCH_EVENT_OCCURRED, TOUCH_EVENT_CLEARED };
@@ -47,13 +65,28 @@ class TouchScreenBase : public Observable<const InputEvent *>, public concurrenc
     uint16_t _display_height;
 
   private:
-    bool _touchedOld = false;  // previous touch state
-    int16_t _first_x, _last_x; // horizontal swipe direction
-    int16_t _first_y, _last_y; // vertical swipe direction
-    time_t _start;             // for LONG_PRESS
-    uint32_t _lastTouchSeenMs; // helps suppress brief touch-controller dropouts
-    bool _tapped;              // for DOUBLE_TAP
-    uint32_t _lastRun = 0;     // helps suppress too fast consecutive runOnce() executions
+#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
+    bool _touchedOld = false;
+    int16_t _last_x = 0;
+    int16_t _last_y = 0;
+    uint32_t _lastTouchSeenMs = 0;
+    uint32_t _lastRun = 0;
+#else
+    bool _touchedOld = false;
+    int16_t _first_x = 0;
+    int16_t _last_x = 0;
+    int16_t _first_y = 0;
+    int16_t _last_y = 0;
+    time_t _start = 0;
+    uint32_t _lastTouchSeenMs = 0;
+    bool _tapped = false;
+    uint32_t _lastRun = 0;
+#endif
+#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
+    meshtastic::TouchGestureRecognizer _recognizer;
+    meshtastic::TouchTargetRegistry _targets;
+    bool _targetCaptureStarted = false;
+#endif
 
     const char *_originName;
 };

--- a/src/input/TouchScreenImpl1.cpp
+++ b/src/input/TouchScreenImpl1.cpp
@@ -146,6 +146,17 @@ void TouchScreenImpl1::onEvent(const TouchEvent &event)
     e.kbchar = 0;
     e.touchX = event.x;
     e.touchY = event.y;
+#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
+    e.touchTargetKind = event.targetKind;
+    e.touchTargetValue = event.targetValue;
+    e.touchTargetLongPress = event.targetLongPress;
+
+    if (event.targetKind != static_cast<uint8_t>(meshtastic::TouchTargetKind::None)) {
+        e.inputEvent = event.targetAction;
+        this->notifyObservers(&e);
+        return;
+    }
+#endif
 
     switch (event.touchEvent) {
     case TOUCH_ACTION_LEFT: {
@@ -165,7 +176,11 @@ void TouchScreenImpl1::onEvent(const TouchEvent &event)
         break;
     }
     case TOUCH_ACTION_LONG_PRESS: {
+#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
+        e.inputEvent = event.targetAction != INPUT_BROKER_NONE ? event.targetAction : INPUT_BROKER_SELECT;
+#else
         e.inputEvent = INPUT_BROKER_SELECT;
+#endif
         break;
     }
     case TOUCH_ACTION_TAP: {

--- a/src/input/TouchTargetRegistry.cpp
+++ b/src/input/TouchTargetRegistry.cpp
@@ -1,0 +1,200 @@
+#include "configuration.h"
+
+#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
+
+#include "TouchTargetRegistry.h"
+
+#include <algorithm>
+
+namespace meshtastic {
+
+TouchTargetRegistry::TouchTargetRegistry(uint16_t width, uint16_t height) : width(width), height(height) {}
+
+bool TouchTargetRegistry::clip(TouchRect &rect) const
+{
+    rect.left = std::max<int16_t>(0, rect.left);
+    rect.top = std::max<int16_t>(0, rect.top);
+    rect.right = std::min<int16_t>(static_cast<int16_t>(width), rect.right);
+    rect.bottom = std::min<int16_t>(static_cast<int16_t>(height), rect.bottom);
+    return rect.right > rect.left && rect.bottom > rect.top;
+}
+
+void TouchTargetRegistry::beginFrame(uint32_t pageGeneration)
+{
+    stagingGeneration = pageGeneration;
+    stagingCount = 0;
+    stagingMapped = false;
+}
+
+void TouchTargetRegistry::clear()
+{
+    stagingCount = 0;
+    stagingMapped = false;
+}
+
+void TouchTargetRegistry::markFrameMapped()
+{
+    stagingMapped = true;
+}
+
+bool TouchTargetRegistry::addFullScreen(input_broker_event tapAction, input_broker_event longPressAction)
+{
+    return add({0, 0, static_cast<int16_t>(width), static_cast<int16_t>(height)}, TouchTargetKind::LegacyFallback, 0,
+               tapAction, longPressAction);
+}
+
+bool TouchTargetRegistry::add(TouchRect rect, TouchTargetKind kind, uint32_t value, input_broker_event tapAction,
+                              input_broker_event longPressAction)
+{
+    if (stagingCount >= MAX_TARGETS || !clip(rect))
+        return false;
+
+    stagingTargets[stagingCount] = {rect, kind, value, tapAction, longPressAction, stagingGeneration};
+    ++stagingCount;
+    stagingMapped = true;
+    return true;
+}
+
+void TouchTargetRegistry::publishFrame()
+{
+    concurrency::LockGuard guard(&lock);
+
+    TouchTarget capturedTarget{};
+    bool preserveCapture = false;
+    if (captureValid && captured >= 0 && captured < activeCount && activeGeneration == stagingGeneration) {
+        capturedTarget = activeTargets[captured];
+        preserveCapture = true;
+    }
+
+    std::copy(stagingTargets, stagingTargets + stagingCount, activeTargets);
+    activeCount = stagingCount;
+    activeGeneration = stagingGeneration;
+    activeMapped = stagingMapped;
+    captured = -1;
+    captureValid = false;
+
+    if (preserveCapture) {
+        for (uint8_t index = 0; index < activeCount; index++) {
+            if (activeTargets[index].kind == capturedTarget.kind && activeTargets[index].value == capturedTarget.value) {
+                captured = static_cast<int8_t>(index);
+                captureValid = true;
+                break;
+            }
+        }
+    }
+}
+
+bool TouchTargetRegistry::hasTargets() const
+{
+    concurrency::LockGuard guard(&lock);
+    return activeCount > 0;
+}
+
+bool TouchTargetRegistry::isStagingFrameMapped() const
+{
+    return stagingMapped;
+}
+
+bool TouchTargetRegistry::isFrameMapped() const
+{
+    concurrency::LockGuard guard(&lock);
+    return activeMapped;
+}
+
+bool TouchTargetRegistry::hitTestLocked(int16_t x, int16_t y, uint8_t &index) const
+{
+    int bestIndex = -1;
+    for (int current = activeCount - 1; current >= 0; current--) {
+        const TouchTarget &candidate = activeTargets[current];
+        if (candidate.pageGeneration != activeGeneration || !candidate.rect.contains(x, y))
+            continue;
+
+        // Registration order remains the priority between different target kinds
+        // (for example, a notification option over the page underneath it). For
+        // adjacent targets of the same kind, use the nearest center to avoid
+        // selecting a neighboring row when expanded hit boxes overlap.
+        if (bestIndex < 0) {
+            bestIndex = current;
+            continue;
+        }
+        if (candidate.kind != activeTargets[bestIndex].kind)
+            continue;
+
+        const int32_t candidateCenterX = static_cast<int32_t>(candidate.rect.left) + candidate.rect.right;
+        const int32_t candidateCenterY = static_cast<int32_t>(candidate.rect.top) + candidate.rect.bottom;
+        const int32_t bestCenterX = static_cast<int32_t>(activeTargets[bestIndex].rect.left) +
+                                    activeTargets[bestIndex].rect.right;
+        const int32_t bestCenterY = static_cast<int32_t>(activeTargets[bestIndex].rect.top) +
+                                    activeTargets[bestIndex].rect.bottom;
+        const int32_t candidateDx = (static_cast<int32_t>(x) * 2) - candidateCenterX;
+        const int32_t candidateDy = (static_cast<int32_t>(y) * 2) - candidateCenterY;
+        const int32_t bestDx = (static_cast<int32_t>(x) * 2) - bestCenterX;
+        const int32_t bestDy = (static_cast<int32_t>(y) * 2) - bestCenterY;
+        const uint32_t candidateDistance = static_cast<uint32_t>(candidateDx * candidateDx + candidateDy * candidateDy);
+        const uint32_t currentBestDistance = static_cast<uint32_t>(bestDx * bestDx + bestDy * bestDy);
+        if (candidateDistance < currentBestDistance) {
+            bestIndex = current;
+        }
+    }
+    if (bestIndex < 0)
+        return false;
+    index = static_cast<uint8_t>(bestIndex);
+    return true;
+}
+
+bool TouchTargetRegistry::hitTest(int16_t x, int16_t y, TouchTarget &out) const
+{
+    concurrency::LockGuard guard(&lock);
+    uint8_t index = 0;
+    if (!hitTestLocked(x, y, index))
+        return false;
+    out = activeTargets[index];
+    return true;
+}
+
+bool TouchTargetRegistry::capture(int16_t x, int16_t y)
+{
+    concurrency::LockGuard guard(&lock);
+    uint8_t index = 0;
+    if (!hitTestLocked(x, y, index))
+        return false;
+    captured = static_cast<int8_t>(index);
+    captureValid = true;
+    return true;
+}
+
+bool TouchTargetRegistry::updateCapture(int16_t x, int16_t y)
+{
+    concurrency::LockGuard guard(&lock);
+    if (captured < 0 || captured >= activeCount || !captureValid)
+        return false;
+    captureValid = activeTargets[captured].rect.contains(x, y);
+    return captureValid;
+}
+
+bool TouchTargetRegistry::release(int16_t x, int16_t y, bool longPress, TouchTarget &out)
+{
+    concurrency::LockGuard guard(&lock);
+    bool result = false;
+    if (captured >= 0 && captured < activeCount && captureValid && activeTargets[captured].rect.contains(x, y)) {
+        const input_broker_event action = longPress ? activeTargets[captured].longPressAction : activeTargets[captured].tapAction;
+        if (action != INPUT_BROKER_NONE || activeTargets[captured].kind != TouchTargetKind::None) {
+            out = activeTargets[captured];
+            result = true;
+        }
+    }
+    captured = -1;
+    captureValid = false;
+    return result;
+}
+
+void TouchTargetRegistry::cancelCapture()
+{
+    concurrency::LockGuard guard(&lock);
+    captured = -1;
+    captureValid = false;
+}
+
+} // namespace meshtastic
+
+#endif // T_DECK_MAX || _VARIANT_T_DECK_PRO_V1_1

--- a/src/input/TouchTargetRegistry.h
+++ b/src/input/TouchTargetRegistry.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "InputBroker.h"
+#include "concurrency/LockGuard.h"
+#include <stdint.h>
+
+namespace meshtastic {
+
+struct TouchRect {
+    int16_t left;
+    int16_t top;
+    int16_t right;
+    int16_t bottom;
+
+    bool contains(int16_t x, int16_t y) const { return x >= left && x < right && y >= top && y < bottom; }
+};
+
+enum class TouchTargetKind : uint8_t {
+    None,
+    LegacyFallback,
+    NavigationPrevious,
+    NavigationNext,
+    Back,
+    MenuOption,
+    NodeRow,
+    MessageRow,
+    EmoteRow,
+    NotificationOption,
+    KeyboardKey,
+    Confirm,
+    Cancel,
+};
+
+struct TouchTarget {
+    TouchRect rect{};
+    TouchTargetKind kind = TouchTargetKind::None;
+    uint32_t value = 0;
+    input_broker_event tapAction = INPUT_BROKER_NONE;
+    input_broker_event longPressAction = INPUT_BROKER_NONE;
+    uint32_t pageGeneration = 0;
+};
+
+class TouchTargetRegistry
+{
+  public:
+    static constexpr uint8_t MAX_TARGETS = 64;
+
+    TouchTargetRegistry(uint16_t width, uint16_t height);
+    void beginFrame(uint32_t pageGeneration);
+    void clear();
+    void markFrameMapped();
+    bool addFullScreen(input_broker_event tapAction, input_broker_event longPressAction = INPUT_BROKER_NONE);
+    bool add(TouchRect rect, TouchTargetKind kind, uint32_t value, input_broker_event tapAction,
+             input_broker_event longPressAction = INPUT_BROKER_NONE);
+    void publishFrame();
+    bool hasTargets() const;
+    bool isStagingFrameMapped() const;
+    bool isFrameMapped() const;
+    bool hitTest(int16_t x, int16_t y, TouchTarget &out) const;
+    bool capture(int16_t x, int16_t y);
+    bool updateCapture(int16_t x, int16_t y);
+    bool release(int16_t x, int16_t y, bool longPress, TouchTarget &out);
+    void cancelCapture();
+
+  private:
+    bool clip(TouchRect &rect) const;
+    bool hitTestLocked(int16_t x, int16_t y, uint8_t &index) const;
+
+    uint16_t width;
+    uint16_t height;
+    uint32_t stagingGeneration = 0;
+    uint32_t activeGeneration = 0;
+    TouchTarget stagingTargets[MAX_TARGETS] = {};
+    TouchTarget activeTargets[MAX_TARGETS] = {};
+    uint8_t stagingCount = 0;
+    uint8_t activeCount = 0;
+    bool stagingMapped = false;
+    bool activeMapped = false;
+    int8_t captured = -1;
+    bool captureValid = false;
+    mutable concurrency::Lock lock;
+};
+
+} // namespace meshtastic

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -176,9 +176,20 @@ MagnetometerThread *magnetometerThread = nullptr;
 AudioThread *audioThread = nullptr;
 #endif
 
-#ifdef USE_XL9555
+#if defined(T_DECK_MAX)
+#include "platform/extra_variants/t_deck_max/TDeckMaxXL9555.hpp"
+ExtensionIOXL9555 io;
+#elif defined(USE_XL9555)
 #include "ExtensionIOXL9555.hpp"
 ExtensionIOXL9555 io;
+#endif
+
+#if defined(T_DECK_MAX)
+#include "platform/extra_variants/t_deck_max/TDeckMaxBoard.h"
+#endif
+
+#if defined(_VARIANT_T_DECK_PRO_V1_1)
+bool tDeckProV1_1RecoverI2C();
 #endif
 
 #ifdef USE_MCP23017
@@ -321,6 +332,21 @@ void lateInitVariant() {}
 
 void earlyInitVariant() __attribute__((weak));
 void earlyInitVariant() {}
+
+#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
+// Weak hook for board setup that depends on the shared I2C bus already being initialized.
+void initVariantAfterI2C() __attribute__((weak));
+void initVariantAfterI2C() {}
+
+static bool recoverTDeckI2C()
+{
+#if defined(T_DECK_MAX)
+    return tDeckMaxRecoverI2C();
+#else
+    return tDeckProV1_1RecoverI2C();
+#endif
+}
+#endif
 
 // NRF52 (and probably other platforms) can report when system is in power failure mode
 // (eg. too low battery voltage) and operating it is unsafe (data corruption, bootloops, etc).
@@ -605,6 +631,10 @@ void setup()
 #endif
 #endif
 
+#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
+    initVariantAfterI2C();
+#endif
+
 #if defined(M5STACK_UNITC6L)
     pinMode(LORA_CS, OUTPUT);
     digitalWrite(LORA_CS, 1);
@@ -631,7 +661,19 @@ void setup()
     power = new Power();
     power->setStatusHandler(powerStatus);
     powerStatus->observe(&power->newStatus);
+#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
+    bool powerReady = power->setup(); // Must be after status handler is installed, so that handler gets notified of the initial configuration
+#else
     power->setup(); // Must be after status handler is installed, so that handler gets notified of the initial configuration
+#endif
+
+#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
+    // XPowersLib may release the shared ESP32 I2C handle while probing an absent
+    // battery gauge. Recreate it before the generic scanner starts probing.
+    bool tDeckI2CReady = powerReady;
+    if (!powerReady)
+        tDeckI2CReady = recoverTDeckI2C();
+#endif
 
 #ifdef USE_MCP23017
     // Bring up the I2C IO expander (LoRa reset, LCD reset, GPS wake) now that the PMU rails are up,
@@ -666,7 +708,14 @@ void setup()
 #endif
 
 #if defined(I2C_SDA)
-    i2cScanner->scanPort(ScanI2C::I2CPort::WIRE);
+#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
+    if (tDeckI2CReady)
+#endif
+        i2cScanner->scanPort(ScanI2C::I2CPort::WIRE);
+#if defined(T_DECK_MAX) || defined(_VARIANT_T_DECK_PRO_V1_1)
+    else
+        LOG_ERROR("T-Deck: skipping I2C scan because the bus is unavailable");
+#endif
 #elif defined(ARCH_PORTDUINO)
     if (portduino_config.i2cdev != "") {
         LOG_INFO("Scan for i2c devices");
@@ -795,6 +844,10 @@ void setup()
     auto acc_info = i2cScanner->firstAccelerometer();
     accelerometer_found = acc_info.type != ScanI2C::DeviceType::NONE ? acc_info.address : accelerometer_found;
     LOG_DEBUG("acc_info = %i", acc_info.type);
+#if defined(T_DECK_MAX)
+    if (acc_info.type == ScanI2C::DeviceType::NONE)
+        tDeckMaxSetImuPower(false);
+#endif
 #endif
 #if !defined(ARCH_STM32WL) && !MESHTASTIC_EXCLUDE_MAGNETOMETER
     auto mag_info = i2cScanner->firstMagnetometer();
@@ -929,7 +982,10 @@ void setup()
 #endif
 
 #ifdef HAS_DRV2605
-#if defined(PIN_DRV_EN)
+#if defined(T_DECK_MAX)
+    tDeckMaxSetMotorPower(true);
+    delay(10);
+#elif defined(PIN_DRV_EN)
     pinMode(PIN_DRV_EN, OUTPUT);
     digitalWrite(PIN_DRV_EN, HIGH);
     delay(10);
@@ -949,6 +1005,9 @@ void setup()
     drv.selectLibrary(1);
     // I2C trigger by sending 'go' command
     drv.setMode(DRV2605_MODE_INTTRIG);
+#if defined(T_DECK_MAX)
+    tDeckMaxSetMotorPower(false);
+#endif
 #endif
 
     // Init our SPI controller (must be before screen and lora)

--- a/src/platform/extra_variants/t_deck_pro/variant.cpp
+++ b/src/platform/extra_variants/t_deck_pro/variant.cpp
@@ -2,9 +2,6 @@
 
 #ifdef T_DECK_PRO
 
-#if defined(_VARIANT_T_DECK_PRO_V1_1) && defined(HAS_A7682_AUDIO)
-#include "audio/A7682Audio.h"
-#endif
 #include "input/TouchScreenImpl1.h"
 #include <CSE_CST328.h>
 #include <Wire.h>
@@ -229,12 +226,4 @@ void lateInitVariant()
     touchScreenImpl1 = new TouchScreenImpl1(EINK_WIDTH, EINK_HEIGHT, readTouch);
     touchScreenImpl1->init();
 }
-
-#if defined(_VARIANT_T_DECK_PRO_V1_1) && defined(HAS_A7682_AUDIO)
-void variant_shutdown()
-{
-    if (a7682Audio)
-        a7682Audio->shutdown();
-}
-#endif
 #endif

--- a/src/platform/extra_variants/t_deck_pro/variant.cpp
+++ b/src/platform/extra_variants/t_deck_pro/variant.cpp
@@ -2,11 +2,28 @@
 
 #ifdef T_DECK_PRO
 
+#if defined(_VARIANT_T_DECK_PRO_V1_1) && defined(HAS_A7682_AUDIO)
+#include "audio/A7682Audio.h"
+#endif
 #include "input/TouchScreenImpl1.h"
 #include <CSE_CST328.h>
 #include <Wire.h>
 
 CSE_CST328 tsPanel = CSE_CST328(EINK_WIDTH, EINK_HEIGHT, &Wire, CST328_PIN_RST, CST328_PIN_INT);
+
+#if defined(_VARIANT_T_DECK_PRO_V1_1)
+void earlyInitVariant()
+{
+    pinMode(LORA_EN, OUTPUT);
+    digitalWrite(LORA_EN, HIGH);
+    pinMode(LORA_CS, OUTPUT);
+    digitalWrite(LORA_CS, HIGH);
+    pinMode(SDCARD_CS, OUTPUT);
+    digitalWrite(SDCARD_CS, HIGH);
+    pinMode(PIN_EINK_CS, OUTPUT);
+    digitalWrite(PIN_EINK_CS, HIGH);
+}
+#endif
 
 static bool is_cst3530 = false;
 volatile bool touch_isr = false;
@@ -36,10 +53,47 @@ bool read_cst3530_touch(int16_t *x, int16_t *y)
         return false;
     }
 
-    uint8_t report_typ = buffer[2];
-    if (report_typ != 0xFF) {
-        return false;
+#if defined(_VARIANT_T_DECK_PRO_V1_1)
+    bool validReport = buffer[2] == 0xFF;
+    const uint8_t touch_points = buffer[3] & 0x0F;
+    if (validReport && (touch_points == 0 || touch_points > 1)) {
+        LOG_DEBUG("CST3530 touch points invalid: %d", touch_points);
+        validReport = false;
     }
+
+    if (validReport) {
+        // CST3530 reports a 16-bit sum (0x55 + the complete point record).
+        uint16_t checksum = 0x55;
+        for (uint8_t index = 4; index < sizeof(buffer); ++index)
+            checksum = static_cast<uint16_t>(checksum + buffer[index]);
+        const uint16_t reportedChecksum = static_cast<uint16_t>(buffer[0]) | (static_cast<uint16_t>(buffer[1]) << 8);
+        if (checksum != reportedChecksum) {
+            LOG_DEBUG("CST3530 report checksum mismatch");
+            validReport = false;
+        }
+    }
+
+    if (validReport && (buffer[8] >> 4) == 0) {
+        // A release frame can retain a non-zero finger count. Only a report
+        // with an active event is a pressed sample.
+        validReport = false;
+    }
+
+    if (validReport) {
+        const uint16_t rawX = buffer[4] + ((static_cast<uint16_t>(buffer[7]) & 0x0F) << 8);
+        const uint16_t rawY = buffer[5] + ((static_cast<uint16_t>(buffer[7]) & 0xF0) << 4);
+        if (rawX >= EINK_WIDTH || rawY >= EINK_HEIGHT) {
+            LOG_DEBUG("CST3530 coordinates out of range: %u,%u", rawX, rawY);
+            validReport = false;
+        } else {
+            *x = static_cast<int16_t>(rawX);
+            *y = static_cast<int16_t>(rawY);
+        }
+    }
+#else
+    uint8_t report_typ = buffer[2];
+    if (report_typ != 0xFF)
+        return false;
 
     uint8_t touch_points = buffer[3] & 0x0F;
     if (touch_points == 0 || touch_points > 1) {
@@ -49,8 +103,7 @@ bool read_cst3530_touch(int16_t *x, int16_t *y)
 
     *x = buffer[4] + ((uint16_t)(buffer[7] & 0x0F) << 8);
     *y = buffer[5] + ((uint16_t)(buffer[7] & 0xF0) << 4);
-
-    // LOG_DEBUG("CST3530 touch: num:%d x=%d,y=%d", touch_points, *x, *y);
+#endif
 
     Wire.beginTransmission(CST3530_ADDR);
     Wire.write(clear_cmd, sizeof(clear_cmd));
@@ -58,27 +111,58 @@ bool read_cst3530_touch(int16_t *x, int16_t *y)
         LOG_DEBUG("CST3530 clear cmd failed");
     }
 
+#if defined(_VARIANT_T_DECK_PRO_V1_1)
+    return validReport;
+#else
     return true;
+#endif
 }
 
 bool readTouch(int16_t *x, int16_t *y)
 {
-
     if (is_cst3530) {
+        // CST3530 sleeps between reports; only read after its IRQ. Polling the
+        // custom report register can replay a stale touch frame as a new press.
         if (touch_isr) {
             touch_isr = false;
             return read_cst3530_touch(x, y);
         }
         return false;
-    } else {
+    }
+
+#if defined(_VARIANT_T_DECK_PRO_V1_1)
+    if (tsPanel.getTouches()) {
+        *x = tsPanel.getPoint(0).x;
+        *y = tsPanel.getPoint(0).y;
+        return true;
+    }
+#else
+    else {
         if (tsPanel.getTouches()) {
             *x = tsPanel.getPoint(0).x;
             *y = tsPanel.getPoint(0).y;
             return true;
         }
     }
+#endif
     return false;
 }
+
+#if defined(_VARIANT_T_DECK_PRO_V1_1)
+bool tDeckProV1_1RecoverI2C()
+{
+    const bool ended = Wire.end();
+    const bool started = Wire.begin(I2C_SDA, I2C_SCL);
+
+    if (!ended || !started) {
+        LOG_ERROR("T-Deck-Pro V1.1: I2C bus recovery failed (end=%d begin=%d)", ended, started);
+        return false;
+    }
+
+    LOG_INFO("T-Deck-Pro V1.1: I2C bus recovered on SDA %d, SCL %d", I2C_SDA, I2C_SCL);
+    return true;
+}
+#endif
 
 static void IRAM_ATTR touchInterruptHandler()
 {
@@ -99,7 +183,11 @@ void lateInitVariant()
 
     int retry = 5;
     uint8_t buffer[7];
+#if defined(_VARIANT_T_DECK_PRO_V1_1)
+    uint8_t r_cmd[] = {0xD0, 0x03, 0x00, 0x00};
+#else
     uint8_t r_cmd[] = {0x0d0, 0x03, 0x00, 0x00};
+#endif
 
     // Probe touch chip
     while (retry--) {
@@ -114,7 +202,11 @@ void lateInitVariant()
 
                 // The CST3530 will automatically enter sleep mode;
                 // polling should not be used, but rather an interrupt method should be employed.
+#if defined(_VARIANT_T_DECK_PRO_V1_1)
+                pinMode(CST328_PIN_INT, INPUT_PULLUP);
+#else
                 pinMode(CST328_PIN_INT, INPUT);
+#endif
                 attachInterrupt(digitalPinToInterrupt(CST328_PIN_INT), touchInterruptHandler, FALLING);
 
                 break;
@@ -129,7 +221,20 @@ void lateInitVariant()
         delay(50);
     }
 
+#if defined(_VARIANT_T_DECK_PRO_V1_1)
+    if (!is_cst3530 && !tsPanel.begin())
+        LOG_WARN("CST328 touch initialization failed");
+#endif
+
     touchScreenImpl1 = new TouchScreenImpl1(EINK_WIDTH, EINK_HEIGHT, readTouch);
     touchScreenImpl1->init();
 }
+
+#if defined(_VARIANT_T_DECK_PRO_V1_1) && defined(HAS_A7682_AUDIO)
+void variant_shutdown()
+{
+    if (a7682Audio)
+        a7682Audio->shutdown();
+}
+#endif
 #endif

--- a/variants/esp32s3/t-deck-pro-v1_1/variant.h
+++ b/variants/esp32s3/t-deck-pro-v1_1/variant.h
@@ -1,3 +1,5 @@
+#define _VARIANT_T_DECK_PRO_V1_1
+
 // Display (E-Ink)
 #define PIN_EINK_CS 34
 #define PIN_EINK_BUSY 37
@@ -102,5 +104,7 @@
 #define MODEM_DTR 8
 #define MODEM_RX 10
 #define MODEM_TX 11
+#define HAS_A7682_AUDIO 1
+#define A7682_AUDIO_DEBUG_FILESYSTEM 1 // Temporary: list C:/ files at modem startup
 
 #define HAS_PHYSICAL_KEYBOARD 1

--- a/variants/esp32s3/t-deck-pro-v1_1/variant.h
+++ b/variants/esp32s3/t-deck-pro-v1_1/variant.h
@@ -104,7 +104,5 @@
 #define MODEM_DTR 8
 #define MODEM_RX 10
 #define MODEM_TX 11
-#define HAS_A7682_AUDIO 1
-#define A7682_AUDIO_DEBUG_FILESYSTEM 1 // Temporary: list C:/ files at modem startup
 
 #define HAS_PHYSICAL_KEYBOARD 1


### PR DESCRIPTION
## Summary

This PR isolates the T-Deck Pro V1.1 and T-Deck-Max touch hardware path and adds the shared touch gesture and target-capture foundation.

## Scope

- Add CST touch handling for the T-Deck-Pro V1.1 and T-Deck-Max board.
- Add filtered gesture recognition, direction locking, long-press handling, and target capture.
- Keep the existing touch path unchanged for other devices.
- Load board configuration before board-scoped declarations so `InputEvent` has a consistent layout across translation units.

## Hardware isolation

- Pro V1.1 hardware is guarded by `_VARIANT_T_DECK_PRO_V1_1`, Max hardware is guarded by`T_DECK_MAX`.

## 🤝 Attestations

- [√ ] I have tested that my proposed changes behave as described.
- [ √] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [√ ] LilyGo T-Deck-ProV1_1
  - [√] LilyGo T-Deck-Max



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added touchscreen gesture support for T-Deck Max and T-Deck Pro V1.1, including taps, swipes, and long presses.
  * Added touch-target mapping for navigation, menus, keyboard keys, confirmations, and other controls.
  * Improved touch accuracy with coordinate transformation, filtering, bounds checking, and gesture cancellation.
  * Added hardware support and I2C recovery improvements for T-Deck variants.
* **Bug Fixes**
  * Added validation for touch reports to reject invalid or corrupted input safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->