### PR TITLE
fix(rp2xx0): ignore iLabs_Hearth so Pico targets build again

### DIFF
--- a/variants/rp2040/rp2040.ini
+++ b/variants/rp2040/rp2040.ini
@@ -25,6 +25,9 @@ build_src_filter =
 lib_ignore =
   BluetoothOTA
   lvgl
+  ; Ships its own Preferences.h, which the LDF matches against the ARCH_ESP32-only
+  ; include in NodeDB.cpp; compiling it then trips its own "not a Challenger" #error.
+  iLabs_Hearth
 
 lib_deps =
   ${arduino_base.lib_deps}

--- a/variants/rp2350/rp2350.ini
+++ b/variants/rp2350/rp2350.ini
@@ -22,6 +22,9 @@ build_src_filter =
 lib_ignore =
   BluetoothOTA
   lvgl
+  ; Ships its own Preferences.h, which the LDF matches against the ARCH_ESP32-only
+  ; include in NodeDB.cpp; compiling it then trips its own "not a Challenger" #error.
+  iLabs_Hearth
 
 lib_deps =
   ${arduino_base.lib_deps}


### PR DESCRIPTION
All rp2040/rp2350 builds currently fail compiling a framework library they never use: arduino-pico now bundles `iLabs_Hearth`, which supplies its own `Preferences.h`. `NodeDB.cpp` includes `<Preferences.h>` inside an `ARCH_ESP32` guard, but the LDF runs in `chain` mode and matches include directives without evaluating the preprocessor, so it pulls the library in and `Hearth.cpp` trips its own `#error` about `ESP_SERIAL_PORT` not being defined. Adding it to `lib_ignore` for both Pico architectures is sufficient, since no Pico target uses Matter.

Worth noting separately: the library only reaches the build because the platform resolves `framework-arduinopico` from an arduino-pico master commit, while the `platform_packages` entry in `rp2040.ini` pins the name `arduino-pico` - a different package, so the intended 6.0.0 pin never takes effect. That is left alone here; changing the framework version is a bigger change than unbreaking CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed build issues for RP2040 and RP2350 variants by preventing an incompatible library from being included during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->