### PR TITLE
Regenerate telemetry protobufs for the SoilWaterMetrics split

### DIFF
--- a/src/mesh/generated/meshtastic/telemetry.pb.cpp
+++ b/src/mesh/generated/meshtastic/telemetry.pb.cpp
@@ -12,6 +12,9 @@ PB_BIND(meshtastic_DeviceMetrics, meshtastic_DeviceMetrics, AUTO)
 PB_BIND(meshtastic_EnvironmentMetrics, meshtastic_EnvironmentMetrics, 2)
 
 
+PB_BIND(meshtastic_SoilWaterMetrics, meshtastic_SoilWaterMetrics, AUTO)
+
+
 PB_BIND(meshtastic_PowerMetrics, meshtastic_PowerMetrics, AUTO)
 
 

--- a/src/mesh/generated/meshtastic/telemetry.pb.h
+++ b/src/mesh/generated/meshtastic/telemetry.pb.h
@@ -118,7 +118,7 @@ typedef enum _meshtastic_TelemetrySensorType {
     meshtastic_TelemetrySensorType_DS248X = 51,
     /* MMC5983MA 3-Axis Digital Magnetic Sensor */
     meshtastic_TelemetrySensorType_MMC5983MA = 52,
-    /* ICM-42607-P 6‑Axis IMU */
+    /* ICM-42607-P 6-Axis IMU */
     meshtastic_TelemetrySensorType_ICM42607P = 53,
     /* SPA06 pressure and temperature */
     meshtastic_TelemetrySensorType_SPA06 = 54,
@@ -274,6 +274,14 @@ typedef struct _meshtastic_EnvironmentMetrics {
     /* Estimated distance to the leading edge of the storm, in km */
     bool has_lightning_distance_km;
     float lightning_distance_km;
+} meshtastic_EnvironmentMetrics;
+
+/* Soil and water probe metrics.
+
+ Chemistry reported by soil probes (RS-485/SDI-12 NPK probes) and by
+ water-quality sondes. Split out of EnvironmentMetrics so that message stays
+ within the mesh payload budget. */
+typedef struct _meshtastic_SoilWaterMetrics {
     /* Soil pH, 0-14 */
     bool has_soil_ph;
     float soil_ph;
@@ -319,7 +327,7 @@ typedef struct _meshtastic_EnvironmentMetrics {
     /* Solar irradiance in W/m^2 (distinct from the radiation field's uR/h) */
     bool has_solar_irradiance;
     float solar_irradiance;
-} meshtastic_EnvironmentMetrics;
+} meshtastic_SoilWaterMetrics;
 
 /* Power Metrics (voltage / current / etc) */
 typedef struct _meshtastic_PowerMetrics {
@@ -573,6 +581,8 @@ typedef struct _meshtastic_Telemetry {
         meshtastic_HostMetrics host_metrics;
         /* Traffic management statistics */
         meshtastic_TrafficManagementStats traffic_management_stats;
+        /* Soil and water probe metrics */
+        meshtastic_SoilWaterMetrics soil_water_metrics;
     } variant;
 } meshtastic_Telemetry;
 
@@ -653,9 +663,11 @@ extern "C" {
 
 
 
+
 /* Initializer values for message structs */
 #define meshtastic_DeviceMetrics_init_default    {false, 0, false, 0, false, 0, false, 0, false, 0}
-#define meshtastic_EnvironmentMetrics_init_default {false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0}
+#define meshtastic_EnvironmentMetrics_init_default {false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0}
+#define meshtastic_SoilWaterMetrics_init_default {false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0}
 #define meshtastic_PowerMetrics_init_default     {false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0}
 #define meshtastic_AirQualityMetrics_init_default {false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0}
 #define meshtastic_LocalStats_init_default       {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
@@ -668,7 +680,8 @@ extern "C" {
 #define meshtastic_SEN5XState_init_default       {0, 0, 0, false, 0, false, 0, false, 0}
 #define meshtastic_SEN6XState_init_default       {0, 0, 0, false, 0, false, 0, false, 0}
 #define meshtastic_DeviceMetrics_init_zero       {false, 0, false, 0, false, 0, false, 0, false, 0}
-#define meshtastic_EnvironmentMetrics_init_zero  {false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0}
+#define meshtastic_EnvironmentMetrics_init_zero  {false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0}
+#define meshtastic_SoilWaterMetrics_init_zero    {false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0}
 #define meshtastic_PowerMetrics_init_zero        {false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0}
 #define meshtastic_AirQualityMetrics_init_zero   {false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0}
 #define meshtastic_LocalStats_init_zero          {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
@@ -727,21 +740,21 @@ extern "C" {
 #define meshtastic_EnvironmentMetrics_one_wire_temperature_ch7_tag 39
 #define meshtastic_EnvironmentMetrics_lightning_strike_count_1h_tag 40
 #define meshtastic_EnvironmentMetrics_lightning_distance_km_tag 41
-#define meshtastic_EnvironmentMetrics_soil_ph_tag 42
-#define meshtastic_EnvironmentMetrics_ph_tag     43
-#define meshtastic_EnvironmentMetrics_electrical_conductivity_tag 44
-#define meshtastic_EnvironmentMetrics_salinity_tag 45
-#define meshtastic_EnvironmentMetrics_nitrogen_tag 46
-#define meshtastic_EnvironmentMetrics_phosphorus_tag 47
-#define meshtastic_EnvironmentMetrics_potassium_tag 48
-#define meshtastic_EnvironmentMetrics_dissolved_oxygen_tag 49
-#define meshtastic_EnvironmentMetrics_orp_tag    50
-#define meshtastic_EnvironmentMetrics_chemical_oxygen_demand_tag 51
-#define meshtastic_EnvironmentMetrics_turbidity_tag 52
-#define meshtastic_EnvironmentMetrics_nitrate_tag 53
-#define meshtastic_EnvironmentMetrics_ammonium_tag 54
-#define meshtastic_EnvironmentMetrics_biochemical_oxygen_demand_tag 55
-#define meshtastic_EnvironmentMetrics_solar_irradiance_tag 56
+#define meshtastic_SoilWaterMetrics_soil_ph_tag  1
+#define meshtastic_SoilWaterMetrics_ph_tag       2
+#define meshtastic_SoilWaterMetrics_electrical_conductivity_tag 3
+#define meshtastic_SoilWaterMetrics_salinity_tag 4
+#define meshtastic_SoilWaterMetrics_nitrogen_tag 5
+#define meshtastic_SoilWaterMetrics_phosphorus_tag 6
+#define meshtastic_SoilWaterMetrics_potassium_tag 7
+#define meshtastic_SoilWaterMetrics_dissolved_oxygen_tag 8
+#define meshtastic_SoilWaterMetrics_orp_tag      9
+#define meshtastic_SoilWaterMetrics_chemical_oxygen_demand_tag 10
+#define meshtastic_SoilWaterMetrics_turbidity_tag 11
+#define meshtastic_SoilWaterMetrics_nitrate_tag  12
+#define meshtastic_SoilWaterMetrics_ammonium_tag 13
+#define meshtastic_SoilWaterMetrics_biochemical_oxygen_demand_tag 14
+#define meshtastic_SoilWaterMetrics_solar_irradiance_tag 15
 #define meshtastic_PowerMetrics_ch1_voltage_tag  1
 #define meshtastic_PowerMetrics_ch1_current_tag  2
 #define meshtastic_PowerMetrics_ch2_voltage_tag  3
@@ -827,6 +840,7 @@ extern "C" {
 #define meshtastic_Telemetry_health_metrics_tag  7
 #define meshtastic_Telemetry_host_metrics_tag    8
 #define meshtastic_Telemetry_traffic_management_stats_tag 9
+#define meshtastic_Telemetry_soil_water_metrics_tag 11
 #define meshtastic_Nau7802Config_zeroOffset_tag  1
 #define meshtastic_Nau7802Config_calibrationFactor_tag 2
 #define meshtastic_AS3935Config_tuning_cap_pf_tag 1
@@ -893,24 +907,28 @@ X(a, STATIC,   OPTIONAL, FLOAT,    one_wire_temperature_ch5,  37) \
 X(a, STATIC,   OPTIONAL, FLOAT,    one_wire_temperature_ch6,  38) \
 X(a, STATIC,   OPTIONAL, FLOAT,    one_wire_temperature_ch7,  39) \
 X(a, STATIC,   OPTIONAL, UINT32,   lightning_strike_count_1h,  40) \
-X(a, STATIC,   OPTIONAL, FLOAT,    lightning_distance_km,  41) \
-X(a, STATIC,   OPTIONAL, FLOAT,    soil_ph,          42) \
-X(a, STATIC,   OPTIONAL, FLOAT,    ph,               43) \
-X(a, STATIC,   OPTIONAL, FLOAT,    electrical_conductivity,  44) \
-X(a, STATIC,   OPTIONAL, FLOAT,    salinity,         45) \
-X(a, STATIC,   OPTIONAL, FLOAT,    nitrogen,         46) \
-X(a, STATIC,   OPTIONAL, FLOAT,    phosphorus,       47) \
-X(a, STATIC,   OPTIONAL, FLOAT,    potassium,        48) \
-X(a, STATIC,   OPTIONAL, FLOAT,    dissolved_oxygen,  49) \
-X(a, STATIC,   OPTIONAL, FLOAT,    orp,              50) \
-X(a, STATIC,   OPTIONAL, FLOAT,    chemical_oxygen_demand,  51) \
-X(a, STATIC,   OPTIONAL, FLOAT,    turbidity,        52) \
-X(a, STATIC,   OPTIONAL, FLOAT,    nitrate,          53) \
-X(a, STATIC,   OPTIONAL, FLOAT,    ammonium,         54) \
-X(a, STATIC,   OPTIONAL, FLOAT,    biochemical_oxygen_demand,  55) \
-X(a, STATIC,   OPTIONAL, FLOAT,    solar_irradiance,  56)
+X(a, STATIC,   OPTIONAL, FLOAT,    lightning_distance_km,  41)
 #define meshtastic_EnvironmentMetrics_CALLBACK NULL
 #define meshtastic_EnvironmentMetrics_DEFAULT NULL
+
+#define meshtastic_SoilWaterMetrics_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, FLOAT,    soil_ph,           1) \
+X(a, STATIC,   OPTIONAL, FLOAT,    ph,                2) \
+X(a, STATIC,   OPTIONAL, FLOAT,    electrical_conductivity,   3) \
+X(a, STATIC,   OPTIONAL, FLOAT,    salinity,          4) \
+X(a, STATIC,   OPTIONAL, FLOAT,    nitrogen,          5) \
+X(a, STATIC,   OPTIONAL, FLOAT,    phosphorus,        6) \
+X(a, STATIC,   OPTIONAL, FLOAT,    potassium,         7) \
+X(a, STATIC,   OPTIONAL, FLOAT,    dissolved_oxygen,   8) \
+X(a, STATIC,   OPTIONAL, FLOAT,    orp,               9) \
+X(a, STATIC,   OPTIONAL, FLOAT,    chemical_oxygen_demand,  10) \
+X(a, STATIC,   OPTIONAL, FLOAT,    turbidity,        11) \
+X(a, STATIC,   OPTIONAL, FLOAT,    nitrate,          12) \
+X(a, STATIC,   OPTIONAL, FLOAT,    ammonium,         13) \
+X(a, STATIC,   OPTIONAL, FLOAT,    biochemical_oxygen_demand,  14) \
+X(a, STATIC,   OPTIONAL, FLOAT,    solar_irradiance,  15)
+#define meshtastic_SoilWaterMetrics_CALLBACK NULL
+#define meshtastic_SoilWaterMetrics_DEFAULT NULL
 
 #define meshtastic_PowerMetrics_FIELDLIST(X, a) \
 X(a, STATIC,   OPTIONAL, FLOAT,    ch1_voltage,       1) \
@@ -1021,7 +1039,8 @@ X(a, STATIC,   ONEOF,    MESSAGE,  (variant,power_metrics,variant.power_metrics)
 X(a, STATIC,   ONEOF,    MESSAGE,  (variant,local_stats,variant.local_stats),   6) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (variant,health_metrics,variant.health_metrics),   7) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (variant,host_metrics,variant.host_metrics),   8) \
-X(a, STATIC,   ONEOF,    MESSAGE,  (variant,traffic_management_stats,variant.traffic_management_stats),   9)
+X(a, STATIC,   ONEOF,    MESSAGE,  (variant,traffic_management_stats,variant.traffic_management_stats),   9) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (variant,soil_water_metrics,variant.soil_water_metrics),  11)
 #define meshtastic_Telemetry_CALLBACK NULL
 #define meshtastic_Telemetry_DEFAULT NULL
 #define meshtastic_Telemetry_variant_device_metrics_MSGTYPE meshtastic_DeviceMetrics
@@ -1032,6 +1051,7 @@ X(a, STATIC,   ONEOF,    MESSAGE,  (variant,traffic_management_stats,variant.tra
 #define meshtastic_Telemetry_variant_health_metrics_MSGTYPE meshtastic_HealthMetrics
 #define meshtastic_Telemetry_variant_host_metrics_MSGTYPE meshtastic_HostMetrics
 #define meshtastic_Telemetry_variant_traffic_management_stats_MSGTYPE meshtastic_TrafficManagementStats
+#define meshtastic_Telemetry_variant_soil_water_metrics_MSGTYPE meshtastic_SoilWaterMetrics
 
 #define meshtastic_Nau7802Config_FIELDLIST(X, a) \
 X(a, STATIC,   SINGULAR, INT32,    zeroOffset,        1) \
@@ -1066,6 +1086,7 @@ X(a, STATIC,   OPTIONAL, FIXED64,  voc_state_array,   6)
 
 extern const pb_msgdesc_t meshtastic_DeviceMetrics_msg;
 extern const pb_msgdesc_t meshtastic_EnvironmentMetrics_msg;
+extern const pb_msgdesc_t meshtastic_SoilWaterMetrics_msg;
 extern const pb_msgdesc_t meshtastic_PowerMetrics_msg;
 extern const pb_msgdesc_t meshtastic_AirQualityMetrics_msg;
 extern const pb_msgdesc_t meshtastic_LocalStats_msg;
@@ -1081,6 +1102,7 @@ extern const pb_msgdesc_t meshtastic_SEN6XState_msg;
 /* Defines for backwards compatibility with code written before nanopb-0.4.0 */
 #define meshtastic_DeviceMetrics_fields &meshtastic_DeviceMetrics_msg
 #define meshtastic_EnvironmentMetrics_fields &meshtastic_EnvironmentMetrics_msg
+#define meshtastic_SoilWaterMetrics_fields &meshtastic_SoilWaterMetrics_msg
 #define meshtastic_PowerMetrics_fields &meshtastic_PowerMetrics_msg
 #define meshtastic_AirQualityMetrics_fields &meshtastic_AirQualityMetrics_msg
 #define meshtastic_LocalStats_fields &meshtastic_LocalStats_msg
@@ -1098,7 +1120,7 @@ extern const pb_msgdesc_t meshtastic_SEN6XState_msg;
 #define meshtastic_AS3935Config_size             6
 #define meshtastic_AirQualityMetrics_size        157
 #define meshtastic_DeviceMetrics_size            27
-#define meshtastic_EnvironmentMetrics_size       312
+#define meshtastic_EnvironmentMetrics_size       222
 #define meshtastic_HealthMetrics_size            11
 #define meshtastic_HostMetrics_size              264
 #define meshtastic_LocalStats_size               87
@@ -1106,7 +1128,8 @@ extern const pb_msgdesc_t meshtastic_SEN6XState_msg;
 #define meshtastic_PowerMetrics_size             81
 #define meshtastic_SEN5XState_size               27
 #define meshtastic_SEN6XState_size               27
-#define meshtastic_Telemetry_size                320
+#define meshtastic_SoilWaterMetrics_size         75
+#define meshtastic_Telemetry_size                272
 #define meshtastic_TrafficManagementStats_size   42
 
 #ifdef __cplusplus


### PR DESCRIPTION
Regenerated telemetry protobufs for meshtastic/protobufs#1071, which moves the
15 soil and water chemistry fields out of `EnvironmentMetrics` into their own
`SoilWaterMetrics` message on `Telemetry` oneof tag 11.

meshtastic/protobufs#1071 is **merged** as `fa26b5b`, and the submodule now
points at that `master` commit. Ready for review.

### What changes

Generated output only, plus the submodule pointer. Nothing in `src/` or `test/`
referenced any of the moved fields, so there are no call sites to update.

| constant | before | after |
| --- | --- | --- |
| `meshtastic_EnvironmentMetrics_size` | 312 | 222 |
| `meshtastic_SoilWaterMetrics_size` | — | 75 |
| `meshtastic_Telemetry_size` | 320 | 272 |

Struct sizes: `EnvironmentMetrics` 424 to 304, `Telemetry` 432 to 312.

### Why it matters here

`EnvironmentMetrics` is stored per node in the NodeDB satellite map
(`src/mesh/NodeDB.h`), so the 120-byte struct reduction is 4,800 bytes at
`MAX_SATELLITE_NODES` 40 on nRF52840, and 30,000 bytes at 250 elsewhere.
`meshtastic_NodeEnvironmentEntry_size` drops 321 to 231, which also lowers the
persisted-database decode ceiling.

### What this does not fix

`Telemetry_size` lands at 272, still above the 233-byte `DATA_PAYLOAD_LEN`,
because `HostMetrics` at 264 becomes the binding variant. That is where it sat
from meshtastic/protobufs#6836 until the recent protobuf pull. The encode
plumbing that turns an oversize message into a silently empty packet is #11797
and is unaffected by this PR.

### Verification

- nanopb 0.4.9.1 reproduced the pre-change constants exactly before generating,
  so the sizes above are generator output, not arithmetic.
- Regenerated unit compiles clean.
- `grep` over `src/` and `test/` for every moved field name returns nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the underlying protocol definitions.
  - This maintenance update does not introduce changes to exported functionality or user-facing behavior.
  - No new features, fixes, or workflow changes are included in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
