### PR TITLE
fix(phoneapi): resend my_info when the node num moves mid-session

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -139,8 +139,10 @@ void MeshService::loop()
     }
     if (oldFromNum != fromNum) { // We don't want to generate extra notifies for multiple new packets
         int result = fromNumChanged.notifyObservers(fromNum);
-        if (result == 0) // If any observer returns non-zero, we will try again
+        if (result == 0) { // If any observer returns non-zero, we will try again
             oldFromNum = fromNum;
+            identityMoved = false;
+        }
     }
 }
 

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -138,10 +138,14 @@ void MeshService::loop()
             (void)sendQueueStatusToPhone(qs, 0, 0);
     }
     if (oldFromNum != fromNum) { // We don't want to generate extra notifies for multiple new packets
-        int result = fromNumChanged.notifyObservers(fromNum);
+        // Snapshot both first: the identity move can run on another task, and anything it bumps during
+        // the pass must still be pending afterwards rather than being marked delivered.
+        const uint32_t num = fromNum;
+        const uint32_t generation = identityGeneration;
+        int result = fromNumChanged.notifyObservers(num);
         if (result == 0) { // If any observer returns non-zero, we will try again
-            oldFromNum = fromNum;
-            identityMoved = false;
+            oldFromNum = num;
+            identityGenerationSeen = generation;
         }
     }
 }

--- a/src/mesh/MeshService.h
+++ b/src/mesh/MeshService.h
@@ -73,8 +73,9 @@ class MeshService
     // This holds the last QueueStatus send
     meshtastic_QueueStatus lastQueueStatus;
 
-    /// The current nonce for the newest packet which has been queued for the phone
-    uint32_t fromNum = 0;
+    /// The current nonce for the newest packet which has been queued for the phone. Bumped from
+    /// whichever task queued it, read by loop(), hence atomic.
+    std::atomic<uint32_t> fromNum{0};
 
     /// Updated in loop() to detect when fromNum changes
     uint32_t oldFromNum = 0;

--- a/src/mesh/MeshService.h
+++ b/src/mesh/MeshService.h
@@ -160,9 +160,13 @@ class MeshService
     /// senders.
     void nudgeFromNum() { fromNum++; }
 
