### PR TITLE
fix(config): load channels before clamping LoRa settings

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -2598,6 +2598,19 @@ void NodeDB::loadFromDisk()
     }
     configLoadComplete = true;
 
+    state = loadProto(channelFileName, meshtastic_ChannelFile_size, sizeof(meshtastic_ChannelFile), &meshtastic_ChannelFile_msg,
+                      &channelFile);
+    if (state != LoadFileResult::LOAD_SUCCESS) {
+        installDefaultChannels(); // Our in RAM copy might now be corrupt
+    } else {
+        if (channelFile.version < DEVICESTATE_MIN_VER) {
+            LOG_WARN("channelFile %d is old, discard", channelFile.version);
+            installDefaultChannels();
+        } else {
+            LOG_INFO("Loaded saved channelFile v%d", channelFile.version);
+        }
+    }
+
     // Coerce LoRa config fields derived from presets while bootstrapping.
     // Some clients/UI components display bandwidth/spread_factor directly from config even in preset mode.
     if (config.has_lora && config.lora.use_preset) {
@@ -2725,19 +2738,6 @@ void NodeDB::loadFromDisk()
         LOG_INFO("Traffic management never configured, installing always-on defaults");
         installTrafficManagementDefaults(moduleConfig);
         saveToDisk(SEGMENT_MODULECONFIG);
-    }
-
-    state = loadProto(channelFileName, meshtastic_ChannelFile_size, sizeof(meshtastic_ChannelFile), &meshtastic_ChannelFile_msg,
-                      &channelFile);
-    if (state != LoadFileResult::LOAD_SUCCESS) {
-        installDefaultChannels(); // Our in RAM copy might now be corrupt
-    } else {
-        if (channelFile.version < DEVICESTATE_MIN_VER) {
-            LOG_WARN("channelFile %d is old, discard", channelFile.version);
-            installDefaultChannels();
-        } else {
-            LOG_INFO("Loaded saved channelFile v%d", channelFile.version);
-        }
     }
 
     state = loadProto(uiconfigFileName, meshtastic_DeviceUIConfig_size, sizeof(meshtastic_DeviceUIConfig),

--- a/test/test_nodedb_boot_recovery/test_main.cpp
+++ b/test/test_nodedb_boot_recovery/test_main.cpp
@@ -17,6 +17,7 @@
 #if defined(FSCom) && !(MESHTASTIC_EXCLUDE_PKI_KEYGEN || MESHTASTIC_EXCLUDE_PKI)
 
 #include "mesh/NodeDB.h"
+#include "mesh/RadioInterface.h"
 #include "mesh/TypeConversions.h"
 #include <ErriezCRC32.h>
 #include <cstdio>
@@ -173,6 +174,32 @@ static void test_healthyReboot_preservesIdentity(void)
     TEST_ASSERT_EQUAL_STRING(baseLongName, owner.long_name);
     // A healthy boot has nothing to persist for config: the on-disk file is already the fixpoint.
     TEST_ASSERT_EQUAL_UINT64(fpBefore, fileFingerprint(configFileName));
+}
+
+static void test_invalidChannelSlot_usesPersistedCustomChannelName(void)
+{
+    const meshtastic_LocalConfig savedConfig = config;
+    const meshtastic_ChannelFile savedChannels = channelFile;
+    TEST_ASSERT_GREATER_THAN_UINT32(0, channelFile.channels_count);
+
+    strncpy(channelFile.channels[0].settings.name, "Boot Slot Test", sizeof(channelFile.channels[0].settings.name) - 1);
+    config.lora.channel_num = UINT32_MAX;
+
+    meshtastic_Config_LoRaConfig expected = config.lora;
+    RadioInterface::clampConfigLora(expected);
+    TEST_ASSERT_TRUE(nodeDB->saveToDisk(SEGMENT_CONFIG | SEGMENT_CHANNELS));
+
+    channelFile = meshtastic_ChannelFile_init_zero;
+    rebootNodeDB();
+
+    const uint32_t actualChannelNum = config.lora.channel_num;
+
+    config = savedConfig;
+    channelFile = savedChannels;
+    TEST_ASSERT_TRUE(nodeDB->saveToDisk(SEGMENT_CONFIG | SEGMENT_CHANNELS));
+    rebootNodeDB();
+
+    TEST_ASSERT_EQUAL_UINT32(expected.channel_num, actualChannelNum);
 }
 
 // --- Degraded boot: present-but-undecodable config ---
@@ -387,6 +414,7 @@ NBR_TEST_ENTRY void setup()
     printf("\n=== Healthy-boot identity ===\n");
     RUN_TEST(test_firstBoot_establishesKeyedIdentity);
     RUN_TEST(test_healthyReboot_preservesIdentity);
+    RUN_TEST(test_invalidChannelSlot_usesPersistedCustomChannelName);
 
     printf("\n=== Degraded boot (corrupt config) ===\n");
     RUN_TEST(test_corruptConfig_freezesIdentity_leavesFileUntouched);


### PR DESCRIPTION
## Summary

- Load the persisted channel file before clamping preset-derived LoRa configuration during boot.
- Add a boot-recovery regression covering an invalid stored slot with a custom primary-channel name.

## Why

`clampConfigLora()` derives a replacement slot from the primary channel name. Previously it ran before `channels.proto` was loaded, so boot recovery could hash a stale/default in-memory name instead of the persisted custom channel name. Loading channels first makes the clamp deterministic from the configuration being recovered.

## Validation

- [x] `trunk fmt src/mesh/NodeDB.cpp test/test_nodedb_boot_recovery/test_main.cpp`
- [x] Fresh-home `test_nodedb_boot_recovery` run (11/11 passed)
- [x] Fresh-home `test_admin_radio` run (109/109 passed)

The direct fresh-home invocation matches the per-suite `$HOME` isolation used by the native CI wrapper. The macOS-only `native-macos` environment does not currently inherit that wrapper and can otherwise load unrelated local Portduino state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup recovery for saved channel settings when a channel slot is invalid.
  - Custom channel names are now retained while the channel slot is corrected during startup.
  - Channel configuration is loaded earlier in the startup process to ensure saved settings are applied consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->