### PR TITLE
fix(test): restore the sendAckNak overrides broken by #10767

### DIFF
--- a/src/mesh/MeshModule.cpp
+++ b/src/mesh/MeshModule.cpp
@@ -80,6 +80,8 @@ meshtastic_MeshPacket *MeshModule::allocAckNak(meshtastic_Routing_Error err, Nod
     // ack is delivered locally (to == us), so Router::send() is bypassed and won't overwrite these.
     if (relaySource) {
         p->relay_node = relaySource->relay_node;
+        // rx_rssi has explicit presence: has_rx_rssi has to travel with it or the reading never encodes
+        p->has_rx_rssi = relaySource->has_rx_rssi;
         p->rx_rssi = relaySource->rx_rssi;
         p->rx_snr = relaySource->rx_snr;
     }

--- a/test/test_mesh_module/test_main.cpp
+++ b/test/test_mesh_module/test_main.cpp
@@ -81,10 +81,11 @@ class MockRoutingModule : public RoutingModule
 {
   public:
     void sendAckNak(meshtastic_Routing_Error err, NodeNum to, PacketId idFrom, ChannelIndex chIndex, uint8_t hopLimit = 0,
-                    bool ackWantsAck = false) override
+                    bool ackWantsAck = false, const meshtastic_MeshPacket *relaySource = nullptr) override
     {
         (void)hopLimit;
         (void)ackWantsAck;
+        (void)relaySource;
         ackNaks.push_back({err, to, idFrom, chIndex});
     }
 
@@ -703,6 +704,51 @@ static void test_localAckNak_reachesPhoneViaRealRoutingModule()
     mockService->releaseToPool(toPhone);
 }
 
+// #10767: the implicit ACK for an overheard rebroadcast of our own packet carries that copy's
+// relaying node and the link metrics we heard it at, so the phone can attribute them to the relayer.
+// rx_rssi has explicit presence, so has_rx_rssi has to travel with it or the reading never encodes.
+static void test_localAck_carriesRelaySourceToPhone()
+{
+    installRealRoutingModule();
+
+    meshtastic_MeshPacket overheard = meshtastic_MeshPacket_init_zero;
+    overheard.from = LOCAL_NODE;
+    overheard.to = REMOTE_NODE;
+    overheard.id = 0xFEEDBEEF;
+    overheard.relay_node = 0xAB;
+    overheard.has_rx_rssi = true;
+    overheard.rx_rssi = -93;
+    overheard.rx_snr = 4.75f;
+
+    realRoutingModule->sendAckNak(meshtastic_Routing_Error_NONE, LOCAL_NODE, overheard.id, 0, /*hopLimit=*/0,
+                                  /*ackWantsAck=*/false, &overheard);
+
+    meshtastic_MeshPacket *toPhone = mockService->getForPhone();
+    TEST_ASSERT_NOT_NULL(toPhone);
+    TEST_ASSERT_EQUAL_UINT32(0xFEEDBEEF, toPhone->decoded.request_id);
+    TEST_ASSERT_EQUAL_HEX8(0xAB, toPhone->relay_node);
+    TEST_ASSERT_TRUE(toPhone->has_rx_rssi);
+    TEST_ASSERT_EQUAL_INT32(-93, toPhone->rx_rssi);
+    TEST_ASSERT_EQUAL_FLOAT(4.75f, toPhone->rx_snr);
+    mockService->releaseToPool(toPhone);
+}
+
+// Every other ACK/NAK passes no relay source and must reach the phone with the relay fields clear,
+// so the client is never told a relayer we did not hear.
+static void test_localAck_withoutRelaySource_leavesRelayFieldsUnset()
+{
+    installRealRoutingModule();
+
+    realRoutingModule->sendAckNak(meshtastic_Routing_Error_NONE, LOCAL_NODE, 0x0BADF00D, 0);
+
+    meshtastic_MeshPacket *toPhone = mockService->getForPhone();
+    TEST_ASSERT_NOT_NULL(toPhone);
+    TEST_ASSERT_EQUAL_UINT32(0x0BADF00D, toPhone->decoded.request_id);
+    TEST_ASSERT_EQUAL_HEX8(NO_RELAY_NODE, toPhone->relay_node);
+    TEST_ASSERT_FALSE(toPhone->has_rx_rssi);
+    mockService->releaseToPool(toPhone);
+}
+
 // The mirror of the above: a broadcast we originated, heard back off the mesh, must not reach the
 // phone even though it travels the same RoutingModule path.
 static void test_ownBroadcastEcho_isDroppedByRealRoutingModule()
