### PR TITLE
chore(deps): Correct library dependencies for T-Deck Pro and T-Watch Ultra

### DIFF
--- a/variants/esp32s3/t-deck-pro/platformio.ini
+++ b/variants/esp32s3/t-deck-pro/platformio.ini
@@ -41,3 +41,5 @@ lib_deps =
   https://github.com/CIRCUITSTATE/CSE_CST328/archive/refs/tags/v0.0.4.zip
   # renovate: datasource=git-refs depName=BQ27220 packageName=https://github.com/mverch67/BQ27220 gitBranch=main
   https://github.com/mverch67/BQ27220/archive/07d92be846abd8a0258a50c23198dac0858b22ed.zip
+  # renovate: datasource=custom.pio depName=Adafruit DRV2605 packageName=adafruit/library/Adafruit DRV2605 Library
+  adafruit/Adafruit DRV2605 Library@1.2.4

--- a/variants/esp32s3/t-watch-ultra/platformio.ini
+++ b/variants/esp32s3/t-watch-ultra/platformio.ini
@@ -47,12 +47,15 @@ build_src_filter =
   +<../variants/esp32s3/t-watch-ultra>
 
 lib_deps = ${esp32s3_base.lib_deps}
+  # renovate: datasource=github-tags depName=LovyanGFX packageName=lovyan03/LovyanGFX
   https://github.com/lovyan03/LovyanGFX/archive/tags/1.2.27.zip
-  adafruit/Adafruit DRV2605 Library@^1.2.4
+  # renovate: datasource=custom.pio depName=Adafruit DRV2605 packageName=adafruit/library/Adafruit DRV2605 Library
+  adafruit/Adafruit DRV2605 Library@1.2.4
   # renovate: datasource=git-refs depName=ESP8266Audio packageName=https://github.com/meshtastic/ESP8266Audio gitBranch=meshtastic-2.0.0-dacfix
   https://github.com/earlephilhower/ESP8266Audio/archive/343024632ee78d6216907b2353fc943a62422d80.zip
   # renovate: datasource=custom.pio depName=ESP8266SAM packageName=earlephilhower/library/ESP8266SAM
   earlephilhower/ESP8266SAM@1.1.0
+  # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
   lewisxhe/SensorLib@0.3.1
 
 [env:t-watch-ultra-tft]


### PR DESCRIPTION
Fixes T-Deck-Pro builds after #8171 and adds renovate tags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hardware compatibility for T-Deck Pro and T-Watch Ultra devices by updating vibration driver library configuration.
  * Locked the T-Watch Ultra vibration driver to version 1.2.4 for more consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->