### PR TITLE
fix(milesight-gs301): fix STM32WL build breakage

### DIFF
--- a/variants/stm32/milesight_gs301/platformio.ini
+++ b/variants/stm32/milesight_gs301/platformio.ini
@@ -13,8 +13,6 @@ build_flags =
   -DMESHTASTIC_EXCLUDE_I2C=1 # Analog ADuCM355 (unsupported) so no point building support for I2C in
   -DMESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR=1
   -DMESHTASTIC_EXCLUDE_AIR_QUALITY_SENSOR=1
-build_unflags =
-  -DDEBUG_MUTE # We have space for debug output until sensor support is added
 build_src_filter =
   ${stm32_base.build_src_filter}
   +<../variants/stm32/milesight_gs301>

--- a/variants/stm32/milesight_gs301/variant.h
+++ b/variants/stm32/milesight_gs301/variant.h
@@ -31,6 +31,9 @@
 #define PIN_SERIAL1_RX NC
 #define PIN_SERIAL1_TX PB6
 
+// Bind the Serial module to Serial1; SerialModule defaults to Serial2, which the RAK3172 module lacks
+#define SERIAL_PRINT_PORT 1
+
 // LoRa
 #define SX126X_DIO3_TCXO_VOLTAGE 3.0
 


### PR DESCRIPTION
The `milesight_gs301` variant has not compiled since it was added in #9359. It is `board_level = extra`, so no CI matrix build exercises it.

Two independent failures on a clean `develop`:

1. `build_unflags` removes `-DDEBUG_MUTE`, but the STM32 base config (`variants/stm32/stm32.ini`) keeps `PIO_FRAMEWORK_ARDUINO_NANOLIB_FLOAT_PRINTF` commented out. `src/platform/stm32wl/architecture.h:54` then fails the build with `#error "You MUST enable PIO_FRAMEWORK_ARDUINO_NANOLIB_FLOAT_PRINTF if debug prints are enabled."` This PR drops the `-DDEBUG_MUTE` unflag so the variant behaves like every other STM32 target. Debug logs are still reachable by `#undef DEBUG_MUTE` at the top of individual source files. Enabling the nanolib flag instead would keep debug prints on by default but overflows the RAK3172 flash budget by 20 bytes.
2. `SerialModule` defaults `SERIAL_PRINT_PORT` to `2`, referencing `Serial2`. The RAK3172 module only exposes `Serial1`, so the link fails with `undefined reference to 'Serial2'`. This PR sets `SERIAL_PRINT_PORT 1` in `variant.h`, matching the sibling RAK3172-based variants `rak3172` and `CDEBYTE_E77-MBL`.

After this change `pio run -e milesight_gs301` succeeds: Flash 76.0% (188424 / 247808 bytes), RAM 39.4%.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described. (build-verified only — `pio run -e milesight_gs301`)
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other: milesight_gs301 — build only; change is confined to that variant's config


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored debug output for the Milesight GS301 build.
  * Configured serial communication to use the available Serial1 port on the RAK3172 module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->