### PR TITLE
feat(detectionsensor): wake on GPIO change instead of 100ms polling

### DIFF
--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -127,7 +127,9 @@ int32_t DetectionSensorModule::runOnce()
     // Even if we haven't detected an event, broadcast our current state to the mesh on the scheduled interval as a sort
     // of heartbeat. We only do this if the minimum broadcast interval is greater than zero, otherwise we'll only broadcast state
     // change detections.
-    if (moduleConfig.detection_sensor.state_broadcast_secs > 0 &&
+    // Skipped while a verdict is pending: sending one resets lastSentToMesh, which could postpone
+    // the pending verdict indefinitely if state_broadcast_secs < minimum_broadcast_secs.
+    if (!pendingDetected && !pendingState && moduleConfig.detection_sensor.state_broadcast_secs > 0 &&
         !Throttle::isWithinTimespanMs(lastSentToMesh,
                                       Default::getConfiguredOrDefaultMs(moduleConfig.detection_sensor.state_broadcast_secs,
                                                                         default_telemetry_broadcast_interval_secs))) {

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -85,16 +85,7 @@ int32_t DetectionSensorModule::runOnce()
         // This is the first time the OSThread library has called this function, so do some setup
         firstTime = false;
         if (moduleConfig.detection_sensor.monitor_pin > 0) {
-            pinMode(moduleConfig.detection_sensor.monitor_pin, moduleConfig.detection_sensor.use_pullup ? INPUT_PULLUP : INPUT);
-            // Wake the module the moment the pin actually changes, instead of relying solely on the
-            // GPIO_POLLING_INTERVAL fallback below to notice it.
-            attachInterrupt(
-                moduleConfig.detection_sensor.monitor_pin,
-                []() {
-                    detectionSensorModule->setIntervalFromNow(0);
-                    runASAP = true;
-                },
-                CHANGE);
+            configureMonitorPin();
         } else {
             LOG_WARN("Detection Sensor Module: Set to enabled but no monitor pin is set. Disable module");
             return disable();
@@ -106,26 +97,24 @@ int32_t DetectionSensorModule::runOnce()
 
     // LOG_DEBUG("Detection Sensor Module: Current pin state: %i", digitalRead(moduleConfig.detection_sensor.monitor_pin));
 
-    // Sample and evaluate the trigger every poll so a transition is never missed; minimum_broadcast_secs
-    // only rate-limits sends, not sampling.
-    bool isDetected = hasDetectionEvent();
-    DetectionSensorTriggerVerdict verdict = handlers[configuredTriggerType()](wasDetected, isDetected);
-    wasDetected = isDetected;
-    switch (verdict) {
-    case DetectionSensorVerdictDetected:
-        if (!pendingDetected)
-            pendingDetectedFirst = !pendingState;
-        pendingDetected = true;
-        break;
-    case DetectionSensorVerdictSendState:
-        if (!pendingState)
-            pendingDetectedFirst = pendingDetected;
-        pendingState = true;
-        pendingStateIsDetected = isDetected;
-        break;
-    case DetectionSensorVerdictNoop:
-        break;
+    // Pick up a runtime change to monitor_pin/use_pullup instead of leaving the interrupt bound to
+    // a stale pin until reboot.
+    if (moduleConfig.detection_sensor.monitor_pin != configuredMonitorPin ||
+        moduleConfig.detection_sensor.use_pullup != configuredUsePullup) {
+        if (moduleConfig.detection_sensor.monitor_pin > 0) {
+            configureMonitorPin();
+        } else {
+            detachInterrupt(configuredMonitorPin);
+            configuredMonitorPin = 0;
+            LOG_WARN("Detection Sensor Module: monitor pin cleared at runtime. Disable module");
+            return disable();
+        }
     }
+    // Also evaluated directly from the monitor-pin interrupt; disable interrupts around this call so
+    // that interrupt can't reenter it mid-update on this thread.
+    noInterrupts();
+    updatePendingVerdict();
+    interrupts();
     if ((pendingDetected || pendingState) &&
         !Throttle::isWithinTimespanMs(lastSentToMesh,
                                       Default::getConfiguredOrDefaultMs(moduleConfig.detection_sensor.minimum_broadcast_secs))) {
@@ -149,7 +138,7 @@ int32_t DetectionSensorModule::runOnce()
         !Throttle::isWithinTimespanMs(lastSentToMesh,
                                       Default::getConfiguredOrDefaultMs(moduleConfig.detection_sensor.state_broadcast_secs,
                                                                         default_telemetry_broadcast_interval_secs))) {
-        sendCurrentStateMessage(isDetected);
+        sendCurrentStateMessage(wasDetected);
         return DELAYED_INTERVAL;
     }
     return GPIO_POLLING_INTERVAL;
@@ -208,4 +197,52 @@ bool DetectionSensorModule::hasDetectionEvent()
     bool currentState = digitalRead(moduleConfig.detection_sensor.monitor_pin);
     // LOG_DEBUG("Detection Sensor Module: Current state: %i", currentState);
     return (configuredTriggerType() & 1) ? currentState : !currentState;
+}
+
+void DetectionSensorModule::configureMonitorPin()
+{
+    if (configuredMonitorPin > 0)
+        detachInterrupt(configuredMonitorPin);
+    configuredMonitorPin = moduleConfig.detection_sensor.monitor_pin;
+    configuredUsePullup = moduleConfig.detection_sensor.use_pullup;
+    pinMode(configuredMonitorPin, configuredUsePullup ? INPUT_PULLUP : INPUT);
+    // Evaluate the trigger right here in the ISR (safe: just a digitalRead and bool bookkeeping, no
+    // allocation/logging/sending) so a transition is captured the instant it happens, then wake the
+    // module to send it - instead of relying solely on the GPIO_POLLING_INTERVAL fallback below,
+    // which could miss a transition that reverses before the thread gets scheduled.
+    attachInterrupt(
+        configuredMonitorPin,
+        []() {
+            detectionSensorModule->updatePendingVerdict();
+            detectionSensorModule->setIntervalFromNow(0);
+            runASAP = true;
+        },
+        CHANGE);
+    // A pin/pullup change invalidates any tracked state from the old pin.
+    wasDetected = false;
+    pendingDetected = false;
+    pendingState = false;
+    pendingDetectedFirst = false;
+}
+
+void DetectionSensorModule::updatePendingVerdict()
+{
+    bool isDetected = hasDetectionEvent();
+    DetectionSensorTriggerVerdict verdict = handlers[configuredTriggerType()](wasDetected, isDetected);
+    wasDetected = isDetected;
+    switch (verdict) {
+    case DetectionSensorVerdictDetected:
+        if (!pendingDetected)
+            pendingDetectedFirst = !pendingState;
+        pendingDetected = true;
+        break;
+    case DetectionSensorVerdictSendState:
+        if (!pendingState)
+            pendingDetectedFirst = pendingDetected;
+        pendingState = true;
+        pendingStateIsDetected = isDetected;
+        break;
+    case DetectionSensorVerdictNoop:
+        break;
+    }
 }

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -8,7 +8,11 @@
 #include <Throttle.h>
 DetectionSensorModule *detectionSensorModule;
 
-#define GPIO_POLLING_INTERVAL 100
+// A CHANGE interrupt on the monitor pin (attached in firstTime setup) gives near-immediate reaction
+// to a real transition, so this is now only a safety-net cadence: it re-arms a level trigger
+// (LOGIC_HIGH/LOGIC_LOW) that's still held once minimum_broadcast_secs reopens, and services the
+// state_broadcast_secs heartbeat. Both are configured in whole seconds, so 1s resolution is exact.
+#define GPIO_POLLING_INTERVAL 1000
 #define DELAYED_INTERVAL 1000
 
 typedef enum {
@@ -85,6 +89,15 @@ int32_t DetectionSensorModule::runOnce()
         firstTime = false;
         if (moduleConfig.detection_sensor.monitor_pin > 0) {
             pinMode(moduleConfig.detection_sensor.monitor_pin, moduleConfig.detection_sensor.use_pullup ? INPUT_PULLUP : INPUT);
+            // Wake the module the moment the pin actually changes, instead of relying solely on the
+            // GPIO_POLLING_INTERVAL fallback below to notice it.
+            attachInterrupt(
+                moduleConfig.detection_sensor.monitor_pin,
+                []() {
+                    detectionSensorModule->setIntervalFromNow(0);
+                    runASAP = true;
+                },
+                CHANGE);
         } else {
             LOG_WARN("Detection Sensor Module: Set to enabled but no monitor pin is set. Disable module");
             return disable();

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -211,6 +211,10 @@ bool DetectionSensorModule::hasDetectionEvent()
 
 bool DetectionSensorModule::configureMonitorPin()
 {
+    // Disabled for the whole rebind: otherwise an old-pin interrupt that's already in flight when
+    // this starts could latch a genuine verdict via updatePendingVerdict() right before the reset
+    // below discards it.
+    noInterrupts();
     if (configuredMonitorPin > 0)
         detachInterrupt(configuredMonitorPin);
     configuredMonitorPin = moduleConfig.detection_sensor.monitor_pin;
@@ -220,8 +224,10 @@ bool DetectionSensorModule::configureMonitorPin()
     pendingDetected = false;
     pendingState = false;
     pendingDetectedFirst = false;
-    if (configuredMonitorPin == 0)
+    if (configuredMonitorPin == 0) {
+        interrupts();
         return false;
+    }
     pinMode(configuredMonitorPin, configuredUsePullup ? INPUT_PULLUP : INPUT);
     // Evaluate the trigger right here in the ISR (safe: just a digitalRead and bool bookkeeping, no
     // allocation/logging/sending) so a transition is captured the instant it happens, then wake the
@@ -235,6 +241,7 @@ bool DetectionSensorModule::configureMonitorPin()
             runASAP = true;
         },
         CHANGE);
+    interrupts();
     return true;
 }
 

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -96,34 +96,31 @@ int32_t DetectionSensorModule::runOnce()
 
     // LOG_DEBUG("Detection Sensor Module: Current pin state: %i", digitalRead(moduleConfig.detection_sensor.monitor_pin));
 
-    // Sample the pin and evaluate the trigger on every poll so a transition is never missed between
-    // sends; minimum_broadcast_secs only rate-limits how often we're allowed to actually transmit.
-    // wasDetected always advances so edge comparisons stay correct; a verdict produced while still
-    // throttled is latched in pendingSend rather than discarded, so it isn't lost.
+    // Sample and evaluate the trigger every poll so a transition is never missed; minimum_broadcast_secs
+    // only rate-limits sends, not sampling.
     bool isDetected = hasDetectionEvent();
     DetectionSensorTriggerVerdict verdict = handlers[configuredTriggerType()](wasDetected, isDetected);
     wasDetected = isDetected;
     switch (verdict) {
     case DetectionSensorVerdictDetected:
-        pendingSend = true;
-        pendingSendIsState = false;
+        pendingDetected = true;
         break;
     case DetectionSensorVerdictSendState:
-        pendingSend = true;
-        pendingSendIsState = true;
-        pendingIsDetected = isDetected;
+        pendingState = true;
+        pendingStateIsDetected = isDetected;
         break;
     case DetectionSensorVerdictNoop:
         break;
     }
-    if (pendingSend &&
+    if ((pendingDetected || pendingState) &&
         !Throttle::isWithinTimespanMs(lastSentToMesh,
                                       Default::getConfiguredOrDefaultMs(moduleConfig.detection_sensor.minimum_broadcast_secs))) {
-        pendingSend = false;
-        if (pendingSendIsState) {
-            sendCurrentStateMessage(pendingIsDetected);
-        } else {
+        if (pendingDetected) {
+            pendingDetected = false;
             sendDetectionMessage();
+        } else {
+            pendingState = false;
+            sendCurrentStateMessage(pendingStateIsDetected);
         }
         return DELAYED_INTERVAL;
     }

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -84,9 +84,7 @@ int32_t DetectionSensorModule::runOnce()
 
         // This is the first time the OSThread library has called this function, so do some setup
         firstTime = false;
-        if (moduleConfig.detection_sensor.monitor_pin > 0) {
-            configureMonitorPin();
-        } else {
+        if (!configureMonitorPin()) {
             LOG_WARN("Detection Sensor Module: Set to enabled but no monitor pin is set. Disable module");
             return disable();
         }
@@ -101,20 +99,20 @@ int32_t DetectionSensorModule::runOnce()
     // a stale pin until reboot.
     if (moduleConfig.detection_sensor.monitor_pin != configuredMonitorPin ||
         moduleConfig.detection_sensor.use_pullup != configuredUsePullup) {
-        if (moduleConfig.detection_sensor.monitor_pin > 0) {
-            configureMonitorPin();
-        } else {
-            detachInterrupt(configuredMonitorPin);
-            configuredMonitorPin = 0;
+        if (!configureMonitorPin()) {
             LOG_WARN("Detection Sensor Module: monitor pin cleared at runtime. Disable module");
             return disable();
         }
     }
-    // Also evaluated directly from the monitor-pin interrupt; disable interrupts around this call so
-    // that interrupt can't reenter it mid-update on this thread.
+    // Also evaluated directly from the monitor-pin interrupt. The whole decide-and-clear sequence
+    // stays inside one interrupt-disabled section - not just the update - so a verdict the interrupt
+    // latches can't be read as part of one decision and then clobbered before the flag it belongs to
+    // is actually cleared; the (possibly slow) send itself happens after interrupts are restored.
     noInterrupts();
     updatePendingVerdict();
-    interrupts();
+    bool sendDetected = false;
+    bool sendState = false;
+    bool stateValue = false;
     if ((pendingDetected || pendingState) &&
         !Throttle::isWithinTimespanMs(lastSentToMesh,
                                       Default::getConfiguredOrDefaultMs(moduleConfig.detection_sensor.minimum_broadcast_secs))) {
@@ -122,11 +120,20 @@ int32_t DetectionSensorModule::runOnce()
         // in the order they actually happened.
         if (pendingDetected && (!pendingState || pendingDetectedFirst)) {
             pendingDetected = false;
-            sendDetectionMessage();
+            sendDetected = true;
         } else {
             pendingState = false;
-            sendCurrentStateMessage(pendingStateIsDetected);
+            stateValue = pendingStateIsDetected;
+            sendState = true;
         }
+    }
+    interrupts();
+    if (sendDetected) {
+        sendDetectionMessage();
+        return DELAYED_INTERVAL;
+    }
+    if (sendState) {
+        sendCurrentStateMessage(stateValue);
         return DELAYED_INTERVAL;
     }
     // Even if we haven't detected an event, broadcast our current state to the mesh on the scheduled interval as a sort
@@ -194,17 +201,27 @@ void DetectionSensorModule::sendCurrentStateMessage(bool state)
 
 bool DetectionSensorModule::hasDetectionEvent()
 {
-    bool currentState = digitalRead(moduleConfig.detection_sensor.monitor_pin);
+    // Read the pin actually behind pinMode()/attachInterrupt(), not moduleConfig directly: on a
+    // runtime pin change, moduleConfig updates before the next poll gets a chance to rebind, so the
+    // still-armed interrupt must keep sampling the pin it's actually attached to.
+    bool currentState = digitalRead(configuredMonitorPin);
     // LOG_DEBUG("Detection Sensor Module: Current state: %i", currentState);
     return (configuredTriggerType() & 1) ? currentState : !currentState;
 }
 
-void DetectionSensorModule::configureMonitorPin()
+bool DetectionSensorModule::configureMonitorPin()
 {
     if (configuredMonitorPin > 0)
         detachInterrupt(configuredMonitorPin);
     configuredMonitorPin = moduleConfig.detection_sensor.monitor_pin;
     configuredUsePullup = moduleConfig.detection_sensor.use_pullup;
+    // A pin/pullup change invalidates any tracked state from the old pin.
+    wasDetected = false;
+    pendingDetected = false;
+    pendingState = false;
+    pendingDetectedFirst = false;
+    if (configuredMonitorPin == 0)
+        return false;
     pinMode(configuredMonitorPin, configuredUsePullup ? INPUT_PULLUP : INPUT);
     // Evaluate the trigger right here in the ISR (safe: just a digitalRead and bool bookkeeping, no
     // allocation/logging/sending) so a transition is captured the instant it happens, then wake the
@@ -218,11 +235,7 @@ void DetectionSensorModule::configureMonitorPin()
             runASAP = true;
         },
         CHANGE);
-    // A pin/pullup change invalidates any tracked state from the old pin.
-    wasDetected = false;
-    pendingDetected = false;
-    pendingState = false;
-    pendingDetectedFirst = false;
+    return true;
 }
 
 void DetectionSensorModule::updatePendingVerdict()

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -8,10 +8,7 @@
 #include <Throttle.h>
 DetectionSensorModule *detectionSensorModule;
 
-// A CHANGE interrupt on the monitor pin (attached in firstTime setup) gives near-immediate reaction
-// to a real transition, so this is now only a safety-net cadence: it re-arms a level trigger
-// (LOGIC_HIGH/LOGIC_LOW) that's still held once minimum_broadcast_secs reopens, and services the
-// state_broadcast_secs heartbeat. Both are configured in whole seconds, so 1s resolution is exact.
+// Safety-net cadence only; the attached CHANGE interrupt handles real transitions immediately.
 #define GPIO_POLLING_INTERVAL 1000
 #define DELAYED_INTERVAL 1000
 

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -103,13 +103,13 @@ int32_t DetectionSensorModule::runOnce()
     wasDetected = isDetected;
     switch (verdict) {
     case DetectionSensorVerdictDetected:
-        if (!pendingDetected && !pendingState)
-            pendingDetectedFirst = true;
+        if (!pendingDetected)
+            pendingDetectedFirst = !pendingState;
         pendingDetected = true;
         break;
     case DetectionSensorVerdictSendState:
-        if (!pendingDetected && !pendingState)
-            pendingDetectedFirst = false;
+        if (!pendingState)
+            pendingDetectedFirst = pendingDetected;
         pendingState = true;
         pendingStateIsDetected = isDetected;
         break;

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -103,9 +103,13 @@ int32_t DetectionSensorModule::runOnce()
     wasDetected = isDetected;
     switch (verdict) {
     case DetectionSensorVerdictDetected:
+        if (!pendingDetected && !pendingState)
+            pendingDetectedFirst = true;
         pendingDetected = true;
         break;
     case DetectionSensorVerdictSendState:
+        if (!pendingDetected && !pendingState)
+            pendingDetectedFirst = false;
         pendingState = true;
         pendingStateIsDetected = isDetected;
         break;
@@ -115,7 +119,9 @@ int32_t DetectionSensorModule::runOnce()
     if ((pendingDetected || pendingState) &&
         !Throttle::isWithinTimespanMs(lastSentToMesh,
                                       Default::getConfiguredOrDefaultMs(moduleConfig.detection_sensor.minimum_broadcast_secs))) {
-        if (pendingDetected) {
+        // Send whichever verdict occurred first when both are outstanding, so the mesh sees them
+        // in the order they actually happened.
+        if (pendingDetected && (!pendingState || pendingDetectedFirst)) {
             pendingDetected = false;
             sendDetectionMessage();
         } else {

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -98,21 +98,34 @@ int32_t DetectionSensorModule::runOnce()
 
     // Sample the pin and evaluate the trigger on every poll so a transition is never missed between
     // sends; minimum_broadcast_secs only rate-limits how often we're allowed to actually transmit.
+    // wasDetected always advances so edge comparisons stay correct; a verdict produced while still
+    // throttled is latched in pendingSend rather than discarded, so it isn't lost.
     bool isDetected = hasDetectionEvent();
     DetectionSensorTriggerVerdict verdict = handlers[configuredTriggerType()](wasDetected, isDetected);
     wasDetected = isDetected;
-    if (!Throttle::isWithinTimespanMs(lastSentToMesh,
+    switch (verdict) {
+    case DetectionSensorVerdictDetected:
+        pendingSend = true;
+        pendingSendIsState = false;
+        break;
+    case DetectionSensorVerdictSendState:
+        pendingSend = true;
+        pendingSendIsState = true;
+        pendingIsDetected = isDetected;
+        break;
+    case DetectionSensorVerdictNoop:
+        break;
+    }
+    if (pendingSend &&
+        !Throttle::isWithinTimespanMs(lastSentToMesh,
                                       Default::getConfiguredOrDefaultMs(moduleConfig.detection_sensor.minimum_broadcast_secs))) {
-        switch (verdict) {
-        case DetectionSensorVerdictDetected:
+        pendingSend = false;
+        if (pendingSendIsState) {
+            sendCurrentStateMessage(pendingIsDetected);
+        } else {
             sendDetectionMessage();
-            return DELAYED_INTERVAL;
-        case DetectionSensorVerdictSendState:
-            sendCurrentStateMessage(isDetected);
-            return DELAYED_INTERVAL;
-        case DetectionSensorVerdictNoop:
-            break;
         }
+        return DELAYED_INTERVAL;
     }
     // Even if we haven't detected an event, broadcast our current state to the mesh on the scheduled interval as a sort
     // of heartbeat. We only do this if the minimum broadcast interval is greater than zero, otherwise we'll only broadcast state

--- a/src/modules/DetectionSensorModule.cpp
+++ b/src/modules/DetectionSensorModule.cpp
@@ -96,11 +96,13 @@ int32_t DetectionSensorModule::runOnce()
 
     // LOG_DEBUG("Detection Sensor Module: Current pin state: %i", digitalRead(moduleConfig.detection_sensor.monitor_pin));
 
+    // Sample the pin and evaluate the trigger on every poll so a transition is never missed between
+    // sends; minimum_broadcast_secs only rate-limits how often we're allowed to actually transmit.
+    bool isDetected = hasDetectionEvent();
+    DetectionSensorTriggerVerdict verdict = handlers[configuredTriggerType()](wasDetected, isDetected);
+    wasDetected = isDetected;
     if (!Throttle::isWithinTimespanMs(lastSentToMesh,
                                       Default::getConfiguredOrDefaultMs(moduleConfig.detection_sensor.minimum_broadcast_secs))) {
-        bool isDetected = hasDetectionEvent();
-        DetectionSensorTriggerVerdict verdict = handlers[configuredTriggerType()](wasDetected, isDetected);
-        wasDetected = isDetected;
         switch (verdict) {
         case DetectionSensorVerdictDetected:
             sendDetectionMessage();
@@ -119,7 +121,7 @@ int32_t DetectionSensorModule::runOnce()
         !Throttle::isWithinTimespanMs(lastSentToMesh,
                                       Default::getConfiguredOrDefaultMs(moduleConfig.detection_sensor.state_broadcast_secs,
                                                                         default_telemetry_broadcast_interval_secs))) {
-        sendCurrentStateMessage(hasDetectionEvent());
+        sendCurrentStateMessage(isDetected);
         return DELAYED_INTERVAL;
     }
     return GPIO_POLLING_INTERVAL;

--- a/src/modules/DetectionSensorModule.h
+++ b/src/modules/DetectionSensorModule.h
@@ -20,6 +20,9 @@ class DetectionSensorModule : public SinglePortModule, private concurrency::OSTh
     bool pendingDetected = false;
     bool pendingState = false;
     bool pendingStateIsDetected = false;
+    // Which of the two above became pending first, while neither was already outstanding; used to
+    // preserve send order when both end up pending at once.
+    bool pendingDetectedFirst = false;
     void sendDetectionMessage();
     void sendCurrentStateMessage(bool state);
     bool hasDetectionEvent();

--- a/src/modules/DetectionSensorModule.h
+++ b/src/modules/DetectionSensorModule.h
@@ -15,6 +15,12 @@ class DetectionSensorModule : public SinglePortModule, private concurrency::OSTh
     bool firstTime = true;
     uint32_t lastSentToMesh = 0;
     bool wasDetected = false;
+    // A verdict produced while minimum_broadcast_secs was still throttling sends is latched here
+    // rather than discarded, so it fires as soon as the throttle window reopens instead of being
+    // silently lost (wasDetected keeps updating every poll for correct edge comparisons regardless).
+    bool pendingSend = false;
+    bool pendingSendIsState = false;
+    bool pendingIsDetected = false;
     void sendDetectionMessage();
     void sendCurrentStateMessage(bool state);
     bool hasDetectionEvent();

--- a/src/modules/DetectionSensorModule.h
+++ b/src/modules/DetectionSensorModule.h
@@ -20,8 +20,8 @@ class DetectionSensorModule : public SinglePortModule, private concurrency::OSTh
     bool pendingDetected = false;
     bool pendingState = false;
     bool pendingStateIsDetected = false;
-    // Which of the two above became pending first, while neither was already outstanding; used to
-    // preserve send order when both end up pending at once.
+    // Which of the two above is the older still-outstanding one; updated whenever pendingDetected
+    // or pendingState newly transitions false->true, so send order matches occurrence order.
     bool pendingDetectedFirst = false;
     void sendDetectionMessage();
     void sendCurrentStateMessage(bool state);

--- a/src/modules/DetectionSensorModule.h
+++ b/src/modules/DetectionSensorModule.h
@@ -15,12 +15,11 @@ class DetectionSensorModule : public SinglePortModule, private concurrency::OSTh
     bool firstTime = true;
     uint32_t lastSentToMesh = 0;
     bool wasDetected = false;
-    // A verdict produced while minimum_broadcast_secs was still throttling sends is latched here
-    // rather than discarded, so it fires as soon as the throttle window reopens instead of being
-    // silently lost (wasDetected keeps updating every poll for correct edge comparisons regardless).
-    bool pendingSend = false;
-    bool pendingSendIsState = false;
-    bool pendingIsDetected = false;
+    // Verdicts throttled by minimum_broadcast_secs are latched here instead of discarded, tracked
+    // separately so a later SendState can't overwrite an already-pending Detected.
+    bool pendingDetected = false;
+    bool pendingState = false;
+    bool pendingStateIsDetected = false;
     void sendDetectionMessage();
     void sendCurrentStateMessage(bool state);
     bool hasDetectionEvent();

--- a/src/modules/DetectionSensorModule.h
+++ b/src/modules/DetectionSensorModule.h
@@ -16,10 +16,12 @@ class DetectionSensorModule : public SinglePortModule, private concurrency::OSTh
     uint32_t lastSentToMesh = 0;
     // Pin/pullup actually behind the current pinMode()+attachInterrupt() setup; 0 = not configured
     // yet. Compared against moduleConfig each poll so a runtime change gets picked up without a
-    // reboot instead of leaving the interrupt bound to a stale pin.
-    uint32_t configuredMonitorPin = 0;
+    // reboot instead of leaving the interrupt bound to a stale pin. hasDetectionEvent() (interrupt
+    // and poll alike) samples this pin, not moduleConfig's, so it never races ahead of the rebind.
+    volatile uint32_t configuredMonitorPin = 0;
     bool configuredUsePullup = false;
-    void configureMonitorPin();
+    // Returns false (and leaves monitoring disabled) if monitor_pin is 0.
+    bool configureMonitorPin();
     // Below: written from both runOnce() and the monitor-pin interrupt (see attachInterrupt and
     // updatePendingVerdict()); volatile so neither side caches a stale value across that boundary.
     volatile bool wasDetected = false;

--- a/src/modules/DetectionSensorModule.h
+++ b/src/modules/DetectionSensorModule.h
@@ -14,18 +14,29 @@ class DetectionSensorModule : public SinglePortModule, private concurrency::OSTh
   private:
     bool firstTime = true;
     uint32_t lastSentToMesh = 0;
-    bool wasDetected = false;
+    // Pin/pullup actually behind the current pinMode()+attachInterrupt() setup; 0 = not configured
+    // yet. Compared against moduleConfig each poll so a runtime change gets picked up without a
+    // reboot instead of leaving the interrupt bound to a stale pin.
+    uint32_t configuredMonitorPin = 0;
+    bool configuredUsePullup = false;
+    void configureMonitorPin();
+    // Below: written from both runOnce() and the monitor-pin interrupt (see attachInterrupt and
+    // updatePendingVerdict()); volatile so neither side caches a stale value across that boundary.
+    volatile bool wasDetected = false;
     // Verdicts throttled by minimum_broadcast_secs are latched here instead of discarded, tracked
     // separately so a later SendState can't overwrite an already-pending Detected.
-    bool pendingDetected = false;
-    bool pendingState = false;
-    bool pendingStateIsDetected = false;
+    volatile bool pendingDetected = false;
+    volatile bool pendingState = false;
+    volatile bool pendingStateIsDetected = false;
     // Which of the two above is the older still-outstanding one; updated whenever pendingDetected
     // or pendingState newly transitions false->true, so send order matches occurrence order.
-    bool pendingDetectedFirst = false;
+    volatile bool pendingDetectedFirst = false;
     void sendDetectionMessage();
     void sendCurrentStateMessage(bool state);
     bool hasDetectionEvent();
+    // Samples the pin and updates the pending-verdict state; called from both runOnce() and the
+    // interrupt. Call with interrupts disabled from runOnce() to avoid reentrant corruption.
+    void updatePendingVerdict();
 };
 
 extern DetectionSensorModule *detectionSensorModule;


### PR DESCRIPTION
## Summary
- `DetectionSensorModule` polled its monitor pin every 100ms unconditionally whenever enabled, forcing the CPU to wake 10x/second continuously regardless of whether anything was happening on the pin — a real cost for a battery-powered, low-event-rate sensor (e.g. a mailbox reed switch), and one that defeats Meshtastic's normal idle power savings between BLE/LoRa duty cycles.
- Attach a `CHANGE` interrupt on the monitor pin (same pattern as `Power::attachPowerInterrupts()` in `src/Power.cpp`) so a real transition wakes the module immediately instead of waiting for the next poll.
- The poll interval itself drops from 100ms to a 1s safety-net cadence — it's now only needed to re-arm a level trigger (`LOGIC_HIGH`/`LOGIC_LOW`) that's still held once `minimum_broadcast_secs` reopens, and to service the `state_broadcast_secs` heartbeat, both of which are configured in whole seconds anyway.

**Note:** this branch is stacked on #11664 (not yet merged), so the diff currently includes that commit too. Will rebase once #11664 lands.

## Test plan
- [x] Native build: `pio run -e seeed_xiao_nrf52840_kit` succeeds
- [x] Flashed to a Seeed XIAO nRF52840 + Wio-SX1262 Kit and verified live: grounding the monitor pin produces an immediate `Detected event observed. Send message` log line and mesh transmission, and holding the pin grounded across the throttle window correctly re-fires at `minimum_broadcast_secs` intervals (two detection messages observed 15s apart with `minimum_broadcast_secs=15`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detection events are now captured reliably, even during broadcast rate limits, and sent when transmission becomes available.
  * Pin transitions can wake the detection sensor immediately for faster event handling.
  * Deferred detection and state updates are transmitted in the order they occurred.
  * Heartbeat reporting now uses the latest detection reading consistently and pauses while updates are pending.
  * Reduced the fallback polling interval to improve efficiency.
  * Monitor pin and pull-up changes now take effect without requiring a restart.
  * Clearing the monitor pin now disables the detection sensor safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->