### PR TITLE
chore: use local device-ui for Heltec R8 development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .pio
+.pio-core/
 pio
 .pio-docker
 pio.tar
@@ -74,4 +75,7 @@ bin/_generated/
 build/wasm/
 build/wasm-obj/
 build/wasm-*.log
+
+# Local firmware build logs.
+build-*.log
 .emsdk/

--- a/GIT-POLICY.md
+++ b/GIT-POLICY.md
@@ -1,0 +1,65 @@
+# Git Policy
+
+This repository has a known-good Meshtastic firmware baseline for `heltec-v4-r8-tft`.
+
+Known-good firmware baseline:
+
+- Firmware commit: `7239fe886a30fa13cd35946fa5ae1a46a2807eeb`
+- Firmware tag at that commit: `v2.8.0.7239fe8`
+- Target: `heltec-v4-r8-tft`
+- Flash mode: `--flash-mode dio`
+- Device UI dependency: `https://github.com/meshtastic/device-ui/archive/9d9b9df81fcde646811a10942d00d5f45f72af7b.zip`
+
+## Rules
+
+1. Never develop directly on the known-good baseline branch.
+
+2. Never permanently edit `.pio/libdeps/`, because it is generated PlatformIO dependency state.
+
+3. All Device UI source changes must live in a proper `meshtastic/device-ui` working repository, fork, branch, submodule, local dependency, or pinned source checkout.
+
+4. External dependencies used for reproducible builds must be pinned to exact commits.
+
+5. Do not use moving branch names such as `develop`, `master`, or `main` as the final production dependency reference.
+
+6. Before every source modification, check:
+
+```powershell
+git status
+git branch --show-current
+git rev-parse HEAD
+```
+
+7. Before every build intended for flashing, record:
+
+- firmware HEAD
+- device-ui HEAD
+- target
+- build identifier
+- flash mode
+
+8. Never allow Codex to commit or push automatically.
+
+9. Commits are only made after:
+
+- build succeeds
+- diff is reviewed
+- physical behavior is tested when relevant
+- user explicitly approves commit
+
+10. Keep logical changes separated. Examples: dependency setup, Quick Message UI, message send helper, incoming-message UI, and BLE/MUI experiment should not all be mixed into one commit.
+
+11. Never rewrite or force-push shared history.
+
+12. Known-good firmware and flash artifacts must remain recoverable.
+
+13. Working clean-flash artifacts must not be overwritten silently.
+
+14. The known working esptool setting `--flash-mode dio` must be preserved unless physical testing proves otherwise.
+
+15. Generated UI files must not be treated as authoritative source without first identifying the generator/source files.
+
+16. Before updating upstream Meshtastic or device-ui, create a separate integration/update branch.
+
+17. Any experimental branch must be trivially removable without damaging the known-good baseline.
+

--- a/docs/development-baseline.md
+++ b/docs/development-baseline.md
@@ -1,0 +1,191 @@
+# Development Baseline
+
+## 1. Firmware Repository Path
+
+`C:\Users\JPJYR\Documents\meshtastic`
+
+## 2. Firmware Remote
+
+`origin https://github.com/meshtastic/firmware.git`
+
+## 3. Firmware Baseline Commit
+
+`7239fe886a30fa13cd35946fa5ae1a46a2807eeb`
+
+This is the current `HEAD` inspected during Phase 0.
+
+## 4. Firmware Baseline Branch/Tag
+
+Current branch during inspection: `develop`.
+
+Tag pointing at current commit:
+
+- `v2.8.0.7239fe8`
+
+No baseline branch or new tag was created because the working tree is not clean. Untracked local preparation/build outputs are present, including `.pio-core/`, `dist/`, build logs, and documentation files.
+
+Recommended future baseline name after review:
+
+- Branch: `baseline/heltec-v4-r8-tft-2.8.0-working`
+- Local tag: `heltec-v4-r8-tft-known-good-2.8.0`
+
+Create these only after deciding what to do with untracked files.
+
+## 5. Device UI Repository Path
+
+Editable local clone prepared at:
+
+`C:\Users\JPJYR\Documents\device-ui`
+
+## 6. Device UI Remote
+
+`origin https://github.com/meshtastic/device-ui.git`
+
+## 7. Device UI Exact Baseline Commit
+
+`9d9b9df81fcde646811a10942d00d5f45f72af7b`
+
+Local Device UI branch created:
+
+`feature/heltec-r8-quick-messages`
+
+No source files were modified in this repository.
+
+## 8. Current PlatformIO Dependency Mechanism
+
+Firmware currently pulls Device UI through `[device-ui_base]` in root `platformio.ini`.
+
+Current declaration:
+
+```ini
+[device-ui_base]
+lib_deps =
+	# renovate: datasource=git-refs depName=meshtastic/device-ui packageName=https://github.com/meshtastic/device-ui gitBranch=master
+	https://github.com/meshtastic/device-ui/archive/9d9b9df81fcde646811a10942d00d5f45f72af7b.zip
+```
+
+The active cached copy appears under:
+
+`.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/`
+
+That directory is generated dependency state and must not be the permanent editable source.
+
+## 9. Known-Good Target
+
+`heltec-v4-r8-tft`
+
+## 10. Known-Good Flash Mode
+
+`--flash-mode dio`
+
+Do not change this to `qio` unless later physical testing proves a safe change.
+
+## 11. LittleFS Offset
+
+`0xc90000`
+
+Known full clean flash map:
+
+```text
+0x0       firmware-heltec-v4-r8-tft-2.8.0.7239fe8.factory.bin
+0xc90000  littlefs-heltec-v4-r8-tft-2.8.0.7239fe8.bin
+```
+
+## 12. Known-Good Artifact Hashes
+
+Existing artifacts found in `dist/heltec-v4-r8-tft/`:
+
+```text
+138FDEB29C5D3D655113ACAE2522328583C8B625D09A8CC5A7FEC816AC7C0830  firmware-heltec-v4-r8-tft-2.8.0.7239fe8.factory.bin
+057092CD73FF7C2020CF9D15E471054E3FE0BA24BD1C825BD600E49B0E64C2AB  littlefs-heltec-v4-r8-tft-2.8.0.7239fe8.bin
+0BF3CAC43B0C5D14482B11FF199DEFD1706D99ADE22CECE5202C0579D2DBE655  firmware-heltec-v4-r8-tft-2.8.0.7239fe8.bin
+FDCE35E146F7C69A413B29CCD124E26099EECEB6511A90172FB2D6130FC5E636  meshtastic-heltec-v4-r8-tft-esptool-package.zip
+```
+
+The existing flashing scripts still contain `--flash-mode dio`.
+
+## 13. Reproducible Build Procedure
+
+Baseline verification command used:
+
+```powershell
+$env:PLATFORMIO_CORE_DIR="C:\p"
+$env:PYTHONUTF8="1"
+$env:PYTHONIOENCODING="utf-8"
+$env:Path=(Resolve-Path ".\.venv\Scripts").Path + ";" + $env:Path
+.\.venv\Scripts\pio.exe run -e heltec-v4-r8-tft -t mtjson -j 2 2>&1 | Tee-Object build-heltec-v4-r8-tft-baseline-verify-20260830.log
+```
+
+Verification result:
+
+```text
+Environment       Status    Duration
+heltec-v4-r8-tft  SUCCESS   00:09:17.053
+```
+
+Tooling recorded:
+
+- PlatformIO Core: `6.1.19`
+- Python: `3.14.3`
+- Platform: `espressif32 @ 55.3.311`
+- Arduino ESP32: `3.3.11`
+- ESP-IDF: `5.5.5`
+- esptool: `5.3.0`
+- LovyanGFX: `1.2.27`
+- lvgl from Device UI dependency: `9.3.0`
+
+Build output reported firmware version:
+
+`2.8.0.7239fe8`
+
+## 14. Development Branch Workflow
+
+Recommended firmware branches:
+
+- Keep current known-good commit recoverable through `v2.8.0.7239fe8` and a future local baseline branch/tag.
+- Create feature work on `feature/heltec-r8-quick-messages`.
+- Create separate experiments on branches such as `experiment/heltec-r8-ble-mui`.
+- Create upstream update work on separate integration branches.
+
+Do not mix dependency setup, Quick Message UI, send-helper refactoring, incoming-message emphasis, and BLE experiments into one commit.
+
+## 15. Device UI Local-Development Workflow
+
+Edit Device UI in:
+
+`C:\Users\JPJYR\Documents\device-ui`
+
+Current local branch:
+
+`feature/heltec-r8-quick-messages`
+
+During development, firmware may temporarily point to this local checkout using a PlatformIO local path dependency on a dedicated firmware feature branch. Final reproducible builds should point to an exact Device UI commit, not a moving branch or unpinned local path.
+
+## 16. Rollback Procedure
+
+To return firmware to the known-good dependency model:
+
+1. Ensure `platformio.ini` `[device-ui_base]` points back to:
+
+```text
+https://github.com/meshtastic/device-ui/archive/9d9b9df81fcde646811a10942d00d5f45f72af7b.zip
+```
+
+2. Build `heltec-v4-r8-tft`.
+3. Flash only with `--flash-mode dio`.
+4. Use the known-good artifacts from `dist/heltec-v4-r8-tft/` if the new build is suspect.
+
+Never use destructive git cleanup commands unless explicitly approved.
+
+## 17. Rules for Codex Before Modifying Code
+
+Before modifying code, Codex must run or review:
+
+```powershell
+.\tools\git-preflight.ps1
+```
+
+Codex must not commit, push, force-push, stash, reset, clean, merge, or rebase without explicit user instruction.
+
+No firmware behavior, Device UI behavior, display/touch behavior, Bluetooth behavior, or generated UI output should be changed during repository preparation.
+

