### PR TITLE
Fill in device registry metadata for recently added hardware

### DIFF
--- a/src/platform/esp32/architecture.h
+++ b/src/platform/esp32/architecture.h
@@ -214,6 +214,8 @@
 #define HW_VENDOR meshtastic_HardwareModel_M5STACK_CARDPUTER_ADV
 #elif defined(MESHNOLOGY_W10)
 #define HW_VENDOR meshtastic_HardwareModel_MESHNOLOGY_W10
+#elif defined(ELECROW_ThinkNode_M9)
+#define HW_VENDOR meshtastic_HardwareModel_THINKNODE_M9
 #else
 #define HW_VENDOR meshtastic_HardwareModel_PRIVATE_HW
 #endif

--- a/variants/esp32c6/m5stack_unitc6l/platformio.ini
+++ b/variants/esp32c6/m5stack_unitc6l/platformio.ini
@@ -7,6 +7,7 @@ custom_meshtastic_support_level = 1
 custom_meshtastic_display_name = M5Stack Unit C6L
 custom_meshtastic_images = m5_c6l.svg
 custom_meshtastic_tags = M5Stack
+custom_meshtastic_partition_scheme = 16MB
 
 extends = esp32c6_base
 board_level = release

--- a/variants/esp32s3/ELECROW-ThinkNode-M9/platformio.ini
+++ b/variants/esp32s3/ELECROW-ThinkNode-M9/platformio.ini
@@ -1,6 +1,6 @@
 [thinknode_m9_base]
 custom_meshtastic_hw_model = 131
-custom_meshtastic_hw_model_slug = ELECROW_ThinkNode_M9
+custom_meshtastic_hw_model_slug = THINKNODE_M9
 custom_meshtastic_architecture = esp32-s3
 custom_meshtastic_actively_supported = true
 custom_meshtastic_support_level = 1

--- a/variants/esp32s3/heltec_wireless_tracker_v2/platformio.ini
+++ b/variants/esp32s3/heltec_wireless_tracker_v2/platformio.ini
@@ -10,7 +10,7 @@ board_build.partitions = default_8MB.csv
 upload_protocol = esptool
 custom_meshtastic_hw_model = 113
 custom_meshtastic_hw_model_slug = HELTEC_WIRELESS_TRACKER_V2
-custom_meshtastic_architecture = esp32s3
+custom_meshtastic_architecture = esp32-s3
 custom_meshtastic_display_name = Heltec Wireless Tracker V2
 custom_meshtastic_actively_supported = true
 

--- a/variants/esp32s3/meshnology-w10/platformio.ini
+++ b/variants/esp32s3/meshnology-w10/platformio.ini
@@ -5,6 +5,8 @@ custom_meshtastic_architecture = esp32-s3
 custom_meshtastic_actively_supported = true
 custom_meshtastic_support_level = 1
 custom_meshtastic_display_name = Meshnology W10
+custom_meshtastic_images = meshnology_w10.svg
+custom_meshtastic_tags = Meshnology
 custom_meshtastic_requires_dfu = true
 custom_meshtastic_partition_scheme = 16MB
 

--- a/variants/esp32s3/meshnology-w12/platformio.ini
+++ b/variants/esp32s3/meshnology-w12/platformio.ini
@@ -7,6 +7,8 @@ custom_meshtastic_architecture = esp32-s3
 custom_meshtastic_actively_supported = true
 custom_meshtastic_support_level = 1
 custom_meshtastic_display_name = Meshnology W12
+custom_meshtastic_images = meshnology_w12.svg
+custom_meshtastic_tags = Meshnology
 custom_meshtastic_requires_dfu = true
 custom_meshtastic_partition_scheme = 16MB
 

--- a/variants/esp32s3/t-beam-1w/platformio.ini
+++ b/variants/esp32s3/t-beam-1w/platformio.ini
@@ -2,7 +2,7 @@
 [env:t-beam-1w]
 custom_meshtastic_hw_model = 122
 custom_meshtastic_hw_model_slug = TBEAM_1_WATT
-custom_meshtastic_architecture = esp32s3
+custom_meshtastic_architecture = esp32-s3
 custom_meshtastic_actively_supported = true
 custom_meshtastic_support_level = 1
 custom_meshtastic_display_name = LILYGO T-Beam 1W

--- a/variants/esp32s3/t-beam-bpf/platformio.ini
+++ b/variants/esp32s3/t-beam-bpf/platformio.ini
@@ -2,12 +2,13 @@
 [env:t-beam-bpf]
 custom_meshtastic_hw_model = 124
 custom_meshtastic_hw_model_slug = TBEAM_BPF
