### PR TITLE
fix(test): unbreak test_radio under ASan

### DIFF
--- a/bin/lib/test-state.sh
+++ b/bin/lib/test-state.sh
@@ -69,8 +69,7 @@ state_find_survivors() {
 	[[ -n $home ]] || return 0
 	for pid in $(ps -u "$(id -u)" -o pid= 2>/dev/null); do
 		[[ $pid == "$$" ]] && continue
-		# The redirect sits inside the group so a vanished or unreadable /proc entry stays silent:
-		# stderr on `tr` alone does not cover the shell's own open failure.
+		# Grouped so the redirect's own open failure is silenced too, not just tr's stderr.
 		if { tr '\0' '\n' <"/proc/$pid/environ"; } 2>/dev/null | grep -qxF "HOME=$home"; then
 			printf '%s\n' "$pid"
 		fi

--- a/bin/lib/test-state.sh
+++ b/bin/lib/test-state.sh
@@ -69,7 +69,9 @@ state_find_survivors() {
 	[[ -n $home ]] || return 0
 	for pid in $(ps -u "$(id -u)" -o pid= 2>/dev/null); do
 		[[ $pid == "$$" ]] && continue
-		if tr '\0' '\n' <"/proc/$pid/environ" 2>/dev/null | grep -qxF "HOME=$home"; then
+		# The redirect sits inside the group so a vanished or unreadable /proc entry stays silent:
+		# stderr on `tr` alone does not cover the shell's own open failure.
+		if { tr '\0' '\n' <"/proc/$pid/environ"; } 2>/dev/null | grep -qxF "HOME=$home"; then
 			printf '%s\n' "$pid"
 		fi
 	done

--- a/test/test_radio/test_main.cpp
+++ b/test/test_radio/test_main.cpp
@@ -419,8 +419,7 @@ static void test_regionPresetMap_unsetCarriesUserprefsIntent()
 #endif
 }
 
-// In-flight packet bytes as packetPool reports them to memaudit, 0 before the first alloc
-// registers the tag.
+// In-flight packet bytes as packetPool reports them, 0 before the first alloc registers the tag.
 static int32_t packetPoolLiveBytes()
 {
     memaudit::Tag rows[memaudit::kMaxTags];
@@ -437,7 +436,7 @@ static void test_beginSending_oversizedPayloadAbortsSafely()
 
     meshtastic_MeshPacket *p = packetPool.allocZeroed();
     TEST_ASSERT_NOT_NULL(p);
-    // The pool accounting has to see this allocation, otherwise the check below proves nothing.
+    // Without this the check below would also pass against a dead probe.
     TEST_ASSERT_GREATER_THAN_INT32(liveBefore, packetPoolLiveBytes());
 
     p->from = 0x12345678;
@@ -453,9 +452,8 @@ static void test_beginSending_oversizedPayloadAbortsSafely()
     TEST_ASSERT_EQUAL_UINT(0, result);
     TEST_ASSERT_NULL(testRadio->getSendingPacket());
 
-    // The rejected packet went back to the pool. Pointer identity is not a usable probe: the
-    // native pool is malloc-backed and ASan quarantines the freed block, so the next alloc
-    // lands at a different address.
+    // The rejected packet went back to the pool. Not pointer identity: the native pool is
+    // malloc-backed and ASan quarantines the freed block, so the next alloc moves.
     TEST_ASSERT_EQUAL_INT32(liveBefore, packetPoolLiveBytes());
 }
 

--- a/test/test_radio/test_main.cpp
+++ b/test/test_radio/test_main.cpp
@@ -3,6 +3,8 @@
 #include "MeshService.h"
 #include "RadioInterface.h"
 #include "TestUtil.h"
+#include "memory/MemAudit.h"
+#include <string.h>
 #include <unity.h>
 
 #include "meshtastic/config.pb.h"
@@ -417,10 +419,27 @@ static void test_regionPresetMap_unsetCarriesUserprefsIntent()
 #endif
 }
 
+// In-flight packet bytes as packetPool reports them to memaudit, 0 before the first alloc
+// registers the tag.
+static int32_t packetPoolLiveBytes()
+{
+    memaudit::Tag rows[memaudit::kMaxTags];
+    size_t n = memaudit::snapshot(rows, memaudit::kMaxTags);
+    for (size_t i = 0; i < n; i++)
+        if (rows[i].tag && strcmp(rows[i].tag, "pktpool(live)") == 0)
+            return rows[i].bytes;
+    return 0;
+}
+
 static void test_beginSending_oversizedPayloadAbortsSafely()
 {
+    const int32_t liveBefore = packetPoolLiveBytes();
+
     meshtastic_MeshPacket *p = packetPool.allocZeroed();
     TEST_ASSERT_NOT_NULL(p);
+    // The pool accounting has to see this allocation, otherwise the check below proves nothing.
+    TEST_ASSERT_GREATER_THAN_INT32(liveBefore, packetPoolLiveBytes());
+
     p->from = 0x12345678;
     p->to = 0x87654321;
     p->id = 0x10203040;
@@ -434,11 +453,10 @@ static void test_beginSending_oversizedPayloadAbortsSafely()
     TEST_ASSERT_EQUAL_UINT(0, result);
     TEST_ASSERT_NULL(testRadio->getSendingPacket());
 
-    // Verify rejected packet was released to packetPool and its slot is reusable
-    meshtastic_MeshPacket *reallocated = packetPool.allocZeroed();
-    TEST_ASSERT_NOT_NULL(reallocated);
-    TEST_ASSERT_EQUAL_PTR(p, reallocated);
-    packetPool.release(reallocated);
+    // The rejected packet went back to the pool. Pointer identity is not a usable probe: the
+    // native pool is malloc-backed and ASan quarantines the freed block, so the next alloc
+    // lands at a different address.
+    TEST_ASSERT_EQUAL_INT32(liveBefore, packetPoolLiveBytes());
 }
 
 void setUp(void)


### PR DESCRIPTION
test_beginSending_oversizedPayloadAbortsSafely asserted pointer identity after a release, which ASan's quarantine never satisfies on the malloc-backed native pool; it now checks the pktpool(live) memaudit balance instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of inaccessible process environment data by suppressing related read errors during state inspection.
  * Preserved existing survivor-matching behavior.

* **Tests**
  * Updated oversized-packet handling coverage to verify memory is correctly returned to the packet pool.
  * Improved test reliability by using live memory accounting instead of pointer identity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->