### PR TITLE
feat: allow client-specified first hop for broadcasts

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -297,7 +297,7 @@ void MeshService::handleToRadio(meshtastic_MeshPacket &p)
 #endif
     p.from = 0;                   // We don't let clients assign nodenums to their sent messages
     p.relay_node = NO_RELAY_NODE; // We don't let clients assign relay_node to their sent messages
-    if (!isBroadcast(p.to))
+    if (!isBroadcast(p.to) || !nodeDB->resolveUniqueLastByte(p.next_hop, /*requireDirectNeighbor=*/true))
         p.next_hop = NO_NEXT_HOP_PREFERENCE;
 
     if (p.id == 0)

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -295,9 +295,10 @@ void MeshService::handleToRadio(meshtastic_MeshPacket &p)
         return;
     }
 #endif
-    p.from = 0;                          // We don't let clients assign nodenums to their sent messages
-    p.next_hop = NO_NEXT_HOP_PREFERENCE; // We don't let clients assign next_hop to their sent messages
-    p.relay_node = NO_RELAY_NODE;        // We don't let clients assign relay_node to their sent messages
+    p.from = 0;                   // We don't let clients assign nodenums to their sent messages
+    p.relay_node = NO_RELAY_NODE; // We don't let clients assign relay_node to their sent messages
+    if (!isBroadcast(p.to))
+        p.next_hop = NO_NEXT_HOP_PREFERENCE;
 
     if (p.id == 0)
         p.id = generatePacketId(); // If the phone didn't supply one, then pick one

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -104,7 +104,8 @@ ErrorCode NextHopRouter::sendWithNextHop(meshtastic_MeshPacket *p, bool trackRet
     p->relay_node = nodeDB->getLastByteOfNodeNum(getNodeNum()); // First set the relayer to us
     wasSeenRecently(p);                                         // FIXME, move this to a sniffSent method
 
-    p->next_hop = getNextHop(p->to, p->relay_node).value_or(NO_NEXT_HOP_PREFERENCE); // set the next hop
+    if (!isBroadcast(p->to) || !isFromUs(p) || p->next_hop == NO_NEXT_HOP_PREFERENCE)
+        p->next_hop = getNextHop(p->to, p->relay_node).value_or(NO_NEXT_HOP_PREFERENCE);
     LOG_TRACE("Set next hop for dest 0x%08x to 0x%x", p->to, p->next_hop);
 
     // If it's from us, ReliableRouter already handles retransmissions if want_ack is set. If a next hop is set and hop limit is

--- a/test/test_nexthop_routing/test_main.cpp
+++ b/test/test_nexthop_routing/test_main.cpp
@@ -334,6 +334,14 @@ static MockRadioInterface *installMockIface()
     return mock;
 }
 
+static CaptureRadioInterface *installCaptureIface()
+{
+    auto *capture = new CaptureRadioInterface();
+    nextHopRadio = capture;
+    shim->addInterface(std::unique_ptr<RadioInterface>(capture));
+    return capture;
+}
+
 static constexpr uint32_t TTL = NextHopRouter::ROUTE_TTL_MSEC;
 static constexpr uint8_t THRESH = NextHopRouter::ROUTE_FAILURE_THRESHOLD;
 static constexpr uint8_t HEALTH_MAX = NextHopRouter::ROUTE_HEALTH_MAX;
@@ -988,6 +996,32 @@ void test_rebroadcast_declined_send_releases_packet(void)
     TEST_ASSERT_EQUAL_MESSAGE(1, mockIface->sendCount, "the copy must have reached the mock radio");
 }
 
+void test_broadcast_first_hop_is_preserved_then_cleared_by_selected_relay(void)
+{
+    constexpr uint8_t selectedRelay = 0x11;
+    constexpr uint8_t otherRelay = 0x33;
+    CaptureRadioInterface *capture = installCaptureIface();
+
+    meshtastic_MeshPacket p = makeBehaviorPacket(meshtastic_PortNum_TEXT_MESSAGE_APP, kLocalNode, NODENUM_BROADCAST, 0);
+    p.next_hop = selectedRelay;
+
+    TEST_ASSERT_EQUAL(ERRNO_OK, shim->send(packetPool.allocCopy(p)));
+    TEST_ASSERT_EQUAL_UINT32(1, capture->sentPackets.size());
+    TEST_ASSERT_EQUAL_HEX8(selectedRelay, capture->sentPackets[0].next_hop);
+
+    capture->reset();
+    p.from = kRemoteNode;
+    p.relay_node = 0x22;
+    p.next_hop = otherRelay;
+    TEST_ASSERT_FALSE(shim->perhapsRebroadcast(&p));
+    TEST_ASSERT_EQUAL_UINT32(0, capture->sentPackets.size());
+
+    p.next_hop = selectedRelay;
+    TEST_ASSERT_TRUE(shim->perhapsRebroadcast(&p));
+    TEST_ASSERT_EQUAL_UINT32(1, capture->sentPackets.size());
+    TEST_ASSERT_EQUAL_HEX8(NO_NEXT_HOP_PREFERENCE, capture->sentPackets[0].next_hop);
+}
+
 // An already-encrypted packet never reaches perhapsEncode's TOO_LARGE check, so Router::send() is the
 // last gate before the radio queue: MeshPacket.encrypted holds 256 bytes, the radio buffer 240.
 void test_send_rejects_payload_larger_than_radio_buffer(void)
