### PR TITLE
fix(position): stamp the broadcast cadence only when a position packet was actually sent

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -414,8 +414,7 @@ bool MeshService::trySendPosition(NodeNum dest, bool wantReplies)
 
     assert(node);
 
-    // Every path that puts no position on the air falls back to nodeinfo, so a false return
-    // always means "nodeinfo went instead" - what the callers report to the user.
+    // A false return always means "nodeinfo went instead" - the callers report that to the user.
     auto sendNodeInfoInstead = [&]() {
         if (nodeInfoModule) {
             LOG_INFO("Send nodeinfo ping to 0x%08x, wantReplies=%d, channel=%d", dest, wantReplies, node->channel);

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -432,8 +432,7 @@ bool MeshService::trySendPosition(NodeNum dest, bool wantReplies)
                 return false;
             }
             LOG_INFO("Send position ping to 0x%08x, wantReplies=%d, channel=%d", dest, wantReplies, sendChan);
-            positionModule->sendOurPosition(dest, wantReplies, sendChan);
-            return true;
+            return positionModule->sendOurPosition(dest, wantReplies, sendChan);
         }
     } else {
 #endif

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -414,30 +414,24 @@ bool MeshService::trySendPosition(NodeNum dest, bool wantReplies)
 
     assert(node);
 
-    // A false return always means "nodeinfo went instead" - the callers report that to the user.
-    auto sendNodeInfoInstead = [&]() {
-        if (nodeInfoModule) {
-            LOG_INFO("Send nodeinfo ping to 0x%08x, wantReplies=%d, channel=%d", dest, wantReplies, node->channel);
-            nodeInfoModule->sendOurNodeInfo(dest, wantReplies, node->channel);
-        }
-        return false;
-    };
-
 #if HAS_GPS && !MESHTASTIC_EXCLUDE_GPS
+    // Prefer the node's current channel, but fall back to the position channel
+    // (matching PositionModule::sendOurPosition() behavior).
+    uint8_t sendChan = node->channel;
     if (nodeDB->hasValidPosition(node) && positionModule &&
-        (config.position.fixed_position || nodeDB->hasLocalPositionSinceBoot())) {
-        // Prefer the node's current channel, but fall back to the position channel
-        // (matching PositionModule::sendOurPosition() behavior).
-        uint8_t sendChan = node->channel;
-        if (getPositionPrecisionForChannel(sendChan) == 0 && !findPositionChannel(sendChan))
-            return sendNodeInfoInstead(); // No channel carries positions
-
+        (config.position.fixed_position || nodeDB->hasLocalPositionSinceBoot()) &&
+        (getPositionPrecisionForChannel(sendChan) != 0 || findPositionChannel(sendChan))) {
         LOG_INFO("Send position ping to 0x%08x, wantReplies=%d, channel=%d", dest, wantReplies, sendChan);
         if (positionModule->sendOurPosition(dest, wantReplies, sendChan))
             return true;
     }
 #endif
-    return sendNodeInfoInstead();
+    // No position went out, so a false return tells the callers the nodeinfo fallback was used.
+    if (nodeInfoModule) {
+        LOG_INFO("Send nodeinfo ping to 0x%08x, wantReplies=%d, channel=%d", dest, wantReplies, node->channel);
+        nodeInfoModule->sendOurNodeInfo(dest, wantReplies, node->channel);
+    }
+    return false;
 }
 
 // ASCII BEL, the in-band alert marker. Numeric so no control byte sits in the source, and

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -368,7 +368,7 @@ ErrorCode MeshService::sendQueueStatusToPhone(const meshtastic_QueueStatus &qs, 
     return res ? ERRNO_OK : ERRNO_UNKNOWN;
 }
 
