### PR TITLE
feat: add exFat support for SDIO SD cards

### DIFF
--- a/extra_scripts/esp32_fatfs_exfat.py
+++ b/extra_scripts/esp32_fatfs_exfat.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# trunk-ignore-all(ruff/F821)
+# trunk-ignore-all(flake8/F821): For SConstruct imports
+import re
+from os.path import exists, join
+
+Import("env")
+
+# ---------------------------------------------------------------------------
+# exFAT for the IDF FatFs component.
+#
+# ESP-IDF exposes no Kconfig symbol for exFAT (checked 5.5.x and master):
+# components/fatfs/src/ffconf.h hardcodes "#define FF_FS_EXFAT 0", so
+# CONFIG_FATFS_FS_EXFAT=y in custom_sdkconfig is silently dropped by kconfgen
+# and an exFAT card fails to mount with ESP_FAIL from esp_vfs_fat_sdmmc_mount.
+# This script turns that inert symbol into a real ffconf.h patch.
+#
+# Two headers must agree, because FF_FS_EXFAT changes the FATFS/FIL/DIR layout
+# in ff.h:
+#   1. framework-espidf - compiled into libfatfs.a by the HybridCompile
+#      IDF-libs rebuild (arduino.py -> espidf.py). Patched in the pre: pass.
+#   2. framework-arduinoespressif32-libs/<chip>/include - used when the
+#      application and the Arduino SD_MMC library are compiled. espidf.py's
+#      idf_lib_copy() copies back archives and sdkconfig.h but no headers, and
+#      a custom_sdkconfig hash change wipes the whole package and reinstalls
+#      it, so this copy is patched again in the post: pass.
+#
+# framework-espidf is shared by every ESP32 env while this script is registered
+# only on the SDIO variants, so the patch there is undone once the build is
+# done: an env that never asked for exFAT must not rebuild its IDF libs against
+# a header the rest of its build does not see. The per-chip -libs copy stays
+# patched, matching the libfatfs.a it was built with.
+#
+# The libs rebuild is keyed on the md5 of custom_sdkconfig, which the patch
+# state does not otherwise reach, so the state is appended as a comment line
+# (inert in kconfig). Keep the marker lowercase: arduino.py greps
+# custom_sdkconfig for "PSRAM" and "CONFIG_SPIRAM=y".
+# ---------------------------------------------------------------------------
+
+SWITCH = "CONFIG_FATFS_FS_EXFAT=y"
+MARKER_KEY = "meshtastic_fatfs_exfat"
+PATTERN = re.compile(r"^(#define\s+FF_FS_EXFAT\s+)([01])", re.MULTILINE)
+
+
+def wants_exfat(env):
+    config = env.GetProjectConfig()
+    section = "env:" + env["PIOENV"]
+    if not config.has_option(section, "custom_sdkconfig"):
+        return False
+    return any(
+        line.strip() == SWITCH
+        for line in env.GetProjectOption("custom_sdkconfig").splitlines()
+    )
+
+
+def ffconf_paths(env, phase):
+    platform = env.PioPlatform()
+    board = env.BoardConfig()
+    chip = board.get("build.chip_variant", "").lower() or board.get(
+        "build.mcu", "esp32"
+    )
+
+    paths = []
+    if phase == "pre":
+        idf = idf_ffconf(env)
+        if idf:
+            paths.append(idf)
+    libs_dir = platform.get_package_dir("framework-arduinoespressif32-libs")
+    if libs_dir:
+        paths.append(join(libs_dir, chip, "include", "fatfs", "src", "ffconf.h"))
+    return [p for p in paths if exists(p)]
+
+
+def idf_ffconf(env):
+    idf_dir = env.PioPlatform().get_package_dir("framework-espidf")
+    return join(idf_dir, "components", "fatfs", "src", "ffconf.h") if idf_dir else None
+
+
+def set_ff_fs_exfat(path, enable):
+    with open(path) as src:
+        content = src.read()
+    patched = PATTERN.sub(r"\g<1>%d" % (1 if enable else 0), content, count=1)
+    if patched == content:
+        return False
+    with open(path, "w") as dst:
+        dst.write(patched)
+    print("*** FF_FS_EXFAT=%d: %s ***" % (1 if enable else 0, path))
+    return True
+
+
+def tag_sdkconfig_state(env, enable):
+    config = env.GetProjectConfig()
+    section = "env:" + env["PIOENV"]
+    if not config.has_option(section, "custom_sdkconfig"):
+        return
+    current = env.GetProjectOption("custom_sdkconfig")
+    if MARKER_KEY in current:
+        return
+    marker = "# %s: %d" % (MARKER_KEY, 1 if enable else 0)
+    config.set(section, "custom_sdkconfig", current.rstrip("\n") + "\n" + marker)
+
+
+phase = "post" if env.get("MESHTASTIC_EXFAT_PATCHED") else "pre"
+enable = wants_exfat(env)
+
+for path in ffconf_paths(env, phase):
+    set_ff_fs_exfat(path, enable)
+
+if phase == "pre":
+    # revert as well as enable, so an env without the switch never links a
+    # FatFs built with a different struct layout than the headers it compiles against
+    tag_sdkconfig_state(env, enable)
+    env["MESHTASTIC_EXFAT_PATCHED"] = True
+
+    if enable:
+
+        def restore_idf_ffconf(target, source, env):
+            idf = idf_ffconf(env)
+            if idf and exists(idf):
+                set_ff_fs_exfat(idf, False)
+
+        # the IDF libs are compiled during the build phase, so this is the first
+        # point at which the shared package can be handed back unpatched
+        env.AddPostAction("checkprogsize", restore_idf_ffconf)

