### PR TITLE
Hide Navigation Bar when shutting down EInk

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,12 +1,10 @@
 {
     "recommendations": [
         "Jason2866.esp-decoder",
-        "pioarduino.pioarduino-ide",
-        "platformio.platformio-ide"
+        "pioarduino.pioarduino-ide"
     ],
     "unwantedRecommendations": [
         "ms-vscode.cpptools-extension-pack",
-        "pioarduino.pioarduino-ide",
         "platformio.platformio-ide"
     ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,10 +1,12 @@
 {
     "recommendations": [
         "Jason2866.esp-decoder",
-        "pioarduino.pioarduino-ide"
+        "pioarduino.pioarduino-ide",
+        "platformio.platformio-ide"
     ],
     "unwantedRecommendations": [
         "ms-vscode.cpptools-extension-pack",
+        "pioarduino.pioarduino-ide",
         "platformio.platformio-ide"
     ]
 }

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1324,6 +1324,10 @@ void Screen::setScreensaverFrames(FrameCallback einkScreensaver)
     if (einkScreensaver != NULL) {
         screensaverFrame = einkScreensaver;
         ui->setFrames(&screensaverFrame, 1);
+
+        // Drop the nav bar before the sleep / shutdown screen is rendered
+        static OverlayCallback screensaverOverlays[] = {NotificationRenderer::drawBannercallback};
+        ui->setOverlays(screensaverOverlays, 1);
     }
 
     // Else, display the usual "overlay" screensaver

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1325,7 +1325,7 @@ void Screen::setScreensaverFrames(FrameCallback einkScreensaver)
         screensaverFrame = einkScreensaver;
         ui->setFrames(&screensaverFrame, 1);
 
-        // Drop the nav bar before the sleep / shutdown screen is rendered
+        // Hide the nav bar before the sleep / shutdown screen is rendered
         static OverlayCallback screensaverOverlays[] = {NotificationRenderer::drawBannercallback};
         ui->setOverlays(screensaverOverlays, 1);
     }

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1324,10 +1324,6 @@ void Screen::setScreensaverFrames(FrameCallback einkScreensaver)
     if (einkScreensaver != NULL) {
         screensaverFrame = einkScreensaver;
         ui->setFrames(&screensaverFrame, 1);
-
-        // Drop the nav bar before the sleep / shutdown screen is rendered
-        static OverlayCallback screensaverOverlays[] = {NotificationRenderer::drawBannercallback};
-        ui->setOverlays(screensaverOverlays, 1);
     }
 
     // Else, display the usual "overlay" screensaver


### PR DESCRIPTION
Hide Navigation Bar when shutting down EInk, this fixes https://github.com/meshtastic/firmware/issues/8897

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The navigation bar is now hidden while a one-off E-Ink screensaver frame is displayed, leaving only the banner overlay visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->