### PR TITLE
fix(traffic-management): disabled except by build flag, and route-rish nodes can issue direct responses beyond 0 hops

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -102,6 +102,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MESHTASTIC_ENABLE_FRAME_INJECTION 0
 #endif
 
+// Answer a unicast NodeInfo request aimed at another node from our local cache, replying with the
+// sender spoofed as that node. Off by default; enable per-build with
+// -D MESHTASTIC_ENABLE_NODEINFO_DIRECT_RESPONSE=1. Unit-test builds opt in so the suite keeps
+// covering the path (mirrors TMM_HAS_NODEINFO_CACHE's PIO_UNIT_TESTING opt-in).
+#ifndef MESHTASTIC_ENABLE_NODEINFO_DIRECT_RESPONSE
+#ifdef PIO_UNIT_TESTING
+#define MESHTASTIC_ENABLE_NODEINFO_DIRECT_RESPONSE 1
+#else
+#define MESHTASTIC_ENABLE_NODEINFO_DIRECT_RESPONSE 0
+#endif
+#endif
+
 /// Convert a preprocessor name into a quoted string
 #define xstr(s) ystr(s)
 #define ystr(s) #s

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -33,6 +33,7 @@ namespace
 
 constexpr uint32_t kMaintenanceIntervalMs = 60 * 1000UL; // Cache cleanup interval
 
+#if MESHTASTIC_ENABLE_NODEINFO_DIRECT_RESPONSE
 // NodeInfo direct response: role-enforced hop ceilings (respond when hopsAway <= threshold);
 // config can only tighten them. nodeinfo_direct_response must also be enabled.
 constexpr uint32_t kRouterDefaultMaxHops = 3; // Routers: max 3 hops (can set lower via config)
@@ -42,6 +43,8 @@ constexpr uint32_t kClientDefaultMaxHops = 0; // Clients: direct only (cannot in
 // entry would be served indefinitely for a long-gone node while the genuine request is
 // suppressed. The cache path enforces the same 6 h in ticks (kNodeInfoMaxServeAgeTicks, header).
 constexpr uint32_t kNodeInfoMaxServeAgeSecs = 6UL * 60UL * 60UL; // 6 h (NodeDB fallback path)
+
+#endif // MESHTASTIC_ENABLE_NODEINFO_DIRECT_RESPONSE
 
 /// Convert seconds to milliseconds with overflow protection.
 uint32_t secsToMs(uint32_t secs)
@@ -1114,6 +1117,7 @@ ProcessMessage TrafficManagementModule::handleReceived(const meshtastic_MeshPack
         updateCachedRoleFromNodeInfo(mp);
     }
 
+#if MESHTASTIC_ENABLE_NODEINFO_DIRECT_RESPONSE
     // -------------------------------------------------------------------------
     // NodeInfo Direct Response
     // -------------------------------------------------------------------------
@@ -1139,6 +1143,7 @@ ProcessMessage TrafficManagementModule::handleReceived(const meshtastic_MeshPack
             return ProcessMessage::STOP; // Consumed - request will not be forwarded
         }
     }
+#endif // MESHTASTIC_ENABLE_NODEINFO_DIRECT_RESPONSE
 
     // -------------------------------------------------------------------------
     // Position Deduplication
@@ -1420,6 +1425,7 @@ bool TrafficManagementModule::shouldDropPosition(const meshtastic_MeshPacket *p,
 #endif
 }
 
+#if MESHTASTIC_ENABLE_NODEINFO_DIRECT_RESPONSE
 bool TrafficManagementModule::shouldRespondToNodeInfo(const meshtastic_MeshPacket *p, bool sendResponse)
 {
     // Caller already verified: nodeinfo_direct_response, portnum, want_response,
@@ -1665,6 +1671,7 @@ bool TrafficManagementModule::isWithinMaxHopsOfRequestor(const meshtastic_MeshPa
                  isRouter, result ? "respond" : "skip");
     return result;
 }
