### PR TITLE
Idle the Wio Tracker L1 buzzer pin at boot

### DIFF
--- a/variants/nrf52840/seeed_solar_node/variant.cpp
+++ b/variants/nrf52840/seeed_solar_node/variant.cpp
@@ -100,7 +100,6 @@ void initVariant()
     digitalWrite(PIN_LED1, LOW);
     pinMode(PIN_LED2, OUTPUT);
     digitalWrite(PIN_LED2, LOW);
-    pinMode(PIN_LED2, OUTPUT);
 
     pinMode(GPS_EN, OUTPUT);
     digitalWrite(GPS_EN, HIGH);

--- a/variants/nrf52840/seeed_wio_tracker_L1/variant.cpp
+++ b/variants/nrf52840/seeed_wio_tracker_L1/variant.cpp
@@ -102,7 +102,10 @@ void initVariant()
     digitalWrite(PIN_LED1, LOW);
     pinMode(PIN_LED2, OUTPUT);
     digitalWrite(PIN_LED2, LOW);
-    pinMode(PIN_LED2, OUTPUT);
+
+    // Idle the buzzer; left floating it can whine until the first tone() call.
+    pinMode(PIN_BUZZER, OUTPUT);
+    digitalWrite(PIN_BUZZER, LOW);
 }
 
 void variant_shutdown()


### PR DESCRIPTION
initVariant() called pinMode(PIN_LED2, OUTPUT) twice and never touched PIN_BUZZER, leaving the buzzer pin floating until the first tone() call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented the buzzer from producing unwanted noise during startup on the Seeed Wio Tracker L1.
  - Preserved LED2 initialization behavior on the Seeed Solar Node while removing redundant setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->