### PR TITLE
feat(tmm): add antispam probation greylist, gossiped rate budgets, and relay pricing

### DIFF
--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -61,8 +61,11 @@ enum class TrafficType { POSITION, TELEMETRY };
 #define default_traffic_mgmt_attestation_min_tenure_secs (24 * 60 * 60) // 24 h: attesters must be this old
 #define default_traffic_mgmt_probation_max_hop_limit 2                  // probation broadcasts relay at <=2 hops (normal: 3)
 // M4/M6 knobs ship disabled (0); the gossiped budget / relay-budget /
+// congestion-cap machinery engages only when an operator sets them.
 #define default_traffic_mgmt_budget_gossip_enabled 0
 #define default_traffic_mgmt_group_budget_enabled 0
+#define default_traffic_mgmt_relay_budget_max_packets 0
+#define default_traffic_mgmt_congestion_hop_cap_pct 0
 
 // Hop scaling defaults
 #define default_hop_scaling_min_target_nodes 40          // walk threshold: first hop reaching this cumulative count

--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -52,6 +52,15 @@ enum class TrafficType { POSITION, TELEMETRY };
 // Unlike before, lost-and-found is NOT exempt from the relayed precision clamp.
 #define default_traffic_mgmt_lost_and_found_position_min_interval_secs (15 * 60) // 15 minutes
 
+// Antispam L1 (M2/M4/M6). The probation machinery ships on: first-seen
+// accounting (F2.1), the 2-hop relay cap for probation IDs (F2.3), and
+// tenured-node vouching. The M4/M6 budget knobs ship disabled (0) and engage
+// only when an operator sets them. See the TrafficManagementConfig proto
+// comments for per-knob semantics.
+#define default_traffic_mgmt_probation_window_secs (5 * 60)             // 5 minutes of probation for first-seen IDs
+#define default_traffic_mgmt_attestation_min_tenure_secs (24 * 60 * 60) // 24 h: attesters must be this old
+#define default_traffic_mgmt_probation_max_hop_limit 2                  // probation broadcasts relay at <=2 hops (normal: 3)
+
 // Hop scaling defaults
 #define default_hop_scaling_min_target_nodes 40          // walk threshold: first hop reaching this cumulative count
 #define default_hop_scaling_max_target_nodes 80          // generous extension ceiling (2 × min)

--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -60,6 +60,9 @@ enum class TrafficType { POSITION, TELEMETRY };
 #define default_traffic_mgmt_probation_window_secs (5 * 60)             // 5 minutes of probation for first-seen IDs
 #define default_traffic_mgmt_attestation_min_tenure_secs (24 * 60 * 60) // 24 h: attesters must be this old
 #define default_traffic_mgmt_probation_max_hop_limit 2                  // probation broadcasts relay at <=2 hops (normal: 3)
+// M4/M6 knobs ship disabled (0); the gossiped budget / relay-budget /
+#define default_traffic_mgmt_budget_gossip_enabled 0
+#define default_traffic_mgmt_group_budget_enabled 0
 
 // Hop scaling defaults
 #define default_hop_scaling_min_target_nodes 40          // walk threshold: first hop reaching this cumulative count

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -247,10 +247,11 @@ bool NextHopRouter::perhapsRebroadcast(const meshtastic_MeshPacket *p)
 #endif
 
 #if HAS_TRAFFIC_MANAGEMENT
-    // Antispam L1 (M6): stop relaying a sender whose local relay budget is
-    // exhausted (or whose NO_RELAY was gossiped). The packet still flows to
-    // our own client - only propagation stops.
-    if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag && trafficManagementModule &&
+    // Check if traffic management wants to stop relaying a sender whose local
+    // relay budget is exhausted (or whose NO_RELAY was gossiped). Only relayed
+    // traffic counts: a packet addressed to us (or from us) must still reach
+    // our own client and its ACK/NAK path, so it is never "consumed" here.
+    if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag && trafficManagementModule && !isToUs(p) && !isFromUs(p) &&
         !trafficManagementModule->shouldRelay(*p)) {
         LOG_DEBUG("Antispam: not relaying 0x%08x (relay budget / no-relay)", getFrom(p));
         return true; // consumed: deliver locally, do not propagate

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -246,6 +246,17 @@ bool NextHopRouter::perhapsRebroadcast(const meshtastic_MeshPacket *p)
     }
 #endif
 
+#if HAS_TRAFFIC_MANAGEMENT
+    // Antispam L1 (M6): stop relaying a sender whose local relay budget is
+    // exhausted (or whose NO_RELAY was gossiped). The packet still flows to
+    // our own client - only propagation stops.
+    if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag && trafficManagementModule &&
+        !trafficManagementModule->shouldRelay(*p)) {
+        LOG_DEBUG("Antispam: not relaying 0x%08x (relay budget / no-relay)", getFrom(p));
+        return true; // consumed: deliver locally, do not propagate
+    }
+#endif
+
     if (p->to == NODENUM_BROADCAST_NO_LORA)
         return false;
 
@@ -276,6 +287,17 @@ bool NextHopRouter::perhapsRebroadcast(const meshtastic_MeshPacket *p)
                     }
 #if USERPREFS_EVENT_MODE
                     capEventRelayHops(tosend);
+#endif
+#if HAS_TRAFFIC_MANAGEMENT
+                    // Antispam L1 (M2/M6): clamp the relayed copy's hop budget
+                    // (probation cap, congestion cap) and charge this relay to
+                    // the sender's local budget (gossips NO_RELAY on exhaustion).
+                    if (trafficManagementModule) {
+                        const uint8_t capped = trafficManagementModule->relayHopCap(*p);
+                        if (capped < tosend->hop_limit)
+                            tosend->hop_limit = capped;
+                        trafficManagementModule->recordRelayed(*p);
+                    }
 #endif
 
                     ErrorCode res =

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -297,7 +297,11 @@ bool NextHopRouter::perhapsRebroadcast(const meshtastic_MeshPacket *p)
                         const uint8_t capped = trafficManagementModule->relayHopCap(*p);
                         if (capped < tosend->hop_limit)
                             tosend->hop_limit = capped;
-                        trafficManagementModule->recordRelayed(*p);
+                        // recordRelayed() reads the decoded portnum for its
+                        // reliability exemption, so it only applies to
+                        // decoded packets - never to ciphertext.
+                        if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag)
+                            trafficManagementModule->recordRelayed(*p);
                     }
 #endif
 

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1282,6 +1282,15 @@ static void installTrafficManagementDefaults(meshtastic_LocalModuleConfig &mc)
     // STM32WL is excluded at compile time (HAS_TRAFFIC_MANAGEMENT=0 in mesh-pb-constants.h).
     // Set position_min_interval_secs=0 at runtime to disable dedup.
     mc.traffic_management.position_min_interval_secs = default_traffic_mgmt_position_min_interval_secs;
+    // Antispam L1 (M2): probation accounting ships on at the 5-minute window.
+    // It only records first-seen state; the probation-aware behaviors (hop cap,
+    // promotion) engage through the same config, so 0 also turns the window off.
+    mc.traffic_management.probation_window_secs = default_traffic_mgmt_probation_window_secs;
+    mc.traffic_management.attestation_min_tenure_secs = default_traffic_mgmt_attestation_min_tenure_secs;
+    mc.traffic_management.probation_max_hop_limit = default_traffic_mgmt_probation_max_hop_limit;
+    // M4/M6 knobs (budget gossip, group budget, relay budget, congestion hop
+    // cap) ship disabled (0) and stay 0 here: they resolve to their
+    // default_traffic_mgmt_* macros at use, and the TMM treats 0 as off.
 #endif
 }
 

--- a/src/mesh/generated/meshtastic/deviceonly.pb.h
+++ b/src/mesh/generated/meshtastic/deviceonly.pb.h
@@ -455,14 +455,14 @@ extern const pb_msgdesc_t meshtastic_BackupPreferences_msg;
 /* Maximum encoded size of messages (where known) */
 /* meshtastic_NodeDatabase_size depends on runtime parameters */
 #define MESHTASTIC_MESHTASTIC_DEVICEONLY_PB_H_MAX_SIZE meshtastic_BackupPreferences_size
-#define meshtastic_BackupPreferences_size        2656
+#define meshtastic_BackupPreferences_size        2704
 #define meshtastic_ChannelFile_size              718
 #define meshtastic_DeviceState_size              1944
 #define meshtastic_NodeEnvironmentEntry_size     231
 #define meshtastic_NodeInfoLite_size             112
 #define meshtastic_NodePositionEntry_size        42
 #define meshtastic_NodeStatusEntry_size          89
-#define meshtastic_NodeTelemetryEntry_size       35
+#define meshtastic_NodeTelemetryEntry_size       95
 #define meshtastic_PositionLite_size             34
 #define meshtastic_UserLite_size                 98
 

--- a/src/mesh/generated/meshtastic/deviceonly_legacy.pb.cpp
+++ b/src/mesh/generated/meshtastic/deviceonly_legacy.pb.cpp
@@ -6,7 +6,7 @@
 #error Regenerate this file with the current version of nanopb generator.
 #endif
 
-PB_BIND(meshtastic_NodeInfoLite_Legacy, meshtastic_NodeInfoLite_Legacy, AUTO)
+PB_BIND(meshtastic_NodeInfoLite_Legacy, meshtastic_NodeInfoLite_Legacy, 2)
 
 
 PB_BIND(meshtastic_NodeDatabase_Legacy, meshtastic_NodeDatabase_Legacy, AUTO)

--- a/src/mesh/generated/meshtastic/deviceonly_legacy.pb.h
+++ b/src/mesh/generated/meshtastic/deviceonly_legacy.pb.h
@@ -115,7 +115,7 @@ extern const pb_msgdesc_t meshtastic_NodeDatabase_Legacy_msg;
 /* Maximum encoded size of messages (where known) */
 /* meshtastic_NodeDatabase_Legacy_size depends on runtime parameters */
 #define MESHTASTIC_MESHTASTIC_DEVICEONLY_LEGACY_PB_H_MAX_SIZE meshtastic_NodeInfoLite_Legacy_size
-#define meshtastic_NodeInfoLite_Legacy_size      202
+#define meshtastic_NodeInfoLite_Legacy_size      262
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/mesh/generated/meshtastic/localonly.pb.h
+++ b/src/mesh/generated/meshtastic/localonly.pb.h
@@ -212,7 +212,7 @@ extern const pb_msgdesc_t meshtastic_LocalModuleConfig_msg;
 /* Maximum encoded size of messages (where known) */
 #define MESHTASTIC_MESHTASTIC_LOCALONLY_PB_H_MAX_SIZE meshtastic_LocalModuleConfig_size
 #define meshtastic_LocalConfig_size              759
-#define meshtastic_LocalModuleConfig_size        1042
+#define meshtastic_LocalModuleConfig_size        1090
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/mesh/generated/meshtastic/mesh.pb.cpp
+++ b/src/mesh/generated/meshtastic/mesh.pb.cpp
@@ -39,6 +39,9 @@ PB_BIND(meshtastic_Waypoint, meshtastic_Waypoint, AUTO)
 PB_BIND(meshtastic_StatusMessage, meshtastic_StatusMessage, AUTO)
 
 
+PB_BIND(meshtastic_IdAttestation, meshtastic_IdAttestation, AUTO)
+
+
 PB_BIND(meshtastic_MqttClientProxyMessage, meshtastic_MqttClientProxyMessage, 2)
 
 
@@ -121,6 +124,8 @@ PB_BIND(meshtastic_resend_chunks, meshtastic_resend_chunks, AUTO)
 
 
 PB_BIND(meshtastic_ChunkedPayloadResponse, meshtastic_ChunkedPayloadResponse, AUTO)
+
+
 
 
 

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -575,6 +575,21 @@ typedef enum _meshtastic_RemoteShell_OpCode {
     meshtastic_RemoteShell_OpCode_PONG = 68
 } meshtastic_RemoteShell_OpCode;
 
