### PR TITLE
fix(ci): build with pioarduino core instead of upstream platformio

### DIFF
--- a/.github/actions/setup-base/action.yml
+++ b/.github/actions/setup-base/action.yml
@@ -29,11 +29,8 @@ runs:
       run: |
         python -m pip install --upgrade pip
         pip install -U --no-build-isolation --no-cache-dir "setuptools<72"
-        pip install -U platformio adafruit-nrfutil --no-build-isolation
+        # pioarduino, not upstream platformio: the espressif32 platform is the
+        # pioarduino fork, and its core pins a working SCons by URL.
+        pip install -U pioarduino adafruit-nrfutil --no-build-isolation
         pip install -U poetry --no-build-isolation
         pip install -U meshtastic --pre --no-build-isolation
-
-    - name: Upgrade platformio
-      shell: bash
-      run: |
-        pio upgrade

--- a/variants/esp32/esp32-common.ini
+++ b/variants/esp32/esp32-common.ini
@@ -12,10 +12,6 @@ platform =
 platform_packages =
   # renovate: datasource=custom.pio depName=platformio/tool-mklittlefs packageName=platformio/tool/tool-mklittlefs
   platformio/tool-mklittlefs@1.203.210628
-  ; Hold at 4.8.1: in 4.11.1 the lazy FortranCommon import in smart_link() kills every
-  ; ESP build before it compiles. Drop once PlatformIO ships a tool-scons that imports.
-  # renovate: datasource=custom.pio depName=platformio/tool-scons packageName=platformio/tool/tool-scons
-  platformio/tool-scons@4.40801.0
 
 extra_scripts =
   ${env.extra_scripts}


### PR DESCRIPTION
Every ESP target currently fails at link-action resolution with `ModuleNotFoundError: No module named 'SCons.Tool.FortranCommon'`, before compiling a single file.

`setup-base` installed upstream `platformio` and then ran `pio upgrade`, so firmware builds ran a core the espressif32 platform is not built against. Upstream 6.2.0 (released 2026-09-05) moved its `tool-scons` core dependency to `~4.41101.0` (SCons 4.11.1), where the lazy `import SCons.Tool.FortranCommon` inside `smart_link()` fails. pioarduino core pins SCons 4.8.1 by URL, so upstream releases cannot reach it.

A `platform_packages` pin does not work here, which is why #11756 had no effect: core resolves `tool-scons` as a core dependency, installs its own version and removes the pinned one.

```
Installing platformio/tool-scons @ 4.40801.0    <- the pin
Installing platformio/tool-scons @ ~4.41101.0   <- core's own dependency
Removing tool-scons @ 4.40801.0                 <- pin evicted
```

`pio upgrade` is dropped too, since it re-pulled the latest upstream core regardless of what pip installed.

Scope is deliberately just `setup-base`, which is what `build-variant` uses for every firmware build. The matrix-generation jobs in `main_matrix.yml` and `build_one_target.yml` install platformio only to parse the ini files and never build firmware. `setup-native-test` is left alone: the whole native suite passes on upstream core with SCons 4.11.1, since that platform does not reach `smart_link`, and it already avoids `pio upgrade`.