### PR TITLE
fix(rp2xx0): match the real library name when ignoring iLabs_Hearth

### DIFF
--- a/variants/rp2040/rp2040.ini
+++ b/variants/rp2040/rp2040.ini
@@ -27,7 +27,7 @@ lib_ignore =
   lvgl
   ; Ships its own Preferences.h, which the LDF matches against the ARCH_ESP32-only
   ; include in NodeDB.cpp; compiling it then trips its own "not a Challenger" #error.
-  iLabs_Hearth
+  iLabs Hearth
 
 lib_deps =
   ${arduino_base.lib_deps}

--- a/variants/rp2350/rp2350.ini
+++ b/variants/rp2350/rp2350.ini
@@ -24,7 +24,7 @@ lib_ignore =
   lvgl
   ; Ships its own Preferences.h, which the LDF matches against the ARCH_ESP32-only
   ; include in NodeDB.cpp; compiling it then trips its own "not a Challenger" #error.
-  iLabs_Hearth
+  iLabs Hearth
 
 lib_deps =
   ${arduino_base.lib_deps}


### PR DESCRIPTION
Follow-up to #11757, which did not work. `lib_ignore` matches the name declared in the library manifest, and iLabs_Hearth's `library.properties` says `name=iLabs Hearth` with a space. #11757 used the directory name, so the entry never matched and the Pico builds still pull the library in and still fail on its `ESP_SERIAL_PORT` #error.

Confirmed from a build after #11757 merged: `picow` compiled 653 objects including `iLabs_Hearth/MatterEndpoints/*.cpp.o` before hitting `*** [.pio/build/picow/libd9c/iLabs_Hearth/Hearth.cpp.o] Error 1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected library exclusion configuration for RP2040 and RP2350 platforms, improving build and dependency handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->