### PR TITLE
Don't show new message banner on message screen

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -2411,6 +2411,12 @@ bool Screen::isOverlayBannerShowing()
     return NotificationRenderer::isOverlayBannerShowing();
 }
 
+bool Screen::isTextMessageFrameShown()
+{
+    return screenOn && showingNormalScreen && framesetInfo.positions.textMessage != 255 && ui &&
+           ui->getUiState()->currentFrame == framesetInfo.positions.textMessage;
+}
+
 bool Screen::isGamesFrameShown()
 {
     return framesetInfo.positions.games != 255 && ui && ui->getUiState()->currentFrame == framesetInfo.positions.games;

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1083,6 +1083,7 @@ int32_t Screen::runOnce()
 {
     // If we don't have a screen, don't ever spend any CPU for us.
     if (!useDisplay) {
+        textMessageFrameShown = false;
         enabled = false;
         return RUN_SAME;
     }
@@ -1223,6 +1224,7 @@ int32_t Screen::runOnce()
 
     if (!screenOn) { // If we didn't just wake and the screen is still off, then
                      // stop updating until it is on again
+        textMessageFrameShown = false;
         enabled = false;
         return 0;
     }
@@ -1275,6 +1277,9 @@ int32_t Screen::runOnce()
             handleOnPress();
         }
     }
+
+    textMessageFrameShown = showingNormalScreen && framesetInfo.positions.textMessage != 255 && ui &&
+                            ui->getUiState()->currentFrame == framesetInfo.positions.textMessage;
 
     // LOG_DEBUG("want fps %d, fixed=%d", targetFramerate,
     // ui->getUiState()->frameState); If we are scrolling we need to be called
@@ -2411,10 +2416,9 @@ bool Screen::isOverlayBannerShowing()
     return NotificationRenderer::isOverlayBannerShowing();
 }
 
-bool Screen::isTextMessageFrameShown()
+bool Screen::isTextMessageFrameShown() const
 {
-    return screenOn && showingNormalScreen && framesetInfo.positions.textMessage != 255 && ui &&
-           ui->getUiState()->currentFrame == framesetInfo.positions.textMessage;
+    return textMessageFrameShown.load();
 }
 
 bool Screen::isGamesFrameShown()

--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -277,6 +277,9 @@ class Screen : public concurrency::OSThread
 
     bool isOverlayBannerShowing();
 
+    // True when the powered-on normal UI is currently displaying the text-message frame.
+    bool isTextMessageFrameShown();
+
     // True if the always-present games frame is the one currently on screen. Lets the games module
     // ignore D-pad input when the player has navigated to a different frame.
     bool isGamesFrameShown();

--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -5,6 +5,7 @@
 #include "detect/ScanI2C.h"
 #include "mesh/generated/meshtastic/config.pb.h"
 #include <OLEDDisplay.h>
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <string>
@@ -277,8 +278,8 @@ class Screen : public concurrency::OSThread
 
     bool isOverlayBannerShowing();
 
-    // True when the powered-on normal UI is currently displaying the text-message frame.
-    bool isTextMessageFrameShown();
+    // Thread-safe snapshot of whether the text-message frame is currently shown.
+    bool isTextMessageFrameShown() const;
 
     // True if the always-present games frame is the one currently on screen. Lets the games module
     // ignore D-pad input when the player has navigated to a different frame.
@@ -804,6 +805,7 @@ class Screen : public concurrency::OSThread
     // Whether we are showing the regular screen (as opposed to booth screen or
     // Bluetooth PIN screen)
     bool showingNormalScreen = false;
+    std::atomic<bool> textMessageFrameShown{false};
     /// Track USB power state to only wake screen on actual power state changes
     bool lastPowerUSBState = false;
 

--- a/src/graphics/draw/MessageRenderer.cpp
+++ b/src/graphics/draw/MessageRenderer.cpp
@@ -1132,8 +1132,8 @@ void handleNewMessage(OLEDDisplay *display, const StoredMessage &sm, const mesht
 {
     if (packet.from != 0) {
         hasUnreadMessage = true;
-        const bool suppressBanner = (cannedMessageModule && cannedMessageModule->isFreeTextActive()) ||
-                                    (screen && screen->isTextMessageFrameShown());
+        const bool suppressBanner =
+            (cannedMessageModule && cannedMessageModule->isFreeTextActive()) || (screen && screen->isTextMessageFrameShown());
         // Don't let the pop-up clobber a menu/picker the user is interacting with; the wake below
         // still happens so a message can light the screen back up.
         const bool menuShowing = NotificationRenderer::isMenuShowing();

--- a/src/graphics/draw/MessageRenderer.cpp
+++ b/src/graphics/draw/MessageRenderer.cpp
@@ -1132,7 +1132,8 @@ void handleNewMessage(OLEDDisplay *display, const StoredMessage &sm, const mesht
 {
     if (packet.from != 0) {
         hasUnreadMessage = true;
-        const bool suppressBanner = cannedMessageModule && cannedMessageModule->isFreeTextActive();
+        const bool suppressBanner = (cannedMessageModule && cannedMessageModule->isFreeTextActive()) ||
+                                    (screen && screen->isTextMessageFrameShown());
         // Don't let the pop-up clobber a menu/picker the user is interacting with; the wake below
         // still happens so a message can light the screen back up.
         const bool menuShowing = NotificationRenderer::isMenuShowing();


### PR DESCRIPTION
This PR prevents the new message banner from showing while on the message screen. It is disruptive specially on chatty meshes as seen on DEF CON

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented incoming-message banners from appearing while the text-message view is open.
  - Improved message display behavior so notifications do not cover the conversation currently being viewed.
  - Improved detection of the active text-message view across screen power, display, and UI states, providing more reliable notification suppression.
  - Ensured the text-message view status remains accurate when the screen is off or the display is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->