### PR TITLE
Meshlink v1.3 board updates and heartbeat LED fixes

### DIFF
--- a/variants/nrf52840/meshlink/platformio.ini
+++ b/variants/nrf52840/meshlink/platformio.ini
@@ -1,10 +1,20 @@
 ; MeshLink board developed by LoraItalia. NRF52840, eByte E22900M22S (Will also come with other frequencies), 25w MPPT solar charger (5v,12v,18v selectable), support for gps, buzzer, oled or e-ink display, 10 gpios, hardware watchdog
-; https://www.loraitalia.it
+; https://www.loraitalia.it/meshlink
+
 ; firmware for boards with or without oled display
 [env:meshlink]
+
+custom_meshtastic_hw_model = 87
+custom_meshtastic_hw_model_slug = MESHLINK
+custom_meshtastic_architecture = nrf52840
+custom_meshtastic_actively_supported = true
+custom_meshtastic_support_level = 1
+custom_meshtastic_display_name = MeshLink
+custom_meshtastic_tags = Loraitalia
+
 extends = nrf52840_base
 board = meshlink
-board_level = extra
+board_level = pr
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/meshlink
   -D MESHLINK
@@ -20,9 +30,18 @@ debug_tool = jlink
 ;upload_protocol = jlink
 
 [env:meshlink_eink]
+
+custom_meshtastic_hw_model = 87
+custom_meshtastic_hw_model_slug = MESHLINK
+custom_meshtastic_architecture = nrf52840
+custom_meshtastic_actively_supported = true
+custom_meshtastic_support_level = 1
+custom_meshtastic_display_name = MeshLink
+custom_meshtastic_tags = Loraitalia
+
 extends = nrf52840_base
 board = meshlink
-board_level = extra
+board_level = pr
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/meshlink
   -D MESHLINK
@@ -35,12 +54,12 @@ build_flags = ${nrf52840_base.build_flags}
   -D EINK_WIDTH=250
   -D EINK_HEIGHT=122
   -D USE_EINK_DYNAMICDISPLAY            ; Enable Dynamic EInk
-  -D EINK_LIMIT_FASTREFRESH=5           ; How many consecutive fast-refreshes are permitted
+  -D EINK_LIMIT_FASTREFRESH=100           ; How many consecutive fast-refreshes are permitted
   -D EINK_LIMIT_RATE_BACKGROUND_SEC=30  ; Minimum interval between BACKGROUND updates
   -D EINK_LIMIT_RATE_RESPONSIVE_SEC=1   ; Minimum interval between RESPONSIVE updates
-  -D EINK_LIMIT_GHOSTING_PX=2000        ; (Optional) How much image ghosting is tolerated
-  -D EINK_BACKGROUND_USES_FAST         ; (Optional) Use FAST refresh for both BACKGROUND and RESPONSIVE, until a limit is reached.
-  -D EINK_HASQUIRK_VICIOUSFASTREFRESH   ; Identify that pixels drawn by fast-refresh are harder to clear
+  ; -D EINK_LIMIT_GHOSTING_PX=2000        ; (Optional) How much image ghosting is tolerated
+  ; -D EINK_BACKGROUND_USES_FAST         ; (Optional) Use FAST refresh for both BACKGROUND and RESPONSIVE, until a limit is reached.
+  ; -D EINK_HASQUIRK_VICIOUSFASTREFRESH   ; Identify that pixels drawn by fast-refresh are harder to clear
 
 
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/meshlink>

--- a/variants/nrf52840/meshlink/platformio.ini
+++ b/variants/nrf52840/meshlink/platformio.ini
@@ -41,7 +41,7 @@ custom_meshtastic_tags = Loraitalia
 
 extends = nrf52840_base
 board = meshlink
-board_level = pr
+board_level = extra
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/meshlink
   -D MESHLINK

--- a/variants/nrf52840/meshlink/platformio.ini
+++ b/variants/nrf52840/meshlink/platformio.ini
@@ -14,7 +14,7 @@ custom_meshtastic_tags = Loraitalia
 
 extends = nrf52840_base
 board = meshlink
-board_level = pr
+board_level = extra
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/meshlink
   -D MESHLINK

--- a/variants/nrf52840/meshlink/platformio.ini
+++ b/variants/nrf52840/meshlink/platformio.ini
@@ -3,15 +3,6 @@
 
 ; firmware for boards with or without oled display
 [env:meshlink]
