### PR TITLE
Publish the Windows MSI to the nightly page and winget

### DIFF
--- a/.github/workflows/build_windows_bin.yml
+++ b/.github/workflows/build_windows_bin.yml
@@ -7,6 +7,12 @@ on:
         required: false
         default: "2025"
         type: string
+      # WiX and the MSI add several minutes to a job every CI run pays for, so the
+      # installer is built by Daily Packaging alongside the deb/rpm packages instead.
+      build_msi:
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -143,6 +149,7 @@ jobs:
             .pio/build/native-windows/meshtasticd.exe
 
       - name: Install WiX
+        if: inputs.build_msi
         shell: pwsh
         run: |
           dotnet tool install --global wix --version 5.0.2
@@ -150,12 +157,14 @@ jobs:
           & "$env:USERPROFILE\.dotnet\tools\wix.exe" extension add -g WixToolset.Util.wixext/5.0.2
 
       - name: Build the MSI and winget manifests
+        if: inputs.build_msi
         shell: pwsh
         run: ./bin/build-winget-package.ps1 -ReleaseTag "v$env:LONG_VERSION" -Validate
         env:
           LONG_VERSION: ${{ steps.version.outputs.long }}
 
       - name: Store the MSI and winget manifests as an artifact
+        if: inputs.build_msi
         uses: actions/upload-artifact@v7
         with:
           name: meshtasticd-msi-${{ inputs.windows_ver }}-${{ steps.version.outputs.long }}

--- a/.github/workflows/build_windows_bin.yml
+++ b/.github/workflows/build_windows_bin.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: false
         type: boolean
+    outputs:
+      # SignPath addresses the artifact to sign by id, not by name.
+      msi_artifact_id:
+        description: Artifact id of the MSI, empty unless build_msi is set
+        value: ${{ jobs.build-Windows.outputs.msi_artifact_id }}
 
 permissions:
   contents: read
@@ -20,6 +25,8 @@ permissions:
 jobs:
   build-Windows:
     runs-on: windows-${{ inputs.windows_ver }}
+    outputs:
+      msi_artifact_id: ${{ steps.msi-artifact.outputs.artifact-id }}
     # Only pushes to the default branch (develop) populate the cache; PR / merge_group runs
     # restore it but never save, so they stop filling up the repo's Actions cache storage.
     env:
@@ -164,6 +171,7 @@ jobs:
           LONG_VERSION: ${{ steps.version.outputs.long }}
 
       - name: Store the MSI and winget manifests as an artifact
+        id: msi-artifact
         if: inputs.build_msi
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/build_windows_bin.yml
+++ b/.github/workflows/build_windows_bin.yml
@@ -7,8 +7,8 @@ on:
         required: false
         default: "2025"
         type: string
-      # WiX and the MSI add several minutes to a job every CI run pays for, so the
-      # installer is built by Daily Packaging alongside the deb/rpm packages instead.
+      # WiX and the MSI add several minutes to a job every CI run pays for, and only the
+      # release and nightly publishes consume one, so those runs opt in instead.
       build_msi:
         required: false
         default: false

--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -487,6 +487,10 @@ jobs:
     permissions: # Needed for 'gh release upload'.
       contents: write
     runs-on: ubuntu-latest
+    # Lifted to the job so the signing step can branch on it: the secrets context is not
+    # available in a step-level `if`.
+    env:
+      SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
     if: github.repository_owner == 'meshtastic' && github.event_name == 'workflow_dispatch' && github.event.inputs.nightly != 'true'
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
@@ -555,6 +559,35 @@ jobs:
           pattern: meshtasticd-msi-*-${{ needs.version.outputs.long }}
           merge-multiple: true
           path: ./output/msi
