### PR TITLE
Update applyLoraRegion to enable TX on set

### DIFF
--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -272,7 +272,7 @@ static void applyLoraRegion(meshtastic_Config_LoRaConfig_RegionCode region, bool
     if (gps != nullptr && !gps->isEnabled() && config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED)
         gps->enable();
 #endif
-    if (config.lora.region != meshtastic_Config_LoRaConfig_RegionCode_UNSET && !config.lora.tx_enabled) {
+    if (config.lora.region != meshtastic_Config_LoRaConfig_RegionCode_UNSET && !config.lora.tx_enabled && !isHam) {
         LOG_WARN("Setting config.lora.tx_enabled to true");
         config.lora.tx_enabled = true;
     }

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -272,6 +272,10 @@ static void applyLoraRegion(meshtastic_Config_LoRaConfig_RegionCode region, bool
     if (gps != nullptr && !gps->isEnabled() && config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED)
         gps->enable();
 #endif
+    if (config.lora.region != meshtastic_Config_LoRaConfig_RegionCode_UNSET && !config.lora.tx_enabled) {
+        LOG_WARN("Setting config.lora.tx_enabled to true");
+        config.lora.tx_enabled = true;
+    }
     service->reloadConfig(changes);
 }
 

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -272,7 +272,7 @@ static void applyLoraRegion(meshtastic_Config_LoRaConfig_RegionCode region, bool
     if (gps != nullptr && !gps->isEnabled() && config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED)
         gps->enable();
 #endif
-    if (config.lora.region != meshtastic_Config_LoRaConfig_RegionCode_UNSET && !config.lora.tx_enabled && !isHam) {
+    if (config.lora.region != meshtastic_Config_LoRaConfig_RegionCode_UNSET && !config.lora.tx_enabled && !owner.is_licensed) {
         LOG_WARN("Setting config.lora.tx_enabled to true");
         config.lora.tx_enabled = true;
     }


### PR DESCRIPTION
- Update applyLoraRegion to enable TX on set
- Don't enable TX when owner.is_licensed is set

Tested on Wio Tracker L1

Steps to reproduce for testing:

1. Update firmware
2. meshtastic --set lora.tx_enabled FALSE 
3. meshtastic --set lora.region UNSET --set lora.modem_preset 0
4. Pick new region and verify region is set and TX is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Applying a configured LoRa region now automatically enables LoRa transmission when transmission is disabled.
* A warning is displayed before the transmission setting changes.
* LoRa transmission remains unchanged for licensed users, including when applying a non-ham region.
* LoRa transmission remains unchanged when applying a region in ham mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->