### PR TITLE
fix(radio): floor Tx power at the radio minimum in limitPower()

### DIFF
--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -1481,6 +1481,17 @@ void RadioInterface::limitPower(int8_t loraMaxPower)
     if (power > loraMaxPower) // Clamp power to maximum defined level
         power = loraMaxPower;
 
+    // Floor as well as ceiling. On a board that declares an external PA gain the
+    // subtraction above can push the level below what the radio can physically
+    // emit: the chip then rejects the setting and stops transmitting altogether
+    // rather than transmitting weakly. Measured on a board with
+    // TX_GAIN_LORA 25 and tx_power -9: "Final Tx power: -34 dBm" and no packet
+    // ever left the queue.
+    if (power < RADIO_MIN_TX_POWER_DBM) {
+        LOG_WARN("Tx power %d dBm below radio minimum, raising to %d dBm", power, RADIO_MIN_TX_POWER_DBM);
+        power = RADIO_MIN_TX_POWER_DBM;
+    }
+
     LOG_INFO("Final Tx power: %d dBm", power);
 }
 

--- a/src/mesh/RadioInterface.h
+++ b/src/mesh/RadioInterface.h
@@ -17,6 +17,15 @@ typedef struct _meshtastic_Config_LoRaConfig meshtastic_Config_LoRaConfig;
 
 #define MAX_TX_QUEUE 16 // max number of packets which can be waiting for transmission
 
+// Lowest level the radio can actually emit. Below this the chip rejects the
+// setting and transmits nothing at all, so limitPower() floors here rather than
+// handing the driver an impossible value. -9 dBm covers SX126x (RadioLib's
+// SX1268::checkOutputPower allows -9..22); boards with a different floor can
+// override it in variant.h.
+#ifndef RADIO_MIN_TX_POWER_DBM
+#define RADIO_MIN_TX_POWER_DBM -9
+#endif
+
 #define MAX_LORA_PAYLOAD_LEN 255 // max length of 255 per Semtech's datasheets on SX12xx
 #define MESHTASTIC_HEADER_LENGTH 16
 #define MESHTASTIC_PKC_OVERHEAD 12


### PR DESCRIPTION
## Problem

`limitPower()` clamps the requested power down to the regional limit and the board ceiling, and subtracts `TX_GAIN_LORA` for boards with an external PA. On a board that declares a large PA gain, that subtraction can push the value **below what the chip can physically emit**.

The chip then rejects the setting outright and transmits **nothing at all**, rather than transmitting weakly. That is a much worse failure mode: the node looks correctly configured, reports no error, and simply never appears on air.

## Measured

On a custom board with `TX_GAIN_LORA 25` and `lora.tx_power = -9`:

```
Requested Tx power: -9 dBm; Device LoRa Tx gain: 25 dB
Final Tx power: -34 dBm
```

−34 dBm is outside the SX126x range (−9..22, per RadioLib's `SX1268::checkOutputPower`). `Started Tx` appeared in the log, but no packet ever left the queue and `airUtilTx` stayed at 0.

## Change

Add `RADIO_MIN_TX_POWER_DBM` (default −9, overridable in `variant.h`) and floor the value in `limitPower()`, symmetric with the existing ceiling clamp. A warning is logged when the floor engages, so an operator sees that the requested power was not achievable rather than silently getting no RF.

## Testing

- `rak4631` (nRF52) builds clean; no behaviour change for boards that do not declare a PA gain, since the floor only engages when the result would be below the chip minimum
- custom `rp2350` variant: the log now shows `Tx power -34 dBm below radio minimum, raising to -9 dBm` instead of failing silently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented transmit power settings from falling below the radio’s supported minimum.
  * Improved compatibility across radio hardware by enforcing a safe default minimum power level.
  * Boards with different hardware limits can now use an appropriate configured minimum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->