### PR TITLE
ci(test): shard the native test suite across a matrix

### DIFF
--- a/.github/actions/setup-native-test/action.yml
+++ b/.github/actions/setup-native-test/action.yml
@@ -1,0 +1,52 @@
+name: Setup native test build
+description: >-
+  Minimal toolchain for the native test suites. Separate from setup-native, which is shared with
+  the firmware matrix and is not the place to trim things only the test path can spare.
+
+runs:
+  using: composite
+  steps:
+    # No checkout: the caller must already have one to reference this action at all.
+    - name: Setup Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: 3.x
+        cache: pip
+        cache-dependency-path: |
+          .github/actions/**
+          **.ini
+
+    - name: Install build and test dependencies
+      shell: bash
+      # C libraries are the full setup-native list: they are real link deps of the portduino HAL,
+      # the web server and the config parser. cppcheck is check_tool for `pio check`, not `pio test`.
+      run: |
+        set -euo pipefail
+        sudo apt-get -y update --fix-missing
+        sudo apt-get install -y ccache lcov \
+          libbluetooth-dev libgpiod-dev libyaml-cpp-dev libjsoncpp-dev openssl libssl-dev \
+          libulfius-dev liborcania-dev libusb-1.0-0-dev libi2c-dev libuv1-dev libcurl4-gnutls-dev
+
+    - name: Install PlatformIO
+      shell: bash
+      # No adafruit-nrfutil (nRF52 DFU), poetry, or meshtastic (the client, needed only by the
+      # simulator job), and no `pio upgrade` right after installing the current release.
+      run: |
+        set -euo pipefail
+        python -m pip install --upgrade pip
+        pip install -U --no-build-isolation --no-cache-dir "setuptools<72"
+        pip install -U platformio --no-build-isolation
+
+    - name: Configure ccache
+      shell: bash
+      # /usr/lib/ccache holds compiler-named symlinks, so PATH is the whole wiring. time_macros:
+      # ccache otherwise refuses any TU mentioning __DATE__/__TIME__, which BUILD_EPOCH disables.
+      run: |
+        set -euo pipefail
+        echo "/usr/lib/ccache" >> "$GITHUB_PATH"
+        {
+          echo "CCACHE_DIR=$HOME/.ccache"
+          echo "CCACHE_COMPRESS=1"
+          echo "CCACHE_MAXSIZE=400M"
+          echo "CCACHE_SLOPPINESS=time_macros"
+        } >> "$GITHUB_ENV"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -632,7 +632,7 @@ The project uses GitHub Actions extensively for CI/CD. Key workflows are in `.gi
   - Includes native tests and hardware-in-the-loop testing
 
 - **`test_native.yml`** - Native platform unit tests
-  - Runs `pio test -e native`
+  - Runs the `test/test_*` suites under `[env:coverage]`, sharded across a matrix. `bin/test-shards.py` derives the matrix from the tree - it groups suites into named areas, splits an area too big for one runner and packs the ones too small to fill one - so adding a suite needs no CI change. The `generate-reports` job collects every shard's JUnit report, checks the union against the canonical `test/test_*` set, and states the verdict; `Native PlatformIO Tests` is the single required check over the fan-out.
 
 ### Release Workflows
 
@@ -719,7 +719,7 @@ Unit tests in `test/` directory. The canonical suite count is detected on the fl
 
 **A signal name from the runner is not a crash.** `exit(UNITY_END())` returns the failure count, and PlatformIO's native runner renders a non-zero exit code as a POSIX signal - 4 failures prints `Program received signal SIGILL`, 5 prints `SIGTRAP`, and the suite is reported `[ERRORED]` instead of `[FAILED]`. Check the exit code against the failure count before theorising about memory bugs; confirm any real crash under a debugger.
 
-**Suite order is randomisable.** `./bin/run-tests.sh --shuffle` runs suites in a seeded random order; `--seed <n>` replays one. The seed defaults to the commit SHA (deterministic per commit, varied across commits), is printed at the start and on the `RESULT:` line, and the full order is printed on failure. CI shuffles its area order the same way, seeded from `GITHUB_SHA`. A single green seed is not evidence of order independence.
+**Suite order is randomisable.** `./bin/run-tests.sh --shuffle` runs suites in a seeded random order; `--seed <n>` replays one. The seed defaults to the commit SHA (deterministic per commit, varied across commits), is printed at the start and on the `RESULT:` line, and the full order is printed on failure. CI seeds from `GITHUB_SHA` the same way, but its shards run in parallel, so there the seed varies which suites _share_ a shard rather than the order they run in; `pull_request` keeps the declared arrangement so a contributor's PR never goes red for a pairing they did not choose. A single green seed is not evidence of order independence.
 
 **`-f` is not a gate.** A filtered run can pass while a full run fails, because filtering removes the suites that _create_ the state a later suite trips over. Iterate with `-f`; gate on a full run.
 

--- a/.github/workflows/test_native.yml
+++ b/.github/workflows/test_native.yml
@@ -5,22 +5,34 @@ on:
     inputs:
       suite_order_seed:
         description: >-
-          Seed for shuffling the test-area order. Empty (the default) means: fixed declared order on
-          pull_request, so a contributor's PR never turns red because of an order they did not
-          choose; commit-SHA-derived elsewhere. Set a number to force that exact order anywhere -
-          that is how you replay a shuffled failure.
+          Seed varying which suites share a shard. Empty (the default) means: the fixed declared
+          arrangement on pull_request, so a contributor's PR never turns red because of a pairing
+          they did not choose; commit-SHA-derived elsewhere. Set a number to force that exact
+          arrangement anywhere - that is how you replay a shuffled failure.
         type: string
         required: false
         default: ""
+      max_suites_per_shard:
+        description: >-
+          Largest shard, in suites. Lower splits the matrix further: faster wall clock, more
+          runners. The floor per shard is checkout + toolchain + one src build, so below about 8
+          the fixed cost starts to dominate what is being parallelised.
+        type: number
+        required: false
+        default: 10
   workflow_dispatch:
 
 permissions: {}
 
 env:
-  # Only pushes to the default branch (develop) populate the cache; PR / merge_group runs
+  # Only pushes to the default branch (develop) populate the caches; PR / merge_group runs
   # restore it but never save, so they stop filling up the repo's Actions cache storage.
   SAVE_CACHE: ${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
-  LCOV_CAPTURE_FLAGS: --quiet --capture --include "${PWD}/src/*" --exclude '*/src/mesh/generated/*' --directory .pio/build/coverage/src --base-directory "${PWD}"
+  # Deliberately without --directory: the caller adds it, because the shards capture out of
+  # .pio/build/<env>/src and there is more than one env. Keeping the include/exclude filters in one
+  # place is the part that matters - a shard that captured a different set of files would quietly
+  # skew the merged report.
+  LCOV_CAPTURE_FLAGS: --quiet --capture --include "${PWD}/src/*" --exclude '*/src/mesh/generated/*' --base-directory "${PWD}"
 
 jobs:
   # Tripwire against the native suite set shrinking by accident. `platformio test` discovers and
@@ -184,7 +196,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get install -y lcov
-          lcov ${{ env.LCOV_CAPTURE_FLAGS }} --initial --output-file coverage_base.info
+          lcov ${{ env.LCOV_CAPTURE_FLAGS }} --directory .pio/build/coverage/src --initial --output-file coverage_base.info
           sed -i -e "s#${PWD}#.#" coverage_base.info # Make paths relative.
 
       - name: Config check tests
@@ -234,7 +246,7 @@ jobs:
       - name: Capture coverage information
         if: always() # run this step even if previous step failed
         run: |
-          lcov ${{ env.LCOV_CAPTURE_FLAGS }} --test-name integration --output-file coverage_integration.info
+          lcov ${{ env.LCOV_CAPTURE_FLAGS }} --directory .pio/build/coverage/src --test-name integration --output-file coverage_integration.info
           sed -i -e "s#${PWD}#.#" coverage_integration.info # Make paths relative.
 
       - name: Get release version string
@@ -250,9 +262,109 @@ jobs:
           overwrite: true
           path: ./coverage_*.info
 
+  # Derive the test matrix from the tree instead of restating it here. bin/test-shards.py walks
+  # test/, groups the suites into named areas, splits an area too big for one runner and packs the
+  # ones too small to deserve their own, and emits a row per shard. Nothing about the shape of the
+  # matrix is maintained in this file, so adding a suite needs no CI change - it lands in an area
+  # (or in "misc") and the matrix grows to fit.
+  #
+  # Cheap job, deliberately: a checkout and a python run. It sits on the critical path of every
+  # shard, so it installs nothing.
+  discover:
+    name: Native Test Shards
+    # ubuntu-latest, not the slim image: this needs a python3 to run bin/test-shards.py, and it is
+    # on the critical path of every shard, so it must not have to install one.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.shards.outputs.matrix }}
+      suites: ${{ steps.shards.outputs.suites }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Build the shard matrix
+        id: shards
+        shell: bash
+        # Both inputs reach the script through env: rather than ${{ }} inside run:, so nothing from
+        # the event payload is ever spliced into the shell text.
+        env:
+          SUITE_ORDER_SEED: ${{ inputs.suite_order_seed }}
+          MAX_SUITES: ${{ inputs.max_suites_per_shard || 10 }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+
+          # Which suites share a shard. Fixing it forever means a co-location problem is never
+          # observed; randomising it on a contributor's PR would turn their run red for a pairing
+          # they did not choose, which is how a randomisation gets reverted instead of the coupling
+          # fixed. So: pull_request keeps the declared arrangement, everywhere else is shuffled from
+          # the commit SHA - deterministic per commit, replayable, attributable. An explicit seed
+          # overrides both, which is how you replay a specific failing arrangement anywhere.
+          #
+          # Co-location, not order: PlatformIO picks the order within a shard itself
+          # (list_test_names() walks test/ with os.walk() and filters only *select*, it does not
+          # order), so controlling that still needs one invocation per suite - what
+          # bin/run-tests.sh --shuffle does locally.
+          if [ -n "${SUITE_ORDER_SEED:-}" ]; then
+            seed="$SUITE_ORDER_SEED"
+            echo "shard arrangement: shuffled with explicitly supplied seed $seed"
+          elif [ "${EVENT_NAME:-}" = "pull_request" ]; then
+            seed=""
+            echo "shard arrangement: declared order (pull_request)"
+            echo "  to exercise a different arrangement, re-run this workflow with a suite_order_seed input"
+          else
+            seed=$((16#${GITHUB_SHA:0:8}))
+            echo "shard arrangement: shuffled with seed $seed (from ${GITHUB_SHA:0:8})"
+          fi
+
+          matrix=$(./bin/test-shards.py --max-suites "$MAX_SUITES" --seed "$seed" --summary)
+          # The canonical suite set, passed to the collector so its whole-run gate checks against
+          # the same walk this matrix was built from rather than a second one.
+          suites=$(find test -maxdepth 1 -type d -name 'test_*' -printf '%f\n' | sort | tr '\n' ' ')
+
+          # $GITHUB_OUTPUT is a `key=value` file, so a value containing a newline writes a second
+          # entry - which is how a step's output becomes a way to set outputs the step never meant
+          # to. Both values here are single-line by construction (json.dumps emits one line, tr
+          # folds the suite list onto one); assert it rather than assume it, because the assumption
+          # is the whole reason the injection would go unnoticed.
+          for value in "$matrix" "$suites"; do
+            if [ "$value" != "${value%%$'\n'*}" ]; then
+              echo "::error title=Multi-line step output::bin/test-shards.py or the suite walk produced a value spanning lines. Refusing to write it to \$GITHUB_OUTPUT - a newline there sets outputs this step did not declare."
+              exit 1
+            fi
+          done
+          [ -n "$matrix" ] && [ -n "$suites" ] || {
+            echo "::error title=Empty shard matrix::the matrix or the suite list came out empty; a downstream gate that expects nothing passes on anything."
+            exit 1
+          }
+
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "suites=$suites" >> "$GITHUB_OUTPUT"
+
+  # One shard per matrix row. Each builds only what its own suites need and reports only on them;
+  # the collector below turns the pile of per-shard reports into one verdict.
+  #
+  # There is no build-then-run split any more. It used to compile src plus all ~75 test programs up
+  # front and then run the areas, but PlatformIO links every native test program to the same
+  # $BUILD_DIR/$PROGNAME path, so the run had to relink each suite anyway - the warm-up bought a
+  # shared src build and paid for ~75 throwaway links to get it. A shard gets the same shared src
+  # build for free by simply running its suites in one invocation, and ccache carries the src
+  # objects between shards and between runs.
   platformio-tests:
-    name: Native PlatformIO Tests
+    name: Suites (${{ matrix.shard }})
+    needs: discover
     runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+    # Every shard runs to completion. A cancelled sibling would leave the collector unable to tell
+    # "this suite failed" from "this suite never ran", and the second failure is the one worth
+    # knowing about.
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -266,8 +378,9 @@ jobs:
         run: echo "long=$(./bin/buildinfo.py long)" >> $GITHUB_OUTPUT
         id: version
 
-      # Disable (comment-out) BUILD_EPOCH. It causes a full rebuild between tests and resets the
-      # coverage information each time.
+      # Disable (comment-out) BUILD_EPOCH. It causes a full rebuild between tests, resets the
+      # coverage information each time, and would put a new timestamp in every translation unit -
+      # which is also what would stop ccache from ever hitting.
       - name: Disable BUILD_EPOCH
         run: sed -i 's/-DBUILD_EPOCH=$UNIX_TIME/#-DBUILD_EPOCH=$UNIX_TIME/' platformio.ini
 
@@ -280,214 +393,214 @@ jobs:
           restore-keys: |
             pio-coverage-tests-
 
-      - name: Warm the shared test build
-        # Compiles src + every test program once so no single area absorbs the whole src build in
-        # its reported duration; gcov then accumulates counts into this shared
-        # .pio/build/coverage/src as the areas run. NOT a substitute for building in the run step:
-        # PlatformIO links every test program to the one .pio/build/coverage/meshtasticd path, so a
-        # --without-building run executes whichever suite was linked last under every suite's name.
-        run: platformio test -e coverage --without-testing
+      # Every shard compiles the same ~450 src translation units before it reaches its own suites.
+      # Unshared, that is the cost of fanning out: it would be paid once per shard, every run.
+      # ccache reduces it to a hash lookup. /usr/lib/ccache holds gcc/g++/cc/c++ symlinks to
+      # ccache, so putting it first on PATH is the whole wiring - PlatformIO invokes the compilers
+      # by name.
+      #
+      # time_macros: the coverage build has no __DATE__/__TIME__ that matters (BUILD_EPOCH is
+      # commented out above), and without the sloppiness ccache refuses to cache any TU that
+      # mentions them at all.
+      - name: Set up ccache
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y ccache
+          echo "/usr/lib/ccache" >> "$GITHUB_PATH"
+          {
+            echo "CCACHE_DIR=$HOME/.ccache"
+            echo "CCACHE_COMPRESS=1"
+            echo "CCACHE_MAXSIZE=400M"
+            echo "CCACHE_SLOPPINESS=time_macros"
+          } >> "$GITHUB_ENV"
+
+      - name: Restore ccache
+        id: ccache-restore
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.ccache
+          # One shared lineage for every shard and every env: the src objects are what dominates,
+          # and they are identical across shards. run_id only makes each save a fresh entry; the
+          # prefix restore-key is what actually selects the most recent one.
+          key: ccache-native-tests-${{ github.run_id }}
+          restore-keys: |
+            ccache-native-tests-
+
+      - name: Run this shard's suites
+        id: run
+        shell: bash
+        # Suite names come from bin/test-shards.py, which refuses any name outside
+        # ^test_[A-Za-z0-9_]+$ - so the word-split below cannot pick up shell metacharacters.
+        env:
+          PIO_ENV: ${{ matrix.env }}
+          SHARD: ${{ matrix.shard }}
+          SUITES: ${{ matrix.suites }}
+        run: |
+          set -uo pipefail
+          filters=()
+          for suite in $SUITES; do filters+=(-f "$suite"); done
+          echo "shard $SHARD: ${#filters[@]} suite(s) under [env:$PIO_ENV] -> $SUITES"
+
+          # Capture platformio's real exit status (not grep's) via a log file, then show the log
+          # with the noisy per-variant SKIPPED rows filtered out. Suites outside this shard are
+          # reported SKIPPED by design (PlatformIO lists every suite in the env and marks the
+          # unselected ones finished), so those rows are noise here. The attribution check below is
+          # what catches a suite that was selected and did not run.
+          rc=0
+          platformio test -e "$PIO_ENV" -v "${filters[@]}" \
+            --junit-output-path "testreport-$SHARD.xml" > shard.log 2>&1 || rc=$?
+          grep -v "[[:space:]]SKIPPED$" shard.log || true
+          exit $rc
+
+      - name: Verify this shard ran its own tests
+        # Not conditional on the run passing: a suite that reported another suite's test cases is a
+        # different, worse finding than a failing assertion, and it must not be hidden behind one.
+        if: always()
+        env:
+          SHARD: ${{ matrix.shard }}
+          SUITES: ${{ matrix.suites }}
+        run: ./bin/check-test-attribution.py --label "shard $SHARD" --expect "$SUITES" "testreport-$SHARD.xml"
+
+      - name: Capture coverage information
+        if: always() # run this step even if previous step failed
+        env:
+          PIO_ENV: ${{ matrix.env }}
+          SHARD: ${{ matrix.shard }}
+        run: |
+          sudo apt-get install -y lcov
+          # One tracefile per shard, named after it: the collector merges them with
+          # --add-tracefile, and lcov sums hit counts, so the union is what a single-runner walk
+          # would have produced. --test-name keeps each shard identifiable in the merged report.
+          lcov ${{ env.LCOV_CAPTURE_FLAGS }} --directory ".pio/build/$PIO_ENV/src" \
+            --test-name "$SHARD" --output-file "coverage_tests_$SHARD.info"
+          sed -i -e "s#${PWD}#.#" "coverage_tests_$SHARD.info" # Make paths relative.
+
+      - name: ccache statistics
+        # Printed, not asserted. A cache that has silently stopped hitting shows up here as the
+        # shards getting slower, which is the symptom worth being able to explain.
+        if: always()
+        run: ccache --show-stats || true
+
+      - name: Save ccache
+        # Exactly one shard saves - see the cache_writer note in bin/test-shards.py. Its cache
+        # holds the src objects every other shard needs; letting all of them save would race for
+        # the key and store the same objects a dozen times over.
+        if: always() && env.SAVE_CACHE == 'true' && matrix.cache_writer
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.ccache
+          key: ccache-native-tests-${{ github.run_id }}
 
       - name: Save PlatformIO cache
-        if: env.SAVE_CACHE == 'true' && steps.pio-cache.outputs.cache-hit != 'true'
+        if: env.SAVE_CACHE == 'true' && matrix.cache_writer && steps.pio-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6
         with:
           path: ~/.platformio/.cache
           key: pio-coverage-tests-${{ hashFiles('platformio.ini', 'variants/native/portduino.ini', 'variants/native/portduino/platformio.ini') }}
 
-      - name: Run tests one area at a time
-        shell: bash
-        # Both values reach the script through env: rather than ${{ }} inside run:, so nothing from
-        # the event payload is ever spliced into the shell text.
-        env:
-          SUITE_ORDER_SEED: ${{ inputs.suite_order_seed }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          set -uo pipefail
-          # One runner, no matrix, no concurrency. Group the test_* suites by area and run each
-          # area sequentially, reusing the single build above (--without-building). Each area gets
-          # its own JUnit report and its own collapsible log, so a failure lands in a small named
-          # section instead of being buried past the log limit. Sequential runs share one build
-          # dir, so gcov coverage accumulates and the single capture in the next step has the union.
-
-          # Ordered area rules "name:ERE"; first match wins. Anything unmatched falls to "misc", so
-          # a newly added suite always runs even before it is placed. Add a suite to an area by
-          # extending that area's regex; add a new area by inserting a rule line.
-          area_rules=(
-            "admin:^test_(admin|pki)_"
-            "crypto:^test_(crypto|packet_signing)$"
-            "routing:^test_(mesh|nexthop|traceroute|hop|traffic|nodedb|warm)_"
-            "position:^test_position_"
-            "fuzz:^test_fuzz_"
-            "packets:^test_(packet|transmit|meshpacket)_"
-            "io:^test_(serial|stream|xmodem|http|mqtt)"
-          )
-
-          mapfile -t suites < <(find test -maxdepth 1 -type d -name 'test_*' -printf '%f\n' | sort)
-          declare -A group
-          for s in "${suites[@]}"; do
-            a="misc"
-            for rule in "${area_rules[@]}"; do
-              if [[ "$s" =~ ${rule#*:} ]]; then a="${rule%%:*}"; break; fi
-            done
-            group[$a]="${group[$a]:-} -f $s"
-          done
-
-          run_order=()
-          for rule in "${area_rules[@]}"; do run_order+=("${rule%%:*}"); done
-          run_order+=("misc")
-
-          # Area order. The rule order above is an accident of how the areas were written, and
-          # running it fixed forever means order dependence between areas is never observed - but
-          # randomising it on a contributor's PR would turn their run red for an order they did not
-          # choose, which is how a randomisation gets reverted instead of the coupling fixed.
-          #
-          # So: pull_request keeps the fixed declared order. Everywhere else (push, schedule) the
-          # order is shuffled, seeded from the commit SHA - deterministic per commit, replayable,
-          # attributable, and it never blocks someone else's PR. An explicit seed input overrides
-          # both, which is how you replay a specific failing order anywhere.
-          #
-          # Intra-area order stays PlatformIO's: filters select suites, they do not order them
-          # (list_test_names() walks test/ with os.walk()), so controlling it needs one invocation
-          # per suite. bin/run-tests.sh --shuffle does exactly that locally.
-          seed_input="${SUITE_ORDER_SEED:-}"
-          if [ -n "$seed_input" ]; then
-            seed="$seed_input"
-            echo "area order: shuffled with explicitly supplied seed $seed"
-          elif [ "${EVENT_NAME:-}" = "pull_request" ]; then
-            seed=""
-            echo "area order: fixed declared order (pull_request) - ${run_order[*]}"
-            echo "  to exercise a different order, re-run this workflow with a suite_order_seed input"
-          else
-            seed=$((16#${GITHUB_SHA:0:8}))
-            echo "area order: shuffled with seed $seed (from ${GITHUB_SHA:0:8})"
-          fi
-
-          if [ -n "$seed" ]; then
-            # Same shuffle_suites() bin/run-tests.sh uses, so the replay hint below is true by
-            # construction rather than by two copies happening to agree.
-            source bin/lib/shuffle.sh
-            mapfile -t run_order < <(shuffle_suites "$seed" "${run_order[@]}")
-            echo "area order: ${run_order[*]}"
-            echo "  replay locally: ./bin/run-tests.sh --shuffle --seed $seed"
-          fi
-
-          fail=0
-          for a in "${run_order[@]}"; do
-            [ -n "${group[$a]:-}" ] || continue
-            echo "::group::area $a (${group[$a]# })"
-            # Capture platformio's real exit status (not grep's) via a log file, then show the log
-            # with the noisy per-variant SKIPPED rows filtered out.
-            if ! platformio test -e coverage -v ${group[$a]# } \
-                 --junit-output-path "testreport-$a.xml" > "area-$a.log" 2>&1; then
-              fail=1
-              echo "::error::area $a had test failures"
-            fi
-            # Suites outside this area are reported SKIPPED by design (PlatformIO lists every suite
-            # in the env and marks the unselected ones finished), so those rows are noise here. The
-            # attribution check below is what catches a suite that was selected and did not run.
-            grep -v "[[:space:]]SKIPPED$" "area-$a.log" || true
-            # Per area, so a mismatch names the area it happened in rather than the whole run.
-            if ! ./bin/check-test-attribution.py --label "area $a" \
-                 --expect "${group[$a]# }" "testreport-$a.xml"; then
-              fail=1
-              echo "::error::area $a ran suites that did not match their own test binaries"
-            fi
-            echo "::endgroup::"
-          done
-          exit $fail
-
-      - name: Merge per-area reports into testreport.xml
-        # Preserve the single-file JUnit contract that downstream consumers rely on
-        # (pr_tests.yml's summary and generate-reports' Test Report both read testreport.xml).
-        # The per-area split is only for readable logs; the report stays consolidated.
-        if: always() # run even when a chunk failed, so the report captures the failures
-        shell: bash
-        run: |
-          python3 - <<'PY'
-          import glob, xml.etree.ElementTree as ET
-          out = ET.Element('testsuites')
-          for f in sorted(glob.glob('testreport-*.xml')):
-              try:
-                  root = ET.parse(f).getroot()
-              except ET.ParseError:
-                  continue
-              # PlatformIO writes a <testsuites> root; fold in a bare <testsuite> too, just in case.
-              out.extend(root.findall('testsuite') if root.tag == 'testsuites' else [root])
-          ET.ElementTree(out).write('testreport.xml', encoding='utf-8', xml_declaration=True)
-          PY
-
-      - name: Verify every suite ran its own tests
-        # Whole-run gate over the merged report: every test_* directory must appear with at least
-        # one test case, and every case must come from the suite that reported it. The per-area
-        # check above cannot see an area that never executed - this can.
-        if: always() # a suite going missing is the finding; do not hide it behind an earlier failure
-        shell: bash
-        run: |
-          set -euo pipefail
-          mapfile -t suites < <(find test -maxdepth 1 -type d -name 'test_*' -printf '%f\n' | sort)
-          ./bin/check-test-attribution.py --label "coverage (all areas)" \
-            --expect "${suites[*]}" testreport.xml
-
-      - name: Capture coverage information
-        if: always() # run this step even if previous step failed
-        run: |
-          sudo apt-get install -y lcov
-          lcov ${{ env.LCOV_CAPTURE_FLAGS }} --test-name tests --output-file coverage_tests.info
-          sed -i -e "s#${PWD}#.#" coverage_tests.info # Make paths relative.
-
-      - name: Attribution canary
-        # Guards the guard above: runs two suites the broken way (--without-building, so PlatformIO
-        # does not relink and both execute the same leftover binary) and requires the checker to
-        # catch it. Fails if the checker regressed, or if the reproduction stops reproducing - in
-        # which case the reason both harnesses stopped passing that flag no longer holds.
-        #
-        # Lives in this job, not simulator-tests: it relinks $BUILD_DIR/$PROGNAME, and there that
-        # replaced the daemon binary with a test suite, so the integration test waited for a socket
-        # a test binary never opens. Here the binary is already per-suite and nothing later needs it.
-        timeout-minutes: 15
-        run: ./bin/test-attribution-canary.sh -e coverage
-
-      - name: Event channel policy tests
-        run: platformio test -e coverage-event-policy -v --junit-output-path event-policy-testreport.xml
-
-      - name: Verify the event-policy suites ran their own tests
-        # Expected set read through PlatformIO's own config parser, so it cannot drift from the
-        # env's test_filter the way a second hand-maintained list would.
-        run: |
-          set -euo pipefail
-          expect=$(python3 -c "from platformio.project.config import ProjectConfig; \
-            print(' '.join(ProjectConfig().get('env:coverage-event-policy', 'test_filter', [])))")
-          ./bin/check-test-attribution.py --label coverage-event-policy \
-            --expect "$expect" event-policy-testreport.xml
-
-      - name: Channel table userPrefs tests
-        run: platformio test -e coverage-channel-table -v --junit-output-path channel-table-testreport.xml
-
-      - name: Verify the channel-table suite ran its own tests
-        run: |
-          set -euo pipefail
-          expect=$(python3 -c "from platformio.project.config import ProjectConfig; \
-            print(' '.join(ProjectConfig().get('env:coverage-channel-table', 'test_filter', [])))")
-          ./bin/check-test-attribution.py --label coverage-channel-table \
-            --expect "$expect" channel-table-testreport.xml
-
       - name: Save test results
         if: always() # run this step even if previous step failed
         uses: actions/upload-artifact@v7
         with:
-          name: platformio-test-report-${{ steps.version.outputs.long }}
+          name: platformio-test-report-${{ matrix.shard }}-${{ steps.version.outputs.long }}
           overwrite: true
-          path: ./*testreport.xml
+          # The exact file this shard was told to write, not ./testreport-*.xml. A test suite runs
+          # arbitrary code with the workspace writable; under a glob it could drop a second
+          # testreport-*.xml of its own invention, and the collector merges whatever arrives into
+          # the report its whole-run gate then reads.
+          path: ./testreport-${{ matrix.shard }}.xml
 
       - name: Save coverage information
-        uses: actions/upload-artifact@v7
         if: always() # run this step even if previous step failed
+        uses: actions/upload-artifact@v7
         with:
-          name: lcov-coverage-info-native-platformio-tests-${{ steps.version.outputs.long }}
+          name: lcov-coverage-info-native-shard-${{ matrix.shard }}-${{ steps.version.outputs.long }}
           overwrite: true
-          path: ./coverage_*.info
+          # Named exactly, for the same reason as the report above: everything uploaded here is
+          # merged into the published coverage report.
+          path: ./coverage_tests_${{ matrix.shard }}.info
 
+  # Guards the attribution check the shards rely on: runs two suites the broken way
+  # (--without-building, so PlatformIO does not relink and both execute the same leftover binary)
+  # and requires the checker to catch it. Fails if the checker regressed, or if the reproduction
+  # stops reproducing - in which case the reason both harnesses stopped passing that flag no longer
+  # holds.
+  #
+  # Its own job rather than a step on a shard: it relinks $BUILD_DIR/$PROGNAME on purpose, so it
+  # must not share a build directory with anything whose binary matters, and as a step it would sit
+  # on one shard's critical path for no reason.
+  attribution-canary:
+    name: Attribution Canary
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          submodules: recursive
+
+      - name: Setup native build
+        uses: ./.github/actions/setup-native
+
+      - name: Disable BUILD_EPOCH
+        run: sed -i 's/-DBUILD_EPOCH=$UNIX_TIME/#-DBUILD_EPOCH=$UNIX_TIME/' platformio.ini
+
+      - name: Restore PlatformIO cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.platformio/.cache
+          key: pio-coverage-tests-${{ hashFiles('platformio.ini', 'variants/native/portduino.ini', 'variants/native/portduino/platformio.ini') }}
+          restore-keys: |
+            pio-coverage-tests-
+
+      - name: Set up ccache
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y ccache
+          echo "/usr/lib/ccache" >> "$GITHUB_PATH"
+          {
+            echo "CCACHE_DIR=$HOME/.ccache"
+            echo "CCACHE_COMPRESS=1"
+            echo "CCACHE_MAXSIZE=400M"
+            echo "CCACHE_SLOPPINESS=time_macros"
+          } >> "$GITHUB_ENV"
+
+      - name: Restore ccache
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.ccache
+          key: ccache-native-tests-${{ github.run_id }}
+          restore-keys: |
+            ccache-native-tests-
+
+      - name: Attribution canary
+        timeout-minutes: 15
+        run: ./bin/test-attribution-canary.sh -e coverage
+
+  # Load-bearing name: upstream branch protection matches this check by name, and the matrix rows
+  # are named per shard so none of them can carry it. It exists to be that single required check
+  # over the fan-out, and it says nothing the collector does not - the collector is where a failure
+  # is explained.
+  platformio-tests-gate:
+    name: Native PlatformIO Tests
+    needs: platformio-tests
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-slim
+    steps:
+      - name: Report the matrix result
+        env:
+          RESULT: ${{ needs.platformio-tests.result }}
+        run: |
+          set -euo pipefail
+          echo "shard matrix: $RESULT"
+          [ "$RESULT" = "success" ]
+
+  # The collector. Nothing above it judges the run as a whole: a shard only knows about its own
+  # suites, and a shard that never started reports nothing at all. This is the process that reads
+  # every shard's report together, checks the union against the canonical suite set, and states the
+  # verdict.
   generate-reports:
     name: Generate Test Reports
     runs-on: ubuntu-latest
@@ -496,8 +609,10 @@ jobs:
       actions: read
       checks: write
     needs:
+      - discover
       - simulator-tests
       - platformio-tests
+      - attribution-canary
     # Run this job even if the previous jobs failed, but skip if the workflow was cancelled.
     if: ${{ !cancelled() }}
     steps:
@@ -507,11 +622,64 @@ jobs:
         run: echo "long=$(./bin/buildinfo.py long)" >> $GITHUB_OUTPUT
         id: version
 
-      - name: Download test artifacts
+      - name: Download per-shard test artifacts
         uses: actions/download-artifact@v8
         with:
-          name: platformio-test-report-${{ steps.version.outputs.long }}
+          pattern: platformio-test-report-*-${{ steps.version.outputs.long }}
           merge-multiple: true
+
+      - name: Merge the shard reports into testreport.xml
+        # Preserve the single-file JUnit contract that downstream consumers rely on
+        # (pr_tests.yml's summary and the Test Report below both read testreport.xml). The split is
+        # only how the run is executed; the report stays consolidated.
+        if: always() # run even when a shard failed, so the report captures the failures
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import glob, xml.etree.ElementTree as ET
+          out = ET.Element('testsuites')
+          files = sorted(glob.glob('testreport-*.xml'))
+          for f in files:
+              try:
+                  root = ET.parse(f).getroot()
+              except ET.ParseError:
+                  print(f"WARNING: {f} is not parseable, skipping")
+                  continue
+              # PlatformIO writes a <testsuites> root; fold in a bare <testsuite> too, just in case.
+              out.extend(root.findall('testsuite') if root.tag == 'testsuites' else [root])
+          ET.ElementTree(out).write('testreport.xml', encoding='utf-8', xml_declaration=True)
+          print(f"merged {len(files)} shard report(s) into testreport.xml")
+          PY
+
+      - name: Verdict - every suite ran, and ran its own tests
+        # The gate the shards cannot provide. Each shard checks the suites it was handed; only here
+        # is the union compared against the canonical test_* set, which is what catches a shard that
+        # failed to start, was cancelled, or was dropped from the matrix by a bad edit. The expected
+        # set is the one bin/test-shards.py built the matrix from, so the two cannot disagree.
+        if: always() # a suite going missing is the finding; do not hide it behind an earlier failure
+        env:
+          SUITES: ${{ needs.discover.outputs.suites }}
+        run: |
+          set -euo pipefail
+          # An empty expected set makes this check pass over anything, including an empty report -
+          # and it is empty exactly when `discover` failed, which is one of the situations this
+          # gate exists to catch. It has to fail loudly instead of reporting OK on nothing.
+          if [ -z "${SUITES// /}" ]; then
+            echo "::error title=No expected suite set::the discover job produced no suite list, so the whole-run attribution gate has nothing to check against. Treating that as a failure - a gate with an empty expectation passes vacuously."
+            exit 1
+          fi
+          ./bin/check-test-attribution.py --label "all shards" --expect "$SUITES" testreport.xml
+
+      - name: Save merged test results
+        # Same artifact name the single-runner job used to publish, so pr_tests.yml's summary keeps
+        # finding it.
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: platformio-test-report-${{ steps.version.outputs.long }}
+          overwrite: true
+          path: ./testreport.xml
 
       - name: Drop no-status testsuites from the report
         # PlatformIO emits a self-closing <testsuite tests="0"/> row for every test_* dir
@@ -519,9 +687,11 @@ jobs:
         # They carry no pass/fail/skip status and bury the suites that actually ran. Strip
         # them so the Test Report lists only suites with a real status. Only the copy the
         # reporter renders is trimmed; the uploaded artifact keeps the full XML.
+        if: always()
         run: sed -i -E 's#<testsuite [^>]*tests="0"[^>]*/>##g' testreport.xml
 
       - name: Test Report
