### PR TITLE
feat(variants): add WaveShark Radio support

### DIFF
--- a/boards/waveshark-radio.json
+++ b/boards/waveshark-radio.json
@@ -1,0 +1,35 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32_out.ld"
+    },
+    "core": "esp32",
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32",
+    "variant": "esp32"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "lora"
+  ],
+  "debug": {
+    "openocd_board": "esp-wroom-32.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "WaveShark Radio",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://waveshark.net/",
+  "vendor": "WaveShark LLC"
+}

--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -540,13 +540,34 @@ class AnalogBatteryLevel : public HasBatteryLevel
         }
 
         if (voltage_mv == 0) {
-            const int bits = adcBitWidthToBits(adc_width);
-            const float max_code = powf(2.0f, bits) - 1.0f;
-            voltage_mv = (int)((raw / max_code) * DEFAULT_VREF);
+            // Approximate conversion when ADC calibration is unavailable
+            float attenuationScale;
+
+            switch (atten) {
+            case ADC_ATTEN_DB_0:
+                attenuationScale = 1.0f;
+                break;
+            case ADC_ATTEN_DB_2_5:
+                attenuationScale = 1.0f / 0.75f;
+                break;
+            case ADC_ATTEN_DB_6:
+                attenuationScale = 1.0f / 0.50f;
+                break;
+            case ADC_ATTEN_DB_12:
+                attenuationScale = 1.0f / 0.25f;
+                break;
+            default:
+                LOG_ERROR("Unsupported ADC attenuation: %d", (int)atten);
+                return 0;
         }
 
-        return voltage_mv;
+        const int bits = adcBitWidthToBits(adc_width);
+        const float max_code = powf(2.0f, bits) - 1.0f;
+        voltage_mv = (int)((raw / max_code) * DEFAULT_VREF * attenuationScale);
     }
+
+    return voltage_mv;
+}
 #endif
 
     /**

--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -103,6 +103,10 @@ static const adc_channel_t adc_channel = ADC_CHANNEL;
 static const adc_unit_t unit = ADC_UNIT_2;
 #endif // BAT_MEASURE_ADC_UNIT
 
+#ifdef EXT_PWR_DETECT_ADC
+static const adc_channel_t ext_pwr_adc_channel = EXT_PWR_DETECT_ADC_CHANNEL;
+#endif
+
 static adc_oneshot_unit_handle_t adc_handle = nullptr;
 static adc_cali_handle_t adc_cali_handle = nullptr;
 static bool adc_calibrated = false;
@@ -204,6 +208,10 @@ static bool initAdcCalibration()
 #ifndef EXT_CHRG_DETECT_VALUE
 #define EXT_CHRG_DETECT_VALUE HIGH
 #endif
+#endif
+
+#if defined(EXT_PWR_DETECT_ADC) && !defined(EXT_PWR_DETECT_ADC_THRESHOLD_MV)
+#error "EXT_PWR_DETECT_ADC_THRESHOLD_MV must be defined with EXT_PWR_DETECT_ADC"
 #endif
 
 #if HAS_TELEMETRY && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
@@ -402,6 +410,14 @@ class AnalogBatteryLevel : public HasBatteryLevel
         return clamp((int)(battery_SOC), 0, 100);
     }
 
+#ifdef EXT_PWR_DETECT_ADC
+    uint16_t getExtPowerSenseVoltage()
+    {
+        uint32_t raw = espAdcRead(ext_pwr_adc_channel);
+        return espAdcRawToMilliVolts(raw);
+    }
+#endif
+
     /**
      * The raw voltage of the batteryin millivolts or NAN if unknown
      */
@@ -450,20 +466,8 @@ class AnalogBatteryLevel : public HasBatteryLevel
             scaled = __LL_ADC_CALC_DATA_TO_VOLTAGE(Vref, raw, LL_ADC_RESOLUTION);
             scaled *= operativeAdcMultiplier;
 #elif defined(ARCH_ESP32) // ADC block for espressif platforms
