### PR TITLE
fix(esp32s3): drop the SenseCAP Indicator's 120 MHz boot clock

### DIFF
--- a/boards/seeed-sensecap-indicator.json
+++ b/boards/seeed-sensecap-indicator.json
@@ -15,7 +15,6 @@
     ],
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "f_boot": "120000000L",
     "boot": "qio",
     "flash_mode": "qio",
     "psram_type": "opi",


### PR DESCRIPTION
Every 2.8.0 build of the Seeed SenseCAP Indicator (2.8.0.7239fe8, 2.8.0.47db0e3, the nightlies) reset-loops on `rst:0x10 (RTCWDT_RTC_RST)` right after the ROM's `entry` line, with no bootloader or app output, also after a full erase and install (#11691). The published artifacts are not the problem: `firmware-seeed-sensecap-indicator{,-tft}-2.8.0.47db0e3.mt.json` and the partition table embedded in the factory image both carry the 8MB layout (app0 0x10000, ota_1 0x5D0000, spiffs 0x670000), identical to 2.7.26, and the web flasher writes exactly those offsets.

### Cause

`boards/seeed-sensecap-indicator.json` is the only board file with `"f_boot": "120000000L"` (added in #5682). Under platformio/espressif32 6.x that key only selected a prebuilt bootloader. Under pioarduino HybridCompile, which the Indicator uses since it moved to the 3.3.11-based core in #11238, `espidf.py` treats `f_boot` as the compile-time clock for both flash and PSRAM. The 2.8.0.47db0e3 CI log for this env prints `Unified frequency mode (>= 80MHz): 120MHz for both Flash and PSRAM` (the T-Deck job prints 80MHz), and the generated sdkconfig carries `CONFIG_ESPTOOLPY_FLASHFREQ_120M=y`, `CONFIG_SPI_FLASH_HPM_ON=y` and `CONFIG_SPIRAM_SPEED_120M=y`. ESP-IDF labels 120 MHz octal PSRAM experimental ("works when the temperature is stable"), flash HPM support "depends on flash model", and when HPM is unsupported or the 120 MHz timing sweep finds no good point IDF only logs a WARN (compiled out at our `CONFIG_LOG_DEFAULT_LEVEL=1`) and enters high-speed mode anyway. With `CONFIG_BOOTLOADER_WDT_ENABLE` the RTC watchdog is only disarmed in the secondary init stage, after flash HPM enable, flash timing tuning and PSRAM init, which is exactly the window a silent `RTCWDT_RTC_RST` loop points at.

This configuration has been in Indicator builds since #10933 (pioarduino 55.03.39 already applied `f_boot` to both clocks) and that PR attested a hardware boot, so the 120 MHz path is unit-dependent (flash model, PSRAM die, temperature) rather than universally fatal. Nothing in 2.8 needs it: 2.7.x ran this board at 80 MHz.

### Change

Remove `f_boot` so the board falls back to `f_flash` (80 MHz) like every other ESP32-S3 board. `boot`/`flash_mode` are unchanged.

### Verification

- `pio run -e seeed-sensecap-indicator` at v2.8.0.47db0e3 with this change: `Unified frequency mode (>= 80MHz): 80MHz for both Flash and PSRAM`, `CONFIG_SPIRAM_SPEED=80`. The resulting bootloader is byte-identical to the T-Deck's 2.8.0.47db0e3 bootloader; the shipped Indicator bootloader differs from it in exactly the 3 bytes that encode the 120 MHz configuration.
- Same env builds on this branch (see the attestation below).
- No Indicator is on my bench, so a boot test on real hardware is still needed, ideally on a unit that currently loops on 2.8.0.47db0e3. If 80 MHz octal PSRAM also proves marginal on this module, `CONFIG_SPIRAM_SPEED_40M=y` (as `t5s3_epaper` does) is the fallback.

Fixes #11691

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described. (build-verified only; no Indicator hardware available, testers with an Indicator welcome)
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)

The change only touches the `seeed-sensecap-indicator` board definition; no other env reads this file, so no other device is affected.
