### PR TITLE
breaking-fix(radio): Align Center Frequency in Japan to comply with ARIB STD-T108

### DIFF
--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -501,7 +501,7 @@ void menuHandler::FrequencySlotPicker()
 
     meshtastic_Config_LoRaConfig &loraConfig = config.lora;
     double bw = loraConfig.use_preset ? modemPresetToBwKHz(loraConfig.modem_preset, myRegion->wideLora)
-                                      : bwCodeToKHz(loraConfig.bandwidth);
+                                      : clampBandwidthKHz(bwCodeToKHz(loraConfig.bandwidth));
 
     uint32_t numChannels = 0;
     if (myRegion) {

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -505,14 +505,14 @@ void menuHandler::FrequencySlotPicker()
 
     uint32_t numChannels = 0;
     if (myRegion) {
-        // Match RadioInterface::applyModemConfig(): include padding, add spacing in numerator, and use round()
-        const double spacing = myRegion->profile->spacing;
-        const double padding = myRegion->profile->padding;
+        // Match RadioInterface::applyModemConfig(): include padding, add spacing in numerator, and use floor()
+        const double spacing = myRegion->getSpacing(bw);
+        const double padding = myRegion->getPadding(bw);
         const double channelBandwidthMHz = bw / 1000.0;
-        const double numerator = (myRegion->freqEnd - myRegion->freqStart) + spacing;
+        const double numerator = (myRegion->freqEnd - myRegion->freqStart) + spacing + 0.001;
         const double denominator = spacing + (padding * 2) + channelBandwidthMHz;
         if (denominator > 0.0) {
-            numChannels = static_cast<uint32_t>(round(numerator / denominator));
+            numChannels = static_cast<uint32_t>(floor(numerator / denominator));
         } else {
             LOG_WARN("Invalid region config: non-positive channel spacing/width");
         }

--- a/src/mesh/MeshRadio.h
+++ b/src/mesh/MeshRadio.h
@@ -5,6 +5,7 @@
 #include "PointerQueue.h"
 #include "configuration.h"
 #include "detect/LoRaRadioType.h"
+#include <math.h>
 
 // Sentinel marking the end of a modem preset array. Declared `const` rather
 // than `constexpr` because the cast from 0xFF to the enum is out-of-range and
@@ -92,6 +93,24 @@ struct RegionInfo {
         while (profile->presets[n] != MODEM_PRESET_END)
             n++;
         return n;
+    }
+    float getSpacing(float bwKHz = 0) const
+    {
+        if (code == meshtastic_Config_LoRaConfig_RegionCode_JP)
+            return 0.0f;
+        return profile ? profile->spacing : 0.0f;
+    }
+    float getPadding(float bwKHz = 0) const
+    {
+        if (code == meshtastic_Config_LoRaConfig_RegionCode_JP) {
+            // ARIB STD-T108: 200 kHz unit channel grid. Center LoRa BW symmetrically within ceil(bw/200kHz) unit channels.
+            const float unitChannelMHz = 0.200f;
+            const float bwMHz = (bwKHz > 0 ? bwKHz : 250.0f) / 1000.0f;
+            const int numUnits = (int)ceil(bwMHz / unitChannelMHz);
+            const float slotWidth = numUnits * unitChannelMHz;
+            return (slotWidth - bwMHz) / 2.0f;
+        }
+        return profile ? profile->padding : 0.0f;
     }
 };
 

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -1183,8 +1183,10 @@ bool RadioInterface::checkOrClampConfigLora(meshtastic_Config_LoRaConfig &loraCo
     // Calculate width of slots (aka channels) based on bandwidth and any spacing or padding required by the region:
     // spacing = gap between slots (0 for continuous spectrum) and at the beginning of the band
     // padding = gap at the beginning and end of the slots (0 for no padding)
-    float freqSlotWidth = newRegion->profile->spacing + (newRegion->profile->padding * 2) + (check_bw / 1000); // in MHz
-    uint32_t numFreqSlots = round((newRegion->freqEnd - newRegion->freqStart + newRegion->profile->spacing) / freqSlotWidth);
+    float spacing = newRegion->getSpacing(check_bw);
+    float padding = newRegion->getPadding(check_bw);
+    float freqSlotWidth = spacing + (padding * 2) + (check_bw / 1000.0f); // in MHz
+    uint32_t numFreqSlots = floor((newRegion->freqEnd - newRegion->freqStart + spacing + 0.001f) / freqSlotWidth);
 
     // Check if the region supports the requested bandwidth
     if ((newRegion->freqEnd - newRegion->freqStart) < freqSlotWidth) {
@@ -1199,8 +1201,10 @@ bool RadioInterface::checkOrClampConfigLora(meshtastic_Config_LoRaConfig &loraCo
             check_bw = bwCodeToKHz(loraConfig.bandwidth);
 
             // Recompute slot width and number of slots based on the new bandwidth
-            freqSlotWidth = newRegion->profile->spacing + (newRegion->profile->padding * 2) + (check_bw / 1000); // in MHz
-            numFreqSlots = round((newRegion->freqEnd - newRegion->freqStart + newRegion->profile->spacing) / freqSlotWidth);
+            spacing = newRegion->getSpacing(check_bw);
+            padding = newRegion->getPadding(check_bw);
+            freqSlotWidth = spacing + (padding * 2) + (check_bw / 1000.0f); // in MHz
+            numFreqSlots = floor((newRegion->freqEnd - newRegion->freqStart + spacing + 0.001f) / freqSlotWidth);
         } else {
             return false;
         }
@@ -1337,8 +1341,10 @@ void RadioInterface::applyModemConfig()
     // Calculate number of frequency slots (aka Channels):
     // spacing = gap between channels (0 for continuous spectrum) and at the beginning of the band
     // padding = gap at the beginning and end of the channel (0 for no padding)
-    float freqSlotWidth = newRegion->profile->spacing + (newRegion->profile->padding * 2) + (bw / 1000); // in MHz
-    uint32_t numFreqSlots = round((newRegion->freqEnd - newRegion->freqStart + newRegion->profile->spacing) / freqSlotWidth);
+    float spacing = newRegion->getSpacing(bw);
+    float padding = newRegion->getPadding(bw);
+    float freqSlotWidth = spacing + (padding * 2) + (bw / 1000.0f); // in MHz
+    uint32_t numFreqSlots = floor((newRegion->freqEnd - newRegion->freqStart + spacing + 0.001f) / freqSlotWidth);
 
     // Calculate hash of channel name and preset name to pick a default frequency slot if user has not specified one.
     // Note that channel_num is actually (channel_num - 1), i.e. zero-based, since modulus (%) returns values from 0 to
@@ -1379,7 +1385,7 @@ void RadioInterface::applyModemConfig()
 
         // Calculate frequency: freqStart is band edge, add half bandwidth (plus optional padding) to get middle of first channel
         // subsequent channels are spaced by freqSlotWidth
-        freq = newRegion->freqStart + (bw / 2000) + newRegion->profile->padding + (channel_num * freqSlotWidth); // in MHz
+        freq = newRegion->freqStart + (bw / 2000.0f) + padding + (channel_num * freqSlotWidth); // in MHz
     }
 
     saveChannelNum(channel_num);

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -976,6 +976,87 @@ static void test_channelSpacingCalculation_EU868_LONG_FAST()
     TEST_ASSERT_EQUAL_UINT32(1, numChannels);
 }
 
+static void test_channelSpacingCalculation_JP_LONG_FAST()
+{
+    // JP: freqStart=920.5, freqEnd=923.5, ARIB STD-T108 200kHz unit channels
+    // LONG_FAST: bw=250 kHz -> 2 unit channels (400 kHz slot), padding=75 kHz, spacing=0
+    // numChannels = floor((923.5 - 920.5 + 0.001) / 0.400) = 7
+    // fc(0) = 920.5 + 0.125 + 0.075 = 920.700 MHz (ARIB ch 24+25 center)
+    const RegionInfo *jp = getRegion(meshtastic_Config_LoRaConfig_RegionCode_JP);
+    float bw = modemPresetToBwKHz(meshtastic_Config_LoRaConfig_ModemPreset_LONG_FAST, jp->wideLora);
+    float spacing = jp->getSpacing(bw);
+    float padding = jp->getPadding(bw);
+    float channelSpacing = spacing + (padding * 2) + (bw / 1000.0f);
+    uint32_t numChannels = (uint32_t)((jp->freqEnd - jp->freqStart + spacing + 0.001f) / channelSpacing);
+    float firstFreq = jp->freqStart + (bw / 2000.0f) + padding;
+    float secondFreq = firstFreq + channelSpacing;
+    float lastFreq = firstFreq + 6 * channelSpacing;
+
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.0f, spacing);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.075f, padding);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.400f, channelSpacing);
+    TEST_ASSERT_EQUAL_UINT32(7, numChannels);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 920.700f, firstFreq);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 921.100f, secondFreq);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 923.100f, lastFreq);
+}
+
+static void test_channelSpacingCalculation_JP_LONG_SLOW()
+{
+    // LONG_SLOW: bw=125 kHz -> 1 unit channel (200 kHz slot), padding=37.5 kHz
+    // fc(0) = 920.5 + 0.0625 + 0.0375 = 920.600 MHz (ARIB ch 24 center)
+    const RegionInfo *jp = getRegion(meshtastic_Config_LoRaConfig_RegionCode_JP);
+    float bw = modemPresetToBwKHz(meshtastic_Config_LoRaConfig_ModemPreset_LONG_SLOW, jp->wideLora);
+    float spacing = jp->getSpacing(bw);
+    float padding = jp->getPadding(bw);
+    float channelSpacing = spacing + (padding * 2) + (bw / 1000.0f);
+    uint32_t numChannels = (uint32_t)((jp->freqEnd - jp->freqStart + spacing + 0.001f) / channelSpacing);
+    float firstFreq = jp->freqStart + (bw / 2000.0f) + padding;
+
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.0375f, padding);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.200f, channelSpacing);
+    TEST_ASSERT_EQUAL_UINT32(15, numChannels);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 920.600f, firstFreq);
+}
+
+static void test_channelSpacingCalculation_JP_NARROW_SLOW()
+{
+    // NARROW_SLOW: bw=62.5 kHz -> 1 unit channel (200 kHz slot), padding=68.75 kHz
+    // fc(0) = 920.5 + 0.03125 + 0.06875 = 920.600 MHz (ARIB ch 24 center)
+    const RegionInfo *jp = getRegion(meshtastic_Config_LoRaConfig_RegionCode_JP);
+    float bw = modemPresetToBwKHz(meshtastic_Config_LoRaConfig_ModemPreset_NARROW_SLOW, jp->wideLora);
+    float spacing = jp->getSpacing(bw);
+    float padding = jp->getPadding(bw);
+    float channelSpacing = spacing + (padding * 2) + (bw / 1000.0f);
+    uint32_t numChannels = (uint32_t)((jp->freqEnd - jp->freqStart + spacing + 0.001f) / channelSpacing);
+    float firstFreq = jp->freqStart + (bw / 2000.0f) + padding;
+
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.06875f, padding);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.200f, channelSpacing);
+    TEST_ASSERT_EQUAL_UINT32(15, numChannels);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 920.600f, firstFreq);
+}
+
+static void test_channelSpacingCalculation_JP_SHORT_TURBO()
+{
+    // SHORT_TURBO: bw=500 kHz -> 3 unit channels (600 kHz slot), padding=50 kHz
+    // fc(0) = 920.5 + 0.250 + 0.050 = 920.800 MHz (ARIB ch 24..26 center)
+    const RegionInfo *jp = getRegion(meshtastic_Config_LoRaConfig_RegionCode_JP);
+    float bw = modemPresetToBwKHz(meshtastic_Config_LoRaConfig_ModemPreset_SHORT_TURBO, jp->wideLora);
+    float spacing = jp->getSpacing(bw);
+    float padding = jp->getPadding(bw);
+    float channelSpacing = spacing + (padding * 2) + (bw / 1000.0f);
+    uint32_t numChannels = (uint32_t)((jp->freqEnd - jp->freqStart + spacing + 0.001f) / channelSpacing);
+    float firstFreq = jp->freqStart + (bw / 2000.0f) + padding;
+    float lastFreq = firstFreq + 4 * channelSpacing;
+
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.050f, padding);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.600f, channelSpacing);
+    TEST_ASSERT_EQUAL_UINT32(5, numChannels);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 920.800f, firstFreq);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 923.200f, lastFreq);
+}
+
 // Placeholder: when protobuf region definitions include non-zero padding/spacing,
 // add tests here to verify the channel count and frequency calculations.
 static void test_channelSpacingCalculation_placeholder()
