### PR TITLE
fix(nodedb): seed and persist the USERPREFS_FIXED_GPS position

### DIFF
--- a/.github/workflows/test_native.yml
+++ b/.github/workflows/test_native.yml
@@ -472,6 +472,17 @@ jobs:
           ./bin/check-test-attribution.py --label coverage-channel-table \
             --expect "$expect" channel-table-testreport.xml
 
+      - name: Build-time fixed position tests
+        run: platformio test -e coverage-fixed-gps -v --junit-output-path fixed-gps-testreport.xml
+
+      - name: Verify the fixed-gps suite ran its own tests
+        run: |
+          set -euo pipefail
+          expect=$(python3 -c "from platformio.project.config import ProjectConfig; \
+            print(' '.join(ProjectConfig().get('env:coverage-fixed-gps', 'test_filter', [])))")
+          ./bin/check-test-attribution.py --label coverage-fixed-gps \
+            --expect "$expect" fixed-gps-testreport.xml
+
       - name: Save test results
         if: always() # run this step even if previous step failed
         uses: actions/upload-artifact@v7

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -647,6 +647,27 @@ NodeDB::NodeDB()
             setLocalPosition(TypeConversions::ConvertToPosition(fixedPos));
             LOG_INFO("Restored fixed position to localPosition: lat=%d lon=%d", fixedPos.latitude_i, fixedPos.longitude_i);
         }
+#if defined(USERPREFS_FIXED_GPS) && defined(USERPREFS_FIXED_GPS_LAT) && defined(USERPREFS_FIXED_GPS_LON)
+        else if (!configDecodeFailed) {
+            // Nothing stored (first boot, factory reset, lost nodes.proto): seed the compiled-in coordinates. Persist explicitly:
+            // nodePositions is invisible to the CRC compare below; without a keypair (region UNSET) this just re-seeds next boot.
+            meshtastic_Position fixedGPS = meshtastic_Position_init_default;
+            fixedGPS.latitude_i = (int32_t)(USERPREFS_FIXED_GPS_LAT * 1e7);
+            fixedGPS.has_latitude_i = true;
+            fixedGPS.longitude_i = (int32_t)(USERPREFS_FIXED_GPS_LON * 1e7);
+            fixedGPS.has_longitude_i = true;
+#ifdef USERPREFS_FIXED_GPS_ALT
+            fixedGPS.altitude = USERPREFS_FIXED_GPS_ALT;
+            fixedGPS.has_altitude = true;
+#endif
+            fixedGPS.location_source = meshtastic_Position_LocSource_LOC_MANUAL;
+            updatePosition(getNodeNum(), fixedGPS, RX_SRC_LOCAL);
+#if !MESHTASTIC_EXCLUDE_POSITIONDB
+            saveWhat |= SEGMENT_CONFIG | SEGMENT_NODEDATABASE;
+#endif
+            LOG_INFO("Seeded build-time fixed position: lat=%d lon=%d", fixedGPS.latitude_i, fixedGPS.longitude_i);
+        }
+#endif
     }
 
     // Ensure that the neighbor info update interval is coerced to the minimum
@@ -681,35 +702,6 @@ NodeDB::NodeDB()
         config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_ENABLED;
         config.position.gps_enabled = 0;
     }
