### PR TITLE
2.7: Update protobufs and classes

### DIFF
--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -333,6 +333,8 @@ typedef enum _meshtastic_HardwareModel {
     meshtastic_HardwareModel_HELTEC_MESH_TOWER_V2 = 139,
     /* Meshnology W10 */
     meshtastic_HardwareModel_MESHNOLOGY_W10 = 140,
+    /* Seeed Wio Tracker L1 Pro 1W, nRF52840 + SX1262 with 1 W external PA */
+    meshtastic_HardwareModel_SEEED_WIO_TRACKER_L1_PRO_1W = 144,
     /* ------------------------------------------------------------------------------------------------------------------------------------------
  Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.
  ------------------------------------------------------------------------------------------------------------------------------------------ */


### PR DESCRIPTION
Bumps the protobufs submodule from `909bedda` to the 2.7 branch tip `cf0a84e`, adding `SEEED_WIO_TRACKER_L1_PRO_1W = 144` (meshtastic/protobufs#1041).

Unblocks #11541, which references the enum from `src/platform/nrf52/architecture.h`.

Generated locally with nanopb 0.4.9.1, the same artifact the CI workflow fetches, against protobufs `2.7` rather than `master`. The 2.7 line tracks the protobufs `2.7` branch, so the regenerated diff is limited to the one enum. Generating from protobufs `master` would pull 149 commits of unrelated proto drift across 12 files.