### PR TITLE
fix(metadata): report all compiled-out module configs

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -602,7 +602,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MESHTASTIC_EXCLUDE_ADMIN 1
 #endif
 
-// // Turn off wifi even if HW supports wifi (webserver relies on wifi and is also disabled)
+// Store & Forward is implemented only for ESP32 and Portduino
+#if !defined(ARCH_ESP32) && !defined(ARCH_PORTDUINO) && !defined(MESHTASTIC_EXCLUDE_STOREFORWARD)
+#define MESHTASTIC_EXCLUDE_STOREFORWARD 1
+#endif
+
+// Turn off wifi even if HW supports wifi (webserver relies on wifi and is also disabled)
 #ifdef MESHTASTIC_EXCLUDE_WIFI
 #define MESHTASTIC_EXCLUDE_WEBSERVER 1
 #undef HAS_WIFI

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1317,6 +1317,18 @@ extern meshtastic_DeviceMetadata getDeviceMetadata()
 #if MESHTASTIC_EXCLUDE_AUDIO
     deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_AUDIO_CONFIG;
 #endif
+#if MESHTASTIC_EXCLUDE_MQTT
+    deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_MQTT_CONFIG;
+#endif
+#if MESHTASTIC_EXCLUDE_NEIGHBORINFO
+    deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_NEIGHBORINFO_CONFIG;
+#endif
+#if MESHTASTIC_EXCLUDE_STOREFORWARD
+    deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_STOREFORWARD_CONFIG;
+#endif
+#if !HAS_TELEMETRY
+    deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_TELEMETRY_CONFIG;
+#endif
 // Option to explicitly include canned messages for edge cases, e.g. niche graphics
 #if ((!HAS_SCREEN || NO_EXT_GPIO) || MESHTASTIC_EXCLUDE_CANNEDMESSAGES) && !defined(MESHTASTIC_INCLUDE_NICHE_GRAPHICS)
     deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_CANNEDMSG_CONFIG;
@@ -1333,7 +1345,7 @@ extern meshtastic_DeviceMetadata getDeviceMetadata()
 #if NO_EXT_GPIO && NO_GPS || MESHTASTIC_EXCLUDE_SERIAL
     deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_SERIAL_CONFIG;
 #endif
-#ifndef ARCH_ESP32
+#if !defined(ARCH_ESP32) || MESHTASTIC_EXCLUDE_PAXCOUNTER
     deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_PAXCOUNTER_CONFIG;
 #endif
 #if !defined(HAS_RGB_LED) && !RAK_4631
@@ -1345,14 +1357,12 @@ extern meshtastic_DeviceMetadata getDeviceMetadata()
 // No bluetooth on these targets (yet):
 // Pico W / 2W may get it at some point
 // Portduino and ESP32-C6 are excluded because we don't have a working bluetooth stacks integrated yet.
-#if defined(ARCH_RP2040) || defined(ARCH_PORTDUINO) || defined(ARCH_STM32) || defined(CONFIG_IDF_TARGET_ESP32C6)
+#if defined(ARCH_RP2040) || defined(ARCH_PORTDUINO) || defined(ARCH_STM32) || defined(CONFIG_IDF_TARGET_ESP32C6) || !HAS_BLUETOOTH
     deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_BLUETOOTH_CONFIG;
 #endif
 
-#if defined(ARCH_NRF52) && !HAS_ETHERNET // nrf52 doesn't have network unless it's a RAK ethernet gateway currently
-    deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_NETWORK_CONFIG; // No network on nRF52
-#elif defined(ARCH_RP2040) && !HAS_WIFI && !HAS_ETHERNET
-    deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_NETWORK_CONFIG; // No network on RP2040
+#if !HAS_NETWORKING // covers nRF52 (non-ethernet RAK) and RP2040 without WiFi/ethernet
+    deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_NETWORK_CONFIG;
 #endif
 
 #if !(MESHTASTIC_EXCLUDE_PKI)


### PR DESCRIPTION
### Problem

