### PR TITLE
fix(nodedb): clear the whole LocalModuleConfig when installing defaults

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1288,7 +1288,7 @@ void optInDisableTelemetryBroadcast(meshtastic_LocalModuleConfig &mc)
 void NodeDB::installDefaultModuleConfig()
 {
     LOG_INFO("Install default ModuleConfig");
-    memset(&moduleConfig, 0, sizeof(meshtastic_ModuleConfig));
+    memset(&moduleConfig, 0, sizeof(meshtastic_LocalModuleConfig));
 
     moduleConfig.version = DEVICESTATE_CUR_VER;
     moduleConfig.has_mqtt = true;
@@ -3262,6 +3262,7 @@ bool NodeDB::saveToDiskNoRetry(int saveWhat)
         moduleConfig.has_audio = true;
         moduleConfig.has_paxcounter = true;
         moduleConfig.has_statusmessage = true;
+        moduleConfig.has_traffic_management = true;
         moduleConfig.has_tak = true;
 #if !MESHTASTIC_EXCLUDE_BEACON
         moduleConfig.has_mesh_beacon = true;

--- a/test/test_nodedb_boot_recovery/test_main.cpp
+++ b/test/test_nodedb_boot_recovery/test_main.cpp
@@ -350,6 +350,33 @@ static void test_loadProto_classifiesFailuresDistinctly(void)
     FSCom.remove(scratchPath); // leave nothing behind
 }
 
+// installDefaultModuleConfig() sized its memset to meshtastic_ModuleConfig (the 368-byte oneof)
+// instead of the 1092-byte LocalModuleConfig, so submessages it never assigns kept their old values.
+static void test_oldModuleConfig_discardClearsTailSubmessages(void)
+{
+    // statusmessage sits at offset 609, past the old 368-byte clear, and the defaults installer
+    // never assigns it - so only the full-struct memset can drop this marker.
+    moduleConfig = meshtastic_LocalModuleConfig_init_zero;
+    moduleConfig.version = DEVICESTATE_MIN_VER - 1;
+    moduleConfig.has_statusmessage = true;
+    strncpy(moduleConfig.statusmessage.node_status, "STALE-TAIL", sizeof(moduleConfig.statusmessage.node_status) - 1);
+
+    uint8_t buf[meshtastic_LocalModuleConfig_size];
+    size_t len = pb_encode_to_bytes(buf, sizeof(buf), &meshtastic_LocalModuleConfig_msg, &moduleConfig);
+    TEST_ASSERT_GREATER_THAN_size_t(0, len);
+    writeFileBytes(moduleConfigFileName, buf, len);
+
+    rebootNodeDB(); // decodes, sees version < DEVICESTATE_MIN_VER, discards
+
+    // The opt-in migration re-stamps the version after the discard, so assert the floor, not equality.
+    TEST_ASSERT_GREATER_OR_EQUAL_UINT32_MESSAGE(DEVICESTATE_CUR_VER, moduleConfig.version, "discard did not reinstall defaults");
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("", moduleConfig.statusmessage.node_status,
+                                     "statusmessage survived the moduleConfig discard");
+
+    FSCom.remove(moduleConfigFileName); // leave the sandbox as we found it
+    rebootNodeDB();
+}
+
 NBR_TEST_ENTRY void setup()
 {
     initializeTestEnvironment();
@@ -373,6 +400,9 @@ NBR_TEST_ENTRY void setup()
     printf("\n=== Devicestate recovery + loadProto classification ===\n");
     RUN_TEST(test_oldDevicestate_recoversOwnerFromNodeDb);
     RUN_TEST(test_loadProto_classifiesFailuresDistinctly);
+
+    printf("\n=== ModuleConfig discard completeness ===\n");
+    RUN_TEST(test_oldModuleConfig_discardClearsTailSubmessages);
 
     exit(UNITY_END());
 }


### PR DESCRIPTION
`NodeDB::installDefaultModuleConfig()` cleared 368 of 1092 bytes:

```c
memset(&moduleConfig, 0, sizeof(meshtastic_ModuleConfig));
```

`moduleConfig` is a **`meshtastic_LocalModuleConfig`** (1092 bytes, every submessage inlined). `meshtastic_ModuleConfig` is the union-backed wire oneof (368 bytes). The function assigns only the fields it cares about and relies on that memset to zero the rest, so **every byte past offset 368 that it never assigns kept its previous value** across what is supposed to be a full reset. `installDefaultConfig()` directly above it already used the correct `sizeof(meshtastic_LocalConfig)`; only the module variant was wrong.

Sizes and offsets confirmed inside the native build, not just on the host:

```
sizeof(ModuleConfig)=368  sizeof(LocalModuleConfig)=1092
audio=420 remote_hardware=436 paxcounter=592 statusmessage=609 traffic=692 tak=716
```

## How it surfaces

`statusmessage` is the field this shows up on: offset 609, never assigned by the defaults installer. It survives both routes into `installDefaultModuleConfig()`:

- **`moduleConfig.version < DEVICESTATE_MIN_VER` → "old, discard".** The decode *succeeded*, so the complete old config is in RAM and its `statusmessage` survives the discard verbatim. Deterministic, and it fires exactly on a version bump.
- **`loadProto()` failure.** Whatever a partial decode wrote there survives. (`loadProto` itself clears correctly — it uses the caller-supplied `objSize`.)

`node_status` is `char[80]`. When the surviving bytes carry no NUL, nanopb refuses the field (`"unterminated string"`), `pb_encode_to_bytes()` returns 0, and `PhoneAPI::getFromRadio()` returns 0. `config_state` has already advanced, so that frame is never retried — and 0 is the client's end-of-data sentinel, so the rest of the config dump goes with it. The client never receives `StatusMessageConfig`, and a status-message editor that gates on it stays disabled.

`traffic_management` is **not** affected: `installDefaultModuleConfig()` calls `installTrafficManagementDefaults()`, which reassigns the whole submessage and its `has_` flag regardless of the memset size. (Thanks @coderabbitai — an earlier revision of this PR claimed otherwise and asserted on TM fields that pass either way.)

## Changes

- `installDefaultModuleConfig()`: `sizeof(meshtastic_ModuleConfig)` → `sizeof(meshtastic_LocalModuleConfig)`.
- `saveToDiskNoRetry()`: add `has_traffic_management` to the `has_*` list for consistency — it was the only module config missing from it.

## Testing

New `test_oldModuleConfig_discardClearsTailSubmessages` in `test_nodedb_boot_recovery`: writes an old-version `moduleConfig` carrying a marker status string, reboots the NodeDB, and asserts the marker is gone.

The assertion is verified to discriminate — without the fix:

```
test_oldModuleConfig_discardClearsTailSubmessages:
  Expected '' Was 'STALE-TAIL'. statusmessage survived the moduleConfig discard
```

- `native-macos`: suite 10/10 with the fix, fails as above without it.
- Linux `coverage` (Docker): suite 10/10; full gate 1099 cases, 1094 succeeded, 0 failures.

Pre-existing on `develop` and unrelated: 2 failures in `test_fscommon_getfiles`, and clang-only `sendAckNak` arity build errors in `test_mqtt` / `test_mesh_module` / `test_packet_signing` / `test_nexthop_routing`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of module configuration data from older versions.
  * Ensured traffic-management defaults are restored correctly when outdated configuration data is discarded.
  * Prevented stale configuration details from persisting after recovery.

* **Tests**
  * Added regression coverage for boot recovery and legacy module configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->