@@ -2622,6 +2703,10 @@ void setup()
     // Channel spacing (current + placeholder)
     RUN_TEST(test_channelSpacingCalculation_US_LONG_FAST);
     RUN_TEST(test_channelSpacingCalculation_EU868_LONG_FAST);
+    RUN_TEST(test_channelSpacingCalculation_JP_LONG_FAST);
+    RUN_TEST(test_channelSpacingCalculation_JP_LONG_SLOW);
+    RUN_TEST(test_channelSpacingCalculation_JP_NARROW_SLOW);
+    RUN_TEST(test_channelSpacingCalculation_JP_SHORT_TURBO);
     RUN_TEST(test_channelSpacingCalculation_placeholder);
 
     // handleSetConfig fromOthers dispatch


### PR DESCRIPTION
# Summary
This PR fixes misaligned center frequency with all bandwidth when region is set to Japan(JP).

# Backgrounds

Under Japanese Radio Law and standard ARIB STD-T108 ("920MHz-Band Telemeter, Telecontrol and Data Transmission Radio Equipment"):

The frequency band for specified low power radio stations is divided into 200 kHz unit channels (channels 24 through 38 spanning 920.5 MHz – 923.5 MHz).
For signals occupying more than one unit channel (e.g. 250 kHz LoRa bandwidth), two consecutive unit channels must be bonded (total allocated width = 400 kHz).
The regulatory center frequency for two bonded channels (e.g., channels 24 & 25) is 920.700 MHz (Table 3-2 and Table 3-12 of ARIB STD-T108).

