### PR TITLE
Extend userPrefs coverage to the whole channel table and the missing config fields

### DIFF
--- a/.github/workflows/test_native.yml
+++ b/.github/workflows/test_native.yml
@@ -461,6 +461,17 @@ jobs:
           ./bin/check-test-attribution.py --label coverage-event-policy \
             --expect "$expect" event-policy-testreport.xml
 
+      - name: Channel table userPrefs tests
+        run: platformio test -e coverage-channel-table -v --junit-output-path channel-table-testreport.xml
+
+      - name: Verify the channel-table suite ran its own tests
+        run: |
+          set -euo pipefail
+          expect=$(python3 -c "from platformio.project.config import ProjectConfig; \
+            print(' '.join(ProjectConfig().get('env:coverage-channel-table', 'test_filter', [])))")
+          ./bin/check-test-attribution.py --label coverage-channel-table \
+            --expect "$expect" channel-table-testreport.xml
+
       - name: Save test results
         if: always() # run this step even if previous step failed
         uses: actions/upload-artifact@v7

--- a/bin/platformio-custom.py
+++ b/bin/platformio-custom.py
@@ -310,7 +310,8 @@ CHANNEL_FIELD_DEFAULTS = {
     "UPLINK_ENABLED": "false",
     "DOWNLINK_ENABLED": "false",
 }
