### PR TITLE
Fix trackball dropping short presses and losing the click when tilted

### DIFF
--- a/src/input/TrackballInterruptBase.cpp
+++ b/src/input/TrackballInterruptBase.cpp
@@ -31,9 +31,10 @@ TrackballInterruptBase::PressResult TrackballInterruptBase::updatePress(bool irq
     if (!irqLatched)
         return PressResult::None;
 
-    // Already released by the time we polled: the tap only exists as the latched interrupt.
+    // Already released by the time we polled: classify from the latched interrupt time, since a
+    // delayed poll can hide a long hold behind the same latch.
     if (!pinLow)
-        return PressResult::Short;
+        return Throttle::isWithinTimespanMs(irqTimeMs, LONG_PRESS_DURATION) ? PressResult::Short : PressResult::None;
 
     pressDetected = true;
     pressStartTime = irqTimeMs;

--- a/src/input/TrackballInterruptBase.cpp
+++ b/src/input/TrackballInterruptBase.cpp
@@ -246,7 +246,8 @@ int32_t TrackballInterruptBase::runOnce()
 
 void TrackballInterruptBase::intPressHandler()
 {
-    if (Throttle::isWithinTimespanMs(lastPressInterruptTime, 10))
+    // pressIrqSeq == 0 means nothing recorded yet, so a press at clock 0 is not read as a cooldown.
+    if (pressIrqSeq != 0 && Throttle::isWithinTimespanMs(lastPressInterruptTime, 10))
         return;
     lastPressInterruptTime = Time::getMillis();
     pressIrqTime = lastPressInterruptTime;

--- a/src/input/TrackballInterruptBase.cpp
+++ b/src/input/TrackballInterruptBase.cpp
@@ -1,10 +1,46 @@
 #include "TrackballInterruptBase.h"
 #include "Throttle.h"
+#include "UptimeClock.h"
 #include "configuration.h"
 
 extern bool osk_found;
 
 TrackballInterruptBase::TrackballInterruptBase(const char *name) : concurrency::OSThread(name), _originName(name) {}
+
+TrackballInterruptBase::PressResult TrackballInterruptBase::updatePress(bool irqLatched, uint32_t irqTimeMs, bool pinLow)
+{
+    if (pressDetected) {
+        if (!pinLow) {
+            const bool wasShort = Throttle::isWithinTimespanMs(pressStartTime, LONG_PRESS_DURATION);
+            pressDetected = false;
+            pressStartTime = 0;
+            lastLongPressEventTime = 0;
+            longPressRepeatSent = false;
+            return wasShort ? PressResult::Short : PressResult::None;
+        }
+        // Tracked by a flag, not by lastLongPressEventTime == 0, which is a valid instant at rollover.
+        if (Throttle::hasElapsed(pressStartTime, LONG_PRESS_DURATION) &&
+            (!longPressRepeatSent || Throttle::hasElapsed(lastLongPressEventTime, LONG_PRESS_REPEAT_INTERVAL))) {
+            lastLongPressEventTime = Time::getMillis();
+            longPressRepeatSent = true;
+            return PressResult::LongRepeat;
+        }
+        return PressResult::None;
+    }
+
+    if (!irqLatched)
+        return PressResult::None;
+
+    // Already released by the time we polled: the tap only exists as the latched interrupt.
+    if (!pinLow)
+        return PressResult::Short;
+
+    pressDetected = true;
+    pressStartTime = irqTimeMs;
+    lastLongPressEventTime = 0;
+    longPressRepeatSent = false;
+    return PressResult::None;
+}
 
 void TrackballInterruptBase::init(uint8_t pinDown, uint8_t pinUp, uint8_t pinLeft, uint8_t pinRight, uint8_t pinPress,
                                   input_broker_event eventDown, input_broker_event eventUp, input_broker_event eventLeft,
@@ -72,33 +108,21 @@ int32_t TrackballInterruptBase::runOnce()
 #endif
 #endif
 
-    // Handle long press detection for press button
-    if (pressDetected && pressStartTime > 0) {
-        uint32_t pressDuration = millis() - pressStartTime;
-        bool buttonStillPressed = false;
-
-        buttonStillPressed = !digitalRead(_pinPress);
-
-        if (!buttonStillPressed) {
-            // Button released
-            if (pressDuration < LONG_PRESS_DURATION) {
-                // Short press
-                e.inputEvent = this->_eventPressed;
-            }
-            // Reset state
-            pressDetected = false;
-            pressStartTime = 0;
-            lastLongPressEventTime = 0;
-            this->action = TB_ACTION_NONE;
-        } else if (pressDuration >= LONG_PRESS_DURATION) {
-            // Long press detected
-            uint32_t currentTime = millis();
-            // Only trigger long press event if enough time has passed since the last one
-            if (lastLongPressEventTime == 0 || (currentTime - lastLongPressEventTime) >= LONG_PRESS_REPEAT_INTERVAL) {
-                e.inputEvent = this->_eventPressedLong;
-                lastLongPressEventTime = currentTime;
-            }
-            this->action = TB_ACTION_PRESSED_LONG;
+    bool pressLatched = false;
+    if (_pinPress != 255) {
+        const uint32_t irqSeq = pressIrqSeq;
+        const uint32_t irqTimeMs = pressIrqTime;
+        pressLatched = irqSeq != pressIrqSeen;
+        pressIrqSeen = irqSeq;
+        switch (updatePress(pressLatched, irqTimeMs, !digitalRead(_pinPress))) {
+        case PressResult::Short:
+            e.inputEvent = this->_eventPressed;
+            break;
+        case PressResult::LongRepeat:
+            e.inputEvent = this->_eventPressedLong;
+            break;
+        case PressResult::None:
+            break;
         }
     }
 
@@ -125,8 +149,9 @@ int32_t TrackballInterruptBase::runOnce()
             directionStartTime = 0;
             directionInterval = 0;
             this->action = TB_ACTION_NONE;
-        } else if (directionDuration >= LONG_PRESS_DURATION && directionInterval >= DIRECTION_REPEAT_THRESHOLD) {
-            // repeat event when long press these direction.
+        } else if (directionDuration >= LONG_PRESS_DURATION && directionInterval >= DIRECTION_REPEAT_THRESHOLD &&
+                   e.inputEvent == INPUT_BROKER_NONE) {
+            // repeat event when long press these direction, unless a press event already claimed this poll.
             switch (directionPressedNow) {
             case TB_ACTION_UP:
                 e.inputEvent = this->_eventUp;
@@ -147,55 +172,51 @@ int32_t TrackballInterruptBase::runOnce()
     }
 
 #if TB_THRESHOLD
-    if (this->action == TB_ACTION_PRESSED && (!pressDetected || pressStartTime == 0)) {
-        // Start long press detection
-        pressDetected = true;
-        pressStartTime = millis();
-        // Don't send event yet, wait to see if it's a long press
-    } else if (up_counter >= TB_THRESHOLD) {
+    // A press starting this poll suppresses direction events, as it always has.
+    if (!pressLatched) {
+        if (up_counter >= TB_THRESHOLD) {
 #ifdef INPUT_DEBUG
-        LOG_DEBUG("Trackball event UP %u", millis());
+            LOG_DEBUG("Trackball event UP %u", millis());
 #endif
-        e.inputEvent = this->_eventUp;
-    } else if (down_counter >= TB_THRESHOLD) {
+            e.inputEvent = this->_eventUp;
+        } else if (down_counter >= TB_THRESHOLD) {
 #ifdef INPUT_DEBUG
-        LOG_DEBUG("Trackball event DOWN %u", millis());
+            LOG_DEBUG("Trackball event DOWN %u", millis());
 #endif
-        e.inputEvent = this->_eventDown;
-    } else if (left_counter >= TB_THRESHOLD) {
+            e.inputEvent = this->_eventDown;
+        } else if (left_counter >= TB_THRESHOLD) {
 #ifdef INPUT_DEBUG
-        LOG_DEBUG("Trackball event LEFT %u", millis());
+            LOG_DEBUG("Trackball event LEFT %u", millis());
 #endif
-        e.inputEvent = this->_eventLeft;
-    } else if (right_counter >= TB_THRESHOLD) {
+            e.inputEvent = this->_eventLeft;
+        } else if (right_counter >= TB_THRESHOLD) {
 #ifdef INPUT_DEBUG
-        LOG_DEBUG("Trackball event RIGHT %u", millis());
+            LOG_DEBUG("Trackball event RIGHT %u", millis());
 #endif
-        e.inputEvent = this->_eventRight;
+            e.inputEvent = this->_eventRight;
+        }
     }
 #else
-    if (this->action == TB_ACTION_PRESSED && !digitalRead(_pinPress) && !pressDetected) {
-        // Start long press detection
-        pressDetected = true;
-        pressStartTime = millis();
-        // Don't send event yet, wait to see if it's a long press
-    } else if (this->action == TB_ACTION_UP && !digitalRead(_pinUp) && !directionDetected) {
-        directionDetected = true;
-        directionStartTime = millis();
-        e.inputEvent = this->_eventUp;
-        // send event first,will automatically trigger every 50ms * 3 after 500ms
-    } else if (this->action == TB_ACTION_DOWN && !digitalRead(_pinDown) && !directionDetected) {
-        directionDetected = true;
-        directionStartTime = millis();
-        e.inputEvent = this->_eventDown;
-    } else if (this->action == TB_ACTION_LEFT && !digitalRead(_pinLeft) && !directionDetected) {
-        directionDetected = true;
-        directionStartTime = millis();
-        e.inputEvent = this->_eventLeft;
-    } else if (this->action == TB_ACTION_RIGHT && !digitalRead(_pinRight) && !directionDetected) {
-        directionDetected = true;
-        directionStartTime = millis();
-        e.inputEvent = this->_eventRight;
+    // A press event already claimed this poll: a direction IRQ must not overwrite the tap.
+    if (e.inputEvent == INPUT_BROKER_NONE) {
+        if (this->action == TB_ACTION_UP && !digitalRead(_pinUp) && !directionDetected) {
+            directionDetected = true;
+            directionStartTime = millis();
+            e.inputEvent = this->_eventUp;
+            // send event first,will automatically trigger every 50ms * 3 after 500ms
+        } else if (this->action == TB_ACTION_DOWN && !digitalRead(_pinDown) && !directionDetected) {
+            directionDetected = true;
+            directionStartTime = millis();
+            e.inputEvent = this->_eventDown;
+        } else if (this->action == TB_ACTION_LEFT && !digitalRead(_pinLeft) && !directionDetected) {
+            directionDetected = true;
+            directionStartTime = millis();
+            e.inputEvent = this->_eventLeft;
+        } else if (this->action == TB_ACTION_RIGHT && !digitalRead(_pinRight) && !directionDetected) {
+            directionDetected = true;
+            directionStartTime = millis();
+            e.inputEvent = this->_eventRight;
+        }
     }
 #endif
 
@@ -224,9 +245,12 @@ int32_t TrackballInterruptBase::runOnce()
 
 void TrackballInterruptBase::intPressHandler()
 {
-    if (!Throttle::isWithinTimespanMs(lastInterruptTime, 10))
-        this->action = TB_ACTION_PRESSED;
-    lastInterruptTime = millis();
+    if (Throttle::isWithinTimespanMs(lastPressInterruptTime, 10))
+        return;
+    lastPressInterruptTime = Time::getMillis();
+    pressIrqTime = lastPressInterruptTime;
+    pressIrqSeq++;
+    this->action = TB_ACTION_PRESSED;
 }
 
 void TrackballInterruptBase::intDownHandler()

--- a/src/input/TrackballInterruptBase.cpp
+++ b/src/input/TrackballInterruptBase.cpp
@@ -172,8 +172,9 @@ int32_t TrackballInterruptBase::runOnce()
     }
 
 #if TB_THRESHOLD
-    // A press starting this poll suppresses direction events, as it always has.
-    if (!pressLatched) {
+    // A starting press suppresses direction events as it always has, and a press event already
+    // emitted this poll (a release classified on a later poll) must not be overwritten either.
+    if (!pressLatched && e.inputEvent == INPUT_BROKER_NONE) {
         if (up_counter >= TB_THRESHOLD) {
 #ifdef INPUT_DEBUG
             LOG_DEBUG("Trackball event UP %u", millis());

--- a/src/input/TrackballInterruptBase.h
+++ b/src/input/TrackballInterruptBase.h
@@ -49,6 +49,12 @@ class TrackballInterruptBase : public Observable<const InputEvent *>, public con
 
     volatile TrackballInterruptBaseActionType action = TB_ACTION_NONE;
 
+    enum class PressResult : uint8_t { None, Short, LongRepeat };
+
+    /// Press state machine, hardware-free so it can be unit tested. irqLatched/irqTimeMs come from
+    /// intPressHandler(), pinLow is the debounced pin state now (pull-up: pressed reads low).
+    PressResult updatePress(bool irqLatched, uint32_t irqTimeMs, bool pinLow);
+
     // Long press detection for press button
     uint32_t pressStartTime = 0;
     uint32_t directionStartTime = 0;
@@ -70,6 +76,13 @@ class TrackballInterruptBase : public Observable<const InputEvent *>, public con
     const char *_originName;
     TrackballInterruptBaseActionType lastEvent = TB_ACTION_NONE;
     volatile uint32_t lastInterruptTime = 0;
+    // Own debounce clock so a tilt cannot swallow the click. A sequence rather than a flag, so an
+    // interrupt landing mid-poll is seen next poll instead of being cleared unread.
+    volatile uint32_t pressIrqSeq = 0;
+    volatile uint32_t pressIrqTime = 0;
+    volatile uint32_t lastPressInterruptTime = 0;
+    uint32_t pressIrqSeen = 0;
+    bool longPressRepeatSent = false;
 
 #if TB_THRESHOLD
     volatile uint8_t left_counter = 0;

--- a/test/test_trackball_press/test_main.cpp
+++ b/test/test_trackball_press/test_main.cpp
@@ -1,0 +1,154 @@
+// Unit tests for TrackballInterruptBase::updatePress(): short/long classification, the interrupt
+// latch that keeps a tap released between polls, and repeat timing across the millis() rollover.
+#include "TestUtil.h"
+#include "UptimeClock.h"
+#include "input/TrackballInterruptBase.h"
+#include <unity.h>
+
+namespace
+{
+// updatePress() is protected: expose it without touching any GPIO.
+class PressProbe : public TrackballInterruptBase
+{
+  public:
+    PressProbe() : TrackballInterruptBase("tbpress") {}
+    using TrackballInterruptBase::PressResult;
+    using TrackballInterruptBase::updatePress;
+};
+
+constexpr uint32_t LONG_PRESS_MS = 500;
+constexpr uint32_t LONG_REPEAT_MS = 300;
+constexpr uint32_t START_MS = 100000;
+} // namespace
+
+void setUp(void)
+{
+    Time::setTestMillis(START_MS);
+}
+
+void tearDown(void)
+{
+    Time::useRealClock();
+}
+
+void test_tap_released_before_poll_emits_short()
+{
+    PressProbe tb;
+    TEST_ASSERT_TRUE(PressProbe::PressResult::Short == tb.updatePress(true, START_MS, false));
+}
+
+void test_held_then_released_under_threshold_emits_short()
+{
+    PressProbe tb;
+    TEST_ASSERT_TRUE(PressProbe::PressResult::None == tb.updatePress(true, START_MS, true));
+
+    Time::advanceTestMillis(LONG_PRESS_MS - 1);
+    TEST_ASSERT_TRUE(PressProbe::PressResult::Short == tb.updatePress(false, 0, false));
+}
+
+void test_still_held_under_threshold_emits_nothing()
+{
+    PressProbe tb;
+    tb.updatePress(true, START_MS, true);
+
+    Time::advanceTestMillis(LONG_PRESS_MS / 2);
+    TEST_ASSERT_TRUE(PressProbe::PressResult::None == tb.updatePress(false, 0, true));
+}
+
+void test_hold_emits_long_repeats_at_the_repeat_interval()
+{
+    PressProbe tb;
+    tb.updatePress(true, START_MS, true);
+
+    Time::advanceTestMillis(LONG_PRESS_MS);
+    TEST_ASSERT_TRUE(PressProbe::PressResult::LongRepeat == tb.updatePress(false, 0, true));
+
+    Time::advanceTestMillis(LONG_REPEAT_MS - 1);
+    TEST_ASSERT_TRUE(PressProbe::PressResult::None == tb.updatePress(false, 0, true));
+
+    Time::advanceTestMillis(1);
+    TEST_ASSERT_TRUE(PressProbe::PressResult::LongRepeat == tb.updatePress(false, 0, true));
+}
+
+void test_release_after_long_press_emits_nothing()
+{
+    PressProbe tb;
+    tb.updatePress(true, START_MS, true);
+
+    Time::advanceTestMillis(LONG_PRESS_MS);
+    TEST_ASSERT_TRUE(PressProbe::PressResult::LongRepeat == tb.updatePress(false, 0, true));
+
+    Time::advanceTestMillis(10);
+    TEST_ASSERT_TRUE(PressProbe::PressResult::None == tb.updatePress(false, 0, false));
+}
+
+void test_press_after_release_is_tracked_again()
+{
+    PressProbe tb;
+    tb.updatePress(true, START_MS, true);
+    Time::advanceTestMillis(10);
+    TEST_ASSERT_TRUE(PressProbe::PressResult::Short == tb.updatePress(false, 0, false));
+
+    Time::advanceTestMillis(10);
+    const uint32_t secondIrq = Time::getMillis();
+    TEST_ASSERT_TRUE(PressProbe::PressResult::None == tb.updatePress(true, secondIrq, true));
+
+    Time::advanceTestMillis(LONG_PRESS_MS);
+    TEST_ASSERT_TRUE(PressProbe::PressResult::LongRepeat == tb.updatePress(false, 0, true));
+}
+
+void test_idle_poll_emits_nothing()
+{
+    PressProbe tb;
+    TEST_ASSERT_TRUE(PressProbe::PressResult::None == tb.updatePress(false, 0, false));
+    TEST_ASSERT_TRUE(PressProbe::PressResult::None == tb.updatePress(false, 0, true));
+}
+
+void test_hold_across_the_millis_wrap()
+{
+    PressProbe tb;
+    const uint32_t nearWrap = 0xFFFFFF00u;
+    Time::setTestMillis(nearWrap);
+    TEST_ASSERT_TRUE(PressProbe::PressResult::None == tb.updatePress(true, nearWrap, true));
+
+    // Crosses the 32-bit rollover mid-press; a raw millis() compare would fire or stall here.
+    Time::advanceTestMillis(LONG_PRESS_MS);
+    TEST_ASSERT_TRUE(PressProbe::PressResult::LongRepeat == tb.updatePress(false, 0, true));
+}
+
+// A repeat emitted exactly when the clock reads 0 must not be mistaken for "no repeat sent yet".
+void test_repeat_emitted_at_clock_zero_still_waits()
+{
+    PressProbe tb;
+    const uint32_t beforeWrap = 0u - LONG_PRESS_MS; // start + LONG_PRESS_MS wraps to exactly 0
+    Time::setTestMillis(beforeWrap);
+    tb.updatePress(true, beforeWrap, true);
+
+    Time::advanceTestMillis(LONG_PRESS_MS);
+    TEST_ASSERT_EQUAL_UINT32(0, Time::getMillis());
+    TEST_ASSERT_TRUE(PressProbe::PressResult::LongRepeat == tb.updatePress(false, 0, true));
+
+    Time::advanceTestMillis(LONG_REPEAT_MS - 1);
+    TEST_ASSERT_TRUE(PressProbe::PressResult::None == tb.updatePress(false, 0, true));
+
+    Time::advanceTestMillis(1);
+    TEST_ASSERT_TRUE(PressProbe::PressResult::LongRepeat == tb.updatePress(false, 0, true));
+}
+
+void setup()
+{
+    initializeTestEnvironment();
+    UNITY_BEGIN();
+    RUN_TEST(test_tap_released_before_poll_emits_short);
+    RUN_TEST(test_held_then_released_under_threshold_emits_short);
+    RUN_TEST(test_still_held_under_threshold_emits_nothing);
+    RUN_TEST(test_hold_emits_long_repeats_at_the_repeat_interval);
+    RUN_TEST(test_release_after_long_press_emits_nothing);
+    RUN_TEST(test_press_after_release_is_tracked_again);
+    RUN_TEST(test_idle_poll_emits_nothing);
+    RUN_TEST(test_hold_across_the_millis_wrap);
+    RUN_TEST(test_repeat_emitted_at_clock_zero_still_waits);
+    exit(UNITY_END());
+}
+
+void loop() {}

--- a/test/test_trackball_press/test_main.cpp
+++ b/test/test_trackball_press/test_main.cpp
@@ -116,6 +116,15 @@ void test_hold_across_the_millis_wrap()
     TEST_ASSERT_TRUE(PressProbe::PressResult::LongRepeat == tb.updatePress(false, 0, true));
 }
 
+// A delayed first poll must not report a long hold as a tap just because the pin is already high.
+void test_long_hold_released_before_first_poll_is_not_short()
+{
+    PressProbe tb;
+    const uint32_t irq = Time::getMillis();
+    Time::advanceTestMillis(LONG_PRESS_MS);
+    TEST_ASSERT_TRUE(PressProbe::PressResult::None == tb.updatePress(true, irq, false));
+}
+
 // A repeat emitted exactly when the clock reads 0 must not be mistaken for "no repeat sent yet".
 void test_repeat_emitted_at_clock_zero_still_waits()
 {
@@ -147,6 +156,7 @@ void setup()
     RUN_TEST(test_press_after_release_is_tracked_again);
     RUN_TEST(test_idle_poll_emits_nothing);
     RUN_TEST(test_hold_across_the_millis_wrap);
+    RUN_TEST(test_long_hold_released_before_first_poll_is_not_short);
     RUN_TEST(test_repeat_emitted_at_clock_zero_still_waits);
     exit(UNITY_END());
 }


### PR DESCRIPTION
The press interrupt shared its debounce timestamp with the direction axes and runOnce() required the pin to still read low, so a tilted click or a tap released between 50 ms polls produced no event at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved trackball press handling with reliable tap, short-press, and long-press recognition.
  - Added repeated input events while a button remains held.
  - Improved press debouncing and handling of rapid retriggering.

- **Bug Fixes**
  - Prevented unintended direction events when a press begins.
  - Improved behavior across timer wraparound conditions.

- **Tests**
  - Added coverage for press timing, release behavior, repeats, retriggering, idle polling, and timer rollover.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->