### PR TITLE
Meshnology W10: enable the AXP2101 power key as a second button

### DIFF
--- a/variants/esp32s3/meshnology-w10/variant.h
+++ b/variants/esp32s3/meshnology-w10/variant.h
@@ -12,9 +12,16 @@
 
 // ─── Power management ─────────────────────────────────────────────────────────
 // AXP2101 PMIC on I2C (pg3). AXP_IRQ → EXIO5 (expander, whose /INT is not routed to the
-// ESP32), so no PMU_IRQ is possible; battery state is polled via the AXP2101 fuel gauge.
-// There is no direct battery ADC - the PMIC is the only voltage source.
+// ESP32), so there is no GPIO-backed PMU_IRQ; battery state is polled via the AXP2101 fuel
+// gauge. There is no direct battery ADC - the PMIC is the only voltage source.
 #define HAS_AXP2101
+
+// Power key: SW3 → R44 510R → PWRON (AXP2101 pin 30, schematic W10-MB-V1.1 pg3), used as a
+// second button. PMU_IRQ is defined below as the expander vpin for AXP_IRQ: Power.cpp keeps
+// the PMU IRQ *enable* (enableIRQ of PKEY_SHORT / VBUS insert+remove) behind #ifdef PMU_IRQ,
+// and init runs disableIRQ(ALL), so without it the status bit never latches and the polled
+// read in Power::runOnce() is always false.
+#define PMU_POWER_BUTTON_IS_CANCEL
 
 // ─── RTC ──────────────────────────────────────────────────────────────────────
 // PCF85063ATL on I2C (pg3); RTC_INT → EXIO4 (unused)
@@ -39,16 +46,23 @@
 #define LORA_DIO1_EXTENDED_IO
 
 // Expander pin map (pg2 "I/O Extensions"; EXIO0..7 = GPA0..7 / P00..P07, EXIO8..15 = GPB0..7 / P10..P17)
-// Not wired up here: EXIO0 CAM_PWDN, EXIO2 TP_INT, EXIO5 AXP_IRQ, EXIO6 SYS_OUT,
+// Not wired up here: EXIO0 CAM_PWDN, EXIO2 TP_INT, EXIO6 SYS_OUT,
 //                    EXIO11 GPS RESET_N (driver FET Q3 unpopulated), EXIO13 TP_RST
 #define EXIO_LCD_RST 1    // GPA1: LCD reset
 #define EXIO_LORA_NRST 3  // GPA3: E22 NRST
 #define EXIO_RTC_INT 4    // GPA4: PCF85063 INT (unused)
+#define EXIO_AXP_IRQ 5    // GPA5: AXP2101 IRQ (pin 38) - see PMU_IRQ below
 #define EXIO_PA_CTRL 7    // GPA7: NS4150 speaker amp enable (driven by AudioThread during playback)
 #define EXIO_IMU_INT1 8   // GPB0: QMI8658 INT1 (input only, no MCU interrupt)
 #define EXIO_LORA_DIO1 9  // GPB1: E22 DIO1
 #define EXIO_LORA_BUSY 10 // GPB2: E22 BUSY
 #define EXIO_GPS_WAKE 12  // GPB4: L76KB WAKE_UP (driven high at boot)
+
+// AXP2101 IRQ as an expander vpin, mirroring LORA_DIO1 below. This is not an ESP32 GPIO, so
+// the attachInterrupt()/gpio_wakeup_enable() uses of PMU_IRQ in Power.cpp and sleep.cpp are
+// inert here (both are unchecked calls, so an invalid pin is ignored rather than fatal); what
+// it buys us is the enableIRQ() of PKEY_SHORT, which Power::runOnce() then polls over I2C.
+#define PMU_IRQ (MCP23017_VPIN_BASE + EXIO_AXP_IRQ) // 105
 
 // ─── LoRa radio ───────────────────────────────────────────────────────────────
 // EBYTE E22-900MM22S (SX1262) - pg4 U10. SPI shared with the LCD, separate chip selects.

--- a/variants/esp32s3/meshnology-w10/variant.h
+++ b/variants/esp32s3/meshnology-w10/variant.h
@@ -97,10 +97,10 @@
 // SPI TFT on the "OLED"-silkscreened header / LCD FPC, sharing the LoRa SPI bus (pg1).
 // Vendor ships two panels on identical pins; the default kit has the ST7789 1.54" IPS 240x240.
 // Build with -D MESHNOLOGY_W10_LCD_ST7796_35 for the 3.5" ST7796 320x480 panel instead.
-#define TFT_CS 10  // pg1: OLED_CS=GPIO10
-#define TFT_DC 16  // pg1: OLED_DC=GPIO16
-#define TFT_BL 6   // pg1: OLED_BL=GPIO6 (backlight PWM)
-#define TFT_RST -1 // panel reset is EXIO1 on the expander, toggled in mcp23017EarlyInit()
+#define TFT_CS 10     // pg1: OLED_CS=GPIO10
+#define TFT_DC 16     // pg1: OLED_DC=GPIO16
+#define TFT_BL 6      // pg1: OLED_BL=GPIO6 (backlight PWM)
+#define TFT_RST -1    // panel reset is EXIO1 on the expander, toggled in mcp23017EarlyInit()
 #define HAS_SPI_TFT 1 // main.cpp keys SPI-TFT Screen creation on this since #10803
 #define USE_TFTDISPLAY 1
 


