### PR TITLE
Report the right hardware model on four boards

### DIFF
--- a/src/platform/esp32/architecture.h
+++ b/src/platform/esp32/architecture.h
@@ -188,10 +188,11 @@
 #define HW_VENDOR meshtastic_HardwareModel_HELTEC_SENSOR_HUB
 #elif defined(ELECROW_PANEL)
 #define HW_VENDOR meshtastic_HardwareModel_CROWPANEL
-#elif defined(RAK3312)
-#define HW_VENDOR meshtastic_HardwareModel_RAK3312
+// The WisMesh Tap V2 is a RAK3312 board, so it must be matched before the generic one.
 #elif defined(RAK_WISMESH_TAP_V2)
 #define HW_VENDOR meshtastic_HardwareModel_WISMESH_TAP_V2
+#elif defined(RAK3312)
+#define HW_VENDOR meshtastic_HardwareModel_RAK3312
 #elif defined(LINK_32)
 #define HW_VENDOR meshtastic_HardwareModel_LINK_32
 #elif defined(T_DECK_PRO)
@@ -216,6 +217,10 @@
 #define HW_VENDOR meshtastic_HardwareModel_MESHNOLOGY_W10
 #elif defined(ELECROW_ThinkNode_M9)
 #define HW_VENDOR meshtastic_HardwareModel_THINKNODE_M9
+#elif defined(HELTEC_V4_R8)
+#define HW_VENDOR meshtastic_HardwareModel_HELTEC_V4_R8
+#elif defined(MINI_EPAPER_S3)
+#define HW_VENDOR meshtastic_HardwareModel_MINI_EPAPER_S3
 #else
 #define HW_VENDOR meshtastic_HardwareModel_PRIVATE_HW
 #endif

--- a/src/platform/nrf52/architecture.h
+++ b/src/platform/nrf52/architecture.h
@@ -147,6 +147,8 @@
 #define HW_VENDOR meshtastic_HardwareModel_MUZI_BASE
 #elif defined(HELTEC_MESH_TOWER_V2)
 #define HW_VENDOR meshtastic_HardwareModel_HELTEC_MESH_TOWER_V2
+#elif defined(HELTEC_MESH_NODE_T096)
+#define HW_VENDOR meshtastic_HardwareModel_HELTEC_MESH_NODE_T096
 #else
 #define HW_VENDOR meshtastic_HardwareModel_NRF52_UNKNOWN
 #endif


### PR DESCRIPTION
Reopens #11568, which picked up an unrelated merge of `master` onto its branch and turned into a 100-file diff. Same two-file change, rebased onto current `develop` on top of #11567.

Four variants declare a `custom_meshtastic_hw_model` that the build never actually reaches, so the device announces a different model in NodeInfo and the apps cannot match it for OTA.

| env | manifest says | device actually reported |
| --- | --- | --- |
| `mini-epaper-s3` | `MINI_EPAPER_S3` (125) | `PRIVATE_HW` (255) |
| `heltec-v4-r8-oled`, `heltec-v4-r8-tft` | `HELTEC_V4_R8` (132) | `PRIVATE_HW` (255) |
| `heltec-mesh-node-t096` | `HELTEC_MESH_NODE_T096` (127) | `NRF52_UNKNOWN` (36) |
| `rak_wismesh_tap_v2`, `rak_wismesh_tap_v2-tft` | `WISMESH_TAP_V2` (116) | `RAK3312` (106) |

The first three had no arm in their platform's `HW_VENDOR` chain at all, so they fell through to `#else`.

The WisMesh Tap V2 is different: it defines **both** `RAK3312` and `RAK_WISMESH_TAP_V2`, and the generic `RAK3312` arm sat ahead of the specific one, so the generic arm always won. Reordered them, following the same rule the nRF52 chain already spells out for keeping custom RAK4630 boards ahead of the generic `RAK4630`.

## Verification

Each platform's `HW_VENDOR` chain was preprocessed with the env's full define set — build flags resolved through `extends`, the board JSON's `build.extra_flags`, and the bare `#define`s in the variant's own `variant.h` (several boards get their key symbol from there rather than from the ini, so reading the ini alone gives false negatives). All four now resolve to their declared model.

Regression-checked the reorder and the merge with #11567: `rak3312`, `heltec-v4`, `heltec-v4-tft` and the `ELECROW_ThinkNode_M9` arm are all unchanged. Swept the other 130 envs with a manifest and found no new mismatches. `bin/generate_ci_matrix.py` runs clean for all five platforms.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected hardware identification for the RAK WisMesh Tap V2.
  - Added hardware recognition for HELTEC V4 R8, Mini Epaper S3, and HELTEC Mesh Node T096 devices.
  - Improved hardware model selection for supported ESP32 and nRF52 boards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->