### PR TITLE
Fix incorrectly placed newline in CSV export

### DIFF
--- a/src/modules/RangeTestModule.cpp
+++ b/src/modules/RangeTestModule.cpp
@@ -310,8 +310,11 @@ bool RangeTestModuleRadio::appendFile(const meshtastic_MeshPacket &mp)
     fileToAppend.printf("%d,", mp.hop_limit); // Packet Hop Limit
 
     // TODO: If quotes are found in the payload, it has to be escaped.
-    fileToAppend.printf("\"%.*s\"\n", (int)p.payload.size, p.payload.bytes);
+    fileToAppend.printf("\"%.*s\",", (int)p.payload.size, p.payload.bytes);
     fileToAppend.printf("%i,", mp.rx_rssi); // RX RSSI
+
+    // EOL
+    fileToAppend.printf("\n");
 
     fileToAppend.flush();
     fileToAppend.close();

--- a/src/modules/RangeTestModule.cpp
+++ b/src/modules/RangeTestModule.cpp
@@ -311,7 +311,7 @@ bool RangeTestModuleRadio::appendFile(const meshtastic_MeshPacket &mp)
 
     // TODO: If quotes are found in the payload, it has to be escaped.
     fileToAppend.printf("\"%.*s\",", (int)p.payload.size, p.payload.bytes);
-    fileToAppend.printf("%i,", mp.rx_rssi); // RX RSSI
+    fileToAppend.printf("%i", mp.rx_rssi); // RX RSSI
 
     fileToAppend.printf("\n");
     fileToAppend.flush();

--- a/src/modules/RangeTestModule.cpp
+++ b/src/modules/RangeTestModule.cpp
@@ -313,9 +313,7 @@ bool RangeTestModuleRadio::appendFile(const meshtastic_MeshPacket &mp)
     fileToAppend.printf("\"%.*s\",", (int)p.payload.size, p.payload.bytes);
     fileToAppend.printf("%i,", mp.rx_rssi); // RX RSSI
 
-    // EOL
     fileToAppend.printf("\n");
-
     fileToAppend.flush();
     fileToAppend.close();
 


### PR DESCRIPTION
PR https://github.com/meshtastic/firmware/pull/8395 added a column for RSSI to the Range Test module's CSV export, but did **not** move the newline that is supposed to appear at the end of each record. This results in misaligned columns in the CSV file.

This PR removes the newline character from inside one of the column printf calls, where it's honestly quite easy to miss, and moves it to its own printf call. Hopefully this makes it less likely that something similar happens again.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected range-test CSV formatting so payload and RSSI values appear on the same row.
  * Added the proper comma separator and row terminator placement for exported test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->