### PR TITLE
fix(rp2040): run the blocking CYW43 WiFi join in a task and retry failed joins

### DIFF
--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -29,11 +29,13 @@
 #include <esp_wifi.h>
 static void WiFiEvent(WiFiEvent_t event);
 #elif defined(ARCH_RP2040)
+#include <FreeRTOS.h>
 #include <SimpleMDNS.h>
+#include <task.h>
 #endif
 
-#ifndef DISABLE_NTP
 #include "Throttle.h"
+#ifndef DISABLE_NTP
 #include <NTPClient.h>
 #endif
 
@@ -61,6 +63,31 @@ unsigned long lastrun_ntp = 0;
 
 bool needReconnect = true;   // If we create our reconnector, run it once at the beginning
 bool isReconnecting = false; // If we are currently reconnecting
+
+#ifdef ARCH_RP2040
+// On the CYW43 under FreeRTOS even WiFi.beginNoBlock() holds the caller for several seconds (up to the WiFi timeout,
+// 15 s); from the main loop that trips the 8 s hardware watchdog. Join from a short-lived task and poll for the link.
+static TaskHandle_t wifiJoinTask = nullptr;
+
+static void wifiJoinTaskFn(void *)
+{
+    const char *psk = config.network.wifi_psk[0] ? config.network.wifi_psk : NULL;
+    WiFi.beginNoBlock(config.network.wifi_ssid, psk);
+    wifiJoinTask = nullptr;
+    vTaskDelete(NULL);
+}
+
+static bool startWifiJoin()
+{
+    if (wifiJoinTask)
+        return true; // previous join still in progress
+    if (xTaskCreate(wifiJoinTaskFn, "wifijoin", 1536, NULL, uxTaskPriorityGet(NULL), &wifiJoinTask) != pdPASS) {
+        LOG_ERROR("Could not start WiFi join task");
+        return false;
+    }
+    return true;
+}
+#endif
 #if defined(USE_WS5500) || defined(USE_CH390D)
 static volatile bool ethNetworkConnectedPending = false;
 #endif
@@ -281,7 +308,11 @@ static int32_t reconnectWiFi()
                 WiFi.useStaticBuffers(true);
                 WiFi.mode(WIFI_STA);
 #endif
+#ifdef ARCH_RP2040
+                startWifiJoin();
+#else
                 WiFi.begin(wifiName, wifiPsw);
+#endif
             }
             isReconnecting = false;
             wifiReconnectPending = false;
