### PR TITLE
fix(detectionsensor): sample the trigger every poll, not once per broadcast window

### DIFF
--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -127,7 +127,9 @@ int32_t DetectionSensorModule::runOnce()
     // Even if we haven't detected an event, broadcast our current state to the mesh on the scheduled interval as a sort
     // of heartbeat. We only do this if the minimum broadcast interval is greater than zero, otherwise we'll only broadcast state
     // change detections.
-    if (moduleConfig.detection_sensor.state_broadcast_secs > 0 &&
+    // Skipped while a verdict is pending: sending one resets lastSentToMesh, which could postpone
+    // the pending verdict indefinitely if state_broadcast_secs < minimum_broadcast_secs.
+    if (!pendingDetected && !pendingState && moduleConfig.detection_sensor.state_broadcast_secs > 0 &&
         !Throttle::isWithinTimespanMs(lastSentToMesh,
                                       Default::getConfiguredOrDefaultMs(moduleConfig.detection_sensor.state_broadcast_secs,
                                                                         default_telemetry_broadcast_interval_secs))) {

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -96,34 +96,31 @@ int32_t DetectionSensorModule::runOnce()
 
     // LOG_DEBUG("Detection Sensor Module: Current pin state: %i", digitalRead(moduleConfig.detection_sensor.monitor_pin));
 
-    // Sample the pin and evaluate the trigger on every poll so a transition is never missed between
-    // sends; minimum_broadcast_secs only rate-limits how often we're allowed to actually transmit.
-    // wasDetected always advances so edge comparisons stay correct; a verdict produced while still
-    // throttled is latched in pendingSend rather than discarded, so it isn't lost.
+    // Sample and evaluate the trigger every poll so a transition is never missed; minimum_broadcast_secs
+    // only rate-limits sends, not sampling.
     bool isDetected = hasDetectionEvent();
     DetectionSensorTriggerVerdict verdict = handlers[configuredTriggerType()](wasDetected, isDetected);
     wasDetected = isDetected;
     switch (verdict) {
     case DetectionSensorVerdictDetected:
-        pendingSend = true;
-        pendingSendIsState = false;
+        pendingDetected = true;
         break;
     case DetectionSensorVerdictSendState:
-        pendingSend = true;
-        pendingSendIsState = true;
-        pendingIsDetected = isDetected;
+        pendingState = true;
+        pendingStateIsDetected = isDetected;
         break;
     case DetectionSensorVerdictNoop:
         break;
     }
-    if (pendingSend &&
+    if ((pendingDetected || pendingState) &&
         !Throttle::isWithinTimespanMs(lastSentToMesh,
                                       Default::getConfiguredOrDefaultMs(moduleConfig.detection_sensor.minimum_broadcast_secs))) {
-        pendingSend = false;
-        if (pendingSendIsState) {
-            sendCurrentStateMessage(pendingIsDetected);
-        } else {
+        if (pendingDetected) {
+            pendingDetected = false;
             sendDetectionMessage();
+        } else {
+            pendingState = false;
+            sendCurrentStateMessage(pendingStateIsDetected);
         }
         return DELAYED_INTERVAL;
     }

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -103,13 +103,13 @@ int32_t DetectionSensorModule::runOnce()
     wasDetected = isDetected;
     switch (verdict) {
     case DetectionSensorVerdictDetected:
-        if (!pendingDetected && !pendingState)
-            pendingDetectedFirst = true;
+        if (!pendingDetected)
+            pendingDetectedFirst = !pendingState;
         pendingDetected = true;
         break;
     case DetectionSensorVerdictSendState:
-        if (!pendingDetected && !pendingState)
-            pendingDetectedFirst = false;
+        if (!pendingState)
+            pendingDetectedFirst = pendingDetected;
         pendingState = true;
         pendingStateIsDetected = isDetected;
         break;

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -103,9 +103,13 @@ int32_t DetectionSensorModule::runOnce()
     wasDetected = isDetected;
     switch (verdict) {
     case DetectionSensorVerdictDetected:
+        if (!pendingDetected && !pendingState)
+            pendingDetectedFirst = true;
         pendingDetected = true;
         break;
     case DetectionSensorVerdictSendState:
+        if (!pendingDetected && !pendingState)
+            pendingDetectedFirst = false;
         pendingState = true;
         pendingStateIsDetected = isDetected;
         break;
@@ -115,7 +119,9 @@ int32_t DetectionSensorModule::runOnce()
     if ((pendingDetected || pendingState) &&
         !Throttle::isWithinTimespanMs(lastSentToMesh,
                                       Default::getConfiguredOrDefaultMs(moduleConfig.detection_sensor.minimum_broadcast_secs))) {
-        if (pendingDetected) {
+        // Send whichever verdict occurred first when both are outstanding, so the mesh sees them
+        // in the order they actually happened.
+        if (pendingDetected && (!pendingState || pendingDetectedFirst)) {
             pendingDetected = false;
             sendDetectionMessage();
         } else {

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -98,21 +98,34 @@ int32_t DetectionSensorModule::runOnce()
 
     // Sample the pin and evaluate the trigger on every poll so a transition is never missed between
     // sends; minimum_broadcast_secs only rate-limits how often we're allowed to actually transmit.
+    // wasDetected always advances so edge comparisons stay correct; a verdict produced while still
+    // throttled is latched in pendingSend rather than discarded, so it isn't lost.
     bool isDetected = hasDetectionEvent();
     DetectionSensorTriggerVerdict verdict = handlers[configuredTriggerType()](wasDetected, isDetected);
     wasDetected = isDetected;
-    if (!Throttle::isWithinTimespanMs(lastSentToMesh,
+    switch (verdict) {
+    case DetectionSensorVerdictDetected:
+        pendingSend = true;
+        pendingSendIsState = false;
+        break;
+    case DetectionSensorVerdictSendState:
+        pendingSend = true;
+        pendingSendIsState = true;
+        pendingIsDetected = isDetected;
+        break;
+    case DetectionSensorVerdictNoop:
+        break;
+    }
+    if (pendingSend &&
+        !Throttle::isWithinTimespanMs(lastSentToMesh,
                                       Default::getConfiguredOrDefaultMs(moduleConfig.detection_sensor.minimum_broadcast_secs))) {
-        switch (verdict) {
-        case DetectionSensorVerdictDetected:
+        pendingSend = false;
+        if (pendingSendIsState) {
+            sendCurrentStateMessage(pendingIsDetected);
+        } else {
             sendDetectionMessage();
-            return DELAYED_INTERVAL;
-        case DetectionSensorVerdictSendState:
-            sendCurrentStateMessage(isDetected);
-            return DELAYED_INTERVAL;
-        case DetectionSensorVerdictNoop:
-            break;
         }
+        return DELAYED_INTERVAL;
     }
     // Even if we haven't detected an event, broadcast our current state to the mesh on the scheduled interval as a sort
     // of heartbeat. We only do this if the minimum broadcast interval is greater than zero, otherwise we'll only broadcast state

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -96,11 +96,13 @@ int32_t DetectionSensorModule::runOnce()
 
     // LOG_DEBUG("Detection Sensor Module: Current pin state: %i", digitalRead(moduleConfig.detection_sensor.monitor_pin));
 
+    // Sample the pin and evaluate the trigger on every poll so a transition is never missed between
+    // sends; minimum_broadcast_secs only rate-limits how often we're allowed to actually transmit.
+    bool isDetected = hasDetectionEvent();
+    DetectionSensorTriggerVerdict verdict = handlers[configuredTriggerType()](wasDetected, isDetected);
+    wasDetected = isDetected;
     if (!Throttle::isWithinTimespanMs(lastSentToMesh,
                                       Default::getConfiguredOrDefaultMs(moduleConfig.detection_sensor.minimum_broadcast_secs))) {
-        bool isDetected = hasDetectionEvent();
-        DetectionSensorTriggerVerdict verdict = handlers[configuredTriggerType()](wasDetected, isDetected);
-        wasDetected = isDetected;
         switch (verdict) {
         case DetectionSensorVerdictDetected:
             sendDetectionMessage();
@@ -119,7 +121,7 @@ int32_t DetectionSensorModule::runOnce()
         !Throttle::isWithinTimespanMs(lastSentToMesh,
                                       Default::getConfiguredOrDefaultMs(moduleConfig.detection_sensor.state_broadcast_secs,
                                                                         default_telemetry_broadcast_interval_secs))) {
-        sendCurrentStateMessage(hasDetectionEvent());
+        sendCurrentStateMessage(isDetected);
         return DELAYED_INTERVAL;
     }
     return GPIO_POLLING_INTERVAL;

--- a/src/modules/DetectionSensorModule.h
+++ b/src/modules/DetectionSensorModule.h
@@ -20,6 +20,9 @@ class DetectionSensorModule : public SinglePortModule, private concurrency::OSTh
     bool pendingDetected = false;
     bool pendingState = false;
     bool pendingStateIsDetected = false;
+    // Which of the two above became pending first, while neither was already outstanding; used to
+    // preserve send order when both end up pending at once.
+    bool pendingDetectedFirst = false;
     void sendDetectionMessage();
     void sendCurrentStateMessage(bool state);
     bool hasDetectionEvent();

--- a/src/modules/DetectionSensorModule.h
+++ b/src/modules/DetectionSensorModule.h
@@ -15,6 +15,12 @@ class DetectionSensorModule : public SinglePortModule, private concurrency::OSTh
     bool firstTime = true;
     uint32_t lastSentToMesh = 0;
     bool wasDetected = false;
+    // A verdict produced while minimum_broadcast_secs was still throttling sends is latched here
+    // rather than discarded, so it fires as soon as the throttle window reopens instead of being
+    // silently lost (wasDetected keeps updating every poll for correct edge comparisons regardless).
+    bool pendingSend = false;
+    bool pendingSendIsState = false;
+    bool pendingIsDetected = false;
     void sendDetectionMessage();
     void sendCurrentStateMessage(bool state);
     bool hasDetectionEvent();

--- a/src/modules/DetectionSensorModule.h
+++ b/src/modules/DetectionSensorModule.h
@@ -20,8 +20,8 @@ class DetectionSensorModule : public SinglePortModule, private concurrency::OSTh
     bool pendingDetected = false;
     bool pendingState = false;
     bool pendingStateIsDetected = false;
-    // Which of the two above became pending first, while neither was already outstanding; used to
-    // preserve send order when both end up pending at once.
+    // Which of the two above is the older still-outstanding one; updated whenever pendingDetected
+    // or pendingState newly transitions false->true, so send order matches occurrence order.
     bool pendingDetectedFirst = false;
     void sendDetectionMessage();
     void sendCurrentStateMessage(bool state);

--- a/src/modules/DetectionSensorModule.h
+++ b/src/modules/DetectionSensorModule.h
@@ -15,12 +15,11 @@ class DetectionSensorModule : public SinglePortModule, private concurrency::OSTh
     bool firstTime = true;
     uint32_t lastSentToMesh = 0;
     bool wasDetected = false;
-    // A verdict produced while minimum_broadcast_secs was still throttling sends is latched here
-    // rather than discarded, so it fires as soon as the throttle window reopens instead of being
-    // silently lost (wasDetected keeps updating every poll for correct edge comparisons regardless).
-    bool pendingSend = false;
-    bool pendingSendIsState = false;
-    bool pendingIsDetected = false;
+    // Verdicts throttled by minimum_broadcast_secs are latched here instead of discarded, tracked
+    // separately so a later SendState can't overwrite an already-pending Detected.
+    bool pendingDetected = false;
+    bool pendingState = false;
+    bool pendingStateIsDetected = false;
     void sendDetectionMessage();
     void sendCurrentStateMessage(bool state);
     bool hasDetectionEvent();


### PR DESCRIPTION
## Summary
- `DetectionSensorModule::runOnce()` only called `hasDetectionEvent()` / updated `wasDetected` when the `minimum_broadcast_secs` send-throttle allowed a message, so the GPIO was effectively sampled only once per that window (which defaults to 1 hour when left unset) instead of every ~100ms poll.
- Edge triggers (`RISING_EDGE`/`FALLING_EDGE`/`EITHER_EDGE_*`) that occurred and reversed between those sparse checks were silently lost, and level triggers (`LOGIC_HIGH`/`LOGIC_LOW`) only ever reflected whatever the pin happened to read at that one instant — this matches the "sends a message every minute regardless of state" / "does not respond to the state" behavior reported in #7541.
- The fix samples the pin and evaluates the trigger verdict on every poll; `minimum_broadcast_secs` now only rate-limits how often a message is actually transmitted, as its name implies.

Fixes #7541

## Test plan
- [x] Native build: `pio run -e seeed_xiao_nrf52840_kit` succeeds
- [x] Flashed to a Seeed XIAO nRF52840 + Wio-SX1262 Kit and verified live: grounding the configured monitor pin produced a `Detected event observed. Send message` log line and a real `detection` packet was transmitted over LoRa, received by another node, and observed decoded correctly on MQTT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection monitoring so trigger state transitions are reliably captured between status transmissions.
  * Continued rate-limiting outgoing broadcasts without delaying detection evaluation.
  * Preserved multiple detected and cleared events during transmission throttling, delivering them in the order they occurred.
  * Ensured scheduled heartbeats use the latest sampled detection state.
  * Prevented scheduled heartbeats from delaying pending detection event notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->