@@ -855,6 +901,8 @@ void setup()
     RUN_TEST(test_handleFromRadio_ownPacketIsNotEchoedToPhone);
     RUN_TEST(test_handleFromRadio_ownPacketAddressedToUsReachesPhone);
     RUN_TEST(test_localAckNak_reachesPhoneViaRealRoutingModule);
+    RUN_TEST(test_localAck_carriesRelaySourceToPhone);
+    RUN_TEST(test_localAck_withoutRelaySource_leavesRelayFieldsUnset);
     RUN_TEST(test_ownBroadcastEcho_isDroppedByRealRoutingModule);
     RUN_TEST(test_phoneRequest_replyReachesPhone);
     RUN_TEST(test_nestedLocalSend_isDeferred_notReentrant);

--- a/test/test_mqtt/MQTT.cpp
+++ b/test/test_mqtt/MQTT.cpp
@@ -103,8 +103,10 @@ class MockRoutingModule : public RoutingModule
 {
   public:
     void sendAckNak(meshtastic_Routing_Error err, NodeNum to, PacketId idFrom, ChannelIndex chIndex, uint8_t hopLimit = 0,
-                    bool ackWantsAck = false) override
+                    bool ackWantsAck = false, const meshtastic_MeshPacket *relaySource = nullptr) override
     {
+        (void)ackWantsAck;
+        (void)relaySource;
         ackNacks_.emplace_back(err, to, idFrom, chIndex, hopLimit);
     }
     std::list<std::tuple<meshtastic_Routing_Error, NodeNum, PacketId, ChannelIndex, uint8_t>>

--- a/test/test_nexthop_routing/test_main.cpp
+++ b/test/test_nexthop_routing/test_main.cpp
@@ -281,8 +281,9 @@ class MockRoutingModule : public RoutingModule
 {
   public:
     void sendAckNak(meshtastic_Routing_Error err, NodeNum to, PacketId idFrom, ChannelIndex chIndex, uint8_t hopLimit = 0,
-                    bool ackWantsAck = false) override
+                    bool ackWantsAck = false, const meshtastic_MeshPacket *relaySource = nullptr) override
     {
+        (void)relaySource;
         ackNaks.emplace_back(err, to, idFrom, chIndex, hopLimit, ackWantsAck);
     }
 

--- a/test/test_packet_signing/test_main.cpp
+++ b/test/test_packet_signing/test_main.cpp
@@ -191,7 +191,11 @@ class AuthPipelineRouter : public ReliableRouter
 class AuthPipelineRoutingModule : public RoutingModule
 {
   public:
-    void sendAckNak(meshtastic_Routing_Error, NodeNum, PacketId, ChannelIndex, uint8_t = 0, bool = false) override { ackCalls++; }
+    void sendAckNak(meshtastic_Routing_Error, NodeNum, PacketId, ChannelIndex, uint8_t = 0, bool = false,
+                    const meshtastic_MeshPacket * = nullptr) override
+    {
+        ackCalls++;
+    }
     uint32_t ackCalls = 0;
 };
 

--- a/test/test_reliable_ack_matrix/test_main.cpp
+++ b/test/test_reliable_ack_matrix/test_main.cpp
@@ -164,13 +164,29 @@ class TimedCaptureRadio : public RadioInterface
 class MockRoutingModule : public RoutingModule
 {
   public:
+    // The relaying copy the caller handed us, flattened to the fields allocAckNak() forwards onto
+    // the ack. One entry per sendAckNak() call, so it stays aligned with ackNaks.
+    struct RelaySource {
+        bool present;
+        uint8_t relayNode;
+        bool hasRxRssi;
+        int32_t rxRssi;
+        float rxSnr;
+    };
+
     void sendAckNak(meshtastic_Routing_Error err, NodeNum to, PacketId idFrom, ChannelIndex chIndex, uint8_t hopLimit = 0,
-                    bool ackWantsAck = false) override
+                    bool ackWantsAck = false, const meshtastic_MeshPacket *relaySource = nullptr) override
     {
         ackNaks.emplace_back(err, to, idFrom, chIndex, hopLimit, ackWantsAck);
+        if (relaySource)
+            relaySources.push_back(
+                {true, relaySource->relay_node, relaySource->has_rx_rssi, relaySource->rx_rssi, relaySource->rx_snr});
+        else
+            relaySources.push_back({false, NO_RELAY_NODE, false, 0, 0.0f});
     }
 
     std::list<std::tuple<meshtastic_Routing_Error, NodeNum, PacketId, ChannelIndex, uint8_t, bool>> ackNaks;
