### PR TITLE
fix(t-deck-pro-v1_1): link variant.cpp so the LoRa radio is powered on

### DIFF
--- a/variants/esp32s3/t-deck-pro-v1_1/platformio.ini
+++ b/variants/esp32s3/t-deck-pro-v1_1/platformio.ini
@@ -15,6 +15,10 @@ board_level = release
 board = t-deck-pro
 upload_protocol = esptool
 
+build_src_filter =
+  ${esp32s3_base.build_src_filter}
+  +<../variants/esp32s3/t-deck-pro-v1_1>
+
 build_flags = 
   ${esp32s3_base.build_flags} -I variants/esp32s3/t-deck-pro-v1_1
   -D T_DECK_PRO

--- a/variants/esp32s3/t-deck-pro-v1_1/variant.cpp
+++ b/variants/esp32s3/t-deck-pro-v1_1/variant.cpp
@@ -1,0 +1,14 @@
+#include "variant.h"
+#include "Arduino.h"
+
+void earlyInitVariant()
+{
+    pinMode(LORA_EN, OUTPUT);
+    digitalWrite(LORA_EN, HIGH);
+    pinMode(LORA_CS, OUTPUT);
+    digitalWrite(LORA_CS, HIGH);
+    pinMode(SDCARD_CS, OUTPUT);
+    digitalWrite(SDCARD_CS, HIGH);
+    pinMode(PIN_EINK_CS, OUTPUT);
+    digitalWrite(PIN_EINK_CS, HIGH);
+}


### PR DESCRIPTION
## Summary

The LilyGo T-Deck Pro V1.1 (`t-deck-pro-v1_1`) boots into Critical Fault #3 (NoRadio) every time: `LORA_EN` (GPIO 46) is never driven high, so the SX1262 never receives power and is never detected. Every other subsystem on the board comes up normally.

Fixes #11708

## Root cause

`LORA_EN` used to be driven from `src/main.cpp`, guarded by the board define:

```cpp
#elif defined(T_DECK_PRO)
    pinMode(LORA_EN, OUTPUT);
    digitalWrite(LORA_EN, HIGH);
    pinMode(LORA_CS, OUTPUT);
    digitalWrite(LORA_CS, HIGH);
    pinMode(SDCARD_CS, OUTPUT);
    digitalWrite(SDCARD_CS, HIGH);
    pinMode(PIN_EINK_CS, OUTPUT);
    digitalWrite(PIN_EINK_CS, HIGH);
```

Both `t-deck-pro` and `t-deck-pro-v1_1` build with `-D T_DECK_PRO`, so both environments got it.

#9438 ("Move device code from main.cpp to earlyInitVariant", c038cfe69) moved that block into `variants/esp32s3/t-deck-pro/variant.cpp` and linked it by adding a `build_src_filter` to `variants/esp32s3/t-deck-pro/platformio.ini` — only. `t-deck-pro-v1_1` had been added five days earlier (d31d0f85f) and has neither a `variant.cpp` nor a `build_src_filter`, so the guard effectively changed from a `-D` define that v1.1 does have to build-file linkage that it does not.

The failure is silent because `earlyInitVariant()` is a weak symbol with an empty default in `src/main.cpp`; with no strong override linked, the empty body is used and there is no compile or link error. This is the trap the `noinline` comment in `src/NodeDB.cpp` already warns about.

First affected release is v2.7.19 (`git tag --contains c038cfe69`), consistent with the reporter seeing it on 2.7.26 and `develop`.

## Change

Give `t-deck-pro-v1_1` the same `variant.cpp` as `t-deck-pro`, plus the `build_src_filter` that links it. The `variant.cpp` is identical to the v1.0 one, and all four pins it touches (`LORA_EN`, `LORA_CS`, `SDCARD_CS`, `PIN_EINK_CS`) are already defined in `variants/esp32s3/t-deck-pro-v1_1/variant.h`.

This also restores the `LORA_CS` / `SDCARD_CS` / `PIN_EINK_CS` pre-init that v1.1 lost at the same time. All three share the SPI bus and need their chip selects deasserted before the bus is used, so v1.1 has had latent SPI contention beyond the dead radio.

## Follow-ups, deliberately not in this PR

- A more robust fix for both T-Deck Pro environments would be to define `SX126X_POWER_EN 46` in `variant.h` rather than relying on the board-local `LORA_EN`. That macro is handled in `src/mesh/SX126xInterface.cpp`, which is always compiled, so it cannot be dropped by a missing `build_src_filter` again. It additionally powers the radio down in `sleep()`, which `LORA_EN` does not do today on either environment — a behaviour change that wants bench testing, so it is kept out of this fix.
- `variants/rp2040/ec_catsniffer/variant.cpp` has the same class of problem independently: its `platformio.ini` has only `-I`, no `build_src_filter`, so the `initVariant()` that configures the LoRa RF switch (CTF1/CTF2/CTF3) has not been compiled in since #7345. Separate issue; `board_level = extra`.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)

**Untested — no T-Deck Pro V1.1 hardware available, and no PlatformIO build was run.** Please treat this as needing confirmation on the affected board before merge. What can be said for it: the added `variant.cpp` is identical to the one already shipping on `t-deck-pro`, the `build_src_filter` matches that environment's, formatting is clean under the repo's `clang-format` config, and the reporter of #11708 independently confirmed on hardware that driving `LORA_EN` high resolves the fault.

---
_Generated by [Claude Code](https://claude.ai/code/session_019vsPNkUDxX2vKmEYVAEbF8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup behavior for the ESP32-S3 T-Deck Pro v1.1 by properly initializing the LoRa radio, SD card, and e-ink display control signals.
  * Ensured board-specific startup configuration is included when building firmware for this hardware variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->