### PR TITLE
fix(ham): synchronize license transitions

### DIFF
--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -30,6 +30,7 @@
 #include "modules/ExternalNotificationModule.h"
 #include "modules/GeofenceModule.h"
 #include "modules/KeyVerificationModule.h"
+#include "modules/NodeInfoModule.h"
 #if HAS_TELEMETRY && HAS_SENSOR && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
 #include "modules/Telemetry/EnvironmentTelemetry.h"
 #endif
@@ -445,6 +446,8 @@ void menuHandler::licensedToNormalConfirmMenu()
             service->reloadOwner(false);
         }
         applyLoraRegion(pendingRegion, false);
+        if (selected == 1 && nodeInfoModule)
+            nodeInfoModule->requestOwnerSync();
     };
     screen->showOverlayBanner(confirmBanner);
 }

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -447,7 +447,7 @@ void menuHandler::licensedToNormalConfirmMenu()
         }
         applyLoraRegion(pendingRegion, false);
         if (selected == 1 && nodeInfoModule)
-            nodeInfoModule->sendOurNodeInfo(NODENUM_BROADCAST, false, 0, true, true);
+            nodeInfoModule->requestOwnerSync();
     };
     screen->showOverlayBanner(confirmBanner);
 }

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -447,7 +447,7 @@ void menuHandler::licensedToNormalConfirmMenu()
         }
         applyLoraRegion(pendingRegion, false);
         if (selected == 1 && nodeInfoModule)
-            nodeInfoModule->requestOwnerSync();
+            nodeInfoModule->sendOurNodeInfo(NODENUM_BROADCAST, false, 0, true, true);
     };
     screen->showOverlayBanner(confirmBanner);
 }

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -837,6 +837,7 @@ void AdminModule::handleSetOwner(const meshtastic_User &o)
 
     if (changed) { // If nothing really changed, don't broadcast on the network or write to flash
         ownerSyncPending = ownerSyncPending || licenseChanged;
+        // A license change can also change the radio config, so announce only after that config commits.
         service->reloadOwner(!hasOpenEditTransaction && !licenseChanged);
         saveChanges(SEGMENT_DEVICESTATE | SEGMENT_NODEDATABASE | (identityUpdated ? SEGMENT_CONFIG : 0) |
                     (channelsSanitized ? SEGMENT_CHANNELS : 0));
@@ -1914,8 +1915,6 @@ void AdminModule::saveChanges(int saveWhat, bool shouldReboot)
     if (!hasOpenEditTransaction) {
         LOG_INFO("Save changes to disk");
         service->reloadConfig(saveWhat); // Calls saveToDisk among other things
-        if (ownerSyncPending)
-            shouldReboot = false;
         flushPendingOwnerSync();
     } else {
         LOG_INFO("Delay disk save until open transaction commits");
@@ -1930,7 +1929,7 @@ void AdminModule::saveChanges(int saveWhat, bool shouldReboot)
 void AdminModule::flushPendingOwnerSync()
 {
     if (ownerSyncPending && nodeInfoModule) {
-        nodeInfoModule->requestOwnerSync();
+        nodeInfoModule->sendOurNodeInfo(NODENUM_BROADCAST, false, 0, true, true);
         ownerSyncPending = false;
     }
 }

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -5,6 +5,7 @@
 #include "HardwareRNG.h"
 #include "MeshService.h"
 #include "NodeDB.h"
+#include "NodeInfoModule.h"
 #include "PositionPrecision.h"
 #include "PowerFSM.h"
 #include "SPILock.h"
@@ -786,6 +787,7 @@ void AdminModule::handleSetOwner(const meshtastic_User &o)
     int changed = 0;
     bool identityUpdated = false;
     bool channelsSanitized = false;
+    const bool licenseChanged = owner.is_licensed != o.is_licensed;
 
     if (*o.long_name) {
         // Apps built against the older 39-byte limit may send longer names; clamp
@@ -804,7 +806,7 @@ void AdminModule::handleSetOwner(const meshtastic_User &o)
         owner.short_name[sizeof(owner.short_name) - 1] = '\0';
         sanitizeUtf8(owner.short_name, sizeof(owner.short_name));
     }
-    if (owner.is_licensed != o.is_licensed) {
+    if (licenseChanged) {
         changed = 1;
 #if !(MESHTASTIC_EXCLUDE_PKI_KEYGEN || MESHTASTIC_EXCLUDE_PKI)
         const bool identityWillMigrate =
@@ -834,7 +836,8 @@ void AdminModule::handleSetOwner(const meshtastic_User &o)
     }
 
     if (changed) { // If nothing really changed, don't broadcast on the network or write to flash
-        service->reloadOwner(!hasOpenEditTransaction);
+        ownerSyncPending = ownerSyncPending || licenseChanged;
+        service->reloadOwner(!hasOpenEditTransaction && !licenseChanged);
         saveChanges(SEGMENT_DEVICESTATE | SEGMENT_NODEDATABASE | (identityUpdated ? SEGMENT_CONFIG : 0) |
                     (channelsSanitized ? SEGMENT_CHANNELS : 0));
     }
@@ -1911,6 +1914,9 @@ void AdminModule::saveChanges(int saveWhat, bool shouldReboot)
     if (!hasOpenEditTransaction) {
         LOG_INFO("Save changes to disk");
         service->reloadConfig(saveWhat); // Calls saveToDisk among other things
+        if (ownerSyncPending)
+            shouldReboot = false;
+        flushPendingOwnerSync();
     } else {
         LOG_INFO("Delay disk save until open transaction commits");
         editTransactionActivityMs = millis(); // still in use, so not the abandoned kind we time out
@@ -1918,6 +1924,14 @@ void AdminModule::saveChanges(int saveWhat, bool shouldReboot)
     }
     if (shouldReboot && !hasOpenEditTransaction) {
         reboot(DEFAULT_REBOOT_SECONDS);
+    }
+}
+
+void AdminModule::flushPendingOwnerSync()
+{
+    if (ownerSyncPending && nodeInfoModule) {
+        nodeInfoModule->requestOwnerSync();
+        ownerSyncPending = false;
     }
 }
 
@@ -1994,6 +2008,7 @@ bool AdminModule::handleSetHamMode(const meshtastic_HamParameters &p)
     }
 
     service->reloadOwner(false);
+    ownerSyncPending = true;
     saveChanges(SEGMENT_CONFIG | SEGMENT_NODEDATABASE | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS);
     return true;
 }

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -1929,7 +1929,7 @@ void AdminModule::saveChanges(int saveWhat, bool shouldReboot)
 void AdminModule::flushPendingOwnerSync()
 {
     if (ownerSyncPending && nodeInfoModule) {
-        nodeInfoModule->sendOurNodeInfo(NODENUM_BROADCAST, false, 0, true, true);
+        nodeInfoModule->requestOwnerSync();
         ownerSyncPending = false;
     }
 }

--- a/src/modules/AdminModule.h
+++ b/src/modules/AdminModule.h
@@ -45,6 +45,7 @@ class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Obser
     static constexpr uint32_t EDIT_TRANSACTION_IDLE_MS = 60 * 1000;
     uint32_t editTransactionActivityMs = 0; // millis() of the last save this transaction deferred
     int deferredEditSegments = 0;           // segments that transaction has touched but not yet saved
+    bool ownerSyncPending = false;
     /// Retire an open edit transaction whose client stopped talking, persisting what it applied.
     void expireStaleEditTransaction();
 #ifdef PIO_UNIT_TESTING
@@ -56,6 +57,7 @@ class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Obser
     bool sessionPasskeyValid = false; // separate flag: millis() 0 at boot is a valid issue time
 
     void saveChanges(int saveWhat, bool shouldReboot = true);
