### PR TITLE
fix(radio): address CodeRabbit findings on the hot-path recovery PR

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1481,11 +1481,11 @@ void loop()
             RadioLibInterface::instance->pollMissedIrqs();
         }
 
-        // Periodic AGC reset - warm sleep + recalibrate to prevent stuck AGC gain
+        // Periodic radio upkeep - re-arms RX if it was left off, else AGC reset (stuck-gain prevention)
         static uint32_t lastAgcReset;
         if (!Throttle::isWithinTimespanMs(lastAgcReset, AGC_RESET_INTERVAL_MS)) {
             lastAgcReset = millis();
-            RadioLibInterface::instance->resetAGC();
+            RadioLibInterface::instance->periodicRadioMaintenance();
         }
     }
 

--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -185,6 +185,8 @@ template <typename T> bool LR11x0Interface<T>::init()
         if (lora.updateFirmware(lr11xx_firmware_image, LR11XX_FIRMWARE_IMAGE_SIZE, true) == RADIOLIB_ERR_NONE) {
             LOG_INFO("LR1110 firmware recovery OK, re-init radio");
             res = lora.begin(getFreq(), bw, sf, cr, syncWord, power, preambleLength, tcxoVoltage);
+            if (res == RADIOLIB_ERR_NONE)
+                resolvedTcxoVoltage = tcxoVoltage;
         }
 #endif
         if (res != RADIOLIB_ERR_NONE)
@@ -222,6 +224,7 @@ template <typename T> bool LR11x0Interface<T>::init()
             LOG_ERROR("LR11x0 re-init after firmware update failed %s%d", radioLibErr, res);
             return false;
         }
+        resolvedTcxoVoltage = tcxoVoltage;
 
         if (lora.getVersionInfo(&version) == RADIOLIB_ERR_NONE) {
             transceiverFw = ((uint16_t)version.fwMajor << 8) | version.fwMinor;

--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -473,8 +473,9 @@ template <typename T> void LR11x0Interface<T>::startReceive()
     }
 
     if (err != RADIOLIB_ERR_NONE) {
-        // No assert: leave RX off rather than reboot; the next startReceive() retries, throttled
+        // No assert: leave RX off rather than reboot; periodicRadioMaintenance() re-arms it, throttled
         LOG_ERROR("LR11x0 RX offline %s%d", radioLibErr, err);
+        rxOffline = true;
         return;
     }
 

--- a/src/mesh/LR20x0Interface.cpp
+++ b/src/mesh/LR20x0Interface.cpp
@@ -260,11 +260,11 @@ template <typename T> bool LR20x0Interface<T>::reconfigure()
             standbySuccess = false;
         }
 
+        // Warn-only, as in LR11x0: a rejected gain mode is cosmetic and not a lost-state signature, so
+        // it must not drag reconfigure() into a full chip reset.
         err = lora.setRxBoostedGainMode(config.lora.sx126x_rx_boosted_gain);
-        if (err != RADIOLIB_ERR_NONE) {
+        if (err != RADIOLIB_ERR_NONE)
             LOG_WARN("LR20x0 setRxBoostedGainMode %s%d", radioLibErr, err);
-            standbySuccess = false;
-        }
     }
 
     if (!standbySuccess) {
@@ -437,8 +437,9 @@ template <typename T> void LR20x0Interface<T>::startReceive()
     }
 
     if (err != RADIOLIB_ERR_NONE) {
-        // No assert: leave RX off rather than reboot; the next startReceive() retries, throttled
+        // No assert: leave RX off rather than reboot; periodicRadioMaintenance() re-arms it, throttled
         LOG_ERROR("LR20x0 RX offline %s%d", radioLibErr, err);
+        rxOffline = true;
         return;
     }
 

