### PR TITLE
fix(touch): stop LONG_PRESS repeating when the suppression deadline wraps

### DIFF
--- a/src/input/TouchScreenBase.cpp
+++ b/src/input/TouchScreenBase.cpp
@@ -1,5 +1,6 @@
 #include "TouchScreenBase.h"
 #include "main.h"
+#include "mesh/Throttle.h"
 
 #if defined(RAK14014) && !defined(MESHTASTIC_EXCLUDE_CANNEDMESSAGES)
 #include "modules/CannedMessageModule.h"
@@ -8,6 +9,16 @@
 #ifndef TIME_LONG_PRESS
 #define TIME_LONG_PRESS 400
 #endif
+
+// The RAK14014 deferred-tap window sits 50ms inside the long-press threshold. That subtraction is
+// unsigned now that the comparison goes through Throttle, so a variant lowering TIME_LONG_PRESS
+// below 50 would underflow it into a ~49.7 day wait and the deferred TAP would never fire. The only
+// override in the tree today is t5s3_epaper at 500; fail the build rather than the touch panel.
+static_assert(TIME_LONG_PRESS >= 50, "TIME_LONG_PRESS must be at least 50ms: see the deferred-tap window below");
+
+// How long a held finger stays suppressed after a LONG_PRESS is reported. Was the bare 30000 in
+// `_start = millis() + 30000`.
+#define LONG_PRESS_REPEAT_SUPPRESS_MS 30000
 
 // Touch sampling cadence (milliseconds).
 // Can be overridden by board variants for faster touch panels.
@@ -49,7 +60,8 @@
 
 TouchScreenBase::TouchScreenBase(const char *name, uint16_t width, uint16_t height)
     : concurrency::OSThread(name), _display_width(width), _display_height(height), _first_x(0), _last_x(0), _first_y(0),
-      _last_y(0), _start(0), _lastTouchSeenMs(0), _tapped(false), _originName(name)
+      _last_y(0), _pressStartMs(0), _longPressSuppressed(false), _longPressSuppressUntilMs(0), _lastTouchSeenMs(0),
+      _tapped(false), _originName(name)
 {
 }
 
