### PR TITLE
Toggle GPS and buzzer together on the ThinkNode M8 function button double click

### DIFF
--- a/src/input/ButtonThread.cpp
+++ b/src/input/ButtonThread.cpp
@@ -102,7 +102,10 @@ bool ButtonThread::initButton(const ButtonConfig &config)
 #endif
     userButton.setPressMs(_longPressTime);
 
-    if (screen) {
+    // A screen makes the single click feel sluggish unless the click window is short, but a 20ms
+    // window closes long before a second click can land. Boards that bind a double or multi click
+    // need the full window, screen or not, otherwise those events never fire.
+    if (screen && _doublePress == INPUT_BROKER_NONE && _triplePress == INPUT_BROKER_NONE) {
         userButton.setClickMs(20);
     } else {
         userButton.setClickMs(BUTTON_CLICK_MS);
@@ -225,15 +228,8 @@ int32_t ButtonThread::runOnce()
             break;
         }
 
-        case BUTTON_EVENT_DOUBLE_PRESSED: { // not wired in if screen detected
+        case BUTTON_EVENT_DOUBLE_PRESSED: { // only fires on boards that bind ButtonConfig::doublePress
             LOG_INFO("Double press");
-#if defined(ELECROW_ThinkNode_M8)
-            if (config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED)
-                config.device.buzzer_mode = meshtastic_Config_DeviceConfig_BuzzerMode_DISABLED;
-            else if (config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_DISABLED)
-                config.device.buzzer_mode = meshtastic_Config_DeviceConfig_BuzzerMode_ALL_ENABLED;
-            service->reloadConfig(SEGMENT_CONFIG);
-#endif
             // Reset combination tracking
             waitingForLongPress = false;
 

--- a/src/input/ButtonThread.cpp
+++ b/src/input/ButtonThread.cpp
@@ -102,9 +102,8 @@ bool ButtonThread::initButton(const ButtonConfig &config)
 #endif
     userButton.setPressMs(_longPressTime);
 
-    // A screen makes the single click feel sluggish unless the click window is short, but a 20ms
-    // window closes long before a second click can land. Boards that bind a double or multi click
-    // need the full window, screen or not, otherwise those events never fire.
+    // The 20ms window a screen normally gets closes before a second click can land, so boards
+    // binding double or multi click need the full one.
     if (screen && _doublePress == INPUT_BROKER_NONE && _triplePress == INPUT_BROKER_NONE) {
         userButton.setClickMs(20);
     } else {
@@ -228,7 +227,7 @@ int32_t ButtonThread::runOnce()
             break;
         }
 
-        case BUTTON_EVENT_DOUBLE_PRESSED: { // only fires on boards that bind ButtonConfig::doublePress
+        case BUTTON_EVENT_DOUBLE_PRESSED: { // only on boards binding ButtonConfig::doublePress
             LOG_INFO("Double press");
             // Reset combination tracking
             waitingForLongPress = false;

--- a/src/input/InputBroker.cpp
+++ b/src/input/InputBroker.cpp
@@ -382,7 +382,7 @@ void InputBroker::Init()
         userConfig.singlePress = INPUT_BROKER_SEND_PING;
         userConfig.longPress = INPUT_BROKER_SHUTDOWN;
         userConfig.longPressTime = 5000;
-        userConfig.doublePress = INPUT_BROKER_GPS_TOGGLE;
+        userConfig.doublePress = INPUT_BROKER_PRIVACY_TOGGLE;
         UserButtonThread->initButton(userConfig);
     }
 #else

--- a/src/input/InputBroker.h
+++ b/src/input/InputBroker.h
@@ -28,9 +28,7 @@ enum input_broker_event {
     INPUT_BROKER_FACTORY_RST = 0x9a,
     INPUT_BROKER_SHUTDOWN = 0x9b,
     INPUT_BROKER_GPS_TOGGLE = 0x9e,
-    // Turns the GPS and the buzzer off together, and back on together, so one gesture makes the
-    // node stop broadcasting its position and stop making noise.
-    INPUT_BROKER_PRIVACY_TOGGLE = 0x9f,
+    INPUT_BROKER_PRIVACY_TOGGLE = 0x9f, // GPS and buzzer off together, and back on together
     INPUT_BROKER_SEND_PING = 0xaf,
     INPUT_BROKER_FN_F1 = 0xf1,
     INPUT_BROKER_FN_F2 = 0xf2,

--- a/src/input/InputBroker.h
+++ b/src/input/InputBroker.h
@@ -28,6 +28,9 @@ enum input_broker_event {
     INPUT_BROKER_FACTORY_RST = 0x9a,
     INPUT_BROKER_SHUTDOWN = 0x9b,
     INPUT_BROKER_GPS_TOGGLE = 0x9e,
+    // Turns the GPS and the buzzer off together, and back on together, so one gesture makes the
+    // node stop broadcasting its position and stop making noise.
+    INPUT_BROKER_PRIVACY_TOGGLE = 0x9f,
     INPUT_BROKER_SEND_PING = 0xaf,
     INPUT_BROKER_FN_F1 = 0xf1,
     INPUT_BROKER_FN_F2 = 0xf2,

--- a/src/modules/SystemCommandsModule.cpp
+++ b/src/modules/SystemCommandsModule.cpp
@@ -91,19 +91,19 @@ int SystemCommandsModule::handleInputEvent(const InputEvent *event)
     case INPUT_BROKER_PRIVACY_TOGGLE:
 #if !MESHTASTIC_EXCLUDE_GPS
         if (gps) {
-            const bool withBuzzer = event->inputEvent == INPUT_BROKER_PRIVACY_TOGGLE;
             const bool wasEnabled = config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED;
+            // toggleGpsMode() only moves between ENABLED and DISABLED, so leave the buzzer alone otherwise.
+            const bool withBuzzer = event->inputEvent == INPUT_BROKER_PRIVACY_TOGGLE &&
+                                    (wasEnabled || config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_DISABLED);
             if (wasEnabled && config.position.fixed_position == false) {
                 nodeDB->clearLocalPosition();
                 nodeDB->saveToDisk();
             }
-            // Unmute before the toggle and mute after it, so the confirmation beep is audible both ways.
-            if (withBuzzer && !wasEnabled)
+            if (withBuzzer) // unmute first, so the confirmation beep is audible in both directions
                 config.device.buzzer_mode = meshtastic_Config_DeviceConfig_BuzzerMode_ALL_ENABLED;
             gps->toggleGpsMode();
             const bool nowEnabled = config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED;
             if (withBuzzer) {
-                // Follow the GPS, which does not move on GpsMode_NOT_PRESENT.
                 config.device.buzzer_mode = nowEnabled ? meshtastic_Config_DeviceConfig_BuzzerMode_ALL_ENABLED
                                                        : meshtastic_Config_DeviceConfig_BuzzerMode_DISABLED;
                 nodeDB->saveToDisk(SEGMENT_CONFIG);

--- a/src/modules/SystemCommandsModule.cpp
+++ b/src/modules/SystemCommandsModule.cpp
@@ -86,18 +86,31 @@ int SystemCommandsModule::handleInputEvent(const InputEvent *event)
     }
 
     switch (event->inputEvent) {
-        // GPS
+        // GPS, on its own or together with the buzzer
     case INPUT_BROKER_GPS_TOGGLE:
+    case INPUT_BROKER_PRIVACY_TOGGLE:
 #if !MESHTASTIC_EXCLUDE_GPS
         if (gps) {
-            if (config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED &&
-                config.position.fixed_position == false) {
+            const bool withBuzzer = event->inputEvent == INPUT_BROKER_PRIVACY_TOGGLE;
+            const bool wasEnabled = config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED;
+            if (wasEnabled && config.position.fixed_position == false) {
                 nodeDB->clearLocalPosition();
                 nodeDB->saveToDisk();
             }
+            // Unmute ahead of the toggle so its confirmation beep is audible; the matching mute happens
+            // after it, so the "GPS off" beep still plays on the way down.
+            if (withBuzzer && !wasEnabled)
+                config.device.buzzer_mode = meshtastic_Config_DeviceConfig_BuzzerMode_ALL_ENABLED;
             gps->toggleGpsMode();
-            const char *msg =
-                (config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED) ? "GPS Enabled" : "GPS Disabled";
+            const bool nowEnabled = config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED;
+            if (withBuzzer) {
+                // Follow whatever the GPS settled on - toggleGpsMode() is a no-op on GpsMode_NOT_PRESENT.
+                config.device.buzzer_mode = nowEnabled ? meshtastic_Config_DeviceConfig_BuzzerMode_ALL_ENABLED
+                                                       : meshtastic_Config_DeviceConfig_BuzzerMode_DISABLED;
+                nodeDB->saveToDisk(SEGMENT_CONFIG);
+            }
+            const char *msg = withBuzzer ? (nowEnabled ? "GPS + Buzzer\nEnabled" : "GPS + Buzzer\nDisabled")
+                                         : (nowEnabled ? "GPS Enabled" : "GPS Disabled");
             IF_SCREEN(screen->forceDisplay(); screen->showSimpleBanner(msg, 3000);)
         }
 #endif

--- a/src/modules/SystemCommandsModule.cpp
+++ b/src/modules/SystemCommandsModule.cpp
@@ -97,14 +97,13 @@ int SystemCommandsModule::handleInputEvent(const InputEvent *event)
                 nodeDB->clearLocalPosition();
                 nodeDB->saveToDisk();
             }
-            // Unmute ahead of the toggle so its confirmation beep is audible; the matching mute happens
-            // after it, so the "GPS off" beep still plays on the way down.
+            // Unmute before the toggle and mute after it, so the confirmation beep is audible both ways.
             if (withBuzzer && !wasEnabled)
                 config.device.buzzer_mode = meshtastic_Config_DeviceConfig_BuzzerMode_ALL_ENABLED;
             gps->toggleGpsMode();
             const bool nowEnabled = config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED;
             if (withBuzzer) {
-                // Follow whatever the GPS settled on - toggleGpsMode() is a no-op on GpsMode_NOT_PRESENT.
+                // Follow the GPS, which does not move on GpsMode_NOT_PRESENT.
                 config.device.buzzer_mode = nowEnabled ? meshtastic_Config_DeviceConfig_BuzzerMode_ALL_ENABLED
                                                        : meshtastic_Config_DeviceConfig_BuzzerMode_DISABLED;
                 nodeDB->saveToDisk(SEGMENT_CONFIG);


### PR DESCRIPTION
Double click of the ThinkNode M8 function button toggles GPS and buzzer together; boards binding double or multi click now keep the full click window, which a detected screen previously shortened to 20ms and which stopped the event from ever firing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Double-pressing the Elecrow ThinkNode M8 button now toggles privacy instead of GPS.
  - Privacy changes coordinate GPS and buzzer behavior when applicable.
  - Confirmation beeps remain available during eligible privacy changes.

- **Bug Fixes**
  - Improved click handling when multi-click actions are configured.
  - Preserved existing buzzer behavior for unaffected GPS states.
  - GPS-only controls continue to work as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->