+    void flushPendingOwnerSync();
 
     /**
      * Getters

--- a/src/modules/NodeInfoModule.cpp
+++ b/src/modules/NodeInfoModule.cpp
@@ -19,6 +19,10 @@
 NodeInfoModule *nodeInfoModule;
 
 static constexpr uint32_t NodeInfoReplySuppressSeconds = USERPREFS_NODEINFO_REPLY_SUPPRESS_SECS;
+static constexpr uint32_t TransitionReplyAllowanceSeconds = 5 * 60;
+static constexpr uint32_t OwnerSyncRetryMs = 5 * 1000;
+static constexpr uint8_t TransitionReplyAttempts = 2;
+static constexpr uint8_t OwnerSyncAttempts = 3;
 
 bool NodeInfoModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_User *pptr)
 {
@@ -50,6 +54,7 @@ bool NodeInfoModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
         return true;
     }
     NodeNum sourceNum = getFrom(&mp);
+    const UserLicenseStatus previousLicense = nodeDB->getLicenseStatus(sourceNum);
     // Broadcasts only: unicast NodeInfo is unsigned off ham, so updateUser refuses the identity
     // write instead. isKnownXeddsaSigner also covers the warm tier.
     if (nodeDB->isKnownXeddsaSigner(sourceNum) && !mp.xeddsa_signed && isBroadcast(mp.to)) {
@@ -63,6 +68,11 @@ bool NodeInfoModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
     // updateUser() refuses the identity write for a known signer sending unsigned (all unicast
     // NodeInfo), so the exchange above still proceeds but cannot spoof the stored name.
     bool hasChanged = nodeDB->updateUser(getFrom(&mp), p, mp.channel, mp.xeddsa_signed);
+    const bool canReply = mp.decoded.want_response && !isFromUs(&mp) && (isBroadcast(mp.to) || isToUs(&mp));
+    if (canReply && hasChanged && previousLicense != UserLicenseStatus::NotKnown &&
+        (previousLicense == UserLicenseStatus::Licensed) != p.is_licensed) {
+        transitionReplyAllowances[sourceNum] = {Time::getUptimeSecs(), TransitionReplyAttempts};
+    }
 
     bool wasBroadcast = isBroadcast(mp.to);
 
@@ -97,19 +107,26 @@ void NodeInfoModule::alterReceivedProtobuf(meshtastic_MeshPacket &mp, meshtastic
 
 bool NodeInfoModule::sendOurNodeInfo(NodeNum dest, bool wantReplies, uint8_t channel, bool _shorterTimeout)
 {
+    return sendOurNodeInfoWithOptions(dest, wantReplies, channel, _shorterTimeout, false);
+}
+
+bool NodeInfoModule::sendOurNodeInfoWithOptions(NodeNum dest, bool wantReplies, uint8_t channel, bool _shorterTimeout,
+                                                bool ownerSync)
+{
     // cancel any not yet sent (now stale) position packets
     if (prevPacketId) // if we wrap around to zero, we'll simply fail to cancel in that rare case (no big deal)
         service->cancelSending(prevPacketId);
     shorterTimeout = _shorterTimeout;
     DEBUG_HEAP_BEFORE;
-    meshtastic_MeshPacket *p = allocReply();
+    meshtastic_MeshPacket *p = allocReplyWithOptions(ownerSync);
     DEBUG_HEAP_AFTER("NodeInfoModule::sendOurNodeInfo", p);
+    shorterTimeout = false;
 
     if (p) { // Check whether we didn't ignore it
         p->to = dest;
-        bool requestWantResponse = (config.device.role != meshtastic_Config_DeviceConfig_Role_TRACKER &&
-                                    config.device.role != meshtastic_Config_DeviceConfig_Role_SENSOR) &&
-                                   wantReplies;
+        bool requestWantResponse =
+            wantReplies && (ownerSync || (config.device.role != meshtastic_Config_DeviceConfig_Role_TRACKER &&
+                                          config.device.role != meshtastic_Config_DeviceConfig_Role_SENSOR));
 
         p->decoded.want_response = requestWantResponse;
         if (_shorterTimeout)
@@ -121,13 +138,22 @@ bool NodeInfoModule::sendOurNodeInfo(NodeNum dest, bool wantReplies, uint8_t cha
             p->channel = channel;
         }
 
-        prevPacketId = p->id;
-
-        service->sendToMesh(p);
-        shorterTimeout = false;
-        return true;
+        const PacketId packetId = p->id;
+        const ErrorCode result = service->sendToMesh(p);
+        if (result == ERRNO_OK) {
+            prevPacketId = packetId;
+            return true;
+        }
+        prevPacketId = 0;
     }
     return false;
+}
+
+void NodeInfoModule::requestOwnerSync()
+{
+    ownerSyncPending = true;
+    ownerSyncAttemptsRemaining = OwnerSyncAttempts;
+    setIntervalFromNow(0);
 }
 
 void NodeInfoModule::triggerImmediateNodeInfoCheck()
@@ -144,7 +170,35 @@ meshtastic_MeshPacket *NodeInfoModule::allocReply()
                                              currentRequest->decoded.portnum == meshtastic_PortNum_NODEINFO_APP &&
                                              currentRequest->decoded.want_response && !isFromUs(currentRequest);
 
-    if (suppressReplyForCurrentRequest && isReplyingToExternalRequest) {
+    bool bypassCadenceThrottle = false;
+    auto allowance = transitionReplyAllowances.end();
+    if (isReplyingToExternalRequest) {
+        allowance = transitionReplyAllowances.find(getFrom(currentRequest));
+        if (allowance != transitionReplyAllowances.end()) {
+            if ((uint32_t)(Time::getUptimeSecs() - allowance->second.startedAt) < TransitionReplyAllowanceSeconds &&
+                allowance->second.remaining > 0) {
+                bypassCadenceThrottle = true;
+            } else {
+                transitionReplyAllowances.erase(allowance);
+                allowance = transitionReplyAllowances.end();
+            }
+        }
+    }
+
+    meshtastic_MeshPacket *reply = allocReplyWithOptions(bypassCadenceThrottle);
+    if (reply && allowance != transitionReplyAllowances.end() && --allowance->second.remaining == 0)
+        transitionReplyAllowances.erase(allowance);
+    return reply;
+}
+
+meshtastic_MeshPacket *NodeInfoModule::allocReplyWithOptions(bool bypassCadenceThrottle)
+{
+    const bool isReplyingToExternalRequest = currentRequest &&
+                                             currentRequest->which_payload_variant == meshtastic_MeshPacket_decoded_tag &&
+                                             currentRequest->decoded.portnum == meshtastic_PortNum_NODEINFO_APP &&
+                                             currentRequest->decoded.want_response && !isFromUs(currentRequest);
+
+    if (!bypassCadenceThrottle && suppressReplyForCurrentRequest && isReplyingToExternalRequest) {
         LOG_DEBUG("Skip send NodeInfo since we heard the requester <12h ago");
         ignoreRequest = true;
         suppressReplyForCurrentRequest = false;
@@ -160,11 +214,12 @@ meshtastic_MeshPacket *NodeInfoModule::allocReply()
     // Use graduated scaling based on active mesh size (10 minute base, scales with congestion coefficient)
     uint32_t timeoutMs = Default::getConfiguredOrDefaultMsScaled(0, 10 * 60, nodeStatus->getNumOnline());
     uint32_t lastNodeInfo = transmitHistory ? transmitHistory->getLastSentToMeshMillis(meshtastic_PortNum_NODEINFO_APP) : 0;
-    if (!shorterTimeout && lastNodeInfo && Throttle::isWithinTimespanMs(lastNodeInfo, timeoutMs)) {
+    if (!bypassCadenceThrottle && !shorterTimeout && lastNodeInfo && Throttle::isWithinTimespanMs(lastNodeInfo, timeoutMs)) {
         LOG_DEBUG("Skip send NodeInfo since we sent it <%us ago", timeoutMs / 1000);
         ignoreRequest = true; // Mark it as ignored for MeshModule
         return NULL;
-    } else if (shorterTimeout && lastNodeInfo && Throttle::isWithinTimespanMs(lastNodeInfo, 60 * 1000)) {
+    } else if (!bypassCadenceThrottle && shorterTimeout && lastNodeInfo &&
+               Throttle::isWithinTimespanMs(lastNodeInfo, 60 * 1000)) {
         // For interactive/urgent requests (e.g., user-triggered or implicit requests), use a shorter 60s timeout
         LOG_DEBUG("Skip send NodeInfo since we sent it <60s ago");
         ignoreRequest = true;
@@ -204,6 +259,14 @@ void NodeInfoModule::pruneLastNodeInfoCache()
         }
     }
 
+    for (auto it = transitionReplyAllowances.begin(); it != transitionReplyAllowances.end();) {
+        if (!nodeDB->getMeshNode(it->first) || (uint32_t)(nowSecs - it->second.startedAt) >= TransitionReplyAllowanceSeconds) {
+            it = transitionReplyAllowances.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
     // Evict by largest elapsed time rather than smallest stamp, so the victim is still the oldest
     // entry if the uptime counter ever wraps underneath us.
     while (!lastNodeInfoSeen.empty() && lastNodeInfoSeen.size() > maxEntries) {
@@ -227,12 +290,19 @@ NodeInfoModule::NodeInfoModule()
 
 int32_t NodeInfoModule::runOnce()
 {
-    if (airTime->isTxAllowedAirUtil() && config.device.role != meshtastic_Config_DeviceConfig_Role_CLIENT_HIDDEN) {
+    if (airTime->isTxAllowedAirUtil() &&
+        (ownerSyncPending || config.device.role != meshtastic_Config_DeviceConfig_Role_CLIENT_HIDDEN)) {
         // If we changed channels, ask everyone else for their latest info
-        bool requestReplies = currentGeneration != radioGeneration;
+        const bool requestOwnerRefresh = ownerSyncPending;
+        bool requestReplies = requestOwnerRefresh || currentGeneration != radioGeneration;
         LOG_INFO("Send our nodeinfo to mesh (wantReplies=%d)", requestReplies);
-        if (sendOurNodeInfo(NODENUM_BROADCAST, requestReplies))
+        if (sendOurNodeInfoWithOptions(NODENUM_BROADCAST, requestReplies, 0, false, requestOwnerRefresh)) {
             currentGeneration = radioGeneration; // only a send that went out consumes the channel change
+            if (ownerSyncPending && --ownerSyncAttemptsRemaining == 0)
+                ownerSyncPending = false;
+        }
     }
+    if (ownerSyncPending)
+        return OwnerSyncRetryMs;
     return Default::getConfiguredOrDefaultMs(config.device.node_info_broadcast_secs, default_node_info_broadcast_secs);
 }

--- a/src/modules/NodeInfoModule.cpp
+++ b/src/modules/NodeInfoModule.cpp
@@ -21,7 +21,7 @@ NodeInfoModule *nodeInfoModule;
 static constexpr uint32_t NodeInfoReplySuppressSeconds = USERPREFS_NODEINFO_REPLY_SUPPRESS_SECS;
 static constexpr uint32_t TransitionReplyAllowanceSeconds = 5 * 60;
 static constexpr uint32_t OwnerSyncRetryMs = 5 * 1000;
-static constexpr uint8_t TransitionReplyAttempts = 2;
+static constexpr uint8_t TransitionReplyAttempts = 1;
 static constexpr uint8_t OwnerSyncAttempts = 3;
 
 bool NodeInfoModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_User *pptr)
@@ -294,7 +294,8 @@ int32_t NodeInfoModule::runOnce()
         (ownerSyncPending || config.device.role != meshtastic_Config_DeviceConfig_Role_CLIENT_HIDDEN)) {
         // If we changed channels, ask everyone else for their latest info
         const bool requestOwnerRefresh = ownerSyncPending;
-        bool requestReplies = requestOwnerRefresh || currentGeneration != radioGeneration;
+        const bool firstOwnerSyncAttempt = requestOwnerRefresh && ownerSyncAttemptsRemaining == OwnerSyncAttempts;
+        bool requestReplies = firstOwnerSyncAttempt || currentGeneration != radioGeneration;
         LOG_INFO("Send our nodeinfo to mesh (wantReplies=%d)", requestReplies);
         if (sendOurNodeInfoWithOptions(NODENUM_BROADCAST, requestReplies, 0, false, requestOwnerRefresh)) {
             currentGeneration = radioGeneration; // only a send that went out consumes the channel change

--- a/src/modules/NodeInfoModule.cpp
+++ b/src/modules/NodeInfoModule.cpp
@@ -19,10 +19,6 @@
 NodeInfoModule *nodeInfoModule;
 
 static constexpr uint32_t NodeInfoReplySuppressSeconds = USERPREFS_NODEINFO_REPLY_SUPPRESS_SECS;
-static constexpr uint32_t TransitionReplyAllowanceSeconds = 5 * 60;
-static constexpr uint32_t OwnerSyncRetryMs = 5 * 1000;
-static constexpr uint8_t TransitionReplyAttempts = 1;
-static constexpr uint8_t OwnerSyncAttempts = 3;
 
 bool NodeInfoModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_User *pptr)
 {
@@ -54,7 +50,6 @@ bool NodeInfoModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
         return true;
     }
     NodeNum sourceNum = getFrom(&mp);
-    const UserLicenseStatus previousLicense = nodeDB->getLicenseStatus(sourceNum);
     // Broadcasts only: unicast NodeInfo is unsigned off ham, so updateUser refuses the identity
     // write instead. isKnownXeddsaSigner also covers the warm tier.
     if (nodeDB->isKnownXeddsaSigner(sourceNum) && !mp.xeddsa_signed && isBroadcast(mp.to)) {
@@ -68,11 +63,6 @@ bool NodeInfoModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
     // updateUser() refuses the identity write for a known signer sending unsigned (all unicast
     // NodeInfo), so the exchange above still proceeds but cannot spoof the stored name.
     bool hasChanged = nodeDB->updateUser(getFrom(&mp), p, mp.channel, mp.xeddsa_signed);
-    const bool canReply = mp.decoded.want_response && !isFromUs(&mp) && (isBroadcast(mp.to) || isToUs(&mp));
-    if (canReply && hasChanged && previousLicense != UserLicenseStatus::NotKnown &&
-        (previousLicense == UserLicenseStatus::Licensed) != p.is_licensed) {
-        transitionReplyAllowances[sourceNum] = {Time::getUptimeSecs(), TransitionReplyAttempts};
-    }
 
     bool wasBroadcast = isBroadcast(mp.to);
 
@@ -105,28 +95,22 @@ void NodeInfoModule::alterReceivedProtobuf(meshtastic_MeshPacket &mp, meshtastic
         pb_encode_to_bytes(mp.decoded.payload.bytes, sizeof(mp.decoded.payload.bytes), &meshtastic_User_msg, p);
 }
 
-bool NodeInfoModule::sendOurNodeInfo(NodeNum dest, bool wantReplies, uint8_t channel, bool _shorterTimeout)
-{
-    return sendOurNodeInfoWithOptions(dest, wantReplies, channel, _shorterTimeout, false);
-}
-
-bool NodeInfoModule::sendOurNodeInfoWithOptions(NodeNum dest, bool wantReplies, uint8_t channel, bool _shorterTimeout,
-                                                bool ownerSync)
+bool NodeInfoModule::sendOurNodeInfo(NodeNum dest, bool wantReplies, uint8_t channel, bool _shorterTimeout,
+                                     bool bypassCadenceThrottle)
 {
     // cancel any not yet sent (now stale) position packets
     if (prevPacketId) // if we wrap around to zero, we'll simply fail to cancel in that rare case (no big deal)
         service->cancelSending(prevPacketId);
     shorterTimeout = _shorterTimeout;
     DEBUG_HEAP_BEFORE;
-    meshtastic_MeshPacket *p = allocReplyWithOptions(ownerSync);
+    meshtastic_MeshPacket *p = allocNodeInfo(bypassCadenceThrottle);
     DEBUG_HEAP_AFTER("NodeInfoModule::sendOurNodeInfo", p);
-    shorterTimeout = false;
 
     if (p) { // Check whether we didn't ignore it
         p->to = dest;
-        bool requestWantResponse =
-            wantReplies && (ownerSync || (config.device.role != meshtastic_Config_DeviceConfig_Role_TRACKER &&
-                                          config.device.role != meshtastic_Config_DeviceConfig_Role_SENSOR));
+        bool requestWantResponse = (config.device.role != meshtastic_Config_DeviceConfig_Role_TRACKER &&
+                                    config.device.role != meshtastic_Config_DeviceConfig_Role_SENSOR) &&
+                                   wantReplies;
 
         p->decoded.want_response = requestWantResponse;
         if (_shorterTimeout)
@@ -138,22 +122,13 @@ bool NodeInfoModule::sendOurNodeInfoWithOptions(NodeNum dest, bool wantReplies, 
             p->channel = channel;
         }
 
-        const PacketId packetId = p->id;
-        const ErrorCode result = service->sendToMesh(p);
-        if (result == ERRNO_OK) {
-            prevPacketId = packetId;
-            return true;
-        }
-        prevPacketId = 0;
+        prevPacketId = p->id;
+
+        service->sendToMesh(p);
+        shorterTimeout = false;
+        return true;
     }
     return false;
-}
-
-void NodeInfoModule::requestOwnerSync()
-{
-    ownerSyncPending = true;
-    ownerSyncAttemptsRemaining = OwnerSyncAttempts;
-    setIntervalFromNow(0);
 }
 
 void NodeInfoModule::triggerImmediateNodeInfoCheck()
@@ -164,41 +139,18 @@ void NodeInfoModule::triggerImmediateNodeInfoCheck()
 
 meshtastic_MeshPacket *NodeInfoModule::allocReply()
 {
+    return allocNodeInfo(false);
+}
+
+meshtastic_MeshPacket *NodeInfoModule::allocNodeInfo(bool bypassCadenceThrottle)
+{
     // Only apply suppression when actually replying to someone else's request, not for periodic broadcasts.
     const bool isReplyingToExternalRequest = currentRequest &&
                                              currentRequest->which_payload_variant == meshtastic_MeshPacket_decoded_tag &&
                                              currentRequest->decoded.portnum == meshtastic_PortNum_NODEINFO_APP &&
                                              currentRequest->decoded.want_response && !isFromUs(currentRequest);
 
-    bool bypassCadenceThrottle = false;
-    auto allowance = transitionReplyAllowances.end();
-    if (isReplyingToExternalRequest) {
-        allowance = transitionReplyAllowances.find(getFrom(currentRequest));
-        if (allowance != transitionReplyAllowances.end()) {
-            if ((uint32_t)(Time::getUptimeSecs() - allowance->second.startedAt) < TransitionReplyAllowanceSeconds &&
-                allowance->second.remaining > 0) {
-                bypassCadenceThrottle = true;
-            } else {
-                transitionReplyAllowances.erase(allowance);
-                allowance = transitionReplyAllowances.end();
-            }
-        }
-    }
-
-    meshtastic_MeshPacket *reply = allocReplyWithOptions(bypassCadenceThrottle);
-    if (reply && allowance != transitionReplyAllowances.end() && --allowance->second.remaining == 0)
-        transitionReplyAllowances.erase(allowance);
-    return reply;
-}
-
-meshtastic_MeshPacket *NodeInfoModule::allocReplyWithOptions(bool bypassCadenceThrottle)
-{
-    const bool isReplyingToExternalRequest = currentRequest &&
-                                             currentRequest->which_payload_variant == meshtastic_MeshPacket_decoded_tag &&
-                                             currentRequest->decoded.portnum == meshtastic_PortNum_NODEINFO_APP &&
-                                             currentRequest->decoded.want_response && !isFromUs(currentRequest);
-
-    if (!bypassCadenceThrottle && suppressReplyForCurrentRequest && isReplyingToExternalRequest) {
+    if (suppressReplyForCurrentRequest && isReplyingToExternalRequest) {
         LOG_DEBUG("Skip send NodeInfo since we heard the requester <12h ago");
         ignoreRequest = true;
         suppressReplyForCurrentRequest = false;
@@ -259,14 +211,6 @@ void NodeInfoModule::pruneLastNodeInfoCache()
         }
     }
 
-    for (auto it = transitionReplyAllowances.begin(); it != transitionReplyAllowances.end();) {
-        if (!nodeDB->getMeshNode(it->first) || (uint32_t)(nowSecs - it->second.startedAt) >= TransitionReplyAllowanceSeconds) {
-            it = transitionReplyAllowances.erase(it);
-        } else {
-            ++it;
-        }
-    }
-
     // Evict by largest elapsed time rather than smallest stamp, so the victim is still the oldest
     // entry if the uptime counter ever wraps underneath us.
     while (!lastNodeInfoSeen.empty() && lastNodeInfoSeen.size() > maxEntries) {
@@ -290,20 +234,12 @@ NodeInfoModule::NodeInfoModule()
 
 int32_t NodeInfoModule::runOnce()
 {
-    if (airTime->isTxAllowedAirUtil() &&
-        (ownerSyncPending || config.device.role != meshtastic_Config_DeviceConfig_Role_CLIENT_HIDDEN)) {
+    if (airTime->isTxAllowedAirUtil() && config.device.role != meshtastic_Config_DeviceConfig_Role_CLIENT_HIDDEN) {
         // If we changed channels, ask everyone else for their latest info
-        const bool requestOwnerRefresh = ownerSyncPending;
-        const bool firstOwnerSyncAttempt = requestOwnerRefresh && ownerSyncAttemptsRemaining == OwnerSyncAttempts;
-        bool requestReplies = firstOwnerSyncAttempt || currentGeneration != radioGeneration;
+        bool requestReplies = currentGeneration != radioGeneration;
         LOG_INFO("Send our nodeinfo to mesh (wantReplies=%d)", requestReplies);
-        if (sendOurNodeInfoWithOptions(NODENUM_BROADCAST, requestReplies, 0, false, requestOwnerRefresh)) {
+        if (sendOurNodeInfo(NODENUM_BROADCAST, requestReplies))
             currentGeneration = radioGeneration; // only a send that went out consumes the channel change
-            if (ownerSyncPending && --ownerSyncAttemptsRemaining == 0)
-                ownerSyncPending = false;
-        }
     }
-    if (ownerSyncPending)
-        return OwnerSyncRetryMs;
     return Default::getConfiguredOrDefaultMs(config.device.node_info_broadcast_secs, default_node_info_broadcast_secs);
 }

--- a/src/modules/NodeInfoModule.cpp
+++ b/src/modules/NodeInfoModule.cpp
@@ -19,6 +19,7 @@
 NodeInfoModule *nodeInfoModule;
 
 static constexpr uint32_t NodeInfoReplySuppressSeconds = USERPREFS_NODEINFO_REPLY_SUPPRESS_SECS;
+static constexpr uint32_t OwnerSyncRetryMs = 30 * 1000;
 
 bool NodeInfoModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_User *pptr)
 {
@@ -137,6 +138,15 @@ void NodeInfoModule::triggerImmediateNodeInfoCheck()
     setIntervalFromNow(0);
 }
 
+void NodeInfoModule::requestOwnerSync()
+{
+    if (config.device.role == meshtastic_Config_DeviceConfig_Role_CLIENT_HIDDEN)
+        return;
+
+    ownerSyncPending = true;
+    setIntervalFromNow(0);
+}
+
 meshtastic_MeshPacket *NodeInfoModule::allocReply()
 {
     return allocNodeInfo(false);
@@ -236,10 +246,15 @@ int32_t NodeInfoModule::runOnce()
 {
     if (airTime->isTxAllowedAirUtil() && config.device.role != meshtastic_Config_DeviceConfig_Role_CLIENT_HIDDEN) {
         // If we changed channels, ask everyone else for their latest info
-        bool requestReplies = currentGeneration != radioGeneration;
+        const bool isOwnerSync = ownerSyncPending;
+        bool requestReplies = !isOwnerSync && currentGeneration != radioGeneration;
         LOG_INFO("Send our nodeinfo to mesh (wantReplies=%d)", requestReplies);
-        if (sendOurNodeInfo(NODENUM_BROADCAST, requestReplies))
+        if (sendOurNodeInfo(NODENUM_BROADCAST, requestReplies, 0, isOwnerSync, isOwnerSync)) {
             currentGeneration = radioGeneration; // only a send that went out consumes the channel change
+            ownerSyncPending = false;
+        }
     }
+    if (ownerSyncPending)
+        return OwnerSyncRetryMs;
     return Default::getConfiguredOrDefaultMs(config.device.node_info_broadcast_secs, default_node_info_broadcast_secs);
 }

--- a/src/modules/NodeInfoModule.h
+++ b/src/modules/NodeInfoModule.h
@@ -24,6 +24,9 @@ class NodeInfoModule : public ProtobufModule<meshtastic_User>, private concurren
     bool sendOurNodeInfo(NodeNum dest = NODENUM_BROADCAST, bool wantReplies = false, uint8_t channel = 0,
                          bool _shorterTimeout = false);
 
+    /** Promptly announce an owner/license transition and ask peers to refresh their NodeInfo. */
+    void requestOwnerSync();
+
     /**
      * Schedule an immediate NodeInfo periodic check.
      * Used when external conditions change (for example time source quality).
@@ -48,13 +51,23 @@ class NodeInfoModule : public ProtobufModule<meshtastic_User>, private concurren
     virtual int32_t runOnce() override;
 
   private:
+    struct TransitionReplyAllowance {
+        uint32_t startedAt;
+        uint8_t remaining;
+    };
+
     bool shorterTimeout = false;
+    bool ownerSyncPending = false;
+    uint8_t ownerSyncAttemptsRemaining = 0;
     bool suppressReplyForCurrentRequest = false;
     /// Sender -> uptime seconds (Time::getUptimeSecs()) at our last reply. Seconds, not millis:
     /// the suppression window is hours wide. See handleReceivedProtobuf().
     std::map<NodeNum, uint32_t> lastNodeInfoSeen;
+    std::map<NodeNum, TransitionReplyAllowance> transitionReplyAllowances;
 
     void pruneLastNodeInfoCache();
+    meshtastic_MeshPacket *allocReplyWithOptions(bool bypassCadenceThrottle);
+    bool sendOurNodeInfoWithOptions(NodeNum dest, bool wantReplies, uint8_t channel, bool _shorterTimeout, bool ownerSync);
 };
 
 extern NodeInfoModule *nodeInfoModule;

--- a/src/modules/NodeInfoModule.h
+++ b/src/modules/NodeInfoModule.h
@@ -24,6 +24,9 @@ class NodeInfoModule : public ProtobufModule<meshtastic_User>, private concurren
     bool sendOurNodeInfo(NodeNum dest = NODENUM_BROADCAST, bool wantReplies = false, uint8_t channel = 0,
                          bool _shorterTimeout = false, bool bypassCadenceThrottle = false);
 
+    /** Queue one owner announcement after a license transition. */
+    void requestOwnerSync();
+
     /**
      * Schedule an immediate NodeInfo periodic check.
      * Used when external conditions change (for example time source quality).
@@ -49,6 +52,7 @@ class NodeInfoModule : public ProtobufModule<meshtastic_User>, private concurren
 
   private:
     bool shorterTimeout = false;
+    bool ownerSyncPending = false;
     bool suppressReplyForCurrentRequest = false;
     /// Sender -> uptime seconds (Time::getUptimeSecs()) at our last reply. Seconds, not millis:
     /// the suppression window is hours wide. See handleReceivedProtobuf().

--- a/src/modules/NodeInfoModule.h
+++ b/src/modules/NodeInfoModule.h
@@ -22,10 +22,7 @@ class NodeInfoModule : public ProtobufModule<meshtastic_User>, private concurren
      * Send our NodeInfo into the mesh. True only when a packet was handed to the router.
      */
     bool sendOurNodeInfo(NodeNum dest = NODENUM_BROADCAST, bool wantReplies = false, uint8_t channel = 0,
-                         bool _shorterTimeout = false);
-
-    /** Promptly announce an owner/license transition and ask peers to refresh their NodeInfo. */
-    void requestOwnerSync();
+                         bool _shorterTimeout = false, bool bypassCadenceThrottle = false);
 
     /**
      * Schedule an immediate NodeInfo periodic check.
@@ -51,23 +48,14 @@ class NodeInfoModule : public ProtobufModule<meshtastic_User>, private concurren
     virtual int32_t runOnce() override;
 
   private:
-    struct TransitionReplyAllowance {
-        uint32_t startedAt;
-        uint8_t remaining;
-    };
-
     bool shorterTimeout = false;
-    bool ownerSyncPending = false;
-    uint8_t ownerSyncAttemptsRemaining = 0;
     bool suppressReplyForCurrentRequest = false;
     /// Sender -> uptime seconds (Time::getUptimeSecs()) at our last reply. Seconds, not millis:
     /// the suppression window is hours wide. See handleReceivedProtobuf().
     std::map<NodeNum, uint32_t> lastNodeInfoSeen;
-    std::map<NodeNum, TransitionReplyAllowance> transitionReplyAllowances;
 
     void pruneLastNodeInfoCache();
-    meshtastic_MeshPacket *allocReplyWithOptions(bool bypassCadenceThrottle);
-    bool sendOurNodeInfoWithOptions(NodeNum dest, bool wantReplies, uint8_t channel, bool _shorterTimeout, bool ownerSync);
+    meshtastic_MeshPacket *allocNodeInfo(bool bypassCadenceThrottle);
 };
 
 extern NodeInfoModule *nodeInfoModule;

--- a/test/support/AdminModuleTestShim.h
+++ b/test/support/AdminModuleTestShim.h
@@ -28,6 +28,7 @@ class AdminModuleTestShim : public AdminModule
         editTransactionActivityMs = millis();
     }
     int savedSegments() const { return lastSaveWhatForTest; }
+    bool ownerSyncIsPending() const { return ownerSyncPending; }
 
     bool editTransactionOpen() const { return hasOpenEditTransaction; }
     // Backdate past the idle window so a test sees an abandoned transaction without waiting it out.

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -1215,6 +1215,17 @@ static void test_handleSetHamMode_blankShortNameKeepsTheExistingOne()
     }
 }
 
+static void test_handleSetHamMode_defersOwnerSyncUntilCommit()
+{
+    primeHamModeTest();
+
+    meshtastic_HamParameters p = meshtastic_HamParameters_init_zero;
+    strncpy(p.call_sign, "KD2ABC", sizeof(p.call_sign) - 1);
+    TEST_ASSERT_TRUE(testAdmin->handleSetHamMode(p));
+
+    TEST_ASSERT_TRUE(testAdmin->ownerSyncIsPending());
+}
+
 // A rejection has to reach the client, not just the log: allocErrorResponse() builds the reply
 // through the router, so this is the one ham test that needs one.
 class HamModeMockRouter : public Router
@@ -2545,6 +2556,7 @@ void setup()
     RUN_TEST(test_handleSetHamMode_omittedLongNameKeepsCallSignAlone);
     RUN_TEST(test_handleSetHamMode_blankLongNameIsIgnoredNotRejected);
     RUN_TEST(test_handleSetHamMode_blankShortNameKeepsTheExistingOne);
+    RUN_TEST(test_handleSetHamMode_defersOwnerSyncUntilCommit);
     RUN_TEST(test_handleSetHamMode_blankCallSignIsRejected);
     RUN_TEST(test_handleSetHamMode_blankCallSignRepliesBadRequest);
     RUN_TEST(test_handleSetHamMode_acceptedRequestAcksSuccess);

--- a/test/test_packet_signing/test_main.cpp
+++ b/test/test_packet_signing/test_main.cpp
@@ -164,6 +164,13 @@ class AuthPipelineRadio : public RadioInterface
 class AuthPipelineRouter : public ReliableRouter
 {
   public:
+    ErrorCode send(meshtastic_MeshPacket *p) override
+    {
+        if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag &&
+            p->decoded.portnum == meshtastic_PortNum_NODEINFO_APP)
+            nodeInfoWantResponses.push_back(p->decoded.want_response);
+        return ReliableRouter::send(p);
+    }
     bool filter(meshtastic_MeshPacket *p) { return ReliableRouter::shouldFilterReceived(p); }
     bool historyContains(const meshtastic_MeshPacket *p) { return wasSeenRecently(p, false); }
     void remember(const meshtastic_MeshPacket *p) { wasSeenRecently(p, true); }
@@ -194,6 +201,7 @@ class AuthPipelineRouter : public ReliableRouter
             packetPool.release(entry.second.packet);
         pending.clear();
     }
+    std::vector<bool> nodeInfoWantResponses;
 };
 
 class AuthPipelineRoutingModule : public RoutingModule
@@ -421,6 +429,7 @@ void setUp(void)
     channels.onConfigChanged();
 
     pipelineRouter->clearPending();
+    pipelineRouter->nodeInfoWantResponses.clear();
     pipelineRouter->rxDupe = 0;
     pipelineRouter->txRelayCanceled = 0;
     pipelineRadio->reset();
@@ -1109,6 +1118,7 @@ class NodeInfoTestShim : public NodeInfoModule
     using MeshModule::currentRequest; // allocReply() only suppresses while a request is in flight
     using NodeInfoModule::allocReply;
     using NodeInfoModule::handleReceivedProtobuf;
+    using NodeInfoModule::runOnce;
 };
 
 static meshtastic_MeshPacket makeNodeInfoPacket(bool signed_)
@@ -1789,7 +1799,7 @@ void test_N11_window_still_applies_across_the_wrap(void)
                              "and must still release once 12h have passed across the wrap");
 }
 
-static void assertLicenseTransitionGetsTwoBoundedReplyAttempts(bool localLicensed)
+static void assertLicenseTransitionGetsOneBoundedReplyAttempt(bool localLicensed)
 {
     owner.is_licensed = localLicensed;
     mockNodeDB->addNode(REMOTE_NODE);
@@ -1800,20 +1810,33 @@ static void assertLicenseTransitionGetsTwoBoundedReplyAttempts(bool localLicense
     NodeInfoTestShim shim;
     TEST_ASSERT_TRUE(wouldReplyToNodeInfoRequest(shim, REMOTE_NODE));
     advanceUptime(60 * 1000);
-    TEST_ASSERT_TRUE_MESSAGE(wouldReplyToNodeInfoRequest(shim, REMOTE_NODE), "one dropped transition reply may be retried");
-    advanceUptime(60 * 1000);
     TEST_ASSERT_FALSE_MESSAGE(wouldReplyToNodeInfoRequest(shim, REMOTE_NODE),
-                              "the transition exception must be consumed after two replies");
+                              "the transition exception must be consumed after one reply");
 }
 
-void test_N12_entering_license_transition_gets_two_bounded_reply_attempts(void)
+void test_N12_entering_license_transition_gets_one_bounded_reply_attempt(void)
 {
-    assertLicenseTransitionGetsTwoBoundedReplyAttempts(true);
+    assertLicenseTransitionGetsOneBoundedReplyAttempt(true);
 }
 
-void test_N13_leaving_license_transition_gets_two_bounded_reply_attempts(void)
+void test_N13_leaving_license_transition_gets_one_bounded_reply_attempt(void)
 {
-    assertLicenseTransitionGetsTwoBoundedReplyAttempts(false);
+    assertLicenseTransitionGetsOneBoundedReplyAttempt(false);
+}
+
+void test_N16_owner_sync_only_first_announcement_requests_replies(void)
+{
+    NodeInfoTestShim shim;
+    shim.requestOwnerSync();
+
+    shim.runOnce();
+    shim.runOnce();
+    shim.runOnce();
+
+    TEST_ASSERT_EQUAL_UINT32(3, pipelineRouter->nodeInfoWantResponses.size());
+    TEST_ASSERT_TRUE(pipelineRouter->nodeInfoWantResponses[0]);
+    TEST_ASSERT_FALSE(pipelineRouter->nodeInfoWantResponses[1]);
+    TEST_ASSERT_FALSE(pipelineRouter->nodeInfoWantResponses[2]);
 }
 
 void test_N14_rejected_transition_does_not_bypass_suppression(void)
@@ -2292,10 +2315,11 @@ void setup()
     RUN_TEST(test_N9_request_after_the_window_is_answered);
     RUN_TEST(test_N10_stale_stamp_does_not_alias_after_a_full_wrap);
     RUN_TEST(test_N11_window_still_applies_across_the_wrap);
-    RUN_TEST(test_N12_entering_license_transition_gets_two_bounded_reply_attempts);
-    RUN_TEST(test_N13_leaving_license_transition_gets_two_bounded_reply_attempts);
+    RUN_TEST(test_N12_entering_license_transition_gets_one_bounded_reply_attempt);
+    RUN_TEST(test_N13_leaving_license_transition_gets_one_bounded_reply_attempt);
     RUN_TEST(test_N14_rejected_transition_does_not_bypass_suppression);
     RUN_TEST(test_N15_overheard_transition_does_not_bypass_a_later_request);
+    RUN_TEST(test_N16_owner_sync_only_first_announcement_requests_replies);
 
     printf("\n=== Group L: licensed identity and plaintext signing ===\n");
     RUN_TEST(test_L1_licensed_nodeinfo_publishes_public_key);

--- a/test/test_packet_signing/test_main.cpp
+++ b/test/test_packet_signing/test_main.cpp
@@ -1110,6 +1110,7 @@ class NodeInfoTestShim : public NodeInfoModule
     using MeshModule::currentRequest; // allocReply() only suppresses while a request is in flight
     using NodeInfoModule::allocReply;
     using NodeInfoModule::handleReceivedProtobuf;
+    using NodeInfoModule::runOnce;
 };
 
 static meshtastic_MeshPacket makeNodeInfoPacket(bool signed_)
@@ -1794,9 +1795,39 @@ void test_N12_owner_sync_announcement_does_not_request_replies(void)
 {
     NodeInfoTestShim shim;
 
-    TEST_ASSERT_TRUE(shim.sendOurNodeInfo(NODENUM_BROADCAST, false, 0, true, true));
+    shim.requestOwnerSync();
+    shim.runOnce();
     TEST_ASSERT_EQUAL_UINT32(1, pipelineRouter->nodeInfoWantResponses.size());
     TEST_ASSERT_FALSE(pipelineRouter->nodeInfoWantResponses[0]);
+}
+
+void test_N13_owner_sync_retries_admission_without_queuing_a_burst(void)
+{
+    static AirTime saturated;
+    c14SavedAirTime = airTime;
+    airTime = &saturated;
+    saturated.logAirtime(TX_LOG, MS_IN_HOUR);
+
+    NodeInfoTestShim shim;
+    shim.requestOwnerSync();
+    TEST_ASSERT_EQUAL_UINT32(30 * 1000, shim.runOnce());
+    TEST_ASSERT_EQUAL_UINT32(0, pipelineRouter->nodeInfoWantResponses.size());
+
+    airTime = c14SavedAirTime;
+    c14SavedAirTime = nullptr;
+    shim.runOnce();
+    TEST_ASSERT_EQUAL_UINT32(1, pipelineRouter->nodeInfoWantResponses.size());
+    TEST_ASSERT_FALSE(pipelineRouter->nodeInfoWantResponses[0]);
+}
+
+void test_N14_owner_sync_preserves_client_hidden_silence(void)
+{
+    config.device.role = meshtastic_Config_DeviceConfig_Role_CLIENT_HIDDEN;
+    NodeInfoTestShim shim;
+
+    shim.requestOwnerSync();
+    shim.runOnce();
+    TEST_ASSERT_EQUAL_UINT32(0, pipelineRouter->nodeInfoWantResponses.size());
 }
 
 void test_L1_licensed_nodeinfo_publishes_public_key(void)
@@ -2222,6 +2253,8 @@ void setup()
     RUN_TEST(test_N10_stale_stamp_does_not_alias_after_a_full_wrap);
     RUN_TEST(test_N11_window_still_applies_across_the_wrap);
     RUN_TEST(test_N12_owner_sync_announcement_does_not_request_replies);
+    RUN_TEST(test_N13_owner_sync_retries_admission_without_queuing_a_burst);
+    RUN_TEST(test_N14_owner_sync_preserves_client_hidden_silence);
 
     printf("\n=== Group L: licensed identity and plaintext signing ===\n");
     RUN_TEST(test_L1_licensed_nodeinfo_publishes_public_key);

--- a/test/test_packet_signing/test_main.cpp
+++ b/test/test_packet_signing/test_main.cpp
@@ -95,6 +95,14 @@ class MockNodeDB : public NodeDB
         nodeInfoLiteSetBit(n, NODEINFO_BITFIELD_HAS_XEDDSA_SIGNED_MASK, value);
     }
 
+    void setLicensed(NodeNum num, bool value)
+    {
+        meshtastic_NodeInfoLite *n = getMeshNode(num);
+        TEST_ASSERT_NOT_NULL(n);
+        nodeInfoLiteSetBit(n, NODEINFO_BITFIELD_HAS_USER_MASK, true);
+        nodeInfoLiteSetBit(n, NODEINFO_BITFIELD_IS_LICENSED_MASK, value);
+    }
+
     void setLongName(NodeNum num, const char *name)
     {
         meshtastic_NodeInfoLite *n = getMeshNode(num);
@@ -1781,6 +1789,87 @@ void test_N11_window_still_applies_across_the_wrap(void)
                              "and must still release once 12h have passed across the wrap");
 }
 
+static void assertLicenseTransitionGetsTwoBoundedReplyAttempts(bool localLicensed)
+{
+    owner.is_licensed = localLicensed;
+    mockNodeDB->addNode(REMOTE_NODE);
+    mockNodeDB->setLicensed(REMOTE_NODE, !localLicensed);
+    Time::setTestMillis(60 * 1000);
+    Time::serviceMonotonic();
+
+    NodeInfoTestShim shim;
+    TEST_ASSERT_TRUE(wouldReplyToNodeInfoRequest(shim, REMOTE_NODE));
+    advanceUptime(60 * 1000);
+    TEST_ASSERT_TRUE_MESSAGE(wouldReplyToNodeInfoRequest(shim, REMOTE_NODE), "one dropped transition reply may be retried");
+    advanceUptime(60 * 1000);
+    TEST_ASSERT_FALSE_MESSAGE(wouldReplyToNodeInfoRequest(shim, REMOTE_NODE),
+                              "the transition exception must be consumed after two replies");
+}
+
+void test_N12_entering_license_transition_gets_two_bounded_reply_attempts(void)
+{
+    assertLicenseTransitionGetsTwoBoundedReplyAttempts(true);
+}
+
+void test_N13_leaving_license_transition_gets_two_bounded_reply_attempts(void)
+{
+    assertLicenseTransitionGetsTwoBoundedReplyAttempts(false);
+}
+
+void test_N14_rejected_transition_does_not_bypass_suppression(void)
+{
+    owner.is_licensed = true;
+    mockNodeDB->addNode(REMOTE_NODE);
+    mockNodeDB->setLicensed(REMOTE_NODE, true);
+    uint8_t storedKey[32] = {0x11};
+    mockNodeDB->setPublicKey(REMOTE_NODE, storedKey);
+    mockNodeDB->setSignerBit(REMOTE_NODE, true);
+    Time::setTestMillis(60 * 1000);
+    Time::serviceMonotonic();
+
+    NodeInfoTestShim shim;
+    TEST_ASSERT_TRUE(wouldReplyToNodeInfoRequest(shim, REMOTE_NODE));
+    mockNodeDB->setLicensed(REMOTE_NODE, false);
+    advanceUptime(60 * 1000);
+
+    meshtastic_MeshPacket mp = makeDecoded(REMOTE_NODE, NODENUM_BROADCAST, meshtastic_PortNum_NODEINFO_APP, SMALL_PAYLOAD);
+    mp.decoded.want_response = true;
+    mp.xeddsa_signed = true;
+    meshtastic_User user = meshtastic_User_init_zero;
+    user.is_licensed = true;
+    user.public_key.size = 32;
+    memset(user.public_key.bytes, 0x22, user.public_key.size);
+    shim.handleReceivedProtobuf(mp, &user);
+
+    NodeInfoTestShim::currentRequest = &mp;
+    meshtastic_MeshPacket *reply = shim.allocReply();
+    NodeInfoTestShim::currentRequest = nullptr;
+    TEST_ASSERT_NULL_MESSAGE(reply, "a rejected identity update must not open a transition reply allowance");
+}
+
+void test_N15_overheard_transition_does_not_bypass_a_later_request(void)
+{
+    owner.is_licensed = true;
+    mockNodeDB->addNode(REMOTE_NODE);
+    mockNodeDB->setLicensed(REMOTE_NODE, true);
+    Time::setTestMillis(60 * 1000);
+    Time::serviceMonotonic();
+
+    NodeInfoTestShim shim;
+    TEST_ASSERT_TRUE(wouldReplyToNodeInfoRequest(shim, REMOTE_NODE));
+    mockNodeDB->setLicensed(REMOTE_NODE, false);
+    advanceUptime(60 * 1000);
+
+    meshtastic_MeshPacket overheard = makeDecoded(REMOTE_NODE, 0x0C0C0C0C, meshtastic_PortNum_NODEINFO_APP, SMALL_PAYLOAD);
+    overheard.decoded.want_response = true;
+    meshtastic_User user = meshtastic_User_init_zero;
+    user.is_licensed = true;
+    TEST_ASSERT_FALSE(shim.handleReceivedProtobuf(overheard, &user));
+
+    TEST_ASSERT_FALSE_MESSAGE(wouldReplyToNodeInfoRequest(shim, REMOTE_NODE),
+                              "an overheard unicast must not arm a transition reply allowance");
+}
+
 void test_L1_licensed_nodeinfo_publishes_public_key(void)
 {
     owner.is_licensed = true;
@@ -2203,6 +2292,10 @@ void setup()
     RUN_TEST(test_N9_request_after_the_window_is_answered);
     RUN_TEST(test_N10_stale_stamp_does_not_alias_after_a_full_wrap);
     RUN_TEST(test_N11_window_still_applies_across_the_wrap);
+    RUN_TEST(test_N12_entering_license_transition_gets_two_bounded_reply_attempts);
+    RUN_TEST(test_N13_leaving_license_transition_gets_two_bounded_reply_attempts);
+    RUN_TEST(test_N14_rejected_transition_does_not_bypass_suppression);
+    RUN_TEST(test_N15_overheard_transition_does_not_bypass_a_later_request);
 
     printf("\n=== Group L: licensed identity and plaintext signing ===\n");
     RUN_TEST(test_L1_licensed_nodeinfo_publishes_public_key);

--- a/test/test_packet_signing/test_main.cpp
+++ b/test/test_packet_signing/test_main.cpp
@@ -95,14 +95,6 @@ class MockNodeDB : public NodeDB
         nodeInfoLiteSetBit(n, NODEINFO_BITFIELD_HAS_XEDDSA_SIGNED_MASK, value);
     }
 
-    void setLicensed(NodeNum num, bool value)
-    {
-        meshtastic_NodeInfoLite *n = getMeshNode(num);
-        TEST_ASSERT_NOT_NULL(n);
-        nodeInfoLiteSetBit(n, NODEINFO_BITFIELD_HAS_USER_MASK, true);
-        nodeInfoLiteSetBit(n, NODEINFO_BITFIELD_IS_LICENSED_MASK, value);
-    }
-
     void setLongName(NodeNum num, const char *name)
     {
         meshtastic_NodeInfoLite *n = getMeshNode(num);
@@ -1118,7 +1110,6 @@ class NodeInfoTestShim : public NodeInfoModule
     using MeshModule::currentRequest; // allocReply() only suppresses while a request is in flight
     using NodeInfoModule::allocReply;
     using NodeInfoModule::handleReceivedProtobuf;
-    using NodeInfoModule::runOnce;
 };
 
 static meshtastic_MeshPacket makeNodeInfoPacket(bool signed_)
@@ -1799,98 +1790,13 @@ void test_N11_window_still_applies_across_the_wrap(void)
                              "and must still release once 12h have passed across the wrap");
 }
 
-static void assertLicenseTransitionGetsOneBoundedReplyAttempt(bool localLicensed)
-{
-    owner.is_licensed = localLicensed;
-    mockNodeDB->addNode(REMOTE_NODE);
-    mockNodeDB->setLicensed(REMOTE_NODE, !localLicensed);
-    Time::setTestMillis(60 * 1000);
-    Time::serviceMonotonic();
-
-    NodeInfoTestShim shim;
-    TEST_ASSERT_TRUE(wouldReplyToNodeInfoRequest(shim, REMOTE_NODE));
-    advanceUptime(60 * 1000);
-    TEST_ASSERT_FALSE_MESSAGE(wouldReplyToNodeInfoRequest(shim, REMOTE_NODE),
-                              "the transition exception must be consumed after one reply");
-}
-
-void test_N12_entering_license_transition_gets_one_bounded_reply_attempt(void)
-{
-    assertLicenseTransitionGetsOneBoundedReplyAttempt(true);
-}
-
-void test_N13_leaving_license_transition_gets_one_bounded_reply_attempt(void)
-{
-    assertLicenseTransitionGetsOneBoundedReplyAttempt(false);
-}
-
-void test_N16_owner_sync_only_first_announcement_requests_replies(void)
+void test_N12_owner_sync_announcement_does_not_request_replies(void)
 {
     NodeInfoTestShim shim;
-    shim.requestOwnerSync();
 
-    shim.runOnce();
-    shim.runOnce();
-    shim.runOnce();
-
-    TEST_ASSERT_EQUAL_UINT32(3, pipelineRouter->nodeInfoWantResponses.size());
-    TEST_ASSERT_TRUE(pipelineRouter->nodeInfoWantResponses[0]);
-    TEST_ASSERT_FALSE(pipelineRouter->nodeInfoWantResponses[1]);
-    TEST_ASSERT_FALSE(pipelineRouter->nodeInfoWantResponses[2]);
-}
-
-void test_N14_rejected_transition_does_not_bypass_suppression(void)
-{
-    owner.is_licensed = true;
-    mockNodeDB->addNode(REMOTE_NODE);
-    mockNodeDB->setLicensed(REMOTE_NODE, true);
-    uint8_t storedKey[32] = {0x11};
-    mockNodeDB->setPublicKey(REMOTE_NODE, storedKey);
-    mockNodeDB->setSignerBit(REMOTE_NODE, true);
-    Time::setTestMillis(60 * 1000);
-    Time::serviceMonotonic();
-
-    NodeInfoTestShim shim;
-    TEST_ASSERT_TRUE(wouldReplyToNodeInfoRequest(shim, REMOTE_NODE));
-    mockNodeDB->setLicensed(REMOTE_NODE, false);
-    advanceUptime(60 * 1000);
-
-    meshtastic_MeshPacket mp = makeDecoded(REMOTE_NODE, NODENUM_BROADCAST, meshtastic_PortNum_NODEINFO_APP, SMALL_PAYLOAD);
-    mp.decoded.want_response = true;
-    mp.xeddsa_signed = true;
-    meshtastic_User user = meshtastic_User_init_zero;
-    user.is_licensed = true;
-    user.public_key.size = 32;
-    memset(user.public_key.bytes, 0x22, user.public_key.size);
-    shim.handleReceivedProtobuf(mp, &user);
-
-    NodeInfoTestShim::currentRequest = &mp;
-    meshtastic_MeshPacket *reply = shim.allocReply();
-    NodeInfoTestShim::currentRequest = nullptr;
-    TEST_ASSERT_NULL_MESSAGE(reply, "a rejected identity update must not open a transition reply allowance");
-}
-
-void test_N15_overheard_transition_does_not_bypass_a_later_request(void)
-{
-    owner.is_licensed = true;
-    mockNodeDB->addNode(REMOTE_NODE);
-    mockNodeDB->setLicensed(REMOTE_NODE, true);
-    Time::setTestMillis(60 * 1000);
-    Time::serviceMonotonic();
-
-    NodeInfoTestShim shim;
-    TEST_ASSERT_TRUE(wouldReplyToNodeInfoRequest(shim, REMOTE_NODE));
-    mockNodeDB->setLicensed(REMOTE_NODE, false);
-    advanceUptime(60 * 1000);
-
-    meshtastic_MeshPacket overheard = makeDecoded(REMOTE_NODE, 0x0C0C0C0C, meshtastic_PortNum_NODEINFO_APP, SMALL_PAYLOAD);
-    overheard.decoded.want_response = true;
-    meshtastic_User user = meshtastic_User_init_zero;
-    user.is_licensed = true;
-    TEST_ASSERT_FALSE(shim.handleReceivedProtobuf(overheard, &user));
-
-    TEST_ASSERT_FALSE_MESSAGE(wouldReplyToNodeInfoRequest(shim, REMOTE_NODE),
-                              "an overheard unicast must not arm a transition reply allowance");
+    TEST_ASSERT_TRUE(shim.sendOurNodeInfo(NODENUM_BROADCAST, false, 0, true, true));
+    TEST_ASSERT_EQUAL_UINT32(1, pipelineRouter->nodeInfoWantResponses.size());
+    TEST_ASSERT_FALSE(pipelineRouter->nodeInfoWantResponses[0]);
 }
 
 void test_L1_licensed_nodeinfo_publishes_public_key(void)
@@ -2315,11 +2221,7 @@ void setup()
     RUN_TEST(test_N9_request_after_the_window_is_answered);
     RUN_TEST(test_N10_stale_stamp_does_not_alias_after_a_full_wrap);
     RUN_TEST(test_N11_window_still_applies_across_the_wrap);
-    RUN_TEST(test_N12_entering_license_transition_gets_one_bounded_reply_attempt);
-    RUN_TEST(test_N13_leaving_license_transition_gets_one_bounded_reply_attempt);
-    RUN_TEST(test_N14_rejected_transition_does_not_bypass_suppression);
-    RUN_TEST(test_N15_overheard_transition_does_not_bypass_a_later_request);
-    RUN_TEST(test_N16_owner_sync_only_first_announcement_requests_replies);
+    RUN_TEST(test_N12_owner_sync_announcement_does_not_request_replies);
 
     printf("\n=== Group L: licensed identity and plaintext signing ===\n");
     RUN_TEST(test_L1_licensed_nodeinfo_publishes_public_key);


### PR DESCRIPTION
## Summary

- announce a Ham/license transition once, after the radio and channel configuration commits
- bypass only the normal NodeInfo cadence for that transition announcement
- send the announcement with `want_response=false`, so peers do not fan out replies
- retain a denied announcement locally until airtime admission allows the single send
- preserve the existing reboot behavior and `CLIENT_HIDDEN` transmission policy
- cover both admin/API transitions and Device UI exit from licensed mode

## Root cause

Peers cache `User.is_licensed` in NodeDB and apply licensed-mode routing rules from that cached state. The previous admin path called `reloadOwner` before `saveChanges` applied the new radio/channel configuration. During a channel transition, that NodeInfo could therefore leave on the old channel and be missed by peers on the new one. The normal NodeInfo cadence could then suppress a timely replacement, leaving peers to reject otherwise valid signed traffic with `Packet to or from unlicensed user, ignoring packet`.

The fix defers the transition NodeInfo until configuration commit and lets this one packet bypass cadence suppression.

## Traffic and compatibility

- multiple transition requests coalesce into one pending announcement
- at most one transition broadcast is handed to the router
- the packet has `want_response=false`, so it solicits zero peer replies
- if airtime admission denies the send, a local check runs again after 30 seconds; denied checks allocate and queue no radio packet
- the pending flag clears as soon as the one packet is admitted, so there is no transmitted retry burst
- packet allocation, signing, and router behavior remain unchanged
- existing reboot semantics remain unchanged
- existing `CLIENT_HIDDEN` behavior remains unchanged

## Validation

- `native-macos:test_admin_radio`: 110/110 passed
- `native-macos:test_packet_signing`: 81/81 passed
- `pio run -e tbeam-s3-core`: passed (RAM 30.1%, flash 71.4%)
- focused tests verify one announcement with `want_response=false`, rejection-without-queue followed by one admitted send, and `CLIENT_HIDDEN` silence
- earlier Muzi Base + T-Beam S3 Core bench reproduction on `develop` confirmed stale licensed-state rejection and showed that a post-config NodeInfo converges peers
- the final sender-only reduction was validated with native tests and the ESP32 build; it has not been reflashed to hardware after removing the earlier retry/reply design

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Owner and license-status changes now publish refreshed node information after changes are committed.
  * Mode transitions can broadcast updated owner details without waiting for the normal messaging cadence.

* **Bug Fixes**
  * Improved owner-information synchronization when switching between licensed and standard modes.
  * Prevented unnecessary transition replies and repeated synchronization attempts.

* **Tests**
  * Added coverage for deferred owner synchronization, retry handling, and client-hidden behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->