-#ifdef USERPREFS_FIXED_GPS
-    if (myNodeInfo.reboot_count == 1) { // Check if First boot ever or after Factory Reset.
-        meshtastic_Position fixedGPS = meshtastic_Position_init_default;
-#ifdef USERPREFS_FIXED_GPS_LAT
-        fixedGPS.latitude_i = (int32_t)(USERPREFS_FIXED_GPS_LAT * 1e7);
-        fixedGPS.has_latitude_i = true;
-#endif
-#ifdef USERPREFS_FIXED_GPS_LON
-        fixedGPS.longitude_i = (int32_t)(USERPREFS_FIXED_GPS_LON * 1e7);
-        fixedGPS.has_longitude_i = true;
-#endif
-#ifdef USERPREFS_FIXED_GPS_ALT
-        fixedGPS.altitude = USERPREFS_FIXED_GPS_ALT;
-        fixedGPS.has_altitude = true;
-#endif
-#if defined(USERPREFS_FIXED_GPS_LAT) && defined(USERPREFS_FIXED_GPS_LON)
-        fixedGPS.location_source = meshtastic_Position_LocSource_LOC_MANUAL;
-        config.has_position = true;
-#if !MESHTASTIC_EXCLUDE_POSITIONDB
-        {
-            concurrency::LockGuard guard(&satelliteMutex);
-            nodePositions[info->num] = TypeConversions::ConvertToPositionLite(fixedGPS);
-        }
-#endif
-        nodeDB->setLocalPosition(fixedGPS);
-        config.position.fixed_position = true;
-#endif
-    }
-#endif
     sortMeshDB();
     saveToDisk(saveWhat);
     bootInitializationInProgress = false;
@@ -1087,6 +1079,11 @@ void NodeDB::installDefaultConfig(bool preserveKey = false)
         config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_DISABLED;
 #else
     config.position.gps_mode = meshtastic_Config_PositionConfig_GpsMode_ENABLED;
+#endif
+
+#if defined(USERPREFS_FIXED_GPS) && defined(USERPREFS_FIXED_GPS_LAT) && defined(USERPREFS_FIXED_GPS_LON)
+    // Build-time fixed position defaults on; the NodeDB ctor seeds the coordinates once our NodeNum is final.
+    config.position.fixed_position = true;
 #endif
 
 #ifdef USERPREFS_CONFIG_SMART_POSITION_ENABLED

--- a/test/state-manifest.tsv
+++ b/test/state-manifest.tsv
@@ -51,6 +51,7 @@ test_admin_session_repro	writes=config.proto,module.proto,device.proto,channels.
 test_event_channel_phone_api	writes=config.proto,module.proto,device.proto,channels.proto,nodes.proto	constructs a NodeDB, whose constructor persists a default set when the prefs directory is empty
 test_event_channel_router	writes=config.proto,module.proto,device.proto,channels.proto,nodes.proto errors=200	subclasses NodeDB for the event-channel fixtures; the base constructor persists a default set when the prefs directory is empty
 test_firmware_edition	writes=config.proto,module.proto,device.proto,channels.proto,nodes.proto	persists an event firmware_edition in devicestate, then reboots a NodeDB to prove a vanilla build resets it
+test_fixed_gps_userprefs	state=per-suite writes=config.proto,module.proto,device.proto,channels.proto,nodes.proto	boots a NodeDB on empty prefs, then reboots it across test cases to prove a build-time fixed position round-trips through config.proto + nodes.proto and yields to a later app set/remove
 test_fuzz_decode	errors=20000..250000	fuzzes protobuf decode; every rejection logs. A collapse to near zero means the corpus stopped reaching the decoder
 test_fuzz_packets	writes=config.proto,module.proto,device.proto,channels.proto,nodes.proto,warm.dat,Messages_default.msgs errors=5000..60000	drives decode of fuzzed packets through the real NodeDB and message store
 test_hop_scaling	writes=config.proto,module.proto,device.proto,channels.proto,nodes.proto	constructs a NodeDB to hold the hop-distance fixtures