-
-custom_meshtastic_hw_model = 87
-custom_meshtastic_hw_model_slug = MESHLINK
-custom_meshtastic_architecture = nrf52840
-custom_meshtastic_actively_supported = true
-custom_meshtastic_support_level = 1
-custom_meshtastic_display_name = MeshLink
-custom_meshtastic_tags = Loraitalia
-
 extends = nrf52840_base
 board = meshlink
 board_level = extra

--- a/variants/nrf52840/meshlink/platformio.ini
+++ b/variants/nrf52840/meshlink/platformio.ini
@@ -30,15 +30,6 @@ debug_tool = jlink
 ;upload_protocol = jlink
 
 [env:meshlink_eink]
-
-custom_meshtastic_hw_model = 87
-custom_meshtastic_hw_model_slug = MESHLINK
-custom_meshtastic_architecture = nrf52840
-custom_meshtastic_actively_supported = true
-custom_meshtastic_support_level = 1
-custom_meshtastic_display_name = MeshLink
-custom_meshtastic_tags = Loraitalia
-
 extends = nrf52840_base
 board = meshlink
 board_level = extra

--- a/variants/nrf52840/meshlink/variant.cpp
+++ b/variants/nrf52840/meshlink/variant.cpp
@@ -12,9 +12,9 @@ const uint32_t g_ADigitalPinMap[] = {
 
 void initVariant()
 {
-    pinMode(LED_HEARTBEAT, OUTPUT);
-    digitalWrite(LED_HEARTBEAT, HIGH); // turn off the white led while booting
-                                  // otherwise it will stay lit for several seconds (could be annoying)
+    // pinMode(LED_HEARTBEAT, OUTPUT);
+    // digitalWrite(LED_HEARTBEAT, HIGH); // turn off the white led while booting
+    //                               // otherwise it will stay lit for several seconds (could be annoying)
 #ifdef PIN_WD_EN
     pinMode(PIN_WD_EN, OUTPUT);
     digitalWrite(PIN_WD_EN, HIGH); // Enable the Watchdog at boot

--- a/variants/nrf52840/meshlink/variant.cpp
+++ b/variants/nrf52840/meshlink/variant.cpp
@@ -12,10 +12,9 @@ const uint32_t g_ADigitalPinMap[] = {
 
 void initVariant()
 {
-    pinMode(PIN_LED1, OUTPUT);
-    digitalWrite(PIN_LED1, HIGH); // turn off the white led while booting
+    pinMode(LED_HEARTBEAT, OUTPUT);
+    digitalWrite(LED_HEARTBEAT, HIGH); // turn off the white led while booting
                                   // otherwise it will stay lit for several seconds (could be annoying)
-
 #ifdef PIN_WD_EN
     pinMode(PIN_WD_EN, OUTPUT);
     digitalWrite(PIN_WD_EN, HIGH); // Enable the Watchdog at boot

--- a/variants/nrf52840/meshlink/variant.h
+++ b/variants/nrf52840/meshlink/variant.h
@@ -131,6 +131,8 @@ static const uint8_t SCK = PIN_SPI_SCK;
 
 
 // Battery
+//our INA219 is reversed (+ sign when discharging and - when charging)
+#define INA219_MULTIPLIER -1.0f //with this we fix the sign shown
 // The battery sense is hooked to pin A0 (2)
 #define BATTERY_PIN (2)
 // and has 12 bit resolution

--- a/variants/nrf52840/meshlink/variant.h
+++ b/variants/nrf52840/meshlink/variant.h
@@ -29,10 +29,8 @@ extern "C" {
 #define BUTTON_NEED_PULLUP
 
 // LEDs
-#define PIN_LED1 (24) // Built in white led for status
-#define LED_BLUE PIN_LED1
-
-#define LED_STATE_ON 0 // State when LED is lit
+#define LED_HEARTBEAT (24)     // Force strictly heartbeat on Pin 24
+#define LED_STATE_ON 0         // Active LOW
 
 // Testing USB detection
 // #define NRF_APM

--- a/variants/nrf52840/meshlink/variant.h
+++ b/variants/nrf52840/meshlink/variant.h
@@ -32,6 +32,11 @@ extern "C" {
 #define LED_HEARTBEAT (24)     // Force strictly heartbeat on Pin 24
 #define LED_STATE_ON 0         // Active LOW
 
+#define HAS_HARDWARE_WATCHDOG
+#define HARDWARE_WATCHDOG_DONE (24)
+#define HARDWARE_WATCHDOG_TIMEOUT_MS (25 * 1000) // our hardware one expires in 30s so we feed it each 25s for safety
+#define HARDWARE_WATCHDOG_WAKE -1
+
 // Testing USB detection
 //#define NRF_APM
 

--- a/variants/nrf52840/meshlink/variant.h
+++ b/variants/nrf52840/meshlink/variant.h
@@ -33,7 +33,7 @@ extern "C" {
 #define LED_STATE_ON 0         // Active LOW
 
 // Testing USB detection
-// #define NRF_APM
+//#define NRF_APM
 
 /*
  * Analog pins
@@ -48,8 +48,8 @@ extern "C" {
 /*
  * Serial interfaces
  */
-#define PIN_SERIAL1_RX (32 + 8)
-#define PIN_SERIAL1_TX (7)
+#define PIN_SERIAL1_TX (32 + 8)
+#define PIN_SERIAL1_RX (7)
 #define SERIAL_PRINT_PORT 0
 
 /*
@@ -124,10 +124,15 @@ static const uint8_t SCK = PIN_SPI_SCK;
 // #define GPS_THREAD_INTERVAL 50
 
 // Define pin to enable GPS toggle (set GPIO to LOW) via user button triple press
-#define PIN_GPS_EN (0)
+#define PIN_GPS_EN (4)
 #define GPS_EN_ACTIVE LOW
 
 #define PIN_BUZZER (31) // P0.31/AIN7
+
+/*
+ * Buttons
+ */
+#define PIN_BUTTON1 (10) // Default GPIO pin used for user button.
 
 // Battery
 // The battery sense is hooked to pin A0 (2)

--- a/variants/nrf52840/meshlink/variant.h
+++ b/variants/nrf52840/meshlink/variant.h
@@ -25,7 +25,7 @@ extern "C" {
 #define NUM_ANALOG_INPUTS (2)
 #define NUM_ANALOG_OUTPUTS (0)
 
-#define BUTTON_PIN (-1) // If defined, this will be used for user button presses,
+#define BUTTON_PIN (10) // If defined, this will be used for user button presses,
 #define BUTTON_NEED_PULLUP
 
 // LEDs
@@ -129,10 +129,6 @@ static const uint8_t SCK = PIN_SPI_SCK;
 
 #define PIN_BUZZER (31) // P0.31/AIN7
 
-/*
- * Buttons
- */
-#define PIN_BUTTON1 (10) // Default GPIO pin used for user button.
 
 // Battery
 // The battery sense is hooked to pin A0 (2)

--- a/variants/nrf52840/meshlink/variant.h
+++ b/variants/nrf52840/meshlink/variant.h
@@ -34,7 +34,7 @@ extern "C" {
 
 #define HAS_HARDWARE_WATCHDOG
 #define HARDWARE_WATCHDOG_DONE (24)
-#define HARDWARE_WATCHDOG_TIMEOUT_MS (25 * 1000) // our hardware one expires in 30s so we feed it each 25s for safety
+#define HARDWARE_WATCHDOG_TIMEOUT_MS (50 * 1000) // our hardware one expires in 60s so we feed it each 50s for safety
 #define HARDWARE_WATCHDOG_WAKE -1
 
 // Testing USB detection
@@ -136,8 +136,6 @@ static const uint8_t SCK = PIN_SPI_SCK;
 
 
 // Battery
-//our INA219 is reversed (+ sign when discharging and - when charging)
-#define INA219_MULTIPLIER -1.0f //with this we fix the sign shown
 // The battery sense is hooked to pin A0 (2)
 #define BATTERY_PIN (2)
 // and has 12 bit resolution


### PR DESCRIPTION
We fixed some stuff needed for V1.3 board revision and did some other changes that may benefit older revisions too.

We still need to make changes to `StatusLEDModule.cpp` otherwise our heartbeat LED is not light up when charging and then the hardware Watchdog timer doesn't get fed, causing the board to reboot every 30s.
These changes are needed for all devices, not just our

More [here on Discord](https://discord.com/channels/867578229534359593/919642584480112750/1542815173906010122)

Tested working on v1.2 and v1.3 board revisions (apart from WD Timer when charging, which as said needs to be addressed upstream)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the MeshLink user button.
  - Updated GPS, serial, and heartbeat LED hardware mappings.
  - Increased the e-ink display’s fast-refresh limit to 100 consecutive refreshes.

- **Bug Fixes**
  - Corrected battery current readings from the INA219 sensor.
  - Improved startup behavior for the white status LED.
  - Updated MeshLink board identification and e-ink refresh configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->