### PR TITLE
fix(extnotif): make isNagging the only armed flag for the nag cycle

### DIFF
--- a/src/mesh/Throttle.h
+++ b/src/mesh/Throttle.h
@@ -32,7 +32,7 @@ class Throttle
     /// Deadline::in(ms) / .armed() / .passed() / .disarm(). A hand-built `now + interval` could then
     /// no longer land on the sentinel by accident, and "armed" would stay a question separate from
     /// "passed" - the split that has to survive, because which way "inactive" falls is the caller's
-    /// to decide. Same size and cost as the bare uint32_t. The conversion sites, grouped by the four
+    /// to decide. Same size and cost as the bare uint32_t. The conversion sites, grouped by the three
     /// meanings they give the sentinel today:
     ///   0 = unarmed - Power.cpp rebootAtMsec/shutdownAtMsec, GPS.cpp fixHoldEnds, AdminModule.cpp
     ///                 enterDfuAtMsec and the other timerEndsAtMillis()/skipZero() arm sites dodge
@@ -41,8 +41,11 @@ class Throttle
     ///                 guard, so this third state wants naming rather than repeating.
     ///   0 = due now - ethClient.cpp ntp_renew, forced at link-up. A computed renewal now dodges 0,
     ///                 so only a deliberate write still means "due now".
-    ///   UINT32_MAX  - ExternalNotificationModule.cpp nagCycleCutoff, whose armed() also lives in a
-    ///                 second variable (isNagging) and whose arm site can land on the sentinel.
+    /// ExternalNotificationModule.cpp nagCycleCutoff used to be a fourth case, reserving UINT32_MAX
+    /// for "unarmed" while ALSO keeping an isNagging flag. It no longer reserves any value: isNagging
+    /// is the only armed flag and the deadline is read only while it is set. That is the shape this
+    /// TODO is aiming at, minus the type - a deadline whose arm site is `millis() + interval` cannot
+    /// safely reserve any value, because the sum can land on all of them.
     static bool deadlinePassed(uint32_t deadlineMs);
 
     /// deadlinePassed() against a caller-supplied "now", for a loop that snapshots the time once and

--- a/src/mesh/Throttle.h
+++ b/src/mesh/Throttle.h
@@ -41,11 +41,8 @@ class Throttle
     ///                 guard, so this third state wants naming rather than repeating.
     ///   0 = due now - ethClient.cpp ntp_renew, forced at link-up. A computed renewal now dodges 0,
     ///                 so only a deliberate write still means "due now".
-    /// ExternalNotificationModule.cpp nagCycleCutoff used to be a fourth case, reserving UINT32_MAX
-    /// for "unarmed" while ALSO keeping an isNagging flag. It no longer reserves any value: isNagging
-    /// is the only armed flag and the deadline is read only while it is set. That is the shape this
-    /// TODO is aiming at, minus the type - a deadline whose arm site is `millis() + interval` cannot
-    /// safely reserve any value, because the sum can land on all of them.
+    /// ExternalNotificationModule.cpp nagCycleCutoff reserves nothing: isNagging is the only armed
+    /// flag and the deadline is read only while it is set.
     static bool deadlinePassed(uint32_t deadlineMs);
 
     /// deadlinePassed() against a caller-supplied "now", for a loop that snapshots the time once and

--- a/src/modules/ExternalNotificationModule.cpp
+++ b/src/modules/ExternalNotificationModule.cpp
@@ -88,12 +88,13 @@ int32_t ExternalNotificationModule::runOnce()
 #if defined(HAS_I2S_SPEAKER_NRF52)
         isRtttlPlaying = isRtttlPlaying || nrf52RtttlPlayer.isPlaying();
 #endif
