### PR TITLE
fix(power): keep light sleep off on native USB-CDC boards running on USB power

### DIFF
--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -58,6 +58,20 @@ static bool isPowered()
     return !isPowerSavingMode && powerStatus && (!powerStatus->getHasBattery() || powerStatus->getHasUSB());
 }
 
+/// True when the CDC console runs on the native USB-OTG peripheral (ARDUINO_USB_MODE=0) and the
+/// board is currently running on USB power. Light sleep powers that PHY down, after which the host
+/// can no longer re-enumerate the device and the console is gone until the cable is replugged.
+/// See https://github.com/meshtastic/firmware/issues/4206
+static bool nativeUsbSerialActive()
+{
+#if defined(ARDUINO_USB_MODE) && (ARDUINO_USB_MODE == 0) && defined(ARDUINO_USB_CDC_ON_BOOT) &&                     \
+    (ARDUINO_USB_CDC_ON_BOOT == 1)
+    return powerStatus && powerStatus->getHasUSB();
+#else
+    return false;
+#endif
+}
+
 static bool isBluetoothEnabledForPowerFSM()
 {
 #if HAS_BLUETOOTH && !MESHTASTIC_EXCLUDE_BLUETOOTH
@@ -144,6 +158,15 @@ static void lsIdle()
     // LOG_INFO("lsIdle begin ls_secs=%u", getPref_ls_secs());
 
 #ifdef ARCH_ESP32
+
+    // USB may have been plugged in after boot, so re-check here instead of relying on the snapshot
+    // taken in PowerFSM_setup(). Leaving light sleep costs a wake cycle; losing the console costs a
+    // physical replug, and on boards without a PMU there is no VBUS insert IRQ to recover us.
+    if (nativeUsbSerialActive()) {
+        LOG_INFO("Native USB-CDC on USB power: leaving light sleep (keeps serial alive)");
+        powerFSM.trigger(EVENT_WAKE_TIMER);
+        return;
+    }
 
     // Do we have more sleeping to do?
     if (secsSlept < config.power.ls_secs) {
@@ -439,18 +462,12 @@ void PowerFSM_setup()
                              config.device.role == meshtastic_Config_DeviceConfig_Role_TAK_TRACKER ||
                              config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR;
 
-    // On ESP32-S3 boards whose CDC console runs on the native USB-OTG peripheral
-    // (ARDUINO_USB_MODE=0), light sleep powers down the USB PHY and the host can no longer
-    // re-enumerate the device: dmesg loops "device descriptor read/64, error -32" until the
-    // cable is physically replugged. See https://github.com/meshtastic/firmware/issues/4206
-    // While actually running on USB power there is no energy to save, so skip light sleep.
-    bool nativeUsbSerialAttached = false;
-#if defined(ARDUINO_USB_MODE) && (ARDUINO_USB_MODE == 0) && defined(ARDUINO_USB_CDC_ON_BOOT) &&                     \
-    (ARDUINO_USB_CDC_ON_BOOT == 1)
-    nativeUsbSerialAttached = powerStatus && powerStatus->getHasUSB();
+    // Already on USB power at boot: skip registering the light-sleep transitions entirely, so a
+    // mains powered node never churns through wake cycles. Cables plugged in later are caught live
+    // by lsIdle(). See nativeUsbSerialActive().
+    bool nativeUsbSerialAttached = nativeUsbSerialActive();
     if (nativeUsbSerialAttached)
         LOG_INFO("Native USB-CDC on USB power: light sleep disabled (keeps serial alive)");
-#endif
 
     if ((isRouter || config.power.is_power_saving) && !isWifiAvailable() && !isTrackerOrSensor &&
         !nativeUsbSerialAttached) {

--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -439,7 +439,21 @@ void PowerFSM_setup()
                              config.device.role == meshtastic_Config_DeviceConfig_Role_TAK_TRACKER ||
                              config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR;
 
-    if ((isRouter || config.power.is_power_saving) && !isWifiAvailable() && !isTrackerOrSensor) {
+    // On ESP32-S3 boards whose CDC console runs on the native USB-OTG peripheral
+    // (ARDUINO_USB_MODE=0), light sleep powers down the USB PHY and the host can no longer
+    // re-enumerate the device: dmesg loops "device descriptor read/64, error -32" until the
+    // cable is physically replugged. See https://github.com/meshtastic/firmware/issues/4206
+    // While actually running on USB power there is no energy to save, so skip light sleep.
+    bool nativeUsbSerialAttached = false;
+#if defined(ARDUINO_USB_MODE) && (ARDUINO_USB_MODE == 0) && defined(ARDUINO_USB_CDC_ON_BOOT) &&                     \
+    (ARDUINO_USB_CDC_ON_BOOT == 1)
+    nativeUsbSerialAttached = powerStatus && powerStatus->getHasUSB();
+    if (nativeUsbSerialAttached)
+        LOG_INFO("Native USB-CDC on USB power: light sleep disabled (keeps serial alive)");
+#endif
+
+    if ((isRouter || config.power.is_power_saving) && !isWifiAvailable() && !isTrackerOrSensor &&
+        !nativeUsbSerialAttached) {
         powerFSM.add_timed_transition(&stateNB, &stateLS,
                                       Default::getConfiguredOrDefaultMs(config.power.min_wake_secs, default_min_wake_secs), NULL,
                                       "Min wake timeout");

--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -58,12 +58,8 @@ static bool isPowered()
     return !isPowerSavingMode && powerStatus && (!powerStatus->getHasBattery() || powerStatus->getHasUSB());
 }
 
-/// True when the CDC console runs on the native USB-OTG peripheral (ARDUINO_USB_MODE=0) and the
-/// board is currently running on USB power. Light sleep powers that PHY down, after which the host
-/// can no longer re-enumerate the device and the console is gone until the cable is replugged.
-/// Needs a PMU: without one getHasUSB() cannot tell mains power from a battery wired to the USB
-/// connector, so boards like the Elecrow panels or the SenseCAP Indicator sleep as they did before.
-/// See https://github.com/meshtastic/firmware/issues/4206
+/// Native USB-CDC console on USB power: light sleep kills that PHY and the host cannot re-enumerate.
+/// Needs a PMU, otherwise getHasUSB() cannot tell mains from a battery on the USB connector. #4206
 static bool nativeUsbSerialActive()
 {
 #if defined(ARDUINO_USB_MODE) && (ARDUINO_USB_MODE == 0) && defined(ARDUINO_USB_CDC_ON_BOOT) &&                     \
@@ -161,9 +157,8 @@ static void lsIdle()
 
 #ifdef ARCH_ESP32
 
-    // USB may have been plugged in after boot, so re-check here instead of relying on the snapshot
-    // taken in PowerFSM_setup(). Leaving light sleep costs a wake cycle; losing the console costs a
-    // physical replug.
+    // Re-check here: USB may have been plugged in after PowerFSM_setup() took its snapshot.
+    // A wake cycle is cheaper than losing the console to a physical replug.
     if (nativeUsbSerialActive()) {
         LOG_INFO("Native USB-CDC on USB power: leaving light sleep (keeps serial alive)");
         powerFSM.trigger(EVENT_WAKE_TIMER);
@@ -464,9 +459,8 @@ void PowerFSM_setup()
                              config.device.role == meshtastic_Config_DeviceConfig_Role_TAK_TRACKER ||
                              config.device.role == meshtastic_Config_DeviceConfig_Role_SENSOR;
 
-    // Already on USB power at boot: skip registering the light-sleep transitions entirely, so a
-    // mains powered node never churns through wake cycles. Cables plugged in later are caught live
-    // by lsIdle(). See nativeUsbSerialActive().
+    // Already on USB power at boot: skip the light-sleep transitions entirely, so a mains powered
+    // node never churns through wake cycles. Cables plugged in later are caught by lsIdle().
     bool nativeUsbSerialAttached = nativeUsbSerialActive();
     if (nativeUsbSerialAttached)
         LOG_INFO("Native USB-CDC on USB power: light sleep disabled (keeps serial alive)");

--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -61,11 +61,13 @@ static bool isPowered()
 /// True when the CDC console runs on the native USB-OTG peripheral (ARDUINO_USB_MODE=0) and the
 /// board is currently running on USB power. Light sleep powers that PHY down, after which the host
 /// can no longer re-enumerate the device and the console is gone until the cable is replugged.
+/// Needs a PMU: without one getHasUSB() cannot tell mains power from a battery wired to the USB
+/// connector, so boards like the Elecrow panels or the SenseCAP Indicator sleep as they did before.
 /// See https://github.com/meshtastic/firmware/issues/4206
 static bool nativeUsbSerialActive()
 {
 #if defined(ARDUINO_USB_MODE) && (ARDUINO_USB_MODE == 0) && defined(ARDUINO_USB_CDC_ON_BOOT) &&                     \
-    (ARDUINO_USB_CDC_ON_BOOT == 1)
+    (ARDUINO_USB_CDC_ON_BOOT == 1) && defined(HAS_PMU)
     return powerStatus && powerStatus->getHasUSB();
 #else
     return false;
@@ -161,7 +163,7 @@ static void lsIdle()
 
     // USB may have been plugged in after boot, so re-check here instead of relying on the snapshot
     // taken in PowerFSM_setup(). Leaving light sleep costs a wake cycle; losing the console costs a
-    // physical replug, and on boards without a PMU there is no VBUS insert IRQ to recover us.
+    // physical replug.
     if (nativeUsbSerialActive()) {
         LOG_INFO("Native USB-CDC on USB power: leaving light sleep (keeps serial alive)");
         powerFSM.trigger(EVENT_WAKE_TIMER);


### PR DESCRIPTION
Issue #4206 described USB serial dying on ESP32-S3 boards after light sleep, with the reporter noting that switching the role from ROUTER to CLIENT worked around it. That issue was closed in October 2024, but the behaviour is still present on current firmware. I ran into it on a T-Beam S3 Core running 2.7.26 and went looking for the cause.

## What happens

Set `device.role` to ROUTER on an S3 board whose console runs on the native USB-OTG peripheral, leave it plugged into a powered hub, and the serial port disappears after roughly 30 seconds. The host then loops:

```
usb 3-1.4: device descriptor read/64, error -32
usb 3-1.4: device not accepting address 100, error -71
usb 3-1-port2: unable to enumerate USB device
```

Same signature the original reporter posted. The device itself is fine, the display keeps working, only USB is gone until the cable is physically replugged. On a desk router that means losing the serial console permanently.

## Why

Three things line up in `PowerFSM.cpp`:

1. `isPowered()` computes `isPowerSavingMode = config.power.is_power_saving || isRouter`, so role ROUTER forces power saving **regardless of whether the board is running on USB power**. `hasPower` comes out false and boot lands in `stateON` instead of `statePOWER`.
2. The guard `if ((isRouter || config.power.is_power_saving) && !isWifiAvailable() && !isTrackerOrSensor)` then adds the timed transitions into `stateLS`.
3. `lsIdle()` calls `doLightSleep()` every `SLEEP_TIME` seconds.

On ESP32-S3 with `ARDUINO_USB_MODE=0` the CDC console lives on the native USB-OTG peripheral, and light sleep powers down the USB PHY. The host cannot re-enumerate it, hence the `error -32` loop. This does not affect boards using an external UART bridge, which is why it only shows up on native USB-CDC hardware.

The comment in `isPowered()` explains the intent: routers are assumed to run all the time from a low current source such as solar. That assumption is reasonable, it just does not hold when the board is demonstrably sitting on USB power.

## The change

Skip the light sleep transitions when the board uses native USB-CDC **and** `powerStatus->getHasUSB()` reports it is actually running on USB power. There is no energy to save in that case. The check is wrapped in `#if defined(ARDUINO_USB_MODE) && (ARDUINO_USB_MODE == 0) && defined(ARDUINO_USB_CDC_ON_BOOT) && (ARDUINO_USB_CDC_ON_BOOT == 1)`, so it compiles out entirely on every other target. Battery and solar behaviour is unchanged, which is the case the original logic was written for.

15 lines, one file, 96 bytes of flash.

## Testing

LilyGO T-Beam S3 Core, firmware built from this branch at 2.7.26.

Before: role ROUTER, USB dies within about 30 seconds, `error -32` in dmesg, `meshtastic --info` times out.

After: role ROUTER confirmed via `--info`, then left running for a 20 minute soak sampling the USB device and the kernel error counter every 30 seconds. 39 of 39 samples showed the device present and zero USB errors. `rebootCount` stayed at the number of deliberate restarts, so nothing crashed and recovered quietly.

```
16:41:34 usb=OK errors=0
...
17:00:37 usb=OK errors=0
```

I have only S3 hardware here, so I could not verify the Station G2 and T-Deck cases from the original report, though both are native USB-CDC boards and should be covered by the same guard.

Refs: #4206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USB serial reliability when native USB is connected after boot.
  * Devices now exit light sleep when USB activity is detected, preserving console access.
  * Light sleep is skipped while native USB serial is attached to prevent the console from becoming unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->