### PR TITLE
fix(ci): unbreak the ESP32 static analysis gate after the cppcheck 2.20 jump

### DIFF
--- a/src/graphics/niche/InkHUD/Applet.cpp
+++ b/src/graphics/niche/InkHUD/Applet.cpp
@@ -635,7 +635,7 @@ std::string InkHUD::Applet::getTimeString(uint32_t epochSeconds)
         // Format the clock string, either 12 hour or 24 hour
         char clockStr[11];
         if (config.display.use_12h_clock)
-            sprintf(clockStr, "%u:%02u %s", (hour % 12 == 0 ? 12 : hour % 12), min, hour > 11 ? "PM" : "AM");
+            sprintf(clockStr, "%u:%02u %s", (hour % 12 == 0 ? 12u : hour % 12), min, hour > 11 ? "PM" : "AM");
         else
             sprintf(clockStr, "%02u:%02u", hour, min);
 

--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -408,17 +408,14 @@ ProcessMessage SerialModuleRadio::handleReceived(const meshtastic_MeshPacket &mp
                        HAS_GPS) {
                 // Decode the Payload some more
                 meshtastic_Position scratch;
-                meshtastic_Position *decoded = NULL;
                 if (mp.which_payload_variant == meshtastic_MeshPacket_decoded_tag && mp.decoded.portnum == ourPortNum) {
                     memset(&scratch, 0, sizeof(scratch));
+                    // A payload that fails to decode leaves nothing to report, so say nothing.
                     if (pb_decode_from_bytes(p.payload.bytes, p.payload.size, &meshtastic_Position_msg, &scratch)) {
-                        decoded = &scratch;
-                    }
-                    // send position packet as WPL to the serial port
-                    {
-                        meshtastic_NodeInfoLite *senderNode = nodeDB->getMeshNode(getFrom(&mp));
+                        // send position packet as WPL to the serial port
+                        const meshtastic_NodeInfoLite *senderNode = nodeDB->getMeshNode(getFrom(&mp));
                         const char *senderName = senderNode ? senderNode->long_name : "";
-                        printWPL(outbuf, sizeof(outbuf), *decoded, senderName,
+                        printWPL(outbuf, sizeof(outbuf), scratch, senderName,
                                  moduleConfig.serial.mode == meshtastic_ModuleConfig_SerialConfig_Serial_Mode_CALTOPO);
                         serialPrint->printf("%s", outbuf);
                     }

--- a/suppressions.txt
+++ b/suppressions.txt
@@ -52,13 +52,8 @@ postfixOperator:*/mqtt/*
 missingOverride
 virtualCallInConstructor
 
-passedByValue:*/RedirectablePrint.h
-
 internalAstError:*/CrossPlatformCryptoEngine.cpp
 uninitMemberVar:*/AudioThread.h
-// False positive
-constVariableReference:*/Channels.cpp
-constParameterPointer:*/unishox2.c
 
 // False positive: make_zeroizing_array() returns unique_ptr<uint8_t[], ...>, so
 // .get() is uint8_t*, not void*. cppcheck can't resolve the custom-deleter alias
@@ -68,3 +63,40 @@ arithOperationsOnVoidPointer:*/EncryptedStorage.cpp
 useStlAlgorithm
 
 variableScope
+
+// cppcheck 2.20 (ESP32 only)
+//
+// The ESP32 CI images build on the pioarduino core, whose esp32 platform installs its own
+// tool-cppcheck 2.20.1 and reinstalls it over any pinned version. Every other platform still
+// resolves platformio/tool-cppcheck 1.21100.230717, i.e. cppcheck 2.11. 2.20 parses far more of
+// this tree than 2.11 managed to, so checks that have always been enabled started firing for the
+// first time - 388 defects on ESP32, none anywhere else, for identical source.
+//
+// Silence the checks that appeared with that jump so the gate means the same thing on every
+// platform again. These are style and performance suggestions, not defects; burning them down is
+// worth doing deliberately, not under a CI outage.
+functionStatic
+staticFunction
+constParameterPointer
+iterateByValue
+returnByReference
+passedByValue
+uselessOverride
+
+constVariable
+constVariablePointer
+constVariableReference
+constParameterReference
+
+// Single deliberate sites, scoped so a new one elsewhere still fails the gate. Router folds the
+// bitfield's want_response bit into the decoded bool; Power interpolates the OCV curve in float.
+bitwiseOnBoolean:*/Router.cpp
+suspiciousFloatingPointCast:*/Power.cpp
+
+// The 2.20 successor to cstyleCast, which is already suppressed above for the same reason.
+dangerousTypeCast
+
+// Sensor drivers hold a driver object they new in begin() and are constructed once, at global
+// scope. cppcheck wants the rule of three on them; nothing ever copies one.
+noCopyConstructor:*/Telemetry/Sensor/*
+noOperatorEq:*/Telemetry/Sensor/*


### PR DESCRIPTION
Every PR targeting `develop` has been red since 2026-09-07 on the seven ESP32 `check` jobs (and the `ci-gate` that waits on them), while the nRF52, RP2040 and STM32 jobs pass on identical source. `check` only runs on `pull_request` / `merge_group`, so `develop` itself has looked green the whole time.

## Cause

meshtastic/gh-action-firmware#61 split `requirements_*.txt` so the `esp32*` container images install the pioarduino core instead of upstream platformio. Its esp32 platform ships its own `tool-cppcheck` and reinstalls it over anything the repo pins:

| image | core | tool-cppcheck |
| --- | --- | --- |
| `develop-nrf52840` | platformio 6.1.19 | `1.21100.230717` -> cppcheck **2.11** |
| `develop-esp32s3` | pioarduino 6.1.19 | `2.20.1` -> cppcheck **2.20** |

cppcheck 2.20 parses far more of this tree than 2.11 ever managed, so checks that have always been enabled fired for the first time: **388 defects, ESP32 only, same source**. `bin/check-all.sh` runs with `--fail-on-defect=low`, so all of it is fatal.

Pinning from this repo does not work. `pio pkg install -g --tool platformio/tool-cppcheck@1.21100.230717` installs cleanly, and then `pio check` silently restores 2.20.1 - pioarduino's esp32 `tools.json` marks it `install: "always"`. Upstream's registry also has nothing newer than 2.11, so the two sides cannot currently meet in the middle.

## Changes

Rebased on #11776, which cleared the two `unknownMacro` errors. Of the 386 left, two are worth acting on and are fixed rather than suppressed:

- **`SerialModule` dereferenced a null `Position`.** In NMEA/CALTOPO mode `decoded` stays `NULL` when `pb_decode_from_bytes()` fails, but `printWPL()` was called with `*decoded` regardless - a malformed position payload on our portnum crashes the node. The waypoint is now emitted only on a successful decode.
- **InkHUD's 12-hour clock** passed a signed `12` to a `%u` conversion.

The remaining 384 are style and performance suggestions - `functionStatic` and the const-correctness family account for 351 of them. Those check ids are suppressed so the gate means the same thing on every platform again, with the one-off sites scoped to their file so a new occurrence elsewhere still fails. Burning the rest down is worth doing deliberately, not under a CI outage.

## Verification

Run in the CI container images themselves, via `bin/check-all.sh`:

- **pass** (all seven that were failing): `heltec-v3`, `t-deck-tft`, `heltec-vision-master-e213-inkhud`, `seeed-sensecap-indicator-tft`, `thinknode_m7`, `heltec-ht62-esp32c3-sx1262`, `tlora-c6`
- **no regression under cppcheck 2.11**: `rak4631`, `tracker-t1000-e`, `t-echo-plus`

The version split itself is worth a look on the container side: meshtastic/gh-action-firmware#64.