--- a/docs/device-ui-development-workflow.md
+++ b/docs/device-ui-development-workflow.md
@@ -1,0 +1,125 @@
+# Device UI Development Workflow
+
+## Where Device UI Is Edited
+
+Do not edit:
+
+`.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/`
+
+That is PlatformIO-generated dependency state.
+
+Edit Device UI in the sibling repository:
+
+`C:\Users\JPJYR\Documents\device-ui`
+
+Current prepared branch:
+
+`feature/heltec-r8-quick-messages`
+
+Current baseline commit:
+
+`9d9b9df81fcde646811a10942d00d5f45f72af7b`
+
+## How Firmware Consumes Device UI
+
+Firmware currently consumes Device UI from an exact archive URL in root `platformio.ini`:
+
+```ini
+[device-ui_base]
+lib_deps =
+	https://github.com/meshtastic/device-ui/archive/9d9b9df81fcde646811a10942d00d5f45f72af7b.zip
+```
+
+The `heltec-v4-r8-tft` environment inherits this through `variants/esp32s3/heltec_v4_r8/platformio.ini`.
+
+## Local Development Dependency
+
+For local work, use a dedicated firmware feature branch and temporarily replace the Device UI dependency with a local path dependency.
+
+PlatformIO supports local library dependencies by path. From this firmware repository, the sibling checkout can be referenced as:
+
+```ini
+[device-ui_base]
+lib_deps =
+	../device-ui
+```
+
+This should be treated as a development-only dependency. Do not use this as the final production/release dependency reference.
+
+## Final Reproducible Dependency
+
+After testing Device UI changes:
+
+1. Commit the Device UI change in `C:\Users\JPJYR\Documents\device-ui` only after user approval.
+2. Push it only after user approval.
+3. Point firmware to an exact commit archive from the fork or accepted upstream commit.
+4. Avoid `master`, `main`, `develop`, or other moving branch names as final dependency references.
+
+Example final style:
+
+```ini
+[device-ui_base]
+lib_deps =
+	https://github.com/<fork-or-upstream>/device-ui/archive/<exact-commit>.zip
+```
+
+## Ranked Development Options
+
+1. Separate local clone with local path dependency during development, then exact commit archive for final builds. Best balance for Codex work, diff review, reproducibility, rebasing, and rollback.
+2. GitHub fork pinned to exact commit. Best for shared reproducible builds after local testing.
+3. Exact zip/archive pinned to commit. Good final dependency mechanism and already used by this firmware checkout.
+4. Git submodule. Technically possible, but more intrusive for this firmware repo and unnecessary unless the team wants submodule management.
+5. Permanent unversioned local dependency. Convenient, but poor reproducibility; use only temporarily on a development branch.
+
+## Generated UI Source Ownership
+
+The generated files are committed to Device UI, but they are not the authoring source.
+
+Relevant generated outputs:
+
+- `generated/ui_320x240/screens.c`
+- `generated/ui_320x240/screens.h`
+
+Authoring files found:
+
+- `studio/320x240/TFT320x240.eez-project`
+- `studio/240x320/TFTView_240x320.eez-project`
+
+The generated directory README says:
+
+```text
+This directory contains the exported ui files. Use eez-studio to design the UI and generate the C code.
+```
+
+`CMakeLists.txt` includes generated sources from `generated/${GENERATED_VIEW}`.
+
+Practical rule: for UI layout work, identify and update the EEZ Studio project first. Manual edits to generated `screens.c` and `screens.h` are fragile and may be overwritten by regeneration.
+
+## Returning to Upstream Device UI
+
+To return to the current upstream pinned Device UI:
+
+1. Restore `[device-ui_base]` in firmware `platformio.ini` to:
+
+```text
+https://github.com/meshtastic/device-ui/archive/9d9b9df81fcde646811a10942d00d5f45f72af7b.zip
+```
+
+2. Remove any local dependency override from the firmware feature branch.
+3. Rebuild `heltec-v4-r8-tft`.
+4. Confirm flash scripts still use `--flash-mode dio`.
+
+## Avoiding `.pio/libdeps` Edits
+
+Use `.pio/libdeps` only for inspection.
+
+Before changing Device UI code, confirm:
+
+```powershell
+git -C ..\device-ui status
+git -C ..\device-ui branch --show-current
+git -C ..\device-ui rev-parse HEAD
+```
+
+Then modify files under `..\device-ui`, not under `.pio\libdeps`.
+

--- a/docs/device-ui-development-workflow.md
+++ b/docs/device-ui-development-workflow.md
@@ -41,10 +41,20 @@ PlatformIO supports local library dependencies by path. From this firmware repos
 ```ini
 [device-ui_base]
 lib_deps =
+	# DEVELOPMENT ONLY for feature/heltec-r8-quick-messages:
+	# use the editable local checkout at C:\Users\JPJYR\Documents\device-ui.
+	# Final reproducible builds must switch back to an exact pinned commit archive.
 	../device-ui
 ```
 
 This should be treated as a development-only dependency. Do not use this as the final production/release dependency reference.
+
+Current firmware feature branch dependency switch:
+
+- Branch: `feature/heltec-r8-quick-messages`
+- Local path dependency: `../device-ui`
+- Absolute local source path: `C:\Users\JPJYR\Documents\device-ui`
+- Device UI baseline at switch time: `9d9b9df81fcde646811a10942d00d5f45f72af7b`
 
 ## Final Reproducible Dependency
 