--- a/src/mesh/LR20x0Interface.cpp
+++ b/src/mesh/LR20x0Interface.cpp
@@ -179,7 +179,9 @@ template <typename T> bool LR20x0Interface<T>::init()
 
 template <typename T> bool LR20x0Interface<T>::reconfigure()
 {
-    bool success = RadioLibInterface::reconfigure();
+    // Propagated to the return value below, separately from the chip-programming outcome, so a
+    // base-class failure isn't masked as success.
+    const bool reconfigureSuccess = RadioLibInterface::reconfigure();
 
     if (config.lora.region == meshtastic_Config_LoRaConfig_RegionCode_LORA_24) {
         limitPower(LR2021_MAX_POWER_HF);
@@ -199,72 +201,73 @@ template <typename T> bool LR20x0Interface<T>::reconfigure()
             return false;
 
         startReceive();
-        return true;
+        return reconfigureSuccess;
     }
 
     // Same-band reconfigure (previous incremental path)
+    bool standbySuccess = true;
     int16_t standbyErr = trySetStandby();
     if (standbyErr != RADIOLIB_ERR_NONE)
-        success = false;
+        standbySuccess = false;
 
     if (standbyErr == RADIOLIB_ERR_NONE) {
         int err = lora.setFrequency(freq);
         if (err != RADIOLIB_ERR_NONE) {
             LOG_ERROR("LR20x0 setFrequency %.3f MHz %s%d", freq, radioLibErr, err);
             RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
-            success = false;
+            standbySuccess = false;
         }
 
         err = lora.setSpreadingFactor(sf);
         if (err != RADIOLIB_ERR_NONE) {
             LOG_ERROR("LR20x0 setSpreadingFactor(%u) %s%d", sf, radioLibErr, err);
             RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
-            success = false;
+            standbySuccess = false;
         }
 
         err = lora.setBandwidth(bw);
         if (err != RADIOLIB_ERR_NONE) {
             LOG_ERROR("LR20x0 setBandwidth(%.1f) %s%d", bw, radioLibErr, err);
             RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
-            success = false;
+            standbySuccess = false;
         }
 
         err = lora.setCodingRate(cr, cr != 7);
         if (err != RADIOLIB_ERR_NONE) {
             LOG_ERROR("LR20x0 setCodingRate(%u) %s%d", cr, radioLibErr, err);
             RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
-            success = false;
+            standbySuccess = false;
         }
 
         err = lora.setSyncWord(syncWord);
         if (err != RADIOLIB_ERR_NONE) {
             LOG_ERROR("LR20x0 setSyncWord %s%d", radioLibErr, err);
             RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
-            success = false;
+            standbySuccess = false;
         }
 
         err = lora.setPreambleLength(preambleLength);
         if (err != RADIOLIB_ERR_NONE) {
             LOG_ERROR("LR20x0 setPreambleLength(%u) %s%d", preambleLength, radioLibErr, err);
             RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
-            success = false;
+            standbySuccess = false;
         }
 
         err = lora.setOutputPower(power);
         if (err != RADIOLIB_ERR_NONE) {
             LOG_ERROR("LR20x0 setOutputPower %d dBm @ %.3f MHz %s%d", power, freq, radioLibErr, err);
             RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
-            success = false;
+            standbySuccess = false;
         }
 
         err = lora.setRxBoostedGainMode(config.lora.sx126x_rx_boosted_gain);
         if (err != RADIOLIB_ERR_NONE) {
             LOG_WARN("LR20x0 setRxBoostedGainMode %s%d", radioLibErr, err);
-            success = false;
+            standbySuccess = false;
         }
     }
 
-    if (!success) {
+    if (!standbySuccess) {
         // A chip that fails standby or rejects parameter programming (typically WRONG_MODEM, -20) has
         // lost its runtime configuration to a chip-internal reset or brownout. Recover in place with the
         // same full begin() the band-hop path uses - it hardware-resets the chip. Crashing here instead
@@ -279,7 +282,7 @@ template <typename T> bool LR20x0Interface<T>::reconfigure()
 
     startReceive();
     lr20x0LastFreqMHz = freq;
-    return true;
+    return reconfigureSuccess;
 }
 
 // The chip-side re-init the band-hop and recovery paths share: front-end switch GPIOs for the target

--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -363,8 +363,9 @@ void RF95Interface::startReceive()
     }
 
     if (err != RADIOLIB_ERR_NONE) {
-        // No assert: leave RX off rather than reboot; the next startReceive() retries, throttled
+        // No assert: leave RX off rather than reboot; periodicRadioMaintenance() re-arms it, throttled
         LOG_ERROR("RF95 RX offline %s%d", radioLibErr, err);
+        rxOffline = true;
         return;
     }
 

--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -369,7 +369,7 @@ void RF95Interface::startReceive()
         return;
     }
 
