### PR TITLE
fix(serial): configure TXD as an output before enabling the UART

### DIFF
--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -208,6 +208,10 @@ int32_t SerialModule::runOnce()
 #elif SERIAL_PRINT_PORT != 0
 
             if (moduleConfig.serial.rxd && moduleConfig.serial.txd) {
+                // begin() assigns PSEL but never configures the GPIO, so a reassigned TX pin
+                // would be left as an input; the UARTE needs it driven and idle-high.
+                pinMode(moduleConfig.serial.txd, OUTPUT);
+                digitalWrite(moduleConfig.serial.txd, HIGH);
 #ifdef ARCH_RP2040
                 Serial2.setFIFOSize(RX_BUFFER);
                 Serial2.setPinout(moduleConfig.serial.txd, moduleConfig.serial.rxd);


### PR DESCRIPTION
## Problem
Where the Serial Module reaches its port through `setPins()`/`setPinout()` rather than passing the pins to `begin()`, nothing configures the TX pin's GPIO direction. The nRF52 core's `Uart::begin()` assigns `PSEL.TXD`/`PSEL.RXD` and enables the UARTE but never touches the GPIO, so a reassigned TX pin that no other driver has claimed is left as an input and never drives.

Nordic's UARTE documentation requires TXD to be configured as an output with an idle-high level before the peripheral is enabled. ESP32 already gets this right, because there Serial2.begin() takes the pins as arguments and the core configures them.

## Why this is rarely hit
On RAK4631 the fault is normally masked by the GPS driver: `variant.h` aliases `GPS_RX_PIN`/`GPS_TX_PIN` onto `PIN_SERIAL1_RX`/`PIN_SERIAL1_TX` (P0.15/P0.16), so `Serial1.begin()` configures those pins as a side effect. Set `position.gps_mode = NOT_PRESENT` and the probe is skipped — `GPS::runOnce()` short-circuits before `setup()` — and the Serial Module's TX pin then never drives at all.

Most boards avoid it entirely: ESP32 takes the other branch, and 12 of the nRF52 variants define `SERIAL_PRINT_PORT 0`, routing the Serial Module to USB so `setPins()` is never called. RAK4631 doesn't define it, so it defaults to `Serial2` + `setPins()`.

The underlying gap is in `adafruit/Adafruit_nRF52_Arduino` (`Uart::begin()`), still present on its master. Fixing it here seemed more practical, since the core version is pinned.

## Testing
### Reproducing
  meshtastic --set serial.enabled true
  meshtastic --set serial.rxd 15
  meshtastic --set serial.txd 16
  meshtastic --set position.gps_mode NOT_PRESENT
 
Then measure the idle voltage on the TX pin (P0.16, J10 TX1 on a RAK19007). It sits at 0.0 V on stock firmware and 3.3 V with this change — a UART TX should idle high. No mesh traffic or attached device is needed to observe it.

`gps_mode NOT_PRESENT` is the load-bearing setting: with GPS enabled or merely probing, `Serial1.begin()` configures those pins as a side effect and the bug is masked. `serial.mode` is irrelevant — the affected code runs before any mode-specific branching.

### Verification
Verified on RAK WisBlock 4631 (RAK19007 base board), Serial Module on P0.15/P0.16 with `gps_mode NOT_PRESENT`:

- _Before_: J10 TX1 idles at 0.0 V and never transmits, in either SIMPLE or PROTO mode
- _After_: J10 TX1 idles at 3.3 V; SIMPLE-mode payloads appear on the wire, and a PROTO-mode client on the UART completes the want_config_id handshake and receives `my_info`

Tested with both `v2.7.26.54e0d8d` and current `develop` (2.8.1) as the base — identical behavior on both. No other hardware tested.


## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [X] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serial initialization for configurations using reassigned RX/TX pins on non-console serial ports.
  * The transmit pin is now correctly prepared before serial communication begins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->