+        if: always()
         uses: dorny/test-reporter@v3.0.0
         with:
           name: PlatformIO Tests
@@ -529,6 +699,7 @@ jobs:
           reporter: java-junit
 
       - name: Download coverage artifacts
+        if: always()
         uses: actions/download-artifact@v8
         with:
           pattern: lcov-coverage-info-native-*-${{ steps.version.outputs.long }}
@@ -537,9 +708,10 @@ jobs:
 
       - name: Generate Code Coverage Report
         # Merge every tracefile the jobs produced: coverage_base.info (zeroed baseline),
-        # coverage_integration.info, and one coverage_tests_<chunk>.info per chunk. lcov
-        # sums hit counts across them, so the merged report is the union of all chunks -
+        # coverage_integration.info, and one coverage_tests_<shard>.info per shard. lcov
+        # sums hit counts across them, so the merged report is the union of all shards -
         # identical to running the whole suite in one job.
+        if: always()
         run: |
           sudo apt-get install -y lcov
           args=()
@@ -550,7 +722,56 @@ jobs:
           genhtml --quiet --legend --prefix "${PWD}" code-coverage-report/coverage_src.info --output-directory code-coverage-report
 
       - name: Save Code Coverage Report
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: code-coverage-report-${{ steps.version.outputs.long }}
           path: code-coverage-report