-            raw = espAdcRead();
-            int voltage_mv = 0;
-            if (adc_calibrated && adc_cali_handle) {
-                if (adc_cali_raw_to_voltage(adc_cali_handle, raw, &voltage_mv) != ESP_OK) {
-                    LOG_WARN("ADC calibration read failed; using raw value");
-                    voltage_mv = 0;
-                }
-            }
-            if (voltage_mv == 0) {
-                // Fallback approximate conversion without calibration
-                const int bits = adcBitWidthToBits(adc_width);
-                const float max_code = powf(2.0f, bits) - 1.0f;
-                voltage_mv = (int)((raw / max_code) * DEFAULT_VREF);
-            }
+            raw = espAdcRead(adc_channel);
+            int voltage_mv = espAdcRawToMilliVolts(raw);
             scaled = voltage_mv * operativeAdcMultiplier;
 #else                     // block for all other platforms
 #ifdef ARCH_NRF52
@@ -500,7 +504,7 @@ class AnalogBatteryLevel : public HasBatteryLevel
     /**
      * ESP32 specific function for getting calibrated ADC reads
      */
-    uint32_t espAdcRead()
+    uint32_t espAdcRead(adc_channel_t channel)
     {
 
         uint32_t raw = 0;
@@ -513,7 +517,7 @@ class AnalogBatteryLevel : public HasBatteryLevel
 
         for (int i = 0; i < BATTERY_SENSE_SAMPLES; i++) {
             int val = 0;
-            esp_err_t err = adc_oneshot_read(adc_handle, adc_channel, &val);
+            esp_err_t err = adc_oneshot_read(adc_handle, channel, &val);
             if (err == ESP_OK) {
                 raw += val;
                 raw_c++;
@@ -523,6 +527,25 @@ class AnalogBatteryLevel : public HasBatteryLevel
         }
 
         return (raw / (raw_c < 1 ? 1 : raw_c));
+    }
+
+    uint16_t espAdcRawToMilliVolts(uint32_t raw) {
+        int voltage_mv = 0;
+
+        if (adc_calibrated && adc_cali_handle) {
+            if (adc_cali_raw_to_voltage(adc_cali_handle, raw, &voltage_mv) != ESP_OK) {
+                LOG_WARN("ADC calibration read failed; using raw value");
+                voltage_mv = 0;
+            }
+        }
+
+        if (voltage_mv == 0) {
+            const int bits = adcBitWidthToBits(adc_width);
+            const float max_code = powf(2.0f, bits) - 1.0f;
+            voltage_mv = (int)((raw / max_code) * DEFAULT_VREF);
+        }
+
+        return voltage_mv;
     }
 #endif
 
@@ -573,6 +596,9 @@ class AnalogBatteryLevel : public HasBatteryLevel
         return false;
 #endif
 
+#elif defined(EXT_PWR_DETECT_ADC)
+        return getExtPowerSenseVoltage() >= EXT_PWR_DETECT_ADC_THRESHOLD_MV;
+
 // technically speaking this should work for all(?) NRF52 boards
 // but needs testing across multiple devices. NRF52 USB would not even work if
 // VBUS was not properly connected and detected by the CPU
@@ -595,6 +621,7 @@ class AnalogBatteryLevel : public HasBatteryLevel
             return (rak9154Sensor.isCharging()) ? OptTrue : OptFalse;
         }
 #endif
+
         // A configured INA outranks the board's own charge-status pin, as it does BATTERY_PIN in
         // getBattVoltage(): an external charger leaves that pin idle, reading "not charging" forever.
 #if HAS_TELEMETRY && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR && !defined(DISABLE_INA_CHARGING_DETECTION)
@@ -610,10 +637,16 @@ class AnalogBatteryLevel : public HasBatteryLevel
 #endif
         }
 #endif
+
 #if defined(ELECROW_ThinkNode_M6)
         return digitalRead(EXT_CHRG_DETECT) == EXT_CHRG_DETECT_VALUE || isVbusIn();
 #elif defined(EXT_CHRG_DETECT)
         return digitalRead(EXT_CHRG_DETECT) == EXT_CHRG_DETECT_VALUE;
+#elif defined(INFER_CHARGING_FROM_EXT_PWR)
+        {
+            int batteryPercent = getBatteryPercent();
+            return isVbusIn() && batteryPercent >= 0 && batteryPercent < 100;
+        }
 #elif defined(BATTERY_CHARGING_INV)
         return !digitalRead(BATTERY_CHARGING_INV);
 #else
@@ -779,6 +812,16 @@ bool Power::analogInit()
         LOG_ERROR("ADC channel config failed: %s", esp_err_to_name(err));
         return false;
     }