@@ -122,4 +132,3 @@ git -C ..\device-ui rev-parse HEAD
 ```
 
 Then modify files under `..\device-ui`, not under `.pio\libdeps`.
-

--- a/docs/git-hygiene-review.md
+++ b/docs/git-hygiene-review.md
@@ -1,0 +1,394 @@
+# Git Hygiene Review
+
+## 1. Executive summary
+
+Firmware source is still at the known-good upstream commit `7239fe886a30fa13cd35946fa5ae1a46a2807eeb`, with tag `v2.8.0.7239fe8` pointing at `HEAD`.
+
+There are no modified tracked firmware files. The dirty state is untracked local output and documentation:
+
+- generated/local PlatformIO state: `.pio-core/`
+- logs: `build-heltec-v4-r8-tft.log`, `build-heltec-v4-r8-tft-baseline-verify-20260830.log`
+- known-good artifacts: `dist/`
+- project documentation/scripts created in Phase 0: `GIT-POLICY.md`, `docs/`, `tools/git-preflight.ps1`
+
+No baseline branch or tag should be created yet. The official Meshtastic tag already identifies the source baseline, and the preparation documentation should not be confused with that upstream baseline.
+
+Recommended next step after user approval: preserve/copy known-good artifacts outside the Git working tree, add only repository-preparation docs and the preflight script, optionally add narrow ignore rules for local generated output/logs, then create a preparation commit on a feature/prep branch.
+
+## 2. Firmware Git state
+
+Repository path:
+
+`C:\Users\JPJYR\Documents\meshtastic`
+
+Current branch:
+
+`develop`
+
+Current `HEAD`:
+
+`7239fe886a30fa13cd35946fa5ae1a46a2807eeb`
+
+Tag pointing at `HEAD`:
+
+`v2.8.0.7239fe8`
+
+Remote:
+
+`origin https://github.com/meshtastic/firmware.git`
+
+Tracked modifications:
+
+None found.
+
+Untracked top-level items:
+
+- `.pio-core/`
+- `GIT-POLICY.md`
+- `build-heltec-v4-r8-tft-baseline-verify-20260830.log`
+- `build-heltec-v4-r8-tft.log`
+- `dist/`
+- `docs/`
+- `tools/git-preflight.ps1`
+
+## 3. Device UI Git state
+
+Repository path:
+
+`C:\Users\JPJYR\Documents\device-ui`
+
+Current branch:
+
+`feature/heltec-r8-quick-messages`
+
+Current `HEAD`:
+
+`9d9b9df81fcde646811a10942d00d5f45f72af7b`
+
+Remote:
+
+`origin https://github.com/meshtastic/device-ui.git`
+
+Status:
+
+Clean. No source modifications were found.
+
+## 4. Complete dirty/untracked file inventory
+
+Untracked files outside large generated directories:
+
+```text
+GIT-POLICY.md
+build-heltec-v4-r8-tft.log
+build-heltec-v4-r8-tft-baseline-verify-20260830.log
+docs/development-baseline.md
+docs/device-ui-development-workflow.md
+docs/heltec-v4-r8-tft-programming-mode-investigation.md
+docs/heltec-v4-r8-tft-quick-message-ui-investigation.md
+docs/git-hygiene-review.md
+tools/git-preflight.ps1
+```
+
+Untracked build/release artifact files:
+
+```text
+dist/heltec-v4-r8-tft/README-FLASHING.md
+dist/heltec-v4-r8-tft/boot_app0.bin
+dist/heltec-v4-r8-tft/bootloader.bin
+dist/heltec-v4-r8-tft/firmware-heltec-v4-r8-tft-2.8.0.7239fe8.bin
+dist/heltec-v4-r8-tft/firmware-heltec-v4-r8-tft-2.8.0.7239fe8.factory.bin
+dist/heltec-v4-r8-tft/firmware-heltec-v4-r8-tft-2.8.0.7239fe8.mt.json
+dist/heltec-v4-r8-tft/flash-full-linux.sh
+dist/heltec-v4-r8-tft/flash-full-windows.bat
+dist/heltec-v4-r8-tft/flash-map.json
+dist/heltec-v4-r8-tft/flash-update-linux.sh
+dist/heltec-v4-r8-tft/flash-update-windows.bat
+dist/heltec-v4-r8-tft/littlefs-heltec-v4-r8-tft-2.8.0.7239fe8.bin
+dist/heltec-v4-r8-tft/partitions.bin
+dist/meshtastic-heltec-v4-r8-tft-esptool-package.zip
+```
+
+Large untracked/generated directory:
+
+```text
+.pio-core/  files=8857  bytes=574665419
+```
+
+Tracked modified files:
+
+None.
+
+Ignored relevant directories:
+
+- `.pio/` is ignored by `.gitignore`.
+- `.venv/` is ignored by `.gitignore`.
+
+## 5. Classification table
+
+| Path | Category | Tracked? | Ignored? | Recommended action | Reason |
+|---|---|---:|---:|---|---|
+| `GIT-POLICY.md` | A. PROJECT SOURCE / DOCUMENTATION | No | No | Include in preparation commit | Defines safety rules before firmware work. |
+| `docs/development-baseline.md` | A. PROJECT SOURCE / DOCUMENTATION | No | No | Include in preparation commit | Records known-good firmware/device-ui/build baseline. |
+| `docs/device-ui-development-workflow.md` | A. PROJECT SOURCE / DOCUMENTATION | No | No | Include in preparation commit | Documents safe Device UI editing workflow. |
+| `docs/heltec-v4-r8-tft-programming-mode-investigation.md` | A. PROJECT SOURCE / DOCUMENTATION | No | No | Include only if user wants investigation reports tracked | Useful project research, but not strictly required for prep policy. |
+| `docs/heltec-v4-r8-tft-quick-message-ui-investigation.md` | A. PROJECT SOURCE / DOCUMENTATION | No | No | Include only if user wants investigation reports tracked | Useful design research, but not strictly required for prep policy. |
+| `docs/git-hygiene-review.md` | A. PROJECT SOURCE / DOCUMENTATION | No | No | Include in preparation commit | This review explains what to track and what not to track. |
+| `tools/git-preflight.ps1` | A. PROJECT SOURCE / DOCUMENTATION | No | No | Include in preparation commit | Read-only safety helper for future Codex/source work. |
+| `.pio-core/` | B. GENERATED / TEMPORARY | No | No | Do not commit; add narrow ignore rule after approval | Local PlatformIO core/packages/cache, about 575 MB. |
+| `.pio/` | B. GENERATED / TEMPORARY | No | Yes | Do not commit | Already ignored PlatformIO build/dependency output. |
+| `.venv/` | B. GENERATED / TEMPORARY | No | Yes | Do not commit | Already ignored local Python virtualenv. |
+| `build-heltec-v4-r8-tft.log` | D. LOGS / REPORTS | No | No | Do not commit by default; optionally archive locally | Large old build log, useful only as temporary diagnostic context. |
+| `build-heltec-v4-r8-tft-baseline-verify-20260830.log` | D. LOGS / REPORTS | No | No | Do not commit by default; optionally archive locally | Verification result is already summarized in docs; full log is reproducible. |
+| `dist/heltec-v4-r8-tft/*.bin` | C. BUILD / RELEASE ARTIFACTS | No | No | Preserve, but do not commit now | Known-good physical rollback artifacts; binaries inflate repo. |
+| `dist/heltec-v4-r8-tft/*.sh` | C. BUILD / RELEASE ARTIFACTS | No | No | Preserve with artifacts, not prep commit | Flash scripts matter for rollback and preserve `--flash-mode dio`. |
+| `dist/heltec-v4-r8-tft/*.bat` | C. BUILD / RELEASE ARTIFACTS | No | No | Preserve with artifacts, not prep commit | Windows flash scripts matter for rollback and preserve `--flash-mode dio`. |
+| `dist/heltec-v4-r8-tft/*.json` | C. BUILD / RELEASE ARTIFACTS | No | No | Preserve with artifacts, not prep commit | Manifests/map belong with binary artifact package. |
+| `dist/heltec-v4-r8-tft/README-FLASHING.md` | C. BUILD / RELEASE ARTIFACTS | No | No | Preserve with artifacts; optionally copy selected facts into docs | Good hardware rollback instructions, already summarized in `development-baseline.md`. |
+| `dist/meshtastic-heltec-v4-r8-tft-esptool-package.zip` | C. BUILD / RELEASE ARTIFACTS | No | No | Preserve, but do not commit now | Useful complete rollback package; binary archive is better outside Git. |
+
+## 6. Current .gitignore analysis
+
+The current `.gitignore` already covers:
+
+- `.pio`
+- `pio`
+- `.pio-docker`
+- `.platformio`
+- `.cache`
+- `.venv/`
+- `venv/`
+- `__pycache__`
+- `release/`
+- `/compile_commands.json`
+- many build and editor artifacts
+
+It does not currently cover:
+
+- `.pio-core/`
+- root build logs such as `build-heltec-v4-r8-tft.log`
+- `dist/`
+
+This is mostly reasonable for an upstream firmware repository. The local `.pio-core/` path is special to this workstation because `PLATFORMIO_CORE_DIR` was set to a project-local directory during setup. It should not be committed.
+
+## 7. Proposed .gitignore changes
+
+No `.gitignore` changes were made in this task.
+
+Recommended narrow additions after user approval:
+
+```gitignore
+# Local PlatformIO core/cache used by this workstation.
+.pio-core/
+
+# Local build verification logs.
+build-*.log
+```
+
+Do not automatically ignore `dist/` yet. It contains known-good rollback artifacts. Decide artifact preservation first.
+
+An alternative to editing repository `.gitignore` is to put purely local rules in `.git/info/exclude`:
+
+```gitignore
+.pio-core/
+build-*.log
+```
+
+That keeps upstream-visible files cleaner but does not help future clones.
+
+## 8. Known-good artifact preservation strategy
+
+Evaluated options:
+
+### Option A: Keep `dist/` untracked but preserved locally
+
+Good short-term option. It preserves the exact files without inflating Git. Risk: a future cleanup could delete them accidentally because they are untracked.
+
+### Option B: Store known-good artifacts outside the Git working tree
+
+Recommended current option.
+
+Suggested location:
+
+```text
+C:\Users\JPJYR\Documents\meshtastic-artifacts\known-good\2.8.0.7239fe8\
+```
+
+This avoids accidental inclusion in source commits, reduces cleanup risk inside the repo, and keeps the rollback package clearly tied to the tested firmware.
+
+### Option C: Track selected release artifacts in Git
+
+Not recommended now. The binaries and ZIP are large, not source, and would mix release payload with firmware development history.
+
+### Option D: Use GitHub Releases later
+
+Good later option after a fork/release process exists. Do not upload anything during hygiene preparation.
+
+Recommendation: use Option B after user approval, while keeping hashes and flash map in `docs/development-baseline.md`.
+
+## 9. Exact proposed preparation commit contents
+
+Proposed commit contents:
+
+```text
+GIT-POLICY.md
+docs/development-baseline.md
+docs/device-ui-development-workflow.md
+docs/git-hygiene-review.md
+tools/git-preflight.ps1
+```
+
+Reasons:
+
+- `GIT-POLICY.md`: central safety policy.
+- `docs/development-baseline.md`: source/build/artifact baseline facts.
+- `docs/device-ui-development-workflow.md`: avoids `.pio/libdeps` edits and documents dependency pinning.
+- `docs/git-hygiene-review.md`: records this classification and next-step plan.
+- `tools/git-preflight.ps1`: read-only local safety check before any later source modifications.
+
+Optional commit contents if the user wants research docs tracked too:
+
+```text
+docs/heltec-v4-r8-tft-programming-mode-investigation.md
+docs/heltec-v4-r8-tft-quick-message-ui-investigation.md
+```
+
+Optional `.gitignore` additions after approval:
+
+```text
+.gitignore
+```
+
+Only include `.gitignore` if the user approves ignoring `.pio-core/` and local build logs.
+
+## 10. Files explicitly NOT to commit
+
+Do not include:
+
+```text
+.pio/
+.pio-core/
+build-heltec-v4-r8-tft.log
+build-heltec-v4-r8-tft-baseline-verify-20260830.log
+dist/
+```
+
+Do not include any generated Device UI files from:
+
+```text
+.pio/libdeps/
+```
+
+Do not include Device UI source changes in the firmware preparation commit.
+
+## 11. Baseline branch/tag recommendation
+
+The official upstream tag `v2.8.0.7239fe8` already points to the exact known-good firmware source commit. A new local baseline tag is therefore optional, not required.
+
+Recommended approach:
+
+1. Treat `v2.8.0.7239fe8` and commit `7239fe886a30fa13cd35946fa5ae1a46a2807eeb` as the immutable source baseline.
+2. Do not create a local baseline branch from a dirty working tree.
+3. After the preparation commit is reviewed, create future work from the known-good commit or from a dedicated prep branch, depending on whether the documentation should travel with the feature branch.
+
+Most precise strategy:
+
+- Baseline source identity: official tag `v2.8.0.7239fe8`.
+- Local preparation branch: `prep/heltec-r8-git-hygiene`.
+- Future firmware feature branch: `feature/heltec-r8-quick-messages`.
+
+Avoid making the documentation commit look like a firmware baseline.
+
+## 12. Future feature branch workflow
+
+Matching firmware and Device UI branch names are sensible:
+
+- Firmware: `feature/heltec-r8-quick-messages`
+- Device UI: `feature/heltec-r8-quick-messages`
+
+The Device UI branch already exists and is clean at commit `9d9b9df81fcde646811a10942d00d5f45f72af7b`.
+
+Recommended sequence after approval:
+
+1. Preserve known-good artifacts outside the Git working tree.
+2. Apply approved ignore rules.
+3. Add preparation docs/script.
+4. Create a repository-preparation commit.
+5. Create firmware feature branch for quick messages.
+6. Temporarily point firmware to local `../device-ui` only on the feature branch.
+7. Verify baseline build still succeeds with the intended dependency mode.
+8. Begin Quick Message implementation in Device UI.
+
+## 13. Exact commands that would be run AFTER user approval
+
+These are proposed commands only. They were not executed during this review.
+
+Preserve artifacts:
+
+```powershell
+New-Item -ItemType Directory -Force C:\Users\JPJYR\Documents\meshtastic-artifacts\known-good\2.8.0.7239fe8
+Copy-Item dist\heltec-v4-r8-tft\* C:\Users\JPJYR\Documents\meshtastic-artifacts\known-good\2.8.0.7239fe8\ -Force
+Copy-Item dist\meshtastic-heltec-v4-r8-tft-esptool-package.zip C:\Users\JPJYR\Documents\meshtastic-artifacts\known-good\2.8.0.7239fe8\ -Force
+```
+
+Add ignore rules if approved:
+
+```powershell
+# Edit .gitignore to add:
+# .pio-core/
+# build-*.log
+```
+
+Create prep branch and commit if approved:
+
+```powershell
+git switch -c prep/heltec-r8-git-hygiene
+git add GIT-POLICY.md docs/development-baseline.md docs/device-ui-development-workflow.md docs/git-hygiene-review.md tools/git-preflight.ps1
+git add .gitignore
+git commit -m "Document Heltec V4 R8 TFT development baseline"
+```
+
+Create future feature branch if approved:
+
+```powershell
+git switch -c feature/heltec-r8-quick-messages
+```
+
+Check Device UI before editing:
+
+```powershell
+git -C ..\device-ui status
+git -C ..\device-ui rev-parse --abbrev-ref HEAD
+git -C ..\device-ui rev-parse HEAD
+```
+
+## 14. Rollback implications
+
+Rollback source identity is already strong because the firmware source baseline is the official tag `v2.8.0.7239fe8` and exact commit `7239fe886a30fa13cd35946fa5ae1a46a2807eeb`.
+
+Rollback artifact identity is strong if the `dist/` artifacts remain available and the hashes in `docs/development-baseline.md` match:
+
+- factory image
+- app image
+- LittleFS image
+- esptool package ZIP
+
+Moving artifacts outside the Git working tree improves safety by separating source hygiene from hardware rollback payloads.
+
+The essential hardware rollback facts are:
+
+```text
+Target: heltec-v4-r8-tft
+Firmware: 7239fe886a30fa13cd35946fa5ae1a46a2807eeb
+Device UI: 9d9b9df81fcde646811a10942d00d5f45f72af7b
+Flash mode: dio
+LittleFS offset: 0xc90000
+```
+
+## 15. Unresolved questions requiring user decision
+
+1. Should known-good artifacts be copied to `C:\Users\JPJYR\Documents\meshtastic-artifacts\known-good\2.8.0.7239fe8\`?
+2. Should `.gitignore` be changed to ignore `.pio-core/` and `build-*.log`, or should those rules stay local in `.git/info/exclude`?
+3. Should the two investigation reports be included in the preparation commit, or only the policy/baseline/workflow/hygiene docs?
+4. Should the preparation commit live on a new branch named `prep/heltec-r8-git-hygiene`?
+5. Is the official tag `v2.8.0.7239fe8` enough as the source baseline, or do you also want a local baseline tag later?
+

--- a/docs/heltec-v4-r8-tft-programming-mode-investigation.md
+++ b/docs/heltec-v4-r8-tft-programming-mode-investigation.md
@@ -1,0 +1,304 @@
+# Heltec V4 R8 TFT Programming Mode Investigation
+
+## 1. Executive summary
+
+`heltec-v4-r8-tft` does not enter Programming Mode because the TFT, touch, or Bluetooth hardware is broken. It enters Programming Mode because this target builds the Device UI through `USE_PACKET_API`, and `PacketAPI::runOnce()` intentionally treats `config.bluetooth.enabled == true` as Programming Mode on non-Portduino targets.
+
+The decisive source path is:
+
+1. `variants/esp32s3/heltec_v4_r8/platformio.ini` enables `HAS_TFT`, `HAS_SCREEN`, and `USE_PACKET_API`.
+2. `src/main.cpp` starts `tftSetup()` when the display mode is color.
+3. `src/graphics/tftSetup.cpp` wires Device UI to firmware through `PacketAPI`.
+4. `src/mesh/api/PacketAPI.cpp` stops sending normal `FromRadio` data to the Device UI when Bluetooth is enabled and instead sends a one-time Bluetooth config packet.
+5. `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/source/graphics/TFT/TFTView_320x240.cpp` interprets that Bluetooth config during early boot as Programming Mode.
+
+Wi-Fi did not exit Programming Mode because the Programming Mode decision is keyed on `config.bluetooth.enabled`, not on `config.network.wifi_enabled`. Enabling Wi-Fi may stop BLE from starting on ESP32, but it does not clear the persisted Bluetooth config bit that drives `PacketAPI`.
+
+BLE and MUI appear technically capable of existing in the same firmware image: the target includes both Bluetooth-capable board metadata and the TFT/LVGL stack, and there is no source-level pin or bus conflict between BLE and the TFT/touch configuration. The current limitation is a deliberate software policy in the Packet API / Device UI bridge, not an obvious hardware conflict.
+
+## 2. Exact source files involved
+
+- `variants/esp32s3/heltec_v4_r8/platformio.ini`
+  - Target and compile-time flags for `env:heltec-v4-r8-tft`.
+- `boards/heltec_v4_r8.json`
+  - ESP32-S3 board definition; declares `wifi`, `bluetooth`, and `lora` connectivity.
+- `variants/esp32s3/heltec_v4_r8/variant.h`
+  - Heltec V4 R8 pins and TFT enable macros.
+- `src/main.cpp`
+  - Loads config, releases unused BT memory, starts TFT setup, and later starts Wi-Fi.
+- `src/platform/esp32/main-esp32.cpp`
+  - ESP32 Bluetooth/Wi-Fi coexistence and Bluetooth memory release logic.
+- `src/graphics/tftSetup.cpp`
+  - Creates Device UI, `PacketAPI`, `PacketServer`, and `PacketClient`.
+- `src/mesh/api/PacketAPI.cpp`
+  - Core Programming Mode trigger.
+- `src/mesh/NodeDB.cpp`
+  - Default config and persistent config saving.
+- `src/modules/AdminModule.cpp`
+  - Applies Bluetooth and Wi-Fi config writes, saves them, and schedules reboot.
+- `src/mesh/wifi/WiFiAPClient.cpp`
+  - Starts Wi-Fi if configured, but does not alter Bluetooth config.
+- `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/README.md`
+  - Documents the intended Programming Mode behavior.
+- `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/include/graphics/common/MeshtasticView.h`
+  - Defines Device UI state machine states including Programming Mode.
+- `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/source/graphics/common/ViewController.cpp`
+  - Requests config, receives packets, and routes Bluetooth config to the view.
+- `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/source/graphics/TFT/TFTView_320x240.cpp`
+  - Implements Programming Mode entry and exit UI.
+
+## 3. Exact functions involved
+
+- `main()` in `src/main.cpp`
+  - Lines 867-873: constructs `NodeDB`, loading persisted config before Bluetooth init.
+  - Lines 878-880: calls `tftSetup()` when `HAS_TFT` and color display mode are active.
+  - Lines 1200-1202: calls `initWifi()` later in boot.
+- `tftSetup()` in `src/graphics/tftSetup.cpp`
+  - Lines 331-334: creates `DeviceScreen`, `PacketAPI`, `PacketServer`, and initializes Device UI with `PacketClient`.
+- `tft_task_handler()` in `src/graphics/tftSetup.cpp`
+  - Lines 314-320: repeatedly runs `deviceScreen->task_handler()` and sleep handling.
+- `PacketAPI::runOnce()` in `src/mesh/api/PacketAPI.cpp`
+  - Lines 35-52: if `config.bluetooth.enabled` is true, enters `programmingMode` and does not call `sendPacket()`.
+- `PacketAPI::notifyProgrammingMode()` in `src/mesh/api/PacketAPI.cpp`
+  - Lines 120-129: sends only Bluetooth config to force client-side Programming Mode.
+- `PacketAPI::receivePacket()` in `src/mesh/api/PacketAPI.cpp`
+  - Lines 54-99: still accepts `ToRadio` packets, including config requests, but the normal outbound stream remains blocked while Bluetooth is enabled.
+- `NodeDB::installDefaultConfig()` in `src/mesh/NodeDB.cpp`
+  - Lines 1108-1117: TFT targets including `HELTEC_V4_R8_TFT` default Bluetooth to off.
+  - Lines 1143-1148: screen devices default to random PIN unless overridden.
+- `NodeDB::saveToDisk()` path in `src/mesh/NodeDB.cpp`
+  - Lines 3252-3262: marks config sections present and saves `config` to `configFileName`.
+- `AdminModule::handleSetConfig()` in `src/modules/AdminModule.cpp`
+  - Lines 868-873: config writes default to `requiresReboot = true`.
+  - Lines 964-971: accepts Wi-Fi/network config.
+  - Bluetooth case is in the same switch below the inspected block and follows the same save/reboot pattern.
+- `AdminModule::saveChanges()` in `src/modules/AdminModule.cpp`
+  - Lines 1877-1891: persists changes and reboots when requested.
+- `initWifi()` in `src/mesh/wifi/WiFiAPClient.cpp`
+  - Lines 364-428: starts Wi-Fi only when `wifi_enabled` and SSID are set.
+- `TFTView_320x240::init()` in Device UI
+  - Lines 160-197: initializes boot screen and installs the Programming Mode timer.
+- `TFTView_320x240::setupUIConfig()` in Device UI
+  - Lines 202-228: if already entering/programming/reboot state, calls `enterProgrammingMode()` instead of completing normal UI setup.
+- `TFTView_320x240::enterProgrammingMode()` in Device UI
+  - Lines 518-548: either enables Bluetooth and waits for reboot, or shows the Programming Mode screen.
+- `TFTView_320x240::timer_event_programming_mode()` in Device UI
+  - Lines 959-969: boot-logo long-hold path into Programming Mode.
+- `TFTView_320x240::ui_event_LogoButton()` in Device UI
+  - Lines 971-1004: click/long-press behavior on boot logo.
+- `TFTView_320x240::ui_event_BluetoothButton()` in Device UI
+  - Lines 1006-1019: long-press Bluetooth button disables Bluetooth and sends Bluetooth config.
+- `TFTView_320x240::updateBluetoothConfig()` in Device UI
+  - Lines 6351-6363: receiving Bluetooth config during early boot calls `enterProgrammingMode()`.
+- `ViewController::runOnce()` in Device UI
+  - Lines 54-66: requests config and avoids receiving normal data when already in Programming Mode.
+- `ViewController::handleFromRadio()` in Device UI
+  - Lines 686-700: drops packets while in Programming Mode, but allows Bluetooth config before setup is complete.
+  - Lines 763-765: passes Bluetooth config to `updateBluetoothConfig()`.
+
+## 4. Exact compile-time flags involved
+
+From `variants/esp32s3/heltec_v4_r8/platformio.ini`:
+
+- Lines 36-48 define `env:heltec-v4-r8-tft` and extend `heltec_v4_r8_base`.
+- Lines 50-52 define `HELTEC_V4_R8_TFT`.
+- Lines 68-69 define `HAS_SCREEN=1` and `HAS_TFT=1`.
+- Line 82 defines `USE_PACKET_API`.
+- Lines 83-87 select the LovyanGFX driver and `VIEW_240x320`.
+- Lines 89-95 define TFT SPI/backlight/reset pins.
+- Lines 96-100 define custom touch driver and touch pins.
+- Lines 111-115 define `ST7789_SPI_HOST=SPI3_HOST`, `SPI_FREQUENCY=75000000`, and SPI read settings.
+- Later target flags define SD card on the same SPI pins with separate CS.
+
+From `variants/esp32s3/heltec_v4_r8/variant.h`:
+
+- Lines 55-58: `#if HAS_TFT`, then `HAS_SPI_TFT=1` and `USE_TFTDISPLAY=1`.
+
+From `boards/heltec_v4_r8.json`:
+
+- Lines 21-24: MCU is `esp32s3`; connectivity includes `wifi`, `bluetooth`, and `lora`.
+- Lines 16-19: 240 MHz CPU, 80 MHz flash, `qio` board metadata, OPI PSRAM.
+
+## 5. Boot-time decision flow
+
+1. `src/main.cpp` constructs `NodeDB` at lines 867-869. That loads persisted config from flash.
+2. Immediately afterward, `esp32ReleaseBluetoothMemoryIfUnused()` is called at lines 870-873. This uses the saved Bluetooth/Wi-Fi configuration before Bluetooth is initialized.
+3. If `HAS_TFT` and display mode is color, `main.cpp` calls `tftSetup()` at lines 878-880.
+4. `tftSetup()` creates the Device UI and Packet API bridge at `src/graphics/tftSetup.cpp` lines 331-334.
+5. Device UI `TFTView_320x240::init()` creates the boot UI and a 3-second Programming Mode timer at Device UI lines 160-197.
+6. `ViewController::runOnce()` requests firmware config when the UI reaches `eBootScreenDone` or `eEnterProgrammingMode`, lines 54-59.
+7. `PacketAPI::runOnce()` checks `config.bluetooth.enabled` at `src/mesh/api/PacketAPI.cpp` line 39.
+8. If Bluetooth is enabled, `PacketAPI` sets its internal `programmingMode` flag and calls `notifyProgrammingMode()` instead of `sendPacket()`, lines 40-48.
+9. `notifyProgrammingMode()` sends only Bluetooth config, lines 120-129.
+10. Device UI receives that Bluetooth config through `ViewController::handleFromRadio()` lines 699-765.
+11. `TFTView_320x240::updateBluetoothConfig()` copies the config and, if still early in boot, calls `enterProgrammingMode()`, lines 6351-6363.
+12. `enterProgrammingMode()` shows `">> Programming mode <<"` and the fixed PIN, lines 537-546.
+
+Clean flash behavior is different: `NodeDB.cpp` lines 1108-1117 defaults Bluetooth off for TFT targets including `HELTEC_V4_R8_TFT`, so the normal UI can boot until some later config write enables Bluetooth.
+
+## 6. Runtime decision flow
+
+While running, the important loop is:
+
+1. Device UI runs on its own task from `tft_task_handler()` in `src/graphics/tftSetup.cpp` lines 314-320.
+2. The Device UI talks to the firmware through `PacketClient` / `PacketServer` created in `tftSetup()`.
+3. `PacketAPI::runOnce()` is the firmware side of that channel.
+4. If `config.bluetooth.enabled == false`, `PacketAPI::runOnce()` calls `sendPacket()` at line 48 and normal `FromRadio` traffic reaches MUI.
+5. If `config.bluetooth.enabled == true`, `PacketAPI::runOnce()` sends only one Programming Mode notification and then suppresses normal outbound packets.
+6. Device UI still can send config writes back through `PacketAPI::receivePacket()`, lines 54-99.
+7. Once Device UI state is `eProgrammingMode`, `ViewController::handleFromRadio()` returns immediately at lines 686-689 and ignores normal radio updates.
+
+This explains the observed "stuck" feeling: after Bluetooth is enabled, both sides have state-machine logic that keeps the UI in the Programming Mode path.
+
+## 7. Why Wi-Fi enable did not exit Programming Mode
+
+Wi-Fi enable did not exit Programming Mode because no inspected Programming Mode branch uses `config.network.wifi_enabled` as the condition to leave Programming Mode.
+
+The controlling firmware condition is only:
+
+- `src/mesh/api/PacketAPI.cpp` line 39: `if (config.bluetooth.enabled)`.
+
+Wi-Fi appears elsewhere:
+
+- `src/mesh/wifi/WiFiAPClient.cpp` lines 364-428 starts Wi-Fi when `config.network.wifi_enabled` and SSID are configured.
+- `src/platform/esp32/main-esp32.cpp` lines 76-81 may release Bluetooth memory when Wi-Fi is configured to disable Bluetooth for that boot.
+
+That memory/resource decision is not the same as clearing `config.bluetooth.enabled`. If the persisted Bluetooth config remains true, `PacketAPI` continues to choose Programming Mode even when Wi-Fi is enabled or BLE service is not started.
+
+## 8. Whether BLE + MUI are technically capable of coexisting
+
+Technically, likely yes at the firmware-image and hardware level:
+
+- The target board declares Bluetooth support in `boards/heltec_v4_r8.json` lines 21-24.
+- The same target enables TFT/MUI through `HAS_SCREEN=1`, `HAS_TFT=1`, and `USE_PACKET_API` in `variants/esp32s3/heltec_v4_r8/platformio.ini` lines 68-82.
+- TFT and touch pins are SPI/I2C GPIO definitions in `platformio.ini` lines 89-115 and do not overlap with BLE, which is internal ESP32-S3 radio/NimBLE functionality.
+- Boot logs from the successfully flashed DIO build showed the TFT UI and SD card initialized when Bluetooth was not enabled.
+
+But in the current source, BLE + normal MUI are not allowed to coexist by policy:
+
+- `PacketAPI::runOnce()` suppresses normal Device UI outbound traffic whenever `config.bluetooth.enabled` is true.
+- Device UI README lines 179-180 explicitly lists disabling the screen to allow USB serial/BT and allowing Bluetooth through "Programming Mode".
+
+So the practical answer is: the hardware/RTOS build can contain both, but the current Packet API bridge intentionally switches the screen into Programming Mode when Bluetooth is enabled.
+
+## 9. Current workaround without reflashing
+
+Disable Bluetooth in persisted config, then reboot.
+
+Available source-backed ways:
+
+- On the Programming Mode screen, long-press the Bluetooth button. `TFTView_320x240::ui_event_BluetoothButton()` lines 1006-1019 sets `bluetooth.enabled = false` and sends Bluetooth config back to firmware.
+- From a connected client, write Bluetooth config with `enabled=false`.
+- After the config write, let the device reboot. `AdminModule::handleSetConfig()` defaults config changes to requiring reboot at lines 868-873, and `AdminModule::saveChanges()` persists and schedules reboot at lines 1877-1891.
+
+If it does not visibly reboot after using the on-screen Bluetooth button, wait a few seconds for the config write to finish and press reset/power-cycle once. On next boot, `config.bluetooth.enabled` should be false and `PacketAPI::runOnce()` should resume the normal `sendPacket()` path.
+
+No reflashing is required unless the config partition is corrupt or the UI cannot send the config write.
+
+## 10. Proposed fixes ranked
+
+### 1. Minimal fix
+
+Change `PacketAPI::runOnce()` so Bluetooth-enabled state alone does not force Programming Mode for Device UI on this target.
+
+Possible narrow condition:
+
+- Only enter Programming Mode when an explicit programming-mode flag/request is active.
+- Or exempt selected TFT targets such as `HELTEC_V4_R8_TFT` from the `config.bluetooth.enabled` gate.
+
+This is the smallest behavioral change but risks missing the original reason why Device UI disabled itself during BT/USB usage.
+
+### 2. Clean architectural fix
+
+Separate "Bluetooth is enabled" from "Device UI is in Programming Mode".
+
+That means adding an explicit state or API signal, for example:
+
+- `PacketAPI::programmingModeRequested`
+- Device UI command/request to enter Programming Mode
+- Config or runtime-only flag distinct from `config.bluetooth.enabled`
+
+Then `PacketAPI::runOnce()` would suppress normal MUI traffic only when Programming Mode is explicitly requested, not whenever BLE is enabled.
+
+### 3. Experimental fix
+
+Allow normal `sendPacket()` even when Bluetooth is enabled, and make Device UI ignore only conflicting operations during active app pairing/config sessions.
+
+This would test true BLE + MUI coexistence, but it has the highest risk of exposing concurrency, heap, or API arbitration problems.
+
+## 11. Recommended first patch
+
+Recommended first patch: replace the broad Bluetooth gate in `src/mesh/api/PacketAPI.cpp` with an explicit Programming Mode trigger.
+
+Current behavior at lines 39-48:
+
+```cpp
+if (config.bluetooth.enabled) {
+    if (!programmingMode) {
+        programmingMode = true;
+        success = notifyProgrammingMode();
+    }
+} else {
+    success = sendPacket();
+}
+```
+
+Recommended direction:
+
+- Keep `config.bluetooth.enabled` as radio/app connectivity state.
+- Add or reuse a separate runtime request that means "Device UI should yield to programming".
+- Make normal `sendPacket()` continue when Bluetooth is merely enabled.
+- Preserve the boot-logo long-press path in Device UI as the explicit request to enter Programming Mode.
+
+This is better than special-casing only `HELTEC_V4_R8_TFT`, because the same `USE_PACKET_API` pattern appears in multiple TFT-style targets.
+
+## 12. Expected behavior after patch
+
+After the recommended patch:
+
+- Clean flash still boots into native MUI.
+- Enabling Bluetooth from Android keeps Bluetooth enabled after reboot.
+- Native MUI still reaches `eRunning` and receives normal `FromRadio` updates.
+- Programming Mode is entered only through an explicit Device UI action, such as boot-logo hold/click behavior.
+- Leaving Programming Mode disables Bluetooth only if that remains the intended product behavior for the explicit mode.
+- Enabling Wi-Fi does not need to be used as an escape hatch for the screen.
+
+## 13. Risks
+
+- The original Programming Mode policy may have been added to avoid two clients competing for the same packet/config API path.
+- Enabling normal Device UI traffic while BLE is active may increase heap pressure on ESP32-S3.
+- Phone API access control is explicitly incompatible with `USE_PACKET_API`; `PacketAPI.cpp` lines 13-16 fail the build if both are enabled.
+- Some other `USE_PACKET_API` targets may rely on the current "Bluetooth means Programming Mode" behavior.
+- If the UI sends config writes while a phone app also writes config, transaction/reboot ordering should be tested.
+- ESP32 Wi-Fi/BLE radio sharing remains a separate limitation. `src/platform/esp32/main-esp32.cpp` lines 76-81 documents that Wi-Fi and BLE share radio resources.
+
+## 14. Files that would need modification
+
+For the recommended clean fix:
+
+- `src/mesh/api/PacketAPI.h`
+  - Add explicit runtime Programming Mode state or setter if needed.
+- `src/mesh/api/PacketAPI.cpp`
+  - Change `PacketAPI::runOnce()` condition.
+  - Keep or adjust `notifyProgrammingMode()`.
+- `src/graphics/tftSetup.cpp`
+  - Wire any explicit Programming Mode request between Device UI and `PacketAPI`, if the request crosses the firmware/device-ui boundary.
+- `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/source/graphics/TFT/TFTView_320x240.cpp`
+  - In upstream dependency source, make boot-logo Programming Mode action send an explicit request instead of relying on `bluetooth.enabled`.
+- `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/source/graphics/common/ViewController.cpp`
+  - If needed, route the explicit request through the client/controller.
+- Dependency manifest / package reference for `meshtastic-device-ui`
+  - Any actual Device UI source patch should be made upstream or by changing the dependency reference, not by editing `.pio/libdeps` as the final product source.
+
+For a minimal target-only workaround patch:
+
+- `src/mesh/api/PacketAPI.cpp`
+  - Add a compile-time exception around the `config.bluetooth.enabled` Programming Mode gate for `HELTEC_V4_R8_TFT`.
+
+That minimal workaround is not the preferred long-term patch because it preserves a confusing coupling between Bluetooth state and Programming Mode on other Device UI targets.
+
+## History notes
+
+Local `git blame` shows the current `PacketAPI::runOnce()` Programming Mode gate at lines 35-51 came from commit `beb268ff25` on 2026-01-04. `git log -S "force client into programmingMode" -- src/mesh/api/PacketAPI.cpp` points to `99d3e5eb7` / "2.6 changes (#5806)" as the introduction of the Programming Mode notification text. The default "switch BT off by default" rule in `NodeDB.cpp` also traces to `99d3e5eb7` / "2.6 changes (#5806)".
+
+No firmware source changes were made for this investigation.

