### PR TITLE
Revert "fix(ci): pin tool-scons to 4.8.1 for ESP targets"

### DIFF
--- a/variants/esp32/esp32-common.ini
+++ b/variants/esp32/esp32-common.ini
@@ -12,10 +12,6 @@ platform =
 platform_packages =
   # renovate: datasource=custom.pio depName=platformio/tool-mklittlefs packageName=platformio/tool/tool-mklittlefs
   platformio/tool-mklittlefs@1.203.210628
-  ; Hold at 4.8.1: in 4.11.1 the lazy FortranCommon import in smart_link() kills every
-  ; ESP build before it compiles. Drop once PlatformIO ships a tool-scons that imports.
-  # renovate: datasource=custom.pio depName=platformio/tool-scons packageName=platformio/tool/tool-scons
-  platformio/tool-scons@4.40801.0
 
 extra_scripts =
   ${env.extra_scripts}


### PR DESCRIPTION
Reverts meshtastic/firmware#11756

This is pinned by pioarduino, and should be fixed by https://github.com/meshtastic/gh-action-firmware/pull/61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ESP32 builds now use PlatformIO’s default `tool-scons` version instead of a pinned version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->