-    /// Set with a nudgeFromNum() when our node num changes, and cleared once the notify pass has
-    /// reached every connected client. PhoneAPI keys its MyInfo re-announce off it.
-    bool identityMoved = false;
+    /// Bumped with a nudgeFromNum() when our node num changes; the seen counter only advances once a
+    /// notify pass has reached every client, so a move landing during a pass stays pending after it.
+    uint32_t identityGeneration = 0;
+    uint32_t identityGenerationSeen = 0;
+
+    /// True while a node num change still owes connected clients a fresh MyInfo.
+    bool identityMovePending() const { return identityGeneration != identityGenerationSeen; }
 
     /**
      *  Given a ToRadio buffer parse it and properly handle it (setup radio, owner or send packet into the mesh)

--- a/src/mesh/MeshService.h
+++ b/src/mesh/MeshService.h
@@ -2,6 +2,7 @@
 
 #include <Arduino.h>
 #include <assert.h>
+#include <atomic>
 #include <string>
 
 #include "GPSStatus.h"
@@ -162,8 +163,8 @@ class MeshService
 
     /// Bumped with a nudgeFromNum() when our node num changes; the seen counter only advances once a
     /// notify pass has reached every client, so a move landing during a pass stays pending after it.
-    uint32_t identityGeneration = 0;
-    uint32_t identityGenerationSeen = 0;
+    std::atomic<uint32_t> identityGeneration{0};
+    std::atomic<uint32_t> identityGenerationSeen{0};
 
     /// True while a node num change still owes connected clients a fresh MyInfo.
     bool identityMovePending() const { return identityGeneration != identityGenerationSeen; }

--- a/src/mesh/MeshService.h
+++ b/src/mesh/MeshService.h
@@ -160,6 +160,10 @@ class MeshService
     /// senders.
     void nudgeFromNum() { fromNum++; }
 
+    /// Set with a nudgeFromNum() when our node num changes, and cleared once the notify pass has
+    /// reached every connected client. PhoneAPI keys its MyInfo re-announce off it.
+    bool identityMoved = false;
+
     /**
      *  Given a ToRadio buffer parse it and properly handle it (setup radio, owner or send packet into the mesh)
      * Called by PhoneAPI.handleToRadio.  Note: p is a scratch buffer, this function is allowed to write to it but it can not keep

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -4561,8 +4561,10 @@ bool NodeDB::createNewIdentity()
         LOG_ERROR("No room for our own node 0x%08x, identity moved without a self record", newNodeNum);
 
     // Clients cache my_node_num from the handshake; the region set that mints the key never reboots.
-    if (service)
+    if (service) {
+        service->identityMoved = true;
         service->nudgeFromNum();
+    }
 
     return true;
 }

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -4562,7 +4562,7 @@ bool NodeDB::createNewIdentity()
 
     // Clients cache my_node_num from the handshake; the region set that mints the key never reboots.
     if (service) {
-        service->identityMoved = true;
+        service->identityGeneration++;
         service->nudgeFromNum();
     }
 

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -4560,6 +4560,10 @@ bool NodeDB::createNewIdentity()
     else
         LOG_ERROR("No room for our own node 0x%08x, identity moved without a self record", newNodeNum);
 
+    // Clients cache my_node_num from the handshake; the region set that mints the key never reboots.
+    if (service)
+        service->nudgeFromNum();
+
     return true;
 }
 

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -4555,9 +4555,13 @@ bool NodeDB::createNewIdentity()
     // The number has moved, so the caller must persist it whatever happens next. Returning false here
     // would leave the new key saved against the old number, which is the break this exists to prevent.
     meshtastic_NodeInfoLite *info = getOrCreateMeshNode(getNodeNum());
-    if (info)
+    if (info) {
         TypeConversions::CopyUserToNodeInfoLite(info, owner);
-    else
+        // Our row was appended, but index 0 is self by invariant: the phone's own-nodeinfo read and the
+        // demote/evict scans that skip index 0 to protect us both depend on it.
+        if (info != &meshNodes->at(0))
+            std::swap(meshNodes->at(0), *info);
+    } else
         LOG_ERROR("No room for our own node 0x%08x, identity moved without a self record", newNodeNum);
 
     // Clients cache my_node_num from the handshake; the region set that mints the key never reboots.

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -1921,6 +1921,13 @@ int PhoneAPI::onNotify(uint32_t newValue)
             state = STATE_RESEND_MY_INFO;
         LOG_INFO("Tell client new packets %u", newValue);
         onNowHasData(newValue);
+    } else if (service->identityMoved && state != STATE_SEND_NOTHING && state != STATE_SEND_MY_INFO &&
+               config_nonce != SPECIAL_NONCE_ONLY_NODES) {
+        // Mid-sync, and our my_info is already out with the old number. There is no steady state to
+        // fall back from here, so restart the dump and let it carry the new one.
+        LOG_INFO("Node num moved mid-sync, restart client config");
+        handleStartConfig();
+        onNowHasData(newValue);
     } else {
         LOG_DEBUG("Client not yet interested in packets (state=%d)", state);
     }

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -573,7 +573,6 @@ void PhoneAPI::fillMyInfo()
         fromRadioScratch.my_info.min_app_version = 0;
     }
 #endif
-    reportedNodeNum = myNodeInfo.my_node_num;
 }
 
 size_t PhoneAPI::getFromRadio(uint8_t *buf)
@@ -1031,12 +1030,7 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
         pauseBluetoothLogging = false;
         // Do we have a message from the mesh or packet from the local device?
         LOG_TRACE("FromRadio=STATE_SEND_PACKETS");
-        if (reportedNodeNum != nodeDB->getNodeNum()) {
-            // The identity moved after the handshake (the first region set mints the PKI key), so tell the
-            // client before it addresses another admin packet to a number we no longer answer to.
-            LOG_INFO("Node num moved to 0x%08x, resend MyInfo", nodeDB->getNodeNum());
-            fillMyInfo();
-        } else if (queueStatusPacketForPhone) {
+        if (queueStatusPacketForPhone) {
             fromRadioScratch.which_payload_variant = meshtastic_FromRadio_queueStatus_tag;
             fromRadioScratch.queueStatus = *queueStatusPacketForPhone;
             releaseQueueStatusPhonePacket();
@@ -1104,6 +1098,14 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
                 fromRadioScratch.packet = replayPkt;
             }
         }
+        break;
+
+    case STATE_RESEND_MY_INFO:
+        // Our node num moved after this client's handshake, so it is addressing a number we no
+        // longer answer to. Re-announce, then carry on with live traffic.
+        LOG_INFO("FromRadio=STATE_RESEND_MY_INFO, node num now 0x%08x", nodeDB->getNodeNum());
+        fillMyInfo();
+        state = STATE_SEND_PACKETS;
         break;
 
     default:
@@ -1677,6 +1679,7 @@ bool PhoneAPI::available()
     case STATE_SEND_OWN_NODEINFO:
     case STATE_SEND_FILEMANIFEST:
     case STATE_SEND_COMPLETE_ID:
+    case STATE_RESEND_MY_INFO:
         return true;
 
     case STATE_SEND_OTHER_NODEINFOS: {
@@ -1691,8 +1694,6 @@ bool PhoneAPI::available()
         prefetchNodeInfos();
         return true;
     case STATE_SEND_PACKETS: {
-        if (reportedNodeNum != nodeDB->getNodeNum())
-            return true;
         if (!queueStatusPacketForPhone)
             queueStatusPacketForPhone = service->getQueueStatusForPhone();
         if (!mqttClientProxyMessageForPhone)
@@ -1915,6 +1916,9 @@ int PhoneAPI::onNotify(uint32_t newValue)
                                              // doesn't call this from idle)
 
     if (state == STATE_SEND_PACKETS) {
+        // Consumed by every connected client in this one notify pass, so no per-connection bookkeeping.
+        if (service->identityMoved)
+            state = STATE_RESEND_MY_INFO;
         LOG_INFO("Tell client new packets %u", newValue);
         onNowHasData(newValue);
     } else {

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -549,6 +549,33 @@ bool PhoneAPI::handleToRadio(const uint8_t *buf, size_t bufLength)
     STATE_SEND_PACKETS // send packets or debug strings
  */
 
