### PR TITLE
fix(input): give the T-Echo touch pad a back action on tap

### DIFF
--- a/src/input/InputBroker.cpp
+++ b/src/input/InputBroker.cpp
@@ -248,7 +248,8 @@ void InputBroker::Init()
     touchConfig.singlePress = INPUT_BROKER_NONE;
     touchConfig.longPress = INPUT_BROKER_BACK;
 #if HAS_BACKLIGHT
-    // Touch pad drives the backlight on devices that have one
+    // Holding the pad lights the backlight on devices that have one, so back moves to a tap
+    touchConfig.singlePress = INPUT_BROKER_BACK;
     touchConfig.longPress = INPUT_BROKER_NONE;
 #endif
 #if HAS_BACKLIGHT || defined(HAPTIC_FEEDBACK_PIN)


### PR DESCRIPTION
Fixes #11610

The capacitive pad on the T-Echo does nothing under BaseUI. Two separate causes:

**Backlight** — already fixed by #11588, which landed after 2.8.0. `InputBroker` was reading the stored `screen_brightness` level as "currently lit", and the 153 default meant press-and-hold never drove the rail. `graphics::backlightIsLit()` now reports the driven state, so holding the pad lights the frontlight again. Nothing to do here.

**Back** — this PR. `touchConfig.singlePress` was `INPUT_BROKER_NONE`, and `longPress` was cleared to `INPUT_BROKER_NONE` on any board with a backlight to keep a hold from also navigating. That left the pad emitting no input event at all. The T-Echo's user button is press-to-page-forward and hold-to-select, so nothing on the device produced `INPUT_BROKER_BACK`.

A tap now emits `INPUT_BROKER_BACK`: pages back on the home frameset, and cancels out of menus, freetext and the games module. Press-and-hold is unchanged — OneButton fires `attachClick` only when the press stays under `longPressTime`, so lighting the screen does not also navigate. A tap while the screen is off still just wakes it; `InputBroker::handleInputEvent` drops the event when the screen was off.

Scope: the two boards with both a touch pad and a backlight, T-Echo and T-Echo Plus, share this path and stay identical to each other. T-Impulse Plus has a touch pad and no backlight, so it keeps back on hold and is unchanged.

Compile-checked `t-echo` (SUCCESS, 2:48). Not yet bench-tested on hardware — I don't have a T-Echo on this machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated touch-button behavior for backlit configurations: tapping now triggers the Back action, while holding no longer triggers an unintended Back event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->