### PR TITLE
Fix architecture name for Seeed Wio Tracker L2

### DIFF
--- a/bin/platformio-custom.py
+++ b/bin/platformio-custom.py
@@ -255,8 +255,16 @@ def manifest_write(files, env, ram_bytes=None, flash_bytes=None):
         if parsed is not None and parsed != "":
             device_meta[manifest_key] = parsed
 
-    # Determine architecture once; if we can't infer it, skip manifest generation
-    board_arch = device_meta.get("architecture") or infer_architecture(env.BoardConfig())
+    # The board MCU wins over a hand-typed custom_meshtastic_architecture: only the
+    # spellings infer_architecture emits are recognized downstream.
+    declared_arch = device_meta.get("architecture")
+    inferred_arch = infer_architecture(env.BoardConfig())
+    if declared_arch and inferred_arch and declared_arch != inferred_arch:
+        print(
+            f"Overriding declared architecture '{declared_arch}' with '{inferred_arch}' "
+            f"from the board MCU (env={pioenv})"
+        )
+    board_arch = inferred_arch or declared_arch
     if not board_arch:
         print(f"Skipping mtjson write for unknown architecture (env={env.get('PIOENV')})")
         return

--- a/bin/platformio-custom.py
+++ b/bin/platformio-custom.py
@@ -255,16 +255,12 @@ def manifest_write(files, env, ram_bytes=None, flash_bytes=None):
         if parsed is not None and parsed != "":
             device_meta[manifest_key] = parsed
 
-    # The board MCU wins over a hand-typed custom_meshtastic_architecture: only the
+    # Board MCU wins over a hand-typed custom_meshtastic_architecture: only the
     # spellings infer_architecture emits are recognized downstream.
-    declared_arch = device_meta.get("architecture")
-    inferred_arch = infer_architecture(env.BoardConfig())
-    if declared_arch and inferred_arch and declared_arch != inferred_arch:
-        print(
-            f"Overriding declared architecture '{declared_arch}' with '{inferred_arch}' "
-            f"from the board MCU (env={pioenv})"
-        )
-    board_arch = inferred_arch or declared_arch
+    declared = device_meta.get("architecture")
+    board_arch = infer_architecture(env.BoardConfig()) or declared
+    if declared and declared != board_arch:
+        print(f"{pioenv}: architecture '{declared}' overridden with '{board_arch}'")
     if not board_arch:
         print(f"Skipping mtjson write for unknown architecture (env={env.get('PIOENV')})")
         return

--- a/variants/esp32s3/seeed_wio_tracker_L2/platformio.ini
+++ b/variants/esp32s3/seeed_wio_tracker_L2/platformio.ini
@@ -1,7 +1,7 @@
 [env:seeed_wio_tracker_L2]
 custom_meshtastic_hw_model = 137
 custom_meshtastic_hw_model_slug = SEEED_WIO_TRACKER_L2
-custom_meshtastic_architecture = esp32s3
+custom_meshtastic_architecture = esp32-s3
 custom_meshtastic_actively_supported = true
 custom_meshtastic_support_level = 1
 custom_meshtastic_display_name = Seeed Wio Tracker L2


### PR DESCRIPTION
Every other ESP32-S3 board spells it esp32-s3. Across all 109 variants declaring an architecture, this is the only one using esp32s3. The web flasher keys on the hyphenated form, so this board's build manifest carries an architecture string nothing else recognizes. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Seeed Wio Tracker L2 build configuration to correctly identify its ESP32-S3 platform architecture.
  * Improved manifest generation so the detected device architecture takes precedence over conflicting configuration values.
  * Clarified the diagnostic message shown when the detected architecture overrides the configured value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->