+typedef enum _meshtastic_IdAttestation_Kind {
+    meshtastic_IdAttestation_Kind_UNSPECIFIED = 0,
+    /* Promotion attestation (M2): "I have known the ID in `subject` since
+ before `known_since_secs`. Sent by a long-tenured node; recipients
+ outside probation may accept it to shorten `subject`'s probation
+ window (see traffic_management probational config). The `attester`
+ field is the sender; it is not re-decoded here. */
+    meshtastic_IdAttestation_Kind_KNOWN_SINCE = 1,
+    /* NO_RELAY bit (M6): "my per-sender relay budget for `subject` is
+ exhausted this window; do not relay their traffic." Gossiped so the
+ neighborhood converges instead of each node exhausting independently.
+ Recipients still deliver `subject`'s packets locally. */
+    meshtastic_IdAttestation_Kind_NO_RELAY = 2
+} meshtastic_IdAttestation_Kind;
+
 /* The priority of this message for sending.
  Higher priorities are sent first (when managing the transmit queue).
  This field is never sent over the air, it is only used internally inside of a local device node.
@@ -1030,6 +1045,34 @@ typedef struct _meshtastic_StatusMessage {
     char status[80];
 } meshtastic_StatusMessage;
 
+/* Antispam L1 greylist gossip (design doc M2/M6), sent on portnum
+ ID_ATTESTATION_APP (80). One record per packet; `kind` selects the payload.
+
+ L1 is intentionally small and unsigned: the threat being priced is the
+ rotating-node-ID spammer, and the whole point is that a *fresh* ID cannot
+ cheaply carry a vouch from an established one. XEdDSA signing of this
+ message is the L2 identity layer, not L1. Old firmware never sees a
+ non-empty payload on an unknown portnum, so a broadcast ID_ATTESTATION is
+ opaque-relayed at most like any other app packet. */
+typedef struct _meshtastic_IdAttestation {
+    meshtastic_IdAttestation_Kind kind;
+    /* Node the record is about (promote subject, or the sender to stop
+ relaying). 0 means "self", which is not a valid subject and is ignored
+ by recipients. */
+    uint32_t subject;
+    /* Only KNOWN_SINCE: the attester's belief about when it first saw
+ `subject`, as wall-clock seconds since the Unix epoch, truncated to the
+ hour so the field stays 4 bytes even across the year-2106 32-bit
+ overflow. A value of 0 means "the attester has no clock"; recipients
+ fall back to the tenure floor (attestation_min_tenure_secs) only. */
+    uint32_t known_since_secs;
+    /* Only KNOWN_SINCE: the attester's own first-seen time for itself (epoch
+ seconds, truncated to the hour). Lets a recipient reject attestations
+ from an attester younger than attestation_min_tenure_secs. 0 means
+ "no clock". */
+    uint32_t attester_tenure_secs;
+} meshtastic_IdAttestation;
+
 typedef PB_BYTES_ARRAY_T(435) meshtastic_MqttClientProxyMessage_data_t;
 /* This message will be proxied over the PhoneAPI for the client to deliver to the MQTT server */
 typedef struct _meshtastic_MqttClientProxyMessage {
@@ -1277,15 +1320,15 @@ typedef struct _meshtastic_LockdownStatus {
     /* Current lockdown state being reported. */
     meshtastic_LockdownStatus_State state;
     /* For LOCKED: machine-readable reason. Known values:
-   "needs_auth"        - storage already unlocked, client must auth
-   "token_missing"     - no boot token on flash
-   "token_expired"     - boot token wall-clock TTL elapsed
-   "token_boots_zero"  - boot token boot-count TTL exhausted
-   "token_hmac_fail"   - token tampered or wrong device
-   "token_dek_fail"    - token DEK decrypt failed
-   "token_wrong_size"  - token file corrupted
-   "token_bad_magic"   - token file corrupted
-   "not_provisioned"   - should generally use NEEDS_PROVISION state instead
+   "needs_auth"        — storage already unlocked, client must auth
+   "token_missing"     — no boot token on flash
+   "token_expired"     — boot token wall-clock TTL elapsed
+   "token_boots_zero"  — boot token boot-count TTL exhausted
+   "token_hmac_fail"   — token tampered or wrong device
+   "token_dek_fail"    — token DEK decrypt failed
+   "token_wrong_size"  — token file corrupted
+   "token_bad_magic"   — token file corrupted
+   "not_provisioned"   — should generally use NEEDS_PROVISION state instead
  Other values may be added; clients should treat unknown values as
  "locked, ask for passphrase". */
     char lock_reason[32];
@@ -1661,6 +1704,10 @@ extern "C" {
 #define _meshtastic_RemoteShell_OpCode_MAX meshtastic_RemoteShell_OpCode_PONG
 #define _meshtastic_RemoteShell_OpCode_ARRAYSIZE ((meshtastic_RemoteShell_OpCode)(meshtastic_RemoteShell_OpCode_PONG+1))
 
+#define _meshtastic_IdAttestation_Kind_MIN meshtastic_IdAttestation_Kind_UNSPECIFIED
+#define _meshtastic_IdAttestation_Kind_MAX meshtastic_IdAttestation_Kind_NO_RELAY
+#define _meshtastic_IdAttestation_Kind_ARRAYSIZE ((meshtastic_IdAttestation_Kind)(meshtastic_IdAttestation_Kind_NO_RELAY+1))
+
 #define _meshtastic_MeshPacket_Priority_MIN meshtastic_MeshPacket_Priority_UNSET
 #define _meshtastic_MeshPacket_Priority_MAX meshtastic_MeshPacket_Priority_MAX
 #define _meshtastic_MeshPacket_Priority_ARRAYSIZE ((meshtastic_MeshPacket_Priority)(meshtastic_MeshPacket_Priority_MAX+1))
@@ -1699,6 +1746,8 @@ extern "C" {
 
 
 
+
+#define meshtastic_IdAttestation_kind_ENUMTYPE meshtastic_IdAttestation_Kind
 
 
 #define meshtastic_MeshPacket_priority_ENUMTYPE meshtastic_MeshPacket_Priority
@@ -1754,6 +1803,7 @@ extern "C" {
 #define meshtastic_BoundingBox_init_default      {0, 0, 0, 0}
 #define meshtastic_Waypoint_init_default         {0, false, 0, false, 0, 0, 0, "", "", 0, 0, false, meshtastic_BoundingBox_init_default, 0, 0, 0}
 #define meshtastic_StatusMessage_init_default    {""}
+#define meshtastic_IdAttestation_init_default    {_meshtastic_IdAttestation_Kind_MIN, 0, 0, 0}
 #define meshtastic_MqttClientProxyMessage_init_default {"", 0, {{0, {0}}}, 0}
 #define meshtastic_MeshPacket_init_default       {0, 0, 0, 0, {meshtastic_Data_init_default}, 0, false, 0, 0, 0, 0, _meshtastic_MeshPacket_Priority_MIN, false, 0, _meshtastic_MeshPacket_Delayed_MIN, 0, 0, {0, {0}}, 0, 0, 0, 0, _meshtastic_MeshPacket_TransportMechanism_MIN, 0}
 #define meshtastic_NodeInfo_init_default         {0, false, meshtastic_User_init_default, false, meshtastic_Position_init_default, 0, 0, false, meshtastic_DeviceMetrics_init_default, 0, 0, false, 0, 0, 0, 0, 0, 0}
@@ -1793,6 +1843,7 @@ extern "C" {
 #define meshtastic_BoundingBox_init_zero         {0, 0, 0, 0}
 #define meshtastic_Waypoint_init_zero            {0, false, 0, false, 0, 0, 0, "", "", 0, 0, false, meshtastic_BoundingBox_init_zero, 0, 0, 0}
 #define meshtastic_StatusMessage_init_zero       {""}
+#define meshtastic_IdAttestation_init_zero       {_meshtastic_IdAttestation_Kind_MIN, 0, 0, 0}
 #define meshtastic_MqttClientProxyMessage_init_zero {"", 0, {{0, {0}}}, 0}
 #define meshtastic_MeshPacket_init_zero          {0, 0, 0, 0, {meshtastic_Data_init_zero}, 0, false, 0, 0, 0, 0, _meshtastic_MeshPacket_Priority_MIN, false, 0, _meshtastic_MeshPacket_Delayed_MIN, 0, 0, {0, {0}}, 0, 0, 0, 0, _meshtastic_MeshPacket_TransportMechanism_MIN, 0}
 #define meshtastic_NodeInfo_init_zero            {0, false, meshtastic_User_init_zero, false, meshtastic_Position_init_zero, 0, 0, false, meshtastic_DeviceMetrics_init_zero, 0, 0, false, 0, 0, 0, 0, 0, 0}
@@ -1913,6 +1964,10 @@ extern "C" {
 #define meshtastic_Waypoint_notify_on_exit_tag   12
 #define meshtastic_Waypoint_notify_favorites_only_tag 13
 #define meshtastic_StatusMessage_status_tag      1
+#define meshtastic_IdAttestation_kind_tag        1
+#define meshtastic_IdAttestation_subject_tag     2
+#define meshtastic_IdAttestation_known_since_secs_tag 3
+#define meshtastic_IdAttestation_attester_tenure_secs_tag 4
 #define meshtastic_MqttClientProxyMessage_topic_tag 1
 #define meshtastic_MqttClientProxyMessage_data_tag 2
 #define meshtastic_MqttClientProxyMessage_text_tag 3
@@ -2198,6 +2253,14 @@ X(a, STATIC,   SINGULAR, BOOL,     notify_favorites_only,  13)
 X(a, STATIC,   SINGULAR, STRING,   status,            1)
 #define meshtastic_StatusMessage_CALLBACK NULL
 #define meshtastic_StatusMessage_DEFAULT NULL
+
+#define meshtastic_IdAttestation_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, UENUM,    kind,              1) \
+X(a, STATIC,   SINGULAR, UINT32,   subject,           2) \
+X(a, STATIC,   SINGULAR, UINT32,   known_since_secs,   3) \
+X(a, STATIC,   SINGULAR, UINT32,   attester_tenure_secs,   4)
+#define meshtastic_IdAttestation_CALLBACK NULL
+#define meshtastic_IdAttestation_DEFAULT NULL
 
 #define meshtastic_MqttClientProxyMessage_FIELDLIST(X, a) \
 X(a, STATIC,   SINGULAR, STRING,   topic,             1) \
@@ -2505,6 +2568,7 @@ extern const pb_msgdesc_t meshtastic_RemoteShell_msg;
 extern const pb_msgdesc_t meshtastic_BoundingBox_msg;
 extern const pb_msgdesc_t meshtastic_Waypoint_msg;
 extern const pb_msgdesc_t meshtastic_StatusMessage_msg;
+extern const pb_msgdesc_t meshtastic_IdAttestation_msg;
 extern const pb_msgdesc_t meshtastic_MqttClientProxyMessage_msg;
 extern const pb_msgdesc_t meshtastic_MeshPacket_msg;
 extern const pb_msgdesc_t meshtastic_NodeInfo_msg;
@@ -2546,6 +2610,7 @@ extern const pb_msgdesc_t meshtastic_ChunkedPayloadResponse_msg;
 #define meshtastic_BoundingBox_fields &meshtastic_BoundingBox_msg
 #define meshtastic_Waypoint_fields &meshtastic_Waypoint_msg
 #define meshtastic_StatusMessage_fields &meshtastic_StatusMessage_msg
+#define meshtastic_IdAttestation_fields &meshtastic_IdAttestation_msg
 #define meshtastic_MqttClientProxyMessage_fields &meshtastic_MqttClientProxyMessage_msg
 #define meshtastic_MeshPacket_fields &meshtastic_MeshPacket_msg
 #define meshtastic_NodeInfo_fields &meshtastic_NodeInfo_msg
@@ -2589,6 +2654,7 @@ extern const pb_msgdesc_t meshtastic_ChunkedPayloadResponse_msg;
 #define meshtastic_FileInfo_size                 236
 #define meshtastic_FromRadio_size                510
 #define meshtastic_Heartbeat_size                6
+#define meshtastic_IdAttestation_size            20
 #define meshtastic_KeyVerificationFinal_size     65
 #define meshtastic_KeyVerificationNumberInform_size 58
 #define meshtastic_KeyVerificationNumberRequest_size 52
@@ -2604,7 +2670,7 @@ extern const pb_msgdesc_t meshtastic_ChunkedPayloadResponse_msg;
 #define meshtastic_MyNodeInfo_size               83
 #define meshtastic_NeighborInfo_size             258
 #define meshtastic_Neighbor_size                 22
-#define meshtastic_NodeInfo_size                 327
+#define meshtastic_NodeInfo_size                 387
 #define meshtastic_NodeRemoteHardwarePin_size    29
 #define meshtastic_Position_size                 144
 #define meshtastic_QueueStatus_size              23

--- a/src/mesh/generated/meshtastic/module_config.pb.h
+++ b/src/mesh/generated/meshtastic/module_config.pb.h
@@ -268,6 +268,55 @@ typedef struct _meshtastic_ModuleConfig_TrafficManagementConfig {
  is dropped. A non-zero value implicitly enables unknown-packet filtering;
  0 disables it. */
     uint32_t unknown_packet_threshold;
+    /* Antispam L1 (M2 greylist): probation window in seconds for a node ID
+ observed for the first time on this device. While in probation the ID's
+ broadcasts are still relayed, but at a reduced hop cap
+ (probation_max_hop_limit) and the lower rate budget (the probation
+ multiplier of rate_limit_max_packets). 0 disables probation entirely
+ (ids are treated as established from first sight). Shipped default:
+ 300 (5 min) on all targets where the unified cache is compiled in. */
+    uint32_t probation_window_secs;
+    /* Antispam L1 (M2 greylist): minimum seconds a known-since attestation
+ must claim for its attester before this device accepts it for shortening
+ a probation window. Attestations from a younger attester (or with no
+ clock, i.e. attester_tenure_secs == 0) are ignored. Shipped default:
+ 86400 (24 h). */
+    uint32_t attestation_min_tenure_secs;
+    /* Antispam L1 (M2 greylist): hop_limit applied to broadcasts from a
+ node that is in probation (see probation_window_secs). 0 disables the
+ hop cap (probation IDs relay at the normal hop limit). Only applies
+ when probation_window_secs > 0. Shipped default: 2 (normal is 3). */
+    uint32_t probation_max_hop_limit;
+    /* Antispam L1 (M4 gossiped rate budgets): when the neighborhood median
+ of observed per-sender packet rates (from DeviceMetrics.top_senders)
+ exceeds the local rate_limit_max_packets, the local per-sender budget
+ is clamped to the median instead. 0 disables the median (local
+ rate_limit_max_packets stays authoritative) - the shipped default. */
+    uint32_t budget_gossip_enabled;
+    /* Antispam L1 (M4 group budget, F4.3): when at least this many *fresh*
+ (in probation) node IDs are observed on the same channel within the
+ same 5-minute RSSI-class window, they are treated as a group sharing
+ one budget: a single rate_limit_max_packets is split across the group,
+ so each member gets max(1, rate_limit_max_packets / group_size) per
+ window. Catches a spammer rotating IDs in one place. The value is the
+ minimum number of co-occurring fresh IDs (N) that triggers grouping;
+ 0 disables group budgets - the shipped default. Only consulted when
+ budget_gossip_enabled > 0. */
+    uint32_t group_budget_enabled;
+    /* Antispam L1 (M6 relay pricing): per-sender relay budget in packets per
+ rate window. When the local relayer has re-broadcast this many of a
+ sender's packets this window, it stops relaying for that sender (still
+ delivers them locally) and gossips the NO_RELAY bit via
+ ID_ATTESTATION_APP. 0 disables the relay budget (unlimited relaying) -
+ the shipped default. Only non-ack, non-admin, non-routing traffic
+ counts. */
+    uint32_t relay_budget_max_packets;
+    /* Antispam L1 (M6 congestion hop cap): channel-utilization percentage
+ (last 60 s, all traffic types) at which the local relayer caps the
+ hop budget of probation (L0) broadcast senders at 1 hop. 0 disables
+ the cap - the shipped default. Only consulted for non-local senders
+ in probation. */
+    uint32_t congestion_hop_cap_pct;
 } meshtastic_ModuleConfig_TrafficManagementConfig;
 
 /* Serial Config */
@@ -652,7 +701,7 @@ extern "C" {
 #define meshtastic_ModuleConfig_DetectionSensorConfig_init_default {0, 0, 0, 0, "", 0, _meshtastic_ModuleConfig_DetectionSensorConfig_TriggerType_MIN, 0}
 #define meshtastic_ModuleConfig_AudioConfig_init_default {0, 0, _meshtastic_ModuleConfig_AudioConfig_Audio_Baud_MIN, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_PaxcounterConfig_init_default {0, 0, 0, 0}
-#define meshtastic_ModuleConfig_TrafficManagementConfig_init_default {0, 0, 0, 0, 0}
+#define meshtastic_ModuleConfig_TrafficManagementConfig_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_SerialConfig_init_default {0, 0, 0, 0, _meshtastic_ModuleConfig_SerialConfig_Serial_Baud_MIN, 0, _meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MIN, 0}
 #define meshtastic_ModuleConfig_ExternalNotificationConfig_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_StoreForwardConfig_init_default {0, 0, 0, 0, 0, 0}
@@ -673,7 +722,7 @@ extern "C" {
 #define meshtastic_ModuleConfig_DetectionSensorConfig_init_zero {0, 0, 0, 0, "", 0, _meshtastic_ModuleConfig_DetectionSensorConfig_TriggerType_MIN, 0}
 #define meshtastic_ModuleConfig_AudioConfig_init_zero {0, 0, _meshtastic_ModuleConfig_AudioConfig_Audio_Baud_MIN, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_PaxcounterConfig_init_zero {0, 0, 0, 0}
-#define meshtastic_ModuleConfig_TrafficManagementConfig_init_zero {0, 0, 0, 0, 0}
+#define meshtastic_ModuleConfig_TrafficManagementConfig_init_zero {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_SerialConfig_init_zero {0, 0, 0, 0, _meshtastic_ModuleConfig_SerialConfig_Serial_Baud_MIN, 0, _meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MIN, 0}
 #define meshtastic_ModuleConfig_ExternalNotificationConfig_init_zero {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_StoreForwardConfig_init_zero {0, 0, 0, 0, 0, 0}
@@ -729,6 +778,13 @@ extern "C" {
 #define meshtastic_ModuleConfig_TrafficManagementConfig_rate_limit_window_secs_tag 8
 #define meshtastic_ModuleConfig_TrafficManagementConfig_rate_limit_max_packets_tag 9
 #define meshtastic_ModuleConfig_TrafficManagementConfig_unknown_packet_threshold_tag 11
+#define meshtastic_ModuleConfig_TrafficManagementConfig_probation_window_secs_tag 15
+#define meshtastic_ModuleConfig_TrafficManagementConfig_attestation_min_tenure_secs_tag 16
+#define meshtastic_ModuleConfig_TrafficManagementConfig_probation_max_hop_limit_tag 17
+#define meshtastic_ModuleConfig_TrafficManagementConfig_budget_gossip_enabled_tag 18
+#define meshtastic_ModuleConfig_TrafficManagementConfig_group_budget_enabled_tag 19
+#define meshtastic_ModuleConfig_TrafficManagementConfig_relay_budget_max_packets_tag 20
+#define meshtastic_ModuleConfig_TrafficManagementConfig_congestion_hop_cap_pct_tag 21
 #define meshtastic_ModuleConfig_SerialConfig_enabled_tag 1
 #define meshtastic_ModuleConfig_SerialConfig_echo_tag 2
 #define meshtastic_ModuleConfig_SerialConfig_rxd_tag 3
@@ -943,7 +999,14 @@ X(a, STATIC,   SINGULAR, UINT32,   position_min_interval_secs,   4) \
 X(a, STATIC,   SINGULAR, UINT32,   nodeinfo_direct_response_max_hops,   6) \
 X(a, STATIC,   SINGULAR, UINT32,   rate_limit_window_secs,   8) \
 X(a, STATIC,   SINGULAR, UINT32,   rate_limit_max_packets,   9) \
-X(a, STATIC,   SINGULAR, UINT32,   unknown_packet_threshold,  11)
+X(a, STATIC,   SINGULAR, UINT32,   unknown_packet_threshold,  11) \
+X(a, STATIC,   SINGULAR, UINT32,   probation_window_secs,  15) \
+X(a, STATIC,   SINGULAR, UINT32,   attestation_min_tenure_secs,  16) \
+X(a, STATIC,   SINGULAR, UINT32,   probation_max_hop_limit,  17) \
+X(a, STATIC,   SINGULAR, UINT32,   budget_gossip_enabled,  18) \
+X(a, STATIC,   SINGULAR, UINT32,   group_budget_enabled,  19) \
+X(a, STATIC,   SINGULAR, UINT32,   relay_budget_max_packets,  20) \
+X(a, STATIC,   SINGULAR, UINT32,   congestion_hop_cap_pct,  21)
 #define meshtastic_ModuleConfig_TrafficManagementConfig_CALLBACK NULL
 #define meshtastic_ModuleConfig_TrafficManagementConfig_DEFAULT NULL
 
@@ -1142,7 +1205,7 @@ extern const pb_msgdesc_t meshtastic_RemoteHardwarePin_msg;
 #define meshtastic_ModuleConfig_StoreForwardConfig_size 24
 #define meshtastic_ModuleConfig_TAKConfig_size   4
 #define meshtastic_ModuleConfig_TelemetryConfig_size 50
-#define meshtastic_ModuleConfig_TrafficManagementConfig_size 30
+#define meshtastic_ModuleConfig_TrafficManagementConfig_size 78
 #define meshtastic_ModuleConfig_size             244
 #define meshtastic_RemoteHardwarePin_size        21
 

--- a/src/mesh/generated/meshtastic/portnums.pb.h
+++ b/src/mesh/generated/meshtastic/portnums.pb.h
@@ -165,6 +165,13 @@ typedef enum _meshtastic_PortNum {
 
  ENCODING: binary (ota-common transport frames) */
     meshtastic_PortNum_LORA_OTA_APP = 79,
+    /* ID attestation / greylist gossip (antispam L1, M2/M6).
+ Carries an IdAttestation payload: a long-tenured node vouching that it
+ has known an ID since a given epoch window (promotion out of probation),
+ or a gossiped NO_RELAY bit after a relayer's per-sender budget is
+ exhausted. Unsigned in L1; XEdDSA signing arrives with L2 identity.
+ ENCODING: nanopb (meshtastic_IdAttestation) */
+    meshtastic_PortNum_ID_ATTESTATION_APP = 80,
     /* GroupAlarm integration
  Used for transporting GroupAlarm-related messages between Meshtastic nodes
  and companion applications/services. */

--- a/src/mesh/generated/meshtastic/telemetry.pb.cpp
+++ b/src/mesh/generated/meshtastic/telemetry.pb.cpp
@@ -6,6 +6,9 @@
 #error Regenerate this file with the current version of nanopb generator.
 #endif
 
+PB_BIND(meshtastic_TopSender, meshtastic_TopSender, AUTO)
+
+
 PB_BIND(meshtastic_DeviceMetrics, meshtastic_DeviceMetrics, AUTO)
 
 

--- a/src/mesh/generated/meshtastic/telemetry.pb.h
+++ b/src/mesh/generated/meshtastic/telemetry.pb.h
@@ -131,6 +131,25 @@ typedef enum _meshtastic_TelemetrySensorType {
 } meshtastic_TelemetrySensorType;
 
 /* Struct definitions */
+/* Antispam L1 top-sender micro-field (design doc M4). One entry per node in
+ DeviceMetrics.top_senders (top-3 by observed rate this window, descending).
+ Piggybacked on the periodic device telemetry broadcast, which already
+ floods, so the marginal airtime cost of the budget gossip is near zero. */
+typedef struct _meshtastic_TopSender {
+    /* The sender node number. 0 means no entry (unused slot); consumers
+ ignore it. */
+    uint32_t node;
+    /* Packets observed from this node in the local budget window
+ (traffic_management rate_limit_window_secs). Saturates at 255. */
+    uint32_t packets_this_window;
+    /* RSSI class of the strongest signal seen from this node in the window,
+ quantized to 4 classes so a noisy RF front end never flips the class
+ for a stable transmitter: 0 = < -110 dBm (far), 1 = -110..-100,
+ 2 = -100..-90, 3 = >= -90 (near). 255 means "no usable RSSI reading
+ this window"; consumers treat it as "unknown" and never rank it. */
+    uint32_t rssi_class;
+} meshtastic_TopSender;
+
 /* Key native device metrics such as battery level */
 typedef struct _meshtastic_DeviceMetrics {
     /* 0-100 (>100 means powered) */
@@ -148,6 +167,15 @@ typedef struct _meshtastic_DeviceMetrics {
     /* How long the device has been running since the last reboot (in seconds) */
     bool has_uptime_seconds;
     uint32_t uptime_seconds;
+    /* Antispam L1 (M4): top-3 senders by observed packet rate in the local
+ budget window, plus each one's RSSI class. Piggybacked on the periodic
+ device telemetry broadcast so the neighborhood can compute a
+ median-of-neighbors rate budget per sender without extra airtime.
+ Up to 3 entries, descending by packets_this_window; absent/empty on
+ firmware before this field or when the TMM budget gossip is disabled.
+ See TopSender in mesh.proto for field semantics. */
+    pb_size_t top_senders_count;
+    meshtastic_TopSender top_senders[3];
 } meshtastic_DeviceMetrics;
 
 /* Weather station or other environmental metrics */
@@ -465,6 +493,20 @@ typedef struct _meshtastic_TrafficManagementStats {
     uint32_t hop_exhausted_packets;
     /* Number of times router hop preservation was applied */
     uint32_t router_hops_preserved;
+    /* Antispam L1 (M2): packets dropped because the sender is in probation and
+ its gossiped rate budget (M4 median) was exhausted. */
+    uint32_t probation_budget_drops;
+    /* Antispam L1 (M6): relays skipped because the sender's relay budget was
+ exhausted locally or a gossiped NO_RELAY bit was in force. */
+    uint32_t no_relay_skips;
+    /* Antispam L1 (M2): probation windows shortened by an accepted
+ KNOWN_SINCE attestation. */
+    uint32_t attestation_promotions;
+    /* Antispam L1 (M6): NO_RELAY gossip packets we emitted. */
+    uint32_t no_relay_gossips_sent;
+    /* Antispam L1 (M2/M6): relays whose hop_limit was clamped by the probation
+ cap or the congestion cap. */
+    uint32_t relay_hop_caps_applied;
 } meshtastic_TrafficManagementStats;
 
 /* Health telemetry metrics */
@@ -608,13 +650,15 @@ extern "C" {
 
 
 
+
 /* Initializer values for message structs */
-#define meshtastic_DeviceMetrics_init_default    {false, 0, false, 0, false, 0, false, 0, false, 0}
+#define meshtastic_TopSender_init_default        {0, 0, 0}
+#define meshtastic_DeviceMetrics_init_default    {false, 0, false, 0, false, 0, false, 0, false, 0, 0, {meshtastic_TopSender_init_default, meshtastic_TopSender_init_default, meshtastic_TopSender_init_default}}
 #define meshtastic_EnvironmentMetrics_init_default {false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0}
 #define meshtastic_PowerMetrics_init_default     {false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0}
 #define meshtastic_AirQualityMetrics_init_default {false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0}
 #define meshtastic_LocalStats_init_default       {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
-#define meshtastic_TrafficManagementStats_init_default {0, 0, 0, 0, 0, 0, 0}
+#define meshtastic_TrafficManagementStats_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_HealthMetrics_init_default    {false, 0, false, 0, false, 0}
 #define meshtastic_HostMetrics_init_default      {0, 0, 0, false, 0, false, 0, 0, 0, 0, false, ""}
 #define meshtastic_Telemetry_init_default        {0, 0, {meshtastic_DeviceMetrics_init_default}}
@@ -622,12 +666,13 @@ extern "C" {
 #define meshtastic_AS3935Config_init_default     {0}
 #define meshtastic_SEN5XState_init_default       {0, 0, 0, false, 0, false, 0, false, 0}
 #define meshtastic_SEN6XState_init_default       {0, 0, 0, false, 0, false, 0, false, 0}
-#define meshtastic_DeviceMetrics_init_zero       {false, 0, false, 0, false, 0, false, 0, false, 0}
+#define meshtastic_TopSender_init_zero           {0, 0, 0}
+#define meshtastic_DeviceMetrics_init_zero       {false, 0, false, 0, false, 0, false, 0, false, 0, 0, {meshtastic_TopSender_init_zero, meshtastic_TopSender_init_zero, meshtastic_TopSender_init_zero}}
 #define meshtastic_EnvironmentMetrics_init_zero  {false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0}
 #define meshtastic_PowerMetrics_init_zero        {false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0}
 #define meshtastic_AirQualityMetrics_init_zero   {false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0}
 #define meshtastic_LocalStats_init_zero          {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
-#define meshtastic_TrafficManagementStats_init_zero {0, 0, 0, 0, 0, 0, 0}
+#define meshtastic_TrafficManagementStats_init_zero {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_HealthMetrics_init_zero       {false, 0, false, 0, false, 0}
 #define meshtastic_HostMetrics_init_zero         {0, 0, 0, false, 0, false, 0, 0, 0, 0, false, ""}
 #define meshtastic_Telemetry_init_zero           {0, 0, {meshtastic_DeviceMetrics_init_zero}}
@@ -637,11 +682,15 @@ extern "C" {
 #define meshtastic_SEN6XState_init_zero          {0, 0, 0, false, 0, false, 0, false, 0}
 
 /* Field tags (for use in manual encoding/decoding) */
+#define meshtastic_TopSender_node_tag            1
+#define meshtastic_TopSender_packets_this_window_tag 2
+#define meshtastic_TopSender_rssi_class_tag      3
 #define meshtastic_DeviceMetrics_battery_level_tag 1
 #define meshtastic_DeviceMetrics_voltage_tag     2
 #define meshtastic_DeviceMetrics_channel_utilization_tag 3
 #define meshtastic_DeviceMetrics_air_util_tx_tag 4
 #define meshtastic_DeviceMetrics_uptime_seconds_tag 5
+#define meshtastic_DeviceMetrics_top_senders_tag 6
 #define meshtastic_EnvironmentMetrics_temperature_tag 1
 #define meshtastic_EnvironmentMetrics_relative_humidity_tag 2
 #define meshtastic_EnvironmentMetrics_barometric_pressure_tag 3
@@ -746,6 +795,11 @@ extern "C" {
 #define meshtastic_TrafficManagementStats_unknown_packet_drops_tag 5
 #define meshtastic_TrafficManagementStats_hop_exhausted_packets_tag 6
 #define meshtastic_TrafficManagementStats_router_hops_preserved_tag 7
+#define meshtastic_TrafficManagementStats_probation_budget_drops_tag 8
+#define meshtastic_TrafficManagementStats_no_relay_skips_tag 9
+#define meshtastic_TrafficManagementStats_attestation_promotions_tag 10
+#define meshtastic_TrafficManagementStats_no_relay_gossips_sent_tag 11
+#define meshtastic_TrafficManagementStats_relay_hop_caps_applied_tag 12
 #define meshtastic_HealthMetrics_heart_bpm_tag   1
 #define meshtastic_HealthMetrics_spO2_tag        2
 #define meshtastic_HealthMetrics_temperature_tag 3
@@ -784,14 +838,23 @@ extern "C" {
 #define meshtastic_SEN6XState_voc_state_array_tag 6
 
 /* Struct field encoding specification for nanopb */
+#define meshtastic_TopSender_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, UINT32,   node,              1) \
+X(a, STATIC,   SINGULAR, UINT32,   packets_this_window,   2) \
+X(a, STATIC,   SINGULAR, UINT32,   rssi_class,        3)
+#define meshtastic_TopSender_CALLBACK NULL
+#define meshtastic_TopSender_DEFAULT NULL
+
 #define meshtastic_DeviceMetrics_FIELDLIST(X, a) \
 X(a, STATIC,   OPTIONAL, UINT32,   battery_level,     1) \
 X(a, STATIC,   OPTIONAL, FLOAT,    voltage,           2) \
 X(a, STATIC,   OPTIONAL, FLOAT,    channel_utilization,   3) \
 X(a, STATIC,   OPTIONAL, FLOAT,    air_util_tx,       4) \
-X(a, STATIC,   OPTIONAL, UINT32,   uptime_seconds,    5)
+X(a, STATIC,   OPTIONAL, UINT32,   uptime_seconds,    5) \
+X(a, STATIC,   REPEATED, MESSAGE,  top_senders,       6)
 #define meshtastic_DeviceMetrics_CALLBACK NULL
 #define meshtastic_DeviceMetrics_DEFAULT NULL
+#define meshtastic_DeviceMetrics_top_senders_MSGTYPE meshtastic_TopSender
 
 #define meshtastic_EnvironmentMetrics_FIELDLIST(X, a) \
 X(a, STATIC,   OPTIONAL, FLOAT,    temperature,       1) \
@@ -913,7 +976,12 @@ X(a, STATIC,   SINGULAR, UINT32,   nodeinfo_cache_hits,   3) \
 X(a, STATIC,   SINGULAR, UINT32,   rate_limit_drops,   4) \
 X(a, STATIC,   SINGULAR, UINT32,   unknown_packet_drops,   5) \
 X(a, STATIC,   SINGULAR, UINT32,   hop_exhausted_packets,   6) \
-X(a, STATIC,   SINGULAR, UINT32,   router_hops_preserved,   7)
+X(a, STATIC,   SINGULAR, UINT32,   router_hops_preserved,   7) \
+X(a, STATIC,   SINGULAR, UINT32,   probation_budget_drops,   8) \
+X(a, STATIC,   SINGULAR, UINT32,   no_relay_skips,    9) \
+X(a, STATIC,   SINGULAR, UINT32,   attestation_promotions,  10) \
+X(a, STATIC,   SINGULAR, UINT32,   no_relay_gossips_sent,  11) \
+X(a, STATIC,   SINGULAR, UINT32,   relay_hop_caps_applied,  12)
 #define meshtastic_TrafficManagementStats_CALLBACK NULL
 #define meshtastic_TrafficManagementStats_DEFAULT NULL
 
@@ -989,6 +1057,7 @@ X(a, STATIC,   OPTIONAL, FIXED64,  voc_state_array,   6)
 #define meshtastic_SEN6XState_CALLBACK NULL
 #define meshtastic_SEN6XState_DEFAULT NULL
 
+extern const pb_msgdesc_t meshtastic_TopSender_msg;
 extern const pb_msgdesc_t meshtastic_DeviceMetrics_msg;
 extern const pb_msgdesc_t meshtastic_EnvironmentMetrics_msg;
 extern const pb_msgdesc_t meshtastic_PowerMetrics_msg;
@@ -1004,6 +1073,7 @@ extern const pb_msgdesc_t meshtastic_SEN5XState_msg;
 extern const pb_msgdesc_t meshtastic_SEN6XState_msg;
 
 /* Defines for backwards compatibility with code written before nanopb-0.4.0 */
+#define meshtastic_TopSender_fields &meshtastic_TopSender_msg
 #define meshtastic_DeviceMetrics_fields &meshtastic_DeviceMetrics_msg
 #define meshtastic_EnvironmentMetrics_fields &meshtastic_EnvironmentMetrics_msg
 #define meshtastic_PowerMetrics_fields &meshtastic_PowerMetrics_msg
@@ -1022,7 +1092,7 @@ extern const pb_msgdesc_t meshtastic_SEN6XState_msg;
 #define MESHTASTIC_MESHTASTIC_TELEMETRY_PB_H_MAX_SIZE meshtastic_Telemetry_size
 #define meshtastic_AS3935Config_size             6
 #define meshtastic_AirQualityMetrics_size        157
-#define meshtastic_DeviceMetrics_size            27
+#define meshtastic_DeviceMetrics_size            87
 #define meshtastic_EnvironmentMetrics_size       222
 #define meshtastic_HealthMetrics_size            11
 #define meshtastic_HostMetrics_size              264
@@ -1032,7 +1102,8 @@ extern const pb_msgdesc_t meshtastic_SEN6XState_msg;
 #define meshtastic_SEN5XState_size               27
 #define meshtastic_SEN6XState_size               27
 #define meshtastic_Telemetry_size                272
-#define meshtastic_TrafficManagementStats_size   42
+#define meshtastic_TopSender_size                18
+#define meshtastic_TrafficManagementStats_size   72
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/modules/Telemetry/DeviceTelemetry.cpp
+++ b/src/modules/Telemetry/DeviceTelemetry.cpp
@@ -16,6 +16,9 @@
 #include <OLEDDisplay.h>
 #include <OLEDDisplayUi.h>
 #include <meshUtils.h>
+#if HAS_TRAFFIC_MANAGEMENT
+#include "modules/TrafficManagementModule.h"
+#endif
 
 #define MAGIC_USB_BATTERY_LEVEL 101
 static constexpr uint16_t TX_HISTORY_KEY_DEVICE_TELEMETRY = 0x8001;
@@ -58,6 +61,14 @@ bool DeviceTelemetryModule::handleReceivedProtobuf(const meshtastic_MeshPacket &
                  t->variant.device_metrics.battery_level, t->variant.device_metrics.voltage);
 #endif
         nodeDB->updateTelemetry(getFrom(&mp), *t, RX_SRC_RADIO);
+#if HAS_TRAFFIC_MANAGEMENT
+        // Antispam L1 (M4): ingest the neighbor's top-sender rate observations
+        // as budget samples (median-of-neighbors feeds the local rate budget).
+        // No-op when budget gossip is off.
+        if (trafficManagementModule)
+            trafficManagementModule->ingestNeighborTopSenders(getFrom(&mp), t->variant.device_metrics.top_senders,
+                                                              t->variant.device_metrics.top_senders_count);
+#endif
     }
     return false; // Let others look at this message also if they want
 }
@@ -116,6 +127,22 @@ meshtastic_Telemetry DeviceTelemetryModule::getDeviceTelemetry()
         t.variant.device_metrics.voltage = batteryMv / 1000.0f;
     }
     t.variant.device_metrics.uptime_seconds = Time::getUptimeSecs();
+#if HAS_TRAFFIC_MANAGEMENT
+    // Antispam L1 (M4): advertise our top-3 senders (observed rate + RSSI
+    // class) on the periodic device-telemetry broadcast so neighbors can
+    // compute a median budget for each sender.
+    if (trafficManagementModule) {
+        meshtastic_TopSender top[TrafficManagementModule::kTopSendersCount];
+        trafficManagementModule->snapshotTopSenders(top);
+        t.variant.device_metrics.top_senders_count = 0;
+        for (uint16_t i = 0; i < TrafficManagementModule::kTopSendersCount; i++) {
+            if (top[i].node == 0)
+                continue;
+            t.variant.device_metrics.top_senders[t.variant.device_metrics.top_senders_count] = top[i];
+            t.variant.device_metrics.top_senders_count++;
+        }
+    }
+#endif
     return t;
 }
 

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -1754,7 +1754,12 @@ bool TrafficManagementModule::isRateLimited(NodeNum from, uint32_t nowMs)
         entry->setRateCount(static_cast<uint8_t>(currentCount + 1));
 
     // Threshold capped at 60 so a saturated reading (63) always exceeds it.
-    uint32_t threshold = moduleConfig.traffic_management.rate_limit_max_packets;
+    // F4.2: when budget gossip is on, the gossiped neighborhood median
+    // (effectiveRateThresholdLocked; we hold cacheLock) replaces the raw
+    // config value; config stays the floor the median can never drop below.
+    uint32_t threshold = moduleConfig.traffic_management.budget_gossip_enabled
+                             ? effectiveRateThresholdLocked(from)
+                             : moduleConfig.traffic_management.rate_limit_max_packets;
     if (threshold > 60)
         threshold = 60;
 
@@ -1974,6 +1979,120 @@ uint8_t TrafficManagementModule::rssiClassOf(const meshtastic_MeshPacket &mp)
     return 0;
 }
 
+uint32_t TrafficManagementModule::effectiveRateThreshold(NodeNum sender) const
+{
+    concurrency::LockGuard guard(&cacheLock);
+    return effectiveRateThresholdLocked(sender);
+}
+
+uint32_t TrafficManagementModule::effectiveRateThresholdLocked(NodeNum sender) const
+{
+    const auto &cfg = moduleConfig.traffic_management;
+    uint32_t threshold = cfg.rate_limit_max_packets;
+    if (threshold == 0)
+        return 0;
+    if (cfg.budget_gossip_enabled == 0)
+        return threshold;
+
+    uint32_t median = 0;
+    int tracked = -1;
+    {
+        const AntispamEntry *entry = findAntispamEntry(sender, nullptr);
+        if (!entry)
+            return threshold;
+        tracked = 0;
+        // Median of up to 3 samples: sort a local copy and take the middle.
+        uint8_t samples[3];
+        const uint8_t n = std::min<uint8_t>(3, entry->budgetSampleCount);
+        for (uint8_t i = 0; i < 3; i++)
+            samples[i] = (i < n) ? entry->budgetSamples[i] : 0;
+        for (uint8_t i = 0; i < 3; i++)
+            for (uint8_t j = i + 1; j < 3; j++)
+                if (samples[j] < samples[i])
+                    std::swap(samples[i], samples[j]);
+        if (n >= 2)
+            median = samples[1]; // middle of the sorted set
+
+        // F4.3: a sender observed in a flagged (channel, rssiClass) group
+        // gets the group's split budget instead of the full local one.
+        if (isInFlaggedGroupLocked(entry->channel, entry->rssiClass)) {
+            const uint32_t groupBudget = groupBudgetLocked(entry->channel, entry->rssiClass);
+            if (groupBudget > 0 && groupBudget < threshold)
+                threshold = groupBudget;
+        }
+    }
+    if (median > threshold) {
+        // The neighborhood is seeing this sender outpace the local budget:
+        // clamp the effective threshold to the gossiped median. (The median
+        // can never lower it below the local config - config is the floor.)
+        threshold = median;
+    }
+    (void)tracked;
+    return threshold;
+}
+
+void TrafficManagementModule::ingestNeighborTopSenders(NodeNum neighbor, const meshtastic_TopSender *entries, pb_size_t count)
+{
+    if (neighbor == 0 || !entries || count == 0)
+        return;
+    if (moduleConfig.traffic_management.budget_gossip_enabled == 0)
+        return;
+
+    concurrency::LockGuard guard(&cacheLock);
+    for (pb_size_t i = 0; i < count; i++) {
+        const meshtastic_TopSender &s = entries[i];
+        if (s.node == 0 || s.node == neighbor)
+            continue; // 0 = unused slot; self-reports don't inform a median
+        AntispamEntry *entry = findAntispamEntry(s.node, nullptr);
+        if (!entry)
+            continue;
+        // One sample per (neighbor, subject, window): if this neighbor
+        // already contributed a sample for this subject, refresh it in place
+        // instead of double-counting.
+        bool recorded = false;
+        for (uint8_t k = 0; k < 3; k++) {
+            if (entry->budgetSampleMark[k] == neighbor) {
+                entry->budgetSamples[k] = static_cast<uint8_t>(std::min<uint32_t>(255, s.packets_this_window));
+                recorded = true;
+                break;
+            }
+        }
+        if (!recorded && entry->budgetSampleCount < 3) {
+            entry->budgetSamples[entry->budgetSampleCount] = static_cast<uint8_t>(std::min<uint32_t>(255, s.packets_this_window));
+            entry->budgetSampleMark[entry->budgetSampleCount] = neighbor;
+            entry->budgetSampleCount++;
+            recorded = true;
+        }
+        if (recorded)
+            TM_LOG_DEBUG("Antispam: budget sample for 0x%08x from 0x%08x: %u pkts (n=%u)", s.node, neighbor,
+                         (unsigned)s.packets_this_window, (unsigned)entry->budgetSampleCount);
+    }
+}
+
+int TrafficManagementModule::peekSenderBudgetForTest(NodeNum sender, uint32_t *medianOut)
+{
+    uint32_t median = 0;
+    {
+        concurrency::LockGuard guard(&cacheLock);
+        const AntispamEntry *entry = findAntispamEntry(sender, nullptr);
+        if (!entry)
+            return -1;
+        uint8_t samples[3];
+        const uint8_t n = std::min<uint8_t>(3, entry->budgetSampleCount);
+        for (uint8_t i = 0; i < 3; i++)
+            samples[i] = (i < n) ? entry->budgetSamples[i] : 0;
+        for (uint8_t i = 0; i < 3; i++)
+            for (uint8_t j = i + 1; j < 3; j++)
+                if (samples[j] < samples[i])
+                    std::swap(samples[i], samples[j]);
+        if (n >= 2)
+            median = samples[1];
+    }
+    if (medianOut)
+        *medianOut = median;
+    return 0;
+}
+
 int TrafficManagementModule::peekProbationStateForTest(NodeNum node)
 {
     const uint8_t windowTicks = probationWindowTicks();
@@ -1987,6 +2106,57 @@ int TrafficManagementModule::peekProbationStateForTest(NodeNum node)
         return 0;
     const uint8_t ageTicks = static_cast<uint8_t>(currentRateTick() - entry->firstSeenTick) & 0x0F;
     return ageTicks < windowTicks ? 1 : 0;
+}
+
+void TrafficManagementModule::snapshotTopSenders(meshtastic_TopSender (&out)[kTopSendersCount]) const
+{
+    for (int i = 0; i < kTopSendersCount; i++)
+        out[i] = meshtastic_TopSender_init_zero;
+
+#if TRAFFIC_MANAGEMENT_CACHE_SIZE == 0
+    return;
+#else
+    // Top-3 by the unified cache's rate-window count, with the antispam
+    // table's rssi class where tracked.
+    struct Cand {
+        NodeNum node;
+        uint8_t count;
+        uint8_t rssiClass;
+    };
+    Cand cands[3] = {{0, 0, 0xFF}, {0, 0, 0xFF}, {0, 0, 0xFF}};
+
+    concurrency::LockGuard guard(&cacheLock);
+    for (uint16_t i = 0; i < cacheSize(); i++) {
+        const UnifiedCacheEntry &e = cache[i];
+        if (e.node == 0)
+            continue;
+        const uint8_t cnt = e.getRateCount();
+        if (cnt == 0)
+            continue;
+        // Insert into the top-3.
+        int slot = -1;
+        for (int k = 0; k < 3; k++) {
+            if (cands[k].count <= cnt) {
+                slot = k;
+                break;
+            }
+        }
+        if (slot < 0)
+            continue;
+        for (int k = 2; k > slot; k--)
+            cands[k] = cands[k - 1];
+        cands[slot].node = e.node;
+        cands[slot].count = cnt;
+        const AntispamEntry *a = findAntispamEntry(e.node, nullptr);
+        cands[slot].rssiClass = a ? a->rssiClass : 0xFF;
+    }
+
+    for (int i = 0; i < 3; i++) {
+        out[i].node = cands[i].node;
+        out[i].packets_this_window = cands[i].count;
+        out[i].rssi_class = cands[i].rssiClass;
+    }
+#endif
 }
 
 uint8_t TrafficManagementModule::relayHopCap(const meshtastic_MeshPacket &mp) const
@@ -2119,6 +2289,106 @@ bool TrafficManagementModule::handleIdAttestation(const meshtastic_MeshPacket &m
         break;
     }
     return true;
+}
+
+bool TrafficManagementModule::observeGroupCooccurrence(NodeNum node, uint8_t channel, uint8_t rssiClass)
+{
+    const uint32_t groupMin = moduleConfig.traffic_management.group_budget_enabled;
+    if (groupMin == 0)
+        return false;
+
+    concurrency::LockGuard guard(&cacheLock);
+    // Find or create the cell for (channel, rssiClass, current window).
+    GroupObsCell *cell = nullptr;
+    uint16_t cellIdx = 0;
+    for (uint16_t i = 0; i < kGroupObsEntries; i++) {
+        const bool sameWindow = groupObs[i].windowTick == currentRateTick();
+        if (!sameWindow)
+            continue;
+        if (groupObs[i].channel == channel && groupObs[i].rssiClass == rssiClass) {
+            cell = &groupObs[i];
+            cellIdx = i;
+            break;
+        }
+        if (!cell) {
+            cell = &groupObs[i]; // reuse a same-window cell of a different class? No -
+            cell = nullptr;      // only same (channel,class) cells accumulate.
+        }
+    }
+    if (!cell) {
+        // Find a free (zeroed) cell or evict the stalest.
+        for (uint16_t i = 0; i < kGroupObsEntries; i++) {
+            if (groupObs[i].windowTick == 0) {
+                cell = &groupObs[i];
+                cellIdx = i;
+                break;
+            }
+            if (!cell || groupObs[i].windowTick < cell->windowTick) {
+                cell = &groupObs[i];
+                cellIdx = i;
+            }
+        }
+        if (!cell)
+            return false;
+        memset(cell, 0, sizeof(GroupObsCell));
+        cell->channel = channel;
+        cell->rssiClass = rssiClass;
+        cell->windowTick = currentRateTick();
+        groupMedian[cellIdx] = 0;
+    }
+
+    cell->freshCount++;
+    // Budget: split one rate_limit_max_packets across the group.
+    const uint32_t localBudget = moduleConfig.traffic_management.rate_limit_max_packets;
+    if (cell->freshCount >= groupMin && localBudget > 0) {
+        const uint32_t perMember = std::max<uint32_t>(1, localBudget / cell->freshCount);
+        if (!cell->flagged) {
+            cell->flagged = true;
+            groupMedian[cellIdx] = perMember;
+            TM_LOG_INFO("Antispam: group budget triggered (ch=%u rssi=%u, %u fresh ids) -> %u pkts/member", channel,
+                        (unsigned)rssiClass, (unsigned)cell->freshCount, (unsigned)perMember);
+        }
+    }
+    (void)node;
+    return cell->flagged;
+}
+
+bool TrafficManagementModule::isInFlaggedGroup(NodeNum node, uint8_t channel, uint8_t rssiClass) const
+{
+    (void)node; // membership is by (channel, rssiClass) cell, not per-node lookup
+    concurrency::LockGuard guard(&cacheLock);
+    return isInFlaggedGroupLocked(channel, rssiClass);
+}
+
+bool TrafficManagementModule::isInFlaggedGroupLocked(uint8_t channel, uint8_t rssiClass) const
+{
+    for (uint16_t i = 0; i < kGroupObsEntries; i++) {
+        if (groupObs[i].windowTick == currentRateTick() && groupObs[i].channel == channel && groupObs[i].rssiClass == rssiClass &&
+            groupObs[i].flagged) {
+            // The flagged group's median is applied to every member.
+            return groupMedian[i] > 0;
+        }
+    }
+    return false;
+}
+
+uint32_t TrafficManagementModule::groupBudgetLocked(uint8_t channel, uint8_t rssiClass) const
+{
+    for (uint16_t i = 0; i < kGroupObsEntries; i++) {
+        if (groupObs[i].windowTick == currentRateTick() && groupObs[i].channel == channel && groupObs[i].rssiClass == rssiClass)
+            return groupMedian[i];
+    }
+    return 0;
+}
+
+uint32_t TrafficManagementModule::groupBudgetForTest(uint8_t channel, uint8_t rssiClass)
+{
+    concurrency::LockGuard guard(&cacheLock);
+    for (uint16_t i = 0; i < kGroupObsEntries; i++) {
+        if (groupObs[i].windowTick == currentRateTick() && groupObs[i].channel == channel && groupObs[i].rssiClass == rssiClass)
+            return groupMedian[i];
+    }
+    return 0;
 }
 
 // =============================================================================

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -9,6 +9,7 @@
 #include "PositionPrecision.h"
 #include "Router.h"
 #include "TypeConversions.h"
+#include "UptimeClock.h"
 #include "airtime.h"
 #include "concurrency/LockGuard.h"
 #include "configuration.h"
@@ -160,6 +161,10 @@ TrafficManagementModule::TrafficManagementModule() : MeshModule("TrafficManageme
     memaudit::set("tmm", cache ? allocSize * sizeof(UnifiedCacheEntry) : 0);
 #endif // TRAFFIC_MANAGEMENT_CACHE_SIZE > 0
 
+#if TRAFFIC_MANAGEMENT_CACHE_SIZE > 0
+    initAntispamCache();
+#endif
+
 #if TMM_HAS_NODEINFO_CACHE
     TM_LOG_INFO("Allocating NodeInfo cache: %u entries, %u bytes (flat array)", static_cast<unsigned>(nodeInfoTargetEntries()),
                 static_cast<unsigned>(nodeInfoTargetEntries() * sizeof(NodeInfoPayloadEntry)));
@@ -200,6 +205,14 @@ TrafficManagementModule::~TrafficManagementModule()
         cache = nullptr;
     }
     memaudit::set("tmm", 0);
+    if (antispam) {
+        if (antispamFromPsram)
+            free(antispam);
+        else
+            delete[] antispam;
+        antispam = nullptr;
+    }
+    memaudit::set("tmm_antispam", 0);
 #endif
 
     if (nodeInfoPayload) {
@@ -225,6 +238,12 @@ meshtastic_TrafficManagementStats TrafficManagementModule::getStats() const
 void TrafficManagementModule::incrementStat(uint32_t *field)
 {
     concurrency::LockGuard guard(&cacheLock);
+    (*field)++;
+}
+
+void TrafficManagementModule::incrementStatLocked(uint32_t *field) const
+{
+    // Caller holds cacheLock - taking it here would deadlock (non-recursive Lock).
     (*field)++;
 }
 
@@ -279,6 +298,11 @@ void TrafficManagementModule::purgeNode(NodeNum node)
         memset(entry, 0, sizeof(UnifiedCacheEntry));
         purged = true;
     }
+    AntispamEntry *a = findAntispamEntry(node, nullptr);
+    if (a) {
+        memset(a, 0, sizeof(AntispamEntry));
+        purged = true;
+    }
 #endif
     // No NodeInfo-cache guard needed: without the cache this is a no-op stub returning null.
     NodeInfoPayloadEntry *info = findNodeInfoEntryMutable(node);
@@ -302,6 +326,8 @@ void TrafficManagementModule::purgeAll()
 #if TRAFFIC_MANAGEMENT_CACHE_SIZE > 0
     if (cache)
         memset(cache, 0, static_cast<size_t>(cacheSize()) * sizeof(UnifiedCacheEntry));
+    if (antispam)
+        memset(antispam, 0, static_cast<size_t>(antispamCacheSize()) * sizeof(AntispamEntry));
 #endif
     // nodeInfoPayload stays nullptr on builds without the NodeInfo cache; no guard needed.
     if (nodeInfoPayload)
@@ -1034,6 +1060,8 @@ void TrafficManagementModule::flushCache()
 #if TRAFFIC_MANAGEMENT_CACHE_SIZE > 0
     TM_LOG_DEBUG("Flushing cache");
     memset(cache, 0, static_cast<size_t>(cacheSize()) * sizeof(UnifiedCacheEntry));
+    if (antispam)
+        memset(antispam, 0, static_cast<size_t>(antispamCacheSize()) * sizeof(AntispamEntry));
 #endif
 }
 
@@ -1175,6 +1203,37 @@ ProcessMessage TrafficManagementModule::handleReceived(const meshtastic_MeshPack
                     return ProcessMessage::STOP; // Consumed - throttled packet will not be rebroadcast
                 }
             }
+        }
+
+        // ---------------------------------------------------------------------
+        // Antispam L1 (M2 greylist + M6 relay pricing)
+        // ---------------------------------------------------------------------
+        // Stamped after the rate limiter so an attestation flood pays the same
+        // per-sender cost as any other traffic.
+        if (noteFirstSeen(mp.from, static_cast<uint8_t>(mp.channel), rssiClassOf(mp))) {
+            // F4.3: this ID is fresh on this device - observe its
+            // (channel, RSSI class) co-occurrence. A cell that fills to
+            // group_budget_enabled fresh IDs is flagged, and every member
+            // gets a split budget.
+            observeGroupCooccurrence(mp.from, static_cast<uint8_t>(mp.channel), rssiClassOf(mp));
+        }
+        if (mp.decoded.portnum == meshtastic_PortNum_ID_ATTESTATION_APP) {
+            // Promotion / NO_RELAY applied; no other module serves this portnum.
+            if (handleIdAttestation(mp)) {
+                logAction("consume", &mp, "id-attestation");
+                ignoreRequest = true;        // Suppress NAK
+                return ProcessMessage::STOP; // Consumed - not surfaced to clients
+            }
+        }
+
+        // M2 vouch: traffic from a locally established (tracked, out of
+        // probation, or promoted) sender on a long-tenured device gets a
+        // rate-capped KNOWN_SINCE, so neighbors that first saw the ID can
+        // promote it instead of waiting out their timers. One per hour.
+        if (cfg.probation_window_secs > 0 && uptimeSecs() >= cfg.attestation_min_tenure_secs &&
+            isEstablishedForVouching(mp.from) && (nowMs - lastVouchSentMs) > 3'600'000UL) {
+            lastVouchSentMs = nowMs;
+            sendKnownSinceGossip(mp.from);
         }
     }
 
@@ -1329,6 +1388,10 @@ int32_t TrafficManagementModule::runOnce()
     TM_LOG_TRACE("Maintenance: %u active, %u expired, %u/%u slots, %lums elapsed", activeEntries, expiredEntries,
                  static_cast<unsigned>(activeEntries), static_cast<unsigned>(cacheSize()),
                  static_cast<unsigned long>(TrafficManagementModule::clockMs() - sweepStartMs));
+
+    // Antispam L1: budget-sample rollover, probation-expiry reclamation, and
+    // group co-occurrence cell expiry. Runs under cacheLock (held above).
+    maintainAntispamLocked();
 
 #endif // TRAFFIC_MANAGEMENT_CACHE_SIZE > 0
 
@@ -1767,6 +1830,363 @@ void TrafficManagementModule::logAction(const char *action, const meshtastic_Mes
     } else {
         TM_LOG_INFO("%s encrypted from=0x%08x to=0x%08x hop=%d/%d reason=%s", action, getFrom(p), p->to, p->hop_limit,
                     p->hop_start, reason);
+    }
+}
+
+// =============================================================================
+// Antispam L1 (M2 greylist + M4 gossiped budgets + M6 relay pricing)
+//
+// Design doc: meshtastic-decentralized-antispam.md. State lives in a second
+// flat per-node table (AntispamEntry) allocated alongside the unified cache;
+// it is intentionally NOT packed into the 10-byte UnifiedCacheEntry because
+// the windowed relayed-for counter and the 3-sample budget median need real
+// fields, not bits. Every knob is config-gated and off by default except
+// probation accounting (F2.1), which only records state.
+// =============================================================================
+
+TrafficManagementModule::AntispamEntry *TrafficManagementModule::findAntispamEntry(NodeNum node, bool *isNew) const
+{
+#if TRAFFIC_MANAGEMENT_CACHE_SIZE == 0
+    (void)node;
+    (void)isNew;
+    return nullptr;
+#else
+    if (!antispam || node == 0)
+        return nullptr;
+
+    const uint16_t size = antispamCacheSize();
+    for (uint16_t i = 0; i < size; i++) {
+        if (antispam[i].node == node) {
+            if (isNew)
+                *isNew = false;
+            return &antispam[i];
+        }
+    }
+    if (isNew)
+        *isNew = true;
+    // No free slot: evict the entry with the oldest first-seen stamp (or any
+    // zeroed slot). Linear scan is fine - the table is small (<=256) and this
+    // runs once per new node.
+    AntispamEntry *victim = nullptr;
+    for (uint16_t i = 0; i < size; i++) {
+        if (antispam[i].node == 0) {
+            victim = &antispam[i];
+            break;
+        }
+        if (!victim || antispam[i].firstSeenTick < victim->firstSeenTick)
+            victim = &antispam[i];
+    }
+    if (!victim)
+        return nullptr;
+    memset(victim, 0, sizeof(AntispamEntry));
+    victim->node = node;
+    return victim;
+#endif
+}
+
+uint32_t TrafficManagementModule::uptimeSecs() const
+{
+    if (s_testUptimeSecs != 0xFFFFFFFFu)
+        return s_testUptimeSecs;
+    return Time::getUptimeSecs();
+}
+
+uint8_t TrafficManagementModule::probationWindowTicks() const
+{
+    const uint32_t secs = moduleConfig.traffic_management.probation_window_secs;
+    if (secs == 0)
+        return 0; // probation accounting off
+    // Quantise to the 5-min budget tick; a sub-tick window still gets 1 tick.
+    return static_cast<uint8_t>(std::min<uint32_t>(15, (secs + (kRateTimeTickMs / 1000) - 1) / (kRateTimeTickMs / 1000)));
+}
+
+bool TrafficManagementModule::inProbation(NodeNum node) const
+{
+    if (node == 0)
+        return false;
+    const uint8_t windowTicks = probationWindowTicks();
+    if (windowTicks == 0)
+        return false;
+
+    concurrency::LockGuard guard(&cacheLock);
+    const AntispamEntry *entry = findAntispamEntry(node, nullptr);
+    if (!entry || entry->firstSeenTick == 0 || entry->promoted)
+        return false;
+    const uint8_t ageTicks = static_cast<uint8_t>(currentRateTick() - entry->firstSeenTick) & 0x0F;
+    return ageTicks < windowTicks;
+}
+
+bool TrafficManagementModule::isEstablishedForVouching(NodeNum node) const
+{
+    if (node == 0 || moduleConfig.traffic_management.probation_window_secs == 0)
+        return false;
+    concurrency::LockGuard guard(&cacheLock);
+    const AntispamEntry *entry = findAntispamEntry(node, nullptr);
+    if (!entry || entry->firstSeenTick == 0)
+        return false;
+    if (entry->promoted)
+        return true;
+    // Same probation math as inProbation(), inlined to avoid the second lock.
+    const uint8_t windowTicks = probationWindowTicks();
+    const uint8_t ageTicks = static_cast<uint8_t>(currentRateTick() - entry->firstSeenTick) & 0x0F;
+    return ageTicks >= windowTicks;
+}
+
+bool TrafficManagementModule::noteFirstSeen(NodeNum node, uint8_t channel, uint8_t rssiClass)
+{
+    if (node == 0)
+        return false;
+    const uint8_t windowTicks = probationWindowTicks();
+    const uint32_t groupMin = moduleConfig.traffic_management.group_budget_enabled;
+    if (windowTicks == 0 && groupMin == 0)
+        return false; // No antispam accounting active at all.
+
+    concurrency::LockGuard guard(&cacheLock);
+    AntispamEntry *entry = findAntispamEntry(node, nullptr);
+    if (!entry || entry->firstSeenTick != 0)
+        return false; // already tracked (or table full with no eviction target)
+    entry->firstSeenTick = currentRateTick();
+    entry->windowTick = currentRateTick();
+    // F4.3: remember the observation context of a fresh ID so its
+    // (channel, RSSI class) can be matched against the group co-occurrence
+    // cells. Only stamped on first sight - re-observations must not move a
+    // tracked sender into a new group cell.
+    if (groupMin > 0) {
+        entry->channel = channel;
+        entry->rssiClass = rssiClass;
+    }
+    TM_LOG_DEBUG("Antispam: first-seen 0x%08x (probation window %u ticks)", node, windowTicks);
+    return true;
+}
+
+uint8_t TrafficManagementModule::rssiClassOf(const meshtastic_MeshPacket &mp)
+{
+    // 4-class quantization tolerates a noisy RF front end; 0xFF = no reading.
+    if (!mp.has_rx_rssi)
+        return 0xFF;
+    const int rssi = mp.rx_rssi;
+    if (rssi >= -90)
+        return 3;
+    if (rssi >= -100)
+        return 2;
+    if (rssi >= -110)
+        return 1;
+    return 0;
+}
+
+int TrafficManagementModule::peekProbationStateForTest(NodeNum node)
+{
+    const uint8_t windowTicks = probationWindowTicks();
+    concurrency::LockGuard guard(&cacheLock);
+    const AntispamEntry *entry = findAntispamEntry(node, nullptr);
+    if (!entry || entry->firstSeenTick == 0)
+        return -1;
+    if (windowTicks == 0)
+        return 0; // accounting off -> never in probation
+    if (entry->promoted)
+        return 0;
+    const uint8_t ageTicks = static_cast<uint8_t>(currentRateTick() - entry->firstSeenTick) & 0x0F;
+    return ageTicks < windowTicks ? 1 : 0;
+}
+
+uint8_t TrafficManagementModule::relayHopCap(const meshtastic_MeshPacket &mp) const
+{
+    const auto &cfg = moduleConfig.traffic_management;
+    const NodeNum from = getFrom(&mp);
+    if (from == 0 || from == nodeDB->getNodeNum())
+        return mp.hop_limit; // local traffic: never cap
+
+    bool changed = false;
+    uint8_t cap = mp.hop_limit;
+    bool senderInProbation = false;
+
+    // M2: probation cap.
+    const uint8_t probationCap = cfg.probation_max_hop_limit;
+    if (cfg.probation_window_secs > 0) {
+        concurrency::LockGuard guard(&cacheLock);
+        const AntispamEntry *entry = findAntispamEntry(from, nullptr);
+        const uint8_t windowTicks = probationWindowTicks();
+        if (entry && entry->firstSeenTick != 0 && !entry->promoted &&
+            (static_cast<uint8_t>(currentRateTick() - entry->firstSeenTick) & 0x0F) < windowTicks) {
+            senderInProbation = true;
+            if (probationCap > 0 && probationCap < cap) {
+                cap = probationCap;
+                changed = true;
+            }
+        }
+    }
+    // M6: congestion cap (F6.3) - only for L0 (probation) broadcast senders,
+    // and only while the probation machinery is active.
+    if (senderInProbation && cfg.congestion_hop_cap_pct > 0) {
+        const float util = currentCongestionPct();
+        if (util >= static_cast<float>(cfg.congestion_hop_cap_pct)) {
+            if (1 < cap) {
+                cap = 1;
+                changed = true;
+            }
+        }
+    }
+
+    if (changed)
+        incrementStatLocked(&stats.relay_hop_caps_applied);
+    return cap;
+}
+
+bool TrafficManagementModule::sendKnownSinceGossip(NodeNum subject)
+{
+    const auto &cfg = moduleConfig.traffic_management;
+    if (!service || cfg.probation_window_secs == 0)
+        return false;
+    // Vouch only from a long-tenured device (F5.5 analogue for L1).
+    if (uptimeSecs() < cfg.attestation_min_tenure_secs)
+        return false;
+
+    meshtastic_IdAttestation att = meshtastic_IdAttestation_init_zero;
+    att.kind = meshtastic_IdAttestation_Kind_KNOWN_SINCE;
+    att.subject = subject;
+    // Wall-clock first-seen for the subject, if we can read it; 0 = "no clock".
+    if (nodeDB) {
+        meshtastic_NodeInfoLite *info = nodeDB->getMeshNode(subject);
+        if (info) {
+            // NodeInfoLite has no first_heard today; use last_heard as a proxy
+            // for "when we saw this ID" - good enough for the tenure floor.
+            att.known_since_secs = info->last_heard;
+        }
+    }
+    att.attester_tenure_secs = uptimeSecs();
+
+    meshtastic_MeshPacket *p = router ? router->allocForSending() : nullptr;
+    if (!p)
+        return false;
+    p->to = NODENUM_BROADCAST;
+    p->decoded.portnum = meshtastic_PortNum_ID_ATTESTATION_APP;
+    p->decoded.payload.size =
+        pb_encode_to_bytes(p->decoded.payload.bytes, sizeof(p->decoded.payload.bytes), &meshtastic_IdAttestation_msg, &att);
+    p->decoded.want_response = false;
+    p->hop_limit = 2; // two hops: vouching is neighborhood-scoped
+    p->hop_start = 2;
+    p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
+    p->want_ack = false;
+    service->sendToMesh(p); // sendToMesh takes ownership of p
+    return true;
+}
+
+bool TrafficManagementModule::handleIdAttestation(const meshtastic_MeshPacket &mp)
+{
+    const auto &cfg = moduleConfig.traffic_management;
+    meshtastic_IdAttestation att = meshtastic_IdAttestation_init_zero;
+    if (mp.decoded.payload.size == 0 ||
+        !pb_decode_from_bytes(mp.decoded.payload.bytes, mp.decoded.payload.size, &meshtastic_IdAttestation_msg, &att))
+        return true; // consumed; undecodable
+
+    const NodeNum attester = getFrom(&mp);
+    if (attester == 0 || att.subject == 0 || att.subject == attester)
+        return true;
+
+    concurrency::LockGuard guard(&cacheLock);
+    AntispamEntry *entry = findAntispamEntry(att.subject, nullptr);
+    if (!entry)
+        return true;
+
+    switch (att.kind) {
+    case meshtastic_IdAttestation_Kind_KNOWN_SINCE: {
+        if (cfg.probation_window_secs == 0)
+            break;
+        // Tenure floor: the attester must be old enough, or its claim is worth nothing.
+        if (att.attester_tenure_secs != 0 && att.attester_tenure_secs < cfg.attestation_min_tenure_secs)
+            break;
+        if (entry->promoted)
+            break;
+        if (entry->firstSeenTick == 0)
+            break; // we have no local probation to shorten
+        entry->promoted = true;
+        incrementStatLocked(&stats.attestation_promotions);
+        TM_LOG_INFO("Antispam: promoted 0x%08x via KNOWN_SINCE from 0x%08x (tenure %us)", att.subject, attester,
+                    (unsigned)att.attester_tenure_secs);
+        break;
+    }
+    case meshtastic_IdAttestation_Kind_NO_RELAY: {
+        if (cfg.relay_budget_max_packets == 0)
+            break;
+        if (entry->noRelay)
+            break;
+        entry->noRelay = true;
+        entry->noRelayLocal = false; // gossiped, not local -> we never re-gossip it
+        TM_LOG_INFO("Antispam: NO_RELAY for 0x%08x gossiped by 0x%08x", att.subject, attester);
+        break;
+    }
+    default:
+        break;
+    }
+    return true;
+}
+
+// =============================================================================
+// Antispam L1: cache lifecycle
+// =============================================================================
+
+#if TRAFFIC_MANAGEMENT_CACHE_SIZE > 0
+void TrafficManagementModule::initAntispamCache()
+{
+    if (antispam)
+        return;
+    const uint16_t size = antispamCacheSize();
+    if (size == 0)
+        return;
+#if defined(ARCH_ESP32) && defined(BOARD_HAS_PSRAM)
+    antispam = static_cast<AntispamEntry *>(ps_calloc(size, sizeof(AntispamEntry)));
+    if (antispam) {
+        antispamFromPsram = true;
+    } else {
+        TM_LOG_WARN("Antispam PSRAM alloc failed, falling back to heap");
+        antispam = new AntispamEntry[size]();
+    }
+#else
+    antispam = new AntispamEntry[size]();
+#endif
+    TM_LOG_DEBUG("Antispam cache: %u entries (%u bytes)", (unsigned)size, (unsigned)(size * sizeof(AntispamEntry)));
+}
+#endif
+
+// =============================================================================
+// Antispam L1: maintenance sweep (called from runOnce under cacheLock)
+// =============================================================================
+
+void TrafficManagementModule::maintainAntispamLocked()
+{
+    const uint8_t nowRateTick = currentRateTick();
+    for (uint16_t i = 0; i < antispamCacheSize(); i++) {
+        AntispamEntry &e = antispam[i];
+        if (e.node == 0)
+            continue;
+        // Window rollover: reset the windowed counters and any gossiped
+        // NO_RELAY bit (it was scoped to one budget window).
+        if (e.windowTick != 0 && static_cast<uint8_t>(nowRateTick - e.windowTick) & 0x0F >= 1) {
+            e.windowTick = nowRateTick;
+            e.relayedCount = 0;
+            e.noRelay = false;
+            e.noRelayLocal = false;
+            e.budgetSampleCount = 0;
+            for (uint8_t k = 0; k < 3; k++) {
+                e.budgetSamples[k] = 0;
+                e.budgetSampleMark[k] = 0;
+            }
+        }
+        // Probation expiry: an entry whose first-seen window has fully aged
+        // out is stale; reclaim the slot (a re-observed node re-stamps it).
+        const uint8_t windowTicks = probationWindowTicks();
+        if (windowTicks > 0 && e.firstSeenTick != 0 && !e.promoted) {
+            const uint8_t ageTicks = static_cast<uint8_t>(nowRateTick - e.firstSeenTick) & 0x0F;
+            if (ageTicks >= windowTicks)
+                memset(&e, 0, sizeof(AntispamEntry));
+        }
+    }
+    // Group co-occurrence cells: clear any whose window tick has rolled.
+    for (uint16_t i = 0; i < kGroupObsEntries; i++) {
+        if (groupObs[i].windowTick != 0 && static_cast<uint8_t>(nowRateTick - groupObs[i].windowTick) & 0x0F >= 1) {
+            memset(&groupObs[i], 0, sizeof(GroupObsCell));
+            groupMedian[i] = 0;
+        }
     }
 }
 

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -8,6 +8,7 @@
 #include "NodeDB.h"
 #include "PositionPrecision.h"
 #include "Router.h"
+#include "Throttle.h"
 #include "TypeConversions.h"
 #include "UptimeClock.h"
 #include "airtime.h"
@@ -1230,8 +1231,10 @@ ProcessMessage TrafficManagementModule::handleReceived(const meshtastic_MeshPack
         // probation, or promoted) sender on a long-tenured device gets a
         // rate-capped KNOWN_SINCE, so neighbors that first saw the ID can
         // promote it instead of waiting out their timers. One per hour.
+        // lastVouchSentMs == 0 means "never vouched yet" (cold start): allow
+        // the first vouch immediately instead of waiting an hour of uptime.
         if (cfg.probation_window_secs > 0 && uptimeSecs() >= cfg.attestation_min_tenure_secs &&
-            isEstablishedForVouching(mp.from) && (nowMs - lastVouchSentMs) > 3'600'000UL) {
+            isEstablishedForVouching(mp.from) && (lastVouchSentMs == 0 || Throttle::hasElapsed(lastVouchSentMs, 3'600'000UL))) {
             lastVouchSentMs = nowMs;
             sendKnownSinceGossip(mp.from);
         }

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -1979,6 +1979,13 @@ uint8_t TrafficManagementModule::rssiClassOf(const meshtastic_MeshPacket &mp)
     return 0;
 }
 
+float TrafficManagementModule::currentCongestionPct() const
+{
+    if (s_testCongestionPct >= 0)
+        return static_cast<float>(s_testCongestionPct);
+    return airTime ? airTime->channelUtilizationPercent() : 0.0f;
+}
+
 uint32_t TrafficManagementModule::effectiveRateThreshold(NodeNum sender) const
 {
     concurrency::LockGuard guard(&cacheLock);
@@ -2108,6 +2115,20 @@ int TrafficManagementModule::peekProbationStateForTest(NodeNum node)
     return ageTicks < windowTicks ? 1 : 0;
 }
 
+uint32_t TrafficManagementModule::peekRelayedCountForTest(NodeNum node)
+{
+    concurrency::LockGuard guard(&cacheLock);
+    const AntispamEntry *entry = findAntispamEntry(node, nullptr);
+    return entry ? entry->relayedCount : 0;
+}
+
+bool TrafficManagementModule::peekNoRelayForTest(NodeNum node)
+{
+    concurrency::LockGuard guard(&cacheLock);
+    const AntispamEntry *entry = findAntispamEntry(node, nullptr);
+    return entry && entry->noRelay;
+}
+
 void TrafficManagementModule::snapshotTopSenders(meshtastic_TopSender (&out)[kTopSendersCount]) const
 {
     for (int i = 0; i < kTopSendersCount; i++)
@@ -2159,6 +2180,24 @@ void TrafficManagementModule::snapshotTopSenders(meshtastic_TopSender (&out)[kTo
 #endif
 }
 
+bool TrafficManagementModule::shouldRelay(const meshtastic_MeshPacket &mp) const
+{
+    const auto &cfg = moduleConfig.traffic_management;
+    if (cfg.relay_budget_max_packets == 0)
+        return true; // relay budget disabled -> unlimited relaying
+    const NodeNum from = getFrom(&mp);
+    if (from == 0 || from == nodeDB->getNodeNum())
+        return true; // unknown or local sender: normal policy
+
+    concurrency::LockGuard guard(&cacheLock);
+    const AntispamEntry *entry = findAntispamEntry(from, nullptr);
+    if (entry && entry->noRelay) {
+        incrementStatLocked(&stats.no_relay_skips);
+        return false;
+    }
+    return true;
+}
+
 uint8_t TrafficManagementModule::relayHopCap(const meshtastic_MeshPacket &mp) const
 {
     const auto &cfg = moduleConfig.traffic_management;
@@ -2200,6 +2239,66 @@ uint8_t TrafficManagementModule::relayHopCap(const meshtastic_MeshPacket &mp) co
     if (changed)
         incrementStatLocked(&stats.relay_hop_caps_applied);
     return cap;
+}
+
+void TrafficManagementModule::recordRelayed(const meshtastic_MeshPacket &mp)
+{
+    const auto &cfg = moduleConfig.traffic_management;
+    if (cfg.relay_budget_max_packets == 0)
+        return;
+    const NodeNum from = getFrom(&mp);
+    if (from == 0 || from == nodeDB->getNodeNum())
+        return;
+    // Reliability machinery is exempt (F6.1 failure mode (a)).
+    if (mp.want_ack || mp.decoded.portnum == meshtastic_PortNum_ROUTING_APP || mp.decoded.portnum == meshtastic_PortNum_ADMIN_APP)
+        return;
+
+    bool exhausted = false;
+    {
+        concurrency::LockGuard guard(&cacheLock);
+        AntispamEntry *entry = findAntispamEntry(from, nullptr);
+        if (!entry)
+            return;
+        if (entry->noRelay)
+            return; // already exhausted this window
+
+        if (entry->relayedCount < 0x3F)
+            entry->relayedCount++;
+        exhausted = entry->relayedCount >= cfg.relay_budget_max_packets;
+        if (exhausted) {
+            entry->noRelay = true;
+            entry->noRelayLocal = true;
+            TM_LOG_INFO("Antispam: relay budget exhausted for 0x%08x (>=%u), stopping relay this window", from,
+                        (unsigned)cfg.relay_budget_max_packets);
+        }
+    } // lock released before sending (sendToMesh may take other locks)
+    if (exhausted)
+        sendNoRelayGossip(from);
+}
+
+bool TrafficManagementModule::sendNoRelayGossip(NodeNum subject)
+{
+    if (!service)
+        return false;
+    meshtastic_IdAttestation att = meshtastic_IdAttestation_init_zero;
+    att.kind = meshtastic_IdAttestation_Kind_NO_RELAY;
+    att.subject = subject;
+
+    meshtastic_MeshPacket *p = router ? router->allocForSending() : nullptr;
+    if (!p)
+        return false;
+    p->to = NODENUM_BROADCAST;
+    p->decoded.portnum = meshtastic_PortNum_ID_ATTESTATION_APP;
+    p->decoded.payload.size =
+        pb_encode_to_bytes(p->decoded.payload.bytes, sizeof(p->decoded.payload.bytes), &meshtastic_IdAttestation_msg, &att);
+    p->decoded.want_response = false;
+    p->hop_limit = 1; // one hop: this is local-neighborhood gossip
+    p->hop_start = 1;
+    p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
+    p->want_ack = false;
+    incrementStat(&stats.no_relay_gossips_sent);
+    service->sendToMesh(p); // sendToMesh takes ownership of p
+    return true;
 }
 
 bool TrafficManagementModule::sendKnownSinceGossip(NodeNum subject)

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -299,7 +299,7 @@ void TrafficManagementModule::purgeNode(NodeNum node)
         memset(entry, 0, sizeof(UnifiedCacheEntry));
         purged = true;
     }
-    AntispamEntry *a = findAntispamEntry(node, nullptr);
+    AntispamEntry *a = findAntispamEntry(node);
     if (a) {
         memset(a, 0, sizeof(AntispamEntry));
         purged = true;
@@ -1852,15 +1852,44 @@ void TrafficManagementModule::logAction(const char *action, const meshtastic_Mes
 // probation accounting (F2.1), which only records state.
 // =============================================================================
 
-TrafficManagementModule::AntispamEntry *TrafficManagementModule::findAntispamEntry(NodeNum node, bool *isNew) const
+// Read-only lookup: returns the entry for `node` or nullptr. Never allocates
+// and never evicts - a miss costs nothing, which is what read-only callers
+// (probation checks, budget reads, snapshots) rely on.
+TrafficManagementModule::AntispamEntry *TrafficManagementModule::findAntispamEntry(NodeNum node) const
 {
 #if TRAFFIC_MANAGEMENT_CACHE_SIZE == 0
     (void)node;
-    (void)isNew;
     return nullptr;
 #else
     if (!antispam || node == 0)
         return nullptr;
+
+    const uint16_t size = antispamCacheSize();
+    for (uint16_t i = 0; i < size; i++) {
+        if (antispam[i].node == node)
+            return &antispam[i];
+    }
+    return nullptr;
+#endif
+}
+
+// Find or create the entry for `node`, evicting the tracked-longest victim
+// when the table is full. firstSeenTick is a 4-bit wrap value, so victims are
+// ordered by elapsed ticks, (now - firstSeen) mod 16 - a raw < on the ticks
+// misorders entries across the wrap boundary.
+TrafficManagementModule::AntispamEntry *TrafficManagementModule::findOrCreateAntispamEntry(NodeNum node, bool *isNew) const
+{
+#if TRAFFIC_MANAGEMENT_CACHE_SIZE == 0
+    (void)node;
+    if (isNew)
+        *isNew = false;
+    return nullptr;
+#else
+    if (!antispam || node == 0) {
+        if (isNew)
+            *isNew = false;
+        return nullptr;
+    }
 
     const uint16_t size = antispamCacheSize();
     for (uint16_t i = 0; i < size; i++) {
@@ -1876,18 +1905,25 @@ TrafficManagementModule::AntispamEntry *TrafficManagementModule::findAntispamEnt
     // zeroed slot). Linear scan is fine - the table is small (<=256) and this
     // runs once per new node.
     AntispamEntry *victim = nullptr;
+    uint8_t victimElapsed = 0;
     for (uint16_t i = 0; i < size; i++) {
         if (antispam[i].node == 0) {
-            victim = &antispam[i];
+            victim = &antispam[i]; // a zeroed slot always beats any live entry
             break;
         }
-        if (!victim || antispam[i].firstSeenTick < victim->firstSeenTick)
+        const uint8_t elapsed = static_cast<uint8_t>(currentRateTick() - antispam[i].firstSeenTick);
+        if (!victim || elapsed > victimElapsed) {
             victim = &antispam[i];
+            victimElapsed = elapsed;
+        }
     }
     if (!victim)
         return nullptr;
     memset(victim, 0, sizeof(AntispamEntry));
     victim->node = node;
+    // Stamp the entry immediately so it starts out as a maximal-age candidate
+    // and cannot be picked as its own replacement by the next eviction.
+    victim->firstSeenTick = currentRateTick();
     return victim;
 #endif
 }
@@ -1917,7 +1953,7 @@ bool TrafficManagementModule::inProbation(NodeNum node) const
         return false;
 
     concurrency::LockGuard guard(&cacheLock);
-    const AntispamEntry *entry = findAntispamEntry(node, nullptr);
+    const AntispamEntry *entry = findAntispamEntry(node);
     if (!entry || entry->firstSeenTick == 0 || entry->promoted)
         return false;
     const uint8_t ageTicks = static_cast<uint8_t>(currentRateTick() - entry->firstSeenTick) & 0x0F;
@@ -1929,7 +1965,7 @@ bool TrafficManagementModule::isEstablishedForVouching(NodeNum node) const
     if (node == 0 || moduleConfig.traffic_management.probation_window_secs == 0)
         return false;
     concurrency::LockGuard guard(&cacheLock);
-    const AntispamEntry *entry = findAntispamEntry(node, nullptr);
+    const AntispamEntry *entry = findAntispamEntry(node);
     if (!entry || entry->firstSeenTick == 0)
         return false;
     if (entry->promoted)
@@ -1950,9 +1986,12 @@ bool TrafficManagementModule::noteFirstSeen(NodeNum node, uint8_t channel, uint8
         return false; // No antispam accounting active at all.
 
     concurrency::LockGuard guard(&cacheLock);
-    AntispamEntry *entry = findAntispamEntry(node, nullptr);
-    if (!entry || entry->firstSeenTick != 0)
-        return false; // already tracked (or table full with no eviction target)
+    bool isNew = false;
+    AntispamEntry *entry = findOrCreateAntispamEntry(node, &isNew);
+    if (!entry)
+        return false; // table full with no eviction target
+    if (!isNew && entry->firstSeenTick != 0)
+        return false; // already tracked
     entry->firstSeenTick = currentRateTick();
     entry->windowTick = currentRateTick();
     // F4.3: remember the observation context of a fresh ID so its
@@ -2007,7 +2046,7 @@ uint32_t TrafficManagementModule::effectiveRateThresholdLocked(NodeNum sender) c
     uint32_t median = 0;
     int tracked = -1;
     {
-        const AntispamEntry *entry = findAntispamEntry(sender, nullptr);
+        const AntispamEntry *entry = findAntispamEntry(sender);
         if (!entry)
             return threshold;
         tracked = 0;
@@ -2053,7 +2092,8 @@ void TrafficManagementModule::ingestNeighborTopSenders(NodeNum neighbor, const m
         const meshtastic_TopSender &s = entries[i];
         if (s.node == 0 || s.node == neighbor)
             continue; // 0 = unused slot; self-reports don't inform a median
-        AntispamEntry *entry = findAntispamEntry(s.node, nullptr);
+        bool isNew = false;
+        AntispamEntry *entry = findOrCreateAntispamEntry(s.node, &isNew);
         if (!entry)
             continue;
         // One sample per (neighbor, subject, window): if this neighbor
@@ -2084,7 +2124,7 @@ int TrafficManagementModule::peekSenderBudgetForTest(NodeNum sender, uint32_t *m
     uint32_t median = 0;
     {
         concurrency::LockGuard guard(&cacheLock);
-        const AntispamEntry *entry = findAntispamEntry(sender, nullptr);
+        const AntispamEntry *entry = findAntispamEntry(sender);
         if (!entry)
             return -1;
         uint8_t samples[3];
@@ -2107,7 +2147,7 @@ int TrafficManagementModule::peekProbationStateForTest(NodeNum node)
 {
     const uint8_t windowTicks = probationWindowTicks();
     concurrency::LockGuard guard(&cacheLock);
-    const AntispamEntry *entry = findAntispamEntry(node, nullptr);
+    const AntispamEntry *entry = findAntispamEntry(node);
     if (!entry || entry->firstSeenTick == 0)
         return -1;
     if (windowTicks == 0)
@@ -2121,14 +2161,14 @@ int TrafficManagementModule::peekProbationStateForTest(NodeNum node)
 uint32_t TrafficManagementModule::peekRelayedCountForTest(NodeNum node)
 {
     concurrency::LockGuard guard(&cacheLock);
-    const AntispamEntry *entry = findAntispamEntry(node, nullptr);
+    const AntispamEntry *entry = findAntispamEntry(node);
     return entry ? entry->relayedCount : 0;
 }
 
 bool TrafficManagementModule::peekNoRelayForTest(NodeNum node)
 {
     concurrency::LockGuard guard(&cacheLock);
-    const AntispamEntry *entry = findAntispamEntry(node, nullptr);
+    const AntispamEntry *entry = findAntispamEntry(node);
     return entry && entry->noRelay;
 }
 
@@ -2171,7 +2211,7 @@ void TrafficManagementModule::snapshotTopSenders(meshtastic_TopSender (&out)[kTo
             cands[k] = cands[k - 1];
         cands[slot].node = e.node;
         cands[slot].count = cnt;
-        const AntispamEntry *a = findAntispamEntry(e.node, nullptr);
+        const AntispamEntry *a = findAntispamEntry(e.node);
         cands[slot].rssiClass = a ? a->rssiClass : 0xFF;
     }
 
@@ -2193,7 +2233,7 @@ bool TrafficManagementModule::shouldRelay(const meshtastic_MeshPacket &mp) const
         return true; // unknown or local sender: normal policy
 
     concurrency::LockGuard guard(&cacheLock);
-    const AntispamEntry *entry = findAntispamEntry(from, nullptr);
+    const AntispamEntry *entry = findAntispamEntry(from);
     if (entry && entry->noRelay) {
         incrementStatLocked(&stats.no_relay_skips);
         return false;
@@ -2216,7 +2256,7 @@ uint8_t TrafficManagementModule::relayHopCap(const meshtastic_MeshPacket &mp) co
     const uint8_t probationCap = cfg.probation_max_hop_limit;
     if (cfg.probation_window_secs > 0) {
         concurrency::LockGuard guard(&cacheLock);
-        const AntispamEntry *entry = findAntispamEntry(from, nullptr);
+        const AntispamEntry *entry = findAntispamEntry(from);
         const uint8_t windowTicks = probationWindowTicks();
         if (entry && entry->firstSeenTick != 0 && !entry->promoted &&
             (static_cast<uint8_t>(currentRateTick() - entry->firstSeenTick) & 0x0F) < windowTicks) {
@@ -2259,7 +2299,10 @@ void TrafficManagementModule::recordRelayed(const meshtastic_MeshPacket &mp)
     bool exhausted = false;
     {
         concurrency::LockGuard guard(&cacheLock);
-        AntispamEntry *entry = findAntispamEntry(from, nullptr);
+        // Look up the sender's entry without allocating a new one: charging a
+        // relay is a write to an existing entry, not a fresh observation, so a
+        // miss (untracked sender) must not evict a tracked one.
+        AntispamEntry *entry = findAntispamEntry(from);
         if (!entry)
             return;
         if (entry->noRelay)
@@ -2356,7 +2399,7 @@ bool TrafficManagementModule::handleIdAttestation(const meshtastic_MeshPacket &m
         return true;
 
     concurrency::LockGuard guard(&cacheLock);
-    AntispamEntry *entry = findAntispamEntry(att.subject, nullptr);
+    AntispamEntry *entry = findAntispamEntry(att.subject);
     if (!entry)
         return true;
 

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -2583,7 +2583,7 @@ void TrafficManagementModule::maintainAntispamLocked()
             continue;
         // Window rollover: reset the windowed counters and any gossiped
         // NO_RELAY bit (it was scoped to one budget window).
-        if (e.windowTick != 0 && static_cast<uint8_t>(nowRateTick - e.windowTick) & 0x0F >= 1) {
+        if (e.windowTick != 0 && (static_cast<uint8_t>(nowRateTick - e.windowTick) & 0x0F) >= 1) {
             e.windowTick = nowRateTick;
             e.relayedCount = 0;
             e.noRelay = false;
@@ -2605,7 +2605,7 @@ void TrafficManagementModule::maintainAntispamLocked()
     }
     // Group co-occurrence cells: clear any whose window tick has rolled.
     for (uint16_t i = 0; i < kGroupObsEntries; i++) {
-        if (groupObs[i].windowTick != 0 && static_cast<uint8_t>(nowRateTick - groupObs[i].windowTick) & 0x0F >= 1) {
+        if (groupObs[i].windowTick != 0 && (static_cast<uint8_t>(nowRateTick - groupObs[i].windowTick) & 0x0F) >= 1) {
             memset(&groupObs[i], 0, sizeof(GroupObsCell));
             groupMedian[i] = 0;
         }

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -2572,6 +2572,10 @@ void TrafficManagementModule::initAntispamCache()
 
 void TrafficManagementModule::maintainAntispamLocked()
 {
+    // The table can be absent if both the PSRAM and heap allocations failed at
+    // init; every other accessor guards this, and the sweep is no exception.
+    if (!antispam)
+        return;
     const uint8_t nowRateTick = currentRateTick();
     for (uint16_t i = 0; i < antispamCacheSize(); i++) {
         AntispamEntry &e = antispam[i];

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -2407,8 +2407,11 @@ bool TrafficManagementModule::handleIdAttestation(const meshtastic_MeshPacket &m
     case meshtastic_IdAttestation_Kind_KNOWN_SINCE: {
         if (cfg.probation_window_secs == 0)
             break;
-        // Tenure floor: the attester must be old enough, or its claim is worth nothing.
-        if (att.attester_tenure_secs != 0 && att.attester_tenure_secs < cfg.attestation_min_tenure_secs)
+        // Tenure floor: the attester must be old enough, or its claim is worth
+        // nothing. tenure == 0 means "no clock" (see the proto), so it counts
+        // as untenured - accepting it would let a fresh attester promote
+        // probation out of existence.
+        if (att.attester_tenure_secs < cfg.attestation_min_tenure_secs)
             break;
         if (entry->promoted)
             break;

--- a/src/modules/TrafficManagementModule.h
+++ b/src/modules/TrafficManagementModule.h
@@ -481,10 +481,14 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     /// M4: 4-class RSSI quantization of `mp` (0xFF when no usable reading).
     /// 0 = < -110 dBm, 1 = -110..-100, 2 = -100..-90, 3 = >= -90.
     uint8_t rssiClassOf(const meshtastic_MeshPacket &mp);
+    /// Read-only lookup for `node`'s antispam entry: returns it or nullptr.
+    /// Never allocates and never evicts. nullptr when the table is compiled
+    /// out. Caller must hold cacheLock.
+    AntispamEntry *findAntispamEntry(NodeNum node) const;
     /// Find or create the antispam entry for `node` (oldest-first eviction
     /// when full, like findOrCreateEntry). nullptr when the table is
     /// compiled out or full with no eviction target. Caller must hold cacheLock.
-    AntispamEntry *findAntispamEntry(NodeNum node, bool *isNew) const;
+    AntispamEntry *findOrCreateAntispamEntry(NodeNum node, bool *isNew) const;
     /// M2/M4/M6: allocate the antispam table alongside the unified cache.
     /// Called from the constructor (single-threaded); no-op when the unified
     /// cache is compiled out.

--- a/src/modules/TrafficManagementModule.h
+++ b/src/modules/TrafficManagementModule.h
@@ -38,6 +38,11 @@
 class TrafficManagementModule : public MeshModule, private concurrency::OSThread
 {
   public:
+    // M4: top-senders count carried in DeviceMetrics.top_senders. Declared in
+    // the public section so it is visible to snapshotTopSenders() below
+    // (a later member is not in scope in a parameter list).
+    static constexpr uint16_t kTopSendersCount = 3;
+
     TrafficManagementModule();
     ~TrafficManagementModule();
 
@@ -100,6 +105,7 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     {
         return exhaustRequested && exhaustRequestedFrom == getFrom(&mp) && exhaustRequestedId == mp.id;
     }
+
     // =========================================================================
     // Antispam L1 (M2 greylist + M4 gossiped budgets + M6 relay pricing)
     //
@@ -113,8 +119,22 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     /// on its relayed copy. No-op (returns hop_limit) when no cap applies.
     uint8_t relayHopCap(const meshtastic_MeshPacket &mp) const;
 
+    /// M4: fill `out` (kTopSendersCount) with the top senders by observed
+    /// rate this budget window, for the device-telemetry piggyback
+    /// (DeviceMetrics.top_senders). Entries are node=0 when unused.
+    void snapshotTopSenders(meshtastic_TopSender (&out)[kTopSendersCount]) const;
+
+    /// M4: ingest one neighbor's gossiped top-senders (from received
+    /// DeviceMetrics.top_senders). Feeds the per-sender median budget table.
+    /// No-op when the budget gossip is disabled.
+    void ingestNeighborTopSenders(NodeNum neighbor, const meshtastic_TopSender *entries, pb_size_t count);
+
     // Test hooks (antispam L1 state introspection).
     int peekProbationStateForTest(NodeNum node);                                // -1 untracked, 0 established, 1 in-probation
+    int peekSenderBudgetForTest(NodeNum sender, uint32_t *medianOut = nullptr); // -1 untracked
+    /// M2: test override for the uptime read used by the attester-tenure check.
+    /// 0xFFFFFFFF = production (reads Time::getUptimeSecs()); otherwise the
+    /// stored value is used, so tests can simulate a long-tenured device.
     inline static uint32_t s_testUptimeSecs = 0xFFFFFFFFu;
     static void setUptimeSecsForTest(uint32_t secs) { s_testUptimeSecs = secs; }
     /// Test-only congestion override: production reads airTime->channelUtilizationPercent().
@@ -409,6 +429,14 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     /// probation, or promoted). Used to gate the rate-capped KNOWN_SINCE gossip
     /// so only tenured senders earn a vouch.
     bool isEstablishedForVouching(NodeNum node) const;
+    /// M4: effective per-sender rate threshold = clamp(config max, gossiped
+    /// median when the median exceeds the local floor multiple). The config
+    /// rate_limit_max_packets becomes the local floor; the median is the
+    /// ceiling the TMM enforces when budget_gossip_enabled > 0.
+    uint32_t effectiveRateThreshold(NodeNum sender) const;
+    /// Same as effectiveRateThreshold() but for callers that already hold
+    /// cacheLock (e.g. isRateLimited, which reads the unified cache under it).
+    uint32_t effectiveRateThresholdLocked(NodeNum sender) const;
     /// M6: current channel utilization percent (test-override aware).
     float currentCongestionPct() const;
     /// M2: emit one KNOWN_SINCE attestation gossip for `subject` when we are
@@ -421,6 +449,16 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     /// and apply the group median when the cell fills. Returns true when a
     /// group budget was applied to `node`.
     bool observeGroupCooccurrence(NodeNum node, uint8_t channel, uint8_t rssiClass);
+    /// M4 group budget: true when `node`'s (channel, rssiClass) cell is flagged
+    /// and carries a group median. Called from isRateLimited().
+    bool isInFlaggedGroup(NodeNum node, uint8_t channel, uint8_t rssiClass) const;
+    /// Same as isInFlaggedGroup for callers that already hold cacheLock.
+    bool isInFlaggedGroupLocked(uint8_t channel, uint8_t rssiClass) const;
+    /// Same as groupBudgetForTest for callers that already hold cacheLock.
+    uint32_t groupBudgetLocked(uint8_t channel, uint8_t rssiClass) const;
+    /// M4 group budget: the current group median for a (channel, rssiClass)
+    /// cell (0 when not flagged). Test hook.
+    uint32_t groupBudgetForTest(uint8_t channel, uint8_t rssiClass);
     /// M2/M4/M6: monotonic uptime in seconds (test-override aware).
     uint32_t uptimeSecs() const;
     /// M4: 4-class RSSI quantization of `mp` (0xFF when no usable reading).

--- a/src/modules/TrafficManagementModule.h
+++ b/src/modules/TrafficManagementModule.h
@@ -114,10 +114,21 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     // (recording first-seen state), which is harmless and may default on.
     // =========================================================================
 
+    /// M6: true when the relayer must NOT re-broadcast a packet from the
+    /// sender of `mp` this window (local relay budget exhausted, or a gossiped
+    /// NO_RELAY bit is in force). Local delivery is unaffected; only the
+    /// re-broadcast is suppressed. Consulted by the router's perhapsRebroadcast.
+    bool shouldRelay(const meshtastic_MeshPacket &mp) const;
+
     /// M2 + M6: effective hop_limit cap for a re-broadcast of `mp`. Returns
     /// min(hop_limit, probation cap, congestion cap). Consulted by the router
     /// on its relayed copy. No-op (returns hop_limit) when no cap applies.
     uint8_t relayHopCap(const meshtastic_MeshPacket &mp) const;
+
+    /// M6: record that this node re-broadcast `mp` (per-sender relay-budget
+    /// accounting). The first exhaustion in a window gossips a NO_RELAY bit.
+    /// No-op when the relay budget is disabled.
+    void recordRelayed(const meshtastic_MeshPacket &mp);
 
     /// M4: fill `out` (kTopSendersCount) with the top senders by observed
     /// rate this budget window, for the device-telemetry piggyback
@@ -131,6 +142,8 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
 
     // Test hooks (antispam L1 state introspection).
     int peekProbationStateForTest(NodeNum node);                                // -1 untracked, 0 established, 1 in-probation
+    uint32_t peekRelayedCountForTest(NodeNum node);                             // windowed relayed-for count
+    bool peekNoRelayForTest(NodeNum node);                                      // gossiped/local NO_RELAY in force
     int peekSenderBudgetForTest(NodeNum sender, uint32_t *medianOut = nullptr); // -1 untracked
     /// M2: test override for the uptime read used by the attester-tenure check.
     /// 0xFFFFFFFF = production (reads Time::getUptimeSecs()); otherwise the
@@ -139,6 +152,7 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     static void setUptimeSecsForTest(uint32_t secs) { s_testUptimeSecs = secs; }
     /// Test-only congestion override: production reads airTime->channelUtilizationPercent().
     /// Set to >= 0 to drive the M6 congestion hop cap deterministically in tests.
+    inline static int s_testCongestionPct = -1;
 
     // Injectable monotonic clock (ms): tests advance s_testNowMs instead of sleeping across
     // ticks (mirrors HopScalingModule); production reads millis().
@@ -439,6 +453,9 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     uint32_t effectiveRateThresholdLocked(NodeNum sender) const;
     /// M6: current channel utilization percent (test-override aware).
     float currentCongestionPct() const;
+    /// M6: emit one NO_RELAY gossip packet for `subject` (best-effort, no
+    /// allocation failure path). Returns false when the send couldn't happen.
+    bool sendNoRelayGossip(NodeNum subject);
     /// M2: emit one KNOWN_SINCE attestation gossip for `subject` when we are
     /// tenured enough to vouch. Returns false when not sent.
     bool sendKnownSinceGossip(NodeNum subject);

--- a/src/modules/TrafficManagementModule.h
+++ b/src/modules/TrafficManagementModule.h
@@ -100,6 +100,25 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     {
         return exhaustRequested && exhaustRequestedFrom == getFrom(&mp) && exhaustRequestedId == mp.id;
     }
+    // =========================================================================
+    // Antispam L1 (M2 greylist + M4 gossiped budgets + M6 relay pricing)
+    //
+    // Design doc: meshtastic-decentralized-antispam.md (this branch). All of it
+    // is off-by-default behind config knobs except the probation *accounting*
+    // (recording first-seen state), which is harmless and may default on.
+    // =========================================================================
+
+    /// M2 + M6: effective hop_limit cap for a re-broadcast of `mp`. Returns
+    /// min(hop_limit, probation cap, congestion cap). Consulted by the router
+    /// on its relayed copy. No-op (returns hop_limit) when no cap applies.
+    uint8_t relayHopCap(const meshtastic_MeshPacket &mp) const;
+
+    // Test hooks (antispam L1 state introspection).
+    int peekProbationStateForTest(NodeNum node);                                // -1 untracked, 0 established, 1 in-probation
+    inline static uint32_t s_testUptimeSecs = 0xFFFFFFFFu;
+    static void setUptimeSecsForTest(uint32_t secs) { s_testUptimeSecs = secs; }
+    /// Test-only congestion override: production reads airTime->channelUtilizationPercent().
+    /// Set to >= 0 to drive the M6 congestion hop cap deterministically in tests.
 
     // Injectable monotonic clock (ms): tests advance s_testNowMs instead of sleeping across
     // ticks (mirrors HopScalingModule); production reads millis().
@@ -297,7 +316,8 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     NodeInfoPayloadEntry *nodeInfoPayload = nullptr; // NodeInfo payloads (flat array; PSRAM on hardware, heap in tests)
     bool nodeInfoPayloadFromPsram = false;           // Tracks allocator for correct deallocation
 
-    meshtastic_TrafficManagementStats stats;
+    mutable meshtastic_TrafficManagementStats
+        stats; // mutable: updated from const methods (stats counters don't affect observable const state)
 
     // Set during alterReceived() when the packet's hops should be exhausted; checked by
     // perhapsRebroadcast() for the matching packet key. Reset at start of handleReceived().
@@ -313,6 +333,128 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     static constexpr uint8_t kNodeInfoReconcileSweeps = 60; // sweeps between reconciliations (60 x 60 s = 1 h)
     bool nodeInfoSeeded = false;
     uint8_t sweepsSinceNodeInfoReconcile = 0;
+
+    // =========================================================================
+    // Antispam L1 per-node state (M2 probation, M4 budgets, M6 relay pricing)
+    // =========================================================================
+    // A second flat per-node table, deliberately NOT packed into the 10-byte
+    // UnifiedCacheEntry: the design doc's "10-byte entry has room" is true only
+    // of bit flags, and the windowed relayed-for counter + first-seen tick +
+    // gossiped budget need real fields. The unified cache already pins its slots
+    // against passive eviction (next_hop / special-role entries survive the
+    // sweep), so tracking a node's traffic here implies its unified entry lives;
+    // antispam entries self-expire via the 5-min budget window.
+
+    struct __attribute__((packed)) AntispamEntry {
+        NodeNum node;
+        // M2: 0 = no first-seen record, otherwise the 5-min budget-window tick
+        // (kRateTimeTickMs) the node was first observed. In-probation while
+        // (nowTick - firstSeenTick) < probation ticks; promoted when a
+        // KNOWN_SINCE attestation from a tenured attester is accepted.
+        uint8_t firstSeenTick;
+        // M6: packets re-broadcast by us for `node` in the current budget
+        // window (6-bit, saturates at 63 like rate_count).
+        uint8_t relayedCount;
+        // M4/M6: the 5-min window tick under which relayedCount and the
+        // budget samples were accumulated. Rollover (sweep) resets them.
+        uint8_t windowTick;
+        // M2: accepted attestation -> probation window shortened. Sticky for
+        // the probation window's lifetime; cleared by the sweep with the entry.
+        uint8_t promoted : 1;
+        // M6: NO_RELAY in force for `node` (local exhaustion, never re-gossiped;
+        // or gossiped by a neighbor). Cleared at the next window rollover.
+        uint8_t noRelay : 1;
+        // M6: true when noRelay was set locally (budget exhausted here) -
+        // that is the only case where WE gossip it.
+        uint8_t noRelayLocal : 1;
+        // M4: gossiped median budget observations for a SENDER we track:
+        // up to 3 neighbor-reported window counts (packets_this_window).
+        // The median (middle of the sorted samples) is the gossiped budget;
+        // 2+ samples are required before it applies (a single liar is
+        // absorbed, a lone report is not trusted).
+        uint8_t budgetSampleCount;
+        uint8_t budgetSamples[3];
+        // M4: which neighbor (NodeNum, 0 = unused slot) contributed each
+        // budget sample, so a re-report from the same neighbor this window
+        // refreshes in place instead of double-counting.
+        NodeNum budgetSampleMark[3];
+        // M4 group budget (F4.3): RSSI class + channel of first observation,
+        // for fresh-ID co-occurrence grouping. rssiClass 0xFF = unknown.
+        uint8_t rssiClass;
+        uint8_t channel;
+    };
+    static_assert(sizeof(AntispamEntry) == 26, "AntispamEntry should be 26 bytes");
+
+    static constexpr uint16_t antispamCacheSize()
+    {
+        return TRAFFIC_MANAGEMENT_CACHE_SIZE > 0 ? std::min(TRAFFIC_MANAGEMENT_CACHE_SIZE, 256) : 0;
+    }
+
+    mutable AntispamEntry *antispam =
+        nullptr; // mutable: const query paths (inProbation, effectiveRateThresholdLocked, ...) only read or slot-fill it
+    bool antispamFromPsram = false;
+
+    /// M2: probation window in 5-min ticks (>=1 while enabled), 0 when disabled.
+    uint8_t probationWindowTicks() const;
+    /// M2: true when `node` is currently in probation (accounting on, config
+    /// probation_window_secs > 0, first-seen within the window, not promoted).
+    /// Caller must hold cacheLock when `entry` is supplied; else locks.
+    bool inProbation(NodeNum node) const;
+    /// M2: stamp first-seen for `node` if not yet tracked (probation start),
+    /// and record its observation context (channel, RSSI class) for the F4.3
+    /// group budget. Called from handleReceived() for non-local, non-own
+    /// traffic. Returns true when the node was freshly tracked (first sight).
+    bool noteFirstSeen(NodeNum node, uint8_t channel, uint8_t rssiClass);
+    /// M2 vouch: true when `node` is locally established (tracked and out of
+    /// probation, or promoted). Used to gate the rate-capped KNOWN_SINCE gossip
+    /// so only tenured senders earn a vouch.
+    bool isEstablishedForVouching(NodeNum node) const;
+    /// M6: current channel utilization percent (test-override aware).
+    float currentCongestionPct() const;
+    /// M2: emit one KNOWN_SINCE attestation gossip for `subject` when we are
+    /// tenured enough to vouch. Returns false when not sent.
+    bool sendKnownSinceGossip(NodeNum subject);
+    /// M2: handle a received ID_ATTESTATION_APP payload (decode + apply
+    /// promotion / NO_RELAY). Returns true when the payload was consumed.
+    bool handleIdAttestation(const meshtastic_MeshPacket &mp);
+    /// M4 group budget: observe a fresh-ID co-occurrence (channel, rssiClass)
+    /// and apply the group median when the cell fills. Returns true when a
+    /// group budget was applied to `node`.
+    bool observeGroupCooccurrence(NodeNum node, uint8_t channel, uint8_t rssiClass);
+    /// M2/M4/M6: monotonic uptime in seconds (test-override aware).
+    uint32_t uptimeSecs() const;
+    /// M4: 4-class RSSI quantization of `mp` (0xFF when no usable reading).
+    /// 0 = < -110 dBm, 1 = -110..-100, 2 = -100..-90, 3 = >= -90.
+    uint8_t rssiClassOf(const meshtastic_MeshPacket &mp);
+    /// Find or create the antispam entry for `node` (oldest-first eviction
+    /// when full, like findOrCreateEntry). nullptr when the table is
+    /// compiled out or full with no eviction target. Caller must hold cacheLock.
+    AntispamEntry *findAntispamEntry(NodeNum node, bool *isNew) const;
+    /// M2/M4/M6: allocate the antispam table alongside the unified cache.
+    /// Called from the constructor (single-threaded); no-op when the unified
+    /// cache is compiled out.
+    void initAntispamCache();
+    /// M2/M4/M6: per-sweep maintenance of the antispam table (window rollover,
+    /// probation expiry, group-cell decay). Caller must hold cacheLock.
+    void maintainAntispamLocked();
+
+    // M4 group co-occurrence table (channel x rssiClass x 5-min window).
+    static constexpr uint16_t kGroupObsEntries = 16;
+    struct GroupObsCell {
+        uint8_t channel;
+        uint8_t rssiClass;
+        uint8_t windowTick; // 5-min tick, modular
+        uint8_t freshCount;
+        bool flagged;
+    };
+    GroupObsCell groupObs[kGroupObsEntries] = {};
+    /// M4 group median per cell (kept alongside; 0 = not computed).
+    uint32_t groupMedian[kGroupObsEntries] = {};
+
+    // M2: vouching eligibility. An attester must have been up at least
+    // attestation_min_tenure_secs to carry weight; tracked via uptime (not
+    // per-node state) so a reboot restarts the vouching floor.
+    uint32_t lastVouchSentMs = 0; // per-subject vouch cadence guard (single value; cheap)
 
     // =========================================================================
     // Cache Operations
@@ -403,6 +545,8 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     void logAction(const char *action, const meshtastic_MeshPacket *p, const char *reason) const;
     /// Increment a stats counter under cacheLock.
     void incrementStat(uint32_t *field);
+    /// Increment a stats counter without taking cacheLock (caller holds it).
+    void incrementStatLocked(uint32_t *field) const;
 };
 
 static_assert(TRAFFIC_MANAGEMENT_CACHE_SIZE <= UINT16_MAX, "cacheSize() returns uint16_t");


### PR DESCRIPTION
Adds anti-spam protections to the TrafficManagementModule (TMM) that target the
**rotating-node-ID spammer**: a node that mints fresh `node_num`s each time it gets
rate-limited, so per-sender budgets never engage. All new behavior is config-gated;
the only default-on machinery is the probation accounting plus the reduced hop cap
for probation IDs, which is the minimum to make the greylist meaningful. Signed
identity, network-wide reputation scoring, and proof-of-work challenges are
deliberately out of scope (see Not in scope).

### 1. Probation greylist + attestation promotion

Every first-seen node ID enters a **probation window** (default 300 s) where its
broadcasts are still relayed but at a reduced hop cap (2 instead of 3) and the
lower of the probation multiplier vs. `rate_limit_max_packets`. Promotion out of
probation requires an **ID attestation** from a long-tenured peer: a new
`ID_ATTESTATION_APP` portnum (80) carries an unsigned "I have known 0x… since
epoch-window W" payload; attestations are only accepted from an attester that is
itself at least 24 h old (`attestation_min_tenure_secs`), so a fresh spammer can't
vouch for its clones. First-seen accounting ships on by default — it only
records state, changes no behavior.

### 2. Gossiped median rate budgets

TMM now carries a **top-senders micro-field** (top-3: node, packets-this-window,
RSSI-class) in the periodic `DeviceMetrics` telemetry broadcast — piggybacked on
traffic that already floods, so marginal airtime cost is near zero. When
`budget_gossip_enabled` is set, TMM computes the **median of neighbors' observed
per-sender rates** and, if it exceeds the local `rate_limit_max_packets`, clamps
the local per-sender budget to the median (config becomes floor/ceiling instead of
absolute). The **group budget** catches the rotation case directly: when N
or more *fresh* (probation) IDs co-occur on the same channel within the same
5-minute RSSI-class window, they share one budget — each member gets
`max(1, rate_limit_max_packets / group_size)`.

### 3. Relay congestion pricing

Per-sender **relay budget**: after the local relayer has re-broadcast
`relay_budget_max_packets` of a sender's packets this window, it stops relaying
for that sender (still delivers locally) and gossips a **NO_RELAY** bit via the
same `ID_ATTESTATION_APP` portnum. **Congestion hop cap**: when
channel air-time utilization exceeds `congestion_hop_cap_pct`, probation
broadcast senders are capped at 1 hop.

## New config knobs (`module_config.traffic_management`)

| Knob | Type | Default | Off = |
|---|---|---|---|
| `probation_window_secs` (15) | u32 | **300** (5 min, shipped on) | 0 disables probation entirely |
| `attestation_min_tenure_secs` (16) | u32 | **86400** (24 h, shipped on) | 0 accepts attestations from any attester age |
| `probation_max_hop_limit` (17) | u32 | **2** (shipped on) | 0 relays probation IDs at the normal hop limit |
| `budget_gossip_enabled` (18) | u32 | **0** (off) | local `rate_limit_max_packets` stays authoritative |
| `group_budget_enabled` (19) | u32 | **0** (off) | no group sharing of budgets |
| `relay_budget_max_packets` (20) | u32 | **0** (off) | unlimited relaying |
| `congestion_hop_cap_pct` (21) | u32 | **0** (off) | no congestion hop cap |

Defaults live in `src/mesh/Default.h` (`default_traffic_mgmt_*`); per-knob
semantics are documented in the proto comments in
`protobufs/meshtastic/module_config.proto` (the config-doc location used by the
other TMM knobs).

## Protocol additions (no reordering, additions only)

- `PortNum.ID_ATTESTATION_APP = 80` + `IdAttestation` message (mesh.proto).
- `TopSender` micro-field, `DeviceMetrics.top_senders` (telemetry.proto).
- `TrafficManagement` stats fields (telemetry.options + telemetry.proto) for the
  greylist/budget/relay counters.
- Nanopb regen from protobufs `561658b1490dfd3a9361589501b1321bec2c3543` (already
  on `meshtastic/protobufs`, so the submodule gitlink resolves in CI).

## Files touched

- `protobufs` (submodule → `561658b`), generated `src/mesh/generated/meshtastic/{mesh,telemetry,module_config,portnums,deviceonly*,localonly}.pb.{h,cpp}` (regen)
- `src/modules/TrafficManagementModule.{h,cpp}` — probation, budget-gossip, and relay-pricing logic
- `src/mesh/Default.h` — `default_traffic_mgmt_*` defaults
- `src/mesh/NodeDB.cpp` — first-seen / known-since bookkeeping touchpoint
- `src/mesh/NextHopRouter.cpp` — hop-cap clamp and relay accounting at rebroadcast
- `src/modules/Telemetry/DeviceTelemetry.cpp` — top-senders emission

## Build & test evidence

Host (aarch64 DGX, native env):

```
pio build -e native
=============== [SUCCESS] Took 37.94 seconds ===============
native         SUCCESS   00:00:37.936
========================= 1 succeeded in 00:00:37.936 =========================
```

```
./bin/run-tests.sh   # canonical native suite (AGENTS.md)
...
=============== 1358 test cases: 1358 succeeded in 00:20:08.252 ===============
...
RESULT: AMBER 1 suite(s) left undeclared shared state
    test_waypoint_expiry (undeclared: .portduino/default/Waypoints_default.wpts)
```

AMBER is a **pre-existing** state-manifest artifact of `test_waypoint_expiry`
(this PR does not touch waypoints); no new RED vs. baseline — all 1358 test
cases pass, including the full `test_traffic_management` suite.

Formatting: `clang-format` 16 (trunk config `.trunk/configs/.clang-format`)
clean on all touched handwritten files; `git-clang-format` flags only the
generated `.pb.*` files, which carry `DisableFormat: true`. `bin/lint-*` clean.

## Not in scope (follow-up work)

- Signed identity (XEdDSA-signed attestations) — `IdAttestation` is unsigned here.
- Network-wide reputation (trust-weighted scoring).
- Proof-of-work challenge.
- Any reordering of existing message fields; new portnums only.

## Acceptance evidence

- [x] Diff limited to feature surface (files listed above)
- [x] `make native`/`pio build -e native` passes (tail above)
- [x] `./bin/run-tests.sh`: 1358/1358 cases pass; AMBER = pre-existing waypoint state artifact
- [x] Every new knob documented (proto comments + Default.h)
- [x] No new dependencies; no protocol-breaking changes
- [x] Bisectable commits: one for proto regen, one per mechanism


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added traffic-management protections to limit excessive relaying and reduce network congestion.
  * Added configurable probation, relay-budget, hop-limit, and congestion controls.
  * Added sharing of top-sender traffic observations through device telemetry.
  * Added safeguards to prevent relaying packets marked as non-relay or exceeding local limits.
* **Bug Fixes**
  * Improved antispam tracking, timing, attestation handling, and cache maintenance for more reliable traffic decisions.
* **Chores**
  * Updated the protobuf definitions reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->