### PR TITLE
fix(observer): suppress cppcheck warning for removeObserver method

### DIFF
--- a/src/Observer.h
+++ b/src/Observer.h
@@ -81,6 +81,7 @@ template <class T> class Observable
     // Not called directly, instead call observer.observe
     void addObserver(Observer<T> *o) { observers.push_back(o); }
 
+    // cppcheck-suppress constParameterPointer ; std::list::remove() needs a non-const pointer
     void removeObserver(Observer<T> *o) { observers.remove(o); }
 };
 


### PR DESCRIPTION
From cppcheck 2.20:
```
src/Observer.h:84: [low:style] Parameter 'o' can be declared as pointer to const [constParameterPointer]
```
Accepting cppcheck's suggestion results in a no-compile, we cannot use a const here. Suppress the warning instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a static-analysis suppression for a known pointer-constness warning in observer removal logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->