### PR TITLE
fix(radio): recover a chip that lost its state instead of assert-crashing in reconfigure()

### DIFF
--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -172,6 +172,8 @@ template <typename T> bool LR11x0Interface<T>::init()
         res = tryBegin(3, attemptVoltage);
     }
 
+    resolvedTcxoVoltage = attemptVoltage;
+
     // \todo Display actual typename of the adapter, not just `LR11x0`
     LOG_INFO("LR11x0 init result %d", res);
 
@@ -269,28 +271,32 @@ template <typename T> bool LR11x0Interface<T>::init()
     return res == RADIOLIB_ERR_NONE;
 }
 
-template <typename T> bool LR11x0Interface<T>::reconfigure()
+template <typename T> int16_t LR11x0Interface<T>::programModemParams()
 {
-    RadioLibInterface::reconfigure();
-
-    // set mode to standby
-    setStandby();
-
     // configure publicly accessible settings
-    int err = lora.setSpreadingFactor(sf);
-    if (err != RADIOLIB_ERR_NONE)
-        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+    int16_t err = lora.setSpreadingFactor(sf);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("LR11x0 setSpreadingFactor(%u) %s%d", sf, radioLibErr, err);
+        return err;
+    }
 
     err = lora.setBandwidth(bw, wideLora() && (getFreq() > 1000.0f));
-    if (err != RADIOLIB_ERR_NONE)
-        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("LR11x0 setBandwidth(%.1f) %s%d", bw, radioLibErr, err);
+        return err;
+    }
 
     err = lora.setCodingRate(cr, cr != 7); // use long interleaving except if CR is 4/7 which doesn't support it
-    if (err != RADIOLIB_ERR_NONE)
-        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("LR11x0 setCodingRate(%u) %s%d", cr, radioLibErr, err);
+        return err;
+    }
 
     err = lora.setSyncWord(syncWord);
-    assert(err == RADIOLIB_ERR_NONE);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("LR11x0 setSyncWord %s%d", radioLibErr, err);
+        return err;
+    }
 
     if (config.lora.region == meshtastic_Config_LoRaConfig_RegionCode_LORA_24) { // clamp if wide freq range
         limitPower(LR1120_MAX_POWER);
@@ -299,19 +305,78 @@ template <typename T> bool LR11x0Interface<T>::reconfigure()
     }
 
     err = lora.setPreambleLength(preambleLength);
-    assert(err == RADIOLIB_ERR_NONE);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("LR11x0 setPreambleLength(%u) %s%d", preambleLength, radioLibErr, err);
+        return err;
+    }
 
     err = lora.setFrequency(getFreq());
-    if (err != RADIOLIB_ERR_NONE)
-        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("LR11x0 setFrequency(%.3f) %s%d", getFreq(), radioLibErr, err);
+        return err;
+    }
 
     err = lora.setOutputPower(power);
-    assert(err == RADIOLIB_ERR_NONE);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("LR11x0 setOutputPower(%d) %s%d", power, radioLibErr, err);
+        return err;
+    }
 
     // Apply RX gain mode - valid in STDBY, matches resetAGC() pattern
     err = lora.setRxBoostedGainMode(config.lora.sx126x_rx_boosted_gain);
     if (err != RADIOLIB_ERR_NONE)
         LOG_WARN("LR11x0 setRxBoostedGainMode %s%d", radioLibErr, err);
