### PR TITLE
Check for ambientLightingThread non-null before use

### DIFF
--- a/src/modules/ExternalNotificationModule.cpp
+++ b/src/modules/ExternalNotificationModule.cpp
@@ -247,7 +247,9 @@ void ExternalNotificationModule::setExternalState(uint8_t index, bool on)
         blue = 0;
         white = 0;
     }
-    ambientLightingThread->setLighting(moduleConfig.ambient_lighting.current, red, green, blue);
+    if (ambientLightingThread) {
+        ambientLightingThread->setLighting(moduleConfig.ambient_lighting.current, red, green, blue);
+    }
 #endif
 
 #ifdef HAS_DRV2605


### PR DESCRIPTION
## 🙏 Thank you for sending in a pull request, here's some tips to get started!

### ❌ (Please delete all these tips and replace them with your text) ❌

Check for `ambientLightingThread` non-null before use in modules/ExternalNotificationModule.cpp.  The `ambientLightingThread`  can be null if `MESHTASTIC_EXCLUDE_I2C` is defined.  I tripped over this testing a build with no I2C support for a RAK WisBlock 4631.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [x] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented RGB ambient lighting updates when the ambient lighting service is unavailable.
  * Improved stability by avoiding unnecessary operations during unavailable lighting states.
  * Improved notification handling for messages and other events, including waypoint and geofence alerts.
  * Ensured vibration, buzzer, and nag-cycle alerts trigger consistently according to configured notification settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->