### PR TITLE
fix(t-watch-s3): declare the 16MB partition scheme actually built

### DIFF
--- a/variants/esp32s3/t-watch-s3/platformio.ini
+++ b/variants/esp32s3/t-watch-s3/platformio.ini
@@ -8,7 +8,7 @@ custom_meshtastic_support_level = 3
 custom_meshtastic_display_name = LILYGO T-Watch S3
 custom_meshtastic_images = t-watch-s3.svg
 custom_meshtastic_tags = LilyGo
-custom_meshtastic_partition_scheme = 8MB
+custom_meshtastic_partition_scheme = 16MB
 
 extends = esp32s3_base
 board_level = release


### PR DESCRIPTION
`variants/esp32s3/t-watch-s3/platformio.ini` declared:

```ini
custom_meshtastic_partition_scheme = 8MB
```

while building, three lines later:

```ini
board_build.partitions = default_16MB.csv
```

against a board defined as 16MB — `boards/t-watch-s3.json` carries `flash_size: "16MB"` / `maximum_size: 16777216`.

The shipped artifact confirms the build is 16MB. `firmware-t-watch-s3-2.8.0.8eda860.factory.bin` has a 16MB image header and the `default_16MB.csv` table:

| partition | offset | size |
| --- | --- | --- |
| app0 | `0x10000` | `0x640000` |
| app1 | `0x650000` | `0x640000` |
| spiffs | `0xC90000` | `0x360000` |
| coredump | `0xFF0000` | `0x10000` |

## Why the string matters

`custom_meshtastic_partition_scheme` is exported verbatim as `partitionScheme` into the Meshtastic device hardware list (`bin/platformio-custom.py:243`), and the web-flasher consumes it. In `stores/firmwareStore.ts`, the legacy `cleanInstallEspFlash` path switches on that string: `partitionScheme == '8MB'` with `hasMui` not true resolves to `otaOffset = 0x340000` and `spiffsOffset = 0x670000`.

Both of those land inside this board's real `app0` (`0x10000..0x650000`). Flashing there overwrites the app image and boot-loops the device. t-watch-s3 sets no `HAS_TFT`, so `hasMui` is absent from its manifest and the published hardware list — it takes exactly that branch.

It is masked on 2.8 only because the manifest-driven path reads real offsets out of the board's `.mt.json` `part[]` array rather than the scheme string (see `bin/device-install.sh:124`, which selects `ota_1` and `spiffs` offsets from the manifest and no longer keeps `BIGDB_8MB`/`BIGDB_16MB` lists at all).

## Where the 8MB came from

- #6311 set `default_16MB.csv` for this variant.
- #6407, "T-Watch-S3 has 8MB Flash", read a broken 16MB filesystem as proof the part was 8MB and reverted to `default_8MB.csv`, moving the board into `BIGDB_8MB`.
- #6563 found the actual cause — `boards/t-watch-s3.json` itself carried `flash_size: "8MB"` / `maximum_size: 8388608`, which is why a 16MB filesystem appeared broken. It corrected the board definition to 16MB and reverted #6407 in full.
- #9214, migrating the Meshtastic API attributes into the ini as source of truth, then reintroduced the already-dead 8MB value as `custom_meshtastic_partition_scheme`.

So the declaration has never matched a build. This changes the string to match what is actually produced; the partition table and board definition are already correct and are untouched.

## Verification

- All 40 ESP32 envs declaring `custom_meshtastic_partition_scheme` were audited against their resolved `board_build.partitions` and board flash size, following `extends` chains for the envs that inherit them (elecrow crowpanel, heltec-v4 / v4-r8, rak3312, t-deck-pro / t-deck-pro-v1_1). t-watch-s3 was the only mismatch; after this change there are none.
- No other reference in the tree claims 8MB for this board.
- `trunk fmt` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased the T-Watch S3 partition capacity from 8 MB to 16 MB, allowing larger application and data storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->