### PR TITLE
backport(mesh): reconfigure() returns true instead of RADIOLIB_ERR_NONE

### DIFF
--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -194,7 +194,7 @@ template <typename T> bool LR11x0Interface<T>::reconfigure()
 
     startReceive(); // restart receiving
 
-    return RADIOLIB_ERR_NONE;
+    return true;
 }
 
 template <typename T> void LR11x0Interface<T>::disableInterrupt()

--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -253,7 +253,7 @@ bool RF95Interface::reconfigure()
 
     startReceive(); // restart receiving
 
-    return RADIOLIB_ERR_NONE;
+    return true;
 }
 
 /**

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -255,7 +255,7 @@ template <typename T> bool SX126xInterface<T>::reconfigure()
 
     startReceive(); // restart receiving
 
-    return RADIOLIB_ERR_NONE;
+    return true;
 }
 
 template <typename T> int16_t SX126xInterface<T>::getCurrentRSSI()

--- a/src/mesh/SX128xInterface.cpp
+++ b/src/mesh/SX128xInterface.cpp
@@ -154,7 +154,7 @@ template <typename T> bool SX128xInterface<T>::reconfigure()
 
     startReceive(); // restart receiving
 
-    return RADIOLIB_ERR_NONE;
+    return true;
 }
 
 template <typename T> void SX128xInterface<T>::disableInterrupt()


### PR DESCRIPTION
Backport of #10407 (b11d29ff3) from develop. Cherry-picked with -x, original authorship preserved.

`reconfigure()` is declared `bool` in four radio interfaces but returns `RADIOLIB_ERR_NONE`, which is 0. A successful reconfigure therefore reports failure:

- src/mesh/LR11x0Interface.cpp
- src/mesh/RF95Interface.cpp
- src/mesh/SX126xInterface.cpp
- src/mesh/SX128xInterface.cpp

The return value is consumed in `RadioInterface::initLoRa()` at RadioInterface.cpp:505. When a non wide band chip is configured for the LORA_24 region, the region is reset to UNSET and `reconfigure()` is called; because it always returns false, that path unconditionally schedules a reboot.

develop has carried this fix since 2026-05-07. master does not.