+void PhoneAPI::fillMyInfo()
+{
+    fromRadioScratch.which_payload_variant = meshtastic_FromRadio_my_info_tag;
+    strncpy(myNodeInfo.pio_env, optstr(APP_ENV), sizeof(myNodeInfo.pio_env));
+    // strncpy does not terminate when the source fills the buffer; a 40+ char
+    // APP_ENV would make nanopb reject the MyInfo encode ("unterminated string").
+    myNodeInfo.pio_env[sizeof(myNodeInfo.pio_env) - 1] = '\0';
+    myNodeInfo.nodedb_count = static_cast<uint16_t>(nodeDB->getNumMeshNodes());
+    fromRadioScratch.my_info = myNodeInfo;
+#ifdef MESHTASTIC_PHONEAPI_ACCESS_CONTROL
+    if (!getAdminAuthorized()) {
+        // device_id is a stable hardware identifier - useful for an attacker
+        // to fingerprint / correlate the device across observations. Strip it
+        // for unauthenticated clients. my_node_num is kept (it's broadcast
+        // on the mesh anyway). pio_env / min_app_version reveal the exact
+        // build flavour, useful only for picking which known-CVE to try.
+        // nodedb_count stays - clients need it to decide whether to pull
+        // the node DB after unlocking.
+        fromRadioScratch.my_info.device_id.size = 0;
+        memset(fromRadioScratch.my_info.device_id.bytes, 0, sizeof(fromRadioScratch.my_info.device_id.bytes));
+        memset(fromRadioScratch.my_info.pio_env, 0, sizeof(fromRadioScratch.my_info.pio_env));
+        fromRadioScratch.my_info.min_app_version = 0;
+    }
+#endif
+    reportedNodeNum = myNodeInfo.my_node_num;
+}
+
 size_t PhoneAPI::getFromRadio(uint8_t *buf)
 {
     // Respond to heartbeat by sending queue status
@@ -575,30 +602,7 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
         break;
     case STATE_SEND_MY_INFO:
         LOG_DEBUG("FromRadio=STATE_SEND_MY_INFO");
-        // If the user has specified they don't want our node to share its location, make sure to tell the phone
-        // app not to send locations on our behalf.
-        fromRadioScratch.which_payload_variant = meshtastic_FromRadio_my_info_tag;
-        strncpy(myNodeInfo.pio_env, optstr(APP_ENV), sizeof(myNodeInfo.pio_env));
-        // strncpy does not terminate when the source fills the buffer; a 40+ char
-        // APP_ENV would make nanopb reject the MyInfo encode ("unterminated string").
-        myNodeInfo.pio_env[sizeof(myNodeInfo.pio_env) - 1] = '\0';
-        myNodeInfo.nodedb_count = static_cast<uint16_t>(nodeDB->getNumMeshNodes());
-        fromRadioScratch.my_info = myNodeInfo;
-#ifdef MESHTASTIC_PHONEAPI_ACCESS_CONTROL
-        if (!getAdminAuthorized()) {
-            // device_id is a stable hardware identifier - useful for an attacker
-            // to fingerprint / correlate the device across observations. Strip it
-            // for unauthenticated clients. my_node_num is kept (it's broadcast
-            // on the mesh anyway). pio_env / min_app_version reveal the exact
-            // build flavour, useful only for picking which known-CVE to try.
-            // nodedb_count stays - clients need it to decide whether to pull
-            // the node DB after unlocking.
-            fromRadioScratch.my_info.device_id.size = 0;
-            memset(fromRadioScratch.my_info.device_id.bytes, 0, sizeof(fromRadioScratch.my_info.device_id.bytes));
-            memset(fromRadioScratch.my_info.pio_env, 0, sizeof(fromRadioScratch.my_info.pio_env));
-            fromRadioScratch.my_info.min_app_version = 0;
-        }
-#endif
+        fillMyInfo();
         state = STATE_SEND_UIDATA;
 
         service->refreshLocalMeshNode(); // Update my NodeInfo because the client will be asking for it soon.
@@ -1027,7 +1031,12 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
         pauseBluetoothLogging = false;
         // Do we have a message from the mesh or packet from the local device?
         LOG_TRACE("FromRadio=STATE_SEND_PACKETS");
-        if (queueStatusPacketForPhone) {
+        if (reportedNodeNum != nodeDB->getNodeNum()) {
+            // The identity moved after the handshake (the first region set mints the PKI key), so tell the
+            // client before it addresses another admin packet to a number we no longer answer to.
+            LOG_INFO("Node num moved to 0x%08x, resend MyInfo", nodeDB->getNodeNum());
+            fillMyInfo();
+        } else if (queueStatusPacketForPhone) {
             fromRadioScratch.which_payload_variant = meshtastic_FromRadio_queueStatus_tag;
             fromRadioScratch.queueStatus = *queueStatusPacketForPhone;
             releaseQueueStatusPhonePacket();
@@ -1682,6 +1691,8 @@ bool PhoneAPI::available()
         prefetchNodeInfos();
         return true;
     case STATE_SEND_PACKETS: {
+        if (reportedNodeNum != nodeDB->getNodeNum())
+            return true;
         if (!queueStatusPacketForPhone)
             queueStatusPacketForPhone = service->getQueueStatusForPhone();
         if (!mqttClientProxyMessageForPhone)

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -1916,10 +1916,9 @@ int PhoneAPI::onNotify(uint32_t newValue)
             state = STATE_RESEND_MY_INFO;
         LOG_INFO("Tell client new packets %u", newValue);
         onNowHasData(newValue);
-    } else if (service->identityMovePending() && state != STATE_SEND_NOTHING && state != STATE_SEND_MY_INFO &&
-               config_nonce != SPECIAL_NONCE_ONLY_NODES) {
-        // Mid-sync, and our my_info is already out with the old number. There is no steady state to
-        // fall back from here, so restart the dump and let it carry the new one.
+    } else if (service->identityMovePending() && state != STATE_SEND_NOTHING && state != STATE_SEND_MY_INFO) {
+        // Mid-sync, so this dump is already carrying the old number in its my_info, its self record or
+        // both, and has no steady state to fall back from. Restart it on the new one.
         LOG_INFO("Node num moved mid-sync, restart client config");
         handleStartConfig();
         onNowHasData(newValue);

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -560,13 +560,8 @@ void PhoneAPI::fillMyInfo()
     fromRadioScratch.my_info = myNodeInfo;
 #ifdef MESHTASTIC_PHONEAPI_ACCESS_CONTROL
     if (!getAdminAuthorized()) {
-        // device_id is a stable hardware identifier - useful for an attacker
-        // to fingerprint / correlate the device across observations. Strip it
-        // for unauthenticated clients. my_node_num is kept (it's broadcast
-        // on the mesh anyway). pio_env / min_app_version reveal the exact
-        // build flavour, useful only for picking which known-CVE to try.
-        // nodedb_count stays - clients need it to decide whether to pull
-        // the node DB after unlocking.
+        // device_id fingerprints the hardware and pio_env/min_app_version name the exact build to pick a
+        // known CVE for. my_node_num is broadcast on the mesh anyway, and nodedb_count is not secret.
         fromRadioScratch.my_info.device_id.size = 0;
         memset(fromRadioScratch.my_info.device_id.bytes, 0, sizeof(fromRadioScratch.my_info.device_id.bytes));
         memset(fromRadioScratch.my_info.pio_env, 0, sizeof(fromRadioScratch.my_info.pio_env));
@@ -1917,11 +1912,11 @@ int PhoneAPI::onNotify(uint32_t newValue)
 
     if (state == STATE_SEND_PACKETS) {
         // Consumed by every connected client in this one notify pass, so no per-connection bookkeeping.
-        if (service->identityMoved)
+        if (service->identityMovePending())
             state = STATE_RESEND_MY_INFO;
         LOG_INFO("Tell client new packets %u", newValue);
         onNowHasData(newValue);
-    } else if (service->identityMoved && state != STATE_SEND_NOTHING && state != STATE_SEND_MY_INFO &&
+    } else if (service->identityMovePending() && state != STATE_SEND_NOTHING && state != STATE_SEND_MY_INFO &&
                config_nonce != SPECIAL_NONCE_ONLY_NODES) {
         // Mid-sync, and our my_info is already out with the old number. There is no steady state to
         // fall back from here, so restart the dump and let it carry the new one.

--- a/src/mesh/PhoneAPI.h
+++ b/src/mesh/PhoneAPI.h
@@ -53,7 +53,8 @@ class PhoneAPI
         STATE_SEND_OTHER_NODEINFOS, // states progress in this order as the device sends to to the client
         STATE_SEND_FILEMANIFEST,    // Send file manifest
         STATE_SEND_COMPLETE_ID,
-        STATE_SEND_PACKETS // live mesh packets + any cached satellite-DB replay that trails sync completion
+        STATE_SEND_PACKETS,  // live mesh packets + any cached satellite-DB replay that trails sync completion
+        STATE_RESEND_MY_INFO // one-shot: our node num moved after the handshake, re-announce and fall back
     };
 
     // Satellite-DB replay (positions / telemetry / environment / status) used to live
@@ -81,10 +82,6 @@ class PhoneAPI
      * Each packet sent to the phone has an incrementing count
      */
     uint32_t fromRadioNum = 0;
-
-    /// my_node_num as last handed to this client. The identity moves live when the first region set
-    /// mints the PKI key, and a client still addressing the old number NAKs PKI_SEND_FAIL_PUBLIC_KEY.
-    uint32_t reportedNodeNum = 0;
 
     /// We temporarily keep the packet here between the call to available and getFromRadio.  We will free it after the phone
     /// downloads it

--- a/src/mesh/PhoneAPI.h
+++ b/src/mesh/PhoneAPI.h
@@ -82,6 +82,10 @@ class PhoneAPI
      */
     uint32_t fromRadioNum = 0;
 
+    /// my_node_num as last handed to this client. The identity moves live when the first region set
+    /// mints the PKI key, and a client still addressing the old number NAKs PKI_SEND_FAIL_PUBLIC_KEY.
+    uint32_t reportedNodeNum = 0;
+
     /// We temporarily keep the packet here between the call to available and getFromRadio.  We will free it after the phone
     /// downloads it
     meshtastic_MeshPacket *packetForPhone = NULL;
@@ -132,6 +136,9 @@ class PhoneAPI
     std::vector<meshtastic_FileInfo> filesManifest = {};
 
     void resetReadIndex() { readIndex = 0; }
+
+    /// Load fromRadioScratch with a MyInfo for this connection and record the number it carried.
+    void fillMyInfo();
 
   public:
     PhoneAPI();

--- a/test/test_phone_api_config_dump/test_main.cpp
+++ b/test/test_phone_api_config_dump/test_main.cpp
@@ -575,10 +575,20 @@ void test_node_num_change_mid_dump_restarts_sync()
                                    "a mid-sync renumber must restart the dump");
     TEST_ASSERT_EQUAL_UINT32(nodeDB->getNodeNum(), msg.my_info.my_node_num);
 
+    // Everything after the my_info already read must arrive again, in order and complete.
     DumpTranscript t;
     TEST_ASSERT_TRUE_MESSAGE(drainUntilComplete(t), "restarted dump never completed");
-    TEST_ASSERT_EQUAL_UINT32(FULL_DUMP_NONCE, t.completeId);
+    const pb_size_t expectedPrefix[] = {meshtastic_FromRadio_deviceuiConfig_tag, meshtastic_FromRadio_node_info_tag,
+                                        meshtastic_FromRadio_metadata_tag, meshtastic_FromRadio_region_presets_tag};
+    TEST_ASSERT_EQUAL_UINT(NUM_SINGLETON_PREFIX - 1, sizeof(expectedPrefix) / sizeof(expectedPrefix[0]));
+    for (unsigned i = 0; i < NUM_SINGLETON_PREFIX - 1; i++)
+        TEST_ASSERT_EQUAL_UINT_MESSAGE(expectedPrefix[i], t.variants[i], "restarted dump changed the header sequence");
+    TEST_ASSERT_EQUAL_UINT((unsigned)MAX_NUM_CHANNELS, t.channelIndices.size());
     TEST_ASSERT_EQUAL_UINT_MESSAGE(NUM_CONFIG_MESSAGES, t.configVariants.size(), "restarted dump lost part of the config");
+    TEST_ASSERT_EQUAL_UINT(NUM_MODULE_CONFIG_MESSAGES, t.moduleConfigVariants.size());
+    TEST_ASSERT_EQUAL_UINT(1, t.nodeNums.size()); // our own record; this test seeds no remotes
+    TEST_ASSERT_EQUAL_UINT32(nodeDB->getNodeNum(), t.nodeNums[0]);
+    TEST_ASSERT_EQUAL_UINT32(FULL_DUMP_NONCE, t.completeId);
 }
 
 } // namespace

--- a/test/test_phone_api_config_dump/test_main.cpp
+++ b/test/test_phone_api_config_dump/test_main.cpp
@@ -26,6 +26,7 @@ constexpr uint32_t FULL_DUMP_NONCE = 0x51C0FFEE;
 constexpr uint32_t SECOND_NONCE = 0x0DDBA11;
 constexpr NodeNum SEEDED_NODE_A = 0x00000A01;
 constexpr NodeNum SEEDED_NODE_B = 0x00000A02;
+constexpr NodeNum RENUMBERED_SELF = 0x00C0FFEE; // stands in for crc32(public_key) after the first region set
 
 constexpr unsigned NUM_SINGLETON_PREFIX = 5; // my_info, deviceuiConfig, own node_info, metadata, region_presets
 constexpr unsigned NUM_CONFIG_MESSAGES = _meshtastic_AdminMessage_ConfigType_MAX + 1;
@@ -219,6 +220,18 @@ bool drainUntilComplete(DumpTranscript &t, unsigned maxMessages = 600)
         default:
             break;
         }
+    }
+    return false;
+}
+
+/// Read until available() reports idle; false if it never does within the cap.
+bool drainToIdle(unsigned maxReads = 8)
+{
+    uint8_t buf[meshtastic_FromRadio_size];
+    for (unsigned i = 0; i <= maxReads; i++) {
+        if (!api->available())
+            return true;
+        api->getFromRadio(buf);
     }
     return false;
 }