refer https://www.arib.or.jp/english/html/overview/doc/5-STD-T108v1_5-E1.pdf for tables and other regulations.

# Current behavior, and why it is problematic
In `src/mesh/RadioInterface.cpp`, region JP used PROFILE_STD with padding = 0 and spacing = 0.
The old formula calculated the frequency like:
```
center_freq = 920.500MHz + 250kHz/2000kHz = 920.625MHz
```
Which is 75kHz below than the standard requires(920.7MHz),
resulting no lower guard band, and all subsequent channels drifts 200kHz(this varies on bandwidth of preset),
any frequency slot selection causing "no guard band" situation regardless of bandwidth.

# Proposing changes
To address this issue while keep any other region unaffected, also any bandwidth shall not use invalid center frequency,
I would like to introduce dynamic unit-channel padding and spacing, as follows:
- `src/mesh/MeshRadio.h` : following two will be added
  - `RegionInfo::getSpacing(float bwKHz)`
    - When region is not JP, it returns profile-specific frequency spacing(thus no effects if region is not JP)
    - If region is set to JP, it calculates the required spacing frequency following the ARIB STD-T108
  - `RegionInfo::getPadding(float bwKHz)`
    - same behavior as `getSpacing`
- `src/mesh/MeshRadio.cpp`: following be added and changed:
  - Update existing lines to use two functions introducing in `src/mesh/MeshRadio.h` 
  - Use `floor()` instad of `round()` so that frequencies do not exceed the upper band limit
    - used `+0.001f` for potential floating-foint imprecision issue
    - *Note: this will affects regardless of region, but result will be exactly same regardless of any config*