+
+    return RADIOLIB_ERR_NONE;
+}
+
+template <typename T> bool LR11x0Interface<T>::reinitChip()
+{
+    int res = lora.begin(getFreq(), bw, sf, cr, syncWord, power, preambleLength, resolvedTcxoVoltage);
+    if (res == RADIOLIB_ERR_NONE)
+        res = lora.setCRC(2);
+    if (res == RADIOLIB_ERR_NONE)
+        res = lora.setRegulatorDCDC();
+
+#ifdef LR11X0_DIO_AS_RF_SWITCH
+    bool dioAsRfSwitch = true;
+#elif defined(ARCH_PORTDUINO)
+    bool dioAsRfSwitch = portduino_config.has_rfswitch_table;
+#else
+    bool dioAsRfSwitch = false;
+#endif
+
+    // setRfSwitchTable() pushed the DIO switch config to the chip when init() called it; a reset chip has
+    // lost it and begin() does not restore it
+    if (res == RADIOLIB_ERR_NONE && dioAsRfSwitch)
+        lora.setRfSwitchTable(rfswitch_dio_pins, rfswitch_table);
+
+    if (res != RADIOLIB_ERR_NONE)
+        LOG_ERROR("LR11x0 re-init failed %s%d", radioLibErr, res);
+    return res == RADIOLIB_ERR_NONE;
+}
+
+template <typename T> bool LR11x0Interface<T>::reconfigure()
+{
+    RadioLibInterface::reconfigure();
+
+    // set mode to standby
+    setStandby();
+
+    int16_t err = programModemParams();
+    if (err != RADIOLIB_ERR_NONE) {
+        // A chip that answers standby() but rejects parameter programming (typically WRONG_MODEM, -20) has
+        // lost its runtime configuration - packet type included - to a chip-internal reset or brownout.
+        // Recover in place: begin() hardware-resets the chip and restores the LoRa packet type. Crashing
+        // here instead would reboot before MeshService persists the config change that triggered us.
+        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+        LOG_ERROR("LR11x0 rejected modem params, chip state lost? Full re-init");
+        if (!reinitChip() || (err = programModemParams()) != RADIOLIB_ERR_NONE) {
+            LOG_ERROR("LR11x0 unrecoverable %s%d, radio down until reboot", radioLibErr, err);
+            return false;
+        }
+        LOG_INFO("LR11x0 recovered after re-init");
+    }
 
     startReceive(); // restart receiving
 

--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -332,6 +332,14 @@ template <typename T> int16_t LR11x0Interface<T>::programModemParams()
 
 template <typename T> bool LR11x0Interface<T>::reinitChip()
 {
+    // Clamp here, not just in programModemParams(): applyModemConfig() resets `power` to the raw
+    // config value, and the recovery path reaches begin() without passing through the params clamp
+    if (config.lora.region == meshtastic_Config_LoRaConfig_RegionCode_LORA_24) { // clamp if wide freq range
+        limitPower(LR1120_MAX_POWER);
+    } else {
+        limitPower(LR1110_MAX_POWER); // default clamp for non-wide freq range
+    }
+
     int res = lora.begin(getFreq(), bw, sf, cr, syncWord, power, preambleLength, resolvedTcxoVoltage);
     if (res == RADIOLIB_ERR_NONE)
         res = lora.setCRC(2);
@@ -360,12 +368,14 @@ template <typename T> bool LR11x0Interface<T>::reconfigure()
 {
     RadioLibInterface::reconfigure();
 
-    // set mode to standby
-    setStandby();
+    // set mode to standby - a chip that lost its state to a reset/brownout can time out here (-707),
+    // so don't let setStandby()'s assert fire before the recovery below gets a chance
+    int16_t err = trySetStandby();
+    if (err == RADIOLIB_ERR_NONE)
+        err = programModemParams();
 
-    int16_t err = programModemParams();
     if (err != RADIOLIB_ERR_NONE) {
-        // A chip that answers standby() but rejects parameter programming (typically WRONG_MODEM, -20) has
+        // A chip that fails standby or rejects parameter programming (typically WRONG_MODEM, -20) has
         // lost its runtime configuration - packet type included - to a chip-internal reset or brownout.
         // Recover in place: begin() hardware-resets the chip and restores the LoRa packet type. Crashing
         // here instead would reboot before MeshService persists the config change that triggered us.
@@ -388,23 +398,28 @@ template <typename T> void LR11x0Interface<T>::clearRadioIsr()
     lora.clearIrqAction();
 }
 
-template <typename T> void LR11x0Interface<T>::setStandby()
+template <typename T> int16_t LR11x0Interface<T>::trySetStandby()
 {
     checkNotification(); // handle any pending interrupts before we force standby
 
-    int err = lora.standby();
+    int16_t err = lora.standby();
 
     if (err != RADIOLIB_ERR_NONE) {
         LOG_DEBUG("LR11x0 standby failed, err %d", err);
     }
-
-    assert(err == RADIOLIB_ERR_NONE);
 
     isReceiving = false; // If we were receiving, not any more
     activeReceiveStart = 0;
     disableInterrupt();
     completeSending(); // If we were sending, not anymore
     RadioLibInterface::setStandby();
+    return err;
+}
+
+template <typename T> void LR11x0Interface<T>::setStandby()
+{
+    int16_t err = trySetStandby();
+    assert(err == RADIOLIB_ERR_NONE);
 }
 
 /**

--- a/src/mesh/LR11x0Interface.h
+++ b/src/mesh/LR11x0Interface.h
@@ -86,6 +86,9 @@ template <class T> class LR11x0Interface : public RadioLibInterface
     /** Reset and re-begin() a chip that lost its runtime configuration (reset/brownout) */
     bool reinitChip();
 
+    /** setStandby()'s body, returning the standby error instead of asserting - for callers that can recover */
+    int16_t trySetStandby();
+
     /// The TCXO Vref that init() settled on, so reinitChip() can begin() with the same oscillator setup
     float resolvedTcxoVoltage = 0;
 };

--- a/src/mesh/LR11x0Interface.h
+++ b/src/mesh/LR11x0Interface.h
@@ -78,5 +78,15 @@ template <class T> class LR11x0Interface : public RadioLibInterface
     virtual void setStandby() override;
 
     uint32_t getPacketTime(uint32_t pl, bool received) override { return computePacketTime(lora, pl, received); }
+
+  private:
+    /** Program all modem parameters into the chip; returns the first RadioLib error, or RADIOLIB_ERR_NONE */
+    int16_t programModemParams();
+
+    /** Reset and re-begin() a chip that lost its runtime configuration (reset/brownout) */
+    bool reinitChip();
+
+    /// The TCXO Vref that init() settled on, so reinitChip() can begin() with the same oscillator setup
+    float resolvedTcxoVoltage = 0;
 };
 #endif

--- a/src/mesh/LR20x0Interface.cpp
+++ b/src/mesh/LR20x0Interface.cpp
@@ -192,8 +192,101 @@ template <typename T> bool LR20x0Interface<T>::reconfigure()
 
     if (bandHop) {
         LOG_INFO("LR20x0 LF/HF band hop %.1f -> %.1f MHz, full begin()", lr20x0LastFreqMHz, freq);
-        setStandby();
+        // fullBegin() hardware-resets the chip, so a standby failure is survivable here
+        (void)trySetStandby();
 
+        if (!fullBegin(freq))
+            return false;
+
+        startReceive();
+        return true;
+    }
+
+    // Same-band reconfigure (previous incremental path)
+    int16_t standbyErr = trySetStandby();
+    if (standbyErr != RADIOLIB_ERR_NONE)
+        success = false;
+
+    if (standbyErr == RADIOLIB_ERR_NONE) {
+        int err = lora.setFrequency(freq);
+        if (err != RADIOLIB_ERR_NONE) {
+            LOG_ERROR("LR20x0 setFrequency %.3f MHz %s%d", freq, radioLibErr, err);
+            RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+            success = false;
+        }
+
+        err = lora.setSpreadingFactor(sf);
+        if (err != RADIOLIB_ERR_NONE) {
+            LOG_ERROR("LR20x0 setSpreadingFactor(%u) %s%d", sf, radioLibErr, err);
+            RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+            success = false;
+        }
+
+        err = lora.setBandwidth(bw);
+        if (err != RADIOLIB_ERR_NONE) {
+            LOG_ERROR("LR20x0 setBandwidth(%.1f) %s%d", bw, radioLibErr, err);
+            RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+            success = false;
+        }
+
+        err = lora.setCodingRate(cr, cr != 7);
+        if (err != RADIOLIB_ERR_NONE) {
+            LOG_ERROR("LR20x0 setCodingRate(%u) %s%d", cr, radioLibErr, err);
+            RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+            success = false;
+        }
+
+        err = lora.setSyncWord(syncWord);
+        if (err != RADIOLIB_ERR_NONE) {
+            LOG_ERROR("LR20x0 setSyncWord %s%d", radioLibErr, err);
+            RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+            success = false;
+        }
+
+        err = lora.setPreambleLength(preambleLength);
+        if (err != RADIOLIB_ERR_NONE) {
+            LOG_ERROR("LR20x0 setPreambleLength(%u) %s%d", preambleLength, radioLibErr, err);
+            RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+            success = false;
+        }
+
+        err = lora.setOutputPower(power);
+        if (err != RADIOLIB_ERR_NONE) {
+            LOG_ERROR("LR20x0 setOutputPower %d dBm @ %.3f MHz %s%d", power, freq, radioLibErr, err);
+            RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+            success = false;
+        }
+
+        err = lora.setRxBoostedGainMode(config.lora.sx126x_rx_boosted_gain);
+        if (err != RADIOLIB_ERR_NONE) {
+            LOG_WARN("LR20x0 setRxBoostedGainMode %s%d", radioLibErr, err);
+            success = false;
+        }
+    }
+
+    if (!success) {
+        // A chip that fails standby or rejects parameter programming (typically WRONG_MODEM, -20) has
+        // lost its runtime configuration to a chip-internal reset or brownout. Recover in place with the
+        // same full begin() the band-hop path uses - it hardware-resets the chip. Crashing here instead
+        // would reboot before MeshService persists the config change that triggered us.
+        LOG_ERROR("LR20x0 rejected modem params, chip state lost? Full re-init");
+        if (!fullBegin(freq)) {
+            LOG_ERROR("LR20x0 unrecoverable, radio down until reboot");
+            return false;
+        }
+        LOG_INFO("LR20x0 recovered after re-init");
+    }
+
+    startReceive();
+    lr20x0LastFreqMHz = freq;
+    return true;
+}
+
+// The chip-side re-init the band-hop and recovery paths share: front-end switch GPIOs for the target
+// band, a fresh begin() (which hardware-resets the chip), CRC, DIO RF-switch table, and RX gain.
+template <typename T> bool LR20x0Interface<T>::fullBegin(float freq)
+{
+    {
         // Match init(): external LF/HF front-end GPIOs (if board defines them).
 #ifdef LR2021_RF_SWITCH_SUBGHZ
         pinMode(LR2021_RF_SWITCH_SUBGHZ, OUTPUT);
@@ -259,68 +352,8 @@ template <typename T> bool LR20x0Interface<T>::reconfigure()
             return false;
         }
 
-        startReceive();
         return true;
     }
