### PR TITLE
feat(baseui): default US to LongTurbo on first region selection

### DIFF
--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -227,8 +227,33 @@ void menuHandler::OnboardMessage()
     screen->showOverlayBanner(bannerOptions);
 }
 
+// Out-of-box US setup starts on LongTurbo rather than the region table's LongFast. Menu-only: the
+// US entry in `regions[]` keeps LongFast, so no other route onto US changes. Anything that already
+// states a preset - a pinned userpref, or a preset moved off the install default - outranks it.
+meshtastic_Config_LoRaConfig_ModemPreset menuHandler::presetForRegionSelection(const meshtastic_Config_LoRaConfig &lora,
+                                                                               meshtastic_Config_LoRaConfig_RegionCode selected)
+{
+#ifdef USERPREFS_LORACONFIG_MODEM_PRESET
+    (void)selected; // the pinned preset wins outright; nothing to decide
+#else
+    if (lora.region == meshtastic_Config_LoRaConfig_RegionCode_UNSET && selected == meshtastic_Config_LoRaConfig_RegionCode_US &&
+        lora.use_preset && lora.modem_preset == meshtastic_Config_LoRaConfig_ModemPreset_LONG_FAST) {
+        return meshtastic_Config_LoRaConfig_ModemPreset_LONG_TURBO;
+    }
+#endif
+    return lora.modem_preset;
+}
+
 static void applyLoraRegion(meshtastic_Config_LoRaConfig_RegionCode region, bool isHam)
 {
+    // Decided first: it keys off the *outgoing* region being UNSET.
+    const meshtastic_Config_LoRaConfig_ModemPreset selectionPreset = menuHandler::presetForRegionSelection(config.lora, region);
+    if (selectionPreset != config.lora.modem_preset) {
+        LOG_INFO("First region is %s, default preset to %s", getRegion(region)->name,
+                 DisplayFormatters::getModemPresetDisplayName(selectionPreset, false, true));
+        config.lora.modem_preset = selectionPreset;
+    }
+
     config.lora.region = region;
     config.lora.channel_num = 0; // Reset to default channel
 

--- a/src/graphics/draw/MenuHandler.h
+++ b/src/graphics/draw/MenuHandler.h
@@ -141,6 +141,11 @@ class menuHandler
     // ever runs via screen->showOverlayBanner(), which is why nothing here was unit-testable.
     static void toggleNodeMuted(uint32_t nodeNum); // uint32_t, matching pickedNodeNum above
 
+    // Preset a region selection should leave installed. `lora` is the config as it stands *before*
+    // the selection is written.
+    static meshtastic_Config_LoRaConfig_ModemPreset presetForRegionSelection(const meshtastic_Config_LoRaConfig &lora,
+                                                                             meshtastic_Config_LoRaConfig_RegionCode selected);
+
   private:
     static void saveUIConfig();
     static void keyVerificationInitMenu();

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -2178,6 +2178,91 @@ static void test_toggleNodeMuted_currentlyRewritesEverySegment()
     for (const char *f : segmentFiles)
         TEST_ASSERT_TRUE_MESSAGE(FSCom.exists(f), f);
 }
