### PR TITLE
Revert "fix(ci): build with pioarduino core instead of upstream platformio"

### DIFF
--- a/.github/actions/setup-base/action.yml
+++ b/.github/actions/setup-base/action.yml
@@ -29,8 +29,11 @@ runs:
       run: |
         python -m pip install --upgrade pip
         pip install -U --no-build-isolation --no-cache-dir "setuptools<72"
-        # pioarduino, not upstream platformio: the espressif32 platform is the
-        # pioarduino fork, and its core pins a working SCons by URL.
-        pip install -U pioarduino adafruit-nrfutil --no-build-isolation
+        pip install -U platformio adafruit-nrfutil --no-build-isolation
         pip install -U poetry --no-build-isolation
         pip install -U meshtastic --pre --no-build-isolation
+
+    - name: Upgrade platformio
+      shell: bash
+      run: |
+        pio upgrade

--- a/variants/esp32/esp32-common.ini
+++ b/variants/esp32/esp32-common.ini
@@ -12,6 +12,10 @@ platform =
 platform_packages =
   # renovate: datasource=custom.pio depName=platformio/tool-mklittlefs packageName=platformio/tool/tool-mklittlefs
   platformio/tool-mklittlefs@1.203.210628
+  ; Hold at 4.8.1: in 4.11.1 the lazy FortranCommon import in smart_link() kills every
+  ; ESP build before it compiles. Drop once PlatformIO ships a tool-scons that imports.
+  # renovate: datasource=custom.pio depName=platformio/tool-scons packageName=platformio/tool/tool-scons
+  platformio/tool-scons@4.40801.0
 
 extra_scripts =
   ${env.extra_scripts}


### PR DESCRIPTION
Reverts meshtastic/firmware#11759 , it's a no-op as is (this change should have been made in `gh-action-firmware`, working with @caveman99 on that now)

setup-action is used by things like the test suite (which should be using platformio)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ESP build reliability by using the standard PlatformIO package and upgrading it during setup.
  - Pinned the SCons build tool to a compatible version to prevent ESP builds from failing before compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->