-    isReceiving = true;
+    RadioLibInterface::startReceive();
 
     // Must be done AFTER, starting receive, because startReceive clears (possibly stale) interrupt pending register bits
     enableInterrupt(isrRxLevel0);

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -707,7 +707,8 @@ void RadioLibInterface::handleReceiveInterrupt()
 void RadioLibInterface::startReceive()
 {
     isReceiving = true;
-    // Drivers only reach here once the chip actually accepted the RX start, so the radio is alive again
+    // Drivers only reach here once the chip actually accepted the RX start, so the radio is alive again.
+    // This is the sole place the recovery ladder is cleared - nothing short of an armed RX counts as fixed.
     rxOffline = false;
     chipRecoveryFailures = 0;
     powerMon->setState(meshtastic_PowerMon_State_Lora_RXOn);
@@ -752,20 +753,23 @@ bool RadioLibInterface::maybeRecoverChipStateLoss()
         LOG_DEBUG("Radio recovery suppressed, %us since the last attempt", (millis() - lastChipRecoveryMs) / 1000);
         return false;
     }
+
+    // The ladder counts re-arms, not re-inits: only RadioLibInterface::startReceive() clears the count, and
+    // only once the chip really accepted RX. Judging the previous attempt here - a throttle window later,
+    // after its retry - is what stops a begin() that succeeded while leaving RX dead from crediting itself.
+    if (chipRecoveryFailures >= MAX_CHIP_RECOVERY_FAILURES && rebootAtMsec == 0) {
+        // Attempts are a throttle window apart, so this is minutes of a provably deaf chip. begin() alone
+        // clearly isn't reviving it; reboot to re-run init(), which redoes the power-on sequence it skips.
+        LOG_ERROR("Radio still deaf after %u re-inits, rebooting", chipRecoveryFailures);
+        rebootAtMsec = millis() + DEFAULT_REBOOT_SECONDS * 1000;
+    }
+    chipRecoveryFailures++;
+
     lastChipRecoveryMs = millis();
     RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
     LOG_ERROR("Radio chip state lost mid-operation, re-init");
     bool recovered = recoverChipStateLoss();
     LOG_INFO("Radio re-init %s", recovered ? "succeeded" : "failed");
-
-    if (recovered) {
-        chipRecoveryFailures = 0;
-    } else if (++chipRecoveryFailures >= MAX_CHIP_RECOVERY_FAILURES && rebootAtMsec == 0) {
-        // Attempts are a throttle window apart, so this is minutes of a provably dead chip. begin() alone
-        // clearly isn't reviving it; reboot to re-run init(), which redoes the power-on sequence it skips.
-        LOG_ERROR("Radio dead after %u re-inits, rebooting", chipRecoveryFailures);
-        rebootAtMsec = millis() + DEFAULT_REBOOT_SECONDS * 1000;
-    }
     return recovered;
 }
 

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -707,6 +707,9 @@ void RadioLibInterface::handleReceiveInterrupt()
 void RadioLibInterface::startReceive()
 {
     isReceiving = true;
+    // Drivers only reach here once the chip actually accepted the RX start, so the radio is alive again
+    rxOffline = false;
+    chipRecoveryFailures = 0;
     powerMon->setState(meshtastic_PowerMon_State_Lora_RXOn);
 }
 
