### PR TITLE
fix(t-watch-ultra): wrap esp_flash_read so NVS survives, keeping BLE bonds

### DIFF
--- a/src/platform/esp32/esp_partition_read_mmap_wrap.c
+++ b/src/platform/esp32/esp_partition_read_mmap_wrap.c
@@ -6,12 +6,20 @@
 // data, writes work, and it's not read-mode/HPM/timing-tuning/PSRAM. So route every
 // esp_partition_read through esp_partition_mmap + memcpy, which uses the working
 // cache path. Activated by `-Wl,--wrap=esp_partition_read` (t-watch-ultra only).
+//
+// That alone isn't enough: nvs_flash reads through the lower-level esp_flash_read,
+// which hits the same 0x00 regression, so NVS came up empty every boot (0 entries)
+// and silently dropped BLE bonds and everything else stored via Preferences. Wrap
+// esp_flash_read too, via raw spi_flash_mmap, for callers that bypass esp_partition_t.
 #if defined(T_WATCH_ULTRA)
 
+#include "esp_flash.h"
 #include "esp_partition.h"
+#include "spi_flash_mmap.h"
 #include <string.h>
 
 extern esp_err_t __real_esp_partition_read(const esp_partition_t *partition, size_t src_offset, void *dst, size_t size);
+extern esp_err_t __real_esp_flash_read(esp_flash_t *chip, void *buffer, uint32_t address, uint32_t length);
 
 esp_err_t __wrap_esp_partition_read(const esp_partition_t *partition, size_t src_offset, void *dst, size_t size)
 {
@@ -36,6 +44,32 @@ esp_err_t __wrap_esp_partition_read(const esp_partition_t *partition, size_t src
     }
     memcpy(dst, (const uint8_t *)ptr + delta, size);
     esp_partition_munmap(handle);
+    return ESP_OK;
+}
+
+esp_err_t __wrap_esp_flash_read(esp_flash_t *chip, void *buffer, uint32_t address, uint32_t length)
+{
+    if (buffer == NULL)
+        return ESP_ERR_INVALID_ARG;
+    if (length == 0)
+        return ESP_OK;
+    // spi_flash_mmap only maps the default (main) chip's address space - anything
+    // else (e.g. a second chip on another bus) falls back to the real call.
+    if (chip != NULL && chip != esp_flash_default_chip)
+        return __real_esp_flash_read(chip, buffer, address, length);
+
+    const size_t PAGE = 0x10000;
+    size_t aligned = address & ~(PAGE - 1);
+    size_t delta = address - aligned;
+
+    const void *ptr = NULL;
+    spi_flash_mmap_handle_t handle;
+    esp_err_t err = spi_flash_mmap(aligned, delta + length, SPI_FLASH_MMAP_DATA, &ptr, &handle);
+    if (err != ESP_OK)
+        return __real_esp_flash_read(chip, buffer, address, length);
+
+    memcpy(buffer, (const uint8_t *)ptr + delta, length);
+    spi_flash_munmap(handle);
     return ESP_OK;
 }
 

--- a/src/platform/esp32/esp_partition_read_mmap_wrap.c
+++ b/src/platform/esp32/esp_partition_read_mmap_wrap.c
@@ -14,6 +14,7 @@
 #if defined(T_WATCH_ULTRA)
 
 #include "esp_flash.h"
+#include "esp_flash_encrypt.h"
 #include "esp_partition.h"
 #include "spi_flash_mmap.h"
 #include <string.h>
@@ -56,6 +57,10 @@ esp_err_t __wrap_esp_flash_read(esp_flash_t *chip, void *buffer, uint32_t addres
     // spi_flash_mmap only maps the default (main) chip's address space - anything
     // else (e.g. a second chip on another bus) falls back to the real call.
     if (chip != NULL && chip != esp_flash_default_chip)
+        return __real_esp_flash_read(chip, buffer, address, length);
+    // esp_flash_read is specified to return raw bytes, but the cache decrypts transparently.
+    // With flash encryption on, the mmap path would hand back plaintext - so don't take it.
+    if (esp_flash_encryption_enabled())
         return __real_esp_flash_read(chip, buffer, address, length);
 
     const size_t PAGE = 0x10000;

--- a/variants/esp32s3/t-watch-ultra/platformio.ini
+++ b/variants/esp32s3/t-watch-ultra/platformio.ini
@@ -26,8 +26,10 @@ custom_sdkconfig =
 
 build_flags = ${esp32_base.build_flags} -Ivariants/esp32s3/t-watch-ultra
   ; Route flash reads through the cache/mmap path (esp_partition_read_mmap_wrap.c)
-  ; to dodge the IDF 5.5 manual-read regression on this board's flash.
+  ; to dodge the IDF 5.5 manual-read regression on this board's flash. esp_flash_read
+  ; is wrapped too - nvs_flash reads through it directly, bypassing esp_partition_read.
   -Wl,--wrap=esp_partition_read
+  -Wl,--wrap=esp_flash_read
   -D T_WATCH_ULTRA
   -D RADIOLIB_EXCLUDE_SX128X=1
   -D RADIOLIB_EXCLUDE_SX127X=1


### PR DESCRIPTION
Fixes #11530.

`[env:t-watch-ultra]` already links `-Wl,--wrap=esp_partition_read` to dodge the
IDF 5.5 direct-read regression on this board's W25Q128JW. That is not enough:
`nvs_flash` does not read through the partition API at all. It reads the NVS
partition via the lower-level `esp_flash_read`, which is unwrapped and still
returns 0x00, so NVS initialised empty on every boot -- zero entries, zero
namespaces -- even though the data was intact on flash.

#11530 proposes that NVS *writes* bypass the wrapper while reads are served from
cache. It is the read path: wrapping `esp_flash_read` alone makes NVS persist.

Everything stored through NVS was discarded each boot. That includes NimBLE's
bond table, so a phone that had already paired was not recognised on reconnect;
the device ran a fresh pairing and displayed a new passkey every time. The PIN
worked, but the bond never stuck. ESP-IDF's PHY calibration data also lives in
NVS and was likewise discarded each boot.

This wraps `esp_flash_read` the same way, using the raw (non-partition)
`spi_flash_mmap` so it serves callers that never go through `esp_partition_t`.
Reads for any chip other than the default fall back to the real implementation,
as do mmap failures. Gated on `T_WATCH_ULTRA`; no other board is affected.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other: LilyGo T-Watch Ultra

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flash memory read compatibility on T-Watch Ultra devices.
  * Fixed direct storage reads, including those used by saved settings, to work reliably with the latest ESP32 framework.
  * Added fallback handling to maintain compatibility across supported flash configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->