### PR TITLE
Wio Tracker L2: try-fix battery percentage

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -762,6 +762,7 @@ class ADS1115BatteryLevel : public HasBatteryLevel
         } else {
             LOG_WARN("[AW35615] not found at 0x22");
         }
+        getBattVoltage(); // initial read cached_mv
         return true;
     }
 

--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -739,7 +739,7 @@ static AnalogBatteryLevel analogLevel;
  * Channel 0 measures battery voltage through a 1:2 resistive divider.
  * USB / Charging status is managed via an AW35615 USB-C CC controller.
  */
-class ADS1115BatteryLevel : public HasBatteryLevel
+class ADS1115BatteryLevel : public AnalogBatteryLevel
 {
   public:
     bool init()
@@ -766,7 +766,6 @@ class ADS1115BatteryLevel : public HasBatteryLevel
         return true;
     }
 
-    virtual int getBatteryPercent() override { return -1; }
     virtual bool isBatteryConnect() override { return true; }
     virtual uint16_t getBattVoltage() override
     {

--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -739,7 +739,7 @@ static AnalogBatteryLevel analogLevel;
  * Channel 0 measures battery voltage through a 1:2 resistive divider.
  * USB / Charging status is managed via an AW35615 USB-C CC controller.
  */
-class ADS1115BatteryLevel : public AnalogBatteryLevel
+class ADS1115BatteryLevel : public HasBatteryLevel
 {
   public:
     bool init()
@@ -765,6 +765,8 @@ class ADS1115BatteryLevel : public AnalogBatteryLevel
         return true;
     }
 
+    virtual int getBatteryPercent() override { return -1; }
+    virtual bool isBatteryConnect() override { return true; }
     virtual uint16_t getBattVoltage() override
     {
         if (!initialized)
@@ -800,7 +802,7 @@ class ADS1115BatteryLevel : public AnalogBatteryLevel
     {
         if (_aw35615.isReady()) {
             concurrency::LockGuard guard(spiLock);
-            return _aw35615.isVbusPresent();
+            return _aw35615.isVbusPresent() && cached_mv >= 4200;
         }
         // Fallback to base GPIO/board checks (or false) if CC chip is absent
         return false;
@@ -813,7 +815,7 @@ class ADS1115BatteryLevel : public AnalogBatteryLevel
 
         if (_aw35615.isReady()) {
             concurrency::LockGuard guard(spiLock);
-            return _aw35615.isSinkAttached();
+            return _aw35615.isSinkAttached() && cached_mv >= 4200;
         }
         return isVbusIn();
     }


### PR DESCRIPTION
It seems when removing the USB power it is not recognized correctly. As a temporary workaround the voltage level is checked and if smaller 4.2V it is assumed it's not connected/charging.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] Wio Tracker L2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved battery status reporting for ADS1115-based devices.
  * Battery voltage is now read during initialization for more accurate status information.
  * VBUS and charging indicators activate only when the battery voltage reaches the required threshold.
  * Battery connection status is reported correctly.
  * Battery percentage is reported as unavailable when it cannot be determined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->