--- a/test/test_fixed_gps_userprefs/test_main.cpp
+++ b/test/test_fixed_gps_userprefs/test_main.cpp
@@ -1,0 +1,246 @@
+// A build-time fixed position (USERPREFS_FIXED_GPS) must land on disk before the boot save decision and behave like
+// every other USERPREFS_ default (app set/remove wins later). Without the define the suite pins the vanilla contract.
+#include "MeshTypes.h" // Include BEFORE TestUtil.h
+#include "TestUtil.h"
+#include "mesh/NodeDB.h"
+#include "mesh/TypeConversions.h"
+#include <unity.h>
+
+#if defined(ARCH_PORTDUINO)
+#define FG_TEST_ENTRY extern "C"
+#else
+#define FG_TEST_ENTRY
+#endif
+
+#if defined(USERPREFS_FIXED_GPS) && defined(USERPREFS_FIXED_GPS_LAT) && defined(USERPREFS_FIXED_GPS_LON)
+#define FIXED_GPS_BAKED 1
+#else
+#define FIXED_GPS_BAKED 0
+#endif
+
+void setUp(void) {}
+void tearDown(void) {}
+
+namespace
+{
+constexpr int32_t kAppLat = 471234567; // 47.1234567
+constexpr int32_t kAppLon = 84567890;  // 8.4567890
+constexpr int32_t kAppAlt = 432;
+
+#if FIXED_GPS_BAKED
+constexpr int32_t kBakedLat = (int32_t)(USERPREFS_FIXED_GPS_LAT * 1e7);
+constexpr int32_t kBakedLon = (int32_t)(USERPREFS_FIXED_GPS_LON * 1e7);
+#ifdef USERPREFS_FIXED_GPS_ALT
+constexpr int32_t kBakedAlt = USERPREFS_FIXED_GPS_ALT;
+#endif
+#endif
+
+// A real reboot starts with an empty localPosition (process global) and a fresh NodeDB.
+void rebootNodeDB()
+{
+    localPosition = meshtastic_Position_init_default;
+    NodeDB *rebooted = new NodeDB();
+    delete nodeDB;
+    nodeDB = rebooted;
+}
+
+bool persistedFixedFlag()
+{
+    meshtastic_LocalConfig saved = meshtastic_LocalConfig_init_zero;
+    TEST_ASSERT_EQUAL(LoadFileResult::LOAD_SUCCESS, nodeDB->loadProto(configFileName, meshtastic_LocalConfig_size, sizeof(saved),
+                                                                      &meshtastic_LocalConfig_msg, &saved));
+    return saved.position.fixed_position;
+}
+
+// True when nodes.proto on disk carries a non-zero position for our own node. Decodes into a scratch
+// struct: with the decode targets disarmed the callback appends to the struct's own vector.
+bool persistedSelfPosition(meshtastic_PositionLite &out)
+{
+    meshtastic_NodeDatabase saved;
+    if (nodeDB->loadProto(nodeDatabaseFileName, nodeDB->getMaxNodesAllocatedSize(), sizeof(saved), &meshtastic_NodeDatabase_msg,
+                          &saved) != LoadFileResult::LOAD_SUCCESS)
+        return false;
+    for (const auto &entry : saved.positions) {
+        if (entry.num == nodeDB->getNodeNum() && entry.has_position) {
+            out = entry.position;
+            return out.latitude_i != 0 || out.longitude_i != 0;
+        }
+    }
+    return false;
+}
+
+meshtastic_Position appPosition(int32_t lat, int32_t lon, int32_t alt)
+{
+    meshtastic_Position p = meshtastic_Position_init_default;
+    p.latitude_i = lat;
+    p.has_latitude_i = true;
+    p.longitude_i = lon;
+    p.has_longitude_i = true;
+    p.altitude = alt;
+    p.has_altitude = true;
+    p.location_source = meshtastic_Position_LocSource_LOC_MANUAL;
+    return p;
+}
+
+// Mirrors AdminModule set_fixed_position: what the phone app does.
+void appSetsFixedPosition(const meshtastic_Position &p)
+{
+    nodeDB->updatePosition(nodeDB->getNodeNum(), p, RX_SRC_LOCAL);
+    nodeDB->setLocalPosition(p);
+    config.position.fixed_position = true;
+    TEST_ASSERT_TRUE(nodeDB->saveToDisk(SEGMENT_NODEDATABASE | SEGMENT_CONFIG));
+}
+
+// Mirrors AdminModule remove_fixed_position.
+void appRemovesFixedPosition()
+{
+    nodeDB->clearLocalPosition();
+    config.position.fixed_position = false;
+    TEST_ASSERT_TRUE(nodeDB->saveToDisk(SEGMENT_NODEDATABASE | SEGMENT_CONFIG));
+}
+
+void assertSelfPositionIs(int32_t lat, int32_t lon)
+{
+    meshtastic_PositionLite self;
+    TEST_ASSERT_TRUE(nodeDB->copyNodePosition(nodeDB->getNodeNum(), self));
+    TEST_ASSERT_EQUAL_INT32(lat, self.latitude_i);
+    TEST_ASSERT_EQUAL_INT32(lon, self.longitude_i);
+}
+} // namespace
+
+#if FIXED_GPS_BAKED
+
+static void test_firstBoot_seedsAndPersistsBakedPosition(void)
+{
+    // In RAM after the very first boot ...
+    TEST_ASSERT_TRUE(config.position.fixed_position);
+    TEST_ASSERT_EQUAL_INT32(kBakedLat, localPosition.latitude_i);
+    TEST_ASSERT_EQUAL_INT32(kBakedLon, localPosition.longitude_i);
+#ifdef USERPREFS_FIXED_GPS_ALT
+    TEST_ASSERT_EQUAL_INT32(kBakedAlt, localPosition.altitude);
+#endif
+    TEST_ASSERT_EQUAL(meshtastic_Position_LocSource_LOC_MANUAL, localPosition.location_source);
+    TEST_ASSERT_TRUE(nodeDB->hasLocalPositionSinceBoot());
+    assertSelfPositionIs(kBakedLat, kBakedLon);
+
+    // ... and on disk, not just in RAM: the seed must land before the boot save decision.
+    TEST_ASSERT_TRUE(persistedFixedFlag());
+    meshtastic_PositionLite onDisk;
+    TEST_ASSERT_TRUE(persistedSelfPosition(onDisk));
+    TEST_ASSERT_EQUAL_INT32(kBakedLat, onDisk.latitude_i);
+    TEST_ASSERT_EQUAL_INT32(kBakedLon, onDisk.longitude_i);
+}
+
+static void test_reboot_restoresBakedPosition(void)
+{
+    // A later boot is not the first boot: the position must come back from disk, not from luck.
+    rebootNodeDB();
+
+    TEST_ASSERT_TRUE(config.position.fixed_position);
+    TEST_ASSERT_EQUAL_INT32(kBakedLat, localPosition.latitude_i);
+    TEST_ASSERT_EQUAL_INT32(kBakedLon, localPosition.longitude_i);
+    TEST_ASSERT_TRUE(nodeDB->hasLocalPositionSinceBoot());
+    assertSelfPositionIs(kBakedLat, kBakedLon);
+}
+
+static void test_appOverride_survivesReboot(void)
+{
+    // The baked value is a default, not a lock: a fixed position set from the app wins on reboot.
+    appSetsFixedPosition(appPosition(kAppLat, kAppLon, kAppAlt));
+    rebootNodeDB();
+
+    TEST_ASSERT_TRUE(config.position.fixed_position);
+    TEST_ASSERT_EQUAL_INT32(kAppLat, localPosition.latitude_i);
+    TEST_ASSERT_EQUAL_INT32(kAppLon, localPosition.longitude_i);
+    assertSelfPositionIs(kAppLat, kAppLon);
+}
+
+static void test_lostSelfPosition_isReseededOnReboot(void)
+{
+    // fixed_position stays on but nodes.proto lost our row (self-care, a reset, a corrupt file):
+    // the compiled-in coordinates come back instead of a node that silently stops reporting.
+    nodeDB->clearLocalPosition(); // erases the self position, keeps fixed_position
+    TEST_ASSERT_TRUE(nodeDB->saveToDisk(SEGMENT_NODEDATABASE));
+    TEST_ASSERT_TRUE(config.position.fixed_position);
+    rebootNodeDB();
+
+    TEST_ASSERT_TRUE(config.position.fixed_position);
+    TEST_ASSERT_EQUAL_INT32(kBakedLat, localPosition.latitude_i);
+    TEST_ASSERT_EQUAL_INT32(kBakedLon, localPosition.longitude_i);
+    assertSelfPositionIs(kBakedLat, kBakedLon);
+    meshtastic_PositionLite onDisk;
+    TEST_ASSERT_TRUE(persistedSelfPosition(onDisk));
+    TEST_ASSERT_EQUAL_INT32(kBakedLat, onDisk.latitude_i);
+}
+
+static void test_appRemove_staysRemovedAfterReboot(void)
+{
+    // Same contract as every other USERPREFS_ default: the user's removal is respected on later boots.
+    appRemovesFixedPosition();
+    TEST_ASSERT_FALSE(persistedFixedFlag());
+    rebootNodeDB();
+
+    TEST_ASSERT_FALSE(config.position.fixed_position);
+    TEST_ASSERT_EQUAL_INT32(0, localPosition.latitude_i);
+    TEST_ASSERT_EQUAL_INT32(0, localPosition.longitude_i);
+    TEST_ASSERT_FALSE(nodeDB->hasLocalPositionSinceBoot());
+    TEST_ASSERT_FALSE(persistedFixedFlag());
+}
+
+#else // vanilla build: no USERPREFS_FIXED_GPS
+
+static void test_vanillaBoot_hasNoPosition(void)
+{
+    TEST_ASSERT_FALSE(config.position.fixed_position);
+    TEST_ASSERT_EQUAL_INT32(0, localPosition.latitude_i);
+    TEST_ASSERT_EQUAL_INT32(0, localPosition.longitude_i);
+    TEST_ASSERT_FALSE(nodeDB->hasLocalPositionSinceBoot());
+    TEST_ASSERT_FALSE(persistedFixedFlag());
+}
+
+static void test_appFixedPosition_isRestoredAfterReboot(void)
+{
+    appSetsFixedPosition(appPosition(kAppLat, kAppLon, kAppAlt));
+    TEST_ASSERT_TRUE(persistedFixedFlag());
+    rebootNodeDB();
+
+    TEST_ASSERT_TRUE(config.position.fixed_position);
+    TEST_ASSERT_EQUAL_INT32(kAppLat, localPosition.latitude_i);
+    TEST_ASSERT_EQUAL_INT32(kAppLon, localPosition.longitude_i);
+    TEST_ASSERT_TRUE(nodeDB->hasLocalPositionSinceBoot());
+    assertSelfPositionIs(kAppLat, kAppLon);
+}
+
+static void test_appRemove_staysRemovedAfterReboot(void)
+{
+    appRemovesFixedPosition();
+    rebootNodeDB();
+
+    TEST_ASSERT_FALSE(config.position.fixed_position);
+    TEST_ASSERT_EQUAL_INT32(0, localPosition.latitude_i);
+    TEST_ASSERT_EQUAL_INT32(0, localPosition.longitude_i);
+    TEST_ASSERT_FALSE(persistedFixedFlag());
+}
+
+#endif
+
+FG_TEST_ENTRY void setup()
+{
+    initializeTestEnvironment();
+    nodeDB = new NodeDB();
+
+    UNITY_BEGIN();
+#if FIXED_GPS_BAKED
+    RUN_TEST(test_firstBoot_seedsAndPersistsBakedPosition);
+    RUN_TEST(test_reboot_restoresBakedPosition);
+    RUN_TEST(test_appOverride_survivesReboot);
+    RUN_TEST(test_lostSelfPosition_isReseededOnReboot);
+    RUN_TEST(test_appRemove_staysRemovedAfterReboot);
+#else
+    RUN_TEST(test_vanillaBoot_hasNoPosition);
+    RUN_TEST(test_appFixedPosition_isRestoredAfterReboot);
+    RUN_TEST(test_appRemove_staysRemovedAfterReboot);
+#endif
+    exit(UNITY_END());
+}
+FG_TEST_ENTRY void loop() {}

