### PR TITLE
Fix backwards GPS_RX_PIN/GPS_TX_PIN direction comments

### DIFF
--- a/variants/esp32s3/ELECROW-ThinkNode-M5/variant.h
+++ b/variants/esp32s3/ELECROW-ThinkNode-M5/variant.h
@@ -45,8 +45,8 @@
 
 #define PIN_GPS_STANDBY 11 // An output to wake GPS, low means allow sleep, high means force wake
 
-#define GPS_TX_PIN 20 // This is for bits going TOWARDS the CPU
-#define GPS_RX_PIN 19 // This is for bits going TOWARDS the GPS
+#define GPS_TX_PIN 20 // This is for bits going TOWARDS the GPS
+#define GPS_RX_PIN 19 // This is for bits going TOWARDS the CPU
 
 #define GPS_THREAD_INTERVAL 50
 

--- a/variants/esp32s3/heltec_v4/variant.h
+++ b/variants/esp32s3/heltec_v4/variant.h
@@ -92,7 +92,7 @@
 #define PERIPHERAL_WARMUP_MS 1000 // Make sure I2C QuickLink has stable power before continuing
 #define PIN_GPS_STANDBY (40)      // An output to wake GPS, low means allow sleep, high means force wake
 #define PIN_GPS_PPS (41)
-// Seems to be missing on this new board
-#define GPS_TX_PIN (38) // This is for bits going TOWARDS the CPU
-#define GPS_RX_PIN (39) // This is for bits going TOWARDS the GPS
+// GNSS is on the V4 expansion kit (CM121, 9600 baud by default), not on the bare board
+#define GPS_TX_PIN (38) // This is for bits going TOWARDS the GPS
+#define GPS_RX_PIN (39) // This is for bits going TOWARDS the CPU
 #define GPS_THREAD_INTERVAL 50

--- a/variants/esp32s3/heltec_v4_r8/variant.h
+++ b/variants/esp32s3/heltec_v4_r8/variant.h
@@ -64,7 +64,7 @@
 #define GPS_EN_ACTIVE LOW
 #define PERIPHERAL_WARMUP_MS 1000 // Make sure I2C QuickLink has stable power before continuing
 #define PIN_GPS_PPS (41)
-// Seems to be missing on this new board
-#define GPS_TX_PIN (38) // This is for bits going TOWARDS the CPU
-#define GPS_RX_PIN (39) // This is for bits going TOWARDS the GPS
+// GNSS is on the V4 expansion kit (CM121, 9600 baud by default), not on the bare board
+#define GPS_TX_PIN (38) // This is for bits going TOWARDS the GPS
+#define GPS_RX_PIN (39) // This is for bits going TOWARDS the CPU
 #define GPS_THREAD_INTERVAL 50

--- a/variants/nrf52840/heltec_mesh_node_t096/variant.h
+++ b/variants/nrf52840/heltec_mesh_node_t096/variant.h
@@ -161,8 +161,8 @@ No longer populated on PCB
 #define GPS_EN_ACTIVE LOW
 #define PERIPHERAL_WARMUP_MS 1000 // Make sure I2C QuickLink has stable power before continuing
 #define PIN_GPS_PPS (32 + 11)
-#define GPS_TX_PIN (0 + 25) // This is for bits going TOWARDS the CPU
-#define GPS_RX_PIN (0 + 23) // This is for bits going TOWARDS the GPS
+#define GPS_TX_PIN (0 + 25) // This is for bits going TOWARDS the GPS
+#define GPS_RX_PIN (0 + 23) // This is for bits going TOWARDS the CPU
 
 #define GPS_THREAD_INTERVAL 50
 

--- a/variants/nrf52840/heltec_mesh_node_t114-inkhud/variant.h
+++ b/variants/nrf52840/heltec_mesh_node_t114-inkhud/variant.h
@@ -115,8 +115,8 @@ No longer populated on PCB
 #define PIN_GPS_PPS (32 + 4)
 // Seems to be missing on this new board
 // #define PIN_GPS_PPS (32 + 4)  // Pulse per second input from the GPS
-#define GPS_TX_PIN (32 + 7) // This is for bits going TOWARDS the CPU
-#define GPS_RX_PIN (32 + 5) // This is for bits going TOWARDS the GPS
+#define GPS_TX_PIN (32 + 7) // This is for bits going TOWARDS the GPS
+#define GPS_RX_PIN (32 + 5) // This is for bits going TOWARDS the CPU
 
 #define GPS_THREAD_INTERVAL 50
 

