### PR TITLE
fix(rp2040/rp2350): resolve RP2040/RP2350 framework package conflict and build failure

### DIFF
--- a/bin/build-rp2xx0.sh
+++ b/bin/build-rp2xx0.sh
@@ -11,6 +11,9 @@ OUTDIR=release
 rm -f $OUTDIR/firmware*
 rm -r $OUTDIR/* || true
 
+# Clean up legacy package from the base CI container if present
+rm -rf "${PLATFORMIO_CORE_DIR:-$HOME/.platformio}/packages/arduino-pico"
+
 # Important to pull latest version of libs into all device flavors, otherwise some devices might be stale
 platformio pkg install -e $1
 

--- a/bin/build-rp2xx0.sh
+++ b/bin/build-rp2xx0.sh
@@ -12,7 +12,7 @@ rm -f $OUTDIR/firmware*
 rm -r $OUTDIR/* || true
 
 # Clean up legacy package from the base CI container if present
-rm -rf "${PLATFORMIO_CORE_DIR:-$HOME/.platformio}/packages/arduino-pico"
+[[ -d "${PLATFORMIO_CORE_DIR:-$HOME/.platformio}/packages/arduino-pico" ]] && rm -rf "${PLATFORMIO_CORE_DIR:-$HOME/.platformio}/packages/arduino-pico"
 
 # Important to pull latest version of libs into all device flavors, otherwise some devices might be stale
 platformio pkg install -e $1

--- a/bin/check-all.sh
+++ b/bin/check-all.sh
@@ -49,7 +49,7 @@ LOG=$(mktemp)
 trap 'rm -f "$LOG"' EXIT
 
 # Clean up legacy package(arduino-pico) used for rp2040/rp2350 from the base CI container if present
-rm -rf "${PLATFORMIO_CORE_DIR:-$HOME/.platformio}/packages/arduino-pico"
+[[ -d "${PLATFORMIO_CORE_DIR:-$HOME/.platformio}/packages/arduino-pico" ]] && rm -rf "${PLATFORMIO_CORE_DIR:-$HOME/.platformio}/packages/arduino-pico"
 
 # Keep streaming to the console so the CI log reads exactly as it did before; tee a copy for the
 # post-mortem classification below.

--- a/bin/check-all.sh
+++ b/bin/check-all.sh
@@ -48,6 +48,9 @@ done
 LOG=$(mktemp)
 trap 'rm -f "$LOG"' EXIT
 
+# Clean up legacy package(arduino-pico) used for rp2040/rp2350 from the base CI container if present
+rm -rf "${PLATFORMIO_CORE_DIR:-$HOME/.platformio}/packages/arduino-pico"
+
 # Keep streaming to the console so the CI log reads exactly as it did before; tee a copy for the
 # post-mortem classification below.
 pio check --flags "-DAPP_VERSION=${APP_VERSION} --suppressions-list=suppressions.txt --inline-suppr" "${CHECK[@]}" --skip-packages --pattern="src/" --fail-on-defect=low --fail-on-defect=medium --fail-on-defect=high 2>&1 | tee "$LOG"

--- a/variants/rp2040/rp2040.ini
+++ b/variants/rp2040/rp2040.ini
@@ -7,7 +7,7 @@ platform =
 extends = arduino_base
 platform_packages =
   # TODO renovate
-  arduino-pico@https://github.com/earlephilhower/arduino-pico/releases/download/6.0.0/rp2040-6.0.0.zip
+  framework-arduinopico@https://github.com/earlephilhower/arduino-pico/releases/download/6.0.0/rp2040-6.0.0.zip
 
 board_build.core = earlephilhower
 board_build.filesystem_size = 0.5m

--- a/variants/rp2350/rp2350.ini
+++ b/variants/rp2350/rp2350.ini
@@ -7,7 +7,7 @@ platform =
 extends = arduino_base
 platform_packages =
   # TODO renovate
-  arduino-pico@https://github.com/earlephilhower/arduino-pico/releases/download/6.0.0/rp2040-6.0.0.zip
+  framework-arduinopico@https://github.com/earlephilhower/arduino-pico/releases/download/6.0.0/rp2040-6.0.0.zip
 
 board_build.core = earlephilhower
 board_build.filesystem_size = 0.5m


### PR DESCRIPTION
## Description

Fixes build failures across RP2040 and RP2350 targets by properly mapping the Earle Philhower core package in PlatformIO configuration to `framework-arduinopico` using the official 6.0.0 release zip archive.

- Related PRs
  - #11351
  - #11383

- Related Issue
  - #11682

---

### Changes

- `variants/rp2040/rp2040.ini`— `platform_packages` entry renamed from `arduino-pico@…` to `framework-arduinopico@…`
- `variants/rp2350/rp2350.ini` — same rename.
- `bin/build-rp2xx0.sh` — added one `rm -rf` before `pio pkg install` to purge the legacy package from the CI container, if exists.
- `bin/check-all.sh` — same as above.

---

### Problem & Root Cause

Builds for RP2040/RP2350 variants were failing with the following error:

```text
.../libraries/iLabs_Hearth/src/Hearth.cpp:121:2: error: #error "iLabs Hearth requires a board variant that defines ESP_SERIAL_PORT (the UART wired to the ESP32-C6 co-processor), e.g. an iLabs Challenger WiFi6 board. Override with -DHEARTH_SERIAL_PORT=... for a board no variant describes."

```

#### Why this happened:

1. **Package Name Mismatch:** The environment configuration defined the package under `arduino-pico`, but PlatformIO's Raspberry Pi platform internally expects the package key to be `framework-arduinopico`.
2. **Dual Package Resolution:** PlatformIO fetched the specified `arduino-pico` package, but because the required `framework-arduinopico` was missing from the configuration, it fell back to its default resolution and fetched a development snapshot alongside it, and used during building, leaving 6.0.0 completely dormant:
```text
PACKAGES:
 - arduino-pico @ 1.60000.0 (6.0.0)
 - framework-arduinopico @ 1.50601.0+sha.832f2c06
 - tool-picotool-rp2040-earlephilhower @ 5.140200.250530 (14.2.0)
 - tool-pioasm-rp2040-earlephilhower @ 5.140200.250530 (14.2.0)
 - toolchain-rp2040-earlephilhower @ 5.140200.250530 (14.2.0)
```


3. **LDF Deep Scan Trigger:** Having two conflicting framework trees confused PlatformIO's Library Dependency Finder (LDF), causing it to aggressively inspect all bundled libraries inside the core directory. When scanning `iLabs_Hearth` (a newly bundled library for ESP32-C6 coprocessor support), it triggered the `#error` guard because non-Challenger variants do not define `ESP_SERIAL_PORT`.

---

### Solution

* Updated `platform_packages` to explicitly target `framework-arduinopico`.
* Pointed the package source directly to the official pre-packaged release zip (`rp2040-6.0.0.zip`). This ensures all necessary submodules (like `pico-sdk`) are packaged in without needing a full git clone.
* With a single, properly mapped framework package, LDF functions as intended and ignores unrelated bundled libraries like `iLabs_Hearth` without needing a manual `lib_ignore`.
* Added clean-up line in `build-rp2xx0.sh` and `bin/check-all.sh` due to following reason

---

### Why the `rm` in `build-rp2xx0.sh` and `check-all.sh`

The CI Docker image (`ghcr.io/meshtastic/gh-action-firmware:develop-rp2350`) was built when `rp2040.ini` still used `arduino-pico`. That package is baked into the image filesystem at:

```
$PLATFORMIO_CORE_DIR/packages/arduino-pico/
```

When `pio pkg install` runs inside the container, it matches the new `framework-arduinopico@<url>` spec against the already-installed package **by URI** (the zip URL is identical), marks it as already satisfied, and skips re-downloading. The installed package's `metadata.name` remains `arduino-pico`.

At build time, `LoadPioPlatform` iterates installed packages and calls `get_package_type(pkg.metadata.name)`. Because `platform_packages` no longer contains `arduino-pico`, that lookup raises `KeyError: 'arduino-pico'` and the build crashes before compiling a single file.

The `rm` removes the stale package before `pio pkg install` runs, forcing a clean install under the new name:

```bash
# Clean up legacy package from the base CI container if present
rm -rf "${PLATFORMIO_CORE_DIR:-$HOME/.platformio}/packages/arduino-pico"
```

This is a no-op on any environment that never had the old name installed (fresh runners, local checkouts that never built RP2040), and a one-time migration on any environment that did.

### For local developers

If you have previously built an RP2040/RP2350 target locally, run once:

```bash
rm -rf "${PLATFORMIO_CORE_DIR:-$HOME/.platformio}/packages/arduino-pico"
```

or simply let `bin/build-rp2xx0.sh` handle it automatically on the next build.

---

### Testing

* Verified clean package resolution in PlatformIO:
```text
PACKAGES:
 - framework-arduinopico @ 1.60000.0+sha.0bcd162
 - tool-picotool-rp2040-earlephilhower @ 5.140200.250530 (14.2.0)
 - tool-pioasm-rp2040-earlephilhower @ 5.140200.250530 (14.2.0)
 - toolchain-rp2040-earlephilhower @ 5.140200.250530 (14.2.0)
```

* Confirmed successful compilation across RP2040 and RP2350 board targets with only using `framework-arduinopico @ 1.60000.0`, without `lib_ignore` workarounds.

---

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] Wiznet W5500-EVB-Pico2 (RP2350-based, paired with Wio-SX1262) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

* Updated RP2040 and RP2350 build configurations to use the standardized Arduino-Pico framework package, pinned to release 6.0.0.
* Improved build and validation cleanup by safely handling cases where legacy Arduino-Pico package directories are not present.
* These changes provide more consistent and reliable firmware compilation for supported RP2040 and RP2350 boards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->