+
+      # Signing happens here rather than in the build so it covers release MSIs only:
+      # nightlies never reach this job. It also has to precede the upload below, because
+      # package_winget.yml hashes the published asset, so signing after would leave every
+      # winget manifest pinning a stale SHA256. Skipped with a warning until the secret
+      # exists, which leaves the MSI unsigned rather than failing the release.
+      - name: Sign the MSI
+        if: env.SIGNPATH_API_TOKEN != ''
+        uses: signpath/github-action-submit-signing-request@c92b958760219087e01f8d67a1669ed57afe2627 # v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+          artifact-configuration-slug: ${{ vars.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+          github-artifact-id: ${{ needs.Windows.outputs.msi_artifact_id }}
+          wait-for-completion: true
+          # A SignPath Foundation certificate needs a human to approve each release, so
+          # this waits far longer than the 600s default before giving up.
+          wait-for-completion-timeout-in-seconds: 3600
+          output-artifact-directory: ./output/msi
+
+      - name: Report the MSI signing state
+        run: |
+          if [ -z "${SIGNPATH_API_TOKEN}" ]; then
+            echo "::warning::SIGNPATH_API_TOKEN is not set; publishing an unsigned MSI."
+          else
+            echo "MSI signed by SignPath."
+          fi
 
       - name: Zip Linux sources
         working-directory: output

--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -178,7 +178,7 @@ jobs:
     # secrets: inherit
 
   Windows:
-    if: github.event_name != 'schedule' && github.event.inputs.nightly != 'true' && !contains(github.ref_name, 'event/')
+    if: "!contains(github.ref_name, 'event/')"
     strategy:
       fail-fast: false
       matrix:
@@ -187,6 +187,9 @@ jobs:
     uses: ./.github/workflows/build_windows_bin.yml
     with:
       windows_ver: ${{ matrix.windows_ver }}
+      # WiX and the MSI cost several minutes, and only the release and nightly publishes
+      # consume one. Push, PR and merge_group runs build just the exe.
+      build_msi: ${{ contains(fromJSON('["workflow_dispatch", "schedule"]'), github.event_name) }}
     # secrets: inherit
 
   package-pio-deps-native-tft:
@@ -493,6 +496,7 @@ jobs:
       - gather-artifacts
       - build-debian-src
       - package-pio-deps-native-tft
+      - Windows
       # - MacOS
     steps:
       - name: Checkout
@@ -543,6 +547,15 @@ jobs:
           merge-multiple: true
           path: ./output/pio-deps-native-tft
 
+      # The winget manifests pin the MSI's SHA256 against its release-asset URL, so
+      # the MSI has to reach the release unchanged or `winget install` fails the hash.
+      - name: Download the Windows MSI
+        uses: actions/download-artifact@v8
+        with:
+          pattern: meshtasticd-msi-*-${{ needs.version.outputs.long }}
+          merge-multiple: true
+          path: ./output/msi
+
       - name: Zip Linux sources
         working-directory: output
         run: |
@@ -574,6 +587,7 @@ jobs:
           gh release upload v${{ needs.version.outputs.long }} ./firmware-${{ needs.version.outputs.long }}.json
           gh release upload v${{ needs.version.outputs.long }} ./output/meshtasticd-${{ needs.version.outputs.deb }}-src.zip
           gh release upload v${{ needs.version.outputs.long }} ./output/platformio-deps-native-tft-${{ needs.version.outputs.long }}.zip
