### PR TITLE
fix(admin): don't disable BLE on config paths that never reboot

### DIFF
--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -653,8 +653,8 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
                                        SEGMENT_DEVICESTATE | SEGMENT_CONFIG | SEGMENT_MODULECONFIG | SEGMENT_CHANNELS)) {
             myReply = allocErrorResponse(meshtastic_Routing_Error_NONE, &mp);
             LOG_DEBUG("Rebooting after preferences restore");
-            reboot(1000);
             disableBluetooth();
+            reboot(DEFAULT_REBOOT_SECONDS);
         } else {
             myReply = allocErrorResponse(meshtastic_Routing_Error_BAD_REQUEST, &mp);
         }
@@ -1233,10 +1233,12 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
 bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
 {
     bool shouldReboot = true;
-    // If we are in an open transaction or configuring MQTT or Serial (which have validation), defer disabling Bluetooth
-    // Otherwise, disable Bluetooth to prevent the phone from interfering with the config
-    if (!hasOpenEditTransaction && !IS_ONE_OF(c.which_payload_variant, meshtastic_ModuleConfig_mqtt_tag,
-                                              meshtastic_ModuleConfig_serial_tag, meshtastic_ModuleConfig_statusmessage_tag)) {
+    // Skip the variants that must not lose BLE here: MQTT and Serial validate first and disable it
+    // themselves, and statusmessage/mesh_beacon never reboot, so a disable would strand BLE until the
+    // next PowerFSM transition. Everything else reboots, so take BLE down before the phone interferes.
+    if (!hasOpenEditTransaction &&
+        !IS_ONE_OF(c.which_payload_variant, meshtastic_ModuleConfig_mqtt_tag, meshtastic_ModuleConfig_serial_tag,
+                   meshtastic_ModuleConfig_statusmessage_tag, meshtastic_ModuleConfig_mesh_beacon_tag)) {
         disableBluetooth();
     }
 
@@ -1250,8 +1252,10 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
         if (!MQTT::isValidConfig(c.payload_variant.mqtt)) {
             return false;
         }
-        // Disable Bluetooth to prevent interference during MQTT configuration
-        disableBluetooth();
+        // Disable Bluetooth to prevent interference during MQTT configuration, except inside an edit
+        // transaction: saveChanges() defers the reboot there, so nothing would bring BLE back.
+        if (!hasOpenEditTransaction)
+            disableBluetooth();
         moduleConfig.has_mqtt = true;
         {
             char prevPass[sizeof(moduleConfig.mqtt.password)];
@@ -1269,7 +1273,9 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
             LOG_ERROR("Invalid serial config");
             return false;
         }
-        disableBluetooth(); // Disable Bluetooth to prevent interference during Serial configuration
+        // Same transaction caveat as MQTT above: a deferred reboot would leave BLE down with no restore.
+        if (!hasOpenEditTransaction)
+            disableBluetooth(); // Disable Bluetooth to prevent interference during Serial configuration
         moduleConfig.has_serial = true;
         moduleConfig.serial = c.payload_variant.serial;
         break;


### PR DESCRIPTION
Follow-up to #11650. Three config paths take BLE down and leave nothing to bring it back.

Until #11650, nRF52 masked all three: `NRF52Bluetooth::shutdown()` failed to clear Bluefruit's `restartOnDisconnect`, so advertising came back on its own about a second later. With that fixed the outage is real — BLE stays down until the next PowerFSM transition, which is up to `screen_on_secs` (600s default for clients, 1s for routers) or the next button press.

None of these are new bugs; #11650 just stopped hiding them.

## `restore_preferences` — ~16.7 minutes unreachable

`AdminModule::reboot()` takes **seconds**, and the call passed `1000` — arming the reset 16.7 minutes out rather than the intended ~1s (the log line reads `Reboot in 1000 seconds`). Because BLE is disabled for a pending reboot, the node was unreachable for that entire window, and the `PowerFSM` guard added in #11650 correctly declines to re-enable while `rebootAtMsec` is armed.

Now uses `DEFAULT_REBOOT_SECONDS` and disables before arming, matching the ordering in the factory-reset and nodedb-reset cases directly above it.

## `mesh_beacon` — disabled with no reboot

`mesh_beacon` sets `shouldReboot = false` but wasn't in the list that spares a variant from the blanket `disableBluetooth()` at the top of `handleSetModuleConfig()`. `statusmessage` does the same thing and *is* in that list. Added it, and rewrote the comment to say what the list actually means now.

## MQTT / Serial inside an edit transaction

Both call `disableBluetooth()` inside their own `case`, bypassing the `!hasOpenEditTransaction` check above them. Inside a transaction `saveChanges()` defers the reboot, so BLE went down with nothing to restore it — and the client can no longer send `commit_edit_settings`, so the transaction runs to its idle timeout.

Reachable today: the Android app wraps `installProfile()` in `begin/commitEditSettings` (`RadioConfigViewModel.kt:478`), so importing a device profile that carries an MQTT or serial module config hits it. Ordinary config screens don't use transactions and were unaffected.

Both inner calls are now gated on `!hasOpenEditTransaction`.

## Testing

- Built `heltec-mesh-node-t096`.
- `pio test -e native-macos -f test_module_config` — 3/3 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bluetooth is now disabled before the device reboots after restoring preferences.
  * Reboot timing now uses the standard delay for more consistent behavior.
  * Bluetooth remains available during supported MQTT, Serial, and mesh beacon configuration edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->