-custom_meshtastic_architecture = esp32s3
+custom_meshtastic_architecture = esp32-s3
 custom_meshtastic_actively_supported = true
 custom_meshtastic_support_level = 3
 custom_meshtastic_display_name = LILYGO T-Beam BPF
 custom_meshtastic_images = tbeam-bpf.svg
 custom_meshtastic_tags = LilyGo
+custom_meshtastic_partition_scheme = 16MB
 
 extends = esp32s3_base
 board_level = release

--- a/variants/nrf52840/seeed_mesh_tracker_X1/platformio.ini
+++ b/variants/nrf52840/seeed_mesh_tracker_X1/platformio.ini
@@ -1,6 +1,6 @@
 [env:seeed_mesh_tracker_X1]
 custom_meshtastic_support_level = 1
-custom_meshtastic_images = seeed-mesh-tracker-x1.svg
+custom_meshtastic_images = seeed_mesh_tracker_x1.svg
 custom_meshtastic_tags = Seeed
 custom_meshtastic_hw_model = 128
 custom_meshtastic_hw_model_slug = MESH_TRACKER_X1
@@ -10,7 +10,7 @@ custom_meshtastic_actively_supported = true
 
 extends = nrf52840_base
 board = mesh-tracker-x1
-board_level = pr
+board_level = release
 build_flags = ${nrf52840_base.build_flags}
   -Ivariants/nrf52840/seeed_mesh_tracker_X1
   -Isrc/platform/nrf52/softdevice


### PR DESCRIPTION
Audit of the `custom_meshtastic_*` manifest on the variants backing the newest boards, checked against the protobuf `HardwareModel` enum, the `HW_VENDOR` the variant actually compiles to, the board's flash size, and the artwork the web flasher actually ships.

No support-flag changes: `custom_meshtastic_actively_supported` is left exactly as each variant already had it.

## Wrong hardware model on the wire

`ELECROW_ThinkNode_M9` has no arm in the `HW_VENDOR` chain in `src/platform/esp32/architecture.h`, so it falls through to `#else` and every ThinkNode M9 reports `PRIVATE_HW` — while its manifest, the protobufs and the API all say `THINKNODE_M9` (131). Added the mapping, and renamed `custom_meshtastic_hw_model_slug` from `ELECROW_ThinkNode_M9` to `THINKNODE_M9` so the slug matches the enum name it is meant to mirror (the M8 next door already does).

## Wrong flash offsets

`t-beam-bpf` and `m5stack-unitc6l` both build `default_16MB.csv` on 16 MB of flash but declared no `custom_meshtastic_partition_scheme`. The flasher's legacy clean-install path keys off that value and falls back to the 4 MB offsets (OTA `0x260000`, SPIFFS `0x300000`) when it is absent. Both now declare `16MB`.

## Architecture string not normalized

`bin/platformio-custom.py` only normalizes the architecture when it has to infer it from the board MCU; an explicit `custom_meshtastic_architecture` is copied verbatim. Three variants spelled it `esp32s3`, and the flash flow matches on the hyphenated `esp32-s3`: `t-beam-bpf`, `t-beam-1w` and `heltec-wireless-tracker-v2`. The last two are outside the set this PR was auditing but are the same one-word fix, so they are included rather than left behind.

## Artwork that resolves to nothing

`seeed_mesh_tracker_X1` pointed at `seeed-mesh-tracker-x1.svg`; the file the flasher ships is `seeed_mesh_tracker_x1.svg`.

Meshnology W10 and W12 gain the `images` and `tags` entries for artwork that already exists in the flasher (`meshnology_w10.svg`, `meshnology_w12.svg`).

## Board level

`seeed_mesh_tracker_X1` moves from `board_level = pr` to `release`, so release firmware is built for it.

## Verification

- `bin/generate_ci_matrix.py` runs clean for `esp32`, `esp32s3`, `esp32c6`, `nrf52840` and `rp2040`, so every touched env still declares a valid `board_level`.
- Each audited variant's declared `hw_model` was preprocessed through its platform's `HW_VENDOR` chain with that env's resolved defines (build flags, board JSON `extra_flags`, and the variant's own `variant.h`). All of them agree with the manifest after this change.

## Left out

Meshnology W12 still declares `hw_model = 255`. `MESHNOLOGY_W12 = 145` is merged in meshtastic/protobufs but this repo's submodule pin predates it, so the value cannot be referenced yet. It should be bumped to 145 after the next protobuf sync.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.