-channelsToWrite = int(userPrefs.get("USERPREFS_CHANNELS_TO_WRITE", "1"))
+channelsToWriteRaw = userPrefs.get("USERPREFS_CHANNELS_TO_WRITE", "1")
+channelsToWrite = int(channelsToWriteRaw, 16 if channelsToWriteRaw.lower().startswith("0x") else 10)
 if channelsToWrite > MAX_NUM_CHANNELS:
     sys.exit(
         f"userPrefs.jsonc: USERPREFS_CHANNELS_TO_WRITE is {channelsToWrite}, "

--- a/bin/platformio-custom.py
+++ b/bin/platformio-custom.py
@@ -299,12 +299,37 @@ with open(jsonLoc) as f:
     jsonStr = re.sub("//.*","", f.read(), flags=re.MULTILINE)
     userPrefs = json.loads(jsonStr)
 
+# Channels::initDefaultChannel() applies a configured index as a whole, so resolve per-field
+# optionality here: any field the vendor left out gets the value that function would have kept.
+MAX_NUM_CHANNELS = 8
+CHANNEL_FIELD_DEFAULTS = {
+    "PSK": "{ 0x01 }",  # short-form index into the well-known default PSK
+    "NAME": "",
+    "PRECISION": "0",
+    "IS_MUTED": "false",
+    "UPLINK_ENABLED": "false",
+    "DOWNLINK_ENABLED": "false",
+}
+channelsToWrite = int(userPrefs.get("USERPREFS_CHANNELS_TO_WRITE", "1"))
+if channelsToWrite > MAX_NUM_CHANNELS:
+    sys.exit(
+        f"userPrefs.jsonc: USERPREFS_CHANNELS_TO_WRITE is {channelsToWrite}, "
+        f"the channel table holds {MAX_NUM_CHANNELS}"
+    )
+for i in range(MAX_NUM_CHANNELS):
+    prefix = f"USERPREFS_CHANNEL_{i}_"
+    if any(k.startswith(prefix) for k in list(userPrefs)):
+        for field, default in CHANNEL_FIELD_DEFAULTS.items():
+            userPrefs.setdefault(prefix + field, default)
+
 pref_flags = []
 # Pre-process the userPrefs
 for pref in userPrefs:
     if userPrefs[pref].startswith("{"):
         pref_flags.append("-D" + pref + "=" + userPrefs[pref])
     elif userPrefs[pref].lstrip("-").replace(".", "").isdigit():
+        pref_flags.append("-D" + pref + "=" + userPrefs[pref])
+    elif re.fullmatch(r"0[xX][0-9a-fA-F]+", userPrefs[pref]):
         pref_flags.append("-D" + pref + "=" + userPrefs[pref])
     elif userPrefs[pref] == "true" or userPrefs[pref] == "false":
         pref_flags.append("-D" + pref + "=" + userPrefs[pref])

--- a/src/mesh/Channels.cpp
+++ b/src/mesh/Channels.cpp
@@ -173,6 +173,8 @@ void Channels::initDefaultChannel(ChannelIndex chIndex)
 #define USERPREFS_APPLY_CHANNEL(n)                                                                                               \
     do {                                                                                                                         \
         static const uint8_t userprefsPsk[] = USERPREFS_CHANNEL_##n##_PSK;                                                       \
+        static_assert(sizeof(userprefsPsk) <= sizeof(channelSettings.psk.bytes),                                                 \
+                      "USERPREFS_CHANNEL_" #n "_PSK is wider than psk.bytes");                                                   \
         memcpy(channelSettings.psk.bytes, userprefsPsk, sizeof(userprefsPsk));                                                   \
         channelSettings.psk.size = sizeof(userprefsPsk);                                                                         \
         strncpy(channelSettings.name, (const char *)USERPREFS_CHANNEL_##n##_NAME, sizeof(channelSettings.name) - 1);             \

--- a/src/mesh/Channels.cpp
+++ b/src/mesh/Channels.cpp
@@ -166,67 +166,68 @@ void Channels::initDefaultChannel(ChannelIndex chIndex)
     ch.has_settings = true;
     ch.role = chIndex == 0 ? meshtastic_Channel_Role_PRIMARY : meshtastic_Channel_Role_SECONDARY;
 
+    static_assert(MAX_NUM_CHANNELS == 8, "the userPrefs switch below covers indices 0-7");
+
+// bin/platformio-custom.py completes every field of an index the vendor configured, so no field is
+// individually optional here and a new index costs one case rather than eighteen lines.
+#define USERPREFS_APPLY_CHANNEL(n)                                                                                               \
+    do {                                                                                                                         \
+        static const uint8_t userprefsPsk[] = USERPREFS_CHANNEL_##n##_PSK;                                                       \
+        memcpy(channelSettings.psk.bytes, userprefsPsk, sizeof(userprefsPsk));                                                   \
+        channelSettings.psk.size = sizeof(userprefsPsk);                                                                         \
+        strncpy(channelSettings.name, (const char *)USERPREFS_CHANNEL_##n##_NAME, sizeof(channelSettings.name) - 1);             \
+        channelSettings.module_settings.position_precision = USERPREFS_CHANNEL_##n##_PRECISION;                                  \
+        channelSettings.module_settings.is_muted = USERPREFS_CHANNEL_##n##_IS_MUTED;                                             \
+        channelSettings.uplink_enabled = USERPREFS_CHANNEL_##n##_UPLINK_ENABLED;                                                 \
+        channelSettings.downlink_enabled = USERPREFS_CHANNEL_##n##_DOWNLINK_ENABLED;                                             \
+    } while (0)
+
     switch (chIndex) {
-    case 0:
 #ifdef USERPREFS_CHANNEL_0_PSK
-        static const uint8_t defaultpsk0[] = USERPREFS_CHANNEL_0_PSK;
-        memcpy(channelSettings.psk.bytes, defaultpsk0, sizeof(defaultpsk0));
-        channelSettings.psk.size = sizeof(defaultpsk0);
-#endif
-#ifdef USERPREFS_CHANNEL_0_NAME
-        strcpy(channelSettings.name, (const char *)USERPREFS_CHANNEL_0_NAME);
-#endif
-#ifdef USERPREFS_CHANNEL_0_PRECISION
-        channelSettings.module_settings.position_precision = USERPREFS_CHANNEL_0_PRECISION;
-#endif
-#ifdef USERPREFS_CHANNEL_0_UPLINK_ENABLED
-        channelSettings.uplink_enabled = USERPREFS_CHANNEL_0_UPLINK_ENABLED;
-#endif
-#ifdef USERPREFS_CHANNEL_0_DOWNLINK_ENABLED
-        channelSettings.downlink_enabled = USERPREFS_CHANNEL_0_DOWNLINK_ENABLED;
-#endif
+    case 0:
+        USERPREFS_APPLY_CHANNEL(0);
         break;
-    case 1:
+#endif
 #ifdef USERPREFS_CHANNEL_1_PSK
-        static const uint8_t defaultpsk1[] = USERPREFS_CHANNEL_1_PSK;
-        memcpy(channelSettings.psk.bytes, defaultpsk1, sizeof(defaultpsk1));
-        channelSettings.psk.size = sizeof(defaultpsk1);
-#endif
-#ifdef USERPREFS_CHANNEL_1_NAME
-        strcpy(channelSettings.name, (const char *)USERPREFS_CHANNEL_1_NAME);
-#endif
-#ifdef USERPREFS_CHANNEL_1_PRECISION
-        channelSettings.module_settings.position_precision = USERPREFS_CHANNEL_1_PRECISION;
-#endif
-#ifdef USERPREFS_CHANNEL_1_UPLINK_ENABLED
-        channelSettings.uplink_enabled = USERPREFS_CHANNEL_1_UPLINK_ENABLED;
-#endif
-#ifdef USERPREFS_CHANNEL_1_DOWNLINK_ENABLED
-        channelSettings.downlink_enabled = USERPREFS_CHANNEL_1_DOWNLINK_ENABLED;
-#endif
+    case 1:
+        USERPREFS_APPLY_CHANNEL(1);
         break;
-    case 2:
+#endif
 #ifdef USERPREFS_CHANNEL_2_PSK
-        static const uint8_t defaultpsk2[] = USERPREFS_CHANNEL_2_PSK;
-        memcpy(channelSettings.psk.bytes, defaultpsk2, sizeof(defaultpsk2));
-        channelSettings.psk.size = sizeof(defaultpsk2);
-#endif
-#ifdef USERPREFS_CHANNEL_2_NAME
-        strcpy(channelSettings.name, (const char *)USERPREFS_CHANNEL_2_NAME);
-#endif
-#ifdef USERPREFS_CHANNEL_2_PRECISION
-        channelSettings.module_settings.position_precision = USERPREFS_CHANNEL_2_PRECISION;
-#endif
-#ifdef USERPREFS_CHANNEL_2_UPLINK_ENABLED
-        channelSettings.uplink_enabled = USERPREFS_CHANNEL_2_UPLINK_ENABLED;
-#endif
-#ifdef USERPREFS_CHANNEL_2_DOWNLINK_ENABLED
-        channelSettings.downlink_enabled = USERPREFS_CHANNEL_2_DOWNLINK_ENABLED;
-#endif
+    case 2:
+        USERPREFS_APPLY_CHANNEL(2);
         break;
+#endif
+#ifdef USERPREFS_CHANNEL_3_PSK
+    case 3:
+        USERPREFS_APPLY_CHANNEL(3);
+        break;
+#endif
+#ifdef USERPREFS_CHANNEL_4_PSK
+    case 4:
+        USERPREFS_APPLY_CHANNEL(4);
+        break;
+#endif
+#ifdef USERPREFS_CHANNEL_5_PSK
+    case 5:
+        USERPREFS_APPLY_CHANNEL(5);
+        break;
+#endif
+#ifdef USERPREFS_CHANNEL_6_PSK
+    case 6:
+        USERPREFS_APPLY_CHANNEL(6);
+        break;
+#endif
+#ifdef USERPREFS_CHANNEL_7_PSK
+    case 7:
+        USERPREFS_APPLY_CHANNEL(7);
+        break;
+#endif
     default:
         break;
     }
+
+#undef USERPREFS_APPLY_CHANNEL
 }
 
 CryptoKey Channels::getKey(ChannelIndex chIndex)

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1010,6 +1010,9 @@ void NodeDB::installDefaultConfig(bool preserveKey = false)
 #else
     config.lora.ignore_mqtt = false;
 #endif
+#ifdef USERPREFS_CONFIG_LORA_CONFIG_OK_TO_MQTT
+    config.lora.config_ok_to_mqtt = USERPREFS_CONFIG_LORA_CONFIG_OK_TO_MQTT;
+#endif
 
     // Initialize admin_key_count to zero
     byte numAdminKeys = 0;
@@ -1042,6 +1045,16 @@ void NodeDB::installDefaultConfig(bool preserveKey = false)
 #endif
 
     config.security.admin_key_count = numAdminKeys;
+
+#ifdef USERPREFS_CONFIG_SECURITY_IS_MANAGED
+    // is_managed is the supported way for a vendor to lock configuration, but without an admin key
+    // it locks the vendor out too and only a factory reset recovers it.
+    if (USERPREFS_CONFIG_SECURITY_IS_MANAGED && numAdminKeys == 0) {
+        LOG_WARN("USERPREFS is_managed needs an admin key, ignored");
+    } else {
+        config.security.is_managed = USERPREFS_CONFIG_SECURITY_IS_MANAGED;
+    }
+#endif
 
     // Left at COMPATIBLE when signature checking is compiled out, so we never report a policy
     // nothing enforces (mirrors the set-config guard in AdminModule).
@@ -1202,6 +1215,23 @@ void NodeDB::installDefaultConfig(bool preserveKey = false)
 #ifdef USERPREFS_CONFIG_DEVICE_ROLE
     // Apply role-specific defaults when role is set via user preferences
     installRoleDefaults(config.device.role);
+#endif
+
+#ifdef USERPREFS_CONFIG_DEVICE_REBROADCAST_MODE
+    config.device.rebroadcast_mode = USERPREFS_CONFIG_DEVICE_REBROADCAST_MODE;
+    // Same restriction AdminModule enforces on a set-config; apply it here so a vendor build can't
+    // ship a combination the device would silently refuse later.
+    if (config.device.rebroadcast_mode == meshtastic_Config_DeviceConfig_RebroadcastMode_NONE &&
+        IS_ONE_OF(config.device.role, meshtastic_Config_DeviceConfig_Role_ROUTER,
+                  meshtastic_Config_DeviceConfig_Role_ROUTER_LATE)) {
+        LOG_WARN("Rebroadcast mode can't be NONE for a router role, use ALL");
+        config.device.rebroadcast_mode = meshtastic_Config_DeviceConfig_RebroadcastMode_ALL;
+    }
+#endif
+#ifdef USERPREFS_CONFIG_DEVICE_NODE_INFO_BROADCAST_SECS
+    // Clamped to the same window AdminModule enforces on a set-config
+    config.device.node_info_broadcast_secs = clamp((uint32_t)USERPREFS_CONFIG_DEVICE_NODE_INFO_BROADCAST_SECS,
+                                                   (uint32_t)min_node_info_broadcast_secs, (uint32_t)MAX_INTERVAL);
 #endif
 
     initConfigIntervals();

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -2311,7 +2311,8 @@ bool CannedMessageModule::saveProtoForModule()
 void CannedMessageModule::installDefaultCannedMessageModuleConfig()
 {
 #ifdef USERPREFS_CANNED_MESSAGES
-    strncpy(cannedMessageModuleConfig.messages, USERPREFS_CANNED_MESSAGES, sizeof(cannedMessageModuleConfig.messages) - 1);
+    strncpy(cannedMessageModuleConfig.messages, USERPREFS_CANNED_MESSAGES, sizeof(cannedMessageModuleConfig.messages));
+    cannedMessageModuleConfig.messages[sizeof(cannedMessageModuleConfig.messages) - 1] = '\0';
 #else
     strncpy(cannedMessageModuleConfig.messages, "Hi|Bye|Yes|No|Ok", sizeof(cannedMessageModuleConfig.messages));
 #endif

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -2310,7 +2310,11 @@ bool CannedMessageModule::saveProtoForModule()
  */
 void CannedMessageModule::installDefaultCannedMessageModuleConfig()
 {
+#ifdef USERPREFS_CANNED_MESSAGES
+    strncpy(cannedMessageModuleConfig.messages, USERPREFS_CANNED_MESSAGES, sizeof(cannedMessageModuleConfig.messages) - 1);
+#else
     strncpy(cannedMessageModuleConfig.messages, "Hi|Bye|Yes|No|Ok", sizeof(cannedMessageModuleConfig.messages));
+#endif
 }
 
 /**

--- a/test/support/userprefs_event_channel.h
+++ b/test/support/userprefs_event_channel.h
@@ -1,0 +1,14 @@
+// Channel 0 as [env:coverage-event-policy] configures it. initDefaultChannel() applies a configured
+// index as a whole, so a build setting the macros by hand supplies every field, as the generator does.
+
+#pragma once
+
+#define USERPREFS_CHANNEL_0_PSK                                                                                                  \
+    {                                                                                                                            \
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f                           \
+    }
+#define USERPREFS_CHANNEL_0_NAME ""
+#define USERPREFS_CHANNEL_0_PRECISION 0
+#define USERPREFS_CHANNEL_0_IS_MUTED false
+#define USERPREFS_CHANNEL_0_UPLINK_ENABLED false
+#define USERPREFS_CHANNEL_0_DOWNLINK_ENABLED false

--- a/test/test_userprefs_channels/test_main.cpp
+++ b/test/test_userprefs_channels/test_main.cpp
@@ -1,0 +1,179 @@
+// Channels::initDefaults() must populate every index named by USERPREFS_CHANNELS_TO_WRITE, and an
+// index configured in part must keep the firmware's own value for every field left out.
+//
+// Under coverage-channel-table / native-windows-channel-table userprefs_fixture.h is -include'd and
+// the configured cases run; under any other env the suite asserts the stock defaults instead.
+
+#include "Channels.h"
+#include "MeshTypes.h" // Include BEFORE TestUtil.h (provides NodeNum, isBroadcast, etc.)
+#include "NodeDB.h"    // channelFile
+#include "TestUtil.h"
+#include "mesh-pb-constants.h"
+#include <cstdio>
+#include <cstring>
+#include <unity.h>
+
+#if defined(ARCH_PORTDUINO)
+#define UPC_TEST_ENTRY extern "C"
+#else
+#define UPC_TEST_ENTRY
+#endif
+
+// The well-known default PSK in its 1-byte short form, i.e. what initDefaultChannel() leaves on an
+// index no userPref touched.
+static const uint8_t kDefaultPskShortForm = 0x01;
+
+void setUp(void)
+{
+    memset(&channelFile, 0, sizeof(channelFile));
+    channels.initDefaults();
+}
+
+void tearDown(void) {}
+
+static void expectShortFormDefaultPsk(const meshtastic_ChannelSettings &s)
+{
+    TEST_ASSERT_EQUAL_UINT(1, s.psk.size);
+    TEST_ASSERT_EQUAL_UINT8(kDefaultPskShortForm, s.psk.bytes[0]);
+}
+
+// An index initDefaultChannel() wrote but no userPref configured: default PSK, empty name, position
+// sharing off, nothing muted, no MQTT.
+static void expectStockChannel(uint8_t idx)
+{
+    const meshtastic_Channel &ch = channels.getByIndex(idx);
+    TEST_ASSERT_TRUE(ch.has_settings);
+    TEST_ASSERT_TRUE(ch.settings.has_module_settings);
+    expectShortFormDefaultPsk(ch.settings);
+    TEST_ASSERT_EQUAL_STRING("", ch.settings.name);
+    TEST_ASSERT_EQUAL_UINT(0, ch.settings.module_settings.position_precision);
+    TEST_ASSERT_FALSE(ch.settings.module_settings.is_muted);
+    TEST_ASSERT_FALSE(ch.settings.uplink_enabled);
+    TEST_ASSERT_FALSE(ch.settings.downlink_enabled);
+}
+
+#ifdef USERPREFS_CHANNELS_TO_WRITE
+
+static const uint8_t kChannel0Psk[] = USERPREFS_CHANNEL_0_PSK;
+static const uint8_t kChannel3Psk[] = USERPREFS_CHANNEL_3_PSK;
+
+// The bug this table replaces: USERPREFS_CHANNELS_TO_WRITE past 3 produced live secondary channels
+// carrying the public default PSK instead of the vendor's, because initDefaultChannel()'s switch
+// stopped at case 2.
+static void test_index_beyond_two_gets_its_configured_psk()
+{
+    const meshtastic_ChannelSettings &s = channels.getByIndex(3).settings;
+    TEST_ASSERT_EQUAL_UINT(sizeof(kChannel3Psk), s.psk.size);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(kChannel3Psk, s.psk.bytes, sizeof(kChannel3Psk));
+    TEST_ASSERT_EQUAL_STRING(USERPREFS_CHANNEL_3_NAME, s.name);
+}
+
+static void test_index_zero_matches_its_userprefs()
+{
+    const meshtastic_ChannelSettings &s = channels.getByIndex(0).settings;
+    TEST_ASSERT_EQUAL_UINT(sizeof(kChannel0Psk), s.psk.size);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(kChannel0Psk, s.psk.bytes, sizeof(kChannel0Psk));
+    TEST_ASSERT_EQUAL_STRING(USERPREFS_CHANNEL_0_NAME, s.name);
+    TEST_ASSERT_EQUAL_UINT(USERPREFS_CHANNEL_0_PRECISION, s.module_settings.position_precision);
+    TEST_ASSERT_TRUE(s.module_settings.is_muted);
+    TEST_ASSERT_TRUE(s.uplink_enabled);
+    TEST_ASSERT_FALSE(s.downlink_enabled);
+}
+
+static void test_every_written_index_has_a_role()
+{
+    for (int i = 0; i < USERPREFS_CHANNELS_TO_WRITE; i++) {
+        const meshtastic_Channel &ch = channels.getByIndex(i);
+        TEST_ASSERT_TRUE(ch.has_settings);
+        TEST_ASSERT_TRUE(ch.settings.has_module_settings);
+        TEST_ASSERT_EQUAL(i == 0 ? meshtastic_Channel_Role_PRIMARY : meshtastic_Channel_Role_SECONDARY, ch.role);
+    }
+}
+
+// Index 1 is inside CHANNELS_TO_WRITE but has no userPref of its own.
+static void test_unconfigured_index_inside_range_is_stock()
+{
+    expectStockChannel(1);
+}
+
+// Index 4 sets only a name upstream; the generator fills the rest with the values
+// initDefaultChannel() would otherwise have left in place, so a partial config is not a way to
+// accidentally ship uplink or a raised position precision.
+static void test_partly_configured_index_keeps_firmware_defaults()
+{
+    const meshtastic_ChannelSettings &s = channels.getByIndex(4).settings;
+    TEST_ASSERT_EQUAL_STRING(USERPREFS_CHANNEL_4_NAME, s.name);
+    expectShortFormDefaultPsk(s);
+    TEST_ASSERT_EQUAL_UINT(0, s.module_settings.position_precision);
+    TEST_ASSERT_FALSE(s.module_settings.is_muted);
+    TEST_ASSERT_FALSE(s.uplink_enabled);
+    TEST_ASSERT_FALSE(s.downlink_enabled);
+}
+
+// Indices past USERPREFS_CHANNELS_TO_WRITE are never handed to initDefaultChannel(), so they must
+// stay zeroed rather than picking up a neighbour's key.
+static void test_index_past_channels_to_write_is_untouched()
+{
+    for (int i = USERPREFS_CHANNELS_TO_WRITE; i < MAX_NUM_CHANNELS; i++) {
+        const meshtastic_ChannelSettings &s = channels.getByIndex(i).settings;
+        TEST_ASSERT_EQUAL_STRING("", s.name);
+        TEST_ASSERT_EQUAL_UINT(0, s.psk.size);
+    }
+}
+
+// The switch this table replaces used strcpy() into a char[12].
+static void test_over_long_name_is_truncated_and_terminated()
+{
+    const meshtastic_ChannelSettings &s = channels.getByIndex(2).settings;
+    TEST_ASSERT_TRUE(strlen(USERPREFS_CHANNEL_2_NAME) >= sizeof(s.name));
+    TEST_ASSERT_EQUAL_UINT(sizeof(s.name) - 1, strlen(s.name));
+    TEST_ASSERT_EQUAL_CHAR('\0', s.name[sizeof(s.name) - 1]);
+    TEST_ASSERT_EQUAL_MEMORY(USERPREFS_CHANNEL_2_NAME, s.name, sizeof(s.name) - 1);
+}
+
+#else // no channel userPrefs: the baseline the table must not have moved
+
+static void test_stock_build_writes_only_index_zero()
+{
+    expectStockChannel(0);
+    TEST_ASSERT_EQUAL(meshtastic_Channel_Role_PRIMARY, channels.getByIndex(0).role);
+    for (int i = 1; i < MAX_NUM_CHANNELS; i++) {
+        const meshtastic_ChannelSettings &s = channels.getByIndex(i).settings;
+        TEST_ASSERT_EQUAL_STRING("", s.name);
+        TEST_ASSERT_EQUAL_UINT(0, s.psk.size);
+    }
+}
+
+static void test_stock_build_fills_the_whole_table()
+{
+    TEST_ASSERT_EQUAL_UINT(MAX_NUM_CHANNELS, channelFile.channels_count);
+}
+
+#endif
+
+UPC_TEST_ENTRY void setup()
+{
+    initializeTestEnvironment();
+    UNITY_BEGIN();
+
+#ifdef USERPREFS_CHANNELS_TO_WRITE
+    printf("\n=== channel table beyond index 2 ===\n");
+    RUN_TEST(test_index_beyond_two_gets_its_configured_psk);
+    RUN_TEST(test_index_zero_matches_its_userprefs);
+    RUN_TEST(test_every_written_index_has_a_role);
+
+    printf("\n=== omitted fields and bounds ===\n");
+    RUN_TEST(test_unconfigured_index_inside_range_is_stock);
+    RUN_TEST(test_partly_configured_index_keeps_firmware_defaults);
+    RUN_TEST(test_index_past_channels_to_write_is_untouched);
+    RUN_TEST(test_over_long_name_is_truncated_and_terminated);
+#else
+    printf("\n=== stock defaults (no channel userPrefs) ===\n");
+    RUN_TEST(test_stock_build_writes_only_index_zero);
+    RUN_TEST(test_stock_build_fills_the_whole_table);
+#endif
+
+    exit(UNITY_END());
+}
+
+UPC_TEST_ENTRY void loop() {}

--- a/test/test_userprefs_channels/userprefs_fixture.h
+++ b/test/test_userprefs_channels/userprefs_fixture.h
@@ -1,0 +1,50 @@
+// What bin/platformio-custom.py emits for a userPrefs.jsonc configuring five channels. -include'd
+// rather than passed as -D flags, which would overrun the Windows command-line limit.
+
+#pragma once
+
+#define USERPREFS_CHANNELS_TO_WRITE 5
+
+// Every field set, with is_muted and uplink on but downlink off, so a test can tell an applied
+// value from a zeroed one.
+#define USERPREFS_CHANNEL_0_PSK                                                                                                  \
+    {                                                                                                                            \
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16                                                                    \
+    }
+#define USERPREFS_CHANNEL_0_NAME "Ops"
+#define USERPREFS_CHANNEL_0_PRECISION 14
+#define USERPREFS_CHANNEL_0_IS_MUTED true
+#define USERPREFS_CHANNEL_0_UPLINK_ENABLED true
+#define USERPREFS_CHANNEL_0_DOWNLINK_ENABLED false
+
+// Name longer than ChannelSettings.name (char[12]); the switch this table replaces used strcpy().
+#define USERPREFS_CHANNEL_2_PSK                                                                                                  \
+    {                                                                                                                            \
+        1                                                                                                                        \
+    }
+#define USERPREFS_CHANNEL_2_NAME "LongerThanTwelve"
+#define USERPREFS_CHANNEL_2_PRECISION 0
+#define USERPREFS_CHANNEL_2_IS_MUTED false
+#define USERPREFS_CHANNEL_2_UPLINK_ENABLED false
+#define USERPREFS_CHANNEL_2_DOWNLINK_ENABLED false
+
+// The index the old switch could not reach at all.
+#define USERPREFS_CHANNEL_3_PSK                                                                                                  \
+    {                                                                                                                            \
+        16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1                                                                    \
+    }
+#define USERPREFS_CHANNEL_3_NAME "Three"
+#define USERPREFS_CHANNEL_3_PRECISION 0
+#define USERPREFS_CHANNEL_3_IS_MUTED false
+#define USERPREFS_CHANNEL_3_UPLINK_ENABLED false
+#define USERPREFS_CHANNEL_3_DOWNLINK_ENABLED false
+
+#define USERPREFS_CHANNEL_4_PSK                                                                                                  \
+    {                                                                                                                            \
+        1                                                                                                                        \
+    }
+#define USERPREFS_CHANNEL_4_NAME "Four"
+#define USERPREFS_CHANNEL_4_PRECISION 0
+#define USERPREFS_CHANNEL_4_IS_MUTED false
+#define USERPREFS_CHANNEL_4_UPLINK_ENABLED false
+#define USERPREFS_CHANNEL_4_DOWNLINK_ENABLED false

--- a/userPrefs.jsonc
+++ b/userPrefs.jsonc
@@ -1,28 +1,49 @@
 {
+  // A value here is a FACTORY DEFAULT. It is applied on first boot and on factory reset, and never
+  // again - once the device has a saved config, that config wins. There is no per-field lock. To
+  // stop a user changing a setting, ship USERPREFS_USE_ADMIN_KEY_0 and set
+  // USERPREFS_CONFIG_SECURITY_IS_MANAGED.
+  //
+  // Numbers must be plain decimal or 0x-prefixed hex; a shift expression such as "(1 << 15)" is
+  // passed to the compiler as a string, not evaluated.
+  //
+  // Channels: indices 0 to 7 are all supported. Setting any USERPREFS_CHANNEL_<n>_* key configures
+  // index <n>; the fields you leave out keep the values the firmware would have used anyway (default
+  // PSK, empty name, precision 0, not muted, no uplink or downlink). USERPREFS_CHANNELS_TO_WRITE is
+  // how many indices are written on first boot and cannot exceed 8.
   // "USERPREFS_BUTTON_PIN": "36",
   // "USERPREFS_CHANNELS_TO_WRITE": "3",
   // "USERPREFS_CHANNEL_0_DOWNLINK_ENABLED": "false",
+  // "USERPREFS_CHANNEL_0_IS_MUTED": "false",
   // "USERPREFS_CHANNEL_0_NAME": "REPLACEME",
   // "USERPREFS_CHANNEL_0_PRECISION": "14",
   // "USERPREFS_CHANNEL_0_PSK": "{ 0x38, 0x4b, 0xbc, 0xc0, 0x1d, 0xc0, 0x22, 0xd1, 0x81, 0xbf, 0x36, 0xb8, 0x61, 0x21, 0xe1, 0xfb, 0x96, 0xb7, 0x2e, 0x55, 0xbf, 0x74, 0x22, 0x7e, 0x9d, 0x6a, 0xfb, 0x48, 0xd6, 0x4c, 0xb1, 0xa1 }",
   // "USERPREFS_CHANNEL_0_UPLINK_ENABLED": "true",
   // "USERPREFS_CHANNEL_1_DOWNLINK_ENABLED": "false",
+  // "USERPREFS_CHANNEL_1_IS_MUTED": "false",
   // "USERPREFS_CHANNEL_1_NAME": "NodeChat",
   // "USERPREFS_CHANNEL_1_PRECISION": "14",
   // "USERPREFS_CHANNEL_1_PSK": "{ 0x4e, 0x22, 0x1d, 0x8b, 0xc3, 0x09, 0x1b, 0xe2, 0x11, 0x9c, 0x89, 0x12, 0xf2, 0x25, 0x19, 0x5d, 0x15, 0x3e, 0x30, 0x7b, 0x86, 0xb6, 0xec, 0xc4, 0x6a, 0xc3, 0x96, 0x5e, 0x9e, 0x10, 0x9d, 0xd5 }",
   // "USERPREFS_CHANNEL_1_UPLINK_ENABLED": "false",
   // "USERPREFS_CHANNEL_2_DOWNLINK_ENABLED": "false",
+  // "USERPREFS_CHANNEL_2_IS_MUTED": "false",
   // "USERPREFS_CHANNEL_2_NAME": "YardSale",
   // "USERPREFS_CHANNEL_2_PRECISION": "14",
   // "USERPREFS_CHANNEL_2_PSK": "{ 0x15, 0x6f, 0xfe, 0x46, 0xd4, 0x56, 0x63, 0x8a, 0x54, 0x43, 0x13, 0xf2, 0xef, 0x6c, 0x63, 0x89, 0xf0, 0x06, 0x30, 0x52, 0xce, 0x36, 0x5e, 0xb1, 0xe8, 0xbb, 0x86, 0xe6, 0x26, 0x5b, 0x1d, 0x58 }",
   // "USERPREFS_CHANNEL_2_UPLINK_ENABLED": "false",
+  // "USERPREFS_CHANNEL_3_NAME": "Ops",
+  // "USERPREFS_CHANNEL_3_PSK": "{ 0x01 }",
   // "USERPREFS_CONFIG_GPS_MODE": "meshtastic_Config_PositionConfig_GpsMode_ENABLED",
   // "USERPREFS_CONFIG_LORA_IGNORE_MQTT": "true",
+  // "USERPREFS_CONFIG_LORA_CONFIG_OK_TO_MQTT": "false",
   // "USERPREFS_LORA_TX_DISABLED": "1", // If set, forces config.lora.tx_enabled=false during lora bootstrap
   // "USERPREFS_CONFIG_LORA_REGION": "meshtastic_Config_LoRaConfig_RegionCode_US",
   // "USERPREFS_CONFIG_OWNER_LONG_NAME": "My Long Name",
   // "USERPREFS_CONFIG_OWNER_SHORT_NAME": "MLN",
   // "USERPREFS_CONFIG_DEVICE_ROLE": "meshtastic_Config_DeviceConfig_Role_CLIENT", // Defaults to CLIENT. ROUTER*, and LOST AND FOUND roles are restricted.
+  // "USERPREFS_CONFIG_DEVICE_REBROADCAST_MODE": "meshtastic_Config_DeviceConfig_RebroadcastMode_LOCAL_ONLY", // NONE falls back to ALL on a router role
+  // "USERPREFS_CONFIG_DEVICE_NODE_INFO_BROADCAST_SECS": "10800", // Clamped to 3600 .. INT32_MAX
+  // "USERPREFS_CANNED_MESSAGES": "Hi|Bye|Yes|No|Ok",
   // "USERPREFS_EVENT_MODE": "1",
   // "USERPREFS_EVENT_MODE_HOP_LIMIT": "3", // Event-mode default and firmware-generated/relay hop cap (0-7; default 3)
   // "USERPREFS_BLOCK_POSITION_ON_EVENT_CHANNEL": "1", // Block location TX + discard inbound location on channels keyed with USERPREFS_CHANNEL_0_PSK. Defaults off, and must be set explicitly.
@@ -50,6 +71,7 @@
   // "USERPREFS_USE_ADMIN_KEY_0": "{ 0xcd, 0xc0, 0xb4, 0x3c, 0x53, 0x24, 0xdf, 0x13, 0xca, 0x5a, 0xa6, 0x0c, 0x0d, 0xec, 0x85, 0x5a, 0x4c, 0xf6, 0x1a, 0x96, 0x04, 0x1a, 0x3e, 0xfc, 0xbb, 0x8e, 0x33, 0x71, 0xe5, 0xfc, 0xff, 0x3c }",
   // "USERPREFS_USE_ADMIN_KEY_1": "{}",
   // "USERPREFS_USE_ADMIN_KEY_2": "{}",
+  // "USERPREFS_CONFIG_SECURITY_IS_MANAGED": "true", // Ignored unless an admin key is also set
   // "USERPREFS_OEM_TEXT": "Caterham Car Club",
   // "USERPREFS_OEM_FONT_SIZE": "0",
   // "USERPREFS_OEM_IMAGE_WIDTH": "50",

--- a/variants/native/portduino/platformio.ini
+++ b/variants/native/portduino/platformio.ini
@@ -144,11 +144,20 @@ test_testing_command =
   ${platformio.build_dir}/${this.__env__}/meshtasticd
   -s
 
+; Channel-table userPrefs: initDefaults() must reach every index, not just 0-2. The fixture header
+; stands in for what bin/platformio-custom.py emits for a vendor who configured five channels.
+[env:coverage-channel-table]
+extends = env:coverage
+build_flags = ${env:coverage.build_flags}
+  -include test/test_userprefs_channels/userprefs_fixture.h
+test_filter =
+  test_userprefs_channels
+
 [env:coverage-event-policy]
 extends = env:coverage
 build_flags = ${env:coverage.build_flags}
   -DUSERPREFS_BLOCK_POSITION_ON_EVENT_CHANNEL=1
-  -DUSERPREFS_CHANNEL_0_PSK='{0x00,0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0a,0x0b,0x0c,0x0d,0x0e,0x0f}'
+  -include test/support/userprefs_event_channel.h
 test_filter =
   test_position_precision
   test_event_channel_router
@@ -361,6 +370,22 @@ lib_ignore =
   ${portduino_base.lib_ignore}
   LovyanGFX
   Pine libch341-spi Userspace library
+
+; Windows counterpart of [env:coverage-channel-table]; same flags, runnable on this host.
+[env:native-windows-channel-table]
+extends = env:native-windows
+build_flags = ${env:native-windows.build_flags}
+  -include test/test_userprefs_channels/userprefs_fixture.h
+test_filter =
+  test_userprefs_channels
+
+; Windows counterpart of [env:coverage-event-policy]; same flags, runnable on this host.
+[env:native-windows-event-policy]
+extends = env:native-windows
+build_flags = ${env:native-windows.build_flags}
+  -DUSERPREFS_BLOCK_POSITION_ON_EVENT_CHANNEL=1
+  -include test/support/userprefs_event_channel.h
+test_filter = ${env:coverage-event-policy.test_filter}
 
 ; ---------------------------------------------------------------------------
 ; WASM (Emscripten) - the portduino node compiled to WebAssembly, driving a real


### PR DESCRIPTION
`Channels::initDefaultChannel()` handled only indices 0-2, so `USERPREFS_CHANNELS_TO_WRITE` above 3 did not leave the extra slots empty but wrote live secondary channels carrying the public default PSK; the switch now covers all eight, with `bin/platformio-custom.py` completing every field of a configured index so indices 0-2 stay byte-identical and the name is copied with `strncpy` instead of `strcpy`. This also adds `USERPREFS_CHANNEL_<n>_IS_MUTED`, `USERPREFS_CONFIG_DEVICE_REBROADCAST_MODE`, `USERPREFS_CONFIG_DEVICE_NODE_INFO_BROADCAST_SECS`, `USERPREFS_CONFIG_LORA_CONFIG_OK_TO_MQTT`, `USERPREFS_CONFIG_SECURITY_IS_MANAGED` and `USERPREFS_CANNED_MESSAGES`, applied after `installRoleDefaults()` because that rewrites two of them per role, and validated the way `AdminModule` validates a set-config. A build that sets the channel macros by hand must now supply the whole set, so `env:coverage-event-policy` moves to `test/support/userprefs_event_channel.h`, and the new `test_userprefs_channels` covers the configured table under `coverage-channel-table` and the stock defaults under every other env.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring channel names, security keys, precision, mute state, and uplink/downlink behavior through user preferences.
  * Added device, security, MQTT, rebroadcast, node information, and canned-message preferences.
  * Added support for hexadecimal preference values and safer handling of incomplete or oversized channel settings.

* **Documentation**
  * Expanded configuration examples and guidance for factory defaults, channel settings, numeric values, and new preferences.

* **Tests**
  * Added channel-table coverage across supported environments, including default, partial, boundary, and truncation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->