### PR TITLE
ci: resolve the PR diff base without a shallow refetch

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -73,8 +73,11 @@ jobs:
           # first env of each ADDED variant config. A new env in an existing one does not count.
           DIFF_BASE=""
           if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-            git fetch --no-tags --depth=1 origin "$BASE_REF"
-            DIFF_BASE=$(git merge-base FETCH_HEAD HEAD)
+            # checkout above already fetched every branch (fetch-depth: 0), so the base ref
+            # is local. Do not re-fetch it with --depth=1: that grafts the fetched tip as
+            # parentless, and merge-base then finds no common commit whenever the base
+            # branch has moved past this merge commit, which is every re-run of an older run.
+            DIFF_BASE=$(git merge-base "origin/$BASE_REF" HEAD)
           elif [[ "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
             DIFF_BASE="$MERGE_GROUP_BASE_SHA"
           fi


### PR DESCRIPTION
The `setup` job's `Generate matrix` step fails with a bare `Process completed with exit code 1` and no error text. Most recently on [run 33013940009](https://github.com/meshtastic/firmware/actions/runs/33013940009/job/98456661215) (#11622, attempt 2).

## Cause

`actions/checkout@v7` runs with `fetch-depth: 0`, so the clone is complete and `origin/<base>` is already present. The step then refetched the base branch:

```bash
git fetch --no-tags --depth=1 origin "$BASE_REF"
DIFF_BASE=$(git merge-base FETCH_HEAD HEAD)
```

A depth-limited fetch into a complete repository writes `.git/shallow` and grafts the fetched tip as parentless. `merge-base` has to walk `FETCH_HEAD`'s ancestry, the graft stops it at the first commit, and if the base tip is not itself reachable from `HEAD` there is no common commit: exit 1, no output. Under `bash -e` the assignment inherits that status and kills the step.

The base tip stops being reachable as soon as the base branch moves past the pull request merge commit, which is the normal state for a re-run of an older run or a run held behind an approval gate. On a fresh run the base tip usually is the merge commit's first parent, so `merge-base` resolves it without walking and the bug stays hidden.

In run 33013940009, `HEAD` is `refs/pull/11622/merge` = `7416a71d5`, merging into `576a1bb00` (Aug 26 20:00Z). The re-run executed Aug 27 08:28Z, by which point `develop` was at `9461670f4`, four commits ahead.

## Fix

Drop the refetch and use the ref the checkout already has.

## Testing

Reproduced and verified in a scratch repository: full clone, base branch advanced past the merge commit.

- Before the depth-1 fetch, `merge-base` returns the base commit.
- After it, `.git/shallow` holds the fetched tip and `merge-base` prints nothing and exits 1.
- With this change, `merge-base "origin/$BASE_REF" HEAD` returns exactly `HEAD^1`, the merge commit's base parent.

YAML parses and the step body passes `bash -n`. `trunk fmt` reports no issues.

Introduced in #11549.

## Attestations

- [x] I have tested that my proposed changes behave as described.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request change detection by calculating comparisons against the correct shared base commit.
  * Reduced potential issues caused by shallow repository fetches during automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->