+
+// -----------------------------------------------------------------------
+// BaseUI region chooser preset default (graphics::menuHandler::presetForRegionSelection)
+// -----------------------------------------------------------------------
+//
+// Out-of-box US setup starts on LongTurbo. Each guard below is load-bearing: widening the rule past
+// "first region ever chosen, US, no preset on record" re-presets nodes that already have an opinion.
+
+// `region` is the region still in place when the user highlights `selected`.
+static meshtastic_Config_LoRaConfig loraAt(meshtastic_Config_LoRaConfig_RegionCode region,
+                                           meshtastic_Config_LoRaConfig_ModemPreset preset, bool usePreset = true)
+{
+    meshtastic_Config_LoRaConfig lora = meshtastic_Config_LoRaConfig_init_default;
+    lora.region = region;
+    lora.modem_preset = preset;
+    lora.use_preset = usePreset;
+    return lora;
+}
+
+#ifndef USERPREFS_LORACONFIG_MODEM_PRESET
+static void test_presetForRegionSelection_firstUsSelectionDefaultsToLongTurbo()
+{
+    const meshtastic_Config_LoRaConfig lora =
+        loraAt(meshtastic_Config_LoRaConfig_RegionCode_UNSET, meshtastic_Config_LoRaConfig_ModemPreset_LONG_FAST);
+
+    TEST_ASSERT_EQUAL(meshtastic_Config_LoRaConfig_ModemPreset_LONG_TURBO,
+                      graphics::menuHandler::presetForRegionSelection(lora, meshtastic_Config_LoRaConfig_RegionCode_US));
+
+    // Unusable unless US offers it: applyLoraRegion()'s reconciliation would throw it straight back.
+    TEST_ASSERT_TRUE_MESSAGE(getRegion(meshtastic_Config_LoRaConfig_RegionCode_US)
+                                 ->supportsPreset(meshtastic_Config_LoRaConfig_ModemPreset_LONG_TURBO),
+                             "US no longer supports LongTurbo");
+}
+#else
+// A pinned preset owns the decision outright.
+static void test_presetForRegionSelection_pinnedUserprefWins()
+{
+    const meshtastic_Config_LoRaConfig_ModemPreset pinned = USERPREFS_LORACONFIG_MODEM_PRESET;
+    const meshtastic_Config_LoRaConfig lora = loraAt(meshtastic_Config_LoRaConfig_RegionCode_UNSET, pinned);
+
+    TEST_ASSERT_EQUAL(pinned, graphics::menuHandler::presetForRegionSelection(lora, meshtastic_Config_LoRaConfig_RegionCode_US));
+}
+#endif
+
+// US on a node that already has a region is a region change, not first-time setup.
+static void test_presetForRegionSelection_laterUsSelectionKeepsCurrentPreset()
+{
+    const meshtastic_Config_LoRaConfig lora =
+        loraAt(meshtastic_Config_LoRaConfig_RegionCode_EU_868, meshtastic_Config_LoRaConfig_ModemPreset_LONG_FAST);
+
+    TEST_ASSERT_EQUAL(meshtastic_Config_LoRaConfig_ModemPreset_LONG_FAST,
+                      graphics::menuHandler::presetForRegionSelection(lora, meshtastic_Config_LoRaConfig_RegionCode_US));
+}
+
+// The default is US-only; no other region's first selection is touched.
+static void test_presetForRegionSelection_firstNonUsSelectionKeepsCurrentPreset()
+{
+    const meshtastic_Config_LoRaConfig lora =
+        loraAt(meshtastic_Config_LoRaConfig_RegionCode_UNSET, meshtastic_Config_LoRaConfig_ModemPreset_LONG_FAST);
+
+    for (auto region : {meshtastic_Config_LoRaConfig_RegionCode_EU_868, meshtastic_Config_LoRaConfig_RegionCode_ANZ,
+                        meshtastic_Config_LoRaConfig_RegionCode_JP})
+        TEST_ASSERT_EQUAL(meshtastic_Config_LoRaConfig_ModemPreset_LONG_FAST,
+                          graphics::menuHandler::presetForRegionSelection(lora, region));
+}
+
+// A preset off the install default is a preference on record (phone app, admin, preset menu).
+static void test_presetForRegionSelection_respectsAPresetAlreadyChosen()
+{
+    const meshtastic_Config_LoRaConfig lora =
+        loraAt(meshtastic_Config_LoRaConfig_RegionCode_UNSET, meshtastic_Config_LoRaConfig_ModemPreset_SHORT_FAST);
+
+    TEST_ASSERT_EQUAL(meshtastic_Config_LoRaConfig_ModemPreset_SHORT_FAST,
+                      graphics::menuHandler::presetForRegionSelection(lora, meshtastic_Config_LoRaConfig_RegionCode_US));
+}
+
+// use_preset false means raw bandwidth/SF/CR: rewriting modem_preset only misleads the preset menu.
+static void test_presetForRegionSelection_ignoresNodesOnRawModemSettings()
+{
+    const meshtastic_Config_LoRaConfig lora = loraAt(meshtastic_Config_LoRaConfig_RegionCode_UNSET,
+                                                     meshtastic_Config_LoRaConfig_ModemPreset_LONG_FAST, /*usePreset=*/false);
+
+    TEST_ASSERT_EQUAL(meshtastic_Config_LoRaConfig_ModemPreset_LONG_FAST,
+                      graphics::menuHandler::presetForRegionSelection(lora, meshtastic_Config_LoRaConfig_RegionCode_US));
+}
 #endif // HAS_SCREEN
 
 // -----------------------------------------------------------------------