-
-    // Same-band reconfigure (previous incremental path)
-    setStandby();
-
-    int err = lora.setFrequency(freq);
-    if (err != RADIOLIB_ERR_NONE) {
-        LOG_ERROR("LR20x0 setFrequency %.3f MHz %s%d", freq, radioLibErr, err);
-        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
-        success = false;
-    }
-
-    err = lora.setSpreadingFactor(sf);
-    if (err != RADIOLIB_ERR_NONE) {
-        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
-        success = false;
-    }
-
-    err = lora.setBandwidth(bw);
-    if (err != RADIOLIB_ERR_NONE) {
-        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
-        success = false;
-    }
-
-    err = lora.setCodingRate(cr, cr != 7);
-    if (err != RADIOLIB_ERR_NONE) {
-        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
-        success = false;
-    }
-
-    err = lora.setSyncWord(syncWord);
-    if (err != RADIOLIB_ERR_NONE) {
-        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
-        success = false;
-    }
-
-    err = lora.setPreambleLength(preambleLength);
-    if (err != RADIOLIB_ERR_NONE) {
-        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
-        success = false;
-    }
-
-    err = lora.setOutputPower(power);
-    if (err != RADIOLIB_ERR_NONE) {
-        LOG_ERROR("LR20x0 setOutputPower %d dBm @ %.3f MHz %s%d", power, freq, radioLibErr, err);
-        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
-        success = false;
-    }
-
-    err = lora.setRxBoostedGainMode(config.lora.sx126x_rx_boosted_gain);
-    if (err != RADIOLIB_ERR_NONE) {
-        LOG_WARN("LR20x0 setRxBoostedGainMode %s%d", radioLibErr, err);
-        success = false;
-    }
-
-    if (success) {
-        startReceive();
-        lr20x0LastFreqMHz = freq;
-    }
-    return success;
 }
 
 template <typename T> void LR20x0Interface<T>::clearRadioIsr()
@@ -328,23 +361,28 @@ template <typename T> void LR20x0Interface<T>::clearRadioIsr()
     lora.clearIrqAction();
 }
 
-template <typename T> void LR20x0Interface<T>::setStandby()
+template <typename T> int16_t LR20x0Interface<T>::trySetStandby()
 {
     checkNotification(); // handle any pending interrupts before we force standby
 
-    int err = lora.standby();
+    int16_t err = lora.standby();
 
     if (err != RADIOLIB_ERR_NONE) {
         LOG_DEBUG("LR20x0 standby failed, err %d", err);
     }
-
-    assert(err == RADIOLIB_ERR_NONE);
 
     isReceiving = false; // If we were receiving, not any more
     activeReceiveStart = 0;
     disableInterrupt();
     completeSending(); // If we were sending, not anymore
     RadioLibInterface::setStandby();
+    return err;
+}
+
+template <typename T> void LR20x0Interface<T>::setStandby()
+{
+    int16_t err = trySetStandby();
+    assert(err == RADIOLIB_ERR_NONE);
 }
 
 /**

--- a/src/mesh/LR20x0Interface.h
+++ b/src/mesh/LR20x0Interface.h
@@ -73,5 +73,12 @@ template <class T> class LR20x0Interface : public RadioLibInterface
     virtual void setStandby() override;
 
     uint32_t getPacketTime(uint32_t pl, bool received) override { return computePacketTime(lora, pl, received); }
+
+  private:
+    /** Chip-side re-init shared by the band-hop and recovery paths: front-end GPIOs, begin(), CRC, RF switch, RX gain */
+    bool fullBegin(float freq);
+
+    /** setStandby()'s body, returning the standby error instead of asserting - for callers that can recover */
+    int16_t trySetStandby();
 };
 #endif