+          gh release upload v${{ needs.version.outputs.long }} ./output/msi/*.msi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -736,7 +750,7 @@ jobs:
   publish-nightly:
     runs-on: ubuntu-24.04
     if: github.repository_owner == 'meshtastic' && (github.event_name == 'schedule' || github.event.inputs.nightly == 'true')
-    needs: [setup, version, gather-artifacts]
+    needs: [setup, version, gather-artifacts, Windows]
     env:
       targets: |-
         esp32,esp32s3,esp32c3,esp32c6,nrf52840,rp2040,rp2350,stm32
@@ -748,6 +762,20 @@ jobs:
           pattern: firmware-{${{ env.targets }}}-${{ needs.version.outputs.long }}
           merge-multiple: true
           path: ./stage
+
+      # The nightly MSI is a plain download off firmware-nightly/; it is deliberately
+      # not submitted to winget, which only carries the alpha and beta channels.
+      - name: Get the Windows MSI
+        uses: actions/download-artifact@v8
+        with:
+          pattern: meshtasticd-msi-*-${{ needs.version.outputs.long }}
+          merge-multiple: true
+          path: ./stage
+
+      - name: Drop the winget manifests from the nightly stage
+        # They ship in the same artifact, but their InstallerUrl points at a release
+        # asset the nightly never publishes. Only the MSI belongs on the page.
+        run: rm -rf ./stage/manifests
 
       - name: Generate Release manifest
         run: |

--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -178,7 +178,10 @@ jobs:
     # secrets: inherit
 
   Windows:
-    if: "!contains(github.ref_name, 'event/')"
+    # release-artifacts and publish-nightly both need this job, so a dispatch or schedule
+    # must reach it on any ref. Skipping event/ refs is only about sparing push and PR
+    # runs on those branches the build cost.
+    if: contains(fromJSON('["workflow_dispatch", "schedule"]'), github.event_name) || !contains(github.ref_name, 'event/')
     strategy:
       fail-fast: false
       matrix:
@@ -484,13 +487,14 @@ jobs:
         run: python3 bin/size_report.py ./current-sizes.json --budgets bin/ram_budgets.json --enforce-budgets
 
   release-artifacts:
-    permissions: # Needed for 'gh release upload'.
-      contents: write
+    permissions:
+      contents: write # Needed for 'gh release upload'.
+      actions: read # SignPath pulls the MSI artifact back through the GitHub API.
     runs-on: ubuntu-latest
-    # Lifted to the job so the signing step can branch on it: the secrets context is not
-    # available in a step-level `if`.
+    # Only the flag is lifted to job scope, so the token itself reaches the signing step
+    # and no other: the secrets context is not available in a step-level `if`.
     env:
-      SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+      SIGNPATH_ENABLED: ${{ secrets.SIGNPATH_API_TOKEN != '' }}
     if: github.repository_owner == 'meshtastic' && github.event_name == 'workflow_dispatch' && github.event.inputs.nightly != 'true'
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
@@ -566,7 +570,7 @@ jobs:
       # winget manifest pinning a stale SHA256. Skipped with a warning until the secret
       # exists, which leaves the MSI unsigned rather than failing the release.
       - name: Sign the MSI
-        if: env.SIGNPATH_API_TOKEN != ''
+        if: env.SIGNPATH_ENABLED == 'true'
         uses: signpath/github-action-submit-signing-request@c92b958760219087e01f8d67a1669ed57afe2627 # v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -582,11 +586,20 @@ jobs:
           output-artifact-directory: ./output/msi
 
       - name: Report the MSI signing state
+        # The signed MSI is extracted over the unsigned download, so a name change on
+        # either side would leave both behind and publish whichever the glob hit first.
+        # Fail here instead: package_winget.yml also rejects a release carrying two MSIs.
         run: |
-          if [ -z "${SIGNPATH_API_TOKEN}" ]; then
-            echo "::warning::SIGNPATH_API_TOKEN is not set; publishing an unsigned MSI."
-          else
+          set -euo pipefail
+          count=$(find ./output/msi -maxdepth 1 -name '*.msi' | wc -l)
+          if [ "$count" -ne 1 ]; then
+            echo "::error::Expected exactly one MSI in ./output/msi, found $count."
+            exit 1
+          fi
+          if [ "${SIGNPATH_ENABLED}" = "true" ]; then
             echo "MSI signed by SignPath."
+          else
+            echo "::warning::SIGNPATH_API_TOKEN is not set; publishing an unsigned MSI."
           fi
 
       - name: Zip Linux sources

--- a/.github/workflows/package_winget.yml
+++ b/.github/workflows/package_winget.yml
@@ -26,17 +26,18 @@ on:
         required: false
   workflow_dispatch:
     inputs:
+      # trunk-ignore(checkov/CKV_GHA_7): intentional manual switch for repackaging a published release
       release_tag:
         description: "Release tag to package (blank: the newest release)"
         required: false
         type: string
       package_identifier:
-        description: "winget PackageIdentifier (Meshtastic.Meshtasticd is the beta/default channel)"
+        description: winget PackageIdentifier (Meshtastic.Meshtasticd is the beta/default channel)
         required: false
         default: Meshtastic.Meshtasticd.Alpha
         type: string
       submit:
-        description: "Open a winget-pkgs pull request instead of only validating"
+        description: Open a winget-pkgs pull request instead of only validating
         required: false
         default: false
         type: boolean

--- a/.github/workflows/package_winget.yml
+++ b/.github/workflows/package_winget.yml
@@ -15,6 +15,10 @@ on:
       package_identifier:
         required: true
         type: string
+      submit:
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       release_tag:
@@ -26,6 +30,11 @@ on:
         required: false
         default: Meshtastic.Meshtasticd.Alpha
         type: string
+      submit:
+        description: "Open a winget-pkgs pull request instead of only validating"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -59,8 +68,14 @@ jobs:
           RELEASE_TAG: ${{ inputs.release_tag }}
 
       - name: Generate manifests for the published MSI
+        id: manifests
         shell: pwsh
-        run: ./bin/build-winget-package.ps1 -MsiPath $env:MSI_PATH -Version $env:PKG_VERSION -Architecture $env:PKG_ARCH -ReleaseTag $env:RELEASE_TAG -PackageIdentifier $env:PKG_ID -Validate
+        run: |
+          # `winget validate` writes to the success stream, so take the trailing
+          # result object rather than the whole pipeline.
+          $result = ./bin/build-winget-package.ps1 -MsiPath $env:MSI_PATH -Version $env:PKG_VERSION -Architecture $env:PKG_ARCH -ReleaseTag $env:RELEASE_TAG -PackageIdentifier $env:PKG_ID -Validate |
+            Select-Object -Last 1
+          "dir=$($result.ManifestDirectory)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         env:
           MSI_PATH: ${{ steps.release.outputs.msi }}
           PKG_VERSION: ${{ steps.release.outputs.version }}
@@ -80,6 +95,24 @@ jobs:
             throw "InstallerUrl $url hashes to $actual, manifest claims $expected"
           }
           "URL and hash agree: $url"
+
+      # wingetcreate forks microsoft/winget-pkgs under the token's account and opens the
+      # PR from there, so WINGET_TOKEN needs a classic PAT with public_repo scope.
+      - name: Submit the manifests to winget-pkgs
+        if: inputs.submit
+        shell: pwsh
+        run: |
+          if (-not $env:WINGET_TOKEN) {
+            Write-Host "::warning::WINGET_TOKEN is not set; skipping the winget-pkgs submission for $env:PKG_ID $env:PKG_VERSION."
+            exit 0
+          }
+          Invoke-WebRequest -Uri https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          ./wingetcreate.exe submit --token $env:WINGET_TOKEN $env:MANIFEST_DIR
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          MANIFEST_DIR: ${{ steps.manifests.outputs.dir }}
+          PKG_ID: ${{ inputs.package_identifier }}
+          PKG_VERSION: ${{ steps.release.outputs.version }}
 
       - name: Upload the manifests as an artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/package_winget.yml
+++ b/.github/workflows/package_winget.yml
@@ -19,6 +19,11 @@ on:
         required: false
         default: false
         type: boolean
+    secrets:
+      # Named rather than inherited: this job runs a third-party binary, so it gets the
+      # one credential it needs instead of every secret the caller can see.
+      WINGET_TOKEN:
+        required: false
   workflow_dispatch:
     inputs:
       release_tag:
@@ -106,9 +111,19 @@ jobs:
             Write-Host "::warning::WINGET_TOKEN is not set; skipping the winget-pkgs submission for $env:PKG_ID $env:PKG_VERSION."
             exit 0
           }
-          Invoke-WebRequest -Uri https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          # Pinned by version and hash rather than aka.ms/wingetcreate/latest: this binary
+          # is handed WINGET_TOKEN, so a moving redirect would be an unverified dependency
+          # with credentials. Bump both values together.
+          Invoke-WebRequest -OutFile wingetcreate.exe `
+            -Uri "https://github.com/microsoft/winget-create/releases/download/$env:WINGETCREATE_VERSION/wingetcreate.exe"
+          $actual = (Get-FileHash wingetcreate.exe -Algorithm SHA256).Hash
+          if ($actual -ne $env:WINGETCREATE_SHA256) {
+            throw "wingetcreate.exe hashes to $actual, expected $env:WINGETCREATE_SHA256"
+          }
           ./wingetcreate.exe submit --token $env:WINGET_TOKEN $env:MANIFEST_DIR
         env:
+          WINGETCREATE_VERSION: v1.12.13.0
+          WINGETCREATE_SHA256: 24042BD37915805615E6CF969AC57C6439124C3FE85823327F5F3FB24BD9FFEA
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
           MANIFEST_DIR: ${{ steps.manifests.outputs.dir }}
           PKG_ID: ${{ inputs.package_identifier }}

--- a/.github/workflows/package_winget.yml
+++ b/.github/workflows/package_winget.yml
@@ -1,7 +1,31 @@
 name: Validate winget manifest
 
+# winget has no channel concept, so each release channel is its own PackageIdentifier.
+# Every version bump ships as Alpha; the subset promoted for wider circulation is
+# republished, same version, under the unsuffixed id that winget treats as the default
+# package. Alpha is therefore always equal to or newer than the unsuffixed package.
+# Nightlies are not published here at all - they are plain downloads off firmware-nightly/.
+
 on:
+  workflow_call:
+    inputs:
+      release_tag:
+        required: true
+        type: string
+      package_identifier:
+        required: true
+        type: string
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag to package (blank: the newest release)"
+        required: false
+        type: string
+      package_identifier:
+        description: "winget PackageIdentifier (Meshtastic.Meshtasticd is the beta/default channel)"
+        required: false
+        default: Meshtastic.Meshtasticd.Alpha
+        type: string
 
 permissions:
   contents: read
@@ -15,11 +39,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Resolve the newest release and download its MSI
+      - name: Resolve the release and download its MSI
         id: release
         shell: pwsh
         run: |
-          $tag = gh release list --limit 1 --json tagName --jq '.[0].tagName'
+          $tag = $env:RELEASE_TAG
+          if (-not $tag) { $tag = gh release list --limit 1 --json tagName --jq '.[0].tagName' }
           if (-not $tag) { throw 'No releases found.' }
           New-Item -ItemType Directory -Force -Path release/download | Out-Null
           gh release download $tag --pattern '*.msi' --dir release/download
@@ -31,15 +56,17 @@ jobs:
           "tag=$tag", "version=$($parsed.Groups[1].Value)", "arch=$($parsed.Groups[2].Value)", "msi=$($msis[0].FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
 
       - name: Generate manifests for the published MSI
         shell: pwsh
-        run: ./bin/build-winget-package.ps1 -MsiPath $env:MSI_PATH -Version $env:PKG_VERSION -Architecture $env:PKG_ARCH -ReleaseTag $env:RELEASE_TAG -Validate
+        run: ./bin/build-winget-package.ps1 -MsiPath $env:MSI_PATH -Version $env:PKG_VERSION -Architecture $env:PKG_ARCH -ReleaseTag $env:RELEASE_TAG -PackageIdentifier $env:PKG_ID -Validate
         env:
           MSI_PATH: ${{ steps.release.outputs.msi }}
           PKG_VERSION: ${{ steps.release.outputs.version }}
           PKG_ARCH: ${{ steps.release.outputs.arch }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          PKG_ID: ${{ inputs.package_identifier || 'Meshtastic.Meshtasticd.Alpha' }}
 
       - name: Verify the manifest URL resolves to the published asset
         shell: pwsh
@@ -57,6 +84,6 @@ jobs:
       - name: Upload the manifests as an artifact
         uses: actions/upload-artifact@v7
         with:
-          name: winget-manifests-${{ steps.release.outputs.version }}
+          name: winget-manifests-${{ inputs.package_identifier || 'Meshtastic.Meshtasticd.Alpha' }}-${{ steps.release.outputs.version }}
           overwrite: true
           path: release/winget/manifests/

--- a/.github/workflows/release_channels.yml
+++ b/.github/workflows/release_channels.yml
@@ -48,6 +48,17 @@ jobs:
         ${{ contains(github.event.release.name, 'Beta') && 'beta' || contains(github.event.release.name, 'Alpha') && 'alpha' }}
     secrets: inherit
 
+  # Beta is the unsuffixed package, so `winget install Meshtastic.Meshtasticd` tracks the
+  # promoted subset. Alpha keeps its own id and gets every version bump, so a promotion
+  # publishes the same version twice: once here as Alpha, once again as Beta.
+  package-winget:
+    uses: ./.github/workflows/package_winget.yml
+    with:
+      release_tag: ${{ github.event.release.tag_name }}
+      package_identifier: |-
+        ${{ contains(github.event.release.name, 'Beta') && 'Meshtastic.Meshtasticd' || 'Meshtastic.Meshtasticd.Alpha' }}
+    secrets: inherit
+
   publish-release-notes:
     if: github.event.action == 'published'
     runs-on: ubuntu-latest

--- a/.github/workflows/release_channels.yml
+++ b/.github/workflows/release_channels.yml
@@ -57,6 +57,7 @@ jobs:
       release_tag: ${{ github.event.release.tag_name }}
       package_identifier: |-
         ${{ contains(github.event.release.name, 'Beta') && 'Meshtastic.Meshtasticd' || 'Meshtastic.Meshtasticd.Alpha' }}
+      submit: true
     secrets: inherit
 
   publish-release-notes:

--- a/.github/workflows/release_channels.yml
+++ b/.github/workflows/release_channels.yml
@@ -58,7 +58,8 @@ jobs:
       package_identifier: |-
         ${{ contains(github.event.release.name, 'Beta') && 'Meshtastic.Meshtasticd' || 'Meshtastic.Meshtasticd.Alpha' }}
       submit: true
-    secrets: inherit
+    secrets:
+      WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
 
   publish-release-notes:
     if: github.event.action == 'published'


### PR DESCRIPTION
Follow-up to #11289, which built the MSI but never published it. The winget manifests pinned a SHA256 against a release-asset URL that nothing uploaded, so `package_winget.yml` could only ever fail with `Release $tag carries no MSI asset.`

## Build cadence

WiX and the MSI cost several minutes, and only the release and nightly publishes consume one. `build_windows_bin.yml` gains a `build_msi` input, default false, so push, PR and merge_group runs build just `meshtasticd.exe`.

| Run | MSI | Destination |
| --- | --- | --- |
| push / PR / merge_group | no | exe only |
| nightly (schedule) | yes | `firmware-nightly/` on meshtastic.github.io and R2 |
| release (workflow_dispatch) | yes | GitHub release asset |
| release published | reuses the asset | winget-pkgs |

The nightly publish uses `keep_files: false` for github.io and `--delete` for the R2 sync, both scoped to the nightly destination, so the MSI has to be staged inside that run rather than written by a separate job. Its winget manifests are dropped from the stage: their `InstallerUrl` points at a release asset the nightly never publishes, and nightlies are download-only.

## Release channels

winget has no channel concept, so each channel is its own `PackageIdentifier`:

- `Meshtastic.Meshtasticd.Alpha` takes every version bump.
- `Meshtastic.Meshtasticd`, the unsuffixed default, takes the subset promoted to beta.

A promotion therefore publishes the same version under both ids, and the alpha package is always equal to or newer than the unsuffixed one. `package_winget.yml` becomes a reusable workflow and `release_channels.yml` selects the id from the release name, alongside the existing ppa, obs and copr fan-out.

## Submission

`wingetcreate submit` sends the generated manifest directory, which already uses the winget-pkgs layout, and forks `microsoft/winget-pkgs` under the token's account.

Requires a `WINGET_TOKEN` repository secret: a classic PAT with `public_repo` scope, on the account that should own the fork. Until it exists the step logs a warning and exits 0, so releases do not fail. Submission is gated on a `submit` input that only `release_channels.yml` sets, so manual dispatches still validate without opening a PR.

The first PR for each id is a new-package submission and gets manual moderator review; later version bumps auto-merge.

## Notes

- `release-artifacts` now needs `Windows`, so a Windows build failure blocks the release. Happy to split it into a non-blocking job if that is not wanted.
- `release_channels.yml` fires on both `published` and `released`. Publishing a non-prerelease directly fires both, which would submit twice. Promotion from prerelease fires only `released`, so the current flow is unaffected, and the existing ppa/obs/copr jobs share the same exposure. Left as is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Windows MSI installers are now available in scheduled and manually triggered builds.
  - Release and nightly artifacts can include the Windows installer, with signing applied when configured.
  - Windows package manifests can be generated and optionally submitted to the Windows Package Manager community repository.
  - Release automation selects the appropriate package identifier for Beta and Alpha channels.
  - Manual package workflows support selecting a release, package identifier, and whether to submit manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->