### PR TITLE
fix(ThinkNode-G3): wire up the LoRa activity LED

### DIFF
--- a/variants/esp32s3/ELECROW-ThinkNode-G3/variant.h
+++ b/variants/esp32s3/ELECROW-ThinkNode-G3/variant.h
@@ -5,7 +5,7 @@
 #define WIFI_LED 5
 #define WIFI_STATE_ON 0
 
-#define LED_PIN 6
+#define LED_LORA 6
 #define LED_STATE_ON 0
 #define BUTTON_PIN 4
 


### PR DESCRIPTION
## What this fixes

The blue LoRa activity LED on the ELECROW ThinkNode-G3 never lights up.

The variant declares the LED as `LED_PIN 6`, but LED handling moved to
`StatusLEDModule`, which uses `LED_LORA`, `LED_PAIRING`, `LED_HEARTBEAT` and
`LED_POWER`.

Since the G3 defines none of those, all the packet-activity blinking guarded by
`#ifdef LED_LORA` in `RadioLibInterface.cpp` and `StatusLEDModule.cpp` is
compiled out, and GPIO6 is never driven.

This renames the define so the existing LED code picks it up. `LED_STATE_OFF`
does not need to be added — `configuration.h` derives it from `LED_STATE_ON`.

`WIFI_LED 5` is left untouched. It works and drives the green front LED on
WiFi connect/disconnect. Note that the enclosure labels that LED "LINK", so it
stays dark when the device is on Ethernet only; that is a separate discussion
and not addressed here.

## Change

variants/esp32s3/ELECROW-ThinkNode-G3/variant.h

```diff
-#define LED_PIN 6
+#define LED_LORA 6
 #define LED_STATE_ON 0
```

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other: ELECROW ThinkNode-G3

The change is confined to a single variant header and cannot affect other
boards. I only have the ThinkNode-G3 to test on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed the board’s LED pin identifier for clearer LoRa-related labeling.
  * The LED remains assigned to the same physical pin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->