--- a/variants/native/portduino/platformio.ini
+++ b/variants/native/portduino/platformio.ini
@@ -165,6 +165,18 @@ test_filter =
   test_event_channel_phone_api
   test_mqtt
 
+; Build-time fixed position (USERPREFS_FIXED_GPS): the suite below asserts the seeded path here and the
+; vanilla path in the plain coverage env. Same shape as coverage-event-policy; CI runs it as its own step.
+[env:coverage-fixed-gps]
+extends = env:coverage
+build_flags = ${env:coverage.build_flags}
+  -DUSERPREFS_FIXED_GPS=1
+  -DUSERPREFS_FIXED_GPS_LAT=48.85873920
+  -DUSERPREFS_FIXED_GPS_LON=2.294508368
+  -DUSERPREFS_FIXED_GPS_ALT=35
+test_filter =
+  test_fixed_gps_userprefs
+
 ; ---------------------------------------------------------------------------
 ; Native build for macOS (Darwin / arm64 + x86_64). Headless meshtasticd that
 ; runs in SimRadio mode (`-s`) or against real LoRa hardware via a CH341


### PR DESCRIPTION
The `USERPREFS_FIXED_GPS` block in `NodeDB.cpp` was broken four ways. It did not compile: the satellite-map insert uses `info->num` with `info` undeclared in that scope. It called `nodeDB->setLocalPosition()` from inside the NodeDB constructor, where the global `nodeDB` pointer is still null — a store through null `this`, which panics with a store-access fault on ESP32-C6 and segfaults the native build. It ran after the boot save decision, so even a successful seed was never written to flash. And it was gated on `myNodeInfo.reboot_count == 1`, an ESP32-only NVS counter that is >1 after any non-erase reflash, so the path effectively never ran on real devices.

