### PR TITLE
fix(telemetry): restore the noise floor feeder and stop shipping its default

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1502,8 +1502,7 @@ void loop()
         static uint32_t lastAgcReset;
         if (!Throttle::isWithinTimespanMs(lastAgcReset, AGC_RESET_INTERVAL_MS)) {
             lastAgcReset = millis();
-            // Sample first: resetAGC() recalibrates the frontend, which biases an RSSI read taken right
-            // after it. This is #9347's periodic feeder, lost when merge e55947595 dropped its call sites.
+            // Sample before resetAGC(): recalibrating the frontend biases an RSSI read taken right after it.
             RadioLibInterface::instance->updateNoiseFloor();
             RadioLibInterface::instance->periodicRadioMaintenance();
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1502,6 +1502,9 @@ void loop()
         static uint32_t lastAgcReset;
         if (!Throttle::isWithinTimespanMs(lastAgcReset, AGC_RESET_INTERVAL_MS)) {
             lastAgcReset = millis();
+            // Sample first: resetAGC() recalibrates the frontend, which biases an RSSI read taken right
+            // after it. This is #9347's periodic feeder, lost when merge e55947595 dropped its call sites.
+            RadioLibInterface::instance->updateNoiseFloor();
             RadioLibInterface::instance->periodicRadioMaintenance();
         }
     }

