### PR TITLE
fix(sx126x): do not assert when setStandby fails

### DIFF
--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -323,12 +323,16 @@ template <typename T> void SX126xInterface<T>::setStandby()
     int err = lora.standby();
 
     if (err != RADIOLIB_ERR_NONE)
-        LOG_DEBUG("SX126x standby %s%d", radioLibErr, err);
+        LOG_WARN("SX126x standby failed %s%d", radioLibErr, err);
 #ifdef ARCH_PORTDUINO
     if (err != RADIOLIB_ERR_NONE)
         portduino_status.LoRa_in_error = true;
 #else
-    assert(err == RADIOLIB_ERR_NONE);
+    // Do not assert. setStandby() runs on the radio thread from inside the TX
+    // path, so an assert kills that thread silently: the queued packet is never
+    // sent, every counter stays at zero and the log just stops mid-trace with no
+    // hint why. A failed standby is recoverable - the next startReceive() or
+    // startSend() reissues the mode change - so warn and carry on.
 #endif
     isReceiving = false; // If we were receiving, not any more
     activeReceiveStart = 0;


### PR DESCRIPTION
## Problem

`setStandby()` runs on the radio thread and is called from inside the TX path. The `assert(err == RADIOLIB_ERR_NONE)` there kills that thread silently when RadioLib returns an error:

- the queued packet is never transmitted
- `airUtilTx` stays at 0
- every TX counter stops incrementing
- the log ends mid-trace with nothing explaining why

On a USB-CDC-only board this is especially bad: the console emits nothing until a client attaches, so the boot log is already unreachable and the failure looks like an undiagnosable hang.

## How I hit it

On a custom RP2350 + E22-400M33S (SX1268) board, `standby()` was returning `RADIOLIB_ERR_SPI_CMD_FAILED` under a supply droop. The symptom was `Started Tx` followed by permanent `Can not send yet, busyTx` — 274 times — with no error in the log at all. Replacing the assert with a warning immediately revealed the real cause (`-707`, then `XOSC_START_ERR`), which turned out to be inadequate power for the 2 W PA rather than a firmware bug.

## Change

Log a warning instead of asserting. A failed standby is recoverable: the next `startReceive()` or `startSend()` reissues the mode change. The `ARCH_PORTDUINO` branch already handled the error non-fatally via `portduino_status.LoRa_in_error`; this makes the embedded path consistent with it.

6 lines changed, no behaviour change when standby succeeds.

## Testing

- `rak4631` (nRF52) builds clean — the file is shared by all SX126x boards
- custom `rp2350` variant builds clean and now reports the underlying error instead of stalling silently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Radio standby failures now generate a warning and allow operation to continue on supported platforms instead of terminating the radio thread.
  * Portduino error handling remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->