+
+    #ifdef EXT_PWR_DETECT_ADC
+    pinMode(EXT_PWR_DETECT_ADC, INPUT);
+
+    err = adc_oneshot_config_channel(adc_handle, ext_pwr_adc_channel, &chan_cfg);
+    if (err != ESP_OK) {
+        LOG_ERROR("External power ADC channel config failed: %s", esp_err_to_name(err));
+        return false;
+    }
+    #endif
 
     adc_calibrated = initAdcCalibration();
 #endif                    // ARCH_ESP32

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -411,11 +411,6 @@ void setup()
     digitalWrite(BLE_LED, LED_STATE_OFF);
 #endif
 
-#ifdef LED_LORA
-    pinMode(LED_LORA, OUTPUT);
-    digitalWrite(LED_LORA, LED_STATE_OFF);
-#endif
-
     concurrency::hasBeenSetup = true;
 #if HAS_SCREEN
     meshtastic_Config_DisplayConfig_OledType screen_model =

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -411,6 +411,11 @@ void setup()
     digitalWrite(BLE_LED, LED_STATE_OFF);
 #endif
 
+#ifdef LED_LORA
+    pinMode(LED_LORA, OUTPUT);
+    digitalWrite(LED_LORA, LED_STATE_OFF);
+#endif
+
     concurrency::hasBeenSetup = true;
 #if HAS_SCREEN
     meshtastic_Config_DisplayConfig_OledType screen_model =

--- a/variants/esp32/waveshark-radio/platformio.ini
+++ b/variants/esp32/waveshark-radio/platformio.ini
@@ -1,0 +1,20 @@
+[env:waveshark-radio]
+extends = esp32_base
+board = waveshark-radio
+board_level = extra
+
+custom_meshtastic_hw_model = 255
+custom_meshtastic_hw_model_slug = PRIVATE_HW
+custom_meshtastic_architecture = esp32
+custom_meshtastic_actively_supported = false
+custom_meshtastic_display_name = WaveShark Radio
+custom_meshtastic_tags = WaveShark
+custom_meshtastic_url = https://www.waveshark.net/
+
+build_flags =
+  ${esp32_base.build_flags}
+  -D PRIVATE_HW
+  -D WAVESHARK_RADIO
+  -D USERPREFS_CONFIG_LORA_REGION=meshtastic_Config_LoRaConfig_RegionCode_US
+  -I variants/esp32/waveshark-radio
+  -ULED_BUILTIN

--- a/variants/esp32/waveshark-radio/variant.h
+++ b/variants/esp32/waveshark-radio/variant.h
@@ -33,7 +33,6 @@
 #define LORA_DIO2 34 // Not really used
 
 // Battery voltage divider: R9 = 47k, R13 = 56k.
-// Ratio of voltage divider = (47 + 56) / 56 = 103 / 56 = ~1.84
 // GPIO12 enables the switched divider; GPIO32 is ADC1 channel 4
 #define ADC_MULTIPLIER (103.0 / 56.0)
 #define BATTERY_PIN 32
@@ -42,8 +41,7 @@
 #define ADC_CTRL_ENABLED HIGH
 
 // USB power sensing
-// R19 = 56k, R18 = 47k.
-// 5 V USB produces approximately 2.28 V at GPIO33.
+// R19 = 56k, R18 = 47k // 5 V USB produces approximately 2.28 V at GPIO33.
 #define EXT_PWR_DETECT_ADC 33
 #define EXT_PWR_DETECT_ADC_CHANNEL ADC_CHANNEL_5
 #define EXT_PWR_DETECT_ADC_THRESHOLD_MV 1500

--- a/variants/esp32/waveshark-radio/variant.h
+++ b/variants/esp32/waveshark-radio/variant.h
@@ -37,7 +37,7 @@
 // GPIO12 enables the switched divider; GPIO32 is ADC1 channel 4
 #define ADC_MULTIPLIER (103.0 / 56.0)
 #define BATTERY_PIN 32
-#define ADC_CHANNEL ADC_CHANNEL_4 // GPIO32 = ADC2 channel 4 on ESP32
+#define ADC_CHANNEL ADC_CHANNEL_4 // GPIO32 = ADC1 channel 4 on ESP32
 #define ADC_CTRL 12
 #define ADC_CTRL_ENABLED HIGH
 

