### PR TITLE
feat(wio-e5): promote Seeed Wio-E5 to actively supported

### DIFF
--- a/variants/stm32/wio-e5/platformio.ini
+++ b/variants/stm32/wio-e5/platformio.ini
@@ -1,4 +1,12 @@
 [env:wio-e5]
+custom_meshtastic_hw_model = 73
+custom_meshtastic_hw_model_slug = WIO_E5
+custom_meshtastic_architecture = stm32
+custom_meshtastic_actively_supported = true
+custom_meshtastic_support_level = 1
+custom_meshtastic_display_name = Seeed Wio-E5
+custom_meshtastic_tags = Seeed
+
 extends = stm32_base
 board = lora_e5_dev_board
 board_level = pr

--- a/variants/stm32/wio-e5/variant.h
+++ b/variants/stm32/wio-e5/variant.h
@@ -1,12 +1,8 @@
 /*
-Wio-E5 mini (formerly LoRa-E5 mini)
-https://www.seeedstudio.com/LoRa-E5-mini-STM32WLE5JC-p-4869.html
-https://www.seeedstudio.com/LoRa-E5-Wireless-Module-p-4745.html
-*/
-
-/*
-This variant is a work in progress.
-Do not expect a working Meshtastic device with this target.
+Seeed LoRa-E5 (STM32WLE5JC) module - Wio-E5 Development Kit and Wio-E5 mini
+https://wiki.seeedstudio.com/LoRa_E5_Dev_Board/
+https://wiki.seeedstudio.com/LoRa_E5_mini/
+LED_POWER (PB5) and the module pin map are common to both boards.
 */
 
 #ifndef _VARIANT_WIOE5_


### PR DESCRIPTION
## What this does

Promotes the `wio-e5` STM32WL variant to an actively supported Meshtastic device, mirroring #11647 for `rak3172`.

Adds the `custom_meshtastic_*` metadata block to `[env:wio-e5]` in `variants/stm32/wio-e5/platformio.ini`, alongside the existing `[env:rak4631]` and `[env:rak3172]` blocks. `bin/platformio-custom.py` reads these keys and emits a per-board build manifest with `activelySupported: true`, `supportLevel: 1`, `hwModel: 73`, `hwModelSlug: "WIO_E5"`, `architecture: "stm32"`, `displayName: "Seeed Wio-E5"`, `tags: ["Seeed"]`. The web flasher board list and `api.meshtastic.org/resource/deviceHardware` are generated from those manifests, so the board becomes a selectable device.

`displayName` is `Seeed Wio-E5` because this single variant builds firmware for both Seeed boards that carry the LoRa-E5 (STM32WLE5JC) module: the Wio-E5 Development Kit and the Wio-E5 mini. They share the module pin map and the PB5 status LED. `custom_meshtastic_images` is omitted because `meshtastic/web-flasher` has no `wio-e5.svg`; the flasher and the CI board-diff comment degrade to no image.

`board_level` stays `pr` (the smallest CI matrix subset, also built in every larger matrix), matching `[env:rak4631]` and `[env:rak3172]`.

`variants/stm32/wio-e5/variant.h`: the header comment is rewritten to drop the "work in progress / do not expect a working Meshtastic device" disclaimer, which contradicts an actively-supported declaration, and to record that the one variant covers both boards. The current Seeed wiki URLs replace the dead store links. No code in `variant.h` changes (`LED_POWER PB5`, the `WIO_E5` define, and the guards are untouched).

No protobuf change: `WIO_E5 = 73` and the `HW_VENDOR` mapping for `_VARIANT_WIOE5_` already exist in the tree.

## Verification

`pio run -e wio-e5` succeeds. Flash 93.0% (230384 / 247808 bytes), RAM 41.5% (27172 / 65536 bytes). The generated `.pio/build/wio-e5/firmware-wio-e5-*.mt.json` contains the expected `activelySupported`, `supportLevel`, `hwModel`, `hwModelSlug`, `architecture`, `displayName`, and `tags` values. `./bin/generate_ci_matrix.py stm32 --level pr` still lists `wio-e5`. `trunk fmt` clean on both files.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below): WIO_E5 — build-verified only so far
