### PR TITLE
fix(position): halve the stationary/fixed-position broadcast floor to 6h

### DIFF
--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -21,7 +21,9 @@
 #define default_broadcast_smart_minimum_interval_secs 5 * 60
 // Floor for our own position broadcasts when stationary (unchanged beyond the broadcast
 // precision) or fixed_position: identical positions get deduped by traffic management anyway.
-#define default_position_stationary_broadcast_secs (12 * 60 * 60)
+// Held one hour above default_traffic_mgmt_position_min_interval_secs so this refresh clears
+// the receivers' dedup window instead of being dropped as a duplicate.
+#define default_position_stationary_broadcast_secs (6 * 60 * 60)
 #define min_default_broadcast_interval_secs IF_ROUTER(ONE_DAY / 2, 60 * 60)
 #define min_default_broadcast_smart_minimum_interval_secs 5 * 60
 #define default_wait_bluetooth_secs IF_ROUTER(1, 60)
@@ -39,9 +41,11 @@
 enum class TrafficType { POSITION, TELEMETRY };
 
 // Traffic management defaults
-#define default_traffic_mgmt_position_precision_bits 19                // ~90m grid cells (±45m)
-#define default_traffic_mgmt_position_min_interval_secs (11 * 60 * 60) // 11 hours between identical positions
-// Role cap: tracker-role origins may refresh a duplicate position this often (vs the 11h default).
+#define default_traffic_mgmt_position_precision_bits 19 // ~90m grid cells (±45m)
+// Kept below default_position_stationary_broadcast_secs so a stationary node's periodic refresh
+// is not deduped away by its neighbours.
+#define default_traffic_mgmt_position_min_interval_secs (5 * 60 * 60) // 5 hours between identical positions
+// Role cap: tracker-role origins may refresh a duplicate position this often (vs the 5h default).
 #define default_traffic_mgmt_tracker_position_min_interval_secs (60 * 60) // 1 hour
 // Role cap: lost-and-found origins may refresh a duplicate position this often, so a lost
 // device updates frequently without flooding. (Quantised to the dedup tick: ~2 ticks.)

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1185,7 +1185,7 @@ static void installTrafficManagementDefaults(meshtastic_LocalModuleConfig &mc)
     mc.has_traffic_management = true;
     mc.traffic_management = meshtastic_ModuleConfig_TrafficManagementConfig_init_zero;
 #if HAS_TRAFFIC_MANAGEMENT
-    // Position dedup ships enabled at the 11-hour default window on all supported targets.
+    // Position dedup ships enabled at the 5-hour default window on all supported targets.
     // STM32WL is excluded at compile time (HAS_TRAFFIC_MANAGEMENT=0 in mesh-pb-constants.h).
     // Set position_min_interval_secs=0 at runtime to disable dedup.
     mc.traffic_management.position_min_interval_secs = default_traffic_mgmt_position_min_interval_secs;

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -540,7 +540,7 @@ int32_t PositionModule::runOnce()
 
     bool waitingForFreshPosition = (lastGpsSend == 0) && !config.position.fixed_position && !nodeDB->hasLocalPositionSinceBoot();
 
