### PR TITLE
fix(checks): silence cppcheck functionStatic on the no-screen Screen stub

### DIFF
--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -67,6 +67,8 @@ class Screen
     };
 
     explicit Screen(ScanI2C::DeviceAddress, meshtastic_Config_DisplayConfig_OledType, OLEDDISPLAY_GEOMETRY);
+    // These are empty stubs, but they mirror the real Screen's instance API, so they can't become static.
+    // cppcheck-suppress-begin functionStatic
     void onPress() {}
     void setup() {}
     void setOn(bool) {}
@@ -87,6 +89,7 @@ class Screen
     bool getIsI2cScreen() const { return false; }
     uint32_t getI2cFrequency() const { return 0; }
     ScanI2C::I2CPort getI2CPort() const { return ScanI2C::I2CPort::NO_I2C; }
+    // cppcheck-suppress-end functionStatic
 };
 } // namespace graphics
 #else


### PR DESCRIPTION
## What

Wraps the no-op `graphics::Screen` stub in `src/graphics/Screen.h` (the `#if !HAS_SCREEN` branch) in an inline `cppcheck-suppress-begin/end functionStatic` block.

## Why

Now that the check matrix runs pioarduino's cppcheck 2.20 instead of PlatformIO's 2.11, all 20 methods of that stub are reported as:

```
src/graphics/Screen.h:70: [low:style] The member function 'graphics::Screen::onPress' can be static. [functionStatic]
... (lines 70-89, one per stub method)
```

None of them touch a member, so cppcheck offers to make them static. That advice is wrong here: the stub exists only to mirror the real `Screen`'s **instance** API so call sites like `screen->setFrames(...)` keep compiling on screenless boards, so they have to stay non-static member functions.

The header is included by 85 translation units, so this fired **1700 times** — 20 × 85 — on the two screenless esp32 boards in the matrix, `heltec-ht62-esp32c3-sx1262` and `tlora-c6`. That is the *entire* `src/graphics` low-severity count for those boards. Since `bin/check-all.sh` passes `--fail-on-defect=low`, it was failing both jobs.

Example failing job: https://github.com/meshtastic/firmware/actions/runs/34272341291/job/102220046118

## Notes for reviewers

- Comments only — no change to any compiled output.
- Suppression scope is deliberately narrow: a `functionStatic:*/graphics/Screen.h` entry in `suppressions.txt` would also hide real findings in the `HAS_SCREEN` class, which has plenty of inline members in the same header.
- Inline suppressions are already the established style here (~24 of them across the tree), and `--inline-suppr` is passed by `check_flags` in `platformio.ini`.
- PlatformIO does not enable `information` severity, so a suppression that stops matching in future could never fail the job.
- The remaining defects on those boards are untouched and still need addressing separately: `dangerousTypeCast` in `CryptoEngine.cpp` / `Screen.cpp`, `passedByValue` on `Screen.cpp:320`, and the `Power.cpp` `functionStatic` cluster.

## Verification

Run with the exact cppcheck CI uses (pioarduino 2.20.1) and PlatformIO's own flag set:

| Config | Before | After |
| --- | --- | --- |
| `HAS_SCREEN=0` | 20 `functionStatic` in `Screen.h` | 0 |
| `HAS_SCREEN=1` | 0 | 0, and 0 `unmatchedSuppression` |

`clang-format` clean against `.trunk/configs/.clang-format`.

I could not validate at the full `pio check` level locally: on macOS `pio check` silently reinstalls cppcheck 2.11 over the pioarduino 2.20.1 package and then analyses almost nothing. Verification above is at the header level with the real binary and flags, which pins the exact finding site. CI on this PR is the real check.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)

No hardware testing was done, and none applies: the change adds two comment lines and cannot affect generated code. The relevant regression signal is the `check` matrix on this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added explanatory comments to clarify the no-screen stub interface and its compatibility with the real screen implementation.
  - Added static-analysis suppression annotations around the stub methods to prevent incorrect warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->