+#endif // MESHTASTIC_ENABLE_NODEINFO_DIRECT_RESPONSE
 
 bool TrafficManagementModule::isRateLimited(NodeNum from, uint32_t nowMs)
 {

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -1428,8 +1428,8 @@ bool TrafficManagementModule::shouldRespondToNodeInfo(const meshtastic_MeshPacke
     if (!isWithinMaxHopsOfRequestor(p))
         return false;
 
-    // A request that crossed a hop reached us through a relayer, and that relayer is the only
-    // return path we can address. Without it, leave the request for the genuine target.
+    // A request that crossed a hop but names no relayer is anomalous: we cannot corroborate the
+    // path it took. Leave it for the genuine target rather than consume it on a guess.
     const int8_t hopsAway = getHopsAway(*p, -1);
     if (hopsAway > 0 && p->relay_node == NO_RELAY_NODE) {
         TM_LOG_DEBUG("NodeInfo request from 0x%08x is %d hops out with no relayer, not responding", getFrom(p),
@@ -1581,8 +1581,8 @@ bool TrafficManagementModule::shouldRespondToNodeInfo(const meshtastic_MeshPacke
     // hop_start is set explicitly because Router::send() only sets it for isFromUs(),
     // and our spoofed from means isFromUs() is false.
     reply->hop_start = reply->hop_limit;
-    // Steer back along the path the request arrived on; a direct requestor is its own relayer.
-    reply->next_hop = (hopsAway > 0) ? p->relay_node : nodeDB->getLastByteOfNodeNum(getFrom(p));
+    // next_hop is deliberately left unset: NextHopRouter::sendWithNextHop() overwrites it from the
+    // NodeDB route (with staleness and unique-neighbour checks, else flooding) on the way out.
     reply->priority = meshtastic_MeshPacket_Priority_DEFAULT;
 
     service->sendToMesh(reply);

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -1425,8 +1425,17 @@ bool TrafficManagementModule::shouldRespondToNodeInfo(const meshtastic_MeshPacke
     // Caller already verified: nodeinfo_direct_response, portnum, want_response,
     // !isBroadcast, !isToUs, !isFromUs
 
-    if (!isMinHopsFromRequestor(p))
+    if (!isWithinMaxHopsOfRequestor(p))
         return false;
+
+    // A request that crossed a hop reached us through a relayer, and that relayer is the only
+    // return path we can address. Without it, leave the request for the genuine target.
+    const int8_t hopsAway = getHopsAway(*p, -1);
+    if (hopsAway > 0 && p->relay_node == NO_RELAY_NODE) {
+        TM_LOG_DEBUG("NodeInfo request from 0x%08x is %d hops out with no relayer, not responding", getFrom(p),
+                     static_cast<int>(hopsAway));
+        return false;
+    }
 
     meshtastic_User cachedUser = meshtastic_User_init_zero;
     bool hasCachedUser = false;
@@ -1562,17 +1571,18 @@ bool TrafficManagementModule::shouldRespondToNodeInfo(const meshtastic_MeshPacke
                      static_cast<unsigned>(cachedSourceChannel), static_cast<unsigned>(p->channel));
     }
 
-    // Spoof the sender as the target node so the requestor sees a valid NodeInfo response.
-    // hop_limit=0 ensures this reply travels only one hop (direct to requestor).
+    // Spoof the sender as the target node so the requestor sees a valid NodeInfo response, and
+    // grant exactly the hops the request spent reaching us so the reply can get back.
     reply->from = p->to;
     reply->to = getFrom(p);
     reply->channel = p->channel;
     reply->decoded.request_id = p->id;
-    reply->hop_limit = 0;
-    // hop_start=0 is set explicitly because Router::send() only sets it for isFromUs(),
+    reply->hop_limit = (hopsAway > 0) ? static_cast<uint8_t>(hopsAway) : 0;
+    // hop_start is set explicitly because Router::send() only sets it for isFromUs(),
     // and our spoofed from means isFromUs() is false.
-    reply->hop_start = 0;
-    reply->next_hop = nodeDB->getLastByteOfNodeNum(getFrom(p));
+    reply->hop_start = reply->hop_limit;
+    // Steer back along the path the request arrived on; a direct requestor is its own relayer.
+    reply->next_hop = (hopsAway > 0) ? p->relay_node : nodeDB->getLastByteOfNodeNum(getFrom(p));
     reply->priority = meshtastic_MeshPacket_Priority_DEFAULT;
 
     service->sendToMesh(reply);
@@ -1631,7 +1641,7 @@ bool TrafficManagementModule::directResponseAllowed(NodeNum requester, NodeNum t
     return true;
 }
 
-bool TrafficManagementModule::isMinHopsFromRequestor(const meshtastic_MeshPacket *p) const
+bool TrafficManagementModule::isWithinMaxHopsOfRequestor(const meshtastic_MeshPacket *p) const
 {
     int8_t hopsAway = getHopsAway(*p, -1);
     if (hopsAway < 0)

--- a/src/modules/TrafficManagementModule.cpp
+++ b/src/modules/TrafficManagementModule.cpp
@@ -36,7 +36,7 @@ constexpr uint32_t kMaintenanceIntervalMs = 60 * 1000UL; // Cache cleanup interv
 #if MESHTASTIC_ENABLE_NODEINFO_DIRECT_RESPONSE
 // NodeInfo direct response: role-enforced hop ceilings (respond when hopsAway <= threshold);
 // config can only tighten them. nodeinfo_direct_response must also be enabled.
-constexpr uint32_t kRouterDefaultMaxHops = 3; // Routers: max 3 hops (can set lower via config)
+constexpr uint32_t kRouterDefaultMaxHops = 1; // Routers: one hop out (can set lower via config)
 constexpr uint32_t kClientDefaultMaxHops = 0; // Clients: direct only (cannot increase)
 
 // Staleness window: never spoof a reply for a node not actually heard within it, or a cached
@@ -1431,12 +1431,13 @@ bool TrafficManagementModule::shouldRespondToNodeInfo(const meshtastic_MeshPacke
     // Caller already verified: nodeinfo_direct_response, portnum, want_response,
     // !isBroadcast, !isToUs, !isFromUs
 
-    if (!isWithinMaxHopsOfRequestor(p))
+    int8_t hopsAway = 0;
+    if (!isWithinMaxHopsOfRequestor(p, hopsAway))
         return false;
 
     // A request that crossed a hop but names no relayer is anomalous: we cannot corroborate the
     // path it took. Leave it for the genuine target rather than consume it on a guess.
-    const int8_t hopsAway = getHopsAway(*p, -1);
+    // NO_RELAY_NODE is 0, so a relayer whose node number ends in 0x00 reads the same here.
     if (hopsAway > 0 && p->relay_node == NO_RELAY_NODE) {
         TM_LOG_DEBUG("NodeInfo request from 0x%08x is %d hops out with no relayer, not responding", getFrom(p),
                      static_cast<int>(hopsAway));
@@ -1647,9 +1648,9 @@ bool TrafficManagementModule::directResponseAllowed(NodeNum requester, NodeNum t
     return true;
 }
 
-bool TrafficManagementModule::isWithinMaxHopsOfRequestor(const meshtastic_MeshPacket *p) const
+bool TrafficManagementModule::isWithinMaxHopsOfRequestor(const meshtastic_MeshPacket *p, int8_t &hopsAway) const
 {
-    int8_t hopsAway = getHopsAway(*p, -1);
+    hopsAway = getHopsAway(*p, -1);
     if (hopsAway < 0)
         return false;
 

--- a/src/modules/TrafficManagementModule.h
+++ b/src/modules/TrafficManagementModule.h
@@ -367,6 +367,7 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
 
     /// True when this position broadcast duplicates the sender's last one within the dedup window.
     bool shouldDropPosition(const meshtastic_MeshPacket *p, const meshtastic_Position *pos, uint32_t nowMs);
+#if MESHTASTIC_ENABLE_NODEINFO_DIRECT_RESPONSE
     /// Decide (and with sendResponse, emit) a spoofed direct NodeInfo reply for a unicast request.
     bool shouldRespondToNodeInfo(const meshtastic_MeshPacket *p, bool sendResponse);
 
@@ -394,6 +395,8 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
                                                            uint32_t windowMs);
     /// True when the requestor is within the role-clamped hop limit for direct responses.
     bool isWithinMaxHopsOfRequestor(const meshtastic_MeshPacket *p) const;
+#endif // MESHTASTIC_ENABLE_NODEINFO_DIRECT_RESPONSE
+
     /// True when `from` exceeded the configured packet budget for the current rate window.
     bool isRateLimited(NodeNum from, uint32_t nowMs);
     /// True when `p`'s sender exceeded the undecodable-packet threshold for the current window.

--- a/src/modules/TrafficManagementModule.h
+++ b/src/modules/TrafficManagementModule.h
@@ -394,7 +394,8 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     static DirectResponseThrottleEntry *directResponseSlot(DirectResponseThrottleEntry *table, NodeNum key, uint32_t nowMs,
                                                            uint32_t windowMs);
     /// True when the requestor is within the role-clamped hop limit for direct responses.
-    bool isWithinMaxHopsOfRequestor(const meshtastic_MeshPacket *p) const;
+    /// Writes the requestor's hop distance to `hopsAway`, which is negative when unknown.
+    bool isWithinMaxHopsOfRequestor(const meshtastic_MeshPacket *p, int8_t &hopsAway) const;
 #endif // MESHTASTIC_ENABLE_NODEINFO_DIRECT_RESPONSE
 
     /// True when `from` exceeded the configured packet budget for the current rate window.

--- a/src/modules/TrafficManagementModule.h
+++ b/src/modules/TrafficManagementModule.h
@@ -393,7 +393,7 @@ class TrafficManagementModule : public MeshModule, private concurrency::OSThread
     static DirectResponseThrottleEntry *directResponseSlot(DirectResponseThrottleEntry *table, NodeNum key, uint32_t nowMs,
                                                            uint32_t windowMs);
     /// True when the requestor is within the role-clamped hop limit for direct responses.
-    bool isMinHopsFromRequestor(const meshtastic_MeshPacket *p) const;
+    bool isWithinMaxHopsOfRequestor(const meshtastic_MeshPacket *p) const;
     /// True when `from` exceeded the configured packet budget for the current rate window.
     bool isRateLimited(NodeNum from, uint32_t nowMs);
     /// True when `p`'s sender exceeded the undecodable-packet threshold for the current window.

--- a/test/test_nexthop_routing/test_main.cpp
+++ b/test/test_nexthop_routing/test_main.cpp
@@ -988,6 +988,32 @@ void test_rebroadcast_declined_send_releases_packet(void)
     TEST_ASSERT_EQUAL_MESSAGE(1, mockIface->sendCount, "the copy must have reached the mock radio");
 }
 
+// A direct NodeInfo reply from TrafficManagementModule is a unicast the mesh must carry back to the
+// requestor. hop_limit 0 is refused outright, so such a reply never leaves the answering node.
+void test_rebroadcast_zeroHopUnicast_isNotRelayed(void)
+{
+    MockRadioInterface *mockIface = installMockIface();
+    meshtastic_MeshPacket p = makeRebroadcastCandidate(0x33333333);
+    p.hop_start = 0;
+    p.hop_limit = 0;
+    p.next_hop = mockNodeDB->getLastByteOfNodeNum(kLocalNode); // addressed at us to relay
+
+    TEST_ASSERT_FALSE_MESSAGE(shim->perhapsRebroadcast(&p), "a zero-hop unicast must not be relayed");
+    TEST_ASSERT_EQUAL_MESSAGE(0, mockIface->sendCount, "no packet should be handed to the radio at all");
+}
+
+void test_rebroadcast_oneHopUnicast_addressedAtUs_isRelayed(void)
+{
+    MockRadioInterface *mockIface = installMockIface();
+    meshtastic_MeshPacket p = makeRebroadcastCandidate(0x33333333);
+    p.hop_start = 1;
+    p.hop_limit = 1;
+    p.next_hop = mockNodeDB->getLastByteOfNodeNum(kLocalNode);
+
+    TEST_ASSERT_TRUE_MESSAGE(shim->perhapsRebroadcast(&p), "a one-hop unicast addressed at us must be relayed");
+    TEST_ASSERT_EQUAL_MESSAGE(1, mockIface->sendCount, "exactly one packet should reach the radio");
+}
+
 // An already-encrypted packet never reaches perhapsEncode's TOO_LARGE check, so Router::send() is the
 // last gate before the radio queue: MeshPacket.encrypted holds 256 bytes, the radio buffer 240.
 void test_send_rejects_payload_larger_than_radio_buffer(void)
@@ -1134,6 +1160,8 @@ void setup()
     RUN_TEST(test_rebroadcast_normal_broadcast_is_relayed);
     RUN_TEST(test_rebroadcast_no_lora_broadcast_is_not_relayed);
     RUN_TEST(test_rebroadcast_declined_send_releases_packet);
+    RUN_TEST(test_rebroadcast_zeroHopUnicast_isNotRelayed);
+    RUN_TEST(test_rebroadcast_oneHopUnicast_addressedAtUs_isRelayed);
     RUN_TEST(test_send_rejects_payload_larger_than_radio_buffer);
 #if USERPREFS_EVENT_MODE
     RUN_TEST(test_event_mode_hop_behavior);

--- a/test/test_traffic_management/test_main.cpp
+++ b/test/test_traffic_management/test_main.cpp
@@ -565,6 +565,89 @@ static void test_tm_nodeinfo_routerClamp_skipsWhenTooManyHops(void)
 }
 
 /**
+ * Verify a ROUTER serving a 1-hop requestor sends a reply that can route back to it.
+ * Important because the request is consumed, so an undeliverable reply answers nobody.
+ */
+static void test_tm_nodeinfo_routerMultiHop_replyRoutesBackToRequestor(void)
+{
+    moduleConfig.traffic_management.nodeinfo_direct_response_max_hops = 3;
+    config.device.role = meshtastic_Config_DeviceConfig_Role_ROUTER;
+    mockNodeDB->setCachedNode(kTargetNode);
+    // Signed-only replay gate (default) requires the target be a known signer to be served.
+    mockNodeDB->cachedNodeForTest().bitfield |= NODEINFO_BITFIELD_HAS_XEDDSA_SIGNED_MASK;
+
+    MockRouter mockRouter;
+    mockRouter.addInterface(std::unique_ptr<RadioInterface>(new MockRadioInterface()));
+    MeshService mockService;
+    router = &mockRouter;
+    service = &mockService;
+
+    TrafficManagementModuleTestShim module;
+    module.dropNodeInfoCacheForTest(); // exercise the NodeDB fallback path
+    meshtastic_MeshPacket request = makeDecodedPacket(meshtastic_PortNum_NODEINFO_APP, kRemoteNode, kTargetNode);
+    request.decoded.want_response = true;
+    request.id = 0x2468ace0;
+    request.hop_start = 3;
+    request.hop_limit = 2;     // 1 hop away: inside the router clamp of 3, outside direct earshot
+    request.relay_node = 0x42; // the neighbour that handed us the request
+    const uint8_t hopsAway = static_cast<uint8_t>(request.hop_start - request.hop_limit);
+
+    ProcessMessage result = module.handleReceived(request);
+    meshtastic_TrafficManagementStats stats = module.getStats();
+
+    TEST_ASSERT_EQUAL_UINT8(1, hopsAway);
+    TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::STOP), static_cast<int>(result));
+    TEST_ASSERT_TRUE(module.ignoreRequestFlag());
+    TEST_ASSERT_EQUAL_UINT32(1, stats.nodeinfo_cache_hits);
+    TEST_ASSERT_EQUAL_UINT32(1, static_cast<uint32_t>(mockRouter.sentPackets.size()));
+
+    const meshtastic_MeshPacket &reply = mockRouter.sentPackets.front();
+    TEST_ASSERT_EQUAL_UINT32(kTargetNode, reply.from);
+    TEST_ASSERT_EQUAL_UINT32(kRemoteNode, reply.to);
+    // Enough hops to cross the distance the request came, and steered back at the relayer we heard.
+    TEST_ASSERT_EQUAL_UINT8(hopsAway, reply.hop_limit);
+    TEST_ASSERT_EQUAL_UINT8(hopsAway, reply.hop_start);
+    TEST_ASSERT_EQUAL_UINT8(request.relay_node, reply.next_hop);
+}
+
+/**
+ * Verify a multi-hop request with no relayer byte is left alone rather than answered.
+ * Important because there is no return path to address, and consuming it would answer nobody.
+ */
+static void test_tm_nodeinfo_routerMultiHop_skipsWhenRelayerUnknown(void)
+{
+    moduleConfig.traffic_management.nodeinfo_direct_response_max_hops = 3;
+    config.device.role = meshtastic_Config_DeviceConfig_Role_ROUTER;
+    mockNodeDB->setCachedNode(kTargetNode);
+    // Signed-only replay gate (default) requires the target be a known signer to be served.
+    mockNodeDB->cachedNodeForTest().bitfield |= NODEINFO_BITFIELD_HAS_XEDDSA_SIGNED_MASK;
+
+    MockRouter mockRouter;
+    mockRouter.addInterface(std::unique_ptr<RadioInterface>(new MockRadioInterface()));
+    MeshService mockService;
+    router = &mockRouter;
+    service = &mockService;
+
+    TrafficManagementModuleTestShim module;
+    module.dropNodeInfoCacheForTest(); // exercise the NodeDB fallback path
+    meshtastic_MeshPacket request = makeDecodedPacket(meshtastic_PortNum_NODEINFO_APP, kRemoteNode, kTargetNode);
+    request.decoded.want_response = true;
+    request.id = 0x13570246;
+    request.hop_start = 3;
+    request.hop_limit = 1;              // 2 hops away
+    request.relay_node = NO_RELAY_NODE; // no relayer learned, so no way to address a reply
+
+    ProcessMessage result = module.handleReceived(request);
+    meshtastic_TrafficManagementStats stats = module.getStats();
+
+    // Forwarded untouched, so the genuine target still gets the chance to answer.
+    TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::CONTINUE), static_cast<int>(result));
+    TEST_ASSERT_FALSE(module.ignoreRequestFlag());
+    TEST_ASSERT_EQUAL_UINT32(0, stats.nodeinfo_cache_hits);
+    TEST_ASSERT_EQUAL_UINT32(0, static_cast<uint32_t>(mockRouter.sentPackets.size()));
+}
+
+/**
  * Verify NodeInfo direct-response success path and reply packet fields.
  * Important because this path consumes the request and generates a spoofed cached reply.
  */
@@ -3327,6 +3410,8 @@ TM_TEST_ENTRY void setup()
     RUN_TEST(test_tm_fromUs_bypassesPositionAndRateFilters);
     RUN_TEST(test_tm_localDestination_bypassesTransitFilters);
     RUN_TEST(test_tm_nodeinfo_routerClamp_skipsWhenTooManyHops);
+    RUN_TEST(test_tm_nodeinfo_routerMultiHop_replyRoutesBackToRequestor);
+    RUN_TEST(test_tm_nodeinfo_routerMultiHop_skipsWhenRelayerUnknown);
     RUN_TEST(test_tm_nodeinfo_directResponse_respondsFromCache);
     RUN_TEST(test_tm_nodeinfo_directResponse_learnsRequestorNodeInfo);
     RUN_TEST(test_tm_nodeinfo_directResponse_ignoresUnsignedSignerIdentity);

--- a/test/test_traffic_management/test_main.cpp
+++ b/test/test_traffic_management/test_main.cpp
@@ -565,10 +565,10 @@ static void test_tm_nodeinfo_routerClamp_skipsWhenTooManyHops(void)
 }
 
 /**
- * Verify a ROUTER serving a 1-hop requestor sends a reply that can route back to it.
- * Important because the request is consumed, so an undeliverable reply answers nobody.
+ * Verify a ROUTER serving a 1-hop requestor grants the reply enough hops to get back.
+ * Important because the request is consumed, so a reply that expires en route answers nobody.
  */
-static void test_tm_nodeinfo_routerMultiHop_replyRoutesBackToRequestor(void)
+static void test_tm_nodeinfo_routerMultiHop_replyCarriesHopBudgetToReturn(void)
 {
     moduleConfig.traffic_management.nodeinfo_direct_response_max_hops = 3;
     config.device.role = meshtastic_Config_DeviceConfig_Role_ROUTER;
@@ -589,7 +589,7 @@ static void test_tm_nodeinfo_routerMultiHop_replyRoutesBackToRequestor(void)
     request.id = 0x2468ace0;
     request.hop_start = 3;
     request.hop_limit = 2;     // 1 hop away: inside the router clamp of 3, outside direct earshot
-    request.relay_node = 0x42; // the neighbour that handed us the request
+    request.relay_node = 0x42; // a relayer is present, so the no-relayer guard does not fire
     const uint8_t hopsAway = static_cast<uint8_t>(request.hop_start - request.hop_limit);
 
     ProcessMessage result = module.handleReceived(request);
@@ -604,15 +604,17 @@ static void test_tm_nodeinfo_routerMultiHop_replyRoutesBackToRequestor(void)
     const meshtastic_MeshPacket &reply = mockRouter.sentPackets.front();
     TEST_ASSERT_EQUAL_UINT32(kTargetNode, reply.from);
     TEST_ASSERT_EQUAL_UINT32(kRemoteNode, reply.to);
-    // Enough hops to cross the distance the request came, and steered back at the relayer we heard.
+    // Enough hops to cross the distance the request came from.
     TEST_ASSERT_EQUAL_UINT8(hopsAway, reply.hop_limit);
     TEST_ASSERT_EQUAL_UINT8(hopsAway, reply.hop_start);
-    TEST_ASSERT_EQUAL_UINT8(request.relay_node, reply.next_hop);
+    // Routing is the router's call: NextHopRouter::sendWithNextHop() sets next_hop from the NodeDB
+    // route, so TMM must leave it unset rather than steer with the relayer byte it happened to see.
+    TEST_ASSERT_EQUAL_UINT8(NO_NEXT_HOP_PREFERENCE, reply.next_hop);
 }
 
 /**
  * Verify a multi-hop request with no relayer byte is left alone rather than answered.
- * Important because there is no return path to address, and consuming it would answer nobody.
+ * Important because consuming an anomalous request would answer nobody if the guess is wrong.
  */
 static void test_tm_nodeinfo_routerMultiHop_skipsWhenRelayerUnknown(void)
 {
@@ -635,7 +637,7 @@ static void test_tm_nodeinfo_routerMultiHop_skipsWhenRelayerUnknown(void)
     request.id = 0x13570246;
     request.hop_start = 3;
     request.hop_limit = 1;              // 2 hops away
-    request.relay_node = NO_RELAY_NODE; // no relayer learned, so no way to address a reply
+    request.relay_node = NO_RELAY_NODE; // no relayer, so the path it took cannot be corroborated
 
     ProcessMessage result = module.handleReceived(request);
     meshtastic_TrafficManagementStats stats = module.getStats();
@@ -690,7 +692,8 @@ static void test_tm_nodeinfo_directResponse_respondsFromCache(void)
     TEST_ASSERT_FALSE(reply.decoded.want_response);
     TEST_ASSERT_EQUAL_UINT8(0, reply.hop_limit);
     TEST_ASSERT_EQUAL_UINT8(0, reply.hop_start);
-    TEST_ASSERT_EQUAL_UINT8(mockNodeDB->getLastByteOfNodeNum(kRemoteNode), reply.next_hop);
+    // Left to NextHopRouter::sendWithNextHop(), which resolves it from the NodeDB route.
+    TEST_ASSERT_EQUAL_UINT8(NO_NEXT_HOP_PREFERENCE, reply.next_hop);
     TEST_ASSERT_TRUE(reply.decoded.has_bitfield);
     TEST_ASSERT_EQUAL_UINT8(BITFIELD_OK_TO_MQTT_MASK, reply.decoded.bitfield);
 }
@@ -3410,7 +3413,7 @@ TM_TEST_ENTRY void setup()
     RUN_TEST(test_tm_fromUs_bypassesPositionAndRateFilters);
     RUN_TEST(test_tm_localDestination_bypassesTransitFilters);
     RUN_TEST(test_tm_nodeinfo_routerClamp_skipsWhenTooManyHops);
-    RUN_TEST(test_tm_nodeinfo_routerMultiHop_replyRoutesBackToRequestor);
+    RUN_TEST(test_tm_nodeinfo_routerMultiHop_replyCarriesHopBudgetToReturn);
     RUN_TEST(test_tm_nodeinfo_routerMultiHop_skipsWhenRelayerUnknown);
     RUN_TEST(test_tm_nodeinfo_directResponse_respondsFromCache);
     RUN_TEST(test_tm_nodeinfo_directResponse_learnsRequestorNodeInfo);

--- a/test/test_traffic_management/test_main.cpp
+++ b/test/test_traffic_management/test_main.cpp
@@ -554,7 +554,7 @@ static void test_tm_nodeinfo_routerClamp_skipsWhenTooManyHops(void)
     meshtastic_MeshPacket request = makeDecodedPacket(meshtastic_PortNum_NODEINFO_APP, kRemoteNode, kTargetNode);
     request.decoded.want_response = true;
     request.hop_start = 5;
-    request.hop_limit = 1; // 4 hops away; router clamp should cap max at 3
+    request.hop_limit = 1; // 4 hops away; router clamp should cap max at 1
 
     ProcessMessage result = module.handleReceived(request);
     meshtastic_TrafficManagementStats stats = module.getStats();
@@ -636,7 +636,7 @@ static void test_tm_nodeinfo_routerMultiHop_skipsWhenRelayerUnknown(void)
     request.decoded.want_response = true;
     request.id = 0x13570246;
     request.hop_start = 3;
-    request.hop_limit = 1;              // 2 hops away
+    request.hop_limit = 2;              // 1 hop away, inside the router ceiling, so the relayer guard is what rejects it
     request.relay_node = NO_RELAY_NODE; // no relayer, so the path it took cannot be corroborated
 
     ProcessMessage result = module.handleReceived(request);
@@ -647,6 +647,32 @@ static void test_tm_nodeinfo_routerMultiHop_skipsWhenRelayerUnknown(void)
     TEST_ASSERT_FALSE(module.ignoreRequestFlag());
     TEST_ASSERT_EQUAL_UINT32(0, stats.nodeinfo_cache_hits);
     TEST_ASSERT_EQUAL_UINT32(0, static_cast<uint32_t>(mockRouter.sentPackets.size()));
+}
+
+/**
+ * Verify a requestor one hop past the router ceiling is skipped even when config asks for more.
+ * Important because the role limit, not the config value, is what bounds a spoofed reply's reach.
+ */
+static void test_tm_nodeinfo_routerClamp_skipsJustBeyondCeiling(void)
+{
+    moduleConfig.traffic_management.nodeinfo_direct_response_max_hops = 3;
+    config.device.role = meshtastic_Config_DeviceConfig_Role_ROUTER;
+    mockNodeDB->setCachedNode(kTargetNode);
+    mockNodeDB->cachedNodeForTest().bitfield |= NODEINFO_BITFIELD_HAS_XEDDSA_SIGNED_MASK;
+
+    TrafficManagementModuleTestShim module;
+    meshtastic_MeshPacket request = makeDecodedPacket(meshtastic_PortNum_NODEINFO_APP, kRemoteNode, kTargetNode);
+    request.decoded.want_response = true;
+    request.hop_start = 3;
+    request.hop_limit = 1; // 2 hops away, one past the ceiling of 1
+    request.relay_node = 0x00000042;
+
+    ProcessMessage result = module.handleReceived(request);
+    meshtastic_TrafficManagementStats stats = module.getStats();
+
+    TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::CONTINUE), static_cast<int>(result));
+    TEST_ASSERT_EQUAL_UINT32(0, stats.nodeinfo_cache_hits);
+    TEST_ASSERT_FALSE(module.ignoreRequestFlag());
 }
 
 /**
@@ -3415,6 +3441,7 @@ TM_TEST_ENTRY void setup()
     RUN_TEST(test_tm_nodeinfo_routerClamp_skipsWhenTooManyHops);
     RUN_TEST(test_tm_nodeinfo_routerMultiHop_replyCarriesHopBudgetToReturn);
     RUN_TEST(test_tm_nodeinfo_routerMultiHop_skipsWhenRelayerUnknown);
+    RUN_TEST(test_tm_nodeinfo_routerClamp_skipsJustBeyondCeiling);
     RUN_TEST(test_tm_nodeinfo_directResponse_respondsFromCache);
     RUN_TEST(test_tm_nodeinfo_directResponse_learnsRequestorNodeInfo);
     RUN_TEST(test_tm_nodeinfo_directResponse_ignoresUnsignedSignerIdentity);


### PR DESCRIPTION
NodeInfo signing has made the direct response function much less effective - 2.8 nodes will always sign their nodeinfo and other 2.8 nodes will reject any unsigned nodeinfo going forward. As a result, the function has been put behind a build flag and disabled by default.

Additionally, a fix has been implemented for router-ish roles (`ROUTER`, `ROUTER_LATE`, `CLIENT_BASE`) to allow them to answer NodeInfo requests from up to 3 hops away, as a traffic reduction measure. That was never possible: the reply was built for the 0-hop case only — hardcoded `hop_limit = 0`, which the relay path refuses — while the request was still consumed, so a requestor further out got no answer at all. The reply now carries `hop_limit`/`hop_start` equal to the hops the request travelled, and `next_hop` is left to `NextHopRouter::sendWithNextHop()`, which resolves it from the NodeDB route (the module's own assignment was overwritten there and never reached the air). A request claiming hops but naming no relayer is forwarded rather than answered. `isMinHopsFromRequestor` is renamed `isWithinMaxHopsOfRequestor` to match what it does; logic unchanged. `test_traffic_management` (88) and `test_nexthop_routing` (51) pass native.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multi-hop NodeInfo responses by applying an appropriate return hop limit.
  - Prevented responses to requests beyond the router’s one-hop limit.
  - Prevented responses to multi-hop requests when the forwarding path cannot be verified.
  - Improved next-hop selection by allowing the routing system to determine the reply route.
  - Corrected rebroadcast behavior for unicast packets addressed to the local node.

- **Configuration**
  - Direct NodeInfo responses can be enabled or disabled per build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->