### PR TITLE
fix(xmodem): close the file when a transmit is aborted

### DIFF
--- a/src/xmodem.cpp
+++ b/src/xmodem.cpp
@@ -220,6 +220,9 @@ void XModemAdapter::handlePacket(meshtastic_XModem xmodemPacket)
             } else if (isTransmitting) {
                 // just received something weird.
                 sendControl(meshtastic_XModem_Control_CAN);
+                spiLock->lock();
+                file.close();
+                spiLock->unlock();
                 isTransmitting = false;
                 break;
             }


### PR DESCRIPTION
## Problem

In `XModemAdapter::handlePacket()`, the branch that cancels an in-progress *transmit* clears the state flag without closing the open file:

https://github.com/meshtastic/firmware/blob/develop/src/xmodem.cpp#L220-L224

```cpp
} else if (isTransmitting) {
    // just received something weird.
    sendControl(meshtastic_XModem_Control_CAN);
    isTransmitting = false;   // <-- file left open
    break;
}
```

It is the only terminal path that doesn't close the file — `EOT`, `CAN`, and both ACK/EOT completion paths all call `file.close()`. The next transfer then reassigns `file` in the STX handler, orphaning the previous handle and its filesystem cache.

## Why it matters

Reaching it takes two frames: `STX seq=0` (with a filename) to start a transmit, then any non-`seq-0` frame to land in the abort branch. XModem frames aren't subject to the PhoneAPI packet throttle, so a client can loop this as fast as the link allows. Anything that can talk to the node over serial/BLE/TCP can exhaust the heap.

## Measurements

Real hardware, `DEBUG_HEAP` builds, 60 iterations of start-then-abort:

| Board | Free heap before → after | Rate |
| --- | --- | --- |
| Heltec Mesh Node T096 (nRF52840) | 44,908 → 32,896 B | **−200 B/iter** |
| Heltec Wireless Tracker V2 (ESP32-S3) | 57,360 → 51,472 B | **−98 B/iter** |

The heap is not reclaimed afterwards. On the T096 that's ~45 KB of free heap gone in roughly 225 iterations.

Log signature while it runs — note the abort every time, and never `Finished send file`:

```
XModem: Transmit file /prefs/config.proto
XModem: STX Notify Send packet 1, 128 Bytes
XModem: Notify Send control 24
```

It reproduces on both platforms. nRF52 leaks about twice as much because `Adafruit_LittleFS`'s `File` has no destructor or assignment operator, so reassignment orphans the handle outright; ESP32's refcounted `fs::File` reduces the loss but doesn't eliminate it.

## Fix

Close the file in the abort branch, under `spiLock`, matching the other terminal paths.

## Verification

Rebuilt and flashed the patched firmware to the T096 and re-ran the same stimulus at **200 iterations** (600 XModem log lines confirming every iteration executed):

```
heap samples: [44968, 44968, 44764, 44968]
NET +0 B over 200 iters = +0.0 B/iter
```

Unpatched, 200 iterations would have cost ~40 KB.

Existing coverage in `test/test_xmodem` (`test_xmodem_soh_mid_transmit_cancels`) exercises this branch and its assertions are unchanged — it still replies `CAN` and clears busy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unexpected packets during XMODEM transfers.
  * Ensured transmission files are closed properly when a transfer encounters an unexpected packet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->