### PR TITLE
refactor(sensorlib): unify on 0.4.1 and move the PCF RTCs to PCF8xRTC

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -29,17 +29,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if __has_include("Melopero_RV3028.h")
 #include "Melopero_RV3028.h"
 #endif
-#if __has_include("SensorRtcHelper.hpp")
-#include "SensorRtcHelper.hpp"
-// SensorLib defines isBitSet as a macro; undefine it here to avoid conflicts
-// with the SparkFun MMC5983MA library, which has a class method of the same name.
-#ifdef isBitSet
-#undef isBitSet
-#endif
+#if __has_include(<PCF8xRTC.h>)
+#include <PCF8xRTC.h>
 #endif
 
 /* Offer chance for variant-specific defines */
 #include "variant.h"
+
+// Both PCF parts answer at the same address and differ only in register layout, so a variant
+// picks one by defining PCF8563_RTC or PCF85063_RTC to it.
+#if defined(PCF8563_RTC)
+#define PCF_RTC_ADDRESS PCF8563_RTC
+#define PCF_RTC_CHIP PCF8xRTC::PCF8563
+#elif defined(PCF85063_RTC)
+#define PCF_RTC_ADDRESS PCF85063_RTC
+#define PCF_RTC_CHIP PCF8xRTC::PCF85063
+#endif
 
 // -----------------------------------------------------------------------------
 // Display feature overrides

--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -156,24 +156,20 @@ RTCSetResult readFromRTC()
         LOG_WARN("RTC read: not found (addr 0x%02X)", rtc_found.address);
     }
 #elif defined(PCF8563_RTC) || defined(PCF85063_RTC)