--- a/docs/heltec-v4-r8-tft-quick-message-ui-investigation.md
+++ b/docs/heltec-v4-r8-tft-quick-message-ui-investigation.md
@@ -1,0 +1,328 @@
+# Heltec V4 R8 TFT Quick Message UI Investigation
+
+Target: `heltec-v4-r8-tft` / Heltec WiFi LoRa 32 V4 R8 Expansion Kit V2 TFT touchscreen.
+
+Firmware source inspected locally from this checkout. No firmware or device-ui source was modified for this investigation.
+
+## 1. Executive summary
+
+The native touchscreen UI for this target is the Meshtastic `device-ui` LVGL UI, pulled into firmware as a PlatformIO library dependency. The target compiles with `HAS_TFT=1`, `HAS_TOUCHSCREEN=1`, `USE_PACKET_API`, `VIEW_240x320`, `DISPLAY_SET_RESOLUTION`, and `LGFX_DRIVER=LGFX_HELTEC_V4_TFT` in `variants/esp32s3/heltec_v4_r8/platformio.ini:36`.
+
+The best architecture for a cycling quick-message UI is to add a dedicated LVGL panel to the Device UI, then send preset text through the existing `ViewController::sendTextMessage()` path. That path already knows how to create Meshtastic `TEXT_MESSAGE_APP` mesh packets, log local outgoing messages, and handle response status coloring.
+
+Do not edit `.pio/libdeps/.../meshtastic-device-ui` as the permanent source of truth. It is a generated dependency cache. For real work, fork or branch `meshtastic/device-ui`, point `[device-ui_base]` in firmware `platformio.ini` at the fork or a pinned zip/commit, and keep firmware-side changes minimal.
+
+## 2. UI architecture overview
+
+Firmware starts the TFT Device UI from `src/graphics/tftSetup.cpp`. `tftSetup()` creates `DeviceScreen`, creates `PacketAPI`, then calls `deviceScreen->init(new PacketClient)` in `src/graphics/tftSetup.cpp:323`. The TFT task later runs `deviceScreen->task_handler()` in `src/graphics/tftSetup.cpp:314`.
+
+`DeviceScreen` owns the GUI instance. Its constructor selects a concrete view through `ViewFactory::create()` in `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/source/graphics/DeviceScreen.cpp:38`.
+
+For this target, `VIEW_240x320` still maps to the `TFTView_320x240` implementation:
+
+- `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/source/graphics/common/ViewFactory.cpp:11` includes `TFTView_320x240.h` for `VIEW_240x320`.
+- `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/source/graphics/common/ViewFactory.cpp:37` returns `TFTView_320x240::instance()` for `VIEW_240x320`.
+
+The actual panel driver is `LGFX_HELTEC_V4_TFT`. It reports `screenWidth = 240` and `screenHeight = 320` in `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/include/graphics/LGFX/LGFX_HELTEC_V4_TFT.h:100`, and the target defines `DISPLAY_SET_RESOLUTION` in `variants/esp32s3/heltec_v4_r8/platformio.ini:85`.
+
+## 3. Screen/state diagram
+
+The runtime flow is:
+
+```text
+src/main.cpp
+  -> tftSetup()
+    -> DeviceScreen::create()
+      -> ViewFactory::create()
+        -> TFTView_320x240::instance()
+    -> PacketAPI::create(PacketServer::init())
+    -> DeviceScreen::init(new PacketClient)
+      -> TFTView_320x240::init()
+        -> ui_init_boot()
+        -> wait for DeviceUIConfig / boot state
+        -> setupUIConfig()
+          -> init_screens()
+            -> ui_init()
+            -> ui_set_active(home_button, home_panel, top_panel)
+            -> lv_screen_load_anim(main_screen)
+```
+
+The UI state enum is in `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/include/graphics/common/MeshtasticView.h:35`. Relevant states include `eBooting`, `eBootScreenDone`, `eSetupUIConfig`, `eInitScreens`, `eInitDone`, `eRunning`, `eScreenSaving`, and `eDisconnected`.
+
+`TFTView_320x240::setupUIConfig()` sets state and calls `init_screens()` once the UI config is valid in `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/source/graphics/TFT/TFTView_320x240.cpp:202`.
+
+## 4. Current screen order
+
+There is not a normal ordered carousel of separate app screens. The generated LVGL screens are only boot/main/blank/lock/calibration, defined by `ScreensEnum` in `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/generated/ui_320x240/screens.h:69`.
+
+The main app is one LVGL `main_screen` containing multiple panels. Navigation is done by calling `ui_set_active(button, panel, topPanel)`, which hides the old active panel and shows the new one in `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/source/graphics/TFT/TFTView_320x240.cpp:460`.
+
+The side navigation order in the generated UI is:
+
+1. Home
+2. Nodes
+3. Groups
+4. Messages
+5. Map
+6. Settings
+
+Those buttons are created in `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/generated/ui_320x240/screens.c:305`, `:318`, `:330`, `:342`, `:354`, and `:366`.
+
+## 5. Current home screen implementation
+
+The current home screen is `objects.home_panel`, created at `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/generated/ui_320x240/screens.c:380`.
+
+On this 240x320 portrait display, the home panel uses:
+
+- Position: `LV_PCT(12), LV_PCT(10)` at `screens.c:383`.
+- Size: `LV_PCT(88), LV_PCT(90)` at `screens.c:384`.
+- Approximate usable area: 211 x 288 pixels.
+
+Inside it, `objects.home_container` is a flex row-wrap container, created at `screens.c:393`. The first home tile, `objects.home_mail_button`, is a 36 x 36 button at `screens.c:424`.
+
+The default active panel is set in `TFTView_320x240::init_screens()`:
+
+- `activeMsgContainer = objects.messages_container` at `.pio/.../TFTView_320x240.cpp:363`.
+- `ui_set_active(objects.home_button, objects.home_panel, objects.top_panel)` at `.pio/.../TFTView_320x240.cpp:372`.
+- `lv_screen_load_anim(objects.main_screen, ...)` at `.pio/.../TFTView_320x240.cpp:376`.
+
+## 6. Touch/navigation architecture
+
+Touch input is an LVGL pointer input device through the LovyanGFX driver. The target defines `CUSTOM_TOUCH_DRIVER`, `TOUCH_I2C_PORT=0`, and `TOUCH_SLAVE_ADDRESS=0x2E` in `variants/esp32s3/heltec_v4_r8/platformio.ini:96`.
+
+The touch implementation is in `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/include/graphics/LGFX/LGFX_HELTEC_V4_TFT.h`:
+
+- `chsc6x.h` is included at line `20`.
+- The driver constructs `chsc6x` on `Wire` when `TOUCH_I2C_PORT != 1` at line `36`.
+- `getTouchXY()` reads raw touch info and rotates coordinates at line `73`.
+
+Event handlers are attached in `TFTView_320x240::ui_events_init()`. The main screen gets an `LV_EVENT_GESTURE` handler at `.pio/.../TFTView_320x240.cpp:891`, but the gesture handler only acts when `activePanel == objects.map_panel` in `.pio/.../TFTView_320x240.cpp:2454`. It maps swipe direction to map pan commands. I found no source-backed global left/right screen cycling gesture.
+
+Long press timing and pointer setup are in `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/include/graphics/driver/LGFXDriver.h`, where `defaultLongPressTime` is 700 ms and `defaultGestureLimit` is 10.
+
+## 7. Existing text-message send path
+
+The current typed-message send flow is:
+
+```text
+LVGL textarea ready event
+  -> TFTView_320x240::ui_event_message_ready()
+    -> TFTView_320x240::handleAddMessage()
+      -> ViewController::sendTextMessage()
+        -> ViewController::send(... TEXT_MESSAGE_APP ...)
+          -> PacketClient::send(ToRadio)
+            -> PacketAPI / MeshService
+```
+
+Exact source points:
+
+- `message_input_area` is created as a one-line textarea with max length 220 in `.pio/.../generated/ui_320x240/screens.c:1256`.
+- `ui_event_message_ready()` reads the textarea and calls `handleAddMessage(txt)` in `.pio/.../TFTView_320x240.cpp:1709`.
+- `handleAddMessage()` chooses broadcast/channel or direct-node destination from `activeMsgContainer->user_data` in `.pio/.../TFTView_320x240.cpp:4536`.
+- For a channel message, `to` remains `UINT32_MAX`, `ch` is the channel index, and a text response request is created at `.pio/.../TFTView_320x240.cpp:4550`.
+- It calls `controller->sendTextMessage(to, ch, hopLimit, actTime, requestId, usePkc, msg)` at `.pio/.../TFTView_320x240.cpp:4570`.
+- It adds the outgoing message bubble locally at `.pio/.../TFTView_320x240.cpp:4571`.
+
+`ViewController::sendTextMessage()` is in `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/source/graphics/common/ViewController.cpp:473`. It sends portnum `meshtastic_PortNum_TEXT_MESSAGE_APP` at line `479` and logs the outgoing message at line `481`.
+
+The generic packet builder sets `.to`, `.channel`, `.id`, `.hop_limit`, `.want_ack`, and `.pki_encrypted` in `.pio/.../ViewController.cpp:534`.
+
+## 8. Existing received-message path
+
+Incoming packets reach Device UI through `ViewController::receive()` in `.pio/.../ViewController.cpp:586`. It calls `handleFromRadio()` at line `594`.
+
+`ViewController::handleFromRadio()` routes decoded packets to `packetReceived(p)` in `.pio/.../ViewController.cpp:686`.
+
+`ViewController::packetReceived()`:
+
+- Calls `view->packetReceived(p)` first at `.pio/.../ViewController.cpp:915`.
+- Handles `ALERT_APP`, `DETECTION_SENSOR_APP`, `TEXT_MESSAGE_APP`, and `RANGE_TEST_APP` as text-like messages at `.pio/.../ViewController.cpp:925`.
+- Calls `view->newMessage(p.from, p.to, p.channel, ..., time)` at `.pio/.../ViewController.cpp:946`.
+- Logs the received message at `.pio/.../ViewController.cpp:947`.
+
+`TFTView_320x240::newMessage()` builds or finds the per-channel/per-node message container in `.pio/.../TFTView_320x240.cpp:6515`. For group messages, it prepends the sender short name or node suffix at `.pio/.../TFTView_320x240.cpp:6521`. If the message is not being restored and the user is not already viewing that chat, it increments unread count and may call `showMessagePopup()` at `.pio/.../TFTView_320x240.cpp:6549`.
+
+`showMessagePopup()` sets popup text, stores channel/node in `objects.msg_popup_button->user_data`, unhides the popup, and focuses it in `.pio/.../TFTView_320x240.cpp:6814`.
+
+## 9. Canned Message / quick-message functionality already present
+
+The firmware already contains `CannedMessageModule`, but it is not currently active for the color Device UI path.
+
+The module is declared in `src/modules/CannedMessageModule.h:52`. It supports up to 50 split messages with an 800-byte internal buffer in `src/modules/CannedMessageModule.h:27`.
+
+Its persistent config file is `/prefs/cannedConf.proto`, set in `src/modules/CannedMessageModule.cpp:60`. Default messages are installed in `CannedMessageModule::installDefaultCannedMessageModuleConfig()` at `src/modules/CannedMessageModule.cpp:2311`.
+
+The protobuf storage type is tiny: `meshtastic_CannedMessageModuleConfig` contains `char messages[201]` in `src/mesh/generated/meshtastic/cannedmessages.pb.h:14`, separated by `|`.
+
+However, `Modules.cpp` only creates `CannedMessageModule` when the display mode is not color:
+
+- `src/modules/Modules.cpp:210` checks `HAS_SCREEN && !MESHTASTIC_EXCLUDE_CANNEDMESSAGES`.
+- `src/modules/Modules.cpp:211` requires `config.display.displaymode != meshtastic_Config_DisplayConfig_DisplayMode_COLOR`.
+- `src/modules/Modules.cpp:212` creates `new CannedMessageModule()`.
+
+Device UI has hooks for canned-message config, but they are effectively no-ops:
+
+- `ViewController::sendConfig(meshtastic_ModuleConfig_CannedMessageConfig &&...)` exists at `.pio/.../ViewController.cpp:367`.
+- Received canned-message module config calls `view->updateCannedMessageModule(cfg)` at `.pio/.../ViewController.cpp:821`.
+- `MeshtasticView::updateCannedMessageModule()` is a virtual no-op in `.pio/.../include/graphics/common/MeshtasticView.h:113`.
+- `TFTView_320x240` overrides it with an empty body in `.pio/.../include/graphics/view/TFT/TFTView_320x240.h:58`.
+
+Conclusion: use the canned-message storage model later, but do not expect the existing module UI to render on this TFT target without additional work.
+
+## 10. Recommended architecture for cycling quick messages
+
+Recommended path: add a new `quick_messages_panel` to the Device UI and route each preset button through the existing typed-message send machinery.
+
+The least risky implementation is:
+
+1. Keep existing `messages_panel`, `groups_panel`, and `home_panel` behavior intact.
+2. Add a dedicated quick-message panel in `device-ui`.
+3. Make it the default visible panel for this fork/target if the cycling device should boot straight to large buttons.
+4. Keep old Home reachable from the side navigation or a small status/action tile.
+5. Send via a small helper that uses the same destination/channel/request/logging logic as `handleAddMessage()`.
+
+For channel broadcast, use the same semantics as current group chat:
+
+- Destination: `UINT32_MAX` / `NODENUM_BROADCAST`.
+- Channel: initially `0` or the currently selected channel.
+- Hop limit: `db.config.lora.hop_limit`.
+- Portnum: `meshtastic_PortNum_TEXT_MESSAGE_APP`.
+
+Best code shape for Phase 1 is to refactor `handleAddMessage()` into a reusable send helper, rather than faking textarea input. For example, conceptually:
+
+```cpp
+sendQuickMessage(uint8_t ch, const char *message)
+```
+
+Internally it should create a `ResponseHandler::TextMessageRequest`, call `controller->sendTextMessage()`, and add the local outgoing bubble exactly like `.pio/.../TFTView_320x240.cpp:4570`.
+
+## 11. Suggested first quick-message screen layout
+
+For this 240x320 portrait screen, the existing app panel area is about 211 x 288 pixels. A cycling UI should prioritize big touch targets over many options.
+
+Recommended first layout:
+
+- Existing side nav remains at left.
+- Existing top panel area remains available for title/status.
+- Quick panel uses the current content rectangle: x 12%, y 10%, w 88%, h 90%.
+- Use a 2 x 3 grid of large buttons.
+- Button target size: roughly 90-96 px wide and 66-76 px tall.
+- Use short visible labels, with the transmitted message stored separately when useful.
+
+This is more usable with gloves and movement than a dense 2 x 4 grid. If eight messages are required immediately, use two pages of four or a 2 x 4 grid with very short labels only.
+
+## 12. Suggested initial message list
+
+Suggested Finnish cycling presets:
+
+1. `OK`
+2. `Pysahdyn`
+3. `Tauko`
+4. `Tarvitsen apua`
+5. `Olen tulossa`
+6. `Missä olet?`
+
+Suggested transmitted text can be slightly longer than button labels:
+
+- Label `OK`, send `OK`
+- Label `Pysahdyn`, send `Pysahdyn hetkeksi`
+- Label `Tauko`, send `Pidetaan tauko`
+- Label `Apua`, send `Tarvitsen apua`
+- Label `Tulossa`, send `Olen tulossa`
+- Label `Missä?`, send `Missä olet?`
+
+Note: the LVGL Montserrat fonts appear to include Latin-1 range in generated font files, so Finnish letters are likely available. If minimizing risk for the first firmware test, use ASCII labels/messages first: `Pysahdyn`, `Pidetaan tauko`, `Missa olet?`.
+
+## 13. How message presets should eventually be stored/configured
+
+Best long-term storage: reuse the existing canned-message protobuf config at `/prefs/cannedConf.proto`.
+
+Reasons:
+
+- It already exists in firmware.
+- It is already exposed through admin messages.
+- It stores `|`-separated messages in `meshtastic_CannedMessageModuleConfig.messages`.
+- It avoids adding a new JSON parser or another settings file format.
+
+The Device UI already receives canned-message module config through `ViewController::handleFromRadio()` and calls `updateCannedMessageModule(cfg)` at `.pio/.../ViewController.cpp:821`. The missing piece is implementing that method for `TFTView_320x240`, parsing the message string, and redrawing/updating quick-message buttons.
+
+A separate `/quickmessages.json` on LittleFS is possible, but less aligned with the existing codebase. Device UI does use LittleFS directly: `TFTView_320x240.cpp` binds `fileSystem = LittleFS` at `.pio/.../TFTView_320x240.cpp:42`, and `ViewController.cpp` binds `persistentFS = LittleFS` at `.pio/.../ViewController.cpp:13`. Still, protobuf config is cleaner here.
+
+## 14. How incoming quick messages could be emphasized
+
+The easiest UI emphasis point is `TFTView_320x240::newMessage()` in `.pio/.../TFTView_320x240.cpp:6515`, because it already has UI context and already decides whether to show a popup.
+
+Options:
+
+- If incoming text exactly matches one of the quick-message presets, set a stronger popup label such as `Quick: Apua` before calling or inside `showMessagePopup()`.
+- Use the existing `msg_popup_panel` as the first phase: it is already a centered 85% x 55 px alert-like panel in generated UI at `.pio/.../generated/ui_320x240/screens.c:6131`.
+- For urgent messages like `Tarvitsen apua`, use `messageAlert()` or a new urgent popup style. `messageAlert()` only sets text and hides/shows `objects.alert_panel` at `.pio/.../TFTView_320x240.cpp:5780`.
+- Consider triggering display wake via the same mechanism already present in `showMessagePopup()`: it calls `lv_disp_trig_activity(NULL)` when `db.module_config.external_notification.alert_message` is set at `.pio/.../TFTView_320x240.cpp:6827`.
+
+Do not implement keyword emphasis in `ViewController::packetReceived()` unless the logic must be shared across multiple views. Device-specific visual behavior belongs closer to `TFTView_320x240`.
+
+## 15. Exact files that would eventually need modification
+
+Device UI fork/branch:
+
+- `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/generated/ui_320x240/screens.h`
+- `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/generated/ui_320x240/screens.c`
+- `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/source/graphics/TFT/TFTView_320x240.cpp`
+- `.pio/libdeps/heltec-v4-r8-tft/meshtastic-device-ui/include/graphics/view/TFT/TFTView_320x240.h`
+
+But these paths are the local dependency cache. The actual editable source should be the corresponding files in a fork of `https://github.com/meshtastic/device-ui`.
+
+Firmware repo:
+
+- `platformio.ini`, specifically `[device-ui_base]` at `platformio.ini:137`, to point at the fork/pinned commit instead of `https://github.com/meshtastic/device-ui/archive/9d9b9df81fcde646811a10942d00d5f45f72af7b.zip` at `platformio.ini:140`.
+- Possibly `variants/esp32s3/heltec_v4_r8/platformio.ini` only if the quick-message UI is target-gated with a new build flag.
+
+Optional later firmware integration:
+
+- `src/modules/CannedMessageModule.*` only if making the canned module active under `COLOR`.
+- `src/graphics/niche/Utils/CannedMessageStore.cpp` is worth studying for reusable admin/storage behavior, because it already handles canned-message config separately from the module UI.
+
+## 16. Recommended development/fork strategy for meshtastic-device-ui
+
+Use a device-ui fork or branch, not `.pio/libdeps` edits.
+
+Recommended workflow:
+
+1. Fork `meshtastic/device-ui`.
+2. Create a branch such as `heltec-v4-r8-quick-messages`.
+3. Implement the panel and send helper in that repo.
+4. Pin firmware `platformio.ini` `[device-ui_base]` to a specific fork commit or zip.
+5. Rebuild `heltec-v4-r8-tft`.
+6. Test on the second identical device first.
+7. Keep a minimal firmware patch that only changes dependency pinning and, if needed, target flags.
+
+This keeps changes reviewable and avoids losing work when PlatformIO refreshes `.pio/libdeps`.
+
+## 17. Risks
+
+The main risks are:
+
+- Generated UI files may be regenerated from the upstream Device UI authoring tool, so manual edits to generated `screens.c/h` can be overwritten.
+- `VIEW_240x320` uses a class and generated folder named `TFTView_320x240` / `ui_320x240`; this is source-backed behavior, but it can be confusing during edits.
+- The content area is small, so too many quick buttons will produce unsafe touch targets.
+- The existing `CannedMessageModule` is not instantiated for `COLOR` display mode, so reusing its UI directly is not a small patch.
+- Incoming-message emphasis must avoid making all text messages noisy.
+- Changes to Device UI can affect other `VIEW_320x240` or `VIEW_240x320` targets unless guarded carefully.
+- A bad display/touch driver change can produce a black screen or unusable UI even if firmware boots.
+
+## 18. Recommended Phase 1 implementation plan
+
+Phase 1 should be deliberately small:
+
+1. Create a device-ui fork/branch and point firmware `[device-ui_base]` at it.
+2. Add a quick-message panel to `TFTView_320x240` for `VIEW_240x320`.
+3. Use six static presets.
+4. Make the quick-message panel the default active panel on this target.
+5. Keep the existing Messages screen and typed input unchanged.
+6. Refactor the send code so quick buttons call the same `ViewController::sendTextMessage()` path as typed messages.
+7. On successful send tap, add the same local outgoing bubble and briefly show an existing alert/popup-style confirmation.
+8. Build only `heltec-v4-r8-tft`.
+9. Flash the second identical device first.
+10. Verify: screen lights, touch works, each preset sends, receiving node sees `TEXT_MESSAGE_APP`, outgoing messages appear in chat history, and normal Messages/Map/Settings navigation still works.
+
+Phase 2 can add canned-message config parsing through `updateCannedMessageModule()`. Phase 3 can add incoming quick-message emphasis and urgent-message styling.