@@ -490,16 +503,31 @@ void test_dump_reaches_idle_after_complete()
     DumpTranscript t;
     TEST_ASSERT_TRUE(drainUntilComplete(t));
 
+    TEST_ASSERT_TRUE_MESSAGE(drainToIdle(), "post-complete drain never went idle: available() stuck true");
     uint8_t buf[meshtastic_FromRadio_size];
-    bool idle = false;
-    for (unsigned i = 0; i < 8 && !idle; i++) {
-        if (!api->available())
-            idle = true;
-        else
-            api->getFromRadio(buf); // replay drain: empty phases must advance toward idle
-    }
-    TEST_ASSERT_TRUE_MESSAGE(idle, "post-complete drain never went idle: available() stuck true");
     TEST_ASSERT_EQUAL_UINT(0, api->getFromRadio(buf));
+}
+
+// The first region set moves my_node_num live (NodeDB::createNewIdentity()) with no reboot to force a
+// re-handshake, so the stream must re-announce my_info - exactly once - on its own.
+void test_node_num_change_resends_my_info()
+{
+    startHandshake(FULL_DUMP_NONCE);
+    DumpTranscript t;
+    TEST_ASSERT_TRUE(drainUntilComplete(t));
+    TEST_ASSERT_TRUE_MESSAGE(drainToIdle(), "post-complete drain never went idle");
+
+    myNodeInfo.my_node_num = RENUMBERED_SELF;
+
+    TEST_ASSERT_TRUE_MESSAGE(api->available(), "a renumber must make the stream readable again");
+    meshtastic_FromRadio msg;
+    TEST_ASSERT_TRUE(readOneFromRadio(msg));
+    TEST_ASSERT_EQUAL_UINT_MESSAGE(meshtastic_FromRadio_my_info_tag, msg.which_payload_variant,
+                                   "a renumber must be announced as my_info");
+    TEST_ASSERT_EQUAL_UINT32(RENUMBERED_SELF, msg.my_info.my_node_num);
+
+    // Keyed on the number itself, not a sticky flag: nothing repeats once the client has been told.
+    TEST_ASSERT_FALSE_MESSAGE(api->available(), "my_info resend repeated after the client was told");
 }
 
 } // namespace