@@ -1134,6 +1168,7 @@ void setup()
     RUN_TEST(test_rebroadcast_normal_broadcast_is_relayed);
     RUN_TEST(test_rebroadcast_no_lora_broadcast_is_not_relayed);
     RUN_TEST(test_rebroadcast_declined_send_releases_packet);
+    RUN_TEST(test_broadcast_first_hop_is_preserved_then_cleared_by_selected_relay);
     RUN_TEST(test_send_rejects_payload_larger_than_radio_buffer);
 #if USERPREFS_EVENT_MODE
     RUN_TEST(test_event_mode_hop_behavior);

--- a/test/test_nexthop_routing/test_main.cpp
+++ b/test/test_nexthop_routing/test_main.cpp
@@ -1001,12 +1001,13 @@ void test_broadcast_first_hop_is_preserved_then_cleared_by_selected_relay(void)
     constexpr uint8_t selectedRelay = 0x11;
     constexpr uint8_t otherRelay = 0x33;
     CaptureRadioInterface *capture = installCaptureIface();
+    mockNodeDB->addNode(0x33333311, 0, true, 60);
 
     meshtastic_MeshPacket p = makeBehaviorPacket(meshtastic_PortNum_TEXT_MESSAGE_APP, kLocalNode, NODENUM_BROADCAST, 0);
     p.next_hop = selectedRelay;
 
     TEST_ASSERT_EQUAL(ERRNO_OK, shim->send(packetPool.allocCopy(p)));
-    TEST_ASSERT_EQUAL_UINT32(1, capture->sentPackets.size());
+    TEST_ASSERT_FALSE(capture->sentPackets.empty());
     TEST_ASSERT_EQUAL_HEX8(selectedRelay, capture->sentPackets[0].next_hop);
 
     capture->reset();
@@ -1014,11 +1015,11 @@ void test_broadcast_first_hop_is_preserved_then_cleared_by_selected_relay(void)
     p.relay_node = 0x22;
     p.next_hop = otherRelay;
     TEST_ASSERT_FALSE(shim->perhapsRebroadcast(&p));
-    TEST_ASSERT_EQUAL_UINT32(0, capture->sentPackets.size());
+    TEST_ASSERT_TRUE(capture->sentPackets.empty());
 
     p.next_hop = selectedRelay;
     TEST_ASSERT_TRUE(shim->perhapsRebroadcast(&p));
-    TEST_ASSERT_EQUAL_UINT32(1, capture->sentPackets.size());
+    TEST_ASSERT_FALSE(capture->sentPackets.empty());
     TEST_ASSERT_EQUAL_HEX8(NO_NEXT_HOP_PREFERENCE, capture->sentPackets[0].next_hop);
 }
 


### PR DESCRIPTION
## Summary

Closes #7770.

- Preserve a client-supplied `MeshPacket.next_hop` for broadcast packets received through the API.
- Honor that hint only on the locally originated broadcast; the selected relay clears it before forwarding so propagation returns to normal flooding.
- Keep normal directed-message next-hop routing unchanged.
- Add a routing regression covering preservation, non-selected relay suppression, and selected-relay clearing.

## Behavioral contract

This is not directed delivery. Every node in radio range can receive and process the original channel message through the normal path. `next_hop` only selects the node eligible to make the first rebroadcast. Once that node forwards, the hint is cleared and subsequent propagation is ordinary mesh flooding.

## Validation

- `~/.platformio/penv/bin/python -m platformio test -e native-macos -f test_nexthop_routing` — 50/50 passed.
- Hardware test: MUZI Base (origin) → T-Echo (selected) / T-Beam S3 (not selected), all on US / LongFast / slot 88 with the same private test channel. Both downstream nodes received the origin packet. The T-Echo alone rebroadcast the origin packet and logged `next_hop=0`; the T-Beam did not rebroadcast the origin copy, then correctly relayed the T-Echo normal-flood copy.
- Meshtasticator three-node simulation passed: the selected node became the first relay; the other node received the original but did not relay it until the normal flood.

## Potential uses

- Seed dissemination through a known reliable nearby relay without changing persistent topology configuration.
- Prefer a gateway or relay during a transient channel-message send.
- Exercise and troubleshoot first-relay behavior in dense or constrained meshes.

## Notes

- This applies to broadcast packets only; direct messages remain on normal next-hop routing.
- The on-air first-hop identifier is one byte, so nodes sharing that last byte remain an existing protocol-level collision caveat.

## Attestations

- [x] I tested that the proposed behavior matches this description.
- [x] Hardware exercised: MUZI Base, T-Echo, and T-Beam S3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved broadcast packet routing by preserving explicitly selected, valid direct next hops during initial delivery.
  * Added safeguards to clear invalid or ambiguous next-hop preferences, allowing normal flooding to proceed reliably.
  * Prevented routing information from being overwritten during relayed or broadcast transmissions.
* **Tests**
  * Expanded coverage for next-hop preservation, validation, and fallback behavior across broadcast and relay transmissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->