### PR TITLE
Pass framebuffer rotation through DisplayDriverConfig

### DIFF
--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -15,8 +15,6 @@
 #endif
 
 #if defined(ARCH_PORTDUINO) || !defined(HAS_FREE_RTOS)
-#include <cstdio>
-#include <cstdlib>
 #include <thread>
 #endif
 
@@ -350,16 +348,13 @@ void tftSetup(void)
         } else
 #elif defined(USE_FRAMEBUFFER)
         if (portduino_config.displayPanel == fb) {
-            // Rotation from yaml Display.OffsetRotate: 1=90, 2=180, 3=270 deg
-            char rbuf[4];
-            snprintf(rbuf, sizeof(rbuf), "%d", portduino_config.displayRotate ? (portduino_config.displayOffsetRotate & 3) : 0);
-            if (setenv("MESHTASTIC_FB_ROTATION", rbuf, 1) != 0)
-                LOG_ERROR("Failed to set MESHTASTIC_FB_ROTATION, framebuffer will use its default rotation");
             if (portduino_config.displayWidth && portduino_config.displayHeight)
                 displayConfig = DisplayDriverConfig(DisplayDriverConfig::device_t::FB, (uint16_t)portduino_config.displayWidth,
                                                     (uint16_t)portduino_config.displayHeight);
             else
                 displayConfig.device(DisplayDriverConfig::device_t::FB);
+            // Rotation from yaml Display.OffsetRotate: 1=90, 2=180, 3=270 deg
+            displayConfig.rotation(portduino_config.displayRotate ? (uint8_t)portduino_config.displayOffsetRotate : 0);
         } else
 #endif
         {

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -350,12 +350,10 @@ void tftSetup(void)
         if (portduino_config.displayPanel == fb) {
             // Rotation from yaml Display.OffsetRotate: 1=90, 2=180, 3=270 deg
             displayConfig.device(DisplayDriverConfig::device_t::FB)
-                .panel(DisplayDriverConfig::panel_config_t{
-                    .type = panels[portduino_config.displayPanel],
-                    .panel_width = (uint16_t)(portduino_config.displayWidth ? portduino_config.displayWidth : c_default_width),
-                    .panel_height =
-                        (uint16_t)(portduino_config.displayHeight ? portduino_config.displayHeight : c_default_height),
-                    .offset_rotation = (uint8_t)(portduino_config.displayRotate ? portduino_config.displayOffsetRotate : 0)});
+                .panel(DisplayDriverConfig::panel_config_t{.type = panels[portduino_config.displayPanel],
+                                                           .panel_width = (uint16_t)portduino_config.displayWidth,
+                                                           .panel_height = (uint16_t)portduino_config.displayHeight,
+                                                           .offset_rotation = (uint8_t)portduino_config.displayOffsetRotate});
         } else
 #endif
         {

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -348,13 +348,14 @@ void tftSetup(void)
         } else
 #elif defined(USE_FRAMEBUFFER)
         if (portduino_config.displayPanel == fb) {
-            if (portduino_config.displayWidth && portduino_config.displayHeight)
-                displayConfig = DisplayDriverConfig(DisplayDriverConfig::device_t::FB, (uint16_t)portduino_config.displayWidth,
-                                                    (uint16_t)portduino_config.displayHeight);
-            else
-                displayConfig.device(DisplayDriverConfig::device_t::FB);
             // Rotation from yaml Display.OffsetRotate: 1=90, 2=180, 3=270 deg
-            displayConfig.rotation(portduino_config.displayRotate ? (uint8_t)portduino_config.displayOffsetRotate : 0);
+            displayConfig.device(DisplayDriverConfig::device_t::FB)
+                .panel(DisplayDriverConfig::panel_config_t{
+                    .type = panels[portduino_config.displayPanel],
+                    .panel_width = (uint16_t)(portduino_config.displayWidth ? portduino_config.displayWidth : c_default_width),
+                    .panel_height =
+                        (uint16_t)(portduino_config.displayHeight ? portduino_config.displayHeight : c_default_height),
+                    .offset_rotation = (uint8_t)(portduino_config.displayRotate ? portduino_config.displayOffsetRotate : 0)});
         } else
 #endif
         {


### PR DESCRIPTION
Follow-up to #11252 and the review of meshtastic/device-ui#355: the framebuffer rotation is handed to device-ui through `DisplayDriverConfig` instead of the `MESHTASTIC_FB_ROTATION` environment variable. `Display.OffsetRotate` is passed unmasked, device-ui maps 0/1/2/3 to the lvgl rotations and warns on unsupported values.

Requires meshtastic/device-ui#355, which adds `DisplayDriverConfig::rotation()` and `FBDriver::create(const DisplayDriverConfig &)`. The rotation stays inactive until the device-ui digest in platformio.ini is bumped past that merge.

`env:native-fb` is the only environment that compiles this path and is not part of the CI matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display setup on Portduino devices by applying screen rotation directly.
  * Preserved support for custom framebuffer dimensions and display-device selection.
  * Display configuration is now more reliable and consistent during startup.
  * Removed reliance on environment-based rotation settings for supported displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->