--- a/src/modules/Telemetry/DeviceTelemetry.cpp
+++ b/src/modules/Telemetry/DeviceTelemetry.cpp
@@ -131,14 +131,10 @@ meshtastic_Telemetry DeviceTelemetryModule::getLocalStatsTelemetry()
     telemetry.variant.local_stats.num_online_nodes = numOnlineNodes;
     telemetry.variant.local_stats.num_total_nodes = nodeDB->getNumMeshNodes();
     if (RadioLibInterface::instance) {
-        RadioLibInterface::instance->updateNoiseFloor();
         // No presence bit: leave zero-init when no valid sample exists instead of publishing
         // NOISE_FLOOR_DEFAULT as a real reading.
-        if (RadioLibInterface::instance->hasNoiseFloorSamples()) {
+        if (RadioLibInterface::instance->hasNoiseFloorSamples())
             telemetry.variant.local_stats.noise_floor = RadioLibInterface::instance->getAverageNoiseFloor();
-        } else {
-            LOG_DEBUG("No valid noise floor samples yet; omitting noise_floor from local stats");
-        }
         telemetry.variant.local_stats.num_packets_tx = RadioLibInterface::instance->txGood;
         telemetry.variant.local_stats.num_packets_rx = RadioLibInterface::instance->rxGood + RadioLibInterface::instance->rxBad;
         telemetry.variant.local_stats.num_packets_rx_bad = RadioLibInterface::instance->rxBad;

--- a/src/modules/Telemetry/DeviceTelemetry.cpp
+++ b/src/modules/Telemetry/DeviceTelemetry.cpp
@@ -132,7 +132,14 @@ meshtastic_Telemetry DeviceTelemetryModule::getLocalStatsTelemetry()
     telemetry.variant.local_stats.num_total_nodes = nodeDB->getNumMeshNodes();
     if (RadioLibInterface::instance) {
         RadioLibInterface::instance->updateNoiseFloor();
-        telemetry.variant.local_stats.noise_floor = RadioLibInterface::instance->getAverageNoiseFloor();
+        // noise_floor has no has_/presence bit on the wire, so an unqualified read here would ship
+        // NOISE_FLOOR_DEFAULT indistinguishably from a real -120 dBm reading. Leave the field at its
+        // zero-init value instead, and say so, whenever we've never actually sampled a valid RSSI.
+        if (RadioLibInterface::instance->hasNoiseFloorSamples()) {
+            telemetry.variant.local_stats.noise_floor = RadioLibInterface::instance->getAverageNoiseFloor();
+        } else {
+            LOG_WARN("No valid noise floor samples yet; omitting noise_floor from local stats");
+        }
         telemetry.variant.local_stats.num_packets_tx = RadioLibInterface::instance->txGood;
         telemetry.variant.local_stats.num_packets_rx = RadioLibInterface::instance->rxGood + RadioLibInterface::instance->rxBad;
         telemetry.variant.local_stats.num_packets_rx_bad = RadioLibInterface::instance->rxBad;

--- a/src/modules/Telemetry/DeviceTelemetry.cpp
+++ b/src/modules/Telemetry/DeviceTelemetry.cpp
@@ -132,13 +132,12 @@ meshtastic_Telemetry DeviceTelemetryModule::getLocalStatsTelemetry()
     telemetry.variant.local_stats.num_total_nodes = nodeDB->getNumMeshNodes();
     if (RadioLibInterface::instance) {
         RadioLibInterface::instance->updateNoiseFloor();
-        // noise_floor has no has_/presence bit on the wire, so an unqualified read here would ship
-        // NOISE_FLOOR_DEFAULT indistinguishably from a real -120 dBm reading. Leave the field at its
-        // zero-init value instead, and say so, whenever we've never actually sampled a valid RSSI.
+        // No presence bit: leave zero-init when no valid sample exists instead of publishing
+        // NOISE_FLOOR_DEFAULT as a real reading.
         if (RadioLibInterface::instance->hasNoiseFloorSamples()) {
             telemetry.variant.local_stats.noise_floor = RadioLibInterface::instance->getAverageNoiseFloor();
         } else {
-            LOG_WARN("No valid noise floor samples yet; omitting noise_floor from local stats");
+            LOG_DEBUG("No valid noise floor samples yet; omitting noise_floor from local stats");
         }
         telemetry.variant.local_stats.num_packets_tx = RadioLibInterface::instance->txGood;
         telemetry.variant.local_stats.num_packets_rx = RadioLibInterface::instance->rxGood + RadioLibInterface::instance->rxBad;


### PR DESCRIPTION
## Summary

Two defects, both ending in a `noise_floor` value that is not a measurement.

### 1. The sampler had no feeder

`updateNoiseFloor()` landed in #9347 with three call sites in `RadioLibInterface`: `onNotify()`, `completeSending()` and `startReceive()`. Review removed the `onNotify()` one, correctly, because a delay on the ISR path can fill the 256-byte radio FIFO before it is read out; the guidance on that thread was to keep a periodic call from ordinary thread context instead.

The remaining two never made it to `develop`. Merge commit `e55947595` "Merge upstream develop into noise-floor" took upstream's rewrite of `completeSending()` and `startReceive()` wholesale and dropped both one-line insertions. Nothing in the PR mentions it and no commit since has added a call back: `git log -S "updateNoiseFloor" -- src/` returns exactly one commit, the introduction.

That left `DeviceTelemetryModule::getLocalStatsTelemetry()` as the only caller. It runs from `sendLocalStatsToPhone()`, throttled to 15 minutes, so the 20-sample rolling window advanced at most once per quarter hour: five hours to fill, and `NOISE_FLOOR_UPDATE_INTERVAL_MS` (5s) never reached. On a node where the idle gate or the `-127..-1` dBm bounds check rejected that one attempt, the buffer stayed empty indefinitely.

Sampling now happens on the existing 60s AGC maintenance tick in `main.cpp`, before `periodicRadioMaintenance()` because `resetAGC()` warm-sleeps and recalibrates the frontend, which biases an RSSI read taken immediately after it. `NOISE_FLOOR_UPDATE_INTERVAL_MS` stays at 5s as an inner floor; the call site sets the real rate. The window fills in roughly 20 minutes, so a 15-minute local stats report carries a populated average instead of a single sample.

With the periodic feeder in place the sampling call on the telemetry path is gone. It contributed about one sample in fifteen and cost an SPI-gated read on the local stats path.

### 2. The empty-buffer default shipped as a real reading

`LocalStats.noise_floor` is a plain proto3 `int32`, no presence bit, so `getAverageNoiseFloor()`'s `NOISE_FLOOR_DEFAULT` (-120 dBm) placeholder was indistinguishable on the wire from a genuine -120 dBm reading whenever no valid sample had been collected.

`getLocalStatsTelemetry()` now checks `hasNoiseFloorSamples()`, which the class already exposed for this and which had no callers. With no sample yet the field stays zero-initialised, which nanopb omits from the encoding entirely; the existing "Sending local stats" `LOG_INFO` in the same function reports `noise_floor=0`. This still matters after the feeder fix: the first report after boot precedes the first sample.

## Changes

- `src/main.cpp`: call `updateNoiseFloor()` from the AGC maintenance tick, ahead of `periodicRadioMaintenance()`.
- `src/modules/Telemetry/DeviceTelemetry.cpp`: gate the `noise_floor` assignment on `hasNoiseFloorSamples()`, drop the now-redundant `updateNoiseFloor()` call.

## Not touched

- `SimRadio::getCurrentRSSI()` hardcodes -120 as a Portduino stub. There is no radio to sample, so it is out of scope.
- `RF95Interface::startReceive()` chains to the base again since #11678, but the periodic tick is used rather than restoring the original `startReceive()` hook, which was dead on RF95 for the whole time it existed.
- `sendStatsToPhoneIntervalMs` stays at 15 minutes. Dropping it to 60s to match the other telemetry modules would skew the packet ratio on the phone queue.

## Verification

CI matrix. No behaviour change on hardware already collecting valid samples, beyond sampling 15x more often.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Noise-floor telemetry now reports readings only when valid samples are available.
  * Missing or invalid noise-floor samples remain represented as zero rather than actual readings.
  * Noise-floor measurements are refreshed during periodic radio maintenance, improving the accuracy of reported readings.
  * Unavailable noise-floor samples no longer generate diagnostic debug messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->