+    std::vector<RelaySource> relaySources;
 };
 
 class ScopedAirTimeFixture
@@ -245,6 +261,26 @@ static void expectSingleAckNak(meshtastic_Routing_Error err, NodeNum to, PacketI
     TEST_ASSERT_EQUAL(ackWantsAck, std::get<5>(ack));
 }
 
+// #10767: only the implicit ack for an overheard rebroadcast of our own packet carries a relay
+// source; every other ACK/NAK must leave it unset so the phone is never told a relayer we did not
+// hear.
+static void expectRelaySource(uint8_t relayNode, int32_t rxRssi, float rxSnr)
+{
+    TEST_ASSERT_EQUAL_UINT32(1, mockRoutingModule->relaySources.size());
+    const auto &relay = mockRoutingModule->relaySources.front();
+    TEST_ASSERT_TRUE(relay.present);
+    TEST_ASSERT_EQUAL_HEX8(relayNode, relay.relayNode);
+    TEST_ASSERT_TRUE(relay.hasRxRssi);
+    TEST_ASSERT_EQUAL_INT32(rxRssi, relay.rxRssi);
+    TEST_ASSERT_EQUAL_FLOAT(rxSnr, relay.rxSnr);
+}
+
+static void expectNoRelaySource()
+{
+    TEST_ASSERT_EQUAL_UINT32(1, mockRoutingModule->relaySources.size());
+    TEST_ASSERT_FALSE(mockRoutingModule->relaySources.front().present);
+}
+
 static void configureChannels()
 {
     memset(&channelFile, 0, sizeof(channelFile));
@@ -286,6 +322,7 @@ void setUp(void)
     reliableShim->resetRouteHealthForTest();
     radio->reset();
     mockRoutingModule->ackNaks.clear();
+    mockRoutingModule->relaySources.clear();
     configureChannels();
 }
 
@@ -298,12 +335,16 @@ void tearDown(void) {}
 void test_text_dm_want_ack_gets_want_ack_ack(void)
 {
     auto p = makeDecodedPacket(meshtastic_PortNum_TEXT_MESSAGE_APP, kRemoteNode, kLocalNode, 1, /*wantAck=*/true);
+    p.relay_node = 0x77; // this ACK travels the mesh for someone else's DM; it must claim no relayer
+    p.has_rx_rssi = true;
+    p.rx_rssi = -55;
     uint8_t expectedHop = mockRoutingModule->getHopLimitForResponse(p);
     TEST_ASSERT_NOT_EQUAL(0, expectedHop); // must be distinguishable from the 0-hop ACK branch
 
     reliableShim->sniffForTest(&p, nullptr);
 
     expectSingleAckNak(meshtastic_Routing_Error_NONE, kRemoteNode, p.id, 1, expectedHop, /*ackWantsAck=*/true);
+    expectNoRelaySource();
 }
 
 void test_text_reply_still_gets_want_ack_ack(void)
@@ -610,11 +651,17 @@ void test_overheard_own_dm_rebroadcast_mints_implicit_ack(void)
     overheard.transport_mechanism = meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA;
     overheard.which_payload_variant = meshtastic_MeshPacket_encrypted_tag;
     overheard.encrypted.size = 32;
+    overheard.relay_node = 0x99;
+    overheard.has_rx_rssi = true;
+    overheard.rx_rssi = -87;
+    overheard.rx_snr = 6.25f;
 
     reliableShim->filterForTest(&overheard);
 
     // ACK is addressed to us (so it reaches the phone) on the pending copy's channel.
     expectSingleAckNak(meshtastic_Routing_Error_NONE, kLocalNode, original.id, 1, /*hopLimit=*/0, /*ackWantsAck=*/false);