+
+      - name: Final verdict
+        # Last step, and the one that decides. Everything above reports; this states the result of
+        # the run as a whole, so a red is explained in one place instead of being reconstructed from
+        # a dozen shard logs.
+        if: always()
+        env:
+          SHARDS: ${{ needs.platformio-tests.result }}
+          SIMULATOR: ${{ needs.simulator-tests.result }}
+          CANARY: ${{ needs.attribution-canary.result }}
+        run: |
+          set -uo pipefail
+          {
+            echo "## Native tests"
+            echo ""
+            echo "| Part | Result |"
+            echo "| --- | --- |"
+            echo "| Suite shards | \`$SHARDS\` |"
+            echo "| Simulator | \`$SIMULATOR\` |"
+            echo "| Attribution canary | \`$CANARY\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import xml.etree.ElementTree as ET
+          cases = fails = skips = 0
+          failed = []
+          for suite in ET.parse('testreport.xml').getroot().iter('testsuite'):
+              n = int(suite.get('tests', '0'))
+              bad = int(suite.get('failures', '0')) + int(suite.get('errors', '0'))
+              cases += n
+              fails += bad
+              skips += int(suite.get('skipped', '0'))
+              if bad:
+                  failed.append(f"{suite.get('name', '?')} ({bad})")
+          print("")
+          print(f"{cases} test case(s), {fails} failed, {skips} skipped.")
+          if failed:
+              print("")
+              print("Failing suites: " + ", ".join(sorted(failed)))
+          PY
+
+          for result in "$SHARDS" "$SIMULATOR" "$CANARY"; do
+            [ "$result" = "success" ] || {
+              echo "::error title=Native tests failed::shards=$SHARDS simulator=$SIMULATOR canary=$CANARY - see the job summary."
+              exit 1
+            }
+          done
+          echo "RESULT: GREEN - every shard, the simulator, and the canary passed."

--- a/.github/workflows/test_native.yml
+++ b/.github/workflows/test_native.yml
@@ -249,7 +249,7 @@ jobs:
 
       - name: Get release version string
         if: always() # run this step even if previous step failed
-        run: echo "long=$(./bin/buildinfo.py long)" >> $GITHUB_OUTPUT
+        run: echo "long=$(./bin/buildinfo.py long)" >> "$GITHUB_OUTPUT"
         id: version
 
       - name: Save coverage information
@@ -351,7 +351,7 @@ jobs:
         uses: ./.github/actions/setup-native-test
 
       - name: Get release version string
-        run: echo "long=$(./bin/buildinfo.py long)" >> $GITHUB_OUTPUT
+        run: echo "long=$(./bin/buildinfo.py long)" >> "$GITHUB_OUTPUT"
         id: version
 
       # Disable (comment-out) BUILD_EPOCH. It forces a full rebuild between tests, resets coverage each
@@ -543,7 +543,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Get release version string
-        run: echo "long=$(./bin/buildinfo.py long)" >> $GITHUB_OUTPUT
+        run: echo "long=$(./bin/buildinfo.py long)" >> "$GITHUB_OUTPUT"
         id: version
 
       - name: Download per-shard test artifacts

--- a/.github/workflows/test_native.yml
+++ b/.github/workflows/test_native.yml
@@ -28,10 +28,8 @@ env:
   # Only pushes to the default branch (develop) populate the caches; PR / merge_group runs
   # restore it but never save, so they stop filling up the repo's Actions cache storage.
   SAVE_CACHE: ${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
-  # Deliberately without --directory: the caller adds it, because the shards capture out of
-  # .pio/build/<env>/src and there is more than one env. Keeping the include/exclude filters in one
-  # place is the part that matters - a shard that captured a different set of files would quietly
-  # skew the merged report.
+  # No --directory: callers add it, since shards capture from .pio/build/<env>/src. Keeping the
+  # include/exclude filters shared is what stops a shard capturing a different file set.
   LCOV_CAPTURE_FLAGS: --quiet --capture --include "${PWD}/src/*" --exclude '*/src/mesh/generated/*' --base-directory "${PWD}"
 
 jobs:
@@ -262,14 +260,8 @@ jobs:
           overwrite: true
           path: ./coverage_*.info
 
-  # Derive the test matrix from the tree instead of restating it here. bin/test-shards.py walks
-  # test/, groups the suites into named areas, splits an area too big for one runner and packs the
-  # ones too small to deserve their own, and emits a row per shard. Nothing about the shape of the
-  # matrix is maintained in this file, so adding a suite needs no CI change - it lands in an area
-  # (or in "misc") and the matrix grows to fit.
-  #
-  # Cheap job, deliberately: a checkout and a python run. It sits on the critical path of every
-  # shard, so it installs nothing.
+  # bin/test-shards.py derives the matrix from test/, so adding a suite needs no CI change.
+  # Cheap by design: a checkout and a python run, sitting on every shard critical path.
   discover:
     name: Native Test Shards
     # ubuntu-latest, not the slim image: this needs a python3 to run bin/test-shards.py, and it is
@@ -297,17 +289,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Which suites share a shard. Fixing it forever means a co-location problem is never
-          # observed; randomising it on a contributor's PR would turn their run red for a pairing
-          # they did not choose, which is how a randomisation gets reverted instead of the coupling
-          # fixed. So: pull_request keeps the declared arrangement, everywhere else is shuffled from
-          # the commit SHA - deterministic per commit, replayable, attributable. An explicit seed
-          # overrides both, which is how you replay a specific failing arrangement anywhere.
-          #
-          # Co-location, not order: PlatformIO picks the order within a shard itself
-          # (list_test_names() walks test/ with os.walk() and filters only *select*, it does not
-          # order), so controlling that still needs one invocation per suite - what
-          # bin/run-tests.sh --shuffle does locally.
+          # pull_request keeps the declared arrangement so a PR never reds for a pairing its author did not
+          # choose; elsewhere the SHA seeds it. Varies co-location, not order within a shard.
           if [ -n "${SUITE_ORDER_SEED:-}" ]; then
             seed="$SUITE_ORDER_SEED"
             echo "shard arrangement: shuffled with explicitly supplied seed $seed"
@@ -325,11 +308,8 @@ jobs:
           # the same walk this matrix was built from rather than a second one.
           suites=$(find test -maxdepth 1 -type d -name 'test_*' -printf '%f\n' | sort | tr '\n' ' ')
 
-          # $GITHUB_OUTPUT is a `key=value` file, so a value containing a newline writes a second
-          # entry - which is how a step's output becomes a way to set outputs the step never meant
-          # to. Both values here are single-line by construction (json.dumps emits one line, tr
-          # folds the suite list onto one); assert it rather than assume it, because the assumption
-          # is the whole reason the injection would go unnoticed.
+          # A newline in a value writes a second entry, setting outputs this step never declared. Both feed
+          # control flow, so assert single-line rather than assume it.
           for value in "$matrix" "$suites"; do
             if [ "$value" != "${value%%$'\n'*}" ]; then
               echo "::error title=Multi-line step output::bin/test-shards.py or the suite walk produced a value spanning lines. Refusing to write it to \$GITHUB_OUTPUT - a newline there sets outputs this step did not declare."
@@ -344,43 +324,38 @@ jobs:
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           echo "suites=$suites" >> "$GITHUB_OUTPUT"
 
-  # One shard per matrix row. Each builds only what its own suites need and reports only on them;
-  # the collector below turns the pile of per-shard reports into one verdict.
-  #
-  # There is no build-then-run split any more. It used to compile src plus all ~75 test programs up
-  # front and then run the areas, but PlatformIO links every native test program to the same
-  # $BUILD_DIR/$PROGNAME path, so the run had to relink each suite anyway - the warm-up bought a
-  # shared src build and paid for ~75 throwaway links to get it. A shard gets the same shared src
-  # build for free by simply running its suites in one invocation, and ccache carries the src
-  # objects between shards and between runs.
+  # No build-then-run split: PlatformIO relinks each suite regardless, so the warm build bought a
+  # shared src build and ~75 throwaway links. ccache carries src objects between shards instead.
   platformio-tests:
     name: Suites (${{ matrix.shard }})
     needs: discover
     runs-on: ubuntu-24.04-arm
+    # Measured cold-cache shards run 5-12 minutes. Without this a hung suite, or a runner that
+    # stops reporting, holds a runner until GitHub's 6-hour default - times twelve shards.
+    timeout-minutes: 30
     permissions:
       contents: read
-    # Every shard runs to completion. A cancelled sibling would leave the collector unable to tell
-    # "this suite failed" from "this suite never ran", and the second failure is the one worth
-    # knowing about.
+    # fail-fast off: a cancelled sibling stops the collector telling "failed" from "never ran".
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
     steps:
+      # No submodules: src/mesh/generated is tracked and meshtestic is the hardware harness, so neither
+      # is reachable from .
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          submodules: recursive
+          persist-credentials: false
 
-      - name: Setup native build
+      - name: Setup native test build
         id: base
-        uses: ./.github/actions/setup-native
+        uses: ./.github/actions/setup-native-test
 
       - name: Get release version string
         run: echo "long=$(./bin/buildinfo.py long)" >> $GITHUB_OUTPUT
         id: version
 
-      # Disable (comment-out) BUILD_EPOCH. It causes a full rebuild between tests, resets the
-      # coverage information each time, and would put a new timestamp in every translation unit -
-      # which is also what would stop ccache from ever hitting.
+      # Disable (comment-out) BUILD_EPOCH. It forces a full rebuild between tests, resets coverage each
+      # time, and would put a fresh timestamp in every TU, which is also what would defeat ccache.
       - name: Disable BUILD_EPOCH
         run: sed -i 's/-DBUILD_EPOCH=$UNIX_TIME/#-DBUILD_EPOCH=$UNIX_TIME/' platformio.ini
 
@@ -393,36 +368,14 @@ jobs:
           restore-keys: |
             pio-coverage-tests-
 
-      # Every shard compiles the same ~450 src translation units before it reaches its own suites.
-      # Unshared, that is the cost of fanning out: it would be paid once per shard, every run.
-      # ccache reduces it to a hash lookup. /usr/lib/ccache holds gcc/g++/cc/c++ symlinks to
-      # ccache, so putting it first on PATH is the whole wiring - PlatformIO invokes the compilers
-      # by name.
-      #
-      # time_macros: the coverage build has no __DATE__/__TIME__ that matters (BUILD_EPOCH is
-      # commented out above), and without the sloppiness ccache refuses to cache any TU that
-      # mentions them at all.
-      - name: Set up ccache
-        shell: bash
-        run: |
-          set -euo pipefail
-          sudo apt-get install -y ccache
-          echo "/usr/lib/ccache" >> "$GITHUB_PATH"
-          {
-            echo "CCACHE_DIR=$HOME/.ccache"
-            echo "CCACHE_COMPRESS=1"
-            echo "CCACHE_MAXSIZE=400M"
-            echo "CCACHE_SLOPPINESS=time_macros"
-          } >> "$GITHUB_ENV"
-
+      # Every shard compiles the same ~450 src TUs; unshared, that is the cost of fanning out.
       - name: Restore ccache
         id: ccache-restore
         uses: actions/cache/restore@v6
         with:
           path: ~/.ccache
-          # One shared lineage for every shard and every env: the src objects are what dominates,
-          # and they are identical across shards. run_id only makes each save a fresh entry; the
-          # prefix restore-key is what actually selects the most recent one.
+          # One lineage for all shards: src objects dominate and are identical. run_id only makes each save
+          # a fresh entry; the prefix restore-key selects the newest.
           key: ccache-native-tests-${{ github.run_id }}
           restore-keys: |
             ccache-native-tests-
@@ -438,15 +391,15 @@ jobs:
           SUITES: ${{ matrix.suites }}
         run: |
           set -uo pipefail
+          # read -ra, not an unquoted expansion: word-splits without letting a token glob against
+          # the workspace. bin/test-shards.py holds every name to ^test_[A-Za-z0-9_]+$ as well.
+          read -ra suites <<<"$SUITES"
           filters=()
-          for suite in $SUITES; do filters+=(-f "$suite"); done
-          echo "shard $SHARD: ${#filters[@]} suite(s) under [env:$PIO_ENV] -> $SUITES"
+          for suite in "${suites[@]}"; do filters+=(-f "$suite"); done
+          echo "shard $SHARD: ${#suites[@]} suite(s) under [env:$PIO_ENV] -> $SUITES"
 
-          # Capture platformio's real exit status (not grep's) via a log file, then show the log
-          # with the noisy per-variant SKIPPED rows filtered out. Suites outside this shard are
-          # reported SKIPPED by design (PlatformIO lists every suite in the env and marks the
-          # unselected ones finished), so those rows are noise here. The attribution check below is
-          # what catches a suite that was selected and did not run.
+          # Log to a file for platformio real exit status, then drop the per-variant SKIPPED rows: suites
+          # outside this shard are reported SKIPPED by design.
           rc=0
           platformio test -e "$PIO_ENV" -v "${filters[@]}" \
             --junit-output-path "testreport-$SHARD.xml" > shard.log 2>&1 || rc=$?
@@ -469,9 +422,7 @@ jobs:
           SHARD: ${{ matrix.shard }}
         run: |
           sudo apt-get install -y lcov
-          # One tracefile per shard, named after it: the collector merges them with
-          # --add-tracefile, and lcov sums hit counts, so the union is what a single-runner walk
-          # would have produced. --test-name keeps each shard identifiable in the merged report.
+          # One tracefile per shard; the collector sums them with --add-tracefile into the union.
           lcov ${{ env.LCOV_CAPTURE_FLAGS }} --directory ".pio/build/$PIO_ENV/src" \
             --test-name "$SHARD" --output-file "coverage_tests_$SHARD.info"
           sed -i -e "s#${PWD}#.#" "coverage_tests_$SHARD.info" # Make paths relative.
@@ -483,9 +434,8 @@ jobs:
         run: ccache --show-stats || true
 
       - name: Save ccache
-        # Exactly one shard saves - see the cache_writer note in bin/test-shards.py. Its cache
-        # holds the src objects every other shard needs; letting all of them save would race for
-        # the key and store the same objects a dozen times over.
+        # Exactly one shard saves (cache_writer): every shard needs the same src objects, and letting all
+        # of them save would race for the key.
         if: always() && env.SAVE_CACHE == 'true' && matrix.cache_writer
         uses: actions/cache/save@v6
         with:
@@ -505,10 +455,8 @@ jobs:
         with:
           name: platformio-test-report-${{ matrix.shard }}-${{ steps.version.outputs.long }}
           overwrite: true
-          # The exact file this shard was told to write, not ./testreport-*.xml. A test suite runs
-          # arbitrary code with the workspace writable; under a glob it could drop a second
-          # testreport-*.xml of its own invention, and the collector merges whatever arrives into
-          # the report its whole-run gate then reads.
+          # Named, not globbed: a test suite can write to the workspace, and the collector merges whatever
+          # arrives into the report its gate reads.
           path: ./testreport-${{ matrix.shard }}.xml
 
       - name: Save coverage information
@@ -521,15 +469,8 @@ jobs:
           # merged into the published coverage report.
           path: ./coverage_tests_${{ matrix.shard }}.info
 
-  # Guards the attribution check the shards rely on: runs two suites the broken way
-  # (--without-building, so PlatformIO does not relink and both execute the same leftover binary)
-  # and requires the checker to catch it. Fails if the checker regressed, or if the reproduction
-  # stops reproducing - in which case the reason both harnesses stopped passing that flag no longer
-  # holds.
-  #
-  # Its own job rather than a step on a shard: it relinks $BUILD_DIR/$PROGNAME on purpose, so it
-  # must not share a build directory with anything whose binary matters, and as a step it would sit
-  # on one shard's critical path for no reason.
+  # Reproduces the false green on purpose (--without-building) and requires the checker to catch it.
+  # Its own job because it relinks $BUILD_DIR/$PROGNAME, which no shard build dir can survive.
   attribution-canary:
     name: Attribution Canary
     runs-on: ubuntu-24.04-arm
@@ -538,10 +479,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          submodules: recursive
+          persist-credentials: false
 
-      - name: Setup native build
-        uses: ./.github/actions/setup-native
+      - name: Setup native test build
+        uses: ./.github/actions/setup-native-test
 
       - name: Disable BUILD_EPOCH
         run: sed -i 's/-DBUILD_EPOCH=$UNIX_TIME/#-DBUILD_EPOCH=$UNIX_TIME/' platformio.ini
@@ -553,19 +494,6 @@ jobs:
           key: pio-coverage-tests-${{ hashFiles('platformio.ini', 'variants/native/portduino.ini', 'variants/native/portduino/platformio.ini') }}
           restore-keys: |
             pio-coverage-tests-
-
-      - name: Set up ccache
-        shell: bash
-        run: |
-          set -euo pipefail
-          sudo apt-get install -y ccache
-          echo "/usr/lib/ccache" >> "$GITHUB_PATH"
-          {
-            echo "CCACHE_DIR=$HOME/.ccache"
-            echo "CCACHE_COMPRESS=1"
-            echo "CCACHE_MAXSIZE=400M"
-            echo "CCACHE_SLOPPINESS=time_macros"
-          } >> "$GITHUB_ENV"
 
       - name: Restore ccache
         uses: actions/cache/restore@v6
@@ -579,10 +507,8 @@ jobs:
         timeout-minutes: 15
         run: ./bin/test-attribution-canary.sh -e coverage
 
-  # Load-bearing name: upstream branch protection matches this check by name, and the matrix rows
-  # are named per shard so none of them can carry it. It exists to be that single required check
-  # over the fan-out, and it says nothing the collector does not - the collector is where a failure
-  # is explained.
+  # Load-bearing name: branch protection matches it, and matrix rows are named per shard so none of
+  # them can carry it.
   platformio-tests-gate:
     name: Native PlatformIO Tests
     needs: platformio-tests
@@ -597,10 +523,8 @@ jobs:
           echo "shard matrix: $RESULT"
           [ "$RESULT" = "success" ]
 
-  # The collector. Nothing above it judges the run as a whole: a shard only knows about its own
-  # suites, and a shard that never started reports nothing at all. This is the process that reads
-  # every shard's report together, checks the union against the canonical suite set, and states the
-  # verdict.
+  # The collector. A shard knows only its own suites and one that never started reports nothing, so
+  # only here can the union be checked against the canonical set.
   generate-reports:
     name: Generate Test Reports
     runs-on: ubuntu-latest
@@ -629,9 +553,8 @@ jobs:
           merge-multiple: true
 
       - name: Merge the shard reports into testreport.xml
-        # Preserve the single-file JUnit contract that downstream consumers rely on
-        # (pr_tests.yml's summary and the Test Report below both read testreport.xml). The split is
-        # only how the run is executed; the report stays consolidated.
+        # Preserve the single-file JUnit contract downstream consumers rely on (pr_tests.yml summary, and
+        # the Test Report below). The split is only how the run executes; the report stays consolidated.
         if: always() # run even when a shard failed, so the report captures the failures
         shell: bash
         run: |
@@ -653,18 +576,15 @@ jobs:
           PY
 
       - name: Verdict - every suite ran, and ran its own tests
-        # The gate the shards cannot provide. Each shard checks the suites it was handed; only here
-        # is the union compared against the canonical test_* set, which is what catches a shard that
-        # failed to start, was cancelled, or was dropped from the matrix by a bad edit. The expected
-        # set is the one bin/test-shards.py built the matrix from, so the two cannot disagree.
+        # Only here is the union compared against the canonical test_* set, which is what catches a shard
+        # that failed to start or was cancelled.
         if: always() # a suite going missing is the finding; do not hide it behind an earlier failure
         env:
           SUITES: ${{ needs.discover.outputs.suites }}
         run: |
           set -euo pipefail
-          # An empty expected set makes this check pass over anything, including an empty report -
-          # and it is empty exactly when `discover` failed, which is one of the situations this
-          # gate exists to catch. It has to fail loudly instead of reporting OK on nothing.
+          # --expect "" passes over anything, and it is empty exactly when discover failed, which is one of
+          # the situations this gate exists to catch.
           if [ -z "${SUITES// /}" ]; then
             echo "::error title=No expected suite set::the discover job produced no suite list, so the whole-run attribution gate has nothing to check against. Treating that as a failure - a gate with an empty expectation passes vacuously."
             exit 1
@@ -729,9 +649,7 @@ jobs:
           path: code-coverage-report
 
       - name: Final verdict
-        # Last step, and the one that decides. Everything above reports; this states the result of
-        # the run as a whole, so a red is explained in one place instead of being reconstructed from
-        # a dozen shard logs.
+        # States the run result in one place, rather than leaving it reconstructed from a dozen shard logs.
         if: always()
         env:
           SHARDS: ${{ needs.platformio-tests.result }}

--- a/bin/check-test-attribution.py
+++ b/bin/check-test-attribution.py
@@ -55,8 +55,12 @@ def collect(paths):
     cases = {}
     for path in paths:
         try:
-            # The input is the JUnit report PlatformIO just wrote in this same run, not untrusted
-            # data, and defusedxml is not installed for this job.
+            # The input is a JUnit report PlatformIO wrote, not untrusted data, and defusedxml is
+            # not installed for this job. In CI the collector reads these back from artifacts
+            # rather than off the same disk that produced them, so what keeps that true is the
+            # upload step naming the one file the shard was told to write instead of globbing:
+            # a test suite can write to the workspace, and under a glob its own XML would ride
+            # along into the merged report. See .github/workflows/test_native.yml.
             # nosemgrep: python.lang.security.use-defused-xml-parse.use-defused-xml-parse
             root = ET.parse(path).getroot()
         except (ET.ParseError, OSError) as exc:

--- a/bin/test-shards.py
+++ b/bin/test-shards.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Emit the native-test CI matrix: one shard per matrix row, derived from test/.
+
+The native suites used to run on a single runner, one area after another, for the better part of an
+hour. This splits that walk into independent shards that run in parallel and are judged together
+afterwards by the collector job in .github/workflows/test_native.yml.
+
+Sharding is safe because isolation is per suite, not per run: every suite executes under its own
+scratch $HOME (bin/pio-test-isolate.sh, registered as test_testing_command in
+variants/native/portduino/platformio.ini), so no suite can observe another one's leftovers whether
+they share a runner or not.
+
+Two kinds of row come out:
+
+  * general - a slice of the test_* tree, run under [env:coverage]. Suites are placed into named
+    areas by the rules below (first match wins; unmatched falls to "misc", so a brand-new suite
+    always runs even before anyone places it). An area larger than --max-suites is split into
+    numbered shards; areas smaller than that are packed together until a shard is full. Both
+    directions matter: an unsplit area of 41 suites is the hour-long run this replaces, and a shard
+    holding one two-suite area spends more time booting a runner than testing.
+
+  * fixed-env - one row per env in SPECIAL_ENVS. Those envs compile a fixed set of suites with
+    different build flags and carry their own test_filter in platformio.ini; that filter is read
+    from the ini rather than restated here, so it cannot drift from the env it describes.
+
+Usage:
+  bin/test-shards.py                       # matrix JSON on stdout
+  bin/test-shards.py --summary             # ... plus a human-readable table on stderr
+  bin/test-shards.py --max-suites 8        # smaller shards, more of them
+  bin/test-shards.py --seed 12345          # vary which suites share a shard
+
+Exit: 0 ok, 2 on a malformed tree or a fixed env whose test_filter went missing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Ordered "area name" -> regex; first match wins. Extend an area by widening its regex, add an area
+# by inserting a line. Anything unmatched lands in FALLBACK_AREA.
+AREA_RULES = [
+    ("admin", r"^test_(admin|pki)_"),
+    ("crypto", r"^test_(crypto|packet_signing)$"),
+    ("routing", r"^test_(mesh|nexthop|traceroute|hop|traffic|nodedb|warm)_"),
+    ("position", r"^test_position_"),
+    ("fuzz", r"^test_fuzz_"),
+    ("packets", r"^test_(packet|transmit|meshpacket)_"),
+    ("io", r"^test_(serial|stream|xmodem|http|mqtt)"),
+]
+FALLBACK_AREA = "misc"
+
+# Envs that rebuild a fixed set of suites with different build flags. Their test_filter lives in
+# the ini and is read from there.
+NATIVE_INI = REPO / "variants" / "native" / "portduino" / "platformio.ini"
+SPECIAL_ENVS = ["coverage-event-policy", "coverage-channel-table"]
+
+# Suite names reach a shell as `-f <name>` in the workflow. Constrain them at the one place the
+# list is produced, so a directory named something creative cannot become shell text.
+SUITE_RE = re.compile(r"^test_[A-Za-z0-9_]+$")
+
+
+def discover_suites():
+    """Every test_* directory directly under test/, sorted. The canonical set."""
+    suites = sorted(
+        p.name for p in (REPO / "test").iterdir() if p.is_dir() and p.name.startswith("test_")
+    )
+    bad = [s for s in suites if not SUITE_RE.match(s)]
+    if bad:
+        sys.exit(f"test-shards: refusing to shard, unusable suite name(s): {' '.join(bad)}")
+    if not suites:
+        sys.exit("test-shards: no test_* directories under test/ - the tree is not what it should be")
+    return suites
+
+
+def shuffle(seed, items):
+    """Reorder through bin/lib/shuffle.sh, the one implementation of the seeded shuffle.
+
+    Shelling out rather than reimplementing: two copies of a Fisher-Yates cannot be relied on to
+    stay byte-identical, and the way they would announce their drift is a replay that quietly
+    reproduces a different arrangement than the one that failed.
+
+    The repo path arrives as $1 rather than interpolated into the shell text: a checkout directory
+    is not this script's to trust, and a quote or a $ in it would otherwise be shell source.
+    """
+    script = 'source "$1"; shift; shuffle_suites "$@"'
+    out = subprocess.run(
+        ["bash", "-c", script, "_", str(REPO / "bin" / "lib" / "shuffle.sh"), seed, *items],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout.split()
+
+
+def areas_of(suites):
+    """Bucket suites into areas, preserving AREA_RULES order and putting misc last."""
+    grouped = {name: [] for name, _ in AREA_RULES}
+    grouped[FALLBACK_AREA] = []
+    for suite in suites:
+        area = next((name for name, rule in AREA_RULES if re.search(rule, suite)), FALLBACK_AREA)
+        grouped[area].append(suite)
+    return {name: members for name, members in grouped.items() if members}
+
+
+def split(members, cap):
+    """Split into the fewest chunks of at most `cap`, sized as evenly as the count allows.
+
+    Even sizing matters more than the cap itself: a matrix's wall clock is its slowest shard, so 11
+    suites at cap 10 becomes 6+5, not 10+1.
+    """
+    chunks = -(-len(members) // cap)  # ceil
+    base, extra = divmod(len(members), chunks)
+    out, start = [], 0
+    for i in range(chunks):
+        size = base + (1 if i < extra else 0)
+        out.append(members[start : start + size])
+        start += size
+    return out
+
+
+def pack(areas, cap):
+    """Pack whole areas into the fewest shards of at most `cap`, keeping the loads even.
+
+    Longest-processing-time-first: take the areas biggest to smallest and drop each into the
+    emptiest shard. It is the classic greedy for this and lands within 4/3 of optimal, which is far
+    inside the noise of how long a suite actually takes. Plain first-fit would pass the cap check
+    and still leave one shard holding a single area.
+    """
+    bins = [[] for _ in range(-(-sum(len(m) for m in areas.values()) // cap))]
+    for area in sorted(areas, key=lambda a: len(areas[a]), reverse=True):
+        smallest = min(bins, key=lambda b: sum(len(areas[a]) for a in b))
+        smallest.append(area)
+    # Report each shard's areas in declared order, so a name reads the same way the rules do.
+    order = list(areas)
+    return [sorted(b, key=order.index) for b in bins if b]
+
+
+def build(areas, cap):
+    """Lay the areas out into shards of at most `cap` suites. Returns (rows, suites placed)."""
+    rows, placed, small = [], [], {}
+    # Oversized areas become numbered shards of their own; what is left is packed together.
+    for area, members in areas.items():
+        if len(members) <= cap:
+            small[area] = members
+            continue
+        for i, chunk in enumerate(split(members, cap), start=1):
+            rows.append({"shard": f"{area}-{i}", "env": "coverage", "suites": " ".join(chunk)})
+            placed += chunk
+    for group in pack(small, cap):
+        members = [suite for area in group for suite in small[area]]
+        rows.append({"shard": "+".join(group), "env": "coverage", "suites": " ".join(members)})
+        placed += members
+    return rows, placed
+
+
+def fixed_env_filter(env):
+    """The suites [env:<env>] pins in its own test_filter."""
+    # interpolation=None: platformio.ini interpolates with ${section.option}, not configparser's
+    # %(name)s, so a bare % in any value elsewhere in the file would otherwise abort the parse.
+    parser = configparser.ConfigParser(strict=False, interpolation=None)
+    parser.read(NATIVE_INI, encoding="utf-8")
+    section = f"env:{env}"
+    if not parser.has_option(section, "test_filter"):
+        sys.exit(
+            f"test-shards: [{section}] in {NATIVE_INI.name} has no test_filter. It had one when this "
+            f"matrix was written; either restore it or drop {env} from SPECIAL_ENVS - silently "
+            f"emitting an empty filter would run every suite under the wrong build flags."
+        )
+    return parser.get(section, "test_filter").split()
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--max-suites",
+        type=int,
+        default=10,
+        help="largest shard, in suites (default: 10). Lower is faster and costs more runners; the "
+        "per-shard floor is checkout + toolchain + one src build, so past ~8 the fixed cost wins.",
+    )
+    ap.add_argument(
+        "--max-shards",
+        type=int,
+        default=24,
+        help="hard ceiling on matrix rows (default: 24). A budget, not a preference: --max-suites "
+        "is raised until the matrix fits, so no branch can size the fan-out by adding directories.",
+    )
+    ap.add_argument(
+        "--seed",
+        default="",
+        help="vary which suites share a shard. Co-location, not order - PlatformIO picks the order "
+        "within a shard either way. Empty means the declared alphabetical arrangement.",
+    )
+    ap.add_argument("--summary", action="store_true", help="also print the shard table to stderr")
+    args = ap.parse_args()
+
+    if args.max_suites < 1:
+        sys.exit("test-shards: --max-suites must be at least 1")
+    if args.max_shards <= len(SPECIAL_ENVS):
+        sys.exit(f"test-shards: --max-shards must leave room for the {len(SPECIAL_ENVS)} fixed envs")
+
+    suites = discover_suites()
+    areas = areas_of(suites)
+    if args.seed:
+        areas = {area: shuffle(args.seed, members) for area, members in areas.items()}
+
+    # Shard size is a preference; shard count is a budget. The matrix decides how many runners a
+    # single push claims, and the tree it is derived from is whatever the branch under test
+    # contains - a branch that adds a few hundred test_* directories, by accident or otherwise,
+    # would otherwise size the fan-out itself. So --max-suites gives way when the two disagree: the
+    # shards get bigger and the run gets slower, but the number of runners stays bounded by
+    # something this repo chose rather than by the contents of a diff.
+    cap = args.max_suites
+    while True:
+        rows, placed = build(areas, cap)
+        if len(rows) + len(SPECIAL_ENVS) <= args.max_shards:
+            break
+        cap += 1
+    if cap != args.max_suites:
+        print(
+            f"test-shards: {len(suites)} suites would need more than {args.max_shards} shards at "
+            f"--max-suites {args.max_suites}; using {cap} per shard instead.",
+            file=sys.stderr,
+        )
+
+    # The whole point of the fallback area is that nothing can fall out of the matrix. Prove it here
+    # rather than discovering an unrun suite from a coverage graph months later.
+    if sorted(placed) != suites:
+        missing = sorted(set(suites) - set(placed))
+        sys.exit(f"test-shards: {len(missing)} suite(s) reached no shard: {' '.join(missing)}")
+
+    for env in SPECIAL_ENVS:
+        rows.append(
+            {
+                "shard": env.removeprefix("coverage-"),
+                "env": env,
+                "suites": " ".join(fixed_env_filter(env)),
+            }
+        )
+
+    # Exactly one shard writes the shared compiler cache. Every shard compiles the same src/ tree
+    # before it reaches its own suites, so one populated cache serves all of them; letting each
+    # shard save would race for the same key and store the same objects a dozen times over.
+    for row in rows:
+        row["cache_writer"] = False
+    rows[0]["cache_writer"] = True
+
+    if args.summary:
+        width = max(len(row["shard"]) for row in rows)
+        for row in rows:
+            count = len(row["suites"].split())
+            print(
+                f"  {row['shard']:<{width}}  {row['env']:<24} {count:>2} suite(s)", file=sys.stderr
+            )
+        print(
+            f"  {len(rows)} shard(s), {len(suites)} suite(s) in test/, "
+            f"largest shard {max(len(row['suites'].split()) for row in rows)}",
+            file=sys.stderr,
+        )
+
+    print(json.dumps({"include": rows}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/test-shards.py
+++ b/bin/test-shards.py
@@ -1,27 +1,16 @@
 #!/usr/bin/env python3
 """Emit the native-test CI matrix: one shard per matrix row, derived from test/.
 
-The native suites used to run on a single runner, one area after another, for the better part of an
-hour. This splits that walk into independent shards that run in parallel and are judged together
-afterwards by the collector job in .github/workflows/test_native.yml.
-
-Sharding is safe because isolation is per suite, not per run: every suite executes under its own
-scratch $HOME (bin/pio-test-isolate.sh, registered as test_testing_command in
-variants/native/portduino/platformio.ini), so no suite can observe another one's leftovers whether
-they share a runner or not.
+Shards are safe to run in parallel because isolation is per suite, not per run: every suite gets
+its own scratch $HOME via bin/pio-test-isolate.sh.
 
 Two kinds of row come out:
 
-  * general - a slice of the test_* tree, run under [env:coverage]. Suites are placed into named
-    areas by the rules below (first match wins; unmatched falls to "misc", so a brand-new suite
-    always runs even before anyone places it). An area larger than --max-suites is split into
-    numbered shards; areas smaller than that are packed together until a shard is full. Both
-    directions matter: an unsplit area of 41 suites is the hour-long run this replaces, and a shard
-    holding one two-suite area spends more time booting a runner than testing.
+  * general - a slice of the test_* tree under [env:coverage]. AREA_RULES place each suite, first
+    match wins, unmatched to "misc". Areas over --max-suites split, smaller ones pack together.
 
-  * fixed-env - one row per env in SPECIAL_ENVS. Those envs compile a fixed set of suites with
-    different build flags and carry their own test_filter in platformio.ini; that filter is read
-    from the ini rather than restated here, so it cannot drift from the env it describes.
+  * fixed-env - one row per SPECIAL_ENVS entry, whose suite list is read from its test_filter in
+    platformio.ini rather than restated here.
 
 Usage:
   bin/test-shards.py                       # matrix JSON on stdout
@@ -62,8 +51,8 @@ FALLBACK_AREA = "misc"
 NATIVE_INI = REPO / "variants" / "native" / "portduino" / "platformio.ini"
 SPECIAL_ENVS = ["coverage-event-policy", "coverage-channel-table"]
 
-# Suite names reach a shell as `-f <name>` in the workflow. Constrain them at the one place the
-# list is produced, so a directory named something creative cannot become shell text.
+# Suite names reach a shell as `-f <name>`. Constrained here, the one place the list is produced,
+# so a creatively named directory cannot become shell text.
 SUITE_RE = re.compile(r"^test_[A-Za-z0-9_]+$")
 
 
@@ -81,14 +70,10 @@ def discover_suites():
 
 
 def shuffle(seed, items):
-    """Reorder through bin/lib/shuffle.sh, the one implementation of the seeded shuffle.
+    """Reorder via bin/lib/shuffle.sh, the one implementation of the seeded shuffle.
 
-    Shelling out rather than reimplementing: two copies of a Fisher-Yates cannot be relied on to
-    stay byte-identical, and the way they would announce their drift is a replay that quietly
-    reproduces a different arrangement than the one that failed.
-
-    The repo path arrives as $1 rather than interpolated into the shell text: a checkout directory
-    is not this script's to trust, and a quote or a $ in it would otherwise be shell source.
+    Two copies of a Fisher-Yates would drift, and announce it as a replay reproducing a different
+    arrangement. The repo path goes in as $1 so a checkout directory never becomes shell source.
     """
     script = 'source "$1"; shift; shuffle_suites "$@"'
     out = subprocess.run(
@@ -113,8 +98,7 @@ def areas_of(suites):
 def split(members, cap):
     """Split into the fewest chunks of at most `cap`, sized as evenly as the count allows.
 
-    Even sizing matters more than the cap itself: a matrix's wall clock is its slowest shard, so 11
-    suites at cap 10 becomes 6+5, not 10+1.
+    Wall clock is the slowest shard, so 11 suites at cap 10 becomes 6+5, not 10+1.
     """
     chunks = -(-len(members) // cap)  # ceil
     base, extra = divmod(len(members), chunks)
@@ -129,15 +113,19 @@ def split(members, cap):
 def pack(areas, cap):
     """Pack whole areas into the fewest shards of at most `cap`, keeping the loads even.
 
-    Longest-processing-time-first: take the areas biggest to smallest and drop each into the
-    emptiest shard. It is the classic greedy for this and lands within 4/3 of optimal, which is far
-    inside the noise of how long a suite actually takes. Plain first-fit would pass the cap check
-    and still leave one shard holding a single area.
+    Longest-processing-time-first: within 4/3 of optimal, and unlike first-fit it will not leave
+    one shard holding a single two-suite area.
     """
-    bins = [[] for _ in range(-(-sum(len(m) for m in areas.values()) // cap))]
-    for area in sorted(areas, key=lambda a: len(areas[a]), reverse=True):
-        smallest = min(bins, key=lambda b: sum(len(areas[a]) for a in b))
-        smallest.append(area)
+    load = lambda b: sum(len(areas[a]) for a in b)  # noqa: E731
+    ranked = sorted(areas, key=lambda a: len(areas[a]), reverse=True)
+    # ceil(total / cap) is a lower bound, not a guarantee - whole areas do not divide, so three
+    # areas of 6 at cap 10 would put 12 in one of two bins. Grow the count until every bin fits.
+    for count in range(-(-sum(len(m) for m in areas.values()) // cap), len(areas) + 1):
+        bins = [[] for _ in range(count)]
+        for area in ranked:
+            min(bins, key=load).append(area)
+        if all(load(b) <= cap for b in bins):
+            break
     # Report each shard's areas in declared order, so a name reads the same way the rules do.
     order = list(areas)
     return [sorted(b, key=order.index) for b in bins if b]
@@ -174,7 +162,16 @@ def fixed_env_filter(env):
             f"matrix was written; either restore it or drop {env} from SPECIAL_ENVS - silently "
             f"emitting an empty filter would run every suite under the wrong build flags."
         )
-    return parser.get(section, "test_filter").split()
+    # test_filter accepts globs, and these tokens reach the same unquoted word-split and the same
+    # attribution gate as discovered names. Hold them to SUITE_RE too, at the producer.
+    names = parser.get(section, "test_filter").split()
+    bad = [n for n in names if not SUITE_RE.match(n)]
+    if bad:
+        sys.exit(
+            f"test-shards: [{section}] test_filter names something that is not a literal suite: "
+            f"{' '.join(bad)}. The matrix and the attribution gate both need exact names."
+        )
+    return names
 
 
 def main():
@@ -214,12 +211,8 @@ def main():
     if args.seed:
         areas = {area: shuffle(args.seed, members) for area, members in areas.items()}
 
-    # Shard size is a preference; shard count is a budget. The matrix decides how many runners a
-    # single push claims, and the tree it is derived from is whatever the branch under test
-    # contains - a branch that adds a few hundred test_* directories, by accident or otherwise,
-    # would otherwise size the fan-out itself. So --max-suites gives way when the two disagree: the
-    # shards get bigger and the run gets slower, but the number of runners stays bounded by
-    # something this repo chose rather than by the contents of a diff.
+    # Shard size is a preference, shard count is a budget: without this a branch could size the
+    # fan-out by adding directories. --max-suites gives way so the runner count stays bounded.
     cap = args.max_suites
     while True:
         rows, placed = build(areas, cap)
@@ -233,8 +226,7 @@ def main():
             file=sys.stderr,
         )
 
-    # The whole point of the fallback area is that nothing can fall out of the matrix. Prove it here
-    # rather than discovering an unrun suite from a coverage graph months later.
+    # Prove nothing fell out, rather than discovering an unrun suite from a coverage graph later.
     if sorted(placed) != suites:
         missing = sorted(set(suites) - set(placed))
         sys.exit(f"test-shards: {len(missing)} suite(s) reached no shard: {' '.join(missing)}")
@@ -248,9 +240,8 @@ def main():
             }
         )
 
-    # Exactly one shard writes the shared compiler cache. Every shard compiles the same src/ tree
-    # before it reaches its own suites, so one populated cache serves all of them; letting each
-    # shard save would race for the same key and store the same objects a dozen times over.
+    # Exactly one shard writes the shared compiler cache: all of them compile the same src/ tree,
+    # and letting each save would race for the key and store the same objects a dozen times.
     for row in rows:
         row["cache_writer"] = False
     rows[0]["cache_writer"] = True


### PR DESCRIPTION
Splits the native test suite across a dynamically generated matrix and collects the results in a separate job.

## Why

`platformio-tests` was one runner walking every `test_*` suite in sequence, up to an hour of wall clock. It also compiled first and ran second: `platformio test -e coverage --without-testing` built src plus every test program, then the run relinked each suite anyway, because PlatformIO links every native test program to the same `$BUILD_DIR/$PROGNAME`. The warm-up bought a shared src build and paid for ~75 throwaway links to get it.

## Matrix

`bin/test-shards.py` derives the matrix from the tree, so adding a suite needs no CI change. It keeps the existing area rules, splits an area too big for one runner, and packs the ones too small to fill one:

```
routing-1       coverage                 7 suites
routing-2       coverage                 6
misc-1..misc-5  coverage               9,8,8,8,8
position+io     coverage                 8
admin+fuzz      coverage                 7
crypto+packets  coverage                 6
event-policy    coverage-event-policy    5
channel-table   coverage-channel-table   1
```

12 shards, largest 9. `misc` held 41 suites unsplit; `crypto` and `position` held 2 each and would have booted a runner apiece. `--max-shards` (24) bounds the row count so no branch can size the fan-out by adding directories.

Sharding is safe because isolation is already per suite, not per run: every suite executes under its own scratch `$HOME` via `bin/pio-test-isolate.sh`.

## Job graph

```
discover ─┬─> platformio-tests (matrix, fail-fast: false) ─┬─> generate-reports (verdict)
          │                                                │
simulator-tests ────────────────────────────────────────────┤
attribution-canary ─────────────────────────────────────────┘

          platformio-tests ─> Native PlatformIO Tests (required check)
```

`generate-reports` merges every shard's JUnit report, checks the union against the canonical `test/test_*` set, merges the coverage tracefiles, and states the verdict. Only the collector can see a shard that never started, which is why the whole-run attribution gate lives there.

`Native PlatformIO Tests` is kept as a job name so branch protection still has a single required check over the fan-out. The `coverage-event-policy` and `coverage-channel-table` envs and the attribution canary are now matrix rows and a parallel job instead of trailing steps.

## Toolchain

`.github/actions/setup-native-test` is a separate action, not a change to `setup-native`, which is shared with the firmware matrix. It drops the redundant second checkout, both submodules (`src/mesh/generated` is tracked, `meshtestic` is the hardware harness), `cppcheck`, and the `adafruit-nrfutil` / `poetry` / `meshtastic` pip installs, and folds in ccache and lcov. Measured saving: 65s to 43s of per-shard setup.

ccache is wired via `/usr/lib/ccache` on `$GITHUB_PATH`, with one shard flagged `cache_writer` so a single entry is saved rather than twelve racing for the key. Writes stay gated on `SAVE_CACHE`, so **no PR run can populate or benefit from it** - the first populated cache appears only after this merges to develop, and the first run to benefit is the one after that. `ccache --show-stats` prints in every shard, so the hit rate will be visible then. If it does not collapse the duplicated src compile, the ~4.5 min per-shard floor stays and `max_suites_per_shard` should go up.

## Measured

Two full runs on this branch, both with a cold ccache. Per-shard run time was flat between them (`admin+fuzz` 725s / 720s, `crypto+packets` 482s / 480s), which is the evidence that ccache contributed nothing yet.

| | run 1 (contended) | run 2 (free) |
| --- | --- | --- |
| mean shard queue | 579 s | 148 s |
| worst shard queue | 975 s | 302 s |
| shard run phase | ~13 min | ~13 min |

Queue time exceeded run time when the pool was contended. A marginal shard therefore costs a queue slot as well as ~4.5 min of duplicated setup, and the peak/off-peak spread is about 4x - larger than any shard-size tuning. `max_suites_per_shard` is a workflow input (default 10) if that needs revisiting.

Run 1 also lost a runner: one shard sat 48 minutes with its step stuck `in_progress` and its log blob never finalised. The collector correctly refused to pass on partial data. All 9 of that shard's suites pass locally and the shard is green in run 2. `timeout-minutes: 30` now caps the exposure, which would otherwise have been GitHub's 360 minute default times twelve shards.

## Hardening

Script output now feeds `strategy.matrix`, a new data path from a script into workflow control:

- The matrix row count is bounded by `--max-shards`. Without it, `--max-suites 1` produced 77 shards.
- `$GITHUB_OUTPUT` values are rejected if multi-line or empty. A newline there writes additional `key=value` entries, letting a step set outputs it never declared.
- The whole-run attribution gate fails on an empty expected set. `check-test-attribution.py --expect ""` over an empty report returns 0, which is reachable when `discover` fails and the collector still runs.
- Artifact uploads name the exact report and tracefile instead of globbing. A test binary runs arbitrary code with the workspace writable, and the collector merges whatever arrives into the report its gate reads.
- Suite names are held to `^test_[A-Za-z0-9_]+$` at the producer, including the tokens read from a fixed env's `test_filter` (PlatformIO accepts globs there). The shard word-splits with `read -ra` so a token cannot glob against the workspace either.
- `bin/test-shards.py` passes the repo path to `bin/lib/shuffle.sh` as an argument rather than interpolating it into `bash -c` source text.

Verified rather than assumed: no caller passes `secrets:` to this workflow, there is no `pull_request_target` in its trigger path, no event data is spliced into a `run:` block, and cache writes remain gated to pushes on the default branch.

## Notes

`pack()` could exceed `--max-suites`: `ceil(total / cap)` is a lower bound and whole areas do not divide, so three areas of 6 at cap 10 put 12 in one of two bins. Fixed by growing the bin count until every bin fits.

`suite_order_seed` still works but is repurposed. Shards run in parallel, so the seed now varies which suites share a shard rather than the order they run in. `pull_request` keeps the declared arrangement so a contributor's PR never goes red for a pairing they did not choose.

`bin/run-tests.sh` is untouched; local runs are unaffected.

## Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Other (please specify below)

CI-only change, no firmware code touched. This PR's own runs are the test: 19/19 test-native jobs green on the second run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI/CD**
  - Native test runs now discover suites and distribute them across configurable parallel shards.
  - Added deterministic suite shuffling, per-shard attribution checks, coverage artifacts, caching, and consolidated test reports.
  - Added controls for maximum suites per shard and suite-order seeding.
  - Final CI results include shard, simulator, and attribution-canary outcomes.
  - Added streamlined setup for native test builds.

- **Documentation**
  - Updated CI and testing guidance to explain sharding, coverage reporting, and seed behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->