--- a/variants/esp32/waveshark-radio/variant.h
+++ b/variants/esp32/waveshark-radio/variant.h
@@ -1,0 +1,52 @@
+#pragma once
+
+// WaveShark Radio is a headless device without a GPS/GNSS receiver.
+#define HAS_SCREEN 0
+#define HAS_GPS 0
+#define HAS_BUTTON 0
+
+// I2C
+#ifndef USE_JTAG
+#define I2C_SDA 4
+#define I2C_SCL 15
+#endif
+
+// User-visible status LEDs
+#define LED_POWER 25
+#define LED_LORA 16
+
+// Semtech SX1276 / RF95-class LoRa transceiver
+#define USE_RF95
+
+// Explicitly specify all LoRa SPI pins rather than relying on ESP32 defaults.
+#define LORA_SCK 5
+#define LORA_MISO 19
+#define LORA_MOSI 27
+#define LORA_CS 18
+
+#ifndef USE_JTAG
+#define LORA_RESET 14
+#endif
+
+#define LORA_DIO0 26
+#define LORA_DIO1 35 // https://www.thethingsnetwork.org/forum/t/big-esp32-sx127x-topic-part-3/18436
+#define LORA_DIO2 34 // Not really used
+
+// Battery voltage divider: R9 = 47k, R13 = 56k.
+// Ratio of voltage divider = (47 + 56) / 56 = 103 / 56 = ~1.84
+// GPIO12 enables the switched divider; GPIO32 is ADC1 channel 4
+#define ADC_MULTIPLIER (103.0 / 56.0)
+#define BATTERY_PIN 32
+#define ADC_CHANNEL ADC_CHANNEL_4 // GPIO32 = ADC2 channel 4 on ESP32
+#define ADC_CTRL 12
+#define ADC_CTRL_ENABLED HIGH
+
+// USB power sensing
+// R19 = 56k, R18 = 47k.
+// 5 V USB produces approximately 2.28 V at GPIO33.
+#define EXT_PWR_DETECT_ADC 33
+#define EXT_PWR_DETECT_ADC_CHANNEL ADC_CHANNEL_5
+#define EXT_PWR_DETECT_ADC_THRESHOLD_MV 1500
+
+// Infer charging from USB presence and battery state of charge.
+#define INFER_CHARGING_FROM_EXT_PWR


### PR DESCRIPTION
## Summary

Adds Meshtastic firmware support for the WaveShark Radio (`waveshark-radio`), a classic ESP32 (ESP32-WROOM-32D) + Semtech SX1276 915 MHz (NiceRF LoRa1276-C1-915) platform used as the radio electronics in both the WaveShark Communicator and WaveShark Repeater products.

The Communicator and Repeater intentionally use the same firmware build. The Repeater consists of a WaveShark Radio PCB installed on a carrier PCB with additional circuitry and peripherals for solar operation and enclosure health monitoring. The underlying radio hardware and firmware image are the same.

WaveShark Radio is a purpose-built ESP32/SX1276 hardware platform with custom PCB, power circuitry, and enclosure integration, rather than a derivative of an existing Meshtastic development board. WaveShark Communicator hardware has previously undergone FCC Part 15 compliance work covering both unintentional-radiator emissions and intentional-radiator operation, and is designed specifically for the U.S. 902-928 MHz ISM band. The hardware has been deployed and used for years with WaveShark's proprietary software and firmware ecosystem. WaveShark is now transitioning these devices to Meshtastic, and this PR adds the required firmware support for that migration.

## Hardware

| Component | Detail |
| --- | --- |
| MCU | ESP32-WROOM-32D |
| LoRa | NiceRF LoRa1276-C1-915 / Semtech SX1276 |
| Band | US 902-928 MHz |
| Display | None |
| GPS | None |
| Buttons | None |
| I2C | SDA GPIO4, SCL GPIO15 |
| Power LED | GPIO25 |
| LoRa LED | GPIO16 |
| Battery sense | GPIO32 through switched resistor divider |
| Battery sense enable | GPIO12 |
| USB/external power sense | GPIO33 through resistor divider |

## Changes

