### PR TITLE
Bump version (2.8.1)

### DIFF
--- a/.github/workflows/release_channels.yml
+++ b/.github/workflows/release_channels.yml
@@ -93,8 +93,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          # Always use master branch for version bumps
-          ref: master
+          # Always use the default branch for version bumps
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/bin/org.meshtastic.meshtasticd.metainfo.xml
+++ b/bin/org.meshtastic.meshtasticd.metainfo.xml
@@ -90,6 +90,18 @@
   </screenshots>
 
   <releases>
+    <release version="2.8.1" date="2026-09-01">
+      <url type="details">https://github.com/meshtastic/firmware/releases?q=tag%3Av2.8.1</url>
+    </release>
+    <release version="2.8.0" date="2026-06-24">
+      <url type="details">https://github.com/meshtastic/firmware/releases?q=tag%3Av2.8.0</url>
+    </release>
+    <release version="2.7.26" date="2026-06-10">
+      <url type="details">https://github.com/meshtastic/firmware/releases?q=tag%3Av2.7.26</url>
+    </release>
+    <release version="2.7.25" date="2026-05-23">
+      <url type="details">https://github.com/meshtastic/firmware/releases?q=tag%3Av2.7.25</url>
+    </release>
     <release version="2.7.24" date="2026-05-08">
       <url type="details">https://github.com/meshtastic/firmware/releases?q=tag%3Av2.7.24</url>
     </release>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,27 @@
+meshtasticd (2.8.1.0) unstable; urgency=medium
+
+  * Version 2.8.1
+
+ -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Tue, 01 Sep 2026 10:59:38 +0000
+
+meshtasticd (2.8.0.0) unstable; urgency=medium
+
+  * Version 2.8.0
+
+ -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Wed, 24 Jun 2026 11:20:05 +0000
+
+meshtasticd (2.7.26.0) unstable; urgency=medium
+
+  * Version 2.7.26
+
+ -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Wed, 10 Jun 2026 00:19:23 +0000
+
+meshtasticd (2.7.25.0) unstable; urgency=medium
+
+  * Version 2.7.25
+
+ -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Sat, 23 May 2026 01:16:20 +0000
+
 meshtasticd (2.7.24.0) unstable; urgency=medium
 
   * Version 2.7.24
@@ -73,14 +97,6 @@ meshtasticd (2.7.13.0) unstable; urgency=medium
 
 meshtasticd (2.7.12.0) unstable; urgency=medium
 
-  [ Austin Lane ]
-  * Initial packaging
-  * Version 2.5.19
-
-  [  ]
-  * GitHub Actions Automatic version bump
-
-  [ GitHub Actions ]
   * Version 2.7.12
 
  -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Wed, 01 Oct 2025 19:51:41 +0000

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 [VERSION]  
 major = 2
 minor = 8
-build = 0
+build = 1


### PR DESCRIPTION
Bump version to 2.8.1
Fix broken meshtasticd version bumps while we're in here

Replaces #11663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release notes and links for versions 2.7.25 through 2.8.1.
  * Updated the Debian changelog with recent release metadata.

* **Chores**
  * Updated the application build version for the 2.8 release series.
  * Improved release versioning to follow the repository’s configured default branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->