### PR TITLE
fix(rp2050/rp2350): resolve RP2040/RP2350 framework package conflict and build failure

### DIFF
--- a/variants/rp2040/rp2040.ini
+++ b/variants/rp2040/rp2040.ini
@@ -7,7 +7,7 @@ platform =
 extends = arduino_base
 platform_packages =
   # TODO renovate
-  arduino-pico@https://github.com/earlephilhower/arduino-pico/releases/download/6.0.0/rp2040-6.0.0.zip
+  framework-arduinopico@https://github.com/earlephilhower/arduino-pico/releases/download/6.0.0/rp2040-6.0.0.zip
 
 board_build.core = earlephilhower
 board_build.filesystem_size = 0.5m

--- a/variants/rp2350/rp2350.ini
+++ b/variants/rp2350/rp2350.ini
@@ -7,7 +7,7 @@ platform =
 extends = arduino_base
 platform_packages =
   # TODO renovate
-  arduino-pico@https://github.com/earlephilhower/arduino-pico/releases/download/6.0.0/rp2040-6.0.0.zip
+  framework-arduinopico@https://github.com/earlephilhower/arduino-pico/releases/download/6.0.0/rp2040-6.0.0.zip
 
 board_build.core = earlephilhower
 board_build.filesystem_size = 0.5m


### PR DESCRIPTION
## Description

Fixes build failures across RP2040 and RP2350 targets by properly mapping the Earle Philhower core package in PlatformIO configuration to `framework-arduinopico` using the official 6.0.0 release zip archive.

---

### Problem & Root Cause

Builds for RP2040/RP2350 variants were failing with the following error:

```text
.../libraries/iLabs_Hearth/src/Hearth.cpp:121:2: error: #error "iLabs Hearth requires a board variant that defines ESP_SERIAL_PORT (the UART wired to the ESP32-C6 co-processor), e.g. an iLabs Challenger WiFi6 board. Override with -DHEARTH_SERIAL_PORT=... for a board no variant describes."

```

#### Why this happened:

1. **Package Name Mismatch:** The environment configuration defined the package under `arduino-pico`, but PlatformIO's Raspberry Pi platform internally expects the package key to be `framework-arduinopico`.
2. **Dual Package Resolution:** PlatformIO fetched the specified `arduino-pico` package, but because the required `framework-arduinopico` was missing from the configuration, it fell back to its default resolution and fetched a development snapshot alongside it:
```text
PACKAGES:
 - arduino-pico @ 1.60000.0 (6.0.0)
 - framework-arduinopico @ 1.50601.0+sha.832f2c06

```


3. **LDF Deep Scan Trigger:** Having two conflicting framework trees confused PlatformIO's Library Dependency Finder (LDF), causing it to aggressively inspect all bundled libraries inside the core directory. When scanning `iLabs_Hearth` (a newly bundled library for ESP32-C6 coprocessor support), it triggered the `#error` guard because non-Challenger variants do not define `ESP_SERIAL_PORT`.

---

### Solution

* Updated `platform_packages` to explicitly target `framework-arduinopico`.
* Pointed the package source directly to the official pre-packaged release zip (`rp2040-6.0.0.zip`). This ensures all necessary submodules (like `pico-sdk`) are packaged in without needing a full git clone.
* With a single, properly mapped framework package, LDF functions as intended and ignores unrelated bundled libraries like `iLabs_Hearth` without needing a manual `lib_ignore`.

---

### Potential Considerations / Caveats

* **Local Developer Cache:** Developers who have already built locally with the mismatched configuration might have conflicting or corrupted packages cached under `~/.platformio/packages/framework-arduinopico`. In such cases, deleting that directory or running a clean build will be required to force a fresh download. Clean CI runners will not be affected.

---

### Testing

* Verified clean package resolution in PlatformIO:
```text
PACKAGES:
 - framework-arduinopico @ 1.60000.0+sha.0bcd162
 - tool-picotool-rp2040-earlephilhower @ 5.140200.250530 (14.2.0)
 - tool-pioasm-rp2040-earlephilhower @ 5.140200.250530 (14.2.0)
 - toolchain-rp2040-earlephilhower @ 5.140200.250530 (14.2.0)

```


* Confirmed successful compilation across RP2040 and RP2350 board targets with only using `framework-arduinopico @ 1.60000.0`, without `lib_ignore` workarounds.


## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated RP2040 and RP2350 framework package references to use the correct package name.
  - Continued using the Arduino-Pico 6.0.0 release package for both board variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->