### PR TITLE
feat(screen): stream the display framebuffer to local clients (DisplayFrame mirroring)

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -645,6 +645,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define HAS_SCREEN_MIRROR 0
 #endif
 
+// Mirroring MUI (device-ui/LVGL) streams RGB565 dirty rects instead of the
+// 1bpp framebuffer, and needs a device-ui carrying the flush observer. Until
+// that lands upstream the whole path - queue, pool and input seam - compiles
+// out, so a color build that does not opt in carries none of it.
+#if HAS_SCREEN_MIRROR && HAS_TFT && defined(MESHTASTIC_MUI_MIRROR)
+#define HAS_MUI_MIRROR 1
+#else
+#define HAS_MUI_MIRROR 0
+#endif
+
 #ifndef USE_ETHERNET_DEFAULT
 #define USE_ETHERNET_DEFAULT 0
 #endif

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -637,6 +637,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define HAS_SCREEN 0
 #endif
 
+// Display mirroring to the client (FromRadio.display_frame) rides the screen
+// and can be excluded independently with MESHTASTIC_EXCLUDE_SCREEN_MIRROR.
+#if HAS_SCREEN && !defined(MESHTASTIC_EXCLUDE_SCREEN_MIRROR)
+#define HAS_SCREEN_MIRROR 1
+#else
+#define HAS_SCREEN_MIRROR 0
+#endif
+
 #ifndef USE_ETHERNET_DEFAULT
 #define USE_ETHERNET_DEFAULT 0
 #endif

--- a/src/graphics/HUB75Display.cpp
+++ b/src/graphics/HUB75Display.cpp
@@ -3,6 +3,7 @@
 #if defined(USE_HUB75)
 
 #include "HUB75Display.h"
+#include "ScreenMirror.h"
 #include "TFTColorRegions.h"
 #include "TFTPalette.h"
 #include <ESP32-HUB75-MatrixPanel-I2S-DMA.h>
@@ -121,6 +122,9 @@ void HUB75Display::display()
     firstFrame = false;
 #if GRAPHICS_TFT_COLORING_ENABLED
     lastColorSig = colorSig;
+#if HAS_SCREEN_MIRROR
+    graphics::screenMirror.capturePalette(colorSig, onBe, offBe, graphics::colorRegions, graphics::getTFTColorRegionCount());
+#endif
     // Regions are re-registered every frame by the renderers; clear so they
     // don't accumulate across frames.
     graphics::clearTFTColorRegions();

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -23,6 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "Screen.h"
 #include "NodeDB.h"
 #include "PowerMon.h"
+#include "ScreenMirror.h"
 #include "Throttle.h"
 #include "configuration.h"
 #include "meshUtils.h"
@@ -181,6 +182,15 @@ static void drawLockdownLockScreen(OLEDDisplay *display)
 }
 #endif
 
+// Give ScreenMirror a look at the committed framebuffer (no-op unless armed).
+static inline void screenMirrorCapture()
+{
+#if HAS_SCREEN && !defined(MESHTASTIC_EXCLUDE_SCREEN_MIRROR)
+    if (screen)
+        screenMirror.onRendered(screen->getDisplayDevice());
+#endif
+}
+
 static inline void updateUiFrame(OLEDDisplayUi *ui)
 {
 #ifdef MESHTASTIC_LOCKDOWN
@@ -208,6 +218,8 @@ static inline void updateUiFrame(OLEDDisplayUi *ui)
             NotificationRenderer::drawBannercallback(display, ui->getUiState());
         }
         display->display();
+        // The mirror sees the LOCKED frame, matching the panel's redaction.
+        screenMirrorCapture();
         return;
     }
 #endif
@@ -215,6 +227,7 @@ static inline void updateUiFrame(OLEDDisplayUi *ui)
     prepareFrameColorRegions();
 #endif
     ui->update();
+    screenMirrorCapture();
 }
 // Global variables for alert banner - explicitly define with extern "C" linkage to prevent optimization
 

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -183,9 +183,12 @@ static void drawLockdownLockScreen(OLEDDisplay *display)
 #endif
 
 // Give ScreenMirror a look at the committed framebuffer (no-op unless armed).