@@ -726,17 +729,43 @@ void RadioLibInterface::resetAGC()
     // Base implementation: no-op. Override in chip-specific subclasses.
 }
 
+void RadioLibInterface::periodicRadioMaintenance()
+{
+    // Every startReceive() call site is event-driven (RX/TX ISR, the CAD-busy branch, reconfigure), and a
+    // radio left with RX off can no longer raise an RX interrupt - on a node with nothing to transmit
+    // nothing would ever re-arm it. This periodic tick is that retry; maybeRecoverChipStateLoss() throttles.
+    if (rxOffline) {
+        LOG_WARN("Radio RX offline, retrying");
+        if (maybeRecoverChipStateLoss())
+            startReceive();
+        return; // a chip just re-inited (or still dead) has no use for an AGC reset this tick
+    }
+
+    resetAGC();
+}
+
 bool RadioLibInterface::maybeRecoverChipStateLoss()
 {
     // One attempt per window: the transient resets this recovers from need a single re-init, and a
     // chip that stays dead must not stall the TX/RX paths with a begin() attempt on every call
-    if (lastChipRecoveryMs && Throttle::isWithinTimespanMs(lastChipRecoveryMs, 30 * 1000UL))
+    if (lastChipRecoveryMs && Throttle::isWithinTimespanMs(lastChipRecoveryMs, 30 * 1000UL)) {
+        LOG_DEBUG("Radio recovery suppressed, %us since the last attempt", (millis() - lastChipRecoveryMs) / 1000);
         return false;
+    }
     lastChipRecoveryMs = millis();
     RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
     LOG_ERROR("Radio chip state lost mid-operation, re-init");
     bool recovered = recoverChipStateLoss();
     LOG_INFO("Radio re-init %s", recovered ? "succeeded" : "failed");
+
+    if (recovered) {
+        chipRecoveryFailures = 0;
+    } else if (++chipRecoveryFailures >= MAX_CHIP_RECOVERY_FAILURES && rebootAtMsec == 0) {
+        // Attempts are a throttle window apart, so this is minutes of a provably dead chip. begin() alone
+        // clearly isn't reviving it; reboot to re-run init(), which redoes the power-on sequence it skips.
+        LOG_ERROR("Radio dead after %u re-inits, rebooting", chipRecoveryFailures);
+        rebootAtMsec = millis() + DEFAULT_REBOOT_SECONDS * 1000;
+    }
     return recovered;
 }
 

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -191,7 +191,7 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
 
     uint32_t lastChipRecoveryMs = 0;
 
-    /// Consecutive failed recoveries before giving up on in-place repair and rebooting to re-run init()
+    /// Consecutive recovery attempts that never got RX armed again, before rebooting to re-run init()
     static constexpr uint8_t MAX_CHIP_RECOVERY_FAILURES = 5;
     uint8_t chipRecoveryFailures = 0;
 

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -180,6 +180,9 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
      */
     virtual void resetAGC();
 
+    /** Periodic radio upkeep: re-arms RX if a failed startReceive() left it off, otherwise resets AGC. */
+    void periodicRadioMaintenance();
+
     /** Chip-specific recovery of a chip that lost its state to a reset/brownout. Returns true if reprogrammed. */
     virtual bool recoverChipStateLoss() { return false; }
 
@@ -187,6 +190,13 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
     bool maybeRecoverChipStateLoss();
 
     uint32_t lastChipRecoveryMs = 0;
+
+    /// Consecutive failed recoveries before giving up on in-place repair and rebooting to re-run init()
+    static constexpr uint8_t MAX_CHIP_RECOVERY_FAILURES = 5;
+    uint8_t chipRecoveryFailures = 0;
+
+    /// Set by a driver's startReceive() when it gives up and leaves RX off; cleared once RX is armed again.
+    bool rxOffline = false;
 
     /**
      * Debugging counts

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -180,17 +180,10 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
      */
     virtual void resetAGC();
 
