### PR TITLE
Actions: Also upload release / nightly builds to R2

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -35,7 +35,8 @@ on:
       #- "**.yml"
 
   schedule:
-    # Nightly develop build, published to meshtastic.github.io firmware-nightly/ (no GitHub release).
+    # Nightly develop build, published to meshtastic.github.io firmware-nightly/ and to the
+    # meshtastic-firmware-nightly R2 bucket (no GitHub release).
     # Scheduled runs execute on the default branch (develop). 07:00 UTC avoids the 00:00 tests
     # and 02:00 daily_packaging crons.
     - cron: 0 7 * * * # Nightly develop build/publish (default branch is develop)
@@ -44,7 +45,7 @@ on:
     inputs:
       # trunk-ignore(checkov/CKV_GHA_7): intentional manual-test switch for the nightly publish path
       nightly:
-        description: "Nightly mode: build + publish develop to github.io firmware-nightly/ (skips creating a GitHub release)"
+        description: "Nightly mode: build + publish develop to github.io firmware-nightly/ and R2 (skips creating a GitHub release)"
         type: boolean
         default: false
 
@@ -649,6 +650,7 @@ jobs:
     env:
       targets: |-
         esp32,esp32s3,esp32c3,esp32c6,nrf52840,rp2040,rp2350,stm32
+      r2_bucket: meshtastic-firmware-release
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -697,10 +699,38 @@ jobs:
           commit_message: ${{ needs.version.outputs.long }}
           enable_jekyll: true
 
+      # Mirror the same staged directory to Cloudflare R2, under a version prefix
+      # at the bucket root. Additive (no --delete), matching keep_files:true
+      # above: release_channels.yml later publishes an updated release_notes.md
+      # into this same prefix, and a --delete sync on a re-run would remove it.
+      - name: Publish firmware to Cloudflare R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          # R2 is single-region; the S3 API still requires a region to be set.
+          AWS_DEFAULT_REGION: auto
+          # Cloudflare's documented aws-cli settings for R2. Left at the AWS
+          # default, CLI >= 2.23 attaches CRC32 request checksums that R2 can
+          # reject, so both of these must stay at when_required.
+          AWS_REQUEST_CHECKSUM_CALCULATION: when_required
+          AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
+          R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          # Same event/* prefixing as the github.io publish above.
+          DEST_PREFIX: ${{ contains(github.ref_name, 'event/') && format('{0}/', github.ref_name) || '' }}
+          VERSION: ${{ needs.version.outputs.long }}
+        run: |
+          set -euo pipefail
+          aws --version
+          aws s3 sync ./publish "s3://${r2_bucket}/${DEST_PREFIX}${VERSION}/" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --no-progress \
+            --cache-control 'public, max-age=3600'
+
   # Nightly publish: refresh the single, stable firmware-nightly/ folder on
-  # meshtastic.github.io with the current develop build. Runs on the cron schedule
-  # (or a manual nightly=true dispatch) and never creates a GitHub release. The
-  # folder's release_notes.md is maintained by hand and deliberately left untouched.
+  # meshtastic.github.io, and the root of the meshtastic-firmware-nightly R2
+  # bucket, with the current develop build. Runs on the cron schedule (or a manual
+  # nightly=true dispatch) and never creates a GitHub release. The folder's
+  # release_notes.md is maintained by hand and deliberately left untouched.
   publish-nightly:
     runs-on: ubuntu-24.04
     if: github.repository_owner == 'meshtastic' && (github.event_name == 'schedule' || github.event.inputs.nightly == 'true')
@@ -708,6 +738,7 @@ jobs:
     env:
       targets: |-
         esp32,esp32s3,esp32c3,esp32c6,nrf52840,rp2040,rp2350,stm32
+      r2_bucket: meshtastic-firmware-nightly
     steps:
       - name: Get firmware artifacts
         uses: actions/download-artifact@v8
@@ -755,6 +786,21 @@ jobs:
       - name: Display structure of files to publish
         run: ls -lR ./stage
 
+      - name: Verify the staged nightly is not empty
+        # Both publishes below refresh their destination in place (keep_files:false
+        # for github.io, --delete for the R2 sync), so an empty ./stage would clear
+        # the live nightly rather than replace it. A failed or pattern-mismatched
+        # artifact download is the way that happens, so fail closed here instead.
+        run: |
+          set -euo pipefail
+          images=$(find ./stage -type f \
+            \( -name 'firmware-*.bin' -o -name 'firmware-*.uf2' -o -name 'firmware-*.hex' \) | wc -l)
+          echo "Staged firmware images: $images"
+          if [ "$images" -eq 0 ]; then
+            echo "::error::No firmware images in ./stage; refusing to publish an empty nightly."
+            exit 1
+          fi
+
       - name: Publish nightly to meshtastic.github.io
         uses: peaceiris/actions-gh-pages@v4
         with:
