### PR TITLE
fix(checks): define PROGMEM to avoid cppcheck reporting unknownMacro

### DIFF
--- a/bin/check-all.sh
+++ b/bin/check-all.sh
@@ -50,7 +50,8 @@ trap 'rm -f "$LOG"' EXIT
 
 # Keep streaming to the console so the CI log reads exactly as it did before; tee a copy for the
 # post-mortem classification below.
-pio check --flags "-DAPP_VERSION=${APP_VERSION} --suppressions-list=suppressions.txt --inline-suppr" "${CHECK[@]}" --skip-packages --pattern="src/" --fail-on-defect=low --fail-on-defect=medium --fail-on-defect=high 2>&1 | tee "$LOG"
+# define PROGMEM to avoid cppcheck reporting unknownMacro (--skip-packages excludes Arduino.h)
+pio check --flags "-DAPP_VERSION=${APP_VERSION} -DPROGMEM= --suppressions-list=suppressions.txt --inline-suppr" "${CHECK[@]}" --skip-packages --pattern="src/" --fail-on-defect=low --fail-on-defect=medium --fail-on-defect=high 2>&1 | tee "$LOG"
 STATUS=${PIPESTATUS[0]}
 
 if [[ $STATUS -eq 0 ]]; then

--- a/platformio.ini
+++ b/platformio.ini
@@ -99,6 +99,8 @@ check_tool = cppcheck
 check_skip_packages = yes
 check_flags =
 	-DAPP_VERSION=1.0.0
+	; define PROGMEM to avoid cppcheck reporting unknownMacro (--skip-packages excludes Arduino.h)
+	-DPROGMEM=
 	--suppressions-list=suppressions.txt
 	--inline-suppr
 


### PR DESCRIPTION
Fix a `HIGH` cppcheck failure after switching to pioarduino-core (which includes an updated `cppcheck` version).

---

This pull request makes a small configuration improvement for static analysis. The change updates the `cppcheck` settings in `platformio.ini` to define the `PROGMEM` macro, which helps prevent false positives related to unknown macros when running `cppcheck` without including `Arduino.h`.

* [`platformio.ini`](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724R102-R103): Added a definition for the `PROGMEM` macro in the `cppcheck` configuration to avoid unknown macro warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved false-positive `PROGMEM` unknown-macro warnings during static code analysis.
  * Improved reliability of automated code checks when Arduino headers are skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->