### PR TITLE
fix(http): keep reaping open TLS connections under low heap so the heap can recover

### DIFF
--- a/src/mesh/http/WebServer.cpp
+++ b/src/mesh/http/WebServer.cpp
@@ -62,24 +62,14 @@ static const uint8_t MAX_HTTPS_CONNECTIONS = 2;
 // Minimum free heap required for SSL handshake (~40KB for mbedTLS contexts)
 static const uint32_t MIN_HEAP_FOR_SSL = 40000;
 
-/**
- * HTTPSServer that can be driven under memory pressure without accepting.
- *
- * HTTPServer::loop() does two things: it services and reaps the connections it already holds
- * (each open one gets ->loop(), which is where the idle timeout and the SSL close-notify state
- * machine run, and closed ones are deleted), and then it accepts a new connection if a slot is
- * free. handleWebResponse() skips the whole loop below MIN_HEAP_FOR_SSL so no new TLS handshake
- * is attempted on a heap that cannot hold its context - but that also froze the connections
- * already open: never looped, they never time out, their mbedTLS contexts are never freed, the
- * heap never climbs back over the threshold, and the loop is skipped forever. Splitting the two
- * halves needs the connection table, which HTTPServer keeps protected.
- */
+// HTTPSServer that can service and reap the connections it already holds without accepting new ones,
+// so a low-heap pause doesn't freeze open TLS sessions (and their heap) in place. Needs the protected table.
 class MeshHTTPSServer : public HTTPSServer
 {
   public:
     using HTTPSServer::HTTPSServer;
 
-    /// The first half of HTTPServer::loop(): drive and reap the connections we already hold, accept nothing.
+    /// The first half of HTTPServer::loop(): drive and reap existing connections, accept nothing.
     void serviceExistingConnections()
     {
         if (!_running)
@@ -115,10 +105,8 @@ static void handleWebResponse()
                 if (freeHeap >= MIN_HEAP_FOR_SSL) {
                     secureServer->loop();
                 } else {
-                    // Low heap: don't accept a new TLS handshake we can't hold a context for, but keep
-                    // driving the connections already open so they can finish, time out and be reaped -
-                    // that is what gives the heap back. Skipping them entirely pins the heap below the
-                    // threshold for good (see MeshHTTPSServer).
+                    // Low heap: accept nothing new, but keep servicing open connections so they can time out
+                    // and free their contexts - skipping them pins the heap below the threshold for good.
                     secureServer->serviceExistingConnections();
                     static uint32_t lastHeapWarning = 0;
                     if (lastHeapWarning == 0 || !Throttle::isWithinTimespanMs(lastHeapWarning, 30000)) {

--- a/src/mesh/http/WebServer.cpp
+++ b/src/mesh/http/WebServer.cpp
@@ -62,8 +62,43 @@ static const uint8_t MAX_HTTPS_CONNECTIONS = 2;
 // Minimum free heap required for SSL handshake (~40KB for mbedTLS contexts)
 static const uint32_t MIN_HEAP_FOR_SSL = 40000;
 
+/**
+ * HTTPSServer that can be driven under memory pressure without accepting.
+ *
+ * HTTPServer::loop() does two things: it services and reaps the connections it already holds
+ * (each open one gets ->loop(), which is where the idle timeout and the SSL close-notify state
+ * machine run, and closed ones are deleted), and then it accepts a new connection if a slot is
+ * free. handleWebResponse() skips the whole loop below MIN_HEAP_FOR_SSL so no new TLS handshake
+ * is attempted on a heap that cannot hold its context - but that also froze the connections
+ * already open: never looped, they never time out, their mbedTLS contexts are never freed, the
+ * heap never climbs back over the threshold, and the loop is skipped forever. Splitting the two
+ * halves needs the connection table, which HTTPServer keeps protected.
+ */
+class MeshHTTPSServer : public HTTPSServer
+{
+  public:
+    using HTTPSServer::HTTPSServer;
+
+    /// The first half of HTTPServer::loop(): drive and reap the connections we already hold, accept nothing.
+    void serviceExistingConnections()
+    {
+        if (!_running)
+            return;
+        for (uint8_t i = 0; i < _maxConnections; i++) {
+            if (!_connections[i])
+                continue;
+            if (_connections[i]->isClosed()) {
+                delete _connections[i];
+                _connections[i] = nullptr;
+            } else {
+                _connections[i]->loop();
+            }
+        }
+    }
+};
+
 static SSLCert *cert;
-static HTTPSServer *secureServer;
+static MeshHTTPSServer *secureServer;
 static HTTPServer *insecureServer;
 
 volatile bool isWebServerReady;
@@ -80,10 +115,14 @@ static void handleWebResponse()
                 if (freeHeap >= MIN_HEAP_FOR_SSL) {
                     secureServer->loop();
                 } else {
-                    // Skip HTTPS when memory is low to prevent SSL setup failures
+                    // Low heap: don't accept a new TLS handshake we can't hold a context for, but keep
+                    // driving the connections already open so they can finish, time out and be reaped -
+                    // that is what gives the heap back. Skipping them entirely pins the heap below the
+                    // threshold for good (see MeshHTTPSServer).
+                    secureServer->serviceExistingConnections();
                     static uint32_t lastHeapWarning = 0;
                     if (lastHeapWarning == 0 || !Throttle::isWithinTimespanMs(lastHeapWarning, 30000)) {
-                        LOG_WARN("Low heap (%u bytes), skipping HTTPS processing", freeHeap);
+                        LOG_WARN("Low heap (%u bytes), not accepting HTTPS connections", freeHeap);
                         lastHeapWarning = millis();
                     }
                 }
@@ -231,7 +270,7 @@ void initWebServer()
     LOG_DEBUG("Init Web Server");
 
     // We can now use the new certificate to setup our server as usual.
-    secureServer = new HTTPSServer(cert, 443, MAX_HTTPS_CONNECTIONS);
+    secureServer = new MeshHTTPSServer(cert, 443, MAX_HTTPS_CONNECTIONS);
     insecureServer = new HTTPServer();
 
     registerHandlers(insecureServer, secureServer);


### PR DESCRIPTION
Fixes #11538.

## Summary

Once free heap dropped below `MIN_HEAP_FOR_SSL` (40 KB) with HTTPS connections open, the node's heap never came back and every later HTTPS or TCP-API connection failed until a reset — node alive, on WiFi, unusable.

`handleWebResponse()` skipped `secureServer->loop()` entirely under low heap so no new TLS handshake would be attempted on a heap that can't hold its context (#9693). But `HTTPServer::loop()` is the **only** place already-accepted connections are serviced and reaped: its first pass calls `->loop()` on each open one (where the 20 s idle timeout and the SSL close-notify state machine run) and deletes the closed ones. Skipping the whole loop froze the ≤`MAX_HTTPS_CONNECTIONS` TLS sessions already open — never looped, they never timed out, their mbedTLS contexts + pbufs were never freed, free heap never climbed back over 40 KB, so the loop was skipped forever. The guard's own precondition kept it from clearing.

## Change

Split the two halves: under low heap keep **driving and reaping** the connections already held, and only skip the **accept**. `HTTPServer` keeps its connection table `protected`, so a thin `MeshHTTPSServer` subclass exposes `serviceExistingConnections()` — the first half of `HTTPServer::loop()` verbatim. No library patch. Log line reworded to say what now happens (`not accepting HTTPS connections`, not "skipping").

One file, +43/−4.

## Verification — Heltec V3, `Endor` AP

Control build = #11537 (so the node survives the squeeze instead of aborting first — on plain develop this state is masked by the reboot).

| | control | this branch |
|---|---|---|
| held sockets on 80/4403 + pending TLS → 100 s HTTPS pokes → repeat | `Low heap` pins at **6–17 KB**, HTTPS dead, 2nd pressure round 0/3 | never dips under 40 KB, both rounds **3/3**, 65 KB after |
| 3 min after all pressure released, **no reset** | still **~12 KB**, `Low heap` every 30 s → permanent | 65 KB, HTTPS `200` |
| low-heap branch driven deliberately (verify-only heap hog pinning free at ~28 KB, real idle TLS session held) | session frozen for the whole window | `serviceExisting: open=1 → reaped=1` at the 20 s idle timeout **under the guard**; heap 26 → 65 KB before the hog is even released |

Control log, 3 min after release (uptime 316→497 s, `heap_free` from `/json/report`):
```
+ 19s heap_free=10532  lastLowHeap=(316, 15080)
+ 95s heap_free=12100  lastLowHeap=(377, 16368)
+190s heap_free=12104  lastLowHeap=(497, 16888)
```
Fix, hog window (guard active the whole time):
```
12:06:43 71 [WebServer] VERIFY-ONLY serviceExisting: open=1 reaped=0
12:06:48 76 [WebServer] VERIFY-ONLY serviceExisting: open=0 reaped=1     ← reaped under low heap
uptime=147 heap(http)=65200                                                 ← recovered before hog release at 150
```

Also seen on both builds and **not** this PR: with heap above the guard but fragmented, `mbedtls_ssl_setup` fails with `Memory allocation failed` and the connection is cleanly closed/reaped — that's a free-vs-largest-block gap in the 40 KB check (worth a follow-up to use `heap_caps_get_largest_free_block`), not a livelock.

esp32 build green locally; `pio check -e rak3172` (cppcheck) PASSED; clang-format 16.0.3 clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTPS connection handling when device memory is low.
  * Existing secure connections continue to be serviced and cleaned up without accepting new connections.
  * Reduced the risk of HTTPS processing being skipped entirely during low-memory conditions.
  * Helps maintain more reliable secure communication while the device is under memory pressure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->