@@ -311,7 +342,9 @@ static int32_t reconnectWiFi()
 
     if (config.network.wifi_enabled && !WiFi.isConnected()) {
 #ifdef ARCH_RP2040 // (ESP32 handles this in WiFiEvent)
-        needReconnect = APStartupComplete;
+        // Lost the link, or a join that has not come up within 30 s: start the join over once the join task is done.
+        needReconnect = !wifiJoinTask && (APStartupComplete || (!isReconnecting && !Throttle::isWithinTimespanMs(
+                                                                                     wifiReconnectStartMillis, 30000)));
 #endif
         return 1000; // check once per second
     } else {

--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -67,6 +67,7 @@ bool isReconnecting = false; // If we are currently reconnecting
 #ifdef ARCH_RP2040
 // On the CYW43 under FreeRTOS even WiFi.beginNoBlock() holds the caller for several seconds (up to the WiFi timeout,
 // 15 s); from the main loop that trips the 8 s hardware watchdog. Join from a short-lived task and poll for the link.
+// Pinned to core 0: the CYW43 shim is written for the core-0 LWIP thread and its core assertions are NDEBUG-only.
 static TaskHandle_t wifiJoinTask = nullptr;
 
 static void wifiJoinTaskFn(void *)
@@ -81,7 +82,8 @@ static bool startWifiJoin()
 {
     if (wifiJoinTask)
         return true; // previous join still in progress
-    if (xTaskCreate(wifiJoinTaskFn, "wifijoin", 1536, NULL, uxTaskPriorityGet(NULL), &wifiJoinTask) != pdPASS) {
+    if (xTaskCreateAffinitySet(wifiJoinTaskFn, "wifijoin", 1536, NULL, uxTaskPriorityGet(NULL), 1u << 0, &wifiJoinTask) !=
+        pdPASS) {
         LOG_ERROR("Could not start WiFi join task");
         return false;
     }

--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -31,6 +31,7 @@ static void WiFiEvent(WiFiEvent_t event);
 #elif defined(ARCH_RP2040)
 #include <FreeRTOS.h>
 #include <SimpleMDNS.h>
+#include <atomic>
 #include <task.h>
 #endif
 
@@ -68,23 +69,25 @@ bool isReconnecting = false; // If we are currently reconnecting
 // On the CYW43 under FreeRTOS even WiFi.beginNoBlock() holds the caller for several seconds (up to the WiFi timeout,
 // 15 s); from the main loop that trips the 8 s hardware watchdog. Join from a short-lived task and poll for the link.
 // Pinned to core 0: the CYW43 shim is written for the core-0 LWIP thread and its core assertions are NDEBUG-only.
-static TaskHandle_t wifiJoinTask = nullptr;
+// The claim is load/store only - ARMv6-M has no LDREX, so an exchange() would call libatomic.
+static std::atomic<bool> wifiJoinRunning{false};
 
 static void wifiJoinTaskFn(void *)
 {
     const char *psk = config.network.wifi_psk[0] ? config.network.wifi_psk : NULL;
     WiFi.beginNoBlock(config.network.wifi_ssid, psk);
-    wifiJoinTask = nullptr;
+    wifiJoinRunning.store(false, std::memory_order_release);
     vTaskDelete(NULL);
 }
 
 static bool startWifiJoin()
 {
-    if (wifiJoinTask)
+    if (wifiJoinRunning.load(std::memory_order_acquire))
         return true; // previous join still in progress
-    if (xTaskCreateAffinitySet(wifiJoinTaskFn, "wifijoin", 1536, NULL, uxTaskPriorityGet(NULL), 1u << 0, &wifiJoinTask) !=
-        pdPASS) {
+    wifiJoinRunning.store(true, std::memory_order_relaxed);
+    if (xTaskCreateAffinitySet(wifiJoinTaskFn, "wifijoin", 1536, NULL, uxTaskPriorityGet(NULL), 1u << 0, NULL) != pdPASS) {
         LOG_ERROR("Could not start WiFi join task");
+        wifiJoinRunning.store(false, std::memory_order_relaxed);
         return false;
     }
     return true;
@@ -345,8 +348,8 @@ static int32_t reconnectWiFi()
     if (config.network.wifi_enabled && !WiFi.isConnected()) {
 #ifdef ARCH_RP2040 // (ESP32 handles this in WiFiEvent)
         // Lost the link, or a join that has not come up within 30 s: start the join over once the join task is done.
-        needReconnect =
-            !wifiJoinTask && (APStartupComplete || (!isReconnecting && Throttle::hasElapsed(wifiReconnectStartMillis, 30000)));
+        needReconnect = !wifiJoinRunning.load(std::memory_order_acquire) &&
+                        (APStartupComplete || (!isReconnecting && Throttle::hasElapsed(wifiReconnectStartMillis, 30000)));
 #endif
         return 1000; // check once per second
     } else {

--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -71,6 +71,7 @@ bool isReconnecting = false; // If we are currently reconnecting
 // Pinned to core 0: the CYW43 shim is written for the core-0 LWIP thread and its core assertions are NDEBUG-only.
 // The claim is load/store only - ARMv6-M has no LDREX, so an exchange() would call libatomic.
 static std::atomic<bool> wifiJoinRunning{false};
+static uint32_t wifiJoinStartMillis = 0; // 0 = nothing in flight
 
 static void wifiJoinTaskFn(void *)
 {
@@ -85,9 +86,12 @@ static bool startWifiJoin()
     if (wifiJoinRunning.load(std::memory_order_acquire))
         return true; // previous join still in progress
     wifiJoinRunning.store(true, std::memory_order_relaxed);
+    uint32_t startedAt = millis();
+    wifiJoinStartMillis = startedAt == 0 ? 1 : startedAt;
     if (xTaskCreateAffinitySet(wifiJoinTaskFn, "wifijoin", 1536, NULL, uxTaskPriorityGet(NULL), 1u << 0, NULL) != pdPASS) {
         LOG_ERROR("Could not start WiFi join task");
         wifiJoinRunning.store(false, std::memory_order_relaxed);
+        wifiJoinStartMillis = 0;
         return false;
     }
     return true;
@@ -348,6 +352,15 @@ static int32_t reconnectWiFi()
 
     if (config.network.wifi_enabled && !WiFi.isConnected()) {
 #ifdef ARCH_RP2040 // (ESP32 handles this in WiFiEvent)
+        // CYW43::begin() can wait on the link past its own timeout with no deadline, never releasing the claim.
+        if (wifiJoinStartMillis != 0 && wifiJoinRunning.load(std::memory_order_relaxed) &&
+            Throttle::hasElapsed(wifiJoinStartMillis, 60000)) {
+            LOG_ERROR("WiFi join stuck in the driver for 60 s, reboot to recover");
+            wifiJoinStartMillis = 0; // say it once
+            uint32_t rebootAt = millis() + 5000;
+            rebootAtMsec = rebootAt == 0 ? 1 : rebootAt;
+        }
+
         // Lost the link, or a join that has not come up within 30 s: start the join over once the join task is done.
         // 0 means not armed, and Throttle::hasElapsed() leaves that test to the caller.
         needReconnect = !wifiJoinRunning.load(std::memory_order_acquire) &&

--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -343,8 +343,8 @@ static int32_t reconnectWiFi()
     if (config.network.wifi_enabled && !WiFi.isConnected()) {
 #ifdef ARCH_RP2040 // (ESP32 handles this in WiFiEvent)
         // Lost the link, or a join that has not come up within 30 s: start the join over once the join task is done.
-        needReconnect = !wifiJoinTask && (APStartupComplete || (!isReconnecting && !Throttle::isWithinTimespanMs(
-                                                                                     wifiReconnectStartMillis, 30000)));
+        needReconnect =
+            !wifiJoinTask && (APStartupComplete || (!isReconnecting && Throttle::hasElapsed(wifiReconnectStartMillis, 30000)));
 #endif
         return 1000; // check once per second
     } else {

--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -297,8 +297,9 @@ static int32_t reconnectWiFi()
 #endif
         LOG_INFO("Reconnecting to WiFi access point %s", wifiName);
 
-        // Start the non-blocking wait for 5 seconds
-        wifiReconnectStartMillis = millis();
+        // Start the non-blocking wait for 5 seconds. 0 is this field's "not armed", so never store it as a time.
+        uint32_t startedAt = millis();
+        wifiReconnectStartMillis = startedAt == 0 ? 1 : startedAt;
         wifiReconnectPending = true;
         // Do not attempt to connect yet, wait for the next invocation
         return 5000; // Schedule next check soon
@@ -348,8 +349,10 @@ static int32_t reconnectWiFi()
     if (config.network.wifi_enabled && !WiFi.isConnected()) {
 #ifdef ARCH_RP2040 // (ESP32 handles this in WiFiEvent)
         // Lost the link, or a join that has not come up within 30 s: start the join over once the join task is done.
+        // 0 means not armed, and Throttle::hasElapsed() leaves that test to the caller.
         needReconnect = !wifiJoinRunning.load(std::memory_order_acquire) &&
-                        (APStartupComplete || (!isReconnecting && Throttle::hasElapsed(wifiReconnectStartMillis, 30000)));
+                        (APStartupComplete || (!isReconnecting && wifiReconnectStartMillis != 0 &&
+                                               Throttle::hasElapsed(wifiReconnectStartMillis, 30000)));
 #endif
         return 1000; // check once per second
     } else {


### PR DESCRIPTION
On the RP2040 (Pico W), joining WiFi resets the node before the join can complete. Meshtastic builds the RP2040 target with FreeRTOS, and under FreeRTOS the arduino-pico CYW43 shim holds the caller for several seconds even in `WiFi.beginNoBlock()` (measured 4.4 s in a bare FreeRTOS sketch, more than 8 s inside Meshtastic with the radio and GPS threads running). The RP2040 hardware watchdog (`watchdog_enable(8000)` in `platform/rp2xx0/main-rp2xx0.cpp`) is only fed from `loop()`, so the reset lands about 8 s after "Reconnecting to WiFi access point ..." and the node never associates. A second, smaller defect: on RP2040 a failed first join was never retried, because `needReconnect` was only re-armed once `APStartupComplete` is set, which requires a successful connection.

Fix: on `ARCH_RP2040` the join runs in a short-lived FreeRTOS task (`startWifiJoin()`); the existing reconnect poll keeps running in the main loop and re-arms a new join if none has come up within 30 s. Other platforms are unchanged.

### Tested

Raspberry Pi Pico W (DIY variant with LLCC68), on hardware, on the branch as it stands.

The original two commits: before, a watchdog reset exactly 8 s after every "Reconnecting" line and the node never appeared on the AP. After, "Obtained IP address", mDNS, NTP and the TCP API all come up, joins survive AP roaming gaps, and there are no watchdog resets. Related report: #3535 (closed unresolved).

The four commits added after review, re-tested on the same board:

- Cold start joins and gets an IP in 129 s. Pinning the join to core 0 changes nothing there.
- 10 minutes connected: rebootCount 0, no spurious "WiFi join stuck in the driver".
- The retry is still live after a failure: rejoin 22 s after the AP let the node back in. Verified by outcome, not by measuring the 35 s cadence.
- 6.5 minutes with the node's MAC blocked at the AP: zero reboots. A normally failed join returns from beginNoBlock and releases the claim, so the wedge detector never arms - which is the failure mode worth being sure about, since a false arm would reboot the node about every 65 s.
- The wedge path cannot be provoked naturally, so it was exercised with a temporary harness (shortened timeout, claim held): exactly one error line per cycle and the scheduled reboot about 5 s later, over 6 cycles. The harness is not in this branch.

One trap worth naming for anyone reproducing this: with a serial monitor attached the node looks like it is in a boot loop. That is the RP2040 CDC config dump starving the 8 s watchdog, not this change. Check RP2040 WiFi behaviour over the network rather than over USB serial.

No Heltec/RAK/T-Beam hardware was available; the change is compile-time inert off RP2040.

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)

Tested on Other: Raspberry Pi Pico W (DIY) + LLCC68.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Wi‑Fi connection reliability on RP2040 devices.
  * Prevented Wi‑Fi association attempts from triggering the hardware watchdog.
  * Added more resilient retry handling when connections do not establish within the expected timeframe.
  * Improved recovery when a Wi‑Fi connection attempt becomes unresponsive, including automatic device restart after 60 seconds.
  * Other supported platforms continue using the existing Wi‑Fi connection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