-    /**
-     * Chip-specific recovery of a chip that lost its runtime state to a reset or brownout
-     * (POR default modem is FSK/GFSK on every supported chip, so guarded commands return
-     * WRONG_MODEM and standby can time out). Returns true when the chip was reprogrammed.
-     */
+    /** Chip-specific recovery of a chip that lost its state to a reset/brownout. Returns true if reprogrammed. */
     virtual bool recoverChipStateLoss() { return false; }
 
-    /**
-     * Throttled recoverChipStateLoss() for the RX/TX hot paths (startReceive, isChannelActive),
-     * so a chip that stays dead cannot stall them with back-to-back begin() attempts.
-     */
+    /** Throttled recoverChipStateLoss(), so a dead chip can't stall the RX/TX hot paths with repeated begin(). */
     bool maybeRecoverChipStateLoss();
 
     uint32_t lastChipRecoveryMs = 0;

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -453,8 +453,9 @@ template <typename T> void SX126xInterface<T>::startReceive()
 #ifdef ARCH_PORTDUINO
         portduino_status.LoRa_in_error = true;
 #else
-        // No assert: leave RX off rather than reboot; the next startReceive() retries, throttled
+        // No assert: leave RX off rather than reboot; periodicRadioMaintenance() re-arms it, throttled
         LOG_ERROR("SX126X RX offline %s%d", radioLibErr, err);