### PR DESCRIPTION
## What

Makes the Meshnology W10's power key (`SW3`) usable as a second button, mapping a short press to the existing `INPUT_BROKER_CANCEL` action. Variant-only change — no shared code is touched.

## Why it doesn't work today

`SW3` is wired to the AXP2101 `PWRON` pin via `R44` 510R (schematic W10-MB-V1.1 pg3), but pressing it does nothing in firmware.

`Power::runOnce()` already polls the PMU IRQ status registers over I2C and maps a PEK short press to `INPUT_BROKER_CANCEL` when `PMU_POWER_BUTTON_IS_CANCEL` is set:

```c
PMU->getIrqStatus();
...
#ifdef PMU_POWER_BUTTON_IS_CANCEL
    if (PMU->isPekeyShortPressIrq()) { ... }
#endif
```

But the matching `PMU->enableIRQ(pmuIrqMask)` sits inside `#ifdef PMU_IRQ`, and PMU init runs `disableIRQ(XPOWERS_AXP2101_ALL_IRQ)` beforehand. So without `PMU_IRQ`, the `PKEY_SHORT` status bit is never armed, the polled read is always false, and `PMU_POWER_BUTTON_IS_CANCEL` on its own is inert. I confirmed this empirically — with only the cancel define, 100s of pressing produced zero events.

## Approach

`AXP_IRQ` on this board reaches only expander `EXIO5` and is not routed to any ESP32 GPIO (confirmed on both schematic sheets), so there is no real pin to give `PMU_IRQ`. This defines it as the MCP23017 virtual pin instead, mirroring how the same limitation is already handled for `LORA_DIO1` on this variant:

```c
#define EXIO_AXP_IRQ 5
#define PMU_IRQ (MCP23017_VPIN_BASE + EXIO_AXP_IRQ) // 105
```

The `attachInterrupt()` and `gpio_wakeup_enable()` uses of `PMU_IRQ` are inert on a non-GPIO value — both are unchecked calls, so an invalid pin is ignored rather than fatal. What the define actually buys is the `enableIRQ()` that they gate.

## ⚠️ Please sanity-check this bit

Using `PMU_IRQ` as a non-GPIO sentinel is arguably leaning on a side effect rather than expressing intent, and I'd rather a maintainer decide whether that's acceptable. The cleaner alternative is to hoist the mask computation and `enableIRQ()` out of `#ifdef PMU_IRQ` in `Power.cpp`, leaving only `pinMode(PMU_IRQ, INPUT)` guarded. That would be a general fix for any AXP board whose IRQ pin isn't routed to a GPIO — and would also restore VBUS insert/remove events, which are dead on such boards for the same reason. I kept this PR variant-scoped to avoid touching shared code without a maintainer's call, but I'm happy to switch it if that's preferred.

## Known limitation

Because there's no real interrupt, the ISR's `power->setIntervalFromNow(0)` never runs, so events surface on the 20s `Power::runOnce()` cadence rather than immediately. The press isn't lost — the AXP2101 latches it — but it can take up to 20s to register. Visible in the test log below as events landing exactly 20s apart.

## Testing

Built and flashed on real Meshnology W10 hardware (firmware `2.8.0.bfd1e1a`; the two files involved are identical between that commit and current `develop`).

```
23:27:58  [UserButton] LONG PRESS RELEASE AFTER 716 MILLIS
23:28:01  [UserButton] LONG PRESS RELEASE AFTER 864 MILLIS
23:28:05  [Power] Input: Corona Button Click
23:28:18  [UserButton] LONG PRESS RELEASE AFTER 777 MILLIS
23:28:22  [UserButton] LONG PRESS RELEASE AFTER 909 MILLIS
23:28:25  [Power] Input: Corona Button Click
23:28:30  [UserButton] LONG PRESS RELEASE AFTER 724 MILLIS
23:28:45  [Power] Input: Corona Button Click
23:29:05  [Power] Input: Corona Button Click
```

- Power key (`SW3`) produces `Input: Corona Button Click`
- The existing GPIO0 user button (`SW2`) continues to work independently
- Board boots normally; the non-GPIO `PMU_IRQ` value causes no crash or boot loop

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other: **Meshnology W10** — the only device tested, and the only one affected. The diff is confined to `variants/esp32s3/meshnology-w10/variant.h`, so no other target's build output changes. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for canceling power-button actions on the Meshtastic W10 variant.
  - Added AXP2101 power-management interrupt handling through the expander’s virtual pin for improved power-event monitoring.

- **Documentation**
  - Clarified that AXP2101 interrupt handling is polled over I2C, while GPIO interrupt and wake-up operations remain inactive for the virtual pin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->