### PR TITLE
fix: play the full RTTTL melody on the I2S buzzer.

### DIFF
--- a/src/buzz/buzz.cpp
+++ b/src/buzz/buzz.cpp
@@ -66,39 +66,31 @@ void playTonesRTTTL(const ToneDuration *tone_durations, int size)
     static std::unordered_map<int, std::string> freqToNote = {
         {NOTE_C3, "c4"},   {NOTE_CS3, "c#4"}, {NOTE_D3, "d4"},   {NOTE_DS3, "d#4"}, {NOTE_E3, "e4"},   {NOTE_F3, "f4"},
         {NOTE_FS3, "f#4"}, {NOTE_G3, "g4"},   {NOTE_GS3, "g#4"}, {NOTE_A3, "a4"},   {NOTE_AS3, "a#4"}, {NOTE_B3, "b4"},
-        {NOTE_C4, "c5"},   {NOTE_E4, "e5"},   {NOTE_G4, "g5"},   {NOTE_A4, "a5"},   {NOTE_C5, "c6"},   {NOTE_E5, "e6"},
-        {NOTE_G5, "g6"},   {NOTE_F5, "f6"},   {NOTE_G6, "g7"},   {NOTE_E7, "e8"}};
+        {NOTE_CS4, "c#5"}, {NOTE_C4, "c5"},   {NOTE_E4, "e5"},   {NOTE_G4, "g5"},   {NOTE_A4, "a5"},   {NOTE_B4, "b5"},
+        {NOTE_C5, "c6"},   {NOTE_E5, "e6"},   {NOTE_G5, "g6"},   {NOTE_F5, "f6"},   {NOTE_G6, "g7"},   {NOTE_E7, "e8"}};
 
     char rtttl[128] = "tone:d=32,o=4,b=200:"; // default duration and octave
     for (int i = 0; i < size; i++) {
         const auto &td = tone_durations[i];
-        std::string note = "b4";
+        std::string note = "p";
         if (freqToNote.find(td.frequency_khz) != freqToNote.end()) {
             note = freqToNote[td.frequency_khz];
         }
-        int dur = 32; // default duration
-        if (td.duration_ms >= 1000)
+        // b=200 makes the whole note 1200ms; pick the nearest 1200ms/duration_ms note length
+        int dur = (1200 + td.duration_ms / 2) / td.duration_ms;
+        if (dur < 1)
             dur = 1;
-        else if (td.duration_ms >= 500)
-            dur = 2;
-        else if (td.duration_ms >= 250)
-            dur = 4;
-        else if (td.duration_ms >= 125)
-            dur = 8;
-        else if (td.duration_ms >= 62)
-            dur = 16;
-        else
-            dur = 32;
 
-        char noteStr[64];
-        snprintf(noteStr, sizeof(noteStr), "%s,%d", note.c_str(), dur);
+        // RTTTL notes must be comma-separated: the parser reads digits until a
+        // non-digit, so without the comma the next note's duration merges into
+        // this note's octave.
+        char noteStr[16];
+        snprintf(noteStr, sizeof(noteStr), "%d%s,", dur, note.c_str());
         strncat(rtttl, noteStr, sizeof(rtttl) - strlen(rtttl) - 1);
-
-        audioThread->beginRttl(rtttl, strlen(rtttl));
-        while (audioThread->isPlaying()) {
-            delay(10);
-        }
-        return;
+    }
+    audioThread->beginRttl(rtttl, strlen(rtttl));
+    while (audioThread->isPlaying()) {
+        delay(10);
     }
 }
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -880,14 +880,6 @@ void setup()
 
     router = new ReliableRouter();
 
-    // only play start melody when role is not tracker or sensor
-    if (config.power.is_power_saving == true &&
-        IS_ONE_OF(config.device.role, meshtastic_Config_DeviceConfig_Role_TRACKER,
-                  meshtastic_Config_DeviceConfig_Role_TAK_TRACKER, meshtastic_Config_DeviceConfig_Role_SENSOR))
-        LOG_DEBUG("Tracker/Sensor: Skip start melody");
-    else
-        playStartMelody();
-
 #if HAS_SCREEN
         // fixed screen override?
         // The geometry picks below are skipped on variants that pin the panel size with
@@ -1175,6 +1167,14 @@ void setup()
     auto rIf = initLoRa();
 
     lateInitVariant(); // Do board specific init (see extra_variants/README.md for documentation)
+
+    // Play only after board-specific peripherals such as external audio codecs are initialized.
+    if (config.power.is_power_saving == true &&
+        IS_ONE_OF(config.device.role, meshtastic_Config_DeviceConfig_Role_TRACKER,
+                  meshtastic_Config_DeviceConfig_Role_TAK_TRACKER, meshtastic_Config_DeviceConfig_Role_SENSOR))
+        LOG_DEBUG("Tracker/Sensor: Skip start melody");
+    else
+        playStartMelody();
 
 #if !MESHTASTIC_EXCLUDE_MQTT
     mqttInit();


### PR DESCRIPTION
The original code suffered from several issues—such as reversed RTTTL note parameters (causing lost durations and incorrect octaves), premature returns within loops (limiting playback to a single note), missing entries in the mapping table, a fallback to note 'b4' for silence, and the startup melody playing before the codec was initialized—resulting in poor performance of system sounds on I2S-equipped boards.

The fix involved updating playTonesRTTTL() to correctly construct the sequence based on duration and note name, allowing the entire melody to play in one go. Additionally, playStartMelody() was moved to after lateInitVariant() to ensure the I2S interface (and the codec) was ready.

This relocation ensures proper I2S audio playback, as the I2S interface is initialized only after audioThread = new AudioThread(); is executed, and some devices initialize the codec within lateInitVariant().

However, this change also affects other devices, resulting in a delay before the startup melody plays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tone playback accuracy by using proportional note durations and correctly handling sharp notes.
  * Unknown frequencies now produce pauses instead of playing an incorrect note.
  * Ensured complete melodies are constructed and started consistently.
  * Startup melodies now play after board initialization, while remaining suppressed for power-saving roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->