+        rxOffline = true;
         return;
 #endif
     }

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -284,10 +284,8 @@ template <typename T> bool SX126xInterface<T>::reconfigure()
         err = programModemParams();
 
     if (err != RADIOLIB_ERR_NONE) {
-        // A chip that fails standby or rejects parameter programming (typically WRONG_MODEM, -20) has
-        // lost its runtime configuration - packet type included - to a chip-internal reset or brownout.
-        // Recover in place: begin() hardware-resets the chip and restores the LoRa packet type. Crashing
-        // here instead would reboot before MeshService persists the config change that triggered us.
+        // Chip likely lost its state (reset/brownout); recover in place rather than crash - see
+        // RadioLibInterface::recoverChipStateLoss().
         RECORD_CRITICALERROR(meshtastic_CriticalErrorCode_INVALID_RADIO_SETTING);
         LOG_ERROR("SX126x rejected modem params, chip state lost? Full re-init");
         if (!reinitChip() || (err = programModemParams()) != RADIOLIB_ERR_NONE) {

--- a/src/mesh/SX128xInterface.cpp
+++ b/src/mesh/SX128xInterface.cpp
@@ -294,8 +294,6 @@ template <typename T> void SX128xInterface<T>::startReceive()
     sleep();
 #else
 
-    setStandby();
-
 #if ARCH_PORTDUINO
     if (portduino_config.lora_rxen_pin.pin != RADIOLIB_NC) {
         digitalWrite(portduino_config.lora_rxen_pin.pin, HIGH);

--- a/src/mesh/SX128xInterface.cpp
+++ b/src/mesh/SX128xInterface.cpp
@@ -62,7 +62,7 @@ template <typename T> bool SX128xInterface<T>::init()
 
     RadioLibInterface::init();
 
-    if (!reinitChip())
+    if (!reinitChip(/*fromInit=*/true))
         return false;
 
     startReceive(); // start receiving
@@ -72,7 +72,7 @@ template <typename T> bool SX128xInterface<T>::init()
 
 // begin() and the chip-side setup that a reset chip loses. Shared by init() and by reconfigure()'s
 // recovery of a chip that lost its state.
-template <typename T> bool SX128xInterface<T>::reinitChip()
+template <typename T> bool SX128xInterface<T>::reinitChip(bool fromInit)
 {
     // Clamp here, not just in programModemParams(): applyModemConfig() resets `power` to the raw
     // config value, and the recovery path reaches begin() without passing through the params clamp
@@ -87,6 +87,12 @@ template <typename T> bool SX128xInterface<T>::reinitChip()
         return false;
 
     if ((config.lora.region != meshtastic_Config_LoRaConfig_RegionCode_LORA_24) && (res == RADIOLIB_ERR_INVALID_FREQUENCY)) {
+        // Boot-time only: rebooting out of a runtime recovery would reintroduce exactly the crash this
+        // recovery path exists to avoid, and would do it while a config save is still pending.
+        if (!fromInit) {
+            LOG_ERROR("SX128x rejected the frequency during recovery; leaving region alone");
+            return false;
+        }
         LOG_WARN("Radio only supports 2.4GHz LoRa. Adjusting Region and rebooting");
         config.lora.region = meshtastic_Config_LoRaConfig_RegionCode_LORA_24;
         nodeDB->saveToDisk(SEGMENT_CONFIG);
@@ -322,8 +328,9 @@ template <typename T> void SX128xInterface<T>::startReceive()
     }
 
     if (err != RADIOLIB_ERR_NONE) {
-        // No assert: leave RX off rather than reboot; the next startReceive() retries, throttled
+        // No assert: leave RX off rather than reboot; periodicRadioMaintenance() re-arms it, throttled
         LOG_ERROR("SX128X RX offline %s%d", radioLibErr, err);
+        rxOffline = true;
         return;
     }
 

--- a/src/mesh/SX128xInterface.h
+++ b/src/mesh/SX128xInterface.h
@@ -80,7 +80,9 @@ template <class T> class SX128xInterface : public RadioLibInterface
     int16_t programModemParams();
 
     /** begin() and chip-side setup, shared by init() and by reconfigure()'s recovery of a chip that lost its state */
-    bool reinitChip();
+    /** @param fromInit true only for the boot-time call, which may adjust region and reboot on a
+     *  2.4GHz-only part; a runtime recovery must never reboot the node. */
+    bool reinitChip(bool fromInit = false);
 
     /** setStandby()'s body, returning the standby error instead of asserting - for callers that can recover */
     int16_t trySetStandby();


### PR DESCRIPTION
Addresses the four items CodeRabbit flagged on this PR:

- **SX128x** (`major`): `startReceive()` still called the old asserting `setStandby()` before the new `trySetStandby()`. The assert fired first, so the recovery path added later in the function was unreachable - the chip-state-loss crash this PR targets was still live on SX128x. Removed the stale call.
- **LR11x0** (`minor`): `resolvedTcxoVoltage` was only set after the primary `begin()` retry sequence. The firmware-recovery and one-shot firmware-update paths call `begin()` again with `tcxoVoltage` and never updated it, so `reinitChip()` could recover with the wrong oscillator setting on a `TCXO_OPTIONAL` board that only came up via one of those paths. Updated `resolvedTcxoVoltage` after both.
- **LR20x0** (`minor`): `reconfigure()` discarded `RadioLibInterface::reconfigure()`'s result - the band-hop path always returned `true` regardless, and the same-band path reused the same flag for chip-programming errors. Split into `reconfigureSuccess` (propagated to the return value) and `standbySuccess` (drives the recovery decision only).
- Comment-length nitpick in `RadioLibInterface.h` / `SX126xInterface.cpp`, shortened to 1-2 lines per repo convention.

Built `tracker-t1000-e` (LR11x0) and `heltec-v3` (SX126x) clean against this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Radios now recover from resets, brownouts, and lost runtime state without immediately crashing or rebooting.
  * Failed receive operations leave the radio safely offline and retry automatically during periodic maintenance.
  * Standby, channel scanning, sleep, and reconfiguration failures are handled gracefully with recovery attempts.
  * Repeated recovery failures eventually trigger a controlled reboot.
* **Reliability**
  * Radio initialization and configuration now preserve successful TCXO settings and retry recoverable errors.
  * Receive recovery tracking now resets only after RX is successfully restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->