- `src/graphics/draw/MenuHandler.cpp`
  - Update existing lines to use two functions introducing in `src/mesh/MeshRadio.h` 
- (not in this PR and WIP on my side) `source/graphics/common/LoRaPresets.cpp` in device-ui
  - requires updating the regionInfo for Japan
    - actually it was older definition, just a display issue though
  - Update `getNumChannels` and `getRadioFreq` to use similar logic to calculate and display the correct value
    - this is also the display issue, but worth fixing it as currently there is no support for any spacing/padding
- `test/test_admin_radio/test_main.cpp`
  - Added test cases covering all bandwidth profiles from 62.5kHz(NARROW_SLOW) to 500kHz (SHORT_TURBO)

# Caveats
## Changes on Frequency Slots
This will changes not only center frequency, but also changes Frequency Slot, both mapping and total available slots with BW > 200kHz as follows:
- 62.5kHz : 15 Frequency Slots as-is, but on different center frequency
- 125kHz : 15 Frequency Slots as-is, but on different center frequency too
- 250kHz: *7 Frequency Slots(currently 12)*, on different center frequency
- 500kHz: *5 Frequency Slots(currently 6)*,  on different center frequency too

## Needs of Frequency Migration
Since this will changes whole frequency assignment when the node's region is set to JP,
node users are required do following upon their situations:
- If they updated the firmware
  - and Frequency Slot has been changed from 0(like 12 as we usually use in here) upon previous setup
    -  Requires changing the Frequency Slot to new one(ex: on LongFast, new default slot(0) will be Slot 6/922.7MHz)
  - but Frequency Slot has *not* been changed from 0
   - The node will run at new default frequency slot, no action required to communicate same config's node
