### PR TITLE
Allow Spacebar to advance frames

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -2307,7 +2307,8 @@ int Screen::handleInputEvent(const InputEvent *event)
 #endif
             if (event->inputEvent == INPUT_BROKER_LEFT || event->inputEvent == INPUT_BROKER_ALT_PRESS) {
                 showFrame(FrameDirection::PREVIOUS);
-            } else if (event->inputEvent == INPUT_BROKER_RIGHT || event->inputEvent == INPUT_BROKER_USER_PRESS) {
+            } else if (event->inputEvent == INPUT_BROKER_RIGHT || event->inputEvent == INPUT_BROKER_USER_PRESS ||
+                       (event->inputEvent == INPUT_BROKER_ANYKEY && event->kbchar == ' ')) {
                 showFrame(FrameDirection::NEXT);
             } else if (event->inputEvent == INPUT_BROKER_FN_F1) {
                 this->ui->switchToFrame(0);

--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -444,6 +444,9 @@ int CannedMessageModule::handleInputEvent(const InputEvent *event)
             LaunchWithDestination(NODENUM_BROADCAST);
             return 1;
         }
+        // Space is reserved for advancing frames (handled by Screen), so it must not open the composer
+        if (event->kbchar == ' ')
+            return 0;
         // Printable char (ASCII) opens free text compose
         if (event->kbchar >= 32 && event->kbchar <= 126) {
             updateState(CANNED_MESSAGE_RUN_STATE_FREETEXT, true);


### PR DESCRIPTION
Allow Spacebar to advance frames, similar to how backspace key allows to go backwards a frame.

Verified that space bar still works inside of canned messages after a message is started.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pressing the spacebar now advances to the next screen frame when keyboard input is not being intercepted.
  * Prevented the spacebar from opening the free-text composer in inactive canned-message screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->