### PR TITLE
fix(TFTDisplay): give the CO5300 its post-sleep-out settle time

### DIFF
--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -25,9 +25,43 @@ uint16_t TFT_MESH = COLOR565(0x67, 0xEA, 0x94);
 
 #if defined(CO5300_CS)
 #include <LovyanGFX.hpp> // Graphics and font library for AMOLED driver chip
+
+// Panel_CO5300's init table sends Sleep Out and Display On with zero delay. The CO5300 needs up
+// to 120 ms after Sleep Out, or Display On is occasionally ignored and the panel stays dark.
+class Panel_CO5300_Delayed : public lgfx::Panel_CO5300
+{
+  protected:
+    const uint8_t *getInitCommands(uint8_t listno) const override
+    {
+        // clang-format off
+        static constexpr uint8_t list0[] = {
+            0xFE, 1, 0x00,                   // page 0
+            0xC4, 1, 0x80,
+            0x3A, 1, 0x55,                   // 16 bit/pixel
+            0x35, 1, 0x00,                   // TE on
+            0x53, 1, 0x20,
+            0x63, 1, 0xFF,
+            0x2A, 4, 0x00, 0x16, 0x01, 0xAF, // column 22..431
+            0x2B, 4, 0x00, 0x00, 0x01, 0xF5, // row 0..501
+            0x11, 0x80, 120,                 // sleep out, then the settle time the datasheet requires
+            0x51, 1, 0x01,                   // brightness dark
+            0x29, 0x80, 20,                  // display on
+            0x51, 1, 0x80,                   // brightness
+            0xff, 0xff
+        };
+        // clang-format on
+        switch (listno) {
+        case 0:
+            return list0;
+        default:
+            return nullptr;
+        }
+    }
+};
+
 class LGFX : public lgfx::LGFX_Device
 {
-    lgfx::Panel_CO5300 _panel_instance;
+    Panel_CO5300_Delayed _panel_instance;
     lgfx::Bus_SPI _bus_instance;
 
   public:


### PR DESCRIPTION
## Symptom

On the T-Watch Ultra the screen sometimes stays dark at boot. The firmware runs
normally, and the panel recovers on the next display wake cycle (which re-runs init).

## Cause

LovyanGFX's `Panel_CO5300` init table issues Sleep Out (0x11) and Display On (0x29)
back-to-back with an explicit **zero-millisecond** delay:
```
0x11, 0x80, 0, // Sleep out
0x51, 1, 0x01, // display brightness dark
0x29, 0x80, 0, // display on
```

The CO5300 needs up to 120 ms after Sleep Out before it accepts further commands; when
the controller is slow finishing its wake sequence, Display On is swallowed and the
panel stays dark. The next re-init succeeds because sleep-out completed long before.

## Fix

Subclass `Panel_CO5300` and override the init table with the datasheet delays: 120 ms
after Sleep Out, 20 ms after Display On. No other change.

The root fix is those same two bytes in LovyanGFX's `Panel_CO5300.hpp` (still present on
their master); this override can be dropped whenever the LovyanGFX pin picks that up.
This covers both t-watch-ultra envs, since BaseUI's TFTDisplay initializes the panel in
each. device-ui carries a duplicate LGFX class with the same broken table, constructed
only when MUI actively drives the display - the same override applies there and can go
to that repo separately.

The entire change sits inside `#if defined(CO5300_CS)`, which only the T-Watch Ultra
defines, so no other device compiles it.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)

Tested on the LilyGo T-Watch Ultra, which reproduced the dark boot readily: not
reproducible with the delays in place. The change is compiled only on that device
(`CO5300_CS` guard), so the listed devices are unaffected by construction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CO5300 display initialization reliability by adding the required startup delays.
  * Ensured the display’s brightness, timing, touch-ready state, and screen activation are applied in the correct sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->