### PR TITLE
fix(traffic): don't re-stamp dropped duplicate positions, which slid the dedup window indefinitely

### DIFF
--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -1406,12 +1406,17 @@ bool TrafficManagementModule::shouldDropPosition(const meshtastic_MeshPacket *p,
     TM_LOG_TRACE("Position dedup 0x%08x: fp=0x%02x prev=0x%02x same=%d within=%d new=%d", p->from, fingerprint,
                  entry->pos_fingerprint, samePosition, withinInterval, isNew);
 
-    // Update cache entry (raw tick; 0 is a valid tick value)
-    entry->pos_fingerprint = fingerprint;
-    entry->pos_time = nowPosTick;
-
     // Drop only if same position AND within the minimum interval
-    return samePosition && withinInterval;
+    const bool drop = samePosition && withinInterval;
+
+    // Stamp only what we let through: re-stamping a dropped duplicate slides the window forward on
+    // every repeat, muting a node that broadcasts faster than the window instead of refreshing it.
+    if (!drop) {
+        entry->pos_fingerprint = fingerprint;
+        entry->pos_time = nowPosTick;
+    }
+
+    return drop;
 #endif
 }
 

--- a/test/test_traffic_management/test_main.cpp
+++ b/test/test_traffic_management/test_main.cpp
@@ -2383,29 +2383,31 @@ static void test_tm_positionDedup_allowsDuplicateAfterIntervalExpires(void)
 }
 
 /**
- * Verify a continuous stream of duplicates still refreshes once per window.
- * Important because a dropped duplicate must not re-stamp the entry: re-stamping slides the
- * window forward on every repeat, so a stationary node broadcasting faster than the window is
- * muted forever instead of getting through once per interval.
+ * Verify a dropped duplicate does not re-stamp the entry: re-stamping slides the window forward on
+ * every repeat, muting a node that broadcasts faster than the window instead of refreshing it.
  */
 static void test_tm_positionDedup_continuousDuplicatesStillRefresh(void)
 {
-    // 720 s = 2 pos-ticks (kPosTimeTickMs = 360 s), fed a duplicate every tick.
-    moduleConfig.traffic_management.position_min_interval_secs = 720;
+    constexpr uint32_t kPosTickMs = 360000; // mirrors the module's private kPosTimeTickMs
+    constexpr uint32_t kWindowTicks = 2;
+    constexpr uint32_t kTicksFed = kWindowTicks * 3; // a duplicate every tick, over whole windows
+    constexpr uint32_t kExpectedPasses = kTicksFed / kWindowTicks;
+    constexpr uint32_t kExpectedDrops = kTicksFed - kExpectedPasses;
+
+    moduleConfig.traffic_management.position_min_interval_secs = (kWindowTicks * kPosTickMs) / 1000;
     installWellKnownPrimaryChannelWithPrecision(16);
     TrafficManagementModuleTestShim module;
 
-    int passed = 0;
-    for (int tick = 0; tick < 6; tick++) {
+    uint32_t passed = 0;
+    for (uint32_t tick = 0; tick < kTicksFed; tick++) {
         meshtastic_MeshPacket dup = makePositionPacket(kRemoteNode, 374221234, -1220845678);
         if (module.handleReceived(dup) == ProcessMessage::CONTINUE)
             passed++;
-        TrafficManagementModule::s_testNowMs += 360000; // one pos-tick
+        TrafficManagementModule::s_testNowMs += kPosTickMs;
     }
 
-    // Ticks 0, 2 and 4 clear the 2-tick window; 1, 3 and 5 are duplicates inside it.
-    TEST_ASSERT_EQUAL_INT(3, passed);
-    TEST_ASSERT_EQUAL_UINT32(3, module.getStats().position_dedup_drops);
+    TEST_ASSERT_EQUAL_UINT32(kExpectedPasses, passed);
+    TEST_ASSERT_EQUAL_UINT32(kExpectedDrops, module.getStats().position_dedup_drops);
 }
 
 /**

--- a/test/test_traffic_management/test_main.cpp
+++ b/test/test_traffic_management/test_main.cpp
@@ -2383,6 +2383,32 @@ static void test_tm_positionDedup_allowsDuplicateAfterIntervalExpires(void)
 }
 
 /**
+ * Verify a continuous stream of duplicates still refreshes once per window.
+ * Important because a dropped duplicate must not re-stamp the entry: re-stamping slides the
+ * window forward on every repeat, so a stationary node broadcasting faster than the window is
+ * muted forever instead of getting through once per interval.
+ */
+static void test_tm_positionDedup_continuousDuplicatesStillRefresh(void)
+{
+    // 720 s = 2 pos-ticks (kPosTimeTickMs = 360 s), fed a duplicate every tick.
+    moduleConfig.traffic_management.position_min_interval_secs = 720;
+    installWellKnownPrimaryChannelWithPrecision(16);
+    TrafficManagementModuleTestShim module;
+
+    int passed = 0;
+    for (int tick = 0; tick < 6; tick++) {
+        meshtastic_MeshPacket dup = makePositionPacket(kRemoteNode, 374221234, -1220845678);
+        if (module.handleReceived(dup) == ProcessMessage::CONTINUE)
+            passed++;
+        TrafficManagementModule::s_testNowMs += 360000; // one pos-tick
+    }
+
+    // Ticks 0, 2 and 4 clear the 2-tick window; 1, 3 and 5 are duplicates inside it.
+    TEST_ASSERT_EQUAL_INT(3, passed);
+    TEST_ASSERT_EQUAL_UINT32(3, module.getStats().position_dedup_drops);
+}
+
+/**
  * Verify interval=0 disables position deduplication.
  * Important because this is an explicit configuration escape hatch.
  */
@@ -3357,6 +3383,7 @@ TM_TEST_ENTRY void setup()
     RUN_TEST(test_tm_alterReceived_telemetryBroadcast_hopLimitUnchanged);
     RUN_TEST(test_tm_alterReceived_skipsLocalAndUnicast);
     RUN_TEST(test_tm_positionDedup_allowsDuplicateAfterIntervalExpires);
+    RUN_TEST(test_tm_positionDedup_continuousDuplicatesStillRefresh);
     RUN_TEST(test_tm_positionDedup_intervalZero_neverDrops);
     RUN_TEST(test_tm_positionDedup_precisionAbove32_usesDefaultPrecision);
     RUN_TEST(test_tm_positionDedup_distinctAtClampedChannelPrecision);


### PR DESCRIPTION
shouldDropPosition() stamped pos_time on packets it dropped, sliding the dedup window forward on every repeat, so a stationary node broadcasting faster than the window was muted indefinitely instead of refreshing once per interval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate position broadcasts.
  * Repeated duplicate packets are now dropped without unnecessarily extending the deduplication window.
  * Valid position updates continue to be accepted at the expected interval.

* **Tests**
  * Added regression coverage for continuous duplicate position broadcasts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->