### PR TITLE
fix(phoneapi): wake clients after config sync

### DIFF
--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -1178,6 +1178,9 @@ void PhoneAPI::sendConfigComplete()
     onConfigComplete();
 
     pauseBluetoothLogging = false;
+
+    // Re-arm polling for anything queued while live-packet notifications were suppressed during sync.
+    service->nudgeFromNum();
 }
 
 void PhoneAPI::releasePhonePacket()

--- a/test/test_phone_api_config_dump/test_main.cpp
+++ b/test/test_phone_api_config_dump/test_main.cpp
@@ -528,6 +528,39 @@ void test_dump_reaches_idle_after_complete()
     TEST_ASSERT_EQUAL_UINT(0, api->getFromRadio(buf));
 }
 
+// A packet queued while the client is still consuming config is not announced by onNotify().
+// Once config completes, re-arm the transport so the queued packet cannot sleep until later traffic.
+void test_packet_queued_mid_sync_is_announced_after_complete()
+{
+    startHandshake(FULL_DUMP_NONCE);
+    api->dataNotifications = 0;
+
+    meshtastic_MeshPacket packet = meshtastic_MeshPacket_init_zero;
+    packet.which_payload_variant = meshtastic_MeshPacket_decoded_tag;
+    packet.decoded.portnum = meshtastic_PortNum_TEXT_MESSAGE_APP;
+    packet.from = SEEDED_NODE_A;
+    packet.to = NODENUM_BROADCAST;
+    packet.id = 0xA11CE001;
+    meshtastic_MeshPacket *queued = packetPool.allocCopy(packet);
+    TEST_ASSERT_NOT_NULL(queued);
+    service->sendToPhone(queued);
+
+    service->loop();
+    TEST_ASSERT_EQUAL_UINT_MESSAGE(0, api->dataNotifications, "mid-sync packet should not interrupt the config dump");
+
+    DumpTranscript t;
+    TEST_ASSERT_TRUE(drainUntilComplete(t));
+    const unsigned notificationsAtComplete = api->dataNotifications;
+    service->loop();
+    TEST_ASSERT_GREATER_THAN_UINT_MESSAGE(notificationsAtComplete, api->dataNotifications,
+                                          "config completion must re-announce packets queued during sync");
+
+    meshtastic_FromRadio msg;
+    TEST_ASSERT_TRUE(readOneFromRadio(msg));
+    TEST_ASSERT_EQUAL_UINT(meshtastic_FromRadio_packet_tag, msg.which_payload_variant);
+    TEST_ASSERT_EQUAL_UINT32(packet.id, msg.packet.id);
+}
+
 // The first region set moves my_node_num live (NodeDB::createNewIdentity()) with no reboot to force a
 // re-handshake, so the stream must re-announce my_info - exactly once - on its own.
 void test_node_num_change_resends_my_info()
@@ -679,6 +712,7 @@ void setup()
     RUN_TEST(test_close_mid_dump_then_reconnect_restarts_clean);
     RUN_TEST(test_rehandshake_mid_dump_restarts_from_my_info);
     RUN_TEST(test_dump_reaches_idle_after_complete);
+    RUN_TEST(test_packet_queued_mid_sync_is_announced_after_complete);
     RUN_TEST(test_node_num_change_resends_my_info);
     RUN_TEST(test_node_num_change_mid_dump_restarts_sync);
     RUN_TEST(test_node_num_change_mid_nodes_only_restarts_sync);


### PR DESCRIPTION
## Summary

- Re-arm the Phone API data notification after a client finishes its config dump.
- Cover a text packet queued during config sync and verify it is announced and delivered after `config_complete`.

## Why

`MeshService::sendToPhone()` increments `fromNum` when a radio packet is queued. During a config dump, `PhoneAPI::onNotify()` intentionally suppresses live-packet notifications, but `MeshService::loop()` still consumes that `fromNum` edge when observers return success. The packet remains queued after `config_complete`, while a BLE client that waits for `FROMNUM` can sleep until unrelated later traffic wakes it.

After entering `STATE_SEND_PACKETS`, this change nudges `fromNum` once so transports re-check the queue. Empty queues only cause a harmless extra poll; packets received during the sync are announced immediately.

## Validation

- [x] Regression test red before the fix: `test_phone_api_config_dump` reported 13 tests, 1 failure in `test_packet_queued_mid_sync_is_announced_after_complete`.
- [x] Regression test green after the fix: isolated-`HOME` native binary reported 13 tests, 0 failures.
- [x] `pio run -e muzi-base` passed.
- [x] `pio run -e tbeam-s3-core` passed.
- [x] `trunk fmt src/mesh/PhoneAPI.cpp test/test_phone_api_config_dump/test_main.cpp` passed.
- [x] Physical BLE/RF A/B passed using a Muzi Base receiver and LilyGo T-Beam S3 Core sender.

### Physical A/B evidence

The harness subscribed to Muzi's BLE `FROMNUM`, began a full 52-item config dump, and sent a uniquely identified channel message over LoRa from the T-Beam after the second config read. It stopped polling when it received the matching `config_complete`, waited five seconds for another notification, and then inspected `FROMRADIO`.

| | Baseline `2.8.1.0f3e268` | Patched `2.8.1.8df9cc8` |
|---|---:|---:|
| Config items read | 52 | 52 |
| `FROMNUM` notifications at completion | 2 | 2 |
| Notifications after wait | 2 | 3 |
| Post-completion wake | No | Yes (`FROMNUM=15`) |
| Test packet available | Yes, but only found by an unprompted manual read | Yes, available after the emitted wake |

On the patched build, the wake arrived about 120 ms after `config_complete`, which gives a notification-driven client the edge it needs to drain `FROMRADIO`. The harness intentionally preserved the full five-second observation window before reading; both runs then recovered the exact packet ID and text sent by the T-Beam. Muzi's complete exported configuration was byte-identical before and after the update, and serial metadata remained healthy with PKC enabled.

## Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause obvious regressions on:
  - [x] LilyGo T-Beam S3 Core (build and real RF sender)
  - [x] Muzi Base (build, flash, BLE receiver, config-preservation check)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Queued live packets are now correctly re-announced after configuration synchronization completes, ensuring clients receive packets that arrived during the sync.
  - Prevented transport notifications from interrupting an active configuration dump while preserving queued packets for subsequent delivery.

- **Tests**
  - Added regression coverage verifying queued packets retain their original identifiers and are delivered after synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->