`getDeviceMetadata().excluded_modules` tells clients which module config screens to hide. Auditing all 15 `ExcludedModules` bits against the registration guards in `src/modules/Modules.cpp`: four are never reported when the module is compiled out (`MQTT`, `NEIGHBOR_INFO`, `STORE_FORWARD`, `TELEMETRY`), and three are set for only a subset of the affected builds (`PAXCOUNTER`, `BLUETOOTH`, `NETWORK`). Clients therefore offer config screens for modules absent from the firmware — MQTT and Store & Forward on every STM32WL / nRF52 / RP2040 target, TELEMETRY on nrf54l15 and minimize builds, NEIGHBOR_INFO on `russell` and several nRF52 RAK boards, NETWORK on all STM32WL.

### Solution

Set the missing bits under the same macros that gate the modules (`MESHTASTIC_EXCLUDE_MQTT`, `MESHTASTIC_EXCLUDE_NEIGHBORINFO`, `MESHTASTIC_EXCLUDE_STOREFORWARD`, `HAS_TELEMETRY`). Widen the three partial conditions: `PAXCOUNTER` also when an ESP32 build sets `MESHTASTIC_EXCLUDE_PAXCOUNTER`; `BLUETOOTH` also when `HAS_BLUETOOTH` is 0; `NETWORK` collapses the per-arch nRF52/RP2040 arms into a single `!HAS_NETWORKING`.

`StoreForwardModule` registers only on `ARCH_ESP32` / `ARCH_PORTDUINO`, but `MESHTASTIC_EXCLUDE_STOREFORWARD` was previously set only by minimize builds and a few variant flags. `configuration.h` now defines it for every other architecture, so it serves as the single availability predicate that both registration and metadata read. Every existing `!MESHTASTIC_EXCLUDE_STOREFORWARD` site is already nested in an `ARCH_ESP32`/`ARCH_PORTDUINO` block, so ESP32 and Portduino builds are unaffected.

### Regression safety

Confined to `getDeviceMetadata()` and one central `#define` in `configuration.h`. The bitmask is advisory — clients use it to hide menu entries; it does not touch the module config wire protocol. No `PhoneAPI`, `NodeDB`, or `AdminModule` changes.

### Bench-tested

`meshtastic --device-metadata` before and after flashing this branch, one variant per architecture:

- **`rak3172` (STM32WL):** `excluded_modules` is `[RANGETEST, CANNEDMSG, AUDIO, REMOTEHARDWARE, AMBIENTLIGHTING, PAXCOUNTER, BLUETOOTH]` on a pre-change build; the branch adds `MQTT_CONFIG`, `NETWORK_CONFIG` and `STOREFORWARD_CONFIG` — all correct, STM32WL builds none of those modules.
- **`heltec-mesh-node-t096` (nRF52840):** `21904` (`[RANGETEST, AUDIO, REMOTEHARDWARE, AMBIENTLIGHTING, PAXCOUNTER, NETWORK]`) on a pre-change build → `21912` on the branch, i.e. `+ STOREFORWARD_CONFIG`; the `NETWORK`/`PAXCOUNTER` condition rewrites leave every other bit unchanged.
- **`tlora-t3s3-v1` (ESP32-S3):** `[RANGETEST, REMOTEHARDWARE, AMBIENTLIGHTING]` — identical before and after; `NETWORK_CONFIG`, `BLUETOOTH_CONFIG`, `PAXCOUNTER_CONFIG` and `STOREFORWARD_CONFIG` all stay absent (ESP32 supports those), so the app keeps offering those screens.
- Native host build also verified. All three boards boot and reconnect normally.

### Related

This is the `getDeviceMetadata()`-only subset of #7838, which was merged and then reverted in `1ac2382d7`. That PR additionally changed `PhoneAPI` config enumeration and `NodeDB` `has_*` defaults; this PR carries none of that.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] RAK3172 — STM32WL
    - [x] Heltec Mesh Node T096 — nRF52840
    - [x] LilyGo T3-S3 — ESP32-S3
    - [x] Native host build
