### PR TITLE
fix(gps): remember valid fixes across search cycle

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1363,7 +1363,7 @@ void GPS::up()
 // We've finished a GPS search cycle (lock or timeout). Enter a low power state, potentially.
 void GPS::down()
 {
-    if (hasValidLocation)
+    if (scheduling.hasValidFixSinceSearchStarted())
         scheduling.informGotLock();
     else
         scheduling.informSearchFailed();
@@ -1545,6 +1545,7 @@ int32_t GPS::runOnce()
         // 2. Got a lock for the first time, or 3. Got a lock after turning back on
         bool gotLoc = lookForLocation();
         if (gotLoc) {
+            scheduling.informValidFix();
 #if GPS_DEBUG
             if (!hasValidLocation) { // declare that we have location ASAP
                 LOG_DEBUG("hasValidLocation RISING EDGE");
@@ -1567,7 +1568,7 @@ int32_t GPS::runOnce()
         }
 
         bool tooLong = scheduling.searchedTooLong();
-        if (tooLong && !gotLoc) {
+        if (tooLong && !scheduling.hasValidFixSinceSearchStarted()) {
             LOG_WARN("Can't publish valid location: no GPS lock in time");
             // we didn't get a location during this ack window, therefore declare loss of lock
             if (hasValidLocation) {

--- a/src/gps/GPSUpdateScheduling.cpp
+++ b/src/gps/GPSUpdateScheduling.cpp
@@ -32,7 +32,14 @@ uint32_t gpsHardsleepThresholdMs(uint32_t predictedSearchSecs)
 void GPSUpdateScheduling::informSearching()
 {
     searching = true;
+    validFixReceived = false;
     searchStartedMs = Time::getMillis();
+}
+
+void GPSUpdateScheduling::informValidFix()
+{
+    if (searching)
+        validFixReceived = true;
 }
 
 // Mark the time when searching for GPS is complete,
@@ -64,6 +71,7 @@ void GPSUpdateScheduling::informSearchFailed()
 void GPSUpdateScheduling::reset()
 {
     searching = false;
+    validFixReceived = false;
     searchStartedMs = 0;
     searchEndedMs = 0;
     searchCount = 0;
@@ -150,6 +158,11 @@ bool GPSUpdateScheduling::searchedTooLong()
 
     // Otherwise, not too long yet!
     return false;
+}
+
+bool GPSUpdateScheduling::hasValidFixSinceSearchStarted() const
+{
+    return searching && validFixReceived;
 }
 
 // Updates the predicted time-to-get-lock, by exponentially smoothing the latest observation

--- a/src/gps/GPSUpdateScheduling.h
+++ b/src/gps/GPSUpdateScheduling.h
@@ -12,12 +12,14 @@ class GPSUpdateScheduling
   public:
     // Marks the time of these events, for calculation use
     void informSearching();
+    void informValidFix();
     void informGotLock();      // Predicted lock-time is recalculated here
     void informSearchFailed(); // Search ended without a fix; prediction is left untouched
 
     void reset();           // Reset the prediction - after GPS::disable() / GPS::enable()
     bool isUpdateDue();     // Is it time to begin searching for a GPS position?
     bool searchedTooLong(); // Have we been searching for too long?
+    bool hasValidFixSinceSearchStarted() const;
 
     uint32_t msUntilNextSearch(); // How long until we need to begin searching for a GPS? Info provided to GPS hardware for sleep
     uint32_t elapsedSearchMs();   // How long have we been searching so far?
@@ -26,6 +28,7 @@ class GPSUpdateScheduling
   private:
     void updateLockTimePrediction(); // Called from informGotLock
     bool searching = false;          // Set by the inform*() calls; never inferred from stamp ordering
+    bool validFixReceived = false;
     uint32_t searchStartedMs = 0;
     uint32_t searchEndedMs = 0;
     uint32_t searchCount = 0;


### PR DESCRIPTION
fixes #11693 

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
           RAK WisMesh Tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPS search-cycle tracking to reliably recognize when a valid location fix is acquired.
  * Improved coordination between GPS fix detection and update scheduling, helping ensure location updates are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->