### PR TITLE
Revert "feat: Skip Bluetooth wait when Bluetooth is disabled"

### DIFF
--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -58,23 +58,6 @@ static bool isPowered()
     return !isPowerSavingMode && powerStatus && (!powerStatus->getHasBattery() || powerStatus->getHasUSB());
 }
 
-static bool isBluetoothEnabledForPowerFSM()
-{
-#if HAS_BLUETOOTH && !MESHTASTIC_EXCLUDE_BLUETOOTH
-    return config.bluetooth.enabled;
-#else
-    return false;
-#endif
-}
-
-static uint32_t getBluetoothWaitMs()
-{
-    if (!isBluetoothEnabledForPowerFSM())
-        return 0;
-
-    return Default::getConfiguredOrDefaultMs(config.power.wait_bluetooth_secs, default_wait_bluetooth_secs);
-}
-
 #if defined(T5_S3_EPAPER_PRO)
 static void t5BacklightOffForSleep()
 {
@@ -446,7 +429,10 @@ void PowerFSM_setup()
 
         // If ESP32 and using power-saving, timer mover from DARK to light-sleep
         // Also serves purpose of the old DARK to DARK transition(?) See https://github.com/meshtastic/firmware/issues/3517
-        powerFSM.add_timed_transition(&stateDARK, &stateLS, getBluetoothWaitMs(), NULL, "Bluetooth timeout");
+        powerFSM.add_timed_transition(
+            &stateDARK, &stateLS,
+            Default::getConfiguredOrDefaultMs(config.power.wait_bluetooth_secs, default_wait_bluetooth_secs), NULL,
+            "Bluetooth timeout");
     } else {
         // If ESP32, but not using power-saving, check periodically if config has drifted out of stateDark
         powerFSM.add_timed_transition(&stateDARK, &stateDARK,


### PR DESCRIPTION
Reverts meshtastic/firmware#10571

This is breaking audio and other things on MUI. We need to figure out a better long term solution but for now, the FSM change causes regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the DARK-to-low-power transition timeout to consistently use the configured Bluetooth wait duration.
  * Improved low-power transition behavior when Bluetooth is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->