### PR TITLE
fix(ci): pin tool-scons to 4.8.1 for ESP targets

### DIFF
--- a/variants/esp32/esp32-common.ini
+++ b/variants/esp32/esp32-common.ini
@@ -12,6 +12,10 @@ platform =
 platform_packages =
   # renovate: datasource=custom.pio depName=platformio/tool-mklittlefs packageName=platformio/tool/tool-mklittlefs
   platformio/tool-mklittlefs@1.203.210628
+  ; Hold at 4.8.1: in 4.11.1 the lazy FortranCommon import in smart_link() kills every
+  ; ESP build before it compiles. Drop once PlatformIO ships a tool-scons that imports.
+  # renovate: datasource=custom.pio depName=platformio/tool-scons packageName=platformio/tool/tool-scons
+  platformio/tool-scons@4.40801.0
 
 extra_scripts =
   ${env.extra_scripts}


### PR DESCRIPTION
Every ESP build currently fails at link-action resolution with `ModuleNotFoundError: No module named 'SCons.Tool.FortranCommon'`, before compiling a single file. PlatformIO Core now installs `tool-scons ~4.41101.0` (SCons 4.11.1) over the 4.8.1 the pioarduino espressif32 platform pins, and in 4.11.1 the lazy import that `smart_link()` uses to choose a linker fails. The package itself is fine, `FortranCommon.py` is present and imports cleanly outside SCons, so this pins the working version back.

Scoped to `esp32_common`, which all six ESP architectures extend; nRF52, STM32 and rp2040 keep their current toolchain. Remove the pin once PlatformIO ships a tool-scons that imports correctly. The separate rp2040 `iLabs_Hearth` failures are unrelated and not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the ESP32 build tooling to a compatible version, improving build reliability across ESP32 targets.
  * Added automated update tracking for the pinned tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->