### PR TITLE
Remove cppcheck suppressions for 2.20

### DIFF
--- a/suppressions.txt
+++ b/suppressions.txt
@@ -64,30 +64,6 @@ useStlAlgorithm
 
 variableScope
 
-// cppcheck 2.20 (ESP32 only)
-//
-// The ESP32 CI images build on the pioarduino core, whose esp32 platform installs its own
-// tool-cppcheck 2.20.1 and reinstalls it over any pinned version. Every other platform still
-// resolves platformio/tool-cppcheck 1.21100.230717, i.e. cppcheck 2.11. 2.20 parses far more of
-// this tree than 2.11 managed to, so checks that have always been enabled started firing for the
-// first time - 388 defects on ESP32, none anywhere else, for identical source.
-//
-// Silence the checks that appeared with that jump so the gate means the same thing on every
-// platform again. These are style and performance suggestions, not defects; burning them down is
-// worth doing deliberately, not under a CI outage.
-functionStatic
-staticFunction
-constParameterPointer
-iterateByValue
-returnByReference
-passedByValue
-uselessOverride
-
-constVariable
-constVariablePointer
-constVariableReference
-constParameterReference
-
 // Single deliberate sites, scoped so a new one elsewhere still fails the gate. Router folds the
 // bitfield's want_response bit into the decoded bool; Power interpolates the OCV curve in float.
 bitwiseOnBoolean:*/Router.cpp


### PR DESCRIPTION
Remove cppcheck 2.20 suppressions so we can fix them!


(This is just a CI canary, please do not merge ...yet)