-    // Hold to the 12h floor when fixed_position (every role: pinning yourself forfeits the
+    // Hold to the 6h floor when fixed_position (every role: pinning yourself forfeits the
     // exception) or when stationary. A real move still goes out early via smart-broadcast below.
     // Not-fixed exceptions: lost-and-found broadcasts freely; trackers judge movement at their
     // own (unclamped) precision rather than the on-wire one (useConfiguredPrecision).

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -1362,7 +1362,7 @@ bool TrafficManagementModule::shouldDropPosition(const meshtastic_MeshPacket *p,
     const int32_t lat_truncated = truncateCoordinate(pos->latitude_i, precision);
     const int32_t lon_truncated = truncateCoordinate(pos->longitude_i, precision);
     const uint8_t fingerprint = computePositionFingerprint(lat_truncated, lon_truncated, precision);
-    // Drop gate uses the RAW configured interval: 0 means "dedup disabled". The 12 h default
+    // Drop gate uses the RAW configured interval: 0 means "dedup disabled". The 5 h default
     // is only for TTL sizing - feeding it here would silently defeat that contract.
     uint32_t minIntervalMs = secsToMs(moduleConfig.traffic_management.position_min_interval_secs);
 

--- a/test/test_traffic_management/test_main.cpp
+++ b/test/test_traffic_management/test_main.cpp
@@ -2806,12 +2806,12 @@ static void test_tm_nextHop_keptAliveAcrossMaintenanceSweep(void)
 
 /**
  * Verify TRACKER role caps the dedup window at 1 hour.
- * A duplicate position that would normally be blocked for 11 h (default) must
+ * A duplicate position that would normally be blocked for 5 h (default) must
  * be forwarded once the 1-hour tracker cap expires.
  */
 static void test_tm_trackerRole_capsDedupWindowAtOneHour(void)
 {
-    // Operator interval is 11 h - longer than the tracker cap.
+    // Operator interval is 5 h - longer than the tracker cap.
     moduleConfig.traffic_management.position_min_interval_secs = default_traffic_mgmt_position_min_interval_secs;
     installWellKnownPrimaryChannelWithPrecision(16);
 
@@ -2872,11 +2872,11 @@ static void test_tm_takTrackerRole_capsDedupWindowAtOneHour(void)
  * hot and warm NodeDB stores - the TMM unified cache is the third fallback. The
  * role is cached on the entry while NodeDB still knows the node; once NodeDB
  * forgets it (getNodeRole → CLIENT), the cached role must keep the 1-hour cap
- * applied instead of reverting to the 11-hour default interval.
+ * applied instead of reverting to the 5-hour default interval.
  */
 static void test_tm_trackerRole_survivesNodeDbEvictionViaCachedRole(void)
 {
-    // Operator interval is 11 h - longer than the tracker cap.
+    // Operator interval is 5 h - longer than the tracker cap.
     moduleConfig.traffic_management.position_min_interval_secs = default_traffic_mgmt_position_min_interval_secs;
     installWellKnownPrimaryChannelWithPrecision(16);
 
@@ -2896,8 +2896,8 @@ static void test_tm_trackerRole_survivesNodeDbEvictionViaCachedRole(void)
     mockNodeDB->clearCachedNode();
 
     ProcessMessage r2 = module.handleReceived(dup); // within 1-hour cap - still drop
-    // Advance past the tracker cap (3600 s) but stay well under the 11-hour default.
-    // Without the cached-role fallback this would still be inside the 11-hour window
+    // Advance past the tracker cap (3600 s) but stay well under the 5-hour default.
+    // Without the cached-role fallback this would still be inside the 5-hour window
     // (CLIENT → no exception) and wrongly drop; with it, the 1-hour cap lets it pass.
     TrafficManagementModule::s_testNowMs += (default_traffic_mgmt_tracker_position_min_interval_secs * 1000UL) + 1;
     ProcessMessage r3 = module.handleReceived(afterCap);
@@ -2935,7 +2935,7 @@ static void test_tm_roleChange_viaNodeInfo_dropsTrackerException(void)
     meshtastic_MeshPacket info = makeNodeInfoPacketWithRole(kRemoteNode, meshtastic_Config_DeviceConfig_Role_CLIENT);
     module.handleReceived(info);
 
-    // Past the 1-hour tracker cap but within the 11-hour CLIENT interval. With the stale
+    // Past the 1-hour tracker cap but within the 5-hour CLIENT interval. With the stale
     // TRACKER role this would pass; after the demotion it must drop (full interval applies).
     TrafficManagementModule::s_testNowMs += (default_traffic_mgmt_tracker_position_min_interval_secs * 1000UL) + 1;
     meshtastic_MeshPacket afterCap = makePositionPacket(kRemoteNode, 374221234, -1220845678);
@@ -3042,12 +3042,12 @@ static void test_tm_trackerRole_doesNotLengthenShorterOperatorInterval(void)
 
 /**
  * Verify LOST_AND_FOUND role caps duplicate-position dedup at ~15 min (2 pos-ticks),
- * not the old one-tick fast-announce. A configured 11-hour interval is shortened to the
+ * not the old one-tick fast-announce. A configured 5-hour interval is shortened to the
  * 15-min cap; a duplicate one tick later still drops, but one past the 2-tick cap passes.
  */
 static void test_tm_lostAndFoundRole_capsDedupAtFifteenMinutes(void)
 {
-    // Long interval that would normally suppress duplicates for 11 h.
+    // Long interval that would normally suppress duplicates for 5 h.
     moduleConfig.traffic_management.position_min_interval_secs = default_traffic_mgmt_position_min_interval_secs;
     installWellKnownPrimaryChannelWithPrecision(16);
 


### PR DESCRIPTION
12 hours was too aggressive.

The stationary/fixed-position broadcast floor added in #10706 means a `fixed_position` node (or any node that hasn't moved beyond the broadcast precision) sends once at boot and then goes silent for half a day. Anything that missed that one packet — a node that joined the mesh later, or one that rebooted — shows it with no position until the next refresh. Two reports of exactly that shape: #11198 and #11547.

## Changes

| Constant | Before | After |
| --- | --- | --- |
| `default_position_stationary_broadcast_secs` | 12 h | **6 h** |
| `default_traffic_mgmt_position_min_interval_secs` | 11 h | **5 h** |

The two move together on purpose. The dedup window was sized just under the broadcast floor so a stationary node's periodic refresh clears its neighbours' window instead of being dropped as a duplicate. Halving only the floor would have left every second broadcast landing inside an 11 h dedup window — aired on the channel, then dropped by every receiver in `shouldDropPosition()` before it reached NodeDB or the phone. Same effective refresh rate as today, double the airtime. So the dedup window comes down with it and keeps the same 1 h margin.

Role caps are untouched and still bind, since both are shorter than the new 5 h default:

- `TRACKER` / `TAK_TRACKER` — 1 h
- `LOST_AND_FOUND` — 15 min

Cache sizing stays comfortably inside its bounds at the new value: the dedup window is 50 pos-ticks (6 min/tick, `uint8` period 25.6 h) and the entry TTL is 200 ticks ≈ 20 h.

## Not changed

- Configured `position_broadcast_secs` — the floor still only raises intervals shorter than itself, and a configured interval already longer than 6 h still wins.
- Smart broadcast — a real move still goes out early, unchanged.
- The 12 hr / 6 hr presets in the on-device menus. Those are user-selectable values for the configured interval, not this floor.

## Testing

`test_traffic_management` and `test_position_module` both green — 101 test cases. The dedup tests reference the default symbolically, so they follow the new value; comments citing "11 h" updated to match.

Refs #11198, #11547



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reduced the default stationary position broadcast interval from 12 hours to 6 hours.
  * Reduced the default position deduplication interval from 11 hours to 5 hours.
  * Updated tracker and lost-device handling to reflect the revised timing defaults while preserving their shorter interval caps.
* **Tests**
  * Updated traffic-management tests to verify the new 5-hour baseline and existing role-specific limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->