--- a/docs/quick-message-development-ready.md
+++ b/docs/quick-message-development-ready.md
@@ -1,0 +1,257 @@
+# Quick Message Development Ready State
+
+## 1. Firmware baseline
+
+Known-good upstream firmware source baseline:
+
+- Commit: `7239fe886a30fa13cd35946fa5ae1a46a2807eeb`
+- Official tag: `v2.8.0.7239fe8`
+- Target: `heltec-v4-r8-tft`
+- Known working flash mode: `dio`
+- LittleFS offset: `0xc90000`
+
+## 2. Repository preparation commit hash
+
+Repository-preparation commit:
+
+`6989949e99d156e4be392a08602e0d9d7c35b3d9`
+
+Short form:
+
+`6989949e9 chore: establish Heltec R8 development baseline`
+
+This commit contains only non-functional repository preparation:
+
+- `.gitignore`
+- `GIT-POLICY.md`
+- `docs/development-baseline.md`
+- `docs/device-ui-development-workflow.md`
+- `docs/git-hygiene-review.md`
+- `tools/git-preflight.ps1`
+
+## 3. Firmware feature branch
+
+Current firmware branch:
+
+`feature/heltec-r8-quick-messages`
+
+Current firmware `HEAD`:
+
+`6989949e99d156e4be392a08602e0d9d7c35b3d9`
+
+## 4. Device UI feature branch
+
+Device UI repository:
+
+`C:\Users\JPJYR\Documents\device-ui`
+
+Branch:
+
+`feature/heltec-r8-quick-messages`
+
+## 5. Device UI exact commit
+
+`9d9b9df81fcde646811a10942d00d5f45f72af7b`
+
+No Device UI source changes have been made.
+
+## 6. Local Device UI path
+
+`C:\Users\JPJYR\Documents\device-ui`
+
+Relative path from firmware repository:
+
+`../device-ui`
+
+## 7. PlatformIO dependency method used
+
+On firmware branch `feature/heltec-r8-quick-messages`, `[device-ui_base]` in `platformio.ini` uses a local path dependency:
+
+```ini
+[device-ui_base]
+lib_deps =
+	# renovate: datasource=git-refs depName=meshtastic/device-ui packageName=https://github.com/meshtastic/device-ui gitBranch=master
+	# DEVELOPMENT ONLY for feature/heltec-r8-quick-messages:
+	# use the editable local checkout at C:\Users\JPJYR\Documents\device-ui.
+	# Final reproducible builds must switch back to an exact pinned commit archive.
+	../device-ui
+```
+
+This is intentionally uncommitted at the time this report was written unless the user later approves committing the local-development dependency switch.
+
+## 8. Proof local Device UI was used by build
+
+PlatformIO dependency graph reported:
+
+```text
+meshtastic-device-ui @ 1.0.0 (required: file://../device-ui)
+```
+
+During dependency resolution, PlatformIO also reported:
+
+```text
+Library Manager: Installing file://../device-ui
+```
+
+This confirms the build used the local editable Device UI checkout rather than the pinned remote archive.
+
+## 9. Build result
+
+Command used:
+
+```powershell
+$env:PLATFORMIO_CORE_DIR="C:\p"
+$env:PYTHONUTF8="1"
+$env:PYTHONIOENCODING="utf-8"
+$env:Path=(Resolve-Path ".\.venv\Scripts").Path + ";" + $env:Path
+.\.venv\Scripts\pio.exe run -e heltec-v4-r8-tft -t mtjson -j 2 2>&1 | Tee-Object build-heltec-v4-r8-tft-local-device-ui-20260830.log
+```
+
+PlatformIO result:
+
+```text
+heltec-v4-r8-tft  SUCCESS  00:23:19.084
+```
+
+Firmware version reported by build:
+
+`2.8.0.6989949`
+
+The version differs from `2.8.0.7239fe8` because the firmware `HEAD` now includes the repository-preparation commit.
+
+## 10. Binary hashes
+
+Build outputs from `.pio/build/heltec-v4-r8-tft/`:
+
+```text
+65F2152CCEF0C02799553BE99EB8EB6AD39D83CF50903572A7DB65AE6F3CCFFC  firmware-heltec-v4-r8-tft-2.8.0.6989949.factory.bin
+6F68B0EC578648B11CCF699AF3902D98F5E8DA4786107F70BA3762FD9C2E697C  firmware-heltec-v4-r8-tft-2.8.0.6989949.bin
+057092CD73FF7C2020CF9D15E471054E3FE0BA24BD1C825BD600E49B0E64C2AB  littlefs-heltec-v4-r8-tft-2.8.0.6989949.bin
+```
+
+The LittleFS hash matches the known-good LittleFS image. Firmware image hashes differ because the build identifier/version changed from `7239fe8` to `6989949`.
+
+## 11. Flash mode confirmation
+
+Existing known-good `dist/` flash scripts still use:
+
+`--flash-mode dio`
+
+The new combined factory image generation also used:
+
+```text
+--flash_mode dio
+```
+
+## 12. LittleFS offset confirmation
+
+Confirmed in current build manifest:
+
+`0xc90000`
+
+Confirmed in known-good `dist/heltec-v4-r8-tft/flash-map.json`:
+
+```text
+0x0
+0xc90000
+```
+
+## 13. External known-good artifact archive path
+
+`C:\Users\JPJYR\Documents\meshtastic-artifacts\known-good\2.8.0.7239fe8`
+
+Archive files include:
+
+- `ARCHIVE-README.md`
+- `SHA256SUMS.txt`
+- factory image
+- app image
+- LittleFS image
+- bootloader/partition helper binaries
+- flash scripts
+- flash map
+- manifest
+- package ZIP
+- flashing README
+
+## 14. Archive SHA256 verification result
+
+Every copied archive file was verified against its source file. All source/archive hash comparisons returned `OK`.
+
+Key known-good hashes:
+
+```text
+138FDEB29C5D3D655113ACAE2522328583C8B625D09A8CC5A7FEC816AC7C0830  firmware-heltec-v4-r8-tft-2.8.0.7239fe8.factory.bin
+057092CD73FF7C2020CF9D15E471054E3FE0BA24BD1C825BD600E49B0E64C2AB  littlefs-heltec-v4-r8-tft-2.8.0.7239fe8.bin
+0BF3CAC43B0C5D14482B11FF199DEFD1706D99ADE22CECE5202C0579D2DBE655  firmware-heltec-v4-r8-tft-2.8.0.7239fe8.bin
+FDCE35E146F7C69A413B29CCD124E26099EECEB6511A90172FB2D6130FC5E636  meshtastic-heltec-v4-r8-tft-esptool-package.zip
+```
+
+## 15. Current uncommitted changes
+
+At report creation time, the expected uncommitted firmware changes are:
+
+- `platformio.ini`: development-only Device UI dependency switch to `../device-ui`
+- `docs/device-ui-development-workflow.md`: documentation of the exact local dependency switch
+- `docs/quick-message-development-ready.md`: this readiness report
+
+Expected untracked files intentionally not committed:
+
+- `dist/`
+- `docs/heltec-v4-r8-tft-programming-mode-investigation.md`
+- `docs/heltec-v4-r8-tft-quick-message-ui-investigation.md`
+
+Ignored local generated files:
+
+- `.pio-core/`
+- `build-*.log`
+
+## 16. Exact rollback procedure
+
+To return firmware dependency to the known-good upstream Device UI archive:
+
+1. Restore `[device-ui_base]` in `platformio.ini` to:
+
+```text
+https://github.com/meshtastic/device-ui/archive/9d9b9df81fcde646811a10942d00d5f45f72af7b.zip
+```
+
+2. Keep flash mode as `dio`.
+3. Keep LittleFS offset as `0xc90000`.
+4. If hardware rollback is needed, use the archived package at:
+
+```text
+C:\Users\JPJYR\Documents\meshtastic-artifacts\known-good\2.8.0.7239fe8
+```
+
+5. Full clean flash map:
+
+```text
+0x0       firmware-heltec-v4-r8-tft-2.8.0.7239fe8.factory.bin
+0xc90000  littlefs-heltec-v4-r8-tft-2.8.0.7239fe8.bin
+```
+
+## 17. Exact state before first Quick Message code modification
+
+Firmware:
+
+- Branch: `feature/heltec-r8-quick-messages`
+- HEAD: `6989949e99d156e4be392a08602e0d9d7c35b3d9`
+- Functional source changes: none
+- Development dependency switch: local `../device-ui`, uncommitted
+
+Device UI:
+
+- Branch: `feature/heltec-r8-quick-messages`
+- HEAD: `9d9b9df81fcde646811a10942d00d5f45f72af7b`
+- Working tree: clean
+- Functional source changes: none
+
+Build:
+
+- Target: `heltec-v4-r8-tft`
+- Result: success
+- Device UI source: `file://../device-ui`
+- Flash mode: `dio`
+- LittleFS offset: `0xc90000`
+

