### PR TITLE
Update ThinkNode M9 (latest MUI updates)

### DIFF
--- a/variants/esp32s3/ELECROW-ThinkNode-M9/platformio.ini
+++ b/variants/esp32s3/ELECROW-ThinkNode-M9/platformio.ini
@@ -91,7 +91,7 @@ build_flags =
 
 lib_deps = 
   ${thinknode_m9_base.lib_deps}
-  https://github.com/meshtastic/device-ui/archive/e8a5ff337d1ead20b290307fb2159ad27fe47f86.zip ; PR314 input-policy
+  https://github.com/meshtastic/device-ui/archive/70a9967f202a69390460c908a1321e475d3d4cdf.zip ; PR314 input-policy
   https://github.com/mverch67/MultiFTPServer/archive/0e854335b9916ed9f2d3bcfe68975ce746992ccd.zip
 
 custom_sdkconfig =


### PR DESCRIPTION
Integrate latest MUI fixes (merge master into PR314):
- persist url template
- fix channel number calculation
- new regions (fixes crash)
- new presets
- default US: long turbo

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] ThinkNode M9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled device interface component to a newer version for the ThinkNode M9 display.
  * No changes were made to FTP functionality or device configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->