### PR TITLE
Let a module hold the screen

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1203,6 +1203,8 @@ int32_t Screen::runOnce()
             handleStartFirmwareUpdateScreen();
             break;
         case Cmd::STOP_ALERT_FRAME:
+            if (hasModalModule())
+                break; // only the owning module may release its own modal frame
             NotificationRenderer::pauseBanner = false;
             // Return from one-off alert mode back to regular frames.
             if (!showingNormalScreen && NotificationRenderer::current_notification_type != notificationTypeEnum::text_input) {
@@ -1262,7 +1264,7 @@ int32_t Screen::runOnce()
     // standard screen switching is stopped.
     if (showingNormalScreen) {
         // standard screen loop handling here
-        if (config.display.auto_screen_carousel_secs > 0 &&
+        if (config.display.auto_screen_carousel_secs > 0 && !hasModalModule() &&
             NotificationRenderer::current_notification_type != notificationTypeEnum::text_input &&
             !Throttle::isWithinTimespanMs(lastScreenTransition, config.display.auto_screen_carousel_secs * 1000)) {
 

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1865,6 +1865,15 @@ void Screen::applyHiddenFramesMask(uint32_t mask)
     hiddenFrames.chirpy = getBit(mask, FVBIT_CHIRPY);
 }
 
+bool Screen::isShowingModuleFrame(const MeshModule *m) const
+{
+    if (!m || !showingNormalScreen)
+        return false;
+    // moduleFrames is index-aligned with the frame list, which is what drawModuleFrame relies on.
+    const uint8_t frame = ui->getUiState()->currentFrame;
+    return frame < moduleFrames.size() && moduleFrames.at(frame) == m;
+}
+
 void Screen::loadFrameVisibility()
 {
 #ifdef FSCom

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1203,9 +1203,11 @@ int32_t Screen::runOnce()
             handleStartFirmwareUpdateScreen();
             break;
         case Cmd::STOP_ALERT_FRAME:
-            if (hasModalModule())
-                break; // only the owning module may release its own modal frame
+            // Cleared even while a module holds the screen: START_ALERT_FRAME set it and nothing
+            // else would, so swallowing it here would leave banners suppressed for good.
             NotificationRenderer::pauseBanner = false;
+            if (hasModalModule())
+                break; // only the owning module may take the screen back off its own frame
             // Return from one-off alert mode back to regular frames.
             if (!showingNormalScreen && NotificationRenderer::current_notification_type != notificationTypeEnum::text_input) {
                 setFrames();

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1869,8 +1869,12 @@ bool Screen::isShowingModuleFrame(const MeshModule *m) const
 {
     if (!m || !showingNormalScreen)
         return false;
-    // moduleFrames is index-aligned with the frame list, which is what drawModuleFrame relies on.
-    const uint8_t frame = ui->getUiState()->currentFrame;
+    // Same effective frame drawModuleFrame() picks: mid-transition the incoming frame is the one
+    // being rendered, so comparing currentFrame would report false while the module is on screen.
+    const OLEDDisplayUiState *state = ui->getUiState();
+    uint8_t frame = state->currentFrame;
+    if (state->frameState == IN_TRANSITION && state->transitionFrameRelationship == TransitionRelationship_INCOMING)
+        frame = state->transitionFrameTarget;
     return frame < moduleFrames.size() && moduleFrames.at(frame) == m;
 }
 

--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -79,6 +79,7 @@ class Screen
     void setModalModule(const MeshModule *) {}
     void clearModalModule(const MeshModule *) {}
     bool hasModalModule() const { return false; }
+    bool isShowingModuleFrame(const MeshModule *) const { return false; }
     void showSimpleBanner(const char *message, uint32_t durationMs = 0) {}
     void showOverlayBanner(BannerOverlayOptions) {}
     void setFrames(FrameFocus focus) {}
@@ -356,6 +357,11 @@ class Screen : public concurrency::OSThread
             modalModule = nullptr;
     }
     bool hasModalModule() const { return modalModule != nullptr; }
+
+    // True while this module's own frame is the one on screen. A module that handles keys
+    // needs this: input observers run before Screen's, so acting unconditionally would take
+    // the key away from whatever frame the user is actually looking at.
+    bool isShowingModuleFrame(const MeshModule *m) const;
 
     void showSimpleBanner(const char *message, uint32_t durationMs = 0);
     void showOverlayBanner(BannerOverlayOptions);

--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -47,6 +47,8 @@ struct BannerOverlayOptions {
 
 bool shouldWakeOnReceivedMessage();
 
+class MeshModule;
+
 #if !HAS_SCREEN
 #include "Power.h"
 namespace graphics
@@ -74,6 +76,9 @@ class Screen
     void increaseBrightness() {}
     void decreaseBrightness() {}
     void startAlert(const char *) {}
+    void setModalModule(MeshModule *) {}
+    void clearModalModule(MeshModule *) {}
+    bool hasModalModule() const { return false; }
     void showSimpleBanner(const char *message, uint32_t durationMs = 0) {}
     void showOverlayBanner(BannerOverlayOptions) {}
     void setFrames(FrameFocus focus) {}
@@ -341,6 +346,16 @@ class Screen : public concurrency::OSThread
         cmd.cmd = Cmd::STOP_ALERT_FRAME;
         enqueueCmd(cmd);
     }
+
+    // Holds the screen against the carousel, the new-message banner and a foreign endAlert().
+    // Only the owner can release it, unlike endAlert(), which any caller can fire.
+    void setModalModule(MeshModule *owner) { modalModule = owner; }
+    void clearModalModule(MeshModule *owner)
+    {
+        if (modalModule == owner)
+            modalModule = nullptr;
+    }
+    bool hasModalModule() const { return modalModule != nullptr; }
 
     void showSimpleBanner(const char *message, uint32_t durationMs = 0);
     void showOverlayBanner(BannerOverlayOptions);
@@ -684,6 +699,9 @@ class Screen : public concurrency::OSThread
     uint16_t displayHeight = 0;
 
   private:
+    // nullptr for every build with no modal module, which is why the three sites are unchanged.
+    MeshModule *modalModule = nullptr;
+
     FrameCallback alertFrames[1];
     struct ScreenCmd {
         Cmd cmd;

--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -358,9 +358,8 @@ class Screen : public concurrency::OSThread
     }
     bool hasModalModule() const { return modalModule != nullptr; }
 
-    // True while this module's own frame is the one on screen. A module that handles keys
-    // needs this: input observers run before Screen's, so acting unconditionally would take
-    // the key away from whatever frame the user is actually looking at.
+    // True while this module's own frame is on screen. Modules observe input before Screen does,
+    // so one handling keys needs this or it takes them from the frame the user is looking at.
     bool isShowingModuleFrame(const MeshModule *m) const;
 
     void showSimpleBanner(const char *message, uint32_t durationMs = 0);

--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -76,8 +76,8 @@ class Screen
     void increaseBrightness() {}
     void decreaseBrightness() {}
     void startAlert(const char *) {}
-    void setModalModule(MeshModule *) {}
-    void clearModalModule(MeshModule *) {}
+    void setModalModule(const MeshModule *) {}
+    void clearModalModule(const MeshModule *) {}
     bool hasModalModule() const { return false; }
     void showSimpleBanner(const char *message, uint32_t durationMs = 0) {}
     void showOverlayBanner(BannerOverlayOptions) {}
@@ -349,8 +349,8 @@ class Screen : public concurrency::OSThread
 
     // Holds the screen against the carousel, the new-message banner and a foreign endAlert().
     // Only the owner can release it, unlike endAlert(), which any caller can fire.
-    void setModalModule(MeshModule *owner) { modalModule = owner; }
-    void clearModalModule(MeshModule *owner)
+    void setModalModule(const MeshModule *owner) { modalModule = owner; }
+    void clearModalModule(const MeshModule *owner)
     {
         if (modalModule == owner)
             modalModule = nullptr;
@@ -700,7 +700,7 @@ class Screen : public concurrency::OSThread
 
   private:
     // nullptr for every build with no modal module, which is why the three sites are unchanged.
-    MeshModule *modalModule = nullptr;
+    const MeshModule *modalModule = nullptr;
 
     FrameCallback alertFrames[1];
     struct ScreenCmd {

--- a/src/graphics/draw/MessageRenderer.cpp
+++ b/src/graphics/draw/MessageRenderer.cpp
@@ -1231,7 +1231,7 @@ void handleNewMessage(OLEDDisplay *display, const StoredMessage &sm, const mesht
             screen->setOn(true);
         }
 
-        if (!suppressBanner && !menuShowing) {
+        if (!suppressBanner && !menuShowing && !screen->hasModalModule()) {
             screen->showSimpleBanner(banner, inThread ? 1000 : 3000);
         }
     }


### PR DESCRIPTION
A module can already own a frame through `wantUIFrame()`, `requestFocus()` and `FOCUS_MODULE`, but it cannot hold it: the carousel advance in `Screen::runOnce()` moves on, `handleNewMessage()` covers it with a banner, and `Cmd::STOP_ALERT_FRAME` is a global one-shot that any caller can fire to cancel an alert frame regardless of who started it, which five call sites do. `Screen::setModalModule()` / `clearModalModule()` / `hasModalModule()` mark one module as the owner and are honoured at exactly those three places, with only the owning pointer able to release it, so a module with a modal state no longer has to patch `Screen.cpp` to keep an alert from vanishing when a chat message arrives. `Screen::isShowingModuleFrame()` answers the related question for a module that is not modal but still handles keys: input observers registered by modules run before Screen's, so one handling UP/DOWN has to know whether its own frame is the one being looked at or it takes the key away from the frame that is.

The default owner is `nullptr` and no in-tree caller sets either, so every existing build behaves exactly as before; `native-windows` builds headless and does not compile any of this, so it is verified by CI and on hardware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automatic carousel advancement while a modal screen is active.
  * Suppressed alert banners during modal interactions to avoid visual conflicts.
  * Ensured stopping an alert always clears its paused-banner state.
  * Improved restoration of the correct screen frame when closing modal screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->