--- a/variants/nrf52840/heltec_mesh_node_t114/variant.h
+++ b/variants/nrf52840/heltec_mesh_node_t114/variant.h
@@ -171,8 +171,8 @@ No longer populated on PCB
 #define PIN_GPS_PPS (32 + 4)
 // Seems to be missing on this new board
 // #define PIN_GPS_PPS (32 + 4)  // Pulse per second input from the GPS
-#define GPS_TX_PIN (32 + 7) // This is for bits going TOWARDS the CPU
-#define GPS_RX_PIN (32 + 5) // This is for bits going TOWARDS the GPS
+#define GPS_TX_PIN (32 + 7) // This is for bits going TOWARDS the GPS
+#define GPS_RX_PIN (32 + 5) // This is for bits going TOWARDS the CPU
 
 #define GPS_THREAD_INTERVAL 50
 

--- a/variants/nrf52840/heltec_mesh_solar/variant.h
+++ b/variants/nrf52840/heltec_mesh_solar/variant.h
@@ -115,8 +115,8 @@ No longer populated on PCB
 #define PIN_GPS_PPS (32 + 4)
 // Seems to be missing on this new board
 // #define PIN_GPS_PPS (32 + 4)  // Pulse per second input from the GPS
-#define GPS_TX_PIN (32 + 7) // This is for bits going TOWARDS the CPU
-#define GPS_RX_PIN (32 + 5) // This is for bits going TOWARDS the GPS
+#define GPS_TX_PIN (32 + 7) // This is for bits going TOWARDS the GPS
+#define GPS_RX_PIN (32 + 5) // This is for bits going TOWARDS the CPU
 
 #define GPS_THREAD_INTERVAL 50
 

--- a/variants/nrf52840/meshlink/variant.h
+++ b/variants/nrf52840/meshlink/variant.h
@@ -120,8 +120,8 @@ static const uint8_t SCK = PIN_SPI_SCK;
 
 #define PIN_GPS_PPS (26) // Pulse per second input from the GPS
 
-#define GPS_TX_PIN PIN_SERIAL1_TX // This is for bits going TOWARDS the CPU
-#define GPS_RX_PIN PIN_SERIAL1_RX // This is for bits going TOWARDS the GPS
+#define GPS_TX_PIN PIN_SERIAL1_TX // This is for bits going TOWARDS the GPS
+#define GPS_RX_PIN PIN_SERIAL1_RX // This is for bits going TOWARDS the CPU
 
 // #define GPS_THREAD_INTERVAL 50
 

--- a/variants/nrf52840/t-echo/variant.h
+++ b/variants/nrf52840/t-echo/variant.h
@@ -177,8 +177,8 @@ External serial flash WP25R1635FZUIL0
 #define PIN_GPS_STANDBY (32 + 2) // An output to wake GPS, low means allow sleep, high means force wake
 // Seems to be missing on this new board
 #define PIN_GPS_PPS (32 + 4) // Pulse per second input from the GPS
-#define GPS_TX_PIN (32 + 8)  // This is for bits going TOWARDS the CPU
-#define GPS_RX_PIN (32 + 9)  // This is for bits going TOWARDS the GPS
+#define GPS_TX_PIN (32 + 8)  // This is for bits going TOWARDS the GPS
+#define GPS_RX_PIN (32 + 9)  // This is for bits going TOWARDS the CPU
 
 #define GPS_THREAD_INTERVAL 50
 


### PR DESCRIPTION
`GPS::createGps()` passes `GPS_RX_PIN` as the MCU's RX pin and `GPS_TX_PIN` as its TX pin (`Serial1.begin(baud, SERIAL_8N1, rx_gpio, tx_gpio)`, src/gps/GPS.cpp:2034; the nRF52/RP2040/STM32 paths do the same).

Nine variants documented the opposite direction, including t-echo, t114 and meshlink where GPS demonstrably works and where `GPS_TX_PIN` is literally assigned `PIN_SERIAL1_TX`. Reading those comments makes correct boards look mis-wired, which is what happened in #11584.

Comment-only change. No pin assignment is modified.

Also replaces the stale "Seems to be missing on this new board" note on heltec_v4 / heltec_v4_r8 with the actual situation: the GNSS sits on the V4 expansion kit and is a CM121 at 9600 baud.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected GPS UART pin direction descriptions across supported hardware variants.
  * Clarified the GNSS hardware location for applicable expansion kits.
  * Pin assignments and device behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->