### PR TITLE
fix(mesh): avoid false PacketHistory size warning

### DIFF
--- a/src/mesh/PacketHistory.cpp
+++ b/src/mesh/PacketHistory.cpp
@@ -17,14 +17,16 @@
 PacketHistory::PacketHistory(uint32_t size) : recentPacketsCapacity(0) // Initialize members
 {
     if (size < 4 || size > PACKETHISTORY_MAX) { // Copilot suggested - makes sense
-        LOG_WARN("Packet History - Invalid size %d, using default %d", size, PACKETHISTORY_MAX);
+        LOG_WARN("Packet History - Invalid size %u, using default %u", static_cast<unsigned>(size),
+                 static_cast<unsigned>(PACKETHISTORY_MAX));
         size = PACKETHISTORY_MAX; // Use default size if invalid
     }
 
 #if !MESHTASTIC_EXCLUDE_PKT_HISTORY_HASH
     // Ensure capacity fits in uint16_t hash index (HASH_EMPTY = 0xFFFF is the sentinel)
     if (size >= HASH_EMPTY) {
-        LOG_WARN("Packet History - Clamping size %d to %d (hash index limit)", size, HASH_EMPTY - 1);
+        LOG_WARN("Packet History - Clamping size %u to %u (hash index limit)", static_cast<unsigned>(size),
+                 static_cast<unsigned>(HASH_EMPTY - 1));
         size = HASH_EMPTY - 1;
     }
 #endif
@@ -33,7 +35,7 @@ PacketHistory::PacketHistory(uint32_t size) : recentPacketsCapacity(0) // Initia
     recentPacketsCapacity = size;
     recentPackets.reset(new PacketRecord[recentPacketsCapacity]);
     if (!recentPackets) { // No logging here, console/log probably uninitialized yet.
-        LOG_ERROR("Packet History - Memory allocation failed for size=%d entries / %d Bytes", size,
+        LOG_ERROR("Packet History - Memory allocation failed for size=%u entries / %zu Bytes", static_cast<unsigned>(size),
                   sizeof(PacketRecord) * recentPacketsCapacity);
         recentPacketsCapacity = 0; // mark allocation fail
         return;                    // return early
@@ -49,7 +51,7 @@ PacketHistory::PacketHistory(uint32_t size) : recentPacketsCapacity(0) // Initia
     hashMask = hashCapacity - 1;
     hashIndex.reset(new uint16_t[hashCapacity]);
     if (!hashIndex) {
-        LOG_ERROR("Packet History - Hash index allocation failed for %d entries", hashCapacity);
+        LOG_ERROR("Packet History - Hash index allocation failed for %u entries", static_cast<unsigned>(hashCapacity));
         hashCapacity = 0;
         hashMask = 0;
         return;

--- a/src/mesh/PacketHistory.h
+++ b/src/mesh/PacketHistory.h
@@ -68,7 +68,7 @@ class PacketHistory
     void setOurTxHopLimit(PacketRecord &r, uint8_t hopLimit);
 
   public:
-    explicit PacketHistory(uint32_t size = -1); // Constructor with size parameter, default is PACKETHISTORY_MAX
+    explicit PacketHistory(uint32_t size = PACKETHISTORY_MAX);
 
     /**
      * Update recentBroadcasts and return true if we have already seen this packet

--- a/test/test_packet_history/test_main.cpp
+++ b/test/test_packet_history/test_main.cpp
@@ -10,8 +10,11 @@
 
 #include "PacketHistory.h"
 
+#include "SerialConsole.h"
 #include "TestUtil.h"
+#include <string>
 #include <unity.h>
+#include <vector>
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -24,6 +27,18 @@ static constexpr uint32_t SMALL_CAPACITY = 8;
 // Per-test state
 // ---------------------------------------------------------------------------
 static PacketHistory *ph = nullptr;
+
+class RecordingPrint : public Print
+{
+  public:
+    size_t write(uint8_t value) override
+    {
+        output.push_back(value);
+        return 1;
+    }
+
+    std::vector<uint8_t> output;
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -63,6 +78,19 @@ void test_init_valid_size(void)
 {
     PacketHistory h(8);
     TEST_ASSERT_TRUE(h.initOk());
+}
+
+void test_init_default_size_does_not_warn(void)
+{
+    RecordingPrint sink;
+    console->setDestination(&sink);
+
+    PacketHistory h;
+
+    console->setDestination(&Serial);
+    const std::string output(sink.output.begin(), sink.output.end());
+    TEST_ASSERT_TRUE(h.initOk());
+    TEST_ASSERT_NULL(strstr(output.c_str(), "Packet History - Invalid size"));
 }
 
 void test_init_minimum_size(void)
@@ -741,6 +769,7 @@ void setup()
 
     // Group 1 - Initialization
     RUN_TEST(test_init_valid_size);
+    RUN_TEST(test_init_default_size_does_not_warn);
     RUN_TEST(test_init_minimum_size);
     RUN_TEST(test_init_too_small_falls_back);
 


### PR DESCRIPTION
## Summary

- Use `PACKETHISTORY_MAX` as the actual default constructor argument.
- Keep invalid explicit sizes on the existing fallback path.
- Use type-correct format specifiers in PacketHistory diagnostics.

## Why

The previous default was `-1` stored in a `uint32_t`, so every normal default construction arrived as `UINT32_MAX`, logged an invalid-size warning, and then fell back to `PACKETHISTORY_MAX`. The resulting capacity was correct, but healthy boots emitted a misleading warning.

## Validation

- [x] `trunk fmt src/mesh/PacketHistory.cpp src/mesh/PacketHistory.h test/test_packet_history/test_main.cpp`
- [x] `pio test -e native-macos -f test_packet_history` (48/48 passed)
- [x] Added a regression test that default construction initializes successfully without logging the invalid-size warning.

## Evidence

The warning was observed in normal bench boot logs without any custom PacketHistory size configured.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Default packet history initialization now uses the maximum supported size without triggering an invalid-size warning.
  * Diagnostic messages display size and index values consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->