### PR TITLE
fix(esp32): rebuild IDF libs when the HybridCompile cache is stale

### DIFF
--- a/extra_scripts/esp32_pre.py
+++ b/extra_scripts/esp32_pre.py
@@ -3,7 +3,8 @@
 # trunk-ignore-all(flake8/F821): For SConstruct imports
 import json
 import sys
-from os.path import isfile
+from os import remove
+from os.path import getmtime, isfile, join
 
 Import("env")
 
@@ -167,3 +168,22 @@ def tag_sdkconfig_cache_key(env):
 
 
 tag_sdkconfig_cache_key(env)
+
+
+# The platform writes its cache-key hash into sdkconfig.defaults before compiling
+# the IDF libs, so an aborted pass leaves it describing libs that were never built.
+def drop_stale_sdkconfig_defaults(env):
+    defaults = join(env.subst("$PROJECT_DIR"), "sdkconfig.defaults")
+    mcu = env.BoardConfig().get("build.mcu", "esp32")
+    try:
+        libs = env.PioPlatform().get_package_dir("framework-arduinoespressif32-libs")
+        # Rewritten last by a completed compile, so it marks "libs built".
+        if getmtime(join(libs, mcu, "sdkconfig")) >= getmtime(defaults):
+            return
+    except (OSError, TypeError):
+        return
+    print("*** Stale %s IDF libs; forcing a HybridCompile rebuild ***" % mcu)
+    remove(defaults)
+
+
+drop_stale_sdkconfig_defaults(env)


### PR DESCRIPTION
espidf.py writes the cache-key hash into sdkconfig.defaults at the start of the IDF-libs pass, before those libs are compiled, so an interrupted, failed or metadata-only pass leaves a hash describing libs that were never built, and every later build of that env matches it, skips the recompile and links the previously compiled board's IDF configuration. Reproduced on tlora-t3s3-v1, which linked a t-connect-pro build's CONFIG_SPIRAM_MODE_OCT libs into a quad-PSRAM ESP32-S3FH4R2 and boot looped silently because esp_psram_init() fails the ID read and aborts before the console exists; the hash itself is correct here (board_memory_fingerprint, #11112), it is simply written too early. This drops sdkconfig.defaults when the package's own <mcu>/sdkconfig, rewritten as the last step of a completed compile, predates it, and was verified against a live desync: without it the build did 0 recompiles and reused the stale octal-PSRAM libs, with it the rebuild produced a binary containing quad_psram and no octal_psram that boots on hardware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build handling by removing outdated local SDK configuration defaults when installed framework libraries are older, ensuring configuration is refreshed during hybrid builds.
  * Builds now avoid using stale configuration data, helping changes to framework libraries take effect more reliably.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->