### PR TITLE
fix(test): stop the survivor scan reporting a hit as a miss

### DIFF
--- a/bin/lib/test-state.sh
+++ b/bin/lib/test-state.sh
@@ -65,14 +65,22 @@ state_fingerprint() {
 # Scoped to this user's processes: /proc/<pid>/environ is unreadable for anyone else's anyway, and
 # the narrower sweep costs ~270ms against ~460ms for all of /proc.
 state_find_survivors() {
-	local home="$1" pid
+	local home="$1" pid entry
+	local -a environ
 	[[ -n $home ]] || return 0
 	for pid in $(ps -u "$(id -u)" -o pid= 2>/dev/null); do
 		[[ $pid == "$$" ]] && continue
-		# Grouped so the redirect's own open failure is silenced too, not just tr's stderr.
-		if { tr '\0' '\n' <"/proc/$pid/environ"; } 2>/dev/null | grep -qxF "HOME=$home"; then
-			printf '%s\n' "$pid"
-		fi
+		environ=()
+		# Read the environment in-shell rather than through `tr | grep -qxF`: -q closes the pipe
+		# on the match, tr takes SIGPIPE, and under `set -o pipefail` the hit reports as a miss.
+		# The redirect is inside the group so a process that exits mid-scan is silent too.
+		{ mapfile -t -d '' environ <"/proc/$pid/environ"; } 2>/dev/null || continue
+		for entry in "${environ[@]}"; do
+			if [[ $entry == "HOME=$home" ]]; then
+				printf '%s\n' "$pid"
+				break
+			fi
+		done
 	done
 }
 

--- a/bin/lib/test-state.sh
+++ b/bin/lib/test-state.sh
@@ -66,20 +66,19 @@ state_fingerprint() {
 # the narrower sweep costs ~270ms against ~460ms for all of /proc.
 state_find_survivors() {
 	local home="$1" pid entry
-	local -a environ
 	[[ -n $home ]] || return 0
 	for pid in $(ps -u "$(id -u)" -o pid= 2>/dev/null); do
 		[[ $pid == "$$" ]] && continue
-		environ=()
 		# In-shell, not `tr | grep -qxF`: -q closes the pipe on the match, tr takes SIGPIPE, and
 		# under `set -o pipefail` the hit reports as a miss. Grouped so a vanished pid is silent.
-		{ mapfile -t -d '' environ <"/proc/$pid/environ"; } 2>/dev/null || continue
-		for entry in "${environ[@]}"; do
-			if [[ $entry == "HOME=$home" ]]; then
-				printf '%s\n' "$pid"
-				break
-			fi
-		done
+		{
+			while IFS= read -r -d '' entry; do
+				if [[ $entry == "HOME=$home" ]]; then
+					printf '%s\n' "$pid"
+					break
+				fi
+			done <"/proc/$pid/environ"
+		} 2>/dev/null
 	done
 }
 

--- a/bin/lib/test-state.sh
+++ b/bin/lib/test-state.sh
@@ -71,9 +71,8 @@ state_find_survivors() {
 	for pid in $(ps -u "$(id -u)" -o pid= 2>/dev/null); do
 		[[ $pid == "$$" ]] && continue
 		environ=()
-		# Read the environment in-shell rather than through `tr | grep -qxF`: -q closes the pipe
-		# on the match, tr takes SIGPIPE, and under `set -o pipefail` the hit reports as a miss.
-		# The redirect is inside the group so a process that exits mid-scan is silent too.
+		# In-shell, not `tr | grep -qxF`: -q closes the pipe on the match, tr takes SIGPIPE, and
+		# under `set -o pipefail` the hit reports as a miss. Grouped so a vanished pid is silent.
 		{ mapfile -t -d '' environ <"/proc/$pid/environ"; } 2>/dev/null || continue
 		for entry in "${environ[@]}"; do
 			if [[ $entry == "HOME=$home" ]]; then

--- a/bin/test-state-check.sh
+++ b/bin/test-state-check.sh
@@ -103,6 +103,9 @@ survivor=$!
 # A real survivor has been running for the whole suite; this one is a microsecond old, and the
 # wrapper scans the instant this shell exits - so wait for the exec before reporting it up.
 for _ in {1..500}; do [[ "$(cat "/proc/$survivor/comm" 2>/dev/null)" == sleep ]] && break; sleep 0.01; done
+# Recheck rather than trust the loop: falling out of it on the timeout would stage a pid the
+# fixture never saw reach exec, which is the race this wait exists to close.
+[[ "$(cat "/proc/$survivor/comm" 2>/dev/null)" == sleep ]] || { echo "fixture: survivor never reached exec" >&2; exit 1; }
 printf '%s\n' "$survivor" > "$HOME/../survivor.pid"
 exit 0
 EOF

--- a/bin/test-state-check.sh
+++ b/bin/test-state-check.sh
@@ -99,7 +99,11 @@ mkdir -p "$HOME/.portduino/default/prefs"
 # Detached from this shell's stdout so the wrapper's `| tee` sees EOF and the pipeline returns -
 # the survivor outlives the suite exactly as a spun loop() does.
 setsid sleep 300 >/dev/null 2>&1 &
-printf '%s\n' "$!" > "$HOME/../survivor.pid"
+survivor=$!
+# A real survivor has been running for the whole suite; this one is a microsecond old, and the
+# wrapper scans the instant this shell exits - so wait for the exec before reporting it up.
+for _ in {1..500}; do [[ "$(cat "/proc/$survivor/comm" 2>/dev/null)" == sleep ]] && break; sleep 0.01; done
+printf '%s\n' "$survivor" > "$HOME/../survivor.pid"
 exit 0
 EOF
 chmod +x "$LEAKY"

--- a/bin/test-state-check.sh
+++ b/bin/test-state-check.sh
@@ -111,7 +111,7 @@ FIXTURE_SUITE=test_fixture_survivor \
 	MESHTASTIC_TEST_STATE_SUMMARY="$survivor_dir/summary.tsv" \
 	MESHTASTIC_TEST_STATE_MANIFEST="$MANIFEST" \
 	MESHTASTIC_TEST_KEEP_STATE=1 \
-	"$SCRIPT_DIR/pio-test-isolate.sh" "$LEAKY" >/dev/null 2>&1
+	"$SCRIPT_DIR/pio-test-isolate.sh" "$LEAKY" >/dev/null 2>"$survivor_dir/wrapper.err"
 
 # Find the pid file by search, not by a glob that assumes a directory depth: the wrapper renames
 # its mktemp'd sandbox to the suite name when it keeps it, so the path is not fixed.
@@ -129,15 +129,16 @@ else
 	if [[ -z $leaked_pid ]]; then
 		alive="no pid staged"
 		listed="n/a"
-		home_lines="n/a"
+		its_home=""
 	else
 		kill -0 "$leaked_pid" 2>/dev/null && alive="alive" || alive="gone"
 		grep -Fxq "$leaked_pid" <<<"$visible_pids" && listed="yes" || listed="no"
-		home_lines="$(tr '\0' '\n' <"/proc/$leaked_pid/environ" 2>/dev/null | grep -c '^HOME=')"
+		its_home="$(tr '\0' '\n' <"/proc/$leaked_pid/environ" 2>/dev/null | grep -m1 '^HOME=')"
 	fi
 	echo "        summary line: $(awk -F'\t' '$1 == "test_fixture_survivor"' "$survivor_dir/summary.tsv" 2>/dev/null | tr '\t' '|')"
-	echo "        staged pid ${leaked_pid:-<none>}: $alive, listed by ps: $listed, HOME entries in its environ: $home_lines"
-	echo "        ps -u $(id -u) listed $(grep -c . <<<"$visible_pids") pids; sandbox HOME was $survivor_dir/*/home"
+	echo "        staged pid ${leaked_pid:-<none>}: $alive, listed by ps: $listed, its ${its_home:-<no HOME in environ>}"
+	echo "        ps -u $(id -u) listed $(grep -c . <<<"$visible_pids") pids; the sandbox is under $survivor_dir"
+	echo "        wrapper stderr: $(tr '\n' '|' <"$survivor_dir/wrapper.err" 2>/dev/null)"
 	FAILURES=$((FAILURES + 1))
 fi
 

--- a/bin/test-state-check.sh
+++ b/bin/test-state-check.sh
@@ -19,6 +19,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$ROOT_DIR" || exit 1
+# shellcheck source=bin/lib/test-state.sh
+source "$SCRIPT_DIR/lib/test-state.sh"
 
 WORK="$(mktemp -d -t meshstatecheck.XXXXXX)"
 trap 'rm -rf "$WORK"' EXIT
@@ -139,6 +141,7 @@ else
 	echo "        staged pid ${leaked_pid:-<none>}: $alive, listed by ps: $listed, its ${its_home:-<no HOME in environ>}"
 	echo "        ps -u $(id -u) listed $(grep -c . <<<"$visible_pids") pids; the sandbox is under $survivor_dir"
 	echo "        wrapper stderr: $(tr '\n' '|' <"$survivor_dir/wrapper.err" 2>/dev/null)"
+	echo "        same scan, run again now: [$(state_find_survivors "${its_home#HOME=}" | tr '\n' ' ')]"
 	FAILURES=$((FAILURES + 1))
 fi
 
@@ -160,8 +163,6 @@ fi
 # it; exercise the assertion the wrapper actually calls instead - same function, same code path.
 echo
 echo "Before-empty assertion (state_assert_empty):"
-# shellcheck source=bin/lib/test-state.sh
-source "$SCRIPT_DIR/lib/test-state.sh"
 
 seeded="$WORK/seeded"
 mkdir -p "$seeded/$PREFS"

--- a/bin/test-state-check.sh
+++ b/bin/test-state-check.sh
@@ -104,11 +104,18 @@ chmod +x "$LEAKY"
 
 survivor_dir="$WORK/state-survivor"
 mkdir -p "$survivor_dir"
+# KEEP_STATE so the sandbox stays whatever the verdict: without it a missed survivor also deletes
+# the pid file staged inside it, and the reap assertion below fails for the wrong reason.
 FIXTURE_SUITE=test_fixture_survivor \
 	MESHTASTIC_TEST_STATE_DIR="$survivor_dir" \
 	MESHTASTIC_TEST_STATE_SUMMARY="$survivor_dir/summary.tsv" \
 	MESHTASTIC_TEST_STATE_MANIFEST="$MANIFEST" \
+	MESHTASTIC_TEST_KEEP_STATE=1 \
 	"$SCRIPT_DIR/pio-test-isolate.sh" "$LEAKY" >/dev/null 2>&1
+
+# Find the pid file by search, not by a glob that assumes a directory depth: the wrapper renames
+# its mktemp'd sandbox to the suite name when it keeps it, so the path is not fixed.
+leaked_pid="$(head -1 "$(find "$survivor_dir" -name survivor.pid -print -quit 2>/dev/null)" 2>/dev/null)"
 
 recorded="$(awk -F'\t' '$1 == "test_fixture_survivor" { print $6; exit }' "$survivor_dir/summary.tsv" 2>/dev/null)"
 if [[ -n ${recorded// /} ]]; then
@@ -116,14 +123,26 @@ if [[ -n ${recorded// /} ]]; then
 	PASSES=$((PASSES + 1))
 else
 	echo "  FAIL  a process outliving the suite went unreported"
+	# Name the cause here rather than spending a CI round-trip on it: whether the fixture's
+	# process exists at all, whether the scan can see it, and what the wrapper recorded instead.
+	visible_pids="$(ps -u "$(id -u)" -o pid= 2>/dev/null | tr -d ' ')"
+	if [[ -z $leaked_pid ]]; then
+		alive="no pid staged"
+		listed="n/a"
+		home_lines="n/a"
+	else
+		kill -0 "$leaked_pid" 2>/dev/null && alive="alive" || alive="gone"
+		grep -Fxq "$leaked_pid" <<<"$visible_pids" && listed="yes" || listed="no"
+		home_lines="$(tr '\0' '\n' <"/proc/$leaked_pid/environ" 2>/dev/null | grep -c '^HOME=')"
+	fi
+	echo "        summary line: $(awk -F'\t' '$1 == "test_fixture_survivor"' "$survivor_dir/summary.tsv" 2>/dev/null | tr '\t' '|')"
+	echo "        staged pid ${leaked_pid:-<none>}: $alive, listed by ps: $listed, HOME entries in its environ: $home_lines"
+	echo "        ps -u $(id -u) listed $(grep -c . <<<"$visible_pids") pids; sandbox HOME was $survivor_dir/*/home"
 	FAILURES=$((FAILURES + 1))
 fi
 
-# Find the pid file by search, not by a glob that assumes a directory depth: the wrapper renames
-# its mktemp'd sandbox to the suite name when it keeps it, so the path is not fixed. Assert the
-# file was found BEFORE asserting the process is gone - otherwise an empty pid takes the "not
-# running" branch and the check passes without having checked anything.
-leaked_pid="$(cat "$(find "$survivor_dir" -name survivor.pid -print -quit 2>/dev/null)" 2>/dev/null | head -1)"
+# Assert the pid file was found BEFORE asserting the process is gone - otherwise an empty pid takes
+# the "not running" branch and the check passes without having checked anything.
 if [[ -z $leaked_pid ]]; then
 	echo "  FAIL  no survivor pid recorded - the reap assertion would pass vacuously"
 	FAILURES=$((FAILURES + 1))


### PR DESCRIPTION
state_find_survivors piped /proc/<pid>/environ through `grep -qxF`, whose early exit SIGPIPEs `tr`; under `set -o pipefail` that turns a detected survivor into no survivor, which is the intermittent 2-of-8 failure in bin/test-state-check.sh. Matching in-shell removes the pipeline, and the self-test now keeps the sandbox and prints what it saw so a miss names its own cause.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved active-process detection during state checks, including more reliable handling of process environment data.
  - Prevented processes that exit during inspection from causing incorrect results.
  - Reduced timing-related false negatives when identifying surviving processes.

- **Tests**
  - Improved survivor-process test reliability by waiting for detached processes to become ready before verification.
  - Added more detailed diagnostics when survivor-process checks fail.
  - Reduced intermittent failures caused by process startup timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->