### PR TITLE
Show waypoints sent with no expiry and stop expiring on an unset clock

### DIFF
--- a/src/meshUtils.h
+++ b/src/meshUtils.h
@@ -85,6 +85,15 @@ bool sanitizeUtf8(char *buf, size_t bufSize);
 // left at the cut.
 void clampLongName(char *longName);
 
+// Is a received Waypoint still live? The clients send expire == 0 for "never expires" and expire == 1
+// to delete; now == 0 means we have no trustworthy clock, which must not expire anything.
+static inline bool waypointIsActive(uint32_t expire, uint32_t now)
+{
+    if (expire <= 1)
+        return expire == 0;
+    return now == 0 || expire > now;
+}
+
 /// Calculate 2^n without calling pow() - used for spreading factor and other calculations
 inline uint32_t pow_of_2(uint32_t n)
 {

--- a/src/modules/WaypointModule.cpp
+++ b/src/modules/WaypointModule.cpp
@@ -60,7 +60,8 @@ bool WaypointModule::shouldDraw()
     meshtastic_Waypoint wp{}; // <- replaces memset
     if (pb_decode_from_bytes(devicestate.rx_waypoint.decoded.payload.bytes, devicestate.rx_waypoint.decoded.payload.size,
                              &meshtastic_Waypoint_msg, &wp)) {
-        return wp.expire > getTime();
+        // getTime() counts from boot until the RTC is set, which reads every real expiry as future.
+        return waypointIsActive(wp.expire, getValidTime(RTCQualityFromNet));
     }
     return false; // no LOG_ERROR, no flag writes
 #else

--- a/test/test_waypoint_expiry/test_main.cpp
+++ b/test/test_waypoint_expiry/test_main.cpp
@@ -1,0 +1,73 @@
+// Unit tests for waypointIsActive() in src/meshUtils.h: the expire == 0 and expire == 1 sentinels,
+// ordinary expiry, and an untrusted clock.
+#include "TestUtil.h"
+#include "meshUtils.h"
+#include <unity.h>
+
+namespace
+{
+constexpr uint32_t NOW = 1767225600; // 2026-01-01
+} // namespace
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_zero_never_expires()
+{
+    TEST_ASSERT_TRUE(waypointIsActive(0, NOW));
+}
+
+void test_one_is_the_delete_convention()
+{
+    TEST_ASSERT_FALSE(waypointIsActive(1, NOW));
+}
+
+void test_future_expiry_is_active()
+{
+    TEST_ASSERT_TRUE(waypointIsActive(NOW + 3600, NOW));
+}
+
+void test_past_expiry_is_not_active()
+{
+    TEST_ASSERT_FALSE(waypointIsActive(NOW - 1, NOW));
+}
+
+void test_expiry_exactly_now_is_not_active()
+{
+    TEST_ASSERT_FALSE(waypointIsActive(NOW, NOW));
+}
+
+void test_int32_max_is_active()
+{
+    // What Android sends when its expiry switch is off; it is 2038, so it must simply compare future.
+    TEST_ASSERT_TRUE(waypointIsActive(INT32_MAX, NOW));
+}
+
+void test_untrusted_clock_expires_nothing()
+{
+    TEST_ASSERT_TRUE(waypointIsActive(NOW - 3600, 0));
+    TEST_ASSERT_TRUE(waypointIsActive(NOW + 3600, 0));
+    TEST_ASSERT_TRUE(waypointIsActive(0, 0));
+}
+
+void test_untrusted_clock_still_honours_delete()
+{
+    TEST_ASSERT_FALSE(waypointIsActive(1, 0));
+}
+
+void setup()
+{
+    initializeTestEnvironment();
+    UNITY_BEGIN();
+    RUN_TEST(test_zero_never_expires);
+    RUN_TEST(test_one_is_the_delete_convention);
+    RUN_TEST(test_future_expiry_is_active);
+    RUN_TEST(test_past_expiry_is_not_active);
+    RUN_TEST(test_expiry_exactly_now_is_not_active);
+    RUN_TEST(test_int32_max_is_active);
+    RUN_TEST(test_untrusted_clock_expires_nothing);
+    RUN_TEST(test_untrusted_clock_still_honours_delete);
+    exit(UNITY_END());
+}
+
+void loop() {}


### PR DESCRIPTION
shouldDraw() tested expire > getTime(), which hid every waypoint sent with expire == 0 (what the clients send when no expiry is picked, while 1 is the delete convention) and, before the RTC is set, compared against seconds since boot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved waypoint expiration handling for greater reliability.
  * Waypoints configured with no expiration remain active indefinitely.
  * Deleted waypoints are correctly recognized as inactive.
  * Expired and currently expiring waypoints are deactivated at the correct time.
  * Expiration checks now behave safely when the device clock is unavailable or untrusted.
* **Tests**
  * Added coverage for expiration boundaries, indefinite waypoints, deletion markers, and invalid clock conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->