### PR TITLE
feat(rak3172): promote to actively supported variant

### DIFF
--- a/variants/stm32/rak3172/platformio.ini
+++ b/variants/stm32/rak3172/platformio.ini
@@ -1,4 +1,12 @@
 [env:rak3172]
+custom_meshtastic_hw_model = 72
+custom_meshtastic_hw_model_slug = RAK3172
+custom_meshtastic_architecture = stm32
+custom_meshtastic_actively_supported = true
+custom_meshtastic_support_level = 1
+custom_meshtastic_display_name = RAK WisDuo 3172/WisBlock 3372
+custom_meshtastic_tags = RAK
+
 extends = stm32_base
 board = wiscore_rak3172
 board_level = pr

--- a/variants/stm32/rak3172/variant.h
+++ b/variants/stm32/rak3172/variant.h
@@ -3,11 +3,6 @@ STM32WLE5 Core Module for LoRaWAN® RAK3372
 https://store.rakwireless.com/products/wisblock-core-module-rak3372
 */
 
-/*
-This variant is a work in progress.
-Do not expect a working Meshtastic device with this target.
-*/
-
 #ifndef _VARIANT_RAK3172_
 #define _VARIANT_RAK3172_
 


### PR DESCRIPTION
Promotes the `rak3172` variant (RAK3172 WisDuo module / RAK3372 WisBlock Core, STM32WLE5CCU6 + integrated SX1262) to an actively supported device.

`variants/stm32/rak3172/platformio.ini` had no `custom_meshtastic_*` metadata block, so `bin/platformio-custom.py` emitted a manifest with `activelySupported: false` and `displayName: "rak3172"`, and the board never appeared in the web flasher list or `api.meshtastic.org/resource/deviceHardware` (both generated from the per-board firmware manifests). No protobuf change is involved: `RAK3172 = 72` already exists in `HardwareModel` and the variant already declares `HW_VENDOR meshtastic_HardwareModel_RAK3172`.

This adds the metadata block, mirroring `[env:rak4631]`:

| field | value |
| --- | --- |
| `custom_meshtastic_hw_model` | `72` (`meshtastic_HardwareModel_RAK3172`) |
| `custom_meshtastic_hw_model_slug` | `RAK3172` |
| `custom_meshtastic_architecture` | `stm32` |
| `custom_meshtastic_actively_supported` | `true` |
| `custom_meshtastic_support_level` | `1` |
| `custom_meshtastic_display_name` | `RAK WisDuo 3172/WisBlock 3372` |
| `custom_meshtastic_tags` | `RAK` |

`board_level` stays `pr` — the smallest matrix subset, also built in every larger matrix, same as `[env:rak4631]`.

`custom_meshtastic_images` is omitted: no `rak3172.svg` exists in `meshtastic/web-flasher` yet. The flasher and CI comment degrade to no image when the file 404s. An illustration can be added upstream in a follow-up, then referenced here.

Also drops the stale "work in progress / do not expect a working device" disclaimer from `variant.h`, which contradicts an actively supported declaration.

### Test plan

- `pio run -e rak3172` succeeds; flash 88.0% (217972 / 247808 bytes), RAM 40.3%.
- Generated `.pio/build/rak3172/firmware-rak3172-*.mt.json` shows `activelySupported: true`, `supportLevel: 1`, `hwModel: 72`, `hwModelSlug: "RAK3172"`, `architecture: "stm32"`.
- `./bin/generate_ci_matrix.py stm32 --level pr` still lists `rak3172`.
- Hardware smoke test on an RAK3172: _pending_.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other: RAK3172 — build-verified only so far