- Add the `waveshark-radio` PlatformIO environment and board definition.
- Add the WaveShark Radio ESP32 variant with its LoRa, I2C, LED, battery, and external-power pin mappings.
- Configure the SX1276/RF95 LoRa interface with explicit SPI, reset, and DIO pin assignments.
- Configure the build for the US LoRa region to match the 915 MHz hardware.
- Add support for switched battery-voltage sensing using the WaveShark resistor divider.
- Extend the ESP32 ADC path so calibrated ADC reads can be made from a specified ADC channel.
- Add optional ADC-based external-power detection for boards that sense VBUS through a resistor divider.
- Add optional charging-state inference when external power is present and battery state of charge is below 100%.
- Initialize `LED_LORA` to its inactive state during system startup when the variant defines it.

The shared `Power.cpp` changes are intended to be generic rather than WaveShark-specific. WaveShark enables the new behavior through variant defines.

## Scope

This PR adds support for the common WaveShark Radio hardware.

The same firmware target is used whether that radio is installed as a WaveShark Communicator or a WaveShark Repeater. There is intentionally no separate `waveshark-repeater` firmware target.

The Repeater carrier also contains an MCP3426 external ADC. MCP3426 support is not part of this PR and can be added separately. BME280 environmental sensors already use Meshtastic's existing BME280 telemetry support.

## Validation

Hardware regression testing was performed with this branch based on `meshtastic/firmware` `develop` at:

`4bf113074a11f96a591b96e69fe6506ca773250a`

Builds were performed using the normal Meshtastic PlatformIO environments.

Successfully built/tested environments include:

- `waveshark-radio`
- `heltec-v3`
- `heltec-v4`
- `heltec-mesh-node-t114`
- `tbeam`

### Battery voltage testing

Battery voltage measurements were tested using a regulated variable bench power supply connected directly to each board's battery input with USB power disconnected. This provides controlled reference voltages across the normal single-cell Li-ion operating range.

| Board | Supply 3.60 V | Supply 3.70 V | Supply 3.80 V | Supply 4.00 V | Supply 4.20 V |
| --- | ---: | ---: | ---: | ---: | ---: |
| LILYGO T-Beam AXP2101 v1.2 | 3.55 | 3.65 | 3.73 | 3.95 | 4.15 |
| Heltec Mesh Node T114 w/ display | 3.59 | 3.70 | 3.79 | 4.00 | 4.19 |
| Heltec Mesh Node T114 w/o display | 3.55 | 3.65 | 3.75 | 3.94 | 4.15 |
| Heltec LoRa 32 V4 w/ display | 3.67 | 3.77 | 3.87 | 4.08 | 4.29 |
| Heltec LoRa 32 V3 w/ display | 3.69 | 3.78 | 3.90 | 4.10 | 4.29 |
| WaveShark Radio / Communicator | 3.61 | 3.70 | 3.79 | 3.97 | 4.20 |

The LILYGO T-Beam was additionally tested with an actual 18650 cell. Battery-powered operation and charging detection both passed.

### Functional regression testing

| Board | LoRa TX | LoRa RX | GPS |
| --- | --- | --- | --- |
| LILYGO T-Beam AXP2101 v1.2 | PASS | PASS | PASS |
| Heltec Mesh Node T114 w/ display | PASS | PASS | Not tested |
| Heltec Mesh Node T114 w/o display | PASS | PASS | Not tested |
| Heltec LoRa 32 V4 w/ display | PASS | PASS | Not tested |
| Heltec LoRa 32 V3 w/ display | PASS | PASS | Not tested |
| WaveShark Radio / Communicator | PASS | PASS | N/A |

LoRa TX/RX testing was performed over the air between physical Meshtastic nodes using the Meshtastic app.

The T-Beam used for regression testing is a LILYGO T-Beam classic ESP32, model `T-BEAM-AXP2101-V1.2`.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [x] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] Heltec Mesh Node T114 w/ display
    - [x] Heltec Mesh Node T114 w/o display
    - [x] Heltec LoRa 32 V4 w/ display
    - [x] WaveShark Communicator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the WaveShark Radio ESP32 board.
  * Enabled LoRa connectivity and Arduino/ESP-IDF development options.
  * Added board-specific configuration for status indicators, USB power detection, and battery monitoring.
  * Added configurable external-power detection and charging-status reporting based on battery voltage.
  * Included debugging and firmware-upload settings for the new hardware variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->