### PR TITLE
fix(test): remove brittle pointer comparison in test_radio

### DIFF
--- a/test/test_radio/test_main.cpp
+++ b/test/test_radio/test_main.cpp
@@ -419,6 +419,7 @@ static void test_regionPresetMap_unsetCarriesUserprefsIntent()
 
 static void test_beginSending_oversizedPayloadAbortsSafely()
 {
+    // Allocate a packet and set required header fields
     meshtastic_MeshPacket *p = packetPool.allocZeroed();
     TEST_ASSERT_NOT_NULL(p);
     p->from = 0x12345678;
@@ -426,19 +427,19 @@ static void test_beginSending_oversizedPayloadAbortsSafely()
     p->id = 0x10203040;
     p->which_payload_variant = meshtastic_MeshPacket_encrypted_tag;
 
-    // Set encrypted size larger than sizeof(radioBuffer.payload) (which is 256 - sizeof(PacketHeader))
+    // Set encrypted size larger than radioBuffer.payload capacity to trigger rejection
     p->encrypted.size = testRadio->getRadioBufferPayloadCapacity() + 10;
 
+    // Call beginSending with the oversized packet
     size_t result = testRadio->beginSendingPublic(p);
 
+    // Verify the send was rejected (returns 0)
     TEST_ASSERT_EQUAL_UINT(0, result);
+
+    // Verify sendingPacket was NOT set (packet was not queued)
     TEST_ASSERT_NULL(testRadio->getSendingPacket());
 
-    // Verify rejected packet was released to packetPool and its slot is reusable
-    meshtastic_MeshPacket *reallocated = packetPool.allocZeroed();
-    TEST_ASSERT_NOT_NULL(reallocated);
-    TEST_ASSERT_EQUAL_PTR(p, reallocated);
-    packetPool.release(reallocated);
+    // LeakSanitizer on CI will automatically detect if p wasn't released to packetPool
 }
 
 void setUp(void)


### PR DESCRIPTION
## Summary
Fixes CI failure in `test_radio` introduced in #11573.

## Root Cause

`test_beginSending_oversizedPayloadAbortsSafely` attempted to verify packet pool release by
allocating a second packet and asserting pointer equality (`TEST_ASSERT_EQUAL_PTR(p, reallocated)`). 

While this passed on local systems using standard glibc/macOS malloc caches (LIFO),
CI runs with AddressSanitizer (`-fsanitize=address` in `env:coverage`), which quarantines freed memory.

This caused the next `malloc` to return a newly mapped chunk instead of the freed pointer, failing the pointer check.

Below is snippet from [Example Failed Job](https://github.com/meshtastic/firmware/actions/runs/32613969701/job/97186444951#step:6:1195) :
```
  ❌ test_beginSending_oversizedPayloadAbortsSafely
  	Expected 0x0000514000000240 Was 0x0000514000000440
  ❌ coverage:test_radio
  	UnitTestError: Program received signal SIGHUP (Hangup)
```

## Changes
- Removed the brittle pointer address equality check and temporary reallocation from `test_beginSending_oversizedPayloadAbortsSafely` in `test/test_radio/test_main.cpp`.
- Verifies `beginSending()` returns `0` and `sendingPacket` remains `nullptr`.
- Packet release is implicitly and strictly verified across native tests by LeakSanitizer (LSan) on exit.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] macOS( Tahoe 26.5.2 (25F84) arm64, with `pio test -e native-macos -f test_radio` )
    - [x] Linux (Debian 13 / Kernel 7.0.12-1 x86_64, with `pio test -e native -f test_radio` and  `pio test -e coverage`)
    - [x] Windows (On WSL2 / Ubuntu 22.04 x86_64 with `pio test -e native -f test_radio` and `pio test -e coverage`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated oversized-payload coverage to confirm that rejected transmissions are not queued.
  * Simplified validation by removing packet-pool reallocation and release checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->