### PR TITLE
Address TFT color overlaps in BaseUI

### DIFF
--- a/src/graphics/SharedUIDisplay.cpp
+++ b/src/graphics/SharedUIDisplay.cpp
@@ -557,13 +557,20 @@ const int *getTextPositions(OLEDDisplay *display)
         textPositions[5] = textFifthLine_medium;
         textPositions[6] = textSixthLine_medium;
     } else {
+        int bodyShift = 0;
+        if (isTFTColoringEnabled()) {
+            const int headerBottom = FONT_HEIGHT_SMALL + 1 + BASEUI_HEADER_MARGIN;
+            const int overlap = headerBottom - textFirstLine;
+            if (overlap > 0 && (textSixthLine + FONT_HEIGHT_SMALL + overlap) <= SCREEN_HEIGHT)
+                bodyShift = overlap;
+        }
         textPositions[0] = textZeroLine;
-        textPositions[1] = textFirstLine;
-        textPositions[2] = textSecondLine;
-        textPositions[3] = textThirdLine;
-        textPositions[4] = textFourthLine;
-        textPositions[5] = textFifthLine;
-        textPositions[6] = textSixthLine;
+        textPositions[1] = textFirstLine + bodyShift;
+        textPositions[2] = textSecondLine + bodyShift;
+        textPositions[3] = textThirdLine + bodyShift;
+        textPositions[4] = textFourthLine + bodyShift;
+        textPositions[5] = textFifthLine + bodyShift;
+        textPositions[6] = textSixthLine + bodyShift;
     }
     return textPositions;
 }

--- a/src/graphics/draw/UIRenderer.cpp
+++ b/src/graphics/draw/UIRenderer.cpp
@@ -545,7 +545,9 @@ void UIRenderer::drawGps(OLEDDisplay *display, int16_t x, int16_t y, const mesht
 
     // Draw satellite image
     if (currentResolution == ScreenResolution::High) {
-        NodeListRenderer::drawScaledXBitmap16x16(x, y - 2, imgGPS_width, imgGPS_height, imgGPS, display);
+        const int iconSlack = FONT_HEIGHT_SMALL - (imgGPS_height * 2);
+        const int iconY = y + (iconSlack > 0 ? iconSlack / 2 : 0);
+        NodeListRenderer::drawScaledXBitmap16x16(x, iconY, imgGPS_width, imgGPS_height, imgGPS, display);
     } else {
         display->drawXbm(x + 1, y + 3, imgGPS_width, imgGPS_height, imgGPS);
     }

--- a/src/modules/Telemetry/PowerTelemetry.cpp
+++ b/src/modules/Telemetry/PowerTelemetry.cpp
@@ -165,7 +165,7 @@ void PowerTelemetryModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *s
 
     // Display current and voltage based on ...power_metrics.has_[channel/voltage/current]... flags
     const auto &m = lastMeasurement.variant.power_metrics;
-    int lineY = textSecondLine;
+    int lineY = graphics::getTextPositions(display)[line];
 
     auto drawLine = [&](const char *label, float voltage, float current) {
         char lineStr[64];


### PR DESCRIPTION
- Address overlap of the GPS icon on Position frame (Cardputer original identified)
- Address overlap on Favorite frames for smaller TFT displays like Heltec T096/T1
- Preventative fix on Power Telemetry frame to ensure no issues


Regression tested on M5Stack Cardputer and Heltec T1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text spacing when TFT coloring is enabled to prevent overlap with the header.
  * Centered the high-resolution GPS satellite icon vertically with its accompanying text.
  * Improved vertical alignment of power telemetry metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->