+// Deliberately scoped to updateUiFrame commits: the few direct display()
+// paths it bypasses (EInk re-commits, boot logo) immediately follow or
+// precede a mirrored frame.
 static inline void screenMirrorCapture()
 {
-#if HAS_SCREEN && !defined(MESHTASTIC_EXCLUDE_SCREEN_MIRROR)
+#if HAS_SCREEN_MIRROR
     if (screen)
         screenMirror.onRendered(screen->getDisplayDevice());
 #endif

--- a/src/graphics/ScreenMirror.cpp
+++ b/src/graphics/ScreenMirror.cpp
@@ -228,7 +228,11 @@ void ScreenMirror::onMuiRect(int16_t x, int16_t y, uint16_t w, uint16_t h, const
 
         uint32_t bytes = (uint32_t)w * h * 2;
         if (!muiPool) {
-            muiPool = (uint8_t *)malloc(MUI_POOL_BYTES);
+#ifdef ESP32
+            muiPool = (uint8_t *)ps_malloc(MUI_POOL_BYTES); // PSRAM first; this is a big buffer
+#endif
+            if (!muiPool)
+                muiPool = (uint8_t *)malloc(MUI_POOL_BYTES);
             if (!muiPool) {
                 mirroring = oneShot = false;
                 return;

--- a/src/graphics/ScreenMirror.cpp
+++ b/src/graphics/ScreenMirror.cpp
@@ -8,10 +8,25 @@
 #include <OLEDDisplay.h>
 #include <cstring>
 
+#include "TFTColorRegions.h" // self-defines GRAPHICS_TFT_COLORING_ENABLED; API is safe when coloring is compiled out
+#include "TFTPalette.h"
+
 namespace graphics
 {
 
 ScreenMirror screenMirror;
+
+#if GRAPHICS_TFT_COLORING_ENABLED
+namespace
+{
+// Region colors are stored panel-byte-order (big-endian RGB565); the wire
+// carries logical bit layout.
+inline uint16_t swap16(uint16_t v)
+{
+    return (uint16_t)((v >> 8) | (v << 8));
+}
+} // namespace
+#endif
 
 void ScreenMirror::freeSnapshotLocked()
 {
@@ -21,6 +36,13 @@ void ScreenMirror::freeSnapshotLocked()
         snapshot = nullptr;
     }
     frameSize = 0;
+    if (paletteRegions) {
+        memaudit::add("display", -(int32_t)(sizeof(PaletteRegion) * MAX_TFT_COLOR_REGIONS));
+        free(paletteRegions);
+        paletteRegions = nullptr;
+    }
+    paletteSig = 0;
+    paletteCount = 0;
 }
 
 void ScreenMirror::setMirror(bool enabled)
@@ -83,10 +105,79 @@ void ScreenMirror::onRendered(OLEDDisplay *display)
         memcpy(snapshot, display->buffer, frameSize);
         frameId++;
         oneShot = false;
+        capturePaletteLocked();
         readyId = frameId;
     }
     // Notify outside the lock: observers (PhoneAPI) may re-enter hasChunkFor.
     frameReady.notifyObservers(readyId);
+}
+
+void ScreenMirror::capturePaletteLocked()
+{
+#if GRAPHICS_TFT_COLORING_ENABLED
+    uint32_t sig = getTFTColorFrameSignature();
+    if (sig == paletteSig && paletteRegions)
+        return;
+    if (!paletteRegions) {
+        paletteRegions = (PaletteRegion *)malloc(sizeof(PaletteRegion) * MAX_TFT_COLOR_REGIONS);
+        if (!paletteRegions)
+            return; // frames still stream; clients render monochrome
+        memaudit::add("display", sizeof(PaletteRegion) * MAX_TFT_COLOR_REGIONS);
+    }
+    uint8_t count = getTFTColorRegionCount();
+    if (count > MAX_TFT_COLOR_REGIONS)
+        count = MAX_TFT_COLOR_REGIONS;
+    for (uint8_t i = 0; i < count; i++) {
+        const TFTColorRegion &r = colorRegions[i];
+        paletteRegions[i] = {(uint16_t)r.x,      (uint16_t)r.y,       (uint16_t)r.width,
+                             (uint16_t)r.height, swap16(r.onColorBe), swap16(r.offColorBe)};
+    }
+    paletteCount = count;
+    paletteDefaultOn = TFTPalette::White;
+    paletteDefaultOff = getThemeBodyBg();
+    paletteSig = sig;
+#endif
+}
+
+bool ScreenMirror::hasPaletteChunkFor(uint32_t clientPaletteSig, uint8_t clientRegionOffset)
+{
+    concurrency::LockGuard g(&lock);
+    if (!paletteRegions || !snapshot)
+        return false;
+    return clientPaletteSig != paletteSig || clientRegionOffset < paletteCount;
+}
+
+bool ScreenMirror::copyPaletteChunk(uint32_t &clientPaletteSig, uint8_t &clientRegionOffset, meshtastic_DisplayPalette &out)
+{
+    concurrency::LockGuard g(&lock);
+    if (!paletteRegions || !snapshot)
+        return false;
+    if (clientPaletteSig != paletteSig) {
+        clientPaletteSig = paletteSig;
+        clientRegionOffset = 0;
+    } else if (clientRegionOffset >= paletteCount) {
+        return false;
+    }
+
+    out.signature = paletteSig;
+    out.default_on_color = paletteDefaultOn;
+    out.default_off_color = paletteDefaultOff;
+    out.region_offset = clientRegionOffset;
+    out.region_total = paletteCount;
+    uint8_t n = 0;
+    while (n < (sizeof(out.regions) / sizeof(out.regions[0])) && clientRegionOffset + n < paletteCount) {
+        const PaletteRegion &r = paletteRegions[clientRegionOffset + n];
+        out.regions[n].x = r.x;
+        out.regions[n].y = r.y;
+        out.regions[n].width = r.w;
+        out.regions[n].height = r.h;
+        out.regions[n].on_color = r.onColor;
+        out.regions[n].off_color = r.offColor;
+        n++;
+    }
+    out.regions_count = n;
+    clientRegionOffset += n;
+    return true;
 }
 
 bool ScreenMirror::hasChunkFor(uint32_t clientFrameId, uint16_t clientOffset)
@@ -114,6 +205,7 @@ bool ScreenMirror::copyChunk(uint32_t &clientFrameId, uint16_t &clientOffset, me
     out.width = width;
     out.height = height;
     out.format = meshtastic_DisplayFrame_Format_MONO_VLSB;
+    out.palette_signature = paletteSig; // 0 on monochrome-only builds
     out.frame_id = frameId;
     out.offset = clientOffset;
     out.total_size = frameSize;

--- a/src/graphics/ScreenMirror.cpp
+++ b/src/graphics/ScreenMirror.cpp
@@ -8,25 +8,22 @@
 #include <OLEDDisplay.h>
 #include <cstring>
 
-#include "TFTColorRegions.h" // self-defines GRAPHICS_TFT_COLORING_ENABLED; API is safe when coloring is compiled out
-#include "TFTPalette.h"
+#include "TFTColorRegions.h"
 
 namespace graphics
 {
 
 ScreenMirror screenMirror;
 
-#if GRAPHICS_TFT_COLORING_ENABLED
 namespace
 {
-// Region colors are stored panel-byte-order (big-endian RGB565); the wire
+// Region colors arrive panel-byte-order (big-endian RGB565); the wire
 // carries logical bit layout.
 inline uint16_t swap16(uint16_t v)
 {
     return (uint16_t)((v >> 8) | (v << 8));
 }
 } // namespace
-#endif
 
 void ScreenMirror::freeSnapshotLocked()
 {
@@ -105,18 +102,21 @@ void ScreenMirror::onRendered(OLEDDisplay *display)
         memcpy(snapshot, display->buffer, frameSize);
         frameId++;
         oneShot = false;
-        capturePaletteLocked();
         readyId = frameId;
     }
     // Notify outside the lock: observers (PhoneAPI) may re-enter hasChunkFor.
     frameReady.notifyObservers(readyId);
 }
 
-void ScreenMirror::capturePaletteLocked()
+void ScreenMirror::capturePalette(uint32_t signature, uint16_t defaultOnBe, uint16_t defaultOffBe, const TFTColorRegion *regions,
+                                  uint8_t count)
 {
-#if GRAPHICS_TFT_COLORING_ENABLED
-    uint32_t sig = getTFTColorFrameSignature();
-    if (sig == paletteSig && paletteRegions)
+    concurrency::LockGuard g(&lock);
+    // Cheap when nothing changed and when the mirror is idle: paint-time
+    // callers hit this every frame, but clients only exist while mirroring.
+    if (!mirroring && !oneShot && !snapshot)
+        return;
+    if (signature == paletteSig && paletteRegions)
         return;
     if (!paletteRegions) {
         paletteRegions = (PaletteRegion *)malloc(sizeof(PaletteRegion) * MAX_TFT_COLOR_REGIONS);
@@ -124,19 +124,17 @@ void ScreenMirror::capturePaletteLocked()
             return; // frames still stream; clients render monochrome
         memaudit::add("display", sizeof(PaletteRegion) * MAX_TFT_COLOR_REGIONS);
     }
-    uint8_t count = getTFTColorRegionCount();
     if (count > MAX_TFT_COLOR_REGIONS)
         count = MAX_TFT_COLOR_REGIONS;
     for (uint8_t i = 0; i < count; i++) {
-        const TFTColorRegion &r = colorRegions[i];
+        const TFTColorRegion &r = regions[i];
         paletteRegions[i] = {(uint16_t)r.x,      (uint16_t)r.y,       (uint16_t)r.width,
                              (uint16_t)r.height, swap16(r.onColorBe), swap16(r.offColorBe)};
     }
     paletteCount = count;
-    paletteDefaultOn = TFTPalette::White;
-    paletteDefaultOff = getThemeBodyBg();
-    paletteSig = sig;
-#endif
+    paletteDefaultOn = swap16(defaultOnBe);
+    paletteDefaultOff = swap16(defaultOffBe);
+    paletteSig = signature;
 }
 
 bool ScreenMirror::hasPaletteChunkFor(uint32_t clientPaletteSig, uint8_t clientRegionOffset)

--- a/src/graphics/ScreenMirror.cpp
+++ b/src/graphics/ScreenMirror.cpp
@@ -1,0 +1,112 @@
+#include "ScreenMirror.h"
+
+#if HAS_SCREEN && !defined(MESHTASTIC_EXCLUDE_SCREEN_MIRROR)
+
+#include "DebugConfiguration.h"
+#include "concurrency/LockGuard.h"
+#include <OLEDDisplay.h>
+#include <cstring>
+
+namespace graphics
+{
+
+ScreenMirror screenMirror;
+
+void ScreenMirror::setMirror(bool enabled)
+{
+    concurrency::LockGuard g(&lock);
+    mirroring = enabled;
+    // Force an immediate frame on enable so the client doesn't wait for the
+    // next on-screen change.
+    if (enabled)
+        oneShot = true;
+    LOG_INFO("Screen mirror %s", enabled ? "enabled" : "disabled");
+}
+
+void ScreenMirror::requestFrame()
+{
+    concurrency::LockGuard g(&lock);
+    oneShot = true;
+}
+
+void ScreenMirror::onRendered(OLEDDisplay *display)
+{
+    uint32_t readyId = 0;
+    {
+        concurrency::LockGuard g(&lock);
+        if (!mirroring && !oneShot)
+            return;
+        if (!display || !display->buffer)
+            return;
+
+        // Don't overwrite a frame the client is still draining; the next
+        // render picks up the latest contents.
+        if (snapshot && sendOffset < frameSize)
+            return;
+
+        uint16_t w = display->getWidth();
+        uint16_t h = display->getHeight();
+        uint16_t size = w * ((h + 7) / 8);
+        if (size == 0)
+            return;
+
+        if (!snapshot) {
+            snapshot = (uint8_t *)malloc(size);
+            if (!snapshot) {
+                LOG_ERROR("Screen mirror: no memory for %u byte snapshot", size);
+                mirroring = oneShot = false;
+                return;
+            }
+            frameSize = size;
+            sendOffset = size; // drained; nothing captured yet
+            width = w;
+            height = h;
+            // Invalidate the change-detect baseline so the first frame always sends
+            memset(snapshot, 0xA5, size);
+        }
+
+        bool changed = memcmp(display->buffer, snapshot, frameSize) != 0;
+        if (!changed && !oneShot)
+            return;
+
+        memcpy(snapshot, display->buffer, frameSize);
+        sendOffset = 0;
+        frameId++;
+        oneShot = false;
+        readyId = frameId;
+    }
+    // Notify outside the lock: observers (PhoneAPI) may re-enter hasChunkForPhone.
+    frameReady.notifyObservers(readyId);
+}
+
+bool ScreenMirror::hasChunkForPhone()
+{
+    concurrency::LockGuard g(&lock);
+    return snapshot && sendOffset < frameSize;
+}
+
+bool ScreenMirror::getChunkForPhone(meshtastic_DisplayFrame &out)
+{
+    concurrency::LockGuard g(&lock);
+    if (!snapshot || sendOffset >= frameSize)
+        return false;
+
+    uint16_t len = frameSize - sendOffset;
+    if (len > sizeof(out.data.bytes))
+        len = sizeof(out.data.bytes);
+
+    out.width = width;
+    out.height = height;
+    out.format = meshtastic_DisplayFrame_Format_MONO_VLSB;
+    out.frame_id = frameId;
+    out.offset = sendOffset;
+    out.total_size = frameSize;
+    out.data.size = len;
+    memcpy(out.data.bytes, snapshot + sendOffset, len);
+    sendOffset += len;
+    return true;
+}
+
+} // namespace graphics
+
+#endif

--- a/src/graphics/ScreenMirror.cpp
+++ b/src/graphics/ScreenMirror.cpp
@@ -1,9 +1,10 @@
 #include "ScreenMirror.h"
 
-#if HAS_SCREEN && !defined(MESHTASTIC_EXCLUDE_SCREEN_MIRROR)
+#if HAS_SCREEN_MIRROR
 
 #include "DebugConfiguration.h"
 #include "concurrency/LockGuard.h"
+#include "memory/MemAudit.h"
 #include <OLEDDisplay.h>
 #include <cstring>
 
@@ -12,14 +13,28 @@ namespace graphics
 
 ScreenMirror screenMirror;
 
+void ScreenMirror::freeSnapshotLocked()
+{
+    if (snapshot) {
+        memaudit::add("display", -(int32_t)frameSize);
+        free(snapshot);
+        snapshot = nullptr;
+    }
+    frameSize = 0;
+}
+
 void ScreenMirror::setMirror(bool enabled)
 {
     concurrency::LockGuard g(&lock);
     mirroring = enabled;
-    // Force an immediate frame on enable so the client doesn't wait for the
-    // next on-screen change.
-    if (enabled)
+    if (enabled) {
+        // Force an immediate frame so the client doesn't wait for the next
+        // on-screen change.
         oneShot = true;
+    } else {
+        oneShot = false;
+        freeSnapshotLocked();
+    }
     LOG_INFO("Screen mirror %s", enabled ? "enabled" : "disabled");
 }
 
@@ -39,59 +54,60 @@ void ScreenMirror::onRendered(OLEDDisplay *display)
         if (!display || !display->buffer)
             return;
 
-        // Don't overwrite a frame the client is still draining; the next
-        // render picks up the latest contents.
-        if (snapshot && sendOffset < frameSize)
-            return;
-
         uint16_t w = display->getWidth();
         uint16_t h = display->getHeight();
         uint16_t size = w * ((h + 7) / 8);
         if (size == 0)
             return;
 
-        if (!snapshot) {
+        if (snapshot && size != frameSize)
+            freeSnapshotLocked(); // display geometry changed; start over
+
+        bool firstFrame = !snapshot;
+        if (firstFrame) {
             snapshot = (uint8_t *)malloc(size);
             if (!snapshot) {
                 LOG_ERROR("Screen mirror: no memory for %u byte snapshot", size);
                 mirroring = oneShot = false;
                 return;
             }
+            memaudit::add("display", size);
             frameSize = size;
-            sendOffset = size; // drained; nothing captured yet
             width = w;
             height = h;
-            // Invalidate the change-detect baseline so the first frame always sends
-            memset(snapshot, 0xA5, size);
         }
 
-        bool changed = memcmp(display->buffer, snapshot, frameSize) != 0;
-        if (!changed && !oneShot)
+        if (!firstFrame && !oneShot && memcmp(display->buffer, snapshot, frameSize) == 0)
             return;
 
         memcpy(snapshot, display->buffer, frameSize);
-        sendOffset = 0;
         frameId++;
         oneShot = false;
         readyId = frameId;
     }
-    // Notify outside the lock: observers (PhoneAPI) may re-enter hasChunkForPhone.
+    // Notify outside the lock: observers (PhoneAPI) may re-enter hasChunkFor.
     frameReady.notifyObservers(readyId);
 }
 
-bool ScreenMirror::hasChunkForPhone()
+bool ScreenMirror::hasChunkFor(uint32_t clientFrameId, uint16_t clientOffset)
 {
     concurrency::LockGuard g(&lock);
-    return snapshot && sendOffset < frameSize;
+    return snapshot && (clientFrameId != frameId || clientOffset < frameSize);
 }
 
-bool ScreenMirror::getChunkForPhone(meshtastic_DisplayFrame &out)
+bool ScreenMirror::copyChunk(uint32_t &clientFrameId, uint16_t &clientOffset, meshtastic_DisplayFrame &out)
 {
     concurrency::LockGuard g(&lock);
-    if (!snapshot || sendOffset >= frameSize)
+    if (!snapshot)
+        return false;
+    if (clientFrameId != frameId) {
+        clientFrameId = frameId;
+        clientOffset = 0;
+    }
+    if (clientOffset >= frameSize)
         return false;
 
-    uint16_t len = frameSize - sendOffset;
+    uint16_t len = frameSize - clientOffset;
     if (len > sizeof(out.data.bytes))
         len = sizeof(out.data.bytes);
 
@@ -99,11 +115,11 @@ bool ScreenMirror::getChunkForPhone(meshtastic_DisplayFrame &out)
     out.height = height;
     out.format = meshtastic_DisplayFrame_Format_MONO_VLSB;
     out.frame_id = frameId;
-    out.offset = sendOffset;
+    out.offset = clientOffset;
     out.total_size = frameSize;
     out.data.size = len;
-    memcpy(out.data.bytes, snapshot + sendOffset, len);
-    sendOffset += len;
+    memcpy(out.data.bytes, snapshot + clientOffset, len);
+    clientOffset += len;
     return true;
 }
 

--- a/src/graphics/ScreenMirror.cpp
+++ b/src/graphics/ScreenMirror.cpp
@@ -45,6 +45,8 @@ void ScreenMirror::freeSnapshotLocked()
 void ScreenMirror::setMirror(bool enabled)
 {
     concurrency::LockGuard g(&lock);
+    if (mirroring == enabled && !(enabled && oneShot))
+        return; // no state change; keeps client disconnects from logging forever
     mirroring = enabled;
     if (enabled) {
         // Force an immediate frame so the client doesn't wait for the next
@@ -75,9 +77,15 @@ void ScreenMirror::onRendered(OLEDDisplay *display)
 
         uint16_t w = display->getWidth();
         uint16_t h = display->getHeight();
-        uint16_t size = w * ((h + 7) / 8);
-        if (size == 0)
+        uint32_t fullSize = (uint32_t)w * ((h + 7) / 8);
+        if (fullSize == 0)
             return;
+        if (fullSize > UINT16_MAX) {
+            LOG_WARN("Screen mirror: %ux%u framebuffer too large to stream", w, h);
+            mirroring = oneShot = false;
+            return;
+        }
+        uint16_t size = (uint16_t)fullSize;
 
         if (snapshot && size != frameSize)
             freeSnapshotLocked(); // display geometry changed; start over
@@ -96,10 +104,14 @@ void ScreenMirror::onRendered(OLEDDisplay *display)
             height = h;
         }
 
-        if (!firstFrame && !oneShot && memcmp(display->buffer, snapshot, frameSize) == 0)
+        // A palette-only change (theme recolor) is frame-worthy even when the
+        // mono bits are identical: the client keys colors off the frame's signature.
+        bool paletteChanged = snapshotPaletteSig != paletteSig;
+        if (!firstFrame && !oneShot && !paletteChanged && memcmp(display->buffer, snapshot, frameSize) == 0)
             return;
 
         memcpy(snapshot, display->buffer, frameSize);
+        snapshotPaletteSig = paletteSig;
         frameId++;
         oneShot = false;
         readyId = frameId;
@@ -203,7 +215,9 @@ bool ScreenMirror::copyChunk(uint32_t &clientFrameId, uint16_t &clientOffset, me
     out.width = width;
     out.height = height;
     out.format = meshtastic_DisplayFrame_Format_MONO_VLSB;
-    out.palette_signature = paletteSig; // 0 on monochrome-only builds
+    // The signature captured WITH this snapshot, not the live one: a drain can
+    // span a display() that already advanced paletteSig for the next frame.
+    out.palette_signature = snapshotPaletteSig;
     out.frame_id = frameId;
     out.offset = clientOffset;
     out.total_size = frameSize;

--- a/src/graphics/ScreenMirror.cpp
+++ b/src/graphics/ScreenMirror.cpp
@@ -40,6 +40,17 @@ void ScreenMirror::freeSnapshotLocked()
     }
     paletteSig = 0;
     paletteCount = 0;
+#if HAS_TFT
+    if (muiPool) {
+        memaudit::add("display", -(int32_t)MUI_POOL_BYTES);
+        free(muiPool);
+        muiPool = nullptr;
+    }
+    muiHead = muiCount = 0;
+    muiPoolUsed = 0;
+    muiRectSendOffset = 0;
+    muiNeedResync = false;
+#endif
 }
 
 void ScreenMirror::setMirror(bool enabled)
@@ -52,6 +63,10 @@ void ScreenMirror::setMirror(bool enabled)
         // Force an immediate frame so the client doesn't wait for the next
         // on-screen change.
         oneShot = true;
+#if HAS_TFT
+        if (muiRefresh)
+            muiRefresh(); // MUI delivers "a frame" as a full-repaint rect burst
+#endif
     } else {
         oneShot = false;
         freeSnapshotLocked();
@@ -63,6 +78,10 @@ void ScreenMirror::requestFrame()
 {
     concurrency::LockGuard g(&lock);
     oneShot = true;
+#if HAS_TFT
+    if (muiRefresh)
+        muiRefresh();
+#endif
 }
 
 void ScreenMirror::onRendered(OLEDDisplay *display)
@@ -190,15 +209,107 @@ bool ScreenMirror::copyPaletteChunk(uint32_t &clientPaletteSig, uint8_t &clientR
     return true;
 }
 
+#if HAS_TFT
+void ScreenMirror::onMuiRect(int16_t x, int16_t y, uint16_t w, uint16_t h, const uint16_t *pixels)
+{
+    uint32_t readyId = 0;
+    {
+        concurrency::LockGuard g(&lock);
+        if (!mirroring && !oneShot)
+            return;
+        if (x < 0 || y < 0 || w == 0 || h == 0)
+            return;
+        // LVGL reports rects in logical coordinates; the panel extent is the
+        // running maximum, exact from the first full repaint onward.
+        if ((uint16_t)(x + w) > muiPanelW)
+            muiPanelW = x + w;
+        if ((uint16_t)(y + h) > muiPanelH)
+            muiPanelH = y + h;
+
+        uint32_t bytes = (uint32_t)w * h * 2;
+        if (!muiPool) {
+            muiPool = (uint8_t *)malloc(MUI_POOL_BYTES);
+            if (!muiPool) {
+                mirroring = oneShot = false;
+                return;
+            }
+            memaudit::add("display", MUI_POOL_BYTES);
+        }
+        if (muiCount >= MUI_MAX_RECTS || bytes > MUI_POOL_BYTES || muiPoolUsed + bytes > MUI_POOL_BYTES) {
+            // Queue full: drop this rect and repaint everything once drained.
+            muiNeedResync = true;
+            return;
+        }
+        memcpy(muiPool + muiPoolUsed, pixels, bytes);
+        MuiRect &r = muiRects[(muiHead + muiCount) % MUI_MAX_RECTS];
+        r = {(uint16_t)x, (uint16_t)y, w, h, bytes, muiPoolUsed, ++frameId};
+        muiPoolUsed += bytes;
+        muiCount++;
+        readyId = frameId;
+    }
+    frameReady.notifyObservers(readyId);
+}
+
+// Fills one chunk of the oldest queued rect; pops it when fully drained.
+bool ScreenMirror::copyMuiChunkLocked(meshtastic_DisplayFrame &out)
+{
+    MuiRect &r = muiRects[muiHead];
+    uint32_t len = r.bytes - muiRectSendOffset;
+    if (len > sizeof(out.data.bytes))
+        len = sizeof(out.data.bytes);
+
+    out.width = muiPanelW;
+    out.height = muiPanelH;
+    out.format = meshtastic_DisplayFrame_Format_RGB565;
+    out.palette_signature = 0;
+    out.frame_id = r.id;
+    out.rect_x = r.x;
+    out.rect_y = r.y;
+    out.rect_width = r.w;
+    out.rect_height = r.h;
+    out.offset = muiRectSendOffset;
+    out.total_size = r.bytes;
+    out.data.size = len;
+    memcpy(out.data.bytes, muiPool + r.poolOffset + muiRectSendOffset, len);
+    muiRectSendOffset += len;
+
+    if (muiRectSendOffset >= r.bytes) {
+        muiHead = (muiHead + 1) % MUI_MAX_RECTS;
+        muiCount--;
+        muiRectSendOffset = 0;
+        if (muiCount == 0) {
+            muiPoolUsed = 0;
+            if (!mirroring)
+                oneShot = false; // one-shot fully delivered
+            if (muiNeedResync && mirroring && muiRefresh) {
+                muiNeedResync = false;
+                muiRefresh();
+            }
+        }
+    }
+    return true;
+}
+#endif
+
 bool ScreenMirror::hasChunkFor(uint32_t clientFrameId, uint16_t clientOffset)
 {
     concurrency::LockGuard g(&lock);
+#if HAS_TFT
+    if (muiCount)
+        return true;
+#endif
     return snapshot && (clientFrameId != frameId || clientOffset < frameSize);
 }
 
 bool ScreenMirror::copyChunk(uint32_t &clientFrameId, uint16_t &clientOffset, meshtastic_DisplayFrame &out)
 {
     concurrency::LockGuard g(&lock);
+#if HAS_TFT
+    // MUI rects drain ahead of (and on MUI builds, instead of) mono snapshots.
+    // Spike scope: the rect queue has a single consumer, not per-client cursors.
+    if (muiCount)
+        return copyMuiChunkLocked(out);
+#endif
     if (!snapshot)
         return false;
     if (clientFrameId != frameId) {

--- a/src/graphics/ScreenMirror.cpp
+++ b/src/graphics/ScreenMirror.cpp
@@ -40,7 +40,7 @@ void ScreenMirror::freeSnapshotLocked()
     }
     paletteSig = 0;
     paletteCount = 0;
-#if HAS_TFT
+#if HAS_MUI_MIRROR
     if (muiPool) {
         memaudit::add("display", -(int32_t)MUI_POOL_BYTES);
         free(muiPool);
@@ -64,14 +64,13 @@ void ScreenMirror::setMirror(bool enabled)
         // Force an immediate frame so the client doesn't wait for the next
         // on-screen change.
         oneShot = true;
-#if HAS_TFT
+#if HAS_MUI_MIRROR
         if (muiRefresh)
             muiRefresh(); // MUI delivers "a frame" as a full-repaint rect burst
 #endif
     } else {
         oneShot = false;
-        freeSnapshotLocked();
-        muiOwner = nullptr;
+        freeSnapshotLocked(); // also releases the MUI pool and rect ownership
     }
     if (changed)
         LOG_INFO("Screen mirror %s", enabled ? "enabled" : "disabled");
@@ -81,7 +80,7 @@ void ScreenMirror::requestFrame()
 {
     concurrency::LockGuard g(&lock);
     oneShot = true;
-#if HAS_TFT
+#if HAS_MUI_MIRROR
     if (muiRefresh)
         muiRefresh();
 #endif
@@ -212,7 +211,7 @@ bool ScreenMirror::copyPaletteChunk(uint32_t &clientPaletteSig, uint8_t &clientR
     return true;
 }
 
-#if HAS_TFT
+#if HAS_MUI_MIRROR
 void ScreenMirror::onMuiRect(int16_t x, int16_t y, uint16_t w, uint16_t h, const uint16_t *pixels)
 {
     uint32_t readyId = 0;
@@ -309,7 +308,7 @@ bool ScreenMirror::copyMuiChunkLocked(meshtastic_DisplayFrame &out)
 bool ScreenMirror::hasChunkFor(const void *client, uint32_t clientFrameId, uint16_t clientOffset)
 {
     concurrency::LockGuard g(&lock);
-#if HAS_TFT
+#if HAS_MUI_MIRROR
     // One shared rect cursor means one consumer; another connection simply
     // sees no rects rather than stealing half of each frame.
     if (muiCount && (muiOwner == nullptr || muiOwner == client))
@@ -321,7 +320,7 @@ bool ScreenMirror::hasChunkFor(const void *client, uint32_t clientFrameId, uint1
 bool ScreenMirror::copyChunk(const void *client, uint32_t &clientFrameId, uint16_t &clientOffset, meshtastic_DisplayFrame &out)
 {
     concurrency::LockGuard g(&lock);
-#if HAS_TFT
+#if HAS_MUI_MIRROR
     // MUI rects drain ahead of (and on MUI builds, instead of) mono snapshots.
     // Spike scope: the rect queue has a single consumer, not per-client cursors.
     if (muiCount) {

--- a/src/graphics/ScreenMirror.cpp
+++ b/src/graphics/ScreenMirror.cpp
@@ -49,15 +49,16 @@ void ScreenMirror::freeSnapshotLocked()
     muiHead = muiCount = 0;
     muiPoolUsed = 0;
     muiRectSendOffset = 0;
-    muiNeedResync = false;
+    muiOwner = nullptr;
 #endif
 }
 
 void ScreenMirror::setMirror(bool enabled)
 {
     concurrency::LockGuard g(&lock);
-    if (mirroring == enabled && !(enabled && oneShot))
-        return; // no state change; keeps client disconnects from logging forever
+    // Cleanup must stay unconditional: a one-shot request leaves mirroring
+    // false, so an early return would strand the pool and the snapshot.
+    const bool changed = mirroring != enabled || oneShot;
     mirroring = enabled;
     if (enabled) {
         // Force an immediate frame so the client doesn't wait for the next
@@ -70,8 +71,10 @@ void ScreenMirror::setMirror(bool enabled)
     } else {
         oneShot = false;
         freeSnapshotLocked();
+        muiOwner = nullptr;
     }
-    LOG_INFO("Screen mirror %s", enabled ? "enabled" : "disabled");
+    if (changed)
+        LOG_INFO("Screen mirror %s", enabled ? "enabled" : "disabled");
 }
 
 void ScreenMirror::requestFrame()
@@ -217,31 +220,39 @@ void ScreenMirror::onMuiRect(int16_t x, int16_t y, uint16_t w, uint16_t h, const
         concurrency::LockGuard g(&lock);
         if (!mirroring && !oneShot)
             return;
-        if (x < 0 || y < 0 || w == 0 || h == 0)
+        // Panel size comes from LVGL at registration, so frames always carry the
+        // full display dimensions the wire contract promises.
+        if (x < 0 || y < 0 || w == 0 || h == 0 || muiPanelW == 0)
             return;
-        // LVGL reports rects in logical coordinates; the panel extent is the
-        // running maximum, exact from the first full repaint onward.
-        if ((uint16_t)(x + w) > muiPanelW)
-            muiPanelW = x + w;
-        if ((uint16_t)(y + h) > muiPanelH)
-            muiPanelH = y + h;
 
         uint32_t bytes = (uint32_t)w * h * 2;
         if (!muiPool) {
+            bool psram = false;
 #ifdef ESP32
             muiPool = (uint8_t *)ps_malloc(MUI_POOL_BYTES); // PSRAM first; this is a big buffer
+            psram = muiPool != nullptr;
 #endif
             if (!muiPool)
                 muiPool = (uint8_t *)malloc(MUI_POOL_BYTES);
             if (!muiPool) {
+                LOG_ERROR("Screen mirror: no memory for the %u byte rect pool", (unsigned)MUI_POOL_BYTES);
                 mirroring = oneShot = false;
                 return;
             }
-            memaudit::add("display", MUI_POOL_BYTES);
+            if (!psram)
+                memaudit::add("display", MUI_POOL_BYTES); // PSRAM is not the constrained budget
         }
-        if (muiCount >= MUI_MAX_RECTS || bytes > MUI_POOL_BYTES || muiPoolUsed + bytes > MUI_POOL_BYTES) {
-            // Queue full: drop this rect and repaint everything once drained.
-            muiNeedResync = true;
+        if (bytes > MUI_POOL_BYTES)
+            return; // a rect larger than the whole pool can never be sent
+        if (muiCount >= MUI_MAX_RECTS || muiPoolUsed + bytes > MUI_POOL_BYTES) {
+            // The consumer is behind. Drop the backlog rather than the newest
+            // pixels and repaint once: stale history has no value, and dropping
+            // only the incoming rect wedges the pool until the queue empties.
+            muiHead = muiCount = 0;
+            muiPoolUsed = 0;
+            muiRectSendOffset = 0;
+            if (muiRefresh)
+                muiRefresh();
             return;
         }
         memcpy(muiPool + muiPoolUsed, pixels, bytes);
@@ -249,9 +260,13 @@ void ScreenMirror::onMuiRect(int16_t x, int16_t y, uint16_t w, uint16_t h, const
         r = {(uint16_t)x, (uint16_t)y, w, h, bytes, muiPoolUsed, ++frameId};
         muiPoolUsed += bytes;
         muiCount++;
-        readyId = frameId;
+        // Only the empty->non-empty transition needs a wakeup; available()
+        // keeps the client draining, and a notify per flush is a storm.
+        if (muiCount == 1)
+            readyId = frameId;
     }
-    frameReady.notifyObservers(readyId);
+    if (readyId)
+        frameReady.notifyObservers(readyId);
 }
 
 // Fills one chunk of the oldest queued rect; pops it when fully drained.
@@ -285,34 +300,37 @@ bool ScreenMirror::copyMuiChunkLocked(meshtastic_DisplayFrame &out)
             muiPoolUsed = 0;
             if (!mirroring)
                 oneShot = false; // one-shot fully delivered
-            if (muiNeedResync && mirroring && muiRefresh) {
-                muiNeedResync = false;
-                muiRefresh();
-            }
         }
     }
     return true;
 }
 #endif
 
-bool ScreenMirror::hasChunkFor(uint32_t clientFrameId, uint16_t clientOffset)
+bool ScreenMirror::hasChunkFor(const void *client, uint32_t clientFrameId, uint16_t clientOffset)
 {
     concurrency::LockGuard g(&lock);
 #if HAS_TFT
-    if (muiCount)
+    // One shared rect cursor means one consumer; another connection simply
+    // sees no rects rather than stealing half of each frame.
+    if (muiCount && (muiOwner == nullptr || muiOwner == client))
         return true;
 #endif
     return snapshot && (clientFrameId != frameId || clientOffset < frameSize);
 }
 
-bool ScreenMirror::copyChunk(uint32_t &clientFrameId, uint16_t &clientOffset, meshtastic_DisplayFrame &out)
+bool ScreenMirror::copyChunk(const void *client, uint32_t &clientFrameId, uint16_t &clientOffset, meshtastic_DisplayFrame &out)
 {
     concurrency::LockGuard g(&lock);
 #if HAS_TFT
     // MUI rects drain ahead of (and on MUI builds, instead of) mono snapshots.
     // Spike scope: the rect queue has a single consumer, not per-client cursors.
-    if (muiCount)
+    if (muiCount) {
+        if (muiOwner == nullptr)
+            muiOwner = client; // first drainer claims the stream
+        if (muiOwner != client)
+            return false;
         return copyMuiChunkLocked(out);
+    }
 #endif
     if (!snapshot)
         return false;

--- a/src/graphics/ScreenMirror.h
+++ b/src/graphics/ScreenMirror.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "configuration.h"
 
-#if HAS_SCREEN && !defined(MESHTASTIC_EXCLUDE_SCREEN_MIRROR)
+#if HAS_SCREEN_MIRROR
 
 #include "Observer.h"
 #include "concurrency/Lock.h"
@@ -13,9 +13,13 @@ namespace graphics
 {
 
 /**
- * Streams 1bpp framebuffer snapshots to the local client as
+ * Streams 1bpp framebuffer snapshots to local clients as
  * FromRadio.display_frame chunks. Armed via AdminMessage
  * set_display_mirror (continuous) or get_display_frame_request (one-shot).
+ *
+ * Holds only the latest captured frame; each PhoneAPI instance keeps its own
+ * (frameId, offset) drain cursor and pulls chunks via copyChunk, so multiple
+ * clients receive complete frames independently.
  */
 class ScreenMirror
 {
@@ -30,18 +34,23 @@ class ScreenMirror
     /// when armed and the contents changed since the last captured frame.
     void onRendered(OLEDDisplay *display);
 
-    /// Fills the next pending chunk for the phone; false when drained.
-    bool getChunkForPhone(meshtastic_DisplayFrame &out);
-    bool hasChunkForPhone();
+    /// True while the client cursor has undelivered bytes of the current frame.
+    bool hasChunkFor(uint32_t clientFrameId, uint16_t clientOffset);
+
+    /// Fills the next chunk for a client cursor, advancing it; false when the
+    /// client is fully caught up (or no frame exists). A frame captured while
+    /// the client was mid-drain restarts it at offset 0 of the new frame.
+    bool copyChunk(uint32_t &clientFrameId, uint16_t &clientOffset, meshtastic_DisplayFrame &out);
 
   private:
+    void freeSnapshotLocked();
+
     concurrency::Lock lock;
     bool mirroring = false;
     bool oneShot = false;
-    // Last captured frame; doubles as the change-detection baseline.
+    // Latest captured frame; doubles as the change-detection baseline.
     uint8_t *snapshot = nullptr;
     uint16_t frameSize = 0;
-    uint16_t sendOffset = 0; // == frameSize when drained
     uint16_t width = 0;
     uint16_t height = 0;
     uint32_t frameId = 0;

--- a/src/graphics/ScreenMirror.h
+++ b/src/graphics/ScreenMirror.h
@@ -57,6 +57,17 @@ class ScreenMirror
     /// when the client holds the full current palette (or coloring is off).
     bool copyPaletteChunk(uint32_t &clientPaletteSig, uint8_t &clientRegionOffset, meshtastic_DisplayPalette &out);
 
+#if HAS_TFT
+    /// MUI path: queues one LVGL dirty rect (native little-endian RGB565).
+    /// Called on the LVGL thread via the device-ui flush observer; copies and returns.
+    void onMuiRect(int16_t x, int16_t y, uint16_t w, uint16_t h, const uint16_t *pixels);
+
+    /// Registers device-ui's thread-safe full-repaint request, used to
+    /// synchronize a newly armed client and to recover from queue overflow.
+    using FullRefreshFn = void (*)();
+    void setMuiRefresh(FullRefreshFn fn) { muiRefresh = fn; }
+#endif
+
   private:
     void freeSnapshotLocked();
 
@@ -82,6 +93,31 @@ class ScreenMirror
     PaletteRegion *paletteRegions = nullptr;
     uint16_t paletteDefaultOn = 0;
     uint16_t paletteDefaultOff = 0;
+
+#if HAS_TFT
+    // MUI dirty-rect queue: FIFO rect headers over a linear pixel pool,
+    // compacted whenever it drains. Spike scope: single consumer.
+    struct MuiRect {
+        uint16_t x, y, w, h;
+        uint32_t bytes;
+        uint32_t poolOffset;
+        uint32_t id;
+    };
+    static constexpr uint8_t MUI_MAX_RECTS = 32;
+    static constexpr uint32_t MUI_POOL_BYTES = 96 * 1024;
+    MuiRect muiRects[MUI_MAX_RECTS];
+    uint8_t muiHead = 0;
+    uint8_t muiCount = 0;
+    uint8_t *muiPool = nullptr;
+    uint32_t muiPoolUsed = 0;
+    uint32_t muiRectSendOffset = 0;
+    bool muiNeedResync = false;
+    uint16_t muiPanelW = 0;
+    uint16_t muiPanelH = 0;
+    FullRefreshFn muiRefresh = nullptr;
+
+    bool copyMuiChunkLocked(meshtastic_DisplayFrame &out);
+#endif
 };
 
 extern ScreenMirror screenMirror;

--- a/src/graphics/ScreenMirror.h
+++ b/src/graphics/ScreenMirror.h
@@ -124,6 +124,16 @@ class ScreenMirror
 
 extern ScreenMirror screenMirror;
 
+#if HAS_TFT
+/**
+ * Routes a remote input event straight into device-ui's injection seam.
+ * MUI builds never construct an InputBroker (Modules.cpp skips it when
+ * displaymode is COLOR), so admin input cannot travel the usual path.
+ * Returns false when MUI is not the active UI.
+ */
+bool muiInjectInputEvent(uint32_t eventCode, uint32_t kbChar, uint32_t touchX, uint32_t touchY);
+#endif
+
 } // namespace graphics
 
 #endif

--- a/src/graphics/ScreenMirror.h
+++ b/src/graphics/ScreenMirror.h
@@ -132,6 +132,9 @@ extern ScreenMirror screenMirror;
  * Returns false when MUI is not the active UI.
  */
 bool muiInjectInputEvent(uint32_t eventCode, uint32_t kbChar, uint32_t touchX, uint32_t touchY);
+
+/** Fills MUI's panel geometry for DeviceMetadata; false when MUI is not active. */
+bool muiDisplayInfo(uint16_t &width, uint16_t &height, bool &hasTouch);
 #endif
 
 } // namespace graphics

--- a/src/graphics/ScreenMirror.h
+++ b/src/graphics/ScreenMirror.h
@@ -36,13 +36,14 @@ class ScreenMirror
     /// when armed and the contents changed since the last captured frame.
     void onRendered(OLEDDisplay *display);
 
-    /// True while the client cursor has undelivered bytes of the current frame.
-    bool hasChunkFor(uint32_t clientFrameId, uint16_t clientOffset);
+    /// True while this client has undelivered bytes of the current frame.
+    /// `client` identifies the connection (its PhoneAPI instance).
+    bool hasChunkFor(const void *client, uint32_t clientFrameId, uint16_t clientOffset);
 
     /// Fills the next chunk for a client cursor, advancing it; false when the
     /// client is fully caught up (or no frame exists). A frame captured while
     /// the client was mid-drain restarts it at offset 0 of the new frame.
-    bool copyChunk(uint32_t &clientFrameId, uint16_t &clientOffset, meshtastic_DisplayFrame &out);
+    bool copyChunk(const void *client, uint32_t &clientFrameId, uint16_t &clientOffset, meshtastic_DisplayFrame &out);
 
     /// Called by the color display drivers at paint time, before they clear
     /// the per-frame region table: stores the palette the frame was painted
@@ -62,10 +63,16 @@ class ScreenMirror
     /// Called on the LVGL thread via the device-ui flush observer; copies and returns.
     void onMuiRect(int16_t x, int16_t y, uint16_t w, uint16_t h, const uint16_t *pixels);
 
-    /// Registers device-ui's thread-safe full-repaint request, used to
-    /// synchronize a newly armed client and to recover from queue overflow.
+    /// Registers device-ui's thread-safe full-repaint request plus the panel
+    /// size, so streamed frames carry the full display dimensions from the
+    /// first rect rather than growing into them.
     using FullRefreshFn = void (*)();
-    void setMuiRefresh(FullRefreshFn fn) { muiRefresh = fn; }
+    void setMuiSource(FullRefreshFn fn, uint16_t panelWidth, uint16_t panelHeight)
+    {
+        muiRefresh = fn;
+        muiPanelW = panelWidth;
+        muiPanelH = panelHeight;
+    }
 #endif
 
   private:
@@ -113,10 +120,10 @@ class ScreenMirror
     uint8_t *muiPool = nullptr;
     uint32_t muiPoolUsed = 0;
     uint32_t muiRectSendOffset = 0;
-    bool muiNeedResync = false;
     uint16_t muiPanelW = 0;
     uint16_t muiPanelH = 0;
     FullRefreshFn muiRefresh = nullptr;
+    const void *muiOwner = nullptr; // connection currently draining rects
 
     bool copyMuiChunkLocked(meshtastic_DisplayFrame &out);
 #endif

--- a/src/graphics/ScreenMirror.h
+++ b/src/graphics/ScreenMirror.h
@@ -1,0 +1,54 @@
+#pragma once
+#include "configuration.h"
+
+#if HAS_SCREEN && !defined(MESHTASTIC_EXCLUDE_SCREEN_MIRROR)
+
+#include "Observer.h"
+#include "concurrency/Lock.h"
+#include "mesh/generated/meshtastic/mesh.pb.h"
+
+class OLEDDisplay;
+
+namespace graphics
+{
+
+/**
+ * Streams 1bpp framebuffer snapshots to the local client as
+ * FromRadio.display_frame chunks. Armed via AdminMessage
+ * set_display_mirror (continuous) or get_display_frame_request (one-shot).
+ */
+class ScreenMirror
+{
+  public:
+    /// Fired when a new frame is ready to drain; PhoneAPI observes this.
+    Observable<uint32_t> frameReady;
+
+    void setMirror(bool enabled);
+    void requestFrame();
+
+    /// Called by Screen after each frame commit. Snapshots the framebuffer
+    /// when armed and the contents changed since the last captured frame.
+    void onRendered(OLEDDisplay *display);
+
+    /// Fills the next pending chunk for the phone; false when drained.
+    bool getChunkForPhone(meshtastic_DisplayFrame &out);
+    bool hasChunkForPhone();
+
+  private:
+    concurrency::Lock lock;
+    bool mirroring = false;
+    bool oneShot = false;
+    // Last captured frame; doubles as the change-detection baseline.
+    uint8_t *snapshot = nullptr;
+    uint16_t frameSize = 0;
+    uint16_t sendOffset = 0; // == frameSize when drained
+    uint16_t width = 0;
+    uint16_t height = 0;
+    uint32_t frameId = 0;
+};
+
+extern ScreenMirror screenMirror;
+
+} // namespace graphics
+
+#endif

--- a/src/graphics/ScreenMirror.h
+++ b/src/graphics/ScreenMirror.h
@@ -42,8 +42,16 @@ class ScreenMirror
     /// the client was mid-drain restarts it at offset 0 of the new frame.
     bool copyChunk(uint32_t &clientFrameId, uint16_t &clientOffset, meshtastic_DisplayFrame &out);
 
+    /// True while the client cursor lacks regions of the current color palette.
+    bool hasPaletteChunkFor(uint32_t clientPaletteSig, uint8_t clientRegionOffset);
+
+    /// Fills the next palette chunk for a client cursor, advancing it; false
+    /// when the client holds the full current palette (or coloring is off).
+    bool copyPaletteChunk(uint32_t &clientPaletteSig, uint8_t &clientRegionOffset, meshtastic_DisplayPalette &out);
+
   private:
     void freeSnapshotLocked();
+    void capturePaletteLocked();
 
     concurrency::Lock lock;
     bool mirroring = false;
@@ -54,6 +62,16 @@ class ScreenMirror
     uint16_t width = 0;
     uint16_t height = 0;
     uint32_t frameId = 0;
+    // Color-region palette captured with the frame (TFT/HUB75 builds only).
+    uint32_t paletteSig = 0;
+    uint8_t paletteCount = 0;
+    struct PaletteRegion {
+        uint16_t x, y, w, h;
+        uint16_t onColor, offColor; // logical RGB565
+    };
+    PaletteRegion *paletteRegions = nullptr;
+    uint16_t paletteDefaultOn = 0;
+    uint16_t paletteDefaultOff = 0;
 };
 
 extern ScreenMirror screenMirror;

--- a/src/graphics/ScreenMirror.h
+++ b/src/graphics/ScreenMirror.h
@@ -58,7 +58,7 @@ class ScreenMirror
     /// when the client holds the full current palette (or coloring is off).
     bool copyPaletteChunk(uint32_t &clientPaletteSig, uint8_t &clientRegionOffset, meshtastic_DisplayPalette &out);
 
-#if HAS_TFT
+#if HAS_MUI_MIRROR
     /// MUI path: queues one LVGL dirty rect (native little-endian RGB565).
     /// Called on the LVGL thread via the device-ui flush observer; copies and returns.
     void onMuiRect(int16_t x, int16_t y, uint16_t w, uint16_t h, const uint16_t *pixels);
@@ -101,7 +101,7 @@ class ScreenMirror
     uint16_t paletteDefaultOn = 0;
     uint16_t paletteDefaultOff = 0;
 
-#if HAS_TFT
+#if HAS_MUI_MIRROR
     // MUI dirty-rect queue: FIFO rect headers over a linear pixel pool,
     // compacted whenever it drains. Spike scope: single consumer.
     struct MuiRect {
@@ -131,7 +131,7 @@ class ScreenMirror
 
 extern ScreenMirror screenMirror;
 
-#if HAS_TFT
+#if HAS_MUI_MIRROR
 /**
  * Routes a remote input event straight into device-ui's injection seam.
  * MUI builds never construct an InputBroker (Modules.cpp skips it when

--- a/src/graphics/ScreenMirror.h
+++ b/src/graphics/ScreenMirror.h
@@ -12,6 +12,8 @@ class OLEDDisplay;
 namespace graphics
 {
 
+struct TFTColorRegion;
+
 /**
  * Streams 1bpp framebuffer snapshots to local clients as
  * FromRadio.display_frame chunks. Armed via AdminMessage
@@ -42,6 +44,12 @@ class ScreenMirror
     /// the client was mid-drain restarts it at offset 0 of the new frame.
     bool copyChunk(uint32_t &clientFrameId, uint16_t &clientOffset, meshtastic_DisplayFrame &out);
 
+    /// Called by the color display drivers at paint time, before they clear
+    /// the per-frame region table: stores the palette the frame was painted
+    /// with. Colors arrive panel-byte-order (big-endian RGB565).
+    void capturePalette(uint32_t signature, uint16_t defaultOnBe, uint16_t defaultOffBe, const TFTColorRegion *regions,
+                        uint8_t count);
+
     /// True while the client cursor lacks regions of the current color palette.
     bool hasPaletteChunkFor(uint32_t clientPaletteSig, uint8_t clientRegionOffset);
 
@@ -51,7 +59,6 @@ class ScreenMirror
 
   private:
     void freeSnapshotLocked();
-    void capturePaletteLocked();
 
     concurrency::Lock lock;
     bool mirroring = false;

--- a/src/graphics/ScreenMirror.h
+++ b/src/graphics/ScreenMirror.h
@@ -103,8 +103,10 @@ class ScreenMirror
         uint32_t poolOffset;
         uint32_t id;
     };
-    static constexpr uint8_t MUI_MAX_RECTS = 32;
-    static constexpr uint32_t MUI_POOL_BYTES = 96 * 1024;
+    static constexpr uint8_t MUI_MAX_RECTS = 64;
+    // Must hold one full repaint (320x240 RGB565 = 150 KB) plus concurrent
+    // incremental rects, or arming can never deliver a complete first frame.
+    static constexpr uint32_t MUI_POOL_BYTES = 192 * 1024;
     MuiRect muiRects[MUI_MAX_RECTS];
     uint8_t muiHead = 0;
     uint8_t muiCount = 0;

--- a/src/graphics/ScreenMirror.h
+++ b/src/graphics/ScreenMirror.h
@@ -69,7 +69,10 @@ class ScreenMirror
     uint16_t width = 0;
     uint16_t height = 0;
     uint32_t frameId = 0;
-    // Color-region palette captured with the frame (TFT/HUB75 builds only).
+    // Signature of the palette the current snapshot was painted with; frames
+    // carry this, not the live paletteSig, so mid-drain captures stay coherent.
+    uint32_t snapshotPaletteSig = 0;
+    // Color-region palette captured at paint time (TFT/HUB75 builds only).
     uint32_t paletteSig = 0;
     uint8_t paletteCount = 0;
     struct PaletteRegion {

--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -1455,6 +1455,7 @@ static LGFX *tft = nullptr;
 
 #endif
 #include "SPILock.h"
+#include "ScreenMirror.h"
 #include "TFTColorRegions.h"
 #include "TFTDisplay.h"
 #include "TFTPalette.h"
@@ -1620,6 +1621,11 @@ void TFTDisplay::display(bool fromBlank)
         haveLastDefaults = true;
         lastDefaultOnColor = defaultOnColor;
         lastDefaultOffColor = defaultOffColor;
+#if HAS_SCREEN_MIRROR
+        // Regions are cleared below; hand the mirror the palette this frame was painted with.
+        graphics::screenMirror.capturePalette(colorFrameSignature, defaultOnColor, defaultOffColor, graphics::colorRegions,
+                                              graphics::getTFTColorRegionCount());
+#endif
         graphics::clearTFTColorRegions();
         return;
     }
@@ -1798,6 +1804,10 @@ void TFTDisplay::display(bool fromBlank)
     haveLastDefaults = true;
     lastDefaultOnColor = defaultOnColor;
     lastDefaultOffColor = defaultOffColor;
+#if HAS_SCREEN_MIRROR
+    graphics::screenMirror.capturePalette(colorFrameSignature, defaultOnColor, defaultOffColor, graphics::colorRegions,
+                                          graphics::getTFTColorRegionCount());
+#endif
     graphics::clearTFTColorRegions();
 }
 

--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -1804,7 +1804,7 @@ void TFTDisplay::display(bool fromBlank)
     haveLastDefaults = true;
     lastDefaultOnColor = defaultOnColor;
     lastDefaultOffColor = defaultOffColor;
-#if HAS_SCREEN_MIRROR
+#if HAS_SCREEN_MIRROR && GRAPHICS_TFT_COLORING_ENABLED
     graphics::screenMirror.capturePalette(colorFrameSignature, defaultOnColor, defaultOffColor, graphics::colorRegions,
                                           graphics::getTFTColorRegionCount());
 #endif

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -351,18 +351,21 @@ bool muiInjectInputEvent(uint32_t eventCode, uint32_t kbChar, uint32_t touchX, u
         return false;
 
     constexpr uint16_t longPressHoldMs = 600;
+    // Mirrors the trackball driver's semantics (EncoderInputDriver, type 3):
+    // vertical is encoder rotation, which is what actually moves focus in a
+    // group; horizontal becomes the slider keys, deliberately inverted there.
     switch (eventCode) {
     case INPUT_BROKER_UP:
-        InputDriver::injectKey(LV_KEY_UP);
+        InputDriver::injectEncoder(-1);
         break;
     case INPUT_BROKER_DOWN:
-        InputDriver::injectKey(LV_KEY_DOWN);
+        InputDriver::injectEncoder(1);
         break;
     case INPUT_BROKER_LEFT:
-        InputDriver::injectKey(LV_KEY_LEFT);
+        InputDriver::injectKey(LV_KEY_DOWN);
         break;
     case INPUT_BROKER_RIGHT:
-        InputDriver::injectKey(LV_KEY_RIGHT);
+        InputDriver::injectKey(LV_KEY_UP);
         break;
     case INPUT_BROKER_SELECT:
         if (touchX || touchY)

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -10,6 +10,10 @@
 #include "graphics/ScreenMirror.h"
 #include "graphics/driver/DisplayDriver.h"
 #include "graphics/driver/DisplayDriverConfig.h"
+#include "input/InputBroker.h"
+#if defined(MESHTASTIC_MUI_MIRROR)
+#include "input/InputDriver.h"
+#endif
 #include "util/ISpiLock.h"
 
 #ifdef ARCH_PORTDUINO
@@ -313,9 +317,73 @@ class ReentrantSpiLock : public ISpiLock
 
 static ReentrantSpiLock reentrantSpiLock;
 
+#if HAS_SCREEN_MIRROR && defined(MESHTASTIC_MUI_MIRROR)
+// Bridges InputBroker events (remote AdminMessage.send_input_event) into
+// device-ui's virtual input devices. Note the LEFT/RIGHT cross-map: the
+// broker's codes were modeled on LVGL keys but those two are swapped.
+class MuiInputBridge
+{
+  public:
+    void attach()
+    {
+        if (!attached && inputBroker) {
+            inputObserver.observe(inputBroker);
+            attached = true;
+        }
+    }
+
+  private:
+    int onInputEvent(const InputEvent *event)
+    {
+        constexpr uint16_t longPressHoldMs = 600;
+        switch (event->inputEvent) {
+        case INPUT_BROKER_UP:
+            InputDriver::injectKey(LV_KEY_UP);
+            break;
+        case INPUT_BROKER_DOWN:
+            InputDriver::injectKey(LV_KEY_DOWN);
+            break;
+        case INPUT_BROKER_LEFT:
+            InputDriver::injectKey(LV_KEY_LEFT);
+            break;
+        case INPUT_BROKER_RIGHT:
+            InputDriver::injectKey(LV_KEY_RIGHT);
+            break;
+        case INPUT_BROKER_SELECT:
+            if (event->touchX || event->touchY)
+                InputDriver::injectTouch(event->touchX, event->touchY, longPressHoldMs);
+            else
+                InputDriver::injectKey(LV_KEY_ENTER);
+            break;
+        case INPUT_BROKER_USER_PRESS:
+            InputDriver::injectTouch(event->touchX, event->touchY);
+            break;
+        case INPUT_BROKER_BACK:
+        case INPUT_BROKER_CANCEL:
+            InputDriver::injectKey(LV_KEY_ESC);
+            break;
+        default:
+            if (event->kbchar)
+                InputDriver::injectKey(event->kbchar);
+            break;
+        }
+        return 0;
+    }
+
+    bool attached = false;
+    CallbackObserver<MuiInputBridge, const InputEvent *> inputObserver =
+        CallbackObserver<MuiInputBridge, const InputEvent *>(this, &MuiInputBridge::onInputEvent);
+};
+static MuiInputBridge muiInputBridge;
+#endif
+
 void tft_task_handler(void *param = nullptr)
 {
     while (true) {
+#if HAS_SCREEN_MIRROR && defined(MESHTASTIC_MUI_MIRROR)
+        // inputBroker is created in setupModules, after tftSetup: attach lazily.
+        muiInputBridge.attach();
+#endif
         // No lock held here on purpose - device-ui guards its own SPI access.
         deviceScreen->task_handler();
         deviceScreen->sleep();

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -3,6 +3,7 @@
 #include "SPILock.h"
 #include "sleep.h"
 
+#include "NodeDB.h" // config
 #include "api/PacketAPI.h"
 #include "comms/PacketClient.h"
 #include "comms/PacketServer.h"
@@ -11,6 +12,7 @@
 #include "graphics/driver/DisplayDriver.h"
 #include "graphics/driver/DisplayDriverConfig.h"
 #include "input/InputBroker.h"
+#include "mesh/Throttle.h"
 #if defined(MESHTASTIC_MUI_MIRROR)
 #include "input/InputDriver.h"
 #endif
@@ -318,72 +320,58 @@ class ReentrantSpiLock : public ISpiLock
 static ReentrantSpiLock reentrantSpiLock;
 
 #if HAS_SCREEN_MIRROR && defined(MESHTASTIC_MUI_MIRROR)
-// Bridges InputBroker events (remote AdminMessage.send_input_event) into
-// device-ui's virtual input devices. Note the LEFT/RIGHT cross-map: the
-// broker's codes were modeled on LVGL keys but those two are swapped.
-class MuiInputBridge
+namespace graphics
 {
-  public:
-    void attach()
-    {
-        if (!attached && inputBroker) {
-            inputObserver.observe(inputBroker);
-            attached = true;
-        }
-    }
+// Maps a remote input event onto device-ui's virtual LVGL devices. Note the
+// LEFT/RIGHT cross-map: the broker's codes were modeled on LVGL keys but
+// those two are swapped.
+bool muiInjectInputEvent(uint32_t eventCode, uint32_t kbChar, uint32_t touchX, uint32_t touchY)
+{
+    if (config.display.displaymode != meshtastic_Config_DisplayConfig_DisplayMode_COLOR)
+        return false;
 
-  private:
-    int onInputEvent(const InputEvent *event)
-    {
-        constexpr uint16_t longPressHoldMs = 600;
-        switch (event->inputEvent) {
-        case INPUT_BROKER_UP:
-            InputDriver::injectKey(LV_KEY_UP);
-            break;
-        case INPUT_BROKER_DOWN:
-            InputDriver::injectKey(LV_KEY_DOWN);
-            break;
-        case INPUT_BROKER_LEFT:
-            InputDriver::injectKey(LV_KEY_LEFT);
-            break;
-        case INPUT_BROKER_RIGHT:
-            InputDriver::injectKey(LV_KEY_RIGHT);
-            break;
-        case INPUT_BROKER_SELECT:
-            if (event->touchX || event->touchY)
-                InputDriver::injectTouch(event->touchX, event->touchY, longPressHoldMs);
-            else
-                InputDriver::injectKey(LV_KEY_ENTER);
-            break;
-        case INPUT_BROKER_USER_PRESS:
-            InputDriver::injectTouch(event->touchX, event->touchY);
-            break;
-        case INPUT_BROKER_BACK:
-        case INPUT_BROKER_CANCEL:
-            InputDriver::injectKey(LV_KEY_ESC);
-            break;
-        default:
-            if (event->kbchar)
-                InputDriver::injectKey(event->kbchar);
-            break;
-        }
-        return 0;
+    constexpr uint16_t longPressHoldMs = 600;
+    switch (eventCode) {
+    case INPUT_BROKER_UP:
+        InputDriver::injectKey(LV_KEY_UP);
+        break;
+    case INPUT_BROKER_DOWN:
+        InputDriver::injectKey(LV_KEY_DOWN);
+        break;
+    case INPUT_BROKER_LEFT:
+        InputDriver::injectKey(LV_KEY_LEFT);
+        break;
+    case INPUT_BROKER_RIGHT:
+        InputDriver::injectKey(LV_KEY_RIGHT);
+        break;
+    case INPUT_BROKER_SELECT:
+        if (touchX || touchY)
+            InputDriver::injectTouch(touchX, touchY, longPressHoldMs);
+        else
+            InputDriver::injectKey(LV_KEY_ENTER);
+        break;
+    case INPUT_BROKER_USER_PRESS:
+        InputDriver::injectTouch(touchX, touchY);
+        break;
+    case INPUT_BROKER_BACK:
+    case INPUT_BROKER_CANCEL:
+        InputDriver::injectKey(LV_KEY_ESC);
+        break;
+    default:
+        if (kbChar)
+            InputDriver::injectKey(kbChar);
+        else
+            return false;
+        break;
     }
-
-    bool attached = false;
-    CallbackObserver<MuiInputBridge, const InputEvent *> inputObserver =
-        CallbackObserver<MuiInputBridge, const InputEvent *>(this, &MuiInputBridge::onInputEvent);
-};
-static MuiInputBridge muiInputBridge;
+    return true;
+}
+} // namespace graphics
 #endif
 
 void tft_task_handler(void *param = nullptr)
 {
     while (true) {
-#if HAS_SCREEN_MIRROR && defined(MESHTASTIC_MUI_MIRROR)
-        // inputBroker is created in setupModules, after tftSetup: attach lazily.
-        muiInputBridge.attach();
-#endif
         // No lock held here on purpose - device-ui guards its own SPI access.
         deviceScreen->task_handler();
         deviceScreen->sleep();

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -12,7 +12,6 @@
 #include "graphics/driver/DisplayDriver.h"
 #include "graphics/driver/DisplayDriverConfig.h"
 #include "input/InputBroker.h"
-#include "mesh/Throttle.h"
 #if defined(MESHTASTIC_MUI_MIRROR)
 #include "input/InputDriver.h"
 #endif
@@ -410,6 +409,11 @@ void tftSetup(void)
     I2CKeyboardScanner::setSecondaryBus(i2cProxy);
 #endif
 #ifndef ARCH_PORTDUINO
+#if HAS_SCREEN_MIRROR && defined(MESHTASTIC_MUI_MIRROR)
+    // Must precede DeviceScreen::init: device-ui only builds its virtual input
+    // devices (and the default focus group they need) when injection is asked for.
+    InputDriver::enableInjection();
+#endif
     deviceScreen = &DeviceScreen::create(reentrantSpiLock);
     PacketAPI::create(PacketServer::init());
     deviceScreen->init(new PacketClient);
@@ -417,7 +421,12 @@ void tftSetup(void)
     // Stream MUI's dirty rects to local clients (see graphics::ScreenMirror).
     // Gated on MESHTASTIC_MUI_MIRROR until the device-ui flush observer merges
     // (jamesarich/device-ui screen-mirror-poc); the vendored pin lacks it.
-    graphics::screenMirror.setMuiRefresh([]() { DisplayDriver::requestFullRefresh(); });
+    {
+        lv_display_t *disp = lv_display_get_default();
+        graphics::screenMirror.setMuiSource([]() { DisplayDriver::requestFullRefresh(); },
+                                            disp ? (uint16_t)lv_display_get_horizontal_resolution(disp) : 0,
+                                            disp ? (uint16_t)lv_display_get_vertical_resolution(disp) : 0);
+    }
     DisplayDriver::setFlushObserver([](int16_t x, int16_t y, uint16_t w, uint16_t h, const uint16_t *px) {
         graphics::screenMirror.onMuiRect(x, y, w, h, px);
     });

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -12,7 +12,7 @@
 #include "graphics/driver/DisplayDriver.h"
 #include "graphics/driver/DisplayDriverConfig.h"
 #include "input/InputBroker.h"
-#if defined(MESHTASTIC_MUI_MIRROR)
+#if HAS_MUI_MIRROR
 #include "input/InputDriver.h"
 #endif
 #include "util/ISpiLock.h"
@@ -318,12 +318,9 @@ class ReentrantSpiLock : public ISpiLock
 
 static ReentrantSpiLock reentrantSpiLock;
 
-#if HAS_SCREEN_MIRROR && defined(MESHTASTIC_MUI_MIRROR)
+#if HAS_MUI_MIRROR
 namespace graphics
 {
-// Maps a remote input event onto device-ui's virtual LVGL devices. Note the
-// LEFT/RIGHT cross-map: the broker's codes were modeled on LVGL keys but
-// those two are swapped.
 // Reports MUI's logical panel geometry for DeviceMetadata.display. The BaseUI
 // `screen` object does not exist on MUI builds, so the dimensions come from
 // LVGL itself (already rotated to the logical orientation).
@@ -344,6 +341,9 @@ bool muiDisplayInfo(uint16_t &width, uint16_t &height, bool &hasTouch)
     return width > 0 && height > 0;
 }
 
+// Maps a remote input event onto device-ui's virtual LVGL devices. Note the
+// LEFT/RIGHT cross-map: the broker's codes were modeled on LVGL keys but
+// those two are swapped.
 bool muiInjectInputEvent(uint32_t eventCode, uint32_t kbChar, uint32_t touchX, uint32_t touchY)
 {
     if (config.display.displaymode != meshtastic_Config_DisplayConfig_DisplayMode_COLOR)
@@ -409,7 +409,7 @@ void tftSetup(void)
     I2CKeyboardScanner::setSecondaryBus(i2cProxy);
 #endif
 #ifndef ARCH_PORTDUINO
-#if HAS_SCREEN_MIRROR && defined(MESHTASTIC_MUI_MIRROR)
+#if HAS_MUI_MIRROR
     // Must precede DeviceScreen::init: device-ui only builds its virtual input
     // devices (and the default focus group they need) when injection is asked for.
     InputDriver::enableInjection();
@@ -417,7 +417,7 @@ void tftSetup(void)
     deviceScreen = &DeviceScreen::create(reentrantSpiLock);
     PacketAPI::create(PacketServer::init());
     deviceScreen->init(new PacketClient);
-#if HAS_SCREEN_MIRROR && defined(MESHTASTIC_MUI_MIRROR)
+#if HAS_MUI_MIRROR
     // Stream MUI's dirty rects to local clients (see graphics::ScreenMirror).
     // Gated on MESHTASTIC_MUI_MIRROR until the device-ui flush observer merges
     // (jamesarich/device-ui screen-mirror-poc); the vendored pin lacks it.

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -334,8 +334,10 @@ void tftSetup(void)
     deviceScreen = &DeviceScreen::create(reentrantSpiLock);
     PacketAPI::create(PacketServer::init());
     deviceScreen->init(new PacketClient);
-#if HAS_SCREEN_MIRROR
+#if HAS_SCREEN_MIRROR && defined(MESHTASTIC_MUI_MIRROR)
     // Stream MUI's dirty rects to local clients (see graphics::ScreenMirror).
+    // Gated on MESHTASTIC_MUI_MIRROR until the device-ui flush observer merges
+    // (jamesarich/device-ui screen-mirror-poc); the vendored pin lacks it.
     graphics::screenMirror.setMuiRefresh([]() { DisplayDriver::requestFullRefresh(); });
     DisplayDriver::setFlushObserver([](int16_t x, int16_t y, uint16_t w, uint16_t h, const uint16_t *px) {
         graphics::screenMirror.onMuiRect(x, y, w, h, px);

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -325,6 +325,26 @@ namespace graphics
 // Maps a remote input event onto device-ui's virtual LVGL devices. Note the
 // LEFT/RIGHT cross-map: the broker's codes were modeled on LVGL keys but
 // those two are swapped.
+// Reports MUI's logical panel geometry for DeviceMetadata.display. The BaseUI
+// `screen` object does not exist on MUI builds, so the dimensions come from
+// LVGL itself (already rotated to the logical orientation).
+bool muiDisplayInfo(uint16_t &width, uint16_t &height, bool &hasTouch)
+{
+    if (config.display.displaymode != meshtastic_Config_DisplayConfig_DisplayMode_COLOR)
+        return false;
+    lv_display_t *disp = lv_display_get_default();
+    if (!disp)
+        return false;
+    width = (uint16_t)lv_display_get_horizontal_resolution(disp);
+    height = (uint16_t)lv_display_get_vertical_resolution(disp);
+#if HAS_TOUCHSCREEN
+    hasTouch = true;
+#else
+    hasTouch = false;
+#endif
+    return width > 0 && height > 0;
+}
+
 bool muiInjectInputEvent(uint32_t eventCode, uint32_t kbChar, uint32_t touchX, uint32_t touchY)
 {
     if (config.display.displaymode != meshtastic_Config_DisplayConfig_DisplayMode_COLOR)

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -7,6 +7,8 @@
 #include "comms/PacketClient.h"
 #include "comms/PacketServer.h"
 #include "graphics/DeviceScreen.h"
+#include "graphics/ScreenMirror.h"
+#include "graphics/driver/DisplayDriver.h"
 #include "graphics/driver/DisplayDriverConfig.h"
 #include "util/ISpiLock.h"
 
@@ -332,6 +334,13 @@ void tftSetup(void)
     deviceScreen = &DeviceScreen::create(reentrantSpiLock);
     PacketAPI::create(PacketServer::init());
     deviceScreen->init(new PacketClient);
+#if HAS_SCREEN_MIRROR
+    // Stream MUI's dirty rects to local clients (see graphics::ScreenMirror).
+    graphics::screenMirror.setMuiRefresh([]() { DisplayDriver::requestFullRefresh(); });
+    DisplayDriver::setFlushObserver([](int16_t x, int16_t y, uint16_t w, uint16_t h, const uint16_t *px) {
+        graphics::screenMirror.onMuiRect(x, y, w, h, px);
+    });
+#endif
 #else
     if (portduino_config.displayPanel != no_screen) {
         DisplayDriverConfig displayConfig;

--- a/src/graphics/tftSetup.cpp
+++ b/src/graphics/tftSetup.cpp
@@ -9,11 +9,10 @@
 #include "comms/PacketServer.h"
 #include "graphics/DeviceScreen.h"
 #include "graphics/ScreenMirror.h"
-#include "graphics/driver/DisplayDriver.h"
 #include "graphics/driver/DisplayDriverConfig.h"
 #include "input/InputBroker.h"
 #if HAS_MUI_MIRROR
-#include "input/InputDriver.h"
+#include "graphics/DisplayMirror.h"
 #endif
 #include "util/ISpiLock.h"
 
@@ -355,33 +354,33 @@ bool muiInjectInputEvent(uint32_t eventCode, uint32_t kbChar, uint32_t touchX, u
     // group; horizontal becomes the slider keys, deliberately inverted there.
     switch (eventCode) {
     case INPUT_BROKER_UP:
-        InputDriver::injectEncoder(-1);
+        DisplayMirror::injectEncoder(-1);
         break;
     case INPUT_BROKER_DOWN:
-        InputDriver::injectEncoder(1);
+        DisplayMirror::injectEncoder(1);
         break;
     case INPUT_BROKER_LEFT:
-        InputDriver::injectKey(LV_KEY_DOWN);
+        DisplayMirror::injectKey(LV_KEY_DOWN);
         break;
     case INPUT_BROKER_RIGHT:
-        InputDriver::injectKey(LV_KEY_UP);
+        DisplayMirror::injectKey(LV_KEY_UP);
         break;
     case INPUT_BROKER_SELECT:
         if (touchX || touchY)
-            InputDriver::injectTouch(touchX, touchY, longPressHoldMs);
+            DisplayMirror::injectTouch(touchX, touchY, longPressHoldMs);
         else
-            InputDriver::injectKey(LV_KEY_ENTER);
+            DisplayMirror::injectKey(LV_KEY_ENTER);
         break;
     case INPUT_BROKER_USER_PRESS:
-        InputDriver::injectTouch(touchX, touchY);
+        DisplayMirror::injectTouch(touchX, touchY);
         break;
     case INPUT_BROKER_BACK:
     case INPUT_BROKER_CANCEL:
-        InputDriver::injectKey(LV_KEY_ESC);
+        DisplayMirror::injectKey(LV_KEY_ESC);
         break;
     default:
         if (kbChar)
-            InputDriver::injectKey(kbChar);
+            DisplayMirror::injectKey(kbChar);
         else
             return false;
         break;
@@ -409,25 +408,22 @@ void tftSetup(void)
     I2CKeyboardScanner::setSecondaryBus(i2cProxy);
 #endif
 #ifndef ARCH_PORTDUINO
-#if HAS_MUI_MIRROR
-    // Must precede DeviceScreen::init: device-ui only builds its virtual input
-    // devices (and the default focus group they need) when injection is asked for.
-    InputDriver::enableInjection();
-#endif
     deviceScreen = &DeviceScreen::create(reentrantSpiLock);
     PacketAPI::create(PacketServer::init());
     deviceScreen->init(new PacketClient);
 #if HAS_MUI_MIRROR
     // Stream MUI's dirty rects to local clients (see graphics::ScreenMirror).
-    // Gated on MESHTASTIC_MUI_MIRROR until the device-ui flush observer merges
-    // (jamesarich/device-ui screen-mirror-poc); the vendored pin lacks it.
+    // Gated on MESHTASTIC_MUI_MIRROR until DisplayMirror merges (jamesarich/device-ui
+    // screen-mirror-poc); the vendored pin lacks it. Armed here because LVGL is up by
+    // now, and the view has not built its widgets yet - see DisplayMirror::start.
+    DisplayMirror::start(deviceScreen->getDisplayDriver());
     {
         lv_display_t *disp = lv_display_get_default();
-        graphics::screenMirror.setMuiSource([]() { DisplayDriver::requestFullRefresh(); },
+        graphics::screenMirror.setMuiSource([]() { DisplayMirror::requestFullRefresh(); },
                                             disp ? (uint16_t)lv_display_get_horizontal_resolution(disp) : 0,
                                             disp ? (uint16_t)lv_display_get_vertical_resolution(disp) : 0);
     }
-    DisplayDriver::setFlushObserver([](int16_t x, int16_t y, uint16_t w, uint16_t h, const uint16_t *px) {
+    DisplayMirror::setFrameObserver([](int16_t x, int16_t y, uint16_t w, uint16_t h, const uint16_t *px) {
         graphics::screenMirror.onMuiRect(x, y, w, h, px);
     });
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1377,7 +1377,7 @@ extern meshtastic_DeviceMetadata getDeviceMetadata()
     deviceMetadata.has_xeddsa = true;
 #endif
 
-#if HAS_TFT && HAS_SCREEN_MIRROR && defined(MESHTASTIC_MUI_MIRROR)
+#if HAS_MUI_MIRROR
     // MUI owns the panel and leaves `screen` null, so ask LVGL instead.
     uint16_t muiW = 0, muiH = 0;
     bool muiTouch = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1405,8 +1405,11 @@ extern meshtastic_DeviceMetadata getDeviceMetadata()
             deviceMetadata.display.panel_class = meshtastic_DisplayInfo_PanelClass_EINK;
 #elif defined(USE_HUB75) || defined(HAS_HUB75_NATIVE)
             deviceMetadata.display.panel_class = meshtastic_DisplayInfo_PanelClass_HUB75;
-#elif defined(USE_TFTDISPLAY) || defined(HAS_SPI_TFT) || defined(USE_ST7789) || defined(USE_ST7796) ||                           \
-    defined(ILI9341_DRIVER) || defined(ILI9342_DRIVER)
+// USE_TFTDISPLAY is value-tested, not defined()-tested: configuration.h
+// defaults it to 0, so it is always defined and every screen build would
+// otherwise report itself as a TFT.
+#elif USE_TFTDISPLAY || defined(HAS_SPI_TFT) || defined(USE_ST7789) || defined(USE_ST7796) || defined(ILI9341_DRIVER) ||         \
+    defined(ILI9342_DRIVER)
             deviceMetadata.display.panel_class = meshtastic_DisplayInfo_PanelClass_TFT;
 #elif defined(USE_ST7567)
             deviceMetadata.display.panel_class = meshtastic_DisplayInfo_PanelClass_LCD;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1375,6 +1375,33 @@ extern meshtastic_DeviceMetadata getDeviceMetadata()
 #if !(MESHTASTIC_EXCLUDE_PKI) && !(MESHTASTIC_EXCLUDE_XEDDSA)
     deviceMetadata.has_xeddsa = true;
 #endif
+
+#if HAS_SCREEN
+    if (screen) {
+        OLEDDisplay *dispdev = screen->getDisplayDevice();
+        if (dispdev && dispdev->getWidth() > 0) {
+            deviceMetadata.has_display = true;
+            deviceMetadata.display.width = dispdev->getWidth();
+            deviceMetadata.display.height = dispdev->getHeight();
+            deviceMetadata.display.format = meshtastic_DisplayFrame_Format_MONO_VLSB;
+#if defined(USE_EINK)
+            deviceMetadata.display.panel_class = meshtastic_DisplayInfo_PanelClass_EINK;
+#elif defined(USE_HUB75) || defined(HAS_HUB75_NATIVE)
+            deviceMetadata.display.panel_class = meshtastic_DisplayInfo_PanelClass_HUB75;
+#elif defined(USE_TFTDISPLAY) || defined(HAS_SPI_TFT) || defined(USE_ST7789) || defined(USE_ST7796) ||                           \
+    defined(ILI9341_DRIVER) || defined(ILI9342_DRIVER)
+            deviceMetadata.display.panel_class = meshtastic_DisplayInfo_PanelClass_TFT;
+#elif defined(USE_ST7567)
+            deviceMetadata.display.panel_class = meshtastic_DisplayInfo_PanelClass_LCD;
+#else
+            deviceMetadata.display.panel_class = meshtastic_DisplayInfo_PanelClass_OLED;
+#endif
+#ifdef HAS_TOUCHSCREEN
+            deviceMetadata.display.has_touch = true;
+#endif
+        }
+    }
+#endif
     return deviceMetadata;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1384,7 +1384,10 @@ extern meshtastic_DeviceMetadata getDeviceMetadata()
             deviceMetadata.display.width = dispdev->getWidth();
             deviceMetadata.display.height = dispdev->getHeight();
             deviceMetadata.display.format = meshtastic_DisplayFrame_Format_MONO_VLSB;
-#if defined(USE_EINK)
+#if defined(ARCH_PORTDUINO)
+            // The native panel is selected at runtime; UNSPECIFIED is honest until derived from portduino_config.
+            deviceMetadata.display.panel_class = meshtastic_DisplayInfo_PanelClass_PANEL_CLASS_UNSPECIFIED;
+#elif defined(USE_EINK)
             deviceMetadata.display.panel_class = meshtastic_DisplayInfo_PanelClass_EINK;
 #elif defined(USE_HUB75) || defined(HAS_HUB75_NATIVE)
             deviceMetadata.display.panel_class = meshtastic_DisplayInfo_PanelClass_HUB75;
@@ -1396,7 +1399,7 @@ extern meshtastic_DeviceMetadata getDeviceMetadata()
 #else
             deviceMetadata.display.panel_class = meshtastic_DisplayInfo_PanelClass_OLED;
 #endif
-#ifdef HAS_TOUCHSCREEN
+#if HAS_TOUCHSCREEN
             deviceMetadata.display.has_touch = true;
 #endif
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,6 +44,7 @@
 #endif
 #include "detect/einkScan.h"
 #include "graphics/Screen.h"
+#include "graphics/ScreenMirror.h"
 #include "main.h"
 #include "memory/MemAudit.h"
 #include "mesh/generated/meshtastic/config.pb.h"
@@ -1376,8 +1377,21 @@ extern meshtastic_DeviceMetadata getDeviceMetadata()
     deviceMetadata.has_xeddsa = true;
 #endif
 
+#if HAS_TFT && HAS_SCREEN_MIRROR && defined(MESHTASTIC_MUI_MIRROR)
+    // MUI owns the panel and leaves `screen` null, so ask LVGL instead.
+    uint16_t muiW = 0, muiH = 0;
+    bool muiTouch = false;
+    if (graphics::muiDisplayInfo(muiW, muiH, muiTouch)) {
+        deviceMetadata.has_display = true;
+        deviceMetadata.display.width = muiW;
+        deviceMetadata.display.height = muiH;
+        deviceMetadata.display.format = meshtastic_DisplayFrame_Format_RGB565;
+        deviceMetadata.display.panel_class = meshtastic_DisplayInfo_PanelClass_TFT;
+        deviceMetadata.display.has_touch = muiTouch;
+    } else
+#endif
 #if HAS_SCREEN
-    if (screen) {
+        if (screen) {
         OLEDDisplay *dispdev = screen->getDisplayDevice();
         if (dispdev && dispdev->getWidth() > 0) {
             deviceMetadata.has_display = true;

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -389,6 +389,8 @@ void PhoneAPI::close()
         graphics::screenMirror.setMirror(false);
         mirrorFrameId = 0;
         mirrorOffset = 0;
+        mirrorPaletteSig = 0;
+        mirrorPaletteOffset = 0;
 #endif
         releasePhonePacket(); // Don't leak phone packets on shutdown
         releaseQueueStatusPhonePacket();
@@ -1106,6 +1108,10 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
                 fromRadioScratch.packet = replayPkt;
             }
 #if HAS_SCREEN_MIRROR
+        } else if (screenMirrorAuthorized() && graphics::screenMirror.copyPaletteChunk(mirrorPaletteSig, mirrorPaletteOffset,
+                                                                                       fromRadioScratch.display_palette)) {
+            // Palette before frames so the client can colorize the first frame it renders.
+            fromRadioScratch.which_payload_variant = meshtastic_FromRadio_display_palette_tag;
         } else if (screenMirrorAuthorized() &&
                    graphics::screenMirror.copyChunk(mirrorFrameId, mirrorOffset, fromRadioScratch.display_frame)) {
             // Lowest priority: mesh traffic and notifications outrank pixels.
@@ -1750,7 +1756,8 @@ bool PhoneAPI::available()
             return true;
 
 #if HAS_SCREEN_MIRROR
-        return screenMirrorAuthorized() && graphics::screenMirror.hasChunkFor(mirrorFrameId, mirrorOffset);
+        return screenMirrorAuthorized() && (graphics::screenMirror.hasPaletteChunkFor(mirrorPaletteSig, mirrorPaletteOffset) ||
+                                            graphics::screenMirror.hasChunkFor(mirrorFrameId, mirrorOffset));
 #else
         return false;
 #endif

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -23,6 +23,7 @@
 #include "SPILock.h"
 #include "TypeConversions.h"
 #include "concurrency/LockGuard.h"
+#include "graphics/ScreenMirror.h"
 #include "main.h"
 #include "modules/NodeInfoModule.h"
 #include "xmodem.h"
@@ -273,6 +274,9 @@ void PhoneAPI::handleStartConfig()
 #ifdef FSCom
         observe(&xModem.packetReady);
 #endif
+#if HAS_SCREEN && !defined(MESHTASTIC_EXCLUDE_SCREEN_MIRROR)
+        observe(&graphics::screenMirror.frameReady);
+#endif
 #ifdef MESHTASTIC_PHONEAPI_ACCESS_CONTROL
         // New physical connection: clear this PhoneAPI's auth slot so the new
         // client must present a passphrase or PKC admin signature before
@@ -376,6 +380,9 @@ void PhoneAPI::close()
         unobserve(&service->fromNumChanged);
 #ifdef FSCom
         unobserve(&xModem.packetReady);
+#endif
+#if HAS_SCREEN && !defined(MESHTASTIC_EXCLUDE_SCREEN_MIRROR)
+        unobserve(&graphics::screenMirror.frameReady);
 #endif
         releasePhonePacket(); // Don't leak phone packets on shutdown
         releaseQueueStatusPhonePacket();
@@ -1051,6 +1058,10 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
                 fromRadioScratch.xmodemPacket = xmodemPacketForPhone;
                 xmodemPacketForPhone = meshtastic_XModem_init_zero;
             }
+#if HAS_SCREEN && !defined(MESHTASTIC_EXCLUDE_SCREEN_MIRROR)
+        } else if (graphics::screenMirror.getChunkForPhone(fromRadioScratch.display_frame)) {
+            fromRadioScratch.which_payload_variant = meshtastic_FromRadio_display_frame_tag;
+#endif
 #ifdef MESHTASTIC_PHONEAPI_ACCESS_CONTROL
         } else if (hasPendingLockdownStatus()) {
             concurrency::LockGuard guard(&g_authSlotsMutex);
@@ -1710,6 +1721,11 @@ bool PhoneAPI::available()
             xModem.resetForPhone();
             return true;
         }
+#endif
+
+#if HAS_SCREEN && !defined(MESHTASTIC_EXCLUDE_SCREEN_MIRROR)
+        if (graphics::screenMirror.hasChunkForPhone())
+            return true;
 #endif
 
 #ifdef ARCH_ESP32

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -1113,7 +1113,7 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
             // Palette before frames so the client can colorize the first frame it renders.
             fromRadioScratch.which_payload_variant = meshtastic_FromRadio_display_palette_tag;
         } else if (screenMirrorAuthorized() &&
-                   graphics::screenMirror.copyChunk(mirrorFrameId, mirrorOffset, fromRadioScratch.display_frame)) {
+                   graphics::screenMirror.copyChunk(this, mirrorFrameId, mirrorOffset, fromRadioScratch.display_frame)) {
             // Lowest priority: mesh traffic and notifications outrank pixels.
             fromRadioScratch.which_payload_variant = meshtastic_FromRadio_display_frame_tag;
 #endif
@@ -1757,7 +1757,7 @@ bool PhoneAPI::available()
 
 #if HAS_SCREEN_MIRROR
         return screenMirrorAuthorized() && (graphics::screenMirror.hasPaletteChunkFor(mirrorPaletteSig, mirrorPaletteOffset) ||
-                                            graphics::screenMirror.hasChunkFor(mirrorFrameId, mirrorOffset));
+                                            graphics::screenMirror.hasChunkFor(this, mirrorFrameId, mirrorOffset));
 #else
         return false;
 #endif

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -274,7 +274,7 @@ void PhoneAPI::handleStartConfig()
 #ifdef FSCom
         observe(&xModem.packetReady);
 #endif
-#if HAS_SCREEN && !defined(MESHTASTIC_EXCLUDE_SCREEN_MIRROR)
+#if HAS_SCREEN_MIRROR
         observe(&graphics::screenMirror.frameReady);
 #endif
 #ifdef MESHTASTIC_PHONEAPI_ACCESS_CONTROL
@@ -381,8 +381,14 @@ void PhoneAPI::close()
 #ifdef FSCom
         unobserve(&xModem.packetReady);
 #endif
-#if HAS_SCREEN && !defined(MESHTASTIC_EXCLUDE_SCREEN_MIRROR)
+#if HAS_SCREEN_MIRROR
         unobserve(&graphics::screenMirror.frameReady);
+        // This client is gone; PoC keeps one arming flag, so disarm and free
+        // the snapshot rather than stream to nobody. A surviving client
+        // re-arms with another set_display_mirror.
+        graphics::screenMirror.setMirror(false);
+        mirrorFrameId = 0;
+        mirrorOffset = 0;
 #endif
         releasePhonePacket(); // Don't leak phone packets on shutdown
         releaseQueueStatusPhonePacket();
@@ -1058,10 +1064,6 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
                 fromRadioScratch.xmodemPacket = xmodemPacketForPhone;
                 xmodemPacketForPhone = meshtastic_XModem_init_zero;
             }
-#if HAS_SCREEN && !defined(MESHTASTIC_EXCLUDE_SCREEN_MIRROR)
-        } else if (graphics::screenMirror.getChunkForPhone(fromRadioScratch.display_frame)) {
-            fromRadioScratch.which_payload_variant = meshtastic_FromRadio_display_frame_tag;
-#endif
 #ifdef MESHTASTIC_PHONEAPI_ACCESS_CONTROL
         } else if (hasPendingLockdownStatus()) {
             concurrency::LockGuard guard(&g_authSlotsMutex);
@@ -1103,6 +1105,12 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
                 fromRadioScratch.which_payload_variant = meshtastic_FromRadio_packet_tag;
                 fromRadioScratch.packet = replayPkt;
             }
+#if HAS_SCREEN_MIRROR
+        } else if (screenMirrorAuthorized() &&
+                   graphics::screenMirror.copyChunk(mirrorFrameId, mirrorOffset, fromRadioScratch.display_frame)) {
+            // Lowest priority: mesh traffic and notifications outrank pixels.
+            fromRadioScratch.which_payload_variant = meshtastic_FromRadio_display_frame_tag;
+#endif
         }
         break;
 
@@ -1723,11 +1731,6 @@ bool PhoneAPI::available()
         }
 #endif
 
-#if HAS_SCREEN && !defined(MESHTASTIC_EXCLUDE_SCREEN_MIRROR)
-        if (graphics::screenMirror.hasChunkForPhone())
-            return true;
-#endif
-
 #ifdef ARCH_ESP32
 #if !MESHTASTIC_EXCLUDE_STOREFORWARD
         // Check if StoreForward has packets stored for us.
@@ -1743,7 +1746,14 @@ bool PhoneAPI::available()
             return true;
         // Trailing replay drain - feeds cached satellite-DB packets alongside
         // (lower priority than) live traffic.
-        return replayPending();
+        if (replayPending())
+            return true;
+
+#if HAS_SCREEN_MIRROR
+        return screenMirrorAuthorized() && graphics::screenMirror.hasChunkFor(mirrorFrameId, mirrorOffset);
+#else
+        return false;
+#endif
     }
     default:
         LOG_ERROR("PhoneAPI::available unexpected state %d", state);
@@ -1930,7 +1940,9 @@ int PhoneAPI::onNotify(uint32_t newValue)
         // Consumed by every connected client in this one notify pass, so no per-connection bookkeeping.
         if (service->identityMovePending())
             state = STATE_RESEND_MY_INFO;
-        LOG_INFO("Tell client new packets %u", newValue);
+        // TRACE, not INFO: with display mirroring active this fires once per
+        // captured frame per client, at screen-change rate.
+        LOG_TRACE("Tell client new packets %u", newValue);
         onNowHasData(newValue);
     } else if (service->identityMovePending() && state != STATE_SEND_NOTHING && state != STATE_SEND_MY_INFO) {
         // Mid-sync, so this dump is already carrying the old number in its my_info, its self record or

--- a/src/mesh/PhoneAPI.h
+++ b/src/mesh/PhoneAPI.h
@@ -91,10 +91,13 @@ class PhoneAPI
     meshtastic_XModem xmodemPacketForPhone = meshtastic_XModem_init_zero;
 
 #if HAS_SCREEN_MIRROR
-    // Per-connection drain cursor into ScreenMirror's current frame, so
-    // coexisting clients (BLE + serial + TCP) each receive complete frames.
+    // Per-connection drain cursors into ScreenMirror's current frame and
+    // color palette, so coexisting clients (BLE + serial + TCP) each receive
+    // complete frames and palettes.
     uint32_t mirrorFrameId = 0;
     uint16_t mirrorOffset = 0;
+    uint32_t mirrorPaletteSig = 0;
+    uint8_t mirrorPaletteOffset = 0;
 
     // Screen pixels carry operator content; under access control only an
     // authorized client may receive them (same rule as mesh packets).

--- a/src/mesh/PhoneAPI.h
+++ b/src/mesh/PhoneAPI.h
@@ -90,6 +90,24 @@ class PhoneAPI
     // file transfer packets destined for phone. Push it to the queue then free it.
     meshtastic_XModem xmodemPacketForPhone = meshtastic_XModem_init_zero;
 
+#if HAS_SCREEN_MIRROR
+    // Per-connection drain cursor into ScreenMirror's current frame, so
+    // coexisting clients (BLE + serial + TCP) each receive complete frames.
+    uint32_t mirrorFrameId = 0;
+    uint16_t mirrorOffset = 0;
+
+    // Screen pixels carry operator content; under access control only an
+    // authorized client may receive them (same rule as mesh packets).
+    bool screenMirrorAuthorized()
+    {
+#ifdef MESHTASTIC_PHONEAPI_ACCESS_CONTROL
+        return getAdminAuthorized();
+#else
+        return true;
+#endif
+    }
+#endif
+
     // Keep QueueStatus packet just as packetForPhone
     meshtastic_QueueStatus *queueStatusPacketForPhone = NULL;
 

--- a/src/mesh/generated/meshtastic/admin.pb.h
+++ b/src/mesh/generated/meshtastic/admin.pb.h
@@ -186,7 +186,7 @@ typedef struct _meshtastic_LockdownAuth {
  token at unlock time: the client-supplied boots_remaining when
  non-zero, otherwise the firmware default (TOKEN_DEFAULT_BOOTS).
  Note that boots_remaining == 0 in this message means "use firmware
- default", NOT "zero boots" — a client computing the ceiling for
+ default", NOT "zero boots" - a client computing the ceiling for
  display should mirror that resolution rather than multiplying the
  raw request value.
 
@@ -196,7 +196,7 @@ typedef struct _meshtastic_LockdownAuth {
 
  Uses millis() (CPU uptime), not wall-clock time, so the cap is
  immune to GPS spoofing, RTC backup-battery removal, and Faraday
- cage isolation — none of those move the uptime counter. The only
+ cage isolation - none of those move the uptime counter. The only
  way to reset the session clock is a reboot, which costs a boot
  from the on-flash, HMAC-bound counter. */
     uint32_t max_session_seconds;
@@ -213,7 +213,7 @@ typedef struct _meshtastic_LockdownAuth {
 
  NOT reversed by this operation: APPROTECT. Once the debug port
  lockout has been burned (on silicon where it is effective) it is
- permanent — disabling lockdown decrypts your data and removes the
+ permanent - disabling lockdown decrypts your data and removes the
  access gates, but the SWD/JTAG port stays locked for the life of
  the device (recoverable only via a full chip erase over a debug
  probe, which destroys all data). Clients should make this

--- a/src/mesh/generated/meshtastic/admin.pb.h
+++ b/src/mesh/generated/meshtastic/admin.pb.h
@@ -186,7 +186,7 @@ typedef struct _meshtastic_LockdownAuth {
  token at unlock time: the client-supplied boots_remaining when
  non-zero, otherwise the firmware default (TOKEN_DEFAULT_BOOTS).
  Note that boots_remaining == 0 in this message means "use firmware
- default", NOT "zero boots" — a client computing the ceiling for
+ default", NOT "zero boots" - a client computing the ceiling for
  display should mirror that resolution rather than multiplying the
  raw request value.
 
@@ -196,7 +196,7 @@ typedef struct _meshtastic_LockdownAuth {
 
  Uses millis() (CPU uptime), not wall-clock time, so the cap is
  immune to GPS spoofing, RTC backup-battery removal, and Faraday
- cage isolation — none of those move the uptime counter. The only
+ cage isolation - none of those move the uptime counter. The only
  way to reset the session clock is a reboot, which costs a boot
  from the on-flash, HMAC-bound counter. */
     uint32_t max_session_seconds;
@@ -213,7 +213,7 @@ typedef struct _meshtastic_LockdownAuth {
 
  NOT reversed by this operation: APPROTECT. Once the debug port
  lockout has been burned (on silicon where it is effective) it is
- permanent — disabling lockdown decrypts your data and removes the
+ permanent - disabling lockdown decrypts your data and removes the
  access gates, but the SWD/JTAG port stays locked for the life of
  the device (recoverable only via a full chip erase over a debug
  probe, which destroys all data). Clients should make this
@@ -504,11 +504,18 @@ typedef struct _meshtastic_AdminMessage {
         uint32_t toggle_muted_node;
         /* Request a single frame of the device's display framebuffer.
      The frame is delivered to the local client as FromRadio.display_frame
-     chunks (see DisplayFrame in mesh.proto). */
+     chunks (see DisplayFrame in mesh.proto) - there is no AdminMessage
+     response. Local connection only: a node receiving this over the mesh,
+     or a build without a display, ignores it. During active mirroring it
+     forces one frame on the next redraw even if the screen is unchanged. */
         bool get_display_frame_request;
-        /* Enable or disable continuous mirroring of the device display.
+        /* Enable (true) or disable (false) continuous mirroring of the device
+     display - unlike most bool verbs in this oneof, false is meaningful.
      While enabled, the device sends a DisplayFrame after each screen
-     redraw that changed the framebuffer, as FromRadio.display_frame chunks. */
+     redraw that changed the framebuffer, as FromRadio.display_frame
+     chunks; the first frame arrives immediately and acts as the
+     acknowledgement. Local connection only (see get_display_frame_request)
+     and not persisted across reboot. */
         bool set_display_mirror;
         /* Begins an edit transaction for config, module config, owner, and channel settings changes
      This will delay the standard *implicit* save to the file system and subsequent reboot behavior until committed (commit_edit_settings) */

--- a/src/mesh/generated/meshtastic/admin.pb.h
+++ b/src/mesh/generated/meshtastic/admin.pb.h
@@ -502,6 +502,14 @@ typedef struct _meshtastic_AdminMessage {
         uint32_t remove_ignored_node;
         /* Set specified node-num to be muted */
         uint32_t toggle_muted_node;
+        /* Request a single frame of the device's display framebuffer.
+     The frame is delivered to the local client as FromRadio.display_frame
+     chunks (see DisplayFrame in mesh.proto). */
+        bool get_display_frame_request;
+        /* Enable or disable continuous mirroring of the device display.
+     While enabled, the device sends a DisplayFrame after each screen
+     redraw that changed the framebuffer, as FromRadio.display_frame chunks. */
+        bool set_display_mirror;
         /* Begins an edit transaction for config, module config, owner, and channel settings changes
      This will delay the standard *implicit* save to the file system and subsequent reboot behavior until committed (commit_edit_settings) */
         bool begin_edit_settings;
@@ -738,6 +746,8 @@ extern "C" {
 #define meshtastic_AdminMessage_set_ignored_node_tag 47
 #define meshtastic_AdminMessage_remove_ignored_node_tag 48
 #define meshtastic_AdminMessage_toggle_muted_node_tag 49
+#define meshtastic_AdminMessage_get_display_frame_request_tag 50
+#define meshtastic_AdminMessage_set_display_mirror_tag 51
 #define meshtastic_AdminMessage_begin_edit_settings_tag 64
 #define meshtastic_AdminMessage_commit_edit_settings_tag 65
 #define meshtastic_AdminMessage_add_contact_tag  66
@@ -800,6 +810,8 @@ X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,store_ui_config,store_ui_con
 X(a, STATIC,   ONEOF,    UINT32,   (payload_variant,set_ignored_node,set_ignored_node),  47) \
 X(a, STATIC,   ONEOF,    UINT32,   (payload_variant,remove_ignored_node,remove_ignored_node),  48) \
 X(a, STATIC,   ONEOF,    UINT32,   (payload_variant,toggle_muted_node,toggle_muted_node),  49) \
+X(a, STATIC,   ONEOF,    BOOL,     (payload_variant,get_display_frame_request,get_display_frame_request),  50) \
+X(a, STATIC,   ONEOF,    BOOL,     (payload_variant,set_display_mirror,set_display_mirror),  51) \
 X(a, STATIC,   ONEOF,    BOOL,     (payload_variant,begin_edit_settings,begin_edit_settings),  64) \
 X(a, STATIC,   ONEOF,    BOOL,     (payload_variant,commit_edit_settings,commit_edit_settings),  65) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,add_contact,add_contact),  66) \

--- a/src/mesh/generated/meshtastic/admin.pb.h
+++ b/src/mesh/generated/meshtastic/admin.pb.h
@@ -186,7 +186,7 @@ typedef struct _meshtastic_LockdownAuth {
  token at unlock time: the client-supplied boots_remaining when
  non-zero, otherwise the firmware default (TOKEN_DEFAULT_BOOTS).
  Note that boots_remaining == 0 in this message means "use firmware
- default", NOT "zero boots" - a client computing the ceiling for
+ default", NOT "zero boots" — a client computing the ceiling for
  display should mirror that resolution rather than multiplying the
  raw request value.
 
@@ -196,7 +196,7 @@ typedef struct _meshtastic_LockdownAuth {
 
  Uses millis() (CPU uptime), not wall-clock time, so the cap is
  immune to GPS spoofing, RTC backup-battery removal, and Faraday
- cage isolation - none of those move the uptime counter. The only
+ cage isolation — none of those move the uptime counter. The only
  way to reset the session clock is a reboot, which costs a boot
  from the on-flash, HMAC-bound counter. */
     uint32_t max_session_seconds;
@@ -213,7 +213,7 @@ typedef struct _meshtastic_LockdownAuth {
 
  NOT reversed by this operation: APPROTECT. Once the debug port
  lockout has been burned (on silicon where it is effective) it is
- permanent - disabling lockdown decrypts your data and removes the
+ permanent — disabling lockdown decrypts your data and removes the
  access gates, but the SWD/JTAG port stays locked for the life of
  the device (recoverable only via a full chip erase over a debug
  probe, which destroys all data). Clients should make this
@@ -504,13 +504,13 @@ typedef struct _meshtastic_AdminMessage {
         uint32_t toggle_muted_node;
         /* Request a single frame of the device's display framebuffer.
      The frame is delivered to the local client as FromRadio.display_frame
-     chunks (see DisplayFrame in mesh.proto) - there is no AdminMessage
+     chunks (see DisplayFrame in mesh.proto). There is no AdminMessage
      response. Local connection only: a node receiving this over the mesh,
      or a build without a display, ignores it. During active mirroring it
      forces one frame on the next redraw even if the screen is unchanged. */
         bool get_display_frame_request;
         /* Enable (true) or disable (false) continuous mirroring of the device
-     display - unlike most bool verbs in this oneof, false is meaningful.
+     display. Unlike most bool verbs in this oneof, false is meaningful.
      While enabled, the device sends a DisplayFrame after each screen
      redraw that changed the framebuffer, as FromRadio.display_frame
      chunks; the first frame arrives immediately and acts as the

--- a/src/mesh/generated/meshtastic/apponly.pb.h
+++ b/src/mesh/generated/meshtastic/apponly.pb.h
@@ -55,7 +55,7 @@ extern const pb_msgdesc_t meshtastic_ChannelSet_msg;
 
 /* Maximum encoded size of messages (where known) */
 #define MESHTASTIC_MESHTASTIC_APPONLY_PB_H_MAX_SIZE meshtastic_ChannelSet_size
-#define meshtastic_ChannelSet_size               685
+#define meshtastic_ChannelSet_size               701
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/mesh/generated/meshtastic/atak.pb.h
+++ b/src/mesh/generated/meshtastic/atak.pb.h
@@ -332,7 +332,7 @@ typedef enum _meshtastic_CotType {
     /* y-: TAKTALK room/membership broadcast. Payload carried via the
  TakTalkRoomData typed variant (sender_callsign, room_id, room_name,
  participants). The CoT type literally has a trailing dash and no
- second atom — not a typo. */
+ second atom - not a typo. */
     meshtastic_CotType_CotType_y = 126
 } meshtastic_CotType;
 
@@ -380,7 +380,7 @@ typedef enum _meshtastic_DrawnShape_Kind {
     /* u-r-b-bullseye: Bullseye ring with range rings and bearing reference */
     meshtastic_DrawnShape_Kind_Kind_Bullseye = 7,
     /* u-d-c-e: Ellipse with distinct major/minor axes (same storage as
- Kind_Circle — uses major_cm/minor_cm/angle_deg — but receivers
+ Kind_Circle - uses major_cm/minor_cm/angle_deg - but receivers
  render it as a non-circular ellipse rather than a round circle). */
     meshtastic_DrawnShape_Kind_Kind_Ellipse = 8,
     /* u-d-v: 2D vehicle outline drawn on the map. Vertices carry the
@@ -400,7 +400,7 @@ typedef enum _meshtastic_DrawnShape_Kind {
  end of parse; builder uses it to decide which of <strokeColor> /
  <fillColor> to emit in the reconstructed XML. */
 typedef enum _meshtastic_DrawnShape_StyleMode {
-    /* Unspecified — receiver infers from which color fields are non-zero. */
+    /* Unspecified - receiver infers from which color fields are non-zero. */
     meshtastic_DrawnShape_StyleMode_StyleMode_Unspecified = 0,
     /* Stroke only. No <fillColor> in the source XML. Used for polylines,
  ranging lines, bullseye rings. */
@@ -417,7 +417,7 @@ typedef enum _meshtastic_DrawnShape_StyleMode {
  alone is ambiguous (e.g. a-u-G could be a 2525 symbol or a custom icon
  depending on the iconset path). */
 typedef enum _meshtastic_Marker_Kind {
-    /* Unspecified — fall back to TAKPacketV2.cot_type_id */
+    /* Unspecified - fall back to TAKPacketV2.cot_type_id */
     meshtastic_Marker_Kind_Kind_Unspecified = 0,
     /* b-m-p-s-m: Spot map marker */
     meshtastic_Marker_Kind_Kind_Spot = 1,
@@ -680,10 +680,10 @@ typedef struct _meshtastic_AircraftTrack {
  hundred meters of the anchor has per-vertex deltas in the ±10^4 range.
  Under sint32+zigzag those encode as 2 bytes each (tag+varint), versus the
  4 bytes that sfixed32 would always require. At 32 vertices that is ~128
- bytes of savings — the difference between fitting under the LoRa MTU or
+ bytes of savings - the difference between fitting under the LoRa MTU or
  not. Absolute coordinates (values ~10^9) would cost sint32 varint 5 bytes
  per field, which is why TAKPacketV2's top-level latitude_i / longitude_i
- stay sfixed32 — only small values win with sint32. */
+ stay sfixed32 - only small values win with sint32. */
 typedef struct _meshtastic_CotGeoPoint {
     /* Latitude delta from TAKPacketV2.latitude_i, in 1e-7 degree units.
  Add to the enclosing event's latitude_i to recover the absolute latitude. */
@@ -791,7 +791,7 @@ typedef struct _meshtastic_Marker {
 
  Covers CoT type u-rb-a. The anchor position is on
  TAKPacketV2.latitude_i/longitude_i; the target endpoint is carried as a
- CotGeoPoint — same delta-from-anchor encoding used by DrawnShape.vertices
+ CotGeoPoint - same delta-from-anchor encoding used by DrawnShape.vertices
  so a self-anchored RAB (common case) encodes in zero bytes. */
 typedef struct _meshtastic_RangeAndBearing {
     /* Target/anchor endpoint (delta-encoded from TAKPacketV2.latitude_i/longitude_i). */
@@ -899,12 +899,12 @@ typedef struct _meshtastic_CasevacReport {
  same as the envelope callsign but ATAK sometimes carries a distinct
  ops-number here. */
     pb_callback_t title;
-    /* Primary medline free-text — the single most clinically important line
+    /* Primary medline free-text - the single most clinically important line
  on a MEDLINE form (e.g. "2 urgent litter patients, smoke on approach").
  MUST be preserved under MTU pressure as long as any casevac is sent. */
     pb_callback_t medline_remarks;
     /* Line 3 (newer ATAK format): patient counts by precedence level.
- Coexists with the enum-style `precedence` field (tag 1) — older ATAK
+ Coexists with the enum-style `precedence` field (tag 1) - older ATAK
  emits a single enum, newer ATAK emits these counts, and both can be
  set simultaneously. Senders populate whichever style(s) the source
  XML had; receivers prefer counts when non-zero. */
@@ -946,19 +946,19 @@ typedef struct _meshtastic_CasevacReport {
  (e.g. "Primary HLZ is soccer field"). */
     pb_callback_t hlz_remarks;
     /* Per-patient clinical records. Each entry is one patient's ZMIST card
- (Zap number / Mechanism / Injuries / Signs / Treatment). Repeatable —
+ (Zap number / Mechanism / Injuries / Signs / Treatment). Repeatable -
  a mass-casualty event can carry 1-6 entries in practice, limited by
  the 237 B LoRa MTU. */
     pb_callback_t zmist;
 } meshtastic_CasevacReport;
 
-/* Per-patient clinical summary record — one entry per patient in a CASEVAC.
+/* Per-patient clinical summary record - one entry per patient in a CASEVAC.
  Maps directly to ATAK's <zMist> child element inside <zMistsMap>.
  All fields are optional free-text; senders populate what they have. */
 typedef struct _meshtastic_ZMistEntry {
     /* Patient identifier / sequence label (e.g. "ZMIST-1", "ZMIST-2"). */
     pb_callback_t title;
-    /* Zap number — unique patient tracking ID (often a terse code like
+    /* Zap number - unique patient tracking ID (often a terse code like
  "Gunshot" or a serial). */
     pb_callback_t z;
     /* Mechanism of injury (e.g. "Penetrating trauma", "Blast injury"). */
@@ -997,7 +997,7 @@ typedef struct _meshtastic_EmergencyAlert {
  creation time; the fields below carry structured metadata the raw-detail
  fallback currently loses.
 
- Fields are deliberately lean — this variant is closer to the MTU ceiling
+ Fields are deliberately lean - this variant is closer to the MTU ceiling
  than the others, so every string is capped in options. */
 typedef struct _meshtastic_TaskRequest {
     /* Short tag for the task category (e.g. "engage", "observe", "recon",
@@ -1017,7 +1017,7 @@ typedef struct _meshtastic_TaskRequest {
 
 /* Weather annotation from <environment> CoT detail element.
 
- Attaches to any TAKPacketV2 regardless of payload_variant — an Aircraft,
+ Attaches to any TAKPacketV2 regardless of payload_variant - an Aircraft,
  PLI, or Marker can all carry observed conditions at the emitting station.
  ATAK-CIV ships an XSD for <environment> but no dedicated handler, so the
  element round-trips through the generic detail pipeline; this message
@@ -1026,7 +1026,7 @@ typedef struct _meshtastic_TaskRequest {
  Target wire cost: ~6-8 bytes compressed with a fully populated instance.
 
  Named `TAKEnvironment` (not just `Environment`) because the bare name
- collides with `SwiftUI.Environment` — every SwiftUI view in a consuming
+ collides with `SwiftUI.Environment` - every SwiftUI view in a consuming
  iOS app uses the `@Environment` property wrapper, and importing the
  generated proto module would make `Environment` ambiguous in every one
  of those files. The `TAK` prefix matches the convention used by the
@@ -1055,7 +1055,7 @@ typedef struct _meshtastic_TAKEnvironment {
  The receiving ATAK client restores those from its own defaults, same as
  every other CoT carried over Meshtastic today.
 
- Attaches to any TAKPacketV2 — a PLI with a sensor on the operator's head,
+ Attaches to any TAKPacketV2 - a PLI with a sensor on the operator's head,
  an Aircraft with a FLIR turret, a Marker dropped on a UAV.
  Target wire cost: ~7-14 bytes compressed (dominated by model string). */
 typedef struct _meshtastic_SensorFov {
@@ -1065,30 +1065,30 @@ typedef struct _meshtastic_SensorFov {
  SensorDetailHandler default (270°) and save varint bytes over centi-deg. */
     uint32_t azimuth_deg;
     /* Maximum range of the cone in meters.
- Optional — if unset, receivers should use the ATAK-CIV default of 100m. */
+ Optional - if unset, receivers should use the ATAK-CIV default of 100m. */
     bool has_range_m;
     uint32_t range_m;
     /* Horizontal field of view in whole degrees (cone's angular width).
  ATAK-CIV default is 45°. */
     uint32_t fov_horizontal_deg;
     /* Vertical field of view in whole degrees. ATAK-CIV default is 45°.
- Optional — a value of 0 means "not set / use horizontal FOV". */
+ Optional - a value of 0 means "not set / use horizontal FOV". */
     uint32_t fov_vertical_deg;
     /* Elevation angle in whole degrees. Positive = up, negative = down.
  Range -90 to +90. sint32 for varint efficiency on small negatives. */
     int32_t elevation_deg;
     /* Roll (camera tilt) in whole degrees, -180 to +180.
- Optional — use 0 if the sensor doesn't track roll. */
+ Optional - use 0 if the sensor doesn't track roll. */
     int32_t roll_deg;
     /* Free-form device model identifier, e.g. "FLIR-Boson-640", "SEEK".
- Optional — empty string means "unknown model" (ATAK-CIV default). */
+ Optional - empty string means "unknown model" (ATAK-CIV default). */
     pb_callback_t model;
 } meshtastic_SensorFov;
 
 /* TAKTALK chat message payload (CoT type m-t-t).
 
  TAKTALK is an ATAK plugin for voice + text team messaging. The voice
- audio stream goes over UDP/RTP and is NOT carried by the mesh — only
+ audio stream goes over UDP/RTP and is NOT carried by the mesh - only
  the text envelope (this message) is. `from_voice` marks messages sent
  via push-to-talk speech-to-text so receivers can render a mic icon
  next to the text.
@@ -1122,7 +1122,7 @@ typedef struct _meshtastic_TakTalkMessage {
  Announces a TAKTALK chatroom's friendly name and roster so peers can
  resolve room UUIDs (used in TakTalkMessage.chatroom_id and
  GeoChat.room_id) to a display name and participant list. Not a chat
- message itself — these events are emitted by TAKTALK when rooms are
+ message itself - these events are emitted by TAKTALK when rooms are
  created or memberships change. */
 typedef struct _meshtastic_TakTalkRoomData {
     /* Callsign of the device broadcasting the room state (typically the
@@ -1161,7 +1161,7 @@ typedef struct _meshtastic_Marti {
  primary-vs-cc distinction the same way ATAK does.
 
  If dest_callsign is [TAKPacketV2.callsign] (self-addressed, unusual but
- legal — e.g. ATAK echoing back to its own room), the builder still emits
+ legal - e.g. ATAK echoing back to its own room), the builder still emits
  the element so loopback shapes round-trip cleanly. */
     pb_callback_t dest_callsign;
 } meshtastic_Marti;

--- a/src/mesh/generated/meshtastic/channel.pb.h
+++ b/src/mesh/generated/meshtastic/channel.pb.h
@@ -97,6 +97,12 @@ typedef struct _meshtastic_ChannelSettings {
     /* Per-channel module settings. */
     bool has_module_settings;
     meshtastic_ModuleSettings module_settings;
+    /* Enable authenticated encryption (AES-CCM) for this channel.
+ When true, messages include a 12-byte authentication tag that prevents
+ forgery and bit-flipping attacks. All nodes on the channel must have
+ this enabled. Unauthenticated (AES-CTR) packets are rejected.
+ Experimental. Default: false (standard AES-CTR encryption). */
+    bool use_aead;
 } meshtastic_ChannelSettings;
 
 /* A pair of a channel number, mode and the (sharable) settings for that channel */
@@ -128,10 +134,10 @@ extern "C" {
 
 
 /* Initializer values for message structs */
-#define meshtastic_ChannelSettings_init_default  {0, {0, {0}}, "", 0, 0, 0, false, meshtastic_ModuleSettings_init_default}
+#define meshtastic_ChannelSettings_init_default  {0, {0, {0}}, "", 0, 0, 0, false, meshtastic_ModuleSettings_init_default, 0}
 #define meshtastic_ModuleSettings_init_default   {0, 0}
 #define meshtastic_Channel_init_default          {0, false, meshtastic_ChannelSettings_init_default, _meshtastic_Channel_Role_MIN}
-#define meshtastic_ChannelSettings_init_zero     {0, {0, {0}}, "", 0, 0, 0, false, meshtastic_ModuleSettings_init_zero}
+#define meshtastic_ChannelSettings_init_zero     {0, {0, {0}}, "", 0, 0, 0, false, meshtastic_ModuleSettings_init_zero, 0}
 #define meshtastic_ModuleSettings_init_zero      {0, 0}
 #define meshtastic_Channel_init_zero             {0, false, meshtastic_ChannelSettings_init_zero, _meshtastic_Channel_Role_MIN}
 
@@ -145,6 +151,7 @@ extern "C" {
 #define meshtastic_ChannelSettings_uplink_enabled_tag 5
 #define meshtastic_ChannelSettings_downlink_enabled_tag 6
 #define meshtastic_ChannelSettings_module_settings_tag 7
+#define meshtastic_ChannelSettings_use_aead_tag  8
 #define meshtastic_Channel_index_tag             1
 #define meshtastic_Channel_settings_tag          2
 #define meshtastic_Channel_role_tag              3
@@ -157,7 +164,8 @@ X(a, STATIC,   SINGULAR, STRING,   name,              3) \
 X(a, STATIC,   SINGULAR, FIXED32,  id,                4) \
 X(a, STATIC,   SINGULAR, BOOL,     uplink_enabled,    5) \
 X(a, STATIC,   SINGULAR, BOOL,     downlink_enabled,   6) \
-X(a, STATIC,   OPTIONAL, MESSAGE,  module_settings,   7)
+X(a, STATIC,   OPTIONAL, MESSAGE,  module_settings,   7) \
+X(a, STATIC,   SINGULAR, BOOL,     use_aead,          8)
 #define meshtastic_ChannelSettings_CALLBACK NULL
 #define meshtastic_ChannelSettings_DEFAULT NULL
 #define meshtastic_ChannelSettings_module_settings_MSGTYPE meshtastic_ModuleSettings
@@ -187,8 +195,8 @@ extern const pb_msgdesc_t meshtastic_Channel_msg;
 
 /* Maximum encoded size of messages (where known) */
 #define MESHTASTIC_MESHTASTIC_CHANNEL_PB_H_MAX_SIZE meshtastic_Channel_size
-#define meshtastic_ChannelSettings_size          72
-#define meshtastic_Channel_size                  87
+#define meshtastic_ChannelSettings_size          74
+#define meshtastic_Channel_size                  89
 #define meshtastic_ModuleSettings_size           8
 
 #ifdef __cplusplus

--- a/src/mesh/generated/meshtastic/deviceonly.pb.h
+++ b/src/mesh/generated/meshtastic/deviceonly.pb.h
@@ -457,8 +457,8 @@ extern const pb_msgdesc_t meshtastic_BackupPreferences_msg;
 /* Maximum encoded size of messages (where known) */
 /* meshtastic_NodeDatabase_size depends on runtime parameters */
 #define MESHTASTIC_MESHTASTIC_DEVICEONLY_PB_H_MAX_SIZE meshtastic_BackupPreferences_size
-#define meshtastic_BackupPreferences_size        2656
-#define meshtastic_ChannelFile_size              718
+#define meshtastic_BackupPreferences_size        2674
+#define meshtastic_ChannelFile_size              734
 #define meshtastic_DeviceState_size              1944
 #define meshtastic_NodeEnvironmentEntry_size     321
 #define meshtastic_NodeInfoLite_size             112

--- a/src/mesh/generated/meshtastic/localonly.pb.h
+++ b/src/mesh/generated/meshtastic/localonly.pb.h
@@ -212,7 +212,7 @@ extern const pb_msgdesc_t meshtastic_LocalModuleConfig_msg;
 /* Maximum encoded size of messages (where known) */
 #define MESHTASTIC_MESHTASTIC_LOCALONLY_PB_H_MAX_SIZE meshtastic_LocalModuleConfig_size
 #define meshtastic_LocalConfig_size              759
-#define meshtastic_LocalModuleConfig_size        1042
+#define meshtastic_LocalModuleConfig_size        1044
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/mesh/generated/meshtastic/mesh.pb.cpp
+++ b/src/mesh/generated/meshtastic/mesh.pb.cpp
@@ -60,6 +60,9 @@ PB_BIND(meshtastic_QueueStatus, meshtastic_QueueStatus, AUTO)
 PB_BIND(meshtastic_FromRadio, meshtastic_FromRadio, 2)
 
 
+PB_BIND(meshtastic_DisplayFrame, meshtastic_DisplayFrame, 2)
+
+
 PB_BIND(meshtastic_LockdownStatus, meshtastic_LockdownStatus, AUTO)
 
 
@@ -121,6 +124,8 @@ PB_BIND(meshtastic_resend_chunks, meshtastic_resend_chunks, AUTO)
 
 
 PB_BIND(meshtastic_ChunkedPayloadResponse, meshtastic_ChunkedPayloadResponse, AUTO)
+
+
 
 
 

--- a/src/mesh/generated/meshtastic/mesh.pb.cpp
+++ b/src/mesh/generated/meshtastic/mesh.pb.cpp
@@ -63,6 +63,12 @@ PB_BIND(meshtastic_FromRadio, meshtastic_FromRadio, 2)
 PB_BIND(meshtastic_DisplayFrame, meshtastic_DisplayFrame, 2)
 
 
+PB_BIND(meshtastic_DisplayPalette, meshtastic_DisplayPalette, 2)
+
+
+PB_BIND(meshtastic_DisplayPalette_ColorRegion, meshtastic_DisplayPalette_ColorRegion, AUTO)
+
+
 PB_BIND(meshtastic_LockdownStatus, meshtastic_LockdownStatus, AUTO)
 
 
@@ -102,6 +108,9 @@ PB_BIND(meshtastic_Neighbor, meshtastic_Neighbor, AUTO)
 PB_BIND(meshtastic_DeviceMetadata, meshtastic_DeviceMetadata, AUTO)
 
 
+PB_BIND(meshtastic_DisplayInfo, meshtastic_DisplayInfo, AUTO)
+
+
 PB_BIND(meshtastic_LoRaPresetGroup, meshtastic_LoRaPresetGroup, AUTO)
 
 
@@ -124,6 +133,8 @@ PB_BIND(meshtastic_resend_chunks, meshtastic_resend_chunks, AUTO)
 
 
 PB_BIND(meshtastic_ChunkedPayloadResponse, meshtastic_ChunkedPayloadResponse, AUTO)
+
+
 
 
 

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -672,6 +672,13 @@ typedef enum _meshtastic_LogRecord_Level {
     meshtastic_LogRecord_Level_TRACE = 5
 } meshtastic_LogRecord_Level;
 
+/* Pixel encodings of the framebuffer bytes. */
+typedef enum _meshtastic_DisplayFrame_Format {
+    /* 1 bit per pixel, vertical LSB-first pages (SSD1306/OLEDDisplay layout):
+ byte index = x + (y / 8) * width, bit index = y % 8. */
+    meshtastic_DisplayFrame_Format_MONO_VLSB = 0
+} meshtastic_DisplayFrame_Format;
+
 typedef enum _meshtastic_LockdownStatus_State {
     /* Default; should not be sent. */
     meshtastic_LockdownStatus_State_STATE_UNSPECIFIED = 0,
@@ -1280,6 +1287,28 @@ typedef struct _meshtastic_QueueStatus {
     uint32_t mesh_packet_id;
 } meshtastic_QueueStatus;
 
+typedef PB_BYTES_ARRAY_T(384) meshtastic_DisplayFrame_data_t;
+/* A chunk of the device's display framebuffer, streamed to the local client
+ over BLE/serial/TCP. Frames larger than one chunk are split by byte offset;
+ a chunk with offset + data length == total_size completes the frame. */
+typedef struct _meshtastic_DisplayFrame {
+    /* Display width in pixels. */
+    uint32_t width;
+    /* Display height in pixels. */
+    uint32_t height;
+    /* Pixel encoding of data. */
+    meshtastic_DisplayFrame_Format format;
+    /* Monotonically increasing frame counter, constant across the chunks of
+ one frame so the client can detect interleaving or loss. */
+    uint32_t frame_id;
+    /* Byte offset of this chunk within the full frame buffer. */
+    uint32_t offset;
+    /* Total size in bytes of the full frame buffer. */
+    uint32_t total_size;
+    /* The framebuffer bytes for this chunk. */
+    meshtastic_DisplayFrame_data_t data;
+} meshtastic_DisplayFrame;
+
 /* Lockdown state report from firmware to client (for hardened builds
  with MESHTASTIC_LOCKDOWN). Sent immediately after config_complete_id
  to inform a freshly-connected unauthorized client what it must do,
@@ -1547,6 +1576,10 @@ typedef struct _meshtastic_FromRadio {
      illegal region+preset combination. A region that does not appear in
      any group carries no constraint info and should not be restricted. */
         meshtastic_LoRaRegionPresetMap region_presets;
+        /* One chunk of the device's display framebuffer, sent while display
+     mirroring is active (see AdminMessage.set_display_mirror and
+     AdminMessage.get_display_frame_request). */
+        meshtastic_DisplayFrame display_frame;
     };
 } meshtastic_FromRadio;
 
@@ -1688,6 +1721,10 @@ extern "C" {
 #define _meshtastic_LogRecord_Level_MAX meshtastic_LogRecord_Level_CRITICAL
 #define _meshtastic_LogRecord_Level_ARRAYSIZE ((meshtastic_LogRecord_Level)(meshtastic_LogRecord_Level_CRITICAL+1))
 
+#define _meshtastic_DisplayFrame_Format_MIN meshtastic_DisplayFrame_Format_MONO_VLSB
+#define _meshtastic_DisplayFrame_Format_MAX meshtastic_DisplayFrame_Format_MONO_VLSB
+#define _meshtastic_DisplayFrame_Format_ARRAYSIZE ((meshtastic_DisplayFrame_Format)(meshtastic_DisplayFrame_Format_MONO_VLSB+1))
+
 #define _meshtastic_LockdownStatus_State_MIN meshtastic_LockdownStatus_State_STATE_UNSPECIFIED
 #define _meshtastic_LockdownStatus_State_MAX meshtastic_LockdownStatus_State_DISABLED
 #define _meshtastic_LockdownStatus_State_ARRAYSIZE ((meshtastic_LockdownStatus_State)(meshtastic_LockdownStatus_State_DISABLED+1))
@@ -1722,6 +1759,8 @@ extern "C" {
 #define meshtastic_LogRecord_level_ENUMTYPE meshtastic_LogRecord_Level
 
 
+
+#define meshtastic_DisplayFrame_format_ENUMTYPE meshtastic_DisplayFrame_Format
 
 #define meshtastic_LockdownStatus_state_ENUMTYPE meshtastic_LockdownStatus_State
 
@@ -1772,6 +1811,7 @@ extern "C" {
 #define meshtastic_LogRecord_init_default        {"", 0, "", _meshtastic_LogRecord_Level_MIN}
 #define meshtastic_QueueStatus_init_default      {0, 0, 0, 0}
 #define meshtastic_FromRadio_init_default        {0, 0, {meshtastic_MeshPacket_init_default}}
+#define meshtastic_DisplayFrame_init_default     {0, 0, _meshtastic_DisplayFrame_Format_MIN, 0, 0, 0, {0, {0}}}
 #define meshtastic_LockdownStatus_init_default   {_meshtastic_LockdownStatus_State_MIN, "", 0, 0, 0}
 #define meshtastic_ClientNotification_init_default {false, 0, 0, _meshtastic_LogRecord_Level_MIN, "", 0, {meshtastic_KeyVerificationNumberInform_init_default}}
 #define meshtastic_KeyVerificationNumberInform_init_default {0, "", 0}
@@ -1811,6 +1851,7 @@ extern "C" {
 #define meshtastic_LogRecord_init_zero           {"", 0, "", _meshtastic_LogRecord_Level_MIN}
 #define meshtastic_QueueStatus_init_zero         {0, 0, 0, 0}
 #define meshtastic_FromRadio_init_zero           {0, 0, {meshtastic_MeshPacket_init_zero}}
+#define meshtastic_DisplayFrame_init_zero        {0, 0, _meshtastic_DisplayFrame_Format_MIN, 0, 0, 0, {0, {0}}}
 #define meshtastic_LockdownStatus_init_zero      {_meshtastic_LockdownStatus_State_MIN, "", 0, 0, 0}
 #define meshtastic_ClientNotification_init_zero  {false, 0, 0, _meshtastic_LogRecord_Level_MIN, "", 0, {meshtastic_KeyVerificationNumberInform_init_zero}}
 #define meshtastic_KeyVerificationNumberInform_init_zero {0, "", 0}
@@ -1980,6 +2021,13 @@ extern "C" {
 #define meshtastic_QueueStatus_free_tag          2
 #define meshtastic_QueueStatus_maxlen_tag        3
 #define meshtastic_QueueStatus_mesh_packet_id_tag 4
+#define meshtastic_DisplayFrame_width_tag        1
+#define meshtastic_DisplayFrame_height_tag       2
+#define meshtastic_DisplayFrame_format_tag       3
+#define meshtastic_DisplayFrame_frame_id_tag     4
+#define meshtastic_DisplayFrame_offset_tag       5
+#define meshtastic_DisplayFrame_total_size_tag   6
+#define meshtastic_DisplayFrame_data_tag         7
 #define meshtastic_LockdownStatus_state_tag      1
 #define meshtastic_LockdownStatus_lock_reason_tag 2
 #define meshtastic_LockdownStatus_boots_remaining_tag 3
@@ -2054,6 +2102,7 @@ extern "C" {
 #define meshtastic_FromRadio_deviceuiConfig_tag  17
 #define meshtastic_FromRadio_lockdown_status_tag 18
 #define meshtastic_FromRadio_region_presets_tag  19
+#define meshtastic_FromRadio_display_frame_tag   20
 #define meshtastic_Heartbeat_nonce_tag           1
 #define meshtastic_ToRadio_packet_tag            1
 #define meshtastic_ToRadio_want_config_id_tag    3
@@ -2314,7 +2363,8 @@ X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,fileInfo,fileInfo),  15) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,clientNotification,clientNotification),  16) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,deviceuiConfig,deviceuiConfig),  17) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,lockdown_status,lockdown_status),  18) \
-X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,region_presets,region_presets),  19)
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,region_presets,region_presets),  19) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,display_frame,display_frame),  20)
 #define meshtastic_FromRadio_CALLBACK NULL
 #define meshtastic_FromRadio_DEFAULT NULL
 #define meshtastic_FromRadio_payload_variant_packet_MSGTYPE meshtastic_MeshPacket
@@ -2333,6 +2383,18 @@ X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,region_presets,region_preset
 #define meshtastic_FromRadio_payload_variant_deviceuiConfig_MSGTYPE meshtastic_DeviceUIConfig
 #define meshtastic_FromRadio_payload_variant_lockdown_status_MSGTYPE meshtastic_LockdownStatus
 #define meshtastic_FromRadio_payload_variant_region_presets_MSGTYPE meshtastic_LoRaRegionPresetMap
+#define meshtastic_FromRadio_payload_variant_display_frame_MSGTYPE meshtastic_DisplayFrame
+
+#define meshtastic_DisplayFrame_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, UINT32,   width,             1) \
+X(a, STATIC,   SINGULAR, UINT32,   height,            2) \
+X(a, STATIC,   SINGULAR, UENUM,    format,            3) \
+X(a, STATIC,   SINGULAR, UINT32,   frame_id,          4) \
+X(a, STATIC,   SINGULAR, UINT32,   offset,            5) \
+X(a, STATIC,   SINGULAR, UINT32,   total_size,        6) \
+X(a, STATIC,   SINGULAR, BYTES,    data,              7)
+#define meshtastic_DisplayFrame_CALLBACK NULL
+#define meshtastic_DisplayFrame_DEFAULT NULL
 
 #define meshtastic_LockdownStatus_FIELDLIST(X, a) \
 X(a, STATIC,   SINGULAR, UENUM,    state,             1) \
@@ -2525,6 +2587,7 @@ extern const pb_msgdesc_t meshtastic_MyNodeInfo_msg;
 extern const pb_msgdesc_t meshtastic_LogRecord_msg;
 extern const pb_msgdesc_t meshtastic_QueueStatus_msg;
 extern const pb_msgdesc_t meshtastic_FromRadio_msg;
+extern const pb_msgdesc_t meshtastic_DisplayFrame_msg;
 extern const pb_msgdesc_t meshtastic_LockdownStatus_msg;
 extern const pb_msgdesc_t meshtastic_ClientNotification_msg;
 extern const pb_msgdesc_t meshtastic_KeyVerificationNumberInform_msg;
@@ -2566,6 +2629,7 @@ extern const pb_msgdesc_t meshtastic_ChunkedPayloadResponse_msg;
 #define meshtastic_LogRecord_fields &meshtastic_LogRecord_msg
 #define meshtastic_QueueStatus_fields &meshtastic_QueueStatus_msg
 #define meshtastic_FromRadio_fields &meshtastic_FromRadio_msg
+#define meshtastic_DisplayFrame_fields &meshtastic_DisplayFrame_msg
 #define meshtastic_LockdownStatus_fields &meshtastic_LockdownStatus_msg
 #define meshtastic_ClientNotification_fields &meshtastic_ClientNotification_msg
 #define meshtastic_KeyVerificationNumberInform_fields &meshtastic_KeyVerificationNumberInform_msg
@@ -2598,6 +2662,7 @@ extern const pb_msgdesc_t meshtastic_ChunkedPayloadResponse_msg;
 #define meshtastic_Compressed_size               239
 #define meshtastic_Data_size                     335
 #define meshtastic_DeviceMetadata_size           56
+#define meshtastic_DisplayFrame_size             419
 #define meshtastic_DuplicatedPublicKey_size      0
 #define meshtastic_FileInfo_size                 236
 #define meshtastic_FromRadio_size                510

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -1316,10 +1316,13 @@ typedef PB_BYTES_ARRAY_T(384) meshtastic_DisplayFrame_data_t;
  over BLE/serial/TCP. Frames larger than one chunk are split by byte offset;
  a chunk with offset + data length == total_size completes the frame.
  Chunks of one frame arrive contiguously (no other display_frame between
- them; display_palette messages may interleave) and in offset order
- (FromRadio is a reliable ordered stream), so clients may reassemble into
- a single buffer without reordering. A frame whose streaming has begun is always drained to
- completion, even if mirroring is disabled mid-frame. */
+ them; display_palette messages may interleave) and in offset order, so a
+ client never has to reorder. It does have to check for loss: the queue to
+ the client drops its oldest entry when full, and a frame in flight can be
+ truncated when mirroring is disabled. A client MUST verify that offset
+ equals the number of bytes it has already accumulated for this frame_id,
+ and discard the partial frame on any gap or frame_id change. An incomplete
+ frame must never be rendered. */
 typedef struct _meshtastic_DisplayFrame {
     /* Display width in pixels. */
     uint16_t width;
@@ -1327,10 +1330,12 @@ typedef struct _meshtastic_DisplayFrame {
     uint16_t height;
     /* Pixel encoding of data. */
     meshtastic_DisplayFrame_Format format;
-    /* Frame counter, constant across the chunks of one frame so the client
- can detect interleaving or loss. Increments per captured frame, wraps
- at uint32 range, and restarts from 1 on device reboot - treat any
- change as "a new frame", not as an ordering guarantee. */
+    /* Frame counter, constant across the chunks of one frame, so a change
+ marks the start of a new frame. It cannot reveal loss WITHIN a frame,
+ since every chunk of that frame carries the same value; only offset
+ contiguity can. Increments per captured frame, wraps at uint32 range,
+ and restarts from 1 on device reboot, so treat any change as "a new
+ frame" rather than as an ordering guarantee. */
     uint32_t frame_id;
     /* Byte offset of this chunk within the full frame buffer. */
     uint32_t offset;
@@ -1411,15 +1416,15 @@ typedef struct _meshtastic_LockdownStatus {
     /* Current lockdown state being reported. */
     meshtastic_LockdownStatus_State state;
     /* For LOCKED: machine-readable reason. Known values:
-   "needs_auth"        - storage already unlocked, client must auth
-   "token_missing"     - no boot token on flash
-   "token_expired"     - boot token wall-clock TTL elapsed
-   "token_boots_zero"  - boot token boot-count TTL exhausted
-   "token_hmac_fail"   - token tampered or wrong device
-   "token_dek_fail"    - token DEK decrypt failed
-   "token_wrong_size"  - token file corrupted
-   "token_bad_magic"   - token file corrupted
-   "not_provisioned"   - should generally use NEEDS_PROVISION state instead
+   "needs_auth"        — storage already unlocked, client must auth
+   "token_missing"     — no boot token on flash
+   "token_expired"     — boot token wall-clock TTL elapsed
+   "token_boots_zero"  — boot token boot-count TTL exhausted
+   "token_hmac_fail"   — token tampered or wrong device
+   "token_dek_fail"    — token DEK decrypt failed
+   "token_wrong_size"  — token file corrupted
+   "token_bad_magic"   — token file corrupted
+   "not_provisioned"   — should generally use NEEDS_PROVISION state instead
  Other values may be added; clients should treat unknown values as
  "locked, ask for passphrase". */
     char lock_reason[32];
@@ -1577,7 +1582,7 @@ typedef struct _meshtastic_DeviceMetadata {
     bool has_xeddsa;
     /* Describes the device's screen when one is present; absent on display-less
  builds. Lets clients gate display-mirroring UI (see DisplayFrame) and
- adapt to the panel - e.g. expect slow refresh from EINK, or offer
+ adapt to the panel, e.g. expect slow refresh from EINK, or offer
  tap-to-touch when has_touch is set. */
     bool has_display;
     meshtastic_DisplayInfo display;

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -678,7 +678,11 @@ typedef enum _meshtastic_DisplayFrame_Format {
     meshtastic_DisplayFrame_Format_FORMAT_UNSPECIFIED = 0,
     /* 1 bit per pixel, vertical LSB-first pages (SSD1306/OLEDDisplay layout):
  byte index = x + (y / 8) * width, bit index = y % 8. */
-    meshtastic_DisplayFrame_Format_MONO_VLSB = 1
+    meshtastic_DisplayFrame_Format_MONO_VLSB = 1,
+    /* 16 bits per pixel, RGB565 in little-endian byte order, rows tightly
+ packed. Used with the partial-update rect fields: data covers only
+ the rectangle. Streamed by LVGL-based color UIs. */
+    meshtastic_DisplayFrame_Format_RGB565 = 2
 } meshtastic_DisplayFrame_Format;
 
 typedef enum _meshtastic_LockdownStatus_State {
@@ -1334,12 +1338,12 @@ typedef struct _meshtastic_DisplayFrame {
     uint32_t total_size;
     /* The framebuffer bytes for this chunk. */
     meshtastic_DisplayFrame_data_t data;
-    /* Optional partial-update rectangle, reserved for richer formats (e.g.
- dirty-rect RGB565 streaming from LVGL-based UIs). When rect_width > 0,
- data carries only the rectangle's pixels and offset/total_size describe
- the rectangle's own buffer; width/height above always remain the full
- display dimensions. Firmware currently sends only full frames (all four
- fields unset). */
+    /* Optional partial-update rectangle (dirty-rect streaming from LVGL-based
+ color UIs, format RGB565). When rect_width > 0, data carries only the
+ rectangle's pixels and offset/total_size describe the rectangle's own
+ buffer; width/height above always remain the full display dimensions,
+ and each rectangle is an independently completed unit under its own
+ frame_id. MONO_VLSB frames never set these fields. */
     uint16_t rect_x;
     /* See rect_x. */
     uint16_t rect_y;
@@ -1837,8 +1841,8 @@ extern "C" {
 #define _meshtastic_LogRecord_Level_ARRAYSIZE ((meshtastic_LogRecord_Level)(meshtastic_LogRecord_Level_CRITICAL+1))
 
 #define _meshtastic_DisplayFrame_Format_MIN meshtastic_DisplayFrame_Format_FORMAT_UNSPECIFIED
-#define _meshtastic_DisplayFrame_Format_MAX meshtastic_DisplayFrame_Format_MONO_VLSB
-#define _meshtastic_DisplayFrame_Format_ARRAYSIZE ((meshtastic_DisplayFrame_Format)(meshtastic_DisplayFrame_Format_MONO_VLSB+1))
+#define _meshtastic_DisplayFrame_Format_MAX meshtastic_DisplayFrame_Format_RGB565
+#define _meshtastic_DisplayFrame_Format_ARRAYSIZE ((meshtastic_DisplayFrame_Format)(meshtastic_DisplayFrame_Format_RGB565+1))
 
 #define _meshtastic_LockdownStatus_State_MIN meshtastic_LockdownStatus_State_STATE_UNSPECIFIED
 #define _meshtastic_LockdownStatus_State_MAX meshtastic_LockdownStatus_State_DISABLED

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -716,7 +716,7 @@ typedef enum _meshtastic_DisplayInfo_PanelClass {
     meshtastic_DisplayInfo_PanelClass_OLED = 1,
     /* Monochrome LCD (ST7567 family). */
     meshtastic_DisplayInfo_PanelClass_LCD = 2,
-    /* Color TFT (currently rendering the 1bpp base UI). */
+    /* Color TFT. */
     meshtastic_DisplayInfo_PanelClass_TFT = 3,
     /* E-ink panel: refresh is slow and full-screen; clients should prefer
  one-shot frame requests over continuous mirroring. */
@@ -1311,9 +1311,10 @@ typedef PB_BYTES_ARRAY_T(384) meshtastic_DisplayFrame_data_t;
 /* A chunk of the device's display framebuffer, streamed to the local client
  over BLE/serial/TCP. Frames larger than one chunk are split by byte offset;
  a chunk with offset + data length == total_size completes the frame.
- Chunks of one frame arrive contiguously and in offset order (FromRadio is
- a reliable ordered stream), so clients may reassemble into a single buffer
- without reordering. A frame whose streaming has begun is always drained to
+ Chunks of one frame arrive contiguously (no other display_frame between
+ them; display_palette messages may interleave) and in offset order
+ (FromRadio is a reliable ordered stream), so clients may reassemble into
+ a single buffer without reordering. A frame whose streaming has begun is always drained to
  completion, even if mirroring is disabled mid-frame. */
 typedef struct _meshtastic_DisplayFrame {
     /* Display width in pixels. */
@@ -1375,9 +1376,11 @@ typedef struct _meshtastic_DisplayPalette_ColorRegion {
  render the mirror in the panel's true colors at 1bpp bandwidth.
  Sent as FromRadio.display_palette, split by region index when the table
  exceeds one message; re-sent only when the region layout or theme changes
- (the signature changes with it). Within a chunk regions are ordered by
- their table index; a later region overrides earlier ones where they
- overlap. All colors are RGB565 in logical bit layout (RRRRRGGGGGGBBBBB). */
+ (the signature changes with it). Regions are ordered by table index; a
+ region with a higher table index overrides lower-indexed ones where they
+ overlap, regardless of chunk boundaries. A client holding partial chunks
+ of a signature that no longer matches incoming chunks should discard
+ them. All colors are RGB565 in logical bit layout (RRRRRGGGGGGBBBBB). */
 typedef struct _meshtastic_DisplayPalette {
     /* Identity of this palette; DisplayFrame.palette_signature references it.
  Changes whenever the region table or theme changes. */

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -707,6 +707,24 @@ typedef enum _meshtastic_LockdownStatus_State {
     meshtastic_LockdownStatus_State_DISABLED = 5
 } meshtastic_LockdownStatus_State;
 
+/* Physical panel technology, as a hint for client rendering and refresh
+ expectations. */
+typedef enum _meshtastic_DisplayInfo_PanelClass {
+    /* Default; should not be sent. */
+    meshtastic_DisplayInfo_PanelClass_PANEL_CLASS_UNSPECIFIED = 0,
+    /* Monochrome OLED (SSD1306/SH1106 family). */
+    meshtastic_DisplayInfo_PanelClass_OLED = 1,
+    /* Monochrome LCD (ST7567 family). */
+    meshtastic_DisplayInfo_PanelClass_LCD = 2,
+    /* Color TFT (currently rendering the 1bpp base UI). */
+    meshtastic_DisplayInfo_PanelClass_TFT = 3,
+    /* E-ink panel: refresh is slow and full-screen; clients should prefer
+ one-shot frame requests over continuous mirroring. */
+    meshtastic_DisplayInfo_PanelClass_EINK = 4,
+    /* LED matrix (HUB75). */
+    meshtastic_DisplayInfo_PanelClass_HUB75 = 5
+} meshtastic_DisplayInfo_PanelClass;
+
 /* Struct definitions */
 /* A GPS Position */
 typedef struct _meshtastic_Position {
@@ -1315,7 +1333,68 @@ typedef struct _meshtastic_DisplayFrame {
     uint32_t total_size;
     /* The framebuffer bytes for this chunk. */
     meshtastic_DisplayFrame_data_t data;
+    /* Optional partial-update rectangle, reserved for richer formats (e.g.
+ dirty-rect RGB565 streaming from LVGL-based UIs). When rect_width > 0,
+ data carries only the rectangle's pixels and offset/total_size describe
+ the rectangle's own buffer; width/height above always remain the full
+ display dimensions. Firmware currently sends only full frames (all four
+ fields unset). */
+    uint16_t rect_x;
+    /* See rect_x. */
+    uint16_t rect_y;
+    /* See rect_x. */
+    uint16_t rect_width;
+    /* See rect_x. */
+    uint16_t rect_height;
+    /* Identity of the DisplayPalette that colorizes this frame, matching
+ DisplayPalette.signature. 0 when the device renders monochrome (no
+ color panel); clients without the referenced palette yet should render
+ monochrome until its chunks arrive. */
+    uint32_t palette_signature;
 } meshtastic_DisplayFrame;
+
+/* One colorized rectangle of the display. */
+typedef struct _meshtastic_DisplayPalette_ColorRegion {
+    /* Region origin and size in pixels. */
+    uint16_t x;
+    /* See x. */
+    uint16_t y;
+    /* See x. */
+    uint16_t width;
+    /* See x. */
+    uint16_t height;
+    /* RGB565 drawn for set (1) pixels inside this region. */
+    uint16_t on_color;
+    /* RGB565 drawn for clear (0) pixels inside this region. */
+    uint16_t off_color;
+} meshtastic_DisplayPalette_ColorRegion;
+
+/* Colorization palette for DisplayFrame streams from devices that paint the
+ 1bpp base UI onto a color panel. The panel applies per-region on/off
+ colors at flush time; streaming the same region table lets a client
+ render the mirror in the panel's true colors at 1bpp bandwidth.
+ Sent as FromRadio.display_palette, split by region index when the table
+ exceeds one message; re-sent only when the region layout or theme changes
+ (the signature changes with it). Within a chunk regions are ordered by
+ their table index; a later region overrides earlier ones where they
+ overlap. All colors are RGB565 in logical bit layout (RRRRRGGGGGGBBBBB). */
+typedef struct _meshtastic_DisplayPalette {
+    /* Identity of this palette; DisplayFrame.palette_signature references it.
+ Changes whenever the region table or theme changes. */
+    uint32_t signature;
+    /* RGB565 for set pixels outside all regions. */
+    uint32_t default_on_color;
+    /* RGB565 for clear pixels outside all regions. */
+    uint32_t default_off_color;
+    /* Table index of the first region in this chunk. */
+    uint8_t region_offset;
+    /* Total regions in the complete palette; region_offset + regions length
+ == region_total completes it. */
+    uint8_t region_total;
+    /* The regions of this chunk, in table order. */
+    pb_size_t regions_count;
+    meshtastic_DisplayPalette_ColorRegion regions[16];
+} meshtastic_DisplayPalette;
 
 /* Lockdown state report from firmware to client (for hardened builds
  with MESHTASTIC_LOCKDOWN). Sent immediately after config_complete_id
@@ -1443,6 +1522,22 @@ typedef struct _meshtastic_NeighborInfo {
     meshtastic_Neighbor neighbors[10];
 } meshtastic_NeighborInfo;
 
+/* Static description of a device's display, sent inside DeviceMetadata
+ during the connection handshake. */
+typedef struct _meshtastic_DisplayInfo {
+    /* Display width in pixels. */
+    uint16_t width;
+    /* Display height in pixels. */
+    uint16_t height;
+    /* Pixel encoding that DisplayFrame streams from this device will use. */
+    meshtastic_DisplayFrame_Format format;
+    /* Physical panel technology. */
+    meshtastic_DisplayInfo_PanelClass panel_class;
+    /* True when the panel accepts touch input; clients may map taps on a
+ mirrored frame to AdminMessage.send_input_event touch coordinates. */
+    bool has_touch;
+} meshtastic_DisplayInfo;
+
 /* Device metadata response */
 typedef struct _meshtastic_DeviceMetadata {
     /* Device firmware version string */
@@ -1473,6 +1568,12 @@ typedef struct _meshtastic_DeviceMetadata {
     /* Indicates whether this firmware build includes XEdDSA packet signature verification.
  This is a read-only capability and must be false when XEdDSA is not compiled in. */
     bool has_xeddsa;
+    /* Describes the device's screen when one is present; absent on display-less
+ builds. Lets clients gate display-mirroring UI (see DisplayFrame) and
+ adapt to the panel - e.g. expect slow refresh from EINK, or offer
+ tap-to-touch when has_touch is set. */
+    bool has_display;
+    meshtastic_DisplayInfo display;
 } meshtastic_DeviceMetadata;
 
 /* A distinct set of legal modem presets shared by one or more LoRa regions.
@@ -1588,6 +1689,9 @@ typedef struct _meshtastic_FromRadio {
      mirroring is active (see AdminMessage.set_display_mirror and
      AdminMessage.get_display_frame_request). */
         meshtastic_DisplayFrame display_frame;
+        /* One chunk of the color palette referenced by display_frame's
+     palette_signature (see DisplayPalette). */
+        meshtastic_DisplayPalette display_palette;
     };
 } meshtastic_FromRadio;
 
@@ -1737,6 +1841,10 @@ extern "C" {
 #define _meshtastic_LockdownStatus_State_MAX meshtastic_LockdownStatus_State_DISABLED
 #define _meshtastic_LockdownStatus_State_ARRAYSIZE ((meshtastic_LockdownStatus_State)(meshtastic_LockdownStatus_State_DISABLED+1))
 
+#define _meshtastic_DisplayInfo_PanelClass_MIN meshtastic_DisplayInfo_PanelClass_PANEL_CLASS_UNSPECIFIED
+#define _meshtastic_DisplayInfo_PanelClass_MAX meshtastic_DisplayInfo_PanelClass_HUB75
+#define _meshtastic_DisplayInfo_PanelClass_ARRAYSIZE ((meshtastic_DisplayInfo_PanelClass)(meshtastic_DisplayInfo_PanelClass_HUB75+1))
+
 #define meshtastic_Position_location_source_ENUMTYPE meshtastic_Position_LocSource
 #define meshtastic_Position_altitude_source_ENUMTYPE meshtastic_Position_AltSource
 
@@ -1770,6 +1878,8 @@ extern "C" {
 
 #define meshtastic_DisplayFrame_format_ENUMTYPE meshtastic_DisplayFrame_Format
 
+
+
 #define meshtastic_LockdownStatus_state_ENUMTYPE meshtastic_LockdownStatus_State
 
 #define meshtastic_ClientNotification_level_ENUMTYPE meshtastic_LogRecord_Level
@@ -1787,6 +1897,9 @@ extern "C" {
 
 #define meshtastic_DeviceMetadata_role_ENUMTYPE meshtastic_Config_DeviceConfig_Role
 #define meshtastic_DeviceMetadata_hw_model_ENUMTYPE meshtastic_HardwareModel
+
+#define meshtastic_DisplayInfo_format_ENUMTYPE meshtastic_DisplayFrame_Format
+#define meshtastic_DisplayInfo_panel_class_ENUMTYPE meshtastic_DisplayInfo_PanelClass
 
 #define meshtastic_LoRaPresetGroup_presets_ENUMTYPE meshtastic_Config_LoRaConfig_ModemPreset
 #define meshtastic_LoRaPresetGroup_default_preset_ENUMTYPE meshtastic_Config_LoRaConfig_ModemPreset
@@ -1819,7 +1932,9 @@ extern "C" {
 #define meshtastic_LogRecord_init_default        {"", 0, "", _meshtastic_LogRecord_Level_MIN}
 #define meshtastic_QueueStatus_init_default      {0, 0, 0, 0}
 #define meshtastic_FromRadio_init_default        {0, 0, {meshtastic_MeshPacket_init_default}}
-#define meshtastic_DisplayFrame_init_default     {0, 0, _meshtastic_DisplayFrame_Format_MIN, 0, 0, 0, {0, {0}}}
+#define meshtastic_DisplayFrame_init_default     {0, 0, _meshtastic_DisplayFrame_Format_MIN, 0, 0, 0, {0, {0}}, 0, 0, 0, 0, 0}
+#define meshtastic_DisplayPalette_init_default   {0, 0, 0, 0, 0, 0, {meshtastic_DisplayPalette_ColorRegion_init_default, meshtastic_DisplayPalette_ColorRegion_init_default, meshtastic_DisplayPalette_ColorRegion_init_default, meshtastic_DisplayPalette_ColorRegion_init_default, meshtastic_DisplayPalette_ColorRegion_init_default, meshtastic_DisplayPalette_ColorRegion_init_default, meshtastic_DisplayPalette_ColorRegion_init_default, meshtastic_DisplayPalette_ColorRegion_init_default, meshtastic_DisplayPalette_ColorRegion_init_default, meshtastic_DisplayPalette_ColorRegion_init_default, meshtastic_DisplayPalette_ColorRegion_init_default, meshtastic_DisplayPalette_ColorRegion_init_default, meshtastic_DisplayPalette_ColorRegion_init_default, meshtastic_DisplayPalette_ColorRegion_init_default, meshtastic_DisplayPalette_ColorRegion_init_default, meshtastic_DisplayPalette_ColorRegion_init_default}}
+#define meshtastic_DisplayPalette_ColorRegion_init_default {0, 0, 0, 0, 0, 0}
 #define meshtastic_LockdownStatus_init_default   {_meshtastic_LockdownStatus_State_MIN, "", 0, 0, 0}
 #define meshtastic_ClientNotification_init_default {false, 0, 0, _meshtastic_LogRecord_Level_MIN, "", 0, {meshtastic_KeyVerificationNumberInform_init_default}}
 #define meshtastic_KeyVerificationNumberInform_init_default {0, "", 0}
@@ -1832,7 +1947,8 @@ extern "C" {
 #define meshtastic_Compressed_init_default       {_meshtastic_PortNum_MIN, {0, {0}}}
 #define meshtastic_NeighborInfo_init_default     {0, 0, 0, 0, {meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default}}
 #define meshtastic_Neighbor_init_default         {0, 0, 0, 0}
-#define meshtastic_DeviceMetadata_init_default   {"", 0, 0, 0, 0, 0, _meshtastic_Config_DeviceConfig_Role_MIN, 0, _meshtastic_HardwareModel_MIN, 0, 0, 0, 0}
+#define meshtastic_DeviceMetadata_init_default   {"", 0, 0, 0, 0, 0, _meshtastic_Config_DeviceConfig_Role_MIN, 0, _meshtastic_HardwareModel_MIN, 0, 0, 0, 0, false, meshtastic_DisplayInfo_init_default}
+#define meshtastic_DisplayInfo_init_default      {0, 0, _meshtastic_DisplayFrame_Format_MIN, _meshtastic_DisplayInfo_PanelClass_MIN, 0}
 #define meshtastic_LoRaPresetGroup_init_default  {0, {_meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN}, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, 0}
 #define meshtastic_LoRaRegionPresets_init_default {_meshtastic_Config_LoRaConfig_RegionCode_MIN, 0}
 #define meshtastic_LoRaRegionPresetMap_init_default {0, {meshtastic_LoRaPresetGroup_init_default, meshtastic_LoRaPresetGroup_init_default, meshtastic_LoRaPresetGroup_init_default, meshtastic_LoRaPresetGroup_init_default, meshtastic_LoRaPresetGroup_init_default, meshtastic_LoRaPresetGroup_init_default, meshtastic_LoRaPresetGroup_init_default, meshtastic_LoRaPresetGroup_init_default}, 0, {meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default, meshtastic_LoRaRegionPresets_init_default}}
@@ -1859,7 +1975,9 @@ extern "C" {
 #define meshtastic_LogRecord_init_zero           {"", 0, "", _meshtastic_LogRecord_Level_MIN}
 #define meshtastic_QueueStatus_init_zero         {0, 0, 0, 0}
 #define meshtastic_FromRadio_init_zero           {0, 0, {meshtastic_MeshPacket_init_zero}}
-#define meshtastic_DisplayFrame_init_zero        {0, 0, _meshtastic_DisplayFrame_Format_MIN, 0, 0, 0, {0, {0}}}
+#define meshtastic_DisplayFrame_init_zero        {0, 0, _meshtastic_DisplayFrame_Format_MIN, 0, 0, 0, {0, {0}}, 0, 0, 0, 0, 0}
+#define meshtastic_DisplayPalette_init_zero      {0, 0, 0, 0, 0, 0, {meshtastic_DisplayPalette_ColorRegion_init_zero, meshtastic_DisplayPalette_ColorRegion_init_zero, meshtastic_DisplayPalette_ColorRegion_init_zero, meshtastic_DisplayPalette_ColorRegion_init_zero, meshtastic_DisplayPalette_ColorRegion_init_zero, meshtastic_DisplayPalette_ColorRegion_init_zero, meshtastic_DisplayPalette_ColorRegion_init_zero, meshtastic_DisplayPalette_ColorRegion_init_zero, meshtastic_DisplayPalette_ColorRegion_init_zero, meshtastic_DisplayPalette_ColorRegion_init_zero, meshtastic_DisplayPalette_ColorRegion_init_zero, meshtastic_DisplayPalette_ColorRegion_init_zero, meshtastic_DisplayPalette_ColorRegion_init_zero, meshtastic_DisplayPalette_ColorRegion_init_zero, meshtastic_DisplayPalette_ColorRegion_init_zero, meshtastic_DisplayPalette_ColorRegion_init_zero}}
+#define meshtastic_DisplayPalette_ColorRegion_init_zero {0, 0, 0, 0, 0, 0}
 #define meshtastic_LockdownStatus_init_zero      {_meshtastic_LockdownStatus_State_MIN, "", 0, 0, 0}
 #define meshtastic_ClientNotification_init_zero  {false, 0, 0, _meshtastic_LogRecord_Level_MIN, "", 0, {meshtastic_KeyVerificationNumberInform_init_zero}}
 #define meshtastic_KeyVerificationNumberInform_init_zero {0, "", 0}
@@ -1872,7 +1990,8 @@ extern "C" {
 #define meshtastic_Compressed_init_zero          {_meshtastic_PortNum_MIN, {0, {0}}}
 #define meshtastic_NeighborInfo_init_zero        {0, 0, 0, 0, {meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero}}
 #define meshtastic_Neighbor_init_zero            {0, 0, 0, 0}
-#define meshtastic_DeviceMetadata_init_zero      {"", 0, 0, 0, 0, 0, _meshtastic_Config_DeviceConfig_Role_MIN, 0, _meshtastic_HardwareModel_MIN, 0, 0, 0, 0}
+#define meshtastic_DeviceMetadata_init_zero      {"", 0, 0, 0, 0, 0, _meshtastic_Config_DeviceConfig_Role_MIN, 0, _meshtastic_HardwareModel_MIN, 0, 0, 0, 0, false, meshtastic_DisplayInfo_init_zero}
+#define meshtastic_DisplayInfo_init_zero         {0, 0, _meshtastic_DisplayFrame_Format_MIN, _meshtastic_DisplayInfo_PanelClass_MIN, 0}
 #define meshtastic_LoRaPresetGroup_init_zero     {0, {_meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, _meshtastic_Config_LoRaConfig_ModemPreset_MIN}, _meshtastic_Config_LoRaConfig_ModemPreset_MIN, 0}
 #define meshtastic_LoRaRegionPresets_init_zero   {_meshtastic_Config_LoRaConfig_RegionCode_MIN, 0}
 #define meshtastic_LoRaRegionPresetMap_init_zero {0, {meshtastic_LoRaPresetGroup_init_zero, meshtastic_LoRaPresetGroup_init_zero, meshtastic_LoRaPresetGroup_init_zero, meshtastic_LoRaPresetGroup_init_zero, meshtastic_LoRaPresetGroup_init_zero, meshtastic_LoRaPresetGroup_init_zero, meshtastic_LoRaPresetGroup_init_zero, meshtastic_LoRaPresetGroup_init_zero}, 0, {meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero, meshtastic_LoRaRegionPresets_init_zero}}
@@ -2036,6 +2155,23 @@ extern "C" {
 #define meshtastic_DisplayFrame_offset_tag       5
 #define meshtastic_DisplayFrame_total_size_tag   6
 #define meshtastic_DisplayFrame_data_tag         7
+#define meshtastic_DisplayFrame_rect_x_tag       8
+#define meshtastic_DisplayFrame_rect_y_tag       9
+#define meshtastic_DisplayFrame_rect_width_tag   10
+#define meshtastic_DisplayFrame_rect_height_tag  11
+#define meshtastic_DisplayFrame_palette_signature_tag 12
+#define meshtastic_DisplayPalette_ColorRegion_x_tag 1
+#define meshtastic_DisplayPalette_ColorRegion_y_tag 2
+#define meshtastic_DisplayPalette_ColorRegion_width_tag 3
+#define meshtastic_DisplayPalette_ColorRegion_height_tag 4
+#define meshtastic_DisplayPalette_ColorRegion_on_color_tag 5
+#define meshtastic_DisplayPalette_ColorRegion_off_color_tag 6
+#define meshtastic_DisplayPalette_signature_tag  1
+#define meshtastic_DisplayPalette_default_on_color_tag 2
+#define meshtastic_DisplayPalette_default_off_color_tag 3
+#define meshtastic_DisplayPalette_region_offset_tag 4
+#define meshtastic_DisplayPalette_region_total_tag 5
+#define meshtastic_DisplayPalette_regions_tag    6
 #define meshtastic_LockdownStatus_state_tag      1
 #define meshtastic_LockdownStatus_lock_reason_tag 2
 #define meshtastic_LockdownStatus_boots_remaining_tag 3
@@ -2071,6 +2207,11 @@ extern "C" {
 #define meshtastic_NeighborInfo_last_sent_by_id_tag 2
 #define meshtastic_NeighborInfo_node_broadcast_interval_secs_tag 3
 #define meshtastic_NeighborInfo_neighbors_tag    4
+#define meshtastic_DisplayInfo_width_tag         1
+#define meshtastic_DisplayInfo_height_tag        2
+#define meshtastic_DisplayInfo_format_tag        3
+#define meshtastic_DisplayInfo_panel_class_tag   4
+#define meshtastic_DisplayInfo_has_touch_tag     5
 #define meshtastic_DeviceMetadata_firmware_version_tag 1
 #define meshtastic_DeviceMetadata_device_state_version_tag 2
 #define meshtastic_DeviceMetadata_canShutdown_tag 3
@@ -2084,6 +2225,7 @@ extern "C" {
 #define meshtastic_DeviceMetadata_hasPKC_tag     11
 #define meshtastic_DeviceMetadata_excluded_modules_tag 12
 #define meshtastic_DeviceMetadata_has_xeddsa_tag 14
+#define meshtastic_DeviceMetadata_display_tag    15
 #define meshtastic_LoRaPresetGroup_presets_tag   1
 #define meshtastic_LoRaPresetGroup_default_preset_tag 2
 #define meshtastic_LoRaPresetGroup_licensed_only_tag 3
@@ -2111,6 +2253,7 @@ extern "C" {
 #define meshtastic_FromRadio_lockdown_status_tag 18
 #define meshtastic_FromRadio_region_presets_tag  19
 #define meshtastic_FromRadio_display_frame_tag   20
+#define meshtastic_FromRadio_display_palette_tag 21
 #define meshtastic_Heartbeat_nonce_tag           1
 #define meshtastic_ToRadio_packet_tag            1
 #define meshtastic_ToRadio_want_config_id_tag    3
@@ -2372,7 +2515,8 @@ X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,clientNotification,clientNot
 X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,deviceuiConfig,deviceuiConfig),  17) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,lockdown_status,lockdown_status),  18) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,region_presets,region_presets),  19) \
-X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,display_frame,display_frame),  20)
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,display_frame,display_frame),  20) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,display_palette,display_palette),  21)
 #define meshtastic_FromRadio_CALLBACK NULL
 #define meshtastic_FromRadio_DEFAULT NULL
 #define meshtastic_FromRadio_payload_variant_packet_MSGTYPE meshtastic_MeshPacket
@@ -2392,6 +2536,7 @@ X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,display_frame,display_frame)
 #define meshtastic_FromRadio_payload_variant_lockdown_status_MSGTYPE meshtastic_LockdownStatus
 #define meshtastic_FromRadio_payload_variant_region_presets_MSGTYPE meshtastic_LoRaRegionPresetMap
 #define meshtastic_FromRadio_payload_variant_display_frame_MSGTYPE meshtastic_DisplayFrame
+#define meshtastic_FromRadio_payload_variant_display_palette_MSGTYPE meshtastic_DisplayPalette
 
 #define meshtastic_DisplayFrame_FIELDLIST(X, a) \
 X(a, STATIC,   SINGULAR, UINT32,   width,             1) \
@@ -2400,9 +2545,35 @@ X(a, STATIC,   SINGULAR, UENUM,    format,            3) \
 X(a, STATIC,   SINGULAR, UINT32,   frame_id,          4) \
 X(a, STATIC,   SINGULAR, UINT32,   offset,            5) \
 X(a, STATIC,   SINGULAR, UINT32,   total_size,        6) \
-X(a, STATIC,   SINGULAR, BYTES,    data,              7)
+X(a, STATIC,   SINGULAR, BYTES,    data,              7) \
+X(a, STATIC,   SINGULAR, UINT32,   rect_x,            8) \
+X(a, STATIC,   SINGULAR, UINT32,   rect_y,            9) \
+X(a, STATIC,   SINGULAR, UINT32,   rect_width,       10) \
+X(a, STATIC,   SINGULAR, UINT32,   rect_height,      11) \
+X(a, STATIC,   SINGULAR, UINT32,   palette_signature,  12)
 #define meshtastic_DisplayFrame_CALLBACK NULL
 #define meshtastic_DisplayFrame_DEFAULT NULL
+
+#define meshtastic_DisplayPalette_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, UINT32,   signature,         1) \
+X(a, STATIC,   SINGULAR, UINT32,   default_on_color,   2) \
+X(a, STATIC,   SINGULAR, UINT32,   default_off_color,   3) \
+X(a, STATIC,   SINGULAR, UINT32,   region_offset,     4) \
+X(a, STATIC,   SINGULAR, UINT32,   region_total,      5) \
+X(a, STATIC,   REPEATED, MESSAGE,  regions,           6)
+#define meshtastic_DisplayPalette_CALLBACK NULL
+#define meshtastic_DisplayPalette_DEFAULT NULL
+#define meshtastic_DisplayPalette_regions_MSGTYPE meshtastic_DisplayPalette_ColorRegion
+
+#define meshtastic_DisplayPalette_ColorRegion_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, UINT32,   x,                 1) \
+X(a, STATIC,   SINGULAR, UINT32,   y,                 2) \
+X(a, STATIC,   SINGULAR, UINT32,   width,             3) \
+X(a, STATIC,   SINGULAR, UINT32,   height,            4) \
+X(a, STATIC,   SINGULAR, UINT32,   on_color,          5) \
+X(a, STATIC,   SINGULAR, UINT32,   off_color,         6)
+#define meshtastic_DisplayPalette_ColorRegion_CALLBACK NULL
+#define meshtastic_DisplayPalette_ColorRegion_DEFAULT NULL
 
 #define meshtastic_LockdownStatus_FIELDLIST(X, a) \
 X(a, STATIC,   SINGULAR, UENUM,    state,             1) \
@@ -2518,9 +2689,20 @@ X(a, STATIC,   SINGULAR, UENUM,    hw_model,          9) \
 X(a, STATIC,   SINGULAR, BOOL,     hasRemoteHardware,  10) \
 X(a, STATIC,   SINGULAR, BOOL,     hasPKC,           11) \
 X(a, STATIC,   SINGULAR, UINT32,   excluded_modules,  12) \
-X(a, STATIC,   SINGULAR, BOOL,     has_xeddsa,       14)
+X(a, STATIC,   SINGULAR, BOOL,     has_xeddsa,       14) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  display,          15)
 #define meshtastic_DeviceMetadata_CALLBACK NULL
 #define meshtastic_DeviceMetadata_DEFAULT NULL
+#define meshtastic_DeviceMetadata_display_MSGTYPE meshtastic_DisplayInfo
+
+#define meshtastic_DisplayInfo_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, UINT32,   width,             1) \
+X(a, STATIC,   SINGULAR, UINT32,   height,            2) \
+X(a, STATIC,   SINGULAR, UENUM,    format,            3) \
+X(a, STATIC,   SINGULAR, UENUM,    panel_class,       4) \
+X(a, STATIC,   SINGULAR, BOOL,     has_touch,         5)
+#define meshtastic_DisplayInfo_CALLBACK NULL
+#define meshtastic_DisplayInfo_DEFAULT NULL
 
 #define meshtastic_LoRaPresetGroup_FIELDLIST(X, a) \
 X(a, STATIC,   REPEATED, UENUM,    presets,           1) \
@@ -2596,6 +2778,8 @@ extern const pb_msgdesc_t meshtastic_LogRecord_msg;
 extern const pb_msgdesc_t meshtastic_QueueStatus_msg;
 extern const pb_msgdesc_t meshtastic_FromRadio_msg;
 extern const pb_msgdesc_t meshtastic_DisplayFrame_msg;
+extern const pb_msgdesc_t meshtastic_DisplayPalette_msg;
+extern const pb_msgdesc_t meshtastic_DisplayPalette_ColorRegion_msg;
 extern const pb_msgdesc_t meshtastic_LockdownStatus_msg;
 extern const pb_msgdesc_t meshtastic_ClientNotification_msg;
 extern const pb_msgdesc_t meshtastic_KeyVerificationNumberInform_msg;
@@ -2609,6 +2793,7 @@ extern const pb_msgdesc_t meshtastic_Compressed_msg;
 extern const pb_msgdesc_t meshtastic_NeighborInfo_msg;
 extern const pb_msgdesc_t meshtastic_Neighbor_msg;
 extern const pb_msgdesc_t meshtastic_DeviceMetadata_msg;
+extern const pb_msgdesc_t meshtastic_DisplayInfo_msg;
 extern const pb_msgdesc_t meshtastic_LoRaPresetGroup_msg;
 extern const pb_msgdesc_t meshtastic_LoRaRegionPresets_msg;
 extern const pb_msgdesc_t meshtastic_LoRaRegionPresetMap_msg;
@@ -2638,6 +2823,8 @@ extern const pb_msgdesc_t meshtastic_ChunkedPayloadResponse_msg;
 #define meshtastic_QueueStatus_fields &meshtastic_QueueStatus_msg
 #define meshtastic_FromRadio_fields &meshtastic_FromRadio_msg
 #define meshtastic_DisplayFrame_fields &meshtastic_DisplayFrame_msg
+#define meshtastic_DisplayPalette_fields &meshtastic_DisplayPalette_msg
+#define meshtastic_DisplayPalette_ColorRegion_fields &meshtastic_DisplayPalette_ColorRegion_msg
 #define meshtastic_LockdownStatus_fields &meshtastic_LockdownStatus_msg
 #define meshtastic_ClientNotification_fields &meshtastic_ClientNotification_msg
 #define meshtastic_KeyVerificationNumberInform_fields &meshtastic_KeyVerificationNumberInform_msg
@@ -2651,6 +2838,7 @@ extern const pb_msgdesc_t meshtastic_ChunkedPayloadResponse_msg;
 #define meshtastic_NeighborInfo_fields &meshtastic_NeighborInfo_msg
 #define meshtastic_Neighbor_fields &meshtastic_Neighbor_msg
 #define meshtastic_DeviceMetadata_fields &meshtastic_DeviceMetadata_msg
+#define meshtastic_DisplayInfo_fields &meshtastic_DisplayInfo_msg
 #define meshtastic_LoRaPresetGroup_fields &meshtastic_LoRaPresetGroup_msg
 #define meshtastic_LoRaRegionPresets_fields &meshtastic_LoRaRegionPresets_msg
 #define meshtastic_LoRaRegionPresetMap_fields &meshtastic_LoRaRegionPresetMap_msg
@@ -2669,8 +2857,11 @@ extern const pb_msgdesc_t meshtastic_ChunkedPayloadResponse_msg;
 #define meshtastic_ClientNotification_size       482
 #define meshtastic_Compressed_size               239
 #define meshtastic_Data_size                     335
-#define meshtastic_DeviceMetadata_size           56
-#define meshtastic_DisplayFrame_size             415
+#define meshtastic_DeviceMetadata_size           72
+#define meshtastic_DisplayFrame_size             437
+#define meshtastic_DisplayInfo_size              14
+#define meshtastic_DisplayPalette_ColorRegion_size 24
+#define meshtastic_DisplayPalette_size           440
 #define meshtastic_DuplicatedPublicKey_size      0
 #define meshtastic_FileInfo_size                 236
 #define meshtastic_FromRadio_size                510

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -1315,6 +1315,13 @@ typedef PB_BYTES_ARRAY_T(384) meshtastic_DisplayFrame_data_t;
 /* A chunk of the device's display framebuffer, streamed to the local client
  over BLE/serial/TCP. Frames larger than one chunk are split by byte offset;
  a chunk with offset + data length == total_size completes the frame.
+ This is application-level chunking of a framebuffer into several complete
+ FromRadio messages, and is unrelated to ClientApiChunkedPayload, which
+ splits ONE serialized FromRadio across a small BLE MTU. A frame cannot ride
+ that wrapper: FromRadio is statically capped at MAX_TO_FROM_RADIO_SIZE, far
+ below a full framebuffer. The two compose - a chunked-transport client
+ receives these frames through it.
+
  Chunks of one frame arrive contiguously (no other display_frame between
  them; display_palette messages may interleave) and in offset order, so a
  client never has to reorder. It does have to check for loss: the queue to
@@ -2237,7 +2244,7 @@ extern "C" {
 #define meshtastic_DeviceMetadata_hasPKC_tag     11
 #define meshtastic_DeviceMetadata_excluded_modules_tag 12
 #define meshtastic_DeviceMetadata_has_xeddsa_tag 14
-#define meshtastic_DeviceMetadata_display_tag    15
+#define meshtastic_DeviceMetadata_display_tag    16
 #define meshtastic_LoRaPresetGroup_presets_tag   1
 #define meshtastic_LoRaPresetGroup_default_preset_tag 2
 #define meshtastic_LoRaPresetGroup_licensed_only_tag 3
@@ -2264,8 +2271,8 @@ extern "C" {
 #define meshtastic_FromRadio_deviceuiConfig_tag  17
 #define meshtastic_FromRadio_lockdown_status_tag 18
 #define meshtastic_FromRadio_region_presets_tag  19
-#define meshtastic_FromRadio_display_frame_tag   20
-#define meshtastic_FromRadio_display_palette_tag 21
+#define meshtastic_FromRadio_display_frame_tag   21
+#define meshtastic_FromRadio_display_palette_tag 22
 #define meshtastic_Heartbeat_nonce_tag           1
 #define meshtastic_ToRadio_packet_tag            1
 #define meshtastic_ToRadio_want_config_id_tag    3
@@ -2527,8 +2534,8 @@ X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,clientNotification,clientNot
 X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,deviceuiConfig,deviceuiConfig),  17) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,lockdown_status,lockdown_status),  18) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,region_presets,region_presets),  19) \
-X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,display_frame,display_frame),  20) \
-X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,display_palette,display_palette),  21)
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,display_frame,display_frame),  21) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,display_palette,display_palette),  22)
 #define meshtastic_FromRadio_CALLBACK NULL
 #define meshtastic_FromRadio_DEFAULT NULL
 #define meshtastic_FromRadio_payload_variant_packet_MSGTYPE meshtastic_MeshPacket
@@ -2702,7 +2709,7 @@ X(a, STATIC,   SINGULAR, BOOL,     hasRemoteHardware,  10) \
 X(a, STATIC,   SINGULAR, BOOL,     hasPKC,           11) \
 X(a, STATIC,   SINGULAR, UINT32,   excluded_modules,  12) \
 X(a, STATIC,   SINGULAR, BOOL,     has_xeddsa,       14) \
-X(a, STATIC,   OPTIONAL, MESSAGE,  display,          15)
+X(a, STATIC,   OPTIONAL, MESSAGE,  display,          16)
 #define meshtastic_DeviceMetadata_CALLBACK NULL
 #define meshtastic_DeviceMetadata_DEFAULT NULL
 #define meshtastic_DeviceMetadata_display_MSGTYPE meshtastic_DisplayInfo
@@ -2869,7 +2876,7 @@ extern const pb_msgdesc_t meshtastic_ChunkedPayloadResponse_msg;
 #define meshtastic_ClientNotification_size       482
 #define meshtastic_Compressed_size               239
 #define meshtastic_Data_size                     335
-#define meshtastic_DeviceMetadata_size           72
+#define meshtastic_DeviceMetadata_size           73
 #define meshtastic_DisplayFrame_size             437
 #define meshtastic_DisplayInfo_size              14
 #define meshtastic_DisplayPalette_ColorRegion_size 24

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -674,9 +674,11 @@ typedef enum _meshtastic_LogRecord_Level {
 
 /* Pixel encodings of the framebuffer bytes. */
 typedef enum _meshtastic_DisplayFrame_Format {
+    /* Default; should not be sent. */
+    meshtastic_DisplayFrame_Format_FORMAT_UNSPECIFIED = 0,
     /* 1 bit per pixel, vertical LSB-first pages (SSD1306/OLEDDisplay layout):
  byte index = x + (y / 8) * width, bit index = y % 8. */
-    meshtastic_DisplayFrame_Format_MONO_VLSB = 0
+    meshtastic_DisplayFrame_Format_MONO_VLSB = 1
 } meshtastic_DisplayFrame_Format;
 
 typedef enum _meshtastic_LockdownStatus_State {
@@ -1290,16 +1292,22 @@ typedef struct _meshtastic_QueueStatus {
 typedef PB_BYTES_ARRAY_T(384) meshtastic_DisplayFrame_data_t;
 /* A chunk of the device's display framebuffer, streamed to the local client
  over BLE/serial/TCP. Frames larger than one chunk are split by byte offset;
- a chunk with offset + data length == total_size completes the frame. */
+ a chunk with offset + data length == total_size completes the frame.
+ Chunks of one frame arrive contiguously and in offset order (FromRadio is
+ a reliable ordered stream), so clients may reassemble into a single buffer
+ without reordering. A frame whose streaming has begun is always drained to
+ completion, even if mirroring is disabled mid-frame. */
 typedef struct _meshtastic_DisplayFrame {
     /* Display width in pixels. */
-    uint32_t width;
+    uint16_t width;
     /* Display height in pixels. */
-    uint32_t height;
+    uint16_t height;
     /* Pixel encoding of data. */
     meshtastic_DisplayFrame_Format format;
-    /* Monotonically increasing frame counter, constant across the chunks of
- one frame so the client can detect interleaving or loss. */
+    /* Frame counter, constant across the chunks of one frame so the client
+ can detect interleaving or loss. Increments per captured frame, wraps
+ at uint32 range, and restarts from 1 on device reboot - treat any
+ change as "a new frame", not as an ordering guarantee. */
     uint32_t frame_id;
     /* Byte offset of this chunk within the full frame buffer. */
     uint32_t offset;
@@ -1317,15 +1325,15 @@ typedef struct _meshtastic_LockdownStatus {
     /* Current lockdown state being reported. */
     meshtastic_LockdownStatus_State state;
     /* For LOCKED: machine-readable reason. Known values:
-   "needs_auth"        — storage already unlocked, client must auth
-   "token_missing"     — no boot token on flash
-   "token_expired"     — boot token wall-clock TTL elapsed
-   "token_boots_zero"  — boot token boot-count TTL exhausted
-   "token_hmac_fail"   — token tampered or wrong device
-   "token_dek_fail"    — token DEK decrypt failed
-   "token_wrong_size"  — token file corrupted
-   "token_bad_magic"   — token file corrupted
-   "not_provisioned"   — should generally use NEEDS_PROVISION state instead
+   "needs_auth"        - storage already unlocked, client must auth
+   "token_missing"     - no boot token on flash
+   "token_expired"     - boot token wall-clock TTL elapsed
+   "token_boots_zero"  - boot token boot-count TTL exhausted
+   "token_hmac_fail"   - token tampered or wrong device
+   "token_dek_fail"    - token DEK decrypt failed
+   "token_wrong_size"  - token file corrupted
+   "token_bad_magic"   - token file corrupted
+   "not_provisioned"   - should generally use NEEDS_PROVISION state instead
  Other values may be added; clients should treat unknown values as
  "locked, ask for passphrase". */
     char lock_reason[32];
@@ -1721,7 +1729,7 @@ extern "C" {
 #define _meshtastic_LogRecord_Level_MAX meshtastic_LogRecord_Level_CRITICAL
 #define _meshtastic_LogRecord_Level_ARRAYSIZE ((meshtastic_LogRecord_Level)(meshtastic_LogRecord_Level_CRITICAL+1))
 
-#define _meshtastic_DisplayFrame_Format_MIN meshtastic_DisplayFrame_Format_MONO_VLSB
+#define _meshtastic_DisplayFrame_Format_MIN meshtastic_DisplayFrame_Format_FORMAT_UNSPECIFIED
 #define _meshtastic_DisplayFrame_Format_MAX meshtastic_DisplayFrame_Format_MONO_VLSB
 #define _meshtastic_DisplayFrame_Format_ARRAYSIZE ((meshtastic_DisplayFrame_Format)(meshtastic_DisplayFrame_Format_MONO_VLSB+1))
 
@@ -2662,7 +2670,7 @@ extern const pb_msgdesc_t meshtastic_ChunkedPayloadResponse_msg;
 #define meshtastic_Compressed_size               239
 #define meshtastic_Data_size                     335
 #define meshtastic_DeviceMetadata_size           56
-#define meshtastic_DisplayFrame_size             419
+#define meshtastic_DisplayFrame_size             415
 #define meshtastic_DuplicatedPublicKey_size      0
 #define meshtastic_FileInfo_size                 236
 #define meshtastic_FromRadio_size                510

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -1423,15 +1423,15 @@ typedef struct _meshtastic_LockdownStatus {
     /* Current lockdown state being reported. */
     meshtastic_LockdownStatus_State state;
     /* For LOCKED: machine-readable reason. Known values:
-   "needs_auth"        — storage already unlocked, client must auth
-   "token_missing"     — no boot token on flash
-   "token_expired"     — boot token wall-clock TTL elapsed
-   "token_boots_zero"  — boot token boot-count TTL exhausted
-   "token_hmac_fail"   — token tampered or wrong device
-   "token_dek_fail"    — token DEK decrypt failed
-   "token_wrong_size"  — token file corrupted
-   "token_bad_magic"   — token file corrupted
-   "not_provisioned"   — should generally use NEEDS_PROVISION state instead
+   "needs_auth"        - storage already unlocked, client must auth
+   "token_missing"     - no boot token on flash
+   "token_expired"     - boot token wall-clock TTL elapsed
+   "token_boots_zero"  - boot token boot-count TTL exhausted
+   "token_hmac_fail"   - token tampered or wrong device
+   "token_dek_fail"    - token DEK decrypt failed
+   "token_wrong_size"  - token file corrupted
+   "token_bad_magic"   - token file corrupted
+   "not_provisioned"   - should generally use NEEDS_PROVISION state instead
  Other values may be added; clients should treat unknown values as
  "locked, ask for passphrase". */
     char lock_reason[32];

--- a/src/mesh/generated/meshtastic/mesh_beacon.pb.h
+++ b/src/mesh/generated/meshtastic/mesh_beacon.pb.h
@@ -15,7 +15,7 @@
 /* Payload for MESH_BEACON_APP packets.
  Periodically broadcast by nodes in beacon mode.
  Listeners deliver the text message to the local inbox and cache any offered
- channel/preset for the client app to act on — the firmware never auto-applies them. */
+ channel/preset for the client app to act on - the firmware never auto-applies them. */
 typedef struct _meshtastic_MeshBeacon {
     /* Human-readable beacon message. Max 100 bytes enforced by firmware on send. */
     char message[101];
@@ -63,7 +63,7 @@ extern const pb_msgdesc_t meshtastic_MeshBeacon_msg;
 
 /* Maximum encoded size of messages (where known) */
 #define MESHTASTIC_MESHTASTIC_MESH_BEACON_PB_H_MAX_SIZE meshtastic_MeshBeacon_size
-#define meshtastic_MeshBeacon_size               180
+#define meshtastic_MeshBeacon_size               182
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/mesh/generated/meshtastic/module_config.pb.h
+++ b/src/mesh/generated/meshtastic/module_config.pb.h
@@ -1138,7 +1138,7 @@ extern const pb_msgdesc_t meshtastic_RemoteHardwarePin_msg;
 #define meshtastic_ModuleConfig_MQTTConfig_size  224
 #define meshtastic_ModuleConfig_MapReportSettings_size 14
 #define meshtastic_ModuleConfig_MeshBeaconConfig_BroadcastTarget_size 10
-#define meshtastic_ModuleConfig_MeshBeaconConfig_size 240
+#define meshtastic_ModuleConfig_MeshBeaconConfig_size 242
 #define meshtastic_ModuleConfig_NeighborInfoConfig_size 10
 #define meshtastic_ModuleConfig_PaxcounterConfig_size 30
 #define meshtastic_ModuleConfig_RangeTestConfig_size 12
@@ -1149,7 +1149,7 @@ extern const pb_msgdesc_t meshtastic_RemoteHardwarePin_msg;
 #define meshtastic_ModuleConfig_TAKConfig_size   4
 #define meshtastic_ModuleConfig_TelemetryConfig_size 50
 #define meshtastic_ModuleConfig_TrafficManagementConfig_size 30
-#define meshtastic_ModuleConfig_size             244
+#define meshtastic_ModuleConfig_size             246
 #define meshtastic_RemoteHardwarePin_size        21
 
 #ifdef __cplusplus

--- a/src/mesh/generated/meshtastic/telemetry.pb.h
+++ b/src/mesh/generated/meshtastic/telemetry.pb.h
@@ -118,7 +118,7 @@ typedef enum _meshtastic_TelemetrySensorType {
     meshtastic_TelemetrySensorType_DS248X = 51,
     /* MMC5983MA 3-Axis Digital Magnetic Sensor */
     meshtastic_TelemetrySensorType_MMC5983MA = 52,
-    /* ICM-42607-P 6‑Axis IMU */
+    /* ICM-42607-P 6-Axis IMU */
     meshtastic_TelemetrySensorType_ICM42607P = 53,
     /* SPA06 pressure and temperature */
     meshtastic_TelemetrySensorType_SPA06 = 54,

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -2233,7 +2233,7 @@ void AdminModule::handleSendInputEvent(const meshtastic_AdminMessage_InputEvent 
     // Wake the device if asleep
     powerFSM.trigger(EVENT_INPUT);
 
-#if HAS_SCREEN_MIRROR && defined(MESHTASTIC_MUI_MIRROR)
+#if HAS_MUI_MIRROR
     // MUI builds never construct an InputBroker (Modules.cpp skips it when
     // displaymode is COLOR), so remote input reaches the LVGL UI directly.
     if (graphics::muiInjectInputEvent(inputEvent.event_code, inputEvent.kb_char, inputEvent.touch_x, inputEvent.touch_y))

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -2232,6 +2232,14 @@ void AdminModule::handleSendInputEvent(const meshtastic_AdminMessage_InputEvent 
 
     // Wake the device if asleep
     powerFSM.trigger(EVENT_INPUT);
+
+#if HAS_SCREEN_MIRROR && defined(MESHTASTIC_MUI_MIRROR)
+    // MUI builds never construct an InputBroker (Modules.cpp skips it when
+    // displaymode is COLOR), so remote input reaches the LVGL UI directly.
+    if (graphics::muiInjectInputEvent(inputEvent.event_code, inputEvent.kb_char, inputEvent.touch_x, inputEvent.touch_y))
+        return;
+#endif
+
 #if !defined(MESHTASTIC_EXCLUDE_INPUTBROKER)
     // Inject the event through InputBroker
     if (inputBroker) {

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -9,6 +9,7 @@
 #include "PowerFSM.h"
 #include "SPILock.h"
 #include "gps/RTC.h"
+#include "graphics/ScreenMirror.h"
 #include "input/InputBroker.h"
 #include "meshUtils.h"
 #include <ErriezCRC32.h>
@@ -692,6 +693,18 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         handleSendInputEvent(r->send_input_event);
         break;
     }
+#if HAS_SCREEN && !defined(MESHTASTIC_EXCLUDE_SCREEN_MIRROR)
+    case meshtastic_AdminMessage_get_display_frame_request_tag: {
+        LOG_INFO("Client requests display frame");
+        graphics::screenMirror.requestFrame();
+        break;
+    }
+    case meshtastic_AdminMessage_set_display_mirror_tag: {
+        LOG_INFO("Client sets display mirror: %d", r->set_display_mirror);
+        graphics::screenMirror.setMirror(r->set_display_mirror);
+        break;
+    }
+#endif
 #ifdef ARCH_PORTDUINO
     case meshtastic_AdminMessage_exit_simulator_tag:
         LOG_INFO("Exiting simulator");
@@ -2181,7 +2194,8 @@ bool AdminModule::messageIsRequest(const meshtastic_AdminMessage *r)
         r->which_payload_variant == meshtastic_AdminMessage_get_ringtone_request_tag ||
         r->which_payload_variant == meshtastic_AdminMessage_get_device_connection_status_request_tag ||
         r->which_payload_variant == meshtastic_AdminMessage_get_node_remote_hardware_pins_request_tag ||
-        r->which_payload_variant == meshtastic_AdminMessage_get_ui_config_request_tag)
+        r->which_payload_variant == meshtastic_AdminMessage_get_ui_config_request_tag ||
+        r->which_payload_variant == meshtastic_AdminMessage_get_display_frame_request_tag)
         return true;
     else
         return false;

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -693,13 +693,20 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         handleSendInputEvent(r->send_input_event);
         break;
     }
-#if HAS_SCREEN && !defined(MESHTASTIC_EXCLUDE_SCREEN_MIRROR)
+#if HAS_SCREEN_MIRROR
+    // Both verbs are documented local-connection-only: frames ride FromRadio,
+    // which never crosses the mesh, so honoring a remote arm request would
+    // stream the screen to whatever local client happens to be attached.
     case meshtastic_AdminMessage_get_display_frame_request_tag: {
+        if (mp.from != 0)
+            break;
         LOG_INFO("Client requests display frame");
         graphics::screenMirror.requestFrame();
         break;
     }
     case meshtastic_AdminMessage_set_display_mirror_tag: {
+        if (mp.from != 0)
+            break;
         LOG_INFO("Client sets display mirror: %d", r->set_display_mirror);
         graphics::screenMirror.setMirror(r->set_display_mirror);
         break;

--- a/variants/esp32s3/t-deck/platformio.ini
+++ b/variants/esp32s3/t-deck/platformio.ini
@@ -45,6 +45,7 @@ extra_scripts =
 
 build_flags =
   ${env:t-deck.build_flags}
+  -D MESHTASTIC_MUI_MIRROR=1 ; SPIKE-LOCAL (do not commit): needs the device-ui flush observer
   -D CONFIG_DISABLE_HAL_LOCKS=1 ; "feels" to be a bit more stable without locks
   -D INPUTDRIVER_I2C_KBD_TYPE=0x55
   -D INPUTDRIVER_ENCODER_TYPE=3

--- a/variants/esp32s3/t-deck/platformio.ini
+++ b/variants/esp32s3/t-deck/platformio.ini
@@ -45,7 +45,6 @@ extra_scripts =
 
 build_flags =
   ${env:t-deck.build_flags}
-  -D MESHTASTIC_MUI_MIRROR=1 ; SPIKE-LOCAL (do not commit): needs the device-ui flush observer
   -D CONFIG_DISABLE_HAL_LOCKS=1 ; "feels" to be a bit more stable without locks
   -D INPUTDRIVER_I2C_KBD_TYPE=0x55
   -D INPUTDRIVER_ENCODER_TYPE=3


### PR DESCRIPTION
Streams the device's screen to its locally connected client and completes the remote-control story started by `send_input_event` (meshtastic/protobufs#702). Prior art: meshtastic/web#224. **Draft until meshtastic/protobufs#1054 merges; the submodule pointer will move to protobufs master after.** Android client: meshtastic/Meshtastic-Android#6987.

## How it works

- `graphics::ScreenMirror` snapshots the 1bpp `OLEDDisplay` framebuffer after each committed frame (single hook at `updateUiFrame`'s exits, so the lockdown build mirrors the redacted LOCKED frame, never operator content). A `memcmp` diff gates capture: a static screen streams nothing.
- Chunks drain through `PhoneAPI`'s existing `getFromRadio` chain at **lowest priority** - mesh packets, notifications and the satellite replay always outrank pixels - with a **per-client cursor** (`frameId`, `offset`), so coexisting BLE/serial/TCP clients each receive complete frames.
- **Color**: `TFTDisplay`/`HUB75Display` hand the mirror their color-region table at paint time (immediately before `clearTFTColorRegions()`), byte-swapped to logical RGB565. Palettes stream as `display_palette` chunks keyed by the existing region-table signature and re-send only when layout/theme changes; frames carry the signature of the palette they were painted with (coherent even across a mid-drain theme change, which also counts as frame-worthy so recolors propagate without pixel churn).
- `DeviceMetadata.display` (`DisplayInfo`) reports geometry, `PanelClass` and touch during the handshake.
- Admin verbs are **local-only** (`mp.from != 0` is dropped): frames ride `FromRadio` and can never cross the mesh.

| Condition | Behavior |
| --- | --- |
| Screen unchanged, mirroring on | nothing sent (diff-gated) |
| Theme recolor, pixels unchanged | new frame + palette sent (signature change is frame-worthy) |
| Client disconnects | mirror disarmed, snapshot + palette freed (memaudit-tracked) |
| Unauthorized client under `MESHTASTIC_PHONEAPI_ACCESS_CONTROL` | never receives frames/palettes (same `getAdminAuthorized` bar as mesh packets) |
| Display-less / `MESHTASTIC_EXCLUDE_SCREEN_MIRROR` build | compiles out (`HAS_SCREEN_MIRROR`), verbs ignored |
| E-ink / HUB75 | same 1bpp path (all BaseUI targets share the buffer) |

## Cost

Zero allocation until armed: snapshot (1 KB on 128×64, 9.6 KB on 320×240 1bpp) + 576 B palette table on arm, freed on disarm/disconnect, `memaudit`-tracked. ~2 KB flash when enabled; excluded builds pay only the nanopb `FromRadio` union growth from the new oneof members (encoded `FromRadio_size` stays 510 ≤ 512).

## Known limitations (deliberate for this round)

- **Single global arm flag**: any local client's disconnect disarms the stream, and under access control an unauthorized local client can arm/disarm (control-plane only - it can never *read* frames). Per-client refcounted arming is the natural follow-up; the per-client drain cursors it needs already exist.
- MUI/LVGL (RGB565) devices aren't mirrored yet; `DisplayFrame`'s reserved rect fields are the path.
- `test_screen_mirror` native suite (chunk reassembly, mid-drain restart, palette signature changes, memaudit balance) is sketched and queued as a follow-up commit.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- Devices this was regression-tested on:
  - [ ] Heltec V3 (builds; not flashed)
  - [x] T-Deck - live color mirror + remote input, plain `t-deck` (BaseUI) env
  - [ ] T-Beam
  - [x] RAK 4631 - live mono mirror + remote input (WisMesh Pocket)
  - [ ] T-1000E
  - [x] Other: `native-macos`, `heltec-mesh-node-t114` (ST7789), `heltec-v3` - build verification incl. the coloring-disabled TFT combination

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Status (2026-09-08)

Rebased onto `develop`. Submodule and generated nanopb headers regenerated with nanopb 0.4.9.1 for the `FromRadio.display_frame` 20 → 21 / `display_palette` 21 → 22 / `DeviceMetadata.display` 15 → 16 renumbering in meshtastic/protobufs#1054 (those tags collided with open PRs #980 and #1030). No source change was needed - every call site already goes through the generated `*_tag` macros.

**Blocked on device-ui.** The MUI/LVGL colour path needs a device-ui carrying `DisplayMirror` (device-ui#394, draft and green). That is in no released device-ui. So `HAS_MUI_MIRROR` is 0 in every configuration this branch commits, and roughly half the diff - `onMuiRect`, the rect pool, `muiInjectInputEvent`, `muiDisplayInfo`, the `DisplayMirror` wiring in `tftSetup`, the `DisplayInfo`-on-MUI branch in `main.cpp` - compiles out. Only the 1bpp mono path is reachable from these branches.

**Fixed:** `3d35b6a0d` set out to drop a spike-local device-ui override but appended a *second* archive to `[device-ui_base] lib_deps`, so every MUI board pulled two libraries both named `device-ui`. Now one pin.

**Known gaps, raised by a cross-repo audit and not yet addressed here:**

- `frameReady.notifyObservers()` runs on the LVGL/tft task on MUI builds, while `Observable`/`Observer` are backed by an unsynchronised `std::list` mutated from the main/BLE thread - and the notify chain reaches NimBLE `notify()` from that task.
- The MUI rect-pool overflow path resets the queue including `muiRectSendOffset`, abandoning a rect the client is mid-way through receiving and re-arming a full repaint that will overflow again.
- `PhoneAPI::close()` calls `setMirror(false)`, so any handshaked client tearing down disarms mirroring for every other client - and `close()` also runs from `checkConnectionTimeout()`, so an idling serial/TCP session silently kills a live stream.


---

## Feature stack

Five repos, and the release order runs top to bottom. Nothing below can ship until the piece above it lands.

| Repo | PR | Role |
| --- | --- | --- |
| meshtastic/design | [#142](https://github.com/meshtastic/design/issues/142) | Cross-platform feature spec |
| meshtastic/device-ui | [#394](https://github.com/meshtastic/device-ui/pull/394) | `DisplayMirror`: frame capture + remote input |
| meshtastic/protobufs | [#1054](https://github.com/meshtastic/protobufs/pull/1054) | `DisplayFrame` / `DisplayPalette` / `DisplayInfo` + the two admin verbs |
| meshtastic/firmware | [#11681](https://github.com/meshtastic/firmware/pull/11681) | Producer: streams the framebuffer, bridges input |
| meshtastic/Meshtastic-Android | [#6987](https://github.com/meshtastic/Meshtastic-Android/pull/6987) | Mirror tab with remote control |
| meshtastic/meshtastic-mcp | [#78](https://github.com/meshtastic/meshtastic-mcp/pull/78) | `capture_display` tooling |

device-ui#394 is the current blocker: without `DisplayMirror` the MUI/colour path compiles out of every committed firmware configuration, leaving only the 1bpp mono path.


