### PR TITLE
feat(status-led): add GPIO_HEARTBEAT liveness pin for external watchdogs

### DIFF
--- a/src/modules/StatusLEDModule.cpp
+++ b/src/modules/StatusLEDModule.cpp
@@ -22,6 +22,10 @@ StatusLEDModule::StatusLEDModule() : concurrency::OSThread("StatusLEDModule")
 #ifdef LED_LORA
     loraRxObserver.observe(&RadioInterface::loraRxPacketObservable);
 #endif
+#ifdef GPIO_HEARTBEAT
+    pinMode(GPIO_HEARTBEAT, OUTPUT);
+    digitalWrite(GPIO_HEARTBEAT, GPIO_HEARTBEAT_state);
+#endif
 #ifdef NEOPIXEL_STATUS_POWER_PIN
     powerPixel.begin();
     powerPixel.clear();
@@ -111,6 +115,16 @@ int StatusLEDModule::handleLoRaRx(uint32_t)
 int32_t StatusLEDModule::runOnce()
 {
     my_interval = 1000;
+
+#ifdef GPIO_HEARTBEAT
+    // External-watchdog liveness pin (see StatusLEDModule.h): gated on nothing, so it stops only
+    // when the firmware does. 10 s leaves margin for a 30 s watchdog that retriggers on one edge.
+    if (Throttle::hasElapsed(GPIO_HEARTBEAT_starttime, GPIO_HEARTBEAT_TOGGLE_MS)) {
+        GPIO_HEARTBEAT_state = !GPIO_HEARTBEAT_state;
+        digitalWrite(GPIO_HEARTBEAT, GPIO_HEARTBEAT_state);
+        GPIO_HEARTBEAT_starttime = millis();
+    }
+#endif
 
     if (power_state == charging) {
 #ifndef POWER_LED_HARDWARE_BLINKS_WHILE_CHARGING

--- a/src/modules/StatusLEDModule.h
+++ b/src/modules/StatusLEDModule.h
@@ -13,6 +13,13 @@
 #include "input/InputBroker.h"
 #endif
 
+// GPIO_HEARTBEAT (optional): liveness pin for an external watchdog, toggled every 10 s. Not an LED -
+// no power-state gating, no LED_STATE_ON polarity, no led_heartbeat_disabled. A watchdog a config
+// flag can switch off is not a watchdog; boards wanting a blinking indicator want LED_HEARTBEAT.
+#if defined(GPIO_HEARTBEAT) && defined(LED_HEARTBEAT) && (GPIO_HEARTBEAT == LED_HEARTBEAT)
+#error "GPIO_HEARTBEAT and LED_HEARTBEAT would drive the same pin - pick one"
+#endif
+
 // WS2812/NeoPixel status-LED support. A variant may define
 //   NEOPIXEL_STATUS_POWER_PIN   (required to enable the power/charge pixel)
 //   NEOPIXEL_STATUS_POWER_COLOR (optional, default red 0xFF0000)
@@ -84,6 +91,11 @@ class StatusLEDModule : private concurrency::OSThread
     uint32_t lastUserbuttonTime = 0;
     uint32_t POWER_LED_starttime = 0;
     bool doing_fast_blink = false;
+#ifdef GPIO_HEARTBEAT
+    static constexpr uint32_t GPIO_HEARTBEAT_TOGGLE_MS = 10000;
+    bool GPIO_HEARTBEAT_state = false;
+    uint32_t GPIO_HEARTBEAT_starttime = 0;
+#endif
 #ifdef LED_LORA
     static constexpr uint32_t LORA_RX_LED_FLASH_MS = 100;
     bool LORA_LED_state = LED_STATE_OFF;


### PR DESCRIPTION
Toggles GPIO_HEARTBEAT (unset by default) every 10 s gated on nothing, so an external watchdog keeps seeing edges while charging, unlike LED_HEARTBEAT which is suppressed in the charging and charged states. Refs #11655

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional external watchdog heartbeat support.
  - When enabled, the device periodically toggles a dedicated heartbeat signal every 10 seconds to indicate that the system is running.
  - Added configuration validation to prevent the watchdog heartbeat signal from conflicting with the status LED heartbeat signal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->