-#if defined(PCF8563_RTC)
-    if (rtc_found.address == PCF8563_RTC) {
-        SensorPCF8563 rtc;
-#elif defined(PCF85063_RTC)
-    if (rtc_found.address == PCF85063_RTC) {
-        SensorPCF85063 rtc;
-
-#endif
+    if (rtc_found.address == PCF_RTC_ADDRESS) {
+        PCF8xRTC rtc;
         const uint64_t now = Time::getMillisMonotonic();
 
 #if WIRE_INTERFACES_COUNT == 2
-        rtc.begin(*ScanI2CTwoWire::fetchI2CBus(rtc_found));
+        TwoWire &rtcBus = *ScanI2CTwoWire::fetchI2CBus(rtc_found);
 #else
-        rtc.begin(Wire);
+        TwoWire &rtcBus = Wire;
 #endif
-
-        RTC_DateTime datetime = rtc.getDateTime();
-        tm t = datetime.toUnixTime();
+        tm t;
+        if (!rtc.begin(rtcBus, PCF_RTC_ADDRESS, PCF_RTC_CHIP) || !rtc.getTime(t)) {
+            LOG_WARN("%s read failed%s", rtc.chipName(), rtc.lostPower() ? " (oscillator stopped)" : "");
+            return RTCSetResultInvalidTime;
+        }
         tv.tv_sec = gm_mktime(&t);
         tv.tv_usec = 0;
         uint32_t printableEpoch = tv.tv_sec; // Print lib only supports 32 bit but time_t can be 64 bit on some platforms
@@ -188,7 +184,7 @@ RTCSetResult readFromRTC()
         }
 #endif
 
-        LOG_DEBUG_GPS("RTC time from %s getDateTime: %02d-%02d-%02d %02d:%02d:%02d (%ld)", rtc.getChipName(), t.tm_year + 1900,
+        LOG_DEBUG_GPS("RTC time from %s getTime: %02d-%02d-%02d %02d:%02d:%02d (%ld)", rtc.chipName(), t.tm_year + 1900,
                       t.tm_mon + 1, t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec, printableEpoch);
         if (currentQuality == RTCQualityNone) {
             RTCQuality oldQuality = currentQuality;
@@ -357,27 +353,23 @@ RTCSetResult perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpd
             LOG_WARN("RTC set: not found (addr 0x%02X)", rtc_found.address);
         }
 #elif defined(PCF8563_RTC) || defined(PCF85063_RTC)
-#if defined(PCF8563_RTC)
-        if (rtc_found.address == PCF8563_RTC) {
-            SensorPCF8563 rtc;
-#elif defined(PCF85063_RTC)
-        if (rtc_found.address == PCF85063_RTC) {
-            SensorPCF85063 rtc;
-
-#endif
-
+        if (rtc_found.address == PCF_RTC_ADDRESS) {
+            PCF8xRTC rtc;
 #if WIRE_INTERFACES_COUNT == 2
-            rtc.begin(*ScanI2CTwoWire::fetchI2CBus(rtc_found));
+            TwoWire &rtcBus = *ScanI2CTwoWire::fetchI2CBus(rtc_found);
 #else
-            rtc.begin(Wire);
+            TwoWire &rtcBus = Wire;
 #endif
             // tv_sec is a long, which is not time_t everywhere: on Windows
             // time_t is 64-bit while long is 32-bit. Copy before taking &.
             time_t setSecs = tv->tv_sec;
             const tm *t = gmtime(&setSecs);
-            rtc.setDateTime(*t);
-            LOG_DEBUG_GPS("%s setDateTime %02d-%02d-%02d %02d:%02d:%02d (%ld)", rtc.getChipName(), t->tm_year + 1900,
-                          t->tm_mon + 1, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec, printableEpoch);
+            if (rtc.begin(rtcBus, PCF_RTC_ADDRESS, PCF_RTC_CHIP) && rtc.setTime(*t)) {
+                LOG_DEBUG_GPS("%s setTime %02d-%02d-%02d %02d:%02d:%02d (%ld)", rtc.chipName(), t->tm_year + 1900, t->tm_mon + 1,
+                              t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec, printableEpoch);
+            } else {
+                LOG_WARN("%s set time failed", rtc.chipName());
+            }
         } else {
             LOG_WARN("RTC set: not found (addr 0x%02X)", rtc_found.address);
         }

--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -166,7 +166,12 @@ RTCSetResult readFromRTC()
         TwoWire &rtcBus = Wire;
 #endif
         tm t;
-        if (!rtc.begin(rtcBus, PCF_RTC_ADDRESS, PCF_RTC_CHIP) || !rtc.getTime(t)) {
+        if (!rtc.begin(rtcBus, PCF_RTC_ADDRESS, PCF_RTC_CHIP)) {
+            LOG_WARN("%s not responding at 0x%02X", rtc.chipName(), PCF_RTC_ADDRESS);
+            return RTCSetResultInvalidTime;
+        }
+        if (!rtc.getTime(t)) {
+            // Only the chip itself can tell us the oscillator stopped, so ask after begin() worked.
             LOG_WARN("%s read failed%s", rtc.chipName(), rtc.lostPower() ? " (oscillator stopped)" : "");
             return RTCSetResultInvalidTime;
         }

--- a/src/motion/BHI260APSensor.cpp
+++ b/src/motion/BHI260APSensor.cpp
@@ -2,7 +2,6 @@
 
 #if !defined(ARCH_STM32WL) && !MESHTASTIC_EXCLUDE_I2C && defined(HAS_BHI260AP) && __has_include(<SensorBHI260AP.hpp>)
 #define BOSCH_BHI260_KLIO
-#define USING_DATA_HELPER
 
 #include <BoschFirmware.h>
 BHI260APSensor::BHI260APSensor(ScanI2C::FoundDevice foundDevice) : MotionSensor::MotionSensor(foundDevice) {}
@@ -14,16 +13,16 @@ bool BHI260APSensor::init()
     sensor.setFirmware(bosch_firmware_image, bosch_firmware_size, bosch_firmware_type);
     sensor.setBootFromFlash(bosch_firmware_type);
     if (sensor.begin(Wire, deviceAddress())) {
-        sensor.setRemapAxes(SensorBHI260AP::TOP_LAYER_BOTTOM_RIGHT_CORNER);
+        sensor.setRemapAxes(SensorRemap::TOP_LAYER_BOTTOM_RIGHT_CORNER);
         BoschSensorInfo info = sensor.getSensorInfo();
 
-        LOG_INFO("Product ID     : %02x\n", info.product_id);
-        LOG_INFO("Kernel version : %04u\n", info.kernel_version);
-        LOG_INFO("User version   : %04u\n", info.user_version);
-        LOG_INFO("ROM version    : %04u\n", info.rom_version);
-        LOG_INFO("Power state    : %s\n", (info.host_status & BHY2_HST_POWER_STATE) ? "sleeping" : "active");
-        LOG_INFO("Host interface : %s\n", (info.host_status & BHY2_HST_HOST_PROTOCOL) ? "SPI" : "I2C");
-        LOG_INFO("Feature status : 0x%02x\n", info.feat_status);
+        LOG_INFO("Product ID     : %02x\n", info.getProductId());
+        LOG_INFO("Kernel version : %04u\n", info.getKernelVersion());
+        LOG_INFO("User version   : %04u\n", info.getUserVersion());
+        LOG_INFO("ROM version    : %04u\n", info.getRomVersion());
+        LOG_INFO("Power state    : %s\n", (info.getHostStatus() & BHY2_HST_POWER_STATE) ? "sleeping" : "active");
+        LOG_INFO("Host interface : %s\n", (info.getHostStatus() & BHY2_HST_HOST_PROTOCOL) ? "SPI" : "I2C");
+        LOG_INFO("Feature status : 0x%02x\n", info.getFeatStatus());
 
         stepCounter = new SensorStepCounter(sensor);
         // stepDetector = new SensorStepDetector(sensor);
@@ -40,13 +39,6 @@ bool BHI260APSensor::init()
                 // Set interrupt to set irq value to true
             },
             RISING); // Select the interrupt mode according to the actual circuit
-#endif
-
-#ifdef T_WATCH_S3
-        // Need to raise the wrist function, need to set the correct axis
-        sensor.setRemapAxes(sensor.REMAP_TOP_LAYER_RIGHT_CORNER);
-#else
-        // sensor.setRemapAxes(sensor.REMAP_BOTTOM_LAYER_BOTTOM_LEFT_CORNER);
 #endif
 
         // stepDetector->enable(1.0, 0);

--- a/src/motion/BMA423Sensor.cpp
+++ b/src/motion/BMA423Sensor.cpp
@@ -6,53 +6,38 @@ BMA423Sensor::BMA423Sensor(ScanI2C::FoundDevice foundDevice) : MotionSensor::Mot
 
 bool BMA423Sensor::init()
 {
-    if (sensor.begin(Wire, deviceAddress())) {
-        sensor.configAccelerometer(sensor.RANGE_2G, sensor.ODR_100HZ, sensor.BW_NORMAL_AVG4, sensor.PERF_CONTINUOUS_MODE);
-        sensor.enableAccelerometer();
-        sensor.configInterrupt();
+    if (!sensor.begin(Wire, deviceAddress())) {
+        LOG_DEBUG("BMA423 init failed");
+        return false;
+    }
 
-#ifdef BMA423_INT
-        pinMode(BMA4XX_INT, INPUT);
-        attachInterrupt(
-            BMA4XX_INT,
-            [] {
-                // Set interrupt to set irq value to true
-                BMA_IRQ = true;
-            },
-            RISING); // Select the interrupt mode according to the actual circuit
-#endif
+    sensor.configAccelerometer(OperationMode::NORMAL, AccelFullScaleRange::FS_2G, 100.0f, AccelBandwidth::NORMAL_AVG4,
+                               AccelPerfMode::CONTINUOUS_MODE);
 
 #ifdef T_WATCH_S3
-        // Need to raise the wrist function, need to set the correct axis
-        sensor.setRemapAxes(sensor.REMAP_TOP_LAYER_RIGHT_CORNER);
+    // Need to raise the wrist function, need to set the correct axis
+    sensor.setRemapAxes(SensorRemap::TOP_LAYER_RIGHT_CORNER);
 #else
-        sensor.setRemapAxes(sensor.REMAP_BOTTOM_LAYER_BOTTOM_LEFT_CORNER);
+    sensor.setRemapAxes(SensorRemap::BOTTOM_LAYER_BOTTOM_LEFT_CORNER);
 #endif
-        // sensor.enableFeature(sensor.FEATURE_STEP_CNTR, true);
-        sensor.enableFeature(sensor.FEATURE_TILT, true);
-        sensor.enableFeature(sensor.FEATURE_WAKEUP, true);
-        // sensor.resetPedometer();
 
-        // Turn on feature interrupt
-        sensor.enablePedometerIRQ();
-        sensor.enableTiltIRQ();
+    // The tap detector defaults to double tap; tilt and double tap both wake the screen.
+    sensor.setOnTiltDetectedCallback([this] { wakeRequested = true; });
+    sensor.setOnTapCallback([this](TapType) { wakeRequested = true; });
+    sensor.enableTiltDetector(true, true);
+    sensor.enableTapDetector(true, true);
 
-        // It corresponds to isDoubleClick interrupt
-        sensor.enableWakeupIRQ();
-        LOG_DEBUG("BMA423 init ok");
-        return true;
-    }
-    LOG_DEBUG("BMA423 init failed");
-    return false;
+    LOG_DEBUG("BMA423 init ok");
+    return true;
 }
 
 int32_t BMA423Sensor::runOnce()
 {
-    if (sensor.readIrqStatus()) {
-        if (sensor.isTilt() || sensor.isDoubleTap()) {
-            wakeScreen();
-            return 500;
-        }
+    wakeRequested = false;
+    sensor.update();
+    if (wakeRequested) {
+        wakeScreen();
+        return 500;
     }
     return MOTION_SENSOR_CHECK_INTERVAL_MS;
 }

--- a/src/motion/BMA423Sensor.cpp
+++ b/src/motion/BMA423Sensor.cpp
@@ -11,8 +11,11 @@ bool BMA423Sensor::init()
         return false;
     }
 
-    sensor.configAccelerometer(OperationMode::NORMAL, AccelFullScaleRange::FS_2G, 100.0f, AccelBandwidth::NORMAL_AVG4,
-                               AccelPerfMode::CONTINUOUS_MODE);
+    if (!sensor.configAccelerometer(OperationMode::NORMAL, AccelFullScaleRange::FS_2G, 100.0f, AccelBandwidth::NORMAL_AVG4,
+                                    AccelPerfMode::CONTINUOUS_MODE)) {
+        LOG_DEBUG("BMA423 accelerometer config failed");
+        return false;
+    }
 
 #ifdef T_WATCH_S3
     // Need to raise the wrist function, need to set the correct axis
@@ -24,8 +27,10 @@ bool BMA423Sensor::init()
     // The tap detector defaults to double tap; tilt and double tap both wake the screen.
     sensor.setOnTiltDetectedCallback([this] { wakeRequested = true; });
     sensor.setOnTapCallback([this](TapType) { wakeRequested = true; });
-    sensor.enableTiltDetector(true, true);
-    sensor.enableTapDetector(true, true);
+    if (!sensor.enableTiltDetector(true, true) || !sensor.enableTapDetector(true, true)) {
+        LOG_DEBUG("BMA423 wake detector setup failed");
+        return false;
+    }
 
     LOG_DEBUG("BMA423 init ok");
     return true;

--- a/src/motion/BMA423Sensor.h
+++ b/src/motion/BMA423Sensor.h
@@ -13,7 +13,7 @@ class BMA423Sensor : public MotionSensor
 {
   private:
     SensorBMA423 sensor;
-    volatile bool BMA_IRQ = false;
+    bool wakeRequested = false;
 
   public:
     explicit BMA423Sensor(ScanI2C::FoundDevice foundDevice);

--- a/src/motion/MMC5983MASensor.h
+++ b/src/motion/MMC5983MASensor.h
@@ -6,6 +6,12 @@
 
 #if !defined(ARCH_STM32WL) && !MESHTASTIC_EXCLUDE_I2C && __has_include(<SparkFun_MMC5983MA_Arduino_Library.h>)
 
+// SensorLib defines isBitSet as a macro, which collides with the class method of the same name
+// below. Drop it here, where the two actually meet, rather than relying on include order.
+#ifdef isBitSet
+#undef isBitSet
+#endif
+
 #include <SparkFun_MMC5983MA_Arduino_Library.h>
 
 class MMC5983MASensor : public MotionSensor

--- a/src/platform/extra_variants/t-watch-ultra/variant.cpp
+++ b/src/platform/extra_variants/t-watch-ultra/variant.cpp
@@ -5,16 +5,16 @@
 // Board-specific init lives here (rather than in variants/esp32s3/t-watch-ultra/variant.cpp)
 // so that PlatformIO's library dependency finder can resolve headers such as
 // input/TouchScreenImpl1.h (which transitively pulls in the ArduinoThread "Thread.h"),
-// ExtensionIOXL9555.hpp and TouchDrvCSTXXX.hpp. Files compiled from outside src/ only get
+// IoExpanderXL9555.hpp and touch/TouchDrvCST92xx.h. Files compiled from outside src/ only get
 // include paths for libraries they reference directly, so the transitive Thread.h include
 // is not found there. See src/platform/extra_variants/README.md.
 
-#include "TouchDrvCSTXXX.hpp"
 #include "input/TouchScreenImpl1.h"
-#include <ExtensionIOXL9555.hpp>
+#include "touch/TouchDrvCST92xx.h"
+#include <IoExpanderXL9555.hpp>
 #include <Wire.h>
 
-static ExtensionIOXL9555 io;
+static IoExpanderXL9555 io;
 static TouchDrvCST92xx touchDrv;
 
 void earlyInitVariant()

--- a/src/platform/extra_variants/t-watch-ultra/variant.cpp
+++ b/src/platform/extra_variants/t-watch-ultra/variant.cpp
@@ -2,12 +2,8 @@
 
 #ifdef T_WATCH_ULTRA
 
-// Board-specific init lives here (rather than in variants/esp32s3/t-watch-ultra/variant.cpp)
-// so that PlatformIO's library dependency finder can resolve headers such as
-// input/TouchScreenImpl1.h (which transitively pulls in the ArduinoThread "Thread.h"),
-// IoExpanderXL9555.hpp and touch/TouchDrvCST92xx.h. Files compiled from outside src/ only get
-// include paths for libraries they reference directly, so the transitive Thread.h include
-// is not found there. See src/platform/extra_variants/README.md.
+// Lives here, not under variants/, so PlatformIO's LDF resolves the Thread.h that
+// input/TouchScreenImpl1.h pulls in transitively. See extra_variants/README.md.
 
 #include "input/TouchScreenImpl1.h"
 #include "touch/TouchDrvCST92xx.h"

--- a/src/platform/extra_variants/t5s3_epaper/variant.cpp
+++ b/src/platform/extra_variants/t5s3_epaper/variant.cpp
@@ -613,9 +613,11 @@ bool readTouch(int16_t *x, int16_t *y)
 #endif
 
     if (!digitalRead(GT911_PIN_INT)) {
-        int16_t raw_x;
-        int16_t raw_y;
-        if (touch.getPoint(&raw_x, &raw_y)) {
+        // 0.4.x deprecates getPoint() in favour of getTouchPoints(); only the first touch is used here.
+        const TouchPoints &points = touch.getTouchPoints();
+        if (points.getPointCount()) {
+            const int16_t raw_x = static_cast<int16_t>(points.getPoint(0).x);
+            const int16_t raw_y = static_cast<int16_t>(points.getPoint(0).y);
 #ifdef MESHTASTIC_INCLUDE_NICHE_GRAPHICS
             // Transform raw GT911 axes to visual-frame coordinates for the current display rotation.
             // rotation=3 is the physical identity (device's default orientation).

--- a/src/platform/extra_variants/t5s3_epaper/variant.cpp
+++ b/src/platform/extra_variants/t5s3_epaper/variant.cpp
@@ -3,7 +3,6 @@
 #ifdef T5_S3_EPAPER_PRO
 
 #include "Observer.h"
-#include "TouchDrvGT911.hpp"
 #include "Wire.h"
 #include "buzz.h"
 #include "concurrency/OSThread.h"
@@ -12,6 +11,7 @@
 #include "main.h"
 #include "mesh/Throttle.h"
 #include "sleep.h"
+#include "touch/TouchDrvGT911.hpp"
 #include <cstring>
 
 #ifdef MESHTASTIC_INCLUDE_NICHE_GRAPHICS

--- a/src/platform/extra_variants/tbeam_displayshield/variant.cpp
+++ b/src/platform/extra_variants/tbeam_displayshield/variant.cpp
@@ -2,8 +2,8 @@
 
 #ifdef HAS_CST226SE
 
-#include "TouchDrvCSTXXX.hpp"
 #include "input/TouchScreenImpl1.h"
+#include "touch/TouchDrvCST226.h"
 #include <Wire.h>
 
 #ifndef TOUCH_RST

--- a/variants/esp32/m5stack_coreink/platformio.ini
+++ b/variants/esp32/m5stack_coreink/platformio.ini
@@ -21,7 +21,7 @@ lib_deps =
   # renovate: datasource=custom.pio depName=GxEPD2 packageName=zinggjm/library/GxEPD2
   zinggjm/GxEPD2@1.6.9
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.4
+  lewisxhe/SensorLib@0.4.1
 lib_ignore =
   m5stack-coreink
 monitor_filters = esp32_exception_decoder

--- a/variants/esp32/m5stack_coreink/platformio.ini
+++ b/variants/esp32/m5stack_coreink/platformio.ini
@@ -20,8 +20,8 @@ lib_deps =
   ${esp32_base.lib_deps}
   # renovate: datasource=custom.pio depName=GxEPD2 packageName=zinggjm/library/GxEPD2
   zinggjm/GxEPD2@1.6.9
-  # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.4.1
+  # renovate: datasource=git-refs depName=meshtastic-PCF8xRTC packageName=https://github.com/meshtastic/PCF8xRTC gitBranch=main
+  https://github.com/meshtastic/PCF8xRTC/archive/efe1d9c92f79d8413f8ac4e9bdce0c48410600de.zip
 lib_ignore =
   m5stack-coreink
 monitor_filters = esp32_exception_decoder

--- a/variants/esp32/tbeam/platformio.ini
+++ b/variants/esp32/tbeam/platformio.ini
@@ -31,4 +31,4 @@ lib_deps =
   # renovate: datasource=github-tags depName=meshtastic-st7796 packageName=meshtastic/st7796
   https://github.com/meshtastic/st7796/archive/1.0.5.zip
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.4
+  lewisxhe/SensorLib@0.4.1

--- a/variants/esp32s3/ELECROW-ThinkNode-M5/platformio.ini
+++ b/variants/esp32s3/ELECROW-ThinkNode-M5/platformio.ini
@@ -35,5 +35,5 @@ lib_deps = ${esp32s3_base.lib_deps}
   https://github.com/meshtastic/GxEPD2/archive/c7eb4c3c167cf396ef4f541cc5d4c6aa42f3c46b.zip
   # renovate: datasource=custom.pio depName=PCA9557-arduino packageName=maxpromer/library/PCA9557-arduino
   maxpromer/PCA9557-arduino@1.0.0
-  # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.4.1
+  # renovate: datasource=git-refs depName=meshtastic-PCF8xRTC packageName=https://github.com/meshtastic/PCF8xRTC gitBranch=main
+  https://github.com/meshtastic/PCF8xRTC/archive/efe1d9c92f79d8413f8ac4e9bdce0c48410600de.zip

--- a/variants/esp32s3/ELECROW-ThinkNode-M5/platformio.ini
+++ b/variants/esp32s3/ELECROW-ThinkNode-M5/platformio.ini
@@ -36,4 +36,4 @@ lib_deps = ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=PCA9557-arduino packageName=maxpromer/library/PCA9557-arduino
   maxpromer/PCA9557-arduino@1.0.0
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.4
+  lewisxhe/SensorLib@0.4.1

--- a/variants/esp32s3/ELECROW-ThinkNode-M9/platformio.ini
+++ b/variants/esp32s3/ELECROW-ThinkNode-M9/platformio.ini
@@ -36,8 +36,8 @@ build_flags =
 lib_deps = ${esp32s3_base.lib_deps}
   # renovate: datasource=custom depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.26
-  # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.4.1
+  # renovate: datasource=git-refs depName=meshtastic-PCF8xRTC packageName=https://github.com/meshtastic/PCF8xRTC gitBranch=main
+  https://github.com/meshtastic/PCF8xRTC/archive/efe1d9c92f79d8413f8ac4e9bdce0c48410600de.zip
 
 [env:thinknode_m9]
 extends = thinknode_m9_base

--- a/variants/esp32s3/ELECROW-ThinkNode-M9/platformio.ini
+++ b/variants/esp32s3/ELECROW-ThinkNode-M9/platformio.ini
@@ -36,7 +36,7 @@ build_flags =
 lib_deps = ${esp32s3_base.lib_deps}
   # renovate: datasource=custom depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.26
-  # renovate: datasource=custom depName=SensorLib packageName=lewisxhe/library/SensorLib
+  # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
   lewisxhe/SensorLib@0.4.1
 
 [env:thinknode_m9]

--- a/variants/esp32s3/meshnology-w10/platformio.ini
+++ b/variants/esp32s3/meshnology-w10/platformio.ini
@@ -33,7 +33,7 @@ lib_deps =
   lovyan03/LovyanGFX@1.2.21
   ; PCF85063 RTC driver (PCF85063_RTC)
   ; renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.4
+  lewisxhe/SensorLib@0.4.1
   ; ES8311 audio codec + I2S notification tones (HAS_I2S)
   ; renovate: datasource=github-tags depName=pschatzmann_arduino-audio-driver packageName=pschatzmann/arduino-audio-driver
   https://github.com/pschatzmann/arduino-audio-driver/archive/v0.3.0.zip

--- a/variants/esp32s3/meshnology-w10/platformio.ini
+++ b/variants/esp32s3/meshnology-w10/platformio.ini
@@ -32,6 +32,9 @@ lib_deps =
   ; renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.21
   ; PCF85063 RTC driver (PCF85063_RTC)
+  ; renovate: datasource=git-refs depName=meshtastic-PCF8xRTC packageName=https://github.com/meshtastic/PCF8xRTC gitBranch=main
+  https://github.com/meshtastic/PCF8xRTC/archive/efe1d9c92f79d8413f8ac4e9bdce0c48410600de.zip
+  ; QMI8658 IMU driver
   ; renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
   lewisxhe/SensorLib@0.4.1
   ; ES8311 audio codec + I2S notification tones (HAS_I2S)

--- a/variants/esp32s3/mini-epaper-s3/platformio.ini
+++ b/variants/esp32s3/mini-epaper-s3/platformio.ini
@@ -33,7 +33,7 @@ lib_deps =
   # renovate: datasource=git-refs depName=meshtastic-GxEPD2 packageName=https://github.com/meshtastic/GxEPD2 gitBranch=master
   https://github.com/meshtastic/GxEPD2/archive/c7eb4c3c167cf396ef4f541cc5d4c6aa42f3c46b.zip
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.4
+  lewisxhe/SensorLib@0.4.1
 
 [env:mini-epaper-s3-inkhud]
 extends = esp32s3_base, inkhud
@@ -52,4 +52,4 @@ lib_deps =
   ${inkhud.lib_deps} ; InkHUD libs first, so we get GFXRoot instead of AdafruitGFX
   ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.4
+  lewisxhe/SensorLib@0.4.1

--- a/variants/esp32s3/mini-epaper-s3/platformio.ini
+++ b/variants/esp32s3/mini-epaper-s3/platformio.ini
@@ -32,8 +32,8 @@ lib_deps =
   ${esp32s3_base.lib_deps}
   # renovate: datasource=git-refs depName=meshtastic-GxEPD2 packageName=https://github.com/meshtastic/GxEPD2 gitBranch=master
   https://github.com/meshtastic/GxEPD2/archive/c7eb4c3c167cf396ef4f541cc5d4c6aa42f3c46b.zip
-  # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.4.1
+  # renovate: datasource=git-refs depName=meshtastic-PCF8xRTC packageName=https://github.com/meshtastic/PCF8xRTC gitBranch=main
+  https://github.com/meshtastic/PCF8xRTC/archive/efe1d9c92f79d8413f8ac4e9bdce0c48410600de.zip
 
 [env:mini-epaper-s3-inkhud]
 extends = esp32s3_base, inkhud
@@ -51,5 +51,5 @@ build_flags =
 lib_deps =
   ${inkhud.lib_deps} ; InkHUD libs first, so we get GFXRoot instead of AdafruitGFX
   ${esp32s3_base.lib_deps}
-  # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.4.1
+  # renovate: datasource=git-refs depName=meshtastic-PCF8xRTC packageName=https://github.com/meshtastic/PCF8xRTC gitBranch=main
+  https://github.com/meshtastic/PCF8xRTC/archive/efe1d9c92f79d8413f8ac4e9bdce0c48410600de.zip

--- a/variants/esp32s3/t-connect-pro/platformio.ini
+++ b/variants/esp32s3/t-connect-pro/platformio.ini
@@ -29,7 +29,7 @@ lib_deps =
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.28
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.4
+  lewisxhe/SensorLib@0.4.1
 
 custom_sdkconfig =
   ${esp32s3_base.custom_sdkconfig}

--- a/variants/esp32s3/t-watch-s3/platformio.ini
+++ b/variants/esp32s3/t-watch-s3/platformio.ini
@@ -24,7 +24,7 @@ lib_deps = ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.28
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.4
+  lewisxhe/SensorLib@0.4.1
   # renovate: datasource=custom.pio depName=Adafruit DRV2605 packageName=adafruit/library/Adafruit DRV2605 Library
   adafruit/Adafruit DRV2605 Library@1.2.4
   # renovate: datasource=git-refs depName=ESP8266Audio packageName=https://github.com/meshtastic/ESP8266Audio gitBranch=meshtastic-2.0.0-dacfix

--- a/variants/esp32s3/t-watch-s3/platformio.ini
+++ b/variants/esp32s3/t-watch-s3/platformio.ini
@@ -25,6 +25,8 @@ lib_deps = ${esp32s3_base.lib_deps}
   lovyan03/LovyanGFX@1.2.28
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
   lewisxhe/SensorLib@0.4.1
+  # renovate: datasource=git-refs depName=meshtastic-PCF8xRTC packageName=https://github.com/meshtastic/PCF8xRTC gitBranch=main
+  https://github.com/meshtastic/PCF8xRTC/archive/efe1d9c92f79d8413f8ac4e9bdce0c48410600de.zip
   # renovate: datasource=custom.pio depName=Adafruit DRV2605 packageName=adafruit/library/Adafruit DRV2605 Library
   adafruit/Adafruit DRV2605 Library@1.2.4
   # renovate: datasource=git-refs depName=ESP8266Audio packageName=https://github.com/meshtastic/ESP8266Audio gitBranch=meshtastic-2.0.0-dacfix

--- a/variants/esp32s3/t-watch-ultra/platformio.ini
+++ b/variants/esp32s3/t-watch-ultra/platformio.ini
@@ -54,7 +54,7 @@ lib_deps = ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=ESP8266SAM packageName=earlephilhower/library/ESP8266SAM
   earlephilhower/ESP8266SAM@1.1.0
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.1
+  lewisxhe/SensorLib@0.4.1
 
 [env:t-watch-ultra-tft]
 board_level = extra

--- a/variants/esp32s3/t-watch-ultra/platformio.ini
+++ b/variants/esp32s3/t-watch-ultra/platformio.ini
@@ -55,6 +55,8 @@ lib_deps = ${esp32s3_base.lib_deps}
   earlephilhower/ESP8266SAM@1.1.0
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
   lewisxhe/SensorLib@0.4.1
+  # renovate: datasource=git-refs depName=meshtastic-PCF8xRTC packageName=https://github.com/meshtastic/PCF8xRTC gitBranch=main
+  https://github.com/meshtastic/PCF8xRTC/archive/efe1d9c92f79d8413f8ac4e9bdce0c48410600de.zip
 
 [env:t-watch-ultra-tft]
 board_level = extra

--- a/variants/esp32s3/t-watch-ultra/variant.h
+++ b/variants/esp32s3/t-watch-ultra/variant.h
@@ -43,8 +43,8 @@
 
 // External expansion chip XL9555
 #define USE_PCA95X5
-#define PCA95X5_CLS ExtensionIOXL9555
-#define PCA95X5_INC "ExtensionIOXL9555.hpp"
+#define PCA95X5_CLS IoExpanderXL9555
+#define PCA95X5_INC "IoExpanderXL9555.hpp"
 
 // PCF85063 RTC Module
 #define PCF85063_RTC 0x51

--- a/variants/esp32s3/t5s3_epaper/platformio.ini
+++ b/variants/esp32s3/t5s3_epaper/platformio.ini
@@ -23,7 +23,7 @@ build_src_filter =
 lib_deps =
   ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.4
+  lewisxhe/SensorLib@0.4.1
   https://github.com/mverch67/BQ27220/archive/07d92be846abd8a0258a50c23198dac0858b22ed.zip
   https://github.com/mverch67/FastEPD/archive/0df1bff329b6fc782e062f611758880762340647.zip
 

--- a/variants/esp32s3/t5s3_epaper/platformio.ini
+++ b/variants/esp32s3/t5s3_epaper/platformio.ini
@@ -24,6 +24,8 @@ lib_deps =
   ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
   lewisxhe/SensorLib@0.4.1
+  # renovate: datasource=git-refs depName=meshtastic-PCF8xRTC packageName=https://github.com/meshtastic/PCF8xRTC gitBranch=main
+  https://github.com/meshtastic/PCF8xRTC/archive/efe1d9c92f79d8413f8ac4e9bdce0c48410600de.zip
   https://github.com/mverch67/BQ27220/archive/07d92be846abd8a0258a50c23198dac0858b22ed.zip
   https://github.com/mverch67/FastEPD/archive/0df1bff329b6fc782e062f611758880762340647.zip
 

--- a/variants/esp32s3/tbeam-s3-core/platformio.ini
+++ b/variants/esp32s3/tbeam-s3-core/platformio.ini
@@ -19,7 +19,7 @@ board_build.partitions = default_8MB.csv
 lib_deps =
   ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.4
+  lewisxhe/SensorLib@0.4.1
 
 build_flags = 
   ${esp32s3_base.build_flags} 

--- a/variants/esp32s3/tbeam-s3-core/platformio.ini
+++ b/variants/esp32s3/tbeam-s3-core/platformio.ini
@@ -18,8 +18,8 @@ board_build.partitions = default_8MB.csv
 
 lib_deps =
   ${esp32s3_base.lib_deps}
-  # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.4.1
+  # renovate: datasource=git-refs depName=meshtastic-PCF8xRTC packageName=https://github.com/meshtastic/PCF8xRTC gitBranch=main
+  https://github.com/meshtastic/PCF8xRTC/archive/efe1d9c92f79d8413f8ac4e9bdce0c48410600de.zip
 
 build_flags = 
   ${esp32s3_base.build_flags} 

--- a/variants/esp32s3/tlora-pager/platformio.ini
+++ b/variants/esp32s3/tlora-pager/platformio.ini
@@ -42,6 +42,8 @@ lib_deps = ${esp32s3_base.lib_deps}
   adafruit/Adafruit DRV2605 Library@1.2.4
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
   lewisxhe/SensorLib@0.4.1
+  # renovate: datasource=git-refs depName=meshtastic-PCF8xRTC packageName=https://github.com/meshtastic/PCF8xRTC gitBranch=main
+  https://github.com/meshtastic/PCF8xRTC/archive/efe1d9c92f79d8413f8ac4e9bdce0c48410600de.zip
   # renovate: datasource=github-tags depName=pschatzmann_arduino-audio-driver packageName=pschatzmann/arduino-audio-driver
   https://github.com/pschatzmann/arduino-audio-driver/archive/v0.3.1.zip
   # TODO renovate

--- a/variants/esp32s3/tlora-pager/platformio.ini
+++ b/variants/esp32s3/tlora-pager/platformio.ini
@@ -40,10 +40,8 @@ lib_deps = ${esp32s3_base.lib_deps}
   earlephilhower/ESP8266SAM@1.1.0
   # renovate: datasource=custom.pio depName=Adafruit DRV2605 packageName=adafruit/library/Adafruit DRV2605 Library
   adafruit/Adafruit DRV2605 Library@1.2.4
-  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
-  lewisxhe/PCF8563_Library@1.0.1
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.4
+  lewisxhe/SensorLib@0.4.1
   # renovate: datasource=github-tags depName=pschatzmann_arduino-audio-driver packageName=pschatzmann/arduino-audio-driver
   https://github.com/pschatzmann/arduino-audio-driver/archive/v0.3.1.zip
   # TODO renovate

--- a/variants/esp32s3/tlora-pager/variant.cpp
+++ b/variants/esp32s3/tlora-pager/variant.cpp
@@ -1,6 +1,6 @@
 #include "variant.h"
-#include "ExtensionIOXL9555.hpp"
-extern ExtensionIOXL9555 io;
+#include "IoExpanderXL9555.hpp"
+extern IoExpanderXL9555 io;
 
 void earlyInitVariant()
 {

--- a/variants/esp32s3/tlora-pager/variant.h
+++ b/variants/esp32s3/tlora-pager/variant.h
@@ -89,8 +89,8 @@
 
 // External expansion chip XL9555
 #define USE_PCA95X5
-#define PCA95X5_CLS ExtensionIOXL9555
-#define PCA95X5_INC "ExtensionIOXL9555.hpp"
+#define PCA95X5_CLS IoExpanderXL9555
+#define PCA95X5_INC "IoExpanderXL9555.hpp"
 #define EXPANDS_DRV_EN (0)
 #define EXPANDS_AMP_EN (1)
 #define EXPANDS_KB_RST (2)

--- a/variants/nrf52840/ELECROW-ThinkNode-M3/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M3/platformio.ini
@@ -24,4 +24,4 @@ lib_deps =
   # renovate: datasource=custom.pio depName=nRF52_PWM packageName=khoih-prog/library/nRF52_PWM
   khoih-prog/nRF52_PWM@1.0.1
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.4
+  lewisxhe/SensorLib@0.4.1

--- a/variants/nrf52840/ELECROW-ThinkNode-M3/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M3/platformio.ini
@@ -23,5 +23,5 @@ lib_deps =
   ${nrf52840_base.lib_deps}
   # renovate: datasource=custom.pio depName=nRF52_PWM packageName=khoih-prog/library/nRF52_PWM
   khoih-prog/nRF52_PWM@1.0.1
-  # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.4.1
+  # renovate: datasource=git-refs depName=meshtastic-PCF8xRTC packageName=https://github.com/meshtastic/PCF8xRTC gitBranch=main
+  https://github.com/meshtastic/PCF8xRTC/archive/efe1d9c92f79d8413f8ac4e9bdce0c48410600de.zip

--- a/variants/nrf52840/ELECROW-ThinkNode-M4/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M4/platformio.ini
@@ -12,5 +12,3 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/ELECROW-ThinkNode-M4>
 lib_deps =
   ${nrf52840_base.lib_deps}
-  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
-  lewisxhe/PCF8563_Library@1.0.1

--- a/variants/nrf52840/ELECROW-ThinkNode-M6/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M6/platformio.ini
@@ -22,4 +22,4 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/ELECROW
 lib_deps =
   ${nrf52840_base.lib_deps}
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.4
+  lewisxhe/SensorLib@0.4.1

--- a/variants/nrf52840/ELECROW-ThinkNode-M6/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M6/platformio.ini
@@ -21,5 +21,5 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/ELECROW-ThinkNode-M6>
 lib_deps =
   ${nrf52840_base.lib_deps}
-  # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.4.1
+  # renovate: datasource=git-refs depName=meshtastic-PCF8xRTC packageName=https://github.com/meshtastic/PCF8xRTC gitBranch=main
+  https://github.com/meshtastic/PCF8xRTC/archive/efe1d9c92f79d8413f8ac4e9bdce0c48410600de.zip

--- a/variants/nrf52840/ELECROW-ThinkNode-M8/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M8/platformio.ini
@@ -36,6 +36,6 @@ lib_deps =
   # renovate: datasource=custom.pio depName=nRF52_PWM packageName=khoih-prog/library/nRF52_PWM
   khoih-prog/nRF52_PWM@1.0.1
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.4
+  lewisxhe/SensorLib@0.4.1
 
 

--- a/variants/nrf52840/ELECROW-ThinkNode-M8/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M8/platformio.ini
@@ -35,7 +35,7 @@ lib_deps =
   https://github.com/meshtastic/GxEPD2/archive/c7eb4c3c167cf396ef4f541cc5d4c6aa42f3c46b.zip
   # renovate: datasource=custom.pio depName=nRF52_PWM packageName=khoih-prog/library/nRF52_PWM
   khoih-prog/nRF52_PWM@1.0.1
-  # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.4.1
+  # renovate: datasource=git-refs depName=meshtastic-PCF8xRTC packageName=https://github.com/meshtastic/PCF8xRTC gitBranch=main
+  https://github.com/meshtastic/PCF8xRTC/archive/efe1d9c92f79d8413f8ac4e9bdce0c48410600de.zip
 
 

--- a/variants/nrf52840/heltec_mesh_node_t1/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_node_t1/platformio.ini
@@ -32,5 +32,4 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/heltec_mesh_node_t1>
 lib_deps =
   ${nrf52840_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1
   bodmer/TFT_eSPI@2.5.43

--- a/variants/nrf52840/nano-g2-ultra/platformio.ini
+++ b/variants/nrf52840/nano-g2-ultra/platformio.ini
@@ -21,5 +21,5 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/nano-g2
 lib_deps = 
   ${nrf52840_base.lib_deps}
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.4
+  lewisxhe/SensorLib@0.4.1
 ;upload_protocol = fs

--- a/variants/nrf52840/nano-g2-ultra/platformio.ini
+++ b/variants/nrf52840/nano-g2-ultra/platformio.ini
@@ -20,6 +20,6 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/nano-g2-ultra>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.4.1
+  # renovate: datasource=git-refs depName=meshtastic-PCF8xRTC packageName=https://github.com/meshtastic/PCF8xRTC gitBranch=main
+  https://github.com/meshtastic/PCF8xRTC/archive/efe1d9c92f79d8413f8ac4e9bdce0c48410600de.zip
 ;upload_protocol = fs

--- a/variants/nrf52840/t-echo-plus/platformio.ini
+++ b/variants/nrf52840/t-echo-plus/platformio.ini
@@ -32,7 +32,5 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/t-echo-
 lib_deps =
   ${nrf52840_base.lib_deps}
   https://github.com/meshtastic/GxEPD2/archive/55f618961db45a23eff0233546430f1e5a80f63a.zip
-  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
-  lewisxhe/PCF8563_Library@1.0.1
   # renovate: datasource=custom.pio depName=Adafruit DRV2605 packageName=adafruit/library/Adafruit DRV2605 Library
   adafruit/Adafruit DRV2605 Library@1.2.4

--- a/variants/nrf52840/t-echo/platformio.ini
+++ b/variants/nrf52840/t-echo/platformio.ini
@@ -32,7 +32,7 @@ lib_deps =
   # renovate: datasource=git-refs depName=meshtastic-GxEPD2 packageName=https://github.com/meshtastic/GxEPD2 gitBranch=master
   https://github.com/meshtastic/GxEPD2/archive/c7eb4c3c167cf396ef4f541cc5d4c6aa42f3c46b.zip
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.4
+  lewisxhe/SensorLib@0.4.1
 ;upload_protocol = fs
 
 [env:t-echo-inkhud]
@@ -52,4 +52,4 @@ lib_deps =
   ${inkhud.lib_deps} ; InkHUD libs first, so we get GFXRoot instead of AdafruitGFX
   ${nrf52840_base.lib_deps}
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.4
+  lewisxhe/SensorLib@0.4.1

--- a/variants/nrf52840/t-echo/platformio.ini
+++ b/variants/nrf52840/t-echo/platformio.ini
@@ -31,8 +31,8 @@ lib_deps =
   ${nrf52840_base.lib_deps}
   # renovate: datasource=git-refs depName=meshtastic-GxEPD2 packageName=https://github.com/meshtastic/GxEPD2 gitBranch=master
   https://github.com/meshtastic/GxEPD2/archive/c7eb4c3c167cf396ef4f541cc5d4c6aa42f3c46b.zip
-  # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.4.1
+  # renovate: datasource=git-refs depName=meshtastic-PCF8xRTC packageName=https://github.com/meshtastic/PCF8xRTC gitBranch=main
+  https://github.com/meshtastic/PCF8xRTC/archive/efe1d9c92f79d8413f8ac4e9bdce0c48410600de.zip
 ;upload_protocol = fs
 
 [env:t-echo-inkhud]
@@ -51,5 +51,5 @@ build_src_filter =
 lib_deps = 
   ${inkhud.lib_deps} ; InkHUD libs first, so we get GFXRoot instead of AdafruitGFX
   ${nrf52840_base.lib_deps}
-  # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.4.1
+  # renovate: datasource=git-refs depName=meshtastic-PCF8xRTC packageName=https://github.com/meshtastic/PCF8xRTC gitBranch=main
+  https://github.com/meshtastic/PCF8xRTC/archive/efe1d9c92f79d8413f8ac4e9bdce0c48410600de.zip


### PR DESCRIPTION
Unifies the SensorLib declarations on 0.4.1 (they were split across 0.3.1, 0.3.4 and 0.4.1), ports the source to the 0.4.x API, and then removes SensorLib from the boards that only ever used it as an RTC driver.

**0.4.x API changes.** `SensorBMA423` lost its poll-based surface and now derives from `SensorBMA4XX` with callbacks driven by `update()`; `SensorRemap` became a scoped enum and `BoschSensorInfo` members are protected; `ExtensionIOXL9555` was renamed `IoExpanderXL9555` and the touch drivers moved under `touch/`. Includes point at the current paths rather than the deprecation shims, which emit warnings on every build.

**PCF RTCs move to [meshtastic/PCF8xRTC](https://github.com/meshtastic/PCF8xRTC).** SensorLib reaches its PCF drivers through a comm layer spanning Arduino, ESP-IDF, SPI and custom callbacks. Measured against develop, boards pulling SensorLib grew ~10 KB going 0.3.4 to 0.4.1, while nRF52 boards that do not pull it moved 100-300 bytes. The new library covers both parts in one class over Adafruit BusIO, which every board with a PCF part already links. SensorLib drops from 15 boards to 7; the remaining seven keep it for a BMA423, BHI260AP, QMI8658, XL9555 or touch controller.

It also reports the oscillator-stop flag both parts latch on power loss, which the old path ignored: `readFromRTC()` now refuses a calendar the chip has marked invalid instead of feeding a plausible wrong date to the `BUILD_EPOCH` check.

**Also in here:** four dead `lewisxhe/PCF8563_Library` declarations (nothing includes `pcf8563.h`), the `BMA423_INT` block (no variant defines it, so it has never compiled - see #11755), and the `T_WATCH_S3` branch in `BHI260APSensor` (that file requires `HAS_BHI260AP`, which `T_WATCH_S3` does not define). The `isBitSet` workaround moves from `configuration.h` to `MMC5983MASensor.h`, where SensorLib and the SparkFun header actually meet; it previously worked only by accident of include order.

`SensorQMC6309.hpp` does not exist in 0.3.4, so `src/motion/QMC6309Sensor.cpp` compiles for the first time on 0.4.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved tilt and tap wake-up handling.
  - Updated sensor axis mapping for more consistent orientation behavior.
  - Improved touch-controller and I/O-expander compatibility across supported devices.
  - Added unified support for PCF8563 and PCF85063 real-time clocks.

- **Bug Fixes**
  - Improved screen wake behavior and sensor event handling.
  - Added clearer motion-sensor and RTC failure reporting.
  - Improved RTC time validation and oscillator-stop reporting.
  - Prevented sensor-library compatibility conflicts.

- **Chores**
  - Updated supported device configurations for current sensor and RTC support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->