### PR TITLE
Change default preset from LONG_FAST to LONG_TURBO

### DIFF
--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -109,7 +109,7 @@ const RegionInfo regions[] = {
         https://link.springer.com/content/pdf/bbm%3A978-1-4842-4357-2%2F1.pdf
         https://www.thethingsnetwork.org/docs/lorawan/regional-parameters/
     */
-    RDEF(US, 902.0f, 928.0f, 100, 30, false, false, PROFILE_STD, PRESET(LONG_FAST), 0),
+    RDEF(US, 902.0f, 928.0f, 100, 30, false, false, PROFILE_STD, PRESET(LONG_TURBO), 0),
 
     /*
         EN300220 ETSI V3.2.1 [Table B.1, Item H, p. 21]


### PR DESCRIPTION
This pull request makes a change to the default US region configuration in the `RegionInfo` array. Specifically, it updates the preset used for the US region from `LONG_FAST` to `LONG_TURBO` in `RadioInterface.cpp`. This will change the default on new devices, and the default offered when a client app connects and receives a list of permitted presets.

- Changed the US region preset from `LONG_FAST` to `LONG_TURBO` in the `RegionInfo` array in `RadioInterface.cpp`

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated the default modem preset for the US region to use the Long Turbo configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->