### PR TITLE
fix(pki): reject a restored pre-2.8 low-entropy key at set time, explain the swap

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -4417,6 +4417,21 @@ bool NodeDB::checkLowEntropyPublicKey(const meshtastic_Config_SecurityConfig_pub
 }
 #endif
 
+#if !(MESHTASTIC_EXCLUDE_PKI_KEYGEN || MESHTASTIC_EXCLUDE_PKI)
+// A freshly minted keypair must not itself land on the blacklist. Retry a bounded number of times,
+// then say so: if the entropy source keeps producing known-weak keys there is nothing better to mint.
+void NodeDB::generateBlacklistCheckedKeyPair()
+{
+    for (uint8_t attempt = 0; attempt < 3; attempt++) {
+        crypto->generateKeyPair(config.security.public_key.bytes, config.security.private_key.bytes);
+        if (!checkLowEntropyPublicKey(config.security.public_key))
+            return;
+        LOG_WARN("Generated keypair is a known low-entropy key; retrying");
+    }
+    LOG_ERROR("PKI keygen keeps producing known low-entropy keys; entropy source is broken");
+}
+#endif
+
 bool NodeDB::generateCryptoKeyPair(const uint8_t *privateKey)
 {
 #if !(MESHTASTIC_EXCLUDE_PKI_KEYGEN || MESHTASTIC_EXCLUDE_PKI)
@@ -4451,7 +4466,7 @@ bool NodeDB::generateCryptoKeyPair(const uint8_t *privateKey)
             if (checkLowEntropyPublicKey(config.security.public_key)) {
                 keyIsLowEntropy = true;
                 LOG_WARN("Provided private key derives a known low-entropy public key; generating a new keypair");
-                crypto->generateKeyPair(config.security.public_key.bytes, config.security.private_key.bytes);
+                generateBlacklistCheckedKeyPair();
             }
             keygenSuccess = true;
         } else {
@@ -4475,7 +4490,7 @@ bool NodeDB::generateCryptoKeyPair(const uint8_t *privateKey)
         LOG_INFO("Generate new PKI keys");
         config.security.public_key.size = 32;
         config.security.private_key.size = 32;
-        crypto->generateKeyPair(config.security.public_key.bytes, config.security.private_key.bytes);
+        generateBlacklistCheckedKeyPair();
         keygenSuccess = true;
     }
 

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -4431,10 +4431,17 @@ bool NodeDB::generateBlacklistCheckedKeyPair()
     return false;
 }
 