--- a/platformio.ini
+++ b/platformio.ini
@@ -137,7 +137,10 @@ lib_deps =
 [device-ui_base]
 lib_deps =
 	# renovate: datasource=git-refs depName=meshtastic/device-ui packageName=https://github.com/meshtastic/device-ui gitBranch=master
-	https://github.com/meshtastic/device-ui/archive/9d9b9df81fcde646811a10942d00d5f45f72af7b.zip
+	# DEVELOPMENT ONLY for feature/heltec-r8-quick-messages:
+	# use the editable local checkout at C:\Users\JPJYR\Documents\device-ui.
+	# Final reproducible builds must switch back to an exact pinned commit archive.
+	../device-ui
 custom_sdkconfig =
 	# CONFIG_MBEDTLS_INTERNAL_MEM_ALLOC is not set
 	CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC=y

--- a/tools/git-preflight.ps1
+++ b/tools/git-preflight.ps1
@@ -1,0 +1,51 @@
+$ErrorActionPreference = "Continue"
+
+Write-Host "Codex Meshtastic preflight"
+Write-Host "Current directory: $(Get-Location)"
+
+$root = git rev-parse --show-toplevel 2>$null
+if ($LASTEXITCODE -ne 0 -or -not $root) {
+    Write-Warning "Not inside a git repository."
+    exit 1
+}
+
+Write-Host "Repository root: $root"
+
+$branch = git branch --show-current
+$head = git rev-parse HEAD
+
+Write-Host "Current branch: $branch"
+Write-Host "HEAD: $head"
+
+Write-Host ""
+Write-Host "Git status --short:"
+$status = git status --short
+if ($status) {
+    $status
+    Write-Warning "Working tree is not clean. Review this before modifying code."
+} else {
+    Write-Host "clean"
+}
+
+Write-Host ""
+Write-Host "Remotes:"
+git remote -v
+
+Write-Host ""
+Write-Host "Firmware target reminder: heltec-v4-r8-tft"
+Write-Host "Known-good flash mode: --flash-mode dio"
+
+Write-Host ""
+Write-Host "Device UI dependency reference:"
+if (Test-Path "platformio.ini") {
+    Select-String -Path "platformio.ini" -Pattern "\[device-ui_base\]|device-ui/archive|meshtastic/device-ui" -Context 0,2
+} else {
+    Write-Warning "platformio.ini not found in current directory."
+}
+
+if ($branch -match "^(baseline/.*|main|master|develop)$") {
+    Write-Warning "Current branch looks like a baseline or shared branch. Do not develop directly here."
+}
+
+Write-Host ""
+Write-Host "Do not modify code until preflight is reviewed."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added development baseline and Device UI workflow documentation.
  * Documented firmware programming-mode behavior and quick-message UI investigations.
  * Added Git hygiene, policy, readiness, rollback, and artifact-management guidance.

* **Chores**
  * Added a Git preflight tool for checking repository and build configuration status.
  * Updated local build configuration to support editable Device UI development.
  * Added ignore rules for local PlatformIO data and firmware build logs.

* **Bug Fixes**
  * No user-facing firmware behavior changes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->