--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -127,8 +127,6 @@ bool RF95Interface::init()
     power = dacDbValues.db;
 #endif
 
-    limitPower(RF95_MAX_POWER);
-
     lora.reset(new RadioLibRF95(&module));
     iface = lora.get();
 
@@ -181,6 +179,26 @@ bool RF95Interface::init()
 #endif
     setTransmitEnable(false);
 
+#if defined(RADIOMASTER_900_BANDIT_NANO) || defined(RADIOMASTER_900_BANDIT)
+    LOG_INFO("DAC output set to %d", powerDAC);
+#endif
+
+    if (!reinitChip())
+        return false;
+
+    startReceive(); // start receiving
+
+    return true;
+}
+
+// begin() and the chip-side setup that a reset chip loses. Shared by init() and by reconfigure()'s
+// recovery of a chip that lost its state.
+bool RF95Interface::reinitChip()
+{
+    // Clamp here, not just in programModemParams(): applyModemConfig() resets `power` to the raw
+    // config value, and the recovery path reaches begin() without passing through the params clamp
+    limitPower(RF95_MAX_POWER);
+
     int res = lora->begin(getFreq(), bw, sf, cr, syncWord, power, preambleLength);
     LOG_INFO("RF95 init result %d", res);
     if (res == RADIOLIB_ERR_CHIP_NOT_FOUND || res == RADIOLIB_ERR_SPI_CMD_FAILED)
@@ -189,16 +207,12 @@ bool RF95Interface::init()
     LOG_INFO("Frequency set to %f", getFreq());
     LOG_INFO("Bandwidth set to %f", bw);
     LOG_INFO("Power output set to %d", power);
-#if defined(RADIOMASTER_900_BANDIT_NANO) || defined(RADIOMASTER_900_BANDIT)
-    LOG_INFO("DAC output set to %d", powerDAC);
-#endif
 
     if (res == RADIOLIB_ERR_NONE)
         res = lora->setCRC(RADIOLIB_SX126X_LORA_CRC_ON);
 
-    if (res == RADIOLIB_ERR_NONE)
-        startReceive(); // start receiving
-
+    if (res != RADIOLIB_ERR_NONE)
+        LOG_ERROR("RF95 re-init failed %s%d", radioLibErr, res);
     return res == RADIOLIB_ERR_NONE;
 }
 
@@ -207,44 +221,50 @@ void RF95Interface::clearRadioIsr()
     lora->clearDio0Action();
 }
 
-bool RF95Interface::reconfigure()
+int16_t RF95Interface::programModemParams()
 {
-    RadioLibInterface::reconfigure();
-
-    // set mode to standby
-    setStandby();
-
     // configure publicly accessible settings
-    int err = lora->setSpreadingFactor(sf);
-    if (err != RADIOLIB_ERR_NONE)
-        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+    int16_t err = lora->setSpreadingFactor(sf);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("RF95 setSpreadingFactor(%u) %s%d", sf, radioLibErr, err);
+        return err;
+    }
 
     err = lora->setBandwidth(bw);
-    if (err != RADIOLIB_ERR_NONE)
-        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("RF95 setBandwidth(%.1f) %s%d", bw, radioLibErr, err);
+        return err;
+    }
 
     err = lora->setCodingRate(cr);
-    if (err != RADIOLIB_ERR_NONE)
-        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("RF95 setCodingRate(%u) %s%d", cr, radioLibErr, err);
+        return err;
+    }
 
     err = lora->setSyncWord(syncWord);
-    if (err != RADIOLIB_ERR_NONE)
+    if (err != RADIOLIB_ERR_NONE) {
         LOG_ERROR("RF95 setSyncWord %s%d", radioLibErr, err);
-    assert(err == RADIOLIB_ERR_NONE);
+        return err;
+    }
 
     err = lora->setCurrentLimit(currentLimit);
-    if (err != RADIOLIB_ERR_NONE)
+    if (err != RADIOLIB_ERR_NONE) {
         LOG_ERROR("RF95 setCurrentLimit %s%d", radioLibErr, err);
-    assert(err == RADIOLIB_ERR_NONE);
+        return err;
+    }
 
     err = lora->setPreambleLength(preambleLength);
-    if (err != RADIOLIB_ERR_NONE)
-        LOG_ERROR("RF95 setPreambleLength %s%d", radioLibErr, err);
-    assert(err == RADIOLIB_ERR_NONE);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("RF95 setPreambleLength(%u) %s%d", preambleLength, radioLibErr, err);
+        return err;
+    }
 
     err = lora->setFrequency(getFreq());
-    if (err != RADIOLIB_ERR_NONE)
-        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("RF95 setFrequency(%.3f) %s%d", getFreq(), radioLibErr, err);
+        return err;
+    }
 
     limitPower(RF95_MAX_POWER);
 
@@ -253,8 +273,37 @@ bool RF95Interface::reconfigure()
 #else
     err = lora->setOutputPower(power);
 #endif