-// A key derived from a stored private key can still be a known pre-2.8 weak one, and the entry check
-// cannot see it when the stored public key is absent: replace the pair rather than adopt it.
-bool NodeDB::replaceDerivedKeyPairIfBlacklisted()
+// Derive the public key from the stored private key and vet it. The entry check cannot see a weak key
+// when the stored public key is absent, and a failed derivation must not leave sizes claiming a pair.
+bool NodeDB::derivePublicKeyFromPrivate()
 {
+    config.security.public_key.size = 32;
+    if (!crypto->regeneratePublicKey(config.security.public_key.bytes, config.security.private_key.bytes)) {
+        LOG_ERROR("Can't generate public key from private key");
+        config.security.public_key.size = 0;
+        config.security.private_key.size = 0;
+        return false;
+    }
     if (!checkLowEntropyPublicKey(config.security.public_key))
         return true;
     keyIsLowEntropy = true;
@@ -4468,31 +4475,17 @@ bool NodeDB::generateCryptoKeyPair(const uint8_t *privateKey)
         LOG_INFO("Using provided private key for PKI");
         memcpy(config.security.private_key.bytes, privateKey, 32);
         config.security.private_key.size = 32;
-        config.security.public_key.size = 32;
 
-        // Generate public key from the provided private key
-        if (crypto->regeneratePublicKey(config.security.public_key.bytes, config.security.private_key.bytes)) {
-            if (!replaceDerivedKeyPairIfBlacklisted())
-                return false;
-            keygenSuccess = true;
-        } else {
-            // Derivation left sizes claiming a 32-byte pair the caller never got. Clear both so an
-            // unusable identity is not persisted and the next keygen mints a fresh one.
-            LOG_ERROR("Can't generate public key from private key");
-            config.security.public_key.size = 0;
-            config.security.private_key.size = 0;
+        if (!derivePublicKeyFromPrivate())
             return false;
-        }
+        keygenSuccess = true;
     }
     // Try to regenerate public key from existing private key if it's valid and not low entropy
     else if (config.security.private_key.size == 32 && !keyIsLowEntropy) {
-        config.security.public_key.size = 32;
         LOG_DEBUG("Regenerate PKI public key from private key");
-        if (crypto->regeneratePublicKey(config.security.public_key.bytes, config.security.private_key.bytes)) {
-            if (!replaceDerivedKeyPairIfBlacklisted())
-                return false;
-            keygenSuccess = true;
-        }
+        if (!derivePublicKeyFromPrivate())
+            return false;
+        keygenSuccess = true;
     } else {
         // Generate a new key pair
         LOG_INFO("Generate new PKI keys");

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -4418,17 +4418,20 @@ bool NodeDB::checkLowEntropyPublicKey(const meshtastic_Config_SecurityConfig_pub
 #endif
 
 #if !(MESHTASTIC_EXCLUDE_PKI_KEYGEN || MESHTASTIC_EXCLUDE_PKI)
-// A freshly minted keypair must not itself land on the blacklist. Retry a bounded number of times,
-// then say so: if the entropy source keeps producing known-weak keys there is nothing better to mint.
-void NodeDB::generateBlacklistCheckedKeyPair()
+// A freshly minted keypair must not itself land on the blacklist. Retry a bounded number of times, and
+// if every attempt is compromised fail with no key rather than persist a known-weak identity.
+bool NodeDB::generateBlacklistCheckedKeyPair()
 {
     for (uint8_t attempt = 0; attempt < 3; attempt++) {
         crypto->generateKeyPair(config.security.public_key.bytes, config.security.private_key.bytes);
         if (!checkLowEntropyPublicKey(config.security.public_key))
-            return;
+            return true;
         LOG_WARN("Generated keypair is a known low-entropy key; retrying");
     }
     LOG_ERROR("PKI keygen keeps producing known low-entropy keys; entropy source is broken");
+    config.security.public_key.size = 0;
+    config.security.private_key.size = 0;
+    return false;
 }
 #endif
 
@@ -4466,7 +4469,8 @@ bool NodeDB::generateCryptoKeyPair(const uint8_t *privateKey)
             if (checkLowEntropyPublicKey(config.security.public_key)) {
                 keyIsLowEntropy = true;
                 LOG_WARN("Provided private key derives a known low-entropy public key; generating a new keypair");
-                generateBlacklistCheckedKeyPair();
+                if (!generateBlacklistCheckedKeyPair())
+                    return false;
             }
             keygenSuccess = true;
         } else {
@@ -4490,7 +4494,8 @@ bool NodeDB::generateCryptoKeyPair(const uint8_t *privateKey)
         LOG_INFO("Generate new PKI keys");
         config.security.public_key.size = 32;
         config.security.private_key.size = 32;
-        generateBlacklistCheckedKeyPair();
+        if (!generateBlacklistCheckedKeyPair())
+            return false;
         keygenSuccess = true;
     }
 

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -4418,17 +4418,14 @@ bool NodeDB::checkLowEntropyPublicKey(const meshtastic_Config_SecurityConfig_pub
 #endif
 
 #if !(MESHTASTIC_EXCLUDE_PKI_KEYGEN || MESHTASTIC_EXCLUDE_PKI)
-// A freshly minted keypair must not itself land on the blacklist. Retry a bounded number of times, and
-// if every attempt is compromised fail with no key rather than persist a known-weak identity.
+// A freshly minted keypair must not itself land on the blacklist. Fail with no key rather than persist
+// a known-weak identity: only a broken entropy source can land here, and retrying would not fix that.
 bool NodeDB::generateBlacklistCheckedKeyPair()
 {
-    for (uint8_t attempt = 0; attempt < 3; attempt++) {
-        crypto->generateKeyPair(config.security.public_key.bytes, config.security.private_key.bytes);
-        if (!checkLowEntropyPublicKey(config.security.public_key))
-            return true;
-        LOG_WARN("Generated keypair is a known low-entropy key; retrying");
-    }
-    LOG_ERROR("PKI keygen keeps producing known low-entropy keys; entropy source is broken");
+    crypto->generateKeyPair(config.security.public_key.bytes, config.security.private_key.bytes);
+    if (!checkLowEntropyPublicKey(config.security.public_key))
+        return true;
+    LOG_ERROR("PKI keygen produced a known low-entropy key; entropy source is broken");
     config.security.public_key.size = 0;
     config.security.private_key.size = 0;
     return false;

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -4446,11 +4446,8 @@ bool NodeDB::generateCryptoKeyPair(const uint8_t *privateKey)
 
         // Generate public key from the provided private key
         if (crypto->regeneratePublicKey(config.security.public_key.bytes, config.security.private_key.bytes)) {
-            // A restored/legacy private key can derive a known low-entropy public key (the pre-2.8
-            // weak-keygen set). The entry check above ran against the *stored* public key, which is
-            // empty on a bare key restore, so it can't catch this — re-check the key we just derived.
-            // If it's compromised, don't hand it back: mint a fresh secure keypair and keep the
-            // keyIsLowEntropy flag set so the user is told why their saved key did not stick.
+            // The check above ran against the stored public key, empty on a bare restore, so re-check
+            // the derived one: a known low-entropy key is replaced rather than handed back.
             if (checkLowEntropyPublicKey(config.security.public_key)) {
                 keyIsLowEntropy = true;
                 LOG_WARN("Provided private key derives a known low-entropy public key; generating a new keypair");

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -4430,6 +4430,17 @@ bool NodeDB::generateBlacklistCheckedKeyPair()
     config.security.private_key.size = 0;
     return false;
 }
+
+// A key derived from a stored private key can still be a known pre-2.8 weak one, and the entry check
+// cannot see it when the stored public key is absent: replace the pair rather than adopt it.
+bool NodeDB::replaceDerivedKeyPairIfBlacklisted()
+{
+    if (!checkLowEntropyPublicKey(config.security.public_key))
+        return true;
+    keyIsLowEntropy = true;
+    LOG_WARN("Private key derives a known low-entropy public key; generating a new keypair");
+    return generateBlacklistCheckedKeyPair();
+}
 #endif
 
 bool NodeDB::generateCryptoKeyPair(const uint8_t *privateKey)
@@ -4461,14 +4472,8 @@ bool NodeDB::generateCryptoKeyPair(const uint8_t *privateKey)
 
         // Generate public key from the provided private key
         if (crypto->regeneratePublicKey(config.security.public_key.bytes, config.security.private_key.bytes)) {
-            // The check above ran against the stored public key, empty on a bare restore, so re-check
-            // the derived one: a known low-entropy key is replaced rather than handed back.
-            if (checkLowEntropyPublicKey(config.security.public_key)) {
-                keyIsLowEntropy = true;
-                LOG_WARN("Provided private key derives a known low-entropy public key; generating a new keypair");
-                if (!generateBlacklistCheckedKeyPair())
-                    return false;
-            }
+            if (!replaceDerivedKeyPairIfBlacklisted())
+                return false;
             keygenSuccess = true;
         } else {
             // Derivation left sizes claiming a 32-byte pair the caller never got. Clear both so an
@@ -4484,6 +4489,8 @@ bool NodeDB::generateCryptoKeyPair(const uint8_t *privateKey)
         config.security.public_key.size = 32;
         LOG_DEBUG("Regenerate PKI public key from private key");
         if (crypto->regeneratePublicKey(config.security.public_key.bytes, config.security.private_key.bytes)) {
+            if (!replaceDerivedKeyPairIfBlacklisted())
+                return false;
             keygenSuccess = true;
         }
     } else {

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -4455,7 +4455,11 @@ bool NodeDB::generateCryptoKeyPair(const uint8_t *privateKey)
             }
             keygenSuccess = true;
         } else {
+            // Derivation left sizes claiming a 32-byte pair the caller never got. Clear both so an
+            // unusable identity is not persisted and the next keygen mints a fresh one.
             LOG_ERROR("Can't generate public key from private key");
+            config.security.public_key.size = 0;
+            config.security.private_key.size = 0;
             return false;
         }
     }

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -4446,6 +4446,16 @@ bool NodeDB::generateCryptoKeyPair(const uint8_t *privateKey)
 
         // Generate public key from the provided private key
         if (crypto->regeneratePublicKey(config.security.public_key.bytes, config.security.private_key.bytes)) {
+            // A restored/legacy private key can derive a known low-entropy public key (the pre-2.8
+            // weak-keygen set). The entry check above ran against the *stored* public key, which is
+            // empty on a bare key restore, so it can't catch this — re-check the key we just derived.
+            // If it's compromised, don't hand it back: mint a fresh secure keypair and keep the
+            // keyIsLowEntropy flag set so the user is told why their saved key did not stick.
+            if (checkLowEntropyPublicKey(config.security.public_key)) {
+                keyIsLowEntropy = true;
+                LOG_WARN("Provided private key derives a known low-entropy public key; generating a new keypair");
+                crypto->generateKeyPair(config.security.public_key.bytes, config.security.private_key.bytes);
+            }
             keygenSuccess = true;
         } else {
             LOG_ERROR("Can't generate public key from private key");

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -591,6 +591,9 @@ class NodeDB
 
 #if !defined(MESHTASTIC_EXCLUDE_PKI)
     bool checkLowEntropyPublicKey(const meshtastic_Config_SecurityConfig_public_key_t &keyToTest);
+#if !(MESHTASTIC_EXCLUDE_PKI_KEYGEN)
+    void generateBlacklistCheckedKeyPair();
+#endif
 #endif
 
     /// Consolidate crypto key generation logic used across multiple modules

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -80,6 +80,11 @@ static const uint8_t LOW_ENTROPY_HASHES[][32] = {
     {0xcc, 0x11, 0xfb, 0x1a, 0xab, 0xa1, 0x31, 0x87, 0x6a, 0xc6, 0xde, 0x88, 0x87, 0xa9, 0xb9, 0x59,
      0x37, 0x82, 0x8d, 0xb2, 0xcc, 0xd8, 0x97, 0x40, 0x9a, 0x5c, 0x8f, 0x40, 0x55, 0xcb, 0x4c, 0x3e}};
 static const char LOW_ENTROPY_WARNING[] = "Compromised keys were detected and regenerated.";
+// Shown when a user tries to restore/set a known pre-2.8 low-entropy key: explains why the saved
+// key did not persist and that the node's identity (NodeNum == crc32(public_key)) changed with it.
+static const char LOW_ENTROPY_RESTORE_WARNING[] =
+    "That key is a known pre-2.8 low-entropy key and can't be restored. A new secure key was "
+    "generated; your node number has changed.";
 #endif
 static const char LICENSED_IDENTITY_MIGRATION_WARNING[] =
     "Licensed signing generated a new identity key; this node identity changed.";

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -591,9 +591,9 @@ class NodeDB
 
 #if !defined(MESHTASTIC_EXCLUDE_PKI)
     bool checkLowEntropyPublicKey(const meshtastic_Config_SecurityConfig_public_key_t &keyToTest);
-#if !(MESHTASTIC_EXCLUDE_PKI_KEYGEN)
-    void generateBlacklistCheckedKeyPair();
 #endif
+#if !(MESHTASTIC_EXCLUDE_PKI_KEYGEN || MESHTASTIC_EXCLUDE_PKI)
+    bool generateBlacklistCheckedKeyPair();
 #endif
 
     /// Consolidate crypto key generation logic used across multiple modules

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -594,7 +594,7 @@ class NodeDB
 #endif
 #if !(MESHTASTIC_EXCLUDE_PKI_KEYGEN || MESHTASTIC_EXCLUDE_PKI)
     bool generateBlacklistCheckedKeyPair();
-    bool replaceDerivedKeyPairIfBlacklisted();
+    bool derivePublicKeyFromPrivate();
 #endif
 
     /// Consolidate crypto key generation logic used across multiple modules

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -594,6 +594,7 @@ class NodeDB
 #endif
 #if !(MESHTASTIC_EXCLUDE_PKI_KEYGEN || MESHTASTIC_EXCLUDE_PKI)
     bool generateBlacklistCheckedKeyPair();
+    bool replaceDerivedKeyPairIfBlacklisted();
 #endif
 
     /// Consolidate crypto key generation logic used across multiple modules

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -1212,12 +1212,11 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
         if (config.security.private_key.size != 32) {
             nodeDB->generateCryptoKeyPair();
         } else if (config.security.public_key.size == 0 || nodeDB->checkLowEntropyPublicKey(config.security.public_key)) {
-            // A rejected pre-2.8 low-entropy key was swapped for a fresh one: say so at set time, not
-            // after the next reboot. Only when the private key really was replaced - a blacklisted public
-            // key whose private key derives a clean one is re-derived, and that key did stick.
+            // Warn at set time, not after the next reboot, and only when the key really was replaced: a
+            // blacklisted public key whose private key derives a clean one is re-derived, and that stuck.
             uint8_t priorPrivateKey[32];
             memcpy(priorPrivateKey, config.security.private_key.bytes, 32);
-            const bool keygenSucceeded = nodeDB->generateCryptoKeyPair(config.security.private_key.bytes);
+            const bool keygenSucceeded = nodeDB->generateCryptoKeyPair(priorPrivateKey);
             const bool keyWasReplaced = memcmp(priorPrivateKey, config.security.private_key.bytes, 32) != 0;
             if (keygenSucceeded && keyWasReplaced && nodeDB->keyIsLowEntropy) {
                 sendWarning(LOW_ENTROPY_RESTORE_WARNING);

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -1210,13 +1210,10 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
         if (config.security.private_key.size != 32) {
             nodeDB->generateCryptoKeyPair();
         } else if (config.security.public_key.size == 0) {
-            nodeDB->generateCryptoKeyPair(config.security.private_key.bytes);
-            // If the restored private key derived a known pre-2.8 low-entropy public key,
-            // generateCryptoKeyPair rejected it and minted a fresh keypair. Tell the user why their
-            // save did not stick (and that their node number changed with the new key) now, at set
-            // time — not after the next reboot's generic warning. Scoped to this call so a stale
-            // flag from a boot-time regeneration doesn't fire on unrelated security sets.
-            if (nodeDB->keyIsLowEntropy) {
+            // A rejected pre-2.8 low-entropy key was swapped for a fresh one: say so at set time, not
+            // after the next reboot. Gated on this call succeeding so a stale flag can't fire.
+            const bool keygenSucceeded = nodeDB->generateCryptoKeyPair(config.security.private_key.bytes);
+            if (keygenSucceeded && nodeDB->keyIsLowEntropy) {
                 sendWarning(LOW_ENTROPY_RESTORE_WARNING);
             }
         }

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -1207,9 +1207,11 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
         config.security = incoming;
 #if !(MESHTASTIC_EXCLUDE_PKI_KEYGEN) && !(MESHTASTIC_EXCLUDE_PKI)
         // First provisioning (no key) generates one; a private key supplied without its public key derives it.
+        // A supplied public key that is itself blacklisted is re-derived too, so a restore carrying a whole
+        // low-entropy pair cannot skip the check just by populating both fields.
         if (config.security.private_key.size != 32) {
             nodeDB->generateCryptoKeyPair();
-        } else if (config.security.public_key.size == 0) {
+        } else if (config.security.public_key.size == 0 || nodeDB->checkLowEntropyPublicKey(config.security.public_key)) {
             // A rejected pre-2.8 low-entropy key was swapped for a fresh one: say so at set time, not
             // after the next reboot. Gated on this call succeeding so a stale flag can't fire.
             const bool keygenSucceeded = nodeDB->generateCryptoKeyPair(config.security.private_key.bytes);

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -1211,6 +1211,14 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
             nodeDB->generateCryptoKeyPair();
         } else if (config.security.public_key.size == 0) {
             nodeDB->generateCryptoKeyPair(config.security.private_key.bytes);
+            // If the restored private key derived a known pre-2.8 low-entropy public key,
+            // generateCryptoKeyPair rejected it and minted a fresh keypair. Tell the user why their
+            // save did not stick (and that their node number changed with the new key) now, at set
+            // time — not after the next reboot's generic warning. Scoped to this call so a stale
+            // flag from a boot-time regeneration doesn't fire on unrelated security sets.
+            if (nodeDB->keyIsLowEntropy) {
+                sendWarning(LOW_ENTROPY_RESTORE_WARNING);
+            }
         }
 #endif
         if (config.security.is_managed && !(config.security.admin_key[0].size == 32 || config.security.admin_key[1].size == 32 ||

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -1213,9 +1213,13 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
             nodeDB->generateCryptoKeyPair();
         } else if (config.security.public_key.size == 0 || nodeDB->checkLowEntropyPublicKey(config.security.public_key)) {
             // A rejected pre-2.8 low-entropy key was swapped for a fresh one: say so at set time, not
-            // after the next reboot. Gated on this call succeeding so a stale flag can't fire.
+            // after the next reboot. Only when the private key really was replaced - a blacklisted public
+            // key whose private key derives a clean one is re-derived, and that key did stick.
+            uint8_t priorPrivateKey[32];
+            memcpy(priorPrivateKey, config.security.private_key.bytes, 32);
             const bool keygenSucceeded = nodeDB->generateCryptoKeyPair(config.security.private_key.bytes);
-            if (keygenSucceeded && nodeDB->keyIsLowEntropy) {
+            const bool keyWasReplaced = memcmp(priorPrivateKey, config.security.private_key.bytes, 32) != 0;
+            if (keygenSucceeded && keyWasReplaced && nodeDB->keyIsLowEntropy) {
                 sendWarning(LOW_ENTROPY_RESTORE_WARNING);
             }
         }

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -21,7 +21,8 @@
 #include "TestUtil.h"
 #include "graphics/draw/MenuHandler.h"
 #include "mesh/Channels.h"
-#include "mesh/Router.h" // router global: allocErrorResponse() allocates the reply through it
+#include "mesh/CryptoEngine.h" // crypto global: the tests swap in a stub engine to drive key derivation
+#include "mesh/Router.h"       // router global: allocErrorResponse() allocates the reply through it
 #include "modules/AdminModule.h"
 #include "modules/NodeInfoModule.h"
 #include <ErriezCRC32.h> // crc32Buffer(), for the my_node_num == crc32(public_key) invariant
@@ -1703,6 +1704,121 @@ static void test_handleSetConfig_security_clearsAdminKeysWhenKeypairUnchanged()
     TEST_ASSERT_EQUAL_UINT(0, config.security.admin_key[0].size);
 }
 
+// Only CryptoEngine knows what public key a private key derives to, and no low-entropy private key
+// is published - so stand in for the engine to make a restore derive a blacklisted key on demand.
+// hash() is left real: the blacklist lookup runs through it.
+static const uint8_t COMPROMISED_PUBLIC_KEY[32] = {0xac, 0xaf, 0x8c, 0x1c, 0x3c, 0x1c, 0x37, 0xac, 0x4f, 0x03, 0xa1,
+                                                   0xe9, 0xfc, 0x37, 0x23, 0x29, 0xc8, 0xa3, 0x5d, 0x7f, 0x05, 0x26,
+                                                   0xeb, 0x00, 0xbd, 0x26, 0xb8, 0x2e, 0xb1, 0x94, 0x7d, 0x24};
+
+class RestoreDerivingCryptoEngine : public CryptoEngine
+{
+  public:
+    bool regenerateSucceeds = true;
+    bool regeneratePublicKey(uint8_t *pubKey, uint8_t *privKey) override
+    {
+        if (!regenerateSucceeds)
+            return false;
+        memcpy(pubKey, COMPROMISED_PUBLIC_KEY, 32);
+        return true;
+    }
+    void generateKeyPair(uint8_t *pubKey, uint8_t *privKey) override
+    {
+        memset(pubKey, 0x5E, 32);
+        memset(privKey, 0x5F, 32);
+    }
+};
+
+static CryptoEngine *savedCrypto;
+static RestoreDerivingCryptoEngine *restoreCrypto;
+
+// Arms a bare private-key restore: region set so keygen runs, private key present, public key absent.
+static meshtastic_Config makeBareKeyRestoreConfig()
+{
+    config.security = meshtastic_Config_SecurityConfig_init_zero;
+    config.lora.region = meshtastic_Config_LoRaConfig_RegionCode_US;
+    initRegion();
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_security_tag;
+    c.payload_variant.security.private_key.size = 32;
+    memset(c.payload_variant.security.private_key.bytes, 0x11, 32);
+    return c;
+}
+
+static bool capturedWarningsContain(const char *needle)
+{
+    for (const std::string &w : capturedWarnings)
+        if (w.find(needle) != std::string::npos)
+            return true;
+    return false;
+}
+
+// A restored private key deriving a blacklisted public key is rejected and rotated at set time, and
+// the client is told why - not left to discover it after the next reboot.
+static void test_handleSetConfig_security_lowEntropyRestoreWarnsAndRotates()
+{
+    savedCrypto = crypto;
+    restoreCrypto = new RestoreDerivingCryptoEngine();
+    crypto = restoreCrypto;
+
+    const meshtastic_Config c = makeBareKeyRestoreConfig();
+    testAdmin->deferSaves();
+    testAdmin->handleSetConfig(c, false);
+
+    TEST_ASSERT_TRUE(nodeDB->keyIsLowEntropy);
+    TEST_ASSERT_EQUAL_UINT(32, config.security.public_key.size);
+    TEST_ASSERT_TRUE(memcmp(COMPROMISED_PUBLIC_KEY, config.security.public_key.bytes, 32) != 0);
+    TEST_ASSERT_FALSE(nodeDB->checkLowEntropyPublicKey(config.security.public_key));
+    TEST_ASSERT_TRUE(capturedWarningsContain(LOW_ENTROPY_RESTORE_WARNING));
+
+    crypto = savedCrypto;
+    delete restoreCrypto;
+    restoreCrypto = nullptr;
+}
+
+// keyIsLowEntropy survives from a boot-time regeneration, and generateCryptoKeyPair returns early on
+// an unset region without clearing it. The restore warning must stay gated on this keygen running.
+static void test_handleSetConfig_security_staleLowEntropyFlagDoesNotWarn()
+{
+    config.security = meshtastic_Config_SecurityConfig_init_zero;
+    config.lora.region = meshtastic_Config_LoRaConfig_RegionCode_UNSET;
+    initRegion();
+    nodeDB->keyIsLowEntropy = true;
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_security_tag;
+    c.payload_variant.security.private_key.size = 32;
+    memset(c.payload_variant.security.private_key.bytes, 0x11, 32);
+
+    testAdmin->deferSaves();
+    testAdmin->handleSetConfig(c, false);
+
+    TEST_ASSERT_FALSE(capturedWarningsContain(LOW_ENTROPY_RESTORE_WARNING));
+}
+
+// A private key that derives nothing usable must not leave sizes claiming a 32-byte pair behind:
+// that state gets persisted, and every later keygen re-derives from the same dead key.
+static void test_handleSetConfig_security_failedDerivationClearsKeySizes()
+{
+    savedCrypto = crypto;
+    restoreCrypto = new RestoreDerivingCryptoEngine();
+    restoreCrypto->regenerateSucceeds = false;
+    crypto = restoreCrypto;
+
+    const meshtastic_Config c = makeBareKeyRestoreConfig();
+    testAdmin->deferSaves();
+    testAdmin->handleSetConfig(c, false);
+
+    TEST_ASSERT_EQUAL_UINT(0, config.security.private_key.size);
+    TEST_ASSERT_EQUAL_UINT(0, config.security.public_key.size);
+    TEST_ASSERT_FALSE(capturedWarningsContain(LOW_ENTROPY_RESTORE_WARNING));
+
+    crypto = savedCrypto;
+    delete restoreCrypto;
+    restoreCrypto = nullptr;
+}
+
 static void test_regionInfo_supportsPreset()
 {
     const RegionInfo *eu868 = getRegion(meshtastic_Config_LoRaConfig_RegionCode_EU_868);
@@ -2397,6 +2513,9 @@ void setup()
     RUN_TEST(test_handleSetConfig_security_acceptsSuppliedKeypair);
     RUN_TEST(test_handleSetConfig_security_rotationPreservesAdminKeys);
     RUN_TEST(test_handleSetConfig_security_clearsAdminKeysWhenKeypairUnchanged);
+    RUN_TEST(test_handleSetConfig_security_lowEntropyRestoreWarnsAndRotates);
+    RUN_TEST(test_handleSetConfig_security_staleLowEntropyFlagDoesNotWarn);
+    RUN_TEST(test_handleSetConfig_security_failedDerivationClearsKeySizes);
     RUN_TEST(test_regionInfo_supportsPreset);
     RUN_TEST(test_checkConfigRegion_quietCheckReportsReason);
     RUN_TEST(test_checkConfigRegion_allowsProspectiveLicensedOwner);

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -1866,16 +1866,34 @@ static void test_handleSetConfig_security_reDerivedCleanKeyDoesNotWarn()
 // retried rather than persisted.
 static void test_handleSetConfig_security_blacklistedReplacementIsRetried()
 {
+    const uint8_t blacklistedMints = 1;
     RestoreDerivingCryptoEngine *stub = installRestoreCrypto();
-    stub->lowEntropyMints = 1;
+    stub->lowEntropyMints = blacklistedMints;
 
     const meshtastic_Config c = makeBareKeyRestoreConfig();
     testAdmin->deferSaves();
     testAdmin->handleSetConfig(c, false);
 
-    TEST_ASSERT_EQUAL_UINT(2, stub->generateKeyPairCalls);
+    // One mint per blacklisted result, plus the clean one that ends the retry loop.
+    TEST_ASSERT_EQUAL_UINT(blacklistedMints + 1, stub->generateKeyPairCalls);
     TEST_ASSERT_FALSE(nodeDB->checkLowEntropyPublicKey(config.security.public_key));
     TEST_ASSERT_TRUE(capturedWarningsContain(LOW_ENTROPY_RESTORE_WARNING));
+}
+
+// When every attempt stays blacklisted, keygen fails and leaves no identity behind - persisting a
+// known-weak key would defeat the rejection this whole path exists for.
+static void test_handleSetConfig_security_exhaustedRetriesLeavesNoKey()
+{
+    RestoreDerivingCryptoEngine *stub = installRestoreCrypto();
+    stub->lowEntropyMints = UINT8_MAX; // never yields a clean key
+
+    const meshtastic_Config c = makeBareKeyRestoreConfig();
+    testAdmin->deferSaves();
+    testAdmin->handleSetConfig(c, false);
+
+    TEST_ASSERT_EQUAL_UINT(0, config.security.private_key.size);
+    TEST_ASSERT_EQUAL_UINT(0, config.security.public_key.size);
+    TEST_ASSERT_FALSE(capturedWarningsContain(LOW_ENTROPY_RESTORE_WARNING));
 }
 
 // keyIsLowEntropy survives from a boot-time regeneration, and generateCryptoKeyPair returns early on
@@ -2611,6 +2629,7 @@ void setup()
     RUN_TEST(test_handleSetConfig_security_lowEntropyFullKeypairRestoreIsRejected);
     RUN_TEST(test_handleSetConfig_security_reDerivedCleanKeyDoesNotWarn);
     RUN_TEST(test_handleSetConfig_security_blacklistedReplacementIsRetried);
+    RUN_TEST(test_handleSetConfig_security_exhaustedRetriesLeavesNoKey);
     RUN_TEST(test_handleSetConfig_security_staleLowEntropyFlagDoesNotWarn);
     RUN_TEST(test_handleSetConfig_security_failedDerivationClearsKeySizes);
     RUN_TEST(test_regionInfo_supportsPreset);

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -1720,11 +1720,15 @@ class RestoreDerivingCryptoEngine : public CryptoEngine
 {
   public:
     bool regenerateSucceeds = true;
+    bool derivesLowEntropy = true;
     bool regeneratePublicKey(uint8_t *pubKey, uint8_t *privKey) override
     {
         if (!regenerateSucceeds)
             return false;
-        memcpy(pubKey, COMPROMISED_PUBLIC_KEY, 32);
+        if (derivesLowEntropy)
+            memcpy(pubKey, COMPROMISED_PUBLIC_KEY, 32);
+        else
+            memset(pubKey, 0x7C, 32);
         return true;
     }
     void generateKeyPair(uint8_t *pubKey, uint8_t *privKey) override
@@ -1819,6 +1823,35 @@ static void test_handleSetConfig_security_lowEntropyFullKeypairRestoreIsRejected
     TEST_ASSERT_TRUE(memcmp(COMPROMISED_PUBLIC_KEY, config.security.public_key.bytes, 32) != 0);
     TEST_ASSERT_FALSE(nodeDB->checkLowEntropyPublicKey(config.security.public_key));
     TEST_ASSERT_TRUE(capturedWarningsContain(LOW_ENTROPY_RESTORE_WARNING));
+}
+
+// A blacklisted public key whose private key derives a clean one is only re-derived - the user's key
+// does stick, so the "a new secure key was generated" warning would be a lie here.
+static void test_handleSetConfig_security_reDerivedCleanKeyDoesNotWarn()
+{
+    installRestoreCrypto()->derivesLowEntropy = false;
+
+    config.security = meshtastic_Config_SecurityConfig_init_zero;
+    config.lora.region = meshtastic_Config_LoRaConfig_RegionCode_US;
+    initRegion();
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_security_tag;
+    c.payload_variant.security.private_key.size = 32;
+    memset(c.payload_variant.security.private_key.bytes, 0x11, 32);
+    c.payload_variant.security.public_key.size = 32;
+    memcpy(c.payload_variant.security.public_key.bytes, COMPROMISED_PUBLIC_KEY, 32);
+
+    testAdmin->deferSaves();
+    testAdmin->handleSetConfig(c, false);
+
+    // The supplied private key survives, and the blacklisted public key is replaced by its derivation.
+    uint8_t expectedPriv[32];
+    memset(expectedPriv, 0x11, 32);
+    TEST_ASSERT_EQUAL_MEMORY(expectedPriv, config.security.private_key.bytes, 32);
+    TEST_ASSERT_FALSE(nodeDB->checkLowEntropyPublicKey(config.security.public_key));
+    TEST_ASSERT_TRUE(memcmp(COMPROMISED_PUBLIC_KEY, config.security.public_key.bytes, 32) != 0);
+    TEST_ASSERT_FALSE(capturedWarningsContain(LOW_ENTROPY_RESTORE_WARNING));
 }
 
 // keyIsLowEntropy survives from a boot-time regeneration, and generateCryptoKeyPair returns early on
@@ -2552,6 +2585,7 @@ void setup()
     RUN_TEST(test_handleSetConfig_security_clearsAdminKeysWhenKeypairUnchanged);
     RUN_TEST(test_handleSetConfig_security_lowEntropyRestoreWarnsAndRotates);
     RUN_TEST(test_handleSetConfig_security_lowEntropyFullKeypairRestoreIsRejected);
+    RUN_TEST(test_handleSetConfig_security_reDerivedCleanKeyDoesNotWarn);
     RUN_TEST(test_handleSetConfig_security_staleLowEntropyFlagDoesNotWarn);
     RUN_TEST(test_handleSetConfig_security_failedDerivationClearsKeySizes);
     RUN_TEST(test_regionInfo_supportsPreset);

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -1872,6 +1872,25 @@ static void test_handleSetConfig_security_blacklistedMintLeavesNoKey()
     TEST_ASSERT_FALSE(capturedWarningsContain(LOW_ENTROPY_RESTORE_WARNING));
 }
 
+// factory_reset_config keeps the private key and clears the public one, so the entry check sees no key
+// and the boot-time derive path used to adopt whatever it produced - including a known-weak key.
+static void test_generateCryptoKeyPair_derivedFromStoredPrivateIsChecked()
+{
+    installRestoreCrypto();
+    config.security = meshtastic_Config_SecurityConfig_init_zero;
+    config.lora.region = meshtastic_Config_LoRaConfig_RegionCode_US;
+    initRegion();
+    config.security.private_key.size = 32;
+    memset(config.security.private_key.bytes, 0x11, 32);
+    config.security.public_key.size = 0; // as installDefaultConfig(preserveKey = true) leaves it
+
+    TEST_ASSERT_TRUE(nodeDB->generateCryptoKeyPair());
+
+    TEST_ASSERT_TRUE(nodeDB->keyIsLowEntropy);
+    TEST_ASSERT_TRUE(memcmp(COMPROMISED_PUBLIC_KEY, config.security.public_key.bytes, 32) != 0);
+    TEST_ASSERT_FALSE(nodeDB->checkLowEntropyPublicKey(config.security.public_key));
+}
+
 // keyIsLowEntropy survives from a boot-time regeneration, and generateCryptoKeyPair returns early on
 // an unset region without clearing it. The restore warning must stay gated on this keygen running.
 static void test_handleSetConfig_security_staleLowEntropyFlagDoesNotWarn()
@@ -2605,6 +2624,7 @@ void setup()
     RUN_TEST(test_handleSetConfig_security_lowEntropyFullKeypairRestoreIsRejected);
     RUN_TEST(test_handleSetConfig_security_reDerivedCleanKeyDoesNotWarn);
     RUN_TEST(test_handleSetConfig_security_blacklistedMintLeavesNoKey);
+    RUN_TEST(test_generateCryptoKeyPair_derivedFromStoredPrivateIsChecked);
     RUN_TEST(test_handleSetConfig_security_staleLowEntropyFlagDoesNotWarn);
     RUN_TEST(test_handleSetConfig_security_failedDerivationClearsKeySizes);
     RUN_TEST(test_regionInfo_supportsPreset);

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -1730,18 +1730,13 @@ class RestoreDerivingCryptoEngine : public CryptoEngine
             memset(pubKey, 0x7C, 32);
         return true;
     }
-    uint8_t lowEntropyMints = 0; // mint this many blacklisted keys before yielding a clean one
-    uint8_t generateKeyPairCalls = 0;
+    bool mintsLowEntropy = false;
     void generateKeyPair(uint8_t *pubKey, uint8_t *privKey) override
     {
-        generateKeyPairCalls++;
-        if (lowEntropyMints > 0) {
-            lowEntropyMints--;
+        if (mintsLowEntropy)
             memcpy(pubKey, COMPROMISED_PUBLIC_KEY, 32);
-            memset(privKey, 0x6F, 32);
-            return;
-        }
-        memset(pubKey, 0x5E, 32);
+        else
+            memset(pubKey, 0x5E, 32);
         memset(privKey, 0x5F, 32);
     }
 };
@@ -1862,30 +1857,11 @@ static void test_handleSetConfig_security_reDerivedCleanKeyDoesNotWarn()
     TEST_ASSERT_FALSE(capturedWarningsContain(LOW_ENTROPY_RESTORE_WARNING));
 }
 
-// The replacement for a rejected key is itself checked: a mint that lands back on the blacklist is
-// retried rather than persisted.
-static void test_handleSetConfig_security_blacklistedReplacementIsRetried()
+// A replacement that is itself blacklisted leaves no identity behind - persisting a known-weak key
+// would defeat the rejection this whole path exists for.
+static void test_handleSetConfig_security_blacklistedMintLeavesNoKey()
 {
-    const uint8_t blacklistedMints = 1;
-    RestoreDerivingCryptoEngine *stub = installRestoreCrypto();
-    stub->lowEntropyMints = blacklistedMints;
-
-    const meshtastic_Config c = makeBareKeyRestoreConfig();
-    testAdmin->deferSaves();
-    testAdmin->handleSetConfig(c, false);
-
-    // One mint per blacklisted result, plus the clean one that ends the retry loop.
-    TEST_ASSERT_EQUAL_UINT(blacklistedMints + 1, stub->generateKeyPairCalls);
-    TEST_ASSERT_FALSE(nodeDB->checkLowEntropyPublicKey(config.security.public_key));
-    TEST_ASSERT_TRUE(capturedWarningsContain(LOW_ENTROPY_RESTORE_WARNING));
-}
-
-// When every attempt stays blacklisted, keygen fails and leaves no identity behind - persisting a
-// known-weak key would defeat the rejection this whole path exists for.
-static void test_handleSetConfig_security_exhaustedRetriesLeavesNoKey()
-{
-    RestoreDerivingCryptoEngine *stub = installRestoreCrypto();
-    stub->lowEntropyMints = UINT8_MAX; // never yields a clean key
+    installRestoreCrypto()->mintsLowEntropy = true;
 
     const meshtastic_Config c = makeBareKeyRestoreConfig();
     testAdmin->deferSaves();
@@ -2628,8 +2604,7 @@ void setup()
     RUN_TEST(test_handleSetConfig_security_lowEntropyRestoreWarnsAndRotates);
     RUN_TEST(test_handleSetConfig_security_lowEntropyFullKeypairRestoreIsRejected);
     RUN_TEST(test_handleSetConfig_security_reDerivedCleanKeyDoesNotWarn);
-    RUN_TEST(test_handleSetConfig_security_blacklistedReplacementIsRetried);
-    RUN_TEST(test_handleSetConfig_security_exhaustedRetriesLeavesNoKey);
+    RUN_TEST(test_handleSetConfig_security_blacklistedMintLeavesNoKey);
     RUN_TEST(test_handleSetConfig_security_staleLowEntropyFlagDoesNotWarn);
     RUN_TEST(test_handleSetConfig_security_failedDerivationClearsKeySizes);
     RUN_TEST(test_regionInfo_supportsPreset);

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -1891,6 +1891,24 @@ static void test_generateCryptoKeyPair_derivedFromStoredPrivateIsChecked()
     TEST_ASSERT_FALSE(nodeDB->checkLowEntropyPublicKey(config.security.public_key));
 }
 
+// Same clear-and-fail on the boot path: a stored private key that derives nothing must not leave both
+// sizes at 32, claiming a pair the node never got.
+static void test_generateCryptoKeyPair_failedDerivationFromStoredPrivateClearsKeySizes()
+{
+    installRestoreCrypto()->regenerateSucceeds = false;
+    config.security = meshtastic_Config_SecurityConfig_init_zero;
+    config.lora.region = meshtastic_Config_LoRaConfig_RegionCode_US;
+    initRegion();
+    config.security.private_key.size = 32;
+    memset(config.security.private_key.bytes, 0x11, 32);
+    config.security.public_key.size = 0;
+
+    TEST_ASSERT_FALSE(nodeDB->generateCryptoKeyPair());
+
+    TEST_ASSERT_EQUAL_UINT(0, config.security.private_key.size);
+    TEST_ASSERT_EQUAL_UINT(0, config.security.public_key.size);
+}
+
 // keyIsLowEntropy survives from a boot-time regeneration, and generateCryptoKeyPair returns early on
 // an unset region without clearing it. The restore warning must stay gated on this keygen running.
 static void test_handleSetConfig_security_staleLowEntropyFlagDoesNotWarn()
@@ -2625,6 +2643,7 @@ void setup()
     RUN_TEST(test_handleSetConfig_security_reDerivedCleanKeyDoesNotWarn);
     RUN_TEST(test_handleSetConfig_security_blacklistedMintLeavesNoKey);
     RUN_TEST(test_generateCryptoKeyPair_derivedFromStoredPrivateIsChecked);
+    RUN_TEST(test_generateCryptoKeyPair_failedDerivationFromStoredPrivateClearsKeySizes);
     RUN_TEST(test_handleSetConfig_security_staleLowEntropyFlagDoesNotWarn);
     RUN_TEST(test_handleSetConfig_security_failedDerivationClearsKeySizes);
     RUN_TEST(test_regionInfo_supportsPreset);

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -1023,8 +1023,13 @@ static void replaceAdminRadioGlobals()
     nodeDB = replacementNodeDB;
 }
 
+// Defined with the crypto stub below; tearDown must undo an install even when a failed assertion
+// longjmped out of the test body before it could.
+static void dropRestoreCryptoStub();
+
 static void restoreAdminRadioGlobals()
 {
+    dropRestoreCryptoStub();
     nodeInfoModule = savedNodeInfoModule;
     nodeDB = savedNodeDB;
     router = savedRouter;
@@ -1732,6 +1737,25 @@ class RestoreDerivingCryptoEngine : public CryptoEngine
 static CryptoEngine *savedCrypto;
 static RestoreDerivingCryptoEngine *restoreCrypto;
 
+// Installed here and torn down in restoreAdminRadioGlobals(), not at the end of the test body: a failed
+// TEST_ASSERT longjmps straight out, which would leave later tests running against a freed stub.
+static RestoreDerivingCryptoEngine *installRestoreCrypto()
+{
+    savedCrypto = crypto;
+    restoreCrypto = new RestoreDerivingCryptoEngine();
+    crypto = restoreCrypto;
+    return restoreCrypto;
+}
+
+static void dropRestoreCryptoStub()
+{
+    if (!restoreCrypto)
+        return;
+    crypto = savedCrypto;
+    delete restoreCrypto;
+    restoreCrypto = nullptr;
+}
+
 // Arms a bare private-key restore: region set so keygen runs, private key present, public key absent.
 static meshtastic_Config makeBareKeyRestoreConfig()
 {
@@ -1758,9 +1782,7 @@ static bool capturedWarningsContain(const char *needle)
 // the client is told why - not left to discover it after the next reboot.
 static void test_handleSetConfig_security_lowEntropyRestoreWarnsAndRotates()
 {
-    savedCrypto = crypto;
-    restoreCrypto = new RestoreDerivingCryptoEngine();
-    crypto = restoreCrypto;
+    installRestoreCrypto();
 
     const meshtastic_Config c = makeBareKeyRestoreConfig();
     testAdmin->deferSaves();
@@ -1771,10 +1793,32 @@ static void test_handleSetConfig_security_lowEntropyRestoreWarnsAndRotates()
     TEST_ASSERT_TRUE(memcmp(COMPROMISED_PUBLIC_KEY, config.security.public_key.bytes, 32) != 0);
     TEST_ASSERT_FALSE(nodeDB->checkLowEntropyPublicKey(config.security.public_key));
     TEST_ASSERT_TRUE(capturedWarningsContain(LOW_ENTROPY_RESTORE_WARNING));
+}
 
-    crypto = savedCrypto;
-    delete restoreCrypto;
-    restoreCrypto = nullptr;
+// A restore carrying a whole blacklisted pair must not skip validation just because it populated the
+// public key too - that path reaches neither keygen branch, so the weak identity used to be kept.
+static void test_handleSetConfig_security_lowEntropyFullKeypairRestoreIsRejected()
+{
+    installRestoreCrypto();
+
+    config.security = meshtastic_Config_SecurityConfig_init_zero;
+    config.lora.region = meshtastic_Config_LoRaConfig_RegionCode_US;
+    initRegion();
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_security_tag;
+    c.payload_variant.security.private_key.size = 32;
+    memset(c.payload_variant.security.private_key.bytes, 0x11, 32);
+    c.payload_variant.security.public_key.size = 32;
+    memcpy(c.payload_variant.security.public_key.bytes, COMPROMISED_PUBLIC_KEY, 32);
+
+    testAdmin->deferSaves();
+    testAdmin->handleSetConfig(c, false);
+
+    TEST_ASSERT_EQUAL_UINT(32, config.security.public_key.size);
+    TEST_ASSERT_TRUE(memcmp(COMPROMISED_PUBLIC_KEY, config.security.public_key.bytes, 32) != 0);
+    TEST_ASSERT_FALSE(nodeDB->checkLowEntropyPublicKey(config.security.public_key));
+    TEST_ASSERT_TRUE(capturedWarningsContain(LOW_ENTROPY_RESTORE_WARNING));
 }
 
 // keyIsLowEntropy survives from a boot-time regeneration, and generateCryptoKeyPair returns early on
@@ -1801,10 +1845,7 @@ static void test_handleSetConfig_security_staleLowEntropyFlagDoesNotWarn()
 // that state gets persisted, and every later keygen re-derives from the same dead key.
 static void test_handleSetConfig_security_failedDerivationClearsKeySizes()
 {
-    savedCrypto = crypto;
-    restoreCrypto = new RestoreDerivingCryptoEngine();
-    restoreCrypto->regenerateSucceeds = false;
-    crypto = restoreCrypto;
+    installRestoreCrypto()->regenerateSucceeds = false;
 
     const meshtastic_Config c = makeBareKeyRestoreConfig();
     testAdmin->deferSaves();
@@ -1813,10 +1854,6 @@ static void test_handleSetConfig_security_failedDerivationClearsKeySizes()
     TEST_ASSERT_EQUAL_UINT(0, config.security.private_key.size);
     TEST_ASSERT_EQUAL_UINT(0, config.security.public_key.size);
     TEST_ASSERT_FALSE(capturedWarningsContain(LOW_ENTROPY_RESTORE_WARNING));
-
-    crypto = savedCrypto;
-    delete restoreCrypto;
-    restoreCrypto = nullptr;
 }
 
 static void test_regionInfo_supportsPreset()
@@ -2514,6 +2551,7 @@ void setup()
     RUN_TEST(test_handleSetConfig_security_rotationPreservesAdminKeys);
     RUN_TEST(test_handleSetConfig_security_clearsAdminKeysWhenKeypairUnchanged);
     RUN_TEST(test_handleSetConfig_security_lowEntropyRestoreWarnsAndRotates);
+    RUN_TEST(test_handleSetConfig_security_lowEntropyFullKeypairRestoreIsRejected);
     RUN_TEST(test_handleSetConfig_security_staleLowEntropyFlagDoesNotWarn);
     RUN_TEST(test_handleSetConfig_security_failedDerivationClearsKeySizes);
     RUN_TEST(test_regionInfo_supportsPreset);

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -1709,9 +1709,8 @@ static void test_handleSetConfig_security_clearsAdminKeysWhenKeypairUnchanged()
     TEST_ASSERT_EQUAL_UINT(0, config.security.admin_key[0].size);
 }
 
-// Only CryptoEngine knows what public key a private key derives to, and no low-entropy private key
-// is published - so stand in for the engine to make a restore derive a blacklisted key on demand.
-// hash() is left real: the blacklist lookup runs through it.
+// No low-entropy private key is published, so stand in for the engine to derive a blacklisted public
+// key on demand. hash() is left real: the blacklist lookup runs through it.
 static const uint8_t COMPROMISED_PUBLIC_KEY[32] = {0xac, 0xaf, 0x8c, 0x1c, 0x3c, 0x1c, 0x37, 0xac, 0x4f, 0x03, 0xa1,
                                                    0xe9, 0xfc, 0x37, 0x23, 0x29, 0xc8, 0xa3, 0x5d, 0x7f, 0x05, 0x26,
                                                    0xeb, 0x00, 0xbd, 0x26, 0xb8, 0x2e, 0xb1, 0x94, 0x7d, 0x24};
@@ -1731,8 +1730,17 @@ class RestoreDerivingCryptoEngine : public CryptoEngine
             memset(pubKey, 0x7C, 32);
         return true;
     }
+    uint8_t lowEntropyMints = 0; // mint this many blacklisted keys before yielding a clean one
+    uint8_t generateKeyPairCalls = 0;
     void generateKeyPair(uint8_t *pubKey, uint8_t *privKey) override
     {
+        generateKeyPairCalls++;
+        if (lowEntropyMints > 0) {
+            lowEntropyMints--;
+            memcpy(pubKey, COMPROMISED_PUBLIC_KEY, 32);
+            memset(privKey, 0x6F, 32);
+            return;
+        }
         memset(pubKey, 0x5E, 32);
         memset(privKey, 0x5F, 32);
     }
@@ -1852,6 +1860,22 @@ static void test_handleSetConfig_security_reDerivedCleanKeyDoesNotWarn()
     TEST_ASSERT_FALSE(nodeDB->checkLowEntropyPublicKey(config.security.public_key));
     TEST_ASSERT_TRUE(memcmp(COMPROMISED_PUBLIC_KEY, config.security.public_key.bytes, 32) != 0);
     TEST_ASSERT_FALSE(capturedWarningsContain(LOW_ENTROPY_RESTORE_WARNING));
+}
+
+// The replacement for a rejected key is itself checked: a mint that lands back on the blacklist is
+// retried rather than persisted.
+static void test_handleSetConfig_security_blacklistedReplacementIsRetried()
+{
+    RestoreDerivingCryptoEngine *stub = installRestoreCrypto();
+    stub->lowEntropyMints = 1;
+
+    const meshtastic_Config c = makeBareKeyRestoreConfig();
+    testAdmin->deferSaves();
+    testAdmin->handleSetConfig(c, false);
+
+    TEST_ASSERT_EQUAL_UINT(2, stub->generateKeyPairCalls);
+    TEST_ASSERT_FALSE(nodeDB->checkLowEntropyPublicKey(config.security.public_key));
+    TEST_ASSERT_TRUE(capturedWarningsContain(LOW_ENTROPY_RESTORE_WARNING));
 }
 
 // keyIsLowEntropy survives from a boot-time regeneration, and generateCryptoKeyPair returns early on
@@ -2586,6 +2610,7 @@ void setup()
     RUN_TEST(test_handleSetConfig_security_lowEntropyRestoreWarnsAndRotates);
     RUN_TEST(test_handleSetConfig_security_lowEntropyFullKeypairRestoreIsRejected);
     RUN_TEST(test_handleSetConfig_security_reDerivedCleanKeyDoesNotWarn);
+    RUN_TEST(test_handleSetConfig_security_blacklistedReplacementIsRetried);
     RUN_TEST(test_handleSetConfig_security_staleLowEntropyFlagDoesNotWarn);
     RUN_TEST(test_handleSetConfig_security_failedDerivationClearsKeySizes);
     RUN_TEST(test_regionInfo_supportsPreset);


### PR DESCRIPTION
When a user restores/sets an old private key, that is a **private-key change** — the public key is *generated* from it (`regeneratePublicKey` → `Curve25519::eval`), and the node number is `crc32(public_key)`.

The low-entropy blacklist (`checkLowEntropyPublicKey` / `LOW_ENTROPY_HASHES`) is checked in `generateCryptoKeyPair` against the **stored** `config.security.public_key` at function entry. On a bare key restore that field is empty, so a known **pre-2.8 weak key** derived from the provided private key is never caught at set time. It is only detected on the **next boot**, once the weak public key has been persisted and re-checked.

To the user that looks like their saved key silently **"did not stick"** — and their **node number changed** with it — for no visible reason.

## Changes
- **`NodeDB::generateCryptoKeyPair`** — in the provided-private-key branch, re-check the *derived* public key against `LOW_ENTROPY_HASHES`. If it matches, replace it with a fresh secure keypair and set `keyIsLowEntropy` so the reason can be surfaced. (The existing boot-time and existing-private-key paths are unchanged.)
- **`AdminModule` set-config(security)** — when the restore path regenerated a rejected low-entropy key, send a client warning **at set time** explaining the key cannot be restored and the node number changed. Scoped to that branch so a stale `keyIsLowEntropy` from a boot-time regeneration cannot fire on unrelated security sets.
- New `LOW_ENTROPY_RESTORE_WARNING` string. **No protobuf changes** — reuses the existing `ClientNotification` warning path.

Net effect: a restored pre-2.8 low-entropy key is now rejected + rotated **at save time** with a clear explanation, instead of a silent revert discovered after the next reboot.

## Testing
> [!IMPORTANT]
> This was drafted with AI assistance and **has not been built or run on hardware** — it needs CI + on-device verification before merge. The diff is source-only (3 files, +23) and does not touch protobufs.

Suggested manual test: from a client, set `security.private_key` to one of the known pre-2.8 low-entropy keys with an empty public key → expect the `LOW_ENTROPY_RESTORE_WARNING` client notification, a fresh non-blacklisted key, and a changed node number. A companion hardware-free harness (replay device presenting a blacklisted key + the notification) is being added to `meshtastic-mcp` to drive the app-side UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents restoration of known low-entropy keys and key pairs from before version 2.8.
  * Generates a secure replacement key when a weak key is detected.
  * Stops immediately if replacement generation fails or the replacement is also blacklisted, preventing an unusable key pair from being saved.
  * Clears stored key data when deriving a public key from a private key fails.
  * Displays a warning when the original key cannot be restored and the node number changes.
  * Applies low-entropy protection when either the private or associated public key is affected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->