### PR TITLE
Generate (very basic) HTML index for Meshtastic Nightlies

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -782,6 +782,13 @@ jobs:
             exit 1
           fi
 
+      - name: Generate nightly html index
+        env:
+          VERSION: ${{ needs.version.outputs.long }}
+        working-directory: ./stage
+        run: |
+          tree -H "." -T "Meshtastic Nightly $VERSION" --noreport -I "index.html" --charset utf-8 > index.html
+
       # Mirror the staged directory to Cloudflare R2. --delete at the bucket root
       # clears stale nightly binaries, and is in scope for the whole bucket because
       # this bucket holds nothing but the nightly build. release_notes.md lives only
@@ -810,11 +817,16 @@ jobs:
             --delete \
             --exclude 'release_notes.md' \
             --exclude 'index.json' \
+            --exclude 'index.html' \
             --metadata "commit=${{ github.sha }},run=${{ github.run_id }}" \
             --cache-control 'public, max-age=3600, s-maxage=86400'
-          # index.json is the pointer to the current nightly, don't cache it so hard (5 minutes).
-          aws s3 cp ./stage/index.json "s3://${r2_bucket}/index.json" \
-            --endpoint-url "$R2_ENDPOINT" \
-            --no-progress \
-            --metadata "commit=${{ github.sha }},run=${{ github.run_id }}" \
-            --cache-control 'public, max-age=300'
+          # The indices point at whatever the current nightly is - index.json for
+          # clients, index.html for browsers - so they are excluded from the sync
+          # above and uploaded here with a 5 minute cache instead.
+          for index in index.json index.html; do
+            aws s3 cp "./stage/$index" "s3://${r2_bucket}/$index" \
+              --endpoint-url "$R2_ENDPOINT" \
+              --no-progress \
+              --metadata "commit=${{ github.sha }},run=${{ github.run_id }}" \
+              --cache-control 'public, max-age=300'
+          done


### PR DESCRIPTION
Generate an index so https://nightly.meshtastic.org doesn't just 404.
We ❤️ our nightly testers, if they don't want to use the Flasher that is fine!

This will need a simple cloudflare rewrite rule to point https://nightly.meshtastic.org to https://nightly.meshtastic.org/index.html 👍 once it's been pushed out once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Nightly build downloads now include a browsable HTML index listing the available files.
  - The nightly build index is published alongside the existing release metadata for easier navigation.
- **Improvements**
  - Nightly build directory listings and metadata are cached for faster access.
  - Index pages are preserved during nightly build synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->