@@ -95,12 +107,13 @@ int32_t TouchScreenBase::runOnce()
         if (touched) {
             hapticFeedback();
             _state = TOUCH_EVENT_OCCURRED;
-            _start = millis();
+            _pressStartMs = nowMs;
+            _longPressSuppressed = false;
             _first_x = x;
             _first_y = y;
         } else {
             _state = TOUCH_EVENT_CLEARED;
-            time_t duration = millis() - _start;
+            uint32_t duration = nowMs - _pressStartMs;
             x = _last_x;
             y = _last_y;
             this->setInterval(fastTapMode ? TOUCH_POLL_INTERVAL_RELEASE_FAST : TOUCH_POLL_INTERVAL_RELEASE);
@@ -157,7 +170,7 @@ int32_t TouchScreenBase::runOnce()
             LOG_DEBUG("action TAP(%d/%d)", _last_x, _last_y);
         }
     } else {
-        if (_tapped && (time_t(millis()) - _start) > TIME_LONG_PRESS - 50) {
+        if (_tapped && Throttle::hasElapsed(_pressStartMs, TIME_LONG_PRESS - 50)) {
             _tapped = false;
             e.touchEvent = static_cast<char>(TOUCH_ACTION_TAP);
             LOG_DEBUG("action TAP(%d/%d)", _last_x, _last_y);
@@ -173,9 +186,18 @@ int32_t TouchScreenBase::runOnce()
 #endif
 
     // fire LONG_PRESS event without the need for release
-    if (allowLongPress && touched && (time_t(millis()) - _start) > TIME_LONG_PRESS) {
-        // tricky: prevent reoccurring events and another touch event when releasing
-        _start = millis() + 30000;
+    // Suppression is armed-ness AND expiry, asked separately. The old single field answered both by
+    // storing `millis() + 30000` into the press-down stamp, so the elapsed-time subtraction here came
+    // out around -30000 and read as "not long enough yet". Where time_t is 64-bit - the portduino
+    // host - that uint32_t sum wraps to a small number while millis() is still just under
+    // 0xFFFFFFFF, the subtraction goes hugely positive instead, and LONG_PRESS then fires on every
+    // 20ms poll for the ~30 s until millis() itself wraps: about 1500 events for one held finger.
+    const bool longPressSuppressed = _longPressSuppressed && !Throttle::deadlinePassed(_longPressSuppressUntilMs);
+    if (allowLongPress && touched && !longPressSuppressed && Throttle::hasElapsed(_pressStartMs, TIME_LONG_PRESS)) {
+        // Same window the bare `+ 30000` gave: a finger held past it re-reports LONG_PRESS once per
+        // window. Preserved rather than quietly narrowed to a once-per-touch latch.
+        _longPressSuppressed = true;
+        _longPressSuppressUntilMs = nowMs + LONG_PRESS_REPEAT_SUPPRESS_MS;
         e.touchEvent = static_cast<char>(TOUCH_ACTION_LONG_PRESS);
         LOG_DEBUG("action LONG PRESS(%d/%d)", _last_x, _last_y);
     }

--- a/src/input/TouchScreenBase.cpp
+++ b/src/input/TouchScreenBase.cpp
@@ -10,14 +10,10 @@
 #define TIME_LONG_PRESS 400
 #endif
 
-// The RAK14014 deferred-tap window sits 50ms inside the long-press threshold. That subtraction is
-// unsigned now that the comparison goes through Throttle, so a variant lowering TIME_LONG_PRESS
-// below 50 would underflow it into a ~49.7 day wait and the deferred TAP would never fire. The only
-// override in the tree today is t5s3_epaper at 500; fail the build rather than the touch panel.
+// The deferred-tap window is `TIME_LONG_PRESS - 50`, unsigned: below 50 it underflows to ~49.7 days.
 static_assert(TIME_LONG_PRESS >= 50, "TIME_LONG_PRESS must be at least 50ms: see the deferred-tap window below");
 
-// How long a held finger stays suppressed after a LONG_PRESS is reported. Was the bare 30000 in
-// `_start = millis() + 30000`.
+// How long a held finger stays suppressed after a LONG_PRESS is reported.
 #define LONG_PRESS_REPEAT_SUPPRESS_MS 30000
 
 // Touch sampling cadence (milliseconds).
@@ -186,16 +182,11 @@ int32_t TouchScreenBase::runOnce()
 #endif
 
     // fire LONG_PRESS event without the need for release
-    // Suppression is armed-ness AND expiry, asked separately. The old single field answered both by
-    // storing `millis() + 30000` into the press-down stamp, so the elapsed-time subtraction here came
-    // out around -30000 and read as "not long enough yet". Where time_t is 64-bit - the portduino
-    // host - that uint32_t sum wraps to a small number while millis() is still just under
-    // 0xFFFFFFFF, the subtraction goes hugely positive instead, and LONG_PRESS then fires on every
-    // 20ms poll for the ~30 s until millis() itself wraps: about 1500 events for one held finger.
+    // Armed and expired are asked separately; folding the deadline into the press stamp repeated
+    // LONG_PRESS every poll across the wrap on 64-bit time_t hosts.
     const bool longPressSuppressed = _longPressSuppressed && !Throttle::deadlinePassed(_longPressSuppressUntilMs);
     if (allowLongPress && touched && !longPressSuppressed && Throttle::hasElapsed(_pressStartMs, TIME_LONG_PRESS)) {
-        // Same window the bare `+ 30000` gave: a finger held past it re-reports LONG_PRESS once per
-        // window. Preserved rather than quietly narrowed to a once-per-touch latch.
+        // A finger held past the window re-reports LONG_PRESS once per window, as before.
         _longPressSuppressed = true;
         _longPressSuppressUntilMs = nowMs + LONG_PRESS_REPEAT_SUPPRESS_MS;
         e.touchEvent = static_cast<char>(TOUCH_ACTION_LONG_PRESS);

--- a/src/input/TouchScreenBase.h
+++ b/src/input/TouchScreenBase.h
@@ -50,17 +50,10 @@ class TouchScreenBase : public Observable<const InputEvent *>, public concurrenc
     bool _touchedOld = false;  // previous touch state
     int16_t _first_x, _last_x; // horizontal swipe direction
     int16_t _first_y, _last_y; // vertical swipe direction
-    // When the current touch began. A past event time, so every "how long has the finger been down"
-    // question goes through Throttle::hasElapsed(), which is wrap-correct and gets the full ~49.7
-    // day range. This and the two fields below used to be a single `time_t _start` that doubled as a
-    // suppression deadline; the LONG_PRESS block in runOnce() records what that cost.
-    uint32_t _pressStartMs;
+    uint32_t _pressStartMs;    // when the current touch began; read via Throttle::hasElapsed()
 
-    // Repeat suppression for LONG_PRESS while one touch is held. Deliberately two fields: the bool
-    // answers "is suppression armed", the deadline answers "has it expired". Packing both into one
-    // timestamp is what made the old code wrong, and no single value can stand for "unarmed" here -
-    // Throttle::deadlinePassed() reads 0 as long past below ~24.8 days of uptime and as far future
-    // above it.
+    // LONG_PRESS repeat suppression while one touch is held: the bool is the armed flag, the
+    // deadline is read only while it is set. No value of the deadline can mean "unarmed".
     bool _longPressSuppressed;
     uint32_t _longPressSuppressUntilMs; // meaningful only while _longPressSuppressed
     uint32_t _lastTouchSeenMs;          // helps suppress brief touch-controller dropouts

--- a/src/input/TouchScreenBase.h
+++ b/src/input/TouchScreenBase.h
@@ -50,10 +50,22 @@ class TouchScreenBase : public Observable<const InputEvent *>, public concurrenc
     bool _touchedOld = false;  // previous touch state
     int16_t _first_x, _last_x; // horizontal swipe direction
     int16_t _first_y, _last_y; // vertical swipe direction
-    time_t _start;             // for LONG_PRESS
-    uint32_t _lastTouchSeenMs; // helps suppress brief touch-controller dropouts
-    bool _tapped;              // for DOUBLE_TAP
-    uint32_t _lastRun = 0;     // helps suppress too fast consecutive runOnce() executions
+    // When the current touch began. A past event time, so every "how long has the finger been down"
+    // question goes through Throttle::hasElapsed(), which is wrap-correct and gets the full ~49.7
+    // day range. This and the two fields below used to be a single `time_t _start` that doubled as a
+    // suppression deadline; the LONG_PRESS block in runOnce() records what that cost.
+    uint32_t _pressStartMs;
+
+    // Repeat suppression for LONG_PRESS while one touch is held. Deliberately two fields: the bool
+    // answers "is suppression armed", the deadline answers "has it expired". Packing both into one
+    // timestamp is what made the old code wrong, and no single value can stand for "unarmed" here -
+    // Throttle::deadlinePassed() reads 0 as long past below ~24.8 days of uptime and as far future
+    // above it.
+    bool _longPressSuppressed;
+    uint32_t _longPressSuppressUntilMs; // meaningful only while _longPressSuppressed
+    uint32_t _lastTouchSeenMs;          // helps suppress brief touch-controller dropouts
+    bool _tapped;                       // for DOUBLE_TAP
+    uint32_t _lastRun = 0;              // helps suppress too fast consecutive runOnce() executions
 
     const char *_originName;
 };


### PR DESCRIPTION
`TouchScreenBase::_start` was one field doing two incompatible jobs: it held the press-down timestamp, and then the LONG_PRESS handler overwrote it with `millis() + 30000` to stop the event repeating for the rest of the hold. Every read was a hand-rolled signed subtraction on `time_t`, and suppression worked only because `time_t(millis()) - _start` came out around `-30000`.

## The failure

Where `time_t` is 64 bits - the portduino host - that `uint32_t` sum wraps to a small number while `millis()` is still just under `0xFFFFFFFF`. The subtraction then goes hugely **positive** instead of negative, the threshold test passes on every 20 ms poll, and each pass re-arms to another wrapped value. It keeps firing until `millis()` itself wraps, up to ~30 s later.

Modelling the old expression across press-start offsets puts the worst case at exactly **1500** `TOUCH_ACTION_LONG_PRESS` events injected into InputBroker for a 60 s hold, where 3 is correct (press-start at `0xFFFFFFFF - 30400`). On a 32-bit `time_t` build the signed wrap happens to keep suppressing, so this is host- and variant-dependent rather than universal.

`Time::skipZero()` / `Time::timerEndsAtMillis()` are no use here - they map `0` to `1`, and `1` reads as "long ago" exactly as `0` does. The defect is the overload, not the zero.

## The split

| Field | Question it answers |
| --- | --- |
| `_pressStartMs` | a past event time - how long has the finger been down |
| `_longPressSuppressed` | is repeat suppression armed |
| `_longPressSuppressUntilMs` | when it expires, read only while the bool is set |

Two fields for the suppression rather than one, for the reason `Throttle.h`'s `TODO(deadline-type)` gives: *armed* has to stay a separate question from *passed*. No single value can stand in for "unarmed" here either, since `deadlinePassed()` reads `0` as long past below ~24.8 days of uptime and as far future above it. Nothing new uses `0` as a sentinel, so `bin/lint-unset-sentinel-millis.sh` needs no entry and this does not depend on #11692.

All three comparisons now go through `Throttle` - `hasElapsed()` for the two elapsed-since-press questions, which also buys the full ~49.7 day range a stored event time gets, and `deadlinePassed()` for the suppression window.

## Behaviour is preserved deliberately

Including the part that is easy to miss: the old `+ 30000` made a held finger re-report LONG_PRESS **once every 30 s**, not once per touch. A bool latch would have been simpler and would have quietly narrowed that, so the window is kept as `LONG_PRESS_REPEAT_SUPPRESS_MS`. Old and new were compared across five wrap scenarios and agree everywhere except the window the old code got wrong:

| scenario | old (64-bit `time_t`) | old (32-bit) | new |
| --- | --- | --- | --- |
| normal uptime, 40 s hold | 2 | 2 | 2 |
| normal uptime, 2 s hold | 1 | 1 | 1 |
| press 500 ms before `+30s` wraps | 1 | 2 | 2 |
| press just before `millis()` wraps | 6 | 2 | 2 |
| press at the 24.8 day boundary | 2 | 2 | 2 |

The tap-on-release suppression the old write also provided is not needed: a hold long enough to reach the LONG_PRESS branch has `duration >= TIME_LONG_PRESS`, so the tap branch already takes its `else` and clears `_tapped`.

## One guard added while here

The RAK14014 deferred-tap window is `TIME_LONG_PRESS - 50`, and that subtraction is unsigned now, so a variant lowering `TIME_LONG_PRESS` below 50 would underflow it into a ~49.7 day wait and the deferred TAP would never fire. The only override in the tree is `t5s3_epaper` at 500; a `static_assert` fails the build instead of the touch panel.

## Testing

`./bin/test-native-docker.sh -f test_trackball_press -f test_throttle` - 24/24 pass. `trunk fmt` clean. The new expressions were additionally type-checked standalone under `-Wall -Wextra -Wconversion` against the real `Throttle.h`, and the old-vs-new comparison above is from a model of both code paths. `TouchScreenBase.cpp` is not in the native test build, so its device compile is covered by the board matrix here rather than locally.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved touchscreen press and long-press timing behavior.
  - Prevented unintended repeat actions after a long press.
  - Improved reliability for deferred tap handling and elapsed-time checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->