### PR TITLE
Light/dark/auto theme toggle for the nightly index

### DIFF
--- a/.github/nightly/hintro.html
+++ b/.github/nightly/hintro.html
@@ -19,8 +19,10 @@
     --notice-bg: #fff9e8;
     --notice-rule: #e8b931;
   }
+  /* One dark palette, reached two ways: the system preference unless light was
+     picked explicitly, or an explicit dark pick. Keep the two selectors in step. */
   @media (prefers-color-scheme: dark) {
-    :root {
+    :root:not([data-theme="light"]) {
       --bg: #1b1c26;
       --panel: #23242f;
       --fg: #e7e8ee;
@@ -31,6 +33,17 @@
       --notice-bg: #2b2618;
       --notice-rule: #b9902a;
     }
+  }
+  :root[data-theme="dark"] {
+    --bg: #1b1c26;
+    --panel: #23242f;
+    --fg: #e7e8ee;
+    --muted: #9a9cb0;
+    --rule: #32343f;
+    --accent: #67ea94;
+    --logo: #ffffff;
+    --notice-bg: #2b2618;
+    --notice-rule: #b9902a;
   }
   * { box-sizing: border-box; }
   body {
@@ -44,6 +57,30 @@
   a { color: var(--accent); }
   header { display: flex; align-items: center; gap: 0.85rem; }
   header svg { width: 46px; height: auto; fill: var(--logo); flex: none; }
+  #theme-toggle {
+    margin-left: auto;
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.7rem;
+    font: inherit;
+    font-size: 0.82rem;
+    color: var(--muted);
+    background: var(--panel);
+    border: 1px solid var(--rule);
+    border-radius: 999px;
+    cursor: pointer;
+  }
+  #theme-toggle:hover { color: var(--fg); border-color: var(--muted); }
+  #theme-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  #theme-toggle svg { width: 15px; height: 15px; fill: currentColor; }
+  /* Show the icon for the active mode only. */
+  #theme-toggle [data-icon] { display: none; }
+  :root:not([data-theme]) #theme-toggle [data-icon="auto"],
+  :root[data-theme="light"] #theme-toggle [data-icon="light"],
+  :root[data-theme="dark"] #theme-toggle [data-icon="dark"] { display: inline-flex; }
+  @media (max-width: 30rem) { #theme-toggle .label { display: none; } }
   h1 {
     margin: 0;
     font-size: 1.6rem;
@@ -117,6 +154,21 @@
   }
   footer a { margin-right: 1.25rem; white-space: nowrap; }
 </style>
+<script>
+  // Matches the Docusaurus bootstrap on the rest of the site: localStorage "theme"
+  // holds "light" or "dark", and its absence means follow the system. Runs before
+  // paint so the page never flashes the wrong palette.
+  (function () {
+    try {
+      var t = localStorage.getItem("theme");
+      if (t === "light" || t === "dark") {
+        document.documentElement.setAttribute("data-theme", t);
+      }
+    } catch (e) {
+      /* storage blocked: fall back to the media query alone */
+    }
+  })();
+</script>
 </head>
 <body>
 <main>
@@ -128,6 +180,12 @@
       </g>
     </svg>
     <h1>Meshtastic<span class="sub">Nightly Firmware</span></h1>
+    <button id="theme-toggle" type="button" aria-live="polite">
+      <span data-icon="auto" aria-hidden="true"><svg viewBox="0 0 16 16"><path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1Zm0 1.5v11a5.5 5.5 0 0 1 0-11Z"/></svg></span>
+      <span data-icon="light" aria-hidden="true"><svg viewBox="0 0 16 16"><path d="M8 4.5A3.5 3.5 0 1 0 8 11.5 3.5 3.5 0 0 0 8 4.5ZM8 0l1 2.2H7L8 0Zm0 16-1-2.2h2L8 16ZM0 8l2.2-1v2L0 8Zm16 0-2.2 1V7L16 8ZM2.3 2.3l2.3.9-.8.8-1.5-1.7Zm11.4 11.4-2.3-.9.8-.8 1.5 1.7ZM13.7 2.3l-1.5 1.7-.8-.8 2.3-.9ZM2.3 13.7l1.5-1.7.8.8-2.3.9Z"/></svg></span>
+      <span data-icon="dark" aria-hidden="true"><svg viewBox="0 0 16 16"><path d="M6.2 1.4a6.6 6.6 0 1 0 8.4 8.4A7 7 0 0 1 6.2 1.4Z"/></svg></span>
+      <span class="label"></span>
+    </button>
   </header>
 
   <p class="lede">

--- a/.github/nightly/houtro.html
+++ b/.github/nightly/houtro.html
@@ -7,5 +7,42 @@
     <a href="https://github.com/meshtastic/firmware/issues">Report a bug</a>
   </footer>
 </main>
+<script>
+  // Cycles light -> dark -> auto. "auto" is the absence of a stored value, which is
+  // how the rest of the site represents it, so the three states stay in step.
+  (function () {
+    var btn = document.getElementById("theme-toggle");
+    if (!btn) return;
+    var root = document.documentElement;
+    var label = btn.querySelector(".label");
+
+    function current() {
+      var t = root.getAttribute("data-theme");
+      return t === "light" || t === "dark" ? t : "auto";
+    }
+
+    function paint() {
+      var mode = current();
+      if (label) label.textContent = mode.charAt(0).toUpperCase() + mode.slice(1);
+      btn.setAttribute("title", "Theme: " + mode + " (click to change)");
+      btn.setAttribute("aria-label", "Theme: " + mode + ". Click to change.");
+    }
+
+    btn.addEventListener("click", function () {
+      var next = { light: "dark", dark: "auto", auto: "light" }[current()];
+      try {
+        if (next === "auto") localStorage.removeItem("theme");
+        else localStorage.setItem("theme", next);
+      } catch (e) {
+        /* storage blocked: the choice still applies for this page view */
+      }
+      if (next === "auto") root.removeAttribute("data-theme");
+      else root.setAttribute("data-theme", next);
+      paint();
+    });
+
+    paint();
+  })();
+</script>
 </body>
 </html>

--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -816,6 +816,15 @@ jobs:
             --hintro "$RUNNER_TEMP/hintro.html" \
             --houtro "$GITHUB_WORKSPACE/.github/nightly/houtro.html" \
             > index.html
+          # tree exits 0 having silently skipped an intro/outro file it could not
+          # open, so a bad path yields a listing with no page chrome around it.
+          # Check a stable marker from each half rather than trusting the exit code.
+          for marker in 'Nightly Firmware' '</footer>'; do
+            if ! grep -qF "$marker" index.html; then
+              echo "::error::nightly index is missing $marker; check the hintro/houtro paths"
+              exit 1
+            fi
+          done
 
       # Mirror the staged directory to Cloudflare R2. --delete at the bucket root
       # clears stale nightly binaries, and is in scope for the whole bucket because


### PR DESCRIPTION
## What did you change

The nightly index gets the same light/dark/auto theme control the rest of the Meshtastic site has, and the marker check that the workflow comment already promises.

**`feat(nightly)`: theme toggle.** The page already carried both palettes as CSS custom properties, but only `prefers-color-scheme` could choose between them — a reader on a dark OS had no way to get the light page, or vice versa.

This adds a cycling light → dark → auto button to the header, using the identical storage contract to the Docusaurus site so behaviour matches: `localStorage["theme"]` holds `"light"` or `"dark"`, and its **absence** means follow the system. The bootstrap runs in `<head>` before paint, so the page never flashes the wrong palette.

The dark palette is now reached two ways, and the two selectors have to stay in step:

- `@media (prefers-color-scheme: dark) :root:not([data-theme="light"])` — so an explicit light choice beats a dark OS
- `:root[data-theme="dark"]` — an explicit dark choice

Worth knowing: `localStorage` is per-origin, so a choice made on `nightly.meshtastic.org` is **not** shared with `meshtastic.org`. Only the behaviour is consistent, not the setting. There is no way around that short of a cookie on a shared parent domain, which seems disproportionate here.

**`fix(nightly)`: check the index markers.** The comment above the generate step says "the rendered page is checked for both markers below" — but no such check existed. It matters because `tree` exits 0 having *silently skipped* an `--hintro`/`--houtro` file it cannot open, so a bad path would publish a bare file listing with no page chrome and nothing would notice. The step now greps a stable marker from each half rather than trusting the exit code.

## How was it tested

No firmware is touched — this is the nightly index page and its CI step — so the hardware attestations below do not apply and I have left them unticked rather than tick them falsely.

What I did verify, rendering through the real `tree -H --hintro/--houtro` pipeline:

- the spliced page is well-formed: `html`/`head`/`body`/`main`/`button` all balanced, both `<script>` blocks parse
- the state machine cycles `auto → light → dark → auto`
- the new guard passes on a good render, and **catches a real failure**: rendering with a deliberately missing `--houtro` still exits 0 and still produces an `index.html`, and the check correctly reports the footer missing
- `trunk fmt` clean

**Not verified: how it looks in a browser.** I had no working headless browser available, so the CSS cascade is correct by inspection rather than by having seen it. A second pair of eyes on the rendered page would be welcome — particularly the button's placement in the flex header at narrow widths, where the text label is deliberately hidden below 30rem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a theme toggle to nightly build pages with Auto, Light, and Dark modes.
  - Theme preferences are remembered between visits, with accessible labels and responsive controls.

- **Bug Fixes**
  - Improved theme behavior when system preferences or saved settings are unavailable.
  - Added validation to help prevent nightly pages from being generated without their expected header and footer content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->