### PR TITLE
Actions: Fix uploading zips to GitHub Releases

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -568,8 +568,8 @@ jobs:
           path: firmware-${{ needs.version.outputs.long }}.json
 
       - name: Add sources to GitHub Release
-        # Only run when targeting master branch with workflow_dispatch
-        if: github.ref_name == 'master'
+        # Only run when targeting the default branch with workflow_dispatch
+        if: github.ref_name == github.event.repository.default_branch
         run: |
           gh release upload v${{ needs.version.outputs.long }} ./firmware-${{ needs.version.outputs.long }}.json
           gh release upload v${{ needs.version.outputs.long }} ./output/meshtasticd-${{ needs.version.outputs.deb }}-src.zip
@@ -635,8 +635,8 @@ jobs:
         run: ls -lR
 
       - name: Add bins and debug elfs to GitHub Release
-        # Only run when targeting master branch with workflow_dispatch
-        if: github.ref_name == 'master'
+        # Only run when targeting the default branch with workflow_dispatch
+        if: github.ref_name == github.event.repository.default_branch
         run: |
           gh release upload v${{ needs.version.outputs.long }} ./firmware-${{matrix.arch}}-${{ needs.version.outputs.long }}.zip
           gh release upload v${{ needs.version.outputs.long }} ./debug-elfs-${{matrix.arch}}-${{ needs.version.outputs.long }}.zip


### PR DESCRIPTION
The last two GitHub releases were *empty*.
`master` -> `develop` bit us here, update the workflows to track the default branch instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release publishing checks to use the repository’s configured default branch, improving compatibility for projects that do not use the previously assumed branch name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->