-void MeshService::sendToMesh(meshtastic_MeshPacket *p, RxSource src, bool ccToPhone)
+ErrorCode MeshService::sendToMesh(meshtastic_MeshPacket *p, RxSource src, bool ccToPhone)
 {
     uint32_t mesh_packet_id = p->id;
     nodeDB->updateFrom(*p); // update our local DB for this packet (because phone might have sent position packets etc...)
@@ -404,6 +404,8 @@ void MeshService::sendToMesh(meshtastic_MeshPacket *p, RxSource src, bool ccToPh
     if (res == ERRNO_SHOULD_RELEASE) {
         releaseToPool(p);
     }
+
+    return res;
 }
 
 bool MeshService::trySendPosition(NodeNum dest, bool wantReplies)
@@ -412,36 +414,31 @@ bool MeshService::trySendPosition(NodeNum dest, bool wantReplies)
 
     assert(node);
 
-    if (nodeDB->hasValidPosition(node)) {
-#if HAS_GPS && !MESHTASTIC_EXCLUDE_GPS
-        if (positionModule) {
-            if (!config.position.fixed_position && !nodeDB->hasLocalPositionSinceBoot()) {
-                LOG_DEBUG("Skip position ping; no fresh position since boot");
-                return false;
-            }
-            // Prefer the node's current channel, but fall back to the position channel
-            // (matching PositionModule::sendOurPosition() behavior).
-            uint8_t sendChan = node->channel;
-            if (getPositionPrecisionForChannel(sendChan) == 0 && !findPositionChannel(sendChan)) {
-                // No channel with position enabled: fall back to sending nodeinfo, as before.
-                if (nodeInfoModule) {
-                    LOG_INFO("No position-enabled channel; send nodeinfo instead to 0x%08x, wantReplies=%d, channel=%d", dest,
-                             wantReplies, node->channel);
-                    nodeInfoModule->sendOurNodeInfo(dest, wantReplies, node->channel);
-                }
-                return false;
-            }
-            LOG_INFO("Send position ping to 0x%08x, wantReplies=%d, channel=%d", dest, wantReplies, sendChan);
-            return positionModule->sendOurPosition(dest, wantReplies, sendChan);
-        }
-    } else {
-#endif
+    // Every path that puts no position on the air falls back to nodeinfo, so a false return
+    // always means "nodeinfo went instead" - what the callers report to the user.
+    auto sendNodeInfoInstead = [&]() {
         if (nodeInfoModule) {
             LOG_INFO("Send nodeinfo ping to 0x%08x, wantReplies=%d, channel=%d", dest, wantReplies, node->channel);
             nodeInfoModule->sendOurNodeInfo(dest, wantReplies, node->channel);
         }
+        return false;
+    };
+
+#if HAS_GPS && !MESHTASTIC_EXCLUDE_GPS
+    if (nodeDB->hasValidPosition(node) && positionModule &&
+        (config.position.fixed_position || nodeDB->hasLocalPositionSinceBoot())) {
+        // Prefer the node's current channel, but fall back to the position channel
+        // (matching PositionModule::sendOurPosition() behavior).
+        uint8_t sendChan = node->channel;
+        if (getPositionPrecisionForChannel(sendChan) == 0 && !findPositionChannel(sendChan))
+            return sendNodeInfoInstead(); // No channel carries positions
+
+        LOG_INFO("Send position ping to 0x%08x, wantReplies=%d, channel=%d", dest, wantReplies, sendChan);
+        if (positionModule->sendOurPosition(dest, wantReplies, sendChan))
+            return true;
     }
-    return false;
+#endif
+    return sendNodeInfoInstead();
 }
 
 // ASCII BEL, the in-band alert marker. Numeric so no control byte sits in the source, and

--- a/src/mesh/MeshService.h
+++ b/src/mesh/MeshService.h
@@ -189,8 +189,7 @@ class MeshService
     /// Send a packet into the mesh - note p must have been allocated from packetPool.  We will return it to that pool after
     /// sending. This is the ONLY function you should use for sending messages into the mesh, because it also updates the nodedb
     /// cache
-    /// Returns the router's verdict: ERRNO_OK or ERRNO_SHOULD_RELEASE mean the packet was accepted,
-    /// anything else that it was rejected and released without being sent.
+    /// Returns the router's verdict: ERRNO_OK / ERRNO_SHOULD_RELEASE accepted, anything else released unsent.
     ErrorCode sendToMesh(meshtastic_MeshPacket *p, RxSource src = RX_SRC_LOCAL, bool ccToPhone = false);
 
     /** Attempt to cancel a previously sent packet from this _local_ node.  Returns true if a packet was found we could cancel */

--- a/src/mesh/MeshService.h
+++ b/src/mesh/MeshService.h
@@ -189,7 +189,9 @@ class MeshService
     /// Send a packet into the mesh - note p must have been allocated from packetPool.  We will return it to that pool after
     /// sending. This is the ONLY function you should use for sending messages into the mesh, because it also updates the nodedb
     /// cache
-    void sendToMesh(meshtastic_MeshPacket *p, RxSource src = RX_SRC_LOCAL, bool ccToPhone = false);
+    /// Returns the router's verdict: ERRNO_OK or ERRNO_SHOULD_RELEASE mean the packet was accepted,
+    /// anything else that it was rejected and released without being sent.
+    ErrorCode sendToMesh(meshtastic_MeshPacket *p, RxSource src = RX_SRC_LOCAL, bool ccToPhone = false);
 
     /** Attempt to cancel a previously sent packet from this _local_ node.  Returns true if a packet was found we could cancel */
     bool cancelSending(PacketId id);

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -400,13 +400,15 @@ meshtastic_MeshPacket *PositionModule::allocAtakPli()
 bool PositionModule::sendOurPosition()
 {
     bool requestReplies = currentGeneration != radioGeneration;
-    currentGeneration = radioGeneration;
 
     // If we changed channels, ask everyone else for their latest info
     uint8_t positionChannel;
     if (findPositionChannel(positionChannel)) {
         LOG_INFO("Send pos@%x:6 to mesh (wantReplies=%d)", localPosition.timestamp, requestReplies);
-        return sendOurPosition(NODENUM_BROADCAST, requestReplies, positionChannel);
+        if (!sendOurPosition(NODENUM_BROADCAST, requestReplies, positionChannel))
+            return false;
+        currentGeneration = radioGeneration; // only a send that went out consumes the channel change
+        return true;
     }
     LOG_INFO("Skip pos@%x:6 broadcast; position sharing disabled on all channels", localPosition.timestamp);
     return false;

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -9,6 +9,7 @@
 #include "Router.h"
 #include "TransmitHistory.h"
 #include "TypeConversions.h"
+#include "UptimeClock.h"
 #include "airtime.h"
 #include "configuration.h"
 #include "gps/GPSLog.h"
@@ -291,7 +292,7 @@ meshtastic_MeshPacket *PositionModule::allocReply()
 
     meshtastic_MeshPacket *reply = allocPositionPacket(precision);
     if (reply) {
-        lastSentReply = millis(); // Track when we sent this reply
+        lastSentReply = Time::getMillis(); // Track when we sent this reply
     }
     return reply;
 }
@@ -463,11 +464,10 @@ bool PositionModule::sendOurPosition(NodeNum dest, bool wantReplies, uint8_t cha
     if (channel > 0)
         p->channel = channel;
 
-    // Only ERRNO_OK / ERRNO_SHOULD_RELEASE mean the router took the packet; anything else (full
-    // TX queue, duty cycle abort) released it unsent, and must not stamp the broadcast cadence.
+    // Rejected (full TX queue, duty cycle abort) means released unsent: never stamp the cadence.
     ErrorCode res = service->sendToMesh(p, RX_SRC_LOCAL, true);
     if (res != ERRNO_OK && res != ERRNO_SHOULD_RELEASE) {
-        LOG_WARN("Position send rejected by router: %d", res);
+        LOG_WARN("Position send rejected by router: 0x%x", res);
         return false;
     }
 
@@ -548,7 +548,7 @@ int32_t PositionModule::runOnce()
     if (node == nullptr)
         return RUNONCE_INTERVAL;
 
-    uint32_t now = millis();
+    uint32_t now = Time::getMillis();
 
     // Local-only delivery, so it runs regardless of mesh opt-in state or channel utilization.
     // Only send while the queue is empty (phone assumed connected), like telemetry. The cadence
@@ -726,7 +726,7 @@ void PositionModule::handleNewPosition()
         if (!nodeDB->copyNodePosition(node->num, selfPos))
             return;
         auto smartPosition = getDistanceTraveledSinceLastSend(selfPos);
-        uint32_t now = millis();
+        uint32_t now = Time::getMillis();
         uint32_t msSinceLastSend = now - lastGpsSend;
         if (smartPosition.hasTraveledOverThreshold) {
             if (!Throttle::hasElapsed(lastGpsSend, minimumTimeThreshold)) {

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -710,6 +710,8 @@ void PositionModule::trySmartBroadcast(const meshtastic_PositionLite &selfPos, u
         return;
 
     lastGpsSend = nowMs;
+    if (transmitHistory)
+        transmitHistory->setLastSentToMesh(meshtastic_PortNum_POSITION_APP);
     LOG_DEBUG("Sent smart pos@%x:6 to mesh (distanceTraveled=%fm, minDistanceThreshold=%im, timeElapsed=%ims, "
               "minTimeInterval=%ims)",
               localPosition.timestamp, smartPosition.distanceTraveled, smartPosition.distanceThreshold, msSinceLastSend,

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -396,7 +396,7 @@ meshtastic_MeshPacket *PositionModule::allocAtakPli()
     return mp;
 }
 
-void PositionModule::sendOurPosition()
+bool PositionModule::sendOurPosition()
 {
     bool requestReplies = currentGeneration != radioGeneration;
     currentGeneration = radioGeneration;
@@ -405,10 +405,10 @@ void PositionModule::sendOurPosition()
     uint8_t positionChannel;
     if (findPositionChannel(positionChannel)) {
         LOG_INFO("Send pos@%x:6 to mesh (wantReplies=%d)", localPosition.timestamp, requestReplies);
-        sendOurPosition(NODENUM_BROADCAST, requestReplies, positionChannel);
-        return;
+        return sendOurPosition(NODENUM_BROADCAST, requestReplies, positionChannel);
     }
     LOG_INFO("Skip pos@%x:6 broadcast; position sharing disabled on all channels", localPosition.timestamp);
+    return false;
 }
 
 // Position broadcasts are opt-in per channel in 2.8, but our own position still plays to the
@@ -431,11 +431,11 @@ bool PositionModule::sendOurPositionToPhone()
     return true;
 }
 
-void PositionModule::sendOurPosition(NodeNum dest, bool wantReplies, uint8_t channel)
+bool PositionModule::sendOurPosition(NodeNum dest, bool wantReplies, uint8_t channel)
 {
     if (!config.position.fixed_position && !nodeDB->hasLocalPositionSinceBoot()) {
         LOG_DEBUG("Skip position send; no fresh position since boot");
-        return;
+        return false;
     }
 
     // cancel any not yet sent (now stale) position packets
@@ -448,7 +448,7 @@ void PositionModule::sendOurPosition(NodeNum dest, bool wantReplies, uint8_t cha
     meshtastic_MeshPacket *p = allocPositionPacket(precision);
     if (p == nullptr) {
         LOG_DEBUG("allocPositionPacket returned a nullptr");
-        return;
+        return false;
     }
 
     p->to = dest;
@@ -481,6 +481,8 @@ void PositionModule::sendOurPosition(NodeNum dest, bool wantReplies, uint8_t cha
         LOG_DEBUG("Start next execution in 5s, then sleep");
         setIntervalFromNow(FIVE_SECONDS_MS);
     }
+
+    return true;
 }
 
 #define RUNONCE_INTERVAL 5000;
@@ -563,7 +565,7 @@ int32_t PositionModule::runOnce()
         return RUNONCE_INTERVAL;
     }
 
-    bool waitingForFreshPosition = (lastGpsSend == 0) && !config.position.fixed_position && !nodeDB->hasLocalPositionSinceBoot();
+    bool waitingForFreshPosition = !config.position.fixed_position && !nodeDB->hasLocalPositionSinceBoot();
 
     // Hold to the 6h floor when fixed_position (every role: pinning yourself forfeits the
     // exception) or when stationary. A real move still goes out early via smart-broadcast below.
@@ -584,7 +586,7 @@ int32_t PositionModule::runOnce()
     if (lastGpsSend == 0 || msSinceLastSend >= effectiveIntervalMs) {
         if (waitingForFreshPosition) {
             LOG_DEBUG_GPS("Skip initial position send; no fresh position since boot");
-        } else if (nodeDB->hasValidPosition(node)) {
+        } else if (nodeDB->hasValidPosition(node) && sendOurPosition()) {
             lastGpsSend = now;
 
             meshtastic_PositionLite selfPos;
@@ -595,7 +597,6 @@ int32_t PositionModule::runOnce()
 
             if (transmitHistory)
                 transmitHistory->setLastSentToMesh(meshtastic_PortNum_POSITION_APP);
-            sendOurPosition();
             if (config.device.role == meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND) {
                 sendLostAndFoundText();
             }
@@ -612,19 +613,21 @@ int32_t PositionModule::runOnce()
             auto smartPosition = getDistanceTraveledSinceLastSend(selfPos);
             msSinceLastSend = now - lastGpsSend;
 
-            if (smartPosition.hasTraveledOverThreshold &&
-                Throttle::execute(
-                    &lastGpsSend, minimumTimeThreshold, []() { positionModule->sendOurPosition(); },
-                    []() { LOG_DEBUG_GPS("Skip smart broadcast: time throttled"); })) {
+            if (smartPosition.hasTraveledOverThreshold) {
+                if (!Throttle::hasElapsed(lastGpsSend, minimumTimeThreshold)) {
+                    LOG_DEBUG_GPS("Skip smart broadcast: time throttled");
+                } else if (sendOurPosition()) {
+                    lastGpsSend = now;
 
-                LOG_DEBUG("Sent smart pos@%x:6 to mesh (distanceTraveled=%fm, minDistanceThreshold=%im, timeElapsed=%ims, "
-                          "minTimeInterval=%ims)",
-                          localPosition.timestamp, smartPosition.distanceTraveled, smartPosition.distanceThreshold,
-                          msSinceLastSend, minimumTimeThreshold);
+                    LOG_DEBUG("Sent smart pos@%x:6 to mesh (distanceTraveled=%fm, minDistanceThreshold=%im, timeElapsed=%ims, "
+                              "minTimeInterval=%ims)",
+                              localPosition.timestamp, smartPosition.distanceTraveled, smartPosition.distanceThreshold,
+                              msSinceLastSend, minimumTimeThreshold);
 
-                // Set the current coords as our last ones, after we've compared distance with current and decided to send
-                lastGpsLatitude = selfPos.latitude_i;
-                lastGpsLongitude = selfPos.longitude_i;
+                    // Set the current coords as our last ones, after we've compared distance with current and decided to send
+                    lastGpsLatitude = selfPos.latitude_i;
+                    lastGpsLongitude = selfPos.longitude_i;
+                }
             }
         }
     }
@@ -717,19 +720,23 @@ void PositionModule::handleNewPosition()
         if (!nodeDB->copyNodePosition(node->num, selfPos))
             return;
         auto smartPosition = getDistanceTraveledSinceLastSend(selfPos);
-        uint32_t msSinceLastSend = millis() - lastGpsSend;
-        if (smartPosition.hasTraveledOverThreshold &&
-            Throttle::execute(
-                &lastGpsSend, minimumTimeThreshold, []() { positionModule->sendOurPosition(); },
-                []() { LOG_DEBUG_GPS("Skip smart broadcast: time throttled"); })) {
-            LOG_DEBUG("Sent smart pos@%x:6 to mesh (distanceTraveled=%fm, minDistanceThreshold=%im, timeElapsed=%ims, "
-                      "minTimeInterval=%ims)",
-                      localPosition.timestamp, smartPosition.distanceTraveled, smartPosition.distanceThreshold, msSinceLastSend,
-                      minimumTimeThreshold);
+        uint32_t now = millis();
+        uint32_t msSinceLastSend = now - lastGpsSend;
+        if (smartPosition.hasTraveledOverThreshold) {
+            if (!Throttle::hasElapsed(lastGpsSend, minimumTimeThreshold)) {
+                LOG_DEBUG_GPS("Skip smart broadcast: time throttled");
+            } else if (sendOurPosition()) {
+                lastGpsSend = now;
 
-            // Set the current coords as our last ones, after we've compared distance with current and decided to send
-            lastGpsLatitude = selfPos.latitude_i;
-            lastGpsLongitude = selfPos.longitude_i;
+                LOG_DEBUG("Sent smart pos@%x:6 to mesh (distanceTraveled=%fm, minDistanceThreshold=%im, timeElapsed=%ims, "
+                          "minTimeInterval=%ims)",
+                          localPosition.timestamp, smartPosition.distanceTraveled, smartPosition.distanceThreshold,
+                          msSinceLastSend, minimumTimeThreshold);
+
+                // Set the current coords as our last ones, after we've compared distance with current and decided to send
+                lastGpsLatitude = selfPos.latitude_i;
+                lastGpsLongitude = selfPos.longitude_i;
+            }
         }
     }
 }

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -463,7 +463,13 @@ bool PositionModule::sendOurPosition(NodeNum dest, bool wantReplies, uint8_t cha
     if (channel > 0)
         p->channel = channel;
 
-    service->sendToMesh(p, RX_SRC_LOCAL, true);
+    // Only ERRNO_OK / ERRNO_SHOULD_RELEASE mean the router took the packet; anything else (full
+    // TX queue, duty cycle abort) released it unsent, and must not stamp the broadcast cadence.
+    ErrorCode res = service->sendToMesh(p, RX_SRC_LOCAL, true);
+    if (res != ERRNO_OK && res != ERRNO_SHOULD_RELEASE) {
+        LOG_WARN("Position send rejected by router: %d", res);
+        return false;
+    }
 
     if (IS_ONE_OF(config.device.role, meshtastic_Config_DeviceConfig_Role_TRACKER,
                   meshtastic_Config_DeviceConfig_Role_TAK_TRACKER) &&

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -573,8 +573,6 @@ int32_t PositionModule::runOnce()
         return RUNONCE_INTERVAL;
     }
 
-    bool waitingForFreshPosition = !config.position.fixed_position && !nodeDB->hasLocalPositionSinceBoot();
-
     // Hold to the 6h floor when fixed_position (every role: pinning yourself forfeits the
     // exception) or when stationary. A real move still goes out early via smart-broadcast below.
     // Not-fixed exceptions: lost-and-found broadcasts freely; trackers judge movement at their
@@ -592,9 +590,7 @@ int32_t PositionModule::runOnce()
         effectiveBroadcastIntervalMs(intervalMs, stationary, (uint32_t)default_position_stationary_broadcast_secs * 1000UL);
 
     if (lastGpsSend == 0 || msSinceLastSend >= effectiveIntervalMs) {
-        if (waitingForFreshPosition) {
-            LOG_DEBUG_GPS("Skip initial position send; no fresh position since boot");
-        } else if (nodeDB->hasValidPosition(node) && sendOurPosition()) {
+        if (nodeDB->hasValidPosition(node) && sendOurPosition()) {
             lastGpsSend = now;
 
             meshtastic_PositionLite selfPos;
@@ -613,30 +609,10 @@ int32_t PositionModule::runOnce()
         const meshtastic_NodeInfoLite *node2 = service->refreshLocalMeshNode(); // should guarantee there is now a position
 
         if (nodeDB->hasValidPosition(node2)) {
-            // The minimum time (in seconds) that would pass before we are able to send a new position packet.
-
             meshtastic_PositionLite selfPos;
             if (!nodeDB->copyNodePosition(node->num, selfPos))
                 return RUNONCE_INTERVAL; // Defensive: hasValidPosition should imply this is non-null
-            auto smartPosition = getDistanceTraveledSinceLastSend(selfPos);
-            msSinceLastSend = now - lastGpsSend;
-
-            if (smartPosition.hasTraveledOverThreshold) {
-                if (!Throttle::hasElapsed(lastGpsSend, minimumTimeThreshold)) {
-                    LOG_DEBUG_GPS("Skip smart broadcast: time throttled");
-                } else if (sendOurPosition()) {
-                    lastGpsSend = now;
-
-                    LOG_DEBUG("Sent smart pos@%x:6 to mesh (distanceTraveled=%fm, minDistanceThreshold=%im, timeElapsed=%ims, "
-                              "minTimeInterval=%ims)",
-                              localPosition.timestamp, smartPosition.distanceTraveled, smartPosition.distanceThreshold,
-                              msSinceLastSend, minimumTimeThreshold);
-
-                    // Set the current coords as our last ones, after we've compared distance with current and decided to send
-                    lastGpsLatitude = selfPos.latitude_i;
-                    lastGpsLongitude = selfPos.longitude_i;
-                }
-            }
+            trySmartBroadcast(selfPos, now);
         }
     }
 
@@ -718,6 +694,30 @@ struct SmartPosition PositionModule::getDistanceTraveledSinceLastSend(meshtastic
                          .hasTraveledOverThreshold = distanceTraveled >= distanceTravelThreshold};
 }
 
+void PositionModule::trySmartBroadcast(const meshtastic_PositionLite &selfPos, uint32_t nowMs)
+{
+    auto smartPosition = getDistanceTraveledSinceLastSend(selfPos);
+    if (!smartPosition.hasTraveledOverThreshold)
+        return;
+
+    if (!Throttle::hasElapsed(lastGpsSend, minimumTimeThreshold)) {
+        LOG_DEBUG_GPS("Skip smart broadcast: time throttled");
+        return;
+    }
+
+    uint32_t msSinceLastSend = nowMs - lastGpsSend;
+    if (!sendOurPosition())
+        return;
+
+    lastGpsSend = nowMs;
+    LOG_DEBUG("Sent smart pos@%x:6 to mesh (distanceTraveled=%fm, minDistanceThreshold=%im, timeElapsed=%ims, "
+              "minTimeInterval=%ims)",
+              localPosition.timestamp, smartPosition.distanceTraveled, smartPosition.distanceThreshold, msSinceLastSend,
+              minimumTimeThreshold);
+    lastGpsLatitude = selfPos.latitude_i;
+    lastGpsLongitude = selfPos.longitude_i;
+}
+
 void PositionModule::handleNewPosition()
 {
     const meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(nodeDB->getNodeNum());
@@ -727,25 +727,7 @@ void PositionModule::handleNewPosition()
         meshtastic_PositionLite selfPos;
         if (!nodeDB->copyNodePosition(node->num, selfPos))
             return;
-        auto smartPosition = getDistanceTraveledSinceLastSend(selfPos);
-        uint32_t now = Time::getMillis();
-        uint32_t msSinceLastSend = now - lastGpsSend;
-        if (smartPosition.hasTraveledOverThreshold) {
-            if (!Throttle::hasElapsed(lastGpsSend, minimumTimeThreshold)) {
-                LOG_DEBUG_GPS("Skip smart broadcast: time throttled");
-            } else if (sendOurPosition()) {
-                lastGpsSend = now;
-
-                LOG_DEBUG("Sent smart pos@%x:6 to mesh (distanceTraveled=%fm, minDistanceThreshold=%im, timeElapsed=%ims, "
-                          "minTimeInterval=%ims)",
-                          localPosition.timestamp, smartPosition.distanceTraveled, smartPosition.distanceThreshold,
-                          msSinceLastSend, minimumTimeThreshold);
-
-                // Set the current coords as our last ones, after we've compared distance with current and decided to send
-                lastGpsLatitude = selfPos.latitude_i;
-                lastGpsLongitude = selfPos.longitude_i;
-            }
-        }
+        trySmartBroadcast(selfPos, Time::getMillis());
     }
 }
 

--- a/src/modules/PositionModule.h
+++ b/src/modules/PositionModule.h
@@ -85,6 +85,9 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
     uint32_t lastPhoneSendMs = 0;
     static constexpr uint32_t sendToPhoneIntervalMs = 60 * 1000; // Matches telemetry's local cadence
     struct SmartPosition getDistanceTraveledSinceLastSend(meshtastic_PositionLite currentPosition);
+    // Broadcast early when we have moved far enough since the last send, subject to the minimum
+    // interval. Stamps the cadence and the last-sent coords only on a send that went out.
+    void trySmartBroadcast(const meshtastic_PositionLite &selfPos, uint32_t nowMs);
     // True when our position is unchanged since the last broadcast: it truncates to the same
     // precision grid cell, so re-sending would be a duplicate that traffic management dedups
     // downstream anyway. Used to hold stationary broadcasts to a 12h floor. useConfiguredPrecision

--- a/src/modules/PositionModule.h
+++ b/src/modules/PositionModule.h
@@ -31,10 +31,11 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
     PositionModule();
 
     /**
-     * Send our position into the mesh
+     * Send our position into the mesh. Returns true only when a packet was handed to the router,
+     * so callers stamp their broadcast cadence on an actual send rather than an attempt.
      */
-    void sendOurPosition(NodeNum dest, bool wantReplies = false, uint8_t channel = 0);
-    void sendOurPosition();
+    bool sendOurPosition(NodeNum dest, bool wantReplies = false, uint8_t channel = 0);
+    bool sendOurPosition();
 
     /**
      * Answer a position request that arrived on a channel we never share position on (the event channel):

--- a/src/modules/PositionModule.h
+++ b/src/modules/PositionModule.h
@@ -31,8 +31,7 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
     PositionModule();
 
     /**
-     * Send our position into the mesh. Returns true only when a packet was handed to the router,
-     * so callers stamp their broadcast cadence on an actual send rather than an attempt.
+     * Send our position into the mesh. True only when the router took the packet.
      */
     bool sendOurPosition(NodeNum dest, bool wantReplies = false, uint8_t channel = 0);
     bool sendOurPosition();


### PR DESCRIPTION
Fixes #11748: `runOnce()` advanced `lastGpsSend`, `lastGpsLatitude/Longitude` and the transmit history before calling `sendOurPosition()`, so a send that bailed on its own guards still burned the cadence and set the stationary baseline to a position never transmitted, freezing the mesh/MQTT view for up to the 6h stationary floor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Position updates now accurately report whether transmission succeeded.
  * Failed or skipped position sends no longer reset broadcast timing or position history.
  * Position sharing remains suppressed when unavailable or when position data is stale.
  * Devices fall back to sending node information when position updates cannot be sent.
  * Packets rejected due to transmission limits or queue availability are no longer treated as successfully sent.
  * Transmission failures are now reported for more reliable send handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->