### PR TITLE
fix(nodedb): build the fixed-GPS userprefs path again

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -710,9 +710,16 @@ NodeDB::NodeDB()
             concurrency::LockGuard guard(&satelliteMutex);
             nodePositions[getNodeNum()] = TypeConversions::ConvertToPositionLite(fixedGPS);
         }
+        // nodePositions is a member map, so the nodeDatabase CRC compare above cannot see this write -
+        // and it has already run. Flag the segment or the fixed position is only persisted by chance.
+        saveWhat |= SEGMENT_NODEDATABASE;
 #endif
         setLocalPosition(fixedGPS);
         config.position.fixed_position = true;
+        // Same for config, whose CRC compare also ran before this block. Keep that compare's
+        // degraded-boot guard so an unreadable config is never overwritten with UNSET defaults.
+        if (!configDecodeFailed)
+            saveWhat |= SEGMENT_CONFIG;
 #endif
     }
 #endif

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -708,10 +708,10 @@ NodeDB::NodeDB()
 #if !MESHTASTIC_EXCLUDE_POSITIONDB
         {
             concurrency::LockGuard guard(&satelliteMutex);
-            nodePositions[info->num] = TypeConversions::ConvertToPositionLite(fixedGPS);
+            nodePositions[getNodeNum()] = TypeConversions::ConvertToPositionLite(fixedGPS);
         }
 #endif
-        nodeDB->setLocalPosition(fixedGPS);
+        setLocalPosition(fixedGPS);
         config.position.fixed_position = true;
 #endif
     }


### PR DESCRIPTION
Fixes #11812

## What is broken

The `USERPREFS_FIXED_GPS` block in the `NodeDB` constructor holds two defects. Both only surface on vendor builds that set `USERPREFS_FIXED_GPS_LAT` and `USERPREFS_FIXED_GPS_LON`. `userPrefs.jsonc` ships those keys commented out and no CI target defines them, so this block is never compiled in this repo and neither defect was caught.

**1. Hard compile error.** `info` is not declared anywhere in the constructor. The reference is a leftover: before 94bb21ecc7 the constructor had a local `meshtastic_NodeInfoLite *info = getOrCreateMeshNode(getNodeNum());`, and the refactor removed the local while keeping the use. Any build with both fixed-GPS keys set fails with `error: 'info' was not declared in this scope`.

Because that local was initialised from `getOrCreateMeshNode(getNodeNum())`, `getNodeNum()` resolves to exactly the key `info->num` used to give. It also matches how `clearLocalPosition()` and the other own-node satellite writers address the local node. The recently added orphan sweep in #11808 exempts `self` explicitly, so a self-keyed entry is the one the pruner is built to keep.

**2. Null pointer dereference on the next line.** `setLocalPosition()` was called through the global `nodeDB`, but `main.cpp` only assigns that global after `new NodeDB` returns. Inside the constructor it is still `nullptr`, so the call stored `localPosition` through a null `this`. This one is older than the refactor, dating to #5341. Calling directly matches the sibling `setLocalPosition()` call earlier in the same constructor.

## Verification

Forcing the two user preference keys on via build flags, against the `native` target:

| | Result |
| --- | --- |
| Before this change | `error: 'info' was not declared in this scope` |
| After this change | builds and links clean |

Native test suite: 1393 of 1393 pass.

## Notes for the reviewer

Two related things I found while confirming this, deliberately **not** in this PR so the fix stays reviewable. Happy to fold either in here if you would rather.

- **The block never marks itself dirty.** `saveWhat` is finalised by the CRC comparisons above, and this block then mutates `nodePositions` (a `std::map` member, invisible to `crc32Buffer(&nodeDatabase, ...)`) plus `config.position.fixed_position`. `saveToDisk(saveWhat)` is the only save left in the constructor, so persisting the fixed position is incidental rather than guaranteed. The bad case is asymmetric: on a build that also pins a region, key generation dirties `config`, so `fixed_position = true` persists while the coordinates do not, which suppresses GPS wake permanently.
- **No CI builds any user preferences.** That is why a hard compile error survived here since May. A `coverage-*` style environment that defines a representative set of keys would close the whole class; the repo already uses that pattern elsewhere.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where a configured fixed GPS position was not reliably saved during first-time setup.
  * Fixed persistence of related position and configuration changes so devices using a fixed GPS location retain and report their configured position correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->