### PR TITLE
fix(radio): MeshBeacon heap leak and runtime packet payload size check

### DIFF
--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -1518,7 +1518,6 @@ size_t RadioInterface::beginSending(meshtastic_MeshPacket *p)
 
     // if the sender nodenum is zero, that means uninitialized
     assert(radioBuffer.header.from);
-    assert(p->encrypted.size <= sizeof(radioBuffer.payload));
     // Runtime packet payload size bounds check against radioBuffer to prevent overflow in memcpy()
     if (static_cast<size_t>(p->encrypted.size) > sizeof(radioBuffer.payload)) {
         LOG_ERROR("Packet payload size %u exceeds radioBuffer capacity %u", static_cast<unsigned>(p->encrypted.size),

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -1519,6 +1519,13 @@ size_t RadioInterface::beginSending(meshtastic_MeshPacket *p)
     // if the sender nodenum is zero, that means uninitialized
     assert(radioBuffer.header.from);
     assert(p->encrypted.size <= sizeof(radioBuffer.payload));
+    // Runtime packet payload size bounds check against radioBuffer to prevent overflow in memcpy()
+    if (static_cast<size_t>(p->encrypted.size) > sizeof(radioBuffer.payload)) {
+        LOG_ERROR("Packet payload size %u exceeds radioBuffer capacity %u", static_cast<unsigned>(p->encrypted.size),
+                  static_cast<unsigned>(sizeof(radioBuffer.payload)));
+        packetPool.release(p);
+        return 0;
+    }
     memcpy(radioBuffer.payload, p->encrypted.bytes, p->encrypted.size);
 
     sendingPacket = p;

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -597,12 +597,13 @@ void RadioLibInterface::completeSending()
         printPacket("Completed sending", p);
 #if !MESHTASTIC_EXCLUDE_BEACON
         MeshBeaconModule::clearTargetRadioSettings(p);
-        MeshBeaconModule::reconfigureForBeaconTX(this, nullptr);
 #endif
-
         // We are done sending that packet, release it
         packetPool.release(p);
     }
+#if !MESHTASTIC_EXCLUDE_BEACON
+    MeshBeaconModule::reconfigureForBeaconTX(this, nullptr);
+#endif
 }
 
 void RadioLibInterface::handleReceiveInterrupt()