-    if (err != RADIOLIB_ERR_NONE)
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("RF95 setOutputPower(%d) %s%d", power, radioLibErr, err);
+        return err;
+    }
+
+    return RADIOLIB_ERR_NONE;
+}
+
+bool RF95Interface::reconfigure()
+{
+    RadioLibInterface::reconfigure();
+
+    // set mode to standby - a chip that lost its state to a reset/brownout can fail here,
+    // so don't let setStandby()'s assert fire before the recovery below gets a chance
+    int16_t err = trySetStandby();
+    if (err == RADIOLIB_ERR_NONE)
+        err = programModemParams();
+
+    if (err != RADIOLIB_ERR_NONE) {
+        // A chip that fails standby or rejects parameter programming (typically WRONG_MODEM, -20) has
+        // lost its runtime configuration to a chip-internal reset or brownout. Recover in place:
+        // begin() reprograms the chip. Crashing here instead would reboot before MeshService persists
+        // the config change that triggered us.
         RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+        LOG_ERROR("RF95 rejected modem params, chip state lost? Full re-init");
+        if (!reinitChip() || (err = programModemParams()) != RADIOLIB_ERR_NONE) {
+            LOG_ERROR("RF95 unrecoverable %s%d, radio down until reboot", radioLibErr, err);
+            return false;
+        }
+        LOG_INFO("RF95 recovered after re-init");
+    }
 
     startReceive(); // restart receiving
 
@@ -272,17 +321,23 @@ void RF95Interface::addReceiveMetadata(meshtastic_MeshPacket *mp)
     LOG_DEBUG("Corrected frequency offset: %f", lora->getFrequencyError());
 }
 
-void RF95Interface::setStandby()
+int16_t RF95Interface::trySetStandby()
 {
-    int err = lora->standby();
+    int16_t err = lora->standby();
     if (err != RADIOLIB_ERR_NONE)
         LOG_ERROR("RF95 standby %s%d", radioLibErr, err);
-    assert(err == RADIOLIB_ERR_NONE);
 
     isReceiving = false; // If we were receiving, not any more
     disableInterrupt();
     completeSending(); // If we were sending, not anymore
     RadioLibInterface::setStandby();
+    return err;
+}
+
+void RF95Interface::setStandby()
+{
+    int16_t err = trySetStandby();
+    assert(err == RADIOLIB_ERR_NONE);
 }
 
 /** We override to turn on transmitter power as needed.

--- a/src/mesh/RF95Interface.h
+++ b/src/mesh/RF95Interface.h
@@ -78,5 +78,14 @@ class RF95Interface : public RadioLibInterface
   private:
     /** Some boards require GPIO control of tx vs rx paths */
     void setTransmitEnable(bool txon);
+
+    /** Program all modem parameters into the chip; returns the first RadioLib error, or RADIOLIB_ERR_NONE */
+    int16_t programModemParams();
+
+    /** begin() and chip-side setup, shared by init() and by reconfigure()'s recovery of a chip that lost its state */
+    bool reinitChip();
+
+    /** setStandby()'s body, returning the standby error instead of asserting - for callers that can recover */
+    int16_t trySetStandby();
 };
 #endif

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -81,15 +81,31 @@ template <typename T> bool SX126xInterface<T>::init()
     else
         LOG_DEBUG("SX126X_DIO3_TCXO_VOLTAGE defined, DIO3 as TCXO Vref %f V", tcxoVoltage);
     setTransmitEnable(false);
-    // FIXME: May want to set depending on a definition, currently all SX126x variant files use the DC-DC regulator option
-    bool useRegulatorLDO = false; // Seems to depend on the connection to pin 9/DCC_SW - if an inductor DCDC?
 
     RadioLibInterface::init();
 
+    if (!reinitChip())
+        return false;
+
+    startReceive(); // start receiving
+
+    return true;
+}
+
+// begin() and the chip-side setup that a reset chip loses: begin() hardware-resets the chip, then
+// PA ramp, OCP limit, DIO2-as-RF-switch, RF switch pins, RX gain, the 0x8B5 RX patch, and CRC are
+// reprogrammed. Shared by init() and by reconfigure()'s recovery path.
+template <typename T> bool SX126xInterface<T>::reinitChip()
+{
+    // Clamp here, not just in programModemParams(): applyModemConfig() resets `power` to the raw
+    // config value, and the recovery path reaches begin() without passing through the params clamp
     limitPower(SX126X_MAX_POWER);
     // Make sure we reach the minimum power supported to turn the chip on (-9dBm)
     if (power < -9)
         power = -9;
+
+    // FIXME: May want to set depending on a definition, currently all SX126x variant files use the DC-DC regulator option
+    bool useRegulatorLDO = false; // Seems to depend on the connection to pin 9/DCC_SW - if an inductor DCDC?
 
     int res = lora.begin(getFreq(), bw, sf, cr, syncWord, power, preambleLength, tcxoVoltage, useRegulatorLDO);
 
@@ -182,50 +198,55 @@ template <typename T> bool SX126xInterface<T>::init()
         res = lora.setOutputPower(power, false);
 #endif
 
-    if (res == RADIOLIB_ERR_NONE)
-        startReceive(); // start receiving
-
+    if (res != RADIOLIB_ERR_NONE)
+        LOG_ERROR("SX126x re-init failed %s%d", radioLibErr, res);
     return res == RADIOLIB_ERR_NONE;
 }
 
-template <typename T> bool SX126xInterface<T>::reconfigure()
+template <typename T> int16_t SX126xInterface<T>::programModemParams()
 {
-    RadioLibInterface::reconfigure();
-
-    // set mode to standby
-    setStandby();
-
     // configure publicly accessible settings
-    int err = lora.setSpreadingFactor(sf);
-    if (err != RADIOLIB_ERR_NONE)
-        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+    int16_t err = lora.setSpreadingFactor(sf);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("SX126X setSpreadingFactor(%u) %s%d", sf, radioLibErr, err);
+        return err;
+    }
 
     err = lora.setBandwidth(bw);
-    if (err != RADIOLIB_ERR_NONE)
-        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("SX126X setBandwidth(%.1f) %s%d", bw, radioLibErr, err);
+        return err;
+    }
 
     err = lora.setCodingRate(cr);