+    // The overheard copy is the relay source, so the phone learns who relayed and at what quality.
+    expectRelaySource(0x99, -87, 6.25f);
     TEST_ASSERT_EQUAL_UINT32(0, reliableShim->pendingCount());
 }
 
@@ -685,6 +732,10 @@ static meshtastic_MeshPacket makeOpaqueOwnOverheard(PacketId id, meshtastic_Mesh
     p.which_payload_variant = meshtastic_MeshPacket_encrypted_tag;
     p.encrypted.size = 32;
     memset(p.encrypted.bytes, 0xC3, p.encrypted.size);
+    p.relay_node = 0x4D;
+    p.has_rx_rssi = true;
+    p.rx_rssi = -112;
+    p.rx_snr = -3.5f;
     return p;
 }
 
@@ -704,6 +755,8 @@ void test_ingress_opaque_own_dm_lora_mints_implicit_ack_and_stops_retries(void)
     ingressOverheard(makeOpaqueOwnOverheard(original.id, meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA));
 
     expectSingleAckNak(meshtastic_Routing_Error_NONE, kLocalNode, original.id, 1, /*hopLimit=*/0, /*ackWantsAck=*/false);
+    // Relay attribution survives the opaque short-circuit too: the header fields are all it needs.
+    expectRelaySource(0x4D, -112, -3.5f);
     TEST_ASSERT_EQUAL_UINT32(0, reliableShim->pendingCount());
 }
 


### PR DESCRIPTION
[#10767](https://github.com/meshtastic/firmware/pull/10767) added a `relaySource` parameter to the `RoutingModule::sendAckNak` **virtual**, but the five test mocks that derive from `RoutingModule` still declared the six-parameter signature with `override`. Nothing overrides the new virtual, so all five suites fail to compile and `test-native / Native PlatformIO Tests` has been red on develop since the merge:

```
test/test_reliable_ack_matrix/test_main.cpp:167:10: error: 'void MockRoutingModule::sendAckNak(
  meshtastic_Routing_Error, NodeNum, PacketId, ChannelIndex, uint8_t, bool)'
  marked 'override', but does not override
```

```
Environment    Test                      Status    Duration
-------------  ------------------------  --------  ------------
coverage       test_reliable_ack_matrix  ERRORED   00:00:11.848
coverage       test_mqtt                 ERRORED   00:00:12.001
coverage       test_nexthop_routing      ERRORED   00:00:11.738
coverage       test_packet_signing       ERRORED   00:00:11.762
coverage       test_mesh_module          ERRORED   00:00:11.854
```

The compile failure also cascaded: no suite emitted results, so the test-attribution gate reported 73 empty suites and lcov found no `.gcda` files.

## What this does

**Widens the five mocks to the new signature.** `test_reliable_ack_matrix`, `test_mqtt`, `test_nexthop_routing`, `test_packet_signing`, `test_mesh_module`.

**Carries `has_rx_rssi` with `rx_rssi` in `allocAckNak()`.** `rx_rssi` has explicit presence (see [#11271](https://github.com/meshtastic/firmware/pull/11271)); copying only the value left `has_rx_rssi` false, so nanopb dropped the field at encode time and the phone never saw the relayer's RSSI that #10767 set out to deliver. `relay_node` and `rx_snr` are unconditional and were arriving fine.

**Adds the coverage that would have caught both.**

- `test_reliable_ack_matrix` now asserts that the overheard rebroadcast is handed to `sendAckNak` as the relay source, with its `relay_node` / `rx_rssi` / `rx_snr` intact - on both the decodable path and the opaque `#11502` ingress short-circuit - and that a normal want-ack ACK claims no relayer.
- `test_mesh_module` drives a real `RoutingModule` and asserts the relay fields survive all the way to the phone, including `has_rx_rssi`; a second test asserts an ack with no relay source reaches the phone with the relay fields clear.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (native test suite only - no device-facing behavior change beyond the `has_rx_rssi` presence flag)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay information in ACK/NAK packets by preserving whether received RSSI data is available.
  * Relay node, RSSI, and SNR details are now correctly delivered for applicable acknowledged messages.

* **Tests**
  * Added coverage verifying relay information is included when available and omitted when no relay source exists.
  * Expanded reliability tests across rebroadcast and ingress scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->