--- a/platformio.ini
+++ b/platformio.ini
@@ -144,6 +144,8 @@ lib_deps =
 custom_sdkconfig =
 	# CONFIG_MBEDTLS_INTERNAL_MEM_ALLOC is not set
 	CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC=y
+	; not an IDF symbol; read by extra_scripts/esp32_fatfs_exfat.py to patch ffconf.h
+	CONFIG_FATFS_FS_EXFAT=y
 
 ; Common libs for environmental measurements in telemetry module
 [environmental_base]

--- a/platformio.ini
+++ b/platformio.ini
@@ -140,12 +140,13 @@ lib_deps =
 [device-ui_base]
 lib_deps =
 	# renovate: datasource=git-refs depName=meshtastic/device-ui packageName=https://github.com/meshtastic/device-ui gitBranch=master
-	https://github.com/meshtastic/device-ui/archive/c6d003eb6d6b65f74de6738be924a49a973608b9.zip
+	https://github.com/meshtastic/device-ui/archive/33738beab3ef0257f6b88486e4e7552d9bd5de4e.zip
 custom_sdkconfig =
 	# CONFIG_MBEDTLS_INTERNAL_MEM_ALLOC is not set
 	CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC=y
 	; not an IDF symbol; read by extra_scripts/esp32_fatfs_exfat.py to patch ffconf.h
 	CONFIG_FATFS_FS_EXFAT=y
+	CONFIG_FATFS_LFN_STACK=y
 
 ; Common libs for environmental measurements in telemetry module
 [environmental_base]

--- a/variants/esp32s3/seeed_wio_tracker_L2/platformio.ini
+++ b/variants/esp32s3/seeed_wio_tracker_L2/platformio.ini
@@ -81,3 +81,10 @@ lib_deps =
 custom_sdkconfig =
   ${esp32s3_base.custom_sdkconfig}
   ${device-ui_base.custom_sdkconfig}
+
+; twice on purpose: the pre pass patches framework-espidf before the IDF-libs
+; rebuild, the post pass re-patches the -libs headers a reinstall just wiped
+extra_scripts =
+  ${esp32s3_base.extra_scripts}
+  pre:extra_scripts/esp32_fatfs_exfat.py
+  post:extra_scripts/esp32_fatfs_exfat.py


### PR DESCRIPTION
Patch esp-idf during build to enable exFat capable FsFat filesystem. Required by MUI PMTiles > 2 GB.
The patch script toggles this [flag](https://github.com/espressif/esp-idf/blob/c712a0dde385d659a1470a136251980d31a70bc1/components/fatfs/src/ffconf.h#L294) in the _framework-espidf_ / _framework-arduinoespressif32-libs_ toolchain .

Current targeted devices (SDIO SD card):
- Wio Tracker L2
- MeshPager X2


depends on: https://github.com/meshtastic/device-ui/pull/397

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
    - [x] Wio Tracker L2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added exFAT support for compatible ESP32 SD card configurations.
* Enabled exFAT support for the Seeed Wio Tracker L2 TFT environment.
* Added support for long filenames stored on supported SD cards.
* Improved compatibility between filesystem components when exFAT is enabled, helping prevent inconsistent file and directory handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->