-    if (err != RADIOLIB_ERR_NONE)
-        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("SX126X setCodingRate(%u) %s%d", cr, radioLibErr, err);
+        return err;
+    }
 
     err = lora.setSyncWord(syncWord);
-    if (err != RADIOLIB_ERR_NONE)
+    if (err != RADIOLIB_ERR_NONE) {
         LOG_ERROR("SX126X setSyncWord %s%d", radioLibErr, err);
-    assert(err == RADIOLIB_ERR_NONE);
+        return err;
+    }
 
     err = lora.setCurrentLimit(currentLimit);
-    if (err != RADIOLIB_ERR_NONE)
+    if (err != RADIOLIB_ERR_NONE) {
         LOG_ERROR("SX126X setCurrentLimit %s%d", radioLibErr, err);
-    assert(err == RADIOLIB_ERR_NONE);
+        return err;
+    }
 
     err = lora.setPreambleLength(preambleLength);
-    if (err != RADIOLIB_ERR_NONE)
-        LOG_ERROR("SX126X setPreambleLength %s%d", radioLibErr, err);
-    assert(err == RADIOLIB_ERR_NONE);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("SX126X setPreambleLength(%u) %s%d", preambleLength, radioLibErr, err);
+        return err;
+    }
 
     err = lora.setFrequency(getFreq());
-    if (err != RADIOLIB_ERR_NONE)
-        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("SX126X setFrequency(%.3f) %s%d", getFreq(), radioLibErr, err);
+        return err;
+    }
 
     limitPower(SX126X_MAX_POWER);
     // Make sure we reach the minimum power supported to turn the chip on (-9dBm)
@@ -248,6 +269,33 @@ template <typename T> bool SX126xInterface<T>::reconfigure()
     err = lora.setRxBoostedGainMode(config.lora.sx126x_rx_boosted_gain);
     if (err != RADIOLIB_ERR_NONE)
         LOG_WARN("SX126X setRxBoostedGainMode %s%d", radioLibErr, err);
+
+    return RADIOLIB_ERR_NONE;
+}
+
+template <typename T> bool SX126xInterface<T>::reconfigure()
+{
+    RadioLibInterface::reconfigure();
+
+    // set mode to standby - a chip that lost its state to a reset/brownout can time out here (-707),
+    // so don't let setStandby()'s assert fire before the recovery below gets a chance
+    int16_t err = trySetStandby();
+    if (err == RADIOLIB_ERR_NONE)
+        err = programModemParams();
+
+    if (err != RADIOLIB_ERR_NONE) {
+        // A chip that fails standby or rejects parameter programming (typically WRONG_MODEM, -20) has
+        // lost its runtime configuration - packet type included - to a chip-internal reset or brownout.
+        // Recover in place: begin() hardware-resets the chip and restores the LoRa packet type. Crashing
+        // here instead would reboot before MeshService persists the config change that triggered us.
+        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
+        LOG_ERROR("SX126x rejected modem params, chip state lost? Full re-init");
+        if (!reinitChip() || (err = programModemParams()) != RADIOLIB_ERR_NONE) {
+            LOG_ERROR("SX126x unrecoverable %s%d, radio down until reboot", radioLibErr, err);
+            return false;
+        }
+        LOG_INFO("SX126x recovered after re-init");
+    }
 
     startReceive(); // restart receiving
 
@@ -316,25 +364,34 @@ template <typename T> void SX126xInterface<T>::handleSoftwareLoraIrqPoll()
 }
 #endif
 
-template <typename T> void SX126xInterface<T>::setStandby()
+template <typename T> int16_t SX126xInterface<T>::trySetStandby()
 {
     checkNotification(); // handle any pending interrupts before we force standby
 
-    int err = lora.standby();
+    int16_t err = lora.standby();
 
     if (err != RADIOLIB_ERR_NONE)
         LOG_DEBUG("SX126x standby %s%d", radioLibErr, err);
 #ifdef ARCH_PORTDUINO
     if (err != RADIOLIB_ERR_NONE)
         portduino_status.LoRa_in_error = true;
-#else
-    assert(err == RADIOLIB_ERR_NONE);
 #endif
     isReceiving = false; // If we were receiving, not any more
     activeReceiveStart = 0;
     disableInterrupt();
     completeSending(); // If we were sending, not anymore
     RadioLibInterface::setStandby();
+    return err;
+}
+
+template <typename T> void SX126xInterface<T>::setStandby()
+{
+    int16_t err = trySetStandby();
+#ifdef ARCH_PORTDUINO
+    (void)err;
+#else
+    assert(err == RADIOLIB_ERR_NONE);
+#endif
 }
 
 /**

--- a/src/mesh/SX126xInterface.h
+++ b/src/mesh/SX126xInterface.h
@@ -90,5 +90,14 @@ template <class T> class SX126xInterface : public RadioLibInterface
 #endif
     /** Some boards require GPIO control of tx vs rx paths */
     void setTransmitEnable(bool txon);
+
+    /** Program all modem parameters into the chip; returns the first RadioLib error, or RADIOLIB_ERR_NONE */
+    int16_t programModemParams();
+
+    /** begin() and chip-side setup, shared by init() and by reconfigure()'s recovery of a chip that lost its state */
+    bool reinitChip();
+
+    /** setStandby()'s body, returning the standby error instead of asserting - for callers that can recover */
+    int16_t trySetStandby();
 };
 #endif

--- a/src/mesh/SX128xInterface.cpp
+++ b/src/mesh/SX128xInterface.cpp
@@ -62,6 +62,20 @@ template <typename T> bool SX128xInterface<T>::init()
 
     RadioLibInterface::init();
 
