### PR TITLE
fix(variants): use enum constants for heltec adc channel definitions

### DIFF
--- a/variants/esp32/heltec_v1/variant.h
+++ b/variants/esp32/heltec_v1/variant.h
@@ -27,5 +27,5 @@
 #define ADC_MULTIPLIER 3.2
 
 #define BATTERY_PIN 13 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
-#define ADC_CHANNEL ADC2_GPIO13_CHANNEL
+#define ADC_CHANNEL ADC_CHANNEL_4
 #define BAT_MEASURE_ADC_UNIT 2

--- a/variants/esp32/heltec_v2.1/variant.h
+++ b/variants/esp32/heltec_v2.1/variant.h
@@ -33,5 +33,5 @@
 // #define ADC_WIDTH ADC_WIDTH_BIT_10
 
 #define BATTERY_PIN 37 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
-#define ADC_CHANNEL ADC1_GPIO37_CHANNEL
+#define ADC_CHANNEL ADC_CHANNEL_1
 #define EXT_NOTIFY_OUT 13 // Default pin to use for Ext Notify Module.

--- a/variants/esp32/heltec_v2/variant.h
+++ b/variants/esp32/heltec_v2/variant.h
@@ -27,5 +27,5 @@
 // ratio of voltage divider = 3.20 (R12=100k, R10=220k)
 #define ADC_MULTIPLIER 3.2
 #define BATTERY_PIN 13 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
-#define ADC_CHANNEL ADC2_GPIO13_CHANNEL
+#define ADC_CHANNEL ADC_CHANNEL_4
 #define BAT_MEASURE_ADC_UNIT 2


### PR DESCRIPTION
## Problem

The three legacy Heltec ESP32 variants fail to compile on `develop`:

```
soc/esp32/include/soc/adc_channel.h:45:33: error: invalid conversion from 'int' to 'adc_channel_t' [-fpermissive]
   45 | #define ADC2_GPIO13_CHANNEL     4
variants/esp32/heltec_v1/variant.h:30:21: note: in expansion of macro 'ADC2_GPIO13_CHANNEL'
src/Power.cpp:107:42: note: in expansion of macro 'ADC_CHANNEL'
  107 | static const adc_channel_t adc_channel = ADC_CHANNEL;
```

The `ADCx_GPIOnn_CHANNEL` macros from the ESP-IDF expand to a plain `int`,
and C++ does not implicitly convert `int` to the `adc_channel_t` enum.

Affected environments: `heltec-v1`, `heltec-v2_0`, `heltec-v2_1`. Because all
three are `board_level = extra` and `actively_supported = false`, they are not
built in CI, so the breakage went unnoticed.

## Fix

Use the enum constants directly, matching what every maintained ESP32 variant
already does (`tbeam`, `tlora_*`, `station-g1`, `rak11200`, `chatter2`, `diy/*`
all use `#define ADC_CHANNEL ADC_CHANNEL_N`).

Channel numbers are unchanged, verified against the ESP-IDF `adc_channel.h`:

| Variant | Battery pin | ADC unit | Channel | Before | After |
|---|---|---|---|---|---|
| `heltec_v1` | GPIO13 | ADC2 | 4 | `ADC2_GPIO13_CHANNEL` | `ADC_CHANNEL_4` |
| `heltec_v2` | GPIO13 | ADC2 | 4 | `ADC2_GPIO13_CHANNEL` | `ADC_CHANNEL_4` |
| `heltec_v2.1` | GPIO37 | ADC1 | 1 | `ADC1_GPIO37_CHANNEL` | `ADC_CHANNEL_1` |

No behavioral change: the numeric channel is identical in each case.

## Testing

Verified in both directions:

- Without the change, `heltec-v1` and `heltec-v2_1` both fail at `Power.cpp`
  with the error above (`heltec-v2_0` uses the same macro as `heltec-v1`).
- With the change, all three build clean:

```
heltec-v1      SUCCESS   00:03:01
heltec-v2_0    SUCCESS   00:04:30
heltec-v2_1    SUCCESS   00:04:44
```

`heltec-v1` was flashed to real hardware — a Heltec WiFi LoRa 32 V1
(ESP32-D0WDQ6, 4MB flash, SX1276) — and runs correctly: boots, initialises the
radio and NimBLE, drives the OLED, and joins a channel with `region=BR_902`.

Note on the battery reading, unrelated to this change: `heltec_v1` and
`heltec_v2` sense the battery on GPIO13, which is ADC2, and ADC2 is unavailable
on the ESP32 while WiFi is active. Battery percentage is therefore unreliable
on those two boards. Left as-is here to keep this PR to the compile fix.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other: Heltec WiFi LoRa 32 V1, flashed and running.

I do not have Heltec V2 or V2.1 hardware, so those two targets are verified by
compilation only. Runtime testing from someone with those boards would be
welcome.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated battery voltage measurement configuration for Heltec V1, V2, and V2.1 boards.
  * Improved compatibility with current ESP32 ADC channel definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->