### PR TITLE
fix(thinknode_m9): define SPI_FREQUENCY for the non-MUI build

### DIFF
--- a/variants/esp32s3/ELECROW-ThinkNode-M9/platformio.ini
+++ b/variants/esp32s3/ELECROW-ThinkNode-M9/platformio.ini
@@ -31,6 +31,7 @@ build_flags =
   -D SDCARD_INIT_SPI
   -D SD_SPI_FREQUENCY=75000000U
   -D HAS_SCREEN=1
+  -D SPI_FREQUENCY=75000000
 ;  -D COMPASS_SENSOR_DEBUG=1
 lib_deps = ${esp32s3_base.lib_deps}
   # renovate: datasource=custom depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
@@ -82,7 +83,6 @@ build_flags =
   -D LGFX_SCREEN_WIDTH=240
   -D LGFX_SCREEN_HEIGHT=320
   -D LGFX_INVERT_LIGHT=true
-  -D SPI_FREQUENCY=75000000
 ;  -D MAP_FULL_REDRAW
   -D MUI_WIFI_PS_MIN_MODEM
   -D DEFAULT_FTP_SERVER_NETWORK_TYPE_ESP32=NETWORK_ESP32


### PR DESCRIPTION
## Problem

`build (thinknode_m9, esp32s3)` has failed on every develop run since #10908 landed. develop was green through `5dffd2258`, red from `c308d0aca` onward, and this is currently the only failing job on develop.

```
src/graphics/TFTDisplay.cpp:504:30: error: 'SPI_FREQUENCY' was not declared in this scope; did you mean 'SD_SPI_FREQUENCY'?
  504 |             cfg.freq_write = SPI_FREQUENCY;
      |                              ^~~~~~~~~~~~~
```

The M9's `variant.h` defines `ST7789_CS`, so `TFTDisplay.cpp` compiles its ST7789 `LGFX` branch, which reads `SPI_FREQUENCY` for the panel write clock — `SPI_READ_FREQUENCY`, its pair, is already in `variant.h`. But `-D SPI_FREQUENCY=75000000` was only set in `[env:thinknode_m9-tft]`, so the plain env has never compiled.

## Change

Move the flag from the `-tft` env up into `thinknode_m9_base`, keeping the 75 MHz the `-tft` env already used for the same panel — and matching `SD_SPI_FREQUENCY` on the bus the two share.

It stays a build flag rather than moving into `variant.h` because device-ui's `LGFX_GENERIC.h` doesn't include `variant.h`: it reads `SPI_FREQUENCY` itself and silently falls back to `#define SPI_FREQUENCY 20000000` when the macro is absent. One flag on the base keeps both consumers on the same value.

`thinknode_m9-tft` is unaffected — it inherits `${thinknode_m9_base.build_flags}`.

## Tests

Resolved flags, via `pio project config --json-output` — the MUI env is unchanged, the plain env gains the macro:

```
env:thinknode_m9      -> ['-D SD_SPI_FREQUENCY=75000000U', '-D SPI_FREQUENCY=75000000']
env:thinknode_m9-tft  -> ['-D SD_SPI_FREQUENCY=75000000U', '-D SPI_FREQUENCY=75000000']
```

`pio run -e thinknode_m9`: SUCCESS in 7:17, zero errors, `src/graphics/TFTDisplay.cpp.o` compiles clean.

No M9 hardware on hand, so this is a build fix verified by building. Since `thinknode_m9-tft`'s resolved flags are identical to before, the MUI build is byte-for-byte unchanged and needs no re-test on device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SPI display communication settings for ThinkNode M9 builds.
  * Standardized the SPI frequency configuration across display environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->