@@ -2342,6 +2427,17 @@ void setup()
     RUN_TEST(test_toggleNodeMuted_flipsBitAndSkipsRadioReload);
     RUN_TEST(test_toggleNodeMuted_unknownNodeDoesNothing);
     RUN_TEST(test_toggleNodeMuted_currentlyRewritesEverySegment);
+
+    // BaseUI region chooser preset default
+#ifndef USERPREFS_LORACONFIG_MODEM_PRESET
+    RUN_TEST(test_presetForRegionSelection_firstUsSelectionDefaultsToLongTurbo);
+#else
+    RUN_TEST(test_presetForRegionSelection_pinnedUserprefWins);
+#endif
+    RUN_TEST(test_presetForRegionSelection_laterUsSelectionKeepsCurrentPreset);
+    RUN_TEST(test_presetForRegionSelection_firstNonUsSelectionKeepsCurrentPreset);
+    RUN_TEST(test_presetForRegionSelection_respectsAPresetAlreadyChosen);
+    RUN_TEST(test_presetForRegionSelection_ignoresNodesOnRawModemSettings);
 #endif
 
     exit(UNITY_END());


### PR DESCRIPTION
Selecting **US** in the BaseUI region chooser now installs **LongTurbo** instead of the region table's LongFast — but only for out-of-box setup.

### Scope

The default applies only when every one of these holds at the moment the region is confirmed:

| Condition | Why |
| --- | --- |
| Outgoing `config.lora.region == UNSET` | first region the node has ever had, i.e. initial setup |
| Selection is `US` | US only |
| `use_preset == true` | not running raw bandwidth/SF/CR |
| `modem_preset == LONG_FAST` | still the install default, so nothing has stated a preference |
| No `USERPREFS_LORACONFIG_MODEM_PRESET` | a build that pins a preset owns the decision |

The US entry in `regions[]` keeps LongFast as its default preset, so preset repair, admin/phone writes, `clampConfigLora()` and every other route onto US are unchanged. A later switch to US on a node that already has a region leaves whatever preset it is running alone.

The decision is lifted into `menuHandler::presetForRegionSelection()` so it is reachable without a Screen, following the existing `toggleNodeMuted()` precedent.

### Tests

Five cases added to `test_admin_radio`, covering the positive path plus each guard: later-US-selection, non-US first selection, a preset already moved off the default, and `use_preset == false`. The pinned-userpref build gets its own case via `#ifdef`.

Full native suite green: 1358/1358.

### Hardware validation

Heltec Mesh Node T096 (nRF52, OLED/BaseUI), driven through the real on-screen chooser via InputBroker events:

| Scenario | Result |
| --- | --- |
| region UNSET → pick US | `LONG_TURBO` — log `First region is US, default preset to LongTurbo` |
| region UNSET → pick EU_868 | stayed `LONG_FAST` |
| region EU_433 (already set) → pick US | stayed `LONG_FAST` |
| 2.7.26 → this build, no reset | region `US` / `LONG_FAST` preserved |

The upgrade case was run from a genuine 2.7 baseline: built and flashed `v2.7.26.54e0d8d`, factory reset to 2.7-era defaults, set US, then flashed this build over the top with no reset. Full config diff across the upgrade:

```
changed: {}
added:   moduleConfig.traffic_management.position_min_interval_secs: 18000
```

Only 2.8's new always-on traffic_management default. `lora.region` and `lora.modem_preset` untouched.

### Note for testers

A node that lands on LongTurbo cannot hear a LongFast mesh — 500 kHz vs 250 kHz — and its default channel name becomes `LongTurbo`, since an empty channel name is derived from the preset. That is intended for a first-time US setup, but it means any path that reinstalls defaults (config version discard, lockdown, degraded boot) followed by re-picking US on the device screen will move an existing node off LongFast. Worth watching during alpha.

Separately, #11636 tracks a pre-existing defect in the same function: the BaseUI chooser does not re-enable `tx_enabled`, so a node recovered from `region = UNSET` stays silent. Not addressed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved region selection defaults for first-time US setup.
  - Automatically selects the long-range turbo preset when no custom modem preset is configured.
  - Preserves existing or manually selected modem settings in all other cases.

- **Bug Fixes**
  - Prevents region changes from unexpectedly overwriting custom modem configurations.

- **Tests**
  - Added coverage for first-time setup, custom presets, non-US regions, and manual modem settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->