@@ -567,6 +595,7 @@ void setup()
     RUN_TEST(test_close_mid_dump_then_reconnect_restarts_clean);
     RUN_TEST(test_rehandshake_mid_dump_restarts_from_my_info);
     RUN_TEST(test_dump_reaches_idle_after_complete);
+    RUN_TEST(test_node_num_change_resends_my_info);
 
     exit(UNITY_END());
 }

--- a/test/test_phone_api_config_dump/test_main.cpp
+++ b/test/test_phone_api_config_dump/test_main.cpp
@@ -26,8 +26,8 @@ constexpr uint32_t FULL_DUMP_NONCE = 0x51C0FFEE;
 constexpr uint32_t SECOND_NONCE = 0x0DDBA11;
 constexpr NodeNum SEEDED_NODE_A = 0x00000A01;
 constexpr NodeNum SEEDED_NODE_B = 0x00000A02;
-constexpr NodeNum RENUMBERED_SELF = 0x00C0FFEE; // stands in for crc32(public_key) after the first region set
 
+constexpr unsigned MAX_IDLE_DRAIN_READS = 8; // replay phases left to drain after config_complete_id
 constexpr unsigned NUM_SINGLETON_PREFIX = 5; // my_info, deviceuiConfig, own node_info, metadata, region_presets
 constexpr unsigned NUM_CONFIG_MESSAGES = _meshtastic_AdminMessage_ConfigType_MAX + 1;
 constexpr unsigned NUM_MODULE_CONFIG_MESSAGES = _meshtastic_AdminMessage_ModuleConfigType_MAX + 1;