@@ -782,7 +783,18 @@ bool RadioLibInterface::startSend(meshtastic_MeshPacket *txp)
     } else {
         configHardwareForSend(); // must be after setStandby
 
+#if !MESHTASTIC_EXCLUDE_BEACON
+        MeshBeaconModule::clearTargetRadioSettings(txp);
+#endif
         size_t numbytes = beginSending(txp);
+        if (numbytes == 0) {
+            if (!sendingPacket) {
+                completeSending();
+                powerMon->clearState(meshtastic_PowerMon_State_Lora_TXOn);
+                startReceive();
+            }
+            return false;
+        }
 
         int res = iface->startTransmit((uint8_t *)&radioBuffer, numbytes);
         if (res != RADIOLIB_ERR_NONE) {

--- a/src/modules/MeshBeaconModule.cpp
+++ b/src/modules/MeshBeaconModule.cpp
@@ -286,8 +286,10 @@ void MeshBeaconBroadcastModule::sendBeaconPacket(meshtastic_MeshPacket *p, mesht
     const bool cryptoOverride =
         has_channel && overrideChannel && (overrideChannel->name[0] != '\0' || overrideChannel->psk.size > 0);
     if (!cryptoOverride) {
-        if (router->send(p) == ERRNO_SHOULD_RELEASE)
+        if (router->send(p) == ERRNO_SHOULD_RELEASE) {
+            MeshBeaconModule::clearTargetRadioSettings(p);
             packetPool.release(p);
+        }
         return;
     }
 
@@ -301,8 +303,10 @@ void MeshBeaconBroadcastModule::sendBeaconPacket(meshtastic_MeshPacket *p, mesht
     primary.settings = beaconChannelSettings(saved, targetPreset, overrideChannel);
     channels.fixupChannel(channels.getPrimaryIndex());
 
-    if (router->send(p) == ERRNO_SHOULD_RELEASE) // encrypts with the beacon channel's key and stamps its hash
+    if (router->send(p) == ERRNO_SHOULD_RELEASE) { // encrypts with the beacon channel's key and stamps its hash
+        MeshBeaconModule::clearTargetRadioSettings(p);
         packetPool.release(p);
+    }
 
     primary.settings = saved;
     channels.fixupChannel(channels.getPrimaryIndex());

--- a/src/modules/MeshBeaconModule.cpp
+++ b/src/modules/MeshBeaconModule.cpp
@@ -286,7 +286,8 @@ void MeshBeaconBroadcastModule::sendBeaconPacket(meshtastic_MeshPacket *p, mesht
     const bool cryptoOverride =
         has_channel && overrideChannel && (overrideChannel->name[0] != '\0' || overrideChannel->psk.size > 0);
     if (!cryptoOverride) {
-        router->send(p);
+        if (router->send(p) == ERRNO_SHOULD_RELEASE)
+            packetPool.release(p);
         return;
     }
 
@@ -300,7 +301,8 @@ void MeshBeaconBroadcastModule::sendBeaconPacket(meshtastic_MeshPacket *p, mesht
     primary.settings = beaconChannelSettings(saved, targetPreset, overrideChannel);
     channels.fixupChannel(channels.getPrimaryIndex());
 
-    router->send(p); // encrypts with the beacon channel's key and stamps its hash
+    if (router->send(p) == ERRNO_SHOULD_RELEASE) // encrypts with the beacon channel's key and stamps its hash
+        packetPool.release(p);
 
     primary.settings = saved;
     channels.fixupChannel(channels.getPrimaryIndex());

--- a/test/test_radio/test_main.cpp
+++ b/test/test_radio/test_main.cpp
@@ -433,6 +433,12 @@ static void test_beginSending_oversizedPayloadAbortsSafely()
 
     TEST_ASSERT_EQUAL_UINT(0, result);
     TEST_ASSERT_NULL(testRadio->getSendingPacket());
+
+    // Verify rejected packet was released to packetPool and its slot is reusable
+    meshtastic_MeshPacket *reallocated = packetPool.allocZeroed();
+    TEST_ASSERT_NOT_NULL(reallocated);
+    TEST_ASSERT_EQUAL_PTR(p, reallocated);
+    packetPool.release(reallocated);
 }
 
 void setUp(void)

--- a/test/test_radio/test_main.cpp
+++ b/test/test_radio/test_main.cpp
@@ -60,6 +60,10 @@ class TestableRadioInterface : public RadioInterface
     uint8_t getSf() const { return sf; }
     float getBw() const { return bw; }
 
+    size_t beginSendingPublic(meshtastic_MeshPacket *p) { return beginSending(p); }
+    meshtastic_MeshPacket *getSendingPacket() const { return sendingPacket; }
+    size_t getRadioBufferPayloadCapacity() const { return sizeof(radioBuffer.payload); }
+
     // Override reconfigure to call the base which invokes applyModemConfig()
     bool reconfigure() override { return RadioInterface::reconfigure(); }
 
@@ -413,6 +417,24 @@ static void test_regionPresetMap_unsetCarriesUserprefsIntent()
 #endif
 }
 
+static void test_beginSending_oversizedPayloadAbortsSafely()
+{
+    meshtastic_MeshPacket *p = packetPool.allocZeroed();
+    TEST_ASSERT_NOT_NULL(p);
+    p->from = 0x12345678;
+    p->to = 0x87654321;
+    p->id = 0x10203040;
+    p->which_payload_variant = meshtastic_MeshPacket_encrypted_tag;
+
+    // Set encrypted size larger than sizeof(radioBuffer.payload) (which is 256 - sizeof(PacketHeader))
+    p->encrypted.size = testRadio->getRadioBufferPayloadCapacity() + 10;
+
+    size_t result = testRadio->beginSendingPublic(p);
+
+    TEST_ASSERT_EQUAL_UINT(0, result);
+    TEST_ASSERT_NULL(testRadio->getSendingPacket());
+}
+
 void setUp(void)
 {
     mockMeshService = new MockMeshService();
@@ -463,6 +485,7 @@ void setup()
     RUN_TEST(test_regionPresetMap_coversAllRegionsWithinBounds);
     RUN_TEST(test_regionPresetMap_matchesRegionTable);
     RUN_TEST(test_regionPresetMap_unsetCarriesUserprefsIntent);
+    RUN_TEST(test_beginSending_oversizedPayloadAbortsSafely);
     exit(UNITY_END());
 }
 


### PR DESCRIPTION
## Summary
this is revised PR of #11223, which originally intended to fix possible memory/heap leaks on packet flow.
upon review on the previous PR, this PR has been narrowed down to three minimal, valuable fixes below with one addition for unit test, total of 4 changes across 4 files:

- Fixed packetPool leak in `MeshBeaconBroadcastModule::sendBeaconPacket` when `router->send()` returns `ERRNO_SHOULD_RELEASE`
- Ensured radio settings are always restored back to home configuration in `RadioLibInterface::completeSending()` even on rejected/aborted transmission paths where `sendingPacket` is null.
- Changed from `assert()` to actual error handling for payload bounds check against `sizeof(radioBuffer.payload)` (240 bytes) in `RadioInterface::beginSending()` to prevent memcpy overflow in NDEBUG release builds
- Added `test_beginSending_oversizedPayloadAbortsSafely()` in `test_radio` as unit test for this behavior.

## Related PRs / Issues
- #11229 
- #11405 

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - ℹ️  testing on other platform as well, will update once these confirmed working
  - [x] Heltec (Lora32) V3
  - [x] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [x] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] Wio-E5 (STM32WL) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Prevented oversized encrypted packets from being transmitted and ensured they are safely released for reuse.
- Improved recovery when radio transmission preparation fails, including restoring beacon settings and restarting receive mode when needed.
- Fixed beacon packet cleanup when transmission is rejected, including transmissions using temporary channel settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->