### PR TITLE
fix(ble): stop BLE from coming back up during the pre-reboot window

### DIFF
--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -195,15 +195,8 @@ static void lsExit()
     t5BacklightWakeFromSleep();
 }
 
-/// Re-enable BLE, unless we are already on our way out.
-///
-/// A reboot or shutdown is armed a few seconds ahead of the reset so the client gets its ack and the
-/// user gets the banner, and the paths that arm it (AdminModule::disableBluetooth()) deliberately take
-/// the radio down first. Any state transition landing in that window - a button press, the screen
-/// timeout, USB being plugged in - would otherwise turn BLE straight back on and let the phone
-/// reconnect to a node that is about to disappear, so the user sees a reconnect immediately followed by
-/// a second disconnect at the reset. Every writer of these two deadlines is an imminent restart, so
-/// suppressing the re-enable here costs nothing in normal operation.
+/// Skip the BLE re-enable while a reboot/shutdown is armed: AdminModule tears BLE down before
+/// scheduling the restart, and a state transition in that window would otherwise bring it back up.
 static void setBluetoothEnableUnlessRestarting()
 {
     if (rebootAtMsec || shutdownAtMsec) {

--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -195,6 +195,24 @@ static void lsExit()
     t5BacklightWakeFromSleep();
 }
 
+/// Re-enable BLE, unless we are already on our way out.
+///
+/// A reboot or shutdown is armed a few seconds ahead of the reset so the client gets its ack and the
+/// user gets the banner, and the paths that arm it (AdminModule::disableBluetooth()) deliberately take
+/// the radio down first. Any state transition landing in that window - a button press, the screen
+/// timeout, USB being plugged in - would otherwise turn BLE straight back on and let the phone
+/// reconnect to a node that is about to disappear, so the user sees a reconnect immediately followed by
+/// a second disconnect at the reset. Every writer of these two deadlines is an imminent restart, so
+/// suppressing the re-enable here costs nothing in normal operation.
+static void setBluetoothEnableUnlessRestarting()
+{
+    if (rebootAtMsec || shutdownAtMsec) {
+        LOG_POWERFSM("Skip BLE enable, restart pending");
+        return;
+    }
+    setBluetoothEnable(true);
+}
+
 static void nbEnter()
 {
     LOG_POWERFSM("State: nbEnter");
@@ -211,7 +229,7 @@ static void nbEnter()
 static void darkEnter()
 {
     LOG_POWERFSM("State: darkEnter");
-    setBluetoothEnable(true);
+    setBluetoothEnableUnlessRestarting();
     if (screen)
         screen->setOn(false);
     // Screen timeout enters DARK; ensure backlight also turns off.
@@ -235,7 +253,7 @@ static void serialExit()
 {
     LOG_POWERFSM("State: serialExit");
     // Turn bluetooth back on when we leave serial stream API
-    setBluetoothEnable(true);
+    setBluetoothEnableUnlessRestarting();
 }
 
 static void powerEnter()
@@ -248,7 +266,7 @@ static void powerEnter()
     } else {
         if (screen)
             screen->setOn(true);
-        setBluetoothEnable(true);
+        setBluetoothEnableUnlessRestarting();
         // within enter() the function getState() returns the state we came from
     }
 }
@@ -266,7 +284,7 @@ static void powerIdle()
 static void powerExit()
 {
     LOG_POWERFSM("State: powerExit");
-    setBluetoothEnable(true);
+    setBluetoothEnableUnlessRestarting();
 }
 
 static void onEnter()
@@ -274,7 +292,7 @@ static void onEnter()
     LOG_POWERFSM("State: onEnter");
     if (screen)
         screen->setOn(true);
-    setBluetoothEnable(true);
+    setBluetoothEnableUnlessRestarting();
 }
 
 static void onIdle()

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -245,8 +245,18 @@ void NRF52Bluetooth::shutdown()
     // Shutdown bluetooth for minimum power draw
     LOG_INFO("Disable NRF52 bluetooth");
     Bluefruit.Security.setPairPasskeyCallback(NRF52Bluetooth::onUnwantedPairing); // Actively refuse (during factory reset)
-    disconnect();
+
+    // Clear Bluefruit's restart-on-disconnect before dropping the link, and do it in that order.
+    // Phone-originated admin messages run synchronously on the BLE event task (toRadio's write
+    // callback is registered undeferred), so the BLE_GAP_EVT_DISCONNECTED we are about to cause is
+    // only handled after we return - and that handler re-starts advertising while the flag is set.
+    // Stopping advertising afterwards does not help: a live connection means the SoftDevice is not
+    // advertising, so sd_ble_gap_adv_stop() is a no-op and the deferred event brings advertising
+    // straight back. The phone then reconnects during the reboot delay only to be dropped again by
+    // the reset. startAdv()/resumeAdvertising() set the flag again on the re-enable path.
+    Bluefruit.Advertising.restartOnDisconnect(false);
     Bluefruit.Advertising.stop();
