### PR TITLE
FU firmware update: restore tlora-v1 (TTGO LoRa32 V1.0) to release builds

### DIFF
--- a/variants/esp32/tlora_v1/platformio.ini
+++ b/variants/esp32/tlora_v1/platformio.ini
@@ -6,7 +6,7 @@ custom_meshtastic_actively_supported = false
 custom_meshtastic_display_name = LILYGO T-LoRa V1
 custom_meshtastic_tags = LilyGo
 
-board_level = extra
+board_level = release
 extends = esp32_base
 board = ttgo-lora32-v1
 build_flags = 


### PR DESCRIPTION
Closes/relates to #11656 and #5210.

`tlora-v1` (LILYGO TTGO LoRa32 V1.0) is set to `board_level = extra`, which excludes it from official release builds. It still builds cleanly against current master with zero source changes:

- Flash: 87.4% used (2,118,521 / 2,424,832 bytes)
- RAM: 34.2%

Flashed to **four separate physical boards** and confirmed working on all of them: OLED display functions normally, and BLE config completes with the current app (previously stuck on old 2.4.2 builds due to a protocol-version gap, not a hardware issue).

This change only flips `board_level` from `extra` to `release` so it's included in the normal release matrix again. No code/pin changes.

## This isn't a new claim - it's already independently confirmed multiple times in #5210

The original reason given for dropping support (@garthvh): *"it has been broken for quite a while... something in the esp32 toolchain seems to have caused issues"* - not a hardware dead-end, just bitrot at some point in the past.

Since then, multiple people have independently built `tlora-v1` from source and confirmed it works fine, across several versions:

- **@C4** (2.5.14): *"Everything worked from there... running with display on my device."*
- **@okaestne** (2.7.15): *"the display works fine"*
- **@sysmanalex** (2.7.19, with GPS): *"IMHO board hw support - should be enabled back. all works ok."*
- **@RobertSasak** opened #9973 fixing the actual build break (missing `LED_BUILTIN`) - already merged (`a632d01`), which is why this now builds clean with zero further changes.

So the toolchain issue was already fixed upstream; this PR is just the remaining step of flipping the release-matrix flag back given that fix and the repeated independent confirmations across multiple units and multiple contributors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TLORA V1 ESP32 build environment to use the release board level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->