@@ -771,3 +817,29 @@ jobs:
           user_email: github-actions[bot]@users.noreply.github.com
           commit_message: Nightly ${{ needs.version.outputs.long }}
           enable_jekyll: true
+
+      # Mirror the same staged directory to Cloudflare R2. --delete at the bucket
+      # root is the counterpart of keep_files:false above - it clears stale nightly
+      # binaries - and is in scope for the whole bucket because this bucket holds
+      # nothing but the nightly build. release_notes.md is carried into ./stage by
+      # the step above, so the sync preserves it here too.
+      - name: Publish nightly to Cloudflare R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          # R2 is single-region; the S3 API still requires a region to be set.
+          AWS_DEFAULT_REGION: auto
+          # Cloudflare's documented aws-cli settings for R2. Left at the AWS
+          # default, CLI >= 2.23 attaches CRC32 request checksums that R2 can
+          # reject, so both of these must stay at when_required.
+          AWS_REQUEST_CHECKSUM_CALCULATION: when_required
+          AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
+          R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+        run: |
+          set -euo pipefail
+          aws --version
+          aws s3 sync ./stage "s3://${r2_bucket}/" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --no-progress \
+            --delete \
+            --cache-control 'public, max-age=300'


### PR DESCRIPTION
This pull request updates the nightly build and publish workflow to add Cloudflare R2 as a new destination for firmware artifacts, alongside the existing GitHub Pages publish. It ensures that both the versioned releases and nightly builds are mirrored to R2 buckets, introduces additional safety checks to prevent accidental empty publishes, and clarifies related documentation.

**Cloudflare R2 Integration:**

* Added steps to publish both versioned firmware releases and nightly builds to Cloudflare R2 buckets (`meshtastic-firmware-release` and `meshtastic-firmware-nightly`), using the AWS S3 API for synchronization. [[1]](diffhunk://#diff-5f7cbc65dcf649428e5309064e31eb87a06161f63db5d037d0308ebe07a14bbaR702-R741) [[2]](diffhunk://#diff-5f7cbc65dcf649428e5309064e31eb87a06161f63db5d037d0308ebe07a14bbaR820-R845)
* Configured environment variables and secrets for R2 access, including endpoint, credentials, and bucket names. [[1]](diffhunk://#diff-5f7cbc65dcf649428e5309064e31eb87a06161f63db5d037d0308ebe07a14bbaR653) [[2]](diffhunk://#diff-5f7cbc65dcf649428e5309064e31eb87a06161f63db5d037d0308ebe07a14bbaR702-R741) [[3]](diffhunk://#diff-5f7cbc65dcf649428e5309064e31eb87a06161f63db5d037d0308ebe07a14bbaR820-R845)

**Nightly Build Workflow Improvements:**

* Updated schedule and input descriptions to reflect that nightly builds are now published to both GitHub Pages and Cloudflare R2. [[1]](diffhunk://#diff-5f7cbc65dcf649428e5309064e31eb87a06161f63db5d037d0308ebe07a14bbaL38-R39) [[2]](diffhunk://#diff-5f7cbc65dcf649428e5309064e31eb87a06161f63db5d037d0308ebe07a14bbaL47-R48)
* Added a verification step to ensure the staged nightly directory contains firmware images before publishing, preventing accidental empty publishes that could clear the live nightly artifacts.

**Documentation and Comments:**

* Improved comments throughout the workflow to clarify the behavior of R2 publishing, retention of release notes, and the rationale for additive vs. destructive syncs. [[1]](diffhunk://#diff-5f7cbc65dcf649428e5309064e31eb87a06161f63db5d037d0308ebe07a14bbaL38-R39) [[2]](diffhunk://#diff-5f7cbc65dcf649428e5309064e31eb87a06161f63db5d037d0308ebe07a14bbaR702-R741) [[3]](diffhunk://#diff-5f7cbc65dcf649428e5309064e31eb87a06161f63db5d037d0308ebe07a14bbaR820-R845)

These changes improve artifact availability and resilience by mirroring releases to Cloudflare R2 and make the nightly workflow safer and more robust.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Firmware release builds are now mirrored to Cloudflare R2.
  * Nightly firmware builds are also published to a dedicated R2 location.
  * Nightly publishing now stops when no firmware images are available.

* **Documentation**
  * Publishing descriptions and input details now mention the additional R2 destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->