This change moves the feature to where the other `USERPREFS_` defaults live: `installDefaultConfig()` turns `config.position.fixed_position` on when the defines are present, and the constructor's existing "restore persisted position" block seeds the compiled-in coordinates via `updatePosition()` when `fixed_position` is on but no self position is stored, ORing `SEGMENT_CONFIG | SEGMENT_NODEDATABASE` into `saveWhat` (the `nodePositions` satellite map is not covered by the nodeDatabase CRC compare). A position set or removed from the app wins on later boots.

Tests: new native suite `test_fixed_gps_userprefs`, run in two flavours. The plain `coverage` env (no defines) covers 3 cases: no position appears from nowhere, an app-set fixed position is restored after reboot, remove stays removed. The new `coverage-fixed-gps` env (defines set) covers 5 cases: first boot seeds and persists, reboot restores, app override survives reboot, a lost self position is re-seeded, remove stays removed. On unfixed code the seeded suite segfaults in the first `new NodeDB()`. CI runs it as its own step, mirroring the existing coverage steps.

Tested on hardware: Seeed XIAO ESP32-C6 DIY node. After erase+flash, the first boot seeded and persisted the position; the next boot logged "Restored fixed position", and the CLI shows `fixedPosition true` with the compiled-in coordinates. No Heltec/RAK hardware available.

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)

Tested on Other: Seeed XIAO ESP32-C6 DIY (LLCC68).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a fixed GPS position at build time.
  * Fixed GPS coordinates are automatically initialized and persisted when no position is already stored.
  * Existing position updates and removals continue to override the configured default.

* **Tests**
  * Added comprehensive coverage for first-boot setup, reboot restoration, overrides, reseeding, and builds without fixed GPS preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->