-        // isNagging is the armed flag; nagCycleCutoff holds a real deadline only while it is set
-        // (UINT32_MAX once stopped, 1 at boot), so short-circuit before the comparison.
+        // isNagging is the armed flag, and nagCycleCutoff is only a deadline while it is set, so
+        // short-circuit before the comparison rather than giving the timestamp a magic value of its
+        // own. armNagCycle() computes `millis() + durationMs`, which can land on any value at all
+        // including UINT32_MAX, so no value is available to reserve as "unarmed".
         const bool nagWindowExpired = !isNagging || Throttle::deadlinePassed(nagCycleCutoff);
         if (nagWindowExpired && !isRtttlPlaying) {
             // Turn off external notification immediately when timeout is reached, regardless of song state
-            nagCycleCutoff = UINT32_MAX;
             ExternalNotificationModule::stopNow();
             isNagging = false;
             return INT32_MAX; // save cycles till we're needed again
@@ -309,9 +310,10 @@ void ExternalNotificationModule::stopNow()
 #endif
 
     // Prevent the state machine from immediately re-triggering outputs after a manual stop.
+    // Clearing isNagging is what disarms the cycle; nagCycleCutoff is left as it is because no read
+    // consults it without checking isNagging first.
     isNagging = false;
     buzzerShouldAlert = false;
-    nagCycleCutoff = UINT32_MAX;
 
 #ifdef HAS_I2S
     // GPIO0 is used as mclk for I2S audio and set to OUTPUT by the sound library
@@ -624,7 +626,16 @@ void ExternalNotificationModule::handleSetRingtone(const char *from_msg)
 #if !MESHTASTIC_EXCLUDE_INPUTBROKER
 int ExternalNotificationModule::handleInputEvent(const InputEvent *event)
 {
-    if (nagCycleCutoff != UINT32_MAX) {
+    // isNagging is the armed flag, the same one every other read here uses. This used to test
+    // `nagCycleCutoff != UINT32_MAX` instead, which made the timestamp its own second armed flag -
+    // true at boot, because the field started at 1, so the first input event of every boot was
+    // answered with stopNow() and a non-zero return. A non-zero return aborts the rest of the
+    // observer chain (Observable::notifyObservers in src/Observer.h returns on the first one), so
+    // that event was swallowed from every later observer.
+    //
+    // Note InputBroker::handleInputEvent already stops a nag on input, before it notifies observers
+    // at all, so in practice this is belt and braces rather than the path that silences a device.
+    if (isNagging) {
         stopNow();
         return 1;
     }

--- a/src/modules/ExternalNotificationModule.cpp
+++ b/src/modules/ExternalNotificationModule.cpp
@@ -88,10 +88,8 @@ int32_t ExternalNotificationModule::runOnce()
 #if defined(HAS_I2S_SPEAKER_NRF52)
         isRtttlPlaying = isRtttlPlaying || nrf52RtttlPlayer.isPlaying();
 #endif
-        // isNagging is the armed flag, and nagCycleCutoff is only a deadline while it is set, so
-        // short-circuit before the comparison rather than giving the timestamp a magic value of its
-        // own. armNagCycle() computes `millis() + durationMs`, which can land on any value at all
-        // including UINT32_MAX, so no value is available to reserve as "unarmed".
+        // isNagging is the armed flag; nagCycleCutoff is only a deadline while it is set, so
+        // short-circuit before the comparison. `millis() + durationMs` can land on any value.
         const bool nagWindowExpired = !isNagging || Throttle::deadlinePassed(nagCycleCutoff);
         if (nagWindowExpired && !isRtttlPlaying) {
             // Turn off external notification immediately when timeout is reached, regardless of song state
@@ -310,8 +308,7 @@ void ExternalNotificationModule::stopNow()
 #endif
 
     // Prevent the state machine from immediately re-triggering outputs after a manual stop.
-    // Clearing isNagging is what disarms the cycle; nagCycleCutoff is left as it is because no read
-    // consults it without checking isNagging first.
+    // Clearing isNagging disarms the cycle; nagCycleCutoff is never read without it.
     isNagging = false;
     buzzerShouldAlert = false;
 
@@ -626,15 +623,8 @@ void ExternalNotificationModule::handleSetRingtone(const char *from_msg)
 #if !MESHTASTIC_EXCLUDE_INPUTBROKER
 int ExternalNotificationModule::handleInputEvent(const InputEvent *event)
 {
-    // isNagging is the armed flag, the same one every other read here uses. This used to test
-    // `nagCycleCutoff != UINT32_MAX` instead, which made the timestamp its own second armed flag -
-    // true at boot, because the field started at 1, so the first input event of every boot was
-    // answered with stopNow() and a non-zero return. A non-zero return aborts the rest of the
-    // observer chain (Observable::notifyObservers in src/Observer.h returns on the first one), so
-    // that event was swallowed from every later observer.
-    //
-    // Note InputBroker::handleInputEvent already stops a nag on input, before it notifies observers
-    // at all, so in practice this is belt and braces rather than the path that silences a device.
+    // Testing the deadline instead of isNagging was true at boot, and the non-zero return
+    // swallowed the first input event from every later observer.
     if (isNagging) {
         stopNow();
         return 1;

--- a/src/modules/ExternalNotificationModule.h
+++ b/src/modules/ExternalNotificationModule.h
@@ -64,8 +64,8 @@ class ExternalNotificationModule : public SinglePortModule, private concurrency:
     int handleInputEvent(const InputEvent *arg);
 #endif
 
-    /// When the current nag cycle ends. Meaningful ONLY while isNagging is set - it is a plain
-    /// deadline, not a sentinel, so never test it for a magic value. isNagging is the armed flag.
+    /// When the current nag cycle ends. Meaningful only while isNagging is set; never test it for a
+    /// magic value.
     uint32_t nagCycleCutoff = 0;
 
     void setExternalState(uint8_t index = 0, bool on = false);

--- a/src/modules/ExternalNotificationModule.h
+++ b/src/modules/ExternalNotificationModule.h
@@ -64,7 +64,9 @@ class ExternalNotificationModule : public SinglePortModule, private concurrency:
     int handleInputEvent(const InputEvent *arg);
 #endif
 
-    uint32_t nagCycleCutoff = 1;
+    /// When the current nag cycle ends. Meaningful ONLY while isNagging is set - it is a plain
+    /// deadline, not a sentinel, so never test it for a magic value. isNagging is the armed flag.
+    uint32_t nagCycleCutoff = 0;
 
     void setExternalState(uint8_t index = 0, bool on = false);
     bool getExternal(uint8_t index = 0);

--- a/test/test_throttle/test_main.cpp
+++ b/test/test_throttle/test_main.cpp
@@ -148,8 +148,12 @@ void test_deadlinePassed_reads_disarmed_sentinels_as_passed()
 {
     Time::setTestMillis(6247);
 
-    TEST_ASSERT_TRUE(Throttle::deadlinePassed(0));          // "inactive" for rebootAtMsec et al
-    TEST_ASSERT_TRUE(Throttle::deadlinePassed(UINT32_MAX)); // "inactive" for nagCycleCutoff
+    TEST_ASSERT_TRUE(Throttle::deadlinePassed(0)); // "inactive" for rebootAtMsec et al
+
+    // UINT32_MAX is not a usable "far future" either - at a low uptime it is a hair BEHIND now, so
+    // it reads as passed like any other past value. ExternalNotificationModule used to reserve it
+    // for "unarmed" and now keeps that state in its isNagging flag instead.
+    TEST_ASSERT_TRUE(Throttle::deadlinePassed(UINT32_MAX));
 
     // The guarded form every caller must use.
     const uint32_t disarmed = 0;


### PR DESCRIPTION
`ExternalNotificationModule` kept the nag cycle's armed state in two places that could disagree: the `isNagging` bool, and `nagCycleCutoff` reserving `UINT32_MAX` for "not armed". `handleInputEvent()` read only the second one:

```cpp
if (nagCycleCutoff != UINT32_MAX) { stopNow(); return 1; }
```

## Defect 1 - live today, every boot

The field is declared `uint32_t nagCycleCutoff = 1;` while `isNagging` starts `false`, so at boot that test says "armed" when nothing is nagging. The first input event of every boot is answered with `stopNow()` and a **non-zero return** - and a non-zero return ends the observer chain (`Observable::notifyObservers` in `src/Observer.h` returns on the first one), so that event is swallowed from every later observer.

The handler is registered whenever `external_notification.enabled`, and `InputBroker::handleInputEvent` only short-circuits while `nagging()` is true - otherwise it falls through to `notifyObservers`, so the event really does reach this.

## Defect 2 - one tick per ~49.7-day wrap

`armNagCycle()` computes `millis() + durationMs`, which can land exactly on `UINT32_MAX`. When it does, a real buzzer/vibra/GPIO nag is running with `isNagging` true, but this read says "not armed", so the module's own handler never stops it.

`Time::skipZero()` cannot help: it lifts `0` to `1` and leaves `UINT32_MAX` alone, which `src/UptimeClock.h` pins with a `static_assert`. This is not a zero-guard problem.

## The fix

Remove the second opinion. `isNagging` is the armed flag - which the comment above the expiry check already claimed, and which the other four reads already use - and `nagCycleCutoff` is now only ever a deadline, read after `isNagging` has been checked.

Nothing reserves a value any more. That matters: an arm site spelled `millis() + interval` can produce *any* value, so no value is safe to reserve as "unarmed". That is the shape the `TODO(deadline-type)` note in `src/mesh/Throttle.h` argues for - "armed would stay a question separate from passed" - and that note is updated to match rather than keep describing the sentinel this removes. A stale comment in `test_throttle` is updated for the same reason; its assertion still holds and is kept.

## Worth knowing for review (not changed here)

`InputBroker::handleInputEvent` already calls `stopNow()` itself when `nagging()` is true, and returns **without** notifying observers. Every path that starts a notification calls `armNagCycle()` first (`startNotification()` and the text-receive path), so `isNagging` is true for the whole life of any real nag.

That makes this handler reachable only when there is nothing to stop - its `stopNow()` was never doing useful work, and the nag-silencing-on-input behaviour users see comes entirely from `InputBroker`. I gated it rather than deleting it, since removing a public handler and its observer registration is a bigger call than fixing the defect. Say the word if you would rather it went.

## Testing

`./bin/test-native-docker.sh -f test_throttle -f test_uptime_clock` - 30/30 pass. `trunk fmt` clean.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where the first input event after startup could be ignored.
  - Improved notification state handling to ensure events are processed according to the active notification state.
  - Corrected handling of notification deadlines when notifications are inactive.

- **Documentation**
  - Clarified deadline behavior, including the meanings of zero and maximum deadline values.
  - Documented notification state tracking and timer behavior.
  - Updated tests to reflect revised handling of inactive notification deadlines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->