### PR TITLE
fix(position): exempt trackers from reply throttle

### DIFF
--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -282,7 +282,8 @@ meshtastic_MeshPacket *PositionModule::allocPositionPacket(uint32_t atPrecision)
 
 meshtastic_MeshPacket *PositionModule::allocReply()
 {
-    if (config.device.role != meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND && lastSentReply &&
+    if (config.device.role != meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND &&
+        config.device.role != meshtastic_Config_DeviceConfig_Role_TRACKER && lastSentReply &&
         Throttle::isWithinTimespanMs(lastSentReply, 3 * 60 * 1000)) {
         LOG_DEBUG("Skip Position reply: sent one <3min ago");
         ignoreRequest = true; // Mark it as ignored for MeshModule


### PR DESCRIPTION
fixes #11696
## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
     RAK WisMesh Tag


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tracker devices now receive position replies without being blocked by the three-minute reply limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->