### PR TITLE
fix(nodedb): drop satellite entries that no hot node owns

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -253,6 +253,12 @@ std::map<NodeNum, meshtastic_EnvironmentMetrics> *s_decodeEnvironmentTarget = nu
 #if !MESHTASTIC_EXCLUDE_STATUSDB
 std::map<NodeNum, meshtastic_StatusMessage> *s_decodeStatusTarget = nullptr;
 #endif
+
+// Keys that can never name a real node.
+[[maybe_unused]] inline bool isUsableSatelliteKey(NodeNum n)
+{
+    return n != 0 && !isBroadcast(n);
+}
 } // namespace
 
 bool meshtastic_NodeDatabase_callback(pb_istream_t *istream, pb_ostream_t *ostream, const pb_field_t *field)
@@ -306,7 +312,7 @@ bool meshtastic_NodeDatabase_callback(pb_istream_t *istream, pb_ostream_t *ostre
             if (pb_decode(istream, meshtastic_NodePositionEntry_fields, &entry)) {
 #if !MESHTASTIC_EXCLUDE_POSITIONDB
                 if (s_decodePositionsTarget) {
-                    if (entry.has_position)
+                    if (entry.has_position && isUsableSatelliteKey(entry.num))
                         (*s_decodePositionsTarget)[entry.num] = entry.position;
                     return true;
                 }
@@ -332,7 +338,7 @@ bool meshtastic_NodeDatabase_callback(pb_istream_t *istream, pb_ostream_t *ostre
             if (pb_decode(istream, meshtastic_NodeTelemetryEntry_fields, &entry)) {
 #if !MESHTASTIC_EXCLUDE_TELEMETRYDB
                 if (s_decodeTelemetryTarget) {
-                    if (entry.has_device_metrics)
+                    if (entry.has_device_metrics && isUsableSatelliteKey(entry.num))
                         (*s_decodeTelemetryTarget)[entry.num] = entry.device_metrics;
                     return true;
                 }
@@ -358,7 +364,7 @@ bool meshtastic_NodeDatabase_callback(pb_istream_t *istream, pb_ostream_t *ostre
             if (pb_decode(istream, meshtastic_NodeStatusEntry_fields, &entry)) {
 #if !MESHTASTIC_EXCLUDE_STATUSDB
                 if (s_decodeStatusTarget) {
-                    if (entry.has_status)
+                    if (entry.has_status && isUsableSatelliteKey(entry.num))
                         (*s_decodeStatusTarget)[entry.num] = entry.status;
                     return true;
                 }
@@ -384,7 +390,7 @@ bool meshtastic_NodeDatabase_callback(pb_istream_t *istream, pb_ostream_t *ostre
             if (pb_decode(istream, meshtastic_NodeEnvironmentEntry_fields, &entry)) {
 #if !MESHTASTIC_EXCLUDE_ENVIRONMENTDB
                 if (s_decodeEnvironmentTarget) {
-                    if (entry.has_environment_metrics)
+                    if (entry.has_environment_metrics && isUsableSatelliteKey(entry.num))
                         (*s_decodeEnvironmentTarget)[entry.num] = entry.environment_metrics;
                     return true;
                 }
@@ -1936,16 +1942,35 @@ bool NodeDB::enforceSatelliteCaps()
 {
     concurrency::LockGuard guard(&satelliteMutex);
     bool trimmedAny = false;
-    auto trim = [this, &trimmedAny](auto &map, const char *name) {
+    const NodeNum self = getNodeNum();
+    // One sorted snapshot of the hot keys serves all four maps; the orphan test is a binary search.
+    std::vector<NodeNum> hotNums;
+    hotNums.reserve(numMeshNodes);
+    for (int i = 0; i < numMeshNodes; i++)
+        hotNums.push_back(meshNodes->at(i).num);
+    std::sort(hotNums.begin(), hotNums.end());
+
+    auto trim = [this, &trimmedAny, &hotNums, self](auto &map, const char *name) {
         const size_t before = map.size();
+        // Orphans (key with no hot-table owner) only ever arrive from disk, and the
+        // cap paths never reclaim them because they fire above the cap, not at it.
+        size_t orphans = 0;
+        for (auto it = map.begin(); it != map.end();) {
+            if (it->first != self && !std::binary_search(hotNums.begin(), hotNums.end(), it->first)) {
+                it = map.erase(it);
+                orphans++;
+            } else {
+                ++it;
+            }
+        }
         while (map.size() > MAX_SATELLITE_NODES) {
             if (!evictStalestSatellite(*this, map))
                 break;
         }
         if (map.size() != before) {
             trimmedAny = true;
-            LOG_MIGRATION("Trimmed %s satellites %u -> %u (cap %d)", name, (unsigned)before, (unsigned)map.size(),
-                          MAX_SATELLITE_NODES);
+            LOG_MIGRATION("Trimmed %s satellites %u -> %u (cap %d, %u orphaned)", name, (unsigned)before, (unsigned)map.size(),
+                          MAX_SATELLITE_NODES, (unsigned)orphans);
         }
     };
 #if !MESHTASTIC_EXCLUDE_POSITIONDB

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -1281,26 +1281,26 @@ bool lastHeardIsWallClock(const meshtastic_NodeInfoLite *header)
 // Previously these packets carried a bare 0, which a client renders as a real reading.
 // Note the asymmetry with rx_snr below: that field is still proto3 singular, so "unknown" and
 //  "0 dB" remain indistinguishable there.
-meshtastic_MeshPacket PhoneAPI::makeReplayPositionPacket(NodeNum num, const meshtastic_PositionLite &pos)
+meshtastic_MeshPacket PhoneAPI::makeReplayPositionPacket(const meshtastic_NodeInfoLite *header,
+                                                         const meshtastic_PositionLite &pos)
 {
     // Shape this exactly like a fresh live broadcast Position from the peer so the
     // phone runs it through its normal "live position broadcast" handler path.
     // to=ourNum would read as a DM-from-peer and never lands in node detail UI.
     meshtastic_MeshPacket pkt = meshtastic_MeshPacket_init_default;
-    const meshtastic_NodeInfoLite *header = nodeDB->getMeshNode(num);
-    pkt.from = num;
+    pkt.from = header->num;
     pkt.to = NODENUM_BROADCAST;
     // rx_time means "when *we* received this" - use last_heard, not the position's own GPS
     // fix time (which is often 0 and, when present, already round-trips inside the payload
     // via ConvertToPosition).
-    pkt.rx_time = header ? header->last_heard : 0;
+    pkt.rx_time = header->last_heard;
     // Present only when last_heard is a genuine epoch - see lastHeardIsWallClock().
     pkt.has_rx_time = lastHeardIsWallClock(header);
     // Stable per-node/per-fix id: replaying the same unchanged history on every
     // reconnect must not look like a brand new packet to the phone's history/dedup.
-    pkt.id = makeReplayPacketId(num, pkt.rx_time, meshtastic_PortNum_POSITION_APP);
-    pkt.channel = header ? header->channel : 0;
-    pkt.rx_snr = header ? header->snr : 0;
+    pkt.id = makeReplayPacketId(header->num, pkt.rx_time, meshtastic_PortNum_POSITION_APP);
+    pkt.channel = header->channel;
+    pkt.rx_snr = header->snr;
     pkt.via_mqtt = nodeInfoLiteViaMqtt(header);
     setReplayHopFields(pkt, header);
     pkt.priority = meshtastic_MeshPacket_Priority_BACKGROUND;
@@ -1315,19 +1315,19 @@ meshtastic_MeshPacket PhoneAPI::makeReplayPositionPacket(NodeNum num, const mesh
     return pkt;
 }
 
-meshtastic_MeshPacket PhoneAPI::makeReplayTelemetryPacket(NodeNum num, const meshtastic_DeviceMetrics &metrics)
+meshtastic_MeshPacket PhoneAPI::makeReplayTelemetryPacket(const meshtastic_NodeInfoLite *header,
+                                                          const meshtastic_DeviceMetrics &metrics)
 {
     meshtastic_MeshPacket pkt = meshtastic_MeshPacket_init_default;
-    pkt.from = num;
+    pkt.from = header->num;
     pkt.to = NODENUM_BROADCAST;
     // No native timestamp on telemetry packets here; use last_heard.
-    const meshtastic_NodeInfoLite *header = nodeDB->getMeshNode(num);
-    pkt.rx_time = header ? header->last_heard : 0;
+    pkt.rx_time = header->last_heard;
     // Present only when last_heard is a genuine epoch - see lastHeardIsWallClock().
     pkt.has_rx_time = lastHeardIsWallClock(header);
-    pkt.id = makeReplayPacketId(num, pkt.rx_time, meshtastic_Telemetry_device_metrics_tag);
-    pkt.channel = header ? header->channel : 0;
-    pkt.rx_snr = header ? header->snr : 0;
+    pkt.id = makeReplayPacketId(header->num, pkt.rx_time, meshtastic_Telemetry_device_metrics_tag);
+    pkt.channel = header->channel;
+    pkt.rx_snr = header->snr;
     pkt.via_mqtt = nodeInfoLiteViaMqtt(header);
     setReplayHopFields(pkt, header);
     pkt.priority = meshtastic_MeshPacket_Priority_BACKGROUND;
@@ -1376,10 +1376,13 @@ void PhoneAPI::prefetchReplayPositions()
         wasEmpty = replayQueue.empty();
         while (replayQueue.size() < kReplayPrefetchDepth && replayPositionIndex < replayPositionOrder.size()) {
             NodeNum num = replayPositionOrder[replayPositionIndex++];
+            const meshtastic_NodeInfoLite *header = nodeDB->getMeshNode(num);
             meshtastic_PositionLite pos;
-            if (!nodeDB->copyNodePosition(num, pos))
-                continue; // entry was evicted between snapshot and now
-            replayQueue.push_back(makeReplayPositionPacket(num, pos));
+            // No header means an orphan the phone cannot attribute; a failed copy means
+            // the entry was evicted between snapshot and now.
+            if (!header || !nodeDB->copyNodePosition(num, pos))
+                continue;
+            replayQueue.push_back(makeReplayPositionPacket(header, pos));
             added = true;
         }
     }
@@ -1412,10 +1415,11 @@ void PhoneAPI::prefetchReplayTelemetry()
         wasEmpty = replayQueue.empty();
         while (replayQueue.size() < kReplayPrefetchDepth && replayTelemetryIndex < replayTelemetryOrder.size()) {
             NodeNum num = replayTelemetryOrder[replayTelemetryIndex++];
+            const meshtastic_NodeInfoLite *header = nodeDB->getMeshNode(num);
             meshtastic_DeviceMetrics dm;
-            if (!nodeDB->copyNodeTelemetry(num, dm))
+            if (!header || !nodeDB->copyNodeTelemetry(num, dm))
                 continue;
-            replayQueue.push_back(makeReplayTelemetryPacket(num, dm));
+            replayQueue.push_back(makeReplayTelemetryPacket(header, dm));
             added = true;
         }
     }
@@ -1424,18 +1428,18 @@ void PhoneAPI::prefetchReplayTelemetry()
 #endif
 }
 
-meshtastic_MeshPacket PhoneAPI::makeReplayEnvironmentPacket(uint32_t num, const meshtastic_EnvironmentMetrics &env)
+meshtastic_MeshPacket PhoneAPI::makeReplayEnvironmentPacket(const meshtastic_NodeInfoLite *header,
+                                                            const meshtastic_EnvironmentMetrics &env)
 {
     meshtastic_MeshPacket pkt = meshtastic_MeshPacket_init_default;
-    pkt.from = num;
+    pkt.from = header->num;
     pkt.to = NODENUM_BROADCAST;
-    const meshtastic_NodeInfoLite *header = nodeDB->getMeshNode(num);
-    pkt.rx_time = header ? header->last_heard : 0;
+    pkt.rx_time = header->last_heard;
     // Present only when last_heard is a genuine epoch - see lastHeardIsWallClock().
     pkt.has_rx_time = lastHeardIsWallClock(header);
-    pkt.id = makeReplayPacketId(num, pkt.rx_time, meshtastic_Telemetry_environment_metrics_tag);
-    pkt.channel = header ? header->channel : 0;
-    pkt.rx_snr = header ? header->snr : 0;
+    pkt.id = makeReplayPacketId(header->num, pkt.rx_time, meshtastic_Telemetry_environment_metrics_tag);
+    pkt.channel = header->channel;
+    pkt.rx_snr = header->snr;
     pkt.via_mqtt = nodeInfoLiteViaMqtt(header);
     setReplayHopFields(pkt, header);
     pkt.priority = meshtastic_MeshPacket_Priority_BACKGROUND;
@@ -1478,10 +1482,11 @@ void PhoneAPI::prefetchReplayEnvironment()
         wasEmpty = replayQueue.empty();
         while (replayQueue.size() < kReplayPrefetchDepth && replayEnvironmentIndex < replayEnvironmentOrder.size()) {
             NodeNum num = replayEnvironmentOrder[replayEnvironmentIndex++];
+            const meshtastic_NodeInfoLite *header = nodeDB->getMeshNode(num);
             meshtastic_EnvironmentMetrics env;
-            if (!nodeDB->copyNodeEnvironment(num, env))
+            if (!header || !nodeDB->copyNodeEnvironment(num, env))
                 continue;
-            replayQueue.push_back(makeReplayEnvironmentPacket(num, env));
+            replayQueue.push_back(makeReplayEnvironmentPacket(header, env));
             added = true;
         }
     }
@@ -1490,19 +1495,19 @@ void PhoneAPI::prefetchReplayEnvironment()
 #endif
 }
 
-meshtastic_MeshPacket PhoneAPI::makeReplayStatusPacket(uint32_t num, const meshtastic_StatusMessage &status)
+meshtastic_MeshPacket PhoneAPI::makeReplayStatusPacket(const meshtastic_NodeInfoLite *header,
+                                                       const meshtastic_StatusMessage &status)
 {
     meshtastic_MeshPacket pkt = meshtastic_MeshPacket_init_default;
-    pkt.from = num;
+    pkt.from = header->num;
     pkt.to = NODENUM_BROADCAST;
     // StatusMessage has no native timestamp; use last_heard.
-    const meshtastic_NodeInfoLite *header = nodeDB->getMeshNode(num);
-    pkt.rx_time = header ? header->last_heard : 0;
+    pkt.rx_time = header->last_heard;
     // Present only when last_heard is a genuine epoch - see lastHeardIsWallClock().
     pkt.has_rx_time = lastHeardIsWallClock(header);
-    pkt.id = makeReplayPacketId(num, pkt.rx_time, meshtastic_PortNum_NODE_STATUS_APP);
-    pkt.channel = header ? header->channel : 0;
-    pkt.rx_snr = header ? header->snr : 0;
+    pkt.id = makeReplayPacketId(header->num, pkt.rx_time, meshtastic_PortNum_NODE_STATUS_APP);
+    pkt.channel = header->channel;
+    pkt.rx_snr = header->snr;
     pkt.via_mqtt = nodeInfoLiteViaMqtt(header);
     setReplayHopFields(pkt, header);
     pkt.priority = meshtastic_MeshPacket_Priority_BACKGROUND;
@@ -1540,10 +1545,11 @@ void PhoneAPI::prefetchReplayStatus()
         wasEmpty = replayQueue.empty();
         while (replayQueue.size() < kReplayPrefetchDepth && replayStatusIndex < replayStatusOrder.size()) {
             NodeNum num = replayStatusOrder[replayStatusIndex++];
+            const meshtastic_NodeInfoLite *header = nodeDB->getMeshNode(num);
             meshtastic_StatusMessage status;
-            if (!nodeDB->copyNodeStatus(num, status) || status.status[0] == '\0')
+            if (!header || !nodeDB->copyNodeStatus(num, status) || status.status[0] == '\0')
                 continue;
-            replayQueue.push_back(makeReplayStatusPacket(num, status));
+            replayQueue.push_back(makeReplayStatusPacket(header, status));
             added = true;
         }
     }

--- a/src/mesh/PhoneAPI.h
+++ b/src/mesh/PhoneAPI.h
@@ -288,10 +288,12 @@ class PhoneAPI
     void prefetchReplayEnvironment();
     void beginReplayStatus();
     void prefetchReplayStatus();
-    meshtastic_MeshPacket makeReplayPositionPacket(uint32_t num, const meshtastic_PositionLite &pos);
-    meshtastic_MeshPacket makeReplayTelemetryPacket(uint32_t num, const meshtastic_DeviceMetrics &metrics);
-    meshtastic_MeshPacket makeReplayEnvironmentPacket(uint32_t num, const meshtastic_EnvironmentMetrics &env);
-    meshtastic_MeshPacket makeReplayStatusPacket(uint32_t num, const meshtastic_StatusMessage &status);
+    meshtastic_MeshPacket makeReplayPositionPacket(const meshtastic_NodeInfoLite *header, const meshtastic_PositionLite &pos);
+    meshtastic_MeshPacket makeReplayTelemetryPacket(const meshtastic_NodeInfoLite *header,
+                                                    const meshtastic_DeviceMetrics &metrics);
+    meshtastic_MeshPacket makeReplayEnvironmentPacket(const meshtastic_NodeInfoLite *header,
+                                                      const meshtastic_EnvironmentMetrics &env);
+    meshtastic_MeshPacket makeReplayStatusPacket(const meshtastic_NodeInfoLite *header, const meshtastic_StatusMessage &status);
 
     // Post-sync replay drain: pop one cached packet from the active phase, advancing
     // through positions -> telemetry -> environment -> status until everything is drained.

--- a/test/test_nodedb_v25_roundtrip/test_main.cpp
+++ b/test/test_nodedb_v25_roundtrip/test_main.cpp
@@ -618,9 +618,12 @@ static void test_bootHeal_unownedSatellitesDropped(void)
     meshtastic_NodeDatabase reloaded{};
     decodeNodesFile(reloaded);
     size_t persisted = 0;
-    for (const auto &e : reloaded.positions)
-        if (e.has_position && e.num >= ownedBase)
-            persisted++;
+    for (const auto &e : reloaded.positions) {
+        if (!e.has_position)
+            continue;
+        TEST_ASSERT_TRUE_MESSAGE(e.num >= ownedBase && e.num < ownedBase + owned, "healed store must contain only owned entries");
+        persisted++;
+    }
     TEST_ASSERT_EQUAL_UINT_MESSAGE((unsigned)owned, (unsigned)persisted, "boot must rewrite the store without the orphans");
 }
 #endif // !MESHTASTIC_EXCLUDE_POSITIONDB

--- a/test/test_nodedb_v25_roundtrip/test_main.cpp
+++ b/test/test_nodedb_v25_roundtrip/test_main.cpp
@@ -115,6 +115,27 @@ meshtastic_StatusMessage makeStatus(const char *text)
     return st;
 }
 
+/// A header row as a saved nodes.proto carries it. HAS_USER matters: cleanupMeshDB
+/// purges a userless row on load and erases its satellites with it.
+meshtastic_NodeInfoLite craftedOwner(NodeNum num, uint32_t lastHeard)
+{
+    meshtastic_NodeInfoLite n = meshtastic_NodeInfoLite_init_zero;
+    n.num = num;
+    n.last_heard = lastHeard;
+    n.bitfield |= NODEINFO_BITFIELD_HAS_USER_MASK;
+    return n;
+}
+
+meshtastic_NodePositionEntry craftedPosition(NodeNum num, int32_t lat)
+{
+    meshtastic_NodePositionEntry e = meshtastic_NodePositionEntry_init_zero;
+    e.num = num;
+    e.has_position = true;
+    e.position.latitude_i = lat;
+    e.position.time = 1000 + (uint32_t)lat;
+    return e;
+}
+
 bool readFileBytes(const char *path, std::vector<uint8_t> &out)
 {
     auto f = FSCom.open(path, FILE_O_READ);
@@ -522,16 +543,14 @@ static void test_bootTrim_overCapSatellitesHealedOnDisk(void)
     const NodeNum base = 0x70000000u;
 
     // Craft a v25 nodes.proto whose position store exceeds this build's cap, as a
-    // larger-cap build (or a peer backup) would leave behind.
+    // larger-cap build (or a peer backup) would leave behind. Every entry has a hot
+    // owner, so the boot orphan sweep keeps all of them and only the cap trims.
     meshtastic_NodeDatabase crafted{};
     crafted.version = DEVICESTATE_CUR_VER;
     for (size_t i = 0; i < (size_t)MAX_SATELLITE_NODES + overBy; i++) {
-        meshtastic_NodePositionEntry e = meshtastic_NodePositionEntry_init_zero;
-        e.num = base + (uint32_t)i;
-        e.has_position = true;
-        e.position.latitude_i = (int32_t)(1000 + i);
-        e.position.time = 1000 + (uint32_t)i;
-        crafted.positions.push_back(e);
+        const NodeNum num = base + (uint32_t)i;
+        crafted.nodes.push_back(craftedOwner(num, 1000 + (uint32_t)i));
+        crafted.positions.push_back(craftedPosition(num, (int32_t)(1000 + i)));
     }
     size_t craftedSize = 0;
     TEST_ASSERT_TRUE(pb_get_encoded_size(&craftedSize, meshtastic_NodeDatabase_fields, &crafted));
@@ -539,8 +558,7 @@ static void test_bootTrim_overCapSatellitesHealedOnDisk(void)
 
     coldBoot();
 
-    // Trimmed in RAM to exactly the cap; all entries were orphans, so the
-    // lowest-recency victims (here: the lowest-numbered) went first.
+    // Trimmed in RAM to exactly the cap, stalest owner first.
     TEST_ASSERT_EQUAL_UINT((unsigned)MAX_SATELLITE_NODES, (unsigned)nodeDB->snapshotPositionNodeNums(0).size());
     TEST_ASSERT_TRUE(db->hasNodePosition(base + (uint32_t)MAX_SATELLITE_NODES + (uint32_t)overBy - 1));
     TEST_ASSERT_FALSE(db->hasNodePosition(base));
@@ -554,6 +572,56 @@ static void test_bootTrim_overCapSatellitesHealedOnDisk(void)
             persisted++;
     TEST_ASSERT_EQUAL_UINT_MESSAGE((unsigned)MAX_SATELLITE_NODES, (unsigned)persisted,
                                    "boot must rewrite the over-cap store trimmed");
+}
+#endif // !MESHTASTIC_EXCLUDE_POSITIONDB
+
+// --- Boot-time heal of a nodes.proto carrying unowned satellite entries ---
+
+#if !MESHTASTIC_EXCLUDE_POSITIONDB
+// Guards #11798: satellite entries whose key names no hot node are dropped on boot and the
+// healed store is rewritten once; keys that cannot name a node (0, NODENUM_BROADCAST) are
+// refused at decode.
+static void test_bootHeal_unownedSatellitesDropped(void)
+{
+    const NodeNum ownedBase = 0x72000000u;
+    const NodeNum orphanBase = 0x73000000u;
+    const size_t owned = 5;
+    const size_t orphans = 6;
+
+    meshtastic_NodeDatabase crafted{};
+    crafted.version = DEVICESTATE_CUR_VER;
+    for (size_t i = 0; i < owned; i++) {
+        const NodeNum num = ownedBase + (uint32_t)i;
+        crafted.nodes.push_back(craftedOwner(num, 1000 + (uint32_t)i));
+        crafted.positions.push_back(craftedPosition(num, (int32_t)(100 + i)));
+    }
+    for (size_t i = 0; i < orphans; i++)
+        crafted.positions.push_back(craftedPosition(orphanBase + (uint32_t)i, (int32_t)(200 + i)));
+    // Keys no NodeNum derivation can produce; these must never reach the map.
+    crafted.positions.push_back(craftedPosition(0, 300));
+    crafted.positions.push_back(craftedPosition(NODENUM_BROADCAST, 301));
+
+    size_t craftedSize = 0;
+    TEST_ASSERT_TRUE(pb_get_encoded_size(&craftedSize, meshtastic_NodeDatabase_fields, &crafted));
+    TEST_ASSERT_TRUE(db->saveProto(nodeDatabaseFileName, craftedSize, &meshtastic_NodeDatabase_msg, &crafted, false));
+
+    coldBoot();
+
+    // In RAM: every owned entry kept, every unowned one gone.
+    for (size_t i = 0; i < owned; i++)
+        TEST_ASSERT_TRUE_MESSAGE(db->hasNodePosition(ownedBase + (uint32_t)i), "hot-owned entry must survive the sweep");
+    for (size_t i = 0; i < orphans; i++)
+        TEST_ASSERT_FALSE_MESSAGE(db->hasNodePosition(orphanBase + (uint32_t)i), "orphan must be swept on boot");
+    TEST_ASSERT_FALSE_MESSAGE(db->hasNodePosition(0), "key 0 must be refused at decode");
+    TEST_ASSERT_FALSE_MESSAGE(db->hasNodePosition(NODENUM_BROADCAST), "broadcast key must be refused at decode");
+    // And healed on disk: nodeDBSelfCare rewrote the store once during the boot.
+    meshtastic_NodeDatabase reloaded{};
+    decodeNodesFile(reloaded);
+    size_t persisted = 0;
+    for (const auto &e : reloaded.positions)
+        if (e.has_position && e.num >= ownedBase)
+            persisted++;
+    TEST_ASSERT_EQUAL_UINT_MESSAGE((unsigned)owned, (unsigned)persisted, "boot must rewrite the store without the orphans");
 }
 #endif // !MESHTASTIC_EXCLUDE_POSITIONDB
 
@@ -666,6 +734,7 @@ NDBR_TEST_ENTRY void setup()
 #endif
 #if !MESHTASTIC_EXCLUDE_POSITIONDB
     RUN_TEST(test_bootTrim_overCapSatellitesHealedOnDisk);
+    RUN_TEST(test_bootHeal_unownedSatellitesDropped);
 #endif
 
     printf("\n=== resetNodes ghost rows ===\n");


### PR DESCRIPTION
Fixes #11798

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented invalid or unassigned satellite data from being stored, improving database accuracy.
  - Automatically removes orphaned satellite entries during database cleanup while preserving valid entries.
  - Improved replay handling by skipping records that no longer have corresponding node information.
  - Added safeguards for recovering node data after restart, including cleanup of invalid persisted entries.
- **Tests**
  - Expanded coverage for satellite database limits, orphan cleanup, invalid keys, and restart recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->