### PR TITLE
fix t-deck-pro-v1.1: disable BHI260AP support

### DIFF
--- a/variants/esp32s3/t-deck-pro-v1_1/variant.h
+++ b/variants/esp32s3/t-deck-pro-v1_1/variant.h
@@ -57,7 +57,8 @@
 
 // gyroscope BHI260AP
 // #define BOARD_1V8_EN 38 //Deck-Pro remove 1.8v en pin
-#define HAS_BHI260AP
+// Disabled until a SensorLib replacement is available
+// #define HAS_BHI260AP
 
 // battery charger BQ25896
 #define HAS_PPM 1


### PR DESCRIPTION
Disable BHI260AP support for now, it's breaking our builds! Adding SensorLib (to support this sensor) currently causes a flash overrun.

---
🤖 AI Summary

This pull request makes a small update to the `variant.h` configuration for the T-Deck Pro v1.1 ESP32S3 board. The main change is the temporary disabling of the `HAS_BHI260AP` macro, which was previously enabled for gyroscope support, pending the availability of a SensorLib replacement.

- Board configuration update:
  * Commented out the `HAS_BHI260AP` macro definition in `variant.h`, disabling gyroscope support until a suitable SensorLib replacement is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled BHI260AP gyroscope support for the T-Deck Pro v1.1 variant until compatible sensor support is available.
  * Other device functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->