- If they updated the firmware, but still need to communicate with nodes with older frequency/firmware
  - They have to override the frequency by hand(ex. LongFast/Slot 12=923.375MHz)
- If they haven't updated the firmware, but need to communicate with newer nodes that uses this frequency plan
  - They have to override the frequency by hand as well(ex. LongFast/Slot 6=922.7MHz)

# Validations
Confirmed that the center frequencies are now in line with all multiple unit-channel bondings written in ARIB STD-T108:

| Preset / Bandwidth | Bonded Unit Channels ($n$) | Slot Width | Symmetric Padding | Center Frequency $f_c(0)$ | ARIB STD-T108 Match | Slots in Band |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| **`LongFast`** (250 kHz) | 2 (400 kHz) | 0.400 MHz | 75 kHz | **920.700 MHz** | **100% Exact** (Table 3-2) | 7 slots |
| **`LongSlow`** (125 kHz) | 1 (200 kHz) | 0.200 MHz | 37.5 kHz | **920.600 MHz** | **100% Exact** (Table 3-1) | 15 slots |
| **`NarrowSlow`** (62.5 kHz) | 1 (200 kHz) | 0.200 MHz | 68.75 kHz | **920.600 MHz** | **100% Exact** (Table 3-1) | 15 slots |
| **`ShortTurbo`** (500 kHz) | 3 (600 kHz) | 0.600 MHz | 50 kHz | **920.800 MHz** | **100% Exact** (Table 3-3) | 5 slots |

note: LongSlow has another issue(too long transmission time for most of payload), only used for 125kHz BW example.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [x] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] Heltec Mesh Node T114 / nRF52840
    - [x] Seeed Studio Wio-E5 / STM32WL
    - [x] WIZnet W5500-EVB-Pico2 & SX1262 / RP2350


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved frequency-slot calculations across regional bandwidth profiles.
  - Corrected channel counts, spacing, padding, and frequency placement for Japanese region configurations.
  - Added precision handling to prevent incorrect rounding at bandwidth boundaries.

- **Tests**
  - Added coverage for four Japanese channel configurations, including channel counts, padding, and calculated frequencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->