+    disconnect();
 }
 void NRF52Bluetooth::startDisabled()
 {

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -246,14 +246,8 @@ void NRF52Bluetooth::shutdown()
     LOG_INFO("Disable NRF52 bluetooth");
     Bluefruit.Security.setPairPasskeyCallback(NRF52Bluetooth::onUnwantedPairing); // Actively refuse (during factory reset)
 
-    // Clear Bluefruit's restart-on-disconnect before dropping the link, and do it in that order.
-    // Phone-originated admin messages run synchronously on the BLE event task (toRadio's write
-    // callback is registered undeferred), so the BLE_GAP_EVT_DISCONNECTED we are about to cause is
-    // only handled after we return - and that handler re-starts advertising while the flag is set.
-    // Stopping advertising afterwards does not help: a live connection means the SoftDevice is not
-    // advertising, so sd_ble_gap_adv_stop() is a no-op and the deferred event brings advertising
-    // straight back. The phone then reconnects during the reboot delay only to be dropped again by
-    // the reset. startAdv()/resumeAdvertising() set the flag again on the re-enable path.
+    // Clear the auto-restart flag before dropping the link: our DISCONNECTED event is only processed
+    // after this callback returns and would re-start advertising. startAdv()/resumeAdvertising() re-set it.
     Bluefruit.Advertising.restartOnDisconnect(false);
     Bluefruit.Advertising.stop();
     disconnect();


### PR DESCRIPTION
## Symptom

Reported by @xaositek on a Heltec T096 (nRF52): connected via BLE, change a reboot-requiring setting like screen-on time → the node disconnects, shows the rebooting banner, the phone **reconnects**, then the node resets and it reconnects a second time. The pre-reboot Bluetooth teardown wasn't sticking.

## Root causes

**nRF52 (deterministic):** Phone-originated admin messages run synchronously on Bluefruit's BLE event task (`toRadio`'s write callback is registered undeferred). `NRF52Bluetooth::shutdown()` called `disconnect()` then `Advertising.stop()`, but:

1. The `BLE_GAP_EVT_DISCONNECTED` we cause can only be processed after our callback returns, so `disconnect()` burns its 1s bound (#11202) and returns with the link still up.
2. `Advertising.stop()` is then a no-op — while a connection is live the SoftDevice isn't advertising (`sd_ble_gap_adv_stop()` returns `NRF_ERROR_INVALID_STATE`).
3. When the deferred disconnect event finally runs, Bluefruit's handler sees `_start_if_disconnect` — latched `true` by `startAdv()`/`resumeAdvertising()` and never cleared — and **restarts advertising**. The phone reconnects during the 7s reboot delay and gets dropped again at `NVIC_SystemReset()`.

**PowerFSM (all platforms):** `darkEnter`/`onEnter`/`powerEnter`/`powerExit`/`serialExit` unconditionally call `setBluetoothEnable(true)`. Any state transition landing inside the reboot window — a button press while the banner is up, the screen timeout (the `DARK→DARK` timed self-transition re-runs `darkEnter`), USB plug/unplug — turned BLE straight back on after AdminModule had deliberately torn it down. On ESP32 this attempted a full NimBLE re-init mid-teardown.

## Fix

- `NRF52Bluetooth::shutdown()`: clear `restartOnDisconnect` and stop advertising **before** dropping the link, mirroring the `ble_enabled` gate nRF54L15 already has. The re-enable paths (`startAdv()`/`resumeAdvertising()`) set the flag back. This also closes a main-thread race on the shutdown/deep-sleep path where `Advertising.stop()` could land in the gap between connection teardown and Bluefruit's auto-restart inside the same event dispatch.
- PowerFSM: route the five re-enable sites through `setBluetoothEnableUnlessRestarting()`, which skips the enable while `rebootAtMsec`/`shutdownAtMsec` is armed. Every writer of those deadlines is an imminent restart, so this costs nothing in normal operation.

Paths that deliberately keep BLE up until the reset (explicit `reboot_seconds`, lockdown lock-now, TX-watchdog reboot) are unchanged: single clean disconnect at reset, acks still reach the phone.

Same-cause triggers also fixed: factory reset, nodedb reset, commit-edit-settings, on-device BT toggle (`SystemCommandsModule`), and phone-initiated shutdown.

Note for testers: the 1s `BLE disconnect unconfirmed after 1000ms` warning is still expected when saving over BLE — the event genuinely can't be observed from that task — it just no longer has consequences. Expected sequence is now disconnect → banner → quiet → single reconnect after boot.

## Testing

- Built `heltec-mesh-node-t096` (nRF52840) clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth shutdown behavior during reboot and power-off.
  * Prevented Bluetooth from being re-enabled when a reboot or shutdown is pending.
  * Prevented unwanted advertising and reconnection during the reboot delay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->