+    if (!reinitChip())
+        return false;
+
+    startReceive(); // start receiving
+
+    return true;
+}
+
+// begin() and the chip-side setup that a reset chip loses. Shared by init() and by reconfigure()'s
+// recovery of a chip that lost its state.
+template <typename T> bool SX128xInterface<T>::reinitChip()
+{
+    // Clamp here, not just in programModemParams(): applyModemConfig() resets `power` to the raw
+    // config value, and the recovery path reaches begin() without passing through the params clamp
     limitPower(SX128X_MAX_POWER);
 
     preambleLength = 12; // 12 is the default for this chip, 32 does not RX at all
@@ -104,52 +118,84 @@ template <typename T> bool SX128xInterface<T>::init()
     if (res == RADIOLIB_ERR_NONE)
         res = lora.setCRC(2);
 
-    if (res == RADIOLIB_ERR_NONE)
-        startReceive(); // start receiving
-
+    if (res != RADIOLIB_ERR_NONE)
+        LOG_ERROR("SX128x re-init failed %s%d", radioLibErr, res);
     return res == RADIOLIB_ERR_NONE;
+}
+
+template <typename T> int16_t SX128xInterface<T>::programModemParams()
+{
+    // configure publicly accessible settings
+    int16_t err = lora.setSpreadingFactor(sf);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("SX128X setSpreadingFactor(%u) %s%d", sf, radioLibErr, err);
+        return err;
+    }
+
+    err = lora.setBandwidth(bw);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("SX128X setBandwidth(%.1f) %s%d", bw, radioLibErr, err);
+        return err;
+    }
+
+    err = lora.setCodingRate(cr, cr != 7); // use long interleaving except if CR is 4/7 which doesn't support it
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("SX128X setCodingRate(%u) %s%d", cr, radioLibErr, err);
+        return err;
+    }
+
+    err = lora.setSyncWord(syncWord);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("SX128X setSyncWord %s%d", radioLibErr, err);
+        return err;
+    }
+
+    err = lora.setPreambleLength(preambleLength);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("SX128X setPreambleLength(%u) %s%d", preambleLength, radioLibErr, err);
+        return err;
+    }
+
+    err = lora.setFrequency(getFreq());
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("SX128X setFrequency(%.3f) %s%d", getFreq(), radioLibErr, err);
+        return err;
+    }
+
+    limitPower(SX128X_MAX_POWER);
+
+    err = lora.setOutputPower(power);
+    if (err != RADIOLIB_ERR_NONE) {
+        LOG_ERROR("SX128X setOutputPower(%d) %s%d", power, radioLibErr, err);
+        return err;
+    }
+
+    return RADIOLIB_ERR_NONE;
 }
 
 template <typename T> bool SX128xInterface<T>::reconfigure()
 {
     RadioLibInterface::reconfigure();
 
-    // set mode to standby
-    setStandby();
+    // set mode to standby - a chip that lost its state to a reset/brownout can time out here,
+    // so don't let setStandby()'s assert fire before the recovery below gets a chance
+    int16_t err = trySetStandby();
+    if (err == RADIOLIB_ERR_NONE)
+        err = programModemParams();
 
-    // configure publicly accessible settings
-    int err = lora.setSpreadingFactor(sf);
-    if (err != RADIOLIB_ERR_NONE)
+    if (err != RADIOLIB_ERR_NONE) {
+        // A chip that fails standby or rejects parameter programming (typically WRONG_MODEM, -20) has
+        // lost its runtime configuration - packet type included - to a chip-internal reset or brownout.
+        // Recover in place: begin() hardware-resets the chip and restores the LoRa packet type. Crashing
+        // here instead would reboot before MeshService persists the config change that triggered us.
         RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
-
-    err = lora.setBandwidth(bw);
-    if (err != RADIOLIB_ERR_NONE)
-        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
-
-    err = lora.setCodingRate(cr, cr != 7); // use long interleaving except if CR is 4/7 which doesn't support it
-    if (err != RADIOLIB_ERR_NONE)
-        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
-
-    err = lora.setSyncWord(syncWord);
-    if (err != RADIOLIB_ERR_NONE)
-        LOG_ERROR("SX128X setSyncWord %s%d", radioLibErr, err);
-    assert(err == RADIOLIB_ERR_NONE);
-
-    err = lora.setPreambleLength(preambleLength);
-    if (err != RADIOLIB_ERR_NONE)
-        LOG_ERROR("SX128X setPreambleLength %s%d", radioLibErr, err);
-    assert(err == RADIOLIB_ERR_NONE);
-
-    err = lora.setFrequency(getFreq());
-    if (err != RADIOLIB_ERR_NONE)
-        RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
-
-    limitPower(SX128X_MAX_POWER);
-
-    err = lora.setOutputPower(power);
-    if (err != RADIOLIB_ERR_NONE)
-        LOG_ERROR("SX128X setOutputPower %s%d", radioLibErr, err);
-    assert(err == RADIOLIB_ERR_NONE);
+        LOG_ERROR("SX128x rejected modem params, chip state lost? Full re-init");
+        if (!reinitChip() || (err = programModemParams()) != RADIOLIB_ERR_NONE) {
+            LOG_ERROR("SX128x unrecoverable %s%d, radio down until reboot", radioLibErr, err);
+            return false;
+        }
+        LOG_INFO("SX128x recovered after re-init");
+    }
 
     startReceive(); // restart receiving
 
@@ -166,15 +212,14 @@ template <typename T> bool SX128xInterface<T>::wideLora()
     return true;
 }
 
