### PR TITLE
fix: Wio Tracker L2 Vbus detection

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -783,6 +783,12 @@ class ADS1115BatteryLevel : public AnalogBatteryLevel
                     int16_t raw = _ads.readADC_SingleEnded(0);
                     sum += _ads.computeVolts(raw);
                 }
+                // Piggyback a toggle-engine watchdog on this same throttle interval.
+                // Only re-arm when VBUS is absent — calling this while attached
+                // would restart CC toggling and could glitch an active sink attach.
+                if (_aw35615.isReady() && !_aw35615.isVbusPresent()) {
+                    _aw35615.rearmToggle();
+                }
             }
 
             // Voltage divider scales by 2.0; convert volts to millivolts
@@ -803,7 +809,14 @@ class ADS1115BatteryLevel : public AnalogBatteryLevel
     {
         if (_aw35615.isReady()) {
             concurrency::LockGuard guard(spiLock);
-            return _aw35615.isVbusPresent() && cached_mv >= 4200;
+
+            bool vbus = _aw35615.isVbusPresent();
+            if (!vbus) {
+                // VBUS just went away (or has been away) — make sure the CC
+                // toggle engine is re-armed so the next attach gets detected.
+                _aw35615.rearmToggle();
+            }
+            return vbus;
         }
         // Fallback to base GPIO/board checks (or false) if CC chip is absent
         return false;
@@ -816,7 +829,10 @@ class ADS1115BatteryLevel : public AnalogBatteryLevel
 
         if (_aw35615.isReady()) {
             concurrency::LockGuard guard(spiLock);
-            return _aw35615.isSinkAttached() && cached_mv >= 4200;
+            // Charging == VBUS present AND we're attached as a sink.
+            // (isSinkAttached() is a latched result — safe to trust here since
+            // isVbusIn() above keeps re-arming toggle on every detach.)
+            return _aw35615.isVbusPresent() && _aw35615.isSinkAttached();
         }
         return isVbusIn();
     }

--- a/variants/esp32s3/seeed_wio_tracker_L2/platformio.ini
+++ b/variants/esp32s3/seeed_wio_tracker_L2/platformio.ini
@@ -47,7 +47,7 @@ lib_deps =
   # renovate: datasource=github-tags depName=Adafruit_ADS1X15 packageName=adafruit/Adafruit_ADS1X15
   https://github.com/adafruit/Adafruit_ADS1X15/archive/refs/tags/2.6.2.zip
   # renovate: datasource=github-tags depName=AW35615 packageName=meshtastic/AW35615
-  https://github.com/mverch67/AW35615/archive/refs/tags/1.0.0.zip
+  https://github.com/mverch67/AW35615/archive/refs/tags/1.0.1.zip
 
 [env:seeed_wio_tracker_L2-tft]
 extends = env:seeed_wio_tracker_L2


### PR DESCRIPTION


## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] Wio Tracker L2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved USB-C power detection when external power is connected or removed.
  - Charging status now more accurately reflects the actual USB-C connection and sink-attach state.
  - Improved recovery of USB-C power detection after VBUS is absent, helping the device recognize power connections reliably.
  - Battery voltage sampling continues to support accurate power-state reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->