### PR TITLE
fix(stm32wl): advertise canShutdown if HAS_LSE

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1302,7 +1302,11 @@ extern meshtastic_DeviceMetadata getDeviceMetadata()
     meshtastic_DeviceMetadata deviceMetadata = meshtastic_DeviceMetadata_init_default;
     strncpy(deviceMetadata.firmware_version, optstr(APP_VERSION), sizeof(deviceMetadata.firmware_version));
     deviceMetadata.device_state_version = DEVICESTATE_CUR_VER;
+#if defined(ARCH_STM32WL) && HAS_CPU_SHUTDOWN
+    deviceMetadata.canShutdown = stm32wlRtcAvailable();
+#else
     deviceMetadata.canShutdown = pmu_found || HAS_CPU_SHUTDOWN;
+#endif
     deviceMetadata.hasBluetooth = HAS_BLUETOOTH;
     deviceMetadata.hasWifi = HAS_WIFI;
     deviceMetadata.hasEthernet = HAS_ETHERNET;

--- a/src/platform/stm32wl/architecture.h
+++ b/src/platform/stm32wl/architecture.h
@@ -33,6 +33,10 @@
     "HAS_LSE is set but STM32WL_LSE_DRIVE is not defined - set it in the variant's variant.h to one of RCC_LSEDRIVE_LOW/MEDIUMLOW/MEDIUMHIGH/HIGH"
 #endif
 
+#if HAS_LSE && !defined(HAS_CPU_SHUTDOWN)
+#define HAS_CPU_SHUTDOWN 1
+#endif
+
 //
 // set HW_VENDOR
 //

--- a/src/platform/stm32wl/architecture.h
+++ b/src/platform/stm32wl/architecture.h
@@ -35,6 +35,8 @@
 
 #if HAS_LSE && !defined(HAS_CPU_SHUTDOWN)
 #define HAS_CPU_SHUTDOWN 1
+#elif HAS_CPU_SHUTDOWN && !HAS_LSE
+#error "STM32WL: HAS_CPU_SHUTDOWN requires HAS_LSE (RTC wake path)"
 #endif
 
 //


### PR DESCRIPTION
### Problem

On STM32WL, `getDeviceMetadata()` has always reported `canShutdown = false` — the expression is `pmu_found || HAS_CPU_SHUTDOWN`, where `pmu_found` is never set on this architecture and `HAS_CPU_SHUTDOWN` was never defined for it. Client apps use `canShutdown` to show or hide the shutdown control, so shutdown is unavailable from the app on STM32WL boards, even though deep-sleep shutdown has worked since #10993 on `HAS_LSE` builds via `cpuDeepSleep()` → `STM32LowPower::shutdown()`, with the LSE-backed hardware RTC (#10961) as the wake path.

### Solution

Define `HAS_CPU_SHUTDOWN` for `HAS_LSE` STM32WL builds, and on that path report `canShutdown` from the runtime `stm32wlRtcAvailable()` check instead of the static macro. A `HAS_LSE` build whose LSE crystal never locks — where `cpuDeepSleep()` deliberately does `HAL_NVIC_SystemReset()` rather than sleeping — then still reports `canShutdown = false`, matching what the device will actually do.

### Regression safety

The `#else` branch is unchanged, so non-STM32WL targets and STM32WL builds without `HAS_LSE` compute `canShutdown` exactly as before. `HAS_LSE` is defined only on `rak3172` and `nucleo_wl55jc` today; the other four STM32WL variants pick this up if/when #11491 enables `HAS_LSE` for them, with no coupling to this PR.

### Bench-tested

- **`rak3172` (`HAS_LSE`)** — flashed the branch and its merge base over the UART bootloader. `meshtastic --device-metadata` reports `canShutdown: false` on the base and `canShutdown: true` on the branch; the device boots and reconnects normally on both.
- **`wio-e5` (no `HAS_LSE`)** — build-verified; `canShutdown` resolves to the unchanged `pmu_found || HAS_CPU_SHUTDOWN` path.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Other: RAK3172 (STM32WL, hardware-tested); Wio-E5 (build-verified)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device capability reporting on supported STM32WL hardware.
  * CPU shutdown availability is now accurately identified using runtime RTC support.
  * STM32WL devices without the required RTC support no longer appear to offer CPU shutdown, ensuring displayed capabilities better match the hardware’s actual behavior.
  * Added validation to prevent unsupported CPU shutdown configurations on STM32WL devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->