### PR TITLE
feat(sx126x): optional CAD timeout so a stuck channel scan cannot hang the radio thread

### DIFF
--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -410,7 +410,30 @@ template <typename T> bool SX126xInterface<T>::isChannelActive()
     int16_t result;
     setTransmitEnable(false);
     setStandby();
+
+#ifdef SX126X_CAD_TIMEOUT_MS
+    // RadioLib's scanChannel() waits on DIO1 in a `while(!digitalRead(irq))` loop
+    // with no timeout (SX126x.cpp). If the chip never raises CADDone the radio
+    // thread is stuck there forever: nothing is transmitted and the stall is
+    // invisible, because the caller simply never returns. Boards that hit this
+    // can define SX126X_CAD_TIMEOUT_MS to drive the scan manually and treat a
+    // timeout as a free channel - the same verdict as RADIOLIB_CHANNEL_FREE.
+    result = lora.startChannelScan(cfg);
+    if (result == RADIOLIB_ERR_NONE) {
+        uint32_t started = millis();
+        while (!digitalRead(SX126X_DIO1)) {
+            if (millis() - started > SX126X_CAD_TIMEOUT_MS) {
+                LOG_WARN("SX126X CAD did not complete in %u ms, treating channel as free", (unsigned)SX126X_CAD_TIMEOUT_MS);
+                startReceive(); // the scan left the chip out of RX; put it back
+                return false;
+            }
+            yield();
+        }
+        result = lora.getChannelScanResult();
+    }
+#else
     result = lora.scanChannel(cfg);
+#endif
     if (result == RADIOLIB_LORA_DETECTED)
         return true;
     if (result != RADIOLIB_CHANNEL_FREE)


### PR DESCRIPTION
## Problem

RadioLib's `scanChannel()` waits on DIO1 in a `while(!digitalRead(irq))` loop with **no timeout**. If the chip never raises CADDone, `isChannelActive()` never returns and the radio thread is stuck there permanently:

- the queued packet stays in the TX queue forever
- nothing is logged
- the trace stops right after the channel-activity check, with no indication that anything failed

There is no recovery path: the thread is inside a library loop that cannot exit.

## How I hit it

On a custom RP2350 + E22-400M33S (SX1268) board, CAD never completed — verified over a direct SPI tunnel that drives the chip without Meshtastic or RadioLib: `cadDone=0` even after 200 ms. Every transmission attempt hung at exactly that point.

## Change

Boards that hit this can define `SX126X_CAD_TIMEOUT_MS` in `variant.h`. The scan is then driven manually via `startChannelScan()` + bounded DIO1 polling, and a timeout is treated as a free channel — the same verdict RadioLib returns for `RADIOLIB_CHANNEL_FREE`. RX is restarted on that path because the aborted scan leaves the chip out of receive.

**Default behaviour is unchanged**: without the macro the original blocking `scanChannel()` is used, so no existing board is affected.

## Testing

- `rak4631` (nRF52) builds clean without the macro — default path untouched
- custom `rp2350` variant with `SX126X_CAD_TIMEOUT_MS 15` builds clean and no longer hangs; transmission proceeds instead of stalling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved channel activity scanning when a custom scan timeout is configured.
  - Prevented incomplete scans from blocking channel availability checks.
  - Restored receive mode reliably after scanning.
  - Added brief polling pauses to improve responsiveness during scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->