-template <typename T> void SX128xInterface<T>::setStandby()
+template <typename T> int16_t SX128xInterface<T>::trySetStandby()
 {
     checkNotification(); // handle any pending interrupts before we force standby
 
-    int err = lora.standby();
+    int16_t err = lora.standby();
 
     if (err != RADIOLIB_ERR_NONE)
         LOG_ERROR("SX128x standby %s%d", radioLibErr, err);
-    assert(err == RADIOLIB_ERR_NONE);
 #if ARCH_PORTDUINO
     if (portduino_config.lora_rxen_pin.pin != RADIOLIB_NC) {
         digitalWrite(portduino_config.lora_rxen_pin.pin, LOW);
@@ -195,6 +240,13 @@ template <typename T> void SX128xInterface<T>::setStandby()
     disableInterrupt();
     completeSending(); // If we were sending, not anymore
     RadioLibInterface::setStandby();
+    return err;
+}
+
+template <typename T> void SX128xInterface<T>::setStandby()
+{
+    int16_t err = trySetStandby();
+    assert(err == RADIOLIB_ERR_NONE);
 }
 
 /**

--- a/src/mesh/SX128xInterface.h
+++ b/src/mesh/SX128xInterface.h
@@ -74,4 +74,14 @@ template <class T> class SX128xInterface : public RadioLibInterface
     virtual void setStandby() override;
 
     uint32_t getPacketTime(uint32_t pl, bool received) override { return computePacketTime(lora, pl, received); }
+
+  private:
+    /** Program all modem parameters into the chip; returns the first RadioLib error, or RADIOLIB_ERR_NONE */
+    int16_t programModemParams();
+
+    /** begin() and chip-side setup, shared by init() and by reconfigure()'s recovery of a chip that lost its state */
+    bool reinitChip();
+
+    /** setStandby()'s body, returning the standby error instead of asserting - for callers that can recover */
+    int16_t trySetStandby();
 };


### PR DESCRIPTION
## Problem

Since #9962, every LoRa config change applies live: `configChanged` observer → the radio driver's `reconfigure()`. If the chip has lost its runtime configuration by then (chip-internal reset/brownout), `reconfigure()` crashes the node on an `assert`: on every one of these chips the power-on-reset modem is FSK/GFSK, so the packet-type-guarded RadioLib setters return `RADIOLIB_ERR_WRONG_MODEM`, and on some (measured on SX1262) the first `standby()` after state loss fails outright with `SPI_CMD_TIMEOUT` (-707), tripping the assert inside `setStandby()` itself.

The assert reboots the node from inside `MeshService::reloadConfig()` **before** `saveToDisk()` runs, so the config change that triggered the reconfigure is lost. On a first-time region set the damage is worse: `ensurePkiIdentity()` has already saved nodes.proto with the old node purged, but the unsaved devicestate reverts to the old identity on reboot — the node comes back with region UNSET, its old node number, and its own entry missing from the node DB.

Observed in the field on a T1000-E (LR1110, 2.8.0.52d5214) during a phone-driven region set:

```
ERROR | 07:14:38 47 NOTE! Record critical error 7 at src/mesh/LR11x0Interface.cpp:282
ERROR | 07:14:38 47 NOTE! Record critical error 7 at src/mesh/LR11x0Interface.cpp:286
ERROR | 07:14:38 47 NOTE! Record critical error 7 at src/mesh/LR11x0Interface.cpp:290
ERROR | 07:14:38 47 assert failed src/mesh/LR11x0I
```

Reproduced on demand on a RAK4631 (SX1262) by cold-sleeping the chip (drops all config, mimicking a brownout) immediately before a live config apply: the stock firmware crash-loops on the `setStandby()` assert; with this PR the same stimulus logs the error, re-inits the chip in place, and the node keeps running:

```
DEBUG | SX126x standby RadioLib err=-707
ERROR | NOTE! Record critical error 7 at src/mesh/SX126xInterface.cpp:301
ERROR | SX126x rejected modem params, chip state lost? Full re-init
INFO  | SX126x init result 0
INFO  | SX126x recovered after re-init
```

The modem parameters themselves were valid in the field trace (SF11/BW500/CR8, provable from the logged preamble time), so this is not the old zero coding-rate/spread-factor bug; the AdminModule clamps already cover that.

## Fix (LR11x0, SX126x, SX128x, RF95, LR20x0)

- `setStandby()` is split: `trySetStandby()` does the work and returns the error; `setStandby()` keeps the assert for all other callers. `reconfigure()` uses `trySetStandby()` so a standby failure routes into recovery instead of crashing.
- Modem parameter programming moves into `programModemParams()`, which returns the first RadioLib error and logs each failure with its error code (previously critical error 7 was recorded with no code, making field logs undiagnosable).
- On failure, `reconfigure()` recovers in place via `reinitChip()` (LR20x0: the existing band-hop `fullBegin()` path, now shared): `begin()` hardware-resets the chip and reprograms it, then chip-side state that `begin()` does not restore is re-applied per family — DIO RF-switch table, DIO2-as-RF-switch, OCP limit, PA ramp, RX gain, RX-sensitivity register patch, CRC. `init()` shares the same helper instead of duplicating it.
- `reinitChip()` clamps `power` before `begin()`: `applyModemConfig()` resets it to the raw config value and the recovery path doesn't pass through the params clamp (without this, tx_power=30 on a 22 dBm part made LR11x0 recovery fail with INVALID_OUTPUT_POWER; observed as `init result -13` on the RAK4631 during bring-up of this fix).
- Only if recovery also fails does `reconfigure()` give up — with a logged error and `return false`, never a crash — so the pending config save still completes.

Recovery deliberately re-runs `begin()` directly rather than `init()`: `Observer::observe()` appends unconditionally, so a second `init()` would double-register `configChangedObserver` and run every subsequent reconfigure twice.

## Testing

- T1000-E (LR1110): flashed; live LoRa config set over serial programs cleanly and persists.
- RAK4631 (SX1262): induced chip state loss (cold sleep) right before a live config apply. Stock develop: assert crash + reboot loop, config change lost. This PR: standby -707 tolerated, full re-init, `SX126x recovered after re-init`, node keeps running and the config persists.
- Builds: `rak4631`, `tracker-t1000-e`, `native-macos` (portduino compiles all five drivers, including SX128x and LR20x0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved modem recovery after resets, brownouts, or power interruptions.
  - Automatically reinitializes affected radios and reapplies communication settings after configuration failures.
  - Preserves the detected oscillator voltage during recovery for more reliable startup.
  - Handles standby and parameter-programming errors without triggering premature assertions.
  - Reports configuration failures accurately and stops recovery when retry attempts are unsuccessful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->