### PR TITLE
fix(test): assert the rejected packet is released, not that malloc reuses its address

### DIFF
--- a/test/test_radio/test_main.cpp
+++ b/test/test_radio/test_main.cpp
@@ -3,6 +3,8 @@
 #include "MeshService.h"
 #include "RadioInterface.h"
 #include "TestUtil.h"
+#include "memory/MemAudit.h"
+#include <cstring>
 #include <unity.h>
 
 #include "meshtastic/config.pb.h"
@@ -417,8 +419,21 @@ static void test_regionPresetMap_unsetCarriesUserprefsIntent()
 #endif
 }
 
+// Live bytes packetPool reports under its memaudit tag, which tracks every alloc/release.
+static int32_t livePacketPoolBytes()
+{
+    memaudit::Tag rows[memaudit::kMaxTags];
+    size_t n = memaudit::snapshot(rows, memaudit::kMaxTags);
+    for (size_t i = 0; i < n; i++)
+        if (rows[i].tag && strcmp(rows[i].tag, "pktpool(live)") == 0)
+            return rows[i].bytes;
+    return 0;
+}
+
 static void test_beginSending_oversizedPayloadAbortsSafely()
 {
+    const int32_t liveBefore = livePacketPoolBytes();
+
     meshtastic_MeshPacket *p = packetPool.allocZeroed();
     TEST_ASSERT_NOT_NULL(p);
     p->from = 0x12345678;
@@ -434,11 +449,11 @@ static void test_beginSending_oversizedPayloadAbortsSafely()
     TEST_ASSERT_EQUAL_UINT(0, result);
     TEST_ASSERT_NULL(testRadio->getSendingPacket());
 
-    // Verify rejected packet was released to packetPool and its slot is reusable
-    meshtastic_MeshPacket *reallocated = packetPool.allocZeroed();
-    TEST_ASSERT_NOT_NULL(reallocated);
-    TEST_ASSERT_EQUAL_PTR(p, reallocated);
-    packetPool.release(reallocated);
+    // beginSending() owns the packet it rejects, so the pool's live byte count has to land back
+    // where it started. Do not assert the next alloc hands the same address back: on native
+    // packetPool is a malloc/free MemoryDynamic and the coverage build's ASan quarantine holds the
+    // freed chunk, so the address always differs.
+    TEST_ASSERT_EQUAL_INT32(liveBefore, livePacketPoolBytes());
 }
 
 void setUp(void)


### PR DESCRIPTION
`develop` has been red since #11573 merged on Aug 23. One assertion in one test fails on every CI run that reaches the native suite:

```
test/test_radio/test_main.cpp:440:test_beginSending_oversizedPayloadAbortsSafely:FAIL:
    Expected 0x0000514000000240 Was 0x0000514000000440
```

## Cause

The test allocated a probe packet after `beginSending()` took its rejection path and asserted the pool handed the same address back:

```cpp
meshtastic_MeshPacket *reallocated = packetPool.allocZeroed();
TEST_ASSERT_EQUAL_PTR(p, reallocated);
```

That holds for the fixed-slot `MemoryPool<T, N>` used on embedded targets. It does not hold where the test actually runs: under `ARCH_PORTDUINO`, `Router.cpp` binds `packetPool` to `MemoryDynamic`, which is plain `malloc`/`free`, and the `coverage` env compiles with `-fsanitize=address`. ASan's quarantine deliberately withholds a freed chunk from the next `malloc`, so the address always differs. The addresses are byte-identical across all three failing CI runs and a local repro — this is deterministic, not a flaky allocator race.

`RadioInterface::beginSending()` is correct and unchanged here. It releases the oversized packet and returns 0. The LeakSanitizer report in the failing logs points at the test's own probe allocation, orphaned because Unity longjmps out of the failed assert before `release()` runs.

The second CI error, `area misc ran suites that did not match their own test binaries (1 unsourced)`, is downstream of the same assert: the ASan abort makes PlatformIO emit a synthetic whole-suite `coverage:test_radio` case with no file attribute, which `check-test-attribution.py` rejects. Both errors clear with this change.

## Change

`packetPool` is already tagged `pktpool(live)` for memaudit, and `memaudit::snapshot()` is used this way in `test_mem_audit`. Comparing live bytes across the call proves the invariant the test is named for — the rejected packet went back to the pool — without depending on allocator behaviour.

## Verification

Run in the `coverage` env (ASan), the same configuration CI uses:

| | Result |
|---|---|
| `develop` as-is | FAILED — `Expected 0x0000514000000240 Was 0x0000514000000440`, suite ERRORED on SIGHUP after the LSan abort |
| with this change | 23/23 PASSED, no sanitizer output |
| with this change + `packetPool.release(p)` removed from `beginSending()` | FAILED — `Expected 0 Was 432` |

The third row confirms the new assertion still catches the regression the test was written for, and reports it as one leaked packet (432 bytes = `sizeof(meshtastic_MeshPacket)`) rather than two opaque addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened validation for oversized payload handling.
  * Confirmed rejected packets do not leave live packet-pool memory allocated.
  * Improved test reliability across different memory-management and sanitizer environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->