@@ -74,8 +74,12 @@ static_assert(sizeof(kExpectedModuleConfigVariants) / sizeof(kExpectedModuleConf
 /// PhoneAPI over a permanently-connected fake transport.
 class PhoneAPITestShim : public PhoneAPI
 {
+  public:
+    unsigned dataNotifications = 0; // transport wake-ups, i.e. "come and read"
+
   protected:
     bool checkIsConnected() override { return true; }
+    void onNowHasData(uint32_t fromRadioNum) override { dataNotifications++; }
 };
 
 /// Concrete Router with no radio interface: getQueueStatus() reports an all-zero queue.
@@ -225,10 +229,10 @@ bool drainUntilComplete(DumpTranscript &t, unsigned maxMessages = 600)
 }
 
 /// Read until available() reports idle; false if it never does within the cap.
-bool drainToIdle(unsigned maxReads = 8)
+bool drainToIdle()
 {
     uint8_t buf[meshtastic_FromRadio_size];
-    for (unsigned i = 0; i <= maxReads; i++) {
+    for (unsigned i = 0; i < MAX_IDLE_DRAIN_READS; i++) {
         if (!api->available())
             return true;
         api->getFromRadio(buf);
@@ -382,6 +386,14 @@ void test_only_nodes_nonce_sends_nodes_then_complete()
     TEST_ASSERT_EQUAL_UINT(0, countVariant(t, meshtastic_FromRadio_config_tag));
     TEST_ASSERT_EQUAL_UINT(0, countVariant(t, meshtastic_FromRadio_moduleConfig_tag));
     TEST_ASSERT_EQUAL_UINT(0, t.fileInfoCount);
+
+    // This nonce skips my_info entirely, so the trailing replay must not produce one either.
+    for (unsigned i = 0; i < MAX_IDLE_DRAIN_READS && api->available(); i++) {
+        meshtastic_FromRadio trailing;
+        if (readOneFromRadio(trailing))
+            TEST_ASSERT_NOT_EQUAL_MESSAGE(meshtastic_FromRadio_my_info_tag, trailing.which_payload_variant,
+                                          "nodes-only sync must not emit my_info");
+    }
 }
 
 // SPECIAL_NONCE_ONLY_CONFIG delivers the full config but skips the non-self node DB, and must
@@ -517,16 +529,26 @@ void test_node_num_change_resends_my_info()
     TEST_ASSERT_TRUE(drainUntilComplete(t));
     TEST_ASSERT_TRUE_MESSAGE(drainToIdle(), "post-complete drain never went idle");
 
-    myNodeInfo.my_node_num = RENUMBERED_SELF;
+    const uint32_t handshakeNodeNum = nodeDB->getNodeNum();
+    const unsigned notificationsBefore = api->dataNotifications;
 
-    TEST_ASSERT_TRUE_MESSAGE(api->available(), "a renumber must make the stream readable again");
+    // What the first region set does to an already-synced client: a minted key moves the number.
+    config.security.public_key.size = 32;
+    memset(config.security.public_key.bytes, 0x5A, sizeof(config.security.public_key.bytes));
+    TEST_ASSERT_TRUE_MESSAGE(nodeDB->createNewIdentity(), "identity did not move");
+    TEST_ASSERT_NOT_EQUAL_MESSAGE(handshakeNodeNum, nodeDB->getNodeNum(), "node num did not actually change");
+
+    service->loop(); // delivers the fromNum notify that arms the re-announce
+    TEST_ASSERT_GREATER_THAN_UINT_MESSAGE(notificationsBefore, api->dataNotifications,
+                                          "transport was never woken to come and read");
+
     meshtastic_FromRadio msg;
     TEST_ASSERT_TRUE(readOneFromRadio(msg));
     TEST_ASSERT_EQUAL_UINT_MESSAGE(meshtastic_FromRadio_my_info_tag, msg.which_payload_variant,
                                    "a renumber must be announced as my_info");
-    TEST_ASSERT_EQUAL_UINT32(RENUMBERED_SELF, msg.my_info.my_node_num);
+    TEST_ASSERT_EQUAL_UINT32(nodeDB->getNodeNum(), msg.my_info.my_node_num);
 
-    // Keyed on the number itself, not a sticky flag: nothing repeats once the client has been told.
+    // One-shot: the stream falls back to live traffic and nothing repeats.
     TEST_ASSERT_FALSE_MESSAGE(api->available(), "my_info resend repeated after the client was told");
 }
 

--- a/test/test_phone_api_config_dump/test_main.cpp
+++ b/test/test_phone_api_config_dump/test_main.cpp
@@ -228,6 +228,14 @@ bool drainUntilComplete(DumpTranscript &t, unsigned maxMessages = 600)
     return false;
 }
 
+/// What the first region set does to a live node: a minted key moves my_node_num with it.
+void mintIdentity()
+{
+    config.security.public_key.size = 32;
+    memset(config.security.public_key.bytes, 0x5A, sizeof(config.security.public_key.bytes));
+    TEST_ASSERT_TRUE_MESSAGE(nodeDB->createNewIdentity(), "identity did not move");
+}
+
 /// Read until available() reports idle; false if it never does within the cap.
 bool drainToIdle()
 {
@@ -532,10 +540,7 @@ void test_node_num_change_resends_my_info()
     const uint32_t handshakeNodeNum = nodeDB->getNodeNum();
     const unsigned notificationsBefore = api->dataNotifications;
 
-    // What the first region set does to an already-synced client: a minted key moves the number.
-    config.security.public_key.size = 32;
-    memset(config.security.public_key.bytes, 0x5A, sizeof(config.security.public_key.bytes));
-    TEST_ASSERT_TRUE_MESSAGE(nodeDB->createNewIdentity(), "identity did not move");
+    mintIdentity();
     TEST_ASSERT_NOT_EQUAL_MESSAGE(handshakeNodeNum, nodeDB->getNodeNum(), "node num did not actually change");
 
     service->loop(); // delivers the fromNum notify that arms the re-announce
@@ -550,6 +555,30 @@ void test_node_num_change_resends_my_info()
 
     // One-shot: the stream falls back to live traffic and nothing repeats.
     TEST_ASSERT_FALSE_MESSAGE(api->available(), "my_info resend repeated after the client was told");
+}
+
+// The same move landing mid-sync: my_info is already out with the old number and there is no
+// steady state to fall back from, so the dump restarts and carries the new one.
+void test_node_num_change_mid_dump_restarts_sync()
+{
+    startHandshake(FULL_DUMP_NONCE);
+
+    meshtastic_FromRadio msg;
+    for (unsigned i = 0; i < NUM_SINGLETON_PREFIX + MAX_NUM_CHANNELS; i++)
+        TEST_ASSERT_TRUE(readOneFromRadio(msg)); // through the channels, my_info long since sent
+
+    mintIdentity();
+    service->loop();
+
+    TEST_ASSERT_TRUE(readOneFromRadio(msg));
+    TEST_ASSERT_EQUAL_UINT_MESSAGE(meshtastic_FromRadio_my_info_tag, msg.which_payload_variant,
+                                   "a mid-sync renumber must restart the dump");
+    TEST_ASSERT_EQUAL_UINT32(nodeDB->getNodeNum(), msg.my_info.my_node_num);
+
+    DumpTranscript t;
+    TEST_ASSERT_TRUE_MESSAGE(drainUntilComplete(t), "restarted dump never completed");
+    TEST_ASSERT_EQUAL_UINT32(FULL_DUMP_NONCE, t.completeId);
+    TEST_ASSERT_EQUAL_UINT_MESSAGE(NUM_CONFIG_MESSAGES, t.configVariants.size(), "restarted dump lost part of the config");
 }
 
 } // namespace
@@ -618,6 +647,7 @@ void setup()
     RUN_TEST(test_rehandshake_mid_dump_restarts_from_my_info);
     RUN_TEST(test_dump_reaches_idle_after_complete);
     RUN_TEST(test_node_num_change_resends_my_info);
+    RUN_TEST(test_node_num_change_mid_dump_restarts_sync);
 
     exit(UNITY_END());
 }

--- a/test/test_phone_api_config_dump/test_main.cpp
+++ b/test/test_phone_api_config_dump/test_main.cpp
@@ -591,6 +591,29 @@ void test_node_num_change_mid_dump_restarts_sync()
     TEST_ASSERT_EQUAL_UINT32(FULL_DUMP_NONCE, t.completeId);
 }
 
+// Same move during a nodes-only sync: the self record it already sent is gone from the DB, so that
+// dump restarts too, even though this nonce never carries a my_info to be stale.
+void test_node_num_change_mid_nodes_only_restarts_sync()
+{
+    seedRemoteNode(SEEDED_NODE_A);
+    startHandshake(SPECIAL_NONCE_ONLY_NODES);
+
+    meshtastic_FromRadio msg;
+    TEST_ASSERT_TRUE(readOneFromRadio(msg));
+    TEST_ASSERT_EQUAL_UINT(meshtastic_FromRadio_node_info_tag, msg.which_payload_variant);
+    const uint32_t staleSelf = msg.node_info.num;
+
+    mintIdentity();
+    service->loop();
+
+    DumpTranscript t;
+    TEST_ASSERT_TRUE_MESSAGE(drainUntilComplete(t), "restarted nodes-only dump never completed");
+    TEST_ASSERT_EQUAL_UINT_MESSAGE(nodeDB->getNumMeshNodes(), t.nodeNums.size(), "restart must resend every node");
+    TEST_ASSERT_NOT_EQUAL_MESSAGE(staleSelf, t.nodeNums[0], "restart must carry the new self record");
+    TEST_ASSERT_EQUAL_UINT32(nodeDB->getNodeNum(), t.nodeNums[0]);
+    TEST_ASSERT_EQUAL_UINT32(SPECIAL_NONCE_ONLY_NODES, t.completeId);
+}
+
 } // namespace
 
 void setUp(void)
@@ -658,6 +681,7 @@ void setup()
     RUN_TEST(test_dump_reaches_idle_after_complete);
     RUN_TEST(test_node_num_change_resends_my_info);
     RUN_TEST(test_node_num_change_mid_dump_restarts_sync);
+    RUN_TEST(test_node_num_change_mid_nodes_only_restarts_sync);
 
     exit(UNITY_END());
 }


### PR DESCRIPTION
Fixes #11718

The first region set mints the PKI key and moves `my_node_num` to `crc32(public_key)` live. `my_info` only went out during the `want_config_id` handshake, so an already-connected client kept addressing the old number and its admin packets NAKed `PKI_SEND_FAIL_PUBLIC_KEY` until it reconnected.

`createNewIdentity()` sets `MeshService::identityMoved` and nudges `fromNum`; the flag clears once the notify pass has reached every observer. `PhoneAPI::onNotify` runs once per connected instance in that pass and either arms a one-shot `STATE_RESEND_MY_INFO`, which emits a fresh `my_info` and falls back to `STATE_SEND_PACKETS`, or restarts the dump of a client still mid-sync, whose `my_info` is already out with the old number. No per-connection state is added to `PhoneAPI`, per the USB-CDC note in that header. Covers all four `ensurePkiIdentity()` call sites, including the on-device region pickers, which do not reboot either.

Tests in `test_phone_api_config_dump`, both driving `NodeDB::createNewIdentity()` and `MeshService::loop()`: `test_node_num_change_resends_my_info` for a synced client, asserting the transport wake-up and the re-announced number, and `test_node_num_change_mid_dump_restarts_sync` for one still in its dump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clients now receive updated node identity information when a device’s node number changes, without requiring a reboot.
  * Refreshed information is sent once before normal packet delivery resumes.
  * In-progress configuration synchronization restarts when the node number changes, ensuring updated identity information is included.
  * Node-info-only requests avoid unnecessary additional identity output.
  * Self-node records remain correctly prioritized for phone dumps and node management.
  * Identity changes are handled reliably during concurrent mesh updates.

* **Tests**
  * Added coverage for identity updates during normal connections and configuration synchronization, including message ordering and duplicate prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->