### PR TITLE
fix(BaseUI): let a module frame with no menu fall through the SELECT dispatch

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -2117,6 +2117,21 @@ int Screen::handleUIFrameEvent(const UIFrameEvent *event)
     return 0;
 }
 
+// Only the environmental telemetry frame answers SELECT with a menu. A module frame that has none
+// must not claim the press, or every frame matched after it in the dispatch chain is unreachable.
+static bool moduleFrameHasMenu(size_t frame)
+{
+#if HAS_TELEMETRY && HAS_SENSOR && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
+    // moduleFrames bounds the module-frame region, before favorites are appended; its leading slots
+    // are nullptr padding for the built-in frames, so only a non-null entry is a real module frame.
+    const MeshModule *module = frame < moduleFrames.size() ? moduleFrames.at(frame) : nullptr;
+    return module != nullptr && environmentTelemetryModule != nullptr && environmentTelemetryModule->ownsFrame(module);
+#else
+    (void)frame;
+    return false;
+#endif
+}
+
 int Screen::handleInputEvent(const InputEvent *event)
 {
     LOG_INPUT("Screen Input event %u! kb %u", event->inputEvent, event->kbchar);
@@ -2344,16 +2359,8 @@ int Screen::handleInputEvent(const InputEvent *event)
                             menuHandler::textMessageBaseMenu();
                         }
                     }
-                    // moduleFrames.size() bounds the module-frame region, before favorites are appended; its leading
-                    // slots are nullptr padding for the built-in frames, so only a non-null entry is a real module frame.
-                } else if (this->ui->getUiState()->currentFrame < moduleFrames.size() &&
-                           moduleFrames.at(this->ui->getUiState()->currentFrame) != nullptr) {
-#if HAS_TELEMETRY && HAS_SENSOR && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
-                    const MeshModule *currentModule = moduleFrames.at(this->ui->getUiState()->currentFrame);
-                    if (environmentTelemetryModule != nullptr && environmentTelemetryModule->ownsFrame(currentModule)) {
-                        menuHandler::environmentTelemetryMenu();
-                    }
-#endif
+                } else if (moduleFrameHasMenu(this->ui->getUiState()->currentFrame)) {
+                    menuHandler::environmentTelemetryMenu();
                 } else if (framesetInfo.positions.firstFavorite != 255 &&
                            this->ui->getUiState()->currentFrame >= framesetInfo.positions.firstFavorite &&
                            this->ui->getUiState()->currentFrame <= framesetInfo.positions.lastFavorite) {


### PR DESCRIPTION
The module-frame branch in the BaseUI SELECT dispatch claims the press for any non-null
`moduleFrames` entry, but its body acts only on the environmental telemetry frame. Every other
module frame is consumed there, so no branch after it in the chain can run.

#11209 added that branch. #11358 narrowed it to skip the leading nullptr padding, which restored
the node list, but a genuine module frame is still swallowed on its merits. The waypoint menu added
in #10920 sits after it in the chain, so select on the waypoint frame has never opened "Waypoint
Action" on BaseUI - neither Geofence Alerts nor Remove Waypoint is reachable from the device, and
the press produces no log or banner to hint at why.

This enters the branch only when the frame actually has a menu, so a module frame without one falls
through to the frames matched after it. #10920's waypoint branch is untouched and becomes reachable
where it was written, rather than each future module frame needing to be hoisted above the catch-all.

No behaviour change otherwise: the condition is exactly the test the branch body already performed,
so the environmental telemetry menu still opens, and a module frame with no menu still does nothing
on select - it just does nothing at the end of the chain instead of halfway down it.

### Verification

Tested on LilyGo T-Watch Ultra:

- Waypoint frame: select opens Waypoint Action, with Geofence Alerts and Remove Waypoint both
  reachable. Before this change the press did nothing.
- Environmental telemetry frame, enabled with no local sensor: select still opens its menu,
  including the data source picker from #11209.
- Node list, favourites and WiFi frames: unchanged.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other: LilyGo T-Watch Ultra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected SELECT-button handling for module frames.
  * Environmental telemetry menus now open only for frames owned by that module.
  * SELECT presses on other module frames correctly continue to the appropriate menus, such as favorites, node lists, Wi‑Fi, or waypoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->