### PR TITLE
fix(audio): amp settle window, and start melody after codec init

### DIFF
--- a/src/AudioThread.h
+++ b/src/AudioThread.h
@@ -14,8 +14,7 @@
 
 // A board with an I2S amplifier opts in by defining AUDIO_AMP_ENABLE(on) in its variant.h to power the
 // amp on/off around playback (e.g. an enable pin on an I/O expander). The includes below expose the
-// expander instances (io / mcpIoExpander) those macros typically reference. A board whose amp needs time
-// to leave shutdown also defines AUDIO_AMP_SETTLE_MS (see ampEnable below).
+// expander instances (io / mcpIoExpander) those macros typically reference.
 #ifdef USE_XL9555
 #include "ExtensionIOXL9555.hpp"
 extern ExtensionIOXL9555 io;
@@ -90,10 +89,8 @@ class AudioThread : public concurrency::OSThread
     }
 
   private:
-    // Amplifiers such as the NS4150 need time to come out of shutdown before they pass audio, and where
-    // the enable line hangs off an I/O expander the write itself is slow too. Short system tones
-    // (playChirp 20 ms, playBoop 50 ms, playBeep ~62 ms) are otherwise finished before the amp is awake
-    // and are never heard. A variant opts into a settle window by defining AUDIO_AMP_SETTLE_MS.
+    // Amps like the NS4150 need time to leave shutdown, longer when the enable is an I/O expander write.
+    // Without a variant's AUDIO_AMP_SETTLE_MS the short system tones are over before any audio gets out.
     static void ampEnable(bool on)
     {
 #ifdef AUDIO_AMP_ENABLE

--- a/src/AudioThread.h
+++ b/src/AudioThread.h
@@ -14,7 +14,8 @@
 
 // A board with an I2S amplifier opts in by defining AUDIO_AMP_ENABLE(on) in its variant.h to power the
 // amp on/off around playback (e.g. an enable pin on an I/O expander). The includes below expose the
-// expander instances (io / mcpIoExpander) those macros typically reference.
+// expander instances (io / mcpIoExpander) those macros typically reference. A board whose amp needs time
+// to leave shutdown also defines AUDIO_AMP_SETTLE_MS (see ampEnable below).
 #ifdef USE_XL9555
 #include "ExtensionIOXL9555.hpp"
 extern ExtensionIOXL9555 io;
@@ -33,9 +34,7 @@ class AudioThread : public concurrency::OSThread
 
     void beginRttl(const void *data, uint32_t len)
     {
-#ifdef AUDIO_AMP_ENABLE
-        AUDIO_AMP_ENABLE(true);
-#endif
+        ampEnable(true);
         setCPUFast(true);
         rtttlFile = std::unique_ptr<AudioFileSourcePROGMEM>(new AudioFileSourcePROGMEM(data, len));
         i2sRtttl = std::unique_ptr<AudioGeneratorRTTTL>(new AudioGeneratorRTTTL());
@@ -61,9 +60,7 @@ class AudioThread : public concurrency::OSThread
         rtttlFile = nullptr;
 
         setCPUFast(false);
-#ifdef AUDIO_AMP_ENABLE
-        AUDIO_AMP_ENABLE(false);
-#endif
+        ampEnable(false);
     }
 
     void readAloud(const char *text)
@@ -73,16 +70,12 @@ class AudioThread : public concurrency::OSThread
             i2sRtttl = nullptr;
         }
 
-#ifdef AUDIO_AMP_ENABLE
-        AUDIO_AMP_ENABLE(true);
-#endif
+        ampEnable(true);
         auto sam = std::unique_ptr<ESP8266SAM>(new ESP8266SAM);
         sam->Say(audioOut.get(), text);
         setCPUFast(false);
         audioOut->stop();
-#ifdef AUDIO_AMP_ENABLE
-        AUDIO_AMP_ENABLE(false);
-#endif
+        ampEnable(false);
     }
 
   protected:
@@ -97,6 +90,23 @@ class AudioThread : public concurrency::OSThread
     }
 
   private:
+    // Amplifiers such as the NS4150 need time to come out of shutdown before they pass audio, and where
+    // the enable line hangs off an I/O expander the write itself is slow too. Short system tones
+    // (playChirp 20 ms, playBoop 50 ms, playBeep ~62 ms) are otherwise finished before the amp is awake
+    // and are never heard. A variant opts into a settle window by defining AUDIO_AMP_SETTLE_MS.
+    static void ampEnable(bool on)
+    {
+#ifdef AUDIO_AMP_ENABLE
+        AUDIO_AMP_ENABLE(on);
+#ifdef AUDIO_AMP_SETTLE_MS
+        if (on)
+            delay(AUDIO_AMP_SETTLE_MS);
+#endif
+#else
+        (void)on;
+#endif
+    }
+
     void initOutput()
     {
         audioOut = std::unique_ptr<AudioOutputI2S>(new AudioOutputI2S(1, AudioOutputI2S::EXTERNAL_I2S));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1170,10 +1170,8 @@ void setup()
 
     lateInitVariant(); // Do board specific init (see extra_variants/README.md for documentation)
 
-    // Play the start melody here rather than earlier in setup(): boards that drive a speaker over I2S
-    // have no audioThread until it is created above, and their codec is only brought up by
-    // lateInitVariant(), so an earlier call is silently dropped. Skipped for tracker/sensor roles that
-    // are power saving.
+    // Must follow lateInitVariant(): on I2S boards audioThread and the codec are only up by this point.
+    // Skipped for power-saving tracker/sensor roles.
     if (config.power.is_power_saving == true &&
         IS_ONE_OF(config.device.role, meshtastic_Config_DeviceConfig_Role_TRACKER,
                   meshtastic_Config_DeviceConfig_Role_TAK_TRACKER, meshtastic_Config_DeviceConfig_Role_SENSOR))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -882,18 +882,10 @@ void setup()
 
     router = new ReliableRouter();
 
-    // only play start melody when role is not tracker or sensor
-    if (config.power.is_power_saving == true &&
-        IS_ONE_OF(config.device.role, meshtastic_Config_DeviceConfig_Role_TRACKER,
-                  meshtastic_Config_DeviceConfig_Role_TAK_TRACKER, meshtastic_Config_DeviceConfig_Role_SENSOR))
-        LOG_DEBUG("Tracker/Sensor: Skip start melody");
-    else
-        playStartMelody();
-
 #if HAS_SCREEN
-        // fixed screen override?
-        // The geometry picks below are skipped on variants that pin the panel size with
-        // OLED_GEOMETRY_OVERRIDE (see the end of this block) - there they would only be dead stores.
+    // fixed screen override?
+    // The geometry picks below are skipped on variants that pin the panel size with
+    // OLED_GEOMETRY_OVERRIDE (see the end of this block) - there they would only be dead stores.
 #if defined(USE_SH1107)
     screen_model = meshtastic_Config_DisplayConfig_OledType_OLED_SH1107; // set dimension of 128x128
 #ifndef OLED_GEOMETRY_OVERRIDE
@@ -994,7 +986,7 @@ void setup()
     SPI.begin();
 #endif
 #else
-        // ESP32
+    // ESP32
 #if defined(HW_SPI1_DEVICE)
     SPI1.begin(LORA_SCK, LORA_MISO, LORA_MOSI, LORA_CS);
     LOG_DEBUG("SPI1.begin(SCK=%d, MISO=%d, MOSI=%d, NSS=%d)", LORA_SCK, LORA_MISO, LORA_MOSI, LORA_CS);
@@ -1177,6 +1169,17 @@ void setup()
     auto rIf = initLoRa();
 
     lateInitVariant(); // Do board specific init (see extra_variants/README.md for documentation)
+
+    // Play the start melody here rather than earlier in setup(): boards that drive a speaker over I2S
+    // have no audioThread until it is created above, and their codec is only brought up by
+    // lateInitVariant(), so an earlier call is silently dropped. Skipped for tracker/sensor roles that
+    // are power saving.
+    if (config.power.is_power_saving == true &&
+        IS_ONE_OF(config.device.role, meshtastic_Config_DeviceConfig_Role_TRACKER,
+                  meshtastic_Config_DeviceConfig_Role_TAK_TRACKER, meshtastic_Config_DeviceConfig_Role_SENSOR))
+        LOG_DEBUG("Tracker/Sensor: Skip start melody");
+    else
+        playStartMelody();
 
 #if !MESHTASTIC_EXCLUDE_MQTT
     mqttInit();

--- a/variants/esp32s3/meshnology-w10/variant.h
+++ b/variants/esp32s3/meshnology-w10/variant.h
@@ -176,9 +176,8 @@
 #define DAC_I2S_DIN 3  // pg3: record data (ES8311 -> ESP32)
 // AudioThread powers the NS4150 amp on/off around playback via this (opt-in) hook.
 #define AUDIO_AMP_ENABLE(on) mcpIoExpander.digitalWrite(EXIO_PA_CTRL, (on) ? HIGH : LOW)
-// The NS4150 does not pass audio the instant it leaves shutdown, and here the enable is an I2C write to
-// the MCP23017 rather than a GPIO toggle, so it is slower still. Without this settle window the short
-// system tones are over before the amp is awake and nothing is heard.
+// NS4150 wake-up, slower here because the enable is an I2C write to the expander, not a GPIO toggle.
+// Without it the short system tones finish before the amp passes audio.
 #define AUDIO_AMP_SETTLE_MS 250
 
 // ─── On-board peripherals not wired up yet ────────────────────────────────────

--- a/variants/esp32s3/meshnology-w10/variant.h
+++ b/variants/esp32s3/meshnology-w10/variant.h
@@ -176,6 +176,10 @@
 #define DAC_I2S_DIN 3  // pg3: record data (ES8311 -> ESP32)
 // AudioThread powers the NS4150 amp on/off around playback via this (opt-in) hook.
 #define AUDIO_AMP_ENABLE(on) mcpIoExpander.digitalWrite(EXIO_PA_CTRL, (on) ? HIGH : LOW)
+// The NS4150 does not pass audio the instant it leaves shutdown, and here the enable is an I2C write to
+// the MCP23017 rather than a GPIO toggle, so it is slower still. Without this settle window the short
+// system tones are over before the amp is awake and nothing is heard.
+#define AUDIO_AMP_SETTLE_MS 250
 
 // ─── On-board peripherals not wired up yet ────────────────────────────────────
 // SHT41 temp/humidity (0x44) and QMI8658 IMU (0x6B): auto-detected on the I2C scan


### PR DESCRIPTION
Fixes #11597.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio amplifier startup timing for RTTTL melodies and speech output.
  * Ensured the startup melody plays only after audio hardware initialization is ready.
  * Prevented short tones from being